### PR TITLE
feat(maestro): provide textDocument/selectionRange for authored .vue ranges

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -1,17 +1,12 @@
 //! IDE features for the LSP server.
 //!
-//! This module provides core IDE functionality including:
-//! - Diagnostics aggregation from multiple sources
-//! - Hover information provider
-//! - Code completion provider
-//! - Go to definition
-//! - Find references
-//! - Code actions (quick fixes)
-//! - Type checking and type information
-//! - Rename refactoring
-//! - Semantic tokens
-//! - Code lens
-//! - Workspace symbols
+//! This module provides core IDE functionality. The module list below is the
+//! authoritative inventory; grouped by what the editor sees:
+//! - Correctness: diagnostics aggregation, type checking and type information
+//! - Authoring: hover, completion, definition, references, code actions, rename
+//! - Presentation: semantic tokens, inlay hints, code lens, document links
+//! - Structure: document symbols, workspace symbols, selection ranges
+//! - Ecosystem: router/i18n awareness, file rename, auto-import
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
 pub mod auto_import;
@@ -33,6 +28,7 @@ pub(crate) mod markup;
 pub(crate) mod musea;
 pub mod references;
 pub mod rename;
+pub mod selection_range;
 pub mod semantic_tokens;
 mod template_expression;
 pub mod type_service;
