### PR TITLE
fix(canon): use tsc's real default `exclude` instead of the package folders

### DIFF
--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -23,6 +23,8 @@ mod type_references;
 #[cfg(test)]
 mod codegen_tests;
 #[cfg(test)]
+mod default_exclude_tests;
+#[cfg(test)]
 mod hidden_include_tests;
 #[cfg(test)]
 mod nuxt_manifest_tests;
@@ -47,7 +49,7 @@ use collect::{
     collect_supported_files_for_include_roots, collect_supported_files_with_options,
     explicit_hidden_include_roots, explicit_hidden_pattern_roots,
 };
-use glob::{default_exclude_specs, normalize_input_path};
+use glob::normalize_input_path;
 use loader::collect_tsconfig_project_paths;
 use matching::{
     SupportedFileOptions, is_declaration_path, is_generated_codegen_declaration_path,
@@ -144,13 +146,8 @@ fn collect_default_check_files_for_tsconfig(
         &spec.includes
     };
 
-    let default_excludes;
-    let excludes: &[GlobSpec] = if !spec.has_excludes {
-        default_excludes = default_exclude_specs(&default_base_dir);
-        &default_excludes
-    } else {
-        &spec.excludes
-    };
+    let excludes = spec.effective_excludes();
+    let excludes: &[GlobSpec] = &excludes;
 
     if !includes.is_empty() {
         let collected = collect_supported_files_for_include_roots(

--- a/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use ignore::WalkBuilder;
 use vize_carton::FxHashSet;
 
-use super::glob::{default_exclude_specs, normalize_input_path, normalize_walked_path};
+use super::glob::{normalize_input_path, normalize_walked_path};
 use super::loader::{TsconfigInputCache, collect_tsconfig_project_paths};
 use super::matching::{
     SupportedFileOptions, is_generated_codegen_declaration_path, is_generated_path,
@@ -274,11 +274,7 @@ impl TsconfigOwnershipMatcher {
         } else {
             spec.includes.clone()
         };
-        let excludes = if !spec.has_excludes {
-            default_exclude_specs(&default_base_dir)
-        } else {
-            spec.excludes.clone()
-        };
+        let excludes = spec.effective_excludes();
 
         Self {
             loaded: true,

--- a/crates/vize/src/commands/check/tsconfig_inputs/default_exclude_tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/default_exclude_tests.rs
@@ -1,0 +1,220 @@
+//! Tests for `tsc`'s real default `exclude` — `outDir` and `declarationDir`,
+//! and nothing else (#3395).
+//!
+//! Every expectation here was taken from `tsgo -p tsconfig.json --noEmit
+//! --listFiles` on the same tree. The three package folder names are *not* part
+//! of this default: they are rejected from wildcard `include` segments instead,
+//! which `package_folder_tests` covers.
+//!
+//! Case directories live under [`std::env::temp_dir`] for the reason spelled out
+//! in `package_folder_tests`: inside the checkout, `.gitignore` would hide
+//! `node_modules` on its own and hide the behavior under test.
+
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
+use std::path::{Path, PathBuf};
+
+use vize_carton::cstr;
+
+use super::TsconfigInputCache;
+
+fn write(root: &Path, relative: &str, contents: &str) {
+    let path = root.join(relative);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, contents).unwrap();
+}
+
+/// A fresh case directory outside the repository holding one source file in
+/// each of the three directories these cases care about, plus a dependency copy
+/// that no case may ever collect.
+fn workspace(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let root = std::env::temp_dir().join(
+        cstr!(
+            "vize-default-exclude-{name}-{}-{case_id}",
+            std::process::id()
+        )
+        .as_str(),
+    );
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+
+    write(&root, "src/index.ts", "export const s = 1;\n");
+    write(&root, "dist/built.ts", "export const d = 1;\n");
+    write(&root, "types/built.ts", "export const y = 1;\n");
+    write(&root, "node_modules/dep/index.ts", "export const p = 1;\n");
+
+    // `temp_dir` is a symlink on macOS and the collector returns canonicalized
+    // paths, so the case root has to be canonical for `collected`.
+    vize_carton::path::canonicalize_non_verbatim(&root)
+}
+
+fn collected(root: &Path, tsconfig: &str) -> Vec<String> {
+    write(root, "tsconfig.json", tsconfig);
+    super::collect_default_check_files(
+        root,
+        Some(&root.join("tsconfig.json")),
+        false,
+        &mut TsconfigInputCache::default(),
+    )
+    .iter()
+    .map(|path| {
+        path.strip_prefix(root)
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/")
+    })
+    .collect()
+}
+
+#[test]
+fn out_dir_is_excluded_when_the_config_declares_no_exclude() {
+    // tsgo: src/index.ts, types/built.ts.
+    let root = workspace("out-dir");
+
+    assert_eq!(
+        collected(&root, r#"{ "compilerOptions": { "outDir": "dist" } }"#),
+        vec!["src/index.ts", "types/built.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn declaration_dir_is_excluded_when_the_config_declares_no_exclude() {
+    // tsgo: dist/built.ts, src/index.ts. `declarationDir` is excluded even
+    // though tsc also reports TS5069 for it without `declaration`.
+    let root = workspace("declaration-dir");
+
+    assert_eq!(
+        collected(
+            &root,
+            r#"{ "compilerOptions": { "declarationDir": "types" } }"#
+        ),
+        vec!["dist/built.ts", "src/index.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn nothing_is_excluded_by_default_without_out_dir_or_declaration_dir() {
+    // tsgo: dist/built.ts, src/index.ts, types/built.ts — and never the
+    // dependency copy, which the default `**/*` include rejects as a wildcard
+    // segment rather than as an `exclude` entry.
+    let root = workspace("no-output-dirs");
+
+    assert_eq!(
+        collected(&root, r#"{ "compilerOptions": { "strict": true } }"#),
+        vec!["dist/built.ts", "src/index.ts", "types/built.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn an_explicit_empty_exclude_replaces_the_out_dir_default() {
+    // The default is the `exclude` *field*'s default, so spelling out any
+    // `exclude` drops it: tsgo lists the output directory too.
+    let root = workspace("empty-exclude");
+
+    assert_eq!(
+        collected(
+            &root,
+            r#"{ "compilerOptions": { "outDir": "dist" }, "exclude": [] }"#
+        ),
+        vec!["dist/built.ts", "src/index.ts", "types/built.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn an_unrelated_explicit_exclude_replaces_the_out_dir_default() {
+    // Same rule with a non-empty `exclude`: tsgo lists dist/built.ts and
+    // types/built.ts, and drops only what the user named.
+    let root = workspace("unrelated-exclude");
+
+    assert_eq!(
+        collected(
+            &root,
+            r#"{ "compilerOptions": { "outDir": "dist" }, "exclude": ["src"] }"#
+        ),
+        vec!["dist/built.ts", "types/built.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn an_out_dir_inherited_through_extends_is_still_excluded() {
+    // `outDir` is an ordinary compiler option, so the extending config inherits
+    // it and with it the default exclusion: tsgo lists src/index.ts and
+    // types/built.ts.
+    let root = workspace("extends-out-dir");
+    write(
+        &root,
+        "base.json",
+        r#"{ "compilerOptions": { "outDir": "dist" } }"#,
+    );
+
+    assert_eq!(
+        collected(&root, r#"{ "extends": "./base.json" }"#),
+        vec!["src/index.ts", "types/built.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn an_absolute_out_dir_is_excluded() {
+    // tsgo resolves `outDir` before excluding, so an absolute spelling behaves
+    // exactly like the relative one: src/index.ts, types/built.ts.
+    let root = workspace("absolute-out-dir");
+    let out_dir = root.join("dist").to_string_lossy().replace('\\', "/");
+
+    assert_eq!(
+        collected(
+            &root,
+            &cstr!("{{ \"compilerOptions\": {{ \"outDir\": \"{out_dir}\" }} }}"),
+        ),
+        vec!["src/index.ts", "types/built.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn out_dir_beats_an_include_that_names_it() {
+    // `exclude` wins over `include` in tsc, and the default is no different:
+    // tsgo lists only src/index.ts.
+    let root = workspace("include-out-dir");
+
+    assert_eq!(
+        collected(
+            &root,
+            r#"{ "compilerOptions": { "outDir": "dist" }, "include": ["dist/**/*.ts", "src/**/*.ts"] }"#
+        ),
+        vec!["src/index.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_files_entry_inside_out_dir_bypasses_the_default_exclude() {
+    // `files` is not subject to `exclude` at all: tsgo lists dist/built.ts and
+    // expands no wildcards.
+    let root = workspace("files-in-out-dir");
+
+    assert_eq!(
+        collected(
+            &root,
+            r#"{ "compilerOptions": { "outDir": "dist" }, "files": ["dist/built.ts"] }"#
+        ),
+        vec!["dist/built.ts"]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/vize/src/commands/check/tsconfig_inputs/glob.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/glob.rs
@@ -60,19 +60,30 @@ pub(super) fn normalize_tsconfig_glob_base(
     (base_dir, normalized)
 }
 
-/// The documented default `exclude`, anchored at `base_dir`.
+/// One half of `tsc`'s default `exclude`: the directory `key` — `outDir` or
+/// `declarationDir` — names in `value`'s `compilerOptions`, as a glob covering
+/// everything below it.
 ///
-/// This only covers the copies sitting directly below the tsconfig directory.
-/// `tsc` drops these three directory names from every wildcard segment at any
-/// depth instead, which [`super::implicit_exclude`] applies on the `include`
-/// side and which stays in force even when the user spells out their own
-/// `exclude`. What remains here is therefore stricter than `tsc`, whose own
-/// `exclude` default is only `outDir` and `declarationDir`: #3395.
-pub(super) fn default_exclude_specs(base_dir: &Path) -> Vec<GlobSpec> {
-    ["node_modules", "bower_components", "jspm_packages"]
-        .into_iter()
-        .filter_map(|value| GlobSpec::new(base_dir, value))
-        .collect()
+/// The spec is anchored at the *resolved* directory rather than at `dir` with a
+/// relative pattern, so an absolute `outDir` works the same as a relative one.
+/// An empty string is not a directory and `tsc` skips it (its default-exclude
+/// check is a truthiness test on the option), so it yields no spec.
+pub(super) fn compiler_option_dir_exclude(
+    value: &serde_json::Value,
+    dir: &Path,
+    key: &str,
+) -> Option<GlobSpec> {
+    let raw = value.get("compilerOptions")?.get(key)?.as_str()?;
+    if raw.is_empty() {
+        return None;
+    }
+    let resolved = Path::new(raw);
+    let resolved = if resolved.is_absolute() {
+        resolved.to_path_buf()
+    } else {
+        dir.join(resolved)
+    };
+    GlobSpec::new(&resolved, "")
 }
 
 pub(super) fn normalize_path_separators(path: &Path) -> std::string::String {

--- a/crates/vize/src/commands/check/tsconfig_inputs/loader.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/loader.rs
@@ -8,7 +8,7 @@ use std::{
 use serde_json::Value;
 use vize_carton::{FxHashMap, FxHashSet, profile, profiler::global_profiler};
 
-use super::glob::normalize_input_path;
+use super::glob::{compiler_option_dir_exclude, normalize_input_path};
 use super::jsonc::parse_jsonc_value;
 use super::spec::{GlobSpec, RelativePathSpec, TsconfigDeclarationOptions, TsconfigInputSpec};
 
@@ -117,6 +117,13 @@ fn load_tsconfig_inputs_inner(
             .into_iter()
             .filter_map(|value| GlobSpec::new(dir, &value))
             .collect();
+    }
+
+    if let Some(out_dir) = compiler_option_dir_exclude(&value, dir, "outDir") {
+        merged.out_dir_exclude = Some(out_dir);
+    }
+    if let Some(declaration_dir) = compiler_option_dir_exclude(&value, dir, "declarationDir") {
+        merged.declaration_dir_exclude = Some(declaration_dir);
     }
 
     Ok(merged)

--- a/crates/vize/src/commands/check/tsconfig_inputs/package_folder_tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/package_folder_tests.rs
@@ -178,11 +178,9 @@ fn a_recursive_wildcard_below_a_literal_package_folder_segment_stays_shallow() {
     // `node_modules/**/*.ts` keeps its literal first segment but the `**` still
     // rejects a package folder at the depths it consumes, so tsgo lists
     // `node_modules/top/index.ts` and nothing from a deeper `node_modules`.
-    // The `exclude` is spelled out because vize's default `exclude` still
-    // shadows the literal first segment, which `tsc`'s does not: #3395.
     let root = workspace(
         "literal-root-segment",
-        r#"{ "include": ["node_modules/**/*.ts"], "exclude": [] }"#,
+        r#"{ "include": ["node_modules/**/*.ts"] }"#,
     );
     write(
         &root,
@@ -191,6 +189,45 @@ fn a_recursive_wildcard_below_a_literal_package_folder_segment_stays_shallow() {
     );
 
     assert_eq!(collected(&root), vec!["node_modules/top/index.ts"]);
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_literal_package_folder_at_the_include_root_is_a_program_root() {
+    // The reachability condition of #3395: vendored-dependency and
+    // "typecheck one dependency" setups name the package folder in `include`.
+    // tsgo, same tree:
+    //   node_modules/top/index.ts
+    // Vize's anchored default `exclude` used to shadow that literal segment and
+    // collect nothing at all.
+    let root = workspace("literal-root", r#"{ "include": ["node_modules/*/*.ts"] }"#);
+
+    assert_eq!(collected(&root), vec!["node_modules/top/index.ts"]);
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn the_other_two_package_folder_names_are_program_roots_when_named_literally() {
+    // `bower_components` and `jspm_packages` get the same treatment as
+    // `node_modules`: implicitly excluded from a wildcard segment, honored as a
+    // literal one. tsgo lists both of these files.
+    let root = workspace(
+        "literal-root-others",
+        r#"{ "include": ["bower_components/**/*.ts", "jspm_packages/**/*.ts"] }"#,
+    );
+    write(
+        &root,
+        "bower_components/b/index.ts",
+        "export const b = 1;\n",
+    );
+    write(&root, "jspm_packages/j/index.ts", "export const j = 1;\n");
+
+    assert_eq!(
+        collected(&root),
+        vec!["bower_components/b/index.ts", "jspm_packages/j/index.ts"]
+    );
 
     let _ = std::fs::remove_dir_all(&root);
 }

--- a/crates/vize/src/commands/check/tsconfig_inputs/spec.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/spec.rs
@@ -16,6 +16,10 @@ pub(super) struct TsconfigInputSpec {
     pub(super) has_files: bool,
     pub(super) has_includes: bool,
     pub(super) has_excludes: bool,
+    /// `compilerOptions.outDir`, as a glob over the directory it resolves to.
+    pub(super) out_dir_exclude: Option<GlobSpec>,
+    /// `compilerOptions.declarationDir`, likewise.
+    pub(super) declaration_dir_exclude: Option<GlobSpec>,
 }
 
 impl TsconfigInputSpec {
@@ -32,6 +36,34 @@ impl TsconfigInputSpec {
             self.excludes = extended.excludes;
             self.has_excludes = true;
         }
+        // Both are ordinary compiler options, so an extending config that does
+        // not restate them keeps the base's value.
+        if extended.out_dir_exclude.is_some() {
+            self.out_dir_exclude = extended.out_dir_exclude;
+        }
+        if extended.declaration_dir_exclude.is_some() {
+            self.declaration_dir_exclude = extended.declaration_dir_exclude;
+        }
+    }
+
+    /// The `exclude` specs in force for this project.
+    ///
+    /// `tsc` has no `node_modules` / `bower_components` / `jspm_packages`
+    /// default `exclude`: it rejects those three names from *wildcard* `include`
+    /// segments instead (see [`super::implicit_exclude`]), which is why a
+    /// literal include segment naming one of them stays a program root. The real
+    /// default is `[outDir, declarationDir]`, applied only when neither the
+    /// config nor anything it extends declares an `exclude` of its own — an
+    /// explicit `exclude`, including `[]`, replaces it wholesale (#3395).
+    pub(super) fn effective_excludes(&self) -> Vec<GlobSpec> {
+        if self.has_excludes {
+            return self.excludes.clone();
+        }
+        self.out_dir_exclude
+            .iter()
+            .chain(self.declaration_dir_exclude.iter())
+            .cloned()
+            .collect()
     }
 }
 


### PR DESCRIPTION
## The divergence

`vize check` modelled the default `exclude` as three literal globs — `node_modules`,
`bower_components`, `jspm_packages` — anchored at the tsconfig directory
(`default_exclude_specs`). `tsc` has no such default.

Those three names come from `implicitExcludePathRegexPattern`, which is compiled *into* a
wildcard `include` segment (that half is #3401 / `tsconfig_inputs::implicit_exclude`). The
`exclude` field's own default is `[outDir, declarationDir]`. Modelling it as an anchored
`exclude` was therefore wrong in both directions:

* an include entry naming a package folder **literally** is a program root in `tsc`, and
  vize dropped it — the `exclude` shadowed the literal segment;
* `outDir` / `declarationDir` were never excluded, so build output became a program root
  whenever a project left `exclude` unset.

## Reproduction

Under `mktemp -d` outside any repository (a checkout's `.gitignore` hides `node_modules`
and the condition with it):

```
node_modules/top/index.ts
packages/a/index.ts
```

```json
{ "compilerOptions": { "noEmit": true, "types": [] }, "include": ["node_modules/**/*.ts"] }
```

| | `tsgo -p tsconfig.json --listFiles` | vize before | vize after |
| --- | --- | --- | --- |
| `include: ["node_modules/**/*.ts"]` | `node_modules/top/index.ts` | *(nothing)* | `node_modules/top/index.ts` |
| same + `"exclude": []` | `node_modules/top/index.ts` | `node_modules/top/index.ts` | `node_modules/top/index.ts` |
| `include: ["bower_components/**/*.ts", "jspm_packages/**/*.ts"]` | both files | *(nothing)* | both files |
| `outDir: "dist"`, no `exclude` | `src/index.ts`, `types/built.ts` | + `dist/built.ts` | `src/index.ts`, `types/built.ts` |
| `declarationDir: "types"`, no `exclude` | `dist/built.ts`, `src/index.ts` | + `types/built.ts` | `dist/built.ts`, `src/index.ts` |
| `outDir: "dist"` + `"exclude": []` | all three | all three | all three |

That the two spellings `exclude` absent / `"exclude": []` disagreed in vize but not in
`tsc` was the tell: in `tsc` they list the same files whenever no output directory is
configured.

## The fix

`TsconfigInputSpec` now carries `outDir` / `declarationDir` as globs over the directories
they resolve to, and `TsconfigInputSpec::effective_excludes` returns the user's `exclude`
when the config chain declares one — including `[]` — and those two otherwise.
`default_exclude_specs` is gone.

Details pinned by tests, each taken from `tsgo`:

* the spec is anchored at the **resolved** directory, so an absolute `outDir` excludes the
  same tree a relative one does;
* both are ordinary compiler options, so a config that `extends` a base declaring `outDir`
  inherits the exclusion;
* an empty string is not a directory and yields no spec (`tsc`'s default-exclude check is a
  truthiness test on the option);
* `files` entries still bypass `exclude` entirely.

## Tests

* `crates/vize/src/commands/check/tsconfig_inputs/default_exclude_tests.rs` — 9 new cases
  for the `outDir` / `declarationDir` default.
* `crates/vize/src/commands/check/tsconfig_inputs/package_folder_tests.rs` — 2 new cases
  for literal package-folder include segments, and
  `a_recursive_wildcard_below_a_literal_package_folder_segment_stays_shallow` loses the
  `"exclude": []` it only needed to work around this defect.

Case directories live under `std::env::temp_dir()` for the reason #3401 established: inside
the checkout, `.gitignore` hides `node_modules` and the assertions pass without the fix.

**Failing before the fix.** Restoring the five pre-fix collector sources under the new tests
(`git checkout origin/main -- tsconfig_inputs.rs glob.rs spec.rs loader.rs collect.rs`,
re-registering the test modules):

```
test result: FAILED. 10 passed; 8 failed
    default_exclude_tests::an_absolute_out_dir_is_excluded
    default_exclude_tests::an_out_dir_inherited_through_extends_is_still_excluded
    default_exclude_tests::declaration_dir_is_excluded_when_the_config_declares_no_exclude
    default_exclude_tests::out_dir_beats_an_include_that_names_it
    default_exclude_tests::out_dir_is_excluded_when_the_config_declares_no_exclude
    package_folder_tests::a_literal_package_folder_at_the_include_root_is_a_program_root
    package_folder_tests::a_recursive_wildcard_below_a_literal_package_folder_segment_stays_shallow
    package_folder_tests::the_other_two_package_folder_names_are_program_roots_when_named_literally
```

with e.g.

```
a_literal_package_folder_at_the_include_root_is_a_program_root
  left: []
 right: ["node_modules/top/index.ts"]
```

Closes #3395

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->