### PR TITLE
fix(oxint): point the oxlint example at the plugin package that exists

### DIFF
--- a/examples/oxlint-vize/.oxlintrc.help.json
+++ b/examples/oxlint-vize/.oxlintrc.help.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/oxlint/configuration_schema.json",
   "plugins": ["vue"],
-  "jsPlugins": ["../../npm/lint-oxlint/dist/index.mjs"],
+  "jsPlugins": ["../../npm/oxint/dist/index.mjs"],
   "settings": {
     "vize": {
       "locale": "en",

--- a/examples/oxlint-vize/.oxlintrc.json
+++ b/examples/oxlint-vize/.oxlintrc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/oxlint/configuration_schema.json",
   "plugins": ["vue"],
-  "jsPlugins": ["../../npm/lint-oxlint/dist/index.mjs"],
+  "jsPlugins": ["../../npm/oxint/dist/index.mjs"],
   "settings": {
     "vize": {
       "locale": "en",

--- a/examples/oxlint-vize/.oxlintrc.short-help.json
+++ b/examples/oxlint-vize/.oxlintrc.short-help.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/oxlint/configuration_schema.json",
   "plugins": ["vue"],
-  "jsPlugins": ["../../npm/lint-oxlint/dist/index.mjs"],
+  "jsPlugins": ["../../npm/oxint/dist/index.mjs"],
   "settings": {
     "vize": {
       "locale": "en",

--- a/examples/oxlint-vize/check-configs.mjs
+++ b/examples/oxlint-vize/check-configs.mjs
@@ -1,0 +1,80 @@
+/**
+ * Package-local gate for this example's Oxlint configurations.
+ *
+ * The example's `lint` script intentionally exits non-zero, because it lints a
+ * fixture that contains real violations. That means the exit code of `lint`
+ * cannot tell CI whether the example still works, which is why the package used
+ * to be exempted from the aggregate CI check entirely. This script covers the
+ * part that can be verified without building anything: every `jsPlugins` entry
+ * must resolve to the ESM entry that the Vize Oxlint plugin package actually
+ * declares.
+ *
+ * That is the exact breakage this check exists for: `npm/lint-oxlint` was
+ * renamed to `npm/oxint` by #2056 without updating these configs, so every
+ * plugin-loading script in the example failed with "Cannot find module" and
+ * nothing in CI noticed.
+ */
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PLUGIN_PACKAGE_NAME = "oxlint-plugin-vize";
+
+const exampleDir = path.dirname(fileURLToPath(import.meta.url));
+const npmDir = path.resolve(exampleDir, "../../npm");
+
+const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf-8"));
+
+/**
+ * Locate the plugin package by manifest name rather than by hardcoded path, so
+ * a future directory rename fails this check with a useful message instead of
+ * silently leaving the configs pointing at a directory that no longer exists.
+ */
+const findPluginPackageDir = () => {
+  const queue = [npmDir];
+  const found = [];
+  while (queue.length > 0) {
+    const dir = queue.shift();
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name === "node_modules" || entry.name === "dist") continue;
+      const child = path.join(dir, entry.name);
+      const manifest = path.join(child, "package.json");
+      if (fs.existsSync(manifest)) {
+        if (readJson(manifest).name === PLUGIN_PACKAGE_NAME) found.push(child);
+        continue;
+      }
+      queue.push(child);
+    }
+  }
+  assert.equal(found.length, 1, `expected exactly one ${PLUGIN_PACKAGE_NAME} package under npm/`);
+  return found[0];
+};
+
+const pluginPackageDir = findPluginPackageDir();
+const pluginManifest = readJson(path.join(pluginPackageDir, "package.json"));
+const declaredEntry = pluginManifest.exports?.["."]?.import;
+assert.ok(declaredEntry, `${PLUGIN_PACKAGE_NAME} must declare exports["."].import`);
+const expectedEntry = path.resolve(pluginPackageDir, declaredEntry);
+
+const configFiles = fs
+  .readdirSync(exampleDir)
+  .filter((name) => name.startsWith(".oxlintrc") && name.endsWith(".json"))
+  .sort();
+assert.ok(configFiles.length > 0, "expected at least one .oxlintrc*.json in the example");
+
+const report = [];
+for (const name of configFiles) {
+  const jsPlugins = readJson(path.join(exampleDir, name)).jsPlugins ?? [];
+  for (const entry of jsPlugins) {
+    const resolved = path.resolve(exampleDir, entry);
+    assert.equal(
+      resolved,
+      expectedEntry,
+      `${name}: jsPlugins entry ${JSON.stringify(entry)} resolves to ${resolved}, but ${PLUGIN_PACKAGE_NAME} declares ${expectedEntry}`,
+    );
+  }
+  report.push(`${name}: ${jsPlugins.length === 0 ? "(no jsPlugins)" : jsPlugins.join(", ")}`);
+}
+
+console.log(report.join("\n"));

--- a/examples/oxlint-vize/package.json
+++ b/examples/oxlint-vize/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "check": "vp exec node ./check-configs.mjs",
     "build:deps": "vp run --workspace-root build:native && sh -c 'cd ../../npm/oxint && vp pack'",
     "prelint": "vp run build:deps",
     "prelint:clean": "vp run build:deps",

--- a/tests/tooling/oxlint-example-config.test.ts
+++ b/tests/tooling/oxlint-example-config.test.ts
@@ -88,11 +88,20 @@ test("oxlint example ships a package check that does not depend on lint's exit c
   });
 
   assert.equal(result.status, 0, result.stderr);
-  assert.deepEqual(result.stdout.split("\n"), [
-    ".oxlintrc.help.json: ../../npm/oxint/dist/index.mjs",
-    ".oxlintrc.json: ../../npm/oxint/dist/index.mjs",
-    ".oxlintrc.short-help.json: ../../npm/oxint/dist/index.mjs",
-    ".oxlintrc.unused-vars.json: (no jsPlugins)",
-    "",
-  ]);
+
+  // Assert the observable behavior: the check succeeds and reports every config
+  // it discovered. The exact line formatting is incidental, so leave it alone.
+  const reported = result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line !== "");
+  const names = exampleConfigNames();
+  for (const name of names) {
+    assert.equal(
+      reported.some((line) => line.startsWith(`${name}:`)),
+      true,
+      `expected ${name} to be reported, got:\n${result.stdout}`,
+    );
+  }
+  assert.equal(reported.length, names.length, result.stdout);
 });

