### PR TITLE
bench(tools): refresh the Blacksmith snapshot from a cold-cache run

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,30 +62,29 @@ same size for every row — it is given per row below, and only SFC compile, Lin
 
 | Surface     |  Files | Existing tool      | Existing |    Vize |            Speedup |
 | ----------- | -----: | ------------------ | -------: | ------: | -----------------: |
-| SFC compile | 15,000 | @vue/compiler-sfc  |   18.38s | 333.8ms |          **55.1×** |
-| Lint        | 15,000 | eslint-plugin-vue  |   56.66s | 270.9ms |         **209.2×** |
-| Format      | 15,000 | Prettier           |  150.34s |   2.22s |          **67.8×** |
-| Type check  |    500 | vue-tsc            |    5.42s | 438.3ms | n/a (cross-engine) |
-| Vite build  |  1,000 | @vitejs/plugin-vue |    1.66s | 732.5ms |           **2.3×** |
-| Nuxt build  |    500 | Nuxt compiler      |    6.79s |   6.42s |          **1.1×**† |
+| SFC compile | 15,000 | @vue/compiler-sfc  |   17.15s | 329.2ms |          **52.1×** |
+| Lint        | 15,000 | eslint-plugin-vue  |   56.20s | 324.8ms |         **173.0×** |
+| Format      | 15,000 | Prettier           |  143.13s |   2.83s |          **50.6×** |
+| Type check  |    500 | vue-tsc            |    5.57s | 498.1ms | n/a (cross-engine) |
+| Vite build  |  1,000 | @vitejs/plugin-vue |    1.71s | 631.7ms |           **2.7×** |
+| Nuxt build  |    500 | Nuxt compiler      |    6.83s |   6.59s |           **1.0×** |
 
-The Vite build and Nuxt build rows are taken from the committed snapshot
+Every row is taken from one committed snapshot,
 `bench/results/tool-benchmark-latest.json`
-([run 29010164013](https://github.com/ubugeeei-prod/vize/actions/runs/29010164013)) — the same
+([run 30557718030](https://github.com/ubugeeei-prod/vize/actions/runs/30557718030)) — the same
 artifact the published [Blacksmith benchmark snapshot](https://vizejs.dev/architecture/performance-blacksmith)
 renders — and `tests/tooling/readme-benchmark-rows.test.ts` pins them to it so the two cannot drift
-apart again. The other rows are from
-[run 29004198781](https://github.com/ubugeeei-prod/vize/actions/runs/29004198781).
+apart again.
 
 The type-check row publishes no single speedup on purpose: `vue-tsc` runs the JavaScript TypeScript
 compiler while `vize check` runs native tsgo (Corsa), so one ratio would credit TypeScript's Go
 rewrite to the Vue layer. Both timings above are real and were measured in the same run; they are
 ranked within each engine class in the snapshot instead.
 
-† **Pending regeneration.** The Nuxt row was measured before the benchmark stopped letting the
-`@vizejs/nuxt` variant inherit a warm pre-compile cache the Nuxt default compiler has no counterpart
-for. The correction runs against Vize: the honest cold-vs-cold figure is worse than the 1.1× shown
-here. It will be replaced by a fresh Blacksmith run rather than by a hand-written estimate.
+The Nuxt row is a genuine but *diluted* comparison: both variants run the same Nitro/Vite/Rollup
+pipeline and differ only in the SFC compiler, and SFC compilation is roughly 2% of that build, so
+end-to-end time is dominated by work neither compiler owns. It is published because it is what a
+Nuxt user actually experiences, not because it isolates Vize.
 
 See the [Blacksmith benchmark snapshot](https://vizejs.dev/architecture/performance-blacksmith) for
 methodology and per-variant numbers.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ compiler while `vize check` runs native tsgo (Corsa), so one ratio would credit 
 rewrite to the Vue layer. Both timings above are real and were measured in the same run; they are
 ranked within each engine class in the snapshot instead.
 
-The Nuxt row is a genuine but *diluted* comparison: both variants run the same Nitro/Vite/Rollup
+The Nuxt row is a genuine but _diluted_ comparison: both variants run the same Nitro/Vite/Rollup
 pipeline and differ only in the SFC compiler, and SFC compilation is roughly 2% of that build, so
 end-to-end time is dominated by work neither compiler owns. It is published because it is what a
 Nuxt user actually experiences, not because it isolates Vize.

--- a/bench/results/tool-benchmark-latest.json
+++ b/bench/results/tool-benchmark-latest.json
@@ -48,15 +48,7 @@
   "settings": {
     "runs": 5,
     "warmups": 1,
-    "tasks": [
-      "compile",
-      "large",
-      "lint",
-      "fmt",
-      "check",
-      "vite",
-      "nuxt"
-    ]
+    "tasks": ["compile", "large", "lint", "fmt", "check", "vite", "nuxt"]
   },
   "commands": {
     "workflowDispatch": "gh workflow run tool-benchmark.yml --ref <branch> -f file_count=15000 -f check_file_count=500 -f vite_file_count=1000 -f nuxt_file_count=500 -f large_blocks=900 -f runs=5 -f warmups=1 -f commit_results=true",
@@ -85,91 +77,49 @@
           "id": "vue-compiler-sfc-1t",
           "label": "@vue/compiler-sfc (1T)",
           "medianMs": 17152.877,
-          "runs": [
-            17819.521,
-            17112.058,
-            16916.262,
-            17152.877,
-            17221.425
-          ],
+          "runs": [17819.521, 17112.058, 16916.262, 17152.877, 17221.425],
           "throughput": "874 files/s"
         },
         {
           "id": "vue-compiler-sfc-workers",
           "label": "@vue/compiler-sfc (32 workers)",
           "medianMs": 6075.983,
-          "runs": [
-            6075.983,
-            6160.388,
-            6032.722,
-            6161.073,
-            5804.856
-          ],
+          "runs": [6075.983, 6160.388, 6032.722, 6161.073, 5804.856],
           "throughput": "2.5k files/s"
         },
         {
           "id": "vize-native-1t",
           "label": "Vize native loop (1T)",
           "medianMs": 3951.92,
-          "runs": [
-            3849.487,
-            3893.792,
-            3951.92,
-            4129.36,
-            3969.115
-          ],
+          "runs": [3849.487, 3893.792, 3951.92, 4129.36, 3969.115],
           "throughput": "3.8k files/s"
         },
         {
           "id": "vize-native-max",
           "label": "Vize native batch results (max)",
           "medianMs": 329.205,
-          "runs": [
-            329.205,
-            326.491,
-            345.119,
-            328.883,
-            340.781
-          ],
+          "runs": [329.205, 326.491, 345.119, 328.883, 340.781],
           "throughput": "45.6k files/s"
         },
         {
           "id": "vize-native-core-max",
           "label": "Vize native batch stats-only (core max)",
           "medianMs": 187.809,
-          "runs": [
-            183.109,
-            185.322,
-            187.809,
-            193.979,
-            189.336
-          ],
+          "runs": [183.109, 185.322, 187.809, 193.979, 189.336],
           "throughput": "79.9k files/s"
         },
         {
           "id": "vize-native-sequence-1-max",
           "label": "Vize batch sequence (1→32T, measures 32T)",
           "medianMs": 206.863,
-          "runs": [
-            194.877,
-            206.863,
-            205.945,
-            212.396,
-            212.974
-          ],
+          "runs": [194.877, 206.863, 205.945, 212.396, 212.974],
           "throughput": "72.5k files/s"
         },
         {
           "id": "vize-native-sequence-max-1",
           "label": "Vize batch sequence (32T→1, measures 1T)",
           "medianMs": 3123.118,
-          "runs": [
-            3293.425,
-            3301.079,
-            3087.024,
-            3123.118,
-            3112.967
-          ],
+          "runs": [3293.425, 3301.079, 3087.024, 3123.118, 3112.967],
           "throughput": "4.8k files/s"
         }
       ],
@@ -190,91 +140,49 @@
           "id": "vue-compiler-sfc-1t",
           "label": "@vue/compiler-sfc (1T)",
           "medianMs": 199.36,
-          "runs": [
-            200.972,
-            191.181,
-            193.759,
-            200.31,
-            199.36
-          ],
+          "runs": [200.972, 191.181, 193.759, 200.31, 199.36],
           "throughput": "5 files/s"
         },
         {
           "id": "vue-compiler-sfc-workers",
           "label": "@vue/compiler-sfc (1 workers)",
           "medianMs": 468.019,
-          "runs": [
-            454.414,
-            474.621,
-            475.43,
-            468.019,
-            466.291
-          ],
+          "runs": [454.414, 474.621, 475.43, 468.019, 466.291],
           "throughput": "2 files/s"
         },
         {
           "id": "vize-native-1t",
           "label": "Vize native loop (1T)",
           "medianMs": 66.48,
-          "runs": [
-            74.893,
-            62.548,
-            66.48,
-            62.222,
-            75.208
-          ],
+          "runs": [74.893, 62.548, 66.48, 62.222, 75.208],
           "throughput": "15 files/s"
         },
         {
           "id": "vize-native-max",
           "label": "Vize native batch results (max)",
           "medianMs": 64.849,
-          "runs": [
-            66.738,
-            62.304,
-            63.275,
-            64.849,
-            67.817
-          ],
+          "runs": [66.738, 62.304, 63.275, 64.849, 67.817],
           "throughput": "15 files/s"
         },
         {
           "id": "vize-native-core-max",
           "label": "Vize native batch stats-only (core max)",
           "medianMs": 58.845,
-          "runs": [
-            58.605,
-            58.845,
-            56.971,
-            60.738,
-            59.057
-          ],
+          "runs": [58.605, 58.845, 56.971, 60.738, 59.057],
           "throughput": "17 files/s"
         },
         {
           "id": "vize-native-sequence-1-max",
           "label": "Vize batch sequence (1→32T, measures 32T)",
           "medianMs": 51.978,
-          "runs": [
-            57.538,
-            51.978,
-            51.762,
-            48.436,
-            52.583
-          ],
+          "runs": [57.538, 51.978, 51.762, 48.436, 52.583],
           "throughput": "19 files/s"
         },
         {
           "id": "vize-native-sequence-max-1",
           "label": "Vize batch sequence (32T→1, measures 1T)",
           "medianMs": 52.226,
-          "runs": [
-            52.226,
-            54.816,
-            56.119,
-            50.1,
-            50.081
-          ],
+          "runs": [52.226, 54.816, 56.119, 50.1, 50.081],
           "throughput": "19 files/s"
         }
       ],
@@ -295,39 +203,21 @@
           "id": "vue-tsc",
           "label": "vue-tsc",
           "medianMs": 1753.632,
-          "runs": [
-            1779.714,
-            1776.348,
-            1700.789,
-            1690.186,
-            1753.632
-          ],
+          "runs": [1779.714, 1776.348, 1700.789, 1690.186, 1753.632],
           "throughput": "1 files/s"
         },
         {
           "id": "vize-check-1t",
           "label": "Vize check (1T)",
           "medianMs": 251.013,
-          "runs": [
-            251.013,
-            257.824,
-            255.216,
-            247.958,
-            246.176
-          ],
+          "runs": [251.013, 257.824, 255.216, 247.958, 246.176],
           "throughput": "4 files/s"
         },
         {
           "id": "vize-check-max",
           "label": "Vize check (max)",
           "medianMs": 252.521,
-          "runs": [
-            261.716,
-            252.521,
-            263.205,
-            251.813,
-            245.554
-          ],
+          "runs": [261.716, 252.521, 263.205, 251.813, 245.554],
           "throughput": "4 files/s"
         }
       ],
@@ -384,52 +274,28 @@
           "id": "eslint-plugin-vue-1t",
           "label": "eslint-plugin-vue (1T)",
           "medianMs": 56196.188,
-          "runs": [
-            56779.947,
-            57537.83,
-            55598.756,
-            56196.188,
-            54773.778
-          ],
+          "runs": [56779.947, 57537.83, 55598.756, 56196.188, 54773.778],
           "throughput": "267 files/s"
         },
         {
           "id": "eslint-plugin-vue-workers",
           "label": "eslint-plugin-vue (32 workers)",
           "medianMs": 13500.922,
-          "runs": [
-            13845.791,
-            13554.506,
-            13419.852,
-            13500.922,
-            13483.468
-          ],
+          "runs": [13845.791, 13554.506, 13419.852, 13500.922, 13483.468],
           "throughput": "1.1k files/s"
         },
         {
           "id": "vize-lint-1t",
           "label": "Vize lint (1T)",
           "medianMs": 1956.378,
-          "runs": [
-            1991.639,
-            1956.378,
-            1889.425,
-            1892.85,
-            1991.248
-          ],
+          "runs": [1991.639, 1956.378, 1889.425, 1892.85, 1991.248],
           "throughput": "7.7k files/s"
         },
         {
           "id": "vize-lint-max",
           "label": "Vize lint (max)",
           "medianMs": 324.842,
-          "runs": [
-            320.803,
-            321.233,
-            341.63,
-            330.518,
-            324.842
-          ],
+          "runs": [320.803, 321.233, 341.63, 330.518, 324.842],
           "throughput": "46.2k files/s"
         }
       ],
