### PR TITLE
fix(canon): report the authored specifier in every module diagnostic

### DIFF
--- a/crates/vize/tests/check_plain_script_namespace_cli.rs
+++ b/crates/vize/tests/check_plain_script_namespace_cli.rs
@@ -283,7 +283,7 @@ const label: string = Bare.label;
     assert_eq!(
         diagnostics(&report),
         vec![
-            "error:2:10 [TS2614] Module '\"../components/Local.vue.ts\"' has no exported member 'Bare'. Did you mean to use 'import Bare from \"../components/Local.vue.ts\"' instead?"
+            "error:2:10 [TS2614] Module '\"../components/Local.vue\"' has no exported member 'Bare'. Did you mean to use 'import Bare from \"../components/Local.vue\"' instead?"
                 .to_string()
         ]
     );

--- a/crates/vize_canon/src/batch/executor/diagnostics.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics.rs
@@ -10,6 +10,7 @@ use vize_carton::{FxHashMap, FxHashSet, String};
 mod keyof_indexed_assignment;
 mod line_index;
 mod module_resolution;
+mod module_specifier;
 mod skip_rules;
 
 use line_index::LineIndex;

--- a/crates/vize_canon/src/batch/executor/diagnostics.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics.rs
@@ -478,51 +478,6 @@ mod tests {
     }
 
     #[test]
-    fn maps_missing_vue_ts2307_back_to_source_file() {
-        let temp_dir = TempDir::new().unwrap();
-        let project_root = temp_dir.path().canonicalize().unwrap();
-        let src_dir = project_root.join("src");
-        std::fs::create_dir_all(&src_dir).unwrap();
-        let app_path = src_dir.join("App.vue");
-        std::fs::write(
-            &app_path,
-            r#"<script setup lang="ts">
-import MissingPanel from './MissingPanel.vue'
-</script>
-
-<template>
-  <MissingPanel />
-</template>
-"#,
-        )
-        .unwrap();
-
-        let mut project = VirtualProject::new(&project_root).unwrap();
-        project.register_path(&app_path).unwrap();
-        let virtual_file = project.find_by_original(&app_path).unwrap();
-        let diagnostic = ts2307_diagnostic_at(
-            virtual_file.content.as_str(),
-            "MissingPanel.vue.ts",
-            "Cannot find module './MissingPanel.vue.ts' or its corresponding type declarations.",
-        );
-
-        let diagnostics = map_batch_diagnostics(
-            vec![(file_uri_for(&virtual_file.virtual_path), vec![diagnostic])],
-            &project,
-        );
-
-        assert_eq!(diagnostics.len(), 1);
-        let diagnostic = &diagnostics[0];
-        assert_eq!(diagnostic.file, app_path);
-        assert_eq!(diagnostic.code, Some(2307));
-        assert_eq!(diagnostic.line, 1);
-        assert_eq!(
-            diagnostic.message,
-            "Cannot find module './MissingPanel.vue' or its corresponding type declarations."
-        );
-    }
-
-    #[test]
     fn suppresses_vue_ts2307_when_vue_sibling_exists_on_disk() {
         let temp_dir = TempDir::new().unwrap();
         let project_root = temp_dir.path().canonicalize().unwrap();

--- a/crates/vize_canon/src/batch/executor/diagnostics/module_resolution.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics/module_resolution.rs
@@ -3,13 +3,12 @@
 //! Type-checking a partial file subset can surface a spurious `Cannot find
 //! module` diagnostic for a sibling that exists on disk but was not registered
 //! in the virtual project. These helpers detect that case so the diagnostic can
-//! be suppressed. The same specifier vocabulary is reused to restore the
-//! authored spelling in a genuinely unresolved import's message.
+//! be suppressed. Restoring the authored spelling in the message of a
+//! diagnostic that survives lives in [`super::module_specifier`].
 
 use std::path::Path;
 
-use super::{DiagnosticMapper, OriginalPosition};
-use vize_carton::{String, cstr};
+use vize_carton::cstr;
 
 /// Extract the specifier from the first `Cannot find module "<spec>"` in
 /// `message`, handling straight and smart quotes.
@@ -42,76 +41,6 @@ pub(crate) fn relative_module_resolves_on_disk(message: &str, importer: &Path) -
         return false;
     };
     relative_specifier_resolves(dir, specifier)
