### PR TITLE
fix(maestro): fold template elements and stop before the closing tag

### DIFF
--- a/crates/vize_maestro/src/server/document_structure.rs
+++ b/crates/vize_maestro/src/server/document_structure.rs
@@ -7,68 +7,16 @@
 //! makes that shared contract explicit.
 #![allow(clippy::disallowed_methods)]
 
+mod folding;
 mod symbols;
 
+pub(super) use folding::folding_ranges;
 pub(super) use symbols::document_symbols;
 
-use tower_lsp::lsp_types::{
-    FoldingRange, FoldingRangeKind, FoldingRangeParams, SelectionRange, SelectionRangeParams,
-};
+use tower_lsp::lsp_types::{SelectionRange, SelectionRangeParams};
 
 use super::ServerState;
 use crate::ide::{SelectionRangeService, position_to_offset};
-
-/// `textDocument/foldingRange`: one region per SFC block that spans more than a
-/// single line.
-pub(super) fn folding_ranges(
-    state: &ServerState,
-    params: &FoldingRangeParams,
-) -> Option<Vec<FoldingRange>> {
-    let uri = &params.text_document.uri;
-    let content = state.documents.text(uri)?;
-
-    let options = vize_atelier_sfc::SfcParseOptions {
-        filename: uri.path().to_string().into(),
-        ..Default::default()
-    };
-    let descriptor = vize_atelier_sfc::parse_sfc(&content, options).ok()?;
-
-    let mut ranges = Vec::new();
-    let labelled_blocks = descriptor
-        .template
-        .as_ref()
-        .map(|block| (&block.loc, "template"))
-        .into_iter()
-        .chain(
-            descriptor
-                .script_setup
-                .as_ref()
-                .map(|block| (&block.loc, "script setup")),
-        )
-        .chain(
-            descriptor
-                .script
-                .as_ref()
-                .map(|block| (&block.loc, "script")),
-        )
-        .chain(descriptor.styles.iter().map(|block| (&block.loc, "style")));
-
-    for (loc, label) in labelled_blocks {
-        if loc.start_line >= loc.end_line {
-            continue;
-        }
-        ranges.push(FoldingRange {
-            start_line: loc.start_line.saturating_sub(1) as u32,
-            start_character: None,
-            end_line: loc.end_line.saturating_sub(1) as u32,
-            end_character: None,
-            kind: Some(FoldingRangeKind::Region),
-            collapsed_text: Some(label.to_string()),
-        });
-    }
-
-    (!ranges.is_empty()).then_some(ranges)
-}
 
 /// `textDocument/selectionRange`: one expand/shrink chain per requested
 /// position.

