### PR TITLE
fix(atelier): reject a non-assignable JSX v-model target

### DIFF
--- a/crates/vize_atelier_jsx/src/lower.rs
+++ b/crates/vize_atelier_jsx/src/lower.rs
@@ -15,6 +15,7 @@ mod name;
 mod slot;
 mod style;
 mod text;
+mod v_model;
 
 pub(crate) use style::{RawScopedStyle, ScopedStyleExpr};
 

--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -10,8 +10,7 @@
 //! - `v-x` / `v-x:arg` -> [`DirectiveNode`] named `x`
 
 use oxc_ast::ast::{
-    ArrayExpressionElement, Expression, JSXAttribute, JSXAttributeItem, JSXAttributeName,
-    JSXAttributeValue, JSXSpreadAttribute,
+    JSXAttribute, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXSpreadAttribute,
 };
 use oxc_span::{GetSpan, Span};
 use vize_carton::{Box, String, Vec};
@@ -22,6 +21,7 @@ use vize_relief::SimpleExpressionNode;
 
 use super::Lowerer;
 use super::expr::container_expr_span;
+use super::v_model::split_underscore_model_modifiers;
 
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Lower a JSX opening element's attribute list into Vize props.
@@ -33,9 +33,15 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         for item in items {
             let prop = match item {
                 JSXAttributeItem::Attribute(attr) => self.lower_attribute(attr),
-                JSXAttributeItem::SpreadAttribute(spread) => self.lower_spread_attribute(spread),
+                JSXAttributeItem::SpreadAttribute(spread) => {
+                    Some(self.lower_spread_attribute(spread))
+                }
             };
-            props.push(prop);
+            // `None` means the attribute was rejected with a diagnostic; it
+            // contributes no prop so no code is generated from it.
+            if let Some(prop) = prop {
+                props.push(prop);
+            }
         }
         props
     }
@@ -48,17 +54,25 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         PropNode::Directive(Box::new_in(directive, self.bump()))
     }
 