-}
-
-/// The authored `.vue` spelling behind a generated mirror-module specifier, or
-/// `None` when `specifier` is not one. `./Panel.vue.ts` is what the import
-/// rewriter writes for an authored `./Panel.vue`; `./Panel.vue.tsx` is the TSX
-/// SFC form. Anything else — including an authored `./util.ts` — is left alone.
-fn mirror_module_specifier_source(specifier: &str) -> Option<&str> {
-    specifier
-        .strip_suffix(".ts")
-        .or_else(|| specifier.strip_suffix(".tsx"))
-        .filter(|source| source.ends_with(".vue"))
-}
-
-impl DiagnosticMapper<'_> {
-    /// Restore the authored specifier in a `Cannot find module` message.
-    ///
-    /// The import rewriter redirects an SFC import onto that file's generated
-    /// mirror module (`./Panel.vue` -> `./Panel.vue.ts`), so a genuinely
-    /// unresolved SFC import reaches the checker under the mirror spelling and
-    /// the message quotes a path the author never wrote — while `vue-tsc`
-    /// quotes `./Panel.vue`. Rewriting is gated on the authored bytes at the
-    /// diagnostic position really being the `.vue` spelling, so a hand-written
-    /// `import x from "./Panel.vue.ts"` keeps reporting exactly what it says.
-    pub(crate) fn devirtualized_module_message(
-        &mut self,
-        original: &OriginalPosition,
-        message: String,
-    ) -> String {
-        let Some(reported) = module_not_found_specifier(&message) else {
-            return message;
-        };
-        let Some(authored) = mirror_module_specifier_source(reported) else {
-            return message;
-        };
-        if !self.source_specifier_matches(original, authored) {
-            return message;
-        }
-        let Some((before, after)) = message.split_once(reported) else {
-            return message;
-        };
-        cstr!("{before}{authored}{after}")
-    }
-
-    /// Whether the authored bytes at `original` are the string literal
-    /// `specifier`. The diagnostic position of an unresolved import points at
-    /// the specifier's opening quote, so this reads the literal that starts
-    /// there and compares it verbatim.
-    fn source_specifier_matches(&mut self, original: &OriginalPosition, specifier: &str) -> bool {
-        let Some(source) = self.original_source(&original.path) else {
-            return false;
-        };
-        let content = &source.content;
-        let index = &source.line_index;
-        let Some(offset) = index.line_col_to_offset(content, original.line, original.column) else {
-            return false;
-        };
-        let Some(rest) = content.get(offset as usize..) else {
-            return false;
-        };
-        let Some(quote) = rest
-            .chars()
-            .next()
-            .filter(|character| matches!(character, '\'' | '"' | '`'))
-        else {
-            return false;
-        };
-        rest[quote.len_utf8()..]
-            .split_once(quote)
-            .is_some_and(|(literal, _)| literal == specifier)
-    }
 }
 
 /// Source extensions a relative specifier may resolve to when appended to the
