### PR TITLE
fix(maestro): align completion trigger characters with the Vue Language Server

### DIFF
--- a/crates/vize_maestro/src/ide/completion/dispatch.rs
+++ b/crates/vize_maestro/src/ide/completion/dispatch.rs
@@ -8,16 +8,41 @@
 pub struct CompletionService;
 
 /// Completion trigger characters for Vue SFC.
+///
+/// This is `@vue/language-server` 3.3.8's list in its order, plus `'`. Every
+/// character here has a handler path that answers with something at that
+/// position — a trigger that can only ever open an empty list is worse than no
+/// trigger, because the user sees the editor react and offer nothing.
+///
+/// Two deliberate differences from the reference server:
+///
+/// - `'` is kept. A single-quoted attribute value is legal Vue and Maestro
+///   answers inside one exactly as it does inside `"`; dropping the trigger
+///   would silently stop the list from opening there.
+/// - ` ` (space) is **not** here. It opened the completion list on every space
+///   typed in a template, including inside text nodes and prose. Attribute
+///   names still complete as they are typed: those are word characters, which
+///   editors suggest on without a trigger character.
+// Grouped one purpose per line; rustfmt would otherwise pull each group's
+// comment onto the end of the previous line, where it reads as documenting the
+// wrong characters.
+#[rustfmt::skip]
 pub const TRIGGER_CHARACTERS: &[char] = &[
-    '.',  // Object property access
-    ':',  // v-bind shorthand
-    '@',  // v-on shorthand
-    '#',  // v-slot shorthand
-    '<',  // HTML tags
-    '/',  // Closing tags
-    '"',  // Attribute values
-    '\'', // Attribute values
-    ' ',  // Space for attribute completion
+    // Attribute values.
+    '"', '\'',
+    // v-bind / v-on shorthands, and property access or a `.prop` modifier.
+    ':', '@', '.',
+    // Tag start, the value position `=` opens before any quote is typed,
+    // closing tags, and the text node that follows the end of a start tag.
+    '<', '=', '/', '>',
+    // Expression syntax inside a directive value or an interpolation, plus the
+    // `#` v-slot shorthand and `$`-prefixed bindings (`$style`, `$attrs`).
+    '+', '^', '*', '(', ')', '#', '[', ']', '$',
+    // kebab-case component and prop names are one hyphenated word, so the list
+    // has to refresh mid-word.
+    '-',
+    // Mustache interpolation `{{`.
+    '{', '}',
 ];
 
 /// Get trigger characters as strings.
@@ -73,5 +98,26 @@ pub(crate) fn should_suggest_variant_block(before: &str) -> bool {
         after_art.contains('>') && !after_art.contains("</art>")
     } else {
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::trigger_characters;
+
+    #[test]
+    fn trigger_characters_match_the_reference_server_plus_single_quote() {
+        // `@vue/language-server` 3.3.8 advertises exactly this list in this
+        // order, minus `'`. Maestro used to advertise `. : @ # < / " ' SPACE`:
+        // thirteen of the reference server's triggers were missing, so
+        // `:title=`, `{{`, `(`, `[` and kebab-case names never opened the list
+        // on their own, and SPACE opened it on every space typed in a template.
+        assert_eq!(
+            trigger_characters(),
+            vec![
+                "\"", "'", ":", "@", ".", "<", "=", "/", ">", "+", "^", "*", "(", ")", "#", "[",
+                "]", "$", "-", "{", "}",
+            ]
+        );
     }
 }

--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -9,6 +9,8 @@
 )]
 
 mod art;
+#[cfg(test)]
+mod attribute_value_tests;
 mod bindings;
 mod component_cache;
 mod component_docs;
