### PR TITLE
fix(armature): stop inventing InvalidEndTag for over-limit nesting

### DIFF
--- a/crates/vize_armature/src/parser.rs
+++ b/crates/vize_armature/src/parser.rs
@@ -11,9 +11,12 @@ mod attribute;
 mod callbacks;
 mod delimiters;
 mod element;
+mod entry;
 #[cfg(test)]
 mod experimental_tests;
 mod whitespace;
+
+pub use entry::*;
 
 #[cfg(test)]
 mod tests;
@@ -36,6 +39,11 @@ pub struct Parser<'a> {
     template_syntax: TemplateSyntaxMode,
     /// Current node stack
     stack: Vec<'a, ParserStackEntry<'a>>,
+    /// Tags of the elements the nesting limit refused to descend into, in source
+    /// order. They are attached to the tree as leaves instead of being pushed
+    /// onto `stack`, so without this their end tags would find nothing to close
+    /// and be reported as `InvalidEndTag` even though the source is correct.
+    flattened_tags: Vec<'a, String>,
     /// Root node
     root: Option<RootNode<'a>>,
     /// Current element being parsed
@@ -167,6 +175,7 @@ impl<'a> Parser<'a> {
             options,
             template_syntax,
             stack: Vec::new_in(allocator),
+            flattened_tags: Vec::new_in(allocator),
             root: None,
             current_element: None,
             current_attr: None,
@@ -327,73 +336,4 @@ impl<'a> Parser<'a> {
             self.emit_stack_entry(entry);
         }
     }
-}
-
-/// Parse a Vue template
-pub fn parse<'a>(allocator: &'a Bump, source: &'a str) -> (RootNode<'a>, Vec<'a, CompilerError>) {
-    Parser::new(allocator, source).parse()
-}
-
-/// Parse a full HTML document (petite-vue / standalone HTML) into the template AST.
-///
-/// Unlike [`parse`], which expects an SFC `<template>` block, this entry point
-/// tolerates a leading `<!DOCTYPE html>` declaration and parses the whole
-/// document (`<html>/<head>/<body>`, `<script>`/`<style>` as raw text) so
-/// downstream lint/scope analysis can run on petite-vue pages whose directives
-/// sit on ordinary DOM elements. Additive: existing template parsing is
-/// unchanged.
-pub fn parse_document<'a>(
-    allocator: &'a Bump,
-    source: &'a str,
-) -> (RootNode<'a>, Vec<'a, CompilerError>) {
-    Parser::new_document(allocator, source).parse()
-}
-
-/// Parse a full HTML document with options. See [`parse_document`].
-pub fn parse_document_with_options<'a>(
-    allocator: &'a Bump,
-    source: &'a str,
-    options: ParserOptions,
-) -> (RootNode<'a>, Vec<'a, CompilerError>) {
-    Parser::document_with_options(allocator, source, options).parse()
-}
-
-/// Parse a Vue template with options
-pub fn parse_with_options<'a>(
-    allocator: &'a Bump,
-    source: &'a str,
-    options: ParserOptions,
-) -> (RootNode<'a>, Vec<'a, CompilerError>) {
-    Parser::with_options(allocator, source, options).parse()
-}
-
-/// Parse a Vue template with options and invalid HTML self-closing compatibility.
-#[deprecated(note = "use parse_with_options_and_template_syntax instead")]
-pub fn parse_with_options_and_invalid_html_self_closing<'a>(
-    allocator: &'a Bump,
-    source: &'a str,
-    options: ParserOptions,
-    allow_invalid_html_self_closing: bool,
-) -> (RootNode<'a>, Vec<'a, CompilerError>) {
-    Parser::with_options_and_template_syntax(
-        allocator,
-        source,
-        options,
-        if allow_invalid_html_self_closing {
-            TemplateSyntaxMode::Quirks
-        } else {
-            TemplateSyntaxMode::Standard
-        },
-    )
-    .parse()
-}
-
-/// Parse a Vue template with options and template syntax compatibility.
-pub fn parse_with_options_and_template_syntax<'a>(
-    allocator: &'a Bump,
-    source: &'a str,
-    options: ParserOptions,
-    template_syntax: TemplateSyntaxMode,
-) -> (RootNode<'a>, Vec<'a, CompilerError>) {
-    Parser::with_options_and_template_syntax(allocator, source, options, template_syntax).parse()
 }