--- a/crates/vize_maestro/src/server/document_structure/folding.rs
+++ b/crates/vize_maestro/src/server/document_structure/folding.rs
@@ -1,0 +1,242 @@
+//! `textDocument/foldingRange` for authored `.vue` documents.
+//!
+//! Two regions are produced: one per multi-line SFC block, and one per
+//! multi-line element or comment inside the template.
+//!
+//! # `endLine` is the last line the client hides
+//!
+//! It is *not* the closing line of the construct. A region that reaches the
+//! closing tag folds the terminator away, leaving a collapsed block with
+//! nothing to show where it ends. `@vue/language-server` 3.3.8 reports `4..8`
+//! for a `<template>` whose `</template>` is on line 9; Maestro reported `4..9`
+//! until #3455. Every region below therefore stops one line short of the
+//! construct's closing line, and a construct with nothing between its opening
+//! and closing lines produces no region at all.
+//!
+//! # Not covered
+//!
+//! Folding *inside* `<script>` (functions, objects) and `<style>` (rule blocks)
+//! needs the TypeScript and CSS services rather than the SFC block layout, and
+//! is tracked separately.
+
+use tower_lsp::lsp_types::{FoldingRange, FoldingRangeKind, FoldingRangeParams};
+
+use crate::server::ServerState;
+
+/// One region per multi-line SFC block, then one per multi-line element or
+/// comment in the template, in document order.
+pub(crate) fn folding_ranges(
+    state: &ServerState,
+    params: &FoldingRangeParams,
+) -> Option<Vec<FoldingRange>> {
+    let uri = &params.text_document.uri;
+    let content = state.documents.text(uri)?;
+
+    let options = vize_atelier_sfc::SfcParseOptions {
+        filename: uri.path().to_string().into(),
+        ..Default::default()
+    };
+    let descriptor = vize_atelier_sfc::parse_sfc(&content, options).ok()?;
+
+    let mut ranges = Vec::new();
+    let labelled_blocks = descriptor
+        .template
+        .as_ref()
+        .map(|block| (&block.loc, "template"))
+        .into_iter()
+        .chain(
+            descriptor
+                .script_setup
+                .as_ref()
+                .map(|block| (&block.loc, "script setup")),
+        )
+        .chain(
+            descriptor
+                .script
+                .as_ref()
+                .map(|block| (&block.loc, "script")),
+        )
+        .chain(descriptor.styles.iter().map(|block| (&block.loc, "style")));
+
+    for (loc, label) in labelled_blocks {
+        // `start_line`/`end_line` are the 1-based lines of the opening and
+        // closing tags.
+        let Some(range) = region(
+            loc.start_line.saturating_sub(1) as u32,
+            loc.end_line.saturating_sub(1) as u32,
+            Some(FoldingRangeKind::Region),
+            Some(label),
+        ) else {
+            continue;
+        };
+        ranges.push(range);
+    }
+
+    if let Some(template) = descriptor.template.as_ref() {
+        // The template block's *content*: its own tags already fold as the
+        // block region above, and scanning them again would emit that range a
+        // second time.
+        ranges.extend(markup_regions(
+            &content,
+            (template.loc.start, template.loc.end),
+        ));
+    }
+
+    (!ranges.is_empty()).then_some(ranges)
+}
+
+/// A region that hides `open_line + 1 ..= close_line - 1`.
+///
+/// `None` when that span is empty, which is every construct whose closing line
+/// is its own line or the one right after it: folding it would hide nothing.
+fn region(
+    open_line: u32,
+    close_line: u32,
+    kind: Option<FoldingRangeKind>,
+    collapsed_text: Option<&str>,
+) -> Option<FoldingRange> {
+    if close_line < open_line + 2 {
+        return None;
+    }
+    Some(FoldingRange {
+        start_line: open_line,
+        start_character: None,
+        end_line: close_line - 1,
+        end_character: None,
+        kind,
+        collapsed_text: collapsed_text.map(|text| text.to_string()),
+    })
+}
+
+/// An element whose start tag has been seen but whose close tag has not.
+struct OpenElement<'a> {
+    name: &'a str,
+    open_line: u32,
+}
+
+/// Fold regions for the elements and comments in `region`, in document order.
+///
+/// A hand-rolled scan rather than a template parse: folding must keep working
+/// while the user is mid-edit and the template does not parse, which is exactly
+/// when they are most likely to collapse a region to see the structure.
+fn markup_regions(content: &str, region_span: (usize, usize)) -> Vec<FoldingRange> {
+    let (region_start, region_end) = region_span;
+    let bytes = content.as_bytes();
+    let mut line = newlines(&content[..region_start]);
+    let mut stack: Vec<OpenElement<'_>> = Vec::new();
+    let mut ranges = Vec::new();
+    let mut cursor = region_start;
+
+    while cursor < region_end {
+        if bytes[cursor] == b'\n' {
+            line += 1;
+            cursor += 1;
+            continue;
+        }
+        if bytes[cursor] != b'<' {
+            cursor += 1;
+            continue;
+        }
+
+        if content[cursor..region_end].starts_with("<!--") {
+            let close = content[cursor..region_end]
+                .find("-->")
+                .map_or(region_end, |relative| cursor + relative);
+            let close_line = line + newlines(&content[cursor..close]);
+            if let Some(range) = region(line, close_line, Some(FoldingRangeKind::Comment), None) {
+                ranges.push(range);
+            }
+            let past = (close + 3).min(region_end);
+            line = close_line + newlines(&content[close..past]);
+            cursor = past;
+            continue;
+        }
+
+        if bytes.get(cursor + 1) == Some(&b'/') {
+            let name_start = cursor + 2;
+            let name = &content[name_start..tag_name_end(bytes, name_start, region_end)];
+            // `rposition` recovers from unclosed inner elements: the nearest
+            // matching open tag wins, and everything above it is dropped
+            // unfolded because it never got a closing line.
+            if let Some(index) = stack.iter().rposition(|open| open.name == name) {
+                let open = &stack[index];
+                if let Some(range) = region(open.open_line, line, None, None) {
+                    ranges.push(range);
+                }
+                stack.truncate(index);
+            }
+            let past = content[cursor..region_end]
+                .find('>')
+                .map_or(region_end, |relative| cursor + relative + 1);
+            line += newlines(&content[cursor..past]);
+            cursor = past;
+            continue;
+        }
+
+        let name_start = cursor + 1;
+        let name_end = tag_name_end(bytes, name_start, region_end);
+        if name_end == name_start {
+            cursor += 1;
+            continue;
+        }
+        let Some(tag_end) = start_tag_end(content, cursor, region_end) else {
+            break;
+        };
+
+        let name = &content[name_start..name_end];
+        let self_closing = content[..tag_end - 1].trim_end().ends_with('/');
+        if !self_closing && !vize_carton::is_void_tag(name) {
+            stack.push(OpenElement {
+                name,
+                open_line: line,
+            });
+        }
+        line += newlines(&content[cursor..tag_end]);
+        cursor = tag_end;
+    }
+
+    // Regions are discovered when the *close* tag is reached, so an outer
+    // element is pushed after the inner ones it contains. Restore document
+    // order, which is what a reader of a pinned expectation expects to see.
+    ranges.sort_by_key(|range| (range.start_line, range.end_line));
+    ranges
+}
+
+#[inline]
+fn newlines(text: &str) -> u32 {
+    text.bytes().filter(|byte| *byte == b'\n').count() as u32
+}
+
+fn tag_name_end(bytes: &[u8], name_start: usize, limit: usize) -> usize {
+    let mut end = name_start;
+    while end < limit
+        && (bytes[end].is_ascii_alphanumeric() || matches!(bytes[end], b'-' | b'_' | b'.' | b':'))
+    {
+        end += 1;
+    }
+    end
+}
+
+/// Byte offset just past the `>` that closes the start tag at `tag_start`.
+fn start_tag_end(content: &str, tag_start: usize, limit: usize) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut cursor = tag_start + 1;
+    let mut quote: Option<u8> = None;
+
+    while cursor < limit {
+        let byte = bytes[cursor];
+        match quote {
+            Some(open) if byte == open => quote = None,
+            Some(_) => {}
+            None if byte == b'"' || byte == b'\'' => quote = Some(byte),
+            None if byte == b'>' => return Some(cursor + 1),
+            None => {}
+        }
+        cursor += 1;
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_maestro/src/server/document_structure/folding.rs
+++ b/crates/vize_maestro/src/server/document_structure/folding.rs
@@ -16,8 +16,8 @@
 //! # Not covered
 //!
 //! Folding *inside* `<script>` (functions, objects) and `<style>` (rule blocks)
-//! needs the TypeScript and CSS services rather than the SFC block layout, and
-//! is tracked separately.
+//! needs the TypeScript and CSS services rather than the SFC block layout; it is
+//! tracked in #3477.
 
 use tower_lsp::lsp_types::{FoldingRange, FoldingRangeKind, FoldingRangeParams};
 

--- a/crates/vize_maestro/src/server/document_structure/folding/tests.rs
+++ b/crates/vize_maestro/src/server/document_structure/folding/tests.rs
@@ -1,0 +1,148 @@
+use tower_lsp::lsp_types::{
+    FoldingRangeKind, FoldingRangeParams, PartialResultParams, TextDocumentIdentifier, Url,
+    WorkDoneProgressParams,
+};
+
+use super::folding_ranges;
+use crate::server::ServerState;
+
+/// The fixture from #3455, with the `<template>` closing on line 9.
+const FOUR_DIVS: &str = "<script setup lang=\"ts\">\nconst count = 1\n</script>\n\n<template>\n  <div class=\"a\">\n    <div class=\"b\">{{ count }}</div>\n  </div>\n  <div class=\"c\" />\n</template>\n";
+
+/// One region as `(start_line, end_line, kind, collapsed_text)`, so a test can
+/// assert the FULL response in one `assert_eq!`.
+type FlatRange = (u32, u32, Option<&'static str>, Option<&'static str>);
+
+fn ranges(source: &str) -> Vec<FlatRange> {
+    let uri = Url::parse("file:///App.vue").unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+
+    let params = FoldingRangeParams {
+        text_document: TextDocumentIdentifier { uri },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    };
+    let Some(ranges) = folding_ranges(&state, &params) else {
+        return Vec::new();
+    };
+
+    ranges
+        .into_iter()
+        .map(|range| {
+            assert_eq!(range.start_character, None, "block folds span lines only");
+            assert_eq!(range.end_character, None, "block folds span lines only");
+            let kind = match range.kind {
+                Some(FoldingRangeKind::Region) => Some("region"),
+                Some(FoldingRangeKind::Comment) => Some("comment"),
+                Some(FoldingRangeKind::Imports) => Some("imports"),
+                None => None,
+            };
+            let collapsed = match range.collapsed_text.as_deref() {
+                Some("template") => Some("template"),
+                Some("script setup") => Some("script setup"),
+                Some("script") => Some("script"),
+                Some("style") => Some("style"),
+                Some(other) => panic!("unexpected collapsedText {other:?}"),
+                None => None,
+            };
+            (range.start_line, range.end_line, kind, collapsed)
+        })
+        .collect()
+}
+
+#[test]
+fn blocks_and_elements_stop_one_line_before_their_closing_tag() {
+    // `@vue/language-server` 3.3.8 reports exactly these three regions for this
+    // fixture: {5,6} (the multi-line `<div class="a">`), {0,1} (script setup)
+    // and {4,8} (template). Before #3455 Maestro reported only the two block
+    // regions, and both ran one line too far: 0..2 and 4..9, folding away
+    // `</script>` and `</template>` themselves.
+    assert_eq!(
+        ranges(FOUR_DIVS),
+        vec![
+            (4, 8, Some("region"), Some("template")),
+            (0, 1, Some("region"), Some("script setup")),
+            // The inner `<div class="b">` opens and closes on line 6 and the
+            // `<div class="c" />` is self-closing: neither hides a line.
+            (5, 6, None, None),
+        ]
+    );
+}
+
+#[test]
+fn a_block_with_nothing_between_its_tags_produces_no_region() {
+    // `endLine` is the last hidden line, so a region would have to hide the
+    // closing tag to be non-empty here.
+    assert_eq!(
+        ranges("<template>\n</template>\n<style>\n</style>\n"),
+        Vec::new()
+    );
+}
+
+#[test]
+fn a_multi_line_comment_folds_as_a_comment_region() {
+    let source = "<template>\n  <!--\n    note\n  -->\n  <div>\n    x\n  </div>\n</template>\n";
+    assert_eq!(
+        ranges(source),
+        vec![
+            (0, 6, Some("region"), Some("template")),
+            (1, 2, Some("comment"), None),
+            (4, 5, None, None),
+        ]
+    );
+}
+
+#[test]
+fn nested_elements_fold_independently_in_document_order() {
+    let source = "<template>\n  <section>\n    <ul>\n      <li>a</li>\n    </ul>\n  </section>\n</template>\n";
+    assert_eq!(
+        ranges(source),
+        vec![
+            (0, 5, Some("region"), Some("template")),
+            (1, 4, None, None),
+            (2, 3, None, None),
+        ]
+    );
+}
+
+#[test]
+fn an_unclosed_element_folds_nothing_and_does_not_steal_the_outer_close_tag() {
+    // `<span>` never closes. The nearest matching open tag wins for `</div>`,
+    // so the `<div>` still folds and the `<span>` contributes no region.
+    let source = "<template>\n  <div>\n    <span>a\n  </div>\n</template>\n";
+    assert_eq!(
+        ranges(source),
+        vec![(0, 3, Some("region"), Some("template")), (1, 2, None, None),]
+    );
+}
+
+#[test]
+fn a_script_body_that_looks_like_markup_is_never_scanned() {
+    // Only the template block is scanned for elements, so `a < b` in a script
+    // body cannot open a phantom element.
+    let source = "<script setup lang=\"ts\">\nconst ok = 1 < 2\nconst n = 2\n</script>\n\n<template>\n  <div>\n    x\n  </div>\n</template>\n";
+    assert_eq!(
+        ranges(source),
+        vec![
+            (5, 8, Some("region"), Some("template")),
+            (0, 2, Some("region"), Some("script setup")),
+            (6, 7, None, None),
+        ]
+    );
+}
+
+#[test]
+fn an_unopened_document_yields_no_folding_ranges() {
+    let state = ServerState::new();
+    let params = FoldingRangeParams {
+        text_document: TextDocumentIdentifier {
+            uri: Url::parse("file:///Missing.vue").unwrap(),
+        },
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    };
+    assert!(folding_ranges(&state, &params).is_none());
+}

--- a/crates/vize_maestro/src/server/document_structure/tests.rs
+++ b/crates/vize_maestro/src/server/document_structure/tests.rs
@@ -34,26 +34,6 @@ fn selection_params(uri: Url, positions: Vec<Position>) -> SelectionRangeParams 
 }
 
 #[test]