-    fn lower_attribute(&mut self, attr: &JSXAttribute<'_>) -> PropNode<'a> {
+    /// Lower one attribute, or `None` when it was rejected with a diagnostic.
+    fn lower_attribute(&mut self, attr: &JSXAttribute<'_>) -> Option<PropNode<'a>> {
         let loc = self.mapper().location(attr.span);
+
+        // `v-model` writes back through an assignment, so its target must be
+        // assignable. Reject early: lowering it anyway produces an assignment to
+        // a non-place expression, i.e. emitted code that does not parse (#3420).
+        if self.reject_unassignable_model_target(attr) {
+            return None;
+        }
 
         // Directive forms: `v-model`, `v-show`, `v-on:click`, custom `v-foo:arg`.
         if let Some(directive) = self.try_directive_attribute(attr, &loc) {
-            return directive;
+            return Some(directive);
         }
 
         let name = String::from(self.mapper().slice(attr.name.span()));
         let name_loc = self.mapper().location(attr.name.span());
-        match attr.value.as_ref() {
+        let prop = match attr.value.as_ref() {
             None => self.boolean_attr(name, name_loc, loc),
             Some(JSXAttributeValue::StringLiteral(string)) => {
                 let value =
@@ -83,15 +97,10 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
                         // listener key. Plain `onClick={h}` has no recognized
                         // suffix and stays a `v-bind` like before.
                         if let Some((event, mods)) = split_on_event_modifiers(&name) {
-                            return self.von_modifier_prop(
-                                &event,
-                                attr.name.span(),
-                                span,
-                                &mods,
-                                loc,
-                            );
+                            self.von_modifier_prop(&event, attr.name.span(), span, &mods, loc)
+                        } else {
+                            self.bind_prop(&name, attr.name.span(), span, loc)
                         }
-                        self.bind_prop(&name, attr.name.span(), span, loc)
                     }
                 }
             }
@@ -101,7 +110,8 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             Some(JSXAttributeValue::Fragment(fragment)) => {
                 self.bind_prop(&name, attr.name.span(), fragment.span(), loc)
             }
-        }
+        };
+        Some(prop)
     }
 
     fn boolean_attr(
@@ -216,86 +226,6 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         Some(PropNode::Directive(Box::new_in(directive, self.bump())))
     }
 
-    /// The `[value, ...]` array literal backing a `v-model={[...]}` attribute,
-    /// or `None` when the value is not an array-literal expression container.
-    fn model_array_value<'e>(
-        &self,
-        value: Option<&'e JSXAttributeValue<'e>>,
-    ) -> Option<&'e oxc_ast::ast::ArrayExpression<'e>> {
-        let JSXAttributeValue::ExpressionContainer(container) = value? else {
-            return None;
-        };
-        match &container.expression {
-            oxc_ast::ast::JSXExpression::ArrayExpression(array) => Some(array),
-            _ => None,
-        }
-    }
-
-    /// Lower a `v-model={[value, argString?, modifiersArray?]}` array into a
-    /// `model` directive. Layout (per babel-plugin-jsx):
-    ///   - element 0: the model expression (required)  -> `exp`
-    ///   - a trailing array-literal element: modifiers  -> `directive.modifiers`
-    ///   - an intermediate string-literal element: arg  -> `directive.arg`
-    ///
-    /// Returns `None` (fall back to default handling) for shapes we cannot
-    /// confidently destructure (e.g. empty array, spread/hole elements).
-    fn lower_model_array(
-        &self,
-        array: &oxc_ast::ast::ArrayExpression<'_>,
-        loc: &SourceLocation,
-    ) -> Option<PropNode<'a>> {
-        // Collect the plain (non-hole, non-spread) expression elements.
-        let mut elems: std::vec::Vec<&Expression<'_>> = std::vec::Vec::new();
-        for element in &array.elements {
-            match element {
-                ArrayExpressionElement::SpreadElement(_) | ArrayExpressionElement::Elision(_) => {
-                    return None;
-                }
-                _ => match element.as_expression() {
-                    Some(expr) => elems.push(expr),
-                    None => return None,
-                },
-            }
-        }
-
-        let value_expr = *elems.first()?;
-
-        // A trailing array-literal element is the modifiers list. Its index marks
-        // the boundary so a middle string element can be recognized as the arg.
-        let modifiers_idx = match elems.last() {
-            Some(Expression::ArrayExpression(_)) if elems.len() >= 2 => Some(elems.len() - 1),
-            _ => None,
-        };
-
-        let mut directive = DirectiveNode::new(self.bump(), "model", loc.clone());
-        directive.exp = Some(self.dyn_expr(value_expr.span()));
-
-        // An intermediate string-literal element (index 1, before any modifiers
-        // array) is the arg: the bound prop name for component v-model.
-        if let Some(Expression::StringLiteral(s)) = elems.get(1).copied()
-            && modifiers_idx != Some(1)
-        {
-            directive.arg = Some(self.static_expr(s.value.as_str(), s.span));
-        }
-
-        if let Some(idx) = modifiers_idx
-            && let Expression::ArrayExpression(modifiers) = elems[idx]
-        {
-            for element in &modifiers.elements {
-                let Some(Expression::StringLiteral(s)) = element.as_expression() else {
-                    continue;
-                };
-                directive.modifiers.push(SimpleExpressionNode::new(
-                    s.value.as_str(),
-                    false,
-                    loc.clone(),
-                ));
-            }
-        }
-
-        Some(PropNode::Directive(Box::new_in(directive, self.bump())))
-    }
-
     fn directive_value_expr(
         &self,
         value: Option<&JSXAttributeValue<'_>>,
@@ -359,26 +289,4 @@ fn split_on_event_modifiers(name: &str) -> Option<(String, std::vec::Vec<&str>)>
     lowered.push(first.to_ascii_lowercase());
     lowered.push_str(chars.as_str());
     Some((lowered, mods))
-}
-
-/// Split a babel-plugin-jsx `v-model_<mod>(_<mod>)*` attribute name (already
-/// stripped of its `v-` prefix) into `("model", [modifiers...])`.
-///
-/// JSX attribute names cannot contain `.`, so babel-plugin-jsx encodes v-model
-/// modifiers as `_`-joined suffixes: `model_lazy`, `model_number_lazy`. The
-/// recognized standard modifiers are `lazy` / `trim` / `number`; any further
-/// `_`-separated segments are passed through verbatim (custom modifiers).
-///
-/// Returns `None` for names that are not `model` with at least one suffix (so
-/// bare `model` and unrelated directives keep their default behavior).
-fn split_underscore_model_modifiers(name: &str) -> Option<(&'static str, std::vec::Vec<&str>)> {
-    let rest = name.strip_prefix("model_")?;
-    if rest.is_empty() {
-        return None;
-    }
-    let mods: std::vec::Vec<&str> = rest.split('_').filter(|s| !s.is_empty()).collect();
-    if mods.is_empty() {
-        return None;
-    }
-    Some(("model", mods))
 }

