### PR TITLE
fix(patina): report prop mutation from a v-on inline handler

### DIFF
--- a/crates/vize_patina/src/rules/vue/no_mutating_props.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props.rs
@@ -6,23 +6,27 @@
 //! Mutating props can lead to unexpected behavior and makes the data flow
 //! harder to understand.
 //!
+//! ## Template coverage
+//!
+//! Two template positions mutate a prop directly, and both are checked:
+//! `v-model` bound to a prop, and an assignment (or `++` / `--`) inside a
+//! `v-on` inline handler. The handler half resolves its targets from a real
+//! oxc parse of the handler body rather than a text scan — see
+//! [`handlers`] for why that distinction matters here.
+//!
 //! ## Examples
 //!
 //! ### Invalid
 //! ```vue
 //! <script setup>
 //! const props = defineProps(['count'])
-//!
-//! // Direct mutation
-//! props.count = 5
-//!
-//! // Mutation via method
-//! props.items.push('new')
 //! </script>
 //!
 //! <template>
-//!   <!-- v-model on prop is also mutation -->
+//!   <!-- v-model on a prop is a mutation -->
 //!   <input v-model="count" />
+//!   <!-- so is an assignment in an inline handler -->
+//!   <button @click="props.count = 0">reset</button>
 //! </template>
 //! ```
 //!
@@ -42,6 +46,13 @@
 
 #![allow(clippy::disallowed_macros)]
 
+mod handlers;
+mod mutation_targets;
+mod scope;
+#[cfg(test)]
+mod tests;
+
+use self::scope::{PropScope, expression_source, push_for_aliases, push_identifier_tokens};
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
@@ -50,7 +61,7 @@ use vize_carton::String;
 use vize_carton::ToCompactString;
 use vize_croquis::reactivity::ReactiveKind;
 use vize_relief::BindingType;