-fn folding_ranges_cover_every_multi_line_block_in_discovery_order() {
-    let uri = Url::parse("file:///App.vue").unwrap();
-    let state = state_with(&uri, SFC);
-
-    let ranges = folding_ranges(&state, &folding_params(uri)).expect("blocks must fold");
-    let summary: Vec<(u32, u32, Option<String>)> = ranges
-        .into_iter()
-        .map(|range| (range.start_line, range.end_line, range.collapsed_text))
-        .collect();
-
-    assert_eq!(
-        summary,
-        vec![
-            (4, 6, Some("template".to_string())),
-            (0, 2, Some("script setup".to_string())),
-        ]
-    );
-}
-
-#[test]
 fn selection_ranges_return_one_chain_per_position() {
     let uri = Url::parse("file:///App.vue").unwrap();
     let state = state_with(&uri, SFC);

--- a/tests/snapshots/check/create-vue-editor-range-oracle.ts
+++ b/tests/snapshots/check/create-vue-editor-range-oracle.ts
@@ -292,9 +292,13 @@ test("create-vue editor features answer in authored Vue ranges", async (t) => {
           ]);
 
           const folding = await ask("textDocument/foldingRange", {});
+          // `endLine` is the last line the client hides, so it stops one line
+          // before each closing tag: `</template>` (14), `</script>` (5), and
+          // the `</p>` (13) closing the multi-line paragraph opened on line 10.
           assert.deepEqual(folding, [
-            { collapsedText: "template", startLine: 7, endLine: 14, kind: "region" },
-            { collapsedText: "script setup", startLine: 0, endLine: 5, kind: "region" },
+            { collapsedText: "template", startLine: 7, endLine: 13, kind: "region" },
+            { collapsedText: "script setup", startLine: 0, endLine: 4, kind: "region" },
+            { startLine: 10, endLine: 12 },
           ]);
         });
       } finally {

--- a/tests/tooling/lsp-document-features.test.ts
+++ b/tests/tooling/lsp-document-features.test.ts
@@ -9,14 +9,17 @@ import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
 import { LspSession } from "./support/lsp/session.ts";
 
 /**
- * Characterization tests for the parse-driven document features exposed by
- * `vize lsp`: `textDocument/documentSymbol` and `textDocument/foldingRange`.
+ * Characterization tests for `textDocument/documentSymbol` in `vize lsp`.
  *
- * Both handlers run purely off the SFC parser (no type checking), so the
- * descriptors they emit are deterministic functions of the block layout. Every
+ * The handler runs purely off the SFC parser (no type checking), so the
+ * descriptors it emits are a deterministic function of the block layout. Every
  * assertion below mirrors what the production server actually returns for the
  * given fixture, including discovery order, MODULE symbol kinds, selection-range
- * widths, CRLF line math, and the omission of folding-range character fields.
+ * widths and CRLF line math.
+ *
+ * `textDocument/foldingRange` lives in `lsp-folding-range.test.ts`; the single
+ * folding assertion left here only pins that an empty document produces no
+ * regions, alongside the documentSymbol behaviour for the same document.
  */
 
 type DocumentSymbol = {
@@ -287,62 +290,5 @@ const label = ref('label')
     assert.equal(symbols[0].name, "script setup");
     assert.equal(symbols[0].kind, SYMBOL_KIND_MODULE);
     assert.equal(symbols[0].detail, "ts");
-  });
-});
-
-test("foldingRange emits one region per multi-line block with block-named collapsedText", async () => {
-  await withSession("lsp-docfeat-folding-regions", async ({ session, workspaceDir }) => {
-    const source = `<script setup lang="ts">
-const x = 1
-</script>
-
-<template>
-  <div>{{ x }}</div>
-</template>
-
-<style scoped>
-.a {
-  color: red;
-}
-</style>
-
-<style module="m">
-.b {
-  color: blue;
-}
-</style>
-`;
-    const { uri } = await openDocument(session, workspaceDir, "Folding.vue", source);
-    const ranges = await requestFoldingRange(session, uri);
-
-    assert.ok(Array.isArray(ranges), JSON.stringify(ranges));
-
-    // template, script setup, then the two styles (styles always collapse to "style").
-    assert.deepEqual(
-      ranges.map((range) => range.collapsedText),
-      ["template", "script setup", "style", "style"],
-    );
-
-    for (const range of ranges) {
-      assert.equal(range.kind, "region");
-      // Block folds span lines only; the character fields are not serialized.
-      assert.equal(range.startCharacter, undefined);
-      assert.equal(range.endCharacter, undefined);
-      assert.ok(
-        range.startLine < range.endLine,
-        `expected startLine < endLine for ${range.collapsedText}: ${JSON.stringify(range)}`,
-      );
-    }
-  });
-});
-
-test("foldingRange omits single-line blocks and returns null when nothing is foldable", async () => {
-  await withSession("lsp-docfeat-folding-singleline", async ({ session, workspaceDir }) => {
-    // Entire template lives on line 0, so there is nothing to fold.
-    const source = "<template><div/></template>\n";
-    const { uri } = await openDocument(session, workspaceDir, "OneLine.vue", source);
-
-    const ranges = await requestFoldingRange(session, uri);
-    assert.equal(ranges, null);
   });
 });

