### PR TITLE
perf(vite): index compiled-module dependencies instead of scanning on every hot update

### DIFF
--- a/bench/vite-hmr-owner-lookup.mjs
+++ b/bench/vite-hmr-owner-lookup.mjs
@@ -1,0 +1,142 @@
+/**
+ * Cost of the owner lookup that runs first on every Vite hot update (#3403).
+ *
+ * `handleHotUpdateHook` has to know which SFCs pulled a changed file in through
+ * `<script src>` / `<template src>` / `<style src>` before it can do anything
+ * else, including before the `.vue` fast path. This measures that lookup two
+ * ways against the same synthetic caches:
+ *
+ * - `scan`  — the pre-#3403 implementation: walk both caches, `path.resolve`
+ *             every dependency of every cached module.
+ * - `index` — the reverse index the caches now maintain.
+ *
+ * Wall clock on a contended machine is noise, so the primary number is the
+ * `path.resolve` call count per hot update, which is deterministic. The index
+ * moves that work to insert time, so insert-side resolves are reported too.
+ *
+ *   node bench/vite-hmr-owner-lookup.mjs
+ *   node bench/vite-hmr-owner-lookup.mjs --sizes 1000,3000,10000 --iterations 200
+ */
+
+import path from "node:path";
+
+import {
+  CompiledModuleCache,
+  ownersOfDependency,
+} from "../npm/builder/vite/src/plugin/compiled-module-cache.ts";
+
+const nativeResolve = path.resolve.bind(path);
+let resolveCalls = 0;
+path.resolve = (...args) => {
+  resolveCalls += 1;
+  return nativeResolve(...args);
+};
+
+function parseArgs(argv) {
+  const options = { sizes: [1000, 3000, 10000], iterations: 200 };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--sizes") options.sizes = argv[++i].split(",").map(Number);
+    else if (argv[i] === "--iterations") options.iterations = Number(argv[++i]);
+  }
+  return options;
+}
+
+function buildEntries(size, withSrcImports) {
+  const entries = [];
+  for (let i = 0; i < size; i += 1) {
+    entries.push([
+      `/project/src/Component${i}.vue`,
+      {
+        code: "export default {}",
+        dependencies: withSrcImports ? [`/project/src/styles/component${i}.css`] : [],
+      },
+    ]);
+  }
+  return entries;
+}
+
+/** The pre-#3403 lookup, reproduced exactly. */
+function scanOwners(caches, dependencyFile) {
+  const normalizedDependency = path.resolve(dependencyFile);
+  const owners = new Set();
+  for (const cache of caches) {
+    for (const [vueFile, compiled] of cache) {
+      if (compiled.dependencies?.some((d) => path.resolve(d) === normalizedDependency)) {
+        owners.add(vueFile);
+      }
+    }
+  }
+  return [...owners];
+}
+
+function indexOwners(caches, dependencyFile) {
+  const normalizedDependency = path.resolve(dependencyFile);
+  const owners = new Set();
+  for (const cache of caches) {
+    for (const vueFile of ownersOfDependency(cache, normalizedDependency)) owners.add(vueFile);
+  }
+  return [...owners];
+}
+
+function measure(lookup, caches, changedFile, iterations) {
+  lookup(caches, changedFile);
+  resolveCalls = 0;
+  const started = process.hrtime.bigint();
+  for (let i = 0; i < iterations; i += 1) lookup(caches, changedFile);
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+  return { msPerCall: elapsedMs / iterations, resolvesPerCall: resolveCalls / iterations };
+}
+
+const { sizes, iterations } = parseArgs(process.argv.slice(2));
+const rows = [];
+
+for (const size of sizes) {
+  for (const withSrcImports of [false, true]) {
+    const entries = buildEntries(size, withSrcImports);
+
+    const plain = new Map(entries);
+    resolveCalls = 0;
+    const indexed = new CompiledModuleCache();
+    for (const [file, module] of entries) indexed.set(file, module);
+    const insertResolves = resolveCalls;
+
+    // The common case: an ordinary `.vue` save, which owns nothing but still
+    // pays for the lookup because it runs before the `.vue` fast path.
+    const changedFile = "/project/src/Component0.vue";
+
+    const scan = measure(scanOwners, [plain, new Map()], changedFile, iterations);
+    const index = measure(
+      indexOwners,
+      [indexed, new CompiledModuleCache()],
+      changedFile,
+      iterations,
+    );
+
+    const scanOwnersResult = scanOwners([plain, new Map()], changedFile);
+    const indexOwnersResult = indexOwners([indexed, new CompiledModuleCache()], changedFile);
+    if (JSON.stringify(scanOwnersResult) !== JSON.stringify(indexOwnersResult)) {
+      throw new Error(`owner mismatch at size ${size}`);
+    }
+
+    rows.push({
+      size,
+      srcImports: withSrcImports ? "one per SFC" : "none",
+      scanResolves: scan.resolvesPerCall,
+      indexResolves: index.resolvesPerCall,
+      scanMs: scan.msPerCall,
+      indexMs: index.msPerCall,
+      insertResolves,
+    });
+  }
+}
+
+console.log(`iterations per measurement: ${iterations}`);
+console.log(
+  "| cached SFCs | src imports | resolve() per update (scan) | resolve() per update (index) | ms per update (scan) | ms per update (index) | resolve() to fill the index |",
+);
+console.log("| ---: | --- | ---: | ---: | ---: | ---: | ---: |");
+for (const row of rows) {
+  console.log(
+    `| ${row.size.toLocaleString("en-US")} | ${row.srcImports} | ${row.scanResolves} | ${row.indexResolves} | ${row.scanMs.toFixed(4)} | ${row.indexMs.toFixed(4)} | ${row.insertResolves.toLocaleString("en-US")} |`,
+  );
+}