-use vize_relief::{DirectiveNode, ElementNode, PropNode, RootNode, TemplateChildNode};
+use vize_relief::{DirectiveNode, ElementNode, ForNode, PropNode, RootNode, TemplateChildNode};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-mutating-props",
@@ -65,94 +76,162 @@ static META: RuleMeta = RuleMeta {
 pub struct NoMutatingProps;
 
 impl NoMutatingProps {
-    /// Check if an expression mutates a prop
+    /// Check if a `v-model` expression mutates a prop.
     fn check_v_model_mutation<'a>(
         &self,
         ctx: &mut LintContext<'a>,
         directive: &DirectiveNode<'a>,
-        prop_names: &FxHashSet<&str>,
-        has_props_object_binding: bool,
+        scope: &PropScope<'_>,
     ) {
         if directive.name.as_str() != "model" {
             return;
         }
 
-        // Get the v-model expression
-        if let Some(ref exp) = directive.exp {
-            let content = match exp {
-                vize_relief::ExpressionNode::Simple(s) => s.content.as_str(),
-                vize_relief::ExpressionNode::Compound(c) => c.loc.source.as_str(),
-            };
+        let Some(exp) = directive.exp.as_ref() else {
+            return;
+        };
+        let content = expression_source(exp);
+        if !scope.is_mutation(content) {
+            return;
+        }
+        ctx.report(
+            crate::diagnostic::LintDiagnostic::error(
+                ctx.current_rule,
+                format!("Unexpected mutation of prop '{}' via v-model", content),
+                directive.loc.start.offset,
+                directive.loc.end.offset,
+            )
+            .with_help("Use a local ref or emit an event instead of mutating props directly"),
+        );
+    }
 
-            if is_prop_mutation_target(content, prop_names, has_props_object_binding) {
-                ctx.report(
-                    crate::diagnostic::LintDiagnostic::error(
-                        ctx.current_rule,
-                        format!("Unexpected mutation of prop '{}' via v-model", content),
-                        directive.loc.start.offset,
-                        directive.loc.end.offset,
-                    )
-                    .with_help(
-                        "Use a local ref or emit an event instead of mutating props directly",
-                    ),
-                );
+    /// Check whether a `v-on` inline handler assigns to a prop.
+    ///
+    /// Reported at the directive, matching the `v-model` half of this rule.
+    /// Upstream highlights the mutated expression instead; that is a location
+    /// divergence for the parity ledger, not a coverage one.
+    fn check_handler_mutation<'a>(
+        &self,
+        ctx: &mut LintContext<'a>,
+        directive: &DirectiveNode<'a>,
+        scope: &PropScope<'_>,
+    ) {
+        if directive.name.as_str() != "on" {
+            return;
+        }
+        let Some(exp) = directive.exp.as_ref() else {
+            return;
+        };
+        let mut mutated: Vec<String> = Vec::new();
+        handlers::for_each_mutation_target(expression_source(exp), |target| {
+            let target = target.trim();
+            if scope.is_mutation(target) && !mutated.iter().any(|seen| seen == target) {
+                mutated.push(String::new(target));
             }
+        });
+        for target in mutated {
+            ctx.report(
+                crate::diagnostic::LintDiagnostic::error(
+                    ctx.current_rule,
+                    format!(
+                        "Unexpected mutation of prop '{}' in an inline handler",
+                        target
+                    ),
+                    directive.loc.start.offset,
+                    directive.loc.end.offset,
+                )
+                .with_help("Use a local ref or emit an event instead of mutating props directly"),
+            );
         }
     }
 
-    /// Recursively check template for prop mutations
+    /// Recursively check template children for prop mutations.
     fn check_children<'a>(
         &self,
         ctx: &mut LintContext<'a>,
         children: &[TemplateChildNode<'a>],
-        prop_names: &FxHashSet<&str>,
-        has_props_object_binding: bool,
+        scope: &mut PropScope<'_>,
     ) {
         for child in children {
             match child {
-                TemplateChildNode::Element(el) => {
-                    self.check_element(ctx, el, prop_names, has_props_object_binding);
-                }
+                TemplateChildNode::Element(el) => self.check_element(ctx, el, scope),
                 TemplateChildNode::If(if_node) => {
                     for branch in if_node.branches.iter() {
-                        self.check_children(
-                            ctx,
-                            &branch.children,
-                            prop_names,
-                            has_props_object_binding,
-                        );
+                        self.check_children(ctx, &branch.children, scope);
                     }
                 }
-                TemplateChildNode::For(for_node) => {
-                    self.check_children(
-                        ctx,
-                        &for_node.children,
-                        prop_names,
-                        has_props_object_binding,
-                    );
-                }
+                TemplateChildNode::For(for_node) => self.check_for(ctx, for_node, scope),
                 _ => {}
             }
         }
     }
 
-    /// Check an element for prop mutations
+    /// A `v-for` binds its aliases for the whole subtree, so they shadow a prop
+    /// of the same name inside it.
+    fn check_for<'a>(
+        &self,
+        ctx: &mut LintContext<'a>,
+        for_node: &ForNode<'a>,
+        scope: &mut PropScope<'_>,
+    ) {
+        let depth = scope.shadowed.len();
+        for alias in [
+            for_node.value_alias.as_ref(),
+            for_node.key_alias.as_ref(),
+            for_node.object_index_alias.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            push_identifier_tokens(expression_source(alias), &mut scope.shadowed);
+        }
+        self.check_children(ctx, &for_node.children, scope);
+        scope.shadowed.truncate(depth);
+    }
+
+    /// Check an element for prop mutations.
     fn check_element<'a>(
         &self,
         ctx: &mut LintContext<'a>,
         element: &ElementNode<'a>,
-        prop_names: &FxHashSet<&str>,
-        has_props_object_binding: bool,
+        scope: &mut PropScope<'_>,
     ) {
-        // Check directives
+        let depth = scope.shadowed.len();
+
+        // A `v-for` alias is in scope for the element's *own* bindings as well
+        // as its children (`v-for="msg in rows" @click="msg = 1"` mutates the
+        // iteration variable, not the prop), so it has to be collected before
+        // any directive on this element is checked. Whether the parse lowered
+        // `v-for` into a `ForNode` or left it as a directive here depends on
+        // the transform stage, so both spellings are handled.
         for prop in element.props.iter() {
-            if let PropNode::Directive(dir) = prop {
-                self.check_v_model_mutation(ctx, dir, prop_names, has_props_object_binding);
+            if let PropNode::Directive(dir) = prop
+                && dir.name.as_str() == "for"
+            {
+                push_for_aliases(dir, &mut scope.shadowed);
             }
         }
 
-        // Check children
-        self.check_children(ctx, &element.children, prop_names, has_props_object_binding);
+        for prop in element.props.iter() {
+            if let PropNode::Directive(dir) = prop {
+                self.check_v_model_mutation(ctx, dir, scope);
+                self.check_handler_mutation(ctx, dir, scope);
+            }
+        }
+
+        // A slot variable, by contrast, scopes the slot *content*, so it is
+        // collected only after this element's own directives are checked.
+        for prop in element.props.iter() {
+            if let PropNode::Directive(dir) = prop
+                && dir.name.as_str() == "slot"
+                && let Some(exp) = dir.exp.as_ref()
+            {
+                push_identifier_tokens(expression_source(exp), &mut scope.shadowed);
+            }
+        }
+
+        self.check_children(ctx, &element.children, scope);
+        scope.shadowed.truncate(depth);
     }
 }
 
@@ -202,172 +281,12 @@ impl Rule for NoMutatingProps {
 
         // Convert to &str set for checking
         let prop_names_ref: FxHashSet<&str> = prop_names.iter().map(|s| s.as_str()).collect();
-
-        // Check template
-        self.check_children(
-            ctx,
-            &root.children,
-            &prop_names_ref,
+        let mut scope = PropScope {
+            prop_names: &prop_names_ref,
             has_props_object_binding,
-        );
-    }
-}
+            shadowed: Vec::new(),
+        };
 