@@ -180,27 +109,9 @@ fn specifier_has_source_extension(specifier: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{mirror_module_specifier_source, relative_module_resolves_on_disk};
+    use super::relative_module_resolves_on_disk;
 
     use tempfile::TempDir;
-
-    #[test]
-    fn only_generated_mirror_specifiers_map_back_to_an_authored_spelling() {
-        assert_eq!(
-            mirror_module_specifier_source("./Panel.vue.ts"),
-            Some("./Panel.vue")
-        );
-        assert_eq!(
-            mirror_module_specifier_source("../widgets/Panel.vue.tsx"),
-            Some("../widgets/Panel.vue")
-        );
-        // An authored TypeScript specifier is not a mirror module, so its
-        // message must keep the spelling the author wrote.
-        assert_eq!(mirror_module_specifier_source("./util.ts"), None);
-        assert_eq!(mirror_module_specifier_source("./Panel.vue"), None);
-        assert_eq!(mirror_module_specifier_source("./types.d.ts"), None);
-        assert_eq!(mirror_module_specifier_source("vue-router"), None);
-    }
 
     #[test]
     fn ts2307_for_resolvable_relative_siblings_is_suppressed() {

--- a/crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs
@@ -1,0 +1,221 @@
+//! Restoring the authored `.vue` specifier in a diagnostic message.
+//!
+//! The import rewriter redirects an SFC import onto that file's generated
+//! mirror module (`./Panel.vue` -> `./Panel.vue.ts`), so every checker message
+//! that interpolates the module specifier quotes a path the author never wrote
+//! while `vue-tsc` quotes the `.vue` spelling. That covers `TS2307`
+//! (`Cannot find module ...`, #3397) but also `TS2305`/`TS2614`
+//! (`Module '"..."' has no exported member ...`, including its
+//! `Did you mean to use 'import X from "..."' instead?` suggestion, which names
+//! a path the user cannot type), `TS2459`, and anything else that prints a
+//! module symbol (#3438).
+//!
+//! Rewriting is therefore driven by the message text rather than by one
+//! diagnostic code, and is gated on proof that the author did not write the
+//! mirror spelling themselves.
+
+use super::{DiagnosticMapper, OriginalPosition};
+use vize_carton::{String, cstr};
+
+/// The authored `.vue` spelling behind a generated mirror-module specifier, or
+/// `None` when `specifier` is not one. `./Panel.vue.ts` is what the import
+/// rewriter writes for an authored `./Panel.vue`; `./Panel.vue.tsx` is the TSX
+/// SFC form. Anything else — including an authored `./util.ts` — is left alone.
+pub(crate) fn mirror_module_specifier_source(specifier: &str) -> Option<&str> {
+    specifier
+        .strip_suffix(".ts")
+        .or_else(|| specifier.strip_suffix(".tsx"))
+        .filter(|source| source.ends_with(".vue"))
+}
+
+/// Every distinct mirror-module specifier quoted in `message`, in first-seen
+/// order.
+///
+/// A checker message quotes a module specifier either directly
+/// (`Cannot find module './Panel.vue.ts'`) or doubly, as a module symbol name
+/// inside a quoted sentence (`Module '"./Panel.vue.ts"' ...`,
+/// `... 'import Panel from "./Panel.vue.ts"' ...`). Single- and double-quoted
+/// runs are therefore scanned in independent passes so a specifier nested
+/// inside another quoted run is still found. A candidate must look like a
+/// specifier — no whitespace and no quote characters — so an unbalanced pairing
+/// can never yield a run of prose that happens to end in `.vue.ts`.
+fn quoted_mirror_specifiers(message: &str) -> Vec<&str> {
+    let mut found: Vec<&str> = Vec::new();
+    for (open, close) in QUOTE_PAIRS {
+        let mut rest = message;
+        while let Some(start) = rest.find(open) {
+            let after_open = &rest[start + open.len_utf8()..];
+            let Some(end) = after_open.find(close) else {
+                break;
+            };
+            let candidate = &after_open[..end];
+            if is_specifier_shaped(candidate)
+                && mirror_module_specifier_source(candidate).is_some()
+                && !found.contains(&candidate)
+            {
+                found.push(candidate);
+            }
+            rest = &after_open[end + close.len_utf8()..];
+        }
+    }
+    found
+}
+
+fn is_specifier_shaped(candidate: &str) -> bool {
+    !candidate.is_empty()
+        && !candidate
+            .chars()
+            .any(|character| character.is_whitespace() || matches!(character, '\'' | '"' | '`'))
+}
+
+/// The quote pairs a checker message may wrap a specifier in.
+const QUOTE_PAIRS: [(char, char); 3] = [('\'', '\''), ('"', '"'), ('\u{2018}', '\u{2019}')];
+
+impl DiagnosticMapper<'_> {
+    /// Rewrite every generated mirror-module specifier in `message` back to the
+    /// spelling the author wrote.
+    ///
+    /// Replacement is quote-delimited rather than a bare substring swap: a
+    /// specifier can be a suffix of a longer one (`./A.vue.ts` inside
+    /// `../A.vue.ts`), and only the run that was actually quoted may change.
+    pub(crate) fn devirtualized_module_message(
+        &mut self,
+        original: &OriginalPosition,
+        message: String,
+    ) -> String {
+        let rewrites: Vec<(String, String)> = quoted_mirror_specifiers(&message)
+            .into_iter()
+            .filter_map(|reported| {
+                let authored = mirror_module_specifier_source(reported)?;
+                self.author_wrote_the_vue_spelling(original, reported, authored)
+                    .then(|| (String::from(reported), String::from(authored)))
+            })
+            .collect();
+        let mut rewritten = message;
+        for (reported, authored) in rewrites {
+            for (open, close) in QUOTE_PAIRS {
+                let quoted = cstr!("{open}{reported}{close}");
+                if !rewritten.contains(quoted.as_str()) {
+                    continue;
+                }
+                rewritten = rewritten
+                    .replace(quoted.as_str(), cstr!("{open}{authored}{close}").as_str())
+                    .into();
+            }
+        }
+        rewritten
+    }
+
+    /// Whether the mirror spelling `reported` is provably the rewriter's and not
+    /// the author's, so replacing it with `authored` cannot misquote the source.
+    ///
+    /// Two independent proofs, either of which suffices:
+    ///
+    /// 1. The authored bytes at the diagnostic position are the `authored`
+    ///    string literal. An unresolved import anchors its diagnostic at the
+    ///    specifier, so this reads exactly the import being reported (#3397).
+    /// 2. The authored file contains the `reported` text nowhere at all. Most
+    ///    messages that embed a specifier anchor somewhere else entirely — a
+    ///    `TS2614` anchors at the imported member name — so there is no literal
+    ///    to read at the position; a spelling absent from the whole file cannot
+    ///    have come from it.
+    ///
+    /// A hand-written `import x from "./Panel.vue.ts"` fails both and keeps
+    /// reporting exactly what it says.
+    fn author_wrote_the_vue_spelling(
+        &mut self,
+        original: &OriginalPosition,
+        reported: &str,
+        authored: &str,
+    ) -> bool {
+        let Some(source) = self.original_source(&original.path) else {
+            return false;
+        };
+        let content = &source.content;
+        let index = &source.line_index;
+        let literal_at_position = index
+            .line_col_to_offset(content, original.line, original.column)
+            .and_then(|offset| content.get(offset as usize..))
+            .and_then(string_literal_at);
+        literal_at_position == Some(authored) || !content.contains(reported)
+    }
+}
+
+/// The contents of the string literal starting at the beginning of `rest`, or
+/// `None` when `rest` does not start with a quote.
+fn string_literal_at(rest: &str) -> Option<&str> {
+    let quote = rest
+        .chars()
+        .next()
+        .filter(|character| matches!(character, '\'' | '"' | '`'))?;
+    rest[quote.len_utf8()..]
+        .split_once(quote)
+        .map(|(literal, _)| literal)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{mirror_module_specifier_source, quoted_mirror_specifiers, string_literal_at};
+
+    #[test]
+    fn only_generated_mirror_specifiers_map_back_to_an_authored_spelling() {
+        assert_eq!(
+            mirror_module_specifier_source("./Panel.vue.ts"),
+            Some("./Panel.vue")
+        );
+        assert_eq!(
+            mirror_module_specifier_source("../widgets/Panel.vue.tsx"),
+            Some("../widgets/Panel.vue")
+        );
+        // An authored TypeScript specifier is not a mirror module, so its
+        // message must keep the spelling the author wrote.
+        assert_eq!(mirror_module_specifier_source("./util.ts"), None);
+        assert_eq!(mirror_module_specifier_source("./Panel.vue"), None);
+        assert_eq!(mirror_module_specifier_source("./types.d.ts"), None);
+        assert_eq!(mirror_module_specifier_source("vue-router"), None);
+    }
+
+    #[test]
+    fn mirror_specifiers_are_found_however_deeply_the_message_quotes_them() {
+        assert_eq!(
+            quoted_mirror_specifiers(
+                "Cannot find module './Absent.vue.ts' or its corresponding type declarations."
+            ),
+            vec!["./Absent.vue.ts"]
+        );
+        // TS2614 quotes the module symbol inside single quotes and repeats the
+        // specifier inside the suggestion, which is itself single-quoted.
+        assert_eq!(
+            quoted_mirror_specifiers(
+                "Module '\"../components/Local.vue.ts\"' has no exported member 'Bare'. \
+                 Did you mean to use 'import Bare from \"../components/Local.vue.ts\"' instead?"
+            ),
+            vec!["../components/Local.vue.ts"]
+        );
+        // Two different mirror modules in one message stay distinct.
+        assert_eq!(
+            quoted_mirror_specifiers(
+                "Module '\"./A.vue.ts\"' declares 'x' locally, but it is exported from './B.vue.tsx'."
+            ),
+            vec!["./B.vue.tsx", "./A.vue.ts"]
+        );
+        // Nothing to rewrite, including a specifier that is not a mirror module
+        // and prose that merely ends in the mirror suffix.
+        assert_eq!(
+            quoted_mirror_specifiers("Cannot find module './util.ts' or its type declarations."),
+            Vec::<&str>::new()
+        );
+        assert_eq!(
+            quoted_mirror_specifiers("Did you mean 'the file ./A.vue.ts'?"),
+            Vec::<&str>::new()
+        );
+    }
+
+    #[test]
+    fn reads_the_string_literal_at_a_diagnostic_position() {
+        assert_eq!(string_literal_at("\"./Panel.vue\";\n"), Some("./Panel.vue"));
+        assert_eq!(string_literal_at("'./Panel.vue'\n"), Some("./Panel.vue"));
+        assert_eq!(string_literal_at("Panel from './x'"), None);
+        assert_eq!(string_literal_at("\"unterminated"), None);
+    }
+}

--- a/crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs
@@ -155,7 +155,13 @@ fn string_literal_at(rest: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::{LineIndex, map_batch_diagnostics};
     use super::{mirror_module_specifier_source, quoted_mirror_specifiers, string_literal_at};
+    use crate::batch::VirtualProject;
+    use crate::corsa_client::{LspDiagnostic, LspPosition, LspRange};
+    use serde_json::json;
+    use tempfile::TempDir;
+    use vize_carton::cstr;
 
     #[test]
     fn only_generated_mirror_specifiers_map_back_to_an_authored_spelling() {
@@ -217,5 +223,72 @@ mod tests {
         assert_eq!(string_literal_at("'./Panel.vue'\n"), Some("./Panel.vue"));
         assert_eq!(string_literal_at("Panel from './x'"), None);
         assert_eq!(string_literal_at("\"unterminated"), None);
+    }
+
+    /// End to end through the collection point: a `TS2307` for an SFC import
+    /// reaches the user quoting the authored `.vue` specifier, not the mirror
+    /// module the rewriter redirected it onto (#3397).
+    #[test]
+    fn maps_missing_vue_ts2307_back_to_source_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let project_root = temp_dir.path().canonicalize().unwrap();
+        let src_dir = project_root.join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        let app_path = src_dir.join("App.vue");
+        std::fs::write(
+            &app_path,
+            r#"<script setup lang="ts">
+import MissingPanel from './MissingPanel.vue'
+</script>
+
+<template>
+  <MissingPanel />
+</template>
+"#,
+        )
+        .unwrap();
+
+        let mut project = VirtualProject::new(&project_root).unwrap();
+        project.register_path(&app_path).unwrap();
+        let virtual_file = project.find_by_original(&app_path).unwrap();
+        let virtual_source = virtual_file.content.as_str();
+        let offset = virtual_source
+            .find("MissingPanel.vue.ts")
+            .expect("the rewriter should redirect the import onto the mirror module");
+        let (line, character) = LineIndex::new(virtual_source)
+            .offset_to_line_col(virtual_source, offset as u32)
+            .expect("virtual offset should map to LSP position");
+
+        let diagnostics = map_batch_diagnostics(
+            vec![(
+                cstr!("file://{}", virtual_file.virtual_path.display()),
+                vec![LspDiagnostic {
+                    range: LspRange {
+                        start: LspPosition { line, character },
+                        end: LspPosition {
+                            line,
+                            character: character + 1,
+                        },
+                    },
+                    severity: Some(1),
+                    code: Some(json!("TS2307")),
+                    source: Some("ts".into()),
+                    message:
+                        "Cannot find module './MissingPanel.vue.ts' or its corresponding type declarations."
+                            .into(),
+                }],
+            )],
+            &project,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        let diagnostic = &diagnostics[0];
+        assert_eq!(diagnostic.file, app_path);
+        assert_eq!(diagnostic.code, Some(2307));
+        assert_eq!(diagnostic.line, 1);
+        assert_eq!(
+            diagnostic.message,
+            "Cannot find module './MissingPanel.vue' or its corresponding type declarations."
+        );
     }
 }

--- a/crates/vize_canon/src/batch/type_checker/tests/package_exports_types.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/package_exports_types.rs
@@ -63,6 +63,90 @@ import Literal from "./Literal.vue.ts";
     );
 }
 
