### PR TITLE
test(canon): pin the upstream vue-benchmarks license in the provenance records

### DIFF
--- a/bench/vue-benchmarks-replay.mjs
+++ b/bench/vue-benchmarks-replay.mjs
@@ -30,6 +30,7 @@ export const UPSTREAM = {
   repository: "pikax/vue-benchmarks",
   url: "https://github.com/pikax/vue-benchmarks",
   commit: "02c0dac76075924bfb8e9b6985e51a9795ff6909",
+  license: "MIT",
 };
 
 /**

--- a/tests/snapshots/check/vue-benchmarks-correctness-plants.ts
+++ b/tests/snapshots/check/vue-benchmarks-correctness-plants.ts
@@ -14,9 +14,17 @@ import {
   type VizeCheckResult,
 } from "../../_helpers/realworld-typecheck.ts";
 
+// #3283 asks for "minimal MIT-licensed typecheck plants". The plant sources
+// below are written here rather than copied, but the gate classes and the
+// confirmation methodology come from pikax/vue-benchmarks, which is
+// MIT-licensed (https://github.com/pikax/vue-benchmarks/blob/main/LICENSE), so
+// the attribution is recorded as data and asserted rather than left in a
+// comment that can rot.
 const upstream = {
   commit: "02c0dac76075924bfb8e9b6985e51a9795ff6909",
+  license: "MIT",
   repository: "pikax/vue-benchmarks",
+  url: "https://github.com/pikax/vue-benchmarks",
 };
 
 const tsconfig = {
@@ -200,8 +208,12 @@ test("vue-benchmarks correctness plants fail closed on current main", async (t) 
   }
 
   await t.test("upstream provenance stays pinned", () => {
-    assert.equal(upstream.repository, "pikax/vue-benchmarks");
-    assert.match(upstream.commit, /^[0-9a-f]{40}$/);
+    assert.deepEqual(upstream, {
+      commit: "02c0dac76075924bfb8e9b6985e51a9795ff6909",
+      license: "MIT",
+      repository: "pikax/vue-benchmarks",
+      url: "https://github.com/pikax/vue-benchmarks",
+    });
   });
 });
 

--- a/tests/snapshots/check/vue-benchmarks-scaled-corpus-plants.ts
+++ b/tests/snapshots/check/vue-benchmarks-scaled-corpus-plants.ts
@@ -19,9 +19,13 @@ import {
 // proves the same four classes are still caught inside a full unique-content
 // corpus checked under one timed-style tsconfig, so `vize check` cannot
 // degrade, sample, or bail at scale without failing an exact assertion.
+// Gate classes and confirmation methodology from the MIT-licensed
+// pikax/vue-benchmarks; see vue-benchmarks-correctness-plants.ts.
 const upstream = {
   commit: "02c0dac76075924bfb8e9b6985e51a9795ff6909",
+  license: "MIT",
   repository: "pikax/vue-benchmarks",
+  url: "https://github.com/pikax/vue-benchmarks",
 };
 
 // One plant per upstream gate class, spread across the corpus (first file,
@@ -242,8 +246,12 @@ test("vue-benchmarks plants stay caught across the scaled unique corpus", async 
     });
 
     await t.test("upstream provenance stays pinned", () => {
-      assert.equal(upstream.repository, "pikax/vue-benchmarks");
-      assert.match(upstream.commit, /^[0-9a-f]{40}$/);
+      assert.deepEqual(upstream, {
+        commit: "02c0dac76075924bfb8e9b6985e51a9795ff6909",
+        license: "MIT",
+        repository: "pikax/vue-benchmarks",
+        url: "https://github.com/pikax/vue-benchmarks",
+      });
     });
   } finally {
     fs.rmSync(workspaceDir, { recursive: true, force: true });

--- a/tests/tooling/vue-benchmarks-replay.test.ts
+++ b/tests/tooling/vue-benchmarks-replay.test.ts
@@ -62,8 +62,12 @@ test("replay expectation drift fails closed in both directions", () => {
 });
 
 test("replay expectation tables stay pinned to the upstream corpus", () => {
-  assert.equal(UPSTREAM.repository, "pikax/vue-benchmarks");
-  assert.match(UPSTREAM.commit, /^[0-9a-f]{40}$/);
+  assert.deepEqual(UPSTREAM, {
+    repository: "pikax/vue-benchmarks",
+    url: "https://github.com/pikax/vue-benchmarks",
+    commit: "02c0dac76075924bfb8e9b6985e51a9795ff6909",
+    license: "MIT",
+  });
 
   const tables = ["main", "release"].map((lane) => {
     const tablePath = path.join(root, `bench/vue-benchmarks-replay-expect-${lane}.json`);


### PR DESCRIPTION
## Why

#3283's first checklist item asks for "minimal **MIT-licensed** typecheck plants". `bench/vue-benchmarks-replay.mjs` and `bench/check-gate-plants.mjs` each say "MIT-licensed pikax/vue-benchmarks" in a header comment, but none of the three machine-readable provenance records carried the license. So the claim was unverified, and nothing in the repo would notice if the upstream relicensed.

Confirmed against the GitHub license API that `pikax/vue-benchmarks` is MIT (`"spdx_id": "MIT"`, `"name": "MIT License"`).

The plant sources themselves are written in this repo rather than copied from upstream; what is adopted is the **set of gate classes and the confirmation methodology**. That distinction, and the attribution, are now recorded next to the pinned commit instead of living in a comment that can rot.

## Change

`license: "MIT"` and the upstream `url` are added to all three provenance records:

- `tests/snapshots/check/vue-benchmarks-correctness-plants.ts`
- `tests/snapshots/check/vue-benchmarks-scaled-corpus-plants.ts`
- `bench/vue-benchmarks-replay.mjs` (`UPSTREAM`)

## Assertion tightening

All three "upstream provenance stays pinned" checks used:

```ts
assert.equal(upstream.repository, "pikax/vue-benchmarks");
assert.match(upstream.commit, /^[0-9a-f]{40}$/);
```

A regex over a known string cannot notice a dropped or added field — which is exactly how the license went unrecorded while three separate tests claimed to pin the provenance. They now `assert.deepEqual` the complete record, so any future field change has to be deliberate.

**Fails before the fix:** the `deepEqual` rejects the pre-change record, which has neither `license` nor `url`.

## Verification

```sh
VIZE_TEST_REQUIRE_TSGO=1 VIZE_TEST_BIN=<vize> VIZE_LSP_BIN=<vize> \
  nix develop -c node --test \
    tests/snapshots/check/vue-benchmarks-correctness-plants.ts \
    tests/snapshots/check/vue-benchmarks-scaled-corpus-plants.ts \
    tests/snapshots/check/vue-benchmarks-lsp-ref-unwrap-oracle.ts
# 15 pass / 0 fail

nix develop -c node --test tests/tooling/vue-benchmarks-replay.test.ts
# 3 pass / 0 fail

nix develop -c vp run fmt:check   # exit 0
nix develop -c vp run check:js    # exit 0
```

No Rust changed.

Refs #3283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the upstream repository’s MIT license to the recorded benchmark metadata.

* **Tests**
  * Updated benchmark validation to verify all pinned upstream metadata, including repository, URL, commit, and license.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->