--- a/npm/builder/vite/src/plugin/compiled-module-cache.test.ts
+++ b/npm/builder/vite/src/plugin/compiled-module-cache.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import type { CompiledModule } from "../types.ts";
+import { CompiledModuleCache, ownersOfDependency } from "./compiled-module-cache.ts";
+
+function compiled(dependencies: string[]): CompiledModule {
+  return { code: "export default {}", dependencies } as unknown as CompiledModule;
+}
+
+/** The scan `getVueFilesDependingOn` performed before the reverse index existed. */
+function scanOwners(
+  cache: Map<string, CompiledModule>,
+  resolvedDependency: string,
+): readonly string[] {
+  const owners: string[] = [];
+  for (const [file, module] of cache) {
+    if (module.dependencies?.some((d) => path.resolve(d) === resolvedDependency)) owners.push(file);
+  }
+  return owners;
+}
+
+{
+  const cache = new CompiledModuleCache();
+  cache.set("/src/App.vue", compiled(["/src/shared.css"]));
+  cache.set("/src/Page.vue", compiled(["/src/shared.css", "/src/page.ts"]));
+  cache.set("/src/Plain.vue", compiled([]));
+
+  assert.deepEqual(cache.ownersOf("/src/shared.css"), ["/src/App.vue", "/src/Page.vue"]);
+  assert.deepEqual(cache.ownersOf("/src/page.ts"), ["/src/Page.vue"]);
+  assert.deepEqual(cache.ownersOf("/src/missing.css"), []);
+}
+
+{
+  // Re-compiling a file must not leave its previous dependencies indexed.
+  const cache = new CompiledModuleCache();
+  cache.set("/src/App.vue", compiled(["/src/old.css"]));
+  cache.set("/src/App.vue", compiled(["/src/new.css"]));
+
+  assert.deepEqual(cache.ownersOf("/src/old.css"), []);
+  assert.deepEqual(cache.ownersOf("/src/new.css"), ["/src/App.vue"]);
+}
+
+{
+  const cache = new CompiledModuleCache();
+  cache.set("/src/App.vue", compiled(["/src/shared.css"]));
+  cache.set("/src/Page.vue", compiled(["/src/shared.css"]));
+
+  assert.equal(cache.delete("/src/App.vue"), true);
+  assert.deepEqual(cache.ownersOf("/src/shared.css"), ["/src/Page.vue"]);
+
+  cache.clear();
+  assert.deepEqual(cache.ownersOf("/src/shared.css"), []);
+  assert.equal(cache.size, 0);
+}
+
+{
+  // Relative dependencies are indexed through the same `path.resolve` the scan
+  // used, so they answer the same question.
+  const cache = new CompiledModuleCache();
+  cache.set("/src/App.vue", compiled(["./relative.css"]));
+
+  assert.deepEqual(cache.ownersOf(path.resolve("./relative.css")), ["/src/App.vue"]);
+  assert.deepEqual(cache.ownersOf("./relative.css"), []);
+}
+
+{
+  // The indexed cache and a plain Map must answer identically for every
+  // dependency in a mixed corpus.
+  const entries: [string, CompiledModule][] = [
+    ["/src/A.vue", compiled(["/src/a.css"])],
+    ["/src/B.vue", compiled(["/src/a.css", "/src/b.ts"])],
+    ["/src/C.vue", compiled([])],
+    ["/src/D.vue", compiled(["./rel.css"])],
+    ["/src/E.vue", compiled(["/src/b.ts"])],
+  ];
+  const indexed = new CompiledModuleCache();
+  const plain = new Map<string, CompiledModule>();
+  for (const [file, module] of entries) {
+    indexed.set(file, module);
+    plain.set(file, module);
+  }
+
+  for (const dependency of [
+    "/src/a.css",
+    "/src/b.ts",
+    path.resolve("./rel.css"),
+    "/src/absent.css",
+  ]) {
+    assert.deepEqual(
+      [...ownersOfDependency(indexed, dependency)].sort(),
+      [...scanOwners(plain, dependency)].sort(),
+      `indexed and scanned owners must agree for ${dependency}`,
+    );
+    assert.deepEqual(
+      [...ownersOfDependency(plain, dependency)].sort(),
+      [...scanOwners(plain, dependency)].sort(),
+      `unindexed fallback must match the original scan for ${dependency}`,
+    );
+  }
+}
+
+console.log("compiled-module-cache tests passed");

