### PR TITLE
fix(atelier): lower JSX v-slots instead of emitting resolveDirective("slots")

### DIFF
--- a/crates/vize_atelier_jsx/src/lower.rs
+++ b/crates/vize_atelier_jsx/src/lower.rs
@@ -17,11 +17,13 @@ mod style;
 mod text;
 mod v_model;
 mod v_models;
+mod v_slots;
 
 pub(crate) use style::{RawScopedStyle, ScopedStyleExpr};
 
 use oxc_ast::ast::{JSXElement, JSXFragment};
-use vize_carton::{Box, Bump, String};
+use oxc_span::Span;
+use vize_carton::{Box, Bump, String, ToCompactString};
 use vize_relief::{RootNode, TemplateChildNode};
 
 use crate::diagnostics::JsxDiagnostic;
@@ -92,6 +94,25 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Record a diagnostic.
     pub fn report(&mut self, diagnostic: JsxDiagnostic) {
         self.diagnostics.push(diagnostic);
+    }
+
+    /// Report a fixed-text error over `span`.
+    ///
+    /// Shared by the built-in attribute lowerings (`v_models`, `v_slots`), which
+    /// reject far more shapes than they accept and would otherwise each repeat
+    /// the same `JsxDiagnostic::error` plumbing.
+    pub(crate) fn reject(&mut self, span: Span, message: &'static str) {
+        self.report(JsxDiagnostic::error(message, span.start, span.end));
+    }
+
+    /// Report a formatted error over `span`, for messages that quote the
+    /// offending source text.
+    pub(crate) fn reject_at(&mut self, span: Span, message: std::fmt::Arguments<'_>) {
+        self.report(JsxDiagnostic::error(
+            message.to_compact_string(),
+            span.start,
+            span.end,
+        ));
     }
 
     /// Lower a JSX element as the single root of a render output.

--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -77,6 +77,13 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             return None;
         }
 
+        // `v-slots` supplies the component's slots, not a prop. It is applied to
+        // the children by `lower_element_node`, which is where the tag kind and
+        // the already-lowered children are both available (#3418).
+        if self.is_v_slots_attribute(attr) {
+            return None;
+        }
+
         // Directive forms: `v-model`, `v-show`, `v-on:click`, custom `v-foo:arg`.
         if let Some(directive) = self.try_directive_attribute(attr, &loc) {
             return Some(directive);

--- a/crates/vize_atelier_jsx/src/lower/element.rs
+++ b/crates/vize_atelier_jsx/src/lower/element.rs
@@ -15,10 +15,11 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         let mut node = ElementNode::new(self.bump(), tag, loc);
         node.tag_type = element_type(&opening.name);
         node.is_self_closing = element.closing_element.is_none();
-        // `v-models` is component-only. A dashed lowercase tag is classified as
-        // an intrinsic element here, but the DOM backend still resolves it with
-        // `resolveComponent`, so custom elements count as components for that
-        // check just as they do for `@vue/babel-plugin-jsx`.
+        // `v-models` and `v-slots` are component-only. A dashed lowercase tag is
+        // classified as an intrinsic element here, but the DOM backend still
+        // resolves it with `resolveComponent`, so custom elements count as
+        // components for those checks just as they do for
+        // `@vue/babel-plugin-jsx`.
         let on_component = node.tag_type == ElementType::Component || node.tag.contains('-');
         node.props = self.lower_attributes(&opening.attributes, on_component);
         // Components route through slot synthesis (object/render-prop children
@@ -29,6 +30,10 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         } else {
             self.lower_children(&element.children)
         };
+        // `v-slots` contributes slot templates, appended after the element's own
+        // children so those still become the `default` slot when the slots object
+        // does not name one (#3418).
+        self.apply_v_slots(&mut node, &opening.attributes, on_component);
         node
     }
 

--- a/crates/vize_atelier_jsx/src/lower/v_models.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_models.rs
@@ -42,12 +42,11 @@
 
 use oxc_ast::ast::{ArrayExpression, Expression, JSXAttribute, JSXAttributeName};
 use oxc_span::{GetSpan, Span};
-use vize_carton::{ToCompactString, Vec};
+use vize_carton::Vec;
 use vize_relief::PropNode;
 
 use super::Lowerer;
 use super::v_model::is_assignable_target;
-use crate::diagnostics::JsxDiagnostic;
 
 /// How a `v-models` attribute was spelled.
 enum Form {
@@ -235,18 +234,6 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
                 classify(self.mapper().slice(id.span()).strip_prefix("v-")?)
             }
         }
-    }
-
-    fn reject(&mut self, span: Span, message: &'static str) {
-        self.report(JsxDiagnostic::error(message, span.start, span.end));
-    }
-
-    fn reject_at(&mut self, span: Span, message: std::fmt::Arguments<'_>) {
-        self.report(JsxDiagnostic::error(
-            message.to_compact_string(),
-            span.start,
-            span.end,
-        ));
     }
 }
 