--- a/tests/tooling/lsp-folding-range.test.ts
+++ b/tests/tooling/lsp-folding-range.test.ts
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isDiagnosticsForUri } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+/**
+ * `textDocument/foldingRange` parity suite for `vize lsp`.
+ *
+ * `endLine` is the last line the client *hides*, not the closing line of the
+ * construct: a region that reaches the closing tag folds the terminator away
+ * and leaves a collapsed block with nothing to show where it ends. Maestro
+ * reported `4..9` for a `<template>` closing on line 9 and folded nothing
+ * inside a block, so a large template was one all-or-nothing region (#3455).
+ *
+ * `VUE_LANGUAGE_SERVER_FOUR_DIVS` is the response `@vue/language-server@3.3.8`
+ * actually returned for FOUR_DIVS, driven over stdio with the same request, so
+ * both sides of the oracle are recorded.
+ */
+
+type FoldingRange = {
+  startLine: number;
+  endLine: number;
+  startCharacter?: number;
+  endCharacter?: number;
+  kind?: string;
+  collapsedText?: string;
+};
+
+/** `[startLine, endLine, kind, collapsedText]` — the FULL serialized region. */
+type FlatRange = [number, number, string | undefined, string | undefined];
+
+const FOUR_DIVS = `<script setup lang="ts">
+const count = 1
+</script>
+
+<template>
+  <div class="a">
+    <div class="b">{{ count }}</div>
+  </div>
+  <div class="c" />
+</template>
+`;
+
+/**
+ * Recorded from `@vue/language-server@3.3.8`: the multi-line `<div class="a">`,
+ * the script-setup block and the template block. Vize reports the same three
+ * regions; it emits blocks before elements and labels blocks with
+ * `collapsedText`, neither of which the reference server does.
+ */
+const VUE_LANGUAGE_SERVER_FOUR_DIVS = [
+  { startLine: 5, endLine: 6 },
+  { startLine: 0, endLine: 1 },
+  { startLine: 4, endLine: 8 },
+];
+
+const MULTI_BLOCK = `<script setup lang="ts">
+const x = 1
+</script>
+
+<template>
+  <div>{{ x }}</div>
+</template>
+
+<style scoped>
+.a {
+  color: red;
+}
+</style>
+
+<style module="m">
+.b {
+  color: blue;
+}
+</style>
+`;
+
+async function withSession(
+  name: string,
+  run: (ask: (source: string, fileName: string) => Promise<FlatRange[]>) => Promise<void>,
+): Promise<void> {
+  const testRootDir = path.join(testOutputRoot, name);
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, { editor: true, lint: false, typecheck: false });
+
+    await run(async (source, fileName) => {
+      const filePath = path.join(workspaceDir, fileName);
+      const uri = pathToFileURL(filePath).href;
+      fs.writeFileSync(filePath, source, "utf8");
+      session.notify("textDocument/didOpen", {
+        textDocument: { uri, languageId: "vue", version: 1, text: source },
+      });
+      await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+        isDiagnosticsForUri(params, uri),
+      );
+
+      const ranges = (await session.request("textDocument/foldingRange", {
+        textDocument: { uri },
+      })) as FoldingRange[] | null;
+      if (ranges == null) return [];
+      return ranges.map((range) => {
+        // Line folds only: the character fields are never serialized.
+        assert.equal(range.startCharacter, undefined, JSON.stringify(range));
+        assert.equal(range.endCharacter, undefined, JSON.stringify(range));
+        return [range.startLine, range.endLine, range.kind, range.collapsedText] as FlatRange;
+      });
+    });
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+}
+
+test("foldingRange folds elements and stops one line before every closing tag", async () => {
+  await withSession("lsp-folding-four-divs", async (ask) => {
+    // Before #3455 this was [[4,9,"region","template"], [0,2,"region","script setup"]]:
+    // no element region at all, and both block regions folded their own
+    // closing tag away.
+    assert.deepEqual(await ask(FOUR_DIVS, "FourDivs.vue"), [
+      [4, 8, "region", "template"],
+      [0, 1, "region", "script setup"],
+      [5, 6, undefined, undefined],
+    ]);
+
+    // Same three regions as the reference server, ignoring order and the
+    // labels Vize adds.
+    assert.deepEqual(
+      [...VUE_LANGUAGE_SERVER_FOUR_DIVS]
+        .map((range) => [range.startLine, range.endLine])
+        .sort((a, b) => a[0] - b[0] || a[1] - b[1]),
+      [
+        [0, 1],
+        [4, 8],
+        [5, 6],
+      ],
+    );
+  });
+});
+
+test("foldingRange emits one region per multi-line block with block-named collapsedText", async () => {
+  await withSession("lsp-folding-multi-block", async (ask) => {
+    // Styles always collapse to "style"; the single-line `<div>{{ x }}</div>`
+    // hides nothing and contributes no element region.
+    assert.deepEqual(await ask(MULTI_BLOCK, "MultiBlock.vue"), [
+      [4, 5, "region", "template"],
+      [0, 1, "region", "script setup"],
+      [8, 11, "region", "style"],
+      [14, 17, "region", "style"],
+    ]);
+  });
+});
+
+test("foldingRange folds a multi-line comment as a comment region", async () => {
+  await withSession("lsp-folding-comment", async (ask) => {
+    const source = `<template>
+  <!--
+    note
+  -->
+  <div>
+    x
+  </div>
+</template>
+`;
+    assert.deepEqual(await ask(source, "Comment.vue"), [
+      [0, 6, "region", "template"],
+      [1, 2, "comment", undefined],
+      [4, 5, undefined, undefined],
+    ]);
+  });
+});
+
+test("foldingRange returns null when nothing hides a line", async () => {
+  await withSession("lsp-folding-nothing", async (ask) => {
+    // Everything on one line, so there is nothing to fold.
+    assert.deepEqual(await ask("<template><div/></template>\n", "OneLine.vue"), []);
+    // Blocks whose tags are on consecutive lines hide nothing either: a region
+    // would have to swallow the closing tag to be non-empty.
+    assert.deepEqual(await ask("<template>\n</template>\n<style>\n</style>\n", "Empty.vue"), []);
+  });
+});