-fn is_prop_mutation_target(
-    content: &str,
-    prop_names: &FxHashSet<&str>,
-    has_props_object_binding: bool,
-) -> bool {
-    let content = content.trim();
-    if prop_names.contains(content) {
-        return true;
-    }
-
-    if has_props_object_binding
-        && content
-            .strip_prefix("props")
-            .is_some_and(|rest| is_props_object_member_mutation(rest, prop_names))
-    {
-        return true;
-    }
-
-    prop_names.iter().any(|name| {
-        content
-            .strip_prefix(*name)
-            .is_some_and(is_member_access_suffix)
-    })
-}
-
-fn is_member_access_suffix(rest: &str) -> bool {
-    rest.starts_with('.') || rest.starts_with('[') || rest.starts_with("?.")
-}
-
-fn is_props_object_member_mutation(rest: &str, prop_names: &FxHashSet<&str>) -> bool {
-    if let Some(name) = props_member_root(rest) {
-        return prop_names.is_empty() || prop_names.contains(name);
-    }
-
-    is_dynamic_props_member_access(rest)
-}
-
-fn is_dynamic_props_member_access(rest: &str) -> bool {
-    let mut rest = rest.trim_start();
-    if let Some(after_optional) = rest.strip_prefix("?.") {
-        rest = after_optional.trim_start();
-    }
-
-    let Some(after_bracket) = rest.strip_prefix('[') else {
-        return false;
-    };
-    let after_bracket = after_bracket.trim_start();
-    !after_bracket.starts_with('\'') && !after_bracket.starts_with('"')
-}
-
-fn props_member_root(rest: &str) -> Option<&str> {
-    let mut rest = rest.trim_start();
-    let mut consumed_optional = false;
-    if let Some(after_optional) = rest.strip_prefix("?.") {
-        rest = after_optional.trim_start();
-        consumed_optional = true;
-    }
-
-    if let Some(after_dot) = rest.strip_prefix('.') {
-        return identifier_root(after_dot);
-    }
-
-    if consumed_optional && let Some(name) = identifier_root(rest) {
-        return Some(name);
-    }
-
-    let after_bracket = rest.strip_prefix('[')?.trim_start();
-    let quote = after_bracket.chars().next()?;
-    if quote != '\'' && quote != '"' {
-        return None;
-    }
-    let name_start = quote.len_utf8();
-    let name_end = after_bracket[name_start..].find(quote)? + name_start;
-    (name_end > name_start).then_some(&after_bracket[name_start..name_end])
-}
-
-fn identifier_root(source: &str) -> Option<&str> {
-    let end = source
-        .find(|ch: char| !(ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()))
-        .unwrap_or(source.len());
-    (end > 0).then_some(&source[..end])
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{NoMutatingProps, is_prop_mutation_target};
-    use crate::diagnostic::Severity;
-    use crate::rule::{Rule, RuleCategory};
-    use vize_carton::FxHashSet;
-
-    #[test]
-    fn test_meta() {
-        let rule = NoMutatingProps;
-        assert_eq!(rule.meta().name, "vue/no-mutating-props");
-        assert_eq!(rule.meta().category, RuleCategory::Essential);
-        assert_eq!(rule.meta().default_severity, Severity::Error);
-    }
-
-    #[test]
-    fn prop_mutation_target_matches_member_roots() {
-        let prop_names = FxHashSet::from_iter(["count", "user"]);
-
-        assert!(is_prop_mutation_target("count", &prop_names, false));
-        assert!(is_prop_mutation_target("user.name", &prop_names, false));
-        assert!(is_prop_mutation_target("user?.name", &prop_names, false));
-        assert!(is_prop_mutation_target("props.count", &prop_names, true));
-        assert!(is_prop_mutation_target(
-            "props.user.name",
-            &prop_names,
-            true
-        ));
-        assert!(is_prop_mutation_target("props['count']", &prop_names, true));
-        assert!(is_prop_mutation_target("props[key]", &prop_names, true));
-        assert!(is_prop_mutation_target(
-            "props[key].name",
-            &prop_names,
-            true
-        ));
-        assert!(is_prop_mutation_target(
-            "props?.user.name",
-            &prop_names,
-            true
-        ));
-        assert!(!is_prop_mutation_target("props.extra", &prop_names, true));
-        assert!(!is_prop_mutation_target(
-            "props['extra']",
-            &prop_names,
-            true
-        ));
-        assert!(!is_prop_mutation_target(
-            "props.user.name",
-            &prop_names,
-            false
-        ));
-        assert!(!is_prop_mutation_target(
-            "counter.value",
-            &prop_names,
-            false
-        ));
-        assert!(!is_prop_mutation_target(
-            "propsState.count",
-            &prop_names,
-            true
-        ));
-
-        let unknown_prop_names = FxHashSet::default();
-        assert!(is_prop_mutation_target(
-            "props.title",
-            &unknown_prop_names,
-            true
-        ));
-        assert!(is_prop_mutation_target(
-            "props[field]",
-            &unknown_prop_names,
-            true
-        ));
+        self.check_children(ctx, &root.children, &mut scope);
     }
 }

