### PR TITLE
perf(vite): stop parsing the emitted module twice in generateOutput

### DIFF
--- a/npm/builder/vite/src/output-module-info.test.ts
+++ b/npm/builder/vite/src/output-module-info.test.ts
@@ -1,0 +1,195 @@
+/**
+ * `ModuleOutputInfo` now carries the two facts `insertBeforeSfcMainDefaultExport`
+ * used to recover by parsing the module a second time (#3425): the end offset of
+ * the `export default ...` statement, and whether its declaration is the
+ * `_sfc_main` identifier. `generateOutput` already analyzed the module, so the
+ * second parse was pure duplicated work -- 60 of 300 modules on the bench corpus
+ * take a full oxc parse, and those same 60 were parsed twice.
+ *
+ * These fixtures are the output shapes the Rust SFC emitter can produce, so the
+ * two new fields are pinned against every branch a real build takes rather than
+ * against a synthetic module.
+ */
+
+import assert from "node:assert/strict";
+
+import {
+  analyzeModuleOutput,
+  insertBeforeSfcMainDefaultExport,
+  type ModuleOutputInfo,
+} from "./utils/module-output.ts";
+
+/** Emitted module shapes, named for the emitter path that produces them. */
+const SHAPES: Record<string, string> = {
+  // Template-only client build: `export function render`, no default export.
+  templateOnlyClient: "export function render(_ctx, _cache) {\n  return null;\n}\n",
+  // Template-only vapor: render is exported AND attached to `_sfc_main`.
+  templateOnlyVapor:
+    "export function render(_ctx) {\n  return null;\n}\nconst _sfc_main = { __vapor: true };\n_sfc_main.render = render;\nexport default _sfc_main",
+  // Template-only SSR: `ssrRender` is a bare function, never exported.
+  templateOnlySsr:
+    "function ssrRender(_ctx, _push) {\n  _push('<div></div>');\n}\nconst _sfc_main = {};\n_sfc_main.ssrRender = ssrRender;\nexport default _sfc_main",
+  // `<script>` + `<template>`: the render function is renamed and attached.
+  scriptWithTemplate:
+    "const _sfc_main = {\n  name: 'Foo'\n};\nfunction _sfc_render(_ctx) {\n  return null;\n}\n_sfc_main.render = _sfc_render;\nexport default _sfc_main",
+  // `<script>` with no `<template>`.
+  scriptOnly: "const _sfc_main = {\n  name: 'Foo'\n};\nexport default _sfc_main",
+  // Template compile error fallback: the script alone, with no default export.
+  templateErrorFallback: "const _sfc_main = {\n  name: 'Foo'\n};\n",
+  // `<script setup>`, plain JS -- the shape the string fast path handles.
+  scriptSetupPlain: "export default {\n  setup() {\n    return {};\n  }\n}",
+  // `<script setup>`, TS -- also fast path, but with an import above it.
+  scriptSetupDefineComponent:
+    "import { defineComponent as _defineComponent } from 'vue';\nexport default /*@__PURE__*/_defineComponent({\n  setup() {\n    return {};\n  }\n})",
+  // `export { render }` forces the full parse and is not an `_sfc_main` shape.
+  namedRenderExportObject:
+    "export { render };\nfunction render(_ctx) {\n  return null;\n}\nexport default { name: 'Foo' }",
+};
+
+const EXPECTED: Record<string, ModuleOutputInfo> = {
+  templateOnlyClient: {
+    hasDefaultExport: false,
+    hasSfcMainDefined: false,
+    hasNamedRenderExport: true,
+    hasNamedSsrRenderExport: false,
+    defaultExportKeywordEnd: null,
+    defaultExportStart: null,
+    defaultExportEnd: null,
+    defaultExportIsSfcMain: false,
+  },
+  templateOnlyVapor: {
+    hasDefaultExport: true,
+    hasSfcMainDefined: true,
+    hasNamedRenderExport: true,
+    hasNamedSsrRenderExport: false,
+    defaultExportKeywordEnd: 126,
+    defaultExportStart: 112,
+    defaultExportEnd: 136,
+    defaultExportIsSfcMain: true,
+  },
+  templateOnlySsr: {
+    hasDefaultExport: true,
+    hasSfcMainDefined: true,
+    hasNamedRenderExport: false,
+    hasNamedSsrRenderExport: false,
+    defaultExportKeywordEnd: 129,
+    defaultExportStart: 115,
+    defaultExportEnd: 139,
+    defaultExportIsSfcMain: true,
+  },
+  scriptWithTemplate: {
+    hasDefaultExport: true,
+    hasSfcMainDefined: true,
+    hasNamedRenderExport: false,
+    hasNamedSsrRenderExport: false,
+    defaultExportKeywordEnd: 129,
+    defaultExportStart: 115,
+    defaultExportEnd: 139,
+    defaultExportIsSfcMain: true,
+  },
+  scriptOnly: {
+    hasDefaultExport: true,
+    hasSfcMainDefined: true,
+    hasNamedRenderExport: false,
+    hasNamedSsrRenderExport: false,
+    defaultExportKeywordEnd: 51,
+    defaultExportStart: 37,
+    defaultExportEnd: 61,
+    defaultExportIsSfcMain: true,
+  },
+  templateErrorFallback: {
+    hasDefaultExport: false,
+    hasSfcMainDefined: true,
+    hasNamedRenderExport: false,
+    hasNamedSsrRenderExport: false,
+    defaultExportKeywordEnd: null,
+    defaultExportStart: null,
+    defaultExportEnd: null,
+    defaultExportIsSfcMain: false,
+  },
+  // Fast path: `_sfc_main` does not occur, so the end offset is not computed
+  // and the default export provably is not that identifier.
+  scriptSetupPlain: {
+    hasDefaultExport: true,
+    hasSfcMainDefined: false,
+    hasNamedRenderExport: false,
+    hasNamedSsrRenderExport: false,
+    defaultExportKeywordEnd: 14,
+    defaultExportStart: 0,
+    defaultExportEnd: null,
+    defaultExportIsSfcMain: false,
+  },
+  scriptSetupDefineComponent: {
+    hasDefaultExport: true,
+    hasSfcMainDefined: false,
+    hasNamedRenderExport: false,
+    hasNamedSsrRenderExport: false,
+    defaultExportKeywordEnd: 73,
+    defaultExportStart: 59,
+    defaultExportEnd: null,
+    defaultExportIsSfcMain: false,
+  },
+  namedRenderExportObject: {
+    hasDefaultExport: true,
+    hasSfcMainDefined: false,
+    hasNamedRenderExport: true,
+    hasNamedSsrRenderExport: false,
+    defaultExportKeywordEnd: 74,
+    defaultExportStart: 60,
+    defaultExportEnd: 90,
+    defaultExportIsSfcMain: false,
+  },
+};
+
+const NAMES = Object.keys(SHAPES);
+
+assert.deepEqual(
+  NAMES.map((name) => [name, analyzeModuleOutput(SHAPES[name])]),
+  NAMES.map((name) => [name, EXPECTED[name]]),
+  "analyzeModuleOutput reports the default export's end offset and whether it is `_sfc_main`",
+);
+
+// Reusing the caller's analysis must produce exactly what a fresh parse does,
+// in both insertion modes.
+const INSERTION = '_sfc_main.__scopeId = "data-v-1a2b3c4d";';
+for (const normalizeSemicolon of [false, true]) {
+  assert.deepEqual(
+    NAMES.map((name) => [
+      name,
+      insertBeforeSfcMainDefaultExport(SHAPES[name], INSERTION, {
+        normalizeSemicolon,
+        moduleInfo: EXPECTED[name],
+      }),
+    ]),
+    NAMES.map((name) => [
+      name,
+      insertBeforeSfcMainDefaultExport(SHAPES[name], INSERTION, { normalizeSemicolon }),
+    ]),
+    `passing moduleInfo changes nothing (normalizeSemicolon: ${normalizeSemicolon})`,
+  );
+}
+
+// And the insertion itself is still the documented rewrite, not just
+// self-consistent: pinned for one `_sfc_main` shape and one non-`_sfc_main`
+// shape, which the function must leave alone.
+assert.equal(
+  insertBeforeSfcMainDefaultExport(SHAPES.scriptOnly, INSERTION, {
+    moduleInfo: EXPECTED.scriptOnly,
+  }),
+  "const _sfc_main = {\n  name: 'Foo'\n};\n_sfc_main.__scopeId = \"data-v-1a2b3c4d\";\nexport default _sfc_main",
+);
+assert.equal(
+  insertBeforeSfcMainDefaultExport(SHAPES.scriptOnly, INSERTION, {
+    normalizeSemicolon: true,
+    moduleInfo: EXPECTED.scriptOnly,
+  }),
+  "const _sfc_main = {\n  name: 'Foo'\n};\n_sfc_main.__scopeId = \"data-v-1a2b3c4d\";\nexport default _sfc_main;",
+);
+assert.equal(
+  insertBeforeSfcMainDefaultExport(SHAPES.scriptSetupPlain, INSERTION, {
+    moduleInfo: EXPECTED.scriptSetupPlain,
+  }),
+  SHAPES.scriptSetupPlain,
+);
+
+console.log("✅ vite-plugin-vize module output info tests passed!");

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -7,6 +7,7 @@ import "./config.test.ts";
 import "./internal/config-bridge.test.ts";
 import "./options-api-events.test.ts";
 import "./output-ast.test.ts";