--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -7,6 +7,7 @@ mod classify;
 mod comment;
 mod errors;
 mod formatting;
+mod nesting;
 mod scope;
 mod table;
 mod tags;

--- a/crates/vize_armature/src/parser/element/nesting.rs
+++ b/crates/vize_armature/src/parser/element/nesting.rs
@@ -1,0 +1,72 @@
+//! The element-nesting depth guard and its end-tag recovery.
+//!
+//! Elements nested deeper than [`MAX_ELEMENT_NESTING_DEPTH`] are attached to the
+//! tree as leaves instead of being pushed onto the open-element stack, so the
+//! AST the recursive later passes (transform, codegen, semantic analysis) walk
+//! stays within a predictable amount of stack space regardless of the input.
+//!
+//! That recovery used to leak into the diagnostics. Because the over-limit
+//! elements never reached the stack, their end tags found nothing to close and
+//! `on_close_tag` reported `InvalidEndTag` for each of them — a false positive
+//! pointing at end tags that are correct in the source, growing as
+//! `2 * (depth - MAX_ELEMENT_NESTING_DEPTH)`. The parser therefore keeps the tags
+//! of the flattened elements here so their end tags can be consumed silently,
+//! and reports the limit once per over-limit region instead of once per element.
+
+use vize_relief::{
+    ElementNode,
+    errors::{CompilerError, ErrorCode},
+};
+
+use super::super::Parser;
+
+/// Maximum element nesting depth retained by the parser.
+///
+/// The limit is far beyond any realistic template while still cheap to enforce.
+pub(super) const MAX_ELEMENT_NESTING_DEPTH: usize = 256;
+
+/// Message attached to the recoverable error raised when the nesting limit is hit.
+const NESTING_TOO_DEEP_MESSAGE: &str = "Element nesting is too deep.";
+
+impl<'a> Parser<'a> {
+    /// Record an element the nesting limit refused to descend into.
+    ///
+    /// The diagnostic is raised once per contiguous over-limit region: entering
+    /// the region is the fact worth reporting, and repeating it for every
+    /// element below it only buries the rest of the diagnostics.
+    pub(super) fn record_flattened_element(&mut self, element: &ElementNode<'a>) {
+        if self.flattened_tags.is_empty() {
+            self.errors.push(CompilerError::with_message(
+                ErrorCode::ExtendPoint,
+                NESTING_TOO_DEEP_MESSAGE,
+                Some(element.loc.clone()),
+            ));
+        }
+        self.flattened_tags.push(element.tag.clone());
+    }
+
+    /// Consume the end tag of a flattened element, if this tag closes one.
+    ///
+    /// Flattened elements are always inner to everything on the open-element
+    /// stack, so they are matched first, and an intervening unmatched tag is
+    /// dropped exactly as the real stack would drop it.
+    pub(super) fn close_flattened_element(&mut self, tag: &str) -> bool {
+        let Some(index) = (0..self.flattened_tags.len())
+            .rev()
+            .find(|&i| self.flattened_tags[i].eq_ignore_ascii_case(tag))
+        else {
+            return false;
+        };
+        self.flattened_tags.truncate(index);
+        true
+    }
+
+    /// Forget every flattened element.
+    ///
+    /// Called whenever an entry is closed on the open-element stack: flattened
+    /// elements only exist below a full stack, so closing any stack entry closes
+    /// all of them too.
+    pub(super) fn clear_flattened_elements(&mut self) {
+        self.flattened_tags.clear();
+    }
+}

