### PR TITLE
perf(vite): gate the native request classifier behind the string tests it duplicates

### DIFF
--- a/npm/builder/vite/src/native-request-gates.test.ts
+++ b/npm/builder/vite/src/native-request-gates.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Soundness matrix for the string pre-gates that keep module IDs off the native
+ * request classifier (#3427).
+ *
+ * A production build of 300 SFCs made 6,934 `classifyVitePluginRequest` NAPI
+ * calls -- 23 per SFC -- and most of them existed only to be told the id is not
+ * Vize's. Each gate below replaces such a call with a string test, so each gate
+ * has to be *weaker* than the native fact it stands in for: every id the
+ * classifier would have accepted must still pass. These tests assert exactly
+ * that, against the real native classifier, over a matrix of realistic and
+ * adversarial ids -- decoy `/@fs` prefixes, Windows drive letters, a `.vue`
+ * directory component, and the three id prefixes Vite and the plugin use.
+ *
+ * `fromPluginVisibleVirtualId` additionally dropped a second classify of
+ * `request.normalizedFsId ?? id` in favour of a string expression, so its whole
+ * 252-id result vector is compared against the pre-#3427 implementation.
+ */
+
+import assert from "node:assert/strict";
+
+import { classifyVitePluginRequest } from "@vizejs/native";
+
+import { fromPluginVisibleVirtualId } from "./virtual.ts";
+import { isPotentialVizeImporter } from "./plugin/resolve.ts";
+import { normalizeVirtualStyleId, transformScopedPreprocessorCss } from "./plugin/compat.ts";
+
+/** Path shapes: every `.vue`-ish and non-`.vue` ending, with `/@fs` decoys. */
+const PATHS = [
+  "/repo/app/Foo.vue.ts",
+  "/repo/app/Foo.vue.tsx",
+  "/repo/app/Foo.vue",
+  "/repo/app/Foo.ts",
+  "/@fs/repo/app/Foo.vue.ts",
+  "/@fs/repo/app/Foo.vue.tsx",
+  "/@fs/repo/app/Foo.vue",
+  "/@fs/repo/app/Foo.ts",
+  // `/@fsnot` starts with the literal `/@fs`, so it is stripped by the native
+  // `normalized_fs_id` too; the JS expression must strip it identically.
+  "/@fsnot/repo/app/Foo.vue.ts",
+  "C:/repo/app/Foo.vue.ts",
+  "/repo/app.vue/Foo.vue.ts",
+  "/@fs/C:/repo/app/Foo.vue.ts",
+];
+
+const QUERIES = [
+  "",
+  "?vue&vize",
+  "?vue&vize-ssr",
+  "?vue&vize&used=true",
+  "?vue&type=style&index=0&lang=scss&scoped=data-v-1a2b3c4d",
+  "?macro=true",
+  "?vue&vize&t=1700000000000",
+];
+
+const PREFIXES = ["", "\0", "\0vize-ssr:"];
+
+const MATRIX = PREFIXES.flatMap((prefix) =>
+  PATHS.flatMap((path) => QUERIES.map((query) => `${prefix}${path}${query}`)),
+);
+
+assert.equal(MATRIX.length, 252, "the matrix is the 12 x 7 x 3 cross product");
+
+/** `fromPluginVisibleVirtualId` exactly as it read before #3427. */
+function fromPluginVisibleVirtualIdBefore(id: string): string | null {
+  if (id.startsWith("\0")) {
+    return null;
+  }
+  const request = classifyVitePluginRequest(id);
+  const isVirtualPath = request.path.endsWith(".vue.ts") || request.path.endsWith(".vue.tsx");
+  if (!isVirtualPath || !request.querySuffix) {
+    return null;
+  }
+  const params = new URLSearchParams(request.querySuffix.slice(1));
+  if (!params.has("vue") || (!params.has("vize") && !params.has("vize-ssr"))) {
+    return null;
+  }
+  const normalizedRequest = classifyVitePluginRequest(request.normalizedFsId ?? id);
+  const normalizedPath = normalizedRequest.path;
+  if (normalizedPath.endsWith(".vue.tsx")) {
+    return normalizedPath.slice(0, -4);
+  }
+  return normalizedPath.endsWith(".vue.ts") ? normalizedPath.slice(0, -3) : normalizedPath;
+}
+
+assert.deepEqual(
+  MATRIX.map((id) => [id, fromPluginVisibleVirtualId(id)]),
+  MATRIX.map((id) => [id, fromPluginVisibleVirtualIdBefore(id)]),
+  "dropping the second classify and adding the `.vue.ts`/`?` pre-gate must not change any result",
+);
+
+// The pre-gate must not be the only thing standing between an id and a non-null
+// result: every id that resolves must also satisfy the gate on its own.
+assert.deepEqual(
+  MATRIX.filter(
+    (id) =>
+      fromPluginVisibleVirtualIdBefore(id) !== null &&
+      !(!id.startsWith("\0") && id.includes(".vue.ts") && id.includes("?")),
+  ),
+  [],
+  "`.vue.ts` + `?` must be implied by a non-null fromPluginVisibleVirtualId",
+);
+
+// `isPotentialVizeImporter` traded `classifyVitePluginRequest(importer).isVueSfcPath`
+// for `importer.includes(".vue")`.
+assert.deepEqual(
+  MATRIX.filter(
+    (importer) =>
+      classifyVitePluginRequest(importer).isVueSfcPath && !isPotentialVizeImporter(importer),
+  ),
+  [],
+  "`.vue` must be implied by the native isVueSfcPath",
+);
+
+assert.equal(
+  isPotentialVizeImporter(undefined),
+  false,
+  "an absent importer is not a Vize importer",
+);
+
+/**
+ * Style IDs as the post-transform plugin actually sees them: the plugin emits
+ * `vue=&type=style`, Vite re-serializes it as `vue&type=style`, and the id
+ * reaching `transform` carries the virtual extension suffix and sometimes a `\0`.
+ */
+const STYLE_IDS = [
+  "/repo/app/Foo.vue?vue=&type=style&index=0&scoped=data-v-1a2b3c4d&lang=scss.scss",
+  "/repo/app/Foo.vue?vue&type=style&index=0&scoped=data-v-1a2b3c4d&lang=scss.scss",
+  "\0/repo/app/Foo.vue?vue&type=style&index=0&scoped=data-v-1a2b3c4d&lang=less.less",
+  "/repo/app/Foo.vue?vue&type=style&index=1&scoped=data-v-1a2b3c4d&lang=scss&module=.module.scss",
+  "/repo/app/Foo.vue?vue&type=style&index=0&lang=scss.scss",
+  "/repo/app/Foo.vue?vue&type=style&index=0&scoped=data-v-1a2b3c4d&lang=css.css",
+  "/repo/app/Foo.vue?other=1&vue&type=style&index=0&scoped=data-v-1a2b3c4d&lang=styl.styl",
+];
+
+// `transformScopedPreprocessorCss` traded a classify of every module in the
+// graph for `id.includes("type=style")`.
+assert.deepEqual(
+  [...MATRIX, ...STYLE_IDS].filter(
+    (id) =>
+      classifyVitePluginRequest(normalizeVirtualStyleId(id)).isVueStyleQuery &&
+      !id.includes("type=style"),
+  ),
+  [],
+  "`type=style` must be implied by the native isVueStyleQuery",
+);
+
+// The gate must not have changed what the hook actually rewrites. The last two
+// are the hook's own rejections -- no `scoped`, and plain `css` which Vite's
+// pipeline already scopes -- and must stay rejections rather than becoming
+// gate misses.
+const SCOPED = ".a[data-v-1a2b3c4d]{color: red}";
+assert.deepEqual(
+  STYLE_IDS.map((id) => [id, transformScopedPreprocessorCss(".a { color: red }", id)]),
+  [
+    [STYLE_IDS[0], SCOPED],
+    [STYLE_IDS[1], SCOPED],
+    [STYLE_IDS[2], SCOPED],
+    [STYLE_IDS[3], SCOPED],
+    [STYLE_IDS[4], null],
+    [STYLE_IDS[5], null],
+    [STYLE_IDS[6], SCOPED],
+  ],
+  "scoped preprocessor CSS rewriting is unchanged by the pre-gate",
+);
+
+console.log("✅ vite-plugin-vize native request gate tests passed!");

--- a/npm/builder/vite/src/plugin/compat.ts
+++ b/npm/builder/vite/src/plugin/compat.ts
@@ -53,7 +53,25 @@ export function normalizeVirtualStyleId(id: string): string {
   return withoutPrefix.replace(/\.module\.\w+$/, "").replace(/\.\w+$/, "");
 }
 
+/**
+ * String pre-gate for {@link transformScopedPreprocessorCss} (#3427).
+ *
+ * The post-transform plugin's `transform` hook sees every module in the graph,
+ * and without this every one of them crossed the NAPI boundary to be told it is
+ * not a style query. The native `isVueStyleQuery` is
+ * `query.contains("vue&type=style") || query.contains("vue=&type=style")`, both
+ * of which contain `type=style`; the query is a substring of the id, and
+ * `normalizeVirtualStyleId` only ever deletes characters, so a normalized id
+ * that classifies as a style query implies `type=style` in the raw id.
+ */
+function mayBeVueStyleQuery(id: string): boolean {
+  return id.includes("type=style");
+}
+
 export function transformScopedPreprocessorCss(code: string, id: string): string | null {
+  if (!mayBeVueStyleQuery(id)) {
+    return null;
+  }
   const request = classifyVitePluginRequest(normalizeVirtualStyleId(id));
   if (
     !request.isVueStyleQuery ||

--- a/npm/builder/vite/src/plugin/resolve.ts
+++ b/npm/builder/vite/src/plugin/resolve.ts
@@ -697,12 +697,12 @@ export function isPotentialVizeImporter(importer: string | undefined): boolean {
     return true;
   }
 
-  // This gate exists to keep ordinary dependency edges off the classifier, so it
-  // must not call the classifier itself (#3427). `isVueSfcPath` is
-  // `normalizedVuePath.endsWith(".vue")`, and `normalizedVuePath` only ever
-  // strips a trailing `.ts`/`.tsx` from the pre-`?` path, so it can only end in
-  // `.vue` when the importer string contains `.vue`. The test is strictly
-  // weaker, so every importer the classifier would have accepted still passes.
+  // This gate keeps ordinary dependency edges off the classifier, so it must not
+  // call the classifier itself (#3427). `isVueSfcPath` is
+  // `normalizedVuePath.endsWith(".vue")`, and `normalizedVuePath` only ever strips
+  // a trailing `.ts`/`.tsx` from the pre-`?` path, so it can only end in `.vue`
+  // when the importer contains `.vue`: a strictly weaker test, so every importer
+  // the classifier would have accepted still reaches it.
   return importer.includes(".vue");
 }
 
@@ -798,15 +798,11 @@ export async function resolveIdHook(
   // Fast-return before request classification for the common case where neither
   // the id nor importer can involve a Vue SFC or Vize virtual module. This was
   // added after profiles showed ordinary dependency graph edges dominating the
-  // plugin hook cost in dev servers.
-  //
-  // Both halves of that gate are string tests, so it runs before the classifier
-  // rather than after it (#3427): classifying first meant every ordinary
-  // dependency edge crossed the NAPI boundary to reach a fast return.
-  //
-  // Past the gate, classify the importer at most once: the later `importerRequest`
-  // derivations all need the same classification, so crossing the boundary again
-  // for the same importer string would be pure overhead.
+  // plugin hook cost in dev servers. Both halves of that gate are string tests,
+  // so it runs before the classifier rather than after it (#3427): classifying
+  // first meant every ordinary dependency edge crossed the NAPI boundary only to
+  // reach a fast return. Past the gate the importer is classified at most once,
+  // since the later `importerRequest` derivations all need the same result.
   if (!isPotentialVizeResolveId(id) && !isPotentialVizeImporter(importer)) {
     return null;
   }

--- a/npm/builder/vite/src/plugin/resolve.ts
+++ b/npm/builder/vite/src/plugin/resolve.ts
@@ -687,10 +687,7 @@ function classifyImporterRequest(
   return importer ? classifyVitePluginRequest(importer) : null;
 }
 
-function isPotentialVizeImporter(
-  importer: string | undefined,
-  importerRequest: ReturnType<typeof classifyVitePluginRequest> | null,
-): boolean {
+export function isPotentialVizeImporter(importer: string | undefined): boolean {
   // Imports from Vize virtual modules still need custom resolution even when the
   // requested id itself is a regular-looking relative or bare specifier.
   if (importer === undefined) {
@@ -700,7 +697,13 @@ function isPotentialVizeImporter(
     return true;
   }
 
-  return importerRequest?.isVueSfcPath ?? false;
+  // This gate exists to keep ordinary dependency edges off the classifier, so it
+  // must not call the classifier itself (#3427). `isVueSfcPath` is
+  // `normalizedVuePath.endsWith(".vue")`, and `normalizedVuePath` only ever
+  // strips a trailing `.ts`/`.tsx` from the pre-`?` path, so it can only end in
+  // `.vue` when the importer string contains `.vue`. The test is strictly
+  // weaker, so every importer the classifier would have accepted still passes.
+  return importer.includes(".vue");
 }
 
 function shouldCompileVueSfcRequest(
@@ -797,16 +800,17 @@ export async function resolveIdHook(
   // added after profiles showed ordinary dependency graph edges dominating the
   // plugin hook cost in dev servers.
   //
-  // Classify the importer at most once: the importer gate (`isPotentialVizeImporter`)
-  // and the later `importerRequest` derivations both need the same classification,
-  // so crossing the NAPI boundary twice for the same importer string is pure
-  // overhead. Classify the defined importer once here and reuse the result for
-  // both the gate below and the rest of the hook; `isPotentialVizeImporter` reads
-  // its `isVueSfcPath` rather than re-classifying.
-  const importerRequest = classifyImporterRequest(importer);
-  if (!isPotentialVizeResolveId(id) && !isPotentialVizeImporter(importer, importerRequest)) {
+  // Both halves of that gate are string tests, so it runs before the classifier
+  // rather than after it (#3427): classifying first meant every ordinary
+  // dependency edge crossed the NAPI boundary to reach a fast return.
+  //
+  // Past the gate, classify the importer at most once: the later `importerRequest`
+  // derivations all need the same classification, so crossing the boundary again
+  // for the same importer string would be pure overhead.
+  if (!isPotentialVizeResolveId(id) && !isPotentialVizeImporter(importer)) {
     return null;
   }
+  const importerRequest = classifyImporterRequest(importer);
 
   const isBuild = state.server === null;
   const isDependencyScan = !!options?.scan;

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -1,4 +1,5 @@
 import "./hmr.test.ts";
+import "./native-request-gates.test.ts";
 import "./compiler.test.ts";
 import "./compiler-src-imports.test.ts";
 import "./compile-options.test.ts";

--- a/npm/builder/vite/src/virtual.ts
+++ b/npm/builder/vite/src/virtual.ts
@@ -52,8 +52,22 @@ export function toPluginVisibleVirtualId(realPath: string, ssr = false, querySuf
   return `${realPath}.ts?vue&${ssr ? "vize-ssr" : "vize"}${rest ? `&${rest}` : ""}`;
 }
 
+/**
+ * String pre-gate for {@link fromPluginVisibleVirtualId}, so ordinary module IDs
+ * never cross the native boundary (#3427).
+ *
+ * A non-null result requires `request.path` to end with `.vue.ts` or `.vue.tsx`
+ * and `request.querySuffix` to be non-empty. `request.path` is `id` up to the
+ * first `?` and `querySuffix` is non-empty exactly when that `?` exists, so both
+ * conditions imply these two substring tests. The tests are strictly weaker, so
+ * everything the old code accepted still reaches the classifier.
+ */
+function mayBePluginVisibleVirtualId(id: string): boolean {
+  return !id.startsWith("\0") && id.includes(".vue.ts") && id.includes("?");
+}
+
 export function fromPluginVisibleVirtualId(id: string): string | null {
-  if (id.startsWith("\0")) {
+  if (!mayBePluginVisibleVirtualId(id)) {
     return null;
   }
   const request = classifyVitePluginRequest(id);
@@ -64,8 +78,21 @@ export function fromPluginVisibleVirtualId(id: string): string | null {
   if (!params.has("vue") || (!params.has("vize") && !params.has("vize-ssr"))) {
     return null;
   }
-  const normalizedRequest = classifyVitePluginRequest(request.normalizedFsId ?? id);
-  return stripPluginVisibleVueVirtualSuffix(normalizedRequest.path);
+  return stripPluginVisibleVueVirtualSuffix(stripFsPrefix(request.path));
+}
+
+/**
+ * The `path` a second `classifyVitePluginRequest(request.normalizedFsId ?? id)`
+ * used to recompute (#3427).
+ *
+ * `normalizedFsId` is `Some` exactly when the pre-`?` path starts with `/@fs`,
+ * and its value is that path with the four-byte prefix removed plus the original
+ * query suffix. Re-splitting that at the first `?` therefore yields the path
+ * without the prefix — and when `normalizedFsId` is `undefined` the second call
+ * classified `id` itself and yielded `request.path` unchanged.
+ */
+function stripFsPrefix(path: string): string {
+  return path.startsWith("/@fs") ? path.slice(4) : path;
 }
 
 function isPluginVisibleVueVirtualPath(path: string): boolean {


### PR DESCRIPTION
perf(vite): gate the native request classifier behind the string tests it duplicates

A cold production Vite build of 300 bench SFCs made 6,934
`classifyVitePluginRequest` NAPI calls -- 23 per SFC -- and most of them existed
only to be told the id is not Vize's. #3427 attributed them per call site and
proposed four reductions; this lands all four.

Each gate is a string test that must be *weaker* than the native fact it stands
in for, so every id the classifier would have accepted still reaches it:

1. `fromPluginVisibleVirtualId` dropped its second classify of
   `request.normalizedFsId ?? id`. In `crates/vize_atelier_sfc/src/vite_plugin/request.rs`,
   `normalized_fs_id` is `Some` exactly when the pre-`?` path starts with `/@fs`,
   and its value is that path minus the four-byte prefix plus the original query
   suffix -- so re-splitting it at the first `?` can only ever yield
   `request.path` with `/@fs` removed. That is now computed in JS.

2. `fromPluginVisibleVirtualId` gained a pre-gate. A non-null result requires
   `request.path` to end with `.vue.ts`/`.vue.tsx` and `querySuffix` to be
   non-empty; `request.path` is `id` up to the first `?`, so both are implied by
   `id.includes(".vue.ts") && id.includes("?")`.

3. `resolveIdHook` classified the importer *before* the gate whose whole purpose
   is to keep ordinary dependency edges off the classifier. Both halves of that
   gate are string tests, so it now runs first; `isPotentialVizeImporter` reads
   `importer.includes(".vue")` instead of `isVueSfcPath`, which is
   `normalizedVuePath.endsWith(".vue")` and can only hold when the raw importer
   contains `.vue`. Past the gate the importer is still classified exactly once
   and reused, as before.

4. `transformScopedPreprocessorCss` runs in a `transform` hook that sees every
   module in the graph and had no cheap guard. Native `isVueStyleQuery` is
   `query.contains("vue&type=style") || query.contains("vue=&type=style")`, both
   of which contain `type=style`; the query is a substring of the id and
   `normalizeVirtualStyleId` only ever deletes characters, so `type=style` in the
   raw id is implied.

`isPluginVisibleSsrVirtualId` (870 calls) is deliberately left alone: its result
comes from `URLSearchParams`, which percent-decodes keys, so `id.includes("vize-ssr")`
is not a sound weaker precondition.

## Test

`npm/builder/vite/src/native-request-gates.test.ts` (new) checks each gate
against the real native classifier over a 252-id matrix -- the 12 x 7 x 3 cross
product of path shapes (`.vue.ts`, `.vue.tsx`, `.vue`, `.ts`, each with and
without `/@fs`, plus a `/@fsnot` decoy, a Windows drive letter, and a `.vue`
directory component), query suffixes, and the three id prefixes (``, `\0`,
`\0vize-ssr:`):

- `fromPluginVisibleVirtualId`'s full 252-entry result vector is compared
  against the pre-change implementation, which is inlined in the test. This
  reproduces the matrix run in #3427's comment (`{ "checked": 252, "mismatches": [] }`).
- Each of the three new pre-gates is asserted to be implied by the native fact
  it guards, as a `deepEqual(violations, [])` over the matrix.
- `transformScopedPreprocessorCss`'s full output is pinned over seven realistic
  style ids, including the two `vue=&type=style` / `vue&type=style` spellings and
  the two shapes the hook rejects on its own.

This is a pure-performance change with no behaviour delta, so the test is an
equivalence oracle rather than a failing-before-the-fix regression test; the
"before" evidence is the byte-identical output below. The test would fail if the
Rust side's `normalized_fs_id`, `is_vue_sfc_path`, or `is_vue_style_query`
semantics were changed without updating these gates -- which is the failure mode
the gates introduce.

## Measurement

Command (one cold production Vite build of the first 300 `bench/__in__` SFCs,
every `@vizejs/native` export wrapped in a call counter before the plugin is
imported; work dir wiped per run so the persistent pre-compile cache is cold and
scope ids are stable):

    node bench/generate.mjs 300
    vp run build:vite-plugin
    # then the counting harness, alternating the two pinned plugin builds

Provenance -- both arms use the *same* native binding, which is the only Rust
artifact involved, so nothing about the shared build directory can bias the A/B:

    npm/native/vize-vitrine.darwin-arm64.node (release)
      sha256 39a7e7265fa023465ab030db9409ed745b1261779ebe3553814fd10ee49dd422
    plugin dist (before) index.mjs
      sha256 48efa77fa7edb9f9ea9b80e54698b4f1d565ac13572d89f0070632016a5980cb
    plugin dist (after) index.mjs
      sha256 d80c379567f1016a1ac7fd74596f748c750c4496c0b1ca2786d7686533680acc

All three were re-hashed after every batch and were unchanged.

Call counts (deterministic across all 16 runs of each arm):

    | native export               | before |  after |  delta |
    | --------------------------- | -----: | -----: | -----: |
    | classifyVitePluginRequest   |  6,934 |  5,192 | -1,742 |
    | all native calls            | 11,296 |  9,554 | -1,742 |

The 6,934 reproduces #3427's figure exactly. Per SFC: 23.1 -> 17.3.

Isolated cost of the 1,742 removed calls, median of 200 reps over ids of the
shapes the gates actually see:

    classifyVitePluginRequest x1742    median 2.487 ms   min 2.300 ms
    string pre-gates x1742             median 0.076 ms   min 0.075 ms

So ~2.4 ms of a ~300 ms build, about 0.8%.

In-build wall clock is **not** reported as a win, because it cannot resolve a
2.4 ms saving on this machine: it was under heavy competing load, and the two
orderings disagree in sign. 8 alternating pairs with `before` first gave medians
295.7 ms (before) vs 313.2 ms (after); 8 pairs with `after` first gave 728.1 ms
(after) vs 799.2 ms (before), with per-run times ranging 261-982 ms. Whichever
arm ran first in a pair won, in 15 of 16 pairs. Call counts are the metric this
change should be judged on.

## Output equivalence

Across all 32 builds -- 16 per arm, both orderings -- every emitted asset was
byte-identical, same names and same digests:

    assets/__entry__-CmeNWQn1.js   0ec5621c9211433b714538a0c9d3bf77904b0cf648255aa41772901e1d00c368
    assets/__entry__-ROcGk7K0.css  3500957806c6fd6435451e2961fdd24d4adce9250dbeb8035a0b4b5560548d48

`node src/test.ts` in `npm/builder/vite` passes (26 tests) with the new file
registered.

Closes #3427
Refs #3363

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->