--- a/crates/vize_atelier_jsx/src/lower/v_model.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_model.rs
@@ -1,0 +1,229 @@
+//! `v-model` attribute lowering: the three spellings `@vue/babel-plugin-jsx`
+//! accepts, and the write-back target validation they share.
+//!
+//! JSX attribute names cannot contain `.`, so `@vue/babel-plugin-jsx` encodes
+//! v-model's arg and modifiers two ways, both of which Vize accepts:
+//!
+//! - underscore suffixes — `v-model_lazy={x}`, `v-model:foo_trim={x}`
+//! - an array value — `v-model={[x, 'arg', ['trim']]}`
+//!
+//! Split out of `attr.rs` so the generic attribute classification stays readable
+//! and both files stay inside the per-file source budget.
+
+use oxc_ast::ast::{
+    ArrayExpressionElement, Expression, JSXAttribute, JSXAttributeName, JSXAttributeValue,
+};
+use oxc_span::GetSpan;
+use vize_carton::{Box, ToCompactString};
+use vize_relief::SourceLocation;
+use vize_relief::{DirectiveNode, PropNode, SimpleExpressionNode};
+
+use super::Lowerer;
+use crate::diagnostics::JsxDiagnostic;
+
+impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// Reject a `v-model` whose bound target cannot be assigned to.
+    ///
+    /// `v-model` compiles to `$event => (target = $event)`, so a target that is
+    /// not a *place* expression — an object literal, a call, a literal — makes
+    /// the emitted module fail to parse. `@vue/babel-plugin-jsx` rejects the same
+    /// inputs (`Property left of AssignmentExpression expected node to be of a
+    /// type ["LVal","OptionalMemberExpression"]`), so this is the compatible
+    /// behavior as well as the correct one (#3420).
+    ///
+    /// Returns `true` when a diagnostic was reported and the attribute must be
+    /// dropped. A `v-model` with no value at all is left alone: the core
+    /// transform already reports "v-model is missing expression."
+    pub(crate) fn reject_unassignable_model_target(&mut self, attr: &JSXAttribute<'_>) -> bool {
+        let Some(target) = self.model_target_expr(attr) else {
+            return false;
+        };
+        if is_assignable_target(target) {
+            return false;
+        }
+        let span = target.span();
+        let source = self.mapper().slice(span);
+        self.report(JsxDiagnostic::error(
+            format_args!(
+                "v-model target `{source}` cannot be assigned to; \
+                 v-model needs a variable or property reference."
+            )
+            .to_compact_string(),
+            span.start,
+            span.end,
+        ));
+        true
+    }
+
+    /// The expression a `v-model` attribute writes back to, for any of the three
+    /// spellings: `v-model={x}`, `v-model_lazy={x}`, and the array form
+    /// `v-model={[x, 'arg', ['mod']]}` (whose first element is the target).
+    ///
+    /// `None` for attributes that are not `v-model`, and for a `v-model` with no
+    /// expression value — those are handled elsewhere.
+    fn model_target_expr<'e>(&self, attr: &'e JSXAttribute<'e>) -> Option<&'e Expression<'e>> {
+        let raw_name = match &attr.name {
+            JSXAttributeName::NamespacedName(named) => self
+                .mapper()
+                .slice(named.namespace.span())
+                .strip_prefix("v-")?,
+            JSXAttributeName::Identifier(id) => {
+                self.mapper().slice(id.span()).strip_prefix("v-")?
+            }
+        };
+        let base = match split_underscore_model_modifiers(raw_name) {
+            Some((name, _)) => name,
+            None => raw_name,
+        };
+        if base != "model" {
+            return None;
+        }
+
+        let JSXAttributeValue::ExpressionContainer(container) = attr.value.as_ref()? else {
+            return None;
+        };
+        match &container.expression {
+            // The array form's first element is the target; the rest are the arg
+            // and modifiers, which are not assigned to.
+            oxc_ast::ast::JSXExpression::ArrayExpression(array) => {
+                array.elements.first().and_then(|e| e.as_expression())
+            }
+            expression => expression.as_expression(),
+        }
+    }
+
+    /// The `[value, ...]` array literal backing a `v-model={[...]}` attribute,
+    /// or `None` when the value is not an array-literal expression container.
+    pub(crate) fn model_array_value<'e>(
+        &self,
+        value: Option<&'e JSXAttributeValue<'e>>,
+    ) -> Option<&'e oxc_ast::ast::ArrayExpression<'e>> {
+        let JSXAttributeValue::ExpressionContainer(container) = value? else {
+            return None;
+        };
+        match &container.expression {
+            oxc_ast::ast::JSXExpression::ArrayExpression(array) => Some(array),
+            _ => None,
+        }
+    }
+
+    /// Lower a `v-model={[value, argString?, modifiersArray?]}` array into a
+    /// `model` directive. Layout (per babel-plugin-jsx):
+    ///   - element 0: the model expression (required)  -> `exp`
+    ///   - a trailing array-literal element: modifiers  -> `directive.modifiers`
+    ///   - an intermediate string-literal element: arg  -> `directive.arg`
+    ///
+    /// Returns `None` (fall back to default handling) for shapes we cannot
+    /// confidently destructure (e.g. empty array, spread/hole elements).
+    pub(crate) fn lower_model_array(
+        &self,
+        array: &oxc_ast::ast::ArrayExpression<'_>,
+        loc: &SourceLocation,
+    ) -> Option<PropNode<'a>> {
+        // Collect the plain (non-hole, non-spread) expression elements.
+        let mut elems: std::vec::Vec<&Expression<'_>> = std::vec::Vec::new();
+        for element in &array.elements {
+            match element {
+                ArrayExpressionElement::SpreadElement(_) | ArrayExpressionElement::Elision(_) => {
+                    return None;
+                }
+                _ => match element.as_expression() {
+                    Some(expr) => elems.push(expr),
+                    None => return None,
+                },
+            }
+        }
+
+        let value_expr = *elems.first()?;
+
+        // A trailing array-literal element is the modifiers list. Its index marks
+        // the boundary so a middle string element can be recognized as the arg.
+        let modifiers_idx = match elems.last() {
+            Some(Expression::ArrayExpression(_)) if elems.len() >= 2 => Some(elems.len() - 1),
+            _ => None,
+        };
+
+        let mut directive = DirectiveNode::new(self.bump(), "model", loc.clone());
+        directive.exp = Some(self.dyn_expr(value_expr.span()));
+
+        // An intermediate string-literal element (index 1, before any modifiers
+        // array) is the arg: the bound prop name for component v-model.
+        if let Some(Expression::StringLiteral(s)) = elems.get(1).copied()
+            && modifiers_idx != Some(1)
+        {
+            directive.arg = Some(self.static_expr(s.value.as_str(), s.span));
+        }
+
+        if let Some(idx) = modifiers_idx
+            && let Expression::ArrayExpression(modifiers) = elems[idx]
+        {
+            for element in &modifiers.elements {
+                let Some(Expression::StringLiteral(s)) = element.as_expression() else {
+                    continue;
+                };
+                directive.modifiers.push(SimpleExpressionNode::new(
+                    s.value.as_str(),
+                    false,
+                    loc.clone(),
+                ));
+            }
+        }
+
+        Some(PropNode::Directive(Box::new_in(directive, self.bump())))
+    }
+}
+
+/// Whether an expression can appear on the left of an assignment.
+///
+/// `v-model` writes back with `target = $event`, so anything that is not a
+/// *place* expression would emit a module that does not parse. The accepted set
+/// mirrors `@vue/babel-plugin-jsx`'s (`LVal` plus optional member access):
+/// identifiers, member access of any form, and private fields. Type-only
+/// wrappers (`x as T`, `x!`, `<T>x`, `x satisfies T`) and parentheses are
+/// transparent — they are stripped by codegen, so the underlying target decides.
+///
+/// Note the deliberate omission of array/object destructuring patterns: they are
+/// valid `LVal`s in general JavaScript, but `v-model` assigns a single event
+/// value, so destructuring one is never meaningful here.
+fn is_assignable_target(expr: &Expression<'_>) -> bool {
+    match expr {
+        Expression::Identifier(_)
+        | Expression::StaticMemberExpression(_)
+        | Expression::ComputedMemberExpression(_)
+        | Expression::PrivateFieldExpression(_) => true,
+        Expression::ParenthesizedExpression(inner) => is_assignable_target(&inner.expression),
+        Expression::TSAsExpression(inner) => is_assignable_target(&inner.expression),
+        Expression::TSSatisfiesExpression(inner) => is_assignable_target(&inner.expression),
+        Expression::TSNonNullExpression(inner) => is_assignable_target(&inner.expression),
+        Expression::TSTypeAssertion(inner) => is_assignable_target(&inner.expression),
+        // `a?.b = x` is not legal JavaScript, but babel accepts an
+        // OptionalMemberExpression as a v-model target, so matching it here keeps
+        // the diagnostic from firing where babel stays quiet.
+        Expression::ChainExpression(_) => true,
+        _ => false,
+    }
+}
+
+/// Split a babel-plugin-jsx `v-model_<mod>(_<mod>)*` attribute name (already
+/// stripped of its `v-` prefix) into `("model", [modifiers...])`.
+///
+/// JSX attribute names cannot contain `.`, so babel-plugin-jsx encodes v-model
+/// modifiers as `_`-joined suffixes: `model_lazy`, `model_number_lazy`. The
+/// recognized standard modifiers are `lazy` / `trim` / `number`; any further
+/// `_`-separated segments are passed through verbatim (custom modifiers).
+///
+/// Returns `None` for names that are not `model` with at least one suffix (so
+/// bare `model` and unrelated directives keep their default behavior).
+pub(crate) fn split_underscore_model_modifiers(
+    name: &str,
+) -> Option<(&'static str, std::vec::Vec<&str>)> {
+    let rest = name.strip_prefix("model_")?;
+    if rest.is_empty() {
+        return None;
+    }
+    let mods: std::vec::Vec<&str> = rest.split('_').filter(|s| !s.is_empty()).collect();
+    if mods.is_empty() {
+        return None;
+    }
+    Some(("model", mods))
+}

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -26,10 +26,19 @@ so babel's side is never guessed. The Rust suite then compares **recorded babel
 output against Vize output as a side-by-side snapshot with a declared verdict**,
 not as an equality assertion — Vize is not trying to be byte-identical (see
 _Global divergences_). The verdict column is where the semantic judgement lives,
