### PR TITLE
fix(canon): hoist plain-script namespace declarations to module scope

### DIFF
--- a/crates/vize/tests/check_plain_script_namespace_cli.rs
+++ b/crates/vize/tests/check_plain_script_namespace_cli.rs
@@ -1,0 +1,330 @@
+//! `vize check` over plain-`<script>` SFCs that declare a `namespace`.
+//!
+//! Covers #3383: the namespace used to stay inside the generated `__setup()`
+//! function, which TypeScript rejects with TS1235, and the export bridge never
+//! reached it so consumers got TS2614 as well. These cases run the real Corsa
+//! CLI so the diagnostics come from a type checker rather than from string
+//! inspection of the generated module.
+
+use std::{path::Path, process::Command};
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn unique_case_dir(name: &str) -> std::path::PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(format!("{name}-{}-{case_id}", std::process::id()))
+}
+
+/// Mirror the workspace dependencies into a **real** `node_modules` directory.
+///
+/// A `node_modules` that is itself a symlink made the Corsa CLI drop every
+/// diagnostic for the project (fixed in #3374), which silently turned the
+/// `errorCount` assertions below into no-ops — that is how this whole family of
+/// defects stayed hidden. `.vize` is deliberately excluded: that is where vize
+/// writes the project's virtual TypeScript, so linking it out would put the
+/// generated files behind a symlink again and re-hide the diagnostics.
+fn mirror_workspace_node_modules(project_root: &Path) {
+    let source = workspace_root().join("node_modules");
+    let target = project_root.join("node_modules");
+    if target.exists() {
+        return;
+    }
+    std::fs::create_dir_all(&target).unwrap();
+    let Ok(entries) = std::fs::read_dir(&source) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        if entry.file_name() == std::ffi::OsStr::new(".vize") {
+            continue;
+        }
+        let link = target.join(entry.file_name());
+        #[cfg(unix)]
+        let _ = std::os::unix::fs::symlink(entry.path(), &link);
+        #[cfg(windows)]
+        let _ = std::os::windows::fs::symlink_dir(entry.path(), &link);
+    }
+}
+
+fn create_cli_project(name: &str, files: &[(&str, &str)]) -> std::path::PathBuf {
+    let project_root = unique_case_dir(name);
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    mirror_workspace_node_modules(&project_root);
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+
+    for (path, source) in files {
+        let file_path = project_root.join(path);
+        if let Some(parent) = file_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(file_path, source).unwrap();
+    }
+
+    project_root
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    let workspace_root = workspace_root();
+    let sibling_cache = workspace_root.parent()?.join("corsa-bind/.cache/tsgo");
+    if sibling_cache.exists() {
+        return Some(sibling_cache.display().to_string());
+    }
+
+    let workspace_bin = workspace_root.join("node_modules/.bin/tsgo");
+    workspace_bin
+        .exists()
+        .then(|| workspace_bin.display().to_string())
+}
+
+fn run_check_json(project_root: &Path, corsa_path: &str) -> serde_json::Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", ".", "--format", "json"])
+        .output()
+        .unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    serde_json::from_str(stdout).unwrap_or_else(|error| {
+        panic!(
+            "check should print JSON ({error}):\nstdout:\n{stdout}\nstderr:\n{}",
+            std::str::from_utf8(&output.stderr).unwrap()
+        )
+    })
+}
+
+/// Every reported diagnostic line, so a case can assert the complete diagnostic
+/// set instead of probing for one substring.
+fn diagnostics(report: &serde_json::Value) -> Vec<String> {
+    let Some(files) = report["files"].as_array() else {
+        return Vec::new();
+    };
+    files
+        .iter()
+        .flat_map(|file| file["diagnostics"].as_array().cloned().unwrap_or_default())
+        .map(|diagnostic| diagnostic.as_str().unwrap_or_default().to_string())
+        .collect()
+}
+
+#[test]
+fn check_accepts_plain_script_namespaces_used_as_values_and_types() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "namespace-plain-script",
+        &[
+            (
+                "src/components/Namespaces.vue",
+                r#"<script lang="ts">
+const localBase = 10;
+
+namespace Bare {
+  export const label = "bare";
+}
+
+export namespace Config {
+  export type Kind = "wide" | "tall";
+  export const spacing = 4;
+}
+
+export namespace Nest.Inner {
+  export const depth = 2;
+}
+
+export namespace Twice {
+  export const one = 1;
+}
+export namespace Twice {
+  export type Two = string;
+}
+
+export class Cursor {
+  line = 0;
+}
+export namespace Cursor {
+  export type Anchor = number;
+}
+
+export function build() {
+  return localBase;
+}
+export namespace build {
+  export const version = 1;
+}
+
+export const captured = 7;
+export namespace Derived {
+  export const total = captured + localBase;
+}
+
+export default { name: "Namespaces" };
+</script>
+
+<template>
+  <div>{{ Bare.label }} {{ Config.spacing }}</div>
+</template>
+"#,
+            ),
+            (
+                "src/pages/Consumer.vue",
+                r#"<script setup lang="ts">
+import {
+  build,
+  captured,
+  Config,
+  Cursor,
+  Derived,
+  Nest,
+  Twice,
+} from "../components/Namespaces.vue";
+
+// Namespace as a value and as a type container.
+const spacing: number = Config.spacing;
+const kind: Config.Kind = "wide";
+const depth: number = Nest.Inner.depth;
+
+// Both blocks of a merged namespace have to survive the relocation.
+const one: number = Twice.one;
+const two: Twice.Two = "s";
+
+// A namespace merged with a class keeps the class's own meanings.
+const cursor: Cursor = new Cursor();
+const anchor: Cursor.Anchor = cursor.line;
+
+// A namespace merged with a function keeps the call signature.
+const built: number = build();
+const version: number = build.version;
+
+// A namespace body reading a plain-script binding still type-checks.
+const total: number = Derived.total;
+const capturedValue: number = captured;
+</script>
+
+<template>
+  <div>
+    {{ spacing }} {{ kind }} {{ depth }} {{ one }} {{ two }} {{ cursor }}
+    {{ anchor }} {{ built }} {{ version }} {{ total }} {{ capturedValue }}
+  </div>
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let report = run_check_json(&project_root, &corsa_path);
+    assert_eq!(diagnostics(&report), Vec::<String>::new());
+    assert_eq!(report["errorCount"], 0);
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+/// A namespace that was never exported must not gain an export on the way out of
+/// `__setup()`: the relocation is verbatim, so `Bare` stays module-local and the
+/// consumer's import is a real error.
+#[test]
+fn check_reports_an_import_of_an_unexported_plain_script_namespace() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "namespace-plain-script-unexported",
+        &[
+            (
+                "src/components/Local.vue",
+                r#"<script lang="ts">
+namespace Bare {
+  export const label = "bare";
+}
+
+export default { name: "Local", data: () => ({ label: Bare.label }) };
+</script>
+"#,
+            ),
+            (
+                "src/pages/LocalConsumer.vue",
+                r#"<script setup lang="ts">
+import { Bare } from "../components/Local.vue";
+
+const label: string = Bare.label;
+</script>
+
+<template>
+  <div>{{ label }}</div>
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let report = run_check_json(&project_root, &corsa_path);
+    assert_eq!(
+        diagnostics(&report),
+        vec![
+            "error:2:10 [TS2614] Module '\"../components/Local.vue.ts\"' has no exported member 'Bare'. Did you mean to use 'import Bare from \"../components/Local.vue.ts\"' instead?"
+                .to_string()
+        ]
+    );
+    assert_eq!(report["errorCount"], 1);
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+/// The legacy `module` keyword is relocated unchanged rather than rewritten to
+/// `namespace`. TypeScript's TS1540 for it is the authored code's diagnostic, and
+/// its presence also proves the harness above is not passing vacuously on a
+/// project whose diagnostics were dropped.
+#[test]
+fn check_reports_the_legacy_module_keyword_from_a_plain_script() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "namespace-plain-script-legacy-module",
+        &[(
+            "src/components/Legacy.vue",
+            r#"<script lang="ts">
+export module Legacy {
+  export const a = 1;
+}
+
+export default { name: "Legacy" };
+</script>
+"#,
+        )],
+    );
+
+    let report = run_check_json(&project_root, &corsa_path);
+    assert_eq!(
+        diagnostics(&report),
+        vec![
+            "error:2:15 [TS1540] A 'namespace' declaration should not be declared using the 'module' keyword. Please use the 'namespace' keyword instead."
+                .to_string()
+        ]
+    );
+    assert_eq!(report["errorCount"], 1);
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -209,11 +209,20 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         .iter()
         .any(|scope| matches!(scope.kind, ScopeKind::NonScriptSetup))
         || (script_content.is_some() && !has_script_setup);
-    let named_value_exports = self::script_module::collect_normal_script_named_value_exports(
+    let mut named_value_exports = self::script_module::collect_normal_script_named_value_exports(
         script_content,
         has_script_setup,
         has_plain_script_scope,
     );
+    // A `namespace` cannot stay inside `__setup()` (TS1235), so it and any
+    // declaration it merges with move to module scope instead of through the
+    // export bridge.
+    let namespace_hoist = self::script_module::NamespaceHoistPlan::collect(
+        script_content,
+        has_script_setup,
+        has_plain_script_scope,
+    );
+    namespace_hoist.reconcile_exports(&mut named_value_exports);
     let setup_type_exports = SetupTypeExportsPlan::new(summary, script_content);
 
     // Classify the main `<script>` default export in one parse. A plain
@@ -253,6 +262,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         if let Some(script) = script_content {
             module_spans.extend(self::script_module::collect_line_module_spans(script));
         }
+        module_spans.extend(namespace_hoist.spans().iter().copied());
         for re in &summary.re_exports {
             module_spans.push((re.start, re.end));
         }
@@ -294,6 +304,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         FxHashMap::default()
     };
 
+    namespace_hoist.emit_ambient_captures(&mut ts, &named_value_exports);
     if let Some(script) = script_content {
         profile!("canon.virtual_ts.emit_module_statements", {
             // Emit each module-level statement with source mapping
@@ -880,6 +891,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
 
     let mut setup_return_fields: Vec<String> = Vec::new();
     self::script_module::push_setup_return_fields(&named_value_exports, &mut setup_return_fields);
+    namespace_hoist.push_captured_return_fields(&named_value_exports, &mut setup_return_fields);
     setup_type_exports.emit_setup_artifacts(&mut ts, &mut setup_return_fields);
     let mut setup_artifact_return_fields = Vec::new();
     setup_props_plan.push_return_field(&mut setup_artifact_return_fields);
@@ -947,30 +959,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         legacy_vue2,
         dialect,
     );
-    ts.push_str("type __VizeVueComponentOptions = {\n");
-    ts.push_str("  name?: string;\n");
-    ts.push_str("  __name?: string;\n");
-    ts.push_str("  __file?: string;\n");
-    ts.push_str("  __vccOpts?: any;\n");
-    ts.push_str("  props?: any;\n");
-    ts.push_str("  emits?: any;\n");
-    ts.push_str("  slots?: any;\n");
-    ts.push_str("  setup?: any;\n");
-    ts.push_str("  render?: Function;\n");
-    ts.push_str("  components?: any;\n");
-    ts.push_str("  directives?: any;\n");
-    ts.push_str("  inheritAttrs?: boolean;\n");
-    ts.push_str("  compatConfig?: any;\n");
-    ts.push_str("  call?: (this: unknown, ...args: unknown[]) => never;\n");
-    ts.push_str("  __isFragment?: never;\n");
-    ts.push_str("  __isTeleport?: never;\n");
-    ts.push_str("  __isSuspense?: never;\n");
-    ts.push_str("  __defaults?: any;\n");
-    ts.push_str("  __vapor?: boolean;\n");
-    ts.push_str("  __multiRoot?: boolean;\n");
-    ts.push_str("  __isKeepAlive?: boolean;\n");
-    ts.push_str("  __isBuiltIn?: boolean;\n");
-    ts.push_str("};\n");
+    ts.push_str(self::component_export::VUE_COMPONENT_OPTIONS_TYPE);
     emit_default_export_declaration(
         &mut ts,
         &emits_info,

--- a/crates/vize_canon/src/virtual_ts/generator/component_export.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/component_export.rs
@@ -2,6 +2,35 @@ use vize_carton::{String, append};
 
 use super::emits::EmitsInfo;
 
+/// Structural shape of the Vue component options object the SFC's default
+/// export is intersected with, so template/`InstanceType` consumers see the
+/// runtime option keys alongside the constructor.
+pub(super) const VUE_COMPONENT_OPTIONS_TYPE: &str = "type __VizeVueComponentOptions = {
+  name?: string;
+  __name?: string;
+  __file?: string;
+  __vccOpts?: any;
+  props?: any;
+  emits?: any;
+  slots?: any;
+  setup?: any;
+  render?: Function;
+  components?: any;
+  directives?: any;
+  inheritAttrs?: boolean;
+  compatConfig?: any;
+  call?: (this: unknown, ...args: unknown[]) => never;
+  __isFragment?: never;
+  __isTeleport?: never;
+  __isSuspense?: never;
+  __defaults?: any;
+  __vapor?: boolean;
+  __multiRoot?: boolean;
+  __isKeepAlive?: boolean;
+  __isBuiltIn?: boolean;
+};
+";
+
 pub(super) fn emit_default_export_declaration(
     ts: &mut String,
     emits_info: &EmitsInfo,

--- a/crates/vize_canon/src/virtual_ts/generator/script_module.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module.rs
@@ -1,5 +1,6 @@
 //! Module-scope facts collected from normal Vue `<script>` blocks.
 
+mod namespace_hoist;
 mod plain_exports;
 
 use oxc_allocator::Allocator;
@@ -9,6 +10,7 @@ use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
 use vize_carton::{CompactString, FxHashSet, String as VizeString};
 
+pub(super) use namespace_hoist::NamespaceHoistPlan;
 pub(super) use plain_exports::{
     collect_normal_script_named_value_exports, emit_setup_invocation_and_exports,
     push_setup_return_fields,

--- a/crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist.rs
@@ -1,0 +1,264 @@
+//! Lifting plain-`<script>` `namespace` declarations out of `__setup()`.
+//!
+//! The plain-`<script>` body is moved inside `__setup()` so its diagnostics stay
+//! anchored to user code (see [`super::plain_exports`]). A `namespace` cannot
+//! survive that move: TypeScript only accepts one at the top level of a module
+//! or namespace, so a namespace left in the function body raises TS1235, and the
+//! `__setup()` export bridge never reaches it either — a consumer importing the
+//! name gets TS2614. Both are false: the authored `<script>` body *is* module
+//! scope in the real SFC.
+//!
+//! So the declaration is emitted at module scope verbatim. Three consequences
+//! have to be handled for that relocation to type-check:
+//!
+//! 1. **Merging.** A namespace merges with a same-named `function`, `class` or
+//!    `enum`. Leaving that partner behind as `export const C = …` makes the
+//!    module-scope namespace collide with a block-scoped variable (TS2451 /
+//!    TS2300), so the partner declaration is hoisted with the namespace and
+//!    dropped from the export bridge, reproducing the authored merge exactly.
+//! 2. **Capture.** The namespace body may read a binding that stays inside
+//!    `__setup()`. Those names are re-declared at module scope as ambient
+//!    aliases of the setup return (`ReturnType<typeof __setup>["x"]`), which
+//!    keeps the original type without duplicating the initializer.
+//! 3. **Ordering.** The bridge's `export const x = …` is emitted *after* the
+//!    namespace, so a captured name that is also exported cannot rely on it
+//!    (TS2448, used before declaration). For those names the ambient alias
+//!    carries the `export` instead and the bridge skips the value line.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Declaration, IdentifierReference, Statement, TSModuleDeclarationName};
+use oxc_ast_visit::Visit;
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType, Span};
+use vize_carton::{CompactString, FxHashSet, String as VizeString, append};
+
+use super::plain_exports::{PlainScriptExport, collect_declaration_exports};
+
+/// Plain-`<script>` declarations that have to be emitted at module scope so a
+/// `namespace` is not stranded inside `__setup()`.
+#[derive(Debug, Default)]
+pub(crate) struct NamespaceHoistPlan {
+    /// Script-relative spans to emit at module scope verbatim.
+    spans: Vec<(u32, u32)>,
+    /// Names whose own declaration moved to module scope (merge partners). The
+    /// export bridge must not re-declare them.
+    hoisted: FxHashSet<CompactString>,
+    /// `__setup()`-scoped bindings the hoisted bodies read, in source order.
+    captured: Vec<PlainScriptExport>,
+}
+
+impl NamespaceHoistPlan {
+    /// Only a plain `<script>` needs the plan: when a `<script setup>` block is
+    /// present the whole plain block is already emitted at module scope.
+    pub(crate) fn collect(
+        script: Option<&str>,
+        has_script_setup: bool,
+        has_plain_script_scope: bool,
+    ) -> Self {
+        if has_script_setup || !has_plain_script_scope {
+            return Self::default();
+        }
+        script.map(Self::from_script).unwrap_or_default()
+    }
+
+    fn from_script(script: &str) -> Self {
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, script, SourceType::ts().with_module(true)).parse();
+        let parsed = if parsed.panicked {
+            Parser::new(&allocator, script, SourceType::tsx().with_module(true)).parse()
+        } else {
+            parsed
+        };
+        if parsed.panicked {
+            return Self::default();
+        }
+
+        let mut spans = Vec::new();
+        let mut namespace_names = FxHashSet::default();
+        for statement in &parsed.program.body {
+            let Some((declaration, span)) = top_level_declaration(statement) else {
+                continue;
+            };
+            let Declaration::TSModuleDeclaration(module) = declaration else {
+                continue;
+            };
+            // `declare module "pkg"` is an augmentation, not a mergeable name.
+            if let TSModuleDeclarationName::Identifier(id) = &module.id {
+                namespace_names.insert(CompactString::new(id.name.as_str()));
+            }
+            spans.push((span.start, span.end));
+        }
+        if spans.is_empty() {
+            return Self::default();
+        }
+
+        let mut hoisted = FxHashSet::default();
+        for statement in &parsed.program.body {
+            let Some((declaration, span)) = top_level_declaration(statement) else {
+                continue;
+            };
+            let Some(name) = merge_partner_name(declaration) else {
+                continue;
+            };
+            if namespace_names.contains(&name) {
+                spans.push((span.start, span.end));
+                hoisted.insert(name);
+            }
+        }
+
+        let captured = collect_captures(&parsed.program.body, &spans, &hoisted);
+        Self {
+            spans,
+            hoisted,
+            captured,
+        }
+    }
+
+    /// Spans to add to the generator's module-scope span list.
+    pub(crate) fn spans(&self) -> &[(u32, u32)] {
+        &self.spans
+    }
+
+    /// Drops bridge entries whose declaration moved to module scope, and marks
+    /// captured names as declared by [`Self::emit_ambient_captures`] instead.
+    pub(crate) fn reconcile_exports(&self, exports: &mut Vec<PlainScriptExport>) {
+        if self.spans.is_empty() {
+            return;
+        }
+        exports.retain(|export| !self.hoisted.contains(&export.name));
+        for export in exports.iter_mut() {
+            if self.captures(&export.name) {
+                export.bridged_value = false;
+            }
+        }
+    }
+
+    /// Ambient module-scope aliases for the captured setup bindings. Emitted
+    /// before the hoisted declarations so the namespace bodies can read them.
+    pub(crate) fn emit_ambient_captures(&self, ts: &mut VizeString, exports: &[PlainScriptExport]) {
+        if self.captured.is_empty() {
+            return;
+        }
+        ts.push_str("// Setup-scope bindings a hoisted namespace body reads\n");
+        for capture in &self.captured {
+            let name = &capture.name;
+            let exported = exports.iter().any(|export| export.name == *name);
+            let visibility = if exported { "export " } else { "" };
+            append!(
+                *ts,
+                "{visibility}declare const {name}: ReturnType<typeof __setup>[\"{name}\"];\n"
+            );
+            // An exported capture already gets its type side from the bridge;
+            // emitting the alias twice would be a duplicate identifier.
+            if !exported && let Some(body) = capture.kind.type_alias_body(name) {
+                append!(*ts, "type {name} = {body};\n");
+            }
+        }
+        ts.push('\n');
+    }
+
+    /// Captured names must leave `__setup()` through its return object, which is
+    /// what the ambient aliases index into. Exported ones are already there.
+    pub(crate) fn push_captured_return_fields(
+        &self,
+        exports: &[PlainScriptExport],
+        fields: &mut Vec<CompactString>,
+    ) {
+        for capture in &self.captured {
+            if !exports.iter().any(|export| export.name == capture.name) {
+                fields.push(capture.name.clone());
+            }
+        }
+    }
+
+    fn captures(&self, name: &CompactString) -> bool {
+        self.captured.iter().any(|capture| capture.name == *name)
+    }
+}
+
+/// The declaration a top-level statement introduces, plus the span that has to
+/// move as a unit — the `export` keyword included, so the relocated namespace
+/// keeps exporting itself.
+fn top_level_declaration<'a>(statement: &'a Statement<'a>) -> Option<(&'a Declaration<'a>, Span)> {
+    match statement {
+        Statement::ExportNamedDeclaration(export) => {
+            if export.source.is_some() || export.export_kind.is_type() {
+                return None;
+            }
+            Some((export.declaration.as_ref()?, export.span))
+        }
+        statement => statement
+            .as_declaration()
+            .map(|declaration| (declaration, statement.span())),
+    }
+}
+
+/// The name a namespace can merge with. `const`/`let` are absent on purpose:
+/// TypeScript does not merge a namespace into a variable, so hoisting one would
+/// not repair the collision.
+fn merge_partner_name(declaration: &Declaration<'_>) -> Option<CompactString> {
+    let name = match declaration {
+        Declaration::FunctionDeclaration(function) => function.id.as_ref()?.name.as_str(),
+        Declaration::ClassDeclaration(class) => class.id.as_ref()?.name.as_str(),
+        Declaration::TSEnumDeclaration(enumeration) => enumeration.id.name.as_str(),
+        _ => return None,
+    };
+    Some(CompactString::new(name))
+}
+
+/// Setup-scope value bindings referenced from inside the hoisted spans.
+///
+/// Type aliases and interfaces are excluded because the generator already emits
+/// those at module scope, so a hoisted body resolves them without help.
+fn collect_captures(
+    body: &[Statement<'_>],
+    spans: &[(u32, u32)],
+    hoisted: &FxHashSet<CompactString>,
+) -> Vec<PlainScriptExport> {
+    let is_hoisted = |span: Span| {
+        spans
+            .iter()
+            .any(|&(start, end)| span.start >= start && span.end <= end)
+    };
+
+    let mut references = ReferencedNames::default();
+    let mut seen = FxHashSet::default();
+    let mut setup_bindings = Vec::new();
+    for statement in body {
+        let Some((declaration, span)) = top_level_declaration(statement) else {
+            continue;
+        };
+        if is_hoisted(span) {
+            references.visit_statement(statement);
+            continue;
+        }
+        if merge_partner_name(declaration).is_some_and(|name| hoisted.contains(&name)) {
+            continue;
+        }
+        collect_declaration_exports(declaration, &mut seen, &mut setup_bindings);
+    }
+
+    setup_bindings
+        .into_iter()
+        .filter(|binding| references.names.contains(&binding.name))
+        .collect()
+}
+
+/// Every identifier read inside a subtree, value and type positions alike:
+/// `typeof x` in a namespace body needs the same module-scope alias that `x + 1`
+/// does. Member property names are `IdentifierName`, so `obj.total` never
+/// reports `total`.
+#[derive(Default)]
+struct ReferencedNames {
+    names: FxHashSet<CompactString>,
+}
+
+impl<'a> Visit<'a> for ReferencedNames {
+    fn visit_identifier_reference(&mut self, reference: &IdentifierReference<'a>) {
+        self.names
+            .insert(CompactString::new(reference.name.as_str()));
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist/tests.rs
@@ -1,0 +1,156 @@
+use super::super::plain_exports::{PlainScriptExport, PlainScriptExportKind};
+use super::NamespaceHoistPlan;
+use vize_carton::{CompactString, String as VizeString};
+
+fn plan(script: &str) -> NamespaceHoistPlan {
+    NamespaceHoistPlan::collect(Some(script), false, true)
+}
+
+fn hoisted_text(script: &str) -> Vec<&str> {
+    plan(script)
+        .spans()
+        .iter()
+        .map(|&(start, end)| &script[start as usize..end as usize])
+        .collect()
+}
+
+fn export(name: &str, kind: PlainScriptExportKind) -> PlainScriptExport {
+    PlainScriptExport {
+        name: CompactString::new(name),
+        kind,
+        bridged_value: true,
+    }
+}
+
+#[test]
+fn every_namespace_form_is_hoisted_with_its_export_keyword() {
+    let script = "namespace Bare {\n  export const a = 1;\n}\nexport namespace Named {\n  export const b = 2;\n}\nexport module Legacy {\n  export const c = 3;\n}\nexport namespace A.B.C {\n  export const d = 4;\n}\ndeclare namespace Ambient {\n  const e: number;\n}\n";
+
+    assert_eq!(
+        hoisted_text(script),
+        vec![
+            "namespace Bare {\n  export const a = 1;\n}",
+            "export namespace Named {\n  export const b = 2;\n}",
+            "export module Legacy {\n  export const c = 3;\n}",
+            "export namespace A.B.C {\n  export const d = 4;\n}",
+            "declare namespace Ambient {\n  const e: number;\n}",
+        ]
+    );
+}
+
+#[test]
+fn a_script_without_namespaces_hoists_nothing() {
+    let script = "export const a = 1;\nexport class C {}\nexport enum E { A }\n";
+
+    assert_eq!(hoisted_text(script), Vec::<&str>::new());
+}
+
+#[test]
+fn a_merge_partner_is_hoisted_and_dropped_from_the_export_bridge() {
+    let script = "export function f() {}\nexport namespace f {\n  export const v = 1;\n}\nexport const other = 2;\n";
+
+    assert_eq!(
+        hoisted_text(script),
+        vec![
+            "export namespace f {\n  export const v = 1;\n}",
+            "export function f() {}",
+        ]
+    );
+
+    let mut exports = vec![
+        export("f", PlainScriptExportKind::Value),
+        export("other", PlainScriptExportKind::Value),
+    ];
+    plan(script).reconcile_exports(&mut exports);
+    assert_eq!(exports, vec![export("other", PlainScriptExportKind::Value)]);
+}
+
+#[test]
+fn a_same_named_variable_is_not_treated_as_a_merge_partner() {
+    // TypeScript does not merge a namespace into a `const`, so hoisting the
+    // variable would relocate user code without repairing anything.
+    let script = "const N = 1;\nnamespace N {\n  export type T = number;\n}\n";
+
+    assert_eq!(
+        hoisted_text(script),
+        vec!["namespace N {\n  export type T = number;\n}"]
+    );
+}
+
+#[test]
+fn captured_setup_bindings_become_ambient_aliases_of_the_setup_return() {
+    let script = "const localBase = 10;\nclass Local {}\nexport const shared = 2;\nconst unused = 3;\nexport namespace Uses {\n  export const derived = localBase + shared;\n  export const made: Local = new Local();\n}\n";
+
+    let plan = plan(script);
+    let mut exports = vec![export("shared", PlainScriptExportKind::Value)];
+    plan.reconcile_exports(&mut exports);
+    assert_eq!(
+        exports,
+        vec![PlainScriptExport {
+            name: CompactString::new("shared"),
+            kind: PlainScriptExportKind::Value,
+            bridged_value: false,
+        }]
+    );
+
+    let mut ts = VizeString::default();
+    plan.emit_ambient_captures(&mut ts, &exports);
+    assert_eq!(
+        ts.as_str(),
+        "// Setup-scope bindings a hoisted namespace body reads\n\
+         declare const localBase: ReturnType<typeof __setup>[\"localBase\"];\n\
+         declare const Local: ReturnType<typeof __setup>[\"Local\"];\n\
+         type Local = InstanceType<typeof Local>;\n\
+         export declare const shared: ReturnType<typeof __setup>[\"shared\"];\n\
+         \n"
+    );
+
+    let mut fields = Vec::new();
+    plan.push_captured_return_fields(&exports, &mut fields);
+    assert_eq!(
+        fields,
+        vec![CompactString::new("localBase"), CompactString::new("Local")]
+    );
+}
+
+#[test]
+fn a_member_property_matching_a_setup_binding_is_not_captured() {
+    let script = "const total = 1;\nconst counts = { total: 2 };\nnamespace Sums {\n  export const value = counts.total;\n}\n";
+
+    let plan = plan(script);
+    let mut ts = VizeString::default();
+    plan.emit_ambient_captures(&mut ts, &[]);
+    assert_eq!(
+        ts.as_str(),
+        "// Setup-scope bindings a hoisted namespace body reads\n\
+         declare const counts: ReturnType<typeof __setup>[\"counts\"];\n\
+         \n"
+    );
+}
+
+#[test]
+fn a_merge_partner_body_capture_is_aliased_too() {
+    let script = "const seed = 1;\nexport function build() {\n  return seed;\n}\nexport namespace build {\n  export const v = 2;\n}\n";
+
+    let plan = plan(script);
+    let mut ts = VizeString::default();
+    plan.emit_ambient_captures(&mut ts, &[]);
+    assert_eq!(
+        ts.as_str(),
+        "// Setup-scope bindings a hoisted namespace body reads\n\
+         declare const seed: ReturnType<typeof __setup>[\"seed\"];\n\
+         \n"
+    );
+}
+
+#[test]
+fn a_script_setup_block_keeps_the_plan_empty() {
+    let script = "export namespace N {\n  export const a = 1;\n}\n";
+
+    let plan = NamespaceHoistPlan::collect(Some(script), true, true);
+    assert_eq!(plan.spans(), &[] as &[(u32, u32)]);
+
+    let mut ts = VizeString::default();
+    plan.emit_ambient_captures(&mut ts, &[]);
+    assert_eq!(ts.as_str(), "");
+}

--- a/crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports.rs
@@ -38,7 +38,7 @@ pub(crate) enum PlainScriptExportKind {
 
 impl PlainScriptExportKind {
     /// The type-side alias body, or `None` when the declaration is value-only.
-    fn type_alias_body(self, name: &str) -> Option<VizeString> {
+    pub(super) fn type_alias_body(self, name: &str) -> Option<VizeString> {
         match self {
             Self::Value => None,
             Self::Enum => Some(vize_carton::cstr!("(typeof {name})[keyof typeof {name}]")),
@@ -52,6 +52,11 @@ impl PlainScriptExportKind {
 pub(crate) struct PlainScriptExport {
     pub(crate) name: CompactString,
     pub(crate) kind: PlainScriptExportKind,
+    /// Whether the bridge declares the value side. Cleared for a name a hoisted
+    /// namespace body captures: that name is declared earlier at module scope as
+    /// an ambient alias instead (see `super::namespace_hoist`), and declaring it
+    /// twice would be a duplicate identifier.
+    pub(crate) bridged_value: bool,
 }
 
 pub(crate) fn collect_normal_script_named_value_exports(
@@ -76,18 +81,21 @@ pub(crate) fn emit_setup_invocation_and_exports(
     ts: &mut VizeString,
     exports: &[PlainScriptExport],
 ) {
-    if exports.is_empty() {
-        ts.push_str("__setup();\n\n");
-        return;
+    if exports.iter().any(|export| export.bridged_value) {
+        ts.push_str("const __vize_plain_script_exports = __setup();\n");
+    } else {
+        // Nothing left to read off the return object; binding it would only add
+        // an unused module-scope const.
+        ts.push_str("__setup();\n");
     }
-
-    ts.push_str("const __vize_plain_script_exports = __setup();\n");
     for export in exports {
         let name = &export.name;
-        append!(
-            *ts,
-            "export const {name} = __vize_plain_script_exports.{name};\n"
-        );
+        if export.bridged_value {
+            append!(
+                *ts,
+                "export const {name} = __vize_plain_script_exports.{name};\n"
+            );
+        }
         // A value+type declaration loses its type meaning when the bridge only
         // re-exports the value. The alias restores it in the type space, which
         // is disjoint from the `const` above, so both names can coexist.
@@ -135,7 +143,7 @@ fn collect_statement_exports(
     collect_declaration_exports(declaration, seen, exports);
 }
 
-fn collect_declaration_exports(
+pub(super) fn collect_declaration_exports(
     declaration: &Declaration<'_>,
     seen: &mut FxHashSet<CompactString>,
     exports: &mut Vec<PlainScriptExport>,
@@ -227,7 +235,11 @@ fn push_export(
     // twice; a second `export const`/`export type` pair would be a duplicate
     // binding, so only the first occurrence is bridged.
     if seen.insert(name.clone()) {
-        exports.push(PlainScriptExport { name, kind });
+        exports.push(PlainScriptExport {
+            name,
+            kind,
+            bridged_value: true,
+        });
     }
 }
 
@@ -242,6 +254,7 @@ mod tests {
         PlainScriptExport {
             name: CompactString::new(name),
             kind,
+            bridged_value: true,
         }
     }
 

--- a/crates/vize_canon/tests/plain_script_namespace_hoisting.rs
+++ b/crates/vize_canon/tests/plain_script_namespace_hoisting.rs
@@ -1,0 +1,236 @@
+//! A `namespace` in a plain (non-setup) `<script>` has to reach module scope.
+//!
+//! The plain-`<script>` body is moved inside `__setup()` so its diagnostics stay
+//! anchored to user code, but TypeScript only accepts a namespace at the top
+//! level of a module or namespace. Leaving one in the function body raised TS1235
+//! and the export bridge never reached it, so a consumer also got TS2614 — both
+//! false, because the authored `<script>` body *is* module scope. See #3383.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use vize_canon::VirtualProject;
+
+const MODULE_HEADER: &str = "// ========== Module Scope (imports) ==========\n";
+const SETUP_HEADER: &str = "// ========== Setup Scope ==========";
+const BRIDGE_HEADER: &str = "// Invoke setup to verify types\n";
+const BRIDGE_END: &str = "export type Emits =";
+/// Emitted by the generator ahead of every module statement in these fixtures,
+/// because each one has an object-literal `export default`.
+const DEFINE_COMPONENT_HELPER: &str =
+    "declare const __vizeDefineComponent: typeof import('vue').defineComponent;\n";
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("vize-tests")
+        .join("tests")
+        .join(format!("{name}-{}-{case_id}", std::process::id()))
+}
+
+/// The generated module for `vue_content`, as `(module scope, export bridge)`.
+///
+/// Both slices are delimited by generator section headers, so each assertion
+/// below compares a *complete* region rather than searching for a fragment.
+fn generated_sections(name: &str, vue_content: &str) -> (String, String) {
+    let case_dir = unique_case_dir(name);
+    let _ = fs::remove_dir_all(&case_dir);
+    let src_dir = case_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    let vue_path = src_dir.join("Namespaces.vue");
+    fs::write(&vue_path, vue_content).unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_vue_file(&vue_path, vue_content).unwrap();
+    let content = project
+        .find_by_original(&vue_path)
+        .unwrap()
+        .content
+        .as_str()
+        .to_string();
+    let _ = fs::remove_dir_all(&case_dir);
+
+    let module_start = content.find(MODULE_HEADER).expect("module scope header")
+        + MODULE_HEADER.len()
+        + DEFINE_COMPONENT_HELPER.len();
+    let module_end = content.find(SETUP_HEADER).expect("setup scope header");
+    let bridge_start = content.find(BRIDGE_HEADER).expect("bridge header") + BRIDGE_HEADER.len();
+    let bridge_end = content.find(BRIDGE_END).expect("emits type");
+    assert!(
+        content[MODULE_HEADER.len()..].contains(DEFINE_COMPONENT_HELPER),
+        "fixture should emit the defineComponent helper:\n{content}"
+    );
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed = oxc_parser::Parser::new(&allocator, &content, oxc_span::SourceType::ts()).parse();
+    assert!(
+        parsed.errors.is_empty(),
+        "virtual TS should parse without errors: {:?}",
+        parsed.errors
+    );
+
+    (
+        content[module_start..module_end].to_string(),
+        content[bridge_start..bridge_end].to_string(),
+    )
+}
+
+#[test]
+fn every_namespace_keyword_form_reaches_module_scope() {
+    let (module, bridge) = generated_sections(
+        "plain-script-namespace-forms",
+        r#"<script lang="ts">
+namespace Bare {
+  export const a = 1;
+}
+export namespace Named {
+  export type T = string;
+  export const b = 2;
+}
+export namespace A.B.C {
+  export const d = 4;
+}
+declare namespace Ambient {
+  const e: number;
+}
+export default { name: "Namespaces" };
+</script>
+"#,
+    );
+
+    // Verbatim relocation: the `export` keyword travels with the declaration, so
+    // an exported namespace stays exported and `Bare` stays module-local.
+    assert_eq!(
+        module,
+        "namespace Bare {\n  export const a = 1;\n}\nexport namespace Named {\n  export type T = string;\n  export const b = 2;\n}\nexport namespace A.B.C {\n  export const d = 4;\n}\ndeclare namespace Ambient {\n  const e: number;\n}\n\n// ========== Exported Types ==========\nexport type Props = {};\n\n"
+    );
+    // No value crossed the setup boundary, so the bridge stays a bare call.
+    assert_eq!(bridge, "__setup();\n\n");
+}
+
+#[test]
+fn the_legacy_module_keyword_form_reaches_module_scope() {
+    let (module, bridge) = generated_sections(
+        "plain-script-namespace-legacy-module",
+        r#"<script lang="ts">
+export module Legacy {
+  export const a = 1;
+}
+export default { name: "Namespaces" };
+</script>
+"#,
+    );
+
+    // `module` is relocated unchanged rather than rewritten to `namespace`: TS
+    // reports TS1540 on the keyword, and that diagnostic is the authored code's,
+    // not vize's to hide.
+    assert_eq!(
+        module,
+        "export module Legacy {\n  export const a = 1;\n}\n\n// ========== Exported Types ==========\nexport type Props = {};\n\n"
+    );
+    assert_eq!(bridge, "__setup();\n\n");
+}
+
+#[test]
+fn same_named_namespace_blocks_are_relocated_separately() {
+    let (module, bridge) = generated_sections(
+        "plain-script-namespace-merged-blocks",
+        r#"<script lang="ts">
+export namespace Twice {
+  export const one = 1;
+}
+export namespace Twice {
+  export type Two = string;
+}
+export default { name: "Namespaces" };
+</script>
+"#,
+    );
+
+    // Two blocks merge in TypeScript, so both have to arrive at module scope;
+    // collapsing them to one would drop half of the namespace.
+    assert_eq!(
+        module,
+        "export namespace Twice {\n  export const one = 1;\n}\nexport namespace Twice {\n  export type Two = string;\n}\n\n// ========== Exported Types ==========\nexport type Props = {};\n\n"
+    );
+    assert_eq!(bridge, "__setup();\n\n");
+}
+
+#[test]
+fn a_merge_partner_declaration_travels_with_the_namespace() {
+    let (module, bridge) = generated_sections(
+        "plain-script-namespace-merge-partners",
+        r#"<script lang="ts">
+export class C {
+  x = 1;
+}
+export namespace C {
+  export type T = number;
+}
+export function f() {
+  return 1;
+}
+export namespace f {
+  export const v = 1;
+}
+export enum E {
+  A = "a",
+}
+export namespace E {
+  export const label = "e";
+}
+export const untouched = 3;
+export default { name: "Namespaces" };
+</script>
+"#,
+    );
+
+    // A namespace merges with a same-named class/function/enum. Bridging the
+    // partner as `export const C = …` would make the module-scope namespace
+    // collide with a block-scoped variable (TS2451/TS2300), so the partner is
+    // relocated too and the merge is reproduced as authored.
+    assert_eq!(
+        module,
+        "export class C {\n  x = 1;\n}\nexport namespace C {\n  export type T = number;\n}\nexport function f() {\n  return 1;\n}\nexport namespace f {\n  export const v = 1;\n}\nexport enum E {\n  A = \"a\",\n}\nexport namespace E {\n  export const label = \"e\";\n}\n\n// ========== Exported Types ==========\nexport type Props = {};\n\n"
+    );
+    // Only the declaration with no namespace to merge into still needs the
+    // bridge, and it keeps the value-only shape #3382 established.
+    assert_eq!(
+        bridge,
+        "const __vize_plain_script_exports = __setup();\nexport const untouched = __vize_plain_script_exports.untouched;\n\n"
+    );
+}
+
+#[test]
+fn captured_setup_bindings_are_re_declared_before_the_namespace() {
+    let (module, bridge) = generated_sections(
+        "plain-script-namespace-captures",
+        r#"<script lang="ts">
+const localBase = 10;
+class Local {
+  id = 1;
+}
+export const shared = 2;
+export namespace Uses {
+  export const derived = localBase + shared;
+  export const made: Local = new Local();
+}
+export default { name: "Namespaces" };
+</script>
+"#,
+    );
+
+    // The namespace body reads bindings that stay inside `__setup()`. They are
+    // re-declared at module scope as ambient aliases of the setup return, which
+    // keeps the authored type without duplicating the initializer. `shared` is
+    // also a plain-script export, and the bridge's `export const shared = …`
+    // lands *after* the namespace (TS2448), so the alias carries the `export`.
+    assert_eq!(
+        module,
+        "// Setup-scope bindings a hoisted namespace body reads\ndeclare const localBase: ReturnType<typeof __setup>[\"localBase\"];\ndeclare const Local: ReturnType<typeof __setup>[\"Local\"];\ntype Local = InstanceType<typeof Local>;\nexport declare const shared: ReturnType<typeof __setup>[\"shared\"];\n\nexport namespace Uses {\n  export const derived = localBase + shared;\n  export const made: Local = new Local();\n}\n\n// ========== Exported Types ==========\nexport type Props = {};\n\n"
+    );
+    // `shared` keeps only its type-space obligations here; its value side is the
+    // ambient alias above, so the bridge must not declare the name twice.
+    assert_eq!(bridge, "__setup();\n\n");
+}


### PR DESCRIPTION
A `namespace` declared in a plain (non-`setup`) `<script>` was never lifted out of the generated `__setup()` function, so it produced a pair of diagnostics that the authored source does not deserve.

Closes #3383.

## Reproduction

`src/components/Namespaces.vue`

```vue
<script lang="ts">
export namespace Config {
  export type Kind = "wide" | "tall";
  export const spacing = 4;
}

export default { name: "Namespaces" };
</script>
```

`src/pages/Consumer.vue`

```vue
<script setup lang="ts">
import { Config } from "../components/Namespaces.vue";

const spacing: number = Config.spacing;
const kind: Config.Kind = "wide";
</script>
```

## Expected vs actual

`tsc`/`vue-tsc` accept both files: the plain `<script>` body *is* module scope in a real SFC, so the namespace is legal and exported.

Before this change `vize check` reported, on `origin/main`:

```
error:8:1 [TS1235] A namespace declaration is only allowed at the top level of a namespace or module.
error:5:3 [TS2614] Module ... has no exported member 'Config'. ...
```

Both are false. The plain-`<script>` body is moved *inside* `__setup()` so diagnostics stay anchored to user code, and a module-scope bridge re-exports what it declares (#3382). A `namespace` cannot survive that move — TypeScript only accepts one at the top level of a module or namespace — and the bridge never collected it either, so consumers saw TS2614 on top of TS1235.

## The fix

Namespace declarations (`namespace`, `module`, `declare namespace`, nested `A.B.C`, exported or not) are emitted at module scope verbatim. A bare `namespace N {}` already was; an `export namespace N {}` was not, because the module-span collector only matched a re-exporting `export … from`. Relocation then needs three further things to actually type-check, each verified against `tsgo` (`@typescript/native-preview`) on hand-written equivalents before being implemented:

- **Merging.** A namespace merges with a same-named `function`/`class`/`enum`. Leaving that partner behind as `export const C = __vize_plain_script_exports.C` makes the module-scope namespace collide with a block-scoped variable — `tsgo` reports TS2451/TS2300 for exactly that shape. The partner declaration is relocated with the namespace and dropped from the bridge, so the authored merge is reproduced as written. A same-named `const` is deliberately *not* treated as a partner: TypeScript does not merge a namespace into a variable, so moving it would relocate user code without repairing anything.
- **Capture.** A namespace body may read a binding that stays inside `__setup()`. Those names are re-declared at module scope as ambient aliases of the setup return — `declare const x: ReturnType<typeof __setup>["x"];` — and added to the setup return object. Value+type kinds (`class`, `enum`) get the matching type alias too, on the same rule #3382 established.
- **Ordering.** The bridge line lands *after* the namespace, so a captured name that is also a plain-script export would be used before its declaration (TS2448, confirmed with `tsgo`). For those names the ambient alias carries the `export` and the bridge skips the value line, leaving exactly one declaration.

The legacy `module` keyword is relocated unchanged rather than rewritten to `namespace`, so TypeScript's TS1540 for it stays the authored code's diagnostic rather than something vize silently launders.

## Tests

`crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist/tests.rs` (8 unit tests) and two new regression files:

- `crates/vize_canon/tests/plain_script_namespace_hoisting.rs` — `assert_eq!` on the **complete** module-scope region and the **complete** export-bridge region of the emitted virtual TS, for: every keyword form (bare / `export` / nested / `declare`), the legacy `module` form, two same-named blocks merging with each other, class+function+enum merge partners, and the closure case.
- `crates/vize/tests/check_plain_script_namespace_cli.rs` — runs the real Corsa CLI and asserts the **complete** diagnostic list: all of the above used as values *and* as types from a consumer SFC reports nothing; an unexported namespace still yields a real TS2614 on import (it must not leak an export); the legacy `module` keyword yields exactly TS1540.

Its fixture mirrors `node_modules` entry by entry and excludes `node_modules/.vize`, per the trap called out in #3383 — a symlinked `node_modules` made the Corsa CLI drop every diagnostic (#3374) and is how this family stayed hidden.

## Pre-fix failure evidence

With the two new test files applied to unmodified `origin/main` source:

- `cargo test -p vize_canon --test plain_script_namespace_hoisting` → **5 failed, 0 passed**; e.g. `every_namespace_keyword_form_reaches_module_scope` emitted only `namespace Bare` and `declare namespace Ambient` at module scope, with `export namespace Named` and `export namespace A.B.C` missing.
- `cargo test -p vize --test check_plain_script_namespace_cli` → **2 failed, 1 passed**. The main case reported 12 errors — 7× TS1235, 4× TS2614, 1× TS2702 — against the expected empty list, and the legacy-`module` case reported TS1235 instead of TS1540. The unexported-namespace case passes both before and after; it is the guard that relocation stays verbatim and does not invent an export.

## Gates

`cargo test -p vize_canon` (652 lib + all integration), `cargo test -p vize`, `cargo test -p vize_maestro` (570), `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`, `cargo check --workspace`, toolchain `rustfmt --edition 2024 --config style_edition=2024 --check`, and `source_file_lengths --check --base-ref origin/main` — all clean. `generator.rs` went 984 → 973 lines: the `__VizeVueComponentOptions` literal moved to a `const` in `component_export.rs` so the over-limit file does not grow.