--- a/crates/vize_patina/src/rules/vue/no_mutating_props/handlers.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props/handlers.rs
@@ -1,0 +1,125 @@
+//! Assignment targets inside a `v-on` inline handler body.
+//!
+//! # Why this needs a real parse
+//!
+//! `vue/no-mutating-props` already sees the template, but it only inspected
+//! `v-model`. An inline handler mutates a prop just as directly
+//! (`@click="props.msg = 'x'"`) and was missed entirely.
+//!
+//! Recovering those call sites *creates* findings from template evidence,
+//! which is the dangerous direction: unlike
+//! [`crate::rules::script::props_emits::template_emits`], where an
+//! over-matching raw scan can only suppress an "unused" report, an over-match
+//! here invents a diagnostic where the user did nothing wrong. Concretely, a
+//! substring sweep for `<prop> =` over the raw template would fire on all of
+//! these, none of which mutate a prop:
+//!
+//! * `<!-- msg = 'x' -->` — an HTML comment.
+//! * `<p>msg = 'x'</p>` — a text node.
+//! * `<div title="msg = 'x'">` — a plain attribute, not an expression.
+//! * `@click="log('msg = 1')"` — an assignment inside a string literal.
+//! * `@click="msgExtra = 1"` — a longer identifier that merely starts with the
+//!   prop name.
+//! * `<pre v-pre>{{ msg = 1 }}</pre>` — a region Vue never compiles.
+//!
+//! So the evidence is taken from the *template AST* — only a `v-on`
+//! [`vize_relief::DirectiveNode`] carrying an expression, which excludes
+//! comments, text nodes, plain attributes and `v-pre` regions — and the
+//! handler body is then parsed with oxc so that only a genuine assignment or
+//! update *target* counts. An occurrence inside a string literal parses to a
+//! `StringLiteral` and can never be one.
+//!
+//! # Direction of error
+//!
+//! * **Over-match** would be a false positive, so every step above is exact.
+//!   The one deliberate imprecision is shadowing (a `v-for` alias or a slot
+//!   variable that reuses a prop name), and it errs towards *not* reporting.
+//! * **Under-match** loses a report: a body oxc cannot parse is skipped, as is
+//!   a destructuring target (`[props.msg] = list`) and a mutation performed
+//!   through a call (`@click="props.items.push(1)"`, which upstream reports
+//!   and this does not). All three leave a real bug unreported, which is the
+//!   tolerable direction.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    AssignmentExpression, AssignmentTarget, SimpleAssignmentTarget, UpdateExpression,
+};
+use oxc_ast_visit::{
+    Visit,
+    walk::{walk_assignment_expression, walk_update_expression},
+};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType, Span};
+
+/// Call `visit` with the source slice of every assignment / update target in
+/// `source`, a `v-on` inline handler body.
+///
+/// A handler body is a statement list rather than a single expression
+/// (`@click="a = 1; b = 2"` is valid), so it is parsed as a program. Bodies
+/// oxc rejects are skipped: a report invented from a mis-parse would be a
+/// false positive, and a template that does not compile has larger problems.
+pub(super) fn for_each_mutation_target(source: &str, mut visit: impl FnMut(&str)) {
+    // Cheap reject for the overwhelmingly common handler (`@click="submit"`,
+    // `@click="emit('x')"`): no mutation operator, nothing to parse.
+    if !source.contains('=') && !source.contains("++") && !source.contains("--") {
+        return;
+    }
+    let allocator = Allocator::default();
+    let parsed = Parser::new(
+        &allocator,
+        source,
+        SourceType::default().with_typescript(true),
+    )
+    .parse();
+    if parsed.panicked || !parsed.errors.is_empty() {
+        return;
+    }
+    let mut collector = MutationTargetCollector { spans: Vec::new() };
+    collector.visit_program(&parsed.program);
+    for span in collector.spans {
+        if let Some(text) = source.get(span.start as usize..span.end as usize) {
+            visit(text);
+        }
+    }
+}
+
+struct MutationTargetCollector {
+    spans: Vec<Span>,
+}
+
+impl<'a> Visit<'a> for MutationTargetCollector {
+    fn visit_assignment_expression(&mut self, it: &AssignmentExpression<'a>) {
+        if let Some(span) = assignment_target_span(&it.left) {
+            self.spans.push(span);
+        }
+        // Keep walking: the right-hand side can hold further assignments
+        // (`a = (props.msg = 'x')`).
+        walk_assignment_expression(self, it);
+    }
+
+    fn visit_update_expression(&mut self, it: &UpdateExpression<'a>) {
+        if let Some(span) = simple_assignment_target_span(&it.argument) {
+            self.spans.push(span);
+        }
+        walk_update_expression(self, it);
+    }
+}
+
+/// The span of an assignment target, when it is a plain identifier or a member
+/// access.
+///
+/// Destructuring targets are deliberately not resolved; see the module-level
+/// note on under-matching.
+fn assignment_target_span(target: &AssignmentTarget<'_>) -> Option<Span> {
+    match target {
+        AssignmentTarget::AssignmentTargetIdentifier(identifier) => Some(identifier.span),
+        other => other.as_member_expression().map(GetSpan::span),
+    }
+}
+
+fn simple_assignment_target_span(target: &SimpleAssignmentTarget<'_>) -> Option<Span> {
+    match target {
+        SimpleAssignmentTarget::AssignmentTargetIdentifier(identifier) => Some(identifier.span),
+        other => other.as_member_expression().map(GetSpan::span),
+    }
+}