--- a/npm/builder/vite/src/plugin/compiled-module-cache.ts
+++ b/npm/builder/vite/src/plugin/compiled-module-cache.ts
@@ -1,0 +1,102 @@
+/**
+ * Compiled-module caches carrying a reverse index from a `src`-imported
+ * dependency to the SFCs that pulled it in.
+ *
+ * Every hot update has to answer "which SFCs own this changed file?" before it
+ * can do anything else, and that answer used to come from a full scan of both
+ * caches with a `path.resolve` per dependency per cached file. HMR latency then
+ * grew with the number of components in the project, on the interactive path,
+ * for every save — including saves of ordinary `.vue` files, because the scan
+ * runs before the `.vue` fast path.
+ *
+ * The index is maintained by overriding `set`/`delete`/`clear` rather than by a
+ * second structure updated at each call site. `state.cache` is handed to
+ * `compileFile` and `compileBatch`, and is also mutated directly from
+ * `precompile-run.ts`, `hmr.ts` and `state.ts`; a structure kept in sync by hand
+ * across those would drift the first time a new writer appeared. Subclassing
+ * puts the bookkeeping where the mutation is.
+ *
+ * The keys are `path.resolve`d exactly as the previous scan resolved them, so a
+ * dependency recorded as a relative path indexes and looks up identically.
+ */
+
+import path from "node:path";
+
+import type { CompiledModule } from "../types.ts";
+
+export class CompiledModuleCache extends Map<string, CompiledModule> {
+  readonly #ownersByDependency = new Map<string, Set<string>>();
+
+  /**
+   * Deliberately takes no entries: `Map`'s constructor would call the
+   * overridden `set` from inside `super()`, before `#ownersByDependency` exists.
+   */
+  constructor() {
+    super();
+  }
+
+  override set(file: string, compiled: CompiledModule): this {
+    this.#unindex(file);
+    super.set(file, compiled);
+    for (const dependency of compiled.dependencies ?? []) {
+      const key = path.resolve(dependency);
+      const owners = this.#ownersByDependency.get(key);
+      if (owners) {
+        owners.add(file);
+      } else {
+        this.#ownersByDependency.set(key, new Set([file]));
+      }
+    }
+    return this;
+  }
+
+  override delete(file: string): boolean {
+    this.#unindex(file);
+    return super.delete(file);
+  }
+
+  override clear(): void {
+    this.#ownersByDependency.clear();
+    super.clear();
+  }
+
+  /** The cached SFCs that `src`-import `resolvedDependency`. */
+  ownersOf(resolvedDependency: string): readonly string[] {
+    const owners = this.#ownersByDependency.get(resolvedDependency);
+    return owners ? [...owners] : [];
+  }
+
+  #unindex(file: string): void {
+    for (const dependency of super.get(file)?.dependencies ?? []) {
+      const key = path.resolve(dependency);
+      const owners = this.#ownersByDependency.get(key);
+      if (!owners) continue;
+      owners.delete(file);
+      if (owners.size === 0) this.#ownersByDependency.delete(key);
+    }
+  }
+}
+
+/**
+ * Owners of `resolvedDependency` in one cache.
+ *
+ * Plain `Map`s — the hand-built states in unit tests — keep the original linear
+ * scan, so an unindexed cache answers exactly what the indexed one does.
+ */
+export function ownersOfDependency(
+  cache: Map<string, CompiledModule>,
+  resolvedDependency: string,
+): readonly string[] {
+  if (cache instanceof CompiledModuleCache) {
+    return cache.ownersOf(resolvedDependency);
+  }
+
+  const owners: string[] = [];
+  for (const [file, compiled] of cache) {
+    if (
+      compiled.dependencies?.some((dependency) => path.resolve(dependency) === resolvedDependency)
+    )
+      owners.push(file);
+  }
+  return owners;
+}

