### PR TITLE
perf(maestro): abandon superseded importer diagnostics passes

### DIFF
--- a/crates/vize_maestro/src/document/store.rs
+++ b/crates/vize_maestro/src/document/store.rs
@@ -169,6 +169,15 @@ impl DocumentStore {
         self.documents.get(uri).map(|document| document.text())
     }
 
+    /// Owned snapshot of a document's version, holding no lock on return.
+    ///
+    /// Same lock discipline as [`Self::text`]: this is the version comparison a
+    /// diagnostics pass makes between its `.await` points to notice that a newer
+    /// `didChange` has superseded it, so it must not leave a shard guard behind.
+    pub fn version(&self, uri: &Url) -> Option<i32> {
+        self.documents.get(uri).map(|document| document.version)
+    }
+
     /// Apply changes to a document.
     pub fn apply_changes(
         &self,

--- a/crates/vize_maestro/src/server/helpers.rs
+++ b/crates/vize_maestro/src/server/helpers.rs
@@ -14,20 +14,59 @@ use crate::ide::DiagnosticService;
 use super::MaestroServer;
 use vize_carton::append;
 
+#[cfg(test)]
+mod supersession_tests;
+
 impl MaestroServer {
     /// Publish the changed document first, then refresh open Vue files that
     /// directly import it. Corsa has already received the changed virtual
     /// document by this point, so importer diagnostics observe the new shape.
     pub(crate) async fn publish_changed_diagnostics(&self, uri: &Url, content: &str) {
         self.state.update_virtual_docs(uri, content);
+        let version = self.state.documents.version(uri);
         self.publish_diagnostics(uri).await;
         if !self.state.is_lsp_typecheck_enabled() {
             return;
         }
 
+        let Some(version) = version else {
+            return;
+        };
+        self.publish_importer_diagnostics(uri, version).await;
+    }
+
+    /// Refresh the open Vue documents that import `uri`, abandoning the fan-out
+    /// as soon as a newer version of `uri` lands. Returns the importers actually
+    /// refreshed, in order, so the supersession rule is directly assertable.
+    ///
+    /// Supersession matters because this loop is the only unbounded work a
+    /// single keystroke schedules: each importer costs a full Corsa diagnostics
+    /// pass, and a `.d.ts` edit fans out to *every* open Vue document
+    /// ([`super::importers::open_vue_dependents`]). Without the check, typing at
+    /// editor speed queues one such fan-out per keystroke, each computed from
+    /// text the user has already replaced and each republished over the last —
+    /// the queue-depth growth behind #3315's silent stalls.
+    ///
+    /// The final publish is never lost: the newest version's pass is by
+    /// definition not superseded, so it always runs the fan-out to completion.
+    /// Abandoning an older pass also cannot leave stale diagnostics on screen,
+    /// because it stops *before* publishing rather than after computing.
+    async fn publish_importer_diagnostics(&self, uri: &Url, version: i32) -> Vec<Url> {
+        let mut refreshed = Vec::new();
         for importer in super::importers::open_vue_dependents(&self.state, uri) {
+            if self.state.documents.version(uri) != Some(version) {
+                tracing::debug!(
+                    "abandoning superseded importer refresh for {}: pass version {}, current {:?}",
+                    uri,
+                    version,
+                    self.state.documents.version(uri)
+                );
+                break;
+            }
             self.publish_diagnostics(&importer).await;
+            refreshed.push(importer);
         }
+        refreshed
     }
 
     /// Publish diagnostics for a document.

--- a/crates/vize_maestro/src/server/helpers/supersession_tests.rs
+++ b/crates/vize_maestro/src/server/helpers/supersession_tests.rs
@@ -1,0 +1,131 @@
+//! Supersession of the importer diagnostics fan-out (#3315).
+//!
+//! Every case asserts the full ordered list of importers actually refreshed, so
+//! a pass that quietly refreshes one of two — or refreshes in a different order
+//! — fails instead of passing on a subset match.
+
+use tower_lsp::LspService;
+use tower_lsp::lsp_types::{TextDocumentContentChangeEvent, Url};
+
+use super::MaestroServer;
+
+const LEAF: &str = "<template>\n  <div>leaf</div>\n</template>\n";
+
+fn importer_source(leaf: &str) -> String {
+    vize_carton::cstr!(
+        "<script setup lang=\"ts\">\nimport Leaf from './{leaf}'\n</script>\n\
+         <template>\n  <Leaf />\n</template>\n"
+    )
+    .to_string()
+}
+
+/// A server with two open Vue documents importing `Leaf.vue`, which is itself
+/// open at version 1. Type checking stays off so the fan-out is pure bookkeeping
+/// and the test needs no Corsa backend.
+struct Fixture {
+    _dir: tempfile::TempDir,
+    service: LspService<MaestroServer>,
+    leaf: Url,
+    importers: Vec<Url>,
+}
+
+fn fixture() -> Fixture {
+    let dir = tempfile::tempdir().unwrap();
+    let leaf_path = dir.path().join("Leaf.vue");
+    std::fs::write(&leaf_path, LEAF).unwrap();
+    let leaf = Url::from_file_path(&leaf_path).unwrap();
+
+    let (service, _socket) = LspService::new(MaestroServer::new);
+    service
+        .inner()
+        .state
+        .apply_lsp_initialization_options(Some(&serde_json::json!({
+            "lint": false,
+            "typecheck": false,
+            "ecosystem": false
+        })));
+    let state = &service.inner().state;
+    state
+        .documents
+        .open(leaf.clone(), LEAF.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&leaf, LEAF);
+
+    let mut importers = Vec::new();
+    for name in ["Alpha.vue", "Beta.vue"] {
+        let path = dir.path().join(name);
+        let source = importer_source("Leaf.vue");
+        std::fs::write(&path, &source).unwrap();
+        let uri = Url::from_file_path(&path).unwrap();
+        state
+            .documents
+            .open(uri.clone(), source.clone(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, &source);
+        importers.push(uri);
+    }
+    importers.sort();
+
+    Fixture {
+        _dir: dir,
+        service,
+        leaf,
+        importers,
+    }
+}
+
+fn refresh(fixture: &Fixture, version: i32) -> Vec<Url> {
+    crate::runtime::block_on(
+        fixture
+            .service
+            .inner()
+            .publish_importer_diagnostics(&fixture.leaf, version),
+    )
+}
+
+fn bump_leaf(fixture: &Fixture, version: i32) {
+    fixture.service.inner().state.documents.apply_changes(
+        &fixture.leaf,
+        vec![TextDocumentContentChangeEvent {
+            range: None,
+            range_length: None,
+            text: LEAF.to_string(),
+        }],
+        version,
+    );
+}
+
+#[test]
+fn current_version_refreshes_every_open_importer() {
+    let fixture = fixture();
+    assert_eq!(refresh(&fixture, 1), fixture.importers);
+}
+
+#[test]
+fn superseded_pass_refreshes_nothing() {
+    let fixture = fixture();
+    bump_leaf(&fixture, 2);
+
+    // The pass for version 1 is dead work: version 2's own pass redoes this
+    // fan-out from the text the user actually has. Publishing nothing here is
+    // also what keeps stale diagnostics off screen — the pass stops before
+    // publishing, not after computing.
+    assert_eq!(refresh(&fixture, 1), Vec::<Url>::new());
+}
+
+#[test]
+fn the_newest_version_still_refreshes_after_superseded_passes() {
+    let fixture = fixture();
+    bump_leaf(&fixture, 2);
+    bump_leaf(&fixture, 3);
+
+    assert_eq!(refresh(&fixture, 1), Vec::<Url>::new());
+    assert_eq!(refresh(&fixture, 2), Vec::<Url>::new());
+    assert_eq!(refresh(&fixture, 3), fixture.importers);
+}
+
+#[test]
+fn a_closed_document_refreshes_nothing() {
+    let fixture = fixture();
+    fixture.service.inner().state.documents.close(&fixture.leaf);
+
+    assert_eq!(refresh(&fixture, 1), Vec::<Url>::new());
+}

--- a/tests/tooling/lsp-publish-supersession.test.ts
+++ b/tests/tooling/lsp-publish-supersession.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { isDiagnosticsForUri } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+// Publish supersession invariants (#3315).
+//
+// `publish_changed_diagnostics` may abandon a pass whose version has already
+// been superseded, and `publish_diagnostics` drops a result whose version went
+// stale while it was being collected. Both are latency wins and both are
+// allowed to skip intermediate versions — but neither may drop the *final*
+// publish or leave a stale payload behind it, because that is a document whose
+// squiggles no longer match its text and no further edit is coming to fix it.
+//
+// The whole publish stream is asserted with `deepEqual`, not probed, so a run
+// that skips a version, reorders two, or emits one extra republish after the
+// final version fails here instead of decaying quietly.
+//
+// Type checking is off: the assertions are about which versions reach the
+// client, so the payloads come from the deterministic parse/lint path and the
+// test needs no Corsa backend. In that configuration nothing on the didChange
+// path yields, so every version is expected to publish and the sequence below
+// is exhaustive — a future supersession that starts dropping versions here has
+// to change this list deliberately rather than silently.
+
+// An unterminated `<template>` block: a `vize/sfc` parse diagnostic, so the
+// broken payload is produced by the parser and needs no lint or type backend.
+const BROKEN = `<template>
+  <p>{{ message }}</p>
+`;
+
+const BROKEN_CODES = ["vize/sfc:Malformed <template> block: the closing tag is missing."];
+
+const CLEAN = `<script setup lang="ts">
+const message = 'hi'
+</script>
+
+<template>
+  <p>{{ message }}</p>
+</template>
+`;
+
+type PublishRecord = { version: number | null; codes: string[] };
+
+function codesOf(params: PublishDiagnosticsParams): string[] {
+  return params.diagnostics
+    .map((diagnostic) => `${diagnostic.source ?? "?"}:${diagnostic.message}`)
+    .sort();
+}
+
+test("vize lsp converges on the final version under rapid successive didChange", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-publish-supersession");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, { editor: true, lint: false, typecheck: false });
+
+    const filePath = path.join(workspaceDir, "Churn.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, CLEAN, "utf8");
+
+    const publishes: PublishRecord[] = [];
+    session.notificationObservers.push((method, params) => {
+      if (method !== "textDocument/publishDiagnostics") return;
+      const publish = params as PublishDiagnosticsParams;
+      if (!isDiagnosticsForUri(publish, uri)) return;
+      publishes.push({ version: publish.version ?? null, codes: codesOf(publish) });
+    });
+
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: CLEAN },
+    });
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params as PublishDiagnosticsParams, uri),
+    );
+    assert.deepEqual(publishes, [{ version: 1, codes: [] }]);
+
+    // Four rapid edits with no wait between them, alternating broken/clean, so
+    // an intermediate publish is distinguishable from the final one by payload
+    // as well as by version.
+    const sources = [BROKEN, CLEAN, BROKEN, CLEAN];
+    sources.forEach((text, index) => {
+      session.notify("textDocument/didChange", {
+        textDocument: { uri, version: index + 2 },
+        contentChanges: [{ text }],
+      });
+    });
+    const finalVersion = sources.length + 1;
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) => {
+      const publish = params as PublishDiagnosticsParams;
+      return isDiagnosticsForUri(publish, uri) && publish.version === finalVersion;
+    });
+
+    assert.deepEqual(publishes, [
+      { version: 1, codes: [] },
+      { version: 2, codes: BROKEN_CODES },
+      { version: 3, codes: [] },
+      { version: 4, codes: BROKEN_CODES },
+      { version: 5, codes: [] },
+    ]);
+
+    // Nothing may trail the final version: a superseded pass that published
+    // late would leave squiggles describing text the document no longer has.
+    session.notify("textDocument/didClose", { textDocument: { uri } });
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) => {
+      const publish = params as PublishDiagnosticsParams;
+      return isDiagnosticsForUri(publish, uri) && publish.version == null;
+    });
+    assert.deepEqual(publishes, [
+      { version: 1, codes: [] },
+      { version: 2, codes: BROKEN_CODES },
+      { version: 3, codes: [] },
+      { version: 4, codes: BROKEN_CODES },
+      { version: 5, codes: [] },
+      { version: null, codes: [] },
+    ]);
+  } finally {
+    await session.shutdown();
+  }
+});