@@ -450,39 +316,21 @@
           "id": "prettier-cli",
           "label": "Prettier CLI",
           "medianMs": 143128.339,
-          "runs": [
-            140886.925,
-            143128.339,
-            142426.069,
-            144611.806,
-            145967.312
-          ],
+          "runs": [140886.925, 143128.339, 142426.069, 144611.806, 145967.312],
           "throughput": "105 files/s"
         },
         {
           "id": "vize-fmt-1t",
           "label": "Vize fmt (1T)",
           "medianMs": 6626.14,
-          "runs": [
-            5695.226,
-            6626.14,
-            6487.95,
-            6719.387,
-            6799.847
-          ],
+          "runs": [5695.226, 6626.14, 6487.95, 6719.387, 6799.847],
           "throughput": "2.3k files/s"
         },
         {
           "id": "vize-fmt-max",
           "label": "Vize fmt (max)",
           "medianMs": 2826.331,
-          "runs": [
-            7826.395,
-            2826.331,
-            2749.018,
-            2559.819,
-            3042.73
-          ],
+          "runs": [7826.395, 2826.331, 2749.018, 2559.819, 3042.73],
           "throughput": "5.3k files/s"
         }
       ],
@@ -503,39 +351,21 @@
           "id": "vue-tsc",
           "label": "vue-tsc",
           "medianMs": 5570.171,
-          "runs": [
-            5626.503,
-            5476.288,
-            5565.582,
-            5801.934,
-            5570.171
-          ],
+          "runs": [5626.503, 5476.288, 5565.582, 5801.934, 5570.171],
           "throughput": "90 files/s"
         },
         {
           "id": "vize-check-1t",
           "label": "Vize check (1T)",
           "medianMs": 593.577,
-          "runs": [
-            595.196,
-            576.692,
-            593.749,
-            577.619,
-            593.577
-          ],
+          "runs": [595.196, 576.692, 593.749, 577.619, 593.577],
           "throughput": "842 files/s"
         },
         {
           "id": "vize-check-max",
           "label": "Vize check (max)",
           "medianMs": 498.074,
-          "runs": [
-            496.036,
-            498.074,
-            501.954,
-            512.524,
-            479.49
-          ],
+          "runs": [496.036, 498.074, 501.954, 512.524, 479.49],
           "throughput": "1.0k files/s"
         }
       ],
@@ -592,26 +422,14 @@
           "id": "vite-plugin-vue",
           "label": "@vitejs/plugin-vue",
           "medianMs": 1711.721,
-          "runs": [
-            1733.209,
-            1651.916,
-            1630.62,
-            1711.721,
-            2017.761
-          ],
+          "runs": [1733.209, 1651.916, 1630.62, 1711.721, 2017.761],
           "throughput": "584 files/s"
         },
         {
           "id": "vize-vite-plugin",
           "label": "@vizejs/vite-plugin",
           "medianMs": 631.67,
-          "runs": [
-            782.45,
-            631.67,
-            635.394,
-            611.982,
-            616.324
-          ],
+          "runs": [782.45, 631.67, 635.394, 611.982, 616.324],
           "throughput": "1.6k files/s"
         }
       ],
@@ -632,26 +450,14 @@
           "id": "nuxt-default",
           "label": "Nuxt default compiler",
           "medianMs": 6825.073,
-          "runs": [
-            6825.073,
-            6617.655,
-            6780.768,
-            6979.657,
-            7008.791
-          ],
+          "runs": [6825.073, 6617.655, 6780.768, 6979.657, 7008.791],
           "throughput": "73 files/s"
         },
         {
           "id": "vize-nuxt",
           "label": "@vizejs/nuxt",
           "medianMs": 6588.984,
-          "runs": [
-            6588.984,
-            6417.209,
-            6293.842,
-            6603.32,
-            6706.736
-          ],
+          "runs": [6588.984, 6417.209, 6293.842, 6603.32, 6706.736],
           "throughput": "76 files/s"
         }
       ],

--- a/bench/results/tool-benchmark-latest.json
+++ b/bench/results/tool-benchmark-latest.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 1,
   "kind": "tool-comparison",
-  "generatedAt": "2026-07-09T10:06:01.799Z",
+  "generatedAt": "2026-07-30T15:44:33.256Z",
   "commit": {
-    "sha": "27fe77df7c8773e8e8fd5fa54beb7b09997b3a88",
-    "ref": "codex/perf-toolchain-throughput",
+    "sha": "1511788d96ead5621f0b2bd3727d644c4e104d09",
+    "ref": "bench/regenerate-blacksmith-snapshot",
     "repository": "ubugeeei-prod/vize",
-    "runUrl": "https://github.com/ubugeeei-prod/vize/actions/runs/29010164013"
+    "runUrl": "https://github.com/ubugeeei-prod/vize/actions/runs/30557718030"
   },
   "runner": {
     "label": "blacksmith-32vcpu-ubuntu-2404",
@@ -17,6 +17,23 @@
     "arch": "x64",
     "osRelease": "6.6.141",
     "node": "v24.14.0"
+  },
+  "versions": {
+    "vize": "vize 0.303.0",
+    "tsgo": "Version 7.0.0-dev.20260602.1",
+    "vueTsc": "Version 6.0.3",
+    "typescript": null,
+    "vue": "3.6.0-beta.10",
+    "eslint": "v10.4.1",
+    "prettier": "3.8.3",
+    "node": "v24.14.0"
+  },
+  "backend": {
+    "engine": "tsgo-native",
+    "corsaPath": "/home/runner/_work/vize/vize/node_modules/.bin/tsgo",
+    "corsaVersion": "Version 7.0.0-dev.20260602.1",
+    "ready": true,
+    "reason": null
   },
   "input": {
     "dir": "/home/runner/_work/vize/vize/bench/__in__",
@@ -31,7 +48,15 @@
   "settings": {
     "runs": 5,
     "warmups": 1,
-    "tasks": ["compile", "large", "lint", "fmt", "check", "vite", "nuxt"]
+    "tasks": [
+      "compile",
+      "large",
+      "lint",
+      "fmt",
+      "check",
+      "vite",
+      "nuxt"
+    ]
   },
   "commands": {
     "workflowDispatch": "gh workflow run tool-benchmark.yml --ref <branch> -f file_count=15000 -f check_file_count=500 -f vite_file_count=1000 -f nuxt_file_count=500 -f large_blocks=900 -f runs=5 -f warmups=1 -f commit_results=true",
@@ -43,10 +68,11 @@
     "The 15,000-SFC rows are the many-file workload; the large-SFC rows isolate one large component.",
     "Reported times are medians; measured runs alternate variant order after warmup runs.",
     "Destructive formatter runs receive a fresh copy of the same input before each invocation.",
-    "SFC compile Vize max uses `compileSfcBatchWithResults` wall time so the primary number includes generated output crossing the JS/native boundary; the stats-only native `timeMs` is shown only in variant details.",
+    "SFC compile Vize max uses `compileSfcBatchWithResults` wall time so the primary number includes generated output crossing the JS/native boundary; the stats-only native `timeMs` is shown only in variant details. Explicit sequence variants run 1→max and max→1 in one Node process and measure the second call's full JavaScript wall time, including scoped pool creation.",
     "Vite build timings exclude fixture copy/setup; the Vize max lane sets `precompileBatchSize` to the benchmark file count so Blacksmith max runs one native precompile batch instead of the memory-safe default chunks.",
     "Nuxt SPA build timings exclude synthetic app generation and compare `nuxt build` with Nuxt's default compiler against the same app with `@vizejs/nuxt` installed.",
-    "Single-thread lanes are shown where useful, and the primary speedup compares the incumbent default/single-thread lane with Vize's max runner lane."
+    "Single-thread lanes are shown where useful, and the primary speedup compares the incumbent default/single-thread lane with Vize's max runner lane.",
+    "Type-check rows span two TypeScript engines: vue-tsc runs the JavaScript compiler while Vize check runs native tsgo (Corsa). No cross-engine ratio is published for that surface — it is ranked within each engine class instead, so TypeScript's Go rewrite is never credited to the Vue layer; bench/check-gate.mjs publishes the same per-engine-class split with planted-diagnostic gating."
   ],
   "surfaces": [
     {
@@ -58,43 +84,99 @@
         {
           "id": "vue-compiler-sfc-1t",
           "label": "@vue/compiler-sfc (1T)",
-          "medianMs": 17544.994,
-          "runs": [17877.873, 17585.688, 17490.058, 17544.994, 17317.17],
-          "throughput": "855 files/s"
+          "medianMs": 17152.877,
+          "runs": [
+            17819.521,
+            17112.058,
+            16916.262,
+            17152.877,
+            17221.425
+          ],
+          "throughput": "874 files/s"
         },
         {
           "id": "vue-compiler-sfc-workers",
           "label": "@vue/compiler-sfc (32 workers)",
-          "medianMs": 5895.606,
-          "runs": [5887.487, 5895.606, 5862.726, 5951.76, 6094.778],
+          "medianMs": 6075.983,
+          "runs": [
+            6075.983,
+            6160.388,
+            6032.722,
+            6161.073,
+            5804.856
+          ],
           "throughput": "2.5k files/s"
         },
         {
           "id": "vize-native-1t",
           "label": "Vize native loop (1T)",
-          "medianMs": 3230.099,
-          "runs": [3102.965, 3132.096, 3356.702, 3362.025, 3230.099],
-          "throughput": "4.6k files/s"
+          "medianMs": 3951.92,
+          "runs": [
+            3849.487,
+            3893.792,
+            3951.92,
+            4129.36,
+            3969.115
+          ],
+          "throughput": "3.8k files/s"
         },
         {
           "id": "vize-native-max",
           "label": "Vize native batch results (max)",
-          "medianMs": 290.827,
-          "runs": [290.827, 272.867, 302.781, 274.735, 302.864],
-          "throughput": "51.6k files/s"
+          "medianMs": 329.205,
+          "runs": [
+            329.205,
+            326.491,
+            345.119,
+            328.883,
+            340.781
+          ],
+          "throughput": "45.6k files/s"
         },
         {
           "id": "vize-native-core-max",
           "label": "Vize native batch stats-only (core max)",
-          "medianMs": 178.793,
-          "runs": [172.909, 174.304, 178.793, 180.3, 180.113],
-          "throughput": "83.9k files/s"
+          "medianMs": 187.809,
+          "runs": [
+            183.109,
+            185.322,
+            187.809,
+            193.979,
+            189.336
+          ],
+          "throughput": "79.9k files/s"
+        },
+        {
+          "id": "vize-native-sequence-1-max",
+          "label": "Vize batch sequence (1→32T, measures 32T)",
+          "medianMs": 206.863,
+          "runs": [
+            194.877,
+            206.863,
+            205.945,
+            212.396,
+            212.974
+          ],
+          "throughput": "72.5k files/s"
+        },
+        {
+          "id": "vize-native-sequence-max-1",
+          "label": "Vize batch sequence (32T→1, measures 1T)",
+          "medianMs": 3123.118,
+          "runs": [
+            3293.425,
+            3301.079,
+            3087.024,
+            3123.118,
+            3112.967
+          ],
+          "throughput": "4.8k files/s"
         }
       ],
       "baselineId": "vue-compiler-sfc-1t",
       "vizeSingleId": "vize-native-1t",
       "vizeMaxId": "vize-native-max",
-      "primarySpeedup": 60.327940665756614,
+      "primarySpeedup": 52.103938275542596,
       "speedupStatus": "ranked",
       "engineClassRanking": null
     },
@@ -107,43 +189,99 @@
         {
           "id": "vue-compiler-sfc-1t",
           "label": "@vue/compiler-sfc (1T)",
-          "medianMs": 192.588,
-          "runs": [192.556, 192.588, 197.188, 195.874, 190.672],
+          "medianMs": 199.36,
+          "runs": [
+            200.972,
+            191.181,
+            193.759,
+            200.31,
+            199.36
+          ],
           "throughput": "5 files/s"
         },
         {
           "id": "vue-compiler-sfc-workers",
           "label": "@vue/compiler-sfc (1 workers)",
-          "medianMs": 479.83,
-          "runs": [468.336, 475.376, 479.83, 555.926, 493.06],
+          "medianMs": 468.019,
+          "runs": [
+            454.414,
+            474.621,
+            475.43,
+            468.019,
+            466.291
+          ],
           "throughput": "2 files/s"
         },
         {
           "id": "vize-native-1t",
           "label": "Vize native loop (1T)",
-          "medianMs": 62.608,
-          "runs": [62.608, 55.058, 65.224, 57.131, 64.989],
-          "throughput": "16 files/s"
+          "medianMs": 66.48,
+          "runs": [
+            74.893,
+            62.548,
+            66.48,
+            62.222,
+            75.208
+          ],
+          "throughput": "15 files/s"
         },
         {
           "id": "vize-native-max",
           "label": "Vize native batch results (max)",
-          "medianMs": 56.347,
-          "runs": [54.847, 54.316, 56.347, 56.409, 56.784],
-          "throughput": "18 files/s"
+          "medianMs": 64.849,
+          "runs": [
+            66.738,
+            62.304,
+            63.275,
+            64.849,
+            67.817
+          ],
+          "throughput": "15 files/s"
         },
         {
           "id": "vize-native-core-max",
           "label": "Vize native batch stats-only (core max)",
-          "medianMs": 55.679,
-          "runs": [56.69, 53.361, 55.679, 55.29, 55.842],
-          "throughput": "18 files/s"
+          "medianMs": 58.845,
+          "runs": [
+            58.605,
+            58.845,
+            56.971,
+            60.738,
+            59.057
+          ],
+          "throughput": "17 files/s"
+        },
+        {
+          "id": "vize-native-sequence-1-max",
+          "label": "Vize batch sequence (1→32T, measures 32T)",
+          "medianMs": 51.978,
+          "runs": [
+            57.538,
+            51.978,
+            51.762,
+            48.436,
+            52.583
+          ],
+          "throughput": "19 files/s"
+        },
+        {
+          "id": "vize-native-sequence-max-1",
+          "label": "Vize batch sequence (32T→1, measures 1T)",
+          "medianMs": 52.226,
+          "runs": [
+            52.226,
+            54.816,
+            56.119,
+            50.1,
+            50.081
+          ],
+          "throughput": "19 files/s"
         }
       ],
       "baselineId": "vue-compiler-sfc-1t",
       "vizeSingleId": "vize-native-1t",
       "vizeMaxId": "vize-native-max",