-and it is asserted to cover the corpus exactly in both directions. A
-runtime-mount (importmap + Playwright) oracle would strengthen the `equivalent`
-verdicts from review-checked to executed; that upgrade is tracked on #3391 and is
-not claimed here.
+and it is asserted to cover the corpus exactly in both directions.
+
+**The `equivalent` verdicts are review-checked, not executed.** Upgrading them to
+executed means mounting both outputs against a real Vue runtime and comparing
+rendered DOM plus patch behavior on update. The repo has no harness that does
+this today: the closest things are `playground/e2e/vrt/vapor-runtime.spec.ts`
+(a Playwright smoke over the playground app, not over compiled output) and
+`npm/fresco/src/testing/mount.ts` (an in-process `@vue/runtime-core` mount for
+Fresco's own renderer). The cheapest viable path is the latter's shape rather
+than an importmap + browser harness: `happy-dom` and `vue` are already workspace
+catalog entries, so each corpus case's two emitted modules can be evaluated and
+mounted in-process, then diffed on `innerHTML` after mount and after a state
+update. Tracked on #3391; deliberately not claimed here.
 
 Regenerate / verify:
 
@@ -46,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   63 |
-| divergent  |   29 |
+| equivalent |   64 |
+| divergent  |   28 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -219,7 +228,7 @@ accept it.
 
 | Case                        | Babel                                                         | Vize today                                                             | Compat mode              | Verdict |
 | --------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------ | ------- |
-| `errors/v_model_non_lval`   | rejects a non-assignable `v-model` target                     | accepts it and emits nested-arrow code that is not valid render output | reject with a diagnostic | ❌      |
+| `errors/v_model_non_lval`   | rejects a non-assignable `v-model` target                     | rejects it too, naming the offending expression (closed by #3420) | no change | ✅      |
 | `errors/v_model_no_value`   | rejects: "You have to use JSX Expression inside your v-model" | rejects: "v-model is missing expression."                              | no change                | ✅      |
 | `errors/v_models_not_array` | rejects a non-array `v-models` value                          | emits a custom `models` directive                                      | reject with a diagnostic | ❌      |
 | `errors/v_slots_not_object` | forwards the value as children                                | emits a custom `slots` directive                                       | forward as children      | ❌      |

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -226,9 +226,9 @@ Compared against Vize's default, which is already fully optimized.
 A compat mode must reject what babel rejects, with a diagnostic — never silently
 accept it.
 
-| Case                        | Babel                                                         | Vize today                                                             | Compat mode              | Verdict |
-| --------------------------- | ------------------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------ | ------- |
-| `errors/v_model_non_lval`   | rejects a non-assignable `v-model` target                     | rejects it too, naming the offending expression (closed by #3420) | no change | ✅      |
-| `errors/v_model_no_value`   | rejects: "You have to use JSX Expression inside your v-model" | rejects: "v-model is missing expression."                              | no change                | ✅      |
-| `errors/v_models_not_array` | rejects a non-array `v-models` value                          | emits a custom `models` directive                                      | reject with a diagnostic | ❌      |
-| `errors/v_slots_not_object` | forwards the value as children                                | emits a custom `slots` directive                                       | forward as children      | ❌      |
+| Case                        | Babel                                                         | Vize today                                                        | Compat mode              | Verdict |
+| --------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------ | ------- |
+| `errors/v_model_non_lval`   | rejects a non-assignable `v-model` target                     | rejects it too, naming the offending expression (closed by #3420) | no change                | ✅      |
+| `errors/v_model_no_value`   | rejects: "You have to use JSX Expression inside your v-model" | rejects: "v-model is missing expression."                         | no change                | ✅      |
+| `errors/v_models_not_array` | rejects a non-array `v-models` value                          | emits a custom `models` directive                                 | reject with a diagnostic | ❌      |
+| `errors/v_slots_not_object` | forwards the value as children                                | emits a custom `slots` directive                                  | forward as children      | ❌      |

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -170,10 +170,8 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("optimize/fragment", Same),
     ("optimize/map_list", Same),
     // -- errors ----------------------------------------------------------
-    (
-        "errors/v_model_non_lval",
-        Diff("non-assignable v-model target accepted"),
-    ),
+    // Closed by #3420: both sides now reject a non-assignable target.
+    ("errors/v_model_non_lval", Same),
     ("errors/v_model_no_value", Same),
     (
         "errors/v_models_not_array",

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (63, 29, 2));
+    assert_eq!((equivalent, divergent, deferred), (64, 28, 2));
     assert_eq!(VERDICTS.len(), 94);
 }
 

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
@@ -4,7 +4,7 @@ expression: body
 ---
 ## errors/v_model_non_lval
 ### verdict
-divergent: non-assignable v-model target accepted
+equivalent
 ### source (jsx)
 const A = () => <input v-model={{a:1}}/>;
 ### babel options
@@ -12,13 +12,10 @@ const A = () => <input v-model={{a:1}}/>;
 ### babel
 <error> Property left of AssignmentExpression expected node to be of a type ["LVal","OptionalMemberExpression"] but instead got "ObjectExpression"
 ### vize (vdom, default config)
-import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+<Error> v-model target `{a:1}` cannot be assigned to; v-model needs a variable or property reference.
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
-  return _withDirectives((_openBlock(), _createElementBlock("input", {
-    "onUpdate:modelValue": $event => ($event => ($event => (({a:1}) = $event)))
-  }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
-    [_vModelText, {a:1}]
-  ])
+  return (_openBlock(), _createElementBlock("input"))
 }
 
 ## errors/v_model_no_value

--- a/crates/vize_atelier_jsx/tests/v_model_target.rs
+++ b/crates/vize_atelier_jsx/tests/v_model_target.rs
@@ -1,0 +1,126 @@
+//! `v-model` write-back target validation (#3420).
+//!
+//! `v-model` compiles to `$event => (target = $event)`, so its target has to be
+//! a place expression. Before this was checked, a non-assignable target such as
+//! `v-model={{a:1}}` lowered anyway and emitted
+//! `$event => ($event => ($event => (({a:1}) = $event)))` — a module that does
+//! not parse. `@vue/babel-plugin-jsx` rejects the same inputs, so diagnosing
+//! here is both the correct behavior and the compatible one.
+
+mod common;
+
+use vize_atelier_jsx::{JsxLang, VdomCompileOptions, compile_to_vdom, lower_source};
+use vize_carton::Bump;
+
+fn errors(source: &str) -> Vec<String> {
+    let bump = Bump::new();
+    let out = lower_source(&bump, source, JsxLang::Jsx);
+    out.diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.is_error())
+        .map(|diagnostic| diagnostic.message.as_str().to_string())
+        .collect()
+}
+
+fn render_code(source: &str) -> String {
+    let bump = Bump::new();
+    let out = compile_to_vdom(&bump, source, JsxLang::Jsx, VdomCompileOptions::default());
+    out.components
+        .into_iter()
+        .map(|component| component.code.as_str().to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn object_literal_target_is_rejected() {
+    assert_eq!(
+        errors("const A = () => <input v-model={{a:1}}/>;"),
+        vec![
+            "v-model target `{a:1}` cannot be assigned to; \
+             v-model needs a variable or property reference."
+                .to_string()
+        ]
+    );
+    // The attribute contributes no prop, so none of the previously-emitted
+    // invalid assignment code reaches the output.
+    assert_eq!(
+        render_code("const A = () => <input v-model={{a:1}}/>;"),
+        "export function render(_ctx, _cache) {\n  return (_openBlock(), _createElementBlock(\"input\"))\n}"
+    );
+}
+
+#[test]
+fn call_and_literal_targets_are_rejected() {
+    assert_eq!(
+        errors("const A = () => <input v-model={get()}/>;"),
+        vec![
+            "v-model target `get()` cannot be assigned to; \
+             v-model needs a variable or property reference."
+                .to_string()
+        ]
+    );
+    assert_eq!(
+        errors("const A = () => <input v-model={\"str\"}/>;"),
+        vec![
+            "v-model target `\"str\"` cannot be assigned to; \
+             v-model needs a variable or property reference."
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn array_form_validates_only_the_first_element() {
+    // `['trim']` is the modifiers list, not an assignment target, so the array
+    // form must not be rejected for it.
+    assert_eq!(
+        errors("const A = () => <input v-model={[val, ['trim']]}/>;"),
+        Vec::<String>::new()
+    );
+    // …but a non-assignable *first* element still is.
+    assert_eq!(
+        errors("const A = () => <input v-model={[{a:1}, ['trim']]}/>;"),
+        vec![
+            "v-model target `{a:1}` cannot be assigned to; \
+             v-model needs a variable or property reference."
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn assignable_targets_are_accepted() {
+    // Identifiers, member access of both forms, optional chaining, and the
+    // type-only wrappers TSX allows must all still lower cleanly.
+    for source in [
+        "const A = () => <input v-model={val}/>;",
+        "const A = () => <input v-model={state.val}/>;",
+        "const A = () => <input v-model={state[key]}/>;",
+        "const A = () => <input v-model={state?.val}/>;",
+        "const A = () => <input v-model={(val)}/>;",
+        "const A = () => <B v-model={[val, 'arg', ['trim']]}/>;",
+        "const A = () => <input v-model_lazy={val}/>;",
+    ] {
+        assert_eq!(errors(source), Vec::<String>::new(), "source: {source}");
+    }
+}
+
+#[test]
+fn missing_expression_keeps_its_own_diagnostic() {
+    // `v-model` with no value at all is a different defect, already reported by
+    // the core transform; the new check must not shadow or duplicate it.
+    let bump = Bump::new();
+    let out = compile_to_vdom(
+        &bump,
+        "const A = () => <input v-model/>;",
+        JsxLang::Jsx,
+        VdomCompileOptions::default(),
+    );
+    let messages: Vec<String> = out
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.message.as_str().to_string())
+        .collect();
+    assert_eq!(messages, vec!["v-model is missing expression.".to_string()]);
+}


### PR DESCRIPTION
Closes #3420. Refs #3391.

## The defect

`v-model` compiles to `$event => (target = $event)`, so its target has to be an
assignable place expression. Vize never checked, so a non-assignable target lowered
anyway and emitted a module that does not parse.

## Minimal reproduction

```jsx
const A = () => <input v-model={{a:1}}/>;
```

**Expected** — `@vue/babel-plugin-jsx` rejects this:

```
Property left of AssignmentExpression expected node to be of a type
["LVal","OptionalMemberExpression"] but instead got "ObjectExpression"
```

**Actual (before this PR)** — accepted, no diagnostic, and the emitted render function
contains an assignment to an object literal wrapped in three redundant arrows:

```js
return _withDirectives((_openBlock(), _createElementBlock("input", {
  "onUpdate:modelValue": $event => ($event => ($event => (({a:1}) = $event)))
}, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
  [_vModelText, {a:1}]
])
```

`({a:1}) = $event` is a syntax error, so the failure surfaces at bundle/parse time in
the user's project, far from the JSX that caused it. Emitting invalid code is strictly
worse than rejecting the input.

## The fix

`lower_attribute` now validates a `v-model` target before lowering it. A non-assignable
target is reported as an error naming the offending expression, and the attribute
contributes no prop, so none of the invalid code is generated:

```
v-model target `{a:1}` cannot be assigned to; v-model needs a variable or property reference.
```

The accepted set mirrors babel's `LVal` plus optional member access — identifiers,
member access of either form, private fields — with parentheses and TypeScript's
type-only wrappers (`as`, `satisfies`, `!`, `<T>x`) treated as transparent, since
codegen strips them and the underlying target is what gets assigned. All three v-model
spellings are covered: `v-model={x}`, `v-model_lazy={x}`, and the array form
`v-model={[x, 'arg', ['trim']]}` (whose *first* element is the target — the modifiers
array is deliberately not validated).

A `v-model` with no value at all is left alone: that is a different defect, already
reported by the core transform as "v-model is missing expression.", and a test pins that
the new check neither shadows nor duplicates it.

## How the tests fail before the fix

`crates/vize_atelier_jsx/tests/v_model_target.rs` — verified by restoring
`lower/attr.rs` from `origin/main` and re-running:

```
test call_and_literal_targets_are_rejected ... FAILED
test array_form_validates_only_the_first_element ... FAILED
test object_literal_target_is_rejected ... FAILED
test missing_expression_keeps_its_own_diagnostic ... ok
test assignable_targets_are_accepted ... ok
test result: FAILED. 2 passed; 3 failed
```

with, e.g.:

```
  left: []
 right: ["v-model target `{a:1}` cannot be assigned to; v-model needs a variable or property reference."]
```

The two that pass before the fix are the guard tests — they exist to catch the check
firing too widely, so they must be green in both directions.

## Oracle row flipped

This closes one row of the `@vue/babel-plugin-jsx` differential oracle (#3408).
`errors/v_model_non_lval` moves from `divergent` to `equivalent`, its recorded snapshot
now shows both sides rejecting, and the inventory totals move **63/29/2 → 64/28/2**
(pinned exactly by `babel_compat_verdict_totals`, so the prose cannot drift).

The inventory's runtime-oracle note is also corrected: I searched for the
importmap + Playwright harness (`git log --all -- '*playwright*' '*importmap*'`,
`grep -rn importmap`) and there is none committed — the closest are
`playground/e2e/vrt/vapor-runtime.spec.ts` (a smoke over the playground app, not over
compiled output) and `npm/fresco/src/testing/mount.ts` (an in-process
`@vue/runtime-core` mount). The note now records the cheaper viable path — `happy-dom`
+ `vue`, both already catalog entries, mounting each case's two emitted modules
in-process — instead of pointing at a harness that does not exist.

## File split

`lower/attr.rs` was already 384 lines, over the 350-line budget, so adding to it would
trip `source:lengths` (`OverLimitFileGrew`). The v-model lowering moved to a new
`lower/v_model.rs`: **attr.rs 384 → 293**, v_model.rs 229. No allowlist entry added.

## Gates

```
$ cargo test -p vize_atelier_jsx
29 test targets, all "test result: ok"
$ cargo test -p vize_atelier_jsx --test v_model_target
test result: ok. 5 passed; 0 failed
$ cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
Finished
$ rustfmt --edition 2024 --config style_edition=2024 --check <changed files>
FMT_OK
$ vp run source:lengths
exit 0
$ node --test tests/tooling/babel-jsx-oracle.test.ts
ℹ pass 3   ℹ fail 0
```

Note: `vize_atelier_sfc`'s 8 `snapshot_tests::*` failures in this environment are
`failed to start pkl server: No such file or directory` — the `pkl` binary is not
installed in this shell. Pre-existing and unrelated.