### PR DESCRIPTION
## The divergence

A `didChange` publishes the changed document, then refreshes every open Vue file that
imports it:

```rust
for importer in open_vue_dependents(&self.state, uri) {
    self.publish_diagnostics(&importer).await;
}
```

That loop is the only unbounded work a single keystroke schedules. Each importer costs a
full Corsa diagnostics pass, and `open_vue_dependents` returns **every open Vue document**
for a `.d.ts` edit, not just direct importers. Nothing checked whether the edit that
started the fan-out was still current, so:

- **Expected:** typing at editor speed schedules one fan-out that matters — the last one.
- **Actual:** every keystroke queues a whole fan-out, each computed from text the user has
  already replaced, each republished over the previous one. Twenty open Vue files and a
  `.d.ts` edit means twenty Corsa passes per keystroke, and `publish_diagnostics`' existing
  staleness check does not help here — it compares the *importer's* version, which never
  changed, so every superseded fan-out publishes in full.

This is the queue-depth growth behind #3315's silent stalls. It is also a plain latency
bug in an editor even when nothing stalls.

## The change

The fan-out captures the changed document's version and stops as soon as a newer one
lands.

- **The final publish cannot be lost.** The newest version's pass is by definition not
  superseded, so it always runs the fan-out to completion.
- **A superseded pass cannot leave stale diagnostics on screen.** It stops *before*
  publishing, not after computing — there is no window where an old payload reaches the
  client.