+import "./output-module-info.test.ts";
 import "./utils-filter.test.ts";
 import "./utils-inline-css.test.ts";
 import "./utils.test.ts";

--- a/npm/builder/vite/src/utils/index.ts
+++ b/npm/builder/vite/src/utils/index.ts
@@ -165,9 +165,15 @@ export function generateOutput(compiled: CompiledModule, options: GenerateOutput
   } else if (hasExportDefault && hasSfcMainDefined) {
     // _sfc_main already defined, just add scopeId if needed
     if (compiled.hasScoped && compiled.scopeId) {
+      // `output` is still `compiled.code` on this branch -- nothing above it
+      // rewrote the module -- so `moduleInfo`'s offsets describe it exactly and
+      // the insertion can reuse them instead of parsing the module again
+      // (#3425). The later CSS-modules insertion below cannot: by then the
+      // module has been rewritten and the offsets are stale.
       output = insertBeforeSfcMainDefaultExport(
         output,
         `_sfc_main.__scopeId = "data-v-${compiled.scopeId}";`,
+        { moduleInfo },
       );
     }
   } else if (!hasExportDefault && !hasSfcMainDefined && hasNamedRenderExport) {

--- a/npm/builder/vite/src/utils/module-output.ts
+++ b/npm/builder/vite/src/utils/module-output.ts
@@ -18,6 +18,18 @@ export type ModuleOutputInfo = {
   hasNamedSsrRenderExport: boolean;
   defaultExportKeywordEnd: number | null;
   defaultExportStart: number | null;
+  /**
+   * End offset of the whole `export default ...` statement, or `null`.
+   *
+   * Recorded so {@link insertBeforeSfcMainDefaultExport} can reuse the caller's
+   * analysis instead of parsing the module a second time (#3425).
+   */
+  defaultExportEnd: number | null;
+  /**
+   * Whether the default export's declaration is exactly the `_sfc_main`
+   * identifier -- the only shape {@link insertBeforeSfcMainDefaultExport} acts on.
+   */
+  defaultExportIsSfcMain: boolean;
 };
 
 function isNode(value: unknown): value is AstNode {
@@ -28,8 +40,17 @@ function getNodeStart(node: AstNode | null | undefined): number | null {
   return typeof node?.start === "number" ? node.start : null;
 }
 
+function getNodeEnd(node: AstNode | null | undefined): number | null {
+  return typeof node?.end === "number" ? node.end : null;
+}
+
 function getNodeName(node: AstNode | null | undefined): string | null {
   return isNode(node) && typeof node.name === "string" ? node.name : null;
+}
+
+function isSfcMainDefaultExport(defaultExport: AstNode | null | undefined): boolean {
+  const declaration = isNode(defaultExport?.declaration) ? defaultExport.declaration : null;
+  return isIdentifierNamed(declaration, SFC_MAIN_NAME);
 }
 
 function parseProgram(code: string): AstNode | null {
@@ -135,6 +156,11 @@ function analyzeFastDefaultOutput(code: string): ModuleOutputInfo | null {
     hasNamedSsrRenderExport: false,
     defaultExportStart,
     defaultExportKeywordEnd: defaultExportStart + EXPORT_DEFAULT.length,
+    // The fast path is only taken when `_sfc_main` does not occur anywhere in
+    // the module, so the default export cannot be that identifier and no caller
+    // needs the statement's end offset.
+    defaultExportEnd: null,
+    defaultExportIsSfcMain: false,
   };
 }
 
@@ -177,6 +203,8 @@ export function analyzeModuleOutput(code: string): ModuleOutputInfo {
     hasNamedSsrRenderExport: exportedNames.includes("ssrRender"),
     defaultExportKeywordEnd,
     defaultExportStart,
+    defaultExportEnd: getNodeEnd(defaultExport),
+    defaultExportIsSfcMain: isSfcMainDefaultExport(defaultExport),
   };
 }
 
@@ -201,16 +229,53 @@ export function rewriteDefaultExportToSfcMain(
   return `${code.slice(0, exportStart)}const ${SFC_MAIN_NAME} =${code.slice(keywordEnd)}`;
 }
 
+/**
+ * Locate `export default _sfc_main` when the caller has no analysis to hand.
+ *
+ * The string test is a sound pre-filter: the AST check below only succeeds when
+ * the default export's declaration *is* the `_sfc_main` identifier, which cannot
+ * happen unless that name occurs in the module.
+ */
+function findSfcMainDefaultExport(code: string): {
+  defaultExportStart: number | null;
+  defaultExportEnd: number | null;
+  defaultExportIsSfcMain: boolean;
+} {
+  if (!code.includes(SFC_MAIN_NAME)) {
+    return { defaultExportStart: null, defaultExportEnd: null, defaultExportIsSfcMain: false };
+  }
+
+  const defaultExport = findDefaultExport(parseProgram(code));
+  return {
+    defaultExportStart: getNodeStart(defaultExport),
+    defaultExportEnd: getNodeEnd(defaultExport),
+    defaultExportIsSfcMain: isSfcMainDefaultExport(defaultExport),
+  };
+}
+
 export function insertBeforeSfcMainDefaultExport(
   code: string,
   insertion: string,
-  options: { normalizeSemicolon?: boolean } = {},
+  options: {
+    normalizeSemicolon?: boolean;
+    /**
+     * Analysis of *this exact* `code`, when the caller already has one. Passing
+     * it removes a second full oxc parse of the module the caller just parsed
+     * (#3425). It must describe `code` as given: every offset is used verbatim,
+     * so a caller that mutated the module after analyzing it must omit this.
+     */
+    moduleInfo?: Pick<
+      ModuleOutputInfo,
+      "defaultExportStart" | "defaultExportEnd" | "defaultExportIsSfcMain"
+    >;
+  } = {},
 ): string {
-  const defaultExport = findDefaultExport(parseProgram(code));
-  const declaration = isNode(defaultExport?.declaration) ? defaultExport.declaration : null;
-  const exportStart = getNodeStart(defaultExport);
-  const exportEnd = typeof defaultExport?.end === "number" ? defaultExport.end : null;
-  if (!isIdentifierNamed(declaration, SFC_MAIN_NAME) || exportStart == null) {
+  const {
+    defaultExportStart: exportStart,
+    defaultExportEnd: exportEnd,
+    defaultExportIsSfcMain,
+  } = options.moduleInfo ?? findSfcMainDefaultExport(code);
+  if (!defaultExportIsSfcMain || exportStart == null) {
     return code;
   }
 


### PR DESCRIPTION
perf(vite): stop parsing the emitted module twice in generateOutput

`generateOutput` calls `analyzeModuleOutput`, which oxc-parses the module when
its string fast path cannot answer -- 60 of 300 modules on the bench corpus.
`insertBeforeSfcMainDefaultExport` then parsed the *same* module again, from
scratch, because it took no analysis from its caller. Every one of those 60
modules paid two full parses of code the caller had already parsed.

This is the JS half of #3425: it carries the facts the caller already has across
the one boundary that was re-deriving them. The Rust half -- having the emitter
report the module's shape so the *first* parse also disappears -- is a larger,
separate change and is not attempted here; see the note on #3425.

## Change

`ModuleOutputInfo` gains the two facts `insertBeforeSfcMainDefaultExport` was
recovering by parsing:

- `defaultExportEnd` -- end offset of the whole `export default ...` statement,
  which the `normalizeSemicolon` mode needs;
- `defaultExportIsSfcMain` -- whether the default export's declaration is exactly
  the `_sfc_main` identifier, the only shape the function acts on.

Both come out of the single parse `analyzeModuleOutput` already does. On the
string fast path they are `null` / `false`, which is exact rather than a
fallback: that path is only taken when `_sfc_main` does not occur anywhere in
the module, so the default export provably is not that identifier and no caller
can need the statement's end.

`insertBeforeSfcMainDefaultExport` accepts the analysis through `options.moduleInfo`
and skips its own parse when given one. `generateOutput` passes it at the
`hasExportDefault && hasSfcMainDefined` branch, where `output` is still
`compiled.code` -- nothing above that branch rewrites the module, so the offsets
describe it exactly. It deliberately does **not** pass it at the later
CSS-modules insertion: by then the module has been rewritten and the offsets are
stale. That call instead gets a sound string pre-filter (`code.includes("_sfc_main")`),
since the AST check can only succeed when that name occurs.

## Test

`npm/builder/vite/src/output-module-info.test.ts` (new) pins the full
`ModuleOutputInfo` object for nine emitted module shapes -- one per branch of the
Rust SFC emitter: template-only client (`export function render`, no default
export), template-only vapor, template-only SSR (`ssrRender` is never exported),
`<script>` + `<template>`, `<script>`-only, the template-error fallback (no
default export at all), plain and `_defineComponent` `<script setup>` (both on
the fast path), and an `export { render }` module. It then asserts that passing
`moduleInfo` to `insertBeforeSfcMainDefaultExport` produces exactly what a fresh
parse produces, in both `normalizeSemicolon` modes, and pins the rewritten text
for one `_sfc_main` shape and one shape the function must leave alone.

It fails on the pre-fix code: `analyzeModuleOutput` does not report
`defaultExportEnd` or `defaultExportIsSfcMain`, so the first `deepEqual` fails
for all nine shapes, and `insertBeforeSfcMainDefaultExport` does not accept
`moduleInfo`.

## Measurement

Isolated, mirroring #3425's own harness -- compile the first 300 `bench/__in__`
SFCs through `compileSfcBatchWithResults`, then time the JS output-assembly pass
over the modules that produced (median of 9, after 3 warmups):

    node bench/generate.mjs 300
    # then, per arm, node <harness> importing src/utils/index.ts directly

    corpus: 300 modules, 2,276,790 emitted bytes, 60 full parses,
            60 of which reached insertBeforeSfcMainDefaultExport

    | round | arm    | analyzeModuleOutput | generateOutput          |
    | ----- | ------ | ------------------: | ----------------------: |
    | 1     | before |    20.64 ms (18.56) | 35.87 ms (min 32.74)    |
    | 1     | after  |    22.69 ms (18.90) | 23.31 ms (min 21.37)    |
    | 2     | before |    29.41 ms (25.86) | 61.94 ms (min 46.54)    |
    | 2     | after  |    19.36 ms (18.83) | 20.29 ms (min 18.98)    |

Round 2's `before` reproduces the issue's figures (56.95 ms median / 46.65 ms
min); the machine was under heavy competing load, which is why the two rounds
differ so much in absolute terms. Comparing minima, which are the least
load-contaminated: `generateOutput` 32.74/46.54 ms -> 21.37/18.98 ms.

In-build, one cold production Vite build of the same 300 SFCs, 5 alternating
pairs with `before` first in every pair (so the ordering bias runs *against* the
change):

    before medians 242.8 ms (min 234.6)
    after  medians 241.0 ms (min 223.3)

That is at the noise floor and is reported as such, not as the win. NAPI call
counts are unchanged (6,934 / 11,296 in both arms), as expected for a change
that touches no native call.

Provenance:

    npm/native/vize-vitrine.darwin-arm64.node (release)
      sha256 39a7e7265fa023465ab030db9409ed745b1261779ebe3553814fd10ee49dd422
    plugin dist (before) index.mjs
      sha256 48efa77fa7edb9f9ea9b80e54698b4f1d565ac13572d89f0070632016a5980cb
    plugin dist (after) index.mjs
      sha256 9573ded8c28f5655994bba727102c121960427cece2720013ad7221d54ca9fca

Re-hashed after every batch, unchanged. The same native binding is used in both
arms; it is the only Rust artifact involved.

## Output equivalence

Isolated: the SHA-256 of every module's `generateOutput` result, concatenated
over all 300 modules, is identical in all four runs of both arms --

    115c0f791b1837c6a619585a5b44e45cca1cb60ea790daefa871a9350b7d6ddd

In-build: all 10 builds emitted byte-identical assets, same names and digests --

    assets/__entry__-CmeNWQn1.js   0ec5621c9211433b714538a0c9d3bf77904b0cf648255aa41772901e1d00c368
    assets/__entry__-ROcGk7K0.css  3500957806c6fd6435451e2961fdd24d4adce9250dbeb8035a0b4b5560548d48

`node src/test.ts` in `npm/builder/vite` passes (26 tests), including the
existing `generateOutput` snapshots.

Refs #3425
Refs #3363

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->