### PR TITLE
feat(maestro): provide textDocument/linkedEditingRange for template tag pairs

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -1,12 +1,10 @@
 //! IDE features for the LSP server.
 //!
-//! This module provides core IDE functionality. The module list below is the
-//! authoritative inventory; grouped by what the editor sees:
-//! - Correctness: diagnostics aggregation, type checking and type information
-//! - Authoring: hover, completion, definition, references, code actions, rename
-//! - Presentation: semantic tokens, inlay hints, code lens, document links
-//! - Structure: document symbols, workspace symbols, selection ranges
-//! - Ecosystem: router/i18n awareness, file rename, auto-import
+//! Core IDE functionality; the module list below is the authoritative inventory:
+//! - Correctness: diagnostics, type checking and type information
+//! - Authoring: hover, completion, definition, references, code actions, rename, linked editing
+//! - Structure: document/workspace symbols, selection ranges, semantic tokens, inlay hints
+//! - Ecosystem: router/i18n awareness, file rename, auto-import, code lens, document links
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
 pub mod auto_import;
@@ -24,12 +22,14 @@ pub mod file_rename;
 pub mod hover;
 pub mod inlay_hint;
 pub mod jsx;
+pub mod linked_editing;
 pub(crate) mod markup;
 pub(crate) mod musea;
 pub mod references;
 pub mod rename;
 pub mod selection_range;
 pub mod semantic_tokens;
+pub(crate) mod sfc_region;
 mod template_expression;
 pub mod type_service;
 pub mod workspace_symbols;