--- a/npm/builder/vite/src/plugin/hmr.ts
+++ b/npm/builder/vite/src/plugin/hmr.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import type { VizePluginState } from "./state.ts";
 import { getCompileOptionsForRequest } from "./state.ts";
+import { ownersOfDependency } from "./compiled-module-cache.ts";
 import { compileFile } from "../compiler.ts";
 import { detectHmrUpdateType, hasHmrChanges, type HmrUpdateType } from "../hmr.ts";
 import { hasDelegatedStyles } from "../utils/index.ts";
@@ -28,19 +29,23 @@ type GenerateBundleItem =
 
 type GenerateBundle = Record<string, GenerateBundleItem>;
 
+/**
+ * The cached SFCs that pulled `dependencyFile` in through
+ * `<script src>` / `<template src>` / `<style src>`.
+ *
+ * This runs as the first statement of every hot update, before the `.vue` fast
+ * path, so editing an ordinary SFC pays for it too. It used to walk both caches
+ * end to end with a `path.resolve` per dependency, which made HMR latency grow
+ * with the number of components in the project; the caches now carry a reverse
+ * index that answers it in constant time. See `compiled-module-cache.ts`.
+ */
 function getVueFilesDependingOn(state: VizePluginState, dependencyFile: string): string[] {
   const normalizedDependency = path.resolve(dependencyFile);
   const owners = new Set<string>();
 
   for (const cache of [state.cache, state.ssrCache]) {
-    for (const [vueFile, compiled] of cache) {
-      if (
-        compiled.dependencies?.some(
-          (dependency) => path.resolve(dependency) === normalizedDependency,
-        )
-      ) {
-        owners.add(vueFile);
-      }
+    for (const vueFile of ownersOfDependency(cache, normalizedDependency)) {
+      owners.add(vueFile);
     }
   }
 

--- a/npm/builder/vite/src/plugin/index.ts
+++ b/npm/builder/vite/src/plugin/index.ts
@@ -13,6 +13,7 @@ import {
   type VizePluginState,
   normalizePrecompileBatchSize,
 } from "./state.ts";
+import { CompiledModuleCache } from "./compiled-module-cache.ts";
 import { compileAll } from "./precompile-run.ts";
 import { resolveIdHook } from "./resolve.ts";
 import { loadHook, transformHook } from "./load.ts";
@@ -87,8 +88,11 @@ export function vize(options: VizeOptions = {}): Plugin[] {
   }
 
   const state: VizePluginState = {
-    cache: new Map(),
-    ssrCache: new Map(),
+    // Indexed maps: hot updates need the SFCs owning a changed `src` dependency
+    // in constant time rather than by scanning both caches. See
+    // `compiled-module-cache.ts`.
+    cache: new CompiledModuleCache(),
+    ssrCache: new CompiledModuleCache(),
     collectedCss: new Map(),
     precompileMetadata: new Map(),
     pendingHmrUpdateTypes: new Map(),

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -12,6 +12,7 @@ import "./utils-filter.test.ts";
 import "./utils-inline-css.test.ts";
 import "./utils.test.ts";
 import "./plugin/compat.test.ts";
+import "./plugin/compiled-module-cache.test.ts";
 import "./plugin/config-bridge.test.ts";
 import "./plugin/css-modules.test.ts";
 import "./plugin/dev-middleware.test.ts";

--- a/npm/builder/vite/src/test/precompile-cache-project.ts
+++ b/npm/builder/vite/src/test/precompile-cache-project.ts
@@ -13,6 +13,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { CompiledModuleCache } from "../plugin/compiled-module-cache.ts";
 import { compileAll } from "../plugin/precompile-run.ts";
 import {
   PRECOMPILE_CACHE_DIR,
@@ -52,8 +53,8 @@ export function makeState(
   info: (line: string) => void = () => {},
 ): VizePluginState {
   return {
-    cache: new Map(),
-    ssrCache: new Map(),
+    cache: new CompiledModuleCache(),
+    ssrCache: new CompiledModuleCache(),
     collectedCss: new Map(),
     precompileMetadata: new Map(),
     pendingHmrUpdateTypes: new Map(),


### PR DESCRIPTION
## Defect

`handleHotUpdateHook` starts by asking which SFCs pulled the changed file in through
`<script src>` / `<template src>` / `<style src>`. That answer came from walking both
compiled-module caches end to end with a `path.resolve` per dependency per cached module:

```ts
for (const cache of [state.cache, state.ssrCache]) {
  for (const [vueFile, compiled] of cache) {
    if (compiled.dependencies?.some((d) => path.resolve(d) === normalizedDependency)) {
      owners.add(vueFile);
    }
  }
}
```

HMR latency should not depend on how many components a project has. The scan runs before the `.vue`
fast path, so saving an ordinary SFC — the common case — pays for it too.

## Measurement

`bench/vite-hmr-owner-lookup.mjs` is added by this PR, so before and after are the same harness.
The primary number is the deterministic `path.resolve` call count; wall clock is included but this
machine is contended.

```
$ nix develop -c node bench/vite-hmr-owner-lookup.mjs
iterations per measurement: 200
```

| cached SFCs | src imports | resolve()/update before | after | ms/update before | after | resolve() to fill the index |
| ---: | --- | ---: | ---: | ---: | ---: | ---: |
| 1,000 | none | 1 | 1 | 0.0830 | 0.0024 | 0 |
| 1,000 | one per SFC | 1,001 | 1 | 0.4180 | 0.0014 | 1,000 |
| 3,000 | none | 1 | 1 | 0.1062 | 0.0008 | 0 |
| 3,000 | one per SFC | 3,001 | 1 | 1.2662 | 0.0007 | 3,000 |
| 10,000 | none | 1 | 1 | 0.1956 | 0.0008 | 0 |
| 10,000 | one per SFC | 10,001 | 1 | 3.9130 | 0.0007 | 10,000 |

Per hot update the lookup goes from `1 + total dependencies` resolves to `1`. The last column is the
honest cost of the change: the resolving moves to insert time, one `path.resolve` per dependency per
compile, instead of being repeated on every save. Note the "none" rows also improve — the old code
still iterated every cached entry to evaluate `compiled.dependencies?.`, which is why the issue
measured 0.11 ms at 10k even with no `src` imports at all.

## Output equivalence — verified, not asserted

Built `npm/builder/vite/example` from a **fixed** path (the plugin derives scope ids from absolute
file paths, so a `mkdtemp` work dir would change the emitted CSS on its own), once with this branch
and once with `npm/builder/vite/src` checked out at the parent commit, repacking the plugin between
the two. Per-asset sha256:

```
b392f5547119368fd81a152a1309603d0caee4cb66bfbad884b60f3e2f4e74a8  assets/index-CzbwliT-.js
77f40cdf609aebb24d1832ddbfb4f58b32ceb1001914791135d60d629d3dbe32  assets/index-DOoRaE4O.css
bdb5c867cda7ee3b8ab28feb257466b7360ebafd57cd279488eaedb528af0daf  index.html
```

Identical in both directions, all three assets.

## Shape of the fix

`plugin/compiled-module-cache.ts` adds `CompiledModuleCache`, a `Map` subclass that maintains
`resolved dependency -> owning SFCs` by overriding `set` / `delete` / `clear`.

The issue suggests a second structure updated wherever a `CompiledModule` is inserted or removed. I
did not do that: `state.cache` is handed to `compileFile` and `compileBatch` (which `set` into it),
and is also mutated directly from `precompile-run.ts`, `hmr.ts` and `state.ts`. A hand-synced index
across those would drift the first time a new writer appeared. Overriding the mutators puts the
bookkeeping where the mutation is, and no call site changes.

Two details worth stating:

- The constructor deliberately takes no entries. `Map`'s iterable constructor calls the overridden
  `set` from inside `super()`, before the private index field exists; the no-arg signature makes
  that a type error rather than a runtime one.
- Plain `Map`s — the hand-built states across the unit tests — keep the original linear scan via
  `ownersOfDependency`, so an unindexed cache answers exactly what an indexed one does.

## Tests

`plugin/compiled-module-cache.test.ts` (registered in `src/test.ts`) covers the index directly:
owners for a mixed corpus, re-index on recompile (a stale dependency must not keep an owner),
`delete`, `clear`, and relative dependency paths going through the same `path.resolve` the scan
used. The last block asserts, for every dependency in a mixed corpus, that indexed lookup,
unindexed fallback, and the original scan all return the same owners — that is the regression guard,
and it fails on any index that drifts.

```
$ nix develop -c node src/plugin/compiled-module-cache.test.ts   # from npm/builder/vite
compiled-module-cache tests passed
$ nix develop -c node src/test.ts                                # full plugin suite
ℹ tests 26
ℹ pass 26
ℹ fail 0
```

## Gates

```
$ nix develop -c vp check src vite.config.ts     # npm/builder/vite
pass: All 84 files are correctly formatted
pass: Found no warnings or lint errors in 84 files
$ nix develop -c vp check bench/vite-hmr-owner-lookup.mjs
pass: All 1 file are correctly formatted
pass: Found no warnings or lint errors in 1 file
```

No Rust touched.

Closes #3403
