### PR TITLE
test(patina): read the tsx script spelling in the upstream reference config

### DIFF
--- a/bench/generate.mjs
+++ b/bench/generate.mjs
@@ -761,13 +761,17 @@ export function generateCorpus({
 
   // Generate eslint.config.mjs; `parserOptions.parser` reads the `lang="ts"`
   // blocks espree turns into one rule-suppressing parse error each (#3410).
+  // `ecmaFeatures.jsx` covers the `lang="tsx"` spelling, which the TypeScript
+  // parser still rejects without it — the one file #3410 left unreadable.
   const eslintConfig = `import tsParser from "@typescript-eslint/parser";
 import pluginVue from "eslint-plugin-vue";
 export default [
   ...pluginVue.configs["flat/recommended"],
   {
     files: ["*.vue"],
-    languageOptions: { parserOptions: { parser: tsParser } },
+    languageOptions: {
+      parserOptions: { parser: tsParser, ecmaFeatures: { jsx: true } },
+    },
     rules: { "vue/multi-word-component-names": "off" },
   },
 ];

--- a/bench/generate.mjs
+++ b/bench/generate.mjs
@@ -759,19 +759,15 @@ export function generateCorpus({
   writeFileSync(join(benchDir, "tsconfig.json"), JSON.stringify(tsconfig, null, 2));
   writeLog("Generated tsconfig.json");
 
-  // Generate eslint.config.mjs; `parserOptions.parser` reads the `lang="ts"`
-  // blocks espree turns into one rule-suppressing parse error each (#3410).
-  // `ecmaFeatures.jsx` covers the `lang="tsx"` spelling, which the TypeScript
-  // parser still rejects without it — the one file #3410 left unreadable.
+  // Generate eslint.config.mjs; `parserOptions.parser` reads `lang="ts"` blocks
+  // and `ecmaFeatures.jsx` the `lang="tsx"` ones, else each is a parse error (#3410).
   const eslintConfig = `import tsParser from "@typescript-eslint/parser";
 import pluginVue from "eslint-plugin-vue";
 export default [
   ...pluginVue.configs["flat/recommended"],
   {
     files: ["*.vue"],
-    languageOptions: {
-      parserOptions: { parser: tsParser, ecmaFeatures: { jsx: true } },
-    },
+    languageOptions: { parserOptions: { parser: tsParser, ecmaFeatures: { jsx: true } } },
     rules: { "vue/multi-word-component-names": "off" },
   },
 ];

--- a/tests/tooling/benchmark-generator.test.ts
+++ b/tests/tooling/benchmark-generator.test.ts
@@ -90,7 +90,8 @@ test("benchmark generator writes a diversified unique SFC corpus", () => {
     // meaningful if it can read the corpus, and it silently cannot unless
     // `parserOptions.parser` is wired for the `lang="ts"` blocks that make up
     // most of it (vue-eslint-parser defaults to espree, which reports the whole
-    // file as one `ruleId: null` parse error). See #3410.
+    // file as one `ruleId: null` parse error). See #3410. `ecmaFeatures.jsx`
+    // covers the `lang="tsx"` spelling the TypeScript parser rejects on its own.
     const eslintConfig = fs.readFileSync(path.join(dir, "eslint.config.mjs"), "utf8");
     assert.equal(
       eslintConfig,
@@ -100,7 +101,9 @@ export default [
   ...pluginVue.configs["flat/recommended"],
   {
     files: ["*.vue"],
-    languageOptions: { parserOptions: { parser: tsParser } },
+    languageOptions: {
+      parserOptions: { parser: tsParser, ecmaFeatures: { jsx: true } },
+    },
     rules: { "vue/multi-word-component-names": "off" },
   },
 ];

--- a/tests/tooling/benchmark-generator.test.ts
+++ b/tests/tooling/benchmark-generator.test.ts
@@ -101,9 +101,7 @@ export default [
   ...pluginVue.configs["flat/recommended"],
   {
     files: ["*.vue"],
-    languageOptions: {
-      parserOptions: { parser: tsParser, ecmaFeatures: { jsx: true } },
-    },
+    languageOptions: { parserOptions: { parser: tsParser, ecmaFeatures: { jsx: true } } },
     rules: { "vue/multi-word-component-names": "off" },
   },
 ];


### PR DESCRIPTION
## Follow-up to #3433

#3433 pinned `@typescript-eslint/parser` for the reference runs and deliberately left one file unreadable: `examples/jsx-tsx/src/FormattedScriptBlock.vue`, whose `lang="tsx"` block the TypeScript parser still rejects without `ecmaFeatures.jsx`. It is a one-line config addition, so it is folded in here.

## Numbers from my own run

168 tracked `.vue` files, `pluginVue.configs["flat/recommended"]` + `vue-eslint-parser`:

| config | rule findings | parse errors |
| --- | --- | --- |
| no TypeScript parser (pre-#3433) | 96 | 129 over 129 files |
| parser only (#3433) | 1761 | 1 over 1 file |
| parser + `ecmaFeatures.jsx` | **1762** | **0** |

Nothing regresses. Enabling JSX in the delegated parse costs the `<T>x` type-assertion spelling, which no SFC in the corpus uses; the clean-parsing file count goes 167 → 168 and no finding is lost.

## How the test fails before the fix

The generated-config assertion in `tests/tooling/benchmark-generator.test.ts` is a full `assert.equal` of the emitted file, so with `bench/generate.mjs` at `origin/main` it reports the missing `ecmaFeatures` line in `actual` vs `expected`.

## Gates run

- `nix develop -c npx oxfmt --check` on both changed files — clean
- `nix develop -c node --test tests/tooling/benchmark-generator.test.ts` — 3/3 pass

Refs #3223
Refs #3410