--- a/crates/vize_patina/src/rules/vue/no_mutating_props/mutation_targets.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props/mutation_targets.rs
@@ -1,0 +1,156 @@
+//! Text-level matching of a mutation target against the component's props.
+//!
+//! Callers pass the *source slice of an assignment target* (`props.msg`,
+//! `user.name`, `count`), never a whole expression, so matching a prefix here
+//! cannot pick up an unrelated occurrence elsewhere in the expression.
+
+use vize_carton::FxHashSet;
+
+pub(super) fn is_prop_mutation_target(
+    content: &str,
+    prop_names: &FxHashSet<&str>,
+    has_props_object_binding: bool,
+) -> bool {
+    let content = content.trim();
+    if prop_names.contains(content) {
+        return true;
+    }
+
+    if has_props_object_binding
+        && content
+            .strip_prefix("props")
+            .is_some_and(|rest| is_props_object_member_mutation(rest, prop_names))
+    {
+        return true;
+    }
+
+    prop_names.iter().any(|name| {
+        content
+            .strip_prefix(*name)
+            .is_some_and(is_member_access_suffix)
+    })
+}
+
+fn is_member_access_suffix(rest: &str) -> bool {
+    rest.starts_with('.') || rest.starts_with('[') || rest.starts_with("?.")
+}
+
+fn is_props_object_member_mutation(rest: &str, prop_names: &FxHashSet<&str>) -> bool {
+    if let Some(name) = props_member_root(rest) {
+        return prop_names.is_empty() || prop_names.contains(name);
+    }
+
+    is_dynamic_props_member_access(rest)
+}
+
+fn is_dynamic_props_member_access(rest: &str) -> bool {
+    let mut rest = rest.trim_start();
+    if let Some(after_optional) = rest.strip_prefix("?.") {
+        rest = after_optional.trim_start();
+    }
+
+    let Some(after_bracket) = rest.strip_prefix('[') else {
+        return false;
+    };
+    let after_bracket = after_bracket.trim_start();
+    !after_bracket.starts_with('\'') && !after_bracket.starts_with('"')
+}
+
+fn props_member_root(rest: &str) -> Option<&str> {
+    let mut rest = rest.trim_start();
+    let mut consumed_optional = false;
+    if let Some(after_optional) = rest.strip_prefix("?.") {
+        rest = after_optional.trim_start();
+        consumed_optional = true;
+    }
+
+    if let Some(after_dot) = rest.strip_prefix('.') {
+        return identifier_root(after_dot);
+    }
+
+    if consumed_optional && let Some(name) = identifier_root(rest) {
+        return Some(name);
+    }
+
+    let after_bracket = rest.strip_prefix('[')?.trim_start();
+    let quote = after_bracket.chars().next()?;
+    if quote != '\'' && quote != '"' {
+        return None;
+    }
+    let name_start = quote.len_utf8();
+    let name_end = after_bracket[name_start..].find(quote)? + name_start;
+    (name_end > name_start).then_some(&after_bracket[name_start..name_end])
+}
+
+fn identifier_root(source: &str) -> Option<&str> {
+    let end = source
+        .find(|ch: char| !(ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()))
+        .unwrap_or(source.len());
+    (end > 0).then_some(&source[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_prop_mutation_target;
+    use vize_carton::FxHashSet;
+
+    #[test]
+    fn prop_mutation_target_matches_member_roots() {
+        let prop_names = FxHashSet::from_iter(["count", "user"]);
+
+        assert!(is_prop_mutation_target("count", &prop_names, false));
+        assert!(is_prop_mutation_target("user.name", &prop_names, false));
+        assert!(is_prop_mutation_target("user?.name", &prop_names, false));
+        assert!(is_prop_mutation_target("props.count", &prop_names, true));
+        assert!(is_prop_mutation_target(
+            "props.user.name",
+            &prop_names,
+            true
+        ));
+        assert!(is_prop_mutation_target("props['count']", &prop_names, true));
+        assert!(is_prop_mutation_target("props[key]", &prop_names, true));
+        assert!(is_prop_mutation_target(
+            "props[key].name",
+            &prop_names,
+            true
+        ));
+        assert!(is_prop_mutation_target(
+            "props?.user.name",
+            &prop_names,
+            true
+        ));
+        assert!(!is_prop_mutation_target("props.extra", &prop_names, true));
+        assert!(!is_prop_mutation_target(
+            "props['extra']",
+            &prop_names,
+            true
+        ));
+        assert!(!is_prop_mutation_target(
+            "props.user.name",
+            &prop_names,
+            false
+        ));
+        assert!(!is_prop_mutation_target(
+            "counter.value",
+            &prop_names,
+            false
+        ));
+        assert!(!is_prop_mutation_target(
+            "propsState.count",
+            &prop_names,
+            true
+        ));
+
+        let unknown_prop_names = FxHashSet::default();
+        assert!(is_prop_mutation_target(
+            "props.title",
+            &unknown_prop_names,
+            true
+        ));
+        assert!(is_prop_mutation_target(
+            "props[field]",
+            &unknown_prop_names,
+            true
+        ));
+    }
+}

--- a/crates/vize_patina/src/rules/vue/no_mutating_props/scope.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props/scope.rs
@@ -1,0 +1,101 @@
+//! Prop-name scope for the template walk of `vue/no-mutating-props`.
+
+use vize_carton::{FxHashSet, String};
+use vize_relief::{DirectiveNode, ExpressionNode};
+
+use super::mutation_targets::is_prop_mutation_target;
+
+/// What the walk needs to decide whether a template mutation targets a prop.
+pub(super) struct PropScope<'names> {
+    pub(super) prop_names: &'names FxHashSet<&'names str>,
+    pub(super) has_props_object_binding: bool,
+    /// Names bound by an enclosing `v-for` alias or slot variable, which
+    /// shadow a prop of the same name for the duration of that subtree.
+    ///
+    /// Collected as bare identifier tokens out of the alias / slot expression
+    /// rather than by parsing the binding pattern, so a destructuring pattern
+    /// contributes every name it mentions — including a renamed source key
+    /// (`v-slot="{ msg: label }"` shadows both `msg` and `label`). That
+    /// over-collects, which only ever *suppresses* a report, the safe
+    /// direction for evidence that creates findings.
+    pub(super) shadowed: Vec<String>,
+}
+
+impl PropScope<'_> {
+    pub(super) fn is_mutation(&self, target: &str) -> bool {
+        let target = target.trim();
+        if self.shadowed.iter().any(|name| {
+            let name = name.as_str();
+            target == name || target.strip_prefix(name).is_some_and(starts_member)
+        }) {
+            return false;
+        }
+        is_prop_mutation_target(target, self.prop_names, self.has_props_object_binding)
+    }
+}
+
+fn starts_member(rest: &str) -> bool {
+    rest.starts_with('.') || rest.starts_with('[') || rest.starts_with("?.")
+}
+
+/// Push the value / key / index aliases of a `v-for` directive.
+///
+/// The parsed aliases are preferred; a `v-for` the parser could not split
+/// falls back to the whole expression, whose identifier tokens include the
+/// source as well as the aliases. Over-collecting only suppresses reports.
+pub(super) fn push_for_aliases(directive: &DirectiveNode<'_>, out: &mut Vec<String>) {
+    if let Some(parsed) = directive.for_parse_result.as_ref() {
+        for alias in [
+            parsed.value.as_ref(),
+            parsed.key.as_ref(),
+            parsed.index.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            push_identifier_tokens(expression_source(alias), out);
+        }
+        return;
+    }
+    if let Some(exp) = directive.exp.as_ref() {
+        push_identifier_tokens(expression_source(exp), out);
+    }
+}
+
+pub(super) fn expression_source<'a>(exp: &'a ExpressionNode<'a>) -> &'a str {
+    match exp {
+        ExpressionNode::Simple(simple) => simple.content.as_str(),
+        ExpressionNode::Compound(compound) => compound.loc.source.as_str(),
+    }
+}
+
+/// Push every identifier-shaped token of `source` onto `out`.
+///
+/// Used for `v-for` aliases and slot variables, where the binding may be a
+/// destructuring pattern. See [`PropScope::shadowed`] for why over-collecting
+/// is the correct direction here.
+pub(super) fn push_identifier_tokens(source: &str, out: &mut Vec<String>) {
+    let bytes = source.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if !is_identifier_start(bytes[index]) {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        while index < bytes.len() && is_identifier_byte(bytes[index]) {
+            index += 1;
+        }
+        out.push(String::new(&source[start..index]));
+    }
+}
+
+#[inline]
+fn is_identifier_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_' || byte == b'$'
+}
+
+#[inline]
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+}