@@ -57,6 +53,7 @@ pub use jsx::{
 pub use jsx::{JsxReferencesService, JsxRenameService, JsxService};
 pub use references::ReferencesService;
 pub use rename::RenameService;
+pub use selection_range::SelectionRangeService;
 pub use semantic_tokens::{SemanticTokensService, TokenModifier, TokenType};
 pub(crate) use template_expression::is_in_vue_template_expression;
 pub use type_service::{LspTypeCheckOptions, TypeService};

--- a/crates/vize_maestro/src/ide/selection_range.rs
+++ b/crates/vize_maestro/src/ide/selection_range.rs
@@ -1,0 +1,202 @@
+//! Selection range provider (`textDocument/selectionRange`).
+//!
+//! `@vue/language-server` advertises `selectionRangeProvider: true`, and
+//! "expand/shrink selection" is bound out of the box in every editor Vize
+//! packages (VS Code `Shift+Alt+Right`/`Left`, Zed `ctrl-shift-right`, Helix
+//! `Alt-o`, Neovim/Emacs through their LSP clients). Maestro advertised nothing,
+//! so the command silently did nothing inside `.vue` files — the worst class of
+//! divergence, because the editor shows no error.
+//!
+//! Every range is computed on the **authored** document, never on the virtual
+//! TypeScript projection, so the chain an editor receives always addresses real
+//! `.vue` byte offsets.
+//!
+//! # Levels
+//!
+//! From innermost outward, the chain can contain:
+//!
+//! 1. the identifier/token under the cursor;
+//! 2. the trimmed expression inside an interpolation (`{{ ␣count␣ }}`);
+//! 3. the whole interpolation including its delimiters (`{{ count }}`);
+//! 4. an attribute value inside its quotes (`:title="␣label␣"`);
+//! 5. the quoted attribute value including the quotes (`:title=␣"label"␣`);
+//! 6. the whole attribute (`:title="label"`);
+//! 7. the start tag (`<Child :title="label" />`);
+//! 8. for each enclosing element, innermost first: its inner content, then the
+//!    element including both tags;
+//! 9. an HTML comment (`<!-- … -->`);
+//! 10. the content of the enclosing SFC block;
+//! 11. the enclosing SFC block including its own tags;
+//! 12. the whole document.
+//!
+//! Levels 2-9 are markup levels and are produced only inside the template block
+//! (or, for standalone petite-vue HTML and `.art.vue` documents, over the whole
+//! file).
+//!
+//! # Measured differences from `@vue/language-server` 3.3.8
+//!
+//! Recorded on the same fixture and positions (see
+//! `tests/tooling/lsp-selection-range.test.ts`, which pins both sides):
+//!
+//! - Vize adds levels Vue LS omits: the identifier token, the start tag as a
+//!   whole (`<div …>`), the SFC block including its own tags, and the whole
+//!   document. Vue LS's chain stops at the block *content*.
+//! - Vue LS offers `div class="wrap"` (the start tag interior, without `<` and
+//!   `>`) where Vize offers `<div class="wrap">` (the start tag as a unit).
+//! - Vue LS returns a statement level inside `<script>` (`const count = 1`)
+//!   because it walks the TypeScript AST. Vize does not yet, so a script cursor
+//!   gets levels 1, 10, 11, 12. Tracked separately; the authored-range levels
+//!   below are unaffected.
+//! - Vue LS returns `null` for positions inside `<style>`; Vize still returns
+//!   the token/block/document chain there.
+
+mod markup;
+
+use tower_lsp::lsp_types::{Position, Range, SelectionRange};
+
+use self::markup::markup_spans;
+use super::{offset_to_position, token_span_at_offset};
+use crate::utils::is_standalone_html_path;
+
+pub struct SelectionRangeService;
+
+impl SelectionRangeService {
+    /// Build the selection-range chain for `offset` in `content`.
+    ///
+    /// `filename` is only used to parse the SFC (block boundaries) and to detect
+    /// standalone HTML documents; no server state is consulted, which keeps the
+    /// provider a pure function of the authored text.
+    pub fn selection_range(content: &str, filename: &str, offset: usize) -> Option<SelectionRange> {
+        let offset = offset.min(content.len());
+        let mut spans = vec![(0, content.len())];
+
+        if let Some((start, end)) = token_span_at_offset(content, offset, is_token_char)
+            && start <= offset
+            && offset <= end
+        {
+            spans.push((start, end));
+        }
+
+        let markup_region = collect_block_spans(content, filename, offset, &mut spans);
+        if let Some(region) = markup_region {
+            markup_spans(content, region, offset, &mut spans);
+        }
+
+        build_chain(content, spans)
+    }
+}
+
+/// Push SFC block levels and return the region that should be scanned as markup.
+///
+/// Returns `None` when the cursor sits in a raw-text block (`<script>`,
+/// `<style>`): scanning those as markup would treat `a < b` as a tag.
+fn collect_block_spans(
+    content: &str,
+    filename: &str,
+    offset: usize,
+    spans: &mut Vec<(usize, usize)>,
+) -> Option<(usize, usize)> {
+    if is_standalone_html_path(filename) || filename.ends_with(".art.vue") {
+        return Some((0, content.len()));
+    }
+
+    let options = vize_atelier_sfc::SfcParseOptions {
+        filename: filename.into(),
+        ..Default::default()
+    };
+    let Ok(descriptor) = vize_atelier_sfc::parse_sfc(content, options) else {
+        return Some((0, content.len()));
+    };
+
+    let mut markup_region = None;
+    let template_loc = descriptor.template.as_ref().map(|block| &block.loc);
+    let raw_text_locs = descriptor
+        .script
+        .as_ref()
+        .map(|block| &block.loc)
+        .into_iter()
+        .chain(descriptor.script_setup.as_ref().map(|block| &block.loc))
+        .chain(descriptor.styles.iter().map(|block| &block.loc));
+
+    let mut in_raw_text = false;
+    for loc in template_loc.into_iter().chain(raw_text_locs.clone()) {
+        if loc.tag_start <= offset && offset <= loc.tag_end {
+            spans.push((loc.tag_start, loc.tag_end));
+            spans.push((loc.start, loc.end));
+        }
+    }
+    for loc in raw_text_locs {
+        if loc.start <= offset && offset <= loc.end {
+            in_raw_text = true;
+        }
+    }
+    if let Some(loc) = template_loc
+        && loc.start <= offset
+        && offset <= loc.end
+    {
+        markup_region = Some((loc.start, loc.end));
+    }
+
+    if in_raw_text {
+        return None;
+    }
+    // Outside every block (for example on a custom block's tag) the whole file
+    // is safe to scan: raw-text interiors were already excluded above.
+    Some(markup_region.unwrap_or((0, content.len())))
+}
+
+#[inline]
+fn is_token_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')
+}
+
+/// Turn candidate spans into a strictly nested innermost-first chain.
+fn build_chain(content: &str, spans: Vec<(usize, usize)>) -> Option<SelectionRange> {
+    let mut sorted: Vec<(usize, usize)> = spans
+        .into_iter()
+        .filter(|(start, end)| start < end)
+        .collect();
+    sorted.sort_by_key(|(start, end)| (end - start, *start));
+    sorted.dedup();
+
+    let mut chain: Vec<(usize, usize)> = Vec::with_capacity(sorted.len());
+    for span in sorted {
+        match chain.last() {
+            None => chain.push(span),
+            Some(&(previous_start, previous_end)) => {
+                let contains = span.0 <= previous_start && span.1 >= previous_end;
+                let strictly_larger = span.0 < previous_start || span.1 > previous_end;
+                if contains && strictly_larger {
+                    chain.push(span);
+                }
+            }
+        }
+    }
+
+    let mut node: Option<Box<SelectionRange>> = None;
+    for span in chain.iter().rev() {
+        node = Some(Box::new(SelectionRange {
+            range: to_range(content, *span),
+            parent: node,
+        }));
+    }
+    node.map(|boxed| *boxed)
+}
+
+fn to_range(content: &str, span: (usize, usize)) -> Range {
+    let (start_line, start_character) = offset_to_position(content, span.0);
+    let (end_line, end_character) = offset_to_position(content, span.1);
+    Range {
+        start: Position {
+            line: start_line,
+            character: start_character,
+        },
+        end: Position {
+            line: end_line,
+            character: end_character,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_maestro/src/ide/selection_range/markup.rs
+++ b/crates/vize_maestro/src/ide/selection_range/markup.rs
@@ -1,0 +1,273 @@
+//! Markup span scanner for [`super::SelectionRangeService`].
+//!
+//! Walks a region of the authored document as HTML/Vue template markup and
+//! reports every element, tag, attribute and interpolation span that contains
+//! the cursor. The caller sorts and nests the spans; this module only has to
+//! find them, so it never allocates a tree.
+//!
+//! The scanner is deliberately text-based rather than AST-based: selection
+//! ranges must keep working while the user is mid-edit and the template does
+//! not parse.
+
+/// An element whose start tag has been seen but whose close tag has not.
+#[derive(Clone, Copy)]
+struct OpenTag<'a> {
+    name: &'a str,
+    tag_start: usize,
+    content_start: usize,
+}
+
+/// Scan `region` as markup, pushing every span that contains `offset`.
+pub(super) fn markup_spans(
+    content: &str,
+    region: (usize, usize),
+    offset: usize,
+    spans: &mut Vec<(usize, usize)>,
+) {
+    let (region_start, region_end) = region;
+    let bytes = content.as_bytes();
+    let mut stack: Vec<OpenTag<'_>> = Vec::new();
+    let mut cursor = region_start;
+
+    while cursor < region_end {
+        match bytes[cursor] {
+            b'<' if content[cursor..region_end].starts_with("<!--") => {
+                let end = content[cursor..region_end]
+                    .find("-->")
+                    .map_or(region_end, |relative| cursor + relative + 3);
+                push_if_contains(spans, (cursor, end), offset);
+                cursor = end;
+            }
+            b'<' if bytes.get(cursor + 1) == Some(&b'/') => {
+                cursor = close_tag(content, region_end, cursor, offset, &mut stack, spans);
+            }
+            b'<' => {
+                let Some(next) = start_tag(content, region_end, cursor, offset, &mut stack, spans)
+                else {
+                    return;
+                };
+                cursor = next;
+            }
+            b'{' if bytes.get(cursor + 1) == Some(&b'{') => {
+                cursor = interpolation(content, region_end, cursor, offset, spans);
+            }
+            _ => cursor += 1,
+        }
+    }
+}
+
+/// Handle `</name>`: pop the matching open tag and report the element and its
+/// inner content. Returns the offset to continue scanning from.
+fn close_tag(
+    content: &str,
+    region_end: usize,
+    cursor: usize,
+    offset: usize,
+    stack: &mut Vec<OpenTag<'_>>,
+    spans: &mut Vec<(usize, usize)>,
+) -> usize {
+    let name_start = cursor + 2;
+    let name_end = tag_name_end(content.as_bytes(), name_start, region_end);
+    let close_end = content[cursor..region_end]
+        .find('>')
+        .map_or(region_end, |relative| cursor + relative + 1);
+
+    let name = &content[name_start..name_end];
+    // `rposition` recovers from unclosed inner elements: the nearest matching
+    // open tag wins and everything opened after it is discarded.
+    if let Some(index) = stack.iter().rposition(|open| open.name == name) {
+        let open = stack[index];
+        stack.truncate(index);
+        push_if_contains(spans, (open.content_start, cursor), offset);
+        push_if_contains(spans, (open.tag_start, close_end), offset);
+    }
+
+    close_end
+}
+
+/// Handle `<name …>`: report the start tag and its attributes, and push the
+/// element onto the stack unless it is self-closing or a void element.
+///
+/// Returns `None` when the start tag never closes, which ends the scan.
+fn start_tag<'a>(
+    content: &'a str,
+    region_end: usize,
+    cursor: usize,
+    offset: usize,
+    stack: &mut Vec<OpenTag<'a>>,
+    spans: &mut Vec<(usize, usize)>,
+) -> Option<usize> {
+    let name_start = cursor + 1;
+    let name_end = tag_name_end(content.as_bytes(), name_start, region_end);
+    let tag_end = start_tag_end(content, cursor, region_end)?;
+    if name_end == name_start {
+        return Some(cursor + 1);
+    }
+
+    attribute_spans(content, (name_end, tag_end - 1), offset, spans);
+    push_if_contains(spans, (cursor, tag_end), offset);
+
+    let name = &content[name_start..name_end];
+    let self_closing = content[..tag_end - 1].trim_end().ends_with('/');
+    if !self_closing && !vize_carton::is_void_tag(name) {
+        stack.push(OpenTag {
+            name,
+            tag_start: cursor,
+            content_start: tag_end,
+        });
+    }
+
+    Some(tag_end)
+}
+
+/// Handle `{{ expr }}`: report the trimmed expression and the whole mustache.
+fn interpolation(
+    content: &str,
+    region_end: usize,
+    cursor: usize,
+    offset: usize,
+    spans: &mut Vec<(usize, usize)>,
+) -> usize {
+    let inner_start = cursor + 2;
+    let Some(relative) = content[inner_start..region_end].find("}}") else {
+        return inner_start;
+    };
+
+    let inner_end = inner_start + relative;
+    let inner = &content[inner_start..inner_end];
+    let trimmed_start = inner_start + (inner.len() - inner.trim_start().len());
+    let trimmed_end = inner_end - (inner.len() - inner.trim_end().len());
+    push_if_contains(spans, (trimmed_start, trimmed_end), offset);
+    push_if_contains(spans, (cursor, inner_end + 2), offset);
+
+    inner_end + 2
+}
+
+/// Scan the interior of a start tag (between the tag name and its `>`).
+fn attribute_spans(
+    content: &str,
+    region: (usize, usize),
+    offset: usize,
+    spans: &mut Vec<(usize, usize)>,
+) {
+    let bytes = content.as_bytes();
+    let (region_start, region_end) = region;
+    let mut cursor = region_start;
+
+    while cursor < region_end {
+        if bytes[cursor].is_ascii_whitespace() || bytes[cursor] == b'/' {
+            cursor += 1;
+            continue;
+        }
+
+        let name_start = cursor;
+        while cursor < region_end && !is_attribute_terminator(bytes[cursor]) {
+            cursor += 1;
+        }
+        let name_end = cursor;
+        if name_end == name_start {
+            cursor += 1;
+            continue;
+        }
+
+        let mut probe = cursor;
+        while probe < region_end && bytes[probe].is_ascii_whitespace() {
+            probe += 1;
+        }
+        if probe >= region_end || bytes[probe] != b'=' {
+            // A valueless attribute such as `disabled`.
+            push_if_contains(spans, (name_start, name_end), offset);
+            continue;
+        }
+
+        probe += 1;
+        while probe < region_end && bytes[probe].is_ascii_whitespace() {
+            probe += 1;
+        }
+        cursor = attribute_value(content, (probe, region_end), (name_start, offset), spans);
+    }
+}
+
+/// Report the value of an attribute starting at `region.0` plus the whole
+/// attribute, and return the offset just past the value.
+fn attribute_value(
+    content: &str,
+    region: (usize, usize),
+    name_start_and_offset: (usize, usize),
+    spans: &mut Vec<(usize, usize)>,
+) -> usize {
+    let bytes = content.as_bytes();
+    let (value_probe, region_end) = region;
+    let (name_start, offset) = name_start_and_offset;
+
+    if value_probe < region_end && (bytes[value_probe] == b'"' || bytes[value_probe] == b'\'') {
+        let quote = bytes[value_probe];
+        let value_start = value_probe + 1;
+        let mut value_end = value_start;
+        while value_end < region_end && bytes[value_end] != quote {
+            value_end += 1;
+        }
+        let quoted_end = (value_end + 1).min(region_end);
+        push_if_contains(spans, (value_start, value_end), offset);
+        // `@vue/language-server` offers the quoted value as its own level
+        // between the bare value and the whole attribute; keep parity.
+        push_if_contains(spans, (value_start - 1, quoted_end), offset);
+        push_if_contains(spans, (name_start, quoted_end), offset);
+        return quoted_end;
+    }
+
+    let mut value_end = value_probe;
+    while value_end < region_end && !bytes[value_end].is_ascii_whitespace() {
+        value_end += 1;
+    }
+    push_if_contains(spans, (value_probe, value_end), offset);
+    push_if_contains(spans, (name_start, value_end), offset);
+    value_end
+}
+
+#[inline]
+fn is_attribute_terminator(byte: u8) -> bool {
+    byte.is_ascii_whitespace() || matches!(byte, b'=' | b'>' | b'/')
+}
+
+fn tag_name_end(bytes: &[u8], name_start: usize, limit: usize) -> usize {
+    let mut end = name_start;
+    while end < limit
+        && (bytes[end].is_ascii_alphanumeric() || matches!(bytes[end], b'-' | b'_' | b'.' | b':'))
+    {
+        end += 1;
+    }
+    end
+}
+
+/// Byte offset just past the `>` that closes the start tag at `tag_start`.
+fn start_tag_end(content: &str, tag_start: usize, limit: usize) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut cursor = tag_start + 1;
+    let mut quote: Option<u8> = None;
+
+    while cursor < limit {
+        let byte = bytes[cursor];
+        match quote {
+            Some(open) if byte == open => quote = None,
+            Some(_) => {}
+            None if byte == b'"' || byte == b'\'' => quote = Some(byte),
+            None if byte == b'>' => return Some(cursor + 1),
+            None => {}
+        }
+        cursor += 1;
+    }
+
+    None
+}
+
+#[inline]
+pub(super) fn push_if_contains(
+    spans: &mut Vec<(usize, usize)>,
+    span: (usize, usize),
+    offset: usize,
+) {
+    if span.0 <= offset && offset <= span.1 {
+        spans.push(span);
+    }
+}

