### PR TITLE
fix(canon): merge a nested `node_modules` mirror instead of dropping its link

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/package_node_modules.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_node_modules.rs
@@ -16,13 +16,22 @@
 //! specifier that `tsc`/`tsgo` resolve cleanly reports `TS2307` (#3366).
 //!
 //! The fix mirrors those directories as symlinks at their rebased location, so
-//! the mirrored ancestor chain matches the real one.
+//! the mirrored ancestor chain matches the real one. A directory the mirror also
+//! materializes files into is reproduced entry by entry rather than as one link;
+//! [`merged`] explains that case.
+
+mod merged;
+
+#[cfg(test)]
+mod tests;
 
 use std::path::{Path, PathBuf};
 
-use vize_carton::FxHashSet;
+use vize_carton::{FxHashMap, FxHashSet};
 
 use crate::batch::runtime_deps::symlink_package_dir;
+
+use merged::{MirroredEntries, merged_links};
 
 /// A real `node_modules` directory and the mirrored path it is linked from.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -41,18 +50,12 @@ pub(super) struct PackageNodeModulesLink {
 /// materialization, and `<project_root>/node_modules` is already on the
 /// mirrored ancestor chain.
 ///
-/// A candidate whose mirrored `node_modules` holds materialized files is
-/// skipped. Those files are the mirror's own copies of a dependency, and
-/// linking the real directory over them would make every write inside the
-/// virtual project land in the user's real `node_modules`.
-///
-/// Since #3385 the input collector no longer sweeps a nested `node_modules` in
-/// through wildcard `include` expansion, so the #3366 shape — a workspace whose
-/// root `tsconfig.json` includes `packages/**/*` — never reaches that skip. It
-/// still can be reached deliberately: `tsc` honors a `files` entry or a literal
-/// `include` segment that names a file inside a nested `node_modules`, so the
-/// guard stays. In that shape the link is dropped and #3366's `TS2307` can still
-/// fire, which is the narrower defect tracked in #3396.
+/// A candidate whose mirrored `node_modules` holds materialized files of its own
+/// cannot be linked as a whole: those files are the mirror's copies of a
+/// dependency, and linking the real directory over them would both bury them and
+/// make every write inside the virtual project land in the user's real
+/// `node_modules`. Such a candidate is merged entry by entry instead — see
+/// [`merged`] for why that shape is reachable at all and what it links.
 pub(super) fn package_node_modules_links<'a>(
     project_root: &Path,
     virtual_root: &Path,
@@ -60,7 +63,7 @@ pub(super) fn package_node_modules_links<'a>(
 ) -> Vec<PackageNodeModulesLink> {
     let mut candidates: Vec<PathBuf> = Vec::new();
     let mut seen: FxHashSet<PathBuf> = FxHashSet::default();
-    let mut materialized_dependency_dirs: FxHashSet<PathBuf> = FxHashSet::default();
+    let mut mirrored: FxHashMap<PathBuf, MirroredEntries> = FxHashMap::default();
 
     for file in materialized_files {
         let Some(relative) = file
@@ -73,11 +76,11 @@ pub(super) fn package_node_modules_links<'a>(
         };
 
         let mut ancestor = PathBuf::new();
-        for component in relative.components() {
+        let mut components = relative.components();
+        let mut inside_node_modules = false;
+        for component in components.by_ref() {
             if component.as_os_str() == NODE_MODULES {
-                // The mirror materializes files under this `node_modules`, so
-                // its enclosing package keeps the mirrored copies.
-                materialized_dependency_dirs.insert(ancestor.clone());
+                inside_node_modules = true;
                 break;
             }
             ancestor.push(component);
@@ -85,19 +88,32 @@ pub(super) fn package_node_modules_links<'a>(
                 candidates.push(ancestor.clone());
             }
         }
+        if inside_node_modules {
+            mirrored
+                .entry(ancestor)
+                .or_default()
+                .record(components.filter_map(|component| component.as_os_str().to_str()));
+        }
     }
 
     candidates.sort();
     candidates
         .into_iter()