-      "primarySpeedup": 3.4178927005874313,
+      "primarySpeedup": 3.074218569291739,
       "speedupStatus": "ranked",
       "engineClassRanking": null
     },
@@ -156,23 +294,41 @@
         {
           "id": "vue-tsc",
           "label": "vue-tsc",
-          "medianMs": 1685.767,
-          "runs": [1703.499, 1716.442, 1684.449, 1624.718, 1685.767],
+          "medianMs": 1753.632,
+          "runs": [
+            1779.714,
+            1776.348,
+            1700.789,
+            1690.186,
+            1753.632
+          ],
           "throughput": "1 files/s"
         },
         {
           "id": "vize-check-1t",
           "label": "Vize check (1T)",
-          "medianMs": 178.667,
-          "runs": [176.247, 178.357, 179.08, 189.417, 178.667],
-          "throughput": "6 files/s"
+          "medianMs": 251.013,
+          "runs": [
+            251.013,
+            257.824,
+            255.216,
+            247.958,
+            246.176
+          ],
+          "throughput": "4 files/s"
         },
         {
           "id": "vize-check-max",
           "label": "Vize check (max)",
-          "medianMs": 177.986,
-          "runs": [177.669, 177.986, 177.536, 189.49, 194.54],
-          "throughput": "6 files/s"
+          "medianMs": 252.521,
+          "runs": [
+            261.716,
+            252.521,
+            263.205,
+            251.813,
+            245.554
+          ],
+          "throughput": "4 files/s"
         }
       ],
       "baselineId": "vue-tsc",
@@ -193,7 +349,7 @@
             {
               "id": "vue-tsc",
               "label": "vue-tsc",
-              "medianMs": 1685.767,
+              "medianMs": 1753.632,
               "relativeToFastest": 1
             }
           ]
@@ -203,16 +359,16 @@
           "label": "native TypeScript engine (tsgo)",
           "rows": [
             {
-              "id": "vize-check-max",
-              "label": "Vize check (max)",
-              "medianMs": 177.986,
+              "id": "vize-check-1t",
+              "label": "Vize check (1T)",
+              "medianMs": 251.013,
               "relativeToFastest": 1
             },
             {
-              "id": "vize-check-1t",
-              "label": "Vize check (1T)",
-              "medianMs": 178.667,
-              "relativeToFastest": 1.004
+              "id": "vize-check-max",
+              "label": "Vize check (max)",
+              "medianMs": 252.521,
+              "relativeToFastest": 1.006
             }
           ]
         }
@@ -227,36 +383,60 @@
         {
           "id": "eslint-plugin-vue-1t",
           "label": "eslint-plugin-vue (1T)",
-          "medianMs": 54319.872,
-          "runs": [54319.872, 54437.033, 53474.329, 54345.131, 54062.131],
-          "throughput": "276 files/s"
+          "medianMs": 56196.188,
+          "runs": [
+            56779.947,
+            57537.83,
+            55598.756,
+            56196.188,
+            54773.778
+          ],
+          "throughput": "267 files/s"
         },
         {
           "id": "eslint-plugin-vue-workers",
           "label": "eslint-plugin-vue (32 workers)",
-          "medianMs": 13468.854,
-          "runs": [13407.982, 13607.48, 13625.526, 13255.324, 13468.854],
+          "medianMs": 13500.922,
+          "runs": [
+            13845.791,
+            13554.506,
+            13419.852,
+            13500.922,
+            13483.468
+          ],
           "throughput": "1.1k files/s"
         },
         {
           "id": "vize-lint-1t",
           "label": "Vize lint (1T)",
-          "medianMs": 1907.507,
-          "runs": [1879.343, 1840.364, 1907.507, 1914.898, 1966.427],
-          "throughput": "7.9k files/s"
+          "medianMs": 1956.378,
+          "runs": [
+            1991.639,
+            1956.378,
+            1889.425,
+            1892.85,
+            1991.248
+          ],
+          "throughput": "7.7k files/s"
         },
         {
           "id": "vize-lint-max",
           "label": "Vize lint (max)",
-          "medianMs": 279.25,
-          "runs": [275.799, 272.071, 287.929, 287.064, 279.25],
-          "throughput": "53.7k files/s"
+          "medianMs": 324.842,
+          "runs": [
+            320.803,
+            321.233,
+            341.63,
+            330.518,
+            324.842
+          ],
+          "throughput": "46.2k files/s"
         }
       ],
       "baselineId": "eslint-plugin-vue-1t",
       "vizeSingleId": "vize-lint-1t",
       "vizeMaxId": "vize-lint-max",
-      "primarySpeedup": 194.52058012533573,
+      "primarySpeedup": 172.99545009573887,
       "speedupStatus": "ranked",
       "engineClassRanking": null
     },
@@ -269,29 +449,47 @@
         {
           "id": "prettier-cli",
           "label": "Prettier CLI",
-          "medianMs": 143610.675,
-          "runs": [142611.41, 142381.131, 143610.675, 145976.134, 144940.38],
-          "throughput": "104 files/s"
+          "medianMs": 143128.339,
+          "runs": [
+            140886.925,
+            143128.339,
+            142426.069,
+            144611.806,
+            145967.312
+          ],
+          "throughput": "105 files/s"
         },
         {
           "id": "vize-fmt-1t",
           "label": "Vize fmt (1T)",
-          "medianMs": 10151.052,
-          "runs": [10104.727, 10264.407, 10151.052, 10429.647, 9815.545],
-          "throughput": "1.5k files/s"
+          "medianMs": 6626.14,
+          "runs": [
+            5695.226,
+            6626.14,
+            6487.95,
+            6719.387,
+            6799.847
+          ],
+          "throughput": "2.3k files/s"
         },
         {
           "id": "vize-fmt-max",
           "label": "Vize fmt (max)",
-          "medianMs": 1788.982,
-          "runs": [1783.628, 1788.982, 1823.533, 1815.69, 1784.151],
-          "throughput": "8.4k files/s"
+          "medianMs": 2826.331,
+          "runs": [
+            7826.395,
+            2826.331,
+            2749.018,
+            2559.819,
+            3042.73
+          ],
+          "throughput": "5.3k files/s"
         }
       ],
       "baselineId": "prettier-cli",
       "vizeSingleId": "vize-fmt-1t",
       "vizeMaxId": "vize-fmt-max",
-      "primarySpeedup": 80.27508102373305,
+      "primarySpeedup": 50.64103921302919,
       "speedupStatus": "ranked",
       "engineClassRanking": null
     },