+/// Every message that embeds a module specifier must quote the authored one.
+///
+/// `TS2614` anchors at the imported member, not at the specifier, so the
+/// positional check that fixed `TS2307` in #3397 cannot see the import at all
+/// and the generated mirror spelling leaked into both the sentence and the
+/// quick-fix suggestion — which named `import Bare from "…/Local.vue.ts"`, a
+/// path the user cannot type (#3438). `vue-tsc` 3.3.4 on the same workspace
+/// reports, at the identical position:
+///
+/// ```text
+/// src/pages/LocalConsumer.vue(2,10): error TS2614: Module '"../components/Local.vue"' has no exported member 'Bare'. Did you mean to use 'import Bare from "../components/Local.vue"' instead?
+/// ```
+///
+/// The second consumer pins the other direction: it hand-writes the `.vue.ts`
+/// specifier, so that spelling really is the author's and must survive
+/// verbatim. (vize resolves that import where `vue-tsc` reports `TS2307` for
+/// it; that resolution difference is not what this test covers.)
+#[test]
+fn module_member_diagnostics_report_the_authored_specifier() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "module-member-authored-specifier",
+        &[
+            (
+                "src/components/Local.vue",
+                r#"<script lang="ts">
+namespace Bare {
+  export const label = "bare";
+}
+
+export default { name: "Local", data: () => ({ label: Bare.label }) };
+</script>
+"#,
+            ),
+            (
+                "src/pages/LocalConsumer.vue",
+                r#"<script setup lang="ts">
+import { Bare } from "../components/Local.vue";
+
+const label: string = Bare.label;
+</script>
+"#,
+            ),
+            (
+                "src/pages/LiteralConsumer.vue",
+                r#"<script setup lang="ts">
+import { Bare } from "../components/Local.vue.ts";
+
+const label: string = Bare.label;
+</script>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else {
+        return;
+    };
+
+    assert_eq!(
+        snapshot,
+        vec![
+            (
+                String::from("src/pages/LiteralConsumer.vue"),
+                Some(2614),
+                String::from(
+                    "2:10:error Module '\"../components/Local.vue.ts\"' has no exported member 'Bare'. Did you mean to use 'import Bare from \"../components/Local.vue.ts\"' instead?"
+                ),
+            ),
+            (
+                String::from("src/pages/LocalConsumer.vue"),
+                Some(2614),
+                String::from(
+                    "2:10:error Module '\"../components/Local.vue\"' has no exported member 'Bare'. Did you mean to use 'import Bare from \"../components/Local.vue\"' instead?"
+                ),
+            ),
+        ]
+    );
+}
+
 #[test]
 fn node_module_resolution_uses_package_types_hidden_by_exports() {
     if resolve_test_tsgo_binary().is_none() {


### PR DESCRIPTION
## Defect

The import rewriter redirects an SFC import onto that file's generated mirror
module (`./Panel.vue` -> `./Panel.vue.ts`), so every checker message that
interpolates the module specifier quotes a path the author never wrote. #3397
fixed `TS2307` by reading the string literal at the diagnostic position — which
works only because an unresolved import anchors *at* the specifier. `TS2614`
anchors at the imported member, so nothing at the position is a specifier and
the mirror spelling leaked into both the sentence and the quick-fix suggestion.

Reproduction (`src/components/Local.vue` exports a `namespace Bare` plus a
default; `src/pages/LocalConsumer.vue` does `import { Bare } from "../components/Local.vue"`).

`vue-tsc` 3.3.4:

```
src/pages/LocalConsumer.vue(2,10): error TS2614: Module '"../components/Local.vue"' has no exported member 'Bare'. Did you mean to use 'import Bare from "../components/Local.vue"' instead?
```

`vize check` before this PR:

```
src/pages/LocalConsumer.vue(2,10): error TS2614: Module '"../components/Local.vue.ts"' has no exported member 'Bare'. Did you mean to use 'import Bare from "../components/Local.vue.ts"' instead?
```

Same file, line, column and code — invisible to the divergence ledger until the
message bucket landed in #3470 — and the suggested fix names
`import Bare from "../components/Local.vue.ts"`, a path the user cannot write.

## Change

Drive the rewrite from the message text instead of from one diagnostic code.
`crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs` finds
every mirror-module specifier quoted anywhere in a message and replaces it with
the authored `.vue` spelling, which covers `TS2305`/`TS2614`/`TS2459` and the
`Did you mean to use ...` suggestion in one pass.

Two details that make it safe:

- **The gate.** A specifier is only rewritten with proof that the author did not
  write the mirror spelling: either the authored bytes at the diagnostic position
  are the `.vue` literal (#3397's check, kept verbatim for the codes that anchor
  there), or the authored file contains the mirror spelling nowhere at all. A
  hand-written `import x from "./Panel.vue.ts"` fails both and keeps reporting
  exactly what it says.
- **Quote-delimited replacement**, not a bare substring swap: `./A.vue.ts` is a
  substring of `../A.vue.ts`, so only the run that was actually quoted may change.

A checker message quotes a specifier either directly
(`Cannot find module './Panel.vue.ts'`) or nested inside another quoted run
(`Module '"./Panel.vue.ts"' ...`), so single- and double-quoted runs are scanned
in independent passes, and a candidate must be specifier-shaped (no whitespace,
no quote characters) so an unbalanced pairing can never yield prose.

The `.vue.ts` -> `.vue` vocabulary and `devirtualized_module_message` move out of
`module_resolution.rs` (which is about suppressing `TS2307` false positives) into
the new module; both files stay well inside the 350-line budget.

## Verification

New test `module_member_diagnostics_report_the_authored_specifier` in
`crates/vize_canon/src/batch/type_checker/tests/package_exports_types.rs` asserts
the **complete** diagnostic strings for two consumers of the same SFC: one that
writes `../components/Local.vue` (must match vue-tsc byte for byte) and one that
hand-writes `../components/Local.vue.ts` (must keep its own spelling).

On the pre-fix code (`git checkout HEAD~1 -- <the two changed source files>` and
removing the new module):

```
---- module_member_diagnostics_report_the_authored_specifier stdout ----
assertion `left == right` failed
  left:  [(... "LiteralConsumer.vue" ... "../components/Local.vue.ts" ...),
          ("src/pages/LocalConsumer.vue", Some(2614), "2:10:error Module '\"../components/Local.vue.ts\"' ...")]
  right: [(... "LiteralConsumer.vue" ... "../components/Local.vue.ts" ...),
          ("src/pages/LocalConsumer.vue", Some(2614), "2:10:error Module '\"../components/Local.vue\"' ...")]
```

Only the authored-specifier consumer differs, so the hand-written direction is
pinned by the same assertion.

Gates run locally (macOS, `nix develop -c`):

- `cargo test -p vize_canon --lib` — 655 passed, 0 failed (the #3397 test
  `unresolved_sfc_import_reports_the_authored_specifier` still passes on the new gate)
- `cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports` — clean
- `rustfmt --edition 2024 --config style_edition=2024 --check` on all changed files — clean

End-to-end against the reproduction workspace with a release build of this branch:

```
src/pages/LiteralConsumer.vue: error:2:10 [TS2614] Module '"../components/Local.vue.ts"' has no exported member 'Bare'. Did you mean to use 'import Bare from "../components/Local.vue.ts"' instead?
src/pages/LocalConsumer.vue:  error:2:10 [TS2614] Module '"../components/Local.vue"' has no exported member 'Bare'. Did you mean to use 'import Bare from "../components/Local.vue"' instead?
```

## Found but not fixed

A hand-written `import … from "./X.vue.ts"` *resolves* in vize (the mirror module
is a real file in the virtual project) where `vue-tsc` reports `TS2307` for it.
That resolution difference is orthogonal to the message spelling this PR fixes;
filed separately as #3482.

Closes #3438

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->