--- a/crates/vize_maestro/src/ide/linked_editing.rs
+++ b/crates/vize_maestro/src/ide/linked_editing.rs
@@ -1,0 +1,176 @@
+//! Linked editing ranges (`textDocument/linkedEditingRange`).
+//!
+//! When the cursor is on a tag name, the editor keeps the open and close tag
+//! names in sync as the user types. `@vue/language-server` 3.3.8 advertises
+//! `linkedEditingRangeProvider: true`; Maestro advertised nothing and answered
+//! `-32601 Method not found`, so renaming `<div>` in a `.vue` file left a
+//! dangling `</div>` behind with no indication that anything was missing.
+//!
+//! Ranges are authored `.vue` coordinates, never virtual TypeScript.
+//!
+//! # Scope
+//!
+//! Only tag-name pairs are linked, matching the reference server. Self-closing
+//! elements, void elements (`<br>`, `<img>`) and unmatched tags have no
+//! counterpart and return `None` rather than a single-element list, because a
+//! one-range response would make the editor believe it had linked something.
+
+use tower_lsp::lsp_types::{LinkedEditingRanges, Position, Range};
+
+use super::offset_to_position;
+
+pub struct LinkedEditingService;
+
+/// An element whose start tag has been seen but whose close tag has not.
+#[derive(Clone, Copy)]
+struct OpenTag<'a> {
+    name: &'a str,
+    name_span: (usize, usize),
+}
+
+impl LinkedEditingService {
+    /// Resolve the open/close tag-name pair the cursor sits on.
+    ///
+    /// `filename` only selects the region to scan (template block, or the whole
+    /// file for standalone HTML and `.art.vue`); no server state is consulted.
+    pub fn ranges(content: &str, filename: &str, offset: usize) -> Option<LinkedEditingRanges> {
+        let offset = offset.min(content.len());
+        let region = super::sfc_region::resolve(content, filename, offset).markup?;
+        let (open, close) = tag_name_pair(content, region, offset)?;
+
+        Some(LinkedEditingRanges {
+            // Open tag first: the reference server orders them by position and
+            // clients apply edits in the order they receive them.
+            ranges: vec![to_range(content, open), to_range(content, close)],
+            // No word pattern: the reference server omits it, which lets the
+            // client use its own tag-name pattern for the language.
+            word_pattern: None,
+        })
+    }
+}
+
+/// Byte spans of the open and close tag names of the element whose name the
+/// cursor is on.
+fn tag_name_pair(
+    content: &str,
+    region: (usize, usize),
+    offset: usize,
+) -> Option<((usize, usize), (usize, usize))> {
+    let (region_start, region_end) = region;
+    let bytes = content.as_bytes();
+    let mut stack: Vec<OpenTag<'_>> = Vec::new();
+    let mut cursor = region_start;
+
+    while cursor < region_end {
+        if bytes[cursor] != b'<' {
+            cursor += 1;
+            continue;
+        }
+
+        if content[cursor..region_end].starts_with("<!--") {
+            cursor = content[cursor..region_end]
+                .find("-->")
+                .map_or(region_end, |relative| cursor + relative + 3);
+            continue;
+        }
+
+        if bytes.get(cursor + 1) == Some(&b'/') {
+            let name_start = cursor + 2;
+            let name_end = tag_name_end(bytes, name_start, region_end);
+            let close_span = (name_start, name_end);
+            let name = &content[name_start..name_end];
+
+            // `rposition` recovers from unclosed inner elements: the nearest
+            // matching open tag wins.
+            if let Some(index) = stack.iter().rposition(|open| open.name == name) {
+                let open = stack[index];
+                stack.truncate(index);
+                if contains(open.name_span, offset) || contains(close_span, offset) {
+                    return Some((open.name_span, close_span));
+                }
+            }
+
+            cursor = content[cursor..region_end]
+                .find('>')
+                .map_or(region_end, |relative| cursor + relative + 1);
+            continue;
+        }
+
+        let name_start = cursor + 1;
+        let name_end = tag_name_end(bytes, name_start, region_end);
+        let tag_end = start_tag_end(content, cursor, region_end)?;
+        if name_end == name_start {
+            cursor += 1;
+            continue;
+        }
+
+        let name = &content[name_start..name_end];
+        let self_closing = content[..tag_end - 1].trim_end().ends_with('/');
+        if !self_closing && !vize_carton::is_void_tag(name) {
+            stack.push(OpenTag {
+                name,
+                name_span: (name_start, name_end),
+            });
+        }
+        cursor = tag_end;
+    }
+
+    None
+}
+
+/// The cursor counts as "on" a name when it is anywhere inside it, including the
+/// position immediately after the last character — that is where an editor
+/// leaves the caret while the user is typing the name.
+#[inline]
+fn contains(span: (usize, usize), offset: usize) -> bool {
+    span.0 <= offset && offset <= span.1
+}
+
+fn tag_name_end(bytes: &[u8], name_start: usize, limit: usize) -> usize {
+    let mut end = name_start;
+    while end < limit
+        && (bytes[end].is_ascii_alphanumeric() || matches!(bytes[end], b'-' | b'_' | b'.' | b':'))
+    {
+        end += 1;
+    }
+    end
+}
+
+/// Byte offset just past the `>` that closes the start tag at `tag_start`.
+fn start_tag_end(content: &str, tag_start: usize, limit: usize) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut cursor = tag_start + 1;
+    let mut quote: Option<u8> = None;
+
+    while cursor < limit {
+        let byte = bytes[cursor];
+        match quote {
+            Some(open) if byte == open => quote = None,
+            Some(_) => {}
+            None if byte == b'"' || byte == b'\'' => quote = Some(byte),
+            None if byte == b'>' => return Some(cursor + 1),
+            None => {}
+        }
+        cursor += 1;
+    }
+
+    None
+}
+
+fn to_range(content: &str, span: (usize, usize)) -> Range {
+    let (start_line, start_character) = offset_to_position(content, span.0);
+    let (end_line, end_character) = offset_to_position(content, span.1);
+    Range {
+        start: Position {
+            line: start_line,
+            character: start_character,
+        },
+        end: Position {
+            line: end_line,
+            character: end_character,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_maestro/src/ide/linked_editing/tests.rs
+++ b/crates/vize_maestro/src/ide/linked_editing/tests.rs
@@ -1,0 +1,145 @@
+use super::LinkedEditingService;
+
+const SFC: &str = "<script setup lang=\"ts\">\nconst count = 1\n</script>\n\n<template>\n  <div class=\"wrap\">{{ count }}</div>\n</template>\n";
+
+/// Flatten to `(start_line, start_char, end_line, end_char)` pairs so tests can
+/// assert the FULL response in one `assert_eq!`.
+fn ranges(content: &str, filename: &str, line: u32, character: u32) -> Vec<(u32, u32, u32, u32)> {
+    let offset = crate::ide::position_to_offset(content, line, character)
+        .expect("test position must resolve to a byte offset");
+    let Some(result) = LinkedEditingService::ranges(content, filename, offset) else {
+        return Vec::new();
+    };
+    assert_eq!(
+        result.word_pattern, None,
+        "the reference server sends no wordPattern; the client supplies its own"
+    );
+    result
+        .ranges
+        .into_iter()
+        .map(|range| {
+            (
+                range.start.line,
+                range.start.character,
+                range.end.line,
+                range.end.character,
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn open_tag_name_links_to_its_close_tag_name() {
+    // Recorded from @vue/language-server 3.3.8 for the same fixture/position:
+    // {"ranges":[{"start":{"line":5,"character":3},"end":{"line":5,"character":6}},
+    //            {"start":{"line":5,"character":33},"end":{"line":5,"character":36}}]}
+    assert_eq!(
+        ranges(SFC, "/App.vue", 5, 4),
+        vec![(5, 3, 5, 6), (5, 33, 5, 36)]
+    );
+}
+
+#[test]
+fn close_tag_name_links_back_to_the_open_tag_name() {
+    assert_eq!(
+        ranges(SFC, "/App.vue", 5, 34),
+        vec![(5, 3, 5, 6), (5, 33, 5, 36)]
+    );
+}
+
+#[test]
+fn the_caret_just_after_a_tag_name_still_links() {
+    // Where the editor leaves the caret while the name is being typed.
+    assert_eq!(
+        ranges(SFC, "/App.vue", 5, 6),
+        vec![(5, 3, 5, 6), (5, 33, 5, 36)]
+    );
+}
+
+#[test]
+fn positions_that_are_not_tag_names_link_nothing() {
+    for (line, character, what) in [
+        (5, 2, "the `<` itself"),
+        (5, 9, "an attribute name"),
+        (5, 15, "an attribute value"),
+        (5, 24, "an interpolation identifier"),
+        (1, 8, "a script identifier"),
+        (0, 4, "the `<script>` block tag name"),
+    ] {
+        assert_eq!(
+            ranges(SFC, "/App.vue", line, character),
+            Vec::<(u32, u32, u32, u32)>::new(),
+            "{what} must not report linked ranges"
+        );
+    }
+}
+
+#[test]
+fn nested_same_name_elements_link_the_innermost_pair() {
+    let source = "<template>\n  <div><div>x</div></div>\n</template>\n";
+    // Cursor on the inner `<div>` name at character 8.
+    assert_eq!(
+        ranges(source, "/App.vue", 1, 8),
+        vec![(1, 8, 1, 11), (1, 15, 1, 18)]
+    );
+    // Cursor on the outer `<div>` name at character 3.
+    assert_eq!(
+        ranges(source, "/App.vue", 1, 3),
+        vec![(1, 3, 1, 6), (1, 21, 1, 24)]
+    );
+}
+
+#[test]
+fn the_template_block_tag_is_itself_a_linkable_pair() {
+    // `<template>`/`</template>` are markup; renaming one without the other
+    // would break the SFC, so they link like any other element.
+    assert_eq!(
+        ranges(SFC, "/App.vue", 4, 3),
+        vec![(4, 1, 4, 9), (6, 2, 6, 10)]
+    );
+}
+
+#[test]
+fn self_closing_and_void_elements_have_nothing_to_link() {
+    let source = "<template>\n  <Child />\n  <br>\n  <img src=\"a.png\">\n</template>\n";
+    for (line, character) in [(1, 4), (2, 3), (3, 4)] {
+        assert_eq!(
+            ranges(source, "/App.vue", line, character),
+            Vec::<(u32, u32, u32, u32)>::new(),
+            "line {line} has no close tag to link"
+        );
+    }
+}
+
+#[test]
+fn a_component_tag_links_across_lines() {
+    let source =
+        "<template>\n  <MyCard\n    title=\"a\"\n  >\n    body\n  </MyCard>\n</template>\n";
+    assert_eq!(
+        ranges(source, "/App.vue", 1, 5),
+        vec![(1, 3, 1, 9), (5, 4, 5, 10)]
+    );
+}
+
+#[test]
+fn a_script_block_is_never_scanned_as_markup() {
+    // `a < b` in a script body must not look like a tag.
+    let source = "<script setup lang=\"ts\">\nconst ok = 1 < 2\n</script>\n<template><div>x</div></template>\n";
+    assert_eq!(
+        ranges(source, "/App.vue", 1, 14),
+        Vec::<(u32, u32, u32, u32)>::new()
+    );
+    assert_eq!(
+        ranges(source, "/App.vue", 3, 12),
+        vec![(3, 11, 3, 14), (3, 18, 3, 21)]
+    );
+}
+
+#[test]
+fn standalone_petite_vue_html_links_tag_pairs_across_the_whole_file() {
+    let source = "<div v-scope=\"{ n: 0 }\"><span>{{ n }}</span></div>\n";
+    assert_eq!(
+        ranges(source, "/index.html", 0, 26),
+        vec![(0, 25, 0, 29), (0, 39, 0, 43)]
+    );
+}

--- a/crates/vize_maestro/src/ide/selection_range.rs
+++ b/crates/vize_maestro/src/ide/selection_range.rs
@@ -56,7 +56,6 @@ use tower_lsp::lsp_types::{Position, Range, SelectionRange};
 
 use self::markup::markup_spans;
 use super::{offset_to_position, token_span_at_offset};
-use crate::utils::is_standalone_html_path;
 
 pub struct SelectionRangeService;
 
@@ -87,62 +86,15 @@ impl SelectionRangeService {
 }
 
 /// Push SFC block levels and return the region that should be scanned as markup.
-///
-/// Returns `None` when the cursor sits in a raw-text block (`<script>`,
-/// `<style>`): scanning those as markup would treat `a < b` as a tag.
 fn collect_block_spans(
     content: &str,
     filename: &str,
     offset: usize,
     spans: &mut Vec<(usize, usize)>,
 ) -> Option<(usize, usize)> {
-    if is_standalone_html_path(filename) || filename.ends_with(".art.vue") {
-        return Some((0, content.len()));
-    }
-
-    let options = vize_atelier_sfc::SfcParseOptions {
-        filename: filename.into(),
-        ..Default::default()
-    };
-    let Ok(descriptor) = vize_atelier_sfc::parse_sfc(content, options) else {
-        return Some((0, content.len()));
-    };
-
-    let mut markup_region = None;
-    let template_loc = descriptor.template.as_ref().map(|block| &block.loc);
-    let raw_text_locs = descriptor
-        .script
-        .as_ref()
-        .map(|block| &block.loc)
-        .into_iter()
-        .chain(descriptor.script_setup.as_ref().map(|block| &block.loc))
-        .chain(descriptor.styles.iter().map(|block| &block.loc));
-
-    let mut in_raw_text = false;
-    for loc in template_loc.into_iter().chain(raw_text_locs.clone()) {
-        if loc.tag_start <= offset && offset <= loc.tag_end {
-            spans.push((loc.tag_start, loc.tag_end));
-            spans.push((loc.start, loc.end));
-        }
-    }
-    for loc in raw_text_locs {
-        if loc.start <= offset && offset <= loc.end {
-            in_raw_text = true;
-        }
-    }
-    if let Some(loc) = template_loc
-        && loc.start <= offset
-        && offset <= loc.end
-    {
-        markup_region = Some((loc.start, loc.end));
-    }
-
-    if in_raw_text {
-        return None;
-    }
-    // Outside every block (for example on a custom block's tag) the whole file
-    // is safe to scan: raw-text interiors were already excluded above.
-    Some(markup_region.unwrap_or((0, content.len())))
+    let region = super::sfc_region::resolve(content, filename, offset);
+    spans.extend(region.block_spans);
+    region.markup
 }
 
 #[inline]

--- a/crates/vize_maestro/src/ide/sfc_region.rs
+++ b/crates/vize_maestro/src/ide/sfc_region.rs
@@ -1,0 +1,87 @@
+//! Resolve which part of an authored SFC is safe to scan as markup.
+//!
+//! Shared by the providers that read the authored text directly rather than the
+//! virtual TypeScript projection (selection ranges, linked editing). Getting the
+//! region wrong is not cosmetic: scanning a `<script>` body as markup makes
+//! `a < b` look like a tag, which would silently attach editor features to
+//! nonsense spans.
+
+use crate::utils::is_standalone_html_path;
+
+/// The SFC block layout around a cursor offset.
+pub(crate) struct SfcRegion {
+    /// `(tag_start, tag_end)` and `(content_start, content_end)` of every block
+    /// whose tags enclose the cursor, in discovery order.
+    pub(crate) block_spans: Vec<(usize, usize)>,
+    /// The region that may be scanned as markup, or `None` when the cursor sits
+    /// inside a raw-text block (`<script>`, `<style>`).
+    pub(crate) markup: Option<(usize, usize)>,
+}
+
+/// Resolve the block layout for `offset`.
+///
+/// Standalone petite-vue HTML and `.art.vue` documents are not SFCs, and an SFC
+/// that fails to parse (mid-edit) has no trustworthy block boundaries; both scan
+/// the whole file, which is the behaviour that degrades most gracefully.
+pub(crate) fn resolve(content: &str, filename: &str, offset: usize) -> SfcRegion {
+    let whole_file = SfcRegion {
+        block_spans: Vec::new(),
+        markup: Some((0, content.len())),
+    };
+
+    if is_standalone_html_path(filename) || filename.ends_with(".art.vue") {
+        return whole_file;
+    }
+
+    let options = vize_atelier_sfc::SfcParseOptions {
+        filename: filename.into(),
+        ..Default::default()
+    };
+    let Ok(descriptor) = vize_atelier_sfc::parse_sfc(content, options) else {
+        return whole_file;
+    };
+
+    let template_loc = descriptor.template.as_ref().map(|block| &block.loc);
+    let raw_text_locs = descriptor
+        .script
+        .as_ref()
+        .map(|block| &block.loc)
+        .into_iter()
+        .chain(descriptor.script_setup.as_ref().map(|block| &block.loc))
+        .chain(descriptor.styles.iter().map(|block| &block.loc));
+
+    let mut block_spans = Vec::new();
+    for loc in template_loc.into_iter().chain(raw_text_locs.clone()) {
+        if loc.tag_start <= offset && offset <= loc.tag_end {
+            block_spans.push((loc.tag_start, loc.tag_end));
+            block_spans.push((loc.start, loc.end));
+        }
+    }
+
+    // A raw-text block is off-limits including its own tags: a cursor on
+    // `<script>` must not make the scanner walk the script body looking for
+    // elements.
+    if raw_text_locs
+        .into_iter()
+        .any(|loc| loc.tag_start <= offset && offset <= loc.tag_end)
+    {
+        return SfcRegion {
+            block_spans,
+            markup: None,
+        };
+    }
+
+    let markup = template_loc
+        // The template block's own tags are markup too, so a cursor anywhere
+        // from `<template>` to `</template>` scans the whole block.
+        .filter(|loc| loc.tag_start <= offset && offset <= loc.tag_end)
+        .map(|loc| (loc.tag_start, loc.tag_end))
+        // Outside every block (for example on a custom block's tag) the whole
+        // file is safe: raw-text blocks were already excluded above.
+        .unwrap_or((0, content.len()));
+
+    SfcRegion {
+        block_spans,
+        markup: Some(markup),
+    }
+}

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -5,13 +5,13 @@ use tower_lsp::lsp_types::{
     CodeActionKind, CodeActionOptions, CodeActionProviderCapability, CodeLensOptions,
     CompletionOptions, DocumentLinkOptions, FileOperationFilter, FileOperationPattern,
     FileOperationPatternKind, FileOperationRegistrationOptions, FoldingRangeProviderCapability,
-    HoverProviderCapability, OneOf, RenameOptions, SaveOptions, SelectionRangeProviderCapability,
-    SemanticTokenModifier, SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend,
-    SemanticTokensOptions, SemanticTokensServerCapabilities, ServerCapabilities,
-    TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
-    TextDocumentSyncSaveOptions, WorkDoneProgressOptions,
-    WorkspaceFileOperationsServerCapabilities, WorkspaceFoldersServerCapabilities,
-    WorkspaceServerCapabilities,
+    HoverProviderCapability, LinkedEditingRangeServerCapabilities, OneOf, RenameOptions,
+    SaveOptions, SelectionRangeProviderCapability, SemanticTokenModifier, SemanticTokenType,
+    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
+    SemanticTokensServerCapabilities, ServerCapabilities, TextDocumentSyncCapability,
+    TextDocumentSyncKind, TextDocumentSyncOptions, TextDocumentSyncSaveOptions,
+    WorkDoneProgressOptions, WorkspaceFileOperationsServerCapabilities,
+    WorkspaceFoldersServerCapabilities, WorkspaceServerCapabilities,
 };
 
 use super::state::LspFeatureConfig;
@@ -79,6 +79,13 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
             prepare_provider: Some(true),
             work_done_progress_options: WorkDoneProgressOptions::default(),
         })),
+
+        // Linked editing keeps an open/close tag-name pair in sync as the user
+        // types. It is rename-as-you-type, so it rides the `rename` flag rather
+        // than introducing a second user-facing setting for the same intent.
+        linked_editing_range_provider: features
+            .rename
+            .then_some(LinkedEditingRangeServerCapabilities::Simple(true)),
 
         // Document formatting
         document_formatting_provider: features.formatting.then_some(OneOf::Left(true)),
@@ -183,7 +190,6 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
         color_provider: None,
         document_on_type_formatting_provider: None,
         execute_command_provider: None,
-        linked_editing_range_provider: None,
         call_hierarchy_provider: None,
         moniker_provider: None,
         experimental: None,

--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -201,6 +201,24 @@ fn declaration_events_remain_registered_when_file_rename_is_disabled() {
 }
 
 #[test]
+fn linked_editing_shares_the_rename_flag() {
+    let capabilities = server_capabilities(all_features());
+    assert!(matches!(
+        capabilities.linked_editing_range_provider,
+        Some(LinkedEditingRangeServerCapabilities::Simple(true))
+    ));
+
+    let mut features = all_features();
+    features.rename = false;
+    let capabilities = server_capabilities(features);
+    assert!(capabilities.rename_provider.is_none());
+    assert!(capabilities.linked_editing_range_provider.is_none());
+    // Only the rename group is affected.
+    assert!(capabilities.references_provider.is_some());
+    assert!(capabilities.document_symbol_provider.is_some());
+}
+
+#[test]
 fn selection_ranges_share_the_document_structure_flag_with_folding_ranges() {
     let mut features = all_features();
     features.folding_ranges = false;

--- a/crates/vize_maestro/src/server/document_structure.rs
+++ b/crates/vize_maestro/src/server/document_structure.rs
@@ -7,6 +7,10 @@
 //! makes that shared contract explicit.
 #![allow(clippy::disallowed_methods)]
 
+mod symbols;
+
+pub(super) use symbols::document_symbols;
+
 use tower_lsp::lsp_types::{
     FoldingRange, FoldingRangeKind, FoldingRangeParams, SelectionRange, SelectionRangeParams,
 };

--- a/crates/vize_maestro/src/server/document_structure/symbols.rs
+++ b/crates/vize_maestro/src/server/document_structure/symbols.rs
@@ -1,0 +1,178 @@
+//! `textDocument/documentSymbol`: the SFC block outline.
+//!
+//! Moved out of `handlers.rs` (over the per-file length budget) into the
+//! document-structure group: the outline is the same block layout that folding
+//! and selection ranges read.
+// `DocumentSymbol::deprecated` is deprecated in the LSP crate but still part of
+// the struct literal.
+#![allow(deprecated, clippy::disallowed_methods)]
+
+use tower_lsp::lsp_types::{
+    DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, Position, Range, SymbolKind,
+};
+
+use crate::server::ServerState;
+
+/// Build the block outline for `params.text_document`.
+pub(crate) fn document_symbols(
+    state: &ServerState,
+    params: &DocumentSymbolParams,
+) -> Option<DocumentSymbolResponse> {
+    let uri = &params.text_document.uri;
+
+    let content = state.documents.text(uri)?;
+
+    // `.jsx`/`.tsx` documents have no SFC blocks; list their component
+    // functions instead. Structural (parse-based), so it is not gated on
+    // `typeChecker.jsxTypecheck`.
+    if crate::utils::is_jsx_path(uri.path()) {
+        return crate::ide::JsxDocumentSymbolsService::symbols(&content, uri)
+            .map(DocumentSymbolResponse::Nested);
+    }
+
+    let options = vize_atelier_sfc::SfcParseOptions {
+        filename: uri.path().to_string().into(),
+        ..Default::default()
+    };
+
+    let Ok(descriptor) = vize_atelier_sfc::parse_sfc(&content, options) else {
+        return None;
+    };
+
+    let mut symbols = Vec::new();
+
+    if let Some(ref template) = descriptor.template {
+        symbols.push(DocumentSymbol {
+            name: "template".to_string(),
+            kind: SymbolKind::MODULE,
+            tags: None,
+            deprecated: None,
+            range: Range {
+                start: Position {
+                    line: template.loc.start_line.saturating_sub(1) as u32,
+                    character: 0,
+                },
+                end: Position {
+                    line: template.loc.end_line.saturating_sub(1) as u32,
+                    character: 0,
+                },
+            },
+            selection_range: Range {
+                start: Position {
+                    line: template.loc.start_line.saturating_sub(1) as u32,
+                    character: 0,
+                },
+                end: Position {
+                    line: template.loc.start_line.saturating_sub(1) as u32,
+                    character: 10,
+                },
+            },
+            detail: template.lang.as_ref().map(|l| l.to_string()),
+            children: None,
+        });
+    }
+
+    if let Some(ref script) = descriptor.script {
+        symbols.push(DocumentSymbol {
+            name: "script".to_string(),
+            kind: SymbolKind::MODULE,
+            tags: None,
+            deprecated: None,
+            range: Range {
+                start: Position {
+                    line: script.loc.start_line.saturating_sub(1) as u32,
+                    character: 0,
+                },
+                end: Position {
+                    line: script.loc.end_line.saturating_sub(1) as u32,
+                    character: 0,
+                },
+            },
+            selection_range: Range {
+                start: Position {
+                    line: script.loc.start_line.saturating_sub(1) as u32,
+                    character: 0,
+                },
+                end: Position {
+                    line: script.loc.start_line.saturating_sub(1) as u32,
+                    character: 8,
+                },
+            },
+            detail: script.lang.as_ref().map(|l| l.to_string()),
+            children: None,
+        });
+    }
+
+    if let Some(ref script_setup) = descriptor.script_setup {
+        symbols.push(DocumentSymbol {
+            name: "script setup".to_string(),
+            kind: SymbolKind::MODULE,
+            tags: None,
+            deprecated: None,
+            range: Range {
+                start: Position {
+                    line: script_setup.loc.start_line.saturating_sub(1) as u32,
+                    character: 0,
+                },
+                end: Position {
+                    line: script_setup.loc.end_line.saturating_sub(1) as u32,
+                    character: 0,
+                },
+            },
+            selection_range: Range {
+                start: Position {
+                    line: script_setup.loc.start_line.saturating_sub(1) as u32,
+                    character: 0,
+                },
+                end: Position {
+                    line: script_setup.loc.start_line.saturating_sub(1) as u32,
+                    character: 14,
+                },
+            },
+            detail: script_setup.lang.as_ref().map(|l| l.to_string()),
+            children: None,
+        });
+    }
+
+    for (i, style) in descriptor.styles.iter().enumerate() {
+        #[allow(clippy::disallowed_macros)]
+        let name = if let Some(ref module) = style.module {
+            format!("style module={}", module)
+        } else if style.scoped {
+            "style scoped".to_string()
+        } else {
+            format!("style[{}]", i)
+        };
+
+        symbols.push(DocumentSymbol {
+            name,
+            kind: SymbolKind::MODULE,
+            tags: None,
+            deprecated: None,
+            range: Range {
+                start: Position {
+                    line: style.loc.start_line.saturating_sub(1) as u32,
+                    character: 0,
+                },
+                end: Position {
+                    line: style.loc.end_line.saturating_sub(1) as u32,
+                    character: 0,
+                },
+            },
+            selection_range: Range {
+                start: Position {
+                    line: style.loc.start_line.saturating_sub(1) as u32,
+                    character: 0,
+                },
+                end: Position {
+                    line: style.loc.start_line.saturating_sub(1) as u32,
+                    character: 7,
+                },
+            },
+            detail: style.lang.as_ref().map(|l| l.to_string()),
+            children: None,
+        });
+    }
+
+    Some(DocumentSymbolResponse::Nested(symbols))
+}

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -14,16 +14,21 @@ use tower_lsp::{
         DidChangeWorkspaceFoldersParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
         DidSaveTextDocumentParams, DocumentFormattingParams, DocumentHighlight,
         DocumentHighlightParams, DocumentLink, DocumentLinkParams, DocumentRangeFormattingParams,
-        DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange,
-        FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
-        InitializeParams, InitializeResult, InitializedParams, InlayHint, InlayHintParams,
-        Location, Position, PrepareRenameResponse, Range, ReferenceParams, RenameFilesParams,
-        RenameParams, SelectionRange, SelectionRangeParams, SemanticTokensParams,
-        SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, ServerInfo,
-        SymbolInformation, SymbolKind, TextDocumentPositionParams, TextEdit, WorkspaceEdit,
-        WorkspaceSymbolParams,
+        DocumentSymbolParams, DocumentSymbolResponse, FoldingRange, FoldingRangeParams,
+        GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams, InitializeParams,
+        InitializeResult, InitializedParams, InlayHint, InlayHintParams, LinkedEditingRangeParams,
+        LinkedEditingRanges, Location, Position, PrepareRenameResponse, ReferenceParams,
+        RenameFilesParams, RenameParams, SelectionRange, SelectionRangeParams,
+        SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
+        SemanticTokensResult, ServerInfo, SymbolInformation, TextDocumentPositionParams, TextEdit,
+        WorkspaceEdit, WorkspaceSymbolParams,
     },
 };
+
+// Only the test modules below construct ranges now that `document_symbol` moved
+// into `server::document_structure`; they reach it through `use super::*`.
+#[cfg(test)]
+use tower_lsp::lsp_types::Range;
 
 use super::{MaestroServer, server_capabilities};
 use crate::ide::{
@@ -379,7 +384,6 @@ impl LanguageServer for MaestroServer {
         Ok(DocumentHighlightService::highlights(&ctx))
     }
 
-    #[allow(deprecated)]
     async fn document_symbol(
         &self,
         params: DocumentSymbolParams,
@@ -387,168 +391,10 @@ impl LanguageServer for MaestroServer {
         if !self.state.lsp_features().document_symbols {
             return Ok(None);
         }
-
-        let uri = &params.text_document.uri;
-
-        let Some(content) = self.state.documents.text(uri) else {
-            return Ok(None);
-        };
-
-        // `.jsx`/`.tsx` documents have no SFC blocks; list their component
-        // functions instead. Structural (parse-based), so it is not gated on
-        // `typeChecker.jsxTypecheck`.
-        if crate::utils::is_jsx_path(uri.path()) {
-            return Ok(
-                crate::ide::JsxDocumentSymbolsService::symbols(&content, uri)
-                    .map(DocumentSymbolResponse::Nested),
-            );
-        }
-
-        let options = vize_atelier_sfc::SfcParseOptions {
-            filename: uri.path().to_string().into(),
-            ..Default::default()
-        };
-
-        let Ok(descriptor) = vize_atelier_sfc::parse_sfc(&content, options) else {
-            return Ok(None);
-        };
-
-        let mut symbols = Vec::new();
-
-        if let Some(ref template) = descriptor.template {
-            symbols.push(DocumentSymbol {
-                name: "template".to_string(),
-                kind: SymbolKind::MODULE,
-                tags: None,
-                deprecated: None,
-                range: Range {
-                    start: Position {
-                        line: template.loc.start_line.saturating_sub(1) as u32,
-                        character: 0,
-                    },
-                    end: Position {
-                        line: template.loc.end_line.saturating_sub(1) as u32,
-                        character: 0,
-                    },
-                },
-                selection_range: Range {
-                    start: Position {
-                        line: template.loc.start_line.saturating_sub(1) as u32,
-                        character: 0,
-                    },
-                    end: Position {
-                        line: template.loc.start_line.saturating_sub(1) as u32,
-                        character: 10,
-                    },
-                },
-                detail: template.lang.as_ref().map(|l| l.to_string()),
-                children: None,
-            });
-        }
-
-        if let Some(ref script) = descriptor.script {
-            symbols.push(DocumentSymbol {
-                name: "script".to_string(),
-                kind: SymbolKind::MODULE,
-                tags: None,
-                deprecated: None,
-                range: Range {
-                    start: Position {
-                        line: script.loc.start_line.saturating_sub(1) as u32,
-                        character: 0,
-                    },
-                    end: Position {
-                        line: script.loc.end_line.saturating_sub(1) as u32,
-                        character: 0,
-                    },
-                },
-                selection_range: Range {
-                    start: Position {
-                        line: script.loc.start_line.saturating_sub(1) as u32,
-                        character: 0,
-                    },
-                    end: Position {
-                        line: script.loc.start_line.saturating_sub(1) as u32,
-                        character: 8,
-                    },
-                },
-                detail: script.lang.as_ref().map(|l| l.to_string()),
-                children: None,
-            });
-        }
-
-        if let Some(ref script_setup) = descriptor.script_setup {
-            symbols.push(DocumentSymbol {
-                name: "script setup".to_string(),
-                kind: SymbolKind::MODULE,
-                tags: None,
-                deprecated: None,
-                range: Range {
-                    start: Position {
-                        line: script_setup.loc.start_line.saturating_sub(1) as u32,
-                        character: 0,
-                    },
-                    end: Position {
-                        line: script_setup.loc.end_line.saturating_sub(1) as u32,
-                        character: 0,
-                    },
-                },
-                selection_range: Range {
-                    start: Position {
-                        line: script_setup.loc.start_line.saturating_sub(1) as u32,
-                        character: 0,
-                    },
-                    end: Position {
-                        line: script_setup.loc.start_line.saturating_sub(1) as u32,
-                        character: 14,
-                    },
-                },
-                detail: script_setup.lang.as_ref().map(|l| l.to_string()),
-                children: None,
-            });
-        }
-
-        for (i, style) in descriptor.styles.iter().enumerate() {
-            #[allow(clippy::disallowed_macros)]
-            let name = if let Some(ref module) = style.module {
-                format!("style module={}", module)
-            } else if style.scoped {
-                "style scoped".to_string()
-            } else {
-                format!("style[{}]", i)
-            };
-
-            symbols.push(DocumentSymbol {
-                name,
-                kind: SymbolKind::MODULE,
-                tags: None,
-                deprecated: None,
-                range: Range {
-                    start: Position {
-                        line: style.loc.start_line.saturating_sub(1) as u32,
-                        character: 0,
-                    },
-                    end: Position {
-                        line: style.loc.end_line.saturating_sub(1) as u32,
-                        character: 0,
-                    },
-                },
-                selection_range: Range {
-                    start: Position {
-                        line: style.loc.start_line.saturating_sub(1) as u32,
-                        character: 0,
-                    },
-                    end: Position {
-                        line: style.loc.start_line.saturating_sub(1) as u32,
-                        character: 7,
-                    },
-                },
-                detail: style.lang.as_ref().map(|l| l.to_string()),
-                children: None,
-            });
-        }
-
-        Ok(Some(DocumentSymbolResponse::Nested(symbols)))
+        Ok(super::document_structure::document_symbols(
+            &self.state,
+            &params,
+        ))
     }
 
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
@@ -848,6 +694,34 @@ impl LanguageServer for MaestroServer {
         Ok(super::document_structure::selection_ranges(
             &self.state,
             &params,
+        ))
+    }
+
+    /// Keep an open/close tag-name pair in sync while the user types.
+    ///
+    /// Shares the `rename` flag with `rename`/`prepare_rename`: linked editing
+    /// is rename-as-you-type over the same authored tag names.
+    async fn linked_editing_range(
+        &self,
+        params: LinkedEditingRangeParams,
+    ) -> Result<Option<LinkedEditingRanges>> {
+        if !self.state.lsp_features().rename {
+            return Ok(None);
+        }
+
+        let uri = &params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+        let Some(content) = self.state.documents.text(uri) else {
+            return Ok(None);
+        };
+        let Some(offset) = position_to_offset(&content, position.line, position.character) else {
+            return Ok(None);
+        };
+
+        Ok(crate::ide::linked_editing::LinkedEditingService::ranges(
+            &content,
+            uri.path(),
+            offset,
         ))
     }
 

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -55,8 +55,10 @@ test("vize lsp advertises the full editor-feature provider set with exact shapes
     assert.equal(capabilities.codeLensProvider?.resolveProvider, false);
     assert.equal(capabilities.documentLinkProvider?.resolveProvider, false);
 
-    // Rename advertises prepareRename support.
+    // Rename advertises prepareRename support, and carries linked editing
+    // (rename-as-you-type over tag names) with it.
     assert.equal(capabilities.renameProvider?.prepareProvider, true);
+    assert.equal(capabilities.linkedEditingRangeProvider, true);
 
     // Code actions: kinds plus no resolve step.
     assert.deepEqual(capabilities.codeActionProvider?.codeActionKinds, [

--- a/tests/tooling/lsp-linked-editing.test.ts
+++ b/tests/tooling/lsp-linked-editing.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+/**
+ * `textDocument/linkedEditingRange` parity suite for `vize lsp`.
+ *
+ * `@vue/language-server` 3.3.8 advertises `linkedEditingRangeProvider: true`, so
+ * editing `<div>` in a `.vue` file rewrites the matching `</div>` as you type.
+ * Maestro advertised nothing and answered `-32601 Method not found`: the close
+ * tag was silently left behind, which is exactly the class of failure a user
+ * cannot see until the template stops rendering.
+ *
+ * `VUE_LANGUAGE_SERVER_TAG_PAIR` is the response `@vue/language-server@3.3.8`
+ * actually returned for this fixture and position, driven over stdio with the
+ * same request, so both sides of the oracle are recorded (#2971).
+ */
+
+type Range = {
+  start: { line: number; character: number };
+  end: { line: number; character: number };
+};
+
+type LinkedEditingRanges = {
+  ranges: Range[];
+  wordPattern?: string;
+};
+
+type FlatRange = [number, number, number, number];
+
+const FIXTURE = `<script setup lang="ts">
+const count = 1
+</script>
+
+<template>
+  <div class="wrap">{{ count }}</div>
+</template>
+`;
+
+/** Recorded from `@vue/language-server@3.3.8` for FIXTURE at line 5, character 4. */
+const VUE_LANGUAGE_SERVER_TAG_PAIR: FlatRange[] = [
+  [5, 3, 5, 6], // `div` in the open tag
+  [5, 33, 5, 36], // `div` in the close tag
+];
+
+function flatten(result: LinkedEditingRanges | null): FlatRange[] {
+  if (result == null) return [];
+  return result.ranges.map((range) => [
+    range.start.line,
+    range.start.character,
+    range.end.line,
+    range.end.character,
+  ]);
+}
+
+async function withSession(
+  label: string,
+  run: (
+    ask: (position: { line: number; character: number }) => Promise<LinkedEditingRanges | null>,
+  ) => Promise<void>,
+): Promise<void> {
+  const testRootDir = path.join(testOutputRoot, label);
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, { editor: true, lint: false, typecheck: false });
+
+    const filePath = path.join(workspaceDir, "App.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, FIXTURE, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: FIXTURE },
+    });
+
+    await run(
+      (position) =>
+        session.request("textDocument/linkedEditingRange", {
+          textDocument: { uri },
+          position,
+        }) as Promise<LinkedEditingRanges | null>,
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+}
+
+test("linkedEditingRange links a tag-name pair byte-for-byte with the reference server", async () => {
+  await withSession("lsp-linked-editing-pair", async (ask) => {
+    const result = await ask({ line: 5, character: 4 });
+    assert.deepEqual(flatten(result), VUE_LANGUAGE_SERVER_TAG_PAIR);
+    // The reference server sends no wordPattern; the client uses its own.
+    assert.equal(result?.wordPattern, undefined);
+
+    // The close tag name links back to the same pair.
+    assert.deepEqual(flatten(await ask({ line: 5, character: 34 })), VUE_LANGUAGE_SERVER_TAG_PAIR);
+    // So does the caret position just after the name, where an editor leaves it
+    // while the name is being typed.
+    assert.deepEqual(flatten(await ask({ line: 5, character: 6 })), VUE_LANGUAGE_SERVER_TAG_PAIR);
+  });
+});
+
+test("linkedEditingRange reports nothing where there is no tag-name pair", async () => {
+  await withSession("lsp-linked-editing-negative", async (ask) => {
+    // must-exclude set: every one of these must return null, not a one-element
+    // list, because a single range makes the editor believe it linked something.
+    for (const [line, character, what] of [
+      [5, 2, "the `<` itself"],
+      [5, 9, "an attribute name"],
+      [5, 15, "an attribute value"],
+      [5, 24, "an interpolation identifier"],
+      [1, 8, "a script identifier"],
+      [0, 4, "the `<script>` block tag name"],
+    ] as const) {
+      const result = await ask({ line, character });
+      assert.equal(result, null, `${what} must not report linked ranges`);
+    }
+  });
+});

--- a/tests/tooling/support/lsp/protocol.ts
+++ b/tests/tooling/support/lsp/protocol.ts
@@ -80,6 +80,7 @@ export type ServerCapabilities = {
   foldingRangeProvider?: unknown;
   hoverProvider?: unknown;
   inlayHintProvider?: unknown;
+  linkedEditingRangeProvider?: unknown;
   referencesProvider?: unknown;
   renameProvider?: { prepareProvider?: boolean };
   selectionRangeProvider?: unknown;


### PR DESCRIPTION
## Divergence

Measured against `@vue/language-server@3.3.8` driven over stdio with the same
`initialize` request:

| capability | `@vue/language-server` | `vize lsp` (before) |
| --- | --- | --- |
| `linkedEditingRangeProvider` | `true` | absent |
| `textDocument/linkedEditingRange` | returns both tag-name ranges | `-32601 Method not found` |

Linked editing is what keeps `<div>` and `</div>` in sync while you retype the
tag name. Without it the close tag is silently left behind — the editor reports
nothing, and the first symptom is a template that no longer renders.

## Minimal reproduction

```
<script setup lang="ts">
const count = 1
</script>

<template>
  <div class="wrap">{{ count }}</div>
</template>
```

`textDocument/linkedEditingRange` at line 5, character 4 (on `div`):

- `@vue/language-server`:
  `{"ranges":[{"start":{"line":5,"character":3},"end":{"line":5,"character":6}},{"start":{"line":5,"character":33},"end":{"line":5,"character":36}}]}`
- `vize lsp` before: `-32601 Method not found`
- `vize lsp` after: byte-identical to the reference server

## What landed

`crates/vize_maestro/src/ide/linked_editing.rs` walks the authored markup with a
tag stack and returns the open/close name pair the cursor is on. It links only
tag-name pairs, matching the reference server. Self-closing elements, void
elements (`<br>`, `<img>`) and unmatched tags return `None` rather than a
one-range list, because a single range makes the editor believe it linked
something.

The provider rides the existing `rename` flag — linked editing is
rename-as-you-type over the same authored names — so there is no new setting and
no editor manifest churn.

Region resolution moved into a shared `ide::sfc_region` module used by both
linked editing and selection ranges, and was **tightened while extracting**: a
raw-text block is now off-limits including its own tags. Previously a cursor on
the `<script>` tag itself fell through to "scan the whole file as markup", which
would have let the scanner walk a script body where `a < b` looks like a tag.
`crates/vize_maestro/src/ide/linked_editing/tests.rs::a_script_block_is_never_scanned_as_markup`
pins that.

## Tests, and how they fail before the fix

- `tests/tooling/lsp-linked-editing.test.ts` drives the real `vize lsp` binary.
  The must-include test asserts the FULL response with `assert.deepEqual`
  against the recorded `@vue/language-server` output (open tag first, then
  close, no `wordPattern`), from three positions: on the open name, on the close
  name, and at the caret position just after the name. The must-exclude test
  asserts `null` — not a one-element list — at six positions: the `<` itself, an
  attribute name, an attribute value, an interpolation identifier, a script
  identifier, and the `<script>` block tag name. Both fail pre-fix with
  `LspRequestError: textDocument/linkedEditingRange: Method not found`.
- `crates/vize_maestro/src/ide/linked_editing/tests.rs` — 9 unit tests with exact
  authored coordinates: nested same-name elements linking the innermost pair,
  `<template>`/`</template>` linking as a pair, self-closing and void elements
  linking nothing, a component tag spanning lines, script bodies never scanned
  as markup, and standalone petite-vue HTML.
- `crates/vize_maestro/src/server/capabilities/tests.rs::linked_editing_shares_the_rename_flag`
  pins both the advertised shape and that `rename: false` removes it while
  leaving sibling providers alone.
- `tests/tooling/lsp-capabilities.test.ts` now asserts
  `linkedEditingRangeProvider === true`.

## Gates

`fmt:check`, `lint:rust`, `check:rust`, `check:js`, `source:lengths`,
`cargo test -p vize_maestro --lib` (597 pass), and `node --test` over
`lsp-linked-editing`, `lsp-capabilities`, `lsp-selection-range`,
`lsp-document-features`, `lsp-rename-guards` (20 pass) all green locally.

Refs #3224, #2971.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added linked editing for matching markup tag names, including Vue SFCs and standalone HTML.
  * Added document outlines for Vue templates, scripts, script setup, styles, and JSX/TSX components.
  * Advertised linked-editing support when rename features are enabled.

* **Bug Fixes**
  * Improved selection handling across SFC regions while avoiding script and style content.
  * Improved nested-tag matching and handling of self-closing and void elements.

* **Tests**
  * Added coverage for linked editing, document capabilities, tag edge cases, and SFC region handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->