-        .filter(|relative| !materialized_dependency_dirs.contains(relative))
         .filter_map(|relative| {
             let real_dir = project_root.join(&relative).join(NODE_MODULES);
-            real_dir.is_dir().then(|| PackageNodeModulesLink {
-                virtual_dir: virtual_root.join(&relative).join(NODE_MODULES),
-                real_dir,
+            if !real_dir.is_dir() {
+                return None;
+            }
+            let virtual_dir = virtual_root.join(&relative).join(NODE_MODULES);
+            Some(match mirrored.get(&relative) {
+                Some(mirrored) => merged_links(&real_dir, &virtual_dir, mirrored),
+                None => vec![PackageNodeModulesLink {
+                    virtual_dir,
+                    real_dir,
+                }],
             })
         })
+        .flatten()
         .collect()
 }
 
@@ -125,93 +141,3 @@ pub(super) fn materialize_package_node_modules(links: &[PackageNodeModulesLink])
 }
 
 const NODE_MODULES: &str = "node_modules";
-
-#[cfg(test)]
-mod tests {
-    use super::{PackageNodeModulesLink, package_node_modules_links};
-    use std::path::{Path, PathBuf};
-    use vize_carton::cstr;
-
-    fn case_dir(name: &str) -> PathBuf {
-        let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("target")
-            .join("vize-tests")
-            .join("package-node-modules")
-            .join(cstr!("{name}-{}", std::process::id()).as_str());
-        let _ = std::fs::remove_dir_all(&dir);
-        dir
-    }
-
-    #[test]
-    fn links_a_sub_package_node_modules_onto_its_mirrored_path() {
-        let root = case_dir("sub-package");
-        std::fs::create_dir_all(root.join("apps/app/node_modules/dep")).unwrap();
-        let virtual_root = root.join("node_modules/.vize/canon");
-        let file = virtual_root.join("apps/app/main.ts");
-
-        let links = package_node_modules_links(&root, &virtual_root, [file.as_path()].into_iter());
-
-        assert_eq!(
-            links,
-            vec![PackageNodeModulesLink {
-                virtual_dir: virtual_root.join("apps/app/node_modules"),
-                real_dir: root.join("apps/app/node_modules"),
-            }]
-        );
-        let _ = std::fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn skips_the_project_root_and_directories_without_node_modules() {
-        let root = case_dir("root-only");
-        std::fs::create_dir_all(root.join("node_modules/dep")).unwrap();
-        std::fs::create_dir_all(root.join("src")).unwrap();
-        let virtual_root = root.join("node_modules/.vize/canon");
-        let file = virtual_root.join("src/main.ts");
-
-        let links = package_node_modules_links(&root, &virtual_root, [file.as_path()].into_iter());
-
-        assert!(links.is_empty(), "{links:?}");
-        let _ = std::fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn keeps_mirrored_dependency_copies_instead_of_linking_over_them() {
-        let root = case_dir("mirrored-dependency");
-        std::fs::create_dir_all(root.join("apps/app/node_modules/dep")).unwrap();
-        let virtual_root = root.join("node_modules/.vize/canon");
-        let mirrored = virtual_root.join("apps/app/node_modules/dep/index.d.cts");
-
-        let links =
-            package_node_modules_links(&root, &virtual_root, [mirrored.as_path()].into_iter());
-
-        assert!(links.is_empty(), "{links:?}");
-        let _ = std::fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn links_every_ancestor_that_carries_its_own_node_modules() {
-        let root = case_dir("nested-chain");
-        std::fs::create_dir_all(root.join("apps/node_modules/dep")).unwrap();
-        std::fs::create_dir_all(root.join("apps/app/node_modules/dep")).unwrap();
-        let virtual_root = root.join("node_modules/.vize/canon");
-        let file = virtual_root.join("apps/app/src/main.ts");
-
-        let links = package_node_modules_links(&root, &virtual_root, [file.as_path()].into_iter());
-
-        assert_eq!(
-            links,
-            vec![
-                PackageNodeModulesLink {
-                    virtual_dir: virtual_root.join("apps/node_modules"),
-                    real_dir: root.join("apps/node_modules"),
-                },
-                PackageNodeModulesLink {
-                    virtual_dir: virtual_root.join("apps/app/node_modules"),
-                    real_dir: root.join("apps/app/node_modules"),
-                },
-            ]
-        );
-        let _ = std::fs::remove_dir_all(&root);
-    }
-}

--- a/crates/vize_canon/src/batch/virtual_project/package_node_modules/merged.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_node_modules/merged.rs
@@ -1,0 +1,119 @@
+//! Merging a mirrored `node_modules` with the real one, entry by entry.
+//!
+//! A nested `node_modules` is normally mirrored as a single symlink at its
+//! rebased location. That is impossible once the mirror materializes files of
+//! its own underneath it — which `tsc` asks for whenever a `files` entry or a
+//! literal `include` segment names a file inside a nested `node_modules` (#3396,
+//! pinned by `a_files_entry_inside_a_nested_package_folder_is_kept` and
+//! `a_literal_package_folder_segment_after_a_wildcard_segment_is_kept` in
+//! `crates/vize/src/commands/check/tsconfig_inputs/package_folder_tests.rs`).
+//! The link would bury those copies, and every virtual-project write below it
+//! would land in the user's real dependency tree.
+//!
+//! Dropping the link instead — what the mirror did before #3396 — costs every
+//! *other* dependency in that directory its resolution and reintroduces #3366's
+//! spurious `TS2307`. So the two outcomes are made independent: the mirrored
+//! directory stays a real directory, and each real entry is linked individually,
+//! skipping only the names the mirror owns.
+//!
+//! Scoped packages are descended one extra level, so a mirrored `@scope/a` costs
+//! the real `@scope/b` nothing. A scope the mirror does not touch at all is
+//! still linked whole, which keeps the syscall count at one per untouched entry.
+
+use std::path::Path;
+
+use vize_carton::{FxHashSet, String as CompactString, ToCompactString, cstr};
+
+use super::PackageNodeModulesLink;
+
+/// What the mirror itself materializes inside one nested `node_modules`.
+#[derive(Debug, Default)]
+pub(super) struct MirroredEntries {
+    /// Entry names directly below the `node_modules` directory, with a scoped
+    /// package spelled `@scope/name`.
+    names: FxHashSet<CompactString>,
+    /// A materialized file sits directly in the `node_modules` directory, so
+    /// there is no entry to split on and the whole directory stays the
+    /// mirror's.
+    owns_root: bool,
+}
+
+impl MirroredEntries {
+    /// Record the mirror's claim from the path segments that follow
+    /// `node_modules` in a materialized file's parent directory.
+    pub(super) fn record<'a>(&mut self, mut segments: impl Iterator<Item = &'a str>) {
+        let Some(first) = segments.next() else {
+            self.owns_root = true;
+            return;
+        };
+        if !first.starts_with('@') {
+            self.names.insert(first.to_compact_string());
+            return;
+        }
+        match segments.next() {
+            Some(scoped) => {
+                self.names.insert(cstr!("{first}/{scoped}"));
+            }
+            None => {
+                self.names.insert(first.to_compact_string());
+            }
+        }
+    }
+}
+
+/// Links that reproduce `real_dir` at `virtual_dir` without disturbing the
+/// entries `mirrored` claims. Returns nothing when the mirror owns the
+/// directory root, and nothing when `real_dir` cannot be read — both degrade to
+/// the pre-#3396 behavior rather than risking a link over a mirrored copy.
+pub(super) fn merged_links(
+    real_dir: &Path,
+    virtual_dir: &Path,
+    mirrored: &MirroredEntries,
+) -> Vec<PackageNodeModulesLink> {
+    if mirrored.owns_root {
+        return Vec::new();
+    }
+
+    let mut links = Vec::new();
+    for name in sorted_entry_names(real_dir) {
+        if mirrored.names.contains(&name) {
+            continue;
+        }
+        let scope_prefix = cstr!("{name}/");
+        if name.starts_with('@')
+            && mirrored
+                .names
+                .iter()
+                .any(|owned| owned.starts_with(scope_prefix.as_str()))
+        {
+            for scoped in sorted_entry_names(&real_dir.join(name.as_str())) {
+                let qualified = cstr!("{name}/{scoped}");
+                if !mirrored.names.contains(&qualified) {
+                    links.push(link(real_dir, virtual_dir, &qualified));
+                }
+            }
+            continue;
+        }
+        links.push(link(real_dir, virtual_dir, &name));
+    }
+    links
+}
+
+fn link(real_dir: &Path, virtual_dir: &Path, name: &str) -> PackageNodeModulesLink {
+    PackageNodeModulesLink {
+        virtual_dir: virtual_dir.join(name),
+        real_dir: real_dir.join(name),
+    }
+}
+
+/// Entry names of `dir`, sorted so the produced link list is deterministic.
+fn sorted_entry_names(dir: &Path) -> Vec<CompactString> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut names: Vec<CompactString> = entries
+        .filter_map(|entry| Some(entry.ok()?.file_name().to_str()?.to_compact_string()))
+        .collect();
+    names.sort();
+    names
+}

--- a/crates/vize_canon/src/batch/virtual_project/package_node_modules/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_node_modules/tests.rs
@@ -1,0 +1,194 @@
+use std::path::{Path, PathBuf};
+
+use vize_carton::cstr;
+
+use super::{PackageNodeModulesLink, materialize_package_node_modules, package_node_modules_links};
+
+fn case_dir(name: &str) -> PathBuf {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("vize-tests")
+        .join("package-node-modules")
+        .join(cstr!("{name}-{}", std::process::id()).as_str());
+    let _ = std::fs::remove_dir_all(&dir);
+    dir
+}
+
+#[test]
+fn links_a_sub_package_node_modules_onto_its_mirrored_path() {
+    let root = case_dir("sub-package");
+    std::fs::create_dir_all(root.join("apps/app/node_modules/dep")).unwrap();
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let file = virtual_root.join("apps/app/main.ts");
+
+    let links = package_node_modules_links(&root, &virtual_root, [file.as_path()].into_iter());
+
+    assert_eq!(
+        links,
+        vec![PackageNodeModulesLink {
+            virtual_dir: virtual_root.join("apps/app/node_modules"),
+            real_dir: root.join("apps/app/node_modules"),
+        }]
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn skips_the_project_root_and_directories_without_node_modules() {
+    let root = case_dir("root-only");
+    std::fs::create_dir_all(root.join("node_modules/dep")).unwrap();
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let file = virtual_root.join("src/main.ts");
+
+    let links = package_node_modules_links(&root, &virtual_root, [file.as_path()].into_iter());
+
+    assert!(links.is_empty(), "{links:?}");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn merges_the_real_entries_beside_the_mirrors_own_copies() {
+    // The #3396 shape: the mirror materializes its own `dep` and `@scope/a`
+    // under a nested `node_modules`, so that directory cannot be one symlink.
+    // Every other real entry must still be linked, or a bare specifier
+    // resolved from this package reports the `TS2307` of #3366.
+    let root = case_dir("merged");
+    for entry in ["dep", "other", "@scope/a", "@scope/b"] {
+        std::fs::create_dir_all(root.join("apps/app/node_modules").join(entry)).unwrap();
+    }
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let mirrored = [
+        virtual_root.join("apps/app/node_modules/dep/index.d.cts"),
+        virtual_root.join("apps/app/node_modules/@scope/a/index.d.cts"),
+    ];
+
+    let links =
+        package_node_modules_links(&root, &virtual_root, mirrored.iter().map(PathBuf::as_path));
+
+    assert_eq!(
+        links,
+        vec![
+            PackageNodeModulesLink {
+                virtual_dir: virtual_root.join("apps/app/node_modules/@scope/b"),
+                real_dir: root.join("apps/app/node_modules/@scope/b"),
+            },
+            PackageNodeModulesLink {
+                virtual_dir: virtual_root.join("apps/app/node_modules/other"),
+                real_dir: root.join("apps/app/node_modules/other"),
+            },
+        ]
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn links_an_untouched_scope_whole_instead_of_per_package() {
+    // A scope the mirror never materializes into needs no per-package split;
+    // one link keeps the syscall count down and the resolution identical.
+    let root = case_dir("untouched-scope");
+    for entry in ["dep", "@scope/a", "@scope/b"] {
+        std::fs::create_dir_all(root.join("apps/app/node_modules").join(entry)).unwrap();
+    }
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let mirrored = virtual_root.join("apps/app/node_modules/dep/index.d.cts");
+
+    let links = package_node_modules_links(&root, &virtual_root, [mirrored.as_path()].into_iter());
+
+    assert_eq!(
+        links,
+        vec![PackageNodeModulesLink {
+            virtual_dir: virtual_root.join("apps/app/node_modules/@scope"),
+            real_dir: root.join("apps/app/node_modules/@scope"),
+        }]
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn keeps_the_whole_directory_when_a_mirrored_file_sits_in_its_root() {
+    // Nothing to split on: the mirrored file has no enclosing package entry, so
+    // the directory stays the mirror's exactly as it did before #3396.
+    let root = case_dir("mirrored-root-file");
+    std::fs::create_dir_all(root.join("apps/app/node_modules/dep")).unwrap();
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let mirrored = virtual_root.join("apps/app/node_modules/Widget.vue.ts");
+
+    let links = package_node_modules_links(&root, &virtual_root, [mirrored.as_path()].into_iter());
+
+    assert!(links.is_empty(), "{links:?}");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn links_every_ancestor_that_carries_its_own_node_modules() {
+    let root = case_dir("nested-chain");
+    std::fs::create_dir_all(root.join("apps/node_modules/dep")).unwrap();
+    std::fs::create_dir_all(root.join("apps/app/node_modules/dep")).unwrap();
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let file = virtual_root.join("apps/app/src/main.ts");
+
+    let links = package_node_modules_links(&root, &virtual_root, [file.as_path()].into_iter());
+
+    assert_eq!(
+        links,
+        vec![
+            PackageNodeModulesLink {
+                virtual_dir: virtual_root.join("apps/node_modules"),
+                real_dir: root.join("apps/node_modules"),
+            },
+            PackageNodeModulesLink {
+                virtual_dir: virtual_root.join("apps/app/node_modules"),
+                real_dir: root.join("apps/app/node_modules"),
+            },
+        ]
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn materializing_a_merge_leaves_the_mirrors_own_copy_in_place() {
+    // The end-to-end guarantee: after materialization the real dependency is
+    // reachable through the mirror *and* the mirror's own copy still holds its
+    // generated content, so no virtual-project write can reach the user's real
+    // dependency tree through it.
+    let root = case_dir("merged-materialize");
+    std::fs::create_dir_all(root.join("apps/app/node_modules/dep")).unwrap();
+    std::fs::create_dir_all(root.join("apps/app/node_modules/other")).unwrap();
+    std::fs::write(
+        root.join("apps/app/node_modules/dep/index.d.ts"),
+        "export declare const real: 1;\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("apps/app/node_modules/other/index.d.ts"),
+        "export declare const other: 1;\n",
+    )
+    .unwrap();
+
+    let virtual_root = root.join("node_modules/.vize/canon");
+    let mirrored_copy = virtual_root.join("apps/app/node_modules/dep/index.d.cts");
+    std::fs::create_dir_all(mirrored_copy.parent().unwrap()).unwrap();
+    std::fs::write(&mirrored_copy, "export declare const generated: 2;\n").unwrap();
+
+    let links =
+        package_node_modules_links(&root, &virtual_root, [mirrored_copy.as_path()].into_iter());
+    materialize_package_node_modules(&links);
+
+    assert_eq!(
+        std::fs::read_to_string(&mirrored_copy).unwrap(),
+        "export declare const generated: 2;\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(virtual_root.join("apps/app/node_modules/other/index.d.ts"))
+            .unwrap(),
+        "export declare const other: 1;\n"
+    );
+    assert!(
+        !virtual_root
+            .join("apps/app/node_modules/dep/index.d.ts")
+            .exists(),
+        "the mirror's own `dep` must not be replaced by a link to the real one"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
## The defect

`package_node_modules_links` mirrors every nested real `node_modules` into the virtual
project as one symlink, so the mirrored ancestor chain matches the real one and bare
specifiers keep resolving (#3366). It could not do that for a package whose *mirrored*
`node_modules` already held materialized files: the link would bury the mirror's own
generated copies, and every virtual-project write below it would land in the user's real
dependency tree. It therefore skipped the package entirely — and with it every *other*
dependency in that directory, which is #3366's spurious `TS2307` again.

The shape is reachable whenever `tsc` puts a file from a nested `node_modules` in the
program without a wildcard. Both spellings are honored by vize and already pinned in
`crates/vize/src/commands/check/tsconfig_inputs/package_folder_tests.rs`:

```json
{ "files": ["packages/a/node_modules/dep/index.ts"] }
```
```json
{ "include": ["packages/*/node_modules/dep/*.ts"] }
```

Verified against `tsgo -p tsconfig.json --listFiles`: both list
`packages/a/node_modules/dep/index.ts`.

## The fix

Stop choosing between the two outcomes and make them independent, as the issue suggested.
A `node_modules` the mirror materializes into stays a real directory, and each *real* entry
is linked individually, skipping only the names the mirror owns.

| mirror materializes | real entries | links produced |
| --- | --- | --- |
| — | `dep`, `other` | `node_modules` (one link, unchanged) |
| `dep` | `dep`, `other`, `@scope/a`, `@scope/b` | `other`, `@scope` |
| `dep`, `@scope/a` | `dep`, `other`, `@scope/a`, `@scope/b` | `@scope/b`, `other` |
| a file in the `node_modules` root | anything | *(none — see below)* |

Scoped packages are descended one level so a mirrored `@scope/a` costs the real `@scope/b`
nothing, while a scope the mirror never touches is still linked whole — the syscall count
only grows where it has to.

Two conservative fallbacks keep the guarantee the old skip was protecting:

* a materialized file sitting directly in the `node_modules` root has no entry to split on,
  so the whole directory stays the mirror's;
* an unreadable real directory yields no links at all.

Both degrade to the pre-#3396 behavior rather than risking a link laid over a mirrored copy.
`preserved_prune_roots` already derives from `PackageNodeModulesLink::virtual_dir`, so each
per-entry link is protected from the materialization garbage collector without further
changes.

## Tests

`crates/vize_canon/src/batch/virtual_project/package_node_modules/tests.rs` (the module's
tests, extracted from the source file so it stays inside the 350-line budget) gains:

* `merges_the_real_entries_beside_the_mirrors_own_copies` — the mixed case above, asserting
  the full link list;
* `links_an_untouched_scope_whole_instead_of_per_package`;
* `keeps_the_whole_directory_when_a_mirrored_file_sits_in_its_root`;
* `materializing_a_merge_leaves_the_mirrors_own_copy_in_place` — runs
  `materialize_package_node_modules` on a real tree and asserts the mirror's generated
  content survives byte for byte, the real sibling is reachable through the mirror, and the
  real `dep/index.d.ts` is *not* visible at the mirrored `dep` path.

**Failing before the fix.** Restoring `package_node_modules.rs` from `origin/main` under the
new tests:

```
test result: FAILED. 4 passed; 3 failed
    links_an_untouched_scope_whole_instead_of_per_package
    materializing_a_merge_leaves_the_mirrors_own_copy_in_place
    merges_the_real_entries_beside_the_mirrors_own_copies
```

with

```
merges_the_real_entries_beside_the_mirrors_own_copies
  left: []
 right: [.../node_modules/@scope/b, .../node_modules/other]
```

Full suite: `cargo test -p vize_canon` — 655 lib tests plus every integration target pass.

Closes #3396

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->