### PR TITLE
feat(patina): report a root v-bind="$attrs" with the default inheritAttrs

### DIFF
--- a/crates/vize_patina/src/linter/script_rules.rs
+++ b/crates/vize_patina/src/linter/script_rules.rs
@@ -157,6 +157,12 @@ pub(crate) fn append_builtin_script_diagnostics<'a>(
             .map(|block| block.content.as_ref()),
         template_root: template_ast.as_ref().map(|ast| &ast.root),
         template_offset: template_ast.as_ref().map(|ast| ast.offset),
+        // Both blocks are linted separately below, so a whole-file conclusion
+        // is only available to a rule when there is a single block to draw it
+        // from. Computed from the descriptor rather than from the filtered
+        // `script` / `script_setup` bindings: a block skipped by the prefilter
+        // still contributes declarations a rule would need to see.
+        sole_script_block: descriptor.script.is_some() != descriptor.script_setup.is_some(),
     };
 
     for entry in active_builtin_script_rule_entries(linter) {

--- a/crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance.rs
+++ b/crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance.rs
@@ -1,43 +1,55 @@
 //! script/no-duplicate-attr-inheritance
 //!
-//! Flag an explicit `inheritAttrs: true` component option as redundant.
+//! Flag a component that applies its fallthrough attributes twice.
 //!
-//! Ports the redundant-by-default core of
-//! [`vue/no-duplicate-attr-inheritance`](https://eslint.vuejs.org/rules/no-duplicate-attr-inheritance.html),
+//! Ports [`vue/no-duplicate-attr-inheritance`](https://eslint.vuejs.org/rules/no-duplicate-attr-inheritance.html),
 //! which warns about *double attribute application*: a component that keeps the
 //! default attribute inheritance (`inheritAttrs: true`) **and** also forwards
-//! `$attrs` manually (typically `v-bind="$attrs"` in the template) ends up
-//! applying the fallthrough attributes twice.
+//! `$attrs` manually with `v-bind="$attrs"` on its root element ends up applying
+//! the fallthrough attributes twice.
 //!
-//! ## Scope (conservative subset)
+//! Two spellings of the same defect are reported:
 //!
-//! eslint's rule pairs a template signal (`v-bind="$attrs"`) with a script
-//! signal (the effective `inheritAttrs` value). In the patina architecture
-//! markup-rules and script-rules are separate passes: a script rule cannot
-//! observe the `v-bind="$attrs"` in the `<template>`. Rather than approximate
-//! that cross-block relationship unsoundly (and risk false positives on the many
-//! components that *don't* forward `$attrs`), this rule implements the sound,
-//! template-independent subset: an **explicit** `inheritAttrs: true` is always
-//! redundant, because `true` is the framework default, so removing it changes
-//! nothing. That is exactly the location eslint also reports when both signals
-//! are present, and because `true` is unconditionally the default the rule fires
-//! with **zero false positives**. Components that opt out with
-//! `inheritAttrs: false`, or that omit the option, are never touched; the
-//! template-side check (`v-bind="$attrs"` with an *implicit* default) is out of
-//! scope.
+//! * **An explicit `inheritAttrs: true`.** `true` is the framework default, so
+//!   stating it changes nothing; it is the location upstream also reports when
+//!   both signals are present, and because `true` is unconditionally the default
+//!   this half fires with zero false positives even without the template.
+//! * **A root `v-bind="$attrs"` with the default left implicit.** This is the
+//!   template half, and it is the one upstream leads with. It needs the
+//!   `<template>` AST — see [`template`] for the over-match analysis.
 //!
-//! The option is resolved like `script/component-options-name-casing`: the
-//! `<script setup>` `defineOptions({ inheritAttrs: true })` macro, plus the
-//! Options API object reached through `export default {...}`,
-//! `defineComponent({...})`, or an identifier bound to one (unwrapping TS
-//! `as`/`satisfies`/non-null/parenthesized wrappers).
+//! When both are present only the first fires: the explicit `true` is the
+//! smaller, more actionable edit, and two diagnostics for one defect is noise.
+//!
+//! ## What stays silent
+//!
+//! * `inheritAttrs: false` — the intended opt-out, in either spelling.
+//! * An `inheritAttrs` whose value is not a boolean literal: the effective value
+//!   is unknown, so neither direction may be assumed.
+//! * `v-bind="$attrs"` on a **nested** element. That is the documented way to
+//!   forward attributes to an inner node, is idiomatic, and is normally paired
+//!   with `inheritAttrs: false` — reporting it would be a false positive.
+//! * A multi-root (fragment) template: there is no single element for the
+//!   fallthrough attributes to land on.
+//! * An SFC with **both** `<script>` and `<script setup>`. The rule is invoked
+//!   once per block and each sees only half the script surface, so an
+//!   `inheritAttrs: false` in the sibling block would be invisible. See
+//!   [`SfcScriptContext::sole_script_block`].
 //!
 //! ## Examples
 //!
-//! ### Invalid (redundant — `true` is the default)
+//! ### Invalid
 //! ```ts
 //! defineOptions({ inheritAttrs: true })
 //! export default { inheritAttrs: true }
+//! ```
+//!
+//! ```vue
+//! <script setup lang="ts"></script>
+//!
+//! <template>
+//!   <div v-bind="$attrs"></div>
+//! </template>
 //! ```
 //!
 //! ### Valid
@@ -46,17 +58,21 @@
 //! export default {}                      // default inheritance, unstated
 //! ```
 
-use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
+mod options;
+mod template;
+#[cfg(test)]
+mod tests;
+
+use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta, SfcScriptContext};
 use crate::diagnostic::{LintDiagnostic, Severity};