- **Nothing regresses when there is no churn.** A document with no further edits sees its
  version unchanged and refreshes every importer, exactly as before.

`DocumentStore::version` is added as the owned, guard-free version read the loop makes
between its awaits, matching the discipline `DocumentStore::text` documents (#3373): a
`DashMap` shard guard alive across an `.await` hangs the whole server.

## Tests

All deterministic — no wall-clock stress run, no Corsa/tsgo backend.

**`crates/vize_maestro/src/server/helpers/supersession_tests.rs`** drives the fan-out
directly and asserts the FULL ordered list of importers actually refreshed, never a subset
or a count:

| test | pre-fix | post-fix |
| --- | --- | --- |
| `current_version_refreshes_every_open_importer` | passes | passes |
| `superseded_pass_refreshes_nothing` | **fails** | passes |
| `the_newest_version_still_refreshes_after_superseded_passes` | **fails** | passes |
| `a_closed_document_refreshes_nothing` | **fails** | passes |

Verified by reverting the version check to the pre-fix loop and re-running:

```
test result: FAILED. 1 passed; 3 failed
  left: [file:///…/Alpha.vue, file:///…/Beta.vue]
 right: []
```

`current_version_refreshes_every_open_importer` passing in both columns is deliberate: it
is the guard that supersession never eats a live pass.

**`tests/tooling/lsp-publish-supersession.test.ts`** drives four rapid `didChange`
versions against a real `vize lsp` with no waits between them and asserts the whole
publish stream with `deepEqual` — every version, its exact diagnostic payload, and that
nothing trails the final version before `didClose`:

```ts
assert.deepEqual(publishes, [
  { version: 1, codes: [] },
  { version: 2, codes: BROKEN_CODES },
  { version: 3, codes: [] },
  { version: 4, codes: BROKEN_CODES },
  { version: 5, codes: [] },
  { version: null, codes: [] },
]);
```

This one is an invariant guard, not a regression — it passes before and after. It is here
because "supersession must never lose the final publish" is the property most likely to be
broken by a later, more aggressive supersession, and this pins the whole stream so such a
change has to be made deliberately rather than silently.

## What this does not claim

It does not claim to close #3315. The stall was observed against a churn harness that
sends only `didChange`, and this change removes one concrete unbounded-work mechanism on
that path — it does not prove that mechanism was the one that stalled. The #3313 gate
stays armed.

## Gates

```
nix develop -c vp run fmt:check                                                    # exit 0
nix develop -c cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports # exit 0
nix develop -c cargo test -p vize_maestro --all-features --lib                     # 590 passed, 0 failed
nix develop -c node --test tests/tooling/lsp-*.test.ts                             # 2186 passed, 0 failed
```

All touched files stay under the 350-line budget (`helpers.rs` 285, `store.rs` 222,
`supersession_tests.rs` 131, the new tooling test 128).

Refs #3315
