### PR TITLE
bench(check-gate): pin the measured binary by content hash

### DIFF
--- a/bench/benchmark-binary.mjs
+++ b/bench/benchmark-binary.mjs
@@ -1,0 +1,75 @@
+/**
+ * Content identity of the binaries a benchmark measures (#3283).
+ *
+ * A version string is not an identity. Two builds of the same commit, a
+ * rebuild that landed mid-run, or a binary another process replaced under a
+ * shared CARGO_TARGET_DIR all answer `--version` identically, so an artifact
+ * that records only versions cannot be reproduced and cannot even prove it
+ * measured one binary throughout. That is precisely the attribution failure
+ * this issue exists to prevent, so the gate records a sha256 and re-checks it.
+ */
+
+import { createHash } from "node:crypto";
+import { copyFileSync, chmodSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+/** sha256 of a file's contents, or null when it cannot be read. */
+export function fileSha256(filePath) {
+  if (!filePath || !existsSync(filePath)) return null;
+  try {
+    return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Copy an executable into the benchmark's own work root and return the copy,
+ * so a rebuild of the source path cannot change what is being measured
+ * halfway through a run.
+ *
+ * Only self-contained executables may be pinned this way. A launcher shim
+ * (`node_modules/.bin/tsgo` is a shell script that resolves its package
+ * relative to its own location) breaks when moved, so those are hashed in
+ * place instead — see `hashInPlace`.
+ */
+export function pinExecutable(sourcePath, workRoot) {
+  const sha256 = fileSha256(sourcePath);
+  if (sha256 == null) {
+    throw new Error(`benchmark-binary: cannot hash ${sourcePath}`);
+  }
+  const pinDir = join(workRoot, "pinned-binaries");
+  mkdirSync(pinDir, { recursive: true });
+  const measuredPath = join(pinDir, `${basename(sourcePath)}-${sha256.slice(0, 16)}`);
+  if (!existsSync(measuredPath)) {
+    copyFileSync(sourcePath, measuredPath);
+    chmodSync(measuredPath, 0o755);
+  }
+  return { source: sourcePath, measuredPath, sha256, pinned: true };
+}
+
+/** Record identity without moving the file, for launcher shims. */
+export function hashInPlace(sourcePath) {
+  return {
+    source: sourcePath,
+    measuredPath: sourcePath,
+    sha256: fileSha256(sourcePath),
+    pinned: false,
+  };
+}
+
+/**
+ * Fail closed when a measured binary changed while the run was in progress.
+ * A timing attributed to a binary that no longer exists is worse than no
+ * timing, because nothing downstream can tell the difference.
+ */
+export function assertBinariesUnchanged(binaries) {
+  for (const [label, binary] of Object.entries(binaries)) {
+    const current = fileSha256(binary.source);
+    if (current !== binary.sha256) {
+      throw new Error(
+        `benchmark-binary: ${label} changed during the run (${binary.sha256} -> ${current ?? "missing"}); refusing to publish a timing`,
+      );
+    }
+  }
+}

--- a/bench/benchmark-provenance.mjs
+++ b/bench/benchmark-provenance.mjs
@@ -18,6 +18,7 @@ import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { fileSha256 } from "./benchmark-binary.mjs";
 import { packageVersion, resolveVuePackageDir, typescriptVersionNear } from "./check-gate-env.mjs";
 
 const benchDir = dirname(fileURLToPath(import.meta.url));
@@ -76,6 +77,16 @@ export function resolveBackend(candidates = TSGO_CANDIDATES) {
  * incumbent tools record `null` rather than being omitted, so the artifact
  * shape is stable across runs that skip a task.
  */
+export function collectBinaryHashes({ vizeBin, corsaPath, vueTscBin, eslintBin, prettierBin }) {
+  return {
+    vize: fileSha256(vizeBin),
+    tsgo: fileSha256(corsaPath),
+    vueTsc: fileSha256(vueTscBin),
+    eslint: fileSha256(eslintBin),
+    prettier: fileSha256(prettierBin),
+  };
+}
+
 export function collectVersions({ vizeBin, corsaVersion, vueTscBin, eslintBin, prettierBin }) {
   const vuePackageDir = resolveVuePackageDir();
   return {
@@ -103,6 +114,11 @@ export function renderProvenanceLines(data) {
   const lines = [
     `Versions: vize ${show(versions.vize)} · tsgo ${show(versions.tsgo)} · vue-tsc ${show(versions.vueTsc)} (typescript ${show(versions.typescript)}) · vue ${show(versions.vue)} · eslint ${show(versions.eslint)} · prettier ${show(versions.prettier)} · node ${show(versions.node)}`,
   ];
+  lines.push(
+    `Binaries (sha256): ${Object.entries(data.binaries ?? {})
+      .map(([label, sha256]) => `${label} ${show(sha256)}`)
+      .join(" ")}`,
+  );
   lines.push(
     backend.ready
       ? `Backend: native TypeScript engine ready at ${show(backend.corsaPath)}. Planted-diagnostic gating for the type-check rows lives in bench/check-gate.mjs (.github/workflows/check-bench.yml).`

--- a/bench/check-gate-report.mjs
+++ b/bench/check-gate-report.mjs
@@ -97,6 +97,13 @@ export function renderMarkdown(data) {
     `Versions: \`${data.versions.vize}\` · tsgo \`${data.versions.tsgo}\` · vue-tsc \`${data.versions.vueTsc ?? "missing"}\` (typescript \`${data.versions.typescript ?? "n/a"}\`) · vue \`${data.versions.vue}\``,
   );
   lines.push(
+    `Binaries (sha256 of the measured file, re-checked after the run): ${Object.entries(
+      data.binaries,
+    )
+      .map(([label, binary]) => `${label}=\`${binary.sha256 ?? "unknown"}\``)
+      .join(" ")}`,
+  );
+  lines.push(
     `Entry point: \`${data.entry.tsconfigPath}\` — ${data.entry.fileCount} unique SFC files, ${data.entry.totalBytes.toLocaleString("en-US")} bytes.`,
   );
   lines.push(

--- a/bench/check-gate.mjs
+++ b/bench/check-gate.mjs
@@ -33,6 +33,7 @@ import {
   prepareCorpusPlant,
   prepareMinimalPlants,
 } from "./check-gate-plants.mjs";
+import { assertBinariesUnchanged, hashInPlace, pinExecutable } from "./benchmark-binary.mjs";
 import { evaluateBudget, measureRows, renderMarkdown } from "./check-gate-report.mjs";
 
 const benchDir = dirname(fileURLToPath(import.meta.url));
@@ -100,13 +101,24 @@ export async function main(argv = process.argv.slice(2)) {
   const workRoot = resolve(args["work-root"] ?? join(rootDir, "target", "check-gate"));
   mkdirSync(workRoot, { recursive: true });
 
-  const vize = requireBinary("vize binary", args["vize-bin"], [
+  const vizeSource = requireBinary("vize binary", args["vize-bin"], [
     join(rootDir, "target", "release", "vize"),
   ]);
-  const tsgo = requireBinary("tsgo binary", process.env.VIZE_CHECK_GATE_TSGO, [
+  const tsgoSource = requireBinary("tsgo binary", process.env.VIZE_CHECK_GATE_TSGO, [
     join(rootDir, "node_modules", ".bin", "tsgo"),
     join(rootDir, "tests", "node_modules", ".bin", "tsgo"),
   ]);
+  // Measure a private copy of the vize binary: a shared CARGO_TARGET_DIR can be
+  // rebuilt by another process mid-run, and a timing attributed to a binary
+  // that no longer exists is worse than no timing. tsgo ships as a launcher
+  // shim that resolves its package relative to itself, so it is hashed in
+  // place; both are re-hashed before the artifact is written.
+  const binaries = {
+    vize: pinExecutable(vizeSource.path, workRoot),
+    tsgo: hashInPlace(tsgoSource.path),
+  };
+  const vize = { ...vizeSource, path: binaries.vize.measuredPath };
+  const tsgo = tsgoSource;
   const vuePackageDir = resolveVuePackageDir();
   if (!vuePackageDir) throw new Error("check-gate: vue package not found in any node_modules");
   const vueTsc = args["skip-vue-tsc"] === "true" ? null : resolveOptionalVueTsc();
@@ -189,6 +201,8 @@ export async function main(argv = process.argv.slice(2)) {
   }
 
   const rows = measureRows(variants, { runs, warmups });
+  // Nothing measured is attributable if a binary moved underneath the run.
+  assertBinariesUnchanged(binaries);
   const budget = evaluateBudget(
     rows.find((row) => row.id === "vize-check-max").medianMs,
     args["budget-baseline"]
@@ -221,6 +235,7 @@ export async function main(argv = process.argv.slice(2)) {
       typescript: vueTsc ? typescriptVersionNear(vueTsc.path) : null,
       vue: packageVersion(vuePackageDir),
     },
+    binaries,
     entry: {
       tsconfigPath: corpus.tsconfigPath,
       corpusDir: corpus.dir,

--- a/bench/compare-tools-metadata.mjs
+++ b/bench/compare-tools-metadata.mjs
@@ -10,7 +10,7 @@
 import os from "node:os";
 
 import { buildFairnessNotes } from "./benchmark-notes.mjs";
-import { collectVersions } from "./benchmark-provenance.mjs";
+import { collectBinaryHashes, collectVersions } from "./benchmark-provenance.mjs";
 
 export const BLACKSMITH_MAX_LABEL = "blacksmith-32vcpu-ubuntu-2404";
 export const BLACKSMITH_MAX_SPEC = "32 vCPU / 128 GB RAM / 1.5 TB storage";
@@ -82,6 +82,7 @@ export function buildMetadata({ args, inputDir, files, totalBytes, taskList, opt
       node: process.version,
     },
     versions: collectVersions({ ...bins, corsaVersion: options.backend.corsaVersion }),
+    binaries: collectBinaryHashes({ ...bins, corsaPath: options.backend.corsaPath }),
     backend: options.backend,
     input: {
       dir: inputDir,

--- a/tests/tooling/benchmark-binary-identity.test.ts
+++ b/tests/tooling/benchmark-binary-identity.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  assertBinariesUnchanged,
+  fileSha256,
+  hashInPlace,
+  pinExecutable,
+} from "../../bench/benchmark-binary.mjs";
+
+function withTempDir<T>(run: (dir: string) => T): T {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-bench-binary-"));
+  try {
+    return run(dir);
+  } finally {
+    fs.rmSync(dir, { force: true, recursive: true });
+  }
+}
+
+function writeBinary(dir: string, name: string, body: string): string {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, body);
+  fs.chmodSync(file, 0o755);
+  return file;
+}
+
+function expectedSha(body: string): string {
+  return createHash("sha256").update(Buffer.from(body)).digest("hex");
+}
+
+test("fileSha256 hashes contents and reports null for anything unreadable", () => {
+  withTempDir((dir) => {
+    const body = "#!/bin/sh\necho vize\n";
+    assert.equal(fileSha256(writeBinary(dir, "vize", body)), expectedSha(body));
+    assert.equal(fileSha256(path.join(dir, "absent")), null);
+    assert.equal(fileSha256(null), null);
+    assert.equal(fileSha256(""), null);
+  });
+});
+
+test("pinExecutable measures a private copy named by its content hash", () => {
+  withTempDir((dir) => {
+    const body = "#!/bin/sh\necho vize\n";
+    const source = writeBinary(dir, "vize", body);
+    const workRoot = path.join(dir, "work");
+    const sha256 = expectedSha(body);
+
+    const pinned = pinExecutable(source, workRoot);
+    assert.deepEqual(pinned, {
+      source,
+      measuredPath: path.join(workRoot, "pinned-binaries", `vize-${sha256.slice(0, 16)}`),
+      sha256,
+      pinned: true,
+    });
+    assert.equal(fs.readFileSync(pinned.measuredPath, "utf8"), body);
+    assert.equal(fs.statSync(pinned.measuredPath).mode & 0o111, 0o111);
+
+    // Rebuilding the source does not change the copy already being measured.
+    fs.writeFileSync(source, "#!/bin/sh\necho rebuilt\n");
+    assert.equal(fs.readFileSync(pinned.measuredPath, "utf8"), body);
+  });
+});
+
+test("pinExecutable refuses a source it cannot hash", () => {
+  withTempDir((dir) => {
+    assert.throws(() => pinExecutable(path.join(dir, "absent"), path.join(dir, "work")), {
+      name: "Error",
+      message: `benchmark-binary: cannot hash ${path.join(dir, "absent")}`,
+    });
+  });
+});
+
+test("hashInPlace records identity without moving a launcher shim", () => {
+  withTempDir((dir) => {
+    const body = '#!/bin/sh\nexec "$(dirname "$0")/../pkg/tsgo" "$@"\n';
+    const source = writeBinary(dir, "tsgo", body);
+
+    assert.deepEqual(hashInPlace(source), {
+      source,
+      measuredPath: source,
+      sha256: expectedSha(body),
+      pinned: false,
+    });
+  });
+});
+
+test("a binary replaced during the run fails the gate closed", () => {
+  withTempDir((dir) => {
+    const source = writeBinary(dir, "vize", "#!/bin/sh\necho one\n");
+    const before = expectedSha("#!/bin/sh\necho one\n");
+    const binaries = { vize: hashInPlace(source) };
+
+    assert.equal(assertBinariesUnchanged(binaries), undefined);
+
+    fs.writeFileSync(source, "#!/bin/sh\necho two\n");
+    const after = expectedSha("#!/bin/sh\necho two\n");
+    assert.throws(() => assertBinariesUnchanged(binaries), {
+      name: "Error",
+      message: `benchmark-binary: vize changed during the run (${before} -> ${after}); refusing to publish a timing`,
+    });
+
+    fs.rmSync(source);
+    assert.throws(() => assertBinariesUnchanged(binaries), {
+      name: "Error",
+      message: `benchmark-binary: vize changed during the run (${before} -> missing); refusing to publish a timing`,
+    });
+  });
+});

--- a/tests/tooling/check-bench-gate.test.ts
+++ b/tests/tooling/check-bench-gate.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
@@ -39,6 +40,10 @@ function resolveTsgoBinary(): string | undefined {
     path.join(root, "tests/node_modules/.bin/tsgo"),
   ];
   return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function sha256Of(filePath: string): string {
+  return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
 }
 
 function readVueVersion(): string {
@@ -87,15 +92,22 @@ test("check-gate budget rule is pure and strict", () => {
   });
 });
 
-test("check-gate fails closed when the pinned tsgo binary is missing", () => {
+test("check-gate fails closed when the pinned tsgo binary is missing", (t) => {
+  // Resolve the vize binary rather than hardcoding target/ci/vize: a worktree
+  // with a shared CARGO_TARGET_DIR has no such path, and this test is about
+  // the tsgo failure, not about where vize was built.
+  const vizeBin = resolveVizeBinary();
+  if (vizeBin == null) {
+    requireTsgoOrSkip(t);
+    return;
+  }
   fs.mkdirSync(outputRoot, { recursive: true });
   const workDir = fs.mkdtempSync(path.join(outputRoot, "missing-tsgo-"));
   const jsonPath = path.join(workDir, "results.json");
   try {
-    const run = runGate(
-      ["--vize-bin", "target/ci/vize", "--json", jsonPath, "--work-root", workDir],
-      { VIZE_CHECK_GATE_TSGO: path.join(workDir, "does-not-exist") },
-    );
+    const run = runGate(["--vize-bin", vizeBin, "--json", jsonPath, "--work-root", workDir], {
+      VIZE_CHECK_GATE_TSGO: path.join(workDir, "does-not-exist"),
+    });
     assert.equal(run.status, 1, run.stderr || run.stdout);
     assert.match(run.stderr, /check-gate: tsgo binary not found/);
     assert.equal(fs.existsSync(jsonPath), false, "no timing artifact may be written");
@@ -189,6 +201,7 @@ test("check-gate publishes reproducibility metadata for a gated run", (t) => {
     // metadata block has to fail this gate.
     assert.deepEqual(Object.keys(data).sort(), [
       "backend",
+      "binaries",
       "budget",
       "commit",
       "entry",
@@ -223,6 +236,25 @@ test("check-gate publishes reproducibility metadata for a gated run", (t) => {
       },
       vueTsc: null,
     });
+
+    // The measured vize is a private copy pinned by content hash, so a rebuild
+    // of the source path cannot change what produced these timings.
+    const vizeSha = sha256Of(vizeBin);
+    assert.deepEqual(data.binaries, {
+      vize: {
+        source: path.resolve(vizeBin),
+        measuredPath: path.join(workDir, "pinned-binaries", `vize-${vizeSha.slice(0, 16)}`),
+        sha256: vizeSha,
+        pinned: true,
+      },
+      tsgo: {
+        source: path.resolve(tsgo),
+        measuredPath: path.resolve(tsgo),
+        sha256: sha256Of(tsgo),
+        pinned: false,
+      },
+    });
+    assert.equal(fs.existsSync(data.binaries.vize.measuredPath), true);
 
     const corpusDir = path.join(workDir, "corpus-6");
     assert.deepEqual(data.entry, {
@@ -280,6 +312,7 @@ test("check-gate publishes reproducibility metadata for a gated run", (t) => {
         "",
         `Measured: ${data.generatedAt}`,
         `Versions: \`${data.versions.vize}\` · tsgo \`${data.versions.tsgo}\` · vue-tsc \`missing\` (typescript \`n/a\`) · vue \`${data.versions.vue}\``,
+        `Binaries (sha256 of the measured file, re-checked after the run): vize=\`${data.binaries.vize.sha256}\` tsgo=\`${data.binaries.tsgo.sha256}\``,
         `Entry point: \`${data.entry.tsconfigPath}\` — 6 unique SFC files, ${data.entry.totalBytes.toLocaleString("en-US")} bytes.`,
         "Backend readiness (planted-diagnostic gates, all required before timing): script=pass templateProp=pass templateEvent=pass componentProp=pass corpus=pass",
         "Budget: no-baseline",

--- a/tests/tooling/tool-benchmark-engine-classes.test.ts
+++ b/tests/tooling/tool-benchmark-engine-classes.test.ts
@@ -185,6 +185,7 @@ test("the type-check summary renders separate engine classes and no cross ratio"
       prettier: "3.4.0",
       node: "v24.0.0",
     },
+    binaries: { vize: "d".repeat(64), tsgo: "e".repeat(64), vueTsc: null },
     backend: {
       engine: "tsgo-native",
       corsaPath: "/repo/node_modules/.bin/tsgo",
@@ -216,6 +217,7 @@ test("the type-check summary renders separate engine classes and no cross ratio"
     "Runner: `local` (8 logical CPU, test cpu)",
     "Input: 500 generated SFC files (976.6 KB). Median of 1 measured run(s) after 1 warmup run(s).",
     "Versions: vize `vize 0.303.0` · tsgo `7.0.0-dev` · vue-tsc `3.2.0` (typescript `5.9.0`) · vue `3.6.0` · eslint `9.0.0` · prettier `3.4.0` · node `v24.0.0`",
+    `Binaries (sha256): vize \`${"d".repeat(64)}\` tsgo \`${"e".repeat(64)}\` vueTsc n/a`,
     "Backend: native TypeScript engine ready at `/repo/node_modules/.bin/tsgo`. Planted-diagnostic gating for the type-check rows lives in bench/check-gate.mjs (.github/workflows/check-bench.yml).",
     "",
     "| Surface | Files | Existing tool | Existing median | Vize 1T | Vize max | Speedup |",

--- a/tests/tooling/tool-benchmark-provenance.test.ts
+++ b/tests/tooling/tool-benchmark-provenance.test.ts
@@ -100,10 +100,19 @@ test("a tsgo that cannot answer --version makes the backend not ready", () => {
   });
 });
 
+const READY_BINARIES = {
+  vize: "a".repeat(64),
+  tsgo: "b".repeat(64),
+  vueTsc: "c".repeat(64),
+  eslint: null,
+  prettier: null,
+};
+
 test("a ready artifact renders every version and names the measured backend", () => {
   assert.deepEqual(
     renderProvenanceLines({
       versions: READY_VERSIONS,
+      binaries: READY_BINARIES,
       backend: {
         engine: "tsgo-native",
         corsaPath: "/repo/node_modules/.bin/tsgo",
@@ -114,6 +123,7 @@ test("a ready artifact renders every version and names the measured backend", ()
     }),
     [
       "Versions: vize `vize 0.303.0` · tsgo `7.0.0-dev.20260602.1` · vue-tsc `3.2.0` (typescript `5.9.0`) · vue `3.6.0` · eslint `9.0.0` · prettier `3.4.0` · node `v24.0.0`",
+      `Binaries (sha256): vize \`${READY_BINARIES.vize}\` tsgo \`${READY_BINARIES.tsgo}\` vueTsc \`${READY_BINARIES.vueTsc}\` eslint n/a prettier n/a`,
       "Backend: native TypeScript engine ready at `/repo/node_modules/.bin/tsgo`. Planted-diagnostic gating for the type-check rows lives in bench/check-gate.mjs (.github/workflows/check-bench.yml).",
     ],
   );
@@ -123,6 +133,7 @@ test("an unready backend is stated outright and forbids a published timing", () 
   assert.deepEqual(
     renderProvenanceLines({
       versions: { ...READY_VERSIONS, tsgo: null, vueTsc: null, typescript: null },
+      binaries: { ...READY_BINARIES, tsgo: null, vueTsc: null },
       backend: {
         engine: "tsgo-native",
         corsaPath: null,
@@ -133,6 +144,7 @@ test("an unready backend is stated outright and forbids a published timing", () 
     }),
     [
       "Versions: vize `vize 0.303.0` · tsgo n/a · vue-tsc n/a (typescript n/a) · vue `3.6.0` · eslint `9.0.0` · prettier `3.4.0` · node `v24.0.0`",
+      `Binaries (sha256): vize \`${READY_BINARIES.vize}\` tsgo n/a vueTsc n/a eslint n/a prettier n/a`,
       "Backend: native TypeScript engine NOT ready (no tsgo binary at: /repo/node_modules/.bin/tsgo); no type-check timing may be published from this artifact.",
     ],
   );


### PR DESCRIPTION
## Defect

A version string is not an identity. Two builds of the same commit, a rebuild that lands mid-run, or a binary another process replaces under a shared `CARGO_TARGET_DIR` all answer `--version` identically. The gate recorded versions but never the *content* of what it measured, so:

- an artifact could not be reproduced — nothing said which build produced the timing;
- the gate could not even prove it measured **one** binary throughout a run.

That is exactly the attribution failure #3283 exists to prevent, and it is invisible: a number produced against a binary that was swapped halfway through looks identical to a correct one.

## Change

**`bench/benchmark-binary.mjs`** (new, 75 lines):

- `fileSha256` — content hash, `null` for anything unreadable;
- `pinExecutable` — copies a self-contained executable into the benchmark's own work root under a content-addressed name and returns the copy to measure, so a rebuild of the source path cannot change what is being timed;
- `hashInPlace` — records identity without moving a file, for launcher shims. `node_modules/.bin/tsgo` is a shell script that resolves its package relative to its own location and breaks when copied, so it is deliberately *not* pinned;
- `assertBinariesUnchanged` — re-hashes every measured binary and throws if one moved.

**The check gate** measures the pinned copy of `vize`, re-hashes both binaries after the measured runs and **before** any artifact is written, and aborts without publishing when a hash changed. The artifact gains a required `binaries` block:

```json
"binaries": {
  "vize": { "source": "...", "measuredPath": ".../pinned-binaries/vize-<sha16>", "sha256": "...", "pinned": true },
  "tsgo": { "source": "...", "measuredPath": "<same>", "sha256": "...", "pinned": false }
}
```

and the report carries `Binaries (sha256 of the measured file, re-checked after the run): vize=… tsgo=…`. The tool-comparison artifact records the same hashes for every measured binary.

## Tests

`tests/tooling/benchmark-binary-identity.test.ts` (new) asserts the complete return shape of each helper with `assert.deepEqual` and the **exact** error messages, including the two cases that matter:

- rebuilding the source after pinning does not change the copy being measured;
- a binary replaced (or deleted) during a run throws `benchmark-binary: vize changed during the run (<before> -> <after>); refusing to publish a timing`.

`tests/tooling/check-bench-gate.test.ts` asserts the complete `binaries` block against hashes the test computes itself, that the pinned copy exists on disk, and the new report line — all inside the existing complete-artifact-shape assertion, so `binaries` is a *required* field: dropping it fails the top-level key-set check.

**Fails before the fix:** the artifact has no `binaries` key, so the key-set assertion and the `binaries`/report-line assertions all fail.

## Drive-by, same lane

`check-gate fails closed when the pinned tsgo binary is missing` hardcoded `--vize-bin target/ci/vize`, which does not exist in a worktree using a shared `CARGO_TARGET_DIR` — it failed on the *vize* binary before ever reaching the tsgo assertion it exists to make. It now resolves the binary like the other cases and skips loudly when there is none, so the whole file passes from a clean checkout.

## Verification

```sh
nix develop -c node --test tests/tooling/check-bench-gate.test.ts \
  tests/tooling/benchmark-binary-identity.test.ts \
  tests/tooling/tool-benchmark-provenance.test.ts \
  tests/tooling/tool-benchmark-engine-classes.test.ts \
  tests/tooling/tool-benchmark.test.ts \
  tests/tooling/published-benchmark-ratios.test.ts
# 27 pass / 0 fail

nix develop -c vp run fmt:check   # exit 0
nix develop -c vp run check:js    # exit 0
```

No Rust changed. No benchmark number is published or altered by this PR.

Refs #3283