-use oxc_ast::ast::{
-    Argument, BindingPattern, BooleanLiteral, CallExpression, ExportDefaultDeclarationKind,
-    Expression, ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
-};
-use vize_carton::FxHashMap;
+use oxc_ast::ast::{BooleanLiteral, Program};
+
+use self::options::{InheritAttrs, declared_inherit_attrs};
+use self::template::{AttrsSpread, root_attrs_spread};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-duplicate-attr-inheritance",
-    description: "Flag an explicit `inheritAttrs: true` option as redundant (true is the default)",
+    description: "Flag a component that applies its fallthrough attributes twice",
     default_severity: Severity::Warning,
 };
 
@@ -66,7 +82,14 @@ const HELP: &str = "Remove `inheritAttrs: true`: attribute inheritance is alread
      Keep this option only to opt out with `inheritAttrs: false` (for example when forwarding \
      `$attrs` manually with `v-bind=\"$attrs\"`).";
 
-/// Flag an explicit `inheritAttrs: true` component option as redundant.
+const SPREAD_MESSAGE: &str = "`v-bind=\"$attrs\"` on the root element applies the fallthrough \
+     attributes twice, because `inheritAttrs` defaults to true.";
+const SPREAD_LABEL: &str = "attributes applied twice";
+const SPREAD_HELP: &str = "Opt out of the automatic inheritance so only this `v-bind` applies \
+     them, e.g. `defineOptions({ inheritAttrs: false })` or `inheritAttrs: false` in the \
+     component options.";
+
+/// Flag a component that applies its fallthrough attributes twice.
 pub struct NoDuplicateAttrInheritance;
 
 impl ScriptRule for NoDuplicateAttrInheritance {
@@ -80,30 +103,65 @@ impl ScriptRule for NoDuplicateAttrInheritance {
     }
 
     #[inline]
+    fn uses_template_ast(&self) -> bool {
+        true
+    }
+
     fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        // Keep the parse-owning `check` path functional: without SFC context
+        // only the explicit-`true` half is observable.
+        self.check_program_with_sfc(program, source, offset, SfcScriptContext::default(), result);
+    }
+
+    fn check_program_with_sfc<'a>(
         &self,
         program: &'a Program<'a>,
         _source: &str,
         offset: usize,
+        sfc: SfcScriptContext<'_>,
         result: &mut ScriptLintResult,
     ) {
-        // Options API: `export default {...}` / `defineComponent({...})` / an
-        // identifier bound to an options object.
-        if let Some(options) = find_component_options(program)
-            && let Some(literal) = inherit_attrs_true_literal(options)
-        {
-            report(literal, offset, result);
+        let mut stated = false;
+        for declared in declared_inherit_attrs(program) {
+            stated = true;
+            if let InheritAttrs::Literal(literal) = declared
+                && literal.value
+            {
+                report_redundant_true(literal, offset, result);
+            }
         }
+        // The template half only speaks about the *implicit* default. An
+        // explicit `true` was just reported at the more actionable location, an
+        // explicit `false` is the intended opt-out, and an opaque value is
+        // unknowable — all three are done here.
+        if stated {
+            return;
+        }
+        check_template(sfc, result);
+    }
+}
 
-        // `<script setup>`: `defineOptions({ inheritAttrs: true })`.
-        if let Some(literal) = define_options_inherit_attrs_true(program) {
-            report(literal, offset, result);
-        }
+/// The template half: a root `v-bind="$attrs"` with `inheritAttrs` left default.
+fn check_template(sfc: SfcScriptContext<'_>, result: &mut ScriptLintResult) {
+    if !sfc.sole_script_block {
+        return;
+    }
+    let Some((root, template_offset)) = sfc.template_ast() else {
+        return;
+    };
+    if let Some(spread) = root_attrs_spread(root) {
+        report_attrs_spread(&spread, template_offset, result);
     }
 }
 
 /// Report the redundant `inheritAttrs: true` boolean literal.