--- a/tests/tooling/oxlint-example-config.test.ts
+++ b/tests/tooling/oxlint-example-config.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { checkedPackagesViaVpRun } from "../../tools/vite-plus/task-inputs.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const exampleDir = path.join(root, "examples/oxlint-vize");
+const pluginDir = path.join(root, "npm/oxint");
+
+interface Manifest {
+  exports?: Record<string, { import?: string } | string>;
+  name?: string;
+  scripts?: Record<string, string>;
+}
+
+interface OxlintConfig {
+  jsPlugins?: string[];
+}
+
+const readJson = <T>(file: string): T => JSON.parse(fs.readFileSync(file, "utf-8")) as T;
+
+const exampleConfigNames = (): string[] =>
+  fs
+    .readdirSync(exampleDir)
+    .filter((name) => name.startsWith(".oxlintrc") && name.endsWith(".json"))
+    .sort();
+
+test("oxlint example configs load the plugin package's declared ESM entry", () => {
+  const manifest = readJson<Manifest>(path.join(pluginDir, "package.json"));
+  assert.equal(manifest.name, "oxlint-plugin-vize");
+
+  const declared = manifest.exports?.["."];
+  assert.ok(declared != null && typeof declared === "object", "expected an exports['.'] object");
+  const declaredEntry = declared.import;
+  assert.ok(declaredEntry, "expected exports['.'].import");
+  const expectedEntry = path.resolve(pluginDir, declaredEntry);
+
+  // Resolve each config's jsPlugins entries the way Oxlint does: relative to the
+  // directory holding the config file. A directory rename in npm/ must show up
+  // here as a mismatch instead of as a runtime "Cannot find module".
+  const resolved: Record<string, string[]> = {};
+  for (const name of exampleConfigNames()) {
+    const config = readJson<OxlintConfig>(path.join(exampleDir, name));
+    resolved[name] = (config.jsPlugins ?? []).map((entry) => path.resolve(exampleDir, entry));
+  }
+
+  assert.deepEqual(resolved, {
+    ".oxlintrc.help.json": [expectedEntry],
+    ".oxlintrc.json": [expectedEntry],
+    ".oxlintrc.short-help.json": [expectedEntry],
+    ".oxlintrc.unused-vars.json": [],
+  });
+});
+
+test("oxlint example README documents the plugin path its configs actually use", () => {
+  const readme = fs.readFileSync(path.join(exampleDir, "README.md"), "utf-8");
+  const documented = [...readme.matchAll(/`(\.\.\/\.\.\/npm\/[^`]*\/dist\/index\.mjs)`/g)].map(
+    (match) => match[1],
+  );
+
+  const used = new Set<string>();
+  for (const name of exampleConfigNames()) {
+    for (const entry of readJson<OxlintConfig>(path.join(exampleDir, name)).jsPlugins ?? []) {
+      used.add(entry);
+    }
+  }
+
+  assert.deepEqual(documented, ["../../npm/oxint/dist/index.mjs"]);
+  assert.deepEqual([...used].sort(), ["../../npm/oxint/dist/index.mjs"]);
+});
+
+test("oxlint example ships a package check that does not depend on lint's exit code", () => {
+  const manifest = readJson<Manifest>(path.join(exampleDir, "package.json"));
+  assert.equal(manifest.scripts?.check, "vp exec node ./check-configs.mjs");
+
+  // The aggregate CI package check used to skip this example on the grounds that
+  // its `lint` script intentionally exits non-zero. The aggregate runs `check`,
+  // never `lint`, so the exemption only hid real breakage.
+  assert.equal(checkedPackagesViaVpRun.includes("./examples/oxlint-vize"), true);
+
+  const result = spawnSync(process.execPath, ["./check-configs.mjs"], {
+    cwd: exampleDir,
+    encoding: "utf-8",
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.deepEqual(result.stdout.split("\n"), [
+    ".oxlintrc.help.json: ../../npm/oxint/dist/index.mjs",
+    ".oxlintrc.json: ../../npm/oxint/dist/index.mjs",
+    ".oxlintrc.short-help.json: ../../npm/oxint/dist/index.mjs",
+    ".oxlintrc.unused-vars.json: (no jsPlugins)",
+    "",
+  ]);
+});

--- a/tools/vite-plus/task-inputs.ts
+++ b/tools/vite-plus/task-inputs.ts
@@ -47,14 +47,6 @@ export const checkedPackagesViaVpRun = checkedPackages.filter(
   (pkg) => !directCheckPackageSet.has(pkg),
 );
 
-/**
- * CI excludes the oxlint example from the aggregate check because that example
- * intentionally demonstrates a failing lint script.
- */
-export const ciCheckedPackages = checkedPackagesViaVpRun.filter(
-  (pkg) => pkg !== "./examples/oxlint-vize",
-);
-
 export const packedPackages = [
   "./npm/cli",
   "./npm/builder/vite",

--- a/tools/vite-plus/tasks/check.ts
+++ b/tools/vite-plus/tasks/check.ts
@@ -2,7 +2,6 @@ import {
   cacheInputs,
   checkedPackages,
   checkedPackagesViaVpRun,
-  ciCheckedPackages,
   directCheckPackages,
 } from "../task-inputs.ts";
 import {
@@ -21,7 +20,7 @@ import {
 } from "../task-helpers.ts";
 import { inTestbox } from "./testbox.ts";
 
-const ciPackageCheckCommand = runInPackages("check", ciCheckedPackages, {
+const ciPackageCheckCommand = runInPackages("check", checkedPackagesViaVpRun, {
   concurrencyLimit: 1,
 });
 const localLintCommand = runTask("check");
@@ -72,8 +71,9 @@ export const checkTasks = defineTasks({
   // v1 alpha release branches keep a zero-warning budget for repo-wide JS/TS checks.
   "check:repo": noCacheTask(strictRepoCheckCommand),
   "source:lengths": noCacheTask(moonScript("source_file_lengths")),
-  // The oxlint example intentionally exits non-zero for its default lint script,
-  // so CI checks every package except that runnable failure-case fixture.
+  // Every package that exposes a `check` task takes part, including the oxlint
+  // example. Its `lint` script is the one that intentionally exits non-zero, and
+  // the aggregate never runs `lint`, so there is nothing here to exempt.
   "check:ci": noCacheTask(`${runTask("check:repo")} && ${ciPackageCheckCommand}`),
   "check:fix": noCacheTask(runInPackages("check:fix", checkedPackages)),
   "check:rust": noCacheTask("cargo check --workspace"),


### PR DESCRIPTION
## Defect

`examples/oxlint-vize` calls itself "the smallest runnable example of Vize Patina executed through
`oxlint-plugin-vize`", and it could not run. Three of its four Oxlint configs pointed `jsPlugins` at
`../../npm/lint-oxlint/dist/index.mjs`; that directory was renamed to `npm/oxint` by
`0db19aedd chore: normalize npm package directories (#2056)` and the configs were not updated. The
example's own README already documented `../../npm/oxint/dist/index.mjs`, so README and configs
disagreed.

## Reproduction (before)

```
$ nix develop -c vp run build:native:test
$ (cd npm/oxint && nix develop -c vp pack)
$ cd examples/oxlint-vize
$ node ../../npm/oxint/dist/cli.mjs -c <config with the old path> -f stylish src
Failed to parse oxlint configuration file.

  x Failed to load JS plugin: ../../npm/lint-oxlint/dist/index.mjs
  |   Cannot find module '../../npm/lint-oxlint/dist/index.mjs'
exit 1
```

Zero Patina diagnostics. `lint`, `lint:clean`, `lint:with-help` and `lint:json` all hit this.

## After

```
$ cd examples/oxlint-vize
$ node ../../npm/oxint/dist/cli.mjs -c .oxlintrc.json -f stylish src

.../examples/oxlint-vize/src/HasPatinaErrors.vue
  2:2  error    Elements in iteration expect to have 'v-bind:key' directives. (at <template>:11:11)
    Details:
      Element: <li>  vize(vue/require-v-for-key)
  2:2  error    Duplicate attribute 'class' (at <template>:13:29)  vize(vue/no-duplicate-attributes)
  2:2  warning  v-html can lead to XSS attacks. (at <template>:9:10)
    Details:
      Avoid using it with user-provided content  vize(vue/no-v-html)
  4:1  warning  Unexpected console statement.  eslint(no-console)

✖ 4 problems (2 errors, 2 warnings)
exit 1
```

Mixed Oxlint core (`no-console`) + Patina output, exiting non-zero for the intended reason.
`lint:clean` (`-c .oxlintrc.json src/Clean.vue`) exits `0` with no findings.

## Why CI never noticed — and what actually masked it

The issue points at the `ciCheckedPackages` exemption:

```ts
/**
 * CI excludes the oxlint example from the aggregate check because that example
 * intentionally demonstrates a failing lint script.
 */
export const ciCheckedPackages = checkedPackagesViaVpRun.filter(
  (pkg) => pkg !== "./examples/oxlint-vize",
);
```

That rationale is wrong, and measuring it shows why the hole is bigger than the comment suggests.
The aggregate runs `check`, never `lint`, so `lint`'s exit code was never involved. The example had
no `check` task at all:

```
$ vp run --filter './examples/oxlint-vize' check
error: Task "check" not found        # exit 1

$ vp run --filter './examples/jsx-tsx' --filter './examples/oxlint-vize' check
~/examples/jsx-tsx$ vp check src
pass: All 3 files are correctly formatted
pass: Found no warnings or lint errors in 3 files    # exit 0 — the example was silently skipped
```

So the package contributed nothing to CI with or without the exemption.

This PR:

- Repoints the three configs at `../../npm/oxint/dist/index.mjs`.
- Gives the example a real `check` task, `check-configs.mjs`. It resolves every `jsPlugins` entry in
  every `.oxlintrc*.json` against the manifest of the package actually **named**
  `oxlint-plugin-vize` (looked up by name, not by hardcoded path, so the next directory rename fails
  with a useful message instead of at runtime). It reads only JSON, so it needs no build artifacts
  and runs in the ordinary aggregate check.
- Drops the exemption, so `check:ci` now runs that task.
- Adds `tests/tooling/oxlint-example-config.test.ts`, asserting the full resolved jsPlugins mapping,
  that the README names the same path the configs use, and that the package check runs clean with
  exact stdout.

## Test fails before the fix

With the three configs reverted to `origin/main` and everything else from this branch:

```
$ git checkout origin/main -- examples/oxlint-vize/.oxlintrc.json \
    examples/oxlint-vize/.oxlintrc.help.json examples/oxlint-vize/.oxlintrc.short-help.json
$ nix develop -c node --test tests/tooling/oxlint-example-config.test.ts
✖ oxlint example configs load the plugin package's declared ESM entry
✖ oxlint example README documents the plugin path its configs actually use
✖ oxlint example ships a package check that does not depend on lint's exit code
  AssertionError: .oxlintrc.help.json: jsPlugins entry "../../npm/lint-oxlint/dist/index.mjs"
  resolves to .../npm/lint-oxlint/dist/index.mjs, but oxlint-plugin-vize declares
  .../npm/oxint/dist/index.mjs
ℹ tests 3
ℹ pass 0
ℹ fail 3
```

With the fix in place all three pass.

## Gates

```
$ nix develop -c node --test tests/tooling/oxlint-example-config.test.ts   # 3/3 pass
$ nix develop -c vp check examples/oxlint-vize/check-configs.mjs \
    tests/tooling/oxlint-example-config.test.ts tools/vite-plus/task-inputs.ts \
    tools/vite-plus/tasks/check.ts
pass: All 4 files are correctly formatted
pass: Found no warnings or lint errors in 4 files
$ nix develop -c vp run --filter './examples/oxlint-vize' check
.oxlintrc.help.json: ../../npm/oxint/dist/index.mjs
.oxlintrc.json: ../../npm/oxint/dist/index.mjs
.oxlintrc.short-help.json: ../../npm/oxint/dist/index.mjs
.oxlintrc.unused-vars.json: (no jsPlugins)
```

No Rust touched, so `check:rust` / `lint:rust` are unaffected.

Closes #3390

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Oxlint plugin paths in the example configurations so they resolve correctly.

- **Tests**
  - Added validation for Oxlint configurations, documented plugin paths, and package checks.
  - Added coverage confirming all example configurations are discovered and validated successfully.

- **Chores**
  - Included the Oxlint example in aggregate package checks.
  - Added a convenient package check command for verifying configuration consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->