--- a/crates/vize_atelier_jsx/src/lower/v_slots.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_slots.rs
@@ -1,0 +1,193 @@
+//! `v-slots` — the `@vue/babel-plugin-jsx` built-in that supplies a component's
+//! slots from an attribute instead of from its children.
+//!
+//! `v-slots={{ default: () => <i/>, foo: (p) => <b/> }}` is the same object the
+//! object-children idiom (`<B>{{ … }}</B>`) accepts, so it is lowered through the
+//! same [`Lowerer::lower_object_slots`] into synthetic `<template v-slot:name>`
+//! children.
+//!
+//! # Why this is a built-in and not a custom directive
+//!
+//! `v-slots` is a plugin built-in, not a user directive. Before #3418 any
+//! unrecognized `v-*` attribute fell through to the generic custom-directive
+//! path, so `v-slots` compiled to `resolveDirective("slots")` — a lookup for a
+//! directive that does not exist, leaving the component with no slots, no error
+//! and no warning. For the object-literal form it was worse than that: the
+//! directive value was emitted as the **raw attribute source**, so
+//! `v-slots={{ default: () => <i/> }}` put unparsed JSX into the generated
+//! JavaScript module.
+//!
+//! # Combining with the element's own children
+//!
+//! The templates are appended **after** the element's own children, so the plain
+//! children still become the `default` slot whenever the slots object does not
+//! name one — babel's `{ default: () => [children], ...slots }`, with the same
+//! keys in a different literal order.
+//!
+//! When the slots object *does* name `default` and the element also has
+//! children, the shared transform reports "Extraneous children found when
+//! component already has an explicit default slot."
+//! (`vize_relief::errors`). Babel instead emits the `default` key twice and lets
+//! JavaScript keep the later one, silently discarding the children — precisely
+//! the failure shape this fix exists to remove — so Vize names the ambiguity
+//! rather than picking a winner.
+//!
+//! # Shapes that are diagnosed rather than lowered
+//!
+//! - `v-slots={slots}` and any other non-object-literal value. Vize builds the
+//!   slots object at compile time and has no IR for spreading an opaque value
+//!   into it; babel emits `{…, ...slots}` or passes the value straight through as
+//!   children. Tracked by #3467, which also records why implementing it needs a
+//!   runtime harness rather than just a codegen change.
+//! - `v-slots` with no value, or with a string value. Babel forwards these as
+//!   `null` / `"str"` children, which is meaningless for a component.
+//! - `v-slots:arg={…}` — `v-slots` takes no argument; the slot names are the
+//!   object's keys.
+//! - `v-slots` on a plain element, which has no slots.
+//! - more than one `v-slots` on the same element. Babel keeps the last and drops
+//!   the rest silently, which is the failure shape #3418 exists to remove.
+//!
+//! Inside the object literal, spread properties and computed keys keep the
+//! existing object-children behavior: a warning naming what was ignored (see
+//! `slot.rs`), not silence.
+
+use oxc_ast::ast::{
+    Expression, JSXAttribute, JSXAttributeItem, JSXAttributeName, JSXAttributeValue,
+};
+use oxc_span::{GetSpan, Span};
+use vize_relief::ElementNode;
+
+use super::Lowerer;
+use super::expr::container_expr_span;
+
+impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// Whether `attr` is a `v-slots` attribute in any spelling.
+    ///
+    /// `lower_attribute` uses this to drop the attribute instead of turning it
+    /// into a prop: `v-slots` supplies children, and it is applied by
+    /// [`Self::apply_v_slots`] once the element's own children are lowered.
+    pub(crate) fn is_v_slots_attribute(&self, attr: &JSXAttribute<'_>) -> bool {
+        self.v_slots_name_span(attr).is_some()
+    }
+
+    /// Append the slot templates a `v-slots` attribute contributes to `node`, or
+    /// report why the attribute could not be lowered.
+    ///
+    /// Called after `node.children` is built so the `v-slots` entries land last,
+    /// leaving the element's plain children to become the `default` slot when the
+    /// slots object does not name one. `on_component` is whether the owning tag
+    /// renders as a component; `false` rejects the attribute.
+    pub(crate) fn apply_v_slots(
+        &mut self,
+        node: &mut ElementNode<'a>,
+        items: &[JSXAttributeItem<'_>],
+        on_component: bool,
+    ) {
+        let attrs: std::vec::Vec<&JSXAttribute<'_>> = items
+            .iter()
+            .filter_map(|item| match item {
+                JSXAttributeItem::Attribute(attr) if self.is_v_slots_attribute(attr) => {
+                    Some(attr.as_ref())
+                }
+                _ => None,
+            })
+            .collect();
+        let Some((attr, rest)) = attrs.split_first() else {
+            return;
+        };
+        if let Some(extra) = rest.first() {
+            self.reject(
+                extra.span,
+                "v-slots is given more than once on this element; babel keeps only the \
+                 last one, so merge them into a single slots object.",
+            );
+            return;
+        }
+
+        if !matches!(&attr.name, JSXAttributeName::Identifier(_)) {
+            self.reject(
+                attr.span,
+                "v-slots does not take an argument; the slot names are the keys of its \
+                 object, e.g. v-slots={{ header: () => <h1/> }}.",
+            );
+            return;
+        }
+        if !on_component {
+            self.reject(
+                attr.span,
+                "v-slots can only be used on a component; a plain element has no slots.",
+            );
+            return;
+        }
+
+        let Some(value) = attr.value.as_ref() else {
+            self.reject(
+                attr.span,
+                "v-slots is missing its slots object, e.g. \
+                 v-slots={{ default: () => <div/> }}.",
+            );
+            return;
+        };
+        let Some(object) = self.v_slots_object(value) else {
+            // Name the expression itself rather than the `{…}` container, so the
+            // message quotes `slots` and not `{slots}`.
+            let span = match value {
+                JSXAttributeValue::ExpressionContainer(container) => {
+                    container_expr_span(container).unwrap_or_else(|| value.span())
+                }
+                other => other.span(),
+            };
+            let source = self.mapper().slice(span);
+            self.reject_at(
+                span,
+                format_args!(
+                    "v-slots value `{source}` is not an object literal: Vize builds the \
+                     slots object at compile time and cannot forward an opaque slots \
+                     value. Write the slots inline, e.g. \
+                     v-slots={{{{ default: () => <div/> }}}}. Forwarding a slots object \
+                     is tracked by #3467."
+                ),
+            );
+            return;
+        };
+
+        for template in self.lower_object_slots(object) {
+            node.children.push(template);
+        }
+    }
+
+    /// The object literal a `v-slots` attribute value carries, or `None` when it
+    /// is anything else.
+    fn v_slots_object<'e>(
+        &self,
+        value: &'e JSXAttributeValue<'e>,
+    ) -> Option<&'e oxc_ast::ast::ObjectExpression<'e>> {
+        let JSXAttributeValue::ExpressionContainer(container) = value else {
+            return None;
+        };
+        match &container.expression {
+            oxc_ast::ast::JSXExpression::ObjectExpression(object) => Some(object),
+            // `v-slots={({ … })}` — parentheses are transparent.
+            oxc_ast::ast::JSXExpression::ParenthesizedExpression(paren) => {
+                match paren.expression.get_inner_expression() {
+                    Expression::ObjectExpression(object) => Some(object),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    /// The span of the `v-slots` name itself, for any spelling, or `None` when
+    /// the attribute is not `v-slots`.
+    fn v_slots_name_span(&self, attr: &JSXAttribute<'_>) -> Option<Span> {
+        let (raw, span) = match &attr.name {
+            JSXAttributeName::NamespacedName(named) => (
+                self.mapper().slice(named.namespace.span()),
+                named.namespace.span(),
+            ),
+            JSXAttributeName::Identifier(id) => (self.mapper().slice(id.span()), id.span()),
+        };
+        (raw == "v-slots").then_some(span)
+    }
+}

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -13,7 +13,7 @@ opt-in compat mode (#3391) is expected to change.
 
 | Artifact                                  | Role                                                                                                       |
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `babel_compat/fixtures/corpus.json`       | the 95 inputs + the babel plugin options each is compiled with                                             |
+| `babel_compat/fixtures/corpus.json`       | the 97 inputs + the babel plugin options each is compiled with                                             |
 | `babel_compat/oracle.mjs`                 | runs the corpus through the real plugin; `--write` records, `--check` verifies                             |
 | `babel_compat/fixtures/babel-output.json` | committed ground truth (generated — do not hand-edit)                                                      |
 | `../babel_compat_oracle.rs`               | snapshots babel's output beside Vize's, per category, with a verdict per row                               |
@@ -55,7 +55,7 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   68 |
+| equivalent |   70 |
 | divergent  |   25 |
 | deferred   |    2 |
 
@@ -191,15 +191,34 @@ it classifies as an intrinsic element but the DOM backend still resolves with
 
 ## Slots
 
-| Case                             | Babel                                 | Vize today                                   | Compat mode                           | Verdict |
-| -------------------------------- | ------------------------------------- | -------------------------------------------- | ------------------------------------- | ------- |
-| `slots/object_children`          | object child becomes the slots object | `withCtx` slots + `_: 1`                     | no change                             | ✅      |
-| `slots/render_prop_child`        | `{default: () => 'foo'}`              | empty default slot — the value is dropped    | keep the non-JSX body                 | ❌      |
-| `slots/scoped_param`             | `default: s => …`                     | `default: withCtx((s) => […])`               | no change                             | ✅      |
-| `slots/v_slots_with_children`    | `{default: () => […], ...slots}`      | falls through to `resolveDirective("slots")` | implement `v-slots`                   | ❌      |
-| `slots/v_slots_only`             | slots object passed as children       | falls through to `resolveDirective("slots")` | implement `v-slots`                   | ❌      |
-| `slots/element_children_default` | `{default: () => […]}`                | `withCtx` default slot + `_: 1`              | no change                             | ✅      |
-| `slots/dynamic_slot_name`        | `{[n]: () => …}`                      | warns and drops the slot                     | deferred: needs dynamic-slot lowering | ⏸       |
+| Case                                 | Babel                                 | Vize today                                  | Compat mode                           | Verdict |
+| ------------------------------------ | ------------------------------------- | ------------------------------------------- | ------------------------------------- | ------- |
+| `slots/object_children`              | object child becomes the slots object | `withCtx` slots + `_: 1`                    | no change                             | ✅      |
+| `slots/render_prop_child`            | `{default: () => 'foo'}`              | empty default slot — the value is dropped   | keep the non-JSX body                 | ❌      |
+| `slots/scoped_param`                 | `default: s => …`                     | `default: withCtx((s) => […])`              | no change                             | ✅      |
+| `slots/v_slots_with_children`        | `{default: () => […], ...slots}`      | diagnosed: opaque slots value (#3418)       | forward the object; needs #3467       | ❌      |
+| `slots/v_slots_only`                 | slots object passed as children       | diagnosed: opaque slots value (#3418)       | forward the object; needs #3467       | ❌      |
+| `slots/v_slots_object_literal`       | object literal becomes the slots      | `withCtx` slots + `_: 1` (#3418)            | no change                             | ✅      |
+| `slots/v_slots_object_with_children` | `{default: () => […], bar: …}`        | same two slots, other literal order (#3418) | no change                             | ✅      |
+| `slots/element_children_default`     | `{default: () => […]}`                | `withCtx` default slot + `_: 1`             | no change                             | ✅      |
+| `slots/dynamic_slot_name`            | `{[n]: () => …}`                      | warns and drops the slot                    | deferred: needs dynamic-slot lowering | ⏸       |
+
+### `v-slots` spellings Vize rejects and babel accepts
+
+Not corpus rows, because a compat mode is not expected to adopt them; recorded
+here so the choice is not implicit (#3418, `src/lower/v_slots.rs`):
+
+- `v-slots` with no value, and `v-slots="str"` — babel forwards `null` / `"str"`
+  as the component's children, which is meaningless for a component.
+- `v-slots:arg={…}` — `v-slots` takes no argument; the slot names are the object's
+  keys.
+- `v-slots` on a plain element — babel drops it silently and emits `[]` children.
+- more than one `v-slots` on the same element — babel keeps the last and drops the
+  rest silently.
+- an object literal that names `default` on an element that also has children.
+  Babel emits the `default` key twice and lets JavaScript keep the later one,
+  silently discarding the children; Vize reports "Extraneous children found when
+  component already has an explicit default slot." from the shared transform.
 
 ## Children
 
@@ -218,34 +237,34 @@ it classifies as an intrinsic element but the DOM backend still resolves with
 
 Compared against Vize's default, which is already fully optimized.
 
-| Case                             | Babel                        | Vize today                                   | Compat mode         | Verdict |
-| -------------------------------- | ---------------------------- | -------------------------------------------- | ------------------- | ------- |
-| `optimize/static`                | no flag                      | no flag                                      | no change           | ✅      |
-| `optimize/class_only`            | `2`                          | `2 /* CLASS */`                              | no change           | ✅      |
-| `optimize/style_only`            | `4`                          | `4 /* STYLE */`                              | no change           | ✅      |
-| `optimize/text_only`             | raw child, no flag           | `toDisplayString(t)` + `1 /* TEXT */`        | emit the raw child  | ❌      |
-| `optimize/class_and_props`       | `10, ["id"]`                 | `11 /* TEXT, CLASS, PROPS */, ["id"]`        | drop the TEXT child | ❌      |
-| `optimize/spread`                | `16`                         | `16 /* FULL_PROPS */`                        | no change           | ✅      |
-| `optimize/ref`                   | `512`                        | `512 /* NEED_PATCH */`                       | no change           | ✅      |
-| `optimize/key`                   | no flag                      | no flag                                      | no change           | ✅      |
-| `optimize/event`                 | `8, ["onClick"]`             | same                                         | no change           | ✅      |
-| `optimize/component_props`       | `8, ["foo"]`                 | same                                         | no change           | ✅      |
-| `optimize/v_model_input`         | `8, ["onUpdate:modelValue"]` | same                                         | no change           | ✅      |
-| `optimize/slots_stability`       | `_: 1`                       | `_: 1 /* STABLE */`                          | no change           | ✅      |
-| `optimize/scoped_slot_stability` | `_: 1`                       | `_: 1 /* STABLE */`                          | no change           | ✅      |
-| `optimize/v_slots_stability`     | slots object as children     | falls through to `resolveDirective("slots")` | implement `v-slots` | ❌      |
-| `optimize/fragment`              | no flag                      | `64 /* STABLE_FRAGMENT */`                   | no change           | ✅      |
-| `optimize/map_list`              | raw array child              | `renderList` + `KEYED_FRAGMENT`              | no change           | ✅      |
+| Case                             | Babel                        | Vize today                            | Compat mode                     | Verdict |
+| -------------------------------- | ---------------------------- | ------------------------------------- | ------------------------------- | ------- |
+| `optimize/static`                | no flag                      | no flag                               | no change                       | ✅      |
+| `optimize/class_only`            | `2`                          | `2 /* CLASS */`                       | no change                       | ✅      |
+| `optimize/style_only`            | `4`                          | `4 /* STYLE */`                       | no change                       | ✅      |
+| `optimize/text_only`             | raw child, no flag           | `toDisplayString(t)` + `1 /* TEXT */` | emit the raw child              | ❌      |
+| `optimize/class_and_props`       | `10, ["id"]`                 | `11 /* TEXT, CLASS, PROPS */, ["id"]` | drop the TEXT child             | ❌      |
+| `optimize/spread`                | `16`                         | `16 /* FULL_PROPS */`                 | no change                       | ✅      |
+| `optimize/ref`                   | `512`                        | `512 /* NEED_PATCH */`                | no change                       | ✅      |
+| `optimize/key`                   | no flag                      | no flag                               | no change                       | ✅      |
+| `optimize/event`                 | `8, ["onClick"]`             | same                                  | no change                       | ✅      |
+| `optimize/component_props`       | `8, ["foo"]`                 | same                                  | no change                       | ✅      |
+| `optimize/v_model_input`         | `8, ["onUpdate:modelValue"]` | same                                  | no change                       | ✅      |
+| `optimize/slots_stability`       | `_: 1`                       | `_: 1 /* STABLE */`                   | no change                       | ✅      |
+| `optimize/scoped_slot_stability` | `_: 1`                       | `_: 1 /* STABLE */`                   | no change                       | ✅      |
+| `optimize/v_slots_stability`     | slots object as children     | diagnosed: opaque slots value (#3418) | forward the object; needs #3467 | ❌      |
+| `optimize/fragment`              | no flag                      | `64 /* STABLE_FRAGMENT */`            | no change                       | ✅      |
+| `optimize/map_list`              | raw array child              | `renderList` + `KEYED_FRAGMENT`       | no change                       | ✅      |
 
 ## Inputs babel rejects
 
 A compat mode must reject what babel rejects, with a diagnostic — never silently
 accept it.
 
-| Case                              | Babel                                                           | Vize today                                                        | Compat mode         | Verdict |
-| --------------------------------- | --------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------- | ------- |
-| `errors/v_model_non_lval`         | rejects a non-assignable `v-model` target                       | rejects it too, naming the offending expression (closed by #3420) | no change           | ✅      |
-| `errors/v_model_no_value`         | rejects: "You have to use JSX Expression inside your v-model"   | rejects: "v-model is missing expression."                         | no change           | ✅      |
-| `errors/v_models_not_array`       | rejects a non-array `v-models` value                            | rejects it too, naming the expected entry shape (closed by #3418) | no change           | ✅      |
-| `errors/v_models_entry_not_array` | rejects: "You should pass a Two-dimensional Arrays to v-models" | rejects it too, naming the offending entry (closed by #3418)      | no change           | ✅      |
-| `errors/v_slots_not_object`       | forwards the value as children                                  | emits a custom `slots` directive                                  | forward as children | ❌      |
+| Case                              | Babel                                                           | Vize today                                                        | Compat mode    | Verdict |
+| --------------------------------- | --------------------------------------------------------------- | ----------------------------------------------------------------- | -------------- | ------- |
+| `errors/v_model_non_lval`         | rejects a non-assignable `v-model` target                       | rejects it too, naming the offending expression (closed by #3420) | no change      | ✅      |
+| `errors/v_model_no_value`         | rejects: "You have to use JSX Expression inside your v-model"   | rejects: "v-model is missing expression."                         | no change      | ✅      |
+| `errors/v_models_not_array`       | rejects a non-array `v-models` value                            | rejects it too, naming the expected entry shape (closed by #3418) | no change      | ✅      |
+| `errors/v_models_entry_not_array` | rejects: "You should pass a Two-dimensional Arrays to v-models" | rejects it too, naming the offending entry (closed by #3418)      | no change      | ✅      |
+| `errors/v_slots_not_object`       | forwards the value as children                                  | rejects it, naming the offending value (#3418)                    | keep rejecting | ❌      |

--- a/crates/vize_atelier_jsx/tests/babel_compat/fixtures/babel-output.json
+++ b/crates/vize_atelier_jsx/tests/babel_compat/fixtures/babel-output.json
@@ -259,6 +259,14 @@
       "status": "ok",
       "code": "import { resolveComponent as _resolveComponent, createVNode as _createVNode } from \"vue\";\nconst A = () => _createVNode(_resolveComponent(\"B\"), null, slots);"
     },
+    "slots/v_slots_object_literal": {
+      "status": "ok",
+      "code": "import { createVNode as _createVNode, resolveComponent as _resolveComponent } from \"vue\";\nconst A = () => _createVNode(_resolveComponent(\"B\"), null, {\n  default: () => _createVNode(\"i\", null, null),\n  bar: () => _createVNode(\"b\", null, null)\n});"
+    },
+    "slots/v_slots_object_with_children": {
+      "status": "ok",
+      "code": "import { createVNode as _createVNode, createTextVNode as _createTextVNode, resolveComponent as _resolveComponent } from \"vue\";\nconst A = () => _createVNode(_resolveComponent(\"B\"), null, {\n  default: () => [_createVNode(\"div\", null, [_createTextVNode(\"A\")])],\n  bar: () => _createVNode(\"b\", null, null)\n});"
+    },
     "slots/element_children_default": {
       "status": "ok",
       "code": "import { createVNode as _createVNode, resolveComponent as _resolveComponent } from \"vue\";\nconst A = () => _createVNode(_resolveComponent(\"B\"), null, {\n  default: () => [_createVNode(\"i\", null, null)]\n});"

--- a/crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json
+++ b/crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json
@@ -405,6 +405,18 @@
       "source": "const A = () => <B v-slots={slots}/>;"
     },
     {
+      "id": "slots/v_slots_object_literal",
+      "category": "slots",
+      "lang": "jsx",
+      "source": "const A = () => <B v-slots={{default: () => <i/>, bar: () => <b/>}}/>;"
+    },
+    {
+      "id": "slots/v_slots_object_with_children",
+      "category": "slots",
+      "lang": "jsx",
+      "source": "const A = () => <B v-slots={{bar: () => <b/>}}><div>A</div></B>;"
+    },
+    {
       "id": "slots/element_children_default",
       "category": "slots",
       "lang": "jsx",

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -125,11 +125,18 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
         Diff("non-JSX render-prop body dropped"),
     ),
     ("slots/scoped_param", Same),
+    // #3418 lowers the object-literal form; an opaque slots value is diagnosed
+    // rather than forwarded, which needs the slots spread tracked by #3467.
     (
         "slots/v_slots_with_children",
-        Diff("v-slots not implemented"),
+        Diff("opaque v-slots value diagnosed; needs #3467"),
     ),
-    ("slots/v_slots_only", Diff("v-slots not implemented")),
+    (
+        "slots/v_slots_only",
+        Diff("opaque v-slots value diagnosed; needs #3467"),
+    ),
+    ("slots/v_slots_object_literal", Same),
+    ("slots/v_slots_object_with_children", Same),
     ("slots/element_children_default", Same),
     (
         "slots/dynamic_slot_name",
@@ -166,7 +173,7 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("optimize/scoped_slot_stability", Same),
     (
         "optimize/v_slots_stability",
-        Diff("v-slots not implemented"),
+        Diff("opaque v-slots value diagnosed; needs #3467"),
     ),
     ("optimize/fragment", Same),
     ("optimize/map_list", Same),
@@ -178,5 +185,8 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     // two-dimensional array.
     ("errors/v_models_not_array", Same),
     ("errors/v_models_entry_not_array", Same),
-    ("errors/v_slots_not_object", Diff("v-slots not implemented")),
+    (
+        "errors/v_slots_not_object",
+        Diff("non-object v-slots value rejected; babel forwards it"),
+    ),
 ];

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,8 +80,8 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (68, 25, 2));
-    assert_eq!(VERDICTS.len(), 95);
+    assert_eq!((equivalent, divergent, deferred), (70, 25, 2));
+    assert_eq!(VERDICTS.len(), 97);
 }
 
 #[test]

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
@@ -72,7 +72,7 @@ export function render(_ctx, _cache) {
 
 ## errors/v_slots_not_object
 ### verdict
-divergent: v-slots not implemented
+divergent: non-object v-slots value rejected; babel forwards it
 ### source (jsx)
 const A = () => <B v-slots={1}/>;
 ### babel options
@@ -81,12 +81,10 @@ const A = () => <B v-slots={1}/>;
 import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_resolveComponent("B"), null, 1);
 ### vize (vdom, default config)
-import { resolveDirective as _resolveDirective, resolveComponent as _resolveComponent, withDirectives as _withDirectives, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+<Error> v-slots value `1` is not an object literal: Vize builds the slots object at compile time and cannot forward an opaque slots value. Write the slots inline, e.g. v-slots={{ default: () => <div/> }}. Forwarding a slots object is tracked by #3467.
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  const _directive_slots = _resolveDirective("slots")
   
-  return _withDirectives((_openBlock(), _createBlock(_component_B, null, null, 512 /* NEED_PATCH */)), [
-    [_directive_slots, 1]
-  ])
+  return (_openBlock(), _createBlock(_component_B))
 }

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__optimize.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__optimize.snap
@@ -268,7 +268,7 @@ export function render(_ctx, _cache) {
 
 ## optimize/v_slots_stability
 ### verdict
-divergent: v-slots not implemented
+divergent: opaque v-slots value diagnosed; needs #3467
 ### source (jsx)
 const A = () => <B v-slots={slots}/>;
 ### babel options
@@ -277,14 +277,12 @@ const A = () => <B v-slots={slots}/>;
 import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_resolveComponent("B"), null, slots);
 ### vize (vdom, default config)
-import { resolveDirective as _resolveDirective, resolveComponent as _resolveComponent, withDirectives as _withDirectives, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+<Error> v-slots value `slots` is not an object literal: Vize builds the slots object at compile time and cannot forward an opaque slots value. Write the slots inline, e.g. v-slots={{ default: () => <div/> }}. Forwarding a slots object is tracked by #3467.
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  const _directive_slots = _resolveDirective("slots")
   
-  return _withDirectives((_openBlock(), _createBlock(_component_B, null, null, 512 /* NEED_PATCH */)), [
-    [_directive_slots, slots]
-  ])
+  return (_openBlock(), _createBlock(_component_B))
 }
 
 ## optimize/fragment

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__slots.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__slots.snap
@@ -82,7 +82,7 @@ export function render(_ctx, _cache) {
 
 ## slots/v_slots_with_children
 ### verdict
-divergent: v-slots not implemented
+divergent: opaque v-slots value diagnosed; needs #3467
 ### source (jsx)
 const A = () => <B v-slots={slots}><div>A</div></B>;
 ### babel options
@@ -94,24 +94,22 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
   ...slots
 });
 ### vize (vdom, default config)
-import { resolveDirective as _resolveDirective, resolveComponent as _resolveComponent, withDirectives as _withDirectives, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
+<Error> v-slots value `slots` is not an object literal: Vize builds the slots object at compile time and cannot forward an opaque slots value. Write the slots inline, e.g. v-slots={{ default: () => <div/> }}. Forwarding a slots object is tracked by #3467.
+import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  const _directive_slots = _resolveDirective("slots")
   
-  return _withDirectives((_openBlock(), _createBlock(_component_B, null, {
+  return (_openBlock(), _createBlock(_component_B, null, {
     default: _withCtx(() => [
       _createElementVNode("div", null, "A")
     ]),
     _: 1 /* STABLE */
-  })), [
-    [_directive_slots, slots]
-  ])
+  }))
 }
 
 ## slots/v_slots_only
 ### verdict
-divergent: v-slots not implemented
+divergent: opaque v-slots value diagnosed; needs #3467
 ### source (jsx)
 const A = () => <B v-slots={slots}/>;
 ### babel options
@@ -120,14 +118,70 @@ const A = () => <B v-slots={slots}/>;
 import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_resolveComponent("B"), null, slots);
 ### vize (vdom, default config)
-import { resolveDirective as _resolveDirective, resolveComponent as _resolveComponent, withDirectives as _withDirectives, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+<Error> v-slots value `slots` is not an object literal: Vize builds the slots object at compile time and cannot forward an opaque slots value. Write the slots inline, e.g. v-slots={{ default: () => <div/> }}. Forwarding a slots object is tracked by #3467.
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  const _directive_slots = _resolveDirective("slots")
   
-  return _withDirectives((_openBlock(), _createBlock(_component_B, null, null, 512 /* NEED_PATCH */)), [
-    [_directive_slots, slots]
-  ])
+  return (_openBlock(), _createBlock(_component_B))
+}
+
+## slots/v_slots_object_literal
+### verdict
+equivalent
+### source (jsx)
+const A = () => <B v-slots={{default: () => <i/>, bar: () => <b/>}}/>;
+### babel options
+(defaults)
+### babel
+import { createVNode as _createVNode, resolveComponent as _resolveComponent } from "vue";
+const A = () => _createVNode(_resolveComponent("B"), null, {
+  default: () => _createVNode("i", null, null),
+  bar: () => _createVNode("b", null, null)
+});
+### vize (vdom, default config)
+import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
+export function render(_ctx, _cache) {
+  const _component_B = _resolveComponent("B")
+  
+  return (_openBlock(), _createBlock(_component_B, null, {
+    default: _withCtx(() => [
+      _createElementVNode("i")
+    ]),
+    bar: _withCtx(() => [
+      _createElementVNode("b")
+    ]),
+    _: 1 /* STABLE */
+  }))
+}
+
+## slots/v_slots_object_with_children
+### verdict
+equivalent
+### source (jsx)
+const A = () => <B v-slots={{bar: () => <b/>}}><div>A</div></B>;
+### babel options
+(defaults)
+### babel
+import { createVNode as _createVNode, createTextVNode as _createTextVNode, resolveComponent as _resolveComponent } from "vue";
+const A = () => _createVNode(_resolveComponent("B"), null, {
+  default: () => [_createVNode("div", null, [_createTextVNode("A")])],
+  bar: () => _createVNode("b", null, null)
+});
+### vize (vdom, default config)
+import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
+export function render(_ctx, _cache) {
+  const _component_B = _resolveComponent("B")
+  
+  return (_openBlock(), _createBlock(_component_B, null, {
+    bar: _withCtx(() => [
+      _createElementVNode("b")
+    ]),
+    default: _withCtx(() => [
+      _createElementVNode("div", null, "A")
+    ]),
+    _: 1 /* STABLE */
+  }))
 }
 
 ## slots/element_children_default

--- a/crates/vize_atelier_jsx/tests/v_slots.rs
+++ b/crates/vize_atelier_jsx/tests/v_slots.rs
@@ -1,0 +1,327 @@
+//! `v-slots` lowering (#3418).
+//!
+//! `v-slots` is a `@vue/babel-plugin-jsx` built-in, not a user directive. Before
+//! this was implemented it fell through the generic custom-directive path and
+//! compiled to `resolveDirective("slots")` — a lookup Vue resolves to nothing at
+//! runtime, so the component rendered with no slots, no error and no warning. For
+//! an object-literal value it was worse: the directive value was emitted as the
+//! **raw attribute source**, so `v-slots={{ default: () => <i/> }}` put unparsed
+//! JSX into the generated JavaScript module.
+//!
+//! The object-literal form is pinned against the real plugin by the differential
+//! oracle (rows `slots/v_slots_object_literal` and
+//! `slots/v_slots_object_with_children`); forwarding an opaque slots object is
+//! still diagnosed and is tracked by #3467.
+
+mod common;
+
+use vize_atelier_jsx::{JsxLang, VdomCompileOptions, compile_to_vdom, lower_source};
+use vize_carton::Bump;
+
+fn diagnostics(source: &str) -> Vec<String> {
+    let bump = Bump::new();
+    let out = lower_source(&bump, source, JsxLang::Jsx);
+    out.diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.message.as_str().to_string())
+        .collect()
+}
+
+fn errors(source: &str) -> Vec<String> {
+    let bump = Bump::new();
+    let out = lower_source(&bump, source, JsxLang::Jsx);
+    out.diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.is_error())
+        .map(|diagnostic| diagnostic.message.as_str().to_string())
+        .collect()
+}
+
+/// Errors from the whole VDOM compile, so checks the shared transform makes
+/// (rather than JSX lowering) are visible too.
+fn compile_errors(source: &str) -> Vec<String> {
+    let bump = Bump::new();
+    let out = compile_to_vdom(&bump, source, JsxLang::Jsx, VdomCompileOptions::default());
+    out.diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.is_error())
+        .map(|diagnostic| diagnostic.message.as_str().to_string())
+        .collect()
+}
+
+fn render_code(source: &str) -> String {
+    let bump = Bump::new();
+    let out = compile_to_vdom(&bump, source, JsxLang::Jsx, VdomCompileOptions::default());
+    out.components
+        .into_iter()
+        .map(|component| component.code.as_str().to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The rejected shapes all leave a component with no slots and, crucially, no
+/// `resolveDirective("slots")`.
+const BARE_COMPONENT: &str = "export function render(_ctx, _cache) {\n  \
+     const _component_B = _resolveComponent(\"B\")\n  \n  \
+     return (_openBlock(), _createBlock(_component_B))\n}";
+
+#[test]
+fn a_default_slot_object_becomes_the_default_slot() {
+    let source = "const A = () => <B v-slots={{default: () => <i/>}}/>;";
+    assert_eq!(diagnostics(source), Vec::<String>::new());
+    assert_eq!(
+        render_code(source),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, null, {\n    \
+         default: _withCtx(() => [\n      \
+         _createElementVNode(\"i\")\n    \
+         ]),\n    \
+         _: 1 /* STABLE */\n  \
+         }))\n}"
+    );
+}
+
+#[test]
+fn named_slots_each_become_their_own_slot() {
+    // The corpus row `slots/v_slots_object_literal`: babel emits
+    // `{default: () => createVNode("i"), bar: () => createVNode("b")}`.
+    let source = "const A = () => <B v-slots={{default: () => <i/>, bar: () => <b/>}}/>;";
+    assert_eq!(diagnostics(source), Vec::<String>::new());
+    assert_eq!(
+        render_code(source),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, null, {\n    \
+         default: _withCtx(() => [\n      \
+         _createElementVNode(\"i\")\n    \
+         ]),\n    \
+         bar: _withCtx(() => [\n      \
+         _createElementVNode(\"b\")\n    \
+         ]),\n    \
+         _: 1 /* STABLE */\n  \
+         }))\n}"
+    );
+}
+
+#[test]
+fn a_scoped_slot_keeps_its_params() {
+    let source = "const A = () => <B v-slots={{header: (p) => <i>{p.x}</i>}}/>;";
+    assert_eq!(diagnostics(source), Vec::<String>::new());
+    assert_eq!(
+        render_code(source),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, null, {\n    \
+         header: _withCtx((p) => [\n      \
+         _createElementVNode(\"i\", null, _toDisplayString(p.x), 1 /* TEXT */)\n    \
+         ]),\n    \
+         _: 1 /* STABLE */\n  \
+         }))\n}"
+    );
+}
+
+#[test]
+fn element_children_still_become_the_default_slot() {
+    // The corpus row `slots/v_slots_object_with_children`: babel emits
+    // `{default: () => [<div>A</div>], foo: () => <b/>}`. Vize emits the same two
+    // slots in the other literal order.
+    let source = "const A = () => <B v-slots={{foo: () => <b/>}}><div>A</div></B>;";
+    assert_eq!(diagnostics(source), Vec::<String>::new());
+    assert_eq!(
+        render_code(source),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, null, {\n    \
+         foo: _withCtx(() => [\n      \
+         _createElementVNode(\"b\")\n    \
+         ]),\n    \
+         default: _withCtx(() => [\n      \
+         _createElementVNode(\"div\", null, \"A\")\n    \
+         ]),\n    \
+         _: 1 /* STABLE */\n  \
+         }))\n}"
+    );
+}
+
+#[test]
+fn a_default_slot_plus_children_is_diagnosed_not_silently_resolved() {
+    // Babel emits the `default` key twice and lets JavaScript keep the later
+    // one, silently discarding the children. Vize names the ambiguity instead,
+    // via the shared transform's existing check.
+    assert_eq!(
+        compile_errors("const A = () => <B v-slots={{default: () => <i/>}}><div>A</div></B>;"),
+        vec![
+            "Extraneous children found when component already has an explicit default slot."
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn a_string_slot_name_is_kept_verbatim() {
+    let source = "const A = () => <B v-slots={{'my-slot': () => <i/>}}/>;";
+    assert_eq!(diagnostics(source), Vec::<String>::new());
+    assert_eq!(
+        render_code(source),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, null, {\n    \
+         \"my-slot\": _withCtx(() => [\n      \
+         _createElementVNode(\"i\")\n    \
+         ]),\n    \
+         _: 1 /* STABLE */\n  \
+         }))\n}"
+    );
+}
+
+#[test]
+fn an_empty_slots_object_contributes_nothing() {
+    let source = "const A = () => <B v-slots={{}}/>;";
+    assert_eq!(diagnostics(source), Vec::<String>::new());
+    assert_eq!(render_code(source), BARE_COMPONENT);
+}
+
+#[test]
+fn v_slots_is_never_a_prop() {
+    // The regression itself: no `slots` directive survives lowering, so no
+    // `resolveDirective("slots")` and no raw JSX source can reach the output.
+    let bump = Bump::new();
+    let root = common::lower_one(
+        &bump,
+        "const A = () => <B class=\"c\" v-slots={{foo: () => <b/>}}/>;",
+    );
+    let element = common::root_element(&root);
+    assert!(common::find_directive(element, "slots").is_none());
+    assert_eq!(element.props.len(), 1);
+    assert_eq!(
+        common::as_attribute(&element.props[0]).name.as_str(),
+        "class"
+    );
+}
+
+#[test]
+fn an_opaque_slots_value_is_rejected() {
+    // Vize builds the slots object at compile time and has no IR for spreading
+    // an opaque value into it; implementing that is #3467.
+    let message = "v-slots value `slots` is not an object literal: Vize builds the slots \
+                   object at compile time and cannot forward an opaque slots value. Write \
+                   the slots inline, e.g. v-slots={{ default: () => <div/> }}. Forwarding \
+                   a slots object is tracked by #3467.";
+    assert_eq!(
+        errors("const A = () => <B v-slots={slots}/>;"),
+        vec![message.to_string()]
+    );
+    // No prop is contributed, so no `resolveDirective("slots")` is emitted.
+    assert_eq!(
+        render_code("const A = () => <B v-slots={slots}/>;"),
+        BARE_COMPONENT
+    );
+    // The element's own children are still lowered.
+    assert_eq!(
+        errors("const A = () => <B v-slots={slots}><div>A</div></B>;"),
+        vec![message.to_string()]
+    );
+    assert_eq!(
+        render_code("const A = () => <B v-slots={slots}><div>A</div></B>;"),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, null, {\n    \
+         default: _withCtx(() => [\n      \
+         _createElementVNode(\"div\", null, \"A\")\n    \
+         ]),\n    \
+         _: 1 /* STABLE */\n  \
+         }))\n}"
+    );
+}
+
+#[test]
+fn a_non_object_value_is_rejected() {
+    // The corpus row `errors/v_slots_not_object`: babel forwards `1` as the
+    // component's children, which is meaningless.
+    assert_eq!(
+        errors("const A = () => <B v-slots={1}/>;"),
+        vec![
+            "v-slots value `1` is not an object literal: Vize builds the slots object at \
+             compile time and cannot forward an opaque slots value. Write the slots \
+             inline, e.g. v-slots={{ default: () => <div/> }}. Forwarding a slots object \
+             is tracked by #3467."
+                .to_string()
+        ]
+    );
+    assert_eq!(
+        errors("const A = () => <B v-slots=\"str\"/>;"),
+        vec![
+            "v-slots value `\"str\"` is not an object literal: Vize builds the slots \
+             object at compile time and cannot forward an opaque slots value. Write the \
+             slots inline, e.g. v-slots={{ default: () => <div/> }}. Forwarding a slots \
+             object is tracked by #3467."
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn a_missing_value_is_rejected() {
+    assert_eq!(
+        errors("const A = () => <B v-slots/>;"),
+        vec![
+            "v-slots is missing its slots object, e.g. v-slots={{ default: () => <div/> }}."
+                .to_string()
+        ]
+    );
+    assert_eq!(render_code("const A = () => <B v-slots/>;"), BARE_COMPONENT);
+}
+
+#[test]
+fn the_argument_spelling_is_rejected() {
+    assert_eq!(
+        errors("const A = () => <B v-slots:x={{foo: () => <i/>}}/>;"),
+        vec![
+            "v-slots does not take an argument; the slot names are the keys of its \
+             object, e.g. v-slots={{ header: () => <h1/> }}."
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn a_plain_element_is_rejected() {
+    // Babel drops `v-slots` on a non-component silently, emitting `[]` children.
+    assert_eq!(
+        errors("const A = () => <div v-slots={{foo: () => <i/>}}/>;"),
+        vec!["v-slots can only be used on a component; a plain element has no slots.".to_string()]
+    );
+    assert_eq!(
+        render_code("const A = () => <div v-slots={{foo: () => <i/>}}/>;"),
+        "export function render(_ctx, _cache) {\n  \
+         return (_openBlock(), _createElementBlock(\"div\"))\n}"
+    );
+}
+
+#[test]
+fn a_repeated_v_slots_is_rejected() {
+    // Babel keeps the last one and drops the rest silently.
+    assert_eq!(
+        errors("const A = () => <B v-slots={{a: () => <i/>}} v-slots={{b: () => <i/>}}/>;"),
+        vec![
+            "v-slots is given more than once on this element; babel keeps only the last \
+             one, so merge them into a single slots object."
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn spreads_and_computed_keys_keep_their_object_children_warnings() {
+    // `lower_object_slots` is shared with the object-children idiom, so these
+    // stay warnings naming what was ignored rather than silence.
+    assert_eq!(
+        diagnostics("const A = () => <B v-slots={{...rest}}/>;"),
+        vec!["spread in a JSX slot object is not supported and was ignored".to_string()]
+    );
+    assert_eq!(
+        diagnostics("const A = () => <B v-slots={{[n]: () => <i/>}}/>;"),
+        vec!["computed JSX slot names are not supported and were ignored".to_string()]
+    );
+}


### PR DESCRIPTION
> **Merge freeze:** auto-merge is deliberately **not** armed on this PR. It is
> opened for review only and must not merge until the coordinator lifts the
> freeze on `main`.

## The defect

`v-slots` is a `@vue/babel-plugin-jsx` **built-in**, not a user directive, but
`crates/vize_atelier_jsx/src/lower/attr.rs` routed every unrecognized `v-*`
attribute to the generic custom-directive path.

```jsx
const A = () => <B v-slots={{default: () => <i/>}}/>;
```

**Actual before this change** — the directive value was emitted as the **raw
attribute source**, so unparsed JSX ended up inside a JavaScript module:

```js
const _directive_slots = _resolveDirective("slots")
return _withDirectives((_openBlock(), _createBlock(_component_B, null, null, 512 /* NEED_PATCH */)), [
  [_directive_slots, {default: () => <i/>}]
])
```

That is worse than #3418 describes: not just a `resolveDirective("slots")` lookup
that Vue resolves to nothing, but output that does not parse. For
`v-slots={slots}` it is the plain silent version — the component renders with no
slots, no error, no warning.

## The fix

`v-slots={{ … }}` carries the same object the object-children idiom
(`<B>{{ … }}</B>`) already accepts, so it now goes through the same
`lower_object_slots` and becomes synthetic `<template v-slot:name>` children.
New module `lower/v_slots.rs` (190 lines).

```js
return (_openBlock(), _createBlock(_component_B, null, {
  default: _withCtx(() => [ _createElementVNode("i") ]),
  _: 1 /* STABLE */
}))
```

Templates are appended **after** the element's own children, so plain children
still become the `default` slot when the slots object does not name one —
babel's `{ default: () => [children], ...slots }`, same keys, different literal
order.

`reject` / `reject_at` move from `lower/v_models.rs` (#3465) up to the shared
`Lowerer` impl; both built-in lowerings need them and duplicate inherent methods
do not compile.

## What is diagnosed rather than implemented, and why

`v-slots={slots}` — **forwarding an opaque slots object is not implemented**, and
is now a named error instead of silence:

```
v-slots value `slots` is not an object literal: Vize builds the slots object at
compile time and cannot forward an opaque slots value. Write the slots inline,
e.g. v-slots={{ default: () => <div/> }}. Forwarding a slots object is tracked
by #3467.
```

Vize lowers JSX slots into `<template v-slot>` children and lets the shared
`vize_atelier_core` slot codegen build the slots object; there is no IR for
"spread this expression into the slots object". Adding one is not just a codegen
edit — it needs a slot-flag/patch-flag decision whose correctness lives entirely
in Vue runtime semantics:

- babel emits **no** `_` flag, so Vue treats the object as raw slots, sets
  `_ctx`, and normalizes each entry;
- Vue core's own dynamic slots use `_: 2 /* DYNAMIC */` **plus** the
  `1024 /* DYNAMIC_SLOTS */` vnode patch flag, and under `_: 2` `updateSlots`
  does a bare `extend(slots, children)` with no normalization;
- keeping today's `_: 1 /* STABLE */` beside a spread would stop the child
  re-rendering when the forwarded slots change.

`BABEL_COMPAT_INVENTORY.md` already records that this repo has **no harness that
mounts compiled output against a real Vue runtime**, so that change cannot be
verified here today. Landing it half-verified against silent-miscompile behavior
would be worse than the bug. Filed as **#3467** with the full analysis and the
harness prerequisite; the diagnostic points at it.

Other rejected shapes, all forms babel accepts by silently dropping something:

| Input | Diagnostic |
| --- | --- |
| `v-slots` (no value) | ``v-slots is missing its slots object, e.g. v-slots={{ default: () => <div/> }}.`` |
| `v-slots={1}` / `v-slots="str"` | ``v-slots value `1` is not an object literal: …`` |
| `v-slots:x={…}` | `v-slots does not take an argument; the slot names are the keys of its object, …` |
| `<div v-slots={…}/>` | `v-slots can only be used on a component; a plain element has no slots.` |
| two `v-slots` on one element | `v-slots is given more than once on this element; babel keeps only the last one, …` |
| `v-slots={{default: …}}` **plus** children | `Extraneous children found when component already has an explicit default slot.` (existing shared-transform check; babel emits the `default` key twice and silently discards the children) |

Spreads and computed keys inside the object keep the existing object-children
warnings rather than becoming silent. All of this is written into
`lower/v_slots.rs` and a new subsection of `BABEL_COMPAT_INVENTORY.md`.

## Oracle rows

Measured against the real plugin
(`node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check` →
`oracle matches 97 recorded cases`).

| Row | Before | After |
| --- | --- | --- |
| `slots/v_slots_object_literal` | *(new corpus row)* | **equivalent** |
| `slots/v_slots_object_with_children` | *(new corpus row)* | **equivalent** |
| `slots/v_slots_only` | divergent: v-slots not implemented | divergent: **opaque v-slots value diagnosed; needs #3467** |
| `slots/v_slots_with_children` | divergent: v-slots not implemented | divergent: **opaque v-slots value diagnosed; needs #3467** |
| `optimize/v_slots_stability` | divergent: v-slots not implemented | divergent: **opaque v-slots value diagnosed; needs #3467** |
| `errors/v_slots_not_object` | divergent: v-slots not implemented | divergent: **non-object v-slots value rejected; babel forwards it** |

The three still-divergent rows are the opaque-forwarding case: they no longer
miscompile, they fail the build with a message naming #3467. Totals in
`BABEL_COMPAT_INVENTORY.md` and `babel_compat_verdict_totals` move together:
**68/25/2 over 95 rows → 70/25/2 over 97**.

## Tests fail before the fix

`crates/vize_atelier_jsx/tests/v_slots.rs` — 15 tests, full-output `assert_eq!`
on emitted render code and on complete diagnostic lists. Verified by restoring
`crates/vize_atelier_jsx/src/` to `origin/main` with the tests in place:

```
running 15 tests
test a_plain_element_is_rejected ... FAILED
test a_repeated_v_slots_is_rejected ... FAILED
... (all 15 FAILED)

---- a_default_slot_object_becomes_the_default_slot stdout ----
assertion `left == right` failed
  left: "…const _directive_slots = _resolveDirective(\"slots\")\n  \n  return _withDirectives(…[_directive_slots, {default: () => <i/>}]…"
 right: "…return (_openBlock(), _createBlock(_component_B, null, {\n    default: _withCtx(() => [\n      _createElementVNode(\"i\")\n    ]),\n    _: 1 /* STABLE */\n  }))\n}"

---- an_opaque_slots_value_is_rejected stdout ----
  left: []
 right: ["v-slots value `slots` is not an object literal: … Forwarding a slots object is tracked by #3467."]
```

After the fix: `test result: ok. 15 passed; 0 failed`.

## Gates run

```
nix develop -c cargo test -p vize_atelier_jsx        # 31 suites ok, 0 failed
nix develop -c node --test tests/tooling/babel-jsx-oracle.test.ts  # 3 pass, 0 fail
nix develop -c node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check
nix develop -c vp run check:rust                     # Finished, no errors
nix develop -c vp run lint:rust                      # clippy -D warnings, clean
nix develop -c vp run source:lengths                 # exit 0
rustfmt --edition 2024 --config style_edition=2024 --check <changed files>  # clean
nix develop -c vp fmt --write                        # no further changes
```

Closes #3418, Refs #3391, Refs #3467

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSX `v-slots` support for component slots, including default, named, and scoped slots.
  * Merges slot definitions with existing component children.
* **Bug Fixes**
  * Prevents `v-slots` from being emitted as a regular prop.
  * Added validation and diagnostics for unsupported syntax, invalid values, duplicate directives, and use on plain elements.
* **Tests**
  * Added comprehensive `v-slots` coverage and updated Babel compatibility fixtures and expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->