### PR TITLE
feat(patina): check template <slot> names against defineSlots

### DIFF
--- a/crates/vize_patina/src/linter/script_rules.rs
+++ b/crates/vize_patina/src/linter/script_rules.rs
@@ -8,6 +8,7 @@ use vize_carton::profile;
 mod html_scripts;
 mod prefilter;
 mod registry;
+mod template_ast;
 
 use html_scripts::extract_inline_scripts;
 use prefilter::{
@@ -140,13 +141,22 @@ pub(crate) fn append_builtin_script_diagnostics<'a>(
         });
 
     // Cross-block context shared by every rule invocation for this SFC: rules
-    // that correlate script declarations with template usage (e.g.
-    // `script/no-unused-emit-declarations`) read the raw `<template>` source.
+    // that correlate script declarations with template usage read the raw
+    // `<template>` source (`script/no-unused-emit-declarations`, where an
+    // over-match only suppresses) or its parsed AST (rules that *create* a
+    // finding from template evidence, where an over-match would be a false
+    // positive). The AST is parsed at most once, and only when some enabled
+    // rule asks for it.
+    let template_allocator = vize_carton::Allocator::default();
+    let template_ast =
+        template_ast::parse_for_script_rules(linter, descriptor, &template_allocator);
     let sfc_context = SfcScriptContext {
         template_source: descriptor
             .template
             .as_ref()
             .map(|block| block.content.as_ref()),
+        template_root: template_ast.as_ref().map(|ast| &ast.root),
+        template_offset: template_ast.as_ref().map(|ast| ast.offset),
     };
 
     for entry in active_builtin_script_rule_entries(linter) {

--- a/crates/vize_patina/src/linter/script_rules/template_ast.rs
+++ b/crates/vize_patina/src/linter/script_rules/template_ast.rs
@@ -1,0 +1,58 @@
+//! One `<template>` parse per SFC, shared by every template-aware script rule.
+//!
+//! A `script/*` rule that creates a finding from template evidence needs the
+//! template **AST**, not the raw text (see
+//! [`crate::rules::script::SfcScriptContext`]). Parsing it per rule would
+//! reparse the same block once for every such rule, so it is parsed here at
+//! most once per SFC and handed to all of them through the shared context.
+//!
+//! The parse is skipped entirely unless some enabled rule declares
+//! [`crate::rules::script::ScriptRule::uses_template_ast`], keeping the common
+//! configuration — where no template-aware script rule is on — exactly as cheap
+//! as before.
+
+use vize_armature::Parser;
+use vize_atelier_sfc::SfcDescriptor;
+use vize_carton::{Allocator, profile};
+use vize_relief::RootNode;
+
+use crate::linter::Linter;
+
+/// The parsed `<template>` block together with its offset in the SFC source.
+pub(super) struct TemplateAst<'a> {
+    pub(super) root: RootNode<'a>,
+    pub(super) offset: u32,
+}
+
+/// Parse the descriptor's `<template>` block for the script rules that need it.
+///
+/// Returns `None` when the SFC has no template, when no enabled rule reads the
+/// AST, or when the template has a fatal parse error — a partial AST is not
+/// evidence, and reporting from one would invent findings on a file whose real
+/// problem is already reported by the template parse pass.
+pub(super) fn parse_for_script_rules<'alloc, 'source>(
+    linter: &Linter,
+    descriptor: &'source SfcDescriptor<'source>,
+    allocator: &'alloc Allocator,
+) -> Option<TemplateAst<'alloc>>
+where
+    'source: 'alloc,
+{
+    if !super::active_builtin_script_rule_entries(linter)
+        .any(|entry| super::resolved_rule(linter, entry).uses_template_ast())
+    {
+        return None;
+    }
+    let template = descriptor.template.as_ref()?;
+    let (root, parse_errors) = profile!(
+        "patina.script_rule.template_parse",
+        Parser::new(allocator.as_bump(), template.content.as_ref()).parse()
+    );
+    if Linter::has_fatal_template_parse_errors(&parse_errors) {
+        return None;
+    }
+    Some(TemplateAst {
+        root,
+        offset: template.loc.start as u32,
+    })
+}

--- a/crates/vize_patina/src/rules/script.rs
+++ b/crates/vize_patina/src/rules/script.rs
@@ -55,6 +55,7 @@ mod require_prop_type_constructor;
 mod require_symbol_provide;
 mod require_typed_ref;
 mod return_in_computed_property;
+mod sfc_context;
 mod valid_define_emits;
 mod valid_define_options;
 mod valid_define_props;
@@ -72,6 +73,7 @@ use crate::diagnostic::{LintDiagnostic, Severity};
 use vize_carton::profile;
 
 pub use exports::*;
+pub use sfc_context::SfcScriptContext;
 
 /// Metadata for a script-level rule
 pub struct ScriptRuleMeta {
@@ -117,24 +119,6 @@ impl ScriptLintResult {
 #[inline]
 pub(crate) fn script_source_type() -> SourceType {
     SourceType::from_path("component.ts").unwrap_or_else(|_| SourceType::ts())
-}
-
-/// Cross-block context available to a script rule when the linted block is
-/// part of an SFC.
-///
-/// Script rules see a single `<script>` / `<script setup>` block and normally
-/// cannot observe the rest of the file. Rules that correlate a script
-/// declaration with `<template>` usage (e.g. `script/no-unused-emit-declarations`,
-/// whose declared events may only be emitted from template handlers) read the
-/// raw template source here, provided as text rather than an AST since patina's
-/// template and script passes are separate. The `Default` value (no template)
-/// is what standalone entry points (inline HTML scripts, [`ScriptLinter::lint`])
-/// pass, so rules must treat a missing template as "no template usage
-/// observable", never as an error.
-#[derive(Clone, Copy, Default)]
-pub struct SfcScriptContext<'a> {
-    /// Raw `<template>` block content, when the SFC declares a template.
-    pub template_source: Option<&'a str>,
 }
 
 /// Trait for script-level lint rules
@@ -198,6 +182,17 @@ pub trait ScriptRule: Send + Sync {
     /// receive a shared parse; byte-only rules `false`.
     #[inline]
     fn uses_ast(&self) -> bool {
+        false
+    }
+
+    /// Whether this rule reads [`SfcScriptContext::template_root`].
+    ///
+    /// The `<template>` block is parsed at most once per SFC and only when some
+    /// enabled rule returns `true` here, so a rule that forgets to override
+    /// this simply sees `template_root: None` rather than paying for a parse no
+    /// one reads.
+    #[inline]
+    fn uses_template_ast(&self) -> bool {
         false
     }
 

--- a/crates/vize_patina/src/rules/script/require_explicit_slots.rs
+++ b/crates/vize_patina/src/rules/script/require_explicit_slots.rs
@@ -1,7 +1,7 @@
 //! script/require-explicit-slots
 //!
-//! Require slots consumed in a TypeScript `<script setup>` to be explicitly
-//! typed with `defineSlots<...>()`.
+//! Require the slots a component uses to be explicitly typed with
+//! `defineSlots<...>()`.
 //!
 //! When a component reads its slots programmatically — via `useSlots()` — but
 //! never declares them with `defineSlots`, the slot names and their prop types
@@ -9,8 +9,13 @@
 //! recommended pattern is to declare slots up front with the type-only
 //! `defineSlots<{ ... }>()` macro so the slot contract is explicit and typed.
 //!
-//! This rule fires only when **all** of the following hold for a single
-//! `<script setup>` block:
+//! Mirrors [`vue/require-explicit-slots`](https://eslint.vuejs.org/rules/require-explicit-slots.html),
+//! which applies to TypeScript only. It has two halves, and both are ported.
+//!
+//! ## Script half — `useSlots()` without `defineSlots`
+//!
+//! Fires only when **all** of the following hold for a single `<script setup>`
+//! block:
 //!
 //! * the block contains TypeScript syntax (a type annotation, interface, type
 //!   alias, `defineProps<T>()`, etc.). Because a script rule does not receive
@@ -22,16 +27,29 @@
 //! * there is **no** `defineSlots(...)` / `defineSlots<...>()` declaration in
 //!   the same block.
 //!
-//! The rule is deliberately conservative — it flags only the clear
-//! "useSlots without defineSlots" case to avoid false positives. The report is
-//! anchored at the first `useSlots()` call so the fix (adding a `defineSlots`
-//! declaration) is obvious.
+//! The report is anchored at the first `useSlots()` call so the fix (adding a
+//! `defineSlots` declaration) is obvious.
 //!
-//! Mirrors [`vue/require-explicit-slots`](https://eslint.vuejs.org/rules/require-explicit-slots.html),
-//! which applies to TypeScript only. That rule additionally validates `<slot>`
-//! usage against the declared slots in the template; this port covers the
-//! script-side `useSlots`-without-`defineSlots` subset, which is the portion
-//! observable from a single script block.
+//! ## Template half — a `<slot>` the declaration does not cover
+//!
+//! When the block *does* declare slots and the declared set is fully
+//! enumerable, a `<slot name="footer" />` rendered by the template but absent
+//! from that set is reported at the `<slot>` element.
+//!
+//! Both sides are deliberately conservative, in opposite ways:
+//!
+//! * The declaration must be a single `defineSlots<{ ... }>()` type literal.
+//!   Anything the rule cannot enumerate — `defineSlots<Slots>()`, an index
+//!   signature, a computed key — reports nothing, because a name missing from a
+//!   half-read set is not evidence that it is undeclared. See
+//!   [`declared::DeclaredSlots`].
+//! * The rendered set must be fully static. One `<slot :name="x" />` anywhere
+//!   makes the whole template unreadable for this purpose and the rule reports
+//!   nothing for the component. See [`template::RenderedSlots`].
+//!
+//! Both leave real problems unreported, which is the tolerable direction: this
+//! half *creates* findings from template evidence, so an over-match would be a
+//! diagnostic on correct code. [`template`] documents the over-match probes.
 //!
 //! ## Examples
 //!
@@ -41,22 +59,35 @@
 //! const slots = useSlots()
 //! ```
 //!
+//! ```vue
+//! <script setup lang="ts">
+//! defineSlots<{ default(): unknown }>()
+//! </script>
+//! <template>
+//!   <div><slot /><slot name="footer" /></div>
+//! </template>
+//! ```
+//!
 //! ### Valid
 //! ```ts
 //! defineSlots<{ default(props: { msg: string }): unknown }>()
 //! const slots = useSlots()
 //! ```
 
-use oxc_ast::ast::{CallExpression, Expression, Program, TSType};
-use oxc_ast_visit::{
-    Visit,
-    walk::{walk_call_expression, walk_ts_type},
-};
+mod declared;
+mod template;
+#[cfg(test)]
+mod tests;
+
+use oxc_ast::ast::Program;
 use oxc_span::Span;
+use vize_carton::CompactString;
 
 use crate::diagnostic::{LintDiagnostic, Severity};
 
-use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
+use self::declared::{DeclaredSlots, ScriptSlots};
+use self::template::{RenderedSlot, RenderedSlots};
+use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta, SfcScriptContext};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/require-explicit-slots",
@@ -68,8 +99,10 @@ const MESSAGE: &str =
     "Slots consumed via useSlots() must be explicitly typed with defineSlots<...>().";
 const HELP: &str = "Declare the slots with the type-only macro, e.g. \
      `defineSlots<{ default(props: {}): unknown }>()`.";
+const UNDECLARED_HELP: &str = "Add this slot to the defineSlots type, e.g. \
+     `defineSlots<{ footer(): unknown }>()`, or remove the <slot> outlet.";
 
-/// Require `defineSlots<...>()` when slots are consumed via `useSlots()`.
+/// Require `defineSlots<...>()` to cover every slot the component uses.
 pub struct RequireExplicitSlots;
 
 impl ScriptRule for RequireExplicitSlots {
@@ -82,200 +115,97 @@ impl ScriptRule for RequireExplicitSlots {
         true
     }
 
+    #[inline]
+    fn uses_template_ast(&self) -> bool {
+        true
+    }
+
     fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        // Keep the parse-owning `check` path functional: without SFC context
+        // only the script half is observable.
+        self.check_program_with_sfc(program, source, offset, SfcScriptContext::default(), result);
+    }
+
+    fn check_program_with_sfc<'a>(
         &self,
         program: &'a Program<'a>,
         _source: &str,
         offset: usize,
+        sfc: SfcScriptContext<'_>,
         result: &mut ScriptLintResult,
     ) {
-        let mut visitor = SlotsVisitor {
-            has_ts_syntax: false,
-            has_define_slots: false,
-            first_use_slots: None,
-        };
-        visitor.visit_program(program);
-
-        // Conservative gate: only a TypeScript block that consumes slots via
-        // `useSlots()` and never declares them with `defineSlots` is flagged.
-        if !visitor.has_ts_syntax || visitor.has_define_slots {
+        let slots = declared::collect(program);
+        if !slots.has_ts_syntax {
             return;
         }
-        let Some(span) = visitor.first_use_slots else {
-            return;
-        };
-
-        let start = offset as u32 + span.start;
-        let end = offset as u32 + span.end;
-        result.add_diagnostic(
-            LintDiagnostic::warn(META.name, MESSAGE, start, end)
-                .with_label("slots consumed here without defineSlots", start, end)
-                .with_help(HELP),
-        );
-    }
-}
-
-struct SlotsVisitor {
-    /// Whether the block contains any TypeScript-specific syntax. Used as a
-    /// sound proxy for `lang="ts"` since a script rule cannot read the SFC
-    /// `lang` attribute.
-    has_ts_syntax: bool,
-    /// Whether a `defineSlots(...)` / `defineSlots<...>()` call is present.
-    has_define_slots: bool,
-    /// Span of the first `useSlots()` call, if any.
-    first_use_slots: Option<Span>,
-}
-
-impl<'a> Visit<'a> for SlotsVisitor {
-    fn visit_ts_type(&mut self, it: &TSType<'a>) {
-        // Any TypeScript type position is a definitive TS-syntax signal.
-        self.has_ts_syntax = true;
-        walk_ts_type(self, it);
-    }
-
-    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
-        if let Expression::Identifier(callee) = &it.callee {
-            match callee.name.as_str() {
-                "defineSlots" => {
-                    self.has_define_slots = true;
-                    // A `defineSlots<T>()` call carries a type argument, which is
-                    // itself TS syntax; mark it so a block whose only TS token is
-                    // the slots declaration is still recognised as TypeScript.
-                    if it.type_arguments.is_some() {
-                        self.has_ts_syntax = true;
-                    }
-                }
-                "useSlots" if self.first_use_slots.is_none() => {
-                    self.first_use_slots = Some(it.span);
-                }
-                _ => {}
+        match &slots.declared {
+            DeclaredSlots::Absent => report_missing_declaration(&slots, offset, result),
+            DeclaredSlots::Unknown => {}
+            DeclaredSlots::Known(names) => {
+                check_template(names, sfc, result);
             }
         }
-        walk_call_expression(self, it);
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::RequireExplicitSlots;
-    use crate::rules::script::ScriptLinter;
+/// The script half: `useSlots()` consumed with no `defineSlots` at all.
+fn report_missing_declaration(slots: &ScriptSlots, offset: usize, result: &mut ScriptLintResult) {
+    let Some(span) = slots.first_use_slots else {
+        return;
+    };
+    let (start, end) = script_span(span, offset);
+    result.add_diagnostic(
+        LintDiagnostic::warn(META.name, MESSAGE, start, end)
+            .with_label("slots consumed here without defineSlots", start, end)
+            .with_help(HELP),
+    );
+}
 
-    fn create_linter() -> ScriptLinter {
-        let mut linter = ScriptLinter::new();
-        linter.add_rule(Box::new(RequireExplicitSlots));
-        linter
+/// The template half: every rendered `<slot>` must be in the declared set.
+fn check_template(
+    declared: &vize_carton::FxHashSet<CompactString>,
+    sfc: SfcScriptContext<'_>,
+    result: &mut ScriptLintResult,
+) {
+    let (Some((root, template_offset)), Some(source)) = (sfc.template_ast(), sfc.template_source)
+    else {
+        return;
+    };
+    let RenderedSlots::Known(rendered) = template::collect_rendered_slots(root, source) else {
+        return;
+    };
+    for slot in rendered {
+        if !declared.contains(&slot.name) {
+            report_undeclared_slot(&slot, template_offset, result);
+        }
     }
+}
 
-    #[test]
-    fn test_invalid_use_slots_without_define_slots() {
-        // TS syntax present (defineProps<T>()), useSlots() consumed, no defineSlots.
-        let result = create_linter().lint(
-            "const props = defineProps<{ id: number }>()\nconst slots = useSlots()",
-            0,
-        );
-        assert_eq!(result.warning_count, 1);
-        insta::assert_debug_snapshot!(result.diagnostics);
-    }
+fn report_undeclared_slot(
+    slot: &RenderedSlot,
+    template_offset: u32,
+    result: &mut ScriptLintResult,
+) {
+    let start = template_offset + slot.start;
+    let end = template_offset + slot.end;
+    let mut message = CompactString::with_capacity(slot.name.len() + 64);
+    message.push_str("Slot '");
+    message.push_str(&slot.name);
+    message.push_str("' is rendered in the template but not declared in defineSlots<...>().");
+    result.add_diagnostic(
+        LintDiagnostic::warn(META.name, message, start, end)
+            .with_label("undeclared slot", start, end)
+            .with_help(UNDECLARED_HELP),
+    );
+}
 
-    #[test]
-    fn test_invalid_use_slots_with_type_annotation() {
-        // TS signalled by a plain type annotation.
-        let result = create_linter().lint("const n: number = 1\nconst slots = useSlots()", 0);
-        assert_eq!(result.warning_count, 1);
-    }
-
-    #[test]
-    fn test_invalid_use_slots_with_interface() {
-        let result =
-            create_linter().lint("interface Props { id: number }\nconst s = useSlots()", 0);
-        assert_eq!(result.warning_count, 1);
-    }
-
-    #[test]
-    fn test_invalid_use_slots_called_without_assignment() {
-        // A bare `useSlots()` expression statement still counts as consumption.
-        let result = create_linter().lint("const x: string = ''\nuseSlots()", 0);
-        assert_eq!(result.warning_count, 1);
-    }
-
-    #[test]
-    fn test_valid_define_slots_typed() {
-        let result = create_linter().lint(
-            "defineSlots<{ default(props: { msg: string }): unknown }>()\nconst slots = useSlots()",
-            0,
-        );
-        assert_eq!(result.warning_count, 0);
-    }
-
-    #[test]
-    fn test_valid_define_slots_alone_satisfies() {
-        // `defineSlots` present (even before `useSlots`) means slots are declared.
-        let result = create_linter().lint(
-            "const props = defineProps<{ id: number }>()\ndefineSlots<{ default(): unknown }>()\nconst slots = useSlots()",
-            0,
-        );
-        assert_eq!(result.warning_count, 0);
-    }
-
-    #[test]
-    fn test_valid_no_use_slots() {
-        // No slot consumption at all.
-        let result = create_linter().lint("const props = defineProps<{ id: number }>()", 0);
-        assert_eq!(result.warning_count, 0);
-    }
-
-    #[test]
-    fn test_valid_javascript_use_slots() {
-        // No TypeScript syntax anywhere => treated as JS, not flagged. In JS the
-        // type-only `defineSlots<T>()` fix is not available, so flagging would be
-        // a false positive.
-        let result = create_linter().lint("const slots = useSlots()", 0);
-        assert_eq!(result.warning_count, 0);
-    }
-
-    #[test]
-    fn test_valid_javascript_use_slots_with_props() {
-        // Runtime `defineProps([...])` carries no TS syntax => still JS.
-        let result = create_linter().lint(
-            "const props = defineProps(['id'])\nconst slots = useSlots()",
-            0,
-        );
-        assert_eq!(result.warning_count, 0);
-    }
-
-    #[test]
-    fn test_valid_define_slots_typed_only_ts_token() {
-        // The only TS token is the `defineSlots<T>()` type argument; since
-        // `defineSlots` is present the block is valid regardless.
-        let result = create_linter().lint(
-            "defineSlots<{ header(): unknown }>()\nconst slots = useSlots()",
-            0,
-        );
-        assert_eq!(result.warning_count, 0);
-    }
-
-    #[test]
-    fn test_no_warn_use_slots_in_string_literal() {
-        // The pattern inside a string literal must not be flagged.
-        let result = create_linter().lint("const code: string = \"const s = useSlots()\"", 0);
-        assert_eq!(result.warning_count, 0);
-    }
-
-    #[test]
-    fn test_multiple_use_slots_reports_once_at_first() {
-        let source = "const x: number = 0\nconst a = useSlots()\nconst b = useSlots()";
-        let result = create_linter().lint(source, 0);
-        assert_eq!(result.warning_count, 1);
-        let first = source.find("useSlots()").unwrap() as u32;
-        assert_eq!(result.diagnostics[0].start, first);
-    }
-
-    #[test]
-    fn test_offset_applied() {
-        let source = "const x: number = 0\nconst slots = useSlots()";
-        let result = create_linter().lint(source, 100);
-        assert_eq!(result.warning_count, 1);
-        let call_start = source.find("useSlots()").unwrap() as u32 + 100;
-        assert_eq!(result.diagnostics[0].start, call_start);
-    }
+#[inline]
+fn script_span(span: Span, offset: usize) -> (u32, u32) {
+    (offset as u32 + span.start, offset as u32 + span.end)
 }

--- a/crates/vize_patina/src/rules/script/require_explicit_slots/declared.rs
+++ b/crates/vize_patina/src/rules/script/require_explicit_slots/declared.rs
@@ -1,0 +1,127 @@
+//! What a single script block declares about its slots.
+
+use oxc_ast::ast::{CallExpression, Expression, Program, PropertyKey, TSSignature, TSType};
+use oxc_ast_visit::{
+    Visit,
+    walk::{walk_call_expression, walk_ts_type},
+};
+use oxc_span::Span;
+use vize_carton::{CompactString, FxHashSet};
+
+/// The slot contract the script states.
+pub(super) enum DeclaredSlots {
+    /// No `defineSlots` in this block. The template half stays silent: without
+    /// a declaration every `<slot>` would be "undeclared", which is the
+    /// `useSlots`-without-`defineSlots` case the script half already owns.
+    Absent,
+    /// A `defineSlots` whose slot set cannot be enumerated — a bare type
+    /// reference (`defineSlots<Slots>()`), an index signature, a computed key,
+    /// or a second `defineSlots` call. The set is not fully known, so checking
+    /// a `<slot>` against it could report a slot that *is* declared.
+    Unknown,
+    /// Every declared slot name, exhaustively.
+    Known(FxHashSet<CompactString>),
+}
+
+/// Everything the script half of the rule needs from one block.
+pub(super) struct ScriptSlots {
+    /// Whether the block contains any TypeScript-specific syntax. Used as a
+    /// sound proxy for `lang="ts"` since a script rule cannot read the SFC
+    /// `lang` attribute.
+    pub(super) has_ts_syntax: bool,
+    /// Span of the first `useSlots()` call, if any.
+    pub(super) first_use_slots: Option<Span>,
+    /// The declared slot contract.
+    pub(super) declared: DeclaredSlots,
+}
+
+pub(super) fn collect(program: &Program<'_>) -> ScriptSlots {
+    let mut visitor = SlotsVisitor {
+        has_ts_syntax: false,
+        first_use_slots: None,
+        declared: DeclaredSlots::Absent,
+    };
+    visitor.visit_program(program);
+    ScriptSlots {
+        has_ts_syntax: visitor.has_ts_syntax,
+        first_use_slots: visitor.first_use_slots,
+        declared: visitor.declared,
+    }
+}
+
+struct SlotsVisitor {
+    has_ts_syntax: bool,
+    first_use_slots: Option<Span>,
+    declared: DeclaredSlots,
+}
+
+impl<'a> Visit<'a> for SlotsVisitor {
+    fn visit_ts_type(&mut self, it: &TSType<'a>) {
+        // Any TypeScript type position is a definitive TS-syntax signal.
+        self.has_ts_syntax = true;
+        walk_ts_type(self, it);
+    }
+
+    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+        if let Expression::Identifier(callee) = &it.callee {
+            match callee.name.as_str() {
+                "defineSlots" => {
+                    // A second `defineSlots` is invalid Vue; which one wins is
+                    // not ours to guess, so the set stops being known.
+                    self.declared = match self.declared {
+                        DeclaredSlots::Absent => declared_from_call(it),
+                        _ => DeclaredSlots::Unknown,
+                    };
+                    // A `defineSlots<T>()` call carries a type argument, which is
+                    // itself TS syntax; mark it so a block whose only TS token is
+                    // the slots declaration is still recognised as TypeScript.
+                    if it.type_arguments.is_some() {
+                        self.has_ts_syntax = true;
+                    }
+                }
+                "useSlots" if self.first_use_slots.is_none() => {
+                    self.first_use_slots = Some(it.span);
+                }
+                _ => {}
+            }
+        }
+        walk_call_expression(self, it);
+    }
+}
+
+/// Enumerate the slot names of a `defineSlots<{ ... }>()` type argument.
+///
+/// Only the single-type-literal form is enumerable. Anything else — no type
+/// argument at all (`defineSlots()`), several, a type reference, or a member
+/// this cannot name (an index signature, a computed key) — yields
+/// [`DeclaredSlots::Unknown`] so the template half reports nothing rather than
+/// flagging a slot the type does declare.
+fn declared_from_call(call: &CallExpression<'_>) -> DeclaredSlots {
+    let Some(type_arguments) = call.type_arguments.as_ref() else {
+        return DeclaredSlots::Unknown;
+    };
+    let [TSType::TSTypeLiteral(literal)] = type_arguments.params.as_slice() else {
+        return DeclaredSlots::Unknown;
+    };
+    let mut names = FxHashSet::default();
+    for member in &literal.members {
+        let key = match member {
+            TSSignature::TSPropertySignature(property) if !property.computed => &property.key,
+            TSSignature::TSMethodSignature(method) if !method.computed => &method.key,
+            _ => return DeclaredSlots::Unknown,
+        };
+        let Some(name) = property_key_name(key) else {
+            return DeclaredSlots::Unknown;
+        };
+        names.insert(CompactString::new(name));
+    }
+    DeclaredSlots::Known(names)
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
+    }
+}

--- a/crates/vize_patina/src/rules/script/require_explicit_slots/snapshots/vize_patina__rules__script__require_explicit_slots__tests__invalid_use_slots_without_define_slots.snap
+++ b/crates/vize_patina/src/rules/script/require_explicit_slots/snapshots/vize_patina__rules__script__require_explicit_slots__tests__invalid_use_slots_without_define_slots.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vize_patina/src/rules/script/require_explicit_slots.rs
+source: crates/vize_patina/src/rules/script/require_explicit_slots/tests.rs
 expression: result.diagnostics
 ---
 [

--- a/crates/vize_patina/src/rules/script/require_explicit_slots/template.rs
+++ b/crates/vize_patina/src/rules/script/require_explicit_slots/template.rs
@@ -1,0 +1,168 @@
+//! `<slot>` outlets recovered from the template AST.
+//!
+//! # Why the AST, and why `v-pre` still needs care
+//!
+//! A recovered outlet *creates* a finding, so an over-match is a false
+//! positive. Most of the ways a raw scan over the template text would
+//! over-match are excluded structurally by taking the evidence from the AST —
+//! `<!-- <slot name="x" /> -->` is a comment node and `<p>slot name="x"</p>` is
+//! a text node, and neither can ever become an [`ElementNode`].
+//!
+//! `v-pre` is the exception. The parser rewrites the directives and
+//! interpolations of a `v-pre` region (which is why the other template-aware
+//! rules get `v-pre` for free), but a `<slot>` element inside one still parses
+//! to an element with [`ElementType::Slot`] — while Vue renders it as a literal
+//! `<slot>` tag, not a slot outlet. The directive itself is *removed* from
+//! `props` by the parser, so the only remaining evidence of it is the element's
+//! start tag, which is what [`start_tag_has_v_pre`] inspects. A start tag that
+//! merely mentions `v-pre` inside some other attribute's value is treated as
+//! `v-pre` too; that suppresses a report, the safe direction here.
+//!
+//! # Direction of error
+//!
+//! * **Over-match** would be a false positive, so a `<slot>` whose name is not
+//!   a static attribute makes the whole scan [`RenderedSlots::Dynamic`] and the
+//!   rule reports nothing at all — the declared set cannot be checked
+//!   exhaustively against a name only the runtime knows.
+//! * **Under-match** loses a report: a `<slot>` in a template the parser could
+//!   not read, or one reached only through a dynamic name, is simply not
+//!   checked.
+
+use vize_carton::CompactString;
+use vize_relief::{
+    ElementNode, ElementType, ExpressionNode, PropNode, RootNode, TemplateChildNode,
+};
+
+/// A `<slot>` outlet and the start-tag range to report it at, relative to the
+/// template block.
+pub(super) struct RenderedSlot {
+    pub(super) name: CompactString,
+    pub(super) start: u32,
+    pub(super) end: u32,
+}
+
+/// Every `<slot>` outlet the template renders.
+pub(super) enum RenderedSlots {
+    /// Every outlet name is statically known.
+    Known(Vec<RenderedSlot>),
+    /// At least one outlet names itself with an expression, so the rendered set
+    /// is not fully known and nothing may be reported.
+    Dynamic,
+}
+
+/// Collect the `<slot>` outlets of `root`. `source` is the raw template block
+/// text the AST was parsed from, used only for the `v-pre` start-tag test.
+pub(super) fn collect_rendered_slots(root: &RootNode<'_>, source: &str) -> RenderedSlots {
+    let mut collector = SlotCollector {
+        source,
+        slots: Vec::new(),
+        dynamic: false,
+    };
+    collector.walk(&root.children, false);
+    if collector.dynamic {
+        RenderedSlots::Dynamic
+    } else {
+        RenderedSlots::Known(collector.slots)
+    }
+}
+
+struct SlotCollector<'source> {
+    source: &'source str,
+    slots: Vec<RenderedSlot>,
+    dynamic: bool,
+}
+
+impl SlotCollector<'_> {
+    fn walk(&mut self, children: &[TemplateChildNode<'_>], in_v_pre: bool) {
+        for child in children {
+            match child {
+                TemplateChildNode::Element(element) => self.visit_element(element, in_v_pre),
+                // `v-if` / `v-for` are still plain directives in the parse this
+                // rule reads, so these arms only matter if a transformed AST is
+                // ever passed in. Walking them keeps that case correct.
+                TemplateChildNode::If(if_node) => {
+                    for branch in if_node.branches.iter() {
+                        self.walk(&branch.children, in_v_pre);
+                    }
+                }
+                TemplateChildNode::For(for_node) => self.walk(&for_node.children, in_v_pre),
+                _ => {}
+            }
+        }
+    }
+
+    fn visit_element(&mut self, element: &ElementNode<'_>, in_v_pre: bool) {
+        let in_v_pre = in_v_pre || start_tag_has_v_pre(self.source, element);
+        if !in_v_pre && element.tag_type == ElementType::Slot {
+            self.record(element);
+        }
+        self.walk(&element.children, in_v_pre);
+    }
+
+    /// Record one `<slot>` outlet, or mark the whole scan dynamic.
+    fn record(&mut self, element: &ElementNode<'_>) {
+        let mut name: Option<&str> = None;
+        for prop in element.props.iter() {
+            match prop {
+                // `<slot name>` with no value renders the default slot, so an
+                // attribute without a value contributes nothing.
+                PropNode::Attribute(attribute) if attribute.name.as_str() == "name" => {
+                    if let Some(value) = attribute.value.as_ref() {
+                        name = Some(value.content.as_str());
+                    }
+                }
+                PropNode::Directive(directive) if directive.name.as_str() == "bind" => {
+                    match directive.arg.as_ref() {
+                        // `:name="x"` names the outlet with an expression.
+                        Some(arg) if argument_name(arg) == Some("name") => self.dynamic = true,
+                        // `:[key]="x"` may or may not be the name.
+                        Some(arg) if argument_name(arg).is_none() => self.dynamic = true,
+                        Some(_) => {}
+                        // An argument-less `v-bind="obj"` can carry a `name`
+                        // key, which only the runtime can resolve.
+                        None => self.dynamic = true,
+                    }
+                }
+                _ => {}
+            }
+        }
+        self.slots.push(RenderedSlot {
+            name: CompactString::new(name.unwrap_or("default")),
+            start: element.loc.start.offset,
+            end: element.loc.end.offset,
+        });
+    }
+}
+
+/// The static name of a directive argument, when it has one.
+fn argument_name<'a>(arg: &'a ExpressionNode<'a>) -> Option<&'a str> {
+    match arg {
+        ExpressionNode::Simple(simple) if simple.is_static => Some(simple.content.as_str()),
+        _ => None,
+    }
+}
+
+/// Whether the element's start tag carries a `v-pre` attribute.
+///
+/// The parser deletes the `v-pre` directive from `props`, so the start-tag text
+/// is the only place it survives. A `v-pre` token is accepted only where an
+/// attribute name can start (after whitespace) and end (before whitespace, `=`,
+/// `/` or `>`); a mention inside another attribute's value can still match,
+/// which suppresses a report rather than inventing one.
+fn start_tag_has_v_pre(source: &str, element: &ElementNode<'_>) -> bool {
+    let start = element.loc.start.offset as usize;
+    let end = element.loc.end.offset as usize;
+    let Some(start_tag) = source.get(start..end) else {
+        return false;
+    };
+    let bytes = start_tag.as_bytes();
+    start_tag.match_indices("v-pre").any(|(index, _)| {
+        let before_ok = index
+            .checked_sub(1)
+            .is_none_or(|i| bytes[i].is_ascii_whitespace());
+        let after_ok = bytes
+            .get(index + "v-pre".len())
+            .is_none_or(|byte| byte.is_ascii_whitespace() || matches!(byte, b'=' | b'/' | b'>'));
+        before_ok && after_ok
+    })
+}

--- a/crates/vize_patina/src/rules/script/require_explicit_slots/tests.rs
+++ b/crates/vize_patina/src/rules/script/require_explicit_slots/tests.rs
@@ -1,0 +1,182 @@
+use super::RequireExplicitSlots;
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rules::script::ScriptLinter;
+
+// Template-half tests (#3414 B) live in the `template` submodule.
+mod template;
+
+fn create_linter() -> ScriptLinter {
+    let mut linter = ScriptLinter::new();
+    linter.add_rule(Box::new(RequireExplicitSlots));
+    linter
+}
+
+/// Lint a full SFC end-to-end with only this rule enabled, exercising the
+/// engine path that supplies the parsed `<template>` AST to the rule.
+fn lint_sfc(sfc: &str) -> LintResult {
+    Linter::new()
+        .with_enabled_rules(Some(vec!["script/require-explicit-slots".into()]))
+        .lint_sfc(sfc, "Probe.vue")
+}
+
+/// The full identity of every finding: rule, severity, byte range, message.
+fn findings(result: &LintResult) -> Vec<(&'static str, Severity, u32, u32, &str)> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            (
+                diagnostic.rule_name,
+                diagnostic.severity,
+                diagnostic.start,
+                diagnostic.end,
+                diagnostic.message.as_str(),
+            )
+        })
+        .collect()
+}
+
+fn none() -> Vec<(&'static str, Severity, u32, u32, &'static str)> {
+    Vec::new()
+}
+
+/// [`findings`] with owned messages, so it compares against [`undeclared`].
+fn owned(result: &LintResult) -> Vec<(&'static str, Severity, u32, u32, std::string::String)> {
+    findings(result)
+        .into_iter()
+        .map(|(rule, severity, start, end, message)| {
+            (rule, severity, start, end, message.to_string())
+        })
+        .collect()
+}
+
+/// The finding the `<slot>` written as `tag` produces, as the full tuple.
+fn undeclared(
+    sfc: &str,
+    tag: &str,
+    name: &str,
+) -> (&'static str, Severity, u32, u32, std::string::String) {
+    let start = sfc.find(tag).expect("slot start tag");
+    (
+        "script/require-explicit-slots",
+        Severity::Warning,
+        start as u32,
+        (start + tag.len()) as u32,
+        format!(
+            "Slot '{name}' is rendered in the template but not declared in defineSlots<...>()."
+        ),
+    )
+}
+
+#[test]
+fn test_invalid_use_slots_without_define_slots() {
+    // TS syntax present (defineProps<T>()), useSlots() consumed, no defineSlots.
+    let result = create_linter().lint(
+        "const props = defineProps<{ id: number }>()\nconst slots = useSlots()",
+        0,
+    );
+    assert_eq!(result.warning_count, 1);
+    insta::assert_debug_snapshot!(result.diagnostics);
+}
+
+#[test]
+fn test_invalid_use_slots_with_type_annotation() {
+    // TS signalled by a plain type annotation.
+    let result = create_linter().lint("const n: number = 1\nconst slots = useSlots()", 0);
+    assert_eq!(result.warning_count, 1);
+}
+
+#[test]
+fn test_invalid_use_slots_with_interface() {
+    let result = create_linter().lint("interface Props { id: number }\nconst s = useSlots()", 0);
+    assert_eq!(result.warning_count, 1);
+}
+
+#[test]
+fn test_invalid_use_slots_called_without_assignment() {
+    // A bare `useSlots()` expression statement still counts as consumption.
+    let result = create_linter().lint("const x: string = ''\nuseSlots()", 0);
+    assert_eq!(result.warning_count, 1);
+}
+
+#[test]
+fn test_valid_define_slots_typed() {
+    let result = create_linter().lint(
+        "defineSlots<{ default(props: { msg: string }): unknown }>()\nconst slots = useSlots()",
+        0,
+    );
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_valid_define_slots_alone_satisfies() {
+    // `defineSlots` present (even before `useSlots`) means slots are declared.
+    let result = create_linter().lint(
+        "const props = defineProps<{ id: number }>()\ndefineSlots<{ default(): unknown }>()\nconst slots = useSlots()",
+        0,
+    );
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_valid_no_use_slots() {
+    // No slot consumption at all.
+    let result = create_linter().lint("const props = defineProps<{ id: number }>()", 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_valid_javascript_use_slots() {
+    // No TypeScript syntax anywhere => treated as JS, not flagged. In JS the
+    // type-only `defineSlots<T>()` fix is not available, so flagging would be
+    // a false positive.
+    let result = create_linter().lint("const slots = useSlots()", 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_valid_javascript_use_slots_with_props() {
+    // Runtime `defineProps([...])` carries no TS syntax => still JS.
+    let result = create_linter().lint(
+        "const props = defineProps(['id'])\nconst slots = useSlots()",
+        0,
+    );
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_valid_define_slots_typed_only_ts_token() {
+    // The only TS token is the `defineSlots<T>()` type argument; since
+    // `defineSlots` is present the block is valid regardless.
+    let result = create_linter().lint(
+        "defineSlots<{ header(): unknown }>()\nconst slots = useSlots()",
+        0,
+    );
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_no_warn_use_slots_in_string_literal() {
+    // The pattern inside a string literal must not be flagged.
+    let result = create_linter().lint("const code: string = \"const s = useSlots()\"", 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_multiple_use_slots_reports_once_at_first() {
+    let source = "const x: number = 0\nconst a = useSlots()\nconst b = useSlots()";
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+    let first = source.find("useSlots()").unwrap() as u32;
+    assert_eq!(result.diagnostics[0].start, first);
+}
+
+#[test]
+fn test_offset_applied() {
+    let source = "const x: number = 0\nconst slots = useSlots()";
+    let result = create_linter().lint(source, 100);
+    assert_eq!(result.warning_count, 1);
+    let call_start = source.find("useSlots()").unwrap() as u32 + 100;
+    assert_eq!(result.diagnostics[0].start, call_start);
+}

--- a/crates/vize_patina/src/rules/script/require_explicit_slots/tests/template.rs
+++ b/crates/vize_patina/src/rules/script/require_explicit_slots/tests/template.rs
@@ -1,0 +1,304 @@
+//! Template half (#3414 B): a `<slot>` the `defineSlots` type does not cover.
+//!
+//! These exercise the SFC engine path that supplies the parsed `<template>`
+//! AST to the rule via [`super::lint_sfc`]. Because this half *creates*
+//! findings from template evidence, the over-match probes below are as
+//! load-bearing as the positive cases: each asserts the full finding set, and
+//! the negative ones assert it is exactly empty.
+
+use super::{findings, lint_sfc, none, owned, undeclared};
+use crate::diagnostic::Severity;
+
+// --- The recovered case: a rendered slot the declaration omits --------------
+
+#[test]
+fn reports_a_slot_missing_from_the_declared_set_issue_3414() {
+    // Exact reproduction from #3414 B.
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ default(): unknown }>();
+</script>
+
+<template>
+  <div><slot /><slot name="footer" /></div>
+</template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![undeclared(sfc, r#"<slot name="footer" />"#, "footer")]
+    );
+}
+
+#[test]
+fn reports_an_undeclared_default_slot() {
+    // A `<slot>` with no `name` renders the default slot.
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ footer(): unknown }>();
+</script>
+
+<template>
+  <div><slot /></div>
+</template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![undeclared(sfc, "<slot />", "default")]
+    );
+}
+
+#[test]
+fn reports_a_slot_nested_in_another_components_slot_content() {
+    // A `<slot>` inside a child component's default slot is still *this*
+    // component's outlet, so it is checked against this component's contract.
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ default(): unknown }>();
+</script>
+
+<template>
+  <Child v-slot="{ footer }"><slot name="footer" /></Child>
+</template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![undeclared(sfc, r#"<slot name="footer" />"#, "footer")]
+    );
+}
+
+#[test]
+fn reports_every_undeclared_slot_in_source_order() {
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ default(): unknown }>();
+</script>
+
+<template>
+  <div>
+    <slot name="header" />
+    <slot name="footer" />
+  </div>
+</template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![
+            undeclared(sfc, r#"<slot name="header" />"#, "header"),
+            undeclared(sfc, r#"<slot name="footer" />"#, "footer"),
+        ]
+    );
+}
+
+#[test]
+fn reports_a_string_literal_slot_name_against_a_string_literal_declaration() {
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ 'my-slot'(): unknown }>();
+</script>
+
+<template>
+  <div><slot name="my-slot" /><slot name="other" /></div>
+</template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![undeclared(sfc, r#"<slot name="other" />"#, "other")]
+    );
+}
+
+// --- Every rendered slot is declared: exactly zero findings ----------------
+
+#[test]
+fn ignores_a_template_whose_slots_are_all_declared() {
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ default(): unknown; footer(): unknown }>();
+</script>
+
+<template>
+  <div><slot /><slot name="footer" /></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_property_signature_declaration() {
+    // `default: () => any` declares the same slot as `default(): unknown`.
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ default: () => unknown }>();
+</script>
+
+<template>
+  <div><slot /></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+// --- Over-match probes: none of these may manufacture a finding ------------
+
+#[test]
+fn ignores_a_slot_inside_an_html_comment() {
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ default(): unknown }>();
+</script>
+
+<template>
+  <div><slot /><!-- <slot name="footer" /> --></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_slot_name_in_a_text_node_or_plain_attribute() {
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ default(): unknown }>();
+</script>
+
+<template>
+  <p title="&lt;slot name=&quot;footer&quot; /&gt;">slot name="footer"</p>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_slot_inside_a_v_pre_region() {
+    // `v-pre` skips compilation, so the `<slot>` renders as a literal tag
+    // rather than as an outlet of this component.
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ default(): unknown }>();
+</script>
+
+<template>
+  <pre v-pre><slot name="footer" /></pre>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_tag_whose_name_merely_starts_with_slot() {
+    // `<slot-machine>` is a component, not a slot outlet.
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ default(): unknown }>();
+</script>
+
+<template>
+  <div><slot /><slot-machine name="footer" /></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_the_whole_component_when_one_slot_name_is_dynamic() {
+    // `:name` is resolved at runtime, so the rendered set is unknown and even
+    // the statically undeclared `footer` must not be reported.
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ default(): unknown }>();
+const which = 'footer';
+</script>
+
+<template>
+  <div><slot :name="which" /><slot name="footer" /></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_the_whole_component_when_a_slot_spreads_a_bound_object() {
+    // An argument-less `v-bind` can supply `name`.
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ default(): unknown }>();
+const attrs = { name: 'footer' };
+</script>
+
+<template>
+  <div><slot v-bind="attrs" /><slot name="footer" /></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_declaration_that_cannot_be_enumerated() {
+    // `defineSlots<Slots>()` names a type this rule does not resolve, so the
+    // declared set is unknown and a missing name proves nothing.
+    let sfc = r#"<script setup lang="ts">
+type Slots = { default(): unknown; footer(): unknown };
+defineSlots<Slots>();
+</script>
+
+<template>
+  <div><slot name="footer" /></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_declaration_with_an_index_signature() {
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ [name: string]: () => unknown }>();
+</script>
+
+<template>
+  <div><slot name="footer" /></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_template_slot_when_no_declaration_exists_at_all() {
+    // Without `defineSlots` every `<slot>` would be "undeclared"; that is the
+    // `useSlots`-without-`defineSlots` case the script half owns, and it needs
+    // a `useSlots()` call to fire.
+    let sfc = r#"<script setup lang="ts">
+const id: number = 1;
+</script>
+
+<template>
+  <div><slot name="footer" /></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+// --- The pre-existing script-only subset must keep working -----------------
+
+#[test]
+fn still_reports_use_slots_without_define_slots_through_the_sfc_path() {
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<{ id: number }>();
+const slots = useSlots();
+</script>
+
+<template>
+  <div><slot /></div>
+</template>
+"#;
+    let call = sfc.find("useSlots()").expect("useSlots call");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![(
+            "script/require-explicit-slots",
+            Severity::Warning,
+            call as u32,
+            (call + "useSlots()".len()) as u32,
+            "Slots consumed via useSlots() must be explicitly typed with defineSlots<...>().",
+        )]
+    );
+}
+
+#[test]
+fn still_reports_nothing_when_define_slots_covers_a_used_slots_call() {
+    let sfc = r#"<script setup lang="ts">
+defineSlots<{ default(): unknown }>();
+const slots = useSlots();
+</script>
+
+<template>
+  <div><slot /></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}

--- a/crates/vize_patina/src/rules/script/sfc_context.rs
+++ b/crates/vize_patina/src/rules/script/sfc_context.rs
@@ -1,0 +1,68 @@
+//! Cross-block SFC context available to a script rule.
+//!
+//! Script rules see a single `<script>` / `<script setup>` block and normally
+//! cannot observe the rest of the file. Rules that correlate a script
+//! declaration with `<template>` usage read the template from here.
+//!
+//! # Two channels, two directions of error
+//!
+//! [`SfcScriptContext::template_source`] is the **raw** template text. It is
+//! what [`crate::rules::script::props_emits::template_emits`] scans, and that
+//! scan is documented as one-directional: a name recovered from it only ever
+//! *suppresses* an "unused" report, so an over-match (a call inside an HTML
+//! comment, a coincidental attribute value) can at worst hide a finding.
+//!
+//! [`SfcScriptContext::template_root`] is the **parsed template AST**, for the
+//! opposite direction: a rule that *creates* a finding from template evidence.
+//! There an over-match is a false positive — a diagnostic at a location where
+//! the user did nothing wrong — so raw text is not good enough. The AST
+//! structurally excludes the cases a text scan cannot:
+//!
+//! * an HTML comment is a `Comment` node, never an expression;
+//! * a text node is a `Text` node;
+//! * a plain attribute is an `Attribute`, not a `Directive` carrying an
+//!   expression;
+//! * a `v-pre` region has its directives rewritten to attributes and its
+//!   interpolations to text, so nothing inside it is compiled.
+//!
+//! Matching a *name* inside a recovered expression still needs an oxc parse of
+//! that expression, so an occurrence inside a string literal cannot count; see
+//! [`crate::rules::vue::no_mutating_props`] for the worked example.
+//!
+//! [`SfcScriptContext::template_offset`] is the byte offset of the template
+//! block's content within the whole SFC source, so a rule reporting at a
+//! *template* location can map an AST offset back to the file.
+//!
+//! The `Default` value (no template) is what standalone entry points (inline
+//! HTML scripts, [`crate::rules::script::ScriptLinter::lint`]) pass, so rules
+//! must treat a missing template as "no template usage observable", never as an
+//! error. `template_root` is additionally `None` unless some enabled rule asked
+//! for it through [`crate::rules::script::ScriptRule::uses_template_ast`], and
+//! when the template failed to parse.
+
+use vize_relief::RootNode;
+
+/// Cross-block context handed to a script rule when the linted block is part of
+/// an SFC. See the module documentation for how the three channels differ.
+#[derive(Clone, Copy, Default)]
+pub struct SfcScriptContext<'a> {
+    /// Raw `<template>` block content, when the SFC declares a template.
+    pub template_source: Option<&'a str>,
+    /// Parsed `<template>` AST, when the SFC declares a template, some enabled
+    /// rule requested it, and it parsed without fatal errors.
+    pub template_root: Option<&'a RootNode<'a>>,
+    /// Byte offset of the `<template>` content inside the SFC source, for
+    /// reporting at a template location.
+    pub template_offset: Option<u32>,
+}
+
+impl<'a> SfcScriptContext<'a> {
+    /// The parsed template together with the offset needed to report inside it.
+    ///
+    /// Both are present or neither is useful, so rules that report at a
+    /// template location take them as a pair rather than unwrapping twice.
+    #[inline]
+    pub fn template_ast(&self) -> Option<(&'a RootNode<'a>, u32)> {
+        Some((self.template_root?, self.template_offset?))
+    }
+}


### PR DESCRIPTION
## Defect (#3414 B)

`script/require-explicit-slots` implements only the **script-side**
`useSlots`-without-`defineSlots` subset — the portion observable from a single
script block. Upstream additionally validates `<slot>` usage against the
declared slots in the template, and that half was missing.

## Minimal reproduction

```vue
<script setup lang="ts">
defineSlots<{ default(): unknown }>();
</script>

<template>
  <div><slot /><slot name="footer" /></div>
</template>
```

`Linter::new().with_enabled_rules(Some(vec!["script/require-explicit-slots"])).lint_sfc(sfc, "Probe.vue")`

- Actual: 0 findings.
- Expected: 1 — `footer` is rendered but not declared.

## Over-match / under-match analysis

This is the direction #3223 calls dangerous: template evidence that **creates** a
finding. The existing raw scan in `props_emits/template_emits.rs` is explicitly
one-directional — over-matching there only suppresses an "unused" report — so it
could not be reused. A raw scan for `<slot name="…">` over the template text
would fire on all of these, none of which render an outlet of this component:

| case | why it must not report |
| --- | --- |
| `<!-- <slot name="footer" /> -->` | HTML comment |
| `<p>slot name="footer"</p>` | text node |
| `<p title="&lt;slot name=…&gt;">` | plain attribute, not markup |
| `<pre v-pre><slot name="footer" /></pre>` | `v-pre` renders a literal `<slot>` tag, not an outlet |
| `<slot-machine name="footer" />` | a longer tag name that merely starts with `slot` |
| `<Child v-slot="{ footer }"><slot name="footer" /></Child>` | a nested slot scope — and this one **does** belong to this component, so it must still report |

So the evidence is taken from the **template AST**: an `ElementNode` whose
`tag_type` is `ElementType::Slot`, with the name read from a static
`AttributeNode`. Comments and text can never become an element, and a plain
attribute is not markup.

`v-pre` is the one case the AST does not give for free. The parser rewrites a
`v-pre` region's directives to attributes and its interpolations to text (which
is why #3451 got `v-pre` for free), but a `<slot>` inside one still parses to an
element with `ElementType::Slot` — while Vue renders it as a literal tag. The
parser also *deletes* the `v-pre` directive from `props`, so the element's start
tag is the only surviving evidence; `start_tag_has_v_pre` inspects exactly that
range, accepting `v-pre` only where an attribute name can start and end.

Every row above has a test asserting **exactly zero** findings — except the last,
which asserts exactly one, since a `<slot>` inside a child component's slot
content is still this component's outlet.

**Where over-matching is still possible it suppresses rather than reports.** A
start tag that mentions `v-pre` inside some other attribute's value is treated as
`v-pre`; that removes a report.

**Under-matching loses a report**, the tolerable direction, and both guards are
deliberately blunt:

- The declaration must be a single `defineSlots<{ … }>()` type literal whose
  every member is a named property/method signature. `defineSlots<Slots>()`, an
  index signature, a computed key or a second `defineSlots` call all yield
  `DeclaredSlots::Unknown` and the template half reports nothing — a name missing
  from a half-read set is not evidence that it is undeclared.
- One `<slot :name="x" />` (or an argument-less `v-bind`, which can carry a
  `name` key) anywhere makes the rendered set unknown, and then **nothing** is
  reported for the component, not even the statically undeclared outlets.

All of this is written into the module docs of
`crates/vize_patina/src/rules/script/require_explicit_slots/template.rs` and
`…/declared.rs`.

## Shared infrastructure

`SfcScriptContext::template_source` is raw text with no offset and no AST, which
is fine for the one-directional scan it was built for but not for a rule that
creates findings. The context now also carries:

- `template_root: Option<&RootNode>` — the parsed template AST;
- `template_offset: Option<u32>` — the template content's byte offset in the SFC,
  so a rule can report at a *template* location.

The block is parsed **at most once per SFC**, in
`linter/script_rules/template_ast.rs`, and only when some enabled rule declares
the new `ScriptRule::uses_template_ast` — so a configuration with no
template-aware script rule pays exactly what it paid before. A template with a
fatal parse error yields `None`: a partial AST is not evidence.

`vize_patina` is not in the `cargo-semver-checks` matrix in
`.github/workflows/check.yml`, so growing `SfcScriptContext` is not a semver
problem.

## Location

Reported at the `<slot>` element's start tag, mapped into whole-SFC coordinates
through `template_offset`. The script half keeps reporting at the first
`useSlots()` call, unchanged.

## How the new tests fail before the fix

With the `DeclaredSlots::Known` arm of `check_program_with_sfc` short-circuited
(the pre-fix behaviour — the rule only ever had the `Absent` arm),
`cargo test -p vize_patina --lib require_explicit_slots::tests::template` fails
exactly the five positive-direction tests and passes all thirteen others,
including every over-match probe and both script-half regression tests:

```
reports_a_slot_missing_from_the_declared_set_issue_3414 ... FAILED
reports_a_slot_nested_in_another_components_slot_content ... FAILED
reports_a_string_literal_slot_name_against_a_string_literal_declaration ... FAILED
reports_an_undeclared_default_slot ... FAILED
reports_every_undeclared_slot_in_source_order ... FAILED
test result: FAILED. 13 passed; 5 failed
```

With the fix: `31 passed; 0 failed` for the whole rule (18 template + 13
pre-existing script-only tests, all of which are unchanged).

## File split

`require_explicit_slots.rs` was 281 lines. It becomes `require_explicit_slots.rs`
(208) plus `declared.rs` (127), `template.rs` (169), `tests.rs` (182) and
`tests/template.rs` (304), so nothing approaches the 350-line budget.
`rules/script.rs` shrinks 349 → 344 (`SfcScriptContext` moved to its own
`sfc_context.rs`, 68) and `linter/script_rules.rs` grows 315 → 324.

## Gates run

- `nix develop -c vp run fmt:check` — pass
- `nix develop -c vp run lint:rust` (clippy `-D warnings`) — pass
- `nix develop -c vp run check:rust` — pass
- `nix develop -c cargo test -p vize_patina` — 2253 passed, 0 failed

Refs #3414
Refs #3223

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->