--- a/crates/vize_maestro/src/ide/selection_range/tests.rs
+++ b/crates/vize_maestro/src/ide/selection_range/tests.rs
@@ -1,0 +1,195 @@
+use super::SelectionRangeService;
+
+const SFC: &str = "<script setup lang=\"ts\">\nconst count = 1\n</script>\n\n<template>\n  <div class=\"wrap\">{{ count }}</div>\n</template>\n";
+
+/// Flatten a selection-range chain into `(start_line, start_char, end_line, end_char)`
+/// tuples, innermost first, so tests can assert the FULL chain in one
+/// `assert_eq!` instead of walking `parent` pointers by hand.
+fn chain(content: &str, filename: &str, line: u32, character: u32) -> Vec<(u32, u32, u32, u32)> {
+    let offset = crate::ide::position_to_offset(content, line, character)
+        .expect("test position must resolve to a byte offset");
+    let mut node = SelectionRangeService::selection_range(content, filename, offset);
+    let mut flattened = Vec::new();
+    while let Some(current) = node {
+        flattened.push((
+            current.range.start.line,
+            current.range.start.character,
+            current.range.end.line,
+            current.range.end.character,
+        ));
+        node = current.parent.map(|parent| *parent);
+    }
+    flattened
+}
+
+#[test]
+fn interpolation_identifier_expands_through_template_and_block_levels() {
+    // Cursor inside `count` of `{{ count }}` on line 5.
+    assert_eq!(
+        chain(SFC, "/App.vue", 5, 24),
+        vec![
+            (5, 23, 5, 28), // the `count` token / trimmed interpolation expression
+            (5, 20, 5, 31), // `{{ count }}` (also the div's inner content)
+            (5, 2, 5, 37),  // `<div class="wrap">{{ count }}</div>`
+            (4, 10, 6, 0),  // template block content
+            (4, 0, 6, 11),  // `<template>` … `</template>`
+            (0, 0, 7, 0),   // whole document
+        ]
+    );
+}
+
+#[test]
+fn attribute_value_expands_value_then_attribute_then_start_tag() {
+    // Cursor inside `wrap` of `class="wrap"` on line 5.
+    assert_eq!(
+        chain(SFC, "/App.vue", 5, 15),
+        vec![
+            (5, 14, 5, 18), // `wrap`
+            (5, 13, 5, 19), // `"wrap"` including the quotes
+            (5, 7, 5, 19),  // `class="wrap"`
+            (5, 2, 5, 20),  // `<div class="wrap">`
+            (5, 2, 5, 37),  // the whole element
+            (4, 10, 6, 0),
+            (4, 0, 6, 11),
+            (0, 0, 7, 0),
+        ]
+    );
+}
+
+#[test]
+fn script_positions_get_the_documented_narrower_chain() {
+    // `<script>` interiors are raw text: markup levels are deliberately skipped,
+    // so the chain is token -> block content -> block -> document.
+    assert_eq!(
+        chain(SFC, "/App.vue", 1, 8),
+        vec![
+            (1, 6, 1, 11), // `count`
+            (0, 24, 2, 0), // script block content
+            (0, 0, 2, 9),  // `<script …>` … `</script>`
+            (0, 0, 7, 0),
+        ]
+    );
+}
+
+#[test]
+fn nested_elements_are_emitted_innermost_first() {
+    let source = "<template>\n  <ul>\n    <li><span>a</span></li>\n  </ul>\n</template>\n";
+    // Cursor on the `a` text node inside `<span>`.
+    assert_eq!(
+        chain(source, "/App.vue", 2, 14),
+        vec![
+            (2, 14, 2, 15), // `a`
+            (2, 8, 2, 22),  // `<span>a</span>`
+            (2, 4, 2, 27),  // `<li>…</li>`
+            (1, 6, 3, 2),   // `<ul>` inner content
+            (1, 2, 3, 7),   // `<ul>…</ul>`
+            (0, 10, 4, 0),  // template block content
+            (0, 0, 4, 11),
+            (0, 0, 5, 0),
+        ]
+    );
+}
+
+#[test]
+fn void_elements_do_not_swallow_their_following_siblings() {
+    // `<br>` has no close tag; a naive tag stack would keep it open and report
+    // `<br>` as the parent of everything after it.
+    let source = "<template>\n  <p><br><b>x</b></p>\n</template>\n";
+    assert_eq!(
+        chain(source, "/App.vue", 1, 12),
+        vec![
+            (1, 12, 1, 13), // `x`
+            (1, 9, 1, 17),  // `<b>x</b>`
+            (1, 5, 1, 17),  // `<p>` inner content: `<br><b>x</b>`
+            (1, 2, 1, 21),  // `<p>…</p>`
+            (0, 10, 2, 0),
+            (0, 0, 2, 11),
+            (0, 0, 3, 0),
+        ],
+        "`<br>` must never appear as a parent of the `<b>` element that follows it"
+    );
+}
+
+#[test]
+fn directive_expression_expands_to_the_attribute_then_the_start_tag() {
+    let source = "<template>\n  <button @click=\"bump(1)\">go</button>\n</template>\n";
+    // Cursor inside `bump` of `@click="bump(1)"`.
+    assert_eq!(
+        chain(source, "/App.vue", 1, 20),
+        vec![
+            (1, 18, 1, 22), // `bump`
+            (1, 18, 1, 25), // `bump(1)`
+            (1, 17, 1, 26), // `"bump(1)"` including the quotes
+            (1, 10, 1, 26), // `@click="bump(1)"`
+            (1, 2, 1, 27),  // `<button @click="bump(1)">`
+            (1, 2, 1, 38),  // the whole element
+            (0, 10, 2, 0),
+            (0, 0, 2, 11),
+            (0, 0, 3, 0),
+        ]
+    );
+}
+
+#[test]
+fn html_comments_are_a_selection_level() {
+    let source = "<template>\n  <!-- keep me -->\n</template>\n";
+    assert_eq!(
+        chain(source, "/App.vue", 1, 9),
+        vec![
+            (1, 7, 1, 11), // `keep`
+            (1, 2, 1, 18), // `<!-- keep me -->`
+            (0, 10, 2, 0),
+            (0, 0, 2, 11),
+            (0, 0, 3, 0),
+        ]
+    );
+}
+
+#[test]
+fn every_chain_link_strictly_contains_the_previous_one() {
+    // Structural invariant of the LSP contract: parents must strictly enclose
+    // their child. Sweep every offset of the fixture rather than trusting the
+    // hand-picked positions above.
+    for offset in 0..=SFC.len() {
+        let Some(root) = SelectionRangeService::selection_range(SFC, "/App.vue", offset) else {
+            continue;
+        };
+        let mut node = Some(root);
+        let mut previous: Option<(u32, u32, u32, u32)> = None;
+        while let Some(current) = node {
+            let span = (
+                current.range.start.line,
+                current.range.start.character,
+                current.range.end.line,
+                current.range.end.character,
+            );
+            if let Some(child) = previous {
+                assert!(
+                    (span.0, span.1) <= (child.0, child.1)
+                        && (span.2, span.3) >= (child.2, child.3),
+                    "offset {offset}: parent {span:?} must enclose child {child:?}"
+                );
+                assert_ne!(
+                    span, child,
+                    "offset {offset}: duplicate chain link {span:?}"
+                );
+            }
+            previous = Some(span);
+            node = current.parent.map(|parent| *parent);
+        }
+    }
+}
+
+#[test]
+fn standalone_petite_vue_html_scans_the_whole_document_as_markup() {
+    let source = "<div v-scope=\"{ count: 0 }\">{{ count }}</div>\n";
+    assert_eq!(
+        chain(source, "/index.html", 0, 32),
+        vec![
+            (0, 31, 0, 36), // `count`
+            (0, 28, 0, 39), // `{{ count }}`
+            (0, 0, 0, 45),  // the whole element
+            (0, 0, 1, 0),   // whole document
+        ]
+    );
+}

