### PR TITLE
fix(typecheck): make the weekly divergence budget breach fail the job

### DIFF
--- a/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
@@ -1,0 +1,160 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Scaffolding shared by every `tools/fixtures/typecheck-divergence-report.mjs`
+ * test. It lives here rather than in one test file so a second suite can drive
+ * the same report without duplicating the matrix artifacts it validates.
+ */
+export const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+export const script = path.join(root, "tools", "fixtures", "typecheck-divergence-report.mjs");
+export const commitSha = "a".repeat(40);
+
+/** The one diagnostic both sides report, so the default fixture diverges nowhere. */
+export const sharedVizeDiagnostic = "error:1:1 [TS2322] shared";
+export const sharedBaselineOutput = "src/App.vue(1,1): error TS2322: shared\n";
+
+export type FixtureOptions = {
+  /** Diagnostics the fake `vize check` artifact reports for `src/App.vue`. */
+  vizeDiagnostics?: string[];
+  /** Raw stdout the fake `vue-tsc` writes before exiting with status 2. */
+  baselineOutput?: string;
+};
+
+export function setup(options: FixtureOptions = {}) {
+  const vizeDiagnostics = options.vizeDiagnostics ?? [sharedVizeDiagnostic];
+  const baselineOutput = options.baselineOutput ?? sharedBaselineOutput;
+  const fixtureRoot = fs.mkdtempSync(path.join(root, "tests", "_fixtures", "typecheck-divergence-"));
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-divergence-report-"));
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-divergence-vue-tsc-"));
+  const fixturePath = path.relative(root, fixtureRoot);
+  const project = {
+    id: "fixture",
+    fixturePath,
+    revision: "b".repeat(40),
+    vueGlobs: ["src/**/*.vue"],
+    tsconfig: "tsconfig.json",
+    typecheckPerformance: {
+      enabled: true,
+      compareTo: "vue-tsc",
+      packageManager: "pnpm",
+      packageManagerVersion: "10.0.0",
+      lockfile: "pnpm-lock.yaml",
+      hangTimeoutMs: 5_000,
+      maxFalsePositiveRatio: 0.05,
+      maxFalseNegativeRatio: 0.05,
+    },
+  };
+  fs.mkdirSync(path.join(fixtureRoot, "src"));
+  fs.writeFileSync(path.join(fixtureRoot, "tsconfig.json"), "{}\n");
+  fs.writeFileSync(path.join(fixtureRoot, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+  fs.writeFileSync(path.join(fixtureRoot, "src", "App.vue"), "<template />\n");
+  const registryPath = path.join(fixtureRoot, "registry.json");
+  writeJson(registryPath, { projects: [project] });
+  const outputPath = path.join(reportDir, "fixture-typechecker.json");
+  const parsed = {
+    errorCount: vizeDiagnostics.length,
+    warningCount: 0,
+    fileCount: 1,
+    files: [{ file: "src/App.vue", diagnostics: vizeDiagnostics }],
+  };
+  writeJson(outputPath, {
+    schema: "vize.fixtureToolRun",
+    version: 1,
+    project: "fixture",
+    tool: "typechecker",
+    exitCode: 1,
+    stdout: JSON.stringify(parsed),
+    stderr: "",
+    parsed,
+  });
+  writeJson(path.join(reportDir, "summary.json"), {
+    schema: "vize.fixtureToolMatrixReport",
+    version: 2,
+    evidence: {
+      commitSha,
+      runtime: { name: "node", version: process.versions.node },
+      machine: {
+        platform: process.platform,
+        arch: process.arch,
+        cpuModel: "synthetic",
+        logicalCpuCount: 1,
+        totalMemoryBytes: 1,
+      },
+    },
+    projects: [
+      {
+        id: "fixture",
+        revision: project.revision,
+        runs: [
+          {
+            tool: "typechecker",
+            status: "findings",
+            exitCode: 1,
+            fileCount: 1,
+            outputPath: path.relative(root, outputPath),
+          },
+        ],
+      },
+    ],
+  });
+  const vueTsc = path.join(fakeDir, "vue-tsc.mjs");
+  const invocationPath = path.join(fakeDir, "invocation.json");
+  writeVueTsc(
+    vueTsc,
+    `process.stdout.write(${JSON.stringify(baselineOutput)}); process.exit(2);`,
+    invocationPath,
+  );
+  return { fixtureRoot, reportDir, fakeDir, registryPath, outputPath, vueTsc, invocationPath };
+}
+
+export function writeVueTsc(pathname: string, runBody: string, invocationPath?: string) {
+  const recordInvocation =
+    invocationPath == null
+      ? ""
+      : `fs.writeFileSync(${JSON.stringify(invocationPath)}, JSON.stringify({ cwd: process.cwd(), args: process.argv.slice(2) }));`;
+  fs.writeFileSync(
+    pathname,
+    `#!/usr/bin/env node\nimport fs from "node:fs";\nif (process.argv.includes("--version")) { console.log("3.3.4"); process.exit(0); }\n${recordInvocation}\n${runBody}\n`,
+  );
+  fs.chmodSync(pathname, 0o755);
+}
+
+export function run(fixture: ReturnType<typeof setup>, env: NodeJS.ProcessEnv = {}) {
+  return spawnSync(
+    process.execPath,
+    [
+      script,
+      "--registry",
+      fixture.registryPath,
+      "--report-dir",
+      fixture.reportDir,
+      "--vue-tsc-bin",
+      fixture.vueTsc,
+    ],
+    { cwd: root, encoding: "utf8", env: { ...process.env, GITHUB_SHA: commitSha, ...env } },
+  );
+}
+
+export function cleanup(fixture: ReturnType<typeof setup>) {
+  fs.rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+  fs.rmSync(fixture.reportDir, { recursive: true, force: true });
+  fs.rmSync(fixture.fakeDir, { recursive: true, force: true });
+}
+
+export function readJson(pathname: string) {
+  return JSON.parse(fs.readFileSync(pathname, "utf8"));
+}
+
+export function writeJson(pathname: string, value: unknown) {
+  fs.writeFileSync(pathname, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export function updateJson(pathname: string, update: (value: any) => void) {
+  const value = readJson(pathname);
+  update(value);
+  writeJson(pathname, value);
+}

--- a/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
@@ -27,7 +27,9 @@ export type FixtureOptions = {
 export function setup(options: FixtureOptions = {}) {
   const vizeDiagnostics = options.vizeDiagnostics ?? [sharedVizeDiagnostic];
   const baselineOutput = options.baselineOutput ?? sharedBaselineOutput;
-  const fixtureRoot = fs.mkdtempSync(path.join(root, "tests", "_fixtures", "typecheck-divergence-"));
+  const fixtureRoot = fs.mkdtempSync(
+    path.join(root, "tests", "_fixtures", "typecheck-divergence-"),
+  );
   const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-divergence-report-"));
   const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-divergence-vue-tsc-"));
   const fixturePath = path.relative(root, fixtureRoot);

--- a/tests/tooling/typecheck-divergence-budget.test.ts
+++ b/tests/tooling/typecheck-divergence-budget.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  cleanup,
+  commitSha,
+  readJson,
+  run,
+  setup,
+  sharedBaselineOutput,
+  sharedVizeDiagnostic,
+} from "./_helpers/typecheck-divergence-report-fixture.ts";
+
+/**
+ * #3460: `budget.passed` was computed, embedded in the artifact, and printed in
+ * the step summary while nothing read it, so a matrix-wide false-positive or
+ * false-negative breach printed `Budget passed: false` and the weekly Real
+ * Project Matrix job still went green. These tests execute the failure path the
+ * gate had never taken.
+ */
+
+const vizeOnly = "error:2:1 [TS2345] vize only";
+const baselineOnly = "src/App.vue(3,1): error TS2345: baseline only\n";
+
+function artifactPath(fixture: ReturnType<typeof setup>, extension: string) {
+  return path.join(fixture.reportDir, `fixture-typecheck-divergence.${extension}`);
+}
+
+test("a false-positive budget breach fails the divergence report", () => {
+  const fixture = setup({ vizeDiagnostics: [sharedVizeDiagnostic, vizeOnly] });
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.equal(
+      result.stderr,
+      "Typecheck divergence budget breached for fixture: 1 false positives (ratio 0.5) exceed maxFalsePositiveRatio 0.05\n",
+    );
+    const artifact = readJson(artifactPath(fixture, "json"));
+    assert.deepEqual(artifact.budget, {
+      maxFalsePositiveRatio: 0.05,
+      maxFalseNegativeRatio: 0.05,
+      falsePositivePassed: false,
+      falseNegativePassed: true,
+      passed: false,
+    });
+    // The breach is uploaded, not swallowed: both artifacts land before the throw.
+    assert.equal(
+      fs.readFileSync(artifactPath(fixture, "md"), "utf8"),
+      [
+        "## fixture typecheck divergence",
+        "",
+        `Commit: ${commitSha}`,
+        "Vize diagnostics: 2",
+        "vue-tsc diagnostics: 1",
+        "Shared: 1",
+        "Message mismatches: 0",
+        "Documented differences: 0",
+        "False positives: 1 (0.5)",
+        "False negatives: 0 (0)",
+        "Vize excluded non-Vue: 0",
+        "vue-tsc excluded non-Vue: 0",
+        "vue-tsc excluded project-level: 0",
+        "vue-tsc excluded external: 0",
+        "Budget passed: false",
+        `Digest: ${artifact.divergence.sha256}`,
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("a false-negative budget breach fails the divergence report", () => {
+  const fixture = setup({ baselineOutput: `${sharedBaselineOutput}${baselineOnly}` });
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.equal(
+      result.stderr,
+      "Typecheck divergence budget breached for fixture: 1 false negatives (ratio 0.5) exceed maxFalseNegativeRatio 0.05\n",
+    );
+    assert.deepEqual(readJson(artifactPath(fixture, "json")).budget, {
+      maxFalsePositiveRatio: 0.05,
+      maxFalseNegativeRatio: 0.05,
+      falsePositivePassed: true,
+      falseNegativePassed: false,
+      passed: false,
+    });
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("a breach of both budgets reports both sides", () => {
+  const fixture = setup({
+    vizeDiagnostics: [sharedVizeDiagnostic, vizeOnly],
+    baselineOutput: `${sharedBaselineOutput}${baselineOnly}`,
+  });
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.equal(
+      result.stderr,
+      "Typecheck divergence budget breached for fixture: " +
+        "1 false positives (ratio 0.5) exceed maxFalsePositiveRatio 0.05; " +
+        "1 false negatives (ratio 0.5) exceed maxFalseNegativeRatio 0.05\n",
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("a ratio exactly at the budget still passes", () => {
+  // 1 false positive in 20 vize diagnostics is exactly maxFalsePositiveRatio,
+  // so this pins the comparison as `<=` and proves the gate is not always-fail.
+  const shared = Array.from(
+    { length: 19 },
+    (_unused, index) => `error:${index + 1}:1 [TS2322] shared`,
+  );
+  const fixture = setup({
+    vizeDiagnostics: [...shared, "error:20:1 [TS2345] vize only"],
+    baselineOutput: shared
+      .map((_unused, index) => `src/App.vue(${index + 1},1): error TS2322: shared\n`)
+      .join(""),
+  });
+  try {
+    const result = run(fixture);
+    assert.equal(result.stderr, "");
+    assert.equal(result.status, 0);
+    const artifact = readJson(artifactPath(fixture, "json"));
+    assert.deepEqual(artifact.budget, {
+      maxFalsePositiveRatio: 0.05,
+      maxFalseNegativeRatio: 0.05,
+      falsePositivePassed: true,
+      falseNegativePassed: true,
+      passed: true,
+    });
+    assert.equal(artifact.divergence.summary.falsePositiveRatio, 0.05);
+  } finally {
+    cleanup(fixture);
+  }
+});

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -1,150 +1,20 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
-import { fileURLToPath } from "node:url";
 
-const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-const script = path.join(root, "tools", "fixtures", "typecheck-divergence-report.mjs");
-const commitSha = "a".repeat(40);
-
-function setup() {
-  const fixtureRoot = fs.mkdtempSync(
-    path.join(root, "tests", "_fixtures", "typecheck-divergence-"),
-  );
-  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-divergence-report-"));
-  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-divergence-vue-tsc-"));
-  const fixturePath = path.relative(root, fixtureRoot);
-  const project = {
-    id: "fixture",
-    fixturePath,
-    revision: "b".repeat(40),
-    vueGlobs: ["src/**/*.vue"],
-    tsconfig: "tsconfig.json",
-    typecheckPerformance: {
-      enabled: true,
-      compareTo: "vue-tsc",
-      packageManager: "pnpm",
-      packageManagerVersion: "10.0.0",
-      lockfile: "pnpm-lock.yaml",
-      hangTimeoutMs: 5_000,
-      maxFalsePositiveRatio: 0.05,
-      maxFalseNegativeRatio: 0.05,
-    },
-  };
-  fs.mkdirSync(path.join(fixtureRoot, "src"));
-  fs.writeFileSync(path.join(fixtureRoot, "tsconfig.json"), "{}\n");
-  fs.writeFileSync(path.join(fixtureRoot, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
-  fs.writeFileSync(path.join(fixtureRoot, "src", "App.vue"), "<template />\n");
-  const registryPath = path.join(fixtureRoot, "registry.json");
-  writeJson(registryPath, { projects: [project] });
-  const outputPath = path.join(reportDir, "fixture-typechecker.json");
-  const parsed = {
-    errorCount: 1,
-    warningCount: 0,
-    fileCount: 1,
-    files: [{ file: "src/App.vue", diagnostics: ["error:1:1 [TS2322] shared"] }],
-  };
-  writeJson(outputPath, {
-    schema: "vize.fixtureToolRun",
-    version: 1,
-    project: "fixture",
-    tool: "typechecker",
-    exitCode: 1,
-    stdout: JSON.stringify(parsed),
-    stderr: "",
-    parsed,
-  });
-  writeJson(path.join(reportDir, "summary.json"), {
-    schema: "vize.fixtureToolMatrixReport",
-    version: 2,
-    evidence: {
-      commitSha,
-      runtime: { name: "node", version: process.versions.node },
-      machine: {
-        platform: process.platform,
-        arch: process.arch,
-        cpuModel: "synthetic",
-        logicalCpuCount: 1,
-        totalMemoryBytes: 1,
-      },
-    },
-    projects: [
-      {
-        id: "fixture",
-        revision: project.revision,
-        runs: [
-          {
-            tool: "typechecker",
-            status: "findings",
-            exitCode: 1,
-            fileCount: 1,
-            outputPath: path.relative(root, outputPath),
-          },
-        ],
-      },
-    ],
-  });
-  const vueTsc = path.join(fakeDir, "vue-tsc.mjs");
-  const invocationPath = path.join(fakeDir, "invocation.json");
-  writeVueTsc(
-    vueTsc,
-    'process.stdout.write("src/App.vue(1,1): error TS2322: shared\\n"); process.exit(2);',
-    invocationPath,
-  );
-  return { fixtureRoot, reportDir, fakeDir, registryPath, outputPath, vueTsc, invocationPath };
-}
-
-function writeVueTsc(pathname: string, runBody: string, invocationPath?: string) {
-  const recordInvocation =
-    invocationPath == null
-      ? ""
-      : `fs.writeFileSync(${JSON.stringify(invocationPath)}, JSON.stringify({ cwd: process.cwd(), args: process.argv.slice(2) }));`;
-  fs.writeFileSync(
-    pathname,
-    `#!/usr/bin/env node\nimport fs from "node:fs";\nif (process.argv.includes("--version")) { console.log("3.3.4"); process.exit(0); }\n${recordInvocation}\n${runBody}\n`,
-  );
-  fs.chmodSync(pathname, 0o755);
-}
-
-function run(fixture: ReturnType<typeof setup>, env: NodeJS.ProcessEnv = {}) {
-  return spawnSync(
-    process.execPath,
-    [
-      script,
-      "--registry",
-      fixture.registryPath,
-      "--report-dir",
-      fixture.reportDir,
-      "--vue-tsc-bin",
-      fixture.vueTsc,
-    ],
-    { cwd: root, encoding: "utf8", env: { ...process.env, GITHUB_SHA: commitSha, ...env } },
-  );
-}
-
-function cleanup(fixture: ReturnType<typeof setup>) {
-  fs.rmSync(fixture.fixtureRoot, { recursive: true, force: true });
-  fs.rmSync(fixture.reportDir, { recursive: true, force: true });
-  fs.rmSync(fixture.fakeDir, { recursive: true, force: true });
-}
-
-function readJson(pathname: string) {
-  return JSON.parse(fs.readFileSync(pathname, "utf8"));
-}
-
-function writeJson(pathname: string, value: unknown) {
-  fs.writeFileSync(pathname, `${JSON.stringify(value, null, 2)}\n`);
-}
-
-function updateJson(pathname: string, update: (value: any) => void) {
-  const value = readJson(pathname);
-  update(value);
-  writeJson(pathname, value);
-}
+import {
+  cleanup,
+  commitSha,
+  readJson,
+  root,
+  run,
+  setup,
+  updateJson,
+  writeJson,
+  writeVueTsc,
+} from "./_helpers/typecheck-divergence-report-fixture.ts";
 
 test("typecheck divergence report binds baseline evidence to the matrix artifact", () => {
   const fixture = setup();

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -87,7 +87,37 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
   writeFileSync(markdownPath, renderMarkdown(artifact));
   process.stdout.write(`Wrote ${relative(repoRoot, jsonPath)}\n`);
   process.stdout.write(`Wrote ${relative(repoRoot, markdownPath)}\n`);
+  assertBudgetPassed(artifact);
   return artifact;
+}
+
+/**
+ * The false-positive/false-negative budget is a gate, not a note (#3460).
+ * `budget.passed` used to be computed, embedded in the artifact, and printed in
+ * the step summary while nothing read it, so a matrix-wide breach reported
+ * `Budget passed: false` and the weekly job still went green.
+ *
+ * This runs after both artifacts are written, so a breach is still uploaded and
+ * reviewable — the run fails with the evidence attached, not instead of it.
+ */
+export function assertBudgetPassed(artifact) {
+  const budget = artifact.budget;
+  if (budget.passed) return;
+  const summary = artifact.divergence.summary;
+  const breaches = [];
+  if (!budget.falsePositivePassed) {
+    breaches.push(
+      `${summary.falsePositiveCount} false positives (ratio ${summary.falsePositiveRatio}) exceed maxFalsePositiveRatio ${budget.maxFalsePositiveRatio}`,
+    );
+  }
+  if (!budget.falseNegativePassed) {
+    breaches.push(
+      `${summary.falseNegativeCount} false negatives (ratio ${summary.falseNegativeRatio}) exceed maxFalseNegativeRatio ${budget.maxFalseNegativeRatio}`,
+    );
+  }
+  throw new Error(
+    `Typecheck divergence budget breached for ${artifact.project}: ${breaches.join("; ")}`,
+  );
 }
 
 function readDocumentedDifferences() {


### PR DESCRIPTION
## The defect

`tools/fixtures/typecheck-divergence-report.mjs` builds a false-positive /
false-negative budget verdict for the weekly Real Project Matrix:

```js
const budget = evaluateBudget(project.typecheckPerformance, divergence.summary);
```

…embeds it in `<project>-typecheck-divergence.json`, and renders
`Budget passed: ${artifact.budget.passed}` into the step summary.

**Nothing ever read it.** `budget.passed` appears exactly three times in the
repository — computed, embedded, printed — and the entrypoint only exits
non-zero when a *validation* error throws. A matrix-wide FP/FN breach printed
`Budget passed: false` and the job went green, so the
`maxFalsePositiveRatio` / `maxFalseNegativeRatio` pair that all 11
`typecheckPerformance` fixtures declare was decorative.

This is the "**weekly matrix FP/FN budget is decorative**" item under #2971's
"Scale and performance gates" checklist.

## Minimal reproduction

Feed the report a vize run with one diagnostic vue-tsc does not report, against
the fixture's `maxFalsePositiveRatio: 0.05`:

- expected: exit 1, `1 false positives (ratio 0.5) exceed maxFalsePositiveRatio 0.05`
- actual (before the fix): exit **0**, artifact says `"passed": false`, step
  summary says `Budget passed: false`, job green.

## The fix

`assertBudgetPassed(artifact)` throws, and it runs **after** both the JSON and
the Markdown artifact are written. A breach is therefore still uploaded by the
`if: always()` artifact step and still rendered into the step summary — the run
fails *with* its evidence, not instead of it. The message names which side
breached and by how much.

## How the tests fail before the fix

`tests/tooling/typecheck-divergence-budget.test.ts` is new and drives the real
script as a subprocess:

| test | asserts |
| --- | --- |
| false-positive breach | exit 1, exact stderr, exact `budget` object, **full** markdown body byte-for-byte (proving the artifact is still written) |
| false-negative breach | exit 1, exact stderr, exact `budget` object |
| both budgets breached | exit 1, stderr names both sides |
| ratio exactly at the budget | exit **0**, `falsePositiveRatio === 0.05` — pins the comparison as `<=` so the gate cannot silently become always-fail |

Verified by deleting the single `assertBudgetPassed(artifact);` call and
re-running:

```
$ nix develop -c node --test --test-concurrency=1 tests/tooling/typecheck-divergence-budget.test.ts
✖ a false-positive budget breach fails the divergence report
  AssertionError: Expected values to be strictly equal:
  0 !== 1
✖ a false-negative budget breach fails the divergence report
✖ a breach of both budgets reports both sides
✔ a ratio exactly at the budget still passes
ℹ pass 1  ℹ fail 3
```

With the call restored, all 15 tests across both report suites pass.

## Why the test scaffolding moved

`tests/tooling/typecheck-divergence-report.test.ts` was at exactly **350
lines** — the per-file source budget — so it could not grow by even one line.
The fixture setup moves verbatim to
`tests/tooling/_helpers/typecheck-divergence-report-fixture.ts` (alongside the
existing `typecheck-divergence-fixture.ts`) and gains two options
(`vizeDiagnostics`, `baselineOutput`) so a suite can construct a divergence.
The original suite drops to 220 lines and its assertions are unchanged.

## Gates run

```
nix develop -c vp run check:js                                        # exit 0
nix develop -c node --test --test-concurrency=1 \
  tests/tooling/typecheck-divergence-budget.test.ts \
  tests/tooling/typecheck-divergence-report.test.ts \
  tests/tooling/typecheck-divergence.test.ts \
  tests/tooling/typecheck-divergence-ledger.test.ts \
  tests/tooling/real-project-matrix-workflow.test.ts                  # 31/31 pass
nix develop -c vp run source:lengths     # new files 160 / 145; edited file 220
```

No Rust changed, so `fmt:check` / `lint:rust` / `check:rust` are untouched by
this diff.

## Note for the first weekly run after this lands

The gate has never fired, so its true state on the live matrix is unknown. If a
shard breaches on the next Sunday sweep, that is the gate working — the
artifact is uploaded and names the project and ratio. `vue-element-admin`'s
baselined false positive (the other open #2971 item) is *not* affected: it has
no `typecheckPerformance` block, so this report never selects it.

Refs #2971, #3460

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->