-fn report(literal: &BooleanLiteral, offset: usize, result: &mut ScriptLintResult) {
+fn report_redundant_true(literal: &BooleanLiteral, offset: usize, result: &mut ScriptLintResult) {
     let start = offset as u32 + literal.span.start;
     let end = offset as u32 + literal.span.end;
     result.add_diagnostic(
@@ -113,168 +171,13 @@ fn report(literal: &BooleanLiteral, offset: usize, result: &mut ScriptLintResult
     );
 }
 
-/// The `true` boolean literal of an `inheritAttrs: true` property, if present.
-///
-/// Only a literal `true` is flagged; `inheritAttrs: false`, a computed key, a
-/// shorthand, or any non-boolean-literal value (an identifier, a call, ...) is
-/// left alone so the rule never guesses at a value it cannot see.
-fn inherit_attrs_true_literal<'a>(options: &'a ObjectExpression<'a>) -> Option<&'a BooleanLiteral> {
-    for property in &options.properties {
-        let ObjectPropertyKind::ObjectProperty(property) = property else {
-            continue;
-        };
-        if property.computed {
-            continue;
-        }
-        if !matches!(property_key_name(&property.key), Some("inheritAttrs")) {
-            continue;
-        }
-        if let Expression::BooleanLiteral(literal) = &property.value
-            && literal.value
-        {
-            return Some(literal);
-        }
-    }
-    None
+/// Report the root `v-bind="$attrs"`, at its location in the template.
+fn report_attrs_spread(spread: &AttrsSpread, template_offset: u32, result: &mut ScriptLintResult) {
+    let start = template_offset + spread.start;
+    let end = template_offset + spread.end;
+    result.add_diagnostic(
+        LintDiagnostic::warn(META.name, SPREAD_MESSAGE, start, end)
+            .with_label(SPREAD_LABEL, start, end)
+            .with_help(SPREAD_HELP),
+    );
 }
-
-/// The `inheritAttrs: true` literal from a top-level
-/// `defineOptions({ inheritAttrs: true })` call, when one is cleanly reachable.
-fn define_options_inherit_attrs_true<'a>(program: &'a Program<'a>) -> Option<&'a BooleanLiteral> {
-    for statement in program.body.iter() {
-        let Statement::ExpressionStatement(expression) = statement else {
-            continue;
-        };
-        let Expression::CallExpression(call) = &expression.expression else {
-            continue;
-        };
-        let Expression::Identifier(callee) = &call.callee else {
-            continue;
-        };
-        if !matches!(callee.name.as_str(), "defineOptions") {
-            continue;
-        }
-        if let Some(Argument::ObjectExpression(object)) = call.arguments.first() {
-            return inherit_attrs_true_literal(object);
-        }
-    }
-    None
-}
-
-fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
-    match key {
-        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
-        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
-        _ => None,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Component options resolution (export default / defineComponent).
-//
-// Mirrors the resolution in `component_options_name_casing` / `no_dupe_keys`: a
-// plain object, an identifier bound to one, or a `defineComponent(...)` wrapper,
-// optionally through TS expression wrappers.
-// ---------------------------------------------------------------------------
-
-fn find_component_options<'a>(program: &'a Program<'a>) -> Option<&'a ObjectExpression<'a>> {
-    let mut bindings: FxHashMap<&'a str, &'a ObjectExpression<'a>> = FxHashMap::default();
-
-    for statement in program.body.iter() {
-        let Statement::VariableDeclaration(declaration) = statement else {
-            continue;
-        };
-        for declarator in &declaration.declarations {
-            let Some(init) = declarator.init.as_ref() else {
-                continue;
-            };
-            if let BindingPattern::BindingIdentifier(id) = &declarator.id
-                && let Some(object) = options_from_expression(init, &bindings)
-            {
-                bindings.insert(id.name.as_str(), object);
-            }
-        }
-    }
-
-    for statement in program.body.iter() {
-        let Statement::ExportDefaultDeclaration(export) = statement else {
-            continue;
-        };
-        if let Some(object) = options_from_export(&export.declaration, &bindings) {
-            return Some(object);
-        }
-    }
-
-    None
-}
-
-fn options_from_export<'a>(
-    declaration: &'a ExportDefaultDeclarationKind<'a>,
-    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
-) -> Option<&'a ObjectExpression<'a>> {
-    match declaration {
-        ExportDefaultDeclarationKind::ObjectExpression(object) => Some(object),
-        ExportDefaultDeclarationKind::CallExpression(call) => options_from_call(call, bindings),
-        ExportDefaultDeclarationKind::Identifier(identifier) => {
-            bindings.get(identifier.name.as_str()).copied()
-        }
-        ExportDefaultDeclarationKind::ParenthesizedExpression(paren) => {
-            options_from_expression(&paren.expression, bindings)
-        }
-        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
-            options_from_expression(&ts_as.expression, bindings)
-        }
-        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
-            options_from_expression(&ts_satisfies.expression, bindings)
-        }
-        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
-            options_from_expression(&ts_non_null.expression, bindings)
-        }
-        _ => None,
-    }
-}
-
-fn options_from_expression<'a>(
-    expression: &'a Expression<'a>,
-    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
-) -> Option<&'a ObjectExpression<'a>> {
-    match expression {
-        Expression::ObjectExpression(object) => Some(object),
-        Expression::CallExpression(call) => options_from_call(call, bindings),
-        Expression::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
-        Expression::ParenthesizedExpression(paren) => {
-            options_from_expression(&paren.expression, bindings)
-        }
-        Expression::TSAsExpression(ts_as) => options_from_expression(&ts_as.expression, bindings),
-        Expression::TSSatisfiesExpression(ts_satisfies) => {
-            options_from_expression(&ts_satisfies.expression, bindings)
-        }
-        Expression::TSNonNullExpression(ts_non_null) => {
-            options_from_expression(&ts_non_null.expression, bindings)
-        }
-        _ => None,
-    }
-}
-
-fn options_from_call<'a>(
-    call: &'a CallExpression<'a>,
-    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
-) -> Option<&'a ObjectExpression<'a>> {
-    let Expression::Identifier(callee) = &call.callee else {
-        return None;
-    };
-    if !matches!(callee.name.as_str(), "defineComponent" | "_defineComponent") {
-        return None;
-    }
-    match call.arguments.first()? {
-        Argument::ObjectExpression(object) => Some(object),
-        Argument::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
-        argument => argument
-            .as_expression()
-            .and_then(|expression| options_from_expression(expression, bindings)),
-    }
-}
-
-#[cfg(test)]
-#[path = "no_duplicate_attr_inheritance_tests.rs"]
-mod tests;