--- a/crates/vize_maestro/src/server.rs
+++ b/crates/vize_maestro/src/server.rs
@@ -3,6 +3,7 @@
 //! This module contains the core LSP server using tower-lsp.
 
 mod capabilities;
+mod document_structure;
 mod format;
 mod handlers;
 mod helpers;

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -5,12 +5,13 @@ use tower_lsp::lsp_types::{
     CodeActionKind, CodeActionOptions, CodeActionProviderCapability, CodeLensOptions,
     CompletionOptions, DocumentLinkOptions, FileOperationFilter, FileOperationPattern,
     FileOperationPatternKind, FileOperationRegistrationOptions, FoldingRangeProviderCapability,
-    HoverProviderCapability, OneOf, RenameOptions, SaveOptions, SemanticTokenModifier,
-    SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
-    SemanticTokensServerCapabilities, ServerCapabilities, TextDocumentSyncCapability,
-    TextDocumentSyncKind, TextDocumentSyncOptions, TextDocumentSyncSaveOptions,
-    WorkDoneProgressOptions, WorkspaceFileOperationsServerCapabilities,
-    WorkspaceFoldersServerCapabilities, WorkspaceServerCapabilities,
+    HoverProviderCapability, OneOf, RenameOptions, SaveOptions, SelectionRangeProviderCapability,
+    SemanticTokenModifier, SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend,
+    SemanticTokensOptions, SemanticTokensServerCapabilities, ServerCapabilities,
+    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
+    TextDocumentSyncSaveOptions, WorkDoneProgressOptions,
+    WorkspaceFileOperationsServerCapabilities, WorkspaceFoldersServerCapabilities,
+    WorkspaceServerCapabilities,
 };
 
 use super::state::LspFeatureConfig;
@@ -153,8 +154,15 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
             .folding_ranges
             .then_some(FoldingRangeProviderCapability::Simple(true)),
 
