### PR TITLE
fix(atelier): implement v-models in JSX instead of emitting resolveDirective("models")

### DIFF
--- a/crates/vize_atelier_jsx/src/lower.rs
+++ b/crates/vize_atelier_jsx/src/lower.rs
@@ -16,6 +16,7 @@ mod slot;
 mod style;
 mod text;
 mod v_model;
+mod v_models;
 
 pub(crate) use style::{RawScopedStyle, ScopedStyleExpr};
 

--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -25,14 +25,26 @@ use super::v_model::split_underscore_model_modifiers;
 
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Lower a JSX opening element's attribute list into Vize props.
+    ///
+    /// `on_component` is whether the owning tag renders as a component; the
+    /// component-only `v-models` built-in is rejected when it is `false`.
     pub(crate) fn lower_attributes(
         &mut self,
         items: &[JSXAttributeItem<'_>],
+        on_component: bool,
     ) -> Vec<'a, PropNode<'a>> {
         let mut props = Vec::new_in(self.bump());
         for item in items {
             let prop = match item {
-                JSXAttributeItem::Attribute(attr) => self.lower_attribute(attr),
+                JSXAttributeItem::Attribute(attr) => {
+                    // `v-models` expands into one model binding per entry, so it
+                    // yields several props (or none, plus a diagnostic) and
+                    // cannot use the one-prop-per-attribute path below.
+                    if self.try_lower_v_models(attr, on_component, &mut props) {
+                        continue;
+                    }
+                    self.lower_attribute(attr)
+                }
                 JSXAttributeItem::SpreadAttribute(spread) => {
                     Some(self.lower_spread_attribute(spread))
                 }

--- a/crates/vize_atelier_jsx/src/lower/element.rs
+++ b/crates/vize_atelier_jsx/src/lower/element.rs
@@ -15,7 +15,12 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         let mut node = ElementNode::new(self.bump(), tag, loc);
         node.tag_type = element_type(&opening.name);
         node.is_self_closing = element.closing_element.is_none();
-        node.props = self.lower_attributes(&opening.attributes);
+        // `v-models` is component-only. A dashed lowercase tag is classified as
+        // an intrinsic element here, but the DOM backend still resolves it with
+        // `resolveComponent`, so custom elements count as components for that
+        // check just as they do for `@vue/babel-plugin-jsx`.
+        let on_component = node.tag_type == ElementType::Component || node.tag.contains('-');
+        node.props = self.lower_attributes(&opening.attributes, on_component);
         // Components route through slot synthesis (object/render-prop children
         // become `<template v-slot>`s); intrinsic elements lower children
         // directly.

--- a/crates/vize_atelier_jsx/src/lower/v_model.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_model.rs
@@ -185,7 +185,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
 /// Note the deliberate omission of array/object destructuring patterns: they are
 /// valid `LVal`s in general JavaScript, but `v-model` assigns a single event
 /// value, so destructuring one is never meaningful here.
-fn is_assignable_target(expr: &Expression<'_>) -> bool {
+pub(crate) fn is_assignable_target(expr: &Expression<'_>) -> bool {
     match expr {
         Expression::Identifier(_)
         | Expression::StaticMemberExpression(_)

--- a/crates/vize_atelier_jsx/src/lower/v_models.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_models.rs
@@ -1,0 +1,267 @@
+//! `v-models` — the `@vue/babel-plugin-jsx` built-in that binds several models
+//! on one component at once.
+//!
+//! `v-models={[[value], [value, "arg"], [value, ["mod"]], [value, "arg", ["mod"]]]}`
+//! is exactly a list of the `v-model={[…]}` array form, so every entry is
+//! lowered through the same [`Lowerer::lower_model_array`] `v-model` uses and the
+//! attribute expands into one `model` directive per entry.
+//!
+//! # Why this is a built-in and not a custom directive
+//!
+//! `v-models` is a plugin built-in, not a user directive. Before #3418 any
+//! unrecognized `v-*` attribute fell through to the generic custom-directive
+//! path, so `v-models` compiled to `resolveDirective("models")` — a lookup for a
+//! directive that does not exist. Vue resolves it to nothing at runtime, so the
+//! component rendered with **no model bindings at all**, with no error and no
+//! warning. Every shape below therefore either lowers or is diagnosed; none may
+//! reach the custom-directive path again.
+//!
+//! # Shapes that are diagnosed rather than lowered
+//!
+//! - `v-models:arg={…}` — babel reads the JSX namespace as a default prop name
+//!   but then ignores each entry's own arg: `v-models:x={[[a], [b, "b"]]}` binds
+//!   `x` and `modelValue`, never `b`. The spelling is undocumented and its babel
+//!   behavior is inconsistent, so Vize rejects it and points at the entry form.
+//! - `v-models_lazy={…}` — the `_`-suffixed modifier spelling. Same reasoning:
+//!   undocumented, and the per-entry modifier array expresses it exactly.
+//! - a missing value, a non-array value, an empty array, a non-array entry, or
+//!   an entry that cannot be destructured. Babel rejects all of these too
+//!   ("You should pass a Two-dimensional Arrays to v-models").
+//! - an entry whose target cannot be assigned to, for the same reason `v-model`
+//!   rejects one (#3420): the write-back compiles to `target = $event`.
+//! - `v-models` on a plain element. Babel: "v-models can only use in custom
+//!   components".
+//!
+//! # Known divergence, deliberately not diagnosed
+//!
+//! Two entries that resolve to the same prop name (`v-models={[[a], [b]]}`, both
+//! `modelValue`) emit a duplicate key. Babel keeps the first value and merges the
+//! update handlers into an array; Vize emits both pairs, so the last one wins.
+//! The input is a user error either way and both outputs parse, so this is
+//! recorded here rather than turned into a diagnostic.
+
+use oxc_ast::ast::{ArrayExpression, Expression, JSXAttribute, JSXAttributeName};
+use oxc_span::{GetSpan, Span};
+use vize_carton::{ToCompactString, Vec};
+use vize_relief::PropNode;
+
+use super::Lowerer;
+use super::v_model::is_assignable_target;
+use crate::diagnostics::JsxDiagnostic;
+
+/// How a `v-models` attribute was spelled.
+enum Form {
+    /// `v-models={…}` — the only supported spelling.
+    Plain,
+    /// `v-models:arg={…}` — a JSX namespace argument.
+    Argument,
+    /// `v-models_lazy={…}` — `_`-suffixed modifiers.
+    UnderscoreModifiers,
+}
+
+impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// Lower a `v-models` attribute into one `model` directive per entry,
+    /// appending them to `props`.
+    ///
+    /// `on_component` is whether the owning tag renders as a component; `false`
+    /// rejects the attribute the way babel does.
+    ///
+    /// Returns `true` when `attr` was a `v-models` attribute and has been fully
+    /// consumed here — **including when it was rejected with a diagnostic**,
+    /// because a rejected built-in must not fall back to the custom-directive
+    /// path that caused #3418.
+    pub(crate) fn try_lower_v_models(
+        &mut self,
+        attr: &JSXAttribute<'_>,
+        on_component: bool,
+        props: &mut Vec<'a, PropNode<'a>>,
+    ) -> bool {
+        let Some(form) = self.v_models_form(attr) else {
+            return false;
+        };
+        let span = attr.span;
+
+        match form {
+            Form::Argument => {
+                self.reject(
+                    span,
+                    "v-models does not take an argument; name the prop inside each entry \
+                     instead, e.g. v-models={[[value, \"name\"]]}.",
+                );
+                return true;
+            }
+            Form::UnderscoreModifiers => {
+                self.reject(
+                    span,
+                    "v-models does not take `_`-suffixed modifiers; list them inside each \
+                     entry instead, e.g. v-models={[[value, [\"lazy\"]]]}.",
+                );
+                return true;
+            }
+            Form::Plain => {}
+        }
+
+        if !on_component {
+            self.reject(
+                span,
+                "v-models can only be used on a component; a plain element binds one \
+                 model with v-model.",
+            );
+            return true;
+        }
+
+        let Some(entries) = self.model_array_value(attr.value.as_ref()) else {
+            self.reject(
+                span,
+                "v-models expects a two-dimensional array of `[value, arg?, modifiers?]` \
+                 entries, e.g. v-models={[[foo], [bar, \"bar\"]]}.",
+            );
+            return true;
+        };
+        if entries.elements.is_empty() {
+            self.reject(
+                span,
+                "v-models was given an empty array; it needs at least one \
+                 `[value, arg?, modifiers?]` entry.",
+            );
+            return true;
+        }
+
+        self.lower_v_models_entries(entries, span, props);
+        true
+    }
+
+    /// Lower every entry of a validated `v-models` array.
+    ///
+    /// All entries are lowered before anything is appended: a rejected entry
+    /// drops the whole attribute, because emitting the entries that happened to
+    /// parse would pair a build error with a partial set of model bindings.
+    fn lower_v_models_entries(
+        &mut self,
+        entries: &ArrayExpression<'_>,
+        attr_span: Span,
+        props: &mut Vec<'a, PropNode<'a>>,
+    ) {
+        let loc = self.mapper().location(attr_span);
+        let mut lowered = std::vec::Vec::with_capacity(entries.elements.len());
+        let mut rejected = false;
+
+        for element in &entries.elements {
+            let element_span = element.span();
+            let Some(Expression::ArrayExpression(entry)) = element.as_expression() else {
+                let source = self.mapper().slice(element_span);
+                self.reject_at(
+                    element_span,
+                    format_args!(
+                        "v-models entry `{source}` is not an array; each entry must be \
+                         `[value, arg?, modifiers?]`."
+                    ),
+                );
+                rejected = true;
+                continue;
+            };
+
+            match entry
+                .elements
+                .first()
+                .and_then(|first| first.as_expression())
+            {
+                Some(target) if is_assignable_target(target) => {}
+                Some(target) => {
+                    let target_span = target.span();
+                    let source = self.mapper().slice(target_span);
+                    self.reject_at(
+                        target_span,
+                        format_args!(
+                            "v-models target `{source}` cannot be assigned to; v-model needs \
+                             a variable or property reference."
+                        ),
+                    );
+                    rejected = true;
+                    continue;
+                }
+                None => {
+                    let source = self.mapper().slice(element_span);
+                    self.reject_at(
+                        element_span,
+                        format_args!(
+                            "v-models entry `{source}` has no bound value; each entry must be \
+                             `[value, arg?, modifiers?]`."
+                        ),
+                    );
+                    rejected = true;
+                    continue;
+                }
+            }
+
+            match self.lower_model_array(entry, &loc) {
+                Some(prop) => lowered.push(prop),
+                None => {
+                    let source = self.mapper().slice(element_span);
+                    self.reject_at(
+                        element_span,
+                        format_args!(
+                            "v-models entry `{source}` cannot be destructured into \
+                             `[value, arg?, modifiers?]`."
+                        ),
+                    );
+                    rejected = true;
+                }
+            }
+        }
+
+        if !rejected {
+            props.extend(lowered);
+        }
+    }
+
+    /// Classify an attribute as one of the `v-models` spellings, or `None` when
+    /// it is not a `v-models` attribute at all.
+    fn v_models_form(&self, attr: &JSXAttribute<'_>) -> Option<Form> {
+        match &attr.name {
+            JSXAttributeName::NamespacedName(named) => {
+                let raw = self
+                    .mapper()
+                    .slice(named.namespace.span())
+                    .strip_prefix("v-")?;
+                // A namespace is an argument, so even bare `v-models:x` is the
+                // argument form rather than the plain one.
+                match classify(raw)? {
+                    Form::Plain => Some(Form::Argument),
+                    other => Some(other),
+                }
+            }
+            JSXAttributeName::Identifier(id) => {
+                classify(self.mapper().slice(id.span()).strip_prefix("v-")?)
+            }
+        }
+    }
+
+    fn reject(&mut self, span: Span, message: &'static str) {
+        self.report(JsxDiagnostic::error(message, span.start, span.end));
+    }
+
+    fn reject_at(&mut self, span: Span, message: std::fmt::Arguments<'_>) {
+        self.report(JsxDiagnostic::error(
+            message.to_compact_string(),
+            span.start,
+            span.end,
+        ));
+    }
+}
+
+/// Classify a `v-`-stripped attribute name as a `v-models` spelling.
+fn classify(name: &str) -> Option<Form> {
+    if name == "models" {
+        return Some(Form::Plain);
+    }
+    // `v-models_lazy` — JSX attribute names cannot contain `.`, so
+    // `@vue/babel-plugin-jsx` also accepts `_`-joined modifier suffixes.
+    if name
+        .strip_prefix("models_")
+        .is_some_and(|rest| !rest.is_empty())
+    {
+        return Some(Form::UnderscoreModifiers);
+    }
+    None
+}

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -13,7 +13,7 @@ opt-in compat mode (#3391) is expected to change.
 
 | Artifact                                  | Role                                                                                                       |
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `babel_compat/fixtures/corpus.json`       | the 94 inputs + the babel plugin options each is compiled with                                             |
+| `babel_compat/fixtures/corpus.json`       | the 95 inputs + the babel plugin options each is compiled with                                             |
 | `babel_compat/oracle.mjs`                 | runs the corpus through the real plugin; `--write` records, `--check` verifies                             |
 | `babel_compat/fixtures/babel-output.json` | committed ground truth (generated — do not hand-edit)                                                      |
 | `../babel_compat_oracle.rs`               | snapshots babel's output beside Vize's, per category, with a verdict per row                               |
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   64 |
-| divergent  |   28 |
+| equivalent |   68 |
+| divergent  |   25 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -162,8 +162,8 @@ deliberate answer, recorded here so it is not relitigated.
 | `directives/v_model_arg_underscore`     | `[[vModelText, val, "foo", {trim: true}]]`                     | rejected as above                                               | accept and pass the arg | ❌      |
 | `directives/v_model_component`          | `modelValue` + `onUpdate:modelValue` props                     | same                                                            | no change               | ✅      |
 | `directives/v_model_component_arg_mods` | `argument`, `argumentModifiers`, `onUpdate:argument`           | same props, different literal order                             | no change               | ✅      |
-| `directives/v_models`                   | expands to one prop pair per entry                             | falls through to `resolveDirective("models")`                   | implement `v-models`    | ❌      |
-| `directives/v_models_mods`              | adds `<arg>Modifiers` per entry                                | falls through to `resolveDirective("models")`                   | implement `v-models`    | ❌      |
+| `directives/v_models`                   | expands to one prop pair per entry                             | same, via one `model` directive per entry (#3418)               | no change               | ✅      |
+| `directives/v_models_mods`              | adds `<arg>Modifiers` per entry                                | same props, different literal order (#3418)                     | no change               | ✅      |
 | `directives/v_show_element`             | `[[vShow, vis]]`                                               | same                                                            | no change               | ✅      |
 | `directives/v_show_component`           | `[[vShow, vis]]` on the component vnode                        | same                                                            | no change               | ✅      |
 | `directives/v_html`                     | `{innerHTML: h}`                                               | same                                                            | no change               | ✅      |
@@ -172,6 +172,22 @@ deliberate answer, recorded here so it is not relitigated.
 | `directives/v_custom_arg`               | `[[resolveDirective("custom"), val, "arg"]]`                   | same                                                            | no change               | ✅      |
 | `directives/v_custom_array`             | unpacks `[val, 'arg', ['a','b']]` into value / arg / modifiers | passes the whole array as the value                             | unpack the array form   | ❌      |
 | `directives/v_dashed_custom`            | `resolveDirective("unknown-thing")`                            | same                                                            | no change               | ✅      |
+
+### `v-models` spellings Vize rejects and babel accepts
+
+Not corpus rows, because a compat mode is not expected to adopt them; recorded
+here so the choice is not implicit (#3418, `src/lower/v_models.rs`):
+
+- `v-models:x={…}` — babel reads the JSX namespace as a default prop name but
+  then ignores each entry's own argument, so `v-models:x={[[a], [b, "b"]]}` binds
+  `x` and `modelValue` and never `b`. The spelling is undocumented and its babel
+  behavior is inconsistent, so Vize rejects it and points at the entry form.
+- `v-models_lazy={…}` — the `_`-suffixed modifier spelling. Same reasoning: the
+  per-entry modifier array expresses it exactly.
+
+Vize also lets `v-models` through on a dashed lowercase tag (`<my-el/>`), which
+it classifies as an intrinsic element but the DOM backend still resolves with
+`resolveComponent` — matching babel, which treats it as a custom component.
 
 ## Slots
 
@@ -226,9 +242,10 @@ Compared against Vize's default, which is already fully optimized.
 A compat mode must reject what babel rejects, with a diagnostic — never silently
 accept it.
 
-| Case                        | Babel                                                         | Vize today                                                        | Compat mode              | Verdict |
-| --------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------ | ------- |
-| `errors/v_model_non_lval`   | rejects a non-assignable `v-model` target                     | rejects it too, naming the offending expression (closed by #3420) | no change                | ✅      |
-| `errors/v_model_no_value`   | rejects: "You have to use JSX Expression inside your v-model" | rejects: "v-model is missing expression."                         | no change                | ✅      |
-| `errors/v_models_not_array` | rejects a non-array `v-models` value                          | emits a custom `models` directive                                 | reject with a diagnostic | ❌      |
-| `errors/v_slots_not_object` | forwards the value as children                                | emits a custom `slots` directive                                  | forward as children      | ❌      |
+| Case                              | Babel                                                           | Vize today                                                        | Compat mode         | Verdict |
+| --------------------------------- | --------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------- | ------- |
+| `errors/v_model_non_lval`         | rejects a non-assignable `v-model` target                       | rejects it too, naming the offending expression (closed by #3420) | no change           | ✅      |
+| `errors/v_model_no_value`         | rejects: "You have to use JSX Expression inside your v-model"   | rejects: "v-model is missing expression."                         | no change           | ✅      |
+| `errors/v_models_not_array`       | rejects a non-array `v-models` value                            | rejects it too, naming the expected entry shape (closed by #3418) | no change           | ✅      |
+| `errors/v_models_entry_not_array` | rejects: "You should pass a Two-dimensional Arrays to v-models" | rejects it too, naming the offending entry (closed by #3418)      | no change           | ✅      |
+| `errors/v_slots_not_object`       | forwards the value as children                                  | emits a custom `slots` directive                                  | forward as children | ❌      |

--- a/crates/vize_atelier_jsx/tests/babel_compat/fixtures/babel-output.json
+++ b/crates/vize_atelier_jsx/tests/babel_compat/fixtures/babel-output.json
@@ -375,6 +375,10 @@
       "status": "error",
       "message": "Property key of ObjectProperty expected node to be of a type [\"Identifier\",\"StringLiteral\",\"NumericLiteral\",\"BigIntLiteral\",\"DecimalLiteral\",\"PrivateName\"] but instead got undefined"
     },
+    "errors/v_models_entry_not_array": {
+      "status": "error",
+      "message": "You should pass a Two-dimensional Arrays to v-models"
+    },
     "errors/v_slots_not_object": {
       "status": "ok",
       "code": "import { resolveComponent as _resolveComponent, createVNode as _createVNode } from \"vue\";\nconst A = () => _createVNode(_resolveComponent(\"B\"), null, 1);"

--- a/crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json
+++ b/crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json
@@ -598,6 +598,12 @@
       "source": "const A = () => <B v-models={foo}/>;"
     },
     {
+      "id": "errors/v_models_entry_not_array",
+      "category": "errors",
+      "lang": "jsx",
+      "source": "const A = () => <B v-models={[foo]}/>;"
+    },
+    {
       "id": "errors/v_slots_not_object",
       "category": "errors",
       "lang": "jsx",

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -101,8 +101,9 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ),
     ("directives/v_model_component", Same),
     ("directives/v_model_component_arg_mods", Same),
-    ("directives/v_models", Diff("v-models not implemented")),
-    ("directives/v_models_mods", Diff("v-models not implemented")),
+    // Closed by #3418: `v-models` expands to one model binding per entry.
+    ("directives/v_models", Same),
+    ("directives/v_models_mods", Same),
     ("directives/v_show_element", Same),
     ("directives/v_show_component", Same),
     ("directives/v_html", Same),
@@ -173,9 +174,9 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     // Closed by #3420: both sides now reject a non-assignable target.
     ("errors/v_model_non_lval", Same),
     ("errors/v_model_no_value", Same),
-    (
-        "errors/v_models_not_array",
-        Diff("v-models not implemented"),
-    ),
+    // Closed by #3418: both sides now reject a `v-models` that is not a
+    // two-dimensional array.
+    ("errors/v_models_not_array", Same),
+    ("errors/v_models_entry_not_array", Same),
     ("errors/v_slots_not_object", Diff("v-slots not implemented")),
 ];

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,8 +80,8 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (64, 28, 2));
-    assert_eq!(VERDICTS.len(), 94);
+    assert_eq!((equivalent, divergent, deferred), (68, 25, 2));
+    assert_eq!(VERDICTS.len(), 95);
 }
 
 #[test]

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
@@ -176,7 +176,7 @@ export function render(_ctx, _cache) {
 
 ## directives/v_models
 ### verdict
-divergent: v-models not implemented
+equivalent
 ### source (jsx)
 const A = () => <B v-models={[[foo], [bar, 'bar']]}/>;
 ### babel options
@@ -190,19 +190,21 @@ const A = () => _createVNode(_resolveComponent("B"), {
   "onUpdate:bar": $event => bar = $event
 }, null);
 ### vize (vdom, default config)
-import { resolveDirective as _resolveDirective, resolveComponent as _resolveComponent, withDirectives as _withDirectives, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  const _directive_models = _resolveDirective("models")
   
-  return _withDirectives((_openBlock(), _createBlock(_component_B, null, null, 512 /* NEED_PATCH */)), [
-    [_directive_models, [[foo], [bar, 'bar']]]
-  ])
+  return (_openBlock(), _createBlock(_component_B, {
+    modelValue: foo,
+    "onUpdate:modelValue": $event => ((foo) = $event),
+    bar: bar,
+    "onUpdate:bar": $event => ((bar) = $event)
+  }, null, 8 /* PROPS */, ["modelValue", "onUpdate:modelValue", "bar", "onUpdate:bar"]))
 }
 
 ## directives/v_models_mods
 ### verdict
-divergent: v-models not implemented
+equivalent
 ### source (jsx)
 const A = () => <B v-models={[[foo, ['m']], [bar, 'bar', ['m']]]}/>;
 ### babel options
@@ -222,14 +224,18 @@ const A = () => _createVNode(_resolveComponent("B"), {
   "onUpdate:bar": $event => bar = $event
 }, null);
 ### vize (vdom, default config)
-import { resolveDirective as _resolveDirective, resolveComponent as _resolveComponent, withDirectives as _withDirectives, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  const _directive_models = _resolveDirective("models")
   
-  return _withDirectives((_openBlock(), _createBlock(_component_B, null, null, 512 /* NEED_PATCH */)), [
-    [_directive_models, [[foo, ['m']], [bar, 'bar', ['m']]]]
-  ])
+  return (_openBlock(), _createBlock(_component_B, {
+    modelValue: foo,
+    "onUpdate:modelValue": $event => ((foo) = $event),
+    modelModifiers: { m: true },
+    bar: bar,
+    "onUpdate:bar": $event => ((bar) = $event),
+    barModifiers: { m: true }
+  }, null, 8 /* PROPS */, ["modelValue", "onUpdate:modelValue", "bar", "onUpdate:bar"]))
 }
 
 ## directives/v_show_element

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
@@ -36,7 +36,7 @@ export function render(_ctx, _cache) {
 
 ## errors/v_models_not_array
 ### verdict
-divergent: v-models not implemented
+equivalent
 ### source (jsx)
 const A = () => <B v-models={foo}/>;
 ### babel options
@@ -44,14 +44,30 @@ const A = () => <B v-models={foo}/>;
 ### babel
 <error> Property key of ObjectProperty expected node to be of a type ["Identifier","StringLiteral","NumericLiteral","BigIntLiteral","DecimalLiteral","PrivateName"] but instead got undefined
 ### vize (vdom, default config)
-import { resolveDirective as _resolveDirective, resolveComponent as _resolveComponent, withDirectives as _withDirectives, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+<Error> v-models expects a two-dimensional array of `[value, arg?, modifiers?]` entries, e.g. v-models={[[foo], [bar, "bar"]]}.
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  const _directive_models = _resolveDirective("models")
   
-  return _withDirectives((_openBlock(), _createBlock(_component_B, null, null, 512 /* NEED_PATCH */)), [
-    [_directive_models, foo]
-  ])
+  return (_openBlock(), _createBlock(_component_B))
+}
+
+## errors/v_models_entry_not_array
+### verdict
+equivalent
+### source (jsx)
+const A = () => <B v-models={[foo]}/>;
+### babel options
+(defaults)
+### babel
+<error> You should pass a Two-dimensional Arrays to v-models
+### vize (vdom, default config)
+<Error> v-models entry `foo` is not an array; each entry must be `[value, arg?, modifiers?]`.
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+export function render(_ctx, _cache) {
+  const _component_B = _resolveComponent("B")
+  
+  return (_openBlock(), _createBlock(_component_B))
 }
 
 ## errors/v_slots_not_object

--- a/crates/vize_atelier_jsx/tests/v_models.rs
+++ b/crates/vize_atelier_jsx/tests/v_models.rs
@@ -1,0 +1,294 @@
+//! `v-models` lowering (#3418).
+//!
+//! `v-models` is a `@vue/babel-plugin-jsx` built-in, not a user directive.
+//! Before this was implemented it fell through the generic custom-directive path
+//! and compiled to `resolveDirective("models")` — a lookup Vue resolves to
+//! nothing at runtime, so the component rendered with **no model bindings at
+//! all**, with no error and no warning.
+//!
+//! The expected output is pinned against the real plugin by the differential
+//! oracle (`babel_compat/fixtures/babel-output.json`, rows `directives/v_models`,
+//! `directives/v_models_mods`, `errors/v_models_not_array` and
+//! `errors/v_models_entry_not_array`); this file asserts the full Vize output for
+//! each shape plus the diagnostics for everything Vize refuses to lower.
+
+mod common;
+
+use vize_atelier_jsx::{JsxLang, VdomCompileOptions, compile_to_vdom, lower_source};
+use vize_carton::Bump;
+
+use common::{find_directive, lower_one, root_element, simple_content};
+
+fn errors(source: &str) -> Vec<String> {
+    let bump = Bump::new();
+    let out = lower_source(&bump, source, JsxLang::Jsx);
+    out.diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.is_error())
+        .map(|diagnostic| diagnostic.message.as_str().to_string())
+        .collect()
+}
+
+fn render_code(source: &str) -> String {
+    let bump = Bump::new();
+    let out = compile_to_vdom(&bump, source, JsxLang::Jsx, VdomCompileOptions::default());
+    out.components
+        .into_iter()
+        .map(|component| component.code.as_str().to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn single_entry_binds_model_value() {
+    assert_eq!(
+        render_code("const A = () => <B v-models={[[foo]]}/>;"),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, {\n    \
+         modelValue: foo,\n    \
+         \"onUpdate:modelValue\": $event => ((foo) = $event)\n  \
+         }, null, 8 /* PROPS */, [\"modelValue\", \"onUpdate:modelValue\"]))\n}"
+    );
+}
+
+#[test]
+fn several_entries_each_become_one_binding() {
+    // The corpus row `directives/v_models`: babel emits
+    // `{"modelValue": foo, "onUpdate:modelValue": …, 'bar': bar, "onUpdate:bar": …}`.
+    assert_eq!(
+        render_code("const A = () => <B v-models={[[foo], [bar, 'bar']]}/>;"),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, {\n    \
+         modelValue: foo,\n    \
+         \"onUpdate:modelValue\": $event => ((foo) = $event),\n    \
+         bar: bar,\n    \
+         \"onUpdate:bar\": $event => ((bar) = $event)\n  \
+         }, null, 8 /* PROPS */, [\"modelValue\", \"onUpdate:modelValue\", \"bar\", \"onUpdate:bar\"]))\n}"
+    );
+}
+
+#[test]
+fn entries_carry_their_own_modifiers() {
+    // The corpus row `directives/v_models_mods`. Vize emits the `<arg>Modifiers`
+    // object after the update handler where babel emits it before; that literal
+    // ordering difference is the one already accepted for single `v-model` on a
+    // component (`directives/v_model_component_arg_mods`).
+    assert_eq!(
+        render_code("const A = () => <B v-models={[[foo, ['m']], [bar, 'bar', ['m']]]}/>;"),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, {\n    \
+         modelValue: foo,\n    \
+         \"onUpdate:modelValue\": $event => ((foo) = $event),\n    \
+         modelModifiers: { m: true },\n    \
+         bar: bar,\n    \
+         \"onUpdate:bar\": $event => ((bar) = $event),\n    \
+         barModifiers: { m: true }\n  \
+         }, null, 8 /* PROPS */, [\"modelValue\", \"onUpdate:modelValue\", \"bar\", \"onUpdate:bar\"]))\n}"
+    );
+}
+
+#[test]
+fn an_entry_combines_a_member_target_an_argument_and_modifiers() {
+    assert_eq!(
+        render_code("const A = () => <B v-models={[[a.b, 'x', ['trim', 'lazy']]]}/>;"),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, {\n    \
+         x: a.b,\n    \
+         \"onUpdate:x\": $event => ((a.b) = $event),\n    \
+         xModifiers: { trim: true, lazy: true }\n  \
+         }, null, 8 /* PROPS */, [\"x\", \"onUpdate:x\"]))\n}"
+    );
+}
+
+#[test]
+fn every_entry_lowers_to_its_own_model_directive() {
+    // The IR shape behind the codegen above: one `model` directive per entry,
+    // never a single `models` directive.
+    let bump = Bump::new();
+    let root = lower_one(
+        &bump,
+        "const A = () => <B v-models={[[foo], [bar, 'bar', ['trim']]]}/>;",
+    );
+    let element = root_element(&root);
+    assert!(find_directive(element, "models").is_none());
+    assert_eq!(element.props.len(), 2);
+
+    let first = common::as_directive(&element.props[0]);
+    assert_eq!(first.name.as_str(), "model");
+    assert!(first.arg.is_none());
+    assert_eq!(simple_content(first.exp.as_ref().unwrap()), "foo");
+    assert_eq!(first.modifiers.len(), 0);
+
+    let second = common::as_directive(&element.props[1]);
+    assert_eq!(second.name.as_str(), "model");
+    assert_eq!(simple_content(second.arg.as_ref().unwrap()), "bar");
+    assert_eq!(simple_content(second.exp.as_ref().unwrap()), "bar");
+    assert_eq!(
+        second
+            .modifiers
+            .iter()
+            .map(|modifier| modifier.content.as_str())
+            .collect::<Vec<_>>(),
+        vec!["trim"]
+    );
+}
+
+#[test]
+fn a_non_array_value_is_rejected() {
+    // Babel rejects this too (corpus row `errors/v_models_not_array`).
+    let source = "const A = () => <B v-models={foo}/>;";
+    assert_eq!(
+        errors(source),
+        vec![
+            "v-models expects a two-dimensional array of `[value, arg?, modifiers?]` \
+             entries, e.g. v-models={[[foo], [bar, \"bar\"]]}."
+                .to_string()
+        ]
+    );
+    // No prop is contributed, so no `resolveDirective("models")` is emitted.
+    assert_eq!(
+        render_code(source),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B))\n}"
+    );
+}
+
+#[test]
+fn a_missing_value_is_rejected() {
+    assert_eq!(
+        errors("const A = () => <B v-models/>;"),
+        vec![
+            "v-models expects a two-dimensional array of `[value, arg?, modifiers?]` \
+             entries, e.g. v-models={[[foo], [bar, \"bar\"]]}."
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn an_empty_array_is_rejected() {
+    assert_eq!(
+        errors("const A = () => <B v-models={[]}/>;"),
+        vec![
+            "v-models was given an empty array; it needs at least one \
+             `[value, arg?, modifiers?]` entry."
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn a_non_array_entry_is_rejected() {
+    // Babel: "You should pass a Two-dimensional Arrays to v-models"
+    // (corpus row `errors/v_models_entry_not_array`).
+    assert_eq!(
+        errors("const A = () => <B v-models={[foo]}/>;"),
+        vec![
+            "v-models entry `foo` is not an array; each entry must be \
+             `[value, arg?, modifiers?]`."
+                .to_string()
+        ]
+    );
+    // A spread cannot be destructured into entries either.
+    assert_eq!(
+        errors("const A = () => <B v-models={[...pairs]}/>;"),
+        vec![
+            "v-models entry `...pairs` is not an array; each entry must be \
+             `[value, arg?, modifiers?]`."
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn an_empty_entry_is_rejected() {
+    assert_eq!(
+        errors("const A = () => <B v-models={[[]]}/>;"),
+        vec![
+            "v-models entry `[]` has no bound value; each entry must be \
+             `[value, arg?, modifiers?]`."
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn a_non_assignable_entry_target_is_rejected() {
+    // Same reason `v-model` rejects one (#3420): the write-back compiles to
+    // `target = $event`, so a call expression would emit code that cannot parse.
+    let source = "const A = () => <B v-models={[[get()], [ok]]}/>;";
+    assert_eq!(
+        errors(source),
+        vec![
+            "v-models target `get()` cannot be assigned to; \
+             v-model needs a variable or property reference."
+                .to_string()
+        ]
+    );
+    // One bad entry rejects the whole attribute: a build error paired with a
+    // partial set of model bindings would be harder to reason about than none.
+    assert_eq!(
+        render_code(source),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B))\n}"
+    );
+}
+
+#[test]
+fn the_argument_spelling_is_rejected() {
+    // Babel accepts `v-models:x` but then ignores every entry's own argument:
+    // `v-models:x={[[a], [b, "b"]]}` binds `x` and `modelValue`, never `b`.
+    assert_eq!(
+        errors("const A = () => <B v-models:x={[[foo]]}/>;"),
+        vec![
+            "v-models does not take an argument; name the prop inside each entry \
+             instead, e.g. v-models={[[value, \"name\"]]}."
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn the_underscore_modifier_spelling_is_rejected() {
+    assert_eq!(
+        errors("const A = () => <B v-models_lazy={[[foo]]}/>;"),
+        vec![
+            "v-models does not take `_`-suffixed modifiers; list them inside each \
+             entry instead, e.g. v-models={[[value, [\"lazy\"]]]}."
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn a_plain_element_is_rejected_but_a_custom_element_is_not() {
+    // Babel: "v-models can only use in custom components".
+    assert_eq!(
+        errors("const A = () => <input v-models={[[foo]]}/>;"),
+        vec![
+            "v-models can only be used on a component; a plain element binds one \
+             model with v-model."
+                .to_string()
+        ]
+    );
+    // A dashed lowercase tag is a custom element: Vize classifies it as an
+    // intrinsic element but the DOM backend resolves it with `resolveComponent`,
+    // so `v-models` is legitimate there and must not be rejected.
+    let source = "const A = () => <my-el v-models={[[foo]]}/>;";
+    assert_eq!(errors(source), Vec::<String>::new());
+    assert_eq!(
+        render_code(source),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_my_el = _resolveComponent(\"my-el\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_my_el, {\n    \
+         modelValue: foo,\n    \
+         \"onUpdate:modelValue\": $event => ((foo) = $event)\n  \
+         }, null, 8 /* PROPS */, [\"modelValue\", \"onUpdate:modelValue\"]))\n}"
+    );
+}


### PR DESCRIPTION
## The defect

`v-models` is a `@vue/babel-plugin-jsx` **built-in**, not a user directive, but
`crates/vize_atelier_jsx/src/lower/attr.rs` routed every unrecognized `v-*`
attribute to the generic custom-directive path.

```jsx
const A = () => <B v-models={[[foo], [bar, 'bar']]}/>;
```

**Expected** (real `@vue/babel-plugin-jsx` 2.0.1, from the committed recording):

```js
_createVNode(_resolveComponent("B"), {
  "modelValue": foo, "onUpdate:modelValue": $event => foo = $event,
  'bar': bar,        "onUpdate:bar": $event => bar = $event
}, null);
```

**Actual before this change:**

```js
const _directive_models = _resolveDirective("models")
return _withDirectives((_openBlock(), _createBlock(_component_B, null, null, 512 /* NEED_PATCH */)), [
  [_directive_models, [[foo], [bar, 'bar']]]
])
```

Vue resolves no `models` directive at runtime, so the component rendered with
**no model bindings at all, with no error and no warning** — silently wrong
output on valid input.

## The fix

Every `v-models` entry is exactly the `v-model={[value, arg?, modifiers?]}` array
form, so entries go through the same `lower_model_array` `v-model` already uses
and the attribute expands into one `model` directive per entry. New module
`lower/v_models.rs` (263 lines); `lower/attr.rs` stays at 304, inside the budget.

Everything that is not lowered is **diagnosed**, so no `v-models` shape can reach
the custom-directive path again:

| Input | Diagnostic |
| --- | --- |
| `v-models={foo}` / `v-models` | `v-models expects a two-dimensional array of \`[value, arg?, modifiers?]\` entries, …` |
| `v-models={[]}` | `v-models was given an empty array; …` |
| `v-models={[foo]}` / `{[...pairs]}` | ``v-models entry `foo` is not an array; …`` |
| `v-models={[[]]}` | ``v-models entry `[]` has no bound value; …`` |
| `v-models={[[get()]]}` | ``v-models target `get()` cannot be assigned to; …`` |
| `<input v-models={…}/>` | `v-models can only be used on a component; …` |
| `v-models:x={…}` | `v-models does not take an argument; …` |
| `v-models_lazy={…}` | ``v-models does not take `_`-suffixed modifiers; …`` |

The last two are spellings babel accepts and Vize deliberately rejects; both are
undocumented, and babel's `v-models:x` is inconsistent — `v-models:x={[[a], [b, "b"]]}`
binds `x` and `modelValue` and never `b`. That reasoning is written into
`lower/v_models.rs` and into a new subsection of `BABEL_COMPAT_INVENTORY.md` so it
is not implicit. A dashed lowercase tag (`<my-el/>`) still counts as a component,
matching babel and matching what Vize's own DOM backend does with it.

## Oracle rows flipped

Measured against the real plugin, not from memory
(`node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check` → `oracle matches 95 recorded cases`).

| Row | Before | After |
| --- | --- | --- |
| `directives/v_models` | divergent: v-models not implemented | **equivalent** |
| `directives/v_models_mods` | divergent: v-models not implemented | **equivalent** |
| `errors/v_models_not_array` | divergent: v-models not implemented | **equivalent** |
| `errors/v_models_entry_not_array` | *(new corpus row)* | **equivalent** |

The new corpus row pins babel's own entry-level rejection —
`You should pass a Two-dimensional Arrays to v-models` — against Vize's. Totals in
`BABEL_COMPAT_INVENTORY.md` and `babel_compat_verdict_totals` move together:
**64/28/2 over 94 rows → 68/25/2 over 95**.

`directives/v_models_mods` emits the `<arg>Modifiers` object after the update
handler where babel emits it before; that literal-ordering difference is the one
already accepted as equivalent for `directives/v_model_component_arg_mods`.

## Tests fail before the fix

`crates/vize_atelier_jsx/tests/v_models.rs` — 14 tests, full-output `assert_eq!`
on emitted render code and on the complete diagnostics list. Verified by restoring
`crates/vize_atelier_jsx/src/` to `origin/main` with the tests in place:

```
running 14 tests
test every_entry_lowers_to_its_own_model_directive ... FAILED
test a_non_array_entry_is_rejected ... FAILED
... (all 14 FAILED)

---- single_entry_binds_model_value stdout ----
assertion `left == right` failed
  left: "…const _directive_models = _resolveDirective(\"models\")\n  \n  return _withDirectives(…[_directive_models, [[foo]]]…"
 right: "…return (_openBlock(), _createBlock(_component_B, {\n    modelValue: foo,\n    \"onUpdate:modelValue\": $event => ((foo) = $event)\n  }, …"

---- a_non_array_value_is_rejected stdout ----
  left: []
 right: ["v-models expects a two-dimensional array of `[value, arg?, modifiers?]` entries, e.g. v-models={[[foo], [bar, \"bar\"]]}."]
```

After the fix: `test result: ok. 14 passed; 0 failed`.

## Gates run

```
nix develop -c cargo test -p vize_atelier_jsx        # all suites ok, 0 failed
nix develop -c node --test tests/tooling/babel-jsx-oracle.test.ts  # 3 pass, 0 fail
nix develop -c node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check
nix develop -c vp run check:rust                     # Finished, no errors
nix develop -c vp run lint:rust                      # clippy -D warnings, clean
nix develop -c vp run source:lengths                 # exit 0
rustfmt --edition 2024 --config style_edition=2024 --check <changed files>  # clean
nix develop -c vp fmt --write                        # no further changes
```

Refs #3418, Refs #3391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `v-models` in JSX, including multiple model bindings and per-model modifiers.
  * Supports `v-models` on components and dashed custom elements.

* **Bug Fixes**
  * Added validation and diagnostics for invalid values, entries, targets, and unsupported syntax.
  * Prevents partial model bindings when validation fails.

* **Tests**
  * Added comprehensive coverage for valid and invalid `v-models` usage.
  * Updated Babel compatibility results and fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->