--- a/crates/vize_armature/src/parser/element/tags.rs
+++ b/crates/vize_armature/src/parser/element/tags.rs
@@ -9,19 +9,7 @@ use vize_relief::{
 
 use super::super::{CurrentElement, Parser, ParserStackEntry, StackInsertion};
 use super::is_html_tree_element;
-
-/// Maximum element nesting depth retained by the parser.
-///
-/// Elements nested deeper than this are flattened with a recoverable error
-/// instead of being pushed onto the open-element stack. This keeps the depth
-/// of the produced AST bounded so the recursive passes that walk it later
-/// (transform, codegen, semantic analysis) stay within a predictable amount of
-/// stack space regardless of the input. The limit is far beyond any realistic
-/// template while still cheap to enforce.
-const MAX_ELEMENT_NESTING_DEPTH: usize = 256;
-
-/// Message attached to the recoverable error raised when the nesting limit is hit.
-const NESTING_TOO_DEEP_MESSAGE: &str = "Element nesting is too deep.";
+use super::nesting::MAX_ELEMENT_NESTING_DEPTH;
 
 impl<'a> Parser<'a> {
     /// Process open tag name
@@ -194,13 +182,10 @@ impl<'a> Parser<'a> {
             } else if self.stack.len() >= MAX_ELEMENT_NESTING_DEPTH {
                 // Nesting limit reached: keep the element but do not descend any
                 // further, so the resulting tree depth stays bounded. The
-                // element is attached at the current level as a leaf and a
-                // recoverable error is recorded.
-                self.errors.push(CompilerError::with_message(
-                    ErrorCode::ExtendPoint,
-                    NESTING_TOO_DEEP_MESSAGE,
-                    Some(element.loc.clone()),
-                ));
+                // element is attached at the current level as a leaf; see
+                // `nesting` for the diagnostic and for how its end tag is
+                // matched even though it never reaches the stack.
+                self.record_flattened_element(&element);
                 let boxed = Box::new_in(element, self.allocator);
                 self.add_child(TemplateChildNode::Element(boxed));
             } else {
@@ -240,6 +225,12 @@ impl<'a> Parser<'a> {
     pub(in crate::parser) fn on_close_tag_impl(&mut self, start: usize, end: usize) {
         let tag = self.get_source(start, end).to_owned();
 
+        // Flattened elements are inner to everything on the stack, so they get
+        // the first chance to claim this end tag.
+        if self.close_flattened_element(tag.as_str()) {
+            return;
+        }
+
         if self.handle_formatting_end_tag(tag.as_str(), start, end) {
             return;
         }
@@ -275,6 +266,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(super) fn close_stack_element_at(&mut self, index: usize, report_unclosed: bool) {
+        self.clear_flattened_elements();
         let mut entries = Vec::new_in(self.allocator);
         while self.stack.len() > index {
             if let Some(entry) = self.pop_stack_entry() {

--- a/crates/vize_armature/src/parser/entry.rs
+++ b/crates/vize_armature/src/parser/entry.rs
@@ -1,0 +1,83 @@
+//! Free-function entry points for the template parser.
+//!
+//! These are thin wrappers over the [`Parser`](super::Parser) constructors. They
+//! live in their own module so `parser.rs` stays within the repository's
+//! per-file source budget.
+
+use vize_carton::{Bump, Vec};
+use vize_relief::{
+    RootNode,
+    errors::CompilerError,
+    options::{ParserOptions, TemplateSyntaxMode},
+};
+
+use super::Parser;
+
+/// Parse a Vue template
+pub fn parse<'a>(allocator: &'a Bump, source: &'a str) -> (RootNode<'a>, Vec<'a, CompilerError>) {
+    Parser::new(allocator, source).parse()
+}
+
+/// Parse a full HTML document (petite-vue / standalone HTML) into the template AST.
+///
+/// Unlike [`parse`], which expects an SFC `<template>` block, this entry point
+/// tolerates a leading `<!DOCTYPE html>` declaration and parses the whole
+/// document (`<html>/<head>/<body>`, `<script>`/`<style>` as raw text) so
+/// downstream lint/scope analysis can run on petite-vue pages whose directives
+/// sit on ordinary DOM elements. Additive: existing template parsing is
+/// unchanged.
+pub fn parse_document<'a>(
+    allocator: &'a Bump,
+    source: &'a str,
+) -> (RootNode<'a>, Vec<'a, CompilerError>) {
+    Parser::new_document(allocator, source).parse()
+}
+
+/// Parse a full HTML document with options. See [`parse_document`].
+pub fn parse_document_with_options<'a>(
+    allocator: &'a Bump,
+    source: &'a str,
+    options: ParserOptions,
+) -> (RootNode<'a>, Vec<'a, CompilerError>) {
+    Parser::document_with_options(allocator, source, options).parse()
+}
+
+/// Parse a Vue template with options
+pub fn parse_with_options<'a>(
+    allocator: &'a Bump,
+    source: &'a str,
+    options: ParserOptions,
+) -> (RootNode<'a>, Vec<'a, CompilerError>) {
+    Parser::with_options(allocator, source, options).parse()
+}
+
+/// Parse a Vue template with options and invalid HTML self-closing compatibility.
+#[deprecated(note = "use parse_with_options_and_template_syntax instead")]
+pub fn parse_with_options_and_invalid_html_self_closing<'a>(
+    allocator: &'a Bump,
+    source: &'a str,
+    options: ParserOptions,
+    allow_invalid_html_self_closing: bool,
+) -> (RootNode<'a>, Vec<'a, CompilerError>) {
+    Parser::with_options_and_template_syntax(
+        allocator,
+        source,
+        options,
+        if allow_invalid_html_self_closing {
+            TemplateSyntaxMode::Quirks
+        } else {
+            TemplateSyntaxMode::Standard
+        },
+    )
+    .parse()
+}
+
+/// Parse a Vue template with options and template syntax compatibility.
+pub fn parse_with_options_and_template_syntax<'a>(
+    allocator: &'a Bump,
+    source: &'a str,
+    options: ParserOptions,
+    template_syntax: TemplateSyntaxMode,
+) -> (RootNode<'a>, Vec<'a, CompilerError>) {
+    Parser::with_options_and_template_syntax(allocator, source, options, template_syntax).parse()
+}

--- a/crates/vize_armature/tests/element_nesting_limit.rs
+++ b/crates/vize_armature/tests/element_nesting_limit.rs
@@ -1,0 +1,140 @@
+//! Behaviour of the element-nesting depth guard.
+//!
+//! The parser stops descending after `MAX_ELEMENT_NESTING_DEPTH` open elements so
+//! the AST it hands to the recursive later passes stays bounded. That guard used
+//! to leak into the diagnostics: over-limit elements were attached as leaves
+//! without being pushed onto the open-element stack, so their perfectly valid end
+//! tags found nothing to close and were reported as `InvalidEndTag`. The error
+//! count then grew as `2 * (depth - limit)`, and every one of those `InvalidEndTag`
+//! diagnostics pointed at correct user code.
+//!
+//! Test-only: `std::string::String` and `format!` build the deeply nested source
+//! strings that the parser is fed here.
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
+use vize_armature::parse;
+use vize_carton::Bump;
+use vize_relief::{
+    TemplateChildNode,
+    errors::{CompilerError, ErrorCode},
+};
+
+/// Mirrors `MAX_ELEMENT_NESTING_DEPTH` in `parser::element::nesting`.
+const NESTING_LIMIT: usize = 256;
+
+const TOO_DEEP: &str = "Element nesting is too deep.";
+
+fn nested_divs(depth: usize) -> String {
+    let mut source = String::with_capacity(depth * 11 + 1);
+    for _ in 0..depth {
+        source.push_str("<div>");
+    }
+    source.push('x');
+    for _ in 0..depth {
+        source.push_str("</div>");
+    }
+    source
+}
+
+fn diagnostics(errors: &[CompilerError]) -> Vec<(ErrorCode, &str)> {
+    errors
+        .iter()
+        .map(|error| (error.code, error.message.as_str()))
+        .collect()
+}
+
+fn element_depth(node: Option<&TemplateChildNode<'_>>) -> usize {
+    let mut node = node;
+    let mut depth = 0;
+    while let Some(TemplateChildNode::Element(element)) = node {
+        depth += 1;
+        node = element.children.first();
+    }
+    depth
+}
+
+#[test]
+fn nesting_at_the_limit_parses_without_diagnostics() {
+    let allocator = Bump::new();
+    let source = nested_divs(NESTING_LIMIT);
+    let (root, errors) = parse(&allocator, &source);
+
+    assert_eq!(diagnostics(&errors), Vec::new());
+    assert_eq!(element_depth(root.children.first()), NESTING_LIMIT);
+}
+
+#[test]
+fn nesting_past_the_limit_reports_the_limit_once_without_inventing_end_tag_errors() {
+    for depth in [NESTING_LIMIT + 1, NESTING_LIMIT + 2, 300, 1000] {
+        let allocator = Bump::new();
+        let source = nested_divs(depth);
+        let (_, errors) = parse(&allocator, &source);
+
+        assert_eq!(
+            diagnostics(&errors),
+            vec![(ErrorCode::ExtendPoint, TOO_DEEP)],
+            "depth {depth}"
+        );
+    }
+}
+
+#[test]
+fn each_over_limit_region_is_reported_at_its_own_location() {
+    // Two independent subtrees that each cross the limit. The recovery is
+    // per-region, so each one is worth a diagnostic; neither should produce an
+    // `InvalidEndTag`.
+    let allocator = Bump::new();
+    let deep = nested_divs(NESTING_LIMIT + 1);
+    let source = format!("<section>{deep}{deep}</section>");
+    let (_, errors) = parse(&allocator, &source);
+
+    assert_eq!(
+        diagnostics(&errors),
+        vec![
+            (ErrorCode::ExtendPoint, TOO_DEEP),
+            (ErrorCode::ExtendPoint, TOO_DEEP),
+        ]
+    );
+}
+
+#[test]
+fn retained_tree_depth_stays_bounded_past_the_limit() {
+    let allocator = Bump::new();
+    let source = nested_divs(5000);
+    let (root, errors) = parse(&allocator, &source);
+
+    assert_eq!(
+        diagnostics(&errors),
+        vec![(ErrorCode::ExtendPoint, TOO_DEEP)]
+    );
+    // The over-limit elements are kept, but flattened onto the deepest retained
+    // parent rather than nested, so the tree the later passes recurse into is
+    // one level deeper than the limit and no more.
+    assert_eq!(element_depth(root.children.first()), NESTING_LIMIT + 1);
+}
+
+#[test]
+fn genuinely_unmatched_end_tags_are_still_reported_past_the_limit() {
+    // The suppression must be limited to end tags that really do close an
+    // over-limit element. A stray `</span>` inside the over-limit region has
+    // nothing to close in the source either, and must keep its diagnostic.
+    let allocator = Bump::new();
+    let mut source = String::new();
+    for _ in 0..NESTING_LIMIT + 1 {
+        source.push_str("<div>");
+    }
+    source.push_str("</span>");
+    for _ in 0..NESTING_LIMIT + 1 {
+        source.push_str("</div>");
+    }
+
+    let (_, errors) = parse(&allocator, &source);
+
+    assert_eq!(
+        diagnostics(&errors),
+        vec![
+            (ErrorCode::ExtendPoint, TOO_DEEP),
+            (ErrorCode::InvalidEndTag, "Invalid end tag."),
+        ]
+    );
+}


### PR DESCRIPTION
## Defect

`MAX_ELEMENT_NESTING_DEPTH = 256` keeps the parsed tree bounded by attaching elements nested deeper
than the limit as leaves instead of pushing them onto the open-element stack. Those elements never
reach the stack, so their end tags find nothing to close and `on_close_tag` reports
`Invalid end tag.` for each one.

At depth 258 a **correct** template produces four diagnostics, and the count grows as
`2 * (depth - 256)`. Half of them point at `</div>` tags that are correct in the source — the
diagnostic is produced by the recovery, not by the input.

## Reproduction

```rust
let depth = 258;
let source = "<div>".repeat(depth) + "x" + &"</div>".repeat(depth);
let (_, errors) = parse(&allocator, &source);
```

Before:

```
[(ExtendPoint, "Element nesting is too deep."),
 (ExtendPoint, "Element nesting is too deep."),
 (InvalidEndTag, "Invalid end tag."),
 (InvalidEndTag, "Invalid end tag.")]
```

After:

```
[(ExtendPoint, "Element nesting is too deep.")]
```

## Fix

The parser records the tags of the elements the limit refused to descend into, and an end tag gets
the chance to close one of those before anything else — they are inner to everything on the stack,
so that is the correct match order. Closing any stack entry drops the whole recorded set, because
flattened elements only exist below a full stack.

The limit is now reported once per contiguous over-limit region instead of once per element, so the
diagnostic count no longer grows with depth. Two independent deep subtrees still get one diagnostic
each, at their own locations.

The suppression is exactly scoped: a stray `</span>` inside an over-limit region has nothing to
close in the source either, and keeps its `InvalidEndTag`.

## Test fails before the fix

`crates/vize_armature/tests/element_nesting_limit.rs`, full-list `assert_eq!` on
`(code, message)` pairs. On the pre-fix parser:

```
$ cargo test -p vize_armature --test element_nesting_limit
test nesting_at_the_limit_parses_without_diagnostics ... ok
test nesting_past_the_limit_reports_the_limit_once_without_inventing_end_tag_errors ... FAILED
test genuinely_unmatched_end_tags_are_still_reported_past_the_limit ... FAILED
test each_over_limit_region_is_reported_at_its_own_location ... FAILED
test retained_tree_depth_stays_bounded_past_the_limit ... FAILED
test result: FAILED. 1 passed; 4 failed

  left: [(ExtendPoint, "Element nesting is too deep."), (InvalidEndTag, "Invalid end tag.")]
 right: [(ExtendPoint, "Element nesting is too deep.")]      # depth 257
```

After: `5 passed; 0 failed`.

## Why the limit itself stays at 256

#3402 also asks for the divergence to go away — upstream `@vue/compiler-sfc` compiles depth 1000
fine. I measured what raising the constant would cost, by lifting it to `1_000_000` and running
`compile_template` end to end on threads with a fixed stack size:

| thread stack | debug build | release build |
| --- | --- | --- |
| 1 MiB | 128 ok, 256 overflows | 1024 ok, 2048 overflows |
| 2 MiB | 256 ok, 512 overflows | 2048 ok |
| 8 MiB | 1024 ok, 2048 overflows | 2048 ok |

Every "overflows" is `fatal runtime error: stack overflow, aborting` — SIGABRT, the whole process,
not a catchable error like upstream's `RangeError`. 256 is precisely what a debug build survives on
Rust's default 2 MiB thread stack. Raising the constant would only move the abort to a different
input; the recursive transform/codegen passes have to become stack-independent first. Filed as
#3480 with this table, and kept out of this PR because it is an architectural change, not a
constant.

## File moves

`parser.rs` was already 399 lines, over the 350-line budget, so it could not take the new field.
Two pure moves make room:

- the free `parse*` entry points -> `parser/entry.rs` (re-exported, so every path stays identical),
  taking `parser.rs` to 339;
- the depth guard and its end-tag recovery -> `parser/element/nesting.rs`, taking `tags.rs` from
  334 to 326.

## Gates

```
$ cargo test -p vize_armature                       # 181 + 5 + 3 passed, 0 failed
$ cargo clippy -p vize_armature -- -D warnings -D clippy::wildcard_imports   # clean
$ rustfmt --edition 2024 --config style_edition=2024 --check <changed files> # clean
```

Run with a private `CARGO_TARGET_DIR`: the shared one produced a phantom failure of all four new
tests while a concurrent release build held the artifact lock, and they pass in isolation.

Closes #3402

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->