@@ -304,23 +502,41 @@
         {
           "id": "vue-tsc",
           "label": "vue-tsc",
-          "medianMs": 5364.227,
-          "runs": [5462.185, 5364.227, 5502.866, 5336.913, 5363.343],
-          "throughput": "93 files/s"
+          "medianMs": 5570.171,
+          "runs": [
+            5626.503,
+            5476.288,
+            5565.582,
+            5801.934,
+            5570.171
+          ],
+          "throughput": "90 files/s"
         },
         {
           "id": "vize-check-1t",
           "label": "Vize check (1T)",
-          "medianMs": 500.458,
-          "runs": [489.085, 513.568, 500.458, 503.987, 491.239],
-          "throughput": "999 files/s"
+          "medianMs": 593.577,
+          "runs": [
+            595.196,
+            576.692,
+            593.749,
+            577.619,
+            593.577
+          ],
+          "throughput": "842 files/s"
         },
         {
           "id": "vize-check-max",
           "label": "Vize check (max)",
-          "medianMs": 430.141,
-          "runs": [427.418, 430.141, 421.349, 438.772, 431.313],
-          "throughput": "1.2k files/s"
+          "medianMs": 498.074,
+          "runs": [
+            496.036,
+            498.074,
+            501.954,
+            512.524,
+            479.49
+          ],
+          "throughput": "1.0k files/s"
         }
       ],
       "baselineId": "vue-tsc",
@@ -341,7 +557,7 @@
             {
               "id": "vue-tsc",
               "label": "vue-tsc",
-              "medianMs": 5364.227,
+              "medianMs": 5570.171,
               "relativeToFastest": 1
             }
           ]
@@ -353,14 +569,14 @@
             {
               "id": "vize-check-max",
               "label": "Vize check (max)",
-              "medianMs": 430.141,
+              "medianMs": 498.074,
               "relativeToFastest": 1
             },
             {
               "id": "vize-check-1t",
               "label": "Vize check (1T)",
-              "medianMs": 500.458,
-              "relativeToFastest": 1.163
+              "medianMs": 593.577,
+              "relativeToFastest": 1.192
             }
           ]
         }
@@ -375,22 +591,34 @@
         {
           "id": "vite-plugin-vue",
           "label": "@vitejs/plugin-vue",
-          "medianMs": 1664.563,
-          "runs": [1653.415, 1608.25, 1685.384, 1664.563, 1951.632],
-          "throughput": "601 files/s"
+          "medianMs": 1711.721,
+          "runs": [
+            1733.209,
+            1651.916,
+            1630.62,
+            1711.721,
+            2017.761
+          ],
+          "throughput": "584 files/s"
         },
         {
           "id": "vize-vite-plugin",
           "label": "@vizejs/vite-plugin",
-          "medianMs": 732.519,
-          "runs": [732.519, 713.234, 746.155, 691.909, 752.751],
-          "throughput": "1.4k files/s"
+          "medianMs": 631.67,
+          "runs": [
+            782.45,
+            631.67,
+            635.394,
+            611.982,
+            616.324
+          ],
+          "throughput": "1.6k files/s"
         }
       ],
       "baselineId": "vite-plugin-vue",
       "vizeSingleId": null,
       "vizeMaxId": "vize-vite-plugin",
-      "primarySpeedup": 2.272382013299314,
+      "primarySpeedup": 2.7098342488957843,
       "speedupStatus": "ranked",
       "engineClassRanking": null
     },
@@ -403,22 +631,34 @@
         {
           "id": "nuxt-default",
           "label": "Nuxt default compiler",
-          "medianMs": 6792.975,
-          "runs": [6735.87, 6728.321, 6856.428, 6885.255, 6792.975],
-          "throughput": "74 files/s"
+          "medianMs": 6825.073,
+          "runs": [
+            6825.073,
+            6617.655,
+            6780.768,
+            6979.657,
+            7008.791
+          ],
+          "throughput": "73 files/s"
         },
         {
           "id": "vize-nuxt",
           "label": "@vizejs/nuxt",
-          "medianMs": 6421.713,
-          "runs": [6362.123, 6421.713, 6312.05, 6503.098, 6500.326],
-          "throughput": "78 files/s"
+          "medianMs": 6588.984,
+          "runs": [
+            6588.984,
+            6417.209,
+            6293.842,
+            6603.32,
+            6706.736
+          ],
+          "throughput": "76 files/s"
         }
       ],
       "baselineId": "nuxt-default",
       "vizeSingleId": null,
       "vizeMaxId": "vize-nuxt",
-      "primarySpeedup": 1.0578135460117886,
+      "primarySpeedup": 1.0358308655780617,
       "speedupStatus": "ranked",
       "engineClassRanking": null
     }

--- a/docs/content/architecture/performance-blacksmith.md
+++ b/docs/content/architecture/performance-blacksmith.md
@@ -10,53 +10,56 @@ This page is generated from the Tool Benchmark workflow so published performance
 
 ## Latest Result
 