--- a/crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/options.rs
+++ b/crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/options.rs
@@ -1,0 +1,181 @@
+//! `inheritAttrs` as the script declares it.
+//!
+//! The option is resolved like `script/component-options-name-casing`: the
+//! `<script setup>` `defineOptions({ ... })` macro, plus the Options API object
+//! reached through `export default {...}`, `defineComponent({...})`, or an
+//! identifier bound to one (unwrapping TS `as`/`satisfies`/non-null and
+//! parenthesized wrappers).
+
+use oxc_ast::ast::{
+    Argument, BindingPattern, BooleanLiteral, CallExpression, ExportDefaultDeclarationKind,
+    Expression, ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
+};
+use vize_carton::FxHashMap;
+
+/// An `inheritAttrs` property the script states.
+pub(super) enum InheritAttrs<'a> {
+    /// `inheritAttrs: true` / `inheritAttrs: false`.
+    Literal(&'a BooleanLiteral),
+    /// Present, but not as a boolean literal — an identifier, a call, a
+    /// computed key. The effective value is not knowable from the syntax, so
+    /// the rule must not guess at it in either direction.
+    Opaque,
+}
+
+/// Every `inheritAttrs` the block states, from the Options API object and from
+/// `defineOptions({ ... })`.
+pub(super) fn declared_inherit_attrs<'a>(program: &'a Program<'a>) -> Vec<InheritAttrs<'a>> {
+    let mut declared = Vec::new();
+    if let Some(options) = find_component_options(program) {
+        declared.extend(inherit_attrs_property(options));
+    }
+    if let Some(options) = define_options_object(program) {
+        declared.extend(inherit_attrs_property(options));
+    }
+    declared
+}
+
+/// The `inheritAttrs` property of an options object, if it has one.
+fn inherit_attrs_property<'a>(options: &'a ObjectExpression<'a>) -> Option<InheritAttrs<'a>> {
+    for property in &options.properties {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            continue;
+        };
+        if property.computed || !matches!(property_key_name(&property.key), Some("inheritAttrs")) {
+            continue;
+        }
+        return Some(match &property.value {
+            Expression::BooleanLiteral(literal) => InheritAttrs::Literal(literal),
+            _ => InheritAttrs::Opaque,
+        });
+    }
+    None
+}
+
+/// The object argument of a top-level `defineOptions({ ... })` call.
+fn define_options_object<'a>(program: &'a Program<'a>) -> Option<&'a ObjectExpression<'a>> {
+    for statement in program.body.iter() {
+        let Statement::ExpressionStatement(expression) = statement else {
+            continue;
+        };
+        let Expression::CallExpression(call) = &expression.expression else {
+            continue;
+        };
+        let Expression::Identifier(callee) = &call.callee else {
+            continue;
+        };
+        if callee.name.as_str() != "defineOptions" {
+            continue;
+        }
+        if let Some(Argument::ObjectExpression(object)) = call.arguments.first() {
+            return Some(object);
+        }
+    }
+    None
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
+    }
+}
+
+fn find_component_options<'a>(program: &'a Program<'a>) -> Option<&'a ObjectExpression<'a>> {
+    let mut bindings: FxHashMap<&'a str, &'a ObjectExpression<'a>> = FxHashMap::default();
+
+    for statement in program.body.iter() {
+        let Statement::VariableDeclaration(declaration) = statement else {
+            continue;
+        };
+        for declarator in &declaration.declarations {
+            let Some(init) = declarator.init.as_ref() else {
+                continue;
+            };
+            if let BindingPattern::BindingIdentifier(id) = &declarator.id
+                && let Some(object) = options_from_expression(init, &bindings)
+            {
+                bindings.insert(id.name.as_str(), object);
+            }
+        }
+    }
+
+    for statement in program.body.iter() {
+        let Statement::ExportDefaultDeclaration(export) = statement else {
+            continue;
+        };
+        if let Some(object) = options_from_export(&export.declaration, &bindings) {
+            return Some(object);
+        }
+    }
+
+    None
+}
+
+fn options_from_export<'a>(
+    declaration: &'a ExportDefaultDeclarationKind<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match declaration {
+        ExportDefaultDeclarationKind::ObjectExpression(object) => Some(object),
+        ExportDefaultDeclarationKind::CallExpression(call) => options_from_call(call, bindings),
+        ExportDefaultDeclarationKind::Identifier(identifier) => {
+            bindings.get(identifier.name.as_str()).copied()
+        }
+        ExportDefaultDeclarationKind::ParenthesizedExpression(paren) => {
+            options_from_expression(&paren.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
+            options_from_expression(&ts_as.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
+            options_from_expression(&ts_satisfies.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
+            options_from_expression(&ts_non_null.expression, bindings)
+        }
+        _ => None,
+    }
+}
+
+fn options_from_expression<'a>(
+    expression: &'a Expression<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object),
+        Expression::CallExpression(call) => options_from_call(call, bindings),
+        Expression::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
+        Expression::ParenthesizedExpression(paren) => {
+            options_from_expression(&paren.expression, bindings)
+        }
+        Expression::TSAsExpression(ts_as) => options_from_expression(&ts_as.expression, bindings),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            options_from_expression(&ts_satisfies.expression, bindings)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            options_from_expression(&ts_non_null.expression, bindings)
+        }
+        _ => None,
+    }
+}
+
+fn options_from_call<'a>(
+    call: &'a CallExpression<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    let Expression::Identifier(callee) = &call.callee else {
+        return None;
+    };
+    if !matches!(callee.name.as_str(), "defineComponent" | "_defineComponent") {
+        return None;
+    }
+    match call.arguments.first()? {
+        Argument::ObjectExpression(object) => Some(object),
+        Argument::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
+        argument => argument
+            .as_expression()
+            .and_then(|expression| options_from_expression(expression, bindings)),
+    }
+}