--- a/crates/vize_patina/src/rules/vue/no_mutating_props/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props/tests.rs
@@ -1,0 +1,337 @@
+use super::NoMutatingProps;
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleCategory};
+
+/// Lint a full SFC with only this rule enabled.
+///
+/// `vue/no-mutating-props` is a member of `SEMANTIC_TEMPLATE_RULES`, so
+/// enabling it alone still produces the croquis analysis the rule reads.
+fn lint_sfc(sfc: &str) -> LintResult {
+    Linter::new()
+        .with_enabled_rules(Some(vec!["vue/no-mutating-props".into()]))
+        .lint_sfc(sfc, "Probe.vue")
+}
+
+/// The full identity of every finding: rule, severity, byte range, message.
+fn findings(result: &LintResult) -> Vec<(&'static str, Severity, u32, u32, &str)> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            (
+                diagnostic.rule_name,
+                diagnostic.severity,
+                diagnostic.start,
+                diagnostic.end,
+                diagnostic.message.as_str(),
+            )
+        })
+        .collect()
+}
+
+fn none() -> Vec<(&'static str, Severity, u32, u32, &'static str)> {
+    Vec::new()
+}
+
+#[test]
+fn test_meta() {
+    let rule = NoMutatingProps;
+    assert_eq!(rule.meta().name, "vue/no-mutating-props");
+    assert_eq!(rule.meta().category, RuleCategory::Essential);
+    assert_eq!(rule.meta().default_severity, Severity::Error);
+}
+
+// --- The recovered case: an assignment inside an inline handler ------------
+
+#[test]
+fn reports_prop_assignment_in_an_inline_handler() {
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <button @click="props.msg = 'x'">{{ props.msg }}</button>
+</template>
+"#;
+    let directive = sfc.find("@click=").expect("handler directive");
+    let directive_end = sfc.find(">{{").expect("end of the start tag");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![(
+            "vue/no-mutating-props",
+            Severity::Error,
+            directive as u32,
+            directive_end as u32,
+            "Unexpected mutation of prop 'props.msg' in an inline handler",
+        )]
+    );
+}
+
+#[test]
+fn reports_bare_prop_assignment_in_an_inline_handler() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <button @click="msg = 'x'">go</button>
+</template>
+"#;
+    let directive = sfc.find("@click=").expect("handler directive");
+    let directive_end = sfc.find(">go").expect("end of the start tag");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![(
+            "vue/no-mutating-props",
+            Severity::Error,
+            directive as u32,
+            directive_end as u32,
+            "Unexpected mutation of prop 'msg' in an inline handler",
+        )]
+    );
+}
+
+#[test]
+fn reports_a_prop_update_expression() {
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<{ count: number }>();
+</script>
+
+<template>
+  <button @click="props.count++">go</button>
+</template>
+"#;
+    let directive = sfc.find("@click=").expect("handler directive");
+    let directive_end = sfc.find(">go").expect("end of the start tag");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![(
+            "vue/no-mutating-props",
+            Severity::Error,
+            directive as u32,
+            directive_end as u32,
+            "Unexpected mutation of prop 'props.count' in an inline handler",
+        )]
+    );
+}
+
+#[test]
+fn reports_each_distinct_prop_of_a_multi_statement_handler_once() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string; count: number }>();
+</script>
+
+<template>
+  <button @click="msg = 'x'; count = 1; msg = 'y'">go</button>
+</template>
+"#;
+    let directive = sfc.find("@click=").expect("handler directive");
+    let directive_end = sfc.find(">go").expect("end of the start tag");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![
+            (
+                "vue/no-mutating-props",
+                Severity::Error,
+                directive as u32,
+                directive_end as u32,
+                "Unexpected mutation of prop 'msg' in an inline handler",
+            ),
+            (
+                "vue/no-mutating-props",
+                Severity::Error,
+                directive as u32,
+                directive_end as u32,
+                "Unexpected mutation of prop 'count' in an inline handler",
+            ),
+        ]
+    );
+}
+
+// --- The template does not mutate a prop: exactly zero findings ------------
+
+#[test]
+fn ignores_a_handler_that_reads_a_prop() {
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<{ msg: string }>();
+const emit = defineEmits<{ go: [string] }>();
+</script>
+
+<template>
+  <button @click="emit('go', props.msg)">{{ props.msg }}</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_an_assignment_to_local_state() {
+    let sfc = r#"<script setup lang="ts">
+import { ref } from 'vue';
+defineProps<{ msg: string }>();
+const draft = ref('');
+</script>
+
+<template>
+  <button @click="draft = 'x'">go</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+// --- Over-match probes: none of these may manufacture a finding ------------
+
+#[test]
+fn ignores_a_prop_assignment_inside_an_html_comment() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <!-- msg = 'x' -->
+  <button @click="void 0">go</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_prop_assignment_in_a_text_node_or_plain_attribute() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <p title="msg = 'x'">msg = 'x'</p>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_prop_assignment_inside_a_string_literal() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <button @click="console.log('msg = 1')">go</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_an_identifier_that_merely_starts_with_a_prop_name() {
+    let sfc = r#"<script setup lang="ts">
+import { ref } from 'vue';
+defineProps<{ msg: string }>();
+const msgExtra = ref('');
+</script>
+
+<template>
+  <button @click="msgExtra = 'x'">go</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_prop_assignment_inside_a_v_pre_region() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <pre v-pre>{{ msg = 1 }}</pre>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_v_for_alias_that_shadows_a_prop_name() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string; rows: string[] }>();
+</script>
+
+<template>
+  <ul>
+    <li v-for="msg in rows" :key="msg">
+      <button @click="msg = 'x'">go</button>
+    </li>
+  </ul>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_slot_variable_that_shadows_a_prop_name() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <Child v-slot="{ msg }">
+    <button @click="msg = 'x'">go</button>
+  </Child>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn still_reports_a_prop_after_a_shadowing_subtree_ends() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string; rows: string[] }>();
+</script>
+
+<template>
+  <ul>
+    <li v-for="msg in rows" :key="msg">
+      <button @click="msg = 'x'">shadowed</button>
+    </li>
+  </ul>
+  <button @click="msg = 'y'">not shadowed</button>
+</template>
+"#;
+    let directive = sfc.rfind("@click=").expect("handler directive");
+    let directive_end = sfc.rfind(">not").expect("end of the start tag");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![(
+            "vue/no-mutating-props",
+            Severity::Error,
+            directive as u32,
+            directive_end as u32,
+            "Unexpected mutation of prop 'msg' in an inline handler",
+        )]
+    );
+}
+
+// --- The pre-existing v-model half must keep working ----------------------
+
+#[test]
+fn reports_v_model_bound_to_a_prop() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <input v-model="msg" />
+</template>
+"#;
+    let directive = sfc.find("v-model=").expect("model directive");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![(
+            "vue/no-mutating-props",
+            Severity::Error,
+            directive as u32,
+            (directive + "v-model=\"msg\"".len()) as u32,
+            "Unexpected mutation of prop 'msg' via v-model",
+        )]
+    );
+}


