### PR TITLE
fix(editor): package the Neovim, Vim, Helix and Emacs extensions on the release path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,18 +143,18 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - uses: ./.github/actions/setup-rust-sticky-cache
-        with:
-          key: release-tools
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+        with: { key: release-tools, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
 
-      - name: Package VS Code extension
-        run: vp run --workspace-root package:vscode-extension
-
-      - name: Check Zed extension
-        run: vp run --workspace-root check:zed-extension
-
-      - name: Package Zed extension source
-        run: vp run --workspace-root package:zed-extension
+      # upload-artifact only fails when NO path matches, so every path it uploads needs a task here.
+      - name: Package editor extensions
+        run: |
+          vp run --workspace-root package:vscode-extension
+          vp run --workspace-root check:zed-extension
+          vp run --workspace-root package:zed-extension
+          vp run --workspace-root package:nvim-extension
+          vp run --workspace-root package:vim-extension
+          vp run --workspace-root package:helix-extension
+          vp run --workspace-root package:emacs-extension
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/tests/tooling/github-workflows-release-build.test.ts
+++ b/tests/tooling/github-workflows-release-build.test.ts
@@ -308,3 +308,38 @@ test("release workflow configures Zig linkers for Linux musl CLI archives", () =
   assert.match(zigLinkerScript, /write_cc X86_64_UNKNOWN_LINUX_MUSL x86_64-linux-musl/);
   assert.match(zigLinkerScript, /write_cc AARCH64_UNKNOWN_LINUX_MUSL aarch64-linux-musl/);
 });
+
+test("release workflow builds every editor-extension artifact it uploads", () => {
+  const workflow = readRepoFile(".github", "workflows", "release.yml");
+  const job = workflowJobBody(workflow, "build-editor-extensions");
+
+  // `actions/upload-artifact` with `if-no-files-found: error` only fails when
+  // *no* path matches, so a tarball nobody packages is dropped from the release
+  // artifact in silence. Pin the producer of every uploaded path instead.
+  const uploadPaths = job
+    .slice(job.indexOf("path: |"))
+    .split("\n")
+    .slice(1)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.includes(":"));
+
+  assert.deepEqual(uploadPaths, [
+    "emacs-vize-extension.tar.gz",
+    "helix-vize-extension.tar.gz",
+    "editors/vscode/dist/vize.vsix",
+    "nvim-vize-extension.tar.gz",
+    "vim-vize-extension.tar.gz",
+    "zed-vize-extension.tar.gz",
+  ]);
+
+  const producingTaskFor = (uploadPath: string): string => {
+    if (uploadPath === "editors/vscode/dist/vize.vsix") return "package:vscode-extension";
+    const editor = uploadPath.replace(/-vize-extension\.tar\.gz$/, "");
+    return `package:${editor}-extension`;
+  };
+
+  const unbuilt = uploadPaths.filter(
+    (uploadPath) => !job.includes(`vp run --workspace-root ${producingTaskFor(uploadPath)}`),
+  );
+  assert.deepEqual(unbuilt, [], "every uploaded editor artifact needs a packaging step");
+});


### PR DESCRIPTION
## Defect

`.github/workflows/release.yml`, job `build-editor-extensions`, uploads six
artifact paths:

```
emacs-vize-extension.tar.gz
helix-vize-extension.tar.gz
editors/vscode/dist/vize.vsix
nvim-vize-extension.tar.gz
vim-vize-extension.tar.gz
zed-vize-extension.tar.gz
```

but its only build steps are `package:vscode-extension`, `check:zed-extension`
and `package:zed-extension`. The four editor tarballs are never produced.

`actions/upload-artifact` with `if-no-files-found: error` fails only when **no**
path matches. The VSIX and the Zed tarball do exist, so the step succeeds and the
`editor-extensions` artifact ships **without** the Neovim, Vim, Helix and Emacs
packages — and their `tools/*/assert-*-package.mjs` packaging assertions never
run on the release path either.

## Fix

Add the four missing `vp run --workspace-root package:<editor>-extension` steps.
Each of those tasks already tars the editor directory and then runs its
`assert-*-package.mjs` contract check, so the release path regains both the
artifacts and their packaging assertions.

## Test that fails before the fix

`tests/tooling/github-workflows-release-build.test.ts` gains
"release workflow builds every editor-extension artifact it uploads". It parses
the job's `path: |` block, asserts the full uploaded list with
`assert.deepEqual`, derives the producing task from each path
(`<editor>-vize-extension.tar.gz` → `package:<editor>-extension`), and asserts
with `assert.deepEqual` that the set of unproduced paths is empty.

On the pre-fix workflow it fails with exactly the four missing tarballs:

```
AssertionError: every uploaded editor artifact needs a packaging step
+ actual - expected
+ [
+   'emacs-vize-extension.tar.gz',
+   'helix-vize-extension.tar.gz',
+   'nvim-vize-extension.tar.gz',
+   'vim-vize-extension.tar.gz'
+ ]
- []
```

(Verified by stashing only the workflow change and re-running the suite.)

## Gates

`fmt:check`, `check:js`, and
`node --test tests/tooling/github-workflows-release-build.test.ts` (13 pass),
`github-workflows-check.test.ts`, `github-workflows-setup.test.ts` (23 pass).

Refs #3224.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release builds now package and upload all supported editor-extension artifacts, reducing the risk of incomplete releases.

* **Tests**
  * Added validation to confirm every configured release artifact has a corresponding packaging step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->