### PR DESCRIPTION
## Defects

`textDocument/foldingRange` diverged from `@vue/language-server` 3.3.8 in two
ways on the same fixture.

### 1. `endLine` swallowed the closing tag

`endLine` is the last line the client **hides**, not the closing line of the
construct. `server/document_structure.rs::folding_ranges` used
`loc.end_line - 1` — the 0-based line of the block's *closing tag* — so
collapsing a block folded `</template>` away and left a region with no visible
terminator.

### 2. Nothing inside a block folded

Vize folded SFC blocks only, so a large template was one all-or-nothing region.
Vue LS folds elements and comments too.

## Reproduction

`App.vue`:

```vue
<script setup lang="ts">      line 0
const count = 1               line 1
</script>                     line 2
                              line 3
<template>                    line 4
  <div class="a">             line 5
    <div class="b">{{ count }}</div>   line 6
  </div>                      line 7
  <div class="c" />           line 8
</template>                   line 9
```

| server | `textDocument/foldingRange` |
| --- | --- |
| `@vue/language-server` 3.3.8 | `[{5,6}, {0,1}, {4,8}]` |
| `vize lsp` before | `[{4,9,collapsedText:"template"}, {0,2,collapsedText:"script setup"}]` |
| `vize lsp` after | `[{4,8,"template"}, {0,1,"script setup"}, {5,6}]` |