-        // Selection ranges are not implemented yet.
-        selection_range_provider: None,
+        // Selection ranges (expand/shrink selection). Gated on the same flag as
+        // folding ranges: both are authored-document *structure* features built
+        // from the SFC block layout and the template markup, so
+        // `vize.foldingRanges.enable` is the single user-facing control for the
+        // structure group — mirroring how `references` gates both
+        // `referencesProvider` and `documentHighlightProvider` above.
+        selection_range_provider: features
+            .folding_ranges
+            .then_some(SelectionRangeProviderCapability::Simple(true)),
 
         // Inlay hints
         inlay_hint_provider: features.inlay_hints.then_some(OneOf::Left(true)),

--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -201,11 +201,27 @@ fn declaration_events_remain_registered_when_file_rename_is_disabled() {
 }
 
 #[test]
+fn selection_ranges_share_the_document_structure_flag_with_folding_ranges() {
+    let mut features = all_features();
+    features.folding_ranges = false;
+    let capabilities = server_capabilities(features);
+
+    assert!(capabilities.folding_range_provider.is_none());
+    assert!(capabilities.selection_range_provider.is_none());
+    // Only the structure group is affected.
+    assert!(capabilities.document_symbol_provider.is_some());
+    assert!(capabilities.hover_provider.is_some());
+}
+
+#[test]
 fn default_features_advertise_non_opinionated_providers() {
     let capabilities = server_capabilities(LspFeatureConfig::default());
 
     assert!(capabilities.signature_help_provider.is_none());
-    assert!(capabilities.selection_range_provider.is_none());
+    assert!(matches!(
+        capabilities.selection_range_provider,
+        Some(SelectionRangeProviderCapability::Simple(true))
+    ));
     assert!(capabilities.completion_provider.is_some());
     assert!(capabilities.hover_provider.is_some());
     assert!(capabilities.definition_provider.is_some());
@@ -218,7 +234,10 @@ fn all_features_skip_unimplemented_providers_and_keep_implemented_ones() {
     let capabilities = server_capabilities(all_features());
 
     assert!(capabilities.signature_help_provider.is_none());
-    assert!(capabilities.selection_range_provider.is_none());
+    assert!(matches!(
+        capabilities.selection_range_provider,
+        Some(SelectionRangeProviderCapability::Simple(true))
+    ));
     assert_eq!(
         capabilities
             .document_link_provider

--- a/crates/vize_maestro/src/server/document_structure.rs
+++ b/crates/vize_maestro/src/server/document_structure.rs
@@ -1,0 +1,95 @@
+//! Document-structure providers: folding ranges and selection ranges.
+//!
+//! Both answer "what are the syntactic regions of this authored document?", are
+//! pure functions of the SFC block layout plus the template markup, and are
+//! gated on the same `folding_ranges` feature flag. Keeping them together (and
+//! out of `handlers.rs`, which is already over the per-file length budget)
+//! makes that shared contract explicit.
+#![allow(clippy::disallowed_methods)]
+
+use tower_lsp::lsp_types::{
+    FoldingRange, FoldingRangeKind, FoldingRangeParams, SelectionRange, SelectionRangeParams,
+};
+
+use super::ServerState;
+use crate::ide::{SelectionRangeService, position_to_offset};
+
+/// `textDocument/foldingRange`: one region per SFC block that spans more than a
+/// single line.
+pub(super) fn folding_ranges(
+    state: &ServerState,
+    params: &FoldingRangeParams,
+) -> Option<Vec<FoldingRange>> {
+    let uri = &params.text_document.uri;
+    let content = state.documents.text(uri)?;
+
+    let options = vize_atelier_sfc::SfcParseOptions {
+        filename: uri.path().to_string().into(),
+        ..Default::default()
+    };
+    let descriptor = vize_atelier_sfc::parse_sfc(&content, options).ok()?;
+
+    let mut ranges = Vec::new();
+    let labelled_blocks = descriptor
+        .template
+        .as_ref()
+        .map(|block| (&block.loc, "template"))
+        .into_iter()
+        .chain(
+            descriptor
+                .script_setup
+                .as_ref()
+                .map(|block| (&block.loc, "script setup")),
+        )
+        .chain(
+            descriptor
+                .script
+                .as_ref()
+                .map(|block| (&block.loc, "script")),
+        )
+        .chain(descriptor.styles.iter().map(|block| (&block.loc, "style")));
+
+    for (loc, label) in labelled_blocks {
+        if loc.start_line >= loc.end_line {
+            continue;
+        }
+        ranges.push(FoldingRange {
+            start_line: loc.start_line.saturating_sub(1) as u32,
+            start_character: None,
+            end_line: loc.end_line.saturating_sub(1) as u32,
+            end_character: None,
+            kind: Some(FoldingRangeKind::Region),
+            collapsed_text: Some(label.to_string()),
+        });
+    }
+
+    (!ranges.is_empty()).then_some(ranges)
+}
+
+/// `textDocument/selectionRange`: one expand/shrink chain per requested
+/// position.
+///
+/// The LSP contract requires one chain per position, so a single unresolvable
+/// position collapses the whole response to `None` rather than returning a
+/// short array the client would mis-index.
+pub(super) fn selection_ranges(
+    state: &ServerState,
+    params: &SelectionRangeParams,
+) -> Option<Vec<SelectionRange>> {
+    let uri = &params.text_document.uri;
+    let content = state.documents.text(uri)?;
+    let filename = uri.path().to_string();
+
+    let mut ranges = Vec::with_capacity(params.positions.len());
+    for position in &params.positions {
+        let offset = position_to_offset(&content, position.line, position.character)?;
+        ranges.push(SelectionRangeService::selection_range(
+            &content, &filename, offset,
+        )?);
+    }
+
+    (!ranges.is_empty()).then_some(ranges)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_maestro/src/server/document_structure/tests.rs
+++ b/crates/vize_maestro/src/server/document_structure/tests.rs
@@ -1,0 +1,96 @@
+use tower_lsp::lsp_types::{
+    FoldingRangeParams, PartialResultParams, Position, SelectionRangeParams,
+    TextDocumentIdentifier, Url, WorkDoneProgressParams,
+};
+
+use super::{folding_ranges, selection_ranges};
+use crate::server::ServerState;
+
+const SFC: &str = "<script setup lang=\"ts\">\nconst count = 1\n</script>\n\n<template>\n  <div class=\"wrap\">{{ count }}</div>\n</template>\n";
+
+fn state_with(uri: &Url, source: &str) -> ServerState {
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state
+}
+
+fn folding_params(uri: Url) -> FoldingRangeParams {
+    FoldingRangeParams {
+        text_document: TextDocumentIdentifier { uri },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+fn selection_params(uri: Url, positions: Vec<Position>) -> SelectionRangeParams {
+    SelectionRangeParams {
+        text_document: TextDocumentIdentifier { uri },
+        positions,
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
+#[test]
+fn folding_ranges_cover_every_multi_line_block_in_discovery_order() {
+    let uri = Url::parse("file:///App.vue").unwrap();
+    let state = state_with(&uri, SFC);
+
+    let ranges = folding_ranges(&state, &folding_params(uri)).expect("blocks must fold");
+    let summary: Vec<(u32, u32, Option<String>)> = ranges
+        .into_iter()
+        .map(|range| (range.start_line, range.end_line, range.collapsed_text))
+        .collect();
+
+    assert_eq!(
+        summary,
+        vec![
+            (4, 6, Some("template".to_string())),
+            (0, 2, Some("script setup".to_string())),
+        ]
+    );
+}
+
+#[test]
+fn selection_ranges_return_one_chain_per_position() {
+    let uri = Url::parse("file:///App.vue").unwrap();
+    let state = state_with(&uri, SFC);
+
+    let chains = selection_ranges(
+        &state,
+        &selection_params(uri, vec![Position::new(5, 24), Position::new(1, 8)]),
+    )
+    .expect("both positions resolve");
+
+    assert_eq!(chains.len(), 2);
+    assert_eq!(chains[0].range.start, Position::new(5, 23));
+    assert_eq!(chains[0].range.end, Position::new(5, 28));
+    assert_eq!(chains[1].range.start, Position::new(1, 6));
+    assert_eq!(chains[1].range.end, Position::new(1, 11));
+}
+
+#[test]
+fn an_out_of_bounds_position_collapses_the_whole_response() {
+    // The LSP contract pairs results with requested positions by index, so a
+    // short array would silently misalign every later position in the request.
+    let uri = Url::parse("file:///App.vue").unwrap();
+    let state = state_with(&uri, SFC);
+
+    let chains = selection_ranges(
+        &state,
+        &selection_params(uri, vec![Position::new(5, 24), Position::new(900, 0)]),
+    );
+
+    assert!(chains.is_none());
+}
+
+#[test]
+fn an_unopened_document_yields_no_structure() {
+    let state = ServerState::new();
+    let uri = Url::parse("file:///Missing.vue").unwrap();
+
+    assert!(folding_ranges(&state, &folding_params(uri.clone())).is_none());
+    assert!(selection_ranges(&state, &selection_params(uri, vec![Position::new(0, 0)])).is_none());
+}

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -15,12 +15,13 @@ use tower_lsp::{
         DidSaveTextDocumentParams, DocumentFormattingParams, DocumentHighlight,
         DocumentHighlightParams, DocumentLink, DocumentLinkParams, DocumentRangeFormattingParams,
         DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange,
-        FoldingRangeKind, FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover,
-        HoverParams, InitializeParams, InitializeResult, InitializedParams, InlayHint,
-        InlayHintParams, Location, Position, PrepareRenameResponse, Range, ReferenceParams,
-        RenameFilesParams, RenameParams, SemanticTokensParams, SemanticTokensRangeParams,
-        SemanticTokensRangeResult, SemanticTokensResult, ServerInfo, SymbolInformation, SymbolKind,
-        TextDocumentPositionParams, TextEdit, WorkspaceEdit, WorkspaceSymbolParams,
+        FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
+        InitializeParams, InitializeResult, InitializedParams, InlayHint, InlayHintParams,
+        Location, Position, PrepareRenameResponse, Range, ReferenceParams, RenameFilesParams,
+        RenameParams, SelectionRange, SelectionRangeParams, SemanticTokensParams,
+        SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, ServerInfo,
+        SymbolInformation, SymbolKind, TextDocumentPositionParams, TextEdit, WorkspaceEdit,
+        WorkspaceSymbolParams,
     },
 };
 
@@ -827,78 +828,27 @@ impl LanguageServer for MaestroServer {
         if !self.state.lsp_features().folding_ranges {
             return Ok(None);
         }
+        Ok(super::document_structure::folding_ranges(
+            &self.state,
+            &params,
+        ))
+    }
 
-        let uri = &params.text_document.uri;
-
-        let Some(content) = self.state.documents.text(uri) else {
+    /// Expand/shrink selection over the **authored** `.vue` document.
+    ///
+    /// Shares the `folding_ranges` flag with `folding_range`: both are
+    /// document-structure providers built from the same block layout.
+    async fn selection_range(
+        &self,
+        params: SelectionRangeParams,
+    ) -> Result<Option<Vec<SelectionRange>>> {
+        if !self.state.lsp_features().folding_ranges {
             return Ok(None);
-        };
-        let mut ranges = Vec::new();
-
-        let options = vize_atelier_sfc::SfcParseOptions {
-            filename: uri.path().to_string().into(),
-            ..Default::default()
-        };
-
-        if let Ok(descriptor) = vize_atelier_sfc::parse_sfc(&content, options) {
-            if let Some(ref template) = descriptor.template
-                && template.loc.start_line < template.loc.end_line
-            {
-                ranges.push(FoldingRange {
-                    start_line: template.loc.start_line.saturating_sub(1) as u32,
-                    start_character: None,
-                    end_line: template.loc.end_line.saturating_sub(1) as u32,
-                    end_character: None,
-                    kind: Some(FoldingRangeKind::Region),
-                    collapsed_text: Some("template".to_string()),
-                });
-            }
-
-            if let Some(ref script) = descriptor.script_setup
-                && script.loc.start_line < script.loc.end_line
-            {
-                ranges.push(FoldingRange {
-                    start_line: script.loc.start_line.saturating_sub(1) as u32,
-                    start_character: None,
-                    end_line: script.loc.end_line.saturating_sub(1) as u32,
-                    end_character: None,
-                    kind: Some(FoldingRangeKind::Region),
-                    collapsed_text: Some("script setup".to_string()),
-                });
-            }
-
-            if let Some(ref script) = descriptor.script
-                && script.loc.start_line < script.loc.end_line
-            {
-                ranges.push(FoldingRange {
-                    start_line: script.loc.start_line.saturating_sub(1) as u32,
-                    start_character: None,
-                    end_line: script.loc.end_line.saturating_sub(1) as u32,
-                    end_character: None,
-                    kind: Some(FoldingRangeKind::Region),
-                    collapsed_text: Some("script".to_string()),
-                });
-            }
-
-            for style in &descriptor.styles {
-                if style.loc.start_line < style.loc.end_line {
-                    ranges.push(FoldingRange {
-                        start_line: style.loc.start_line.saturating_sub(1) as u32,
-                        start_character: None,
-                        end_line: style.loc.end_line.saturating_sub(1) as u32,
-                        end_character: None,
-                        kind: Some(FoldingRangeKind::Region),
-                        collapsed_text: Some("style".to_string()),
-                    });
-                }
-            }
         }
-
-        if ranges.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(ranges))
-        }
+        Ok(super::document_structure::selection_ranges(
+            &self.state,
+            &params,
+        ))
     }
 
     async fn formatting(&self, params: DocumentFormattingParams) -> Result<Option<Vec<TextEdit>>> {

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -84,9 +84,11 @@ test("vize lsp advertises the full editor-feature provider set with exact shapes
       " ",
     ]);
 
+    // Selection ranges ship with the document-structure group.
+    assert.equal(capabilities.selectionRangeProvider, true);
+
     // Providers that are intentionally not yet advertised stay absent.
     assert.equal(capabilities.signatureHelpProvider, undefined);
-    assert.equal(capabilities.selectionRangeProvider, undefined);
     assert.equal(capabilities.documentRangeFormattingProvider, undefined);
   });
 });
@@ -100,6 +102,7 @@ test("vize lsp editor:false strips editor providers but keeps lint-driven codeAc
       assert.equal(capabilities.semanticTokensProvider, undefined);
       assert.equal(capabilities.documentSymbolProvider, undefined);
       assert.equal(capabilities.foldingRangeProvider, undefined);
+      assert.equal(capabilities.selectionRangeProvider, undefined);
       assert.equal(capabilities.inlayHintProvider, undefined);
       assert.equal(capabilities.completionProvider, undefined);
       assert.equal(capabilities.codeLensProvider, undefined);
@@ -134,6 +137,8 @@ test("vize lsp per-feature init flags toggle individual providers independently"
     (capabilities) => {
       assert.equal(capabilities.inlayHintProvider, undefined);
       assert.equal(capabilities.foldingRangeProvider, undefined);
+      // Selection ranges share the document-structure flag with folding ranges.
+      assert.equal(capabilities.selectionRangeProvider, undefined);
       assert.equal(capabilities.documentSymbolProvider, undefined);
       assert.equal(capabilities.semanticTokensProvider, undefined);
       // A sibling editor provider is untouched.

--- a/tests/tooling/lsp-selection-range.test.ts
+++ b/tests/tooling/lsp-selection-range.test.ts
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+/**
+ * `textDocument/selectionRange` parity suite for `vize lsp`.
+ *
+ * `@vue/language-server` 3.3.8 advertises `selectionRangeProvider: true`, so
+ * "expand/shrink selection" (VS Code `Shift+Alt+Right`, Zed, Helix `Alt-o`,
+ * Neovim/Emacs via their LSP clients) works inside `.vue` files there. Maestro
+ * advertised nothing and answered `-32601 Method not found`, so the command
+ * silently did nothing — a failure a user cannot see.
+ *
+ * `VUE_LANGUAGE_SERVER_CHAIN` below is not hand-written: it is the response
+ * `@vue/language-server@3.3.8` returned for this exact fixture and position,
+ * driven over stdio with the same request. Both sides of the oracle are
+ * therefore recorded, per #2971. The suite asserts:
+ *
+ *   1. the FULL chain Vize returns, link by link (no substring matching), and
+ *   2. that every link Vue LS returns is present in Vize's chain, in order,
+ *      with byte-identical authored ranges.
+ *
+ * Every range addresses the authored `.vue` document, never virtual TypeScript.
+ */
+
+type Range = {
+  start: { line: number; character: number };
+  end: { line: number; character: number };
+};
+
+type SelectionRange = {
+  range: Range;
+  parent?: SelectionRange;
+};
+
+/** `[startLine, startCharacter, endLine, endCharacter]`. */
+type FlatRange = [number, number, number, number];
+
+const FIXTURE = `<script setup lang="ts">
+const count = 1
+</script>
+
+<template>
+  <div class="wrap">{{ count }}</div>
+</template>
+`;
+
+/**
+ * Recorded from `@vue/language-server@3.3.8` for FIXTURE at line 5 character 24
+ * (inside `count` in `{{ count }}`), driven over stdio with a client-side
+ * tsserver bridge answering `_vue:projectInfo`.
+ */
+const VUE_LANGUAGE_SERVER_CHAIN: FlatRange[] = [
+  [5, 20, 5, 31], // `{{ count }}`
+  [5, 2, 5, 37], // `<div class="wrap">{{ count }}</div>`
+  [4, 10, 6, 0], // template block content
+];
+
+/**
+ * Recorded from `@vue/language-server@3.3.8` for FIXTURE at line 5 character 15
+ * (inside `wrap` in `class="wrap"`).
+ */
+const VUE_LANGUAGE_SERVER_ATTRIBUTE_CHAIN: FlatRange[] = [
+  [5, 14, 5, 18], // `wrap`
+  [5, 13, 5, 19], // `"wrap"` including the quotes
+  [5, 7, 5, 19], // `class="wrap"`
+  [5, 3, 5, 19], // `div class="wrap"` (start tag interior)
+  [5, 2, 5, 37], // the whole element
+  [4, 10, 6, 0], // template block content
+];
+
+function flatten(chain: SelectionRange): FlatRange[] {
+  const flattened: FlatRange[] = [];
+  let node: SelectionRange | undefined = chain;
+  while (node) {
+    flattened.push([
+      node.range.start.line,
+      node.range.start.character,
+      node.range.end.line,
+      node.range.end.character,
+    ]);
+    node = node.parent;
+  }
+  return flattened;
+}
+
+/**
+ * Every entry of `expected` must appear in `actual` in the same relative order
+ * with identical coordinates. Used to prove Vize's chain is a superset of the
+ * reference server's, not merely a chain of the same length.
+ */
+function assertOrderedSuperset(actual: FlatRange[], expected: FlatRange[], label: string): void {
+  const missing: FlatRange[] = [];
+  let cursor = 0;
+  for (const link of expected) {
+    const index = actual.findIndex(
+      (candidate, position) =>
+        position >= cursor &&
+        candidate[0] === link[0] &&
+        candidate[1] === link[1] &&
+        candidate[2] === link[2] &&
+        candidate[3] === link[3],
+    );
+    if (index < 0) {
+      missing.push(link);
+      continue;
+    }
+    cursor = index + 1;
+  }
+  assert.deepEqual(
+    missing,
+    [],
+    `${label}: these @vue/language-server links are missing from the Vize chain (actual: ${JSON.stringify(actual)})`,
+  );
+}
+
+async function withSelectionRanges(
+  label: string,
+  positions: Array<{ line: number; character: number }>,
+  run: (chains: SelectionRange[]) => void,
+): Promise<void> {
+  const testRootDir = path.join(testOutputRoot, label);
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, { editor: true, lint: false, typecheck: false });
+
+    const filePath = path.join(workspaceDir, "App.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, FIXTURE, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: FIXTURE },
+    });
+
+    const chains = (await session.request("textDocument/selectionRange", {
+      textDocument: { uri },
+      positions,
+    })) as SelectionRange[] | null;
+    assert.ok(chains, "vize lsp must answer textDocument/selectionRange");
+    run(chains);
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+}
+
+test("selectionRange expands an interpolation identifier through authored .vue levels", async () => {
+  await withSelectionRanges(
+    "lsp-selrange-interpolation",
+    [{ line: 5, character: 24 }],
+    (chains) => {
+      assert.equal(chains.length, 1, "one chain per requested position");
+      const actual = flatten(chains[0]);
+
+      assert.deepEqual(actual, [
+        [5, 23, 5, 28], // `count`
+        [5, 20, 5, 31], // `{{ count }}` (also the div's inner content)
+        [5, 2, 5, 37], // `<div class="wrap">{{ count }}</div>`
+        [4, 10, 6, 0], // template block content
+        [4, 0, 6, 11], // `<template>` … `</template>`
+        [0, 0, 7, 0], // whole document
+      ]);
+
+      assertOrderedSuperset(actual, VUE_LANGUAGE_SERVER_CHAIN, "interpolation identifier");
+    },
+  );
+});
+
+test("selectionRange expands an attribute value through value, quotes and attribute", async () => {
+  await withSelectionRanges("lsp-selrange-attribute", [{ line: 5, character: 15 }], (chains) => {
+    const actual = flatten(chains[0]);
+
+    assert.deepEqual(actual, [
+      [5, 14, 5, 18], // `wrap`
+      [5, 13, 5, 19], // `"wrap"` including the quotes
+      [5, 7, 5, 19], // `class="wrap"`
+      [5, 2, 5, 20], // `<div class="wrap">`
+      [5, 2, 5, 37], // the whole element
+      [4, 10, 6, 0],
+      [4, 0, 6, 11],
+      [0, 0, 7, 0],
+    ]);
+
+    // Vue LS additionally offers `div class="wrap"` (the start tag *interior*)
+    // where Vize offers `<div class="wrap">` (the start tag as a unit). Pin the
+    // divergence explicitly so it cannot regress into an accident.
+    assert.equal(
+      actual.some((link) => link[0] === 5 && link[1] === 3 && link[2] === 5 && link[3] === 19),
+      false,
+      "documented difference: Vize does not offer the bare start-tag interior level",
+    );
+    assertOrderedSuperset(
+      actual,
+      VUE_LANGUAGE_SERVER_ATTRIBUTE_CHAIN.filter(
+        (link) => !(link[0] === 5 && link[1] === 3 && link[2] === 5 && link[3] === 19),
+      ),
+      "attribute value",
+    );
+  });
+});
+
+test("selectionRange answers every requested position and keeps chains strictly nested", async () => {
+  const positions = [
+    { line: 1, character: 8 }, // `count` in `<script setup>`
+    { line: 5, character: 4 }, // `div` tag name
+    { line: 5, character: 24 }, // `count` in the interpolation
+  ];
+
+  await withSelectionRanges("lsp-selrange-multi", positions, (chains) => {
+    assert.equal(chains.length, positions.length);
+
+    assert.deepEqual(flatten(chains[0]), [
+      [1, 6, 1, 11], // `count`
+      [0, 24, 2, 0], // script block content
+      [0, 0, 2, 9], // `<script setup lang="ts">` … `</script>`
+      [0, 0, 7, 0],
+    ]);
+    assert.deepEqual(flatten(chains[1]), [
+      [5, 3, 5, 6], // `div`
+      [5, 2, 5, 20], // `<div class="wrap">`
+      [5, 2, 5, 37],
+      [4, 10, 6, 0],
+      [4, 0, 6, 11],
+      [0, 0, 7, 0],
+    ]);
+    assert.deepEqual(flatten(chains[2]), [
+      [5, 23, 5, 28],
+      [5, 20, 5, 31],
+      [5, 2, 5, 37],
+      [4, 10, 6, 0],
+      [4, 0, 6, 11],
+      [0, 0, 7, 0],
+    ]);
+
+    for (const [index, chain] of chains.entries()) {
+      const links = flatten(chain);
+      for (let position = 1; position < links.length; position += 1) {
+        const child = links[position - 1];
+        const parent = links[position];
+        assert.ok(
+          (parent[0] < child[0] || (parent[0] === child[0] && parent[1] <= child[1])) &&
+            (parent[2] > child[2] || (parent[2] === child[2] && parent[3] >= child[3])),
+          `chain ${index}: parent ${JSON.stringify(parent)} must enclose child ${JSON.stringify(child)}`,
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Divergence

Measured against `@vue/language-server@3.3.8` driven over stdio with the same
`initialize` request:

| capability | `@vue/language-server` | `vize lsp` (before) |
| --- | --- | --- |
| `selectionRangeProvider` | `true` | absent |
| `textDocument/selectionRange` | returns a chain | `-32601 Method not found` |

Expand/shrink selection is bound out of the box in every editor Vize packages
(VS Code `Shift+Alt+Right`/`Left`, Zed, Helix `Alt-o`, Neovim and Emacs through
their LSP clients). Because Maestro advertised nothing, the command silently did
nothing inside `.vue` files — the user sees no error, just a keystroke that does
not work.

## Minimal reproduction

```
<script setup lang="ts">
const count = 1
</script>

<template>
  <div class="wrap">{{ count }}</div>
</template>
```

`textDocument/selectionRange` at line 5, character 24 (inside `count`):

- `@vue/language-server`: `{{ count }}` → `<div …>…</div>` → template block content
- `vize lsp` before: `-32601 Method not found`
- `vize lsp` after:
  `count` → `{{ count }}` → `<div …>…</div>` → template block content →
  `<template>…</template>` → whole document

Every level addresses the **authored** `.vue` document, never virtual TypeScript.

## What landed

`crates/vize_maestro/src/ide/selection_range.rs` builds the chain purely from the
authored text (no server state, no type information), so it keeps working while
the template is mid-edit and does not parse. Levels, innermost first: token,
trimmed interpolation expression, whole interpolation, attribute value, quoted
attribute value, whole attribute, start tag, then for each enclosing element its
inner content and the element itself, HTML comments, SFC block content, SFC block
with tags, whole document.

The provider is gated on the existing `folding_ranges` flag, mirroring how
`references` already gates both `referencesProvider` and
`documentHighlightProvider`: folding and selection ranges are the same
document-structure group and share one user-facing setting
(`vize.foldingRanges.enable`). No new setting, so no editor manifest churn.

`folding_range` moved into the new `server::document_structure` module next to
it, which takes `handlers.rs` from 1327 to 1277 lines — an over-budget file that
shrinks instead of growing.

## Measured differences that remain (documented, not accidental)

- Vue LS offers `div class="wrap"` (the start tag *interior*) where Vize offers
  `<div class="wrap">` (the start tag as a unit). The test asserts Vize does
  **not** emit the interior level so the difference cannot regress into an
  accident.
- Vue LS emits a statement level inside `<script>` (`const count = 1`) from the
  TypeScript AST; Vize does not yet. Filed separately.
- Vue LS returns `null` for positions inside `<style>`; Vize returns the
  token/block/document chain there.

## Tests, and how they fail before the fix

- `tests/tooling/lsp-selection-range.test.ts` — drives the real `vize lsp`
  binary over stdio. Asserts the FULL chain with `assert.deepEqual` (no
  substring matching) and separately asserts that every link
  `@vue/language-server` returned for the same fixture is present in Vize's
  chain, in order, with byte-identical coordinates. The Vue LS side is recorded
  from an actual run, not hand-written. On the pre-fix binary all three tests
  fail with `LspRequestError: textDocument/selectionRange: Method not found`.
- `tests/tooling/lsp-capabilities.test.ts` previously asserted
  `selectionRangeProvider === undefined`; it now asserts `true`, plus that the
  provider disappears with `foldingRanges: false`.
- `crates/vize_maestro/src/server/capabilities/tests.rs` had two assertions
  pinning `selection_range_provider.is_none()`; both now pin the advertised
  shape, and a new test covers the shared gating flag.
- `crates/vize_maestro/src/ide/selection_range/tests.rs` — 9 unit tests with
  exact authored coordinates, including a sweep over every byte offset of the
  fixture asserting each chain link strictly encloses the previous one, a void
  element (`<br>`) not swallowing its siblings, and standalone petite-vue HTML.
- `crates/vize_maestro/src/server/document_structure/tests.rs` — folding-range
  behaviour preserved through the move, plus the "one unresolvable position
  collapses the whole response" rule (a short array would misalign every later
  position in the request).

## Gates

`fmt:check`, `lint:rust`, `check:rust`, `check:js`, `check:editor-extensions`,
`source:lengths` (`--check --base-ref origin/main`), `cargo test -p vize_maestro
--lib` (584 pass), and
`node --test tests/tooling/lsp-{selection-range,capabilities,document-features}.test.ts`
(13 pass) all green locally.

Refs #3224, #2971.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->