### PR DESCRIPTION
## Defect (#3416 A)

`vue/no-mutating-props` sees the template but only inspected `v-model`. An
assignment inside a `v-on` inline handler mutates a prop just as directly and was
missed entirely.

## Minimal reproduction

```vue
<script setup lang="ts">
const props = defineProps<{ msg: string }>();
</script>

<template>
  <button @click="props.msg = 'x'">{{ props.msg }}</button>
</template>
```

`Linter::new().with_enabled_rules(Some(vec!["vue/no-mutating-props"])).lint_sfc(sfc, "Probe.vue")`

- Actual: 0 findings.
- Expected: 1 finding.

The `v-model` path already worked, so the rule did see the template and did
resolve props; only handler expressions were unread.

## Over-match / under-match analysis

This is the direction #3223 calls dangerous: template evidence that **creates** a
finding. The existing raw scan in `props_emits/template_emits.rs` is explicitly
one-directional — over-matching there only suppresses an "unused" report — so it
could not be reused. A substring sweep for `<prop> =` over the raw template
would fire on all of these, none of which mutate a prop:

| case | why it must not report |
| --- | --- |
| `<!-- msg = 'x' -->` | HTML comment |
| `<p>msg = 'x'</p>` | text node |
| `<div title="msg = 'x'">` | plain attribute, not an expression |
| `@click="log('msg = 1')"` | assignment inside a string literal |
| `@click="msgExtra = 1"` | longer identifier starting with the prop name |
| `<pre v-pre>{{ msg = 1 }}</pre>` | region Vue never compiles |
| `v-for="msg in rows"` / `v-slot="{ msg }"` | the name is shadowed |