@@ -57,6 +59,21 @@ pub(crate) fn complete_template(ctx: &IdeContext) -> Vec<CompletionItem> {
 
     if let Some(tag_ctx) = tag_context::opening_tag_context_at_offset(&ctx.content, ctx.offset) {
         if !tag_ctx.inside_attribute_value {
+            // `:title=|`: the caret is already at a value position even though
+            // no quote has been typed yet, so the attribute-name list is over.
+            // Without this, `=` as a completion trigger could only ever open an
+            // empty list (`open_tag_completion_matches_prefix` rejects every
+            // name once the prefix contains `=`).
+            if let Some(name) = tag_ctx.current_token.strip_suffix('=') {
+                return if is_expression_valued_attribute(name) {
+                    analyzed_template_binding_completions(ctx, true)
+                } else {
+                    // A plain HTML attribute takes a literal, not an
+                    // expression. Its allowed values are not modelled (#3484).
+                    Vec::new()
+                };
+            }
+
             let mut items_vec = contextual_directive_completions(ctx);
             items_vec.extend(native::native_element_attribute_completions(ctx));
             items_vec.extend(component_meta::component_surface_completions(ctx));
@@ -86,6 +103,16 @@ pub(crate) fn complete_template(ctx: &IdeContext) -> Vec<CompletionItem> {
     items_vec.extend(bindings::template_snippets());
 
     items_vec
+}
+
+/// Attributes whose value is a Vue expression rather than a literal string:
+/// `v-bind` (`:x`, `v-bind:x`), `v-on` (`@x`), the `.prop` shorthand, and every
+/// other `v-` directive. Everything else is a plain HTML attribute.
+fn is_expression_valued_attribute(name: &str) -> bool {
+    name.starts_with(':')
+        || name.starts_with('@')
+        || name.starts_with('.')
+        || name.starts_with("v-")
 }
 
 fn filter_open_tag_completions(

--- a/crates/vize_maestro/src/ide/completion/template/attribute_value_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/template/attribute_value_tests.rs
@@ -1,0 +1,70 @@
+//! The attribute *value* position reached by typing `=`, before any quote.
+//!
+//! `=` is a completion trigger character (#3458), so this position must answer
+//! with something: the reference server opens the value list there, and a
+//! trigger that can only ever open an empty list is worse than no trigger.
+
+use std::fs;
+
+use tower_lsp::lsp_types::{CompletionResponse, Url};
+
+use crate::ide::{CompletionService, IdeContext};
+use crate::server::ServerState;
+
+const SOURCE: &str = r#"<script setup lang="ts">
+const count = 1
+const label = 'x'
+function pick(n: number) { return n }
+</script>
+<template>
+  <button :title= @click= v-if= type= class= />
+</template>
+"#;
+
+fn labels_after(marker: &str) -> Vec<String> {
+    let dir = tempfile::tempdir().unwrap();
+    let source_path = dir.path().join("AttributeValue.vue");
+    fs::write(&source_path, SOURCE).unwrap();
+
+    let uri = Url::from_file_path(&source_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), SOURCE.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, SOURCE);
+
+    let offset = SOURCE.find(marker).unwrap() + marker.len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let Some(CompletionResponse::Array(items)) = CompletionService::complete(&ctx) else {
+        return Vec::new();
+    };
+    let mut labels: Vec<String> = items.into_iter().map(|item| item.label).collect();
+    labels.sort();
+    labels
+}
+
+#[test]
+fn a_bound_attribute_offers_the_template_bindings_right_after_the_equals() {
+    // Every binding in scope, and nothing else: no directive names, because
+    // the attribute-name list is over once `=` has been typed.
+    for marker in [":title=", "@click=", "v-if="] {
+        assert_eq!(
+            labels_after(marker),
+            vec!["count".to_string(), "label".to_string(), "pick".to_string(),],
+            "`{marker}` must offer the template bindings"
+        );
+    }
+}
+
+#[test]
+fn a_plain_html_attribute_offers_nothing_after_the_equals() {
+    // Its value is a literal, not an expression, so the bindings would be
+    // wrong. The set of allowed literals is not modelled (#3484).
+    for marker in ["type=", "class="] {
+        assert_eq!(
+            labels_after(marker),
+            Vec::<String>::new(),
+            "`{marker}` takes a literal, not an expression"
+        );
+    }
+}

--- a/crates/vize_maestro/src/ide/completion/tests.rs
+++ b/crates/vize_maestro/src/ide/completion/tests.rs
@@ -2,9 +2,7 @@
 
 use std::fs;
 
-use super::{
-    CompletionService, is_inside_html_comment, items, script, style, template, trigger_characters,
-};
+use super::{CompletionService, is_inside_html_comment, items, script, style, template};
 use crate::{ide::IdeContext, server::ServerState};
 use tower_lsp::lsp_types::{CompletionItemKind, CompletionResponse, InsertTextFormat, Url};
 use vize_relief::BindingType;
@@ -56,14 +54,6 @@ fn test_vue_css_completions() {
 
     let deep = items.iter().find(|i| i.label == ":deep");
     assert!(deep.is_some());
-}
-
-#[test]
-fn test_trigger_characters() {
-    let chars = trigger_characters();
-    assert!(chars.contains(&"<".to_string()));
-    assert!(chars.contains(&":".to_string()));
-    assert!(chars.contains(&"@".to_string()));
 }
 
 #[test]

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -73,17 +73,32 @@ test("vize lsp advertises the full editor-feature provider set with exact shapes
     assert.equal(capabilities.textDocumentSync?.openClose, true);
     assert.equal(capabilities.textDocumentSync?.save?.includeText, false);
 
-    // Completion trigger characters, exact ordered set.
+    // Completion trigger characters, exact ordered set: `@vue/language-server`
+    // 3.3.8's list in its order, plus `'` (a single-quoted attribute value is
+    // legal Vue and Maestro answers inside one). Space is deliberately absent —
+    // it opened the list on every space typed in a template (#3458).
     assert.deepEqual(capabilities.completionProvider?.triggerCharacters, [
-      ".",
-      ":",
-      "@",
-      "#",
-      "<",
-      "/",
       '"',
       "'",
-      " ",
+      ":",
+      "@",
+      ".",
+      "<",
+      "=",
+      "/",
+      ">",
+      "+",
+      "^",
+      "*",
+      "(",
+      ")",
+      "#",
+      "[",
+      "]",
+      "$",
+      "-",
+      "{",
+      "}",
     ]);
 
     // Selection ranges ship with the document-structure group.

--- a/tests/tooling/lsp-completion-triggers.test.ts
+++ b/tests/tooling/lsp-completion-triggers.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+/**
+ * Behavioural cover for the completion trigger characters `vize lsp` advertises
+ * (#3458).
+ *
+ * `lsp-capabilities.test.ts` pins the exact ordered list. This suite pins that
+ * each character actually *does* something: a trigger whose position answers
+ * with an empty list is worse than no trigger at all, because the editor reacts
+ * and offers nothing. Every case asserts a must-include AND a must-exclude set
+ * with `assert.deepEqual` over the filtered labels — never `.includes` on its
+ * own, which would pass on a list of the wrong things.
+ *
+ * The session runs with `typecheck: false`, so every label below comes from
+ * Maestro's own template analysis rather than a tsserver round trip.
+ */
+
+type CompletionItem = { label: string };
+
+const HEAD = `<script setup lang="ts">
+const count = 1
+const items = [1, 2]
+function pick(n: number) { return n }
+</script>
+
+<template>
+`;
+const TAIL = `
+</template>
+`;
+
+/** Every binding the fixture's `<script setup>` puts in template scope. */
+const BINDINGS = ["count", "items", "pick"];
+/** Directive names, which only belong to an attribute-*name* position. */
+const DIRECTIVES = ["v-if", "v-for"];
+
+type Case = {
+  /** The trigger character this position is reached by typing. */
+  trigger: string;
+  /** A single template line; `|` marks the caret and is stripped. */
+  line: string;
+  include: string[];
+  exclude: string[];
+};
+
+const CASES: Case[] = [
+  // `=` had no handler at all before #3458: the attribute-name list rejects
+  // every candidate once the prefix contains `=`, so this position answered
+  // with nothing.
+  { trigger: "=", line: `  <div :title=|></div>`, include: BINDINGS, exclude: DIRECTIVES },
+  { trigger: "=", line: `  <div @click=|></div>`, include: BINDINGS, exclude: DIRECTIVES },
+  // End of a start tag: the text node that follows takes elements and
+  // directives, never bare bindings.
+  { trigger: ">", line: `  <div>|</div>`, include: DIRECTIVES, exclude: BINDINGS },
+  // kebab-case attribute names are one hyphenated word, so the list has to
+  // refresh mid-word.
+  {
+    trigger: "-",
+    line: `  <div :aria-|></div>`,
+    include: ["aria-label"],
+    exclude: [...DIRECTIVES, ...BINDINGS],
+  },
+  { trigger: "{", line: `  <div>{{|}}</div>`, include: BINDINGS, exclude: DIRECTIVES },
+  { trigger: "}", line: `  <div>{{ count }|}</div>`, include: DIRECTIVES, exclude: BINDINGS },
+  { trigger: "(", line: `  <div>{{ pick(| }}</div>`, include: BINDINGS, exclude: DIRECTIVES },
+  { trigger: ")", line: `  <div>{{ pick(count)| }}</div>`, include: BINDINGS, exclude: DIRECTIVES },
+  { trigger: "[", line: `  <div>{{ items[| }}</div>`, include: BINDINGS, exclude: DIRECTIVES },
+  { trigger: "]", line: `  <div>{{ items[0]| }}</div>`, include: BINDINGS, exclude: DIRECTIVES },
+  { trigger: "$", line: `  <div>{{ $| }}</div>`, include: BINDINGS, exclude: DIRECTIVES },
+  { trigger: "+", line: `  <div>{{ count +| }}</div>`, include: BINDINGS, exclude: DIRECTIVES },
+  { trigger: "^", line: `  <div>{{ count ^| }}</div>`, include: BINDINGS, exclude: DIRECTIVES },
+  { trigger: "*", line: `  <div>{{ count *| }}</div>`, include: BINDINGS, exclude: DIRECTIVES },
+  // Already advertised before #3458; kept so the whole advertised set is
+  // covered by one suite.
+  { trigger: '"', line: `  <div :title="|"></div>`, include: BINDINGS, exclude: DIRECTIVES },
+  { trigger: "'", line: `  <div :title='|'></div>`, include: BINDINGS, exclude: DIRECTIVES },
+  { trigger: ":", line: `  <div :|></div>`, include: ["class"], exclude: BINDINGS },
+  { trigger: "@", line: `  <div @|></div>`, include: ["@click"], exclude: BINDINGS },
+  { trigger: "<", line: `  <|`, include: ["Transition"], exclude: BINDINGS },
+  { trigger: ".", line: `  <div>{{ count.|}}</div>`, include: [], exclude: DIRECTIVES },
+  { trigger: "#", line: `  <Child #|></Child>`, include: ["#"], exclude: BINDINGS },
+  { trigger: "/", line: `  <div></|`, include: DIRECTIVES, exclude: BINDINGS },
+];
+
+function positionAt(text: string, offset: number): { line: number; character: number } {
+  let line = 0;
+  let character = 0;
+  for (let index = 0; index < offset; index += 1) {
+    if (text[index] === "\n") {
+      line += 1;
+      character = 0;
+    } else {
+      character += 1;
+    }
+  }
+  return { line, character };
+}
+
+test("every advertised completion trigger answers with a useful list", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-completion-triggers");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, { editor: true, lint: false, typecheck: false });
+
+    for (const [index, testCase] of CASES.entries()) {
+      const marked = HEAD + testCase.line + TAIL;
+      const caret = marked.indexOf("|");
+      const source = marked.replace("|", "");
+      const filePath = path.join(workspaceDir, `Case${index}.vue`);
+      const uri = pathToFileURL(filePath).href;
+      fs.writeFileSync(filePath, source, "utf8");
+      session.notify("textDocument/didOpen", {
+        textDocument: { uri, languageId: "vue", version: 1, text: source },
+      });
+
+      const result = (await session.request("textDocument/completion", {
+        textDocument: { uri },
+        position: positionAt(source, caret),
+      })) as CompletionItem[] | { items: CompletionItem[] } | null;
+      const items = Array.isArray(result) ? result : (result?.items ?? []);
+      const labels = new Set(items.map((item) => item.label));
+      const where = `${testCase.trigger} in ${JSON.stringify(testCase.line)}`;
+
+      // Non-empty is the floor: the trigger fired, so something must come back.
+      assert.ok(labels.size > 0, `${where} opened an empty completion list`);
+      assert.deepEqual(
+        testCase.include.filter((label) => labels.has(label)),
+        testCase.include,
+        `${where} is missing expected labels`,
+      );
+      assert.deepEqual(
+        testCase.exclude.filter((label) => labels.has(label)),
+        [],
+        `${where} offered labels that do not belong at this position`,
+      );
+    }
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Defect

`completionProvider.triggerCharacters` was `.` `:` `@` `#` `<` `/` `"` `'`
`SPACE`. Measured against `@vue/language-server` 3.3.8:

| server | trigger characters |
| --- | --- |
| `@vue/language-server` | `"` `:` `@` `.` `<` `=` `/` `>` `+` `^` `*` `(` `)` `#` `[` `]` `$` `-` `{` `}` |
| `vize lsp` before | `.` `:` `@` `#` `<` `/` `"` `'` `SPACE` |
| `vize lsp` after | `"` `'` `:` `@` `.` `<` `=` `/` `>` `+` `^` `*` `(` `)` `#` `[` `]` `$` `-` `{` `}` |

Thirteen missing triggers, each invisible to a user: `:title=`, `{{`, `(`, `[`,
`$` and kebab-case names never opened the completion list on their own, and
there is no error to see. `SPACE` was the opposite problem — it opened the list
on every space typed in a template, including inside text nodes and prose.

## Deliberate differences from the reference server

- **`'` is kept.** A single-quoted attribute value is legal Vue and Maestro
  answers inside one exactly as it does inside `"`. Dropping the trigger would
  silently stop the list from opening there, which is the same class of defect
  this PR fixes. Happy to drop it if you'd rather have byte-exact parity.
- **`SPACE` is gone.** Attribute names still complete as they are typed: those
  are word characters, which editors suggest on without a trigger character.

## Each added trigger has a handler

The issue's warning was the design constraint: a trigger that can only open an
empty list is worse than no trigger, because the editor reacts and offers
nothing. Twelve of the thirteen already answered — measured against the pre-fix
binary with a scripted stdio client, `typecheck: false` so every label comes
from Maestro's own analysis:

```
= (":title=|")      ->   0 items   []                       <- the hole
> ("<div>|")        ->  42 items   ["v-if","v-for",…]
- (":aria-|")       ->  11 items   ["v-bind",":","id","class",…,"aria-label"]
{ ("{{|")           ->   3 items   ["pick","count","items"]
} ("{{ count }|")   ->  42 items   ["v-if","v-for",…]
( ("pick(|")        ->   3 items   ["pick","count","items"]
) (")|")            ->   3 items   ["pick","count","items"]
[ ("items[|")       ->   3 items   ["pick","count","items"]
] ("items[0]|")     ->   3 items   ["pick","count","items"]
$ ("{{ $|")         ->   3 items   ["pick","count","items"]
+ ^ * ("count +|")  ->   3 items   ["pick","count","items"]
```

`=` had no handler at all: `open_tag_completion_matches_prefix` rejects every
candidate once the prefix contains `=`, which is correct for the attribute
*name* list but leaves the value position answering nothing.

`complete_template` now recognises the value position `=` opens before any quote
is typed, and answers with the template bindings when the attribute is
expression-valued (`:x`, `v-bind:x`, `@x`, `.prop`, any other `v-` directive) —
the same items the caret gets one character later, inside the quotes.

A plain HTML attribute (`type=`, `class=`) takes a literal, so offering bindings
would be wrong; it keeps returning nothing. Modelling the allowed literals needs
a per-element value-set table Maestro does not have. Filed as #3484.

## How the tests fail before the fix

Against a `vize lsp` built from the pre-fix tree (sha256
`5c59332f0c3532056ba13f47727b5c28696e420bc99e2278afbda05d91ead07d`):

```
$ VIZE_LSP_BIN=<pre-fix vize> node --test --test-concurrency=1 \
    tests/tooling/lsp-completion-triggers.test.ts tests/tooling/lsp-capabilities.test.ts
✖ vize lsp advertises the full editor-feature provider set with exact shapes
✖ every advertised completion trigger answers with a useful list
  AssertionError [ERR_ASSERTION]: = in "  <div :title=|></div>" opened an empty completion list
ℹ pass 2  ℹ fail 2
```

Post-fix binary sha256
`ba8fed97dc14e1f918bca169994920a476f32ef2cd49abcaa1fefefa57324589`:

```
✔ vize lsp advertises the full editor-feature provider set with exact shapes
✔ every advertised completion trigger answers with a useful list
✔ vize lsp smoke-tests production editor flows        (+ 6 more smoke tests)
✔ vize lsp surfaces template completion contexts
ℹ tests 24  ℹ pass 24  ℹ fail 0
```

The new suite covers all 21 advertised characters, and every case asserts a
must-include AND a must-exclude set with `assert.deepEqual` over the filtered
labels — never a bare `.includes`, which would pass on a list of the wrong
things. Bindings must not appear in a text node; directive names must not appear
in a value position.

Rust side: `test_trigger_characters` was three `.contains` calls; it moves next
to the constant and asserts the full ordered list. Two new tests in
`completion/template/attribute_value_tests.rs` pin the `=` behaviour with
`assert_eq!` on the complete sorted label list, for both an expression-valued
and a plain attribute. Both fail before the fix (the bound case returns an empty
list).

## Gates

```
cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports   # clean
cargo test -p vize_maestro                                            # 604 lib (1 ignored) + 3 + 1 doc, 0 failed
rustfmt --edition 2024 --config style_edition=2024 --check <touched>  # clean
npx oxfmt --check / npx oxlint <touched .ts>                          # clean
```

All touched files are under the 350-line budget; `completion/tests.rs` (990,
already over) shrinks by 8.

Refs #3224
Closes #3458
