### PR TITLE
fix(maestro): drop the virtual-docs shard guard before awaiting

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -13,3 +13,19 @@ disallowed-types = [
 disallowed-methods = [
   { path = "std::string::ToString::to_string", reason = "Use cstr!() or .to_compact_string() instead" },
 ]
+
+# A `DashMap` shard guard alive at an `.await` deadlocks the LSP: `vize lsp`
+# polls several queued messages concurrently on one thread, so a suspended
+# reader and a `didOpen`/`didChange` writer share it, and the writer parks in
+# `parking_lot` on a guard only the parked thread could release (#3315, #3373,
+# #3377). Take an owned snapshot instead — `DocumentStore::text`,
+# `ServerState::get_virtual_docs`.
+#
+# Partial gate, not a proof: clippy only matches the coroutine's top-level
+# field types, so a guard wrapped in `Option` or embedded in a struct
+# (`IdeContext`) still slips through and has to be caught by review.
+await-holding-invalid-types = [
+  { path = "dashmap::mapref::one::Ref", reason = "Use an owned snapshot; a live shard guard across an await hangs the LSP" },
+  { path = "dashmap::mapref::one::RefMut", reason = "Use an owned snapshot; a live shard guard across an await hangs the LSP" },
+  { path = "dashmap::mapref::multiple::RefMulti", reason = "Collect the iteration before awaiting; a live shard guard across an await hangs the LSP" },
+]

--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -313,8 +313,8 @@ pub struct IdeContext<'a> {
     pub offset: usize,
     /// Which block the cursor is in
     pub block_type: Option<BlockType>,
-    /// Virtual documents for this file
-    pub virtual_docs: Option<dashmap::mapref::one::Ref<'a, Url, VirtualDocuments>>,
+    /// Virtual documents for this file. An owned snapshot, never a `DashMap` shard guard: `&IdeContext` crosses the `.await` points of hover, completion, definition, references and rename, where a live guard hangs the server — see [`ServerState::get_virtual_docs`] (#3377).
+    pub virtual_docs: Option<std::sync::Arc<VirtualDocuments>>,
 }
 
 impl<'a> IdeContext<'a> {
@@ -325,7 +325,7 @@ impl<'a> IdeContext<'a> {
     /// [`IdeContext::with_content`] to avoid a redundant document lookup and a
     /// second full Rope→String allocation.
     pub fn new(state: &'a ServerState, uri: &'a Url, offset: usize) -> Option<Self> {
-        let content = state.documents.get(uri)?.text();
+        let content = state.documents.text(uri)?;
         Some(Self::with_content(state, uri, offset, content))
     }
 

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -19,6 +19,7 @@ mod config_tests;
 mod tests;
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use dashmap::DashMap;
@@ -27,8 +28,6 @@ use tower_lsp::lsp_types::Url;
 use vize_carton::config::{GlobalTypesConfig, LinterConfig, TypeCheckerConfig};
 use vize_carton::dialect::VueDialect;
 
-#[cfg(feature = "native")]
-use std::sync::Arc;
 #[cfg(feature = "native")]
 use std::sync::OnceLock;
 
@@ -52,8 +51,14 @@ pub struct ServerState {
     pub documents: DocumentStore,
     /// Virtual code generator (reusable)
     virtual_gen: RwLock<VirtualCodeGenerator>,
-    /// Cached virtual documents per file
-    virtual_docs_cache: DashMap<Url, VirtualDocuments>,
+    /// Cached virtual documents per file.
+    ///
+    /// Stored behind an `Arc` so [`Self::get_virtual_docs`] can hand out an
+    /// owned snapshot instead of a `DashMap` shard guard: readers on the LSP's
+    /// single executor thread stay alive across `.await` points, and a live
+    /// shard guard there deadlocks the whole server against the next
+    /// `didOpen`/`didChange` write (#3377, same class as #3315/#3373).
+    virtual_docs_cache: DashMap<Url, Arc<VirtualDocuments>>,
     pub(super) open_vue_imports: super::importers::OpenVueImportIndex,
     /// Parsed metadata for imported components, keyed by resolved path.
     /// Lets template completion skip re-reading + re-parsing + re-analyzing an

--- a/crates/vize_maestro/src/server/state/virtual_docs.rs
+++ b/crates/vize_maestro/src/server/state/virtual_docs.rs
@@ -1,6 +1,7 @@
 //! Virtual document generation and caching.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use dashmap::DashMap;
 use tower_lsp::lsp_types::Url;
@@ -9,6 +10,9 @@ use crate::utils::is_standalone_html_path;
 use crate::virtual_code::VirtualDocuments;
 
 use super::ServerState;
+
+#[cfg(test)]
+mod tests;
 
 impl ServerState {
     /// Generate and cache virtual documents for a document.
@@ -42,7 +46,8 @@ impl ServerState {
         let base_uri = uri.path();
         let mut virtual_docs = self.virtual_gen.write().generate(&descriptor, base_uri);
         add_inline_art_template_virtual_docs(&mut virtual_docs, &descriptor, base_uri);
-        self.virtual_docs_cache.insert(uri.clone(), virtual_docs);
+        self.virtual_docs_cache
+            .insert(uri.clone(), Arc::new(virtual_docs));
     }
 
     /// Generate and cache virtual documents for standalone HTML files.
@@ -60,7 +65,7 @@ impl ServerState {
 
         let mut docs = VirtualDocuments::new();
         docs.template = Some(template_doc);
-        self.virtual_docs_cache.insert(uri.clone(), docs);
+        self.virtual_docs_cache.insert(uri.clone(), Arc::new(docs));
     }
 
     /// Generate and cache virtual documents for a `.jsx`/`.tsx` document.
@@ -79,7 +84,7 @@ impl ServerState {
         }
         let mut docs = VirtualDocuments::new();
         docs.styles = styles;
-        self.virtual_docs_cache.insert(uri.clone(), docs);
+        self.virtual_docs_cache.insert(uri.clone(), Arc::new(docs));
     }
 
     /// Generate and cache virtual documents for an art file (*.art.vue).
@@ -157,15 +162,28 @@ impl ServerState {
             }
         }
 
-        self.virtual_docs_cache.insert(uri.clone(), docs);
+        self.virtual_docs_cache.insert(uri.clone(), Arc::new(docs));
     }
 
-    /// Get cached virtual documents for a document.
-    pub fn get_virtual_docs(
-        &self,
-        uri: &Url,
-    ) -> Option<dashmap::mapref::one::Ref<'_, Url, VirtualDocuments>> {
-        self.virtual_docs_cache.get(uri)
+    /// Owned snapshot of a document's cached virtual documents: an `Arc` clone,
+    /// never a `DashMap` shard guard, so nothing stays locked after it returns.
+    ///
+    /// Load-bearing, not a style choice (#3377). `vize lsp` drives tower-lsp on
+    /// one `block_on` thread while `Server::serve` polls up to four queued
+    /// messages concurrently, so a handler suspended at an `.await` and a
+    /// `didOpen`/`didChange`/`didClose` write share that thread. A suspended
+    /// handler still holding a shard read guard — as [`crate::ide::IdeContext`]
+    /// used to across the hover, completion, definition, references and rename
+    /// awaits — parks [`Self::update_virtual_docs`] in `parking_lot` on the
+    /// shard write lock, and the only thread that could poll the reader into
+    /// releasing it is the parked one: a permanent, silent server hang. #3373
+    /// removed the same shape from the open-document store, see
+    /// [`crate::document::DocumentStore::text`]. The `Arc` keeps the cost at a
+    /// refcount bump instead of cloning every virtual document per request.
+    pub fn get_virtual_docs(&self, uri: &Url) -> Option<Arc<VirtualDocuments>> {
+        self.virtual_docs_cache
+            .get(uri)
+            .map(|entry| Arc::clone(entry.value()))
     }
 
     /// Remove cached virtual documents when a document is closed.

--- a/crates/vize_maestro/src/server/state/virtual_docs/tests.rs
+++ b/crates/vize_maestro/src/server/state/virtual_docs/tests.rs
@@ -1,0 +1,92 @@
+//! Lock-discipline regressions for the virtual-document cache (#3377).
+//!
+//! Both tests below deadlock instead of failing on the pre-fix code, because
+//! that is exactly what the defect does to a live `vize lsp` session: the
+//! reader holding a `DashMap` shard guard can only release it by being polled
+//! on the very thread that is already parked in `parking_lot` waiting for the
+//! shard's write lock. A hung test is the honest reproduction of a hung server.
+
+use tower_lsp::lsp_types::Url;
+
+use crate::ide::IdeContext;
+use crate::server::ServerState;
+use crate::virtual_code::VirtualDocuments;
+
+fn source(color: &str) -> String {
+    vize_carton::cstr!(
+        "<script setup lang=\"ts\">\nconst message = 'hi'\n</script>\n\
+         <template>\n  <div>{{{{ message }}}}</div>\n</template>\n\
+         <style scoped>\n.box {{ color: {color}; }}\n</style>\n"
+    )
+    .to_string()
+}
+
+/// Every style virtual document as `(uri, content)`, so assertions pin the
+/// whole generated set rather than one probed field.
+fn styles(docs: &VirtualDocuments) -> Vec<(String, String)> {
+    docs.styles
+        .iter()
+        .map(|style| (style.uri.clone(), style.content.clone()))
+        .collect()
+}
+
+fn style_documents(color: &str) -> Vec<(String, String)> {
+    vec![(
+        "/Snapshot.vue.__style_0.css".to_string(),
+        vize_carton::cstr!("\n.box {{ color: {color}; }}\n").to_string(),
+    )]
+}
+
+/// `get_virtual_docs` must return an owned snapshot, never a shard guard, so a
+/// snapshot that is still alive cannot block a concurrent cache write.
+#[test]
+fn get_virtual_docs_snapshot_holds_no_shard_lock() {
+    let state = ServerState::new();
+    let uri = Url::parse("file:///Snapshot.vue").unwrap();
+    state.update_virtual_docs(&uri, &source("red"));
+
+    let snapshot = state.get_virtual_docs(&uri).unwrap();
+    state.update_virtual_docs(&uri, &source("blue"));
+
+    assert_eq!(styles(&snapshot), style_documents("red"));
+    assert_eq!(
+        styles(&state.get_virtual_docs(&uri).unwrap()),
+        style_documents("blue")
+    );
+    assert!(
+        state
+            .get_virtual_docs(&Url::parse("file:///Absent.vue").unwrap())
+            .is_none()
+    );
+}
+
+/// The shape the LSP actually runs: `&IdeContext` stays alive across an
+/// `.await` (hover, completion, definition, references, rename all do this),
+/// and a `didChange` polled on the same executor thread writes the cache while
+/// that context is suspended.
+#[test]
+fn ide_context_survives_a_virtual_docs_write_across_an_await() {
+    let state = ServerState::new();
+    let uri = Url::parse("file:///Snapshot.vue").unwrap();
+    let before = source("red");
+    state
+        .documents
+        .open(uri.clone(), before.clone(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, &before);
+
+    let observed = crate::runtime::block_on(async {
+        let ctx = IdeContext::new(&state, &uri, 0).unwrap();
+        // Stands in for `get_corsa_bridge().await` handing the single executor
+        // thread to a queued `didChange` while `ctx` is still live.
+        futures::future::ready(()).await;
+        state.update_virtual_docs(&uri, &source("blue"));
+        futures::future::ready(()).await;
+        styles(ctx.virtual_docs.as_ref().unwrap())
+    });
+
+    assert_eq!(observed, style_documents("red"));
+    assert_eq!(
+        styles(&state.get_virtual_docs(&uri).unwrap()),
+        style_documents("blue")
+    );
+}


### PR DESCRIPTION
## The defect

`IdeContext` carried a live `DashMap` shard read guard on the virtual-document cache:

```rust
pub virtual_docs: Option<dashmap::mapref::one::Ref<'a, Url, VirtualDocuments>>,
```

and `&ctx` crosses the `.await` points of `hover`, `completion`, `goto_definition`,
`references`, `prepare_rename` and `rename`, plus the JSX branch of
`DiagnosticService::collect_async`.

`vize lsp` drives tower-lsp with `runtime::block_on` on a single thread while
`Server::serve` polls up to four queued messages concurrently. So a request handler
suspended at an `.await` and a `didOpen`/`didChange`/`didClose` write share one thread:
the writer parks in `parking_lot` on the shard's write lock, and the only thread that
could poll the reader into releasing its guard is the parked one. The server goes
permanently silent, publishing nothing and answering nothing, with normal memory use.
That is the shape #3373 removed from the open-document store, one `DashMap` over.

**#3377 records this as latent because "every await on those request paths is
synchronous underneath". That is no longer accurate, and the correction is the reason
this is worth fixing now rather than filing forward:**
`self.state.get_corsa_bridge().await` sits directly after the `IdeContext` construction
in `hover` (`handlers.rs:148` then `:164`) and in the other five handlers, and it awaits
`self.corsa_init_lock.lock().await` — a `futures::lock::Mutex`, which genuinely yields
whenever a second request reaches it while the bridge is still spawning. A cold session
with two concurrent editor requests and one `didChange` on the same document is a
constructible hang today, no new await required.

## Reproduction / test

Two Rust regressions in `crates/vize_maestro/src/server/state/virtual_docs/tests.rs`:

- `get_virtual_docs_snapshot_holds_no_shard_lock` — a live snapshot must not block a
  concurrent `update_virtual_docs` on the same key.
- `ide_context_survives_a_virtual_docs_write_across_an_await` — the shape the LSP
  actually runs: an `IdeContext` alive across an `.await`, with a cache write happening
  on the same executor thread while it is suspended.

Both assert the **full** generated style-document set (`Vec<(uri, content)>`) for the
pre-edit snapshot and the post-edit cache, so a snapshot that silently aliased the new
value would fail rather than pass.

**They fail before the fix by hanging** — which is the honest reproduction, because a
hung test is exactly what the defect does to a live session. Verified by reverting the
three source hunks and re-running:

```
running 2 tests
test server::state::virtual_docs::tests::get_virtual_docs_snapshot_holds_no_shard_lock has been running for over 60 seconds
test server::state::virtual_docs::tests::ide_context_survives_a_virtual_docs_write_across_an_await has been running for over 60 seconds
error: test failed  (signal: 15, SIGTERM)
```

With the fix both pass in 0.01s.

## The fix

`virtual_docs_cache` stores `Arc<VirtualDocuments>` and `get_virtual_docs` returns an
owned `Option<Arc<VirtualDocuments>>`, so no guard survives the call. #3377 worried the
alternative was a clone per request on hot editor paths; the `Arc` makes it a refcount
bump instead. No call site changed — deref coercion covers every existing
`ctx.virtual_docs.as_ref()` use.

`vize_maestro` is `publish = false` and is not in the `cargo-semver-checks` matrix, so
the public type change carries no semver obligation.

## Structural gate

`clippy.toml` gains `await-holding-invalid-types` for `dashmap::mapref::one::Ref`,
`RefMut` and `mapref::multiple::RefMulti`, so a bare guard held across an await fails
`cargo clippy -- -D warnings`. Verified it fires (probed with a deliberate
guard-across-await, which clippy rejected) and that the workspace is clean under it.

It is documented in the file as a **partial** gate, not a proof: clippy matches only the
coroutine's top-level field types, so a guard wrapped in `Option` or embedded in a struct
— exactly this bug — still slips past and has to be caught by review.

## Audit

Every remaining guard-across-await site in `crates/vize_maestro/` was checked:

- `ServerState::get_corsa_bridge` holds `corsa_init_lock` (a `futures::lock::Mutex`)
  across `bridge.spawn().await` — async-aware, correct by construction.
- `GlobalComponentReferences::paths` holds `scan_lock` (also a `futures::lock::Mutex`)
  across `discover_in_background().await`; its `parking_lot` write guard is explicitly
  dropped before the loop's `continue`.
- `try_collect_corsa_diagnostics`' `state.documents.iter()` overlay collection and
  `publish_diagnostics`' two `documents.get(uri).map(..)` version reads are
  statement-local temporaries, released before the next `.await`.

No other production path holds a `DashMap`/`RwLock`/`Mutex` guard across an await.

## Gates

```
nix develop -c vp run fmt:check                                    # exit 0
nix develop -c cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports  # exit 0
nix develop -c cargo test -p vize_maestro --all-features --lib     # 572 passed, 0 failed
nix develop -c node --test tests/tooling/lsp-*.test.ts             # 2185 passed, 0 failed
nix develop -c vp run source:lengths                               # ide.rs unchanged at 422; virtual_docs.rs 347 (<350)
```

Closes #3377
Refs #3315, #3373

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->