### PR TITLE
fix(maestro): highlight the matching tag pair, not every same-named tag

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -292,11 +292,10 @@ fn last_start_tag(content: &str, tag_name: &str) -> Option<usize> {
 
 fn is_inside_html_comment_at(content: &str, offset: usize) -> bool {
     let before = &content[..offset.min(content.len())];
-    let last_open = before.rfind("<!--");
-    let last_close = before.rfind("-->");
-
-    matches!((last_open, last_close), (Some(open), Some(close)) if open > close)
-        || matches!((last_open, last_close), (Some(_), None))
+    let Some(open) = before.rfind("<!--") else {
+        return false;
+    };
+    before.rfind("-->").is_none_or(|close| open > close)
 }
 
 /// Context for IDE operations.

--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -30,6 +30,7 @@ pub mod rename;
 pub mod selection_range;
 pub mod semantic_tokens;
 pub(crate) mod sfc_region;
+pub(crate) mod tag_pair;
 mod template_expression;
 pub mod type_service;
 pub mod workspace_symbols;

--- a/crates/vize_maestro/src/ide/document_highlight.rs
+++ b/crates/vize_maestro/src/ide/document_highlight.rs
@@ -86,7 +86,7 @@ impl DocumentHighlightService {
             return Some(tag_highlights(&ctx.content, &names));
         }
 
-        let (start, end) = token_span_at_offset(&ctx.content, ctx.offset, is_identifier_char)?;
+        let (start, end) = token_span_at_offset(&ctx.content, offset, is_identifier_char)?;
         let symbol = &ctx.content[start..end];
         if !is_highlightable_symbol(symbol) {
             return None;

--- a/crates/vize_maestro/src/ide/document_highlight.rs
+++ b/crates/vize_maestro/src/ide/document_highlight.rs
@@ -1,6 +1,13 @@
 //! Document highlight provider.
 //!
-//! Highlights matching tag names and identifier occurrences in Vue and Art documents.
+//! Highlights the tag-name pair of the element under the cursor, or the
+//! occurrences of the identifier under the cursor, in Vue and Art documents.
+//!
+//! Tag highlighting resolves the enclosing element with the shared stack-based
+//! scanner in [`super::tag_pair`]. The previous implementation scanned the whole
+//! document for the name, so a cursor on one of four `<div>`s highlighted all
+//! eight names — which destroys the one signal the feature exists to give:
+//! *which* close tag belongs to the tag under the cursor (#3454).
 
 use tower_lsp::lsp_types::{DocumentHighlight, DocumentHighlightKind, Position, Range};
 
@@ -68,9 +75,15 @@ impl<'a> PositionWalker<'a> {
 
 impl DocumentHighlightService {
     pub fn highlights(ctx: &IdeContext<'_>) -> Option<Vec<DocumentHighlight>> {
-        if let Some((tag_name, _, _)) = tag_name_at_offset(&ctx.content, ctx.offset) {
-            let highlights = tag_highlights(&ctx.content, &tag_name);
-            return (!highlights.is_empty()).then_some(highlights);
+        let offset = ctx.offset.min(ctx.content.len());
+        // A cursor inside a raw-text block (`<script>`, `<style>`) has no markup
+        // region, so it never takes the tag path and falls through to the
+        // identifier scan below.
+        if let Some(region) =
+            super::sfc_region::resolve(&ctx.content, ctx.uri.path(), offset).markup
+            && let Some(names) = super::tag_pair::names_at(&ctx.content, region, offset)
+        {
+            return Some(tag_highlights(&ctx.content, &names));
         }
 
         let (start, end) = token_span_at_offset(&ctx.content, ctx.offset, is_identifier_char)?;
@@ -118,35 +131,12 @@ fn identifier_highlights(content: &str, symbol: &str) -> Vec<DocumentHighlight> 
     highlights
 }
 
-fn tag_highlights(content: &str, tag_name: &str) -> Vec<DocumentHighlight> {
-    let mut spans = Vec::new();
-    let mut search_start = 0usize;
-    let bytes = content.as_bytes();
-    while let Some(relative) = content[search_start..].find('<') {
-        let tag_start = search_start + relative;
-        let mut name_start = tag_start + 1;
-
-        if bytes.get(name_start) == Some(&b'/') {
-            name_start += 1;
-        }
-
-        let name_end = name_start + tag_name.len();
-        if name_end <= content.len()
-            && &content[name_start..name_end] == tag_name
-            && is_tag_name_boundary(bytes, name_start, name_end)
-        {
-            spans.push((name_start, name_end));
-        }
-
-        search_start = tag_start + 1;
-    }
-    if spans.is_empty() {
-        return Vec::new();
-    }
-
+/// One highlight per name of the resolved element: two for a matched pair, one
+/// for a self-closing, void or unmatched tag. Never a document-wide name scan.
+fn tag_highlights(content: &str, names: &super::tag_pair::TagNames) -> Vec<DocumentHighlight> {
     let mut walker = PositionWalker::new(content);
-    let mut highlights = Vec::with_capacity(spans.len());
-    for (start, end) in spans {
+    let mut highlights = Vec::with_capacity(2);
+    for (start, end) in [Some(names.first), names.second].into_iter().flatten() {
         let (start_line, start_character) = walker.position_at(start);
         let (end_line, end_character) = walker.position_at(end);
         highlights.push(span_highlight(
@@ -158,81 +148,6 @@ fn tag_highlights(content: &str, tag_name: &str) -> Vec<DocumentHighlight> {
         ));
     }
     highlights
-}
-
-fn tag_name_at_offset(content: &str, offset: usize) -> Option<(String, usize, usize)> {
-    let bytes = content.as_bytes();
-    if bytes.is_empty() {
-        return None;
-    }
-
-    let mut cursor = offset.min(bytes.len());
-    if cursor == bytes.len() {
-        cursor = cursor.saturating_sub(1);
-    }
-
-    let mut tag_start = None;
-    let mut pos = cursor + 1;
-    while pos > 0 {
-        pos -= 1;
-        match bytes[pos] {
-            b'<' => {
-                tag_start = Some(pos);
-                break;
-            }
-            b'>' | b'\n' | b'\r' => return None,
-            _ => {}
-        }
-    }
-
-    let tag_start = tag_start?;
-    let mut tag_end = tag_start;
-    let mut quote = None;
-
-    while tag_end < bytes.len() {
-        let byte = bytes[tag_end];
-        if let Some(current_quote) = quote {
-            if byte == current_quote {
-                quote = None;
-            }
-        } else if byte == b'"' || byte == b'\'' {
-            quote = Some(byte);
-        } else if byte == b'>' {
-            break;
-        } else if byte == b'\n' || byte == b'\r' {
-            return None;
-        }
-        tag_end += 1;
-    }
-
-    if tag_end >= bytes.len() || bytes[tag_end] != b'>' {
-        return None;
-    }
-
-    let mut name_start = tag_start + 1;
-    if bytes.get(name_start) == Some(&b'/') {
-        name_start += 1;
-    }
-
-    let mut name_end = name_start;
-    while name_end < tag_end {
-        let byte = bytes[name_end];
-        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_') {
-            name_end += 1;
-        } else {
-            break;
-        }
-    }
-
-    if name_start == name_end || cursor < name_start || cursor > name_end {
-        return None;
-    }
-
-    Some((
-        content[name_start..name_end].to_string(),
-        name_start,
-        name_end,
-    ))
 }
 
 fn span_highlight(
@@ -310,85 +225,5 @@ fn is_identifier_boundary(bytes: &[u8], start: usize, end: usize) -> bool {
         && !after.is_some_and(|byte| is_identifier_char(*byte))
 }
 
-fn is_tag_name_boundary(bytes: &[u8], start: usize, end: usize) -> bool {
-    let before = start.checked_sub(1).and_then(|index| bytes.get(index));
-    let after = bytes.get(end);
-
-    !before.is_some_and(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
-        && !after.is_some_and(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
-}
-
 #[cfg(test)]
-mod tests {
-    use super::{DocumentHighlightService, PositionWalker};
-    use crate::{ide::IdeContext, server::ServerState};
-    use tower_lsp::lsp_types::Url;
-
-    #[test]
-    fn position_walker_matches_offset_to_position_str() {
-        // Multi-line content with a multi-byte (UTF-16 surrogate pair) char so
-        // the walker's line/column tracking is exercised against the canonical
-        // converter at every char boundary, including ascending re-queries.
-        let content = "abc\ndé😀f\n\nghi";
-        let mut walker = PositionWalker::new(content);
-        let mut prev = 0usize;
-        for offset in 0..=content.len() {
-            if !content.is_char_boundary(offset) {
-                continue;
-            }
-            // Walker requires monotonic targets; advance from the previous one.
-            assert!(offset >= prev);
-            prev = offset;
-            let expected = crate::utils::offset_to_position_str(content, offset);
-            let (line, character) = walker.position_at(offset);
-            assert_eq!(
-                (line, character),
-                (expected.line, expected.character),
-                "mismatch at byte offset {offset}",
-            );
-        }
-    }
-
-    fn context_for(source: &str, cursor_text: &str) -> (ServerState, Url, usize) {
-        let state = ServerState::new();
-        let uri = Url::parse("file:///Button.art.vue").unwrap();
-        state
-            .documents
-            .open(uri.clone(), source.to_string(), 1, "art-vue".to_string());
-        state.update_virtual_docs(&uri, source);
-        let offset = source.find(cursor_text).unwrap();
-        (state, uri, offset)
-    }
-
-    #[test]
-    fn highlights_identifier_occurrences_in_art_variant() {
-        let source = r#"<art title="Button">
-  <variant name="Primary">
-    <Button :label="label">{{ label }}</Button>
-  </variant>
-</art>
-
-<script setup lang="ts">
-const label = "Primary"
-</script>"#;
-        let (state, uri, offset) = context_for(source, "label\">{{");
-        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-        let highlights = DocumentHighlightService::highlights(&ctx).unwrap();
-
-        assert!(highlights.len() >= 3, "{highlights:#?}");
-    }
-
-    #[test]
-    fn highlights_matching_component_tags_in_art_variant() {
-        let source = r#"<art title="Button">
-  <variant name="Primary">
-    <Button :label="label"><span>Label</span></Button>
-  </variant>
-</art>"#;
-        let (state, uri, offset) = context_for(source, "Button :label");
-        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-        let highlights = DocumentHighlightService::highlights(&ctx).unwrap();
-
-        assert_eq!(highlights.len(), 2, "{highlights:#?}");
-    }
-}
+mod tests;

--- a/crates/vize_maestro/src/ide/document_highlight/tests.rs
+++ b/crates/vize_maestro/src/ide/document_highlight/tests.rs
@@ -1,0 +1,190 @@
+use super::{DocumentHighlightService, PositionWalker};
+use crate::{ide::IdeContext, server::ServerState};
+use tower_lsp::lsp_types::{DocumentHighlightKind, Url};
+
+/// The fixture from #3454. Four `<div>`s so a document-wide name scan and a
+/// stack-based pair resolution give visibly different answers.
+const FOUR_DIVS: &str = r#"<script setup lang="ts">
+const count = 1
+</script>
+
+<template>
+  <div class="a">
+    <div class="b">{{ count }}</div>
+  </div>
+  <div class="c" />
+</template>
+"#;
+
+const TEXT: Option<DocumentHighlightKind> = Some(DocumentHighlightKind::TEXT);
+const READ: Option<DocumentHighlightKind> = Some(DocumentHighlightKind::READ);
+const WRITE: Option<DocumentHighlightKind> = Some(DocumentHighlightKind::WRITE);
+
+#[test]
+fn position_walker_matches_offset_to_position_str() {
+    // Multi-line content with a multi-byte (UTF-16 surrogate pair) char so
+    // the walker's line/column tracking is exercised against the canonical
+    // converter at every char boundary, including ascending re-queries.
+    let content = "abc\ndé😀f\n\nghi";
+    let mut walker = PositionWalker::new(content);
+    let mut prev = 0usize;
+    for offset in 0..=content.len() {
+        if !content.is_char_boundary(offset) {
+            continue;
+        }
+        // Walker requires monotonic targets; advance from the previous one.
+        assert!(offset >= prev);
+        prev = offset;
+        let expected = crate::utils::offset_to_position_str(content, offset);
+        let (line, character) = walker.position_at(offset);
+        assert_eq!(
+            (line, character),
+            (expected.line, expected.character),
+            "mismatch at byte offset {offset}",
+        );
+    }
+}
+
+fn state_for(source: &str, uri: &str, language_id: &str) -> (ServerState, Url) {
+    let state = ServerState::new();
+    let uri = Url::parse(uri).unwrap();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, language_id.to_string());
+    state.update_virtual_docs(&uri, source);
+    (state, uri)
+}
+
+/// Full response as `(line, start_character, end_character, kind)` so every test
+/// can assert the complete highlight list in one `assert_eq!`.
+type FlatHighlight = (u32, u32, u32, Option<DocumentHighlightKind>);
+
+fn highlights_at(
+    state: &ServerState,
+    uri: &Url,
+    source: &str,
+    line: u32,
+    character: u32,
+) -> Vec<FlatHighlight> {
+    let offset = crate::ide::position_to_offset(source, line, character)
+        .expect("test position must resolve to a byte offset");
+    let ctx = IdeContext::new(state, uri, offset).unwrap();
+    let Some(highlights) = DocumentHighlightService::highlights(&ctx) else {
+        return Vec::new();
+    };
+    highlights
+        .into_iter()
+        .map(|highlight| {
+            assert_eq!(
+                highlight.range.start.line, highlight.range.end.line,
+                "a highlight never spans lines: {highlight:?}"
+            );
+            (
+                highlight.range.start.line,
+                highlight.range.start.character,
+                highlight.range.end.character,
+                highlight.kind,
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn tag_highlight_is_the_matching_pair_not_every_same_named_tag() {
+    let (state, uri) = state_for(FOUR_DIVS, "file:///App.vue", "vue");
+
+    // Recorded from @vue/language-server 3.3.8 for this fixture at line 6,
+    // character 6: [[6,5,6,8], [6,32,6,35]]. Before #3454 Maestro answered five
+    // ranges here, adding the outer `<div class="a">` pair and the unrelated
+    // self-closing `<div class="c" />`.
+    assert_eq!(
+        highlights_at(&state, &uri, FOUR_DIVS, 6, 6),
+        vec![(6, 5, 8, TEXT), (6, 32, 35, TEXT)]
+    );
+
+    // The close tag name resolves back to the same pair.
+    assert_eq!(
+        highlights_at(&state, &uri, FOUR_DIVS, 6, 33),
+        vec![(6, 5, 8, TEXT), (6, 32, 35, TEXT)]
+    );
+
+    // The outer `<div class="a">` pairs with the `</div>` on line 7, not with
+    // the inner element's close tag on line 6.
+    assert_eq!(
+        highlights_at(&state, &uri, FOUR_DIVS, 5, 4),
+        vec![(5, 3, 6, TEXT), (7, 4, 7, TEXT)]
+    );
+}
+
+#[test]
+fn a_self_closing_tag_highlights_only_its_own_name() {
+    let (state, uri) = state_for(FOUR_DIVS, "file:///App.vue", "vue");
+    assert_eq!(
+        highlights_at(&state, &uri, FOUR_DIVS, 8, 4),
+        vec![(8, 3, 6, TEXT)]
+    );
+}
+
+#[test]
+fn the_template_block_tag_highlights_as_a_pair() {
+    let (state, uri) = state_for(FOUR_DIVS, "file:///App.vue", "vue");
+    assert_eq!(
+        highlights_at(&state, &uri, FOUR_DIVS, 4, 3),
+        vec![(4, 1, 9, TEXT), (9, 2, 10, TEXT)]
+    );
+}
+
+#[test]
+fn a_script_body_is_never_scanned_as_markup() {
+    // `a < b` in a script body must not look like a tag: the old scanner would
+    // have treated `< 2` as a tag start.
+    let source = "<script setup lang=\"ts\">\nconst ok = 1 < 2\n</script>\n<template><div>x</div></template>\n";
+    let (state, uri) = state_for(source, "file:///App.vue", "vue");
+
+    // The cursor sits right after the `<` on the script line; the identifier
+    // scan owns this position, and there is no identifier there.
+    assert_eq!(highlights_at(&state, &uri, source, 1, 14), Vec::new());
+    assert_eq!(
+        highlights_at(&state, &uri, source, 3, 12),
+        vec![(3, 11, 14, TEXT), (3, 18, 21, TEXT)]
+    );
+}
+
+#[test]
+fn highlights_identifier_occurrences_in_art_variant() {
+    let source = r#"<art title="Button">
+  <variant name="Primary">
+    <Button :label="label">{{ label }}</Button>
+  </variant>
+</art>
+
+<script setup lang="ts">
+const label = "Primary"
+</script>"#;
+    let (state, uri) = state_for(source, "file:///Button.art.vue", "art-vue");
+
+    // Cursor on the `label` attribute *value*, which is not a tag name.
+    assert_eq!(
+        highlights_at(&state, &uri, source, 2, 21),
+        vec![
+            (2, 13, 18, READ),
+            (2, 20, 25, READ),
+            (2, 30, 35, READ),
+            (7, 6, 11, WRITE),
+        ]
+    );
+}
+
+#[test]
+fn highlights_matching_component_tags_in_art_variant() {
+    let source = r#"<art title="Button">
+  <variant name="Primary">
+    <Button :label="label"><span>Label</span></Button>
+  </variant>
+</art>"#;
+    let (state, uri) = state_for(source, "file:///Button.art.vue", "art-vue");
+    assert_eq!(
+        highlights_at(&state, &uri, source, 2, 6),
+        vec![(2, 5, 11, TEXT), (2, 47, 53, TEXT)]
+    );
+}

--- a/crates/vize_maestro/src/ide/linked_editing.rs
+++ b/crates/vize_maestro/src/ide/linked_editing.rs
@@ -21,13 +21,6 @@ use super::offset_to_position;
 
 pub struct LinkedEditingService;
 
-/// An element whose start tag has been seen but whose close tag has not.
-#[derive(Clone, Copy)]
-struct OpenTag<'a> {
-    name: &'a str,
-    name_span: (usize, usize),
-}
-
 impl LinkedEditingService {
     /// Resolve the open/close tag-name pair the cursor sits on.
     ///
@@ -36,125 +29,19 @@ impl LinkedEditingService {
     pub fn ranges(content: &str, filename: &str, offset: usize) -> Option<LinkedEditingRanges> {
         let offset = offset.min(content.len());
         let region = super::sfc_region::resolve(content, filename, offset).markup?;
-        let (open, close) = tag_name_pair(content, region, offset)?;
+        let names = super::tag_pair::names_at(content, region, offset)?;
+        // A tag with no counterpart is deliberately dropped: see the module doc.
+        let close = names.second?;
 
         Some(LinkedEditingRanges {
             // Open tag first: the reference server orders them by position and
             // clients apply edits in the order they receive them.
-            ranges: vec![to_range(content, open), to_range(content, close)],
+            ranges: vec![to_range(content, names.first), to_range(content, close)],
             // No word pattern: the reference server omits it, which lets the
             // client use its own tag-name pattern for the language.
             word_pattern: None,
         })
     }
-}
-
-/// Byte spans of the open and close tag names of the element whose name the
-/// cursor is on.
-fn tag_name_pair(
-    content: &str,
-    region: (usize, usize),
-    offset: usize,
-) -> Option<((usize, usize), (usize, usize))> {
-    let (region_start, region_end) = region;
-    let bytes = content.as_bytes();
-    let mut stack: Vec<OpenTag<'_>> = Vec::new();
-    let mut cursor = region_start;
-
-    while cursor < region_end {
-        if bytes[cursor] != b'<' {
-            cursor += 1;
-            continue;
-        }
-
-        if content[cursor..region_end].starts_with("<!--") {
-            cursor = content[cursor..region_end]
-                .find("-->")
-                .map_or(region_end, |relative| cursor + relative + 3);
-            continue;
-        }
-
-        if bytes.get(cursor + 1) == Some(&b'/') {
-            let name_start = cursor + 2;
-            let name_end = tag_name_end(bytes, name_start, region_end);
-            let close_span = (name_start, name_end);
-            let name = &content[name_start..name_end];
-
-            // `rposition` recovers from unclosed inner elements: the nearest
-            // matching open tag wins.
-            if let Some(index) = stack.iter().rposition(|open| open.name == name) {
-                let open = stack[index];
-                stack.truncate(index);
-                if contains(open.name_span, offset) || contains(close_span, offset) {
-                    return Some((open.name_span, close_span));
-                }
-            }
-
-            cursor = content[cursor..region_end]
-                .find('>')
-                .map_or(region_end, |relative| cursor + relative + 1);
-            continue;
-        }
-
-        let name_start = cursor + 1;
-        let name_end = tag_name_end(bytes, name_start, region_end);
-        let tag_end = start_tag_end(content, cursor, region_end)?;
-        if name_end == name_start {
-            cursor += 1;
-            continue;
-        }
-
-        let name = &content[name_start..name_end];
-        let self_closing = content[..tag_end - 1].trim_end().ends_with('/');
-        if !self_closing && !vize_carton::is_void_tag(name) {
-            stack.push(OpenTag {
-                name,
-                name_span: (name_start, name_end),
-            });
-        }
-        cursor = tag_end;
-    }
-
-    None
-}
-
-/// The cursor counts as "on" a name when it is anywhere inside it, including the
-/// position immediately after the last character — that is where an editor
-/// leaves the caret while the user is typing the name.
-#[inline]
-fn contains(span: (usize, usize), offset: usize) -> bool {
-    span.0 <= offset && offset <= span.1
-}
-
-fn tag_name_end(bytes: &[u8], name_start: usize, limit: usize) -> usize {
-    let mut end = name_start;
-    while end < limit
-        && (bytes[end].is_ascii_alphanumeric() || matches!(bytes[end], b'-' | b'_' | b'.' | b':'))
-    {
-        end += 1;
-    }
-    end
-}
-
-/// Byte offset just past the `>` that closes the start tag at `tag_start`.
-fn start_tag_end(content: &str, tag_start: usize, limit: usize) -> Option<usize> {
-    let bytes = content.as_bytes();
-    let mut cursor = tag_start + 1;
-    let mut quote: Option<u8> = None;
-
-    while cursor < limit {
-        let byte = bytes[cursor];
-        match quote {
-            Some(open) if byte == open => quote = None,
-            Some(_) => {}
-            None if byte == b'"' || byte == b'\'' => quote = Some(byte),
-            None if byte == b'>' => return Some(cursor + 1),
-            None => {}
-        }
-        cursor += 1;
-    }
-
-    None
 }
 
 fn to_range(content: &str, span: (usize, usize)) -> Range {

--- a/crates/vize_maestro/src/ide/tag_pair.rs
+++ b/crates/vize_maestro/src/ide/tag_pair.rs
@@ -57,6 +57,14 @@ pub(crate) fn names_at(content: &str, region: (usize, usize), offset: usize) -> 
         if bytes.get(cursor + 1) == Some(&b'/') {
             let name_start = cursor + 2;
             let name_end = tag_name_end(bytes, name_start, region_end);
+            if name_end == name_start {
+                // `</` with no name yet: a zero-width span the cursor would
+                // "sit on", which must not become a zero-width highlight.
+                cursor = content[cursor..region_end]
+                    .find('>')
+                    .map_or(region_end, |relative| cursor + relative + 1);
+                continue;
+            }
             let close_span = (name_start, name_end);
             let name = &content[name_start..name_end];
 
@@ -88,7 +96,6 @@ pub(crate) fn names_at(content: &str, region: (usize, usize), offset: usize) -> 
 
         let name_start = cursor + 1;
         let name_end = tag_name_end(bytes, name_start, region_end);
-        let tag_end = start_tag_end(content, cursor, region_end)?;
         if name_end == name_start {
             cursor += 1;
             continue;
@@ -96,6 +103,18 @@ pub(crate) fn names_at(content: &str, region: (usize, usize), offset: usize) -> 
 
         let name = &content[name_start..name_end];
         let name_span = (name_start, name_end);
+        // A start tag with no `>` is a name being typed (or a stray `<`): no tag
+        // in the rest of the region can close either, so stop instead of
+        // discarding the pair or unclosed name already resolved.
+        let Some(tag_end) = start_tag_end(content, cursor, region_end) else {
+            if contains(name_span, offset) {
+                return Some(TagNames {
+                    first: name_span,
+                    second: None,
+                });
+            }
+            break;
+        };
         let self_closing = content[..tag_end - 1].trim_end().ends_with('/');
         if self_closing || vize_carton::is_void_tag(name) {
             if contains(name_span, offset) {
@@ -157,3 +176,6 @@ fn start_tag_end(content: &str, tag_start: usize, limit: usize) -> Option<usize>
 
     None
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_maestro/src/ide/tag_pair.rs
+++ b/crates/vize_maestro/src/ide/tag_pair.rs
@@ -1,0 +1,159 @@
+//! Resolve the open/close tag-name pair of the element under a cursor.
+//!
+//! Shared by `textDocument/linkedEditingRange` and
+//! `textDocument/documentHighlight`: both answer "which tag names belong to the
+//! element the caret is on?", and both are wrong in a way the user cannot see
+//! when the answer is approximated. A document-wide name scan looks plausible
+//! in a screenshot and is useless in a template with many `<div>`s, so the
+//! nesting is modelled with a stack rather than matched by name.
+//!
+//! The caller supplies the byte region that is safe to read as markup (see
+//! [`super::sfc_region`]); this module never decides that on its own, because
+//! scanning a `<script>` body as markup makes `a < b` look like a tag.
+
+/// Tag-name byte spans of the element under the cursor, in ascending document
+/// order.
+pub(crate) struct TagNames {
+    /// The name the cursor is on, or the open-tag name when the pair resolved.
+    pub(crate) first: (usize, usize),
+    /// The counterpart name. `None` for a self-closing element, a void element
+    /// (`<br>`, `<img>`), an open tag that is never closed, and a close tag
+    /// with no open tag — none of which have a second name to keep in sync.
+    pub(crate) second: Option<(usize, usize)>,
+}
+
+/// An element whose start tag has been seen but whose close tag has not.
+#[derive(Clone, Copy)]
+struct OpenTag<'a> {
+    name: &'a str,
+    name_span: (usize, usize),
+}
+
+/// Resolve the tag names of the element whose name `offset` sits on.
+///
+/// Returns `None` when the cursor is not on a tag name at all.
+pub(crate) fn names_at(content: &str, region: (usize, usize), offset: usize) -> Option<TagNames> {
+    let (region_start, region_end) = region;
+    let bytes = content.as_bytes();
+    let mut stack: Vec<OpenTag<'_>> = Vec::new();
+    // Set when the cursor's own open tag is pushed. If the scan ends without
+    // ever matching it, the element is unclosed and has a single name.
+    let mut unclosed: Option<(usize, usize)> = None;
+    let mut cursor = region_start;
+
+    while cursor < region_end {
+        if bytes[cursor] != b'<' {
+            cursor += 1;
+            continue;
+        }
+
+        if content[cursor..region_end].starts_with("<!--") {
+            cursor = content[cursor..region_end]
+                .find("-->")
+                .map_or(region_end, |relative| cursor + relative + 3);
+            continue;
+        }
+
+        if bytes.get(cursor + 1) == Some(&b'/') {
+            let name_start = cursor + 2;
+            let name_end = tag_name_end(bytes, name_start, region_end);
+            let close_span = (name_start, name_end);
+            let name = &content[name_start..name_end];
+
+            // `rposition` recovers from unclosed inner elements: the nearest
+            // matching open tag wins.
+            if let Some(index) = stack.iter().rposition(|open| open.name == name) {
+                let open = stack[index];
+                stack.truncate(index);
+                if contains(open.name_span, offset) || contains(close_span, offset) {
+                    return Some(TagNames {
+                        first: open.name_span,
+                        second: Some(close_span),
+                    });
+                }
+            } else if contains(close_span, offset) {
+                // A close tag with no open tag: still a tag name, but nothing
+                // is paired with it.
+                return Some(TagNames {
+                    first: close_span,
+                    second: None,
+                });
+            }
+
+            cursor = content[cursor..region_end]
+                .find('>')
+                .map_or(region_end, |relative| cursor + relative + 1);
+            continue;
+        }
+
+        let name_start = cursor + 1;
+        let name_end = tag_name_end(bytes, name_start, region_end);
+        let tag_end = start_tag_end(content, cursor, region_end)?;
+        if name_end == name_start {
+            cursor += 1;
+            continue;
+        }
+
+        let name = &content[name_start..name_end];
+        let name_span = (name_start, name_end);
+        let self_closing = content[..tag_end - 1].trim_end().ends_with('/');
+        if self_closing || vize_carton::is_void_tag(name) {
+            if contains(name_span, offset) {
+                return Some(TagNames {
+                    first: name_span,
+                    second: None,
+                });
+            }
+        } else {
+            if contains(name_span, offset) {
+                unclosed = Some(name_span);
+            }
+            stack.push(OpenTag { name, name_span });
+        }
+        cursor = tag_end;
+    }
+
+    unclosed.map(|name_span| TagNames {
+        first: name_span,
+        second: None,
+    })
+}
+
+/// The cursor counts as "on" a name when it is anywhere inside it, including the
+/// position immediately after the last character — that is where an editor
+/// leaves the caret while the user is typing the name.
+#[inline]
+fn contains(span: (usize, usize), offset: usize) -> bool {
+    span.0 <= offset && offset <= span.1
+}
+
+fn tag_name_end(bytes: &[u8], name_start: usize, limit: usize) -> usize {
+    let mut end = name_start;
+    while end < limit
+        && (bytes[end].is_ascii_alphanumeric() || matches!(bytes[end], b'-' | b'_' | b'.' | b':'))
+    {
+        end += 1;
+    }
+    end
+}
+
+/// Byte offset just past the `>` that closes the start tag at `tag_start`.
+fn start_tag_end(content: &str, tag_start: usize, limit: usize) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut cursor = tag_start + 1;
+    let mut quote: Option<u8> = None;
+
+    while cursor < limit {
+        let byte = bytes[cursor];
+        match quote {
+            Some(open) if byte == open => quote = None,
+            Some(_) => {}
+            None if byte == b'"' || byte == b'\'' => quote = Some(byte),
+            None if byte == b'>' => return Some(cursor + 1),
+            None => {}
+        }
+        cursor += 1;
+    }
+
+    None
+}

--- a/crates/vize_maestro/src/ide/tag_pair/tests.rs
+++ b/crates/vize_maestro/src/ide/tag_pair/tests.rs
@@ -1,0 +1,67 @@
+use super::names_at;
+
+/// Resolve the names at the caret marked with `|` and render them back into the
+/// input with `[...]` around each resolved span, so a table of cases reads as
+/// the markup the editor would highlight.
+fn resolved(marked: &str) -> Option<String> {
+    let offset = marked
+        .find('|')
+        .expect("test input marks the caret with `|`");
+    let content = marked.replace('|', "");
+    let names = names_at(&content, (0, content.len()), offset)?;
+
+    let mut rendered = String::with_capacity(content.len() + 4);
+    let mut cursor = 0;
+    for (start, end) in [Some(names.first), names.second].into_iter().flatten() {
+        rendered.push_str(&content[cursor..start]);
+        rendered.push('[');
+        rendered.push_str(&content[start..end]);
+        rendered.push(']');
+        cursor = end;
+    }
+    rendered.push_str(&content[cursor..]);
+    Some(rendered)
+}
+
+#[test]
+fn resolves_pairs_and_recovers_from_malformed_markup() {
+    let cases = [
+        // The pair resolves from either side of the element.
+        ("<di|v>x</div>", Some("<[div]>x</[div]>")),
+        ("<div>x</di|v>", Some("<[div]>x</[div]>")),
+        // Nesting is resolved by stack depth, never by name.
+        (
+            "<div><di|v>x</div></div>",
+            Some("<div><[div]>x</[div]></div>"),
+        ),
+        // An unclosed inner element does not hide the enclosing pair.
+        ("<di|v><span>x</div>", Some("<[div]><span>x</[div]>")),
+        // Elements with no second name to keep in sync.
+        ("<b|r>", Some("<[br]>")),
+        ("<di|v />", Some("<[div] />")),
+        ("<di|v>x", Some("<[div]>x")),
+        ("x</di|v>", Some("x</[div]>")),
+        // Comments are text, not markup.
+        (
+            "<!-- <div> --><di|v>x</div>",
+            Some("<!-- <div> --><[div]>x</[div]>"),
+        ),
+        // An unterminated start tag keeps its own name ...
+        ("<div>x</div><sp|a", Some("<div>x</div><[spa]")),
+        // ... and never discards what was already resolved before it.
+        ("<di|v>x<spa", Some("<[div]>x<spa")),
+        ("<di|v>x</div><spa", Some("<[div]>x</[div]><spa")),
+        // A bare `<` in text is not a tag, with or without a `>` after it.
+        ("<di|v>a < b</div>", Some("<[div]>a < b</[div]>")),
+        ("<di|v>x</div>a < b", Some("<[div]>x</[div]>a < b")),
+        // A close tag with no name yet has no span to highlight.
+        ("<div>x</|", None),
+        ("<div>x</| >", None),
+        // The cursor is not on a tag name at all.
+        ("<div>|x</div>", None),
+    ];
+
+    for (marked, expected) in cases {
+        assert_eq!(resolved(marked).as_deref(), expected, "input: {marked}");
+    }
+}

--- a/tests/tooling/lsp-document-highlight.test.ts
+++ b/tests/tooling/lsp-document-highlight.test.ts
@@ -133,6 +133,74 @@ test("documentHighlight marks the script declaration WRITE and other uses READ",
   });
 });
 
+/**
+ * Fixture from #3454: four `<div>`s, so a document-wide name scan and a
+ * stack-based pair resolution give visibly different answers.
+ */
+const FOUR_DIVS = `<script setup lang="ts">
+const count = 1
+</script>
+
+<template>
+  <div class="a">
+    <div class="b">{{ count }}</div>
+  </div>
+  <div class="c" />
+</template>
+`;
+
+type FlatHighlight = [number, number, number, number, number | undefined];
+
+function flatten(highlights: DocumentHighlight[] | null): FlatHighlight[] {
+  if (highlights == null) return [];
+  return highlights.map((highlight) => [
+    highlight.range.start.line,
+    highlight.range.start.character,
+    highlight.range.end.line,
+    highlight.range.end.character,
+    highlight.kind,
+  ]);
+}
+
+test("documentHighlight on a tag name reports the matching pair, not every same-named tag", async () => {
+  await withSession("lsp-document-highlight-pair", async ({ session, workspaceDir }) => {
+    const { uri, ready } = openVue(session, workspaceDir, "FourDivs.vue", FOUR_DIVS);
+    await ready;
+
+    const ask = (position: { line: number; character: number }) =>
+      session.request("textDocument/documentHighlight", {
+        textDocument: { uri },
+        position,
+      }) as Promise<DocumentHighlight[] | null>;
+
+    // Recorded from `@vue/language-server@3.3.8` for this fixture at line 6,
+    // character 6: [[6,5,6,8], [6,32,6,35]] — the matching pair only. Before
+    // #3454 `vize lsp` answered five ranges here, adding [5,3,5,6], [7,4,7,7]
+    // and [8,3,8,6] (the outer element's pair and the unrelated self-closing
+    // `<div class="c" />`), which is exactly the must-exclude set below.
+    assert.deepEqual(flatten(await ask({ line: 6, character: 6 })), [
+      [6, 5, 6, 8, 1],
+      [6, 32, 6, 35, 1],
+    ]);
+
+    // The close tag name resolves back to the same pair.
+    assert.deepEqual(flatten(await ask({ line: 6, character: 33 })), [
+      [6, 5, 6, 8, 1],
+      [6, 32, 6, 35, 1],
+    ]);
+
+    // The outer element pairs with the `</div>` on line 7, never with the
+    // inner element's close tag on line 6.
+    assert.deepEqual(flatten(await ask({ line: 5, character: 4 })), [
+      [5, 3, 5, 6, 1],
+      [7, 4, 7, 7, 1],
+    ]);
+
+    // A self-closing element has no counterpart: exactly its own name.
+    assert.deepEqual(flatten(await ask({ line: 8, character: 4 })), [[8, 3, 8, 6, 1]]);
+  });
+});
+
 test("documentHighlight on a tag name highlights open and close tags as TEXT", async () => {
   await withSession("lsp-document-highlight-tag", async ({ session, workspaceDir }) => {
     const { uri, ready } = openVue(session, workspaceDir, "Dh.vue", DH_SOURCE);


### PR DESCRIPTION
## Defect

`textDocument/documentHighlight` on a tag name highlighted **every** same-named
tag in the document instead of the open/close pair of the element under the
cursor. `ide/document_highlight.rs::tag_highlights` was a substring scan for the
name over the whole file with a character-boundary check — no tag stack, no
pairing, nesting not modelled at all.

The highlight is the one signal that tells a user *which* close tag belongs to
the tag they are on. On a template with many `<div>`s it was noise.

## Reproduction

`App.vue`:

```vue
<script setup lang="ts">
const count = 1
</script>

<template>
  <div class="a">
    <div class="b">{{ count }}</div>
  </div>
  <div class="c" />
</template>
```

`textDocument/documentHighlight` at line 6, character 6 (the **inner** `div`
open tag name), as `[startLine, startChar, endLine, endChar]`:

| server | result |
| --- | --- |
| `@vue/language-server` 3.3.8 | `[[6,5,6,8], [6,32,6,35]]` |
| `vize lsp` before | `[[5,3,5,6], [6,5,6,8], [6,32,6,35], [7,4,7,7], [8,3,8,6]]` |
| `vize lsp` after | `[[6,5,6,8], [6,32,6,35]]` |

## Fix

The stack-based pair scan added for `textDocument/linkedEditingRange` (#3453)
already resolves the enclosing open/close pair, handles void and self-closing
elements, and refuses to read raw-text blocks as markup. It moves out of
`ide/linked_editing.rs` into `ide/tag_pair.rs`, and both providers share it.

Two behaviours are new in the shared scanner, both needed by the highlight
provider and both rejected by linked editing (which keeps requiring a real
counterpart, because one range makes the editor believe it linked something):

- a self-closing / void element reports its own single name;
- an open tag that is never closed, and a close tag with no open tag, report
  their own single name.

This also closes the raw-text hazard the old highlight scanner had: a `<script>`
body containing `a < b` could feed it, because the region safe to read as markup
is now resolved through `ide::sfc_region` rather than assumed.

## How the tests fail before the fix

New tooling test
`tests/tooling/lsp-document-highlight.test.ts::"documentHighlight on a tag name
reports the matching pair, not every same-named tag"` run against a `vize lsp`
binary built from the pre-fix tree
(sha256 `5c59332f0c3532056ba13f47727b5c28696e420bc99e2278afbda05d91ead07d`):

```
$ VIZE_LSP_BIN=<pre-fix vize> node --test \
    --test-name-pattern="matching pair" tests/tooling/lsp-document-highlight.test.ts
✖ documentHighlight on a tag name reports the matching pair, not every same-named tag
  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
  + actual - expected
    [
  +   [5, 3, 5, 6, 1],
      [6, 5, 6, 8, 1],
      [6, 32, 6, 35, 1],
  +   [7, 4, 7, 7, 1],
  +   [8, 3, 8, 6, 1]
    ]
```

(reformatted for readability; the raw diff is one element per line)

Post-fix binary sha256
`60477698ad9201dca7091e652617fbf62f87f9816f584002a240c0d2e33541d7`:

```
✔ documentHighlight on a tag name reports the matching pair, not every same-named tag
✔ documentHighlight on a tag name highlights open and close tags as TEXT
✔ documentHighlight marks the script declaration WRITE and other uses READ
✔ documentHighlight handles CRLF line endings without column drift
✔ documentHighlight returns null for an empty document
✔ linkedEditingRange links a tag-name pair byte-for-byte with the reference server
✔ linkedEditingRange reports nothing where there is no tag-name pair
```

Assertions are full-response `assert.deepEqual` / `assert_eq!` over the complete
highlight list, with the must-exclude ranges `[5,3,5,6]`, `[7,4,7,7]`,
`[8,3,8,6]` pinned by the equality itself. Two pre-existing Rust unit tests that
asserted `highlights.len() >= 3` / `len() == 2` were converted to full
`assert_eq!` over every range and kind while being moved.

## File budget

`ide/document_highlight.rs` was 394 lines (over the 350 budget) and shrinks to
229; its inline test module moves to `ide/document_highlight/tests.rs` (190).
`ide/linked_editing.rs` 176 → 63, new `ide/tag_pair.rs` 159.

## Gates

```
cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports   # clean
cargo test -p vize_maestro                                            # 605 + 3 + 1 doc, 0 failed
rustfmt --edition 2024 --config style_edition=2024 --check <touched>  # clean
npx oxfmt --check / npx oxlint tests/tooling/lsp-document-highlight.test.ts  # clean
```

Refs #3224
Closes #3454

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved document highlighting for nested, matching, and self-closing markup tags.
  * Added accurate highlighting for template, script, component, and identifier contexts.
  * Improved linked editing so matching tag names update together when a counterpart exists.

* **Bug Fixes**
  * Prevented unrelated tags with the same name from being highlighted or linked.
  * Improved handling of comments, raw-text regions, unmatched tags, and UTF-16 positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->