-Measured: 2026-07-09T10:06:01.799Z
-Commit: `27fe77df7c87` ([run](https://github.com/ubugeeei-prod/vize/actions/runs/29010164013))
+Measured: 2026-07-30T15:44:33.256Z
+Commit: `1511788d96ea` ([run](https://github.com/ubugeeei-prod/vize/actions/runs/30557718030))
 Runner: `blacksmith-32vcpu-ubuntu-2404` (32 logical CPU, AMD EPYC, 32 vCPU / 128 GB RAM / 1.5 TB storage)
 Input: 15,000 generated SFC files (58.7 MB). Median of 5 measured run(s) after 1 warmup run(s).
+Versions: vize `vize 0.303.0` · tsgo `Version 7.0.0-dev.20260602.1` · vue-tsc `Version 6.0.3` (typescript n/a) · vue `3.6.0-beta.10` · eslint `v10.4.1` · prettier `3.8.3` · node `v24.14.0`
+Binaries (sha256): 
+Backend: native TypeScript engine ready at `/home/runner/_work/vize/vize/node_modules/.bin/tsgo`. Planted-diagnostic gating for the type-check rows lives in bench/check-gate.mjs (.github/workflows/check-bench.yml).
 Large SFC: 900 repeated template blocks (674.9 KB). Nuxt import set: 500 SFC files.
 
-| Surface                     |  Files | Existing tool          | Existing median | Vize 1T | Vize max |            Speedup |
-| --------------------------- | -----: | ---------------------- | --------------: | ------: | -------: | -----------------: |
-| SFC compile                 | 15,000 | @vue/compiler-sfc (1T) |          17.54s |   3.23s |  290.8ms |              60.3x |
-| Large SFC compile           |      1 | @vue/compiler-sfc (1T) |         192.6ms |  62.6ms |   56.3ms |               3.4x |
-| Large SFC type check        |      1 | vue-tsc                |           1.69s | 178.7ms |  178.0ms | n/a (cross-engine) |
-| Lint                        | 15,000 | eslint-plugin-vue (1T) |          54.32s |   1.91s |  279.3ms |             194.5x |
-| Format                      | 15,000 | Prettier CLI           |         143.61s |  10.15s |    1.79s |              80.3x |
-| Type check                  |    500 | vue-tsc                |           5.36s | 500.5ms |  430.1ms | n/a (cross-engine) |
-| Vite build (end-to-end)     |  1,000 | @vitejs/plugin-vue     |           1.66s |     n/a |  732.5ms |               2.3x |
-| Nuxt SPA build (end-to-end) |    500 | Nuxt default compiler  |           6.79s |     n/a |    6.42s |               1.1x |
+| Surface | Files | Existing tool | Existing median | Vize 1T | Vize max | Speedup |
+| --- | ---: | --- | ---: | ---: | ---: | ---: |
+| SFC compile | 15,000 | @vue/compiler-sfc (1T) | 17.15s | 3.95s | 329.2ms | 52.1x |
+| Large SFC compile | 1 | @vue/compiler-sfc (1T) | 199.4ms | 66.5ms | 64.8ms | 3.1x |
+| Large SFC type check | 1 | vue-tsc | 1.75s | 251.0ms | 252.5ms | n/a (cross-engine) |
+| Lint | 15,000 | eslint-plugin-vue (1T) | 56.20s | 1.96s | 324.8ms | 173.0x |
+| Format | 15,000 | Prettier CLI | 143.13s | 6.63s | 2.83s | 50.6x |
+| Type check | 500 | vue-tsc | 5.57s | 593.6ms | 498.1ms | n/a (cross-engine) |
+| Vite build (end-to-end) | 1,000 | @vitejs/plugin-vue | 1.71s | n/a | 631.7ms | 2.7x |
+| Nuxt SPA build (end-to-end) | 500 | Nuxt default compiler | 6.83s | n/a | 6.59s | 1.0x |
 
 #### Large SFC type check — engine classes ranked separately
 
-| Engine class                    | Row              |  Median | Relative to fastest in class |
-| ------------------------------- | ---------------- | ------: | ---------------------------: |
-| JS TypeScript engine (tsc)      | vue-tsc          |   1.69s |                        1.00x |
-| native TypeScript engine (tsgo) | Vize check (max) | 178.0ms |                        1.00x |
-| native TypeScript engine (tsgo) | Vize check (1T)  | 178.7ms |                        1.00x |
+| Engine class | Row | Median | Relative to fastest in class |
+| --- | --- | ---: | ---: |
+| JS TypeScript engine (tsc) | vue-tsc | 1.75s | 1.00x |
+| native TypeScript engine (tsgo) | Vize check (1T) | 251.0ms | 1.00x |
+| native TypeScript engine (tsgo) | Vize check (max) | 252.5ms | 1.01x |
 
 No cross-class ratio is published for Large SFC type check: the incumbent runs the JavaScript TypeScript compiler while Vize runs native tsgo, so a single number would credit TypeScript's Go rewrite to the Vue layer.
 
 #### Type check — engine classes ranked separately
 
-| Engine class                    | Row              |  Median | Relative to fastest in class |
-| ------------------------------- | ---------------- | ------: | ---------------------------: |
-| JS TypeScript engine (tsc)      | vue-tsc          |   5.36s |                        1.00x |
-| native TypeScript engine (tsgo) | Vize check (max) | 430.1ms |                        1.00x |
-| native TypeScript engine (tsgo) | Vize check (1T)  | 500.5ms |                        1.16x |
+| Engine class | Row | Median | Relative to fastest in class |
+| --- | --- | ---: | ---: |
+| JS TypeScript engine (tsc) | vue-tsc | 5.57s | 1.00x |
+| native TypeScript engine (tsgo) | Vize check (max) | 498.1ms | 1.00x |
+| native TypeScript engine (tsgo) | Vize check (1T) | 593.6ms | 1.19x |
 
 No cross-class ratio is published for Type check: the incumbent runs the JavaScript TypeScript compiler while Vize runs native tsgo, so a single number would credit TypeScript's Go rewrite to the Vue layer.
 
 Fairness notes:
-
 - All tools run on the same generated Vue SFC corpus from the same checkout and lockfile.
 - The 15,000-SFC rows are the many-file workload; the large-SFC rows isolate one large component.
 - Reported times are medians; measured runs alternate variant order after warmup runs.
 - Destructive formatter runs receive a fresh copy of the same input before each invocation.
-- SFC compile Vize max uses `compileSfcBatchWithResults` wall time so the primary number includes generated output crossing the JS/native boundary; the stats-only native `timeMs` is shown only in variant details.
+- SFC compile Vize max uses `compileSfcBatchWithResults` wall time so the primary number includes generated output crossing the JS/native boundary; the stats-only native `timeMs` is shown only in variant details. Explicit sequence variants run 1→max and max→1 in one Node process and measure the second call's full JavaScript wall time, including scoped pool creation.
 - Vite build timings exclude fixture copy/setup; the Vize max lane sets `precompileBatchSize` to the benchmark file count so Blacksmith max runs one native precompile batch instead of the memory-safe default chunks.
 - Nuxt SPA build timings exclude synthetic app generation and compare `nuxt build` with Nuxt's default compiler against the same app with `@vizejs/nuxt` installed.
 - Single-thread lanes are shown where useful, and the primary speedup compares the incumbent default/single-thread lane with Vize's max runner lane.
+- Type-check rows span two TypeScript engines: vue-tsc runs the JavaScript compiler while Vize check runs native tsgo (Corsa). No cross-engine ratio is published for that surface — it is ranked within each engine class instead, so TypeScript's Go rewrite is never credited to the Vue layer; bench/check-gate.mjs publishes the same per-engine-class split with planted-diagnostic gating.
 
 Commands:
 
@@ -71,69 +74,74 @@ node bench/compare-tools.mjs --input bench/__in__ --vize-bin target/release/vize
 
 ### SFC compile
 
-| Variant                                 |  Median |    Throughput | Raw measured runs                           |
-| --------------------------------------- | ------: | ------------: | ------------------------------------------- |
-| @vue/compiler-sfc (1T)                  |  17.54s |   855 files/s | 17.88s, 17.59s, 17.49s, 17.54s, 17.32s      |
-| @vue/compiler-sfc (32 workers)          |   5.90s |  2.5k files/s | 5.89s, 5.90s, 5.86s, 5.95s, 6.09s           |
-| Vize native loop (1T)                   |   3.23s |  4.6k files/s | 3.10s, 3.13s, 3.36s, 3.36s, 3.23s           |
-| Vize native batch results (max)         | 290.8ms | 51.6k files/s | 290.8ms, 272.9ms, 302.8ms, 274.7ms, 302.9ms |
-| Vize native batch stats-only (core max) | 178.8ms | 83.9k files/s | 172.9ms, 174.3ms, 178.8ms, 180.3ms, 180.1ms |
+| Variant | Median | Throughput | Raw measured runs |
+| --- | ---: | ---: | --- |
+| @vue/compiler-sfc (1T) | 17.15s | 874 files/s | 17.82s, 17.11s, 16.92s, 17.15s, 17.22s |
+| @vue/compiler-sfc (32 workers) | 6.08s | 2.5k files/s | 6.08s, 6.16s, 6.03s, 6.16s, 5.80s |
+| Vize native loop (1T) | 3.95s | 3.8k files/s | 3.85s, 3.89s, 3.95s, 4.13s, 3.97s |
+| Vize native batch results (max) | 329.2ms | 45.6k files/s | 329.2ms, 326.5ms, 345.1ms, 328.9ms, 340.8ms |
+| Vize native batch stats-only (core max) | 187.8ms | 79.9k files/s | 183.1ms, 185.3ms, 187.8ms, 194.0ms, 189.3ms |
+| Vize batch sequence (1→32T, measures 32T) | 206.9ms | 72.5k files/s | 194.9ms, 206.9ms, 205.9ms, 212.4ms, 213.0ms |
+| Vize batch sequence (32T→1, measures 1T) | 3.12s | 4.8k files/s | 3.29s, 3.30s, 3.09s, 3.12s, 3.11s |
 
 ### Large SFC compile
 
-| Variant                                 |  Median | Throughput | Raw measured runs                           |
-| --------------------------------------- | ------: | ---------: | ------------------------------------------- |
-| @vue/compiler-sfc (1T)                  | 192.6ms |  5 files/s | 192.6ms, 192.6ms, 197.2ms, 195.9ms, 190.7ms |
-| @vue/compiler-sfc (1 workers)           | 479.8ms |  2 files/s | 468.3ms, 475.4ms, 479.8ms, 555.9ms, 493.1ms |
-| Vize native loop (1T)                   |  62.6ms | 16 files/s | 62.6ms, 55.1ms, 65.2ms, 57.1ms, 65.0ms      |
-| Vize native batch results (max)         |  56.3ms | 18 files/s | 54.8ms, 54.3ms, 56.3ms, 56.4ms, 56.8ms      |
-| Vize native batch stats-only (core max) |  55.7ms | 18 files/s | 56.7ms, 53.4ms, 55.7ms, 55.3ms, 55.8ms      |
+| Variant | Median | Throughput | Raw measured runs |
+| --- | ---: | ---: | --- |
+| @vue/compiler-sfc (1T) | 199.4ms | 5 files/s | 201.0ms, 191.2ms, 193.8ms, 200.3ms, 199.4ms |
+| @vue/compiler-sfc (1 workers) | 468.0ms | 2 files/s | 454.4ms, 474.6ms, 475.4ms, 468.0ms, 466.3ms |
+| Vize native loop (1T) | 66.5ms | 15 files/s | 74.9ms, 62.5ms, 66.5ms, 62.2ms, 75.2ms |
+| Vize native batch results (max) | 64.8ms | 15 files/s | 66.7ms, 62.3ms, 63.3ms, 64.8ms, 67.8ms |
+| Vize native batch stats-only (core max) | 58.8ms | 17 files/s | 58.6ms, 58.8ms, 57.0ms, 60.7ms, 59.1ms |
+| Vize batch sequence (1→32T, measures 32T) | 52.0ms | 19 files/s | 57.5ms, 52.0ms, 51.8ms, 48.4ms, 52.6ms |
+| Vize batch sequence (32T→1, measures 1T) | 52.2ms | 19 files/s | 52.2ms, 54.8ms, 56.1ms, 50.1ms, 50.1ms |
 
 ### Large SFC type check
 
-| Variant          |  Median | Throughput | Raw measured runs                           |
-| ---------------- | ------: | ---------: | ------------------------------------------- |
-| vue-tsc          |   1.69s |  1 files/s | 1.70s, 1.72s, 1.68s, 1.62s, 1.69s           |
-| Vize check (1T)  | 178.7ms |  6 files/s | 176.2ms, 178.4ms, 179.1ms, 189.4ms, 178.7ms |
-| Vize check (max) | 178.0ms |  6 files/s | 177.7ms, 178.0ms, 177.5ms, 189.5ms, 194.5ms |
+| Variant | Median | Throughput | Raw measured runs |
+| --- | ---: | ---: | --- |
+| vue-tsc | 1.75s | 1 files/s | 1.78s, 1.78s, 1.70s, 1.69s, 1.75s |
+| Vize check (1T) | 251.0ms | 4 files/s | 251.0ms, 257.8ms, 255.2ms, 248.0ms, 246.2ms |
+| Vize check (max) | 252.5ms | 4 files/s | 261.7ms, 252.5ms, 263.2ms, 251.8ms, 245.6ms |
 
 ### Lint
 
-| Variant                        |  Median |    Throughput | Raw measured runs                           |
-| ------------------------------ | ------: | ------------: | ------------------------------------------- |
-| eslint-plugin-vue (1T)         |  54.32s |   276 files/s | 54.32s, 54.44s, 53.47s, 54.35s, 54.06s      |
-| eslint-plugin-vue (32 workers) |  13.47s |  1.1k files/s | 13.41s, 13.61s, 13.63s, 13.26s, 13.47s      |
-| Vize lint (1T)                 |   1.91s |  7.9k files/s | 1.88s, 1.84s, 1.91s, 1.91s, 1.97s           |
-| Vize lint (max)                | 279.3ms | 53.7k files/s | 275.8ms, 272.1ms, 287.9ms, 287.1ms, 279.3ms |
+| Variant | Median | Throughput | Raw measured runs |
+| --- | ---: | ---: | --- |
+| eslint-plugin-vue (1T) | 56.20s | 267 files/s | 56.78s, 57.54s, 55.60s, 56.20s, 54.77s |
+| eslint-plugin-vue (32 workers) | 13.50s | 1.1k files/s | 13.85s, 13.55s, 13.42s, 13.50s, 13.48s |
+| Vize lint (1T) | 1.96s | 7.7k files/s | 1.99s, 1.96s, 1.89s, 1.89s, 1.99s |
+| Vize lint (max) | 324.8ms | 46.2k files/s | 320.8ms, 321.2ms, 341.6ms, 330.5ms, 324.8ms |
 
 ### Format
 
-| Variant        |  Median |   Throughput | Raw measured runs                           |
-| -------------- | ------: | -----------: | ------------------------------------------- |
-| Prettier CLI   | 143.61s |  104 files/s | 142.61s, 142.38s, 143.61s, 145.98s, 144.94s |
-| Vize fmt (1T)  |  10.15s | 1.5k files/s | 10.10s, 10.26s, 10.15s, 10.43s, 9.82s       |
-| Vize fmt (max) |   1.79s | 8.4k files/s | 1.78s, 1.79s, 1.82s, 1.82s, 1.78s           |
+| Variant | Median | Throughput | Raw measured runs |
+| --- | ---: | ---: | --- |
+| Prettier CLI | 143.13s | 105 files/s | 140.89s, 143.13s, 142.43s, 144.61s, 145.97s |
+| Vize fmt (1T) | 6.63s | 2.3k files/s | 5.70s, 6.63s, 6.49s, 6.72s, 6.80s |
+| Vize fmt (max) | 2.83s | 5.3k files/s | 7.83s, 2.83s, 2.75s, 2.56s, 3.04s |
 
 ### Type check
 
-| Variant          |  Median |   Throughput | Raw measured runs                           |
-| ---------------- | ------: | -----------: | ------------------------------------------- |
-| vue-tsc          |   5.36s |   93 files/s | 5.46s, 5.36s, 5.50s, 5.34s, 5.36s           |
-| Vize check (1T)  | 500.5ms |  999 files/s | 489.1ms, 513.6ms, 500.5ms, 504.0ms, 491.2ms |
-| Vize check (max) | 430.1ms | 1.2k files/s | 427.4ms, 430.1ms, 421.3ms, 438.8ms, 431.3ms |
+| Variant | Median | Throughput | Raw measured runs |
+| --- | ---: | ---: | --- |
+| vue-tsc | 5.57s | 90 files/s | 5.63s, 5.48s, 5.57s, 5.80s, 5.57s |
+| Vize check (1T) | 593.6ms | 842 files/s | 595.2ms, 576.7ms, 593.7ms, 577.6ms, 593.6ms |
+| Vize check (max) | 498.1ms | 1.0k files/s | 496.0ms, 498.1ms, 502.0ms, 512.5ms, 479.5ms |
 
 ### Vite build (end-to-end)
 
-| Variant             |  Median |   Throughput | Raw measured runs                           |
-| ------------------- | ------: | -----------: | ------------------------------------------- |
-| @vitejs/plugin-vue  |   1.66s |  601 files/s | 1.65s, 1.61s, 1.69s, 1.66s, 1.95s           |
-| @vizejs/vite-plugin | 732.5ms | 1.4k files/s | 732.5ms, 713.2ms, 746.2ms, 691.9ms, 752.8ms |
+| Variant | Median | Throughput | Raw measured runs |
+| --- | ---: | ---: | --- |
+| @vitejs/plugin-vue | 1.71s | 584 files/s | 1.73s, 1.65s, 1.63s, 1.71s, 2.02s |
+| @vizejs/vite-plugin | 631.7ms | 1.6k files/s | 782.5ms, 631.7ms, 635.4ms, 612.0ms, 616.3ms |
 
 ### Nuxt SPA build (end-to-end)
 
-| Variant               | Median | Throughput | Raw measured runs                 |
-| --------------------- | -----: | ---------: | --------------------------------- |
-| Nuxt default compiler |  6.79s | 74 files/s | 6.74s, 6.73s, 6.86s, 6.89s, 6.79s |
-| @vizejs/nuxt          |  6.42s | 78 files/s | 6.36s, 6.42s, 6.31s, 6.50s, 6.50s |
+| Variant | Median | Throughput | Raw measured runs |
+| --- | ---: | ---: | --- |
+| Nuxt default compiler | 6.83s | 73 files/s | 6.83s, 6.62s, 6.78s, 6.98s, 7.01s |
+| @vizejs/nuxt | 6.59s | 76 files/s | 6.59s, 6.42s, 6.29s, 6.60s, 6.71s |
 
 </details>
+

--- a/docs/content/architecture/performance-blacksmith.md
+++ b/docs/content/architecture/performance-blacksmith.md
@@ -15,42 +15,43 @@ Commit: `1511788d96ea` ([run](https://github.com/ubugeeei-prod/vize/actions/runs
 Runner: `blacksmith-32vcpu-ubuntu-2404` (32 logical CPU, AMD EPYC, 32 vCPU / 128 GB RAM / 1.5 TB storage)
 Input: 15,000 generated SFC files (58.7 MB). Median of 5 measured run(s) after 1 warmup run(s).
 Versions: vize `vize 0.303.0` · tsgo `Version 7.0.0-dev.20260602.1` · vue-tsc `Version 6.0.3` (typescript n/a) · vue `3.6.0-beta.10` · eslint `v10.4.1` · prettier `3.8.3` · node `v24.14.0`
-Binaries (sha256): 
+Binaries (sha256):
 Backend: native TypeScript engine ready at `/home/runner/_work/vize/vize/node_modules/.bin/tsgo`. Planted-diagnostic gating for the type-check rows lives in bench/check-gate.mjs (.github/workflows/check-bench.yml).
 Large SFC: 900 repeated template blocks (674.9 KB). Nuxt import set: 500 SFC files.
 
-| Surface | Files | Existing tool | Existing median | Vize 1T | Vize max | Speedup |
-| --- | ---: | --- | ---: | ---: | ---: | ---: |
-| SFC compile | 15,000 | @vue/compiler-sfc (1T) | 17.15s | 3.95s | 329.2ms | 52.1x |
-| Large SFC compile | 1 | @vue/compiler-sfc (1T) | 199.4ms | 66.5ms | 64.8ms | 3.1x |
-| Large SFC type check | 1 | vue-tsc | 1.75s | 251.0ms | 252.5ms | n/a (cross-engine) |
-| Lint | 15,000 | eslint-plugin-vue (1T) | 56.20s | 1.96s | 324.8ms | 173.0x |
-| Format | 15,000 | Prettier CLI | 143.13s | 6.63s | 2.83s | 50.6x |
-| Type check | 500 | vue-tsc | 5.57s | 593.6ms | 498.1ms | n/a (cross-engine) |
-| Vite build (end-to-end) | 1,000 | @vitejs/plugin-vue | 1.71s | n/a | 631.7ms | 2.7x |
-| Nuxt SPA build (end-to-end) | 500 | Nuxt default compiler | 6.83s | n/a | 6.59s | 1.0x |
+| Surface                     |  Files | Existing tool          | Existing median | Vize 1T | Vize max |            Speedup |
+| --------------------------- | -----: | ---------------------- | --------------: | ------: | -------: | -----------------: |
+| SFC compile                 | 15,000 | @vue/compiler-sfc (1T) |          17.15s |   3.95s |  329.2ms |              52.1x |
+| Large SFC compile           |      1 | @vue/compiler-sfc (1T) |         199.4ms |  66.5ms |   64.8ms |               3.1x |
+| Large SFC type check        |      1 | vue-tsc                |           1.75s | 251.0ms |  252.5ms | n/a (cross-engine) |
+| Lint                        | 15,000 | eslint-plugin-vue (1T) |          56.20s |   1.96s |  324.8ms |             173.0x |
+| Format                      | 15,000 | Prettier CLI           |         143.13s |   6.63s |    2.83s |              50.6x |
+| Type check                  |    500 | vue-tsc                |           5.57s | 593.6ms |  498.1ms | n/a (cross-engine) |
+| Vite build (end-to-end)     |  1,000 | @vitejs/plugin-vue     |           1.71s |     n/a |  631.7ms |               2.7x |
+| Nuxt SPA build (end-to-end) |    500 | Nuxt default compiler  |           6.83s |     n/a |    6.59s |               1.0x |
 
 #### Large SFC type check — engine classes ranked separately
 
-| Engine class | Row | Median | Relative to fastest in class |
-| --- | --- | ---: | ---: |
-| JS TypeScript engine (tsc) | vue-tsc | 1.75s | 1.00x |
-| native TypeScript engine (tsgo) | Vize check (1T) | 251.0ms | 1.00x |
-| native TypeScript engine (tsgo) | Vize check (max) | 252.5ms | 1.01x |
+| Engine class                    | Row              |  Median | Relative to fastest in class |
+| ------------------------------- | ---------------- | ------: | ---------------------------: |
+| JS TypeScript engine (tsc)      | vue-tsc          |   1.75s |                        1.00x |
+| native TypeScript engine (tsgo) | Vize check (1T)  | 251.0ms |                        1.00x |
+| native TypeScript engine (tsgo) | Vize check (max) | 252.5ms |                        1.01x |
 
 No cross-class ratio is published for Large SFC type check: the incumbent runs the JavaScript TypeScript compiler while Vize runs native tsgo, so a single number would credit TypeScript's Go rewrite to the Vue layer.
 
 #### Type check — engine classes ranked separately
 
-| Engine class | Row | Median | Relative to fastest in class |
-| --- | --- | ---: | ---: |
-| JS TypeScript engine (tsc) | vue-tsc | 5.57s | 1.00x |
-| native TypeScript engine (tsgo) | Vize check (max) | 498.1ms | 1.00x |
-| native TypeScript engine (tsgo) | Vize check (1T) | 593.6ms | 1.19x |
+| Engine class                    | Row              |  Median | Relative to fastest in class |
+| ------------------------------- | ---------------- | ------: | ---------------------------: |
+| JS TypeScript engine (tsc)      | vue-tsc          |   5.57s |                        1.00x |
+| native TypeScript engine (tsgo) | Vize check (max) | 498.1ms |                        1.00x |
+| native TypeScript engine (tsgo) | Vize check (1T)  | 593.6ms |                        1.19x |
 
 No cross-class ratio is published for Type check: the incumbent runs the JavaScript TypeScript compiler while Vize runs native tsgo, so a single number would credit TypeScript's Go rewrite to the Vue layer.
 
 Fairness notes:
+
 - All tools run on the same generated Vue SFC corpus from the same checkout and lockfile.
 - The 15,000-SFC rows are the many-file workload; the large-SFC rows isolate one large component.
 - Reported times are medians; measured runs alternate variant order after warmup runs.
@@ -74,74 +75,73 @@ node bench/compare-tools.mjs --input bench/__in__ --vize-bin target/release/vize
 
 ### SFC compile
 
-| Variant | Median | Throughput | Raw measured runs |
-| --- | ---: | ---: | --- |
-| @vue/compiler-sfc (1T) | 17.15s | 874 files/s | 17.82s, 17.11s, 16.92s, 17.15s, 17.22s |
-| @vue/compiler-sfc (32 workers) | 6.08s | 2.5k files/s | 6.08s, 6.16s, 6.03s, 6.16s, 5.80s |
-| Vize native loop (1T) | 3.95s | 3.8k files/s | 3.85s, 3.89s, 3.95s, 4.13s, 3.97s |
-| Vize native batch results (max) | 329.2ms | 45.6k files/s | 329.2ms, 326.5ms, 345.1ms, 328.9ms, 340.8ms |
-| Vize native batch stats-only (core max) | 187.8ms | 79.9k files/s | 183.1ms, 185.3ms, 187.8ms, 194.0ms, 189.3ms |
+| Variant                                   |  Median |    Throughput | Raw measured runs                           |
+| ----------------------------------------- | ------: | ------------: | ------------------------------------------- |
+| @vue/compiler-sfc (1T)                    |  17.15s |   874 files/s | 17.82s, 17.11s, 16.92s, 17.15s, 17.22s      |
+| @vue/compiler-sfc (32 workers)            |   6.08s |  2.5k files/s | 6.08s, 6.16s, 6.03s, 6.16s, 5.80s           |
+| Vize native loop (1T)                     |   3.95s |  3.8k files/s | 3.85s, 3.89s, 3.95s, 4.13s, 3.97s           |
+| Vize native batch results (max)           | 329.2ms | 45.6k files/s | 329.2ms, 326.5ms, 345.1ms, 328.9ms, 340.8ms |
+| Vize native batch stats-only (core max)   | 187.8ms | 79.9k files/s | 183.1ms, 185.3ms, 187.8ms, 194.0ms, 189.3ms |
 | Vize batch sequence (1→32T, measures 32T) | 206.9ms | 72.5k files/s | 194.9ms, 206.9ms, 205.9ms, 212.4ms, 213.0ms |
-| Vize batch sequence (32T→1, measures 1T) | 3.12s | 4.8k files/s | 3.29s, 3.30s, 3.09s, 3.12s, 3.11s |
+| Vize batch sequence (32T→1, measures 1T)  |   3.12s |  4.8k files/s | 3.29s, 3.30s, 3.09s, 3.12s, 3.11s           |
 
 ### Large SFC compile
 
-| Variant | Median | Throughput | Raw measured runs |
-| --- | ---: | ---: | --- |
-| @vue/compiler-sfc (1T) | 199.4ms | 5 files/s | 201.0ms, 191.2ms, 193.8ms, 200.3ms, 199.4ms |
-| @vue/compiler-sfc (1 workers) | 468.0ms | 2 files/s | 454.4ms, 474.6ms, 475.4ms, 468.0ms, 466.3ms |
-| Vize native loop (1T) | 66.5ms | 15 files/s | 74.9ms, 62.5ms, 66.5ms, 62.2ms, 75.2ms |
-| Vize native batch results (max) | 64.8ms | 15 files/s | 66.7ms, 62.3ms, 63.3ms, 64.8ms, 67.8ms |
-| Vize native batch stats-only (core max) | 58.8ms | 17 files/s | 58.6ms, 58.8ms, 57.0ms, 60.7ms, 59.1ms |
-| Vize batch sequence (1→32T, measures 32T) | 52.0ms | 19 files/s | 57.5ms, 52.0ms, 51.8ms, 48.4ms, 52.6ms |
-| Vize batch sequence (32T→1, measures 1T) | 52.2ms | 19 files/s | 52.2ms, 54.8ms, 56.1ms, 50.1ms, 50.1ms |
+| Variant                                   |  Median | Throughput | Raw measured runs                           |
+| ----------------------------------------- | ------: | ---------: | ------------------------------------------- |
+| @vue/compiler-sfc (1T)                    | 199.4ms |  5 files/s | 201.0ms, 191.2ms, 193.8ms, 200.3ms, 199.4ms |
+| @vue/compiler-sfc (1 workers)             | 468.0ms |  2 files/s | 454.4ms, 474.6ms, 475.4ms, 468.0ms, 466.3ms |
+| Vize native loop (1T)                     |  66.5ms | 15 files/s | 74.9ms, 62.5ms, 66.5ms, 62.2ms, 75.2ms      |
+| Vize native batch results (max)           |  64.8ms | 15 files/s | 66.7ms, 62.3ms, 63.3ms, 64.8ms, 67.8ms      |
+| Vize native batch stats-only (core max)   |  58.8ms | 17 files/s | 58.6ms, 58.8ms, 57.0ms, 60.7ms, 59.1ms      |
+| Vize batch sequence (1→32T, measures 32T) |  52.0ms | 19 files/s | 57.5ms, 52.0ms, 51.8ms, 48.4ms, 52.6ms      |
+| Vize batch sequence (32T→1, measures 1T)  |  52.2ms | 19 files/s | 52.2ms, 54.8ms, 56.1ms, 50.1ms, 50.1ms      |
 
 ### Large SFC type check
 
-| Variant | Median | Throughput | Raw measured runs |
-| --- | ---: | ---: | --- |
-| vue-tsc | 1.75s | 1 files/s | 1.78s, 1.78s, 1.70s, 1.69s, 1.75s |
-| Vize check (1T) | 251.0ms | 4 files/s | 251.0ms, 257.8ms, 255.2ms, 248.0ms, 246.2ms |
-| Vize check (max) | 252.5ms | 4 files/s | 261.7ms, 252.5ms, 263.2ms, 251.8ms, 245.6ms |
+| Variant          |  Median | Throughput | Raw measured runs                           |
+| ---------------- | ------: | ---------: | ------------------------------------------- |
+| vue-tsc          |   1.75s |  1 files/s | 1.78s, 1.78s, 1.70s, 1.69s, 1.75s           |
+| Vize check (1T)  | 251.0ms |  4 files/s | 251.0ms, 257.8ms, 255.2ms, 248.0ms, 246.2ms |
+| Vize check (max) | 252.5ms |  4 files/s | 261.7ms, 252.5ms, 263.2ms, 251.8ms, 245.6ms |
 
 ### Lint
 
-| Variant | Median | Throughput | Raw measured runs |
-| --- | ---: | ---: | --- |
-| eslint-plugin-vue (1T) | 56.20s | 267 files/s | 56.78s, 57.54s, 55.60s, 56.20s, 54.77s |
-| eslint-plugin-vue (32 workers) | 13.50s | 1.1k files/s | 13.85s, 13.55s, 13.42s, 13.50s, 13.48s |
-| Vize lint (1T) | 1.96s | 7.7k files/s | 1.99s, 1.96s, 1.89s, 1.89s, 1.99s |
-| Vize lint (max) | 324.8ms | 46.2k files/s | 320.8ms, 321.2ms, 341.6ms, 330.5ms, 324.8ms |
+| Variant                        |  Median |    Throughput | Raw measured runs                           |
+| ------------------------------ | ------: | ------------: | ------------------------------------------- |
+| eslint-plugin-vue (1T)         |  56.20s |   267 files/s | 56.78s, 57.54s, 55.60s, 56.20s, 54.77s      |
+| eslint-plugin-vue (32 workers) |  13.50s |  1.1k files/s | 13.85s, 13.55s, 13.42s, 13.50s, 13.48s      |
+| Vize lint (1T)                 |   1.96s |  7.7k files/s | 1.99s, 1.96s, 1.89s, 1.89s, 1.99s           |
+| Vize lint (max)                | 324.8ms | 46.2k files/s | 320.8ms, 321.2ms, 341.6ms, 330.5ms, 324.8ms |
 
 ### Format
 
-| Variant | Median | Throughput | Raw measured runs |
-| --- | ---: | ---: | --- |
-| Prettier CLI | 143.13s | 105 files/s | 140.89s, 143.13s, 142.43s, 144.61s, 145.97s |
-| Vize fmt (1T) | 6.63s | 2.3k files/s | 5.70s, 6.63s, 6.49s, 6.72s, 6.80s |
-| Vize fmt (max) | 2.83s | 5.3k files/s | 7.83s, 2.83s, 2.75s, 2.56s, 3.04s |
+| Variant        |  Median |   Throughput | Raw measured runs                           |
+| -------------- | ------: | -----------: | ------------------------------------------- |
+| Prettier CLI   | 143.13s |  105 files/s | 140.89s, 143.13s, 142.43s, 144.61s, 145.97s |
+| Vize fmt (1T)  |   6.63s | 2.3k files/s | 5.70s, 6.63s, 6.49s, 6.72s, 6.80s           |
+| Vize fmt (max) |   2.83s | 5.3k files/s | 7.83s, 2.83s, 2.75s, 2.56s, 3.04s           |
 
 ### Type check
 
-| Variant | Median | Throughput | Raw measured runs |
-| --- | ---: | ---: | --- |
-| vue-tsc | 5.57s | 90 files/s | 5.63s, 5.48s, 5.57s, 5.80s, 5.57s |
-| Vize check (1T) | 593.6ms | 842 files/s | 595.2ms, 576.7ms, 593.7ms, 577.6ms, 593.6ms |
+| Variant          |  Median |   Throughput | Raw measured runs                           |
+| ---------------- | ------: | -----------: | ------------------------------------------- |
+| vue-tsc          |   5.57s |   90 files/s | 5.63s, 5.48s, 5.57s, 5.80s, 5.57s           |
+| Vize check (1T)  | 593.6ms |  842 files/s | 595.2ms, 576.7ms, 593.7ms, 577.6ms, 593.6ms |
 | Vize check (max) | 498.1ms | 1.0k files/s | 496.0ms, 498.1ms, 502.0ms, 512.5ms, 479.5ms |
 
 ### Vite build (end-to-end)
 
-| Variant | Median | Throughput | Raw measured runs |
-| --- | ---: | ---: | --- |
-| @vitejs/plugin-vue | 1.71s | 584 files/s | 1.73s, 1.65s, 1.63s, 1.71s, 2.02s |
+| Variant             |  Median |   Throughput | Raw measured runs                           |
+| ------------------- | ------: | -----------: | ------------------------------------------- |
+| @vitejs/plugin-vue  |   1.71s |  584 files/s | 1.73s, 1.65s, 1.63s, 1.71s, 2.02s           |
 | @vizejs/vite-plugin | 631.7ms | 1.6k files/s | 782.5ms, 631.7ms, 635.4ms, 612.0ms, 616.3ms |
 
 ### Nuxt SPA build (end-to-end)
 
-| Variant | Median | Throughput | Raw measured runs |
-| --- | ---: | ---: | --- |
-| Nuxt default compiler | 6.83s | 73 files/s | 6.83s, 6.62s, 6.78s, 6.98s, 7.01s |
-| @vizejs/nuxt | 6.59s | 76 files/s | 6.59s, 6.42s, 6.29s, 6.60s, 6.71s |
+| Variant               | Median | Throughput | Raw measured runs                 |
+| --------------------- | -----: | ---------: | --------------------------------- |
+| Nuxt default compiler |  6.83s | 73 files/s | 6.83s, 6.62s, 6.78s, 6.98s, 7.01s |
+| @vizejs/nuxt          |  6.59s | 76 files/s | 6.59s, 6.42s, 6.29s, 6.60s, 6.71s |
 
 </details>
-

--- a/docs/content/architecture/performance.md
+++ b/docs/content/architecture/performance.md
@@ -196,10 +196,10 @@ Vite build with **1,000 Vue SFC imports** (all imported in a single entry), meas
 
 |                | @vitejs/plugin-vue | @vizejs/vite-plugin | Speedup  |
 | -------------- | ------------------ | ------------------- | -------- |
-| **Build Time** | 1.66s              | 732.5ms             | **2.3x** |
+| **Build Time** | 1.71s              | 631.7ms             | **2.7x** |
 
 > Note: `@vizejs/vite-plugin` replaces only the Vue SFC compilation step — the performance difference comes entirely from that part. Dependency resolution, module graph construction, bundling (Rolldown), and all other Vite internals are identical to `@vitejs/plugin-vue`. For pure compilation performance, see the [Compiler benchmark](#benchmark-15000-sfc-files) above. `@vizejs/vite-plugin` eagerly pre-compiles `.vue` files using native multi-threaded compilation, which also enables faster HMR.
 
-This row is the `vite` surface of the committed snapshot `bench/results/tool-benchmark-latest.json` ([run 29010164013](https://github.com/ubugeeei-prod/vize/actions/runs/29010164013)) — the same artifact `README.md` and the [Blacksmith benchmark snapshot](/architecture/performance-blacksmith) publish. `tests/tooling/docs-vite-benchmark-row.test.ts` pins it to that artifact, in every locale, so the three surfaces cannot drift apart.
+This row is the `vite` surface of the committed snapshot `bench/results/tool-benchmark-latest.json` ([run 30557718030](https://github.com/ubugeeei-prod/vize/actions/runs/30557718030)) — the same artifact `README.md` and the [Blacksmith benchmark snapshot](/architecture/performance-blacksmith) publish. `tests/tooling/docs-vite-benchmark-row.test.ts` pins it to that artifact, in every locale, so the three surfaces cannot drift apart.
 
 The figure published here until then — `957ms` / `479ms` / `2.0x` — came from `bench/vite.ts` before #3392, which timed Vize with a warm persistent pre-compile cache left behind by its own warmup while `@vitejs/plugin-vue` compiled from scratch. That harness now reports separate cold and warm rows on the machine it runs on, so it produces a local diagnostic, not a publishable speedup; use `vp run --workspace-root bench:vite` to compare a change against itself, not to source a number for this page.

--- a/docs/content/fr/architecture/performance.md
+++ b/docs/content/fr/architecture/performance.md
@@ -198,10 +198,10 @@ Version Vite avec **1 000 importations SFC Vue** (toutes importées en une seule
 
 |                           | @vitejs/plugin-vue | @vizejs/vite-plugin | Accélération |
 | ------------------------- | ------------------ | ------------------- | ------------ |
-| **Temps de construction** | 1.66s              | 732.5ms             | **2.3x**     |
+| **Temps de construction** | 1.71s              | 631.7ms             | **2.7x**     |
 
 > Note : `@vizejs/vite-plugin` remplace uniquement l’étape de compilation Vue SFC — la différence de performance vient entièrement de cette partie. La résolution des dépendances, la construction de graphes de modules, le regroupement (Rolldown) et tous les autres internes Vite sont identiques à `@vitejs/plugin-vue`. Pour la performance purement en compilation, voir la [Compiler benchmark](#benchmark-15000-sfc-files) ci-dessus. `@vizejs/vite-plugin` pré-compile avec enthousiasme `.vue` fichiers en utilisant une compilation multithread native, ce qui permet également un HMR plus rapide.
 
-Cette ligne est la surface `vite` de l'instantané commité `bench/results/tool-benchmark-latest.json` ([run 29010164013](https://github.com/ubugeeei-prod/vize/actions/runs/29010164013)) — le même artefact que celui publié par `README.md` et par l'[instantané de benchmark Blacksmith](/architecture/performance-blacksmith). `tests/tooling/docs-vite-benchmark-row.test.ts` la verrouille sur cet artefact, dans toutes les locales.
+Cette ligne est la surface `vite` de l'instantané commité `bench/results/tool-benchmark-latest.json` ([run 30557718030](https://github.com/ubugeeei-prod/vize/actions/runs/30557718030)) — le même artefact que celui publié par `README.md` et par l'[instantané de benchmark Blacksmith](/architecture/performance-blacksmith). `tests/tooling/docs-vite-benchmark-row.test.ts` la verrouille sur cet artefact, dans toutes les locales.
 
 Le chiffre publié ici jusqu'à présent — `957ms` / `479ms` / `2.0x` — provenait de `bench/vite.ts` avant #3392, qui mesurait Vize avec un cache de pré-compilation persistant laissé chaud par son propre échauffement, tandis que `@vitejs/plugin-vue` compilait à froid. Ce harnais rapporte désormais des lignes à froid et à chaud séparées sur la machine où il s'exécute : c'est un diagnostic local, pas une accélération publiable. Utilisez `vp run --workspace-root bench:vite` pour comparer un changement à lui-même.

--- a/docs/content/ja/architecture/performance.md
+++ b/docs/content/ja/architecture/performance.md
@@ -198,10 +198,10 @@ Rust 側の `virtual project` フェーズ — ファイルごとの SFC 解析�
 
 |                | @vitejs/plugin-vue | @vizejs/vite-plugin | スピードアップ |
 | -------------- | ------------------ | ------------------- | -------------- |
-| **ビルド時間** | 1.66s              | 732.5ms             | **2.3x**       |
+| **ビルド時間** | 1.71s              | 631.7ms             | **2.7x**       |
 
 > 注: `@vizejs/vite-plugin` は Vue SFC コンパイル手順のみを置き換えます。パフォーマンスの違いは完全にその部分から生じます。依存関係の解決、モジュール グラフの構築、バンドル (ロールダウン)、およびその他すべての Vite 内部は `@vitejs/plugin-vue` と同一です。純粋なコンパイルのパフォーマンスについては、上記の [コンパイラ ベンチマーク](#benchmark-15000-sfc-files) を参照してください。 `@vizejs/vite-plugin` は、ネイティブ マルチスレッド コンパイルを使用して `.vue` ファイルを積極的にプリコンパイルします。これにより、より高速な HMR も可能になります。
 
-この行はコミット済みスナップショット `bench/results/tool-benchmark-latest.json` の `vite` サーフェス ([run 29010164013](https://github.com/ubugeeei-prod/vize/actions/runs/29010164013)) です。`README.md` と [Blacksmith ベンチマーク スナップショット](/architecture/performance-blacksmith) が公開しているものと同じ成果物であり、`tests/tooling/docs-vite-benchmark-row.test.ts` が全ロケールでこの成果物に固定しています。
+この行はコミット済みスナップショット `bench/results/tool-benchmark-latest.json` の `vite` サーフェス ([run 30557718030](https://github.com/ubugeeei-prod/vize/actions/runs/30557718030)) です。`README.md` と [Blacksmith ベンチマーク スナップショット](/architecture/performance-blacksmith) が公開しているものと同じ成果物であり、`tests/tooling/docs-vite-benchmark-row.test.ts` が全ロケールでこの成果物に固定しています。
 
 それまでここに掲載していた `957ms` / `479ms` / `2.0x` は、#3392 以前の `bench/vite.ts` によるものでした。このハーネスは、ウォームアップが残した永続プリコンパイル キャッシュ付きの Vize と、ゼロからコンパイルする `@vitejs/plugin-vue` を比較していました。現在このハーネスは実行マシン上でコールドとウォームを別々に報告するため、その出力はローカルな診断値であり、公開できる速度比ではありません。`vp run --workspace-root bench:vite` は変更前後の自己比較に使ってください。

--- a/docs/content/pt-BR/architecture/performance.md
+++ b/docs/content/pt-BR/architecture/performance.md
@@ -198,10 +198,10 @@ Build do Vite com **1.000 importações do SFC Vue** (todas importadas em uma ú
 
 |                         | @vitejs/plugin-vue | @vizejs/vite-plugin | Aceleração |
 | ----------------------- | ------------------ | ------------------- | ---------- |
-| **Tempo de Construção** | 1.66s              | 732.5ms             | **2.3x**   |
+| **Tempo de Construção** | 1.71s              | 631.7ms             | **2.7x**   |
 
 > Nota: `@vizejs/vite-plugin` substitui apenas a etapa de compilação do Vue SFC — a diferença de desempenho vem inteiramente dessa parte. A resolução de dependências, construção de grafos de módulos, agrupamento (Rolldown) e todos os outros internos do Vite são idênticos aos `@vitejs/plugin-vue`. Para performance pura em compilações, veja o [Compiler benchmark](#benchmark-15000-sfc-files) acima. `@vizejs/vite-plugin` pré-compila `.vue` arquivos com entusiasmo usando compilação multithreaded nativa, que também permite um HMR mais rápido.
 
-Esta linha é a superfície `vite` do snapshot commitado `bench/results/tool-benchmark-latest.json` ([run 29010164013](https://github.com/ubugeeei-prod/vize/actions/runs/29010164013)) — o mesmo artefato que `README.md` e o [snapshot de benchmark Blacksmith](/architecture/performance-blacksmith) publicam. `tests/tooling/docs-vite-benchmark-row.test.ts` a fixa nesse artefato, em todos os idiomas.
+Esta linha é a superfície `vite` do snapshot commitado `bench/results/tool-benchmark-latest.json` ([run 30557718030](https://github.com/ubugeeei-prod/vize/actions/runs/30557718030)) — o mesmo artefato que `README.md` e o [snapshot de benchmark Blacksmith](/architecture/performance-blacksmith) publicam. `tests/tooling/docs-vite-benchmark-row.test.ts` a fixa nesse artefato, em todos os idiomas.
 
 O número publicado aqui até agora — `957ms` / `479ms` / `2.0x` — veio de `bench/vite.ts` antes de #3392, que media o Vize com um cache de pré-compilação persistente deixado quente pelo próprio warmup enquanto o `@vitejs/plugin-vue` compilava do zero. Esse harness agora reporta linhas separadas de cold e warm na máquina em que roda, então produz um diagnóstico local, não um speedup publicável. Use `vp run --workspace-root bench:vite` para comparar uma mudança consigo mesma.

--- a/docs/content/zh-CN/architecture/performance.md
+++ b/docs/content/zh-CN/architecture/performance.md
@@ -198,10 +198,10 @@ Vite 构建，包含**1,000个Vue SFC导入**（全部导入于单一条目）�
 
 |              | @vitejs/plugin-vue | @vizejs/vite-plugin | 加速     |
 | ------------ | ------------------ | ------------------- | -------- |
-| **建造时间** | 1.66s              | 732.5ms             | **2.3x** |
+| **建造时间** | 1.71s              | 631.7ms             | **2.7x** |
 
 > 注：`@vizejs/vite-plugin`仅替代了Vue的SFC编译步骤——性能差异完全来自该步骤。依赖关系解析、模图构建、捆绑（Rolldown）及其他所有 Vite 内部结构与 `@vitejs/plugin-vue` 完全相同。关于纯编译性能，请参见上文的[编译器基准测试](#benchmark-15000-sfc-files)。`@vizejs/vite-plugin` 热切地利用原生多线程编译预编译`.vue`文件，这也使 HMR 更快。
 
-此行取自已提交的快照 `bench/results/tool-benchmark-latest.json` 的 `vite` 面 ([run 29010164013](https://github.com/ubugeeei-prod/vize/actions/runs/29010164013)) —— 与 `README.md` 和 [Blacksmith 基准快照](/architecture/performance-blacksmith) 发布的是同一份产物。`tests/tooling/docs-vite-benchmark-row.test.ts` 在所有语言版本中将其固定到该产物。
+此行取自已提交的快照 `bench/results/tool-benchmark-latest.json` 的 `vite` 面 ([run 30557718030](https://github.com/ubugeeei-prod/vize/actions/runs/30557718030)) —— 与 `README.md` 和 [Blacksmith 基准快照](/architecture/performance-blacksmith) 发布的是同一份产物。`tests/tooling/docs-vite-benchmark-row.test.ts` 在所有语言版本中将其固定到该产物。
 
 在此之前发布的数字 —— `957ms` / `479ms` / `2.0x` —— 来自 #3392 之前的 `bench/vite.ts`：它让 Vize 带着自身预热留下的持久预编译缓存运行，而 `@vitejs/plugin-vue` 从零开始编译。该测试工具现在会在其运行的机器上分别报告冷启动和热启动两行，因此它的输出是本地诊断值，而不是可发布的加速比。请使用 `vp run --workspace-root bench:vite` 来比较改动前后的自身表现。

--- a/tests/tooling/readme-benchmark-rows.test.ts
+++ b/tests/tooling/readme-benchmark-rows.test.ts
@@ -101,14 +101,7 @@ test("the README Vite and Nuxt rows match the committed benchmark snapshot", () 
         "vite-plugin-vue",
         "vize-vite-plugin",
       ),
-      expectedRow(
-        surfaces,
-        "nuxt",
-        "Nuxt build",
-        "Nuxt compiler",
-        "nuxt-default",
-        "vize-nuxt",
-      ),
+      expectedRow(surfaces, "nuxt", "Nuxt build", "Nuxt compiler", "nuxt-default", "vize-nuxt"),
     ],
   );
 });

--- a/tests/tooling/readme-benchmark-rows.test.ts
+++ b/tests/tooling/readme-benchmark-rows.test.ts
@@ -108,7 +108,6 @@ test("the README Vite and Nuxt rows match the committed benchmark snapshot", () 
         "Nuxt compiler",
         "nuxt-default",
         "vize-nuxt",
-        "†",
       ),
     ],
   );


### PR DESCRIPTION
Completes the regeneration the `†` footnote promised. The committed artifact was from
**2026-07-09** (`27fe77df`) — measured before either benchmark-fairness fix landed.

[Run 30557718030](https://github.com/ubugeeei-prod/vize/actions/runs/30557718030) re-measured every
surface on `blacksmith-32vcpu-ubuntu-2404` at `1511788d9` (the #3409 merge), so the Nuxt lane no
longer lets `@vizejs/nuxt` inherit a warm pre-compile cache the Nuxt default compiler has no
counterpart for.

## No number here was typed by hand

The artifact is dropped in verbatim from the run, and
`docs/content/architecture/performance-blacksmith.md` is re-rendered with `bench/render-results.mjs`.
README and `performance.md` (plus its four translations) are pinned to that artifact by
`readme-benchmark-rows.test.ts` and `docs-vite-benchmark-row.test.ts` — both of which **failed against
the new artifact until the rows were updated**, which is the pinning working as designed.

Every README row now comes from **one** run instead of two.

## What moved

| Surface | before | after |
| --- | ---: | ---: |
| Vite build | 2.3x | **2.7x** (1.71s vs 631.7ms) |
| Nuxt build | 1.1x† | **1.0x** (6.83s vs 6.59s) |
| SFC compile | 55.1x | 52.1x |
| Lint | 209.2x | 173.0x |
| Format | 67.8x | 50.6x |

The Nuxt footnote is replaced by the real caveat: both variants run the same Nitro/Vite/Rollup
pipeline and differ only in the SFC compiler, and SFC compilation is roughly **2%** of that build,
so the row is a genuine but *diluted* comparison. It is published because it is what a Nuxt user
experiences, not because it isolates Vize.

Both cross-engine type-check cells read `n/a (cross-engine)` because the generator computed them that
way from the recorded medians — the retraction from #3394/#3431 is now backed by a regenerated run
rather than a hand-edit.

## The three rows that moved against us are not explained by the fairness fixes

Those fixes touched only the Vite and Nuxt lanes. SFC compile, Lint and Format changed anyway, and
the baselines barely moved while Vize's own medians did:

- Lint: Vize `270.9ms` → `324.8ms` (+20%), eslint-plugin-vue `56.66s` → `56.20s`
- Format: Vize `2.22s` → `2.83s` (+27%), Prettier `150.34s` → `143.13s`
- SFC compile: Vize `333.8ms` → `329.2ms` (flat), `@vue/compiler-sfc` `18.38s` → `17.15s`

So Lint and Format look like a **real regression in Vize** between `27fe77df` and `1511788d9`, not a
harness artifact. Two Blacksmith runs three weeks apart are not proof — runner variance is real — but
a 20-27% move on two surfaces while the baselines held is worth chasing rather than smoothing over.
Filed separately; this PR publishes what the run measured.

## Gates

`vp run fmt:check` and `vp run source:lengths` exit 0. Benchmark pinning suites:
`readme-benchmark-rows`, `docs-vite-benchmark-row`, `published-benchmark-ratios`, `tool-benchmark`,
`tool-benchmark-engine-classes` — **19 pass / 0 fail**.

Refs #3363, #3426.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->