--- a/crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/snapshots/vize_patina__rules__script__no_duplicate_attr_inheritance__tests__invalid_define_options_inherit_attrs_true.snap
+++ b/crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/snapshots/vize_patina__rules__script__no_duplicate_attr_inheritance__tests__invalid_define_options_inherit_attrs_true.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance.rs
+source: crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/tests.rs
 expression: result.diagnostics
 ---
 [

--- a/crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/template.rs
+++ b/crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/template.rs
@@ -1,0 +1,107 @@
+//! The template signal: `v-bind="$attrs"` on the component's root element.
+//!
+//! # Why the AST, and why the *root* element specifically
+//!
+//! A recovered `v-bind="$attrs"` *creates* a finding, so an over-match is a
+//! false positive. Taking the evidence from the template AST excludes the cases
+//! a raw scan over the template text cannot:
+//!
+//! * `<!-- v-bind="$attrs" -->` is a comment node;
+//! * `<p>v-bind="$attrs"</p>` is a text node;
+//! * `@click="log('$attrs')"` is a `v-on` expression, not a `v-bind`, and the
+//!   occurrence is inside a string literal;
+//! * inside a `v-pre` region the parser rewrites every directive to a plain
+//!   attribute, so nothing there is a `DirectiveNode` at all.
+//!
+//! The trap is **which element**. Upstream reports the duplication on the
+//! *root* element's `v-bind="$attrs"`, because that is where the fallthrough
+//! attributes are applied a second time. `v-bind="$attrs"` on a nested element
+//! is the documented way to forward attributes to an inner node, is idiomatic,
+//! and is normally paired with `inheritAttrs: false`; reporting it would be a
+//! false positive on correct code. So only the single root element counts, and
+//! a multi-root (fragment) template — which has no single fallthrough target —
+//! records nothing.
+//!
+//! # Direction of error
+//!
+//! * **Over-match** would be a false positive, so the directive must be a
+//!   `bind` with **no argument** whose expression is exactly `$attrs`. `:x="$attrs"`
+//!   carries an argument and binds one prop; `v-bind="$attrsExtra"` is a
+//!   different identifier.
+//! * **Under-match** loses a report: an expression that only *contains* `$attrs`
+//!   (`v-bind="{ ...$attrs }"`) is not matched, and neither is a root
+//!   `<template v-if>` wrapper, whose real root is decided at runtime.
+
+use vize_relief::{DirectiveNode, ElementNode, ExpressionNode, PropNode, RootNode};
+
+/// The location of a root `v-bind="$attrs"`, relative to the template block.
+pub(super) struct AttrsSpread {
+    pub(super) start: u32,
+    pub(super) end: u32,
+}
+
+/// Find `v-bind="$attrs"` on the template's single root element.
+///
+/// Returns `None` when the template has no single root element, when that root
+/// is a `<template>` wrapper (its rendered root is not statically known), or
+/// when the root does not spread `$attrs`.
+pub(super) fn root_attrs_spread(root: &RootNode<'_>) -> Option<AttrsSpread> {
+    let element = single_root_element(root)?;
+    // A root `<template v-if>` / `<template v-for>` renders its children, so
+    // the element that receives the fallthrough attributes is not this node.
+    if element.tag.as_str() == "template" {
+        return None;
+    }
+    element.props.iter().find_map(|prop| match prop {
+        PropNode::Directive(directive) if is_attrs_spread(directive) => Some(AttrsSpread {
+            start: directive.loc.start.offset,
+            end: directive.loc.end.offset,
+        }),
+        _ => None,
+    })
+}
+
+/// The template's single root element, if it has exactly one.
+///
+/// Whitespace-only text and comments are not rendered content, so they do not
+/// make a template multi-root. Anything else that renders — a second element,
+/// an interpolation, real text — does, and a fragment has no single element to
+/// receive the fallthrough attributes.
+fn single_root_element<'a, 'ast>(root: &'a RootNode<'ast>) -> Option<&'a ElementNode<'ast>> {
+    let mut found = None;
+    for child in root.children.iter() {
+        match child {
+            vize_relief::TemplateChildNode::Comment(_) => {}
+            vize_relief::TemplateChildNode::Text(text) if text.content.trim().is_empty() => {}
+            vize_relief::TemplateChildNode::Element(element) if found.is_none() => {
+                found = Some(&**element);
+            }
+            _ => return None,
+        }
+    }
+    found
+}
+
+/// Whether the directive is exactly `v-bind="$attrs"`.
+///
+/// An argument (`:id="$attrs"`) binds a single prop rather than spreading the
+/// fallthrough attributes, so it does not count. The expression is compared as
+/// a whole — trimmed — rather than searched: the construct *is* the entire
+/// expression, so equality is exact, and anything richer
+/// (`v-bind="{ ...$attrs }"`) is deliberately not matched.
+fn is_attrs_spread(directive: &DirectiveNode<'_>) -> bool {
+    if directive.name.as_str() != "bind" || directive.arg.is_some() {
+        return false;
+    }
+    directive
+        .exp
+        .as_ref()
+        .is_some_and(|exp| expression_source(exp).trim() == "$attrs")
+}
+
+fn expression_source<'a>(exp: &'a ExpressionNode<'a>) -> &'a str {
+    match exp {
+        ExpressionNode::Simple(simple) => simple.content.as_str(),
+        ExpressionNode::Compound(compound) => compound.loc.source.as_str(),
+    }
+}

--- a/crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/tests.rs
+++ b/crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/tests.rs
@@ -1,10 +1,44 @@
 use super::NoDuplicateAttrInheritance;
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
 use crate::rules::script::ScriptLinter;
+
+// Template-half tests (#3414 C) live in the `template` submodule.
+mod template;
 
 fn create_linter() -> ScriptLinter {
     let mut linter = ScriptLinter::new();
     linter.add_rule(Box::new(NoDuplicateAttrInheritance));
     linter
+}
+
+/// Lint a full SFC end-to-end with only this rule enabled, exercising the
+/// engine path that supplies the parsed `<template>` AST to the rule.
+fn lint_sfc(sfc: &str) -> LintResult {
+    Linter::new()
+        .with_enabled_rules(Some(vec!["script/no-duplicate-attr-inheritance".into()]))
+        .lint_sfc(sfc, "Probe.vue")
+}
+
+/// The full identity of every finding: rule, severity, byte range, message.
+fn findings(result: &LintResult) -> Vec<(&'static str, Severity, u32, u32, &str)> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            (
+                diagnostic.rule_name,
+                diagnostic.severity,
+                diagnostic.start,
+                diagnostic.end,
+                diagnostic.message.as_str(),
+            )
+        })
+        .collect()
+}
+
+fn none() -> Vec<(&'static str, Severity, u32, u32, &'static str)> {
+    Vec::new()
 }
 
 #[test]