So the evidence is taken from the **template AST** — only a `v-on`
`DirectiveNode` carrying an expression, which structurally excludes comments,
text nodes, plain attributes and `v-pre` regions — and the handler body is then
**parsed with oxc**, so only a genuine `AssignmentExpression` /
`UpdateExpression` *target* counts. An occurrence inside a string literal parses
to a `StringLiteral` and can never be an assignment target.

Every row above has a test asserting **exactly zero** findings.

**Where over-matching is still possible, it suppresses rather than reports.**
Shadowing names are collected as bare identifier tokens out of the `v-for` alias
/ slot expression rather than by parsing the binding pattern, so
`v-slot="{ msg: label }"` shadows both `msg` and `label`. Over-collecting only
ever removes a report.

**Under-matching loses a report**, the tolerable direction: an unparseable
handler body is skipped, as is a destructuring target (`[props.msg] = list`) and
a mutation performed through a call (`@click="props.items.push(1)"`, which
upstream reports and this does not).

All of the above is written into the module docs of
`crates/vize_patina/src/rules/vue/no_mutating_props/handlers.rs`.

## Location

Reported at the directive, matching this rule's existing `v-model` half. Upstream
highlights the mutated expression instead — a location divergence for the parity
ledger, not a coverage one.

## How the new tests fail before the fix

With the body of `check_handler_mutation` short-circuited (the pre-fix
behaviour), `cargo test -p vize_patina --lib no_mutating_props` fails exactly the
five positive-direction tests and passes all fourteen others, including every
over-match probe and the pre-existing `v-model` case:

```
reports_prop_assignment_in_an_inline_handler ... FAILED
reports_bare_prop_assignment_in_an_inline_handler ... FAILED
reports_a_prop_update_expression ... FAILED
reports_each_distinct_prop_of_a_multi_statement_handler_once ... FAILED
still_reports_a_prop_after_a_shadowing_subtree_ends ... FAILED
test result: FAILED. 14 passed; 5 failed
```

With the fix: `19 passed; 0 failed`.

## File split

`no_mutating_props.rs` was already 373 lines. It is split into `handlers`,
`mutation_targets` and `scope` submodules so nothing grows past the 350-line
budget (291 / 121 / 156 / 101 / 337 for the tests).

## Gates run

- `nix develop -c vp run fmt:check` — pass
- `nix develop -c vp run lint:rust` (clippy `-D warnings`) — pass
- `nix develop -c vp run check:rust` — pass
- `nix develop -c vp run source:lengths --check --base-ref origin/main` — exit 0
- `nix develop -c cargo test -p vize_patina` — 2235 passed, 0 failed, **re-verified
  in a private `CARGO_TARGET_DIR`** (same 2235/0, so not a shared-target artifact)

Refs #3223