Same three regions as the reference server. Vize additionally labels block
regions with `collapsedText` and orders blocks before elements; neither is
something the reference server does, and neither is semantic — clients do not
require a sorted or unlabelled list.

## Fix

- Every region stops one line short of the construct's closing line, via a
  single `region(open_line, close_line, …)` helper. A construct with nothing
  between its opening and closing lines now produces **no** region, because
  folding it would hide zero lines — this replaces the old
  `start_line >= end_line` guard, which let 2-line blocks through.
- Elements and comments inside the template block fold, resolved with a tag
  stack so nesting is modelled and an unclosed inner element cannot steal an
  outer close tag. Only the template block's *content* is scanned: its own tags
  already fold as the block region, and scanning them again would emit that
  range twice.
- Comments carry `kind: "comment"`; elements carry no `kind`, matching what a
  "Fold All Regions" command should and should not collapse. Block regions keep
  `kind: "region"`.
- A hand-rolled scan rather than a template parse, deliberately: folding must
  keep working while the template is mid-edit and does not parse, which is
  exactly when a user reaches for it.

## Not in this change

Folding **inside** `<script>` (functions, objects) and `<style>` (rule blocks)
needs the TypeScript and CSS services rather than the SFC block layout. Filed
separately as #3477.

## How the tests fail before the fix