--- a/crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/tests/template.rs
+++ b/crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/tests/template.rs
@@ -1,0 +1,307 @@
+//! Template half (#3414 C): a root `v-bind="$attrs"` with the default implicit.
+//!
+//! Because this half *creates* findings from template evidence, the over-match
+//! probes are as load-bearing as the positive cases: each asserts the full
+//! finding set, and the negative ones assert it is exactly empty.
+
+use super::{findings, lint_sfc, none};
+use crate::diagnostic::Severity;
+
+const SPREAD_MESSAGE: &str = "`v-bind=\"$attrs\"` on the root element applies the fallthrough \
+     attributes twice, because `inheritAttrs` defaults to true.";
+
+/// The finding the `v-bind="$attrs"` written as `directive` produces.
+fn duplicated(sfc: &str, directive: &str) -> (&'static str, Severity, u32, u32, &'static str) {
+    let start = sfc.find(directive).expect("bind directive");
+    (
+        "script/no-duplicate-attr-inheritance",
+        Severity::Warning,
+        start as u32,
+        (start + directive.len()) as u32,
+        SPREAD_MESSAGE,
+    )
+}
+
+// --- The recovered case: a root spread with the default left implicit ------
+
+#[test]
+fn reports_a_root_attrs_spread_issue_3414() {
+    // Exact reproduction from #3414 C.
+    let sfc = r#"<script setup lang="ts">
+</script>
+
+<template>
+  <div v-bind="$attrs"></div>
+</template>
+"#;
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![duplicated(sfc, r#"v-bind="$attrs""#)]
+    );
+}
+
+#[test]
+fn reports_a_root_attrs_spread_with_an_options_api_block() {
+    let sfc = r#"<script>
+export default { name: 'Probe' };
+</script>
+
+<template>
+  <div v-bind="$attrs"></div>
+</template>
+"#;
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![duplicated(sfc, r#"v-bind="$attrs""#)]
+    );
+}
+
+#[test]
+fn reports_a_root_attrs_spread_alongside_other_root_bindings() {
+    let sfc = r#"<script setup lang="ts">
+const id = 'x';
+</script>
+
+<template>
+  <div :id="id" v-bind="$attrs" class="card"></div>
+</template>
+"#;
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![duplicated(sfc, r#"v-bind="$attrs""#)]
+    );
+}
+
+// --- The documented opt-outs must stay silent ------------------------------
+
+#[test]
+fn ignores_a_root_attrs_spread_with_define_options_opt_out() {
+    let sfc = r#"<script setup lang="ts">
+defineOptions({ inheritAttrs: false });
+</script>
+
+<template>
+  <div v-bind="$attrs"></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_root_attrs_spread_with_an_options_api_opt_out() {
+    let sfc = r#"<script>
+export default { inheritAttrs: false };
+</script>
+
+<template>
+  <div v-bind="$attrs"></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn reports_only_the_redundant_true_when_both_signals_are_present() {
+    // The explicit `true` is the smaller edit and is reported there; the
+    // template must not add a second diagnostic for the same defect.
+    let sfc = r#"<script setup lang="ts">
+defineOptions({ inheritAttrs: true });
+</script>
+
+<template>
+  <div v-bind="$attrs"></div>
+</template>
+"#;
+    let literal = sfc.find("true").expect("boolean literal");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![(
+            "script/no-duplicate-attr-inheritance",
+            Severity::Warning,
+            literal as u32,
+            (literal + "true".len()) as u32,
+            "`inheritAttrs: true` is redundant because it is the default.",
+        )]
+    );
+}
+
+#[test]
+fn ignores_a_root_attrs_spread_when_inherit_attrs_is_not_a_literal() {
+    let sfc = r#"<script>
+const inherit = false;
+export default { inheritAttrs: inherit };
+</script>
+
+<template>
+  <div v-bind="$attrs"></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_root_attrs_spread_when_a_sibling_script_block_exists() {
+    // Each block is linted separately, so the `inheritAttrs: false` in the
+    // plain `<script>` is invisible to the `<script setup>` pass. Reporting
+    // from either would be a false positive, and reporting from both would
+    // double the diagnostic.
+    let sfc = r#"<script>
+export default { inheritAttrs: false };
+</script>
+
+<script setup lang="ts">
+const id = 'x';
+</script>
+
+<template>
+  <div :id="id" v-bind="$attrs"></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+// --- Over-match probes: none of these may manufacture a finding ------------
+
+#[test]
+fn ignores_an_attrs_spread_on_a_nested_element() {
+    // Forwarding `$attrs` to an inner node is the idiomatic pattern; only the
+    // root element duplicates the fallthrough attributes.
+    let sfc = r#"<script setup lang="ts">
+</script>
+
+<template>
+  <div><span v-bind="$attrs"></span></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_an_attrs_spread_in_a_multi_root_template() {
+    // A fragment has no single element for the fallthrough attributes.
+    let sfc = r#"<script setup lang="ts">
+</script>
+
+<template>
+  <div v-bind="$attrs"></div>
+  <p>second root</p>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_an_attrs_spread_inside_an_html_comment() {
+    let sfc = r#"<script setup lang="ts">
+</script>
+
+<template>
+  <!-- <div v-bind="$attrs"></div> -->
+  <div></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_an_attrs_spread_in_a_text_node_or_plain_attribute() {
+    let sfc = r#"<script setup lang="ts">
+</script>
+
+<template>
+  <div title="v-bind=&quot;$attrs&quot;">v-bind="$attrs"</div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_an_attrs_mention_inside_a_string_literal() {
+    let sfc = r#"<script setup lang="ts">
+</script>
+
+<template>
+  <div @click="console.log('v-bind=$attrs')"></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_an_attrs_spread_inside_a_v_pre_region() {
+    let sfc = r#"<script setup lang="ts">
+</script>
+
+<template>
+  <pre v-pre><div v-bind="$attrs"></div></pre>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_an_identifier_that_merely_starts_with_attrs() {
+    let sfc = r#"<script setup lang="ts">
+const $attrsExtra = { id: 'x' };
+</script>
+
+<template>
+  <div v-bind="$attrsExtra"></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_an_argument_bind_of_attrs() {
+    // `:id="$attrs"` binds one prop rather than spreading the fallthrough set.
+    let sfc = r#"<script setup lang="ts">
+</script>
+
+<template>
+  <div :id="$attrs"></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_spread_of_an_object_containing_attrs() {
+    // `v-bind="{ ...$attrs }"` is not matched: the construct must be the whole
+    // expression. A missed report is the tolerable direction.
+    let sfc = r#"<script setup lang="ts">
+</script>
+
+<template>
+  <div v-bind="{ ...$attrs }"></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_root_template_wrapper() {
+    // A root `<template v-if>` renders its children, so the element that
+    // receives the fallthrough attributes is not statically known.
+    let sfc = r#"<script setup lang="ts">
+const ok = true;
+</script>
+
+<template>
+  <template v-if="ok"><div v-bind="$attrs"></div></template>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_template_with_no_attrs_spread_at_all() {
+    let sfc = r#"<script setup lang="ts">
+</script>
+
+<template>
+  <div class="card"></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}

--- a/crates/vize_patina/src/rules/script/sfc_context.rs
+++ b/crates/vize_patina/src/rules/script/sfc_context.rs
@@ -54,6 +54,20 @@ pub struct SfcScriptContext<'a> {
     /// Byte offset of the `<template>` content inside the SFC source, for
     /// reporting at a template location.
     pub template_offset: Option<u32>,
+    /// Whether the block being linted is the SFC's **only** script block.
+    ///
+    /// A rule whose conclusion is a property of the whole file rather than of
+    /// one block has to be careful with an SFC carrying both `<script>` and
+    /// `<script setup>`: it is invoked once per block, each invocation sees
+    /// only half the script surface, so a conclusion drawn there would be both
+    /// wrong (an option declared in the sibling block is invisible — a
+    /// `<script> export default { inheritAttrs: false }` next to a
+    /// `<script setup>`) and doubled (both invocations would report it). Such
+    /// a rule reports only when this is `true`.
+    ///
+    /// `false` in the `Default` value: a standalone script has no template to
+    /// correlate with, so no whole-file conclusion is available there either.
+    pub sole_script_block: bool,
 }
 
 impl<'a> SfcScriptContext<'a> {


### PR DESCRIPTION
## Defect (#3414 C)

`script/no-duplicate-attr-inheritance` implemented only the sound,
template-independent core: *an explicit `inheritAttrs: true` is always
redundant*. The case upstream leads with — `v-bind="$attrs"` on the root element
while `inheritAttrs` keeps its **implicit** default `true`, so the fallthrough
attributes are applied twice — was out of scope because a `script/*` rule could
not observe the `<template>`.

## Minimal reproduction

```vue
<script setup lang="ts">
</script>

<template>
  <div v-bind="$attrs"></div>
</template>
```

`Linter::new().with_enabled_rules(Some(vec!["script/no-duplicate-attr-inheritance"])).lint_sfc(sfc, "Probe.vue")`

- Actual: 0 findings.
- Expected: 1 — `inheritAttrs` is not `false`, so `v-bind="$attrs"` applies the
  fallthrough attributes twice.

## Over-match / under-match analysis

This is the direction #3223 calls dangerous: template evidence that **creates** a
finding. The existing raw scan in `props_emits/template_emits.rs` is explicitly
one-directional — over-matching there only suppresses an "unused" report — so it
could not be reused. A raw scan for `v-bind="$attrs"` over the template text
would fire on all of these:

| case | why it must not report |
| --- | --- |
| `<!-- <div v-bind="$attrs"></div> -->` | HTML comment |
| `<div title="v-bind=&quot;$attrs&quot;">v-bind="$attrs"</div>` | plain attribute and text node |
| `@click="console.log('v-bind=$attrs')"` | inside a string literal, and a `v-on`, not a `v-bind` |
| `<pre v-pre><div v-bind="$attrs"></div></pre>` | `v-pre` rewrites every directive to a plain attribute |
| `v-bind="$attrsExtra"` | a longer identifier that merely starts with `$attrs` |
| `:id="$attrs"` | an argument binds one prop, it does not spread the set |
| `<div><span v-bind="$attrs"></span></div>` | **nested** — the idiomatic forwarding pattern |
| `<div v-bind="$attrs"></div><p>…</p>` | multi-root: no single fallthrough target |

So the evidence is taken from the **template AST**: a `DirectiveNode` named
`bind`, with **no argument**, whose expression is exactly `$attrs`, on the
template's single root element. Comments and text can never be a directive, a
plain attribute is not one either, and a `v-pre` region has none left.

No oxc parse is needed here and none would be stricter: the construct *is* the
whole expression, so trimmed string equality against `$attrs` is exact — unlike
#3451, where the construct was one node inside a larger handler body.

**The root-scoping is the load-bearing part.** `v-bind="$attrs"` on a nested
element is the documented way to forward attributes to an inner node, is
idiomatic, and is normally paired with an `inheritAttrs: false` elsewhere.
Reporting it would be a false positive on correct code. Whitespace-only text and
comments do not make a template multi-root; anything else that renders does.

Every row above has a test asserting **exactly zero** findings.

**Under-matching loses a report**, the tolerable direction:

- `v-bind="{ ...$attrs }"` resolves to `$attrs` only at runtime and is not
  matched.
- A root `<template v-if>` wrapper renders its children, so the element that
  receives the fallthrough attributes is not statically known — nothing is
  reported.
- An SFC with **both** `<script>` and `<script setup>` reports nothing (below).
- An SFC with no script block at all never reaches a script rule.

All of this is written into the module docs of
`crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/template.rs`.

## The opt-outs stay silent, and there is no double report

`inheritAttrs: false` in either spelling (`defineOptions({...})` or the Options
API object) reports nothing, as before. An `inheritAttrs` whose value is not a
boolean literal is `Opaque` — the effective value is unknowable, so neither
direction is assumed.

When **both** signals are present (`inheritAttrs: true` *and* a root
`v-bind="$attrs"`) only the explicit `true` is reported: it is the smaller, more
actionable edit, and two diagnostics for one defect is noise. Upstream reports
the template location instead; that is a location divergence for the parity
ledger, not a coverage one.

## `sole_script_block`

This conclusion is a property of the **whole file**, not of one block. An SFC
with both `<script>` and `<script setup>` invokes the rule once per block, and
each invocation sees only half the script surface — so a
`<script>export default { inheritAttrs: false }</script>` next to a
`<script setup>` would be invisible to the setup pass (a false positive) and the
two passes would report twice. `SfcScriptContext` therefore gains
`sole_script_block`, and the template half runs only when it is `true`. There is
a test for exactly that shape.

## Location

Reported at the `v-bind="$attrs"` directive, mapped into whole-SFC coordinates
through `template_offset`. The explicit-`true` half keeps reporting at the
boolean literal, unchanged.

## How the new tests fail before the fix

With the `check_template` call short-circuited (the pre-fix behaviour),
`cargo test -p vize_patina --lib no_duplicate_attr_inheritance::tests::template`
fails exactly the three positive-direction tests and passes all sixteen others,
including every over-match probe, both opt-out tests, the two-script-block test
and the both-signals test:

```
reports_a_root_attrs_spread_issue_3414 ... FAILED
reports_a_root_attrs_spread_with_an_options_api_block ... FAILED
reports_a_root_attrs_spread_alongside_other_root_bindings ... FAILED
test result: FAILED. 16 passed; 3 failed
```

With the fix: `33 passed; 0 failed` for the whole rule (19 template + 14
pre-existing script-only tests, all unchanged).

## File split

`no_duplicate_attr_inheritance.rs` was 280 lines. It becomes 183, plus
`options.rs` (181, the component-options resolution moved verbatim),
`template.rs` (107), `tests.rs` (147, moved from the sibling
`no_duplicate_attr_inheritance_tests.rs`) and `tests/template.rs` (307).
`linter/script_rules.rs` grows 324 → 330.

## Gates run

- `nix develop -c vp run fmt:check` — pass
- `nix develop -c vp run lint:rust` (clippy `-D warnings`) — pass
- `nix develop -c vp run check:rust` — pass
- `nix develop -c cargo test -p vize_patina` — 2272 passed, 0 failed (rebased on
  `f35a3d974`)

Refs #3414
Refs #3223

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->