`tests/tooling/lsp-folding-range.test.ts` (new) against a `vize lsp` built from
the pre-fix tree (sha256
`5c59332f0c3532056ba13f47727b5c28696e420bc99e2278afbda05d91ead07d`) — all four
fail:

```
$ VIZE_LSP_BIN=<pre-fix vize> node --test --test-concurrency=1 \
    tests/tooling/lsp-folding-range.test.ts
✖ foldingRange folds elements and stops one line before every closing tag
✖ foldingRange emits one region per multi-line block with block-named collapsedText
✖ foldingRange folds a multi-line comment as a comment region
✖ foldingRange returns null when nothing hides a line
ℹ pass 0
ℹ fail 4
```

For the comment fixture the pre-fix response was
`[[0, 7, 'region', 'template']]` against an expected
`[[0,6,'region','template'], [1,2,'comment',undefined], [4,5,undefined,undefined]]`.

The Rust unit test `folding_ranges_cover_every_multi_line_block_in_discovery_order`
pinned the divergent block ranges `(4,6)` / `(0,2)`; it moves to
`server/document_structure/folding/tests.rs` and now pins `(4,8)` / `(0,1)` plus
the element region for the #3455 fixture.

Post-fix binary sha256
`597f0aabb068aa04868bb48b0e5eb466c109647fa82b48010ca87582ca9cf643`:

```
✔ foldingRange folds elements and stops one line before every closing tag
✔ foldingRange emits one region per multi-line block with block-named collapsedText
✔ foldingRange folds a multi-line comment as a comment region
✔ foldingRange returns null when nothing hides a line
✔ documentSymbol … (5 tests, unchanged)
ℹ pass 9  ℹ fail 0
```

Every assertion is a full-response `assert.deepEqual` / `assert_eq!` over
`[startLine, endLine, kind, collapsedText]`; the previous tooling assertions
were `startLine < endLine` plus a `collapsedText` list, which could not have
caught either divergence.

## File budget

`server/document_structure.rs` 99 → 47 (folding moves to
`document_structure/folding.rs`, 242 + 148 test lines).
`tests/tooling/lsp-document-features.test.ts` 348 → 295 (was one line under the
budget; the folding tests move out).

## Gates

```
cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports   # clean
cargo test -p vize_maestro                                            # 607 + 3 + 1 doc, 0 failed
rustfmt --edition 2024 --config style_edition=2024 --check <touched>  # clean
npx oxfmt --check / npx oxlint <touched .ts>                          # clean
```

Refs #3224
Closes #3455
