### PR TITLE
feat(patina): report a computed called like a method from the template

### DIFF
--- a/crates/vize_patina/src/rules/script.rs
+++ b/crates/vize_patina/src/rules/script.rs
@@ -56,6 +56,7 @@ mod require_symbol_provide;
 mod require_typed_ref;
 mod return_in_computed_property;
 mod sfc_context;
+mod template_scan;
 mod valid_define_emits;
 mod valid_define_options;
 mod valid_define_props;

--- a/crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs
+++ b/crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs
@@ -7,18 +7,38 @@
 //! parentheses are almost always a mistake for `this.fullName`.
 //!
 //! Port of [`vue/no-use-computed-property-like-method`](https://eslint.vuejs.org/rules/no-use-computed-property-like-method.html),
-//! scoped conservatively to the Options API: only `this.<computedName>(...)`
-//! member calls are flagged, where `<computedName>` is declared in `computed`.
+//! scoped to the Options API: the computed names come from the `computed`
+//! option, and both places they can be called are checked.
+//!
+//! ## Script call sites
+//!
+//! `this.<computedName>(...)` inside a direct member of the options object,
+//! where `this` is the component instance. A non-arrow function nested deeper
+//! rebinds `this`, so calls there are skipped.
+//!
+//! ## Template call sites
+//!
+//! `{{ total() }}`, `:title="total()"`, `@click="total()"` — the template
+//! reaches a computed by bare name, and this is exactly where the mistake is
+//! made, since `{{ total() }}` throws at runtime unless the computed happens to
+//! return a function. Recovering those calls *creates* findings from template
+//! evidence, so they come from the template AST and an oxc parse of each
+//! expression; see [`super::template_scan`] for the over-match analysis and the
+//! shadowing rules.
 
-use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
+mod computed_names;
+#[cfg(test)]
+mod tests;
+
+use super::template_scan::{TemplateCall, for_each_template_call};
+use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta, SfcScriptContext};
 use crate::diagnostic::{LintDiagnostic, Severity};
-use oxc_ast::ast::{
-    Argument, CallExpression, ExportDefaultDeclarationKind, Expression, ObjectExpression,
-    ObjectPropertyKind, Program, PropertyKey, Statement,
-};
+use oxc_ast::ast::{CallExpression, Expression, Program};
 use oxc_ast_visit::{Visit, walk::walk_call_expression};
 use oxc_span::Span;
-use vize_carton::{CompactString, FxHashMap, FxHashSet};
+use vize_carton::{CompactString, FxHashSet};
+
+use self::computed_names::{collect_computed_names, find_component_options};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-use-computed-property-like-method",
@@ -40,11 +60,28 @@ impl ScriptRule for NoUseComputedPropertyLikeMethod {
     }
 
     #[inline]
+    fn uses_template_ast(&self) -> bool {
+        true
+    }
+
     fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        // Keep the parse-owning `check` path functional: without SFC context
+        // only the script call sites are observable.
+        self.check_program_with_sfc(program, source, offset, SfcScriptContext::default(), result);
+    }
+
+    fn check_program_with_sfc<'a>(
         &self,
         program: &'a Program<'a>,
         _source: &str,
         offset: usize,
+        sfc: SfcScriptContext<'_>,
         result: &mut ScriptLintResult,
     ) {
         let Some(options) = find_component_options(program) else {
@@ -61,29 +98,32 @@ impl ScriptRule for NoUseComputedPropertyLikeMethod {
             fn_depth: 0,
         };
         visitor.visit_object_expression(options);
+
+        check_template(&computed_names, sfc, result);
     }
 }
 
-/// Collect the names declared in the `computed` option. Only plain
-/// (non-computed-key) properties contribute; spreads like `...mapGetters([..])`
-/// are skipped since their member names are not statically known.
-fn collect_computed_names<'a>(options: &'a ObjectExpression<'a>) -> FxHashSet<CompactString> {
-    let mut names = FxHashSet::default();
-    let Some(computed) = find_computed_object(options) else {
-        return names;
+/// The template half: a bare `computedName(...)` in a template expression.
+fn check_template(
+    computed_names: &FxHashSet<CompactString>,
+    sfc: SfcScriptContext<'_>,
+    result: &mut ScriptLintResult,
+) {
+    let Some((root, template_offset)) = sfc.template_ast() else {
+        return;
     };
-    for property in &computed.properties {
-        let ObjectPropertyKind::ObjectProperty(property) = property else {
-            continue;
-        };
-        if property.computed {
-            continue;
+    for_each_template_call(root, |call: TemplateCall<'_>| {
+        if !computed_names.contains(call.callee) {
+            return;
         }
-        if let Some(name) = property_key_name(&property.key) {
-            names.insert(CompactString::from(name));
-        }
-    }
-    names
+        report(
+            template_offset + call.start,
+            template_offset + call.end,
+            call.callee,
+            TEMPLATE_HELP,
+            result,
+        );
+    });
 }
 
 /// Walks the component and reports `this.<computedName>(...)` member calls.
@@ -128,128 +168,23 @@ impl ComputedCallVisitor<'_> {
     fn report(&mut self, span: Span, name: &str) {
         let start = self.offset as u32 + span.start;
         let end = self.offset as u32 + span.end;
-        let mut message = CompactString::with_capacity(name.len() + 56);
-        message.push_str("'");
-        message.push_str(name);
-        message.push_str("' is a computed property and must not be called like a method.");
-        let diagnostic = LintDiagnostic::error(META.name, message, start, end)
-            .with_label("computed value called as a function", start, end)
-            .with_help(
-                "A computed property exposes a value, not a function. Read it as \
-                 `this.<name>` (drop the call parentheses), or move the logic into a \
-                 `method` if you need to invoke it.",
-            );
-        self.result.add_diagnostic(diagnostic);
+        report(start, end, name, SCRIPT_HELP, self.result);
     }
 }
 
-fn find_computed_object<'a>(options: &'a ObjectExpression<'a>) -> Option<&'a ObjectExpression<'a>> {
-    for property in &options.properties {
-        let ObjectPropertyKind::ObjectProperty(property) = property else {
-            continue;
-        };
-        if property.computed {
-            continue;
-        }
-        if matches!(property_key_name(&property.key), Some("computed"))
-            && let Expression::ObjectExpression(object) = &property.value
-        {
-            return Some(object);
-        }
-    }
-    None
+const SCRIPT_HELP: &str = "A computed property exposes a value, not a function. Read it as \
+     `this.<name>` (drop the call parentheses), or move the logic into a \
+     `method` if you need to invoke it.";
+const TEMPLATE_HELP: &str = "A computed property exposes a value, not a function. Drop the call \
+     parentheses (`{{ name }}`), or move the logic into a `method` if you need to invoke it.";
+
+fn report(start: u32, end: u32, name: &str, help: &'static str, result: &mut ScriptLintResult) {
+    let mut message = CompactString::with_capacity(name.len() + 56);
+    message.push_str("'");
+    message.push_str(name);
+    message.push_str("' is a computed property and must not be called like a method.");
+    let diagnostic = LintDiagnostic::error(META.name, message, start, end)
+        .with_label("computed value called as a function", start, end)
+        .with_help(help);
+    result.add_diagnostic(diagnostic);
 }
-
-fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
-    match key {
-        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
-        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
-        _ => None,
-    }
-}
-
-// Component options resolution (export default / defineComponent), mirroring
-// `no_side_effects_in_computed`: a plain object, an identifier bound to one, or
-// a `defineComponent(...)` wrapper, optionally through TS expression wrappers.
-fn find_component_options<'a>(program: &'a Program<'a>) -> Option<&'a ObjectExpression<'a>> {
-    let mut bindings: FxHashMap<&'a str, &'a ObjectExpression<'a>> = FxHashMap::default();
-
-    for statement in program.body.iter() {
-        let Statement::VariableDeclaration(declaration) = statement else {
-            continue;
-        };
-        for declarator in &declaration.declarations {
-            let Some(init) = declarator.init.as_ref() else {
-                continue;
-            };
-            if let oxc_ast::ast::BindingPattern::BindingIdentifier(id) = &declarator.id
-                && let Some(object) = options_from_expression(init, &bindings)
-            {
-                bindings.insert(id.name.as_str(), object);
-            }
-        }
-    }
-
-    for statement in program.body.iter() {
-        let Statement::ExportDefaultDeclaration(export) = statement else {
-            continue;
-        };
-        if let Some(object) = options_from_export(&export.declaration, &bindings) {
-            return Some(object);
-        }
-    }
-
-    None
-}
-
-fn options_from_export<'a>(
-    declaration: &'a ExportDefaultDeclarationKind<'a>,
-    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
-) -> Option<&'a ObjectExpression<'a>> {
-    // Every export-default kind we care about is also an `Expression` variant,
-    // so route through the shared expression resolver.
-    options_from_expression(declaration.as_expression()?, bindings)
-}
-
-/// Resolve an expression to the component options object, peeling
-/// parenthesized/TS-cast wrappers, following identifier bindings, and entering
-/// `defineComponent(...)` calls.
-fn options_from_expression<'a>(
-    expression: &'a Expression<'a>,
-    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
-) -> Option<&'a ObjectExpression<'a>> {
-    match expression {
-        Expression::ObjectExpression(object) => Some(object),
-        Expression::CallExpression(call) => options_from_call(call, bindings),
-        Expression::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
-        Expression::ParenthesizedExpression(paren) => {
-            options_from_expression(&paren.expression, bindings)
-        }
-        Expression::TSAsExpression(ts_as) => options_from_expression(&ts_as.expression, bindings),
-        Expression::TSSatisfiesExpression(ts) => options_from_expression(&ts.expression, bindings),
-        Expression::TSNonNullExpression(ts) => options_from_expression(&ts.expression, bindings),
-        _ => None,
-    }
-}
-
-fn options_from_call<'a>(
-    call: &'a CallExpression<'a>,
-    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
-) -> Option<&'a ObjectExpression<'a>> {
-    let Expression::Identifier(callee) = &call.callee else {
-        return None;
-    };
-    if !matches!(callee.name.as_str(), "defineComponent" | "_defineComponent") {
-        return None;
-    }
-    match call.arguments.first()? {
-        Argument::ObjectExpression(object) => Some(object),
-        Argument::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
-        argument => argument
-            .as_expression()
-            .and_then(|expression| options_from_expression(expression, bindings)),
-    }
-}
-
-#[cfg(test)]
-mod tests;

--- a/crates/vize_patina/src/rules/script/no_use_computed_property_like_method/computed_names.rs
+++ b/crates/vize_patina/src/rules/script/no_use_computed_property_like_method/computed_names.rs
@@ -1,0 +1,142 @@
+//! The names declared in the Options API `computed` option.
+//!
+//! Component options resolution mirrors `no_side_effects_in_computed`: a plain
+//! object, an identifier bound to one, or a `defineComponent(...)` wrapper,
+//! optionally through TS expression wrappers.
+
+use oxc_ast::ast::{
+    Argument, BindingPattern, CallExpression, ExportDefaultDeclarationKind, Expression,
+    ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
+};
+use vize_carton::{CompactString, FxHashMap, FxHashSet};
+
+/// Collect the names declared in the `computed` option. Only plain
+/// (non-computed-key) properties contribute; spreads like `...mapGetters([..])`
+/// are skipped since their member names are not statically known.
+pub(super) fn collect_computed_names<'a>(
+    options: &'a ObjectExpression<'a>,
+) -> FxHashSet<CompactString> {
+    let mut names = FxHashSet::default();
+    let Some(computed) = find_computed_object(options) else {
+        return names;
+    };
+    for property in &computed.properties {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            continue;
+        };
+        if property.computed {
+            continue;
+        }
+        if let Some(name) = property_key_name(&property.key) {
+            names.insert(CompactString::from(name));
+        }
+    }
+    names
+}
+
+fn find_computed_object<'a>(options: &'a ObjectExpression<'a>) -> Option<&'a ObjectExpression<'a>> {
+    for property in &options.properties {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            continue;
+        };
+        if property.computed {
+            continue;
+        }
+        if matches!(property_key_name(&property.key), Some("computed"))
+            && let Expression::ObjectExpression(object) = &property.value
+        {
+            return Some(object);
+        }
+    }
+    None
+}
+
+pub(super) fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
+    }
+}
+
+pub(super) fn find_component_options<'a>(
+    program: &'a Program<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    let mut bindings: FxHashMap<&'a str, &'a ObjectExpression<'a>> = FxHashMap::default();
+
+    for statement in program.body.iter() {
+        let Statement::VariableDeclaration(declaration) = statement else {
+            continue;
+        };
+        for declarator in &declaration.declarations {
+            let Some(init) = declarator.init.as_ref() else {
+                continue;
+            };
+            if let BindingPattern::BindingIdentifier(id) = &declarator.id
+                && let Some(object) = options_from_expression(init, &bindings)
+            {
+                bindings.insert(id.name.as_str(), object);
+            }
+        }
+    }
+
+    for statement in program.body.iter() {
+        let Statement::ExportDefaultDeclaration(export) = statement else {
+            continue;
+        };
+        if let Some(object) = options_from_export(&export.declaration, &bindings) {
+            return Some(object);
+        }
+    }
+
+    None
+}
+
+fn options_from_export<'a>(
+    declaration: &'a ExportDefaultDeclarationKind<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    // Every export-default kind we care about is also an `Expression` variant,
+    // so route through the shared expression resolver.
+    options_from_expression(declaration.as_expression()?, bindings)
+}
+
+/// Resolve an expression to the component options object, peeling
+/// parenthesized/TS-cast wrappers, following identifier bindings, and entering
+/// `defineComponent(...)` calls.
+fn options_from_expression<'a>(
+    expression: &'a Expression<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object),
+        Expression::CallExpression(call) => options_from_call(call, bindings),
+        Expression::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
+        Expression::ParenthesizedExpression(paren) => {
+            options_from_expression(&paren.expression, bindings)
+        }
+        Expression::TSAsExpression(ts_as) => options_from_expression(&ts_as.expression, bindings),
+        Expression::TSSatisfiesExpression(ts) => options_from_expression(&ts.expression, bindings),
+        Expression::TSNonNullExpression(ts) => options_from_expression(&ts.expression, bindings),
+        _ => None,
+    }
+}
+
+fn options_from_call<'a>(
+    call: &'a CallExpression<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    let Expression::Identifier(callee) = &call.callee else {
+        return None;
+    };
+    if !matches!(callee.name.as_str(), "defineComponent" | "_defineComponent") {
+        return None;
+    }
+    match call.arguments.first()? {
+        Argument::ObjectExpression(object) => Some(object),
+        Argument::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
+        argument => argument
+            .as_expression()
+            .and_then(|expression| options_from_expression(expression, bindings)),
+    }
+}

--- a/crates/vize_patina/src/rules/script/no_use_computed_property_like_method/tests.rs
+++ b/crates/vize_patina/src/rules/script/no_use_computed_property_like_method/tests.rs
@@ -1,11 +1,47 @@
 use super::NoUseComputedPropertyLikeMethod;
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
 use crate::rules::script::ScriptLinter;
+
+// Template-half tests (#3414 A) live in the `template` submodule.
+mod template;
 
 /// Lint `source` with only this rule enabled and return the error count.
 fn count(source: &str) -> usize {
     let mut linter = ScriptLinter::new();
     linter.add_rule(Box::new(NoUseComputedPropertyLikeMethod));
     linter.lint(source, 0).error_count
+}
+
+/// Lint a full SFC end-to-end with only this rule enabled, exercising the
+/// engine path that supplies the parsed `<template>` AST to the rule.
+fn lint_sfc(sfc: &str) -> LintResult {
+    Linter::new()
+        .with_enabled_rules(Some(vec![
+            "script/no-use-computed-property-like-method".into(),
+        ]))
+        .lint_sfc(sfc, "Probe.vue")
+}
+
+/// The full identity of every finding: rule, severity, byte range, message.
+fn findings(result: &LintResult) -> Vec<(&'static str, Severity, u32, u32, &str)> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            (
+                diagnostic.rule_name,
+                diagnostic.severity,
+                diagnostic.start,
+                diagnostic.end,
+                diagnostic.message.as_str(),
+            )
+        })
+        .collect()
+}
+
+fn none() -> Vec<(&'static str, Severity, u32, u32, &'static str)> {
+    Vec::new()
 }
 
 // Each case is `(source, expected_error_count)`.

--- a/crates/vize_patina/src/rules/script/no_use_computed_property_like_method/tests/template.rs
+++ b/crates/vize_patina/src/rules/script/no_use_computed_property_like_method/tests/template.rs
@@ -1,0 +1,233 @@
+//! Template half (#3414 A): a computed called like a method from the template.
+//!
+//! Because this half *creates* findings from template evidence, the over-match
+//! probes are as load-bearing as the positive cases: each asserts the full
+//! finding set, and the negative ones assert it is exactly empty.
+
+use super::{findings, lint_sfc, none};
+use crate::diagnostic::Severity;
+
+const OPTIONS: &str = r#"<script>
+export default {
+  computed: {
+    total() { return 1; },
+  },
+};
+</script>
+"#;
+
+/// The finding the call written as `call` produces. `call` is located inside
+/// the `<template>` block, since the shared script declares `total()` too.
+fn called(sfc: &str, call: &str, name: &str) -> (&'static str, Severity, u32, u32, &'static str) {
+    let template = sfc.find("<template>").expect("template block");
+    let start = template + sfc[template..].find(call).expect("call expression");
+    (
+        "script/no-use-computed-property-like-method",
+        Severity::Error,
+        start as u32,
+        (start + call.len()) as u32,
+        match name {
+            "total" => "'total' is a computed property and must not be called like a method.",
+            other => panic!("unexpected computed name {other}"),
+        },
+    )
+}
+
+/// An SFC made of the shared Options API script plus `template`.
+fn sfc(template: &str) -> std::string::String {
+    format!("{OPTIONS}\n<template>\n{template}\n</template>\n")
+}
+
+// --- The recovered case: a computed called from a template expression ------
+
+#[test]
+fn reports_a_computed_called_in_an_interpolation_issue_3414() {
+    // Exact reproduction from #3414 A.
+    let source = sfc("  <div>{{ total() }}</div>");
+    assert_eq!(
+        findings(&lint_sfc(&source)),
+        vec![called(&source, "total()", "total")]
+    );
+}
+
+#[test]
+fn reports_a_computed_called_in_a_bound_attribute() {
+    let source = sfc(r#"  <div :title="total()"></div>"#);
+    assert_eq!(
+        findings(&lint_sfc(&source)),
+        vec![called(&source, "total()", "total")]
+    );
+}
+
+#[test]
+fn reports_a_computed_called_in_an_inline_handler() {
+    let source = sfc(r#"  <button @click="total()">go</button>"#);
+    assert_eq!(
+        findings(&lint_sfc(&source)),
+        vec![called(&source, "total()", "total")]
+    );
+}
+
+#[test]
+fn reports_a_computed_called_inside_a_v_for_body() {
+    let source = sfc(r#"  <ul><li v-for="row in rows" :key="row">{{ total() }}</li></ul>"#);
+    assert_eq!(
+        findings(&lint_sfc(&source)),
+        vec![called(&source, "total()", "total")]
+    );
+}
+
+#[test]
+fn reports_a_computed_called_as_a_nested_argument() {
+    let source = sfc(r#"  <div>{{ String(total()) }}</div>"#);
+    assert_eq!(
+        findings(&lint_sfc(&source)),
+        vec![called(&source, "total()", "total")]
+    );
+}
+
+// --- The computed is read, not called: exactly zero findings ---------------
+
+#[test]
+fn ignores_a_computed_read_as_a_value() {
+    let source = sfc("  <div>{{ total }}</div>");
+    assert_eq!(findings(&lint_sfc(&source)), none());
+}
+
+#[test]
+fn ignores_a_method_called_from_the_template() {
+    let source = r#"<script>
+export default {
+  computed: {
+    total() { return 1; },
+  },
+  methods: {
+    reload() { return 2; },
+  },
+};
+</script>
+
+<template>
+  <button @click="reload()">go</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(source)), none());
+}
+
+// --- Over-match probes: none of these may manufacture a finding ------------
+
+#[test]
+fn ignores_a_call_inside_an_html_comment() {
+    let source = sfc("  <div><!-- total() --></div>");
+    assert_eq!(findings(&lint_sfc(&source)), none());
+}
+
+#[test]
+fn ignores_a_call_in_a_text_node_or_plain_attribute() {
+    let source = sfc(r#"  <p title="total()">total()</p>"#);
+    assert_eq!(findings(&lint_sfc(&source)), none());
+}
+
+#[test]
+fn ignores_a_call_inside_a_string_literal() {
+    let source = sfc(r#"  <button @click="console.log('total()')">go</button>"#);
+    assert_eq!(findings(&lint_sfc(&source)), none());
+}
+
+#[test]
+fn ignores_a_call_inside_a_v_pre_region() {
+    let source = sfc("  <pre v-pre>{{ total() }}</pre>");
+    assert_eq!(findings(&lint_sfc(&source)), none());
+}
+
+#[test]
+fn ignores_an_identifier_that_merely_ends_with_the_computed_name() {
+    let source = sfc("  <div>{{ subtotal() }}</div>");
+    assert_eq!(findings(&lint_sfc(&source)), none());
+}
+
+#[test]
+fn ignores_a_member_call_whose_property_is_the_computed_name() {
+    // `bus.total()` dispatches on another object, not on this component.
+    let source = sfc("  <div>{{ bus.total() }}</div>");
+    assert_eq!(findings(&lint_sfc(&source)), none());
+}
+
+#[test]
+fn ignores_a_slot_variable_that_shadows_the_computed_name() {
+    let source = sfc(r#"  <Child v-slot="{ total }">{{ total() }}</Child>"#);
+    assert_eq!(findings(&lint_sfc(&source)), none());
+}
+
+#[test]
+fn ignores_a_v_for_alias_that_shadows_the_computed_name() {
+    let source = sfc(r#"  <ul><li v-for="total in rows" :key="total">{{ total() }}</li></ul>"#);
+    assert_eq!(findings(&lint_sfc(&source)), none());
+}
+
+#[test]
+fn still_reports_a_computed_after_a_shadowing_subtree_ends() {
+    let source = sfc(
+        "  <ul><li v-for=\"total in rows\" :key=\"total\">{{ total() }}</li></ul>\n  <p>{{ total() }}</p>",
+    );
+    let last = source.rfind("total()").expect("second call");
+    assert_eq!(
+        findings(&lint_sfc(&source)),
+        vec![(
+            "script/no-use-computed-property-like-method",
+            Severity::Error,
+            last as u32,
+            (last + "total()".len()) as u32,
+            "'total' is a computed property and must not be called like a method.",
+        )]
+    );
+}
+
+#[test]
+fn ignores_a_template_when_the_script_declares_no_computed() {
+    let source = r#"<script>
+export default {
+  methods: {
+    total() { return 1; },
+  },
+};
+</script>
+
+<template>
+  <div>{{ total() }}</div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(source)), none());
+}
+
+// --- The pre-existing script-only subset must keep working -----------------
+
+#[test]
+fn still_reports_a_this_member_call_through_the_sfc_path() {
+    let source = r#"<script>
+export default {
+  computed: {
+    total() { return 1; },
+  },
+  methods: {
+    go() { return this.total(); },
+  },
+};
+</script>
+
+<template>
+  <div>{{ total }}</div>
+</template>
+"#;
+    let call = source.find("this.total()").expect("member call");
+    assert_eq!(
+        findings(&lint_sfc(source)),
+        vec![(
+            "script/no-use-computed-property-like-method",
+            Severity::Error,
+            call as u32,
+            (call + "this.total()".len()) as u32,
+            "'total' is a computed property and must not be called like a method.",
+        )]
+    );
+}

--- a/crates/vize_patina/src/rules/script/template_scan.rs
+++ b/crates/vize_patina/src/rules/script/template_scan.rs
@@ -1,0 +1,214 @@
+//! Calls a `<template>` performs, recovered exactly enough to *create* a
+//! finding.
+//!
+//! # Why the AST plus a real parse
+//!
+//! A call recovered from the template creates a diagnostic, so an over-match is
+//! a false positive — the direction #3223 calls dangerous, and the opposite of
+//! [`crate::rules::script::props_emits::template_emits`], whose raw scan can
+//! only ever suppress an "unused" report. A substring sweep for `name(` over
+//! the raw template would fire on all of these, none of which call anything:
+//!
+//! * `<!-- total() -->` — an HTML comment.
+//! * `<p>total()</p>` — a text node.
+//! * `<div title="total()">` — a plain attribute, not an expression.
+//! * `@click="log('total()')"` — the call is inside a string literal.
+//! * `@click="subtotal()"` — a longer identifier ending in the name.
+//! * `<pre v-pre>{{ total() }}</pre>` — a region Vue never compiles.
+//! * `<Child v-slot="{ total }">{{ total() }}</Child>` — the name is a slot
+//!   variable, not the component's own binding.
+//!
+//! So the evidence is taken from the **template AST** — only a directive
+//! carrying an expression and an interpolation's content, which structurally
+//! excludes comments, text nodes, plain attributes and `v-pre` regions (the
+//! parser rewrites a `v-pre` region's directives to attributes and its
+//! interpolations to text) — and each expression is then **parsed with oxc**,
+//! so only a genuine `CallExpression` with a plain identifier callee counts. An
+//! occurrence inside a string literal parses to a `StringLiteral` and can never
+//! be a callee, and `subtotal` is a different `IdentifierReference`.
+//!
+//! # Direction of error
+//!
+//! * **Over-match** would be a false positive, so every step above is exact.
+//!   The one deliberate imprecision is shadowing (a `v-for` alias or a slot
+//!   variable reusing a name), and it errs towards *not* reporting.
+//! * **Under-match** loses a report: an expression oxc cannot parse is skipped,
+//!   as is a member callee (`bus.emit('x')`, deliberately — it dispatches on
+//!   another object) and a dynamic directive argument (`:[key]="…"`).
+
+mod calls;
+
+use vize_carton::String;
+use vize_relief::{
+    DirectiveNode, ElementNode, ExpressionNode, PropNode, RootNode, TemplateChildNode,
+};
+
+pub(super) use calls::TemplateCall;
+
+/// Visit every call with a plain identifier callee that the template performs.
+///
+/// Calls whose callee is shadowed by an enclosing `v-for` alias or slot
+/// variable are skipped: inside that subtree the name is the iteration /slot
+/// binding, not the component's own.
+pub(super) fn for_each_template_call(root: &RootNode<'_>, mut visit: impl FnMut(TemplateCall<'_>)) {
+    let mut walker = Walker {
+        shadowed: Vec::new(),
+    };
+    walker.walk(&root.children, &mut visit);
+}
+
+struct Walker {
+    /// Names bound by an enclosing `v-for` alias or slot variable.
+    ///
+    /// Collected as bare identifier tokens out of the alias / slot expression
+    /// rather than by parsing the binding pattern, so a destructuring pattern
+    /// contributes every name it mentions — including a renamed source key
+    /// (`v-slot="{ total: sum }"` shadows both `total` and `sum`). That
+    /// over-collects, which only ever *suppresses* a call, the safe direction
+    /// for evidence that creates findings.
+    shadowed: Vec<String>,
+}
+
+impl Walker {
+    fn walk(
+        &mut self,
+        children: &[TemplateChildNode<'_>],
+        visit: &mut impl FnMut(TemplateCall<'_>),
+    ) {
+        for child in children {
+            match child {
+                TemplateChildNode::Element(element) => self.walk_element(element, visit),
+                TemplateChildNode::Interpolation(interpolation) => {
+                    self.scan(&interpolation.content, visit);
+                }
+                // `v-if` / `v-for` are still plain directives in the parse this
+                // reads, so these arms only matter if a transformed AST is ever
+                // passed in. Walking them keeps that case correct.
+                TemplateChildNode::If(if_node) => {
+                    for branch in if_node.branches.iter() {
+                        self.walk(&branch.children, visit);
+                    }
+                }
+                TemplateChildNode::For(for_node) => self.walk(&for_node.children, visit),
+                _ => {}
+            }
+        }
+    }
+
+    fn walk_element(
+        &mut self,
+        element: &ElementNode<'_>,
+        visit: &mut impl FnMut(TemplateCall<'_>),
+    ) {
+        let depth = self.shadowed.len();
+
+        // A `v-for` alias is in scope for the element's *own* bindings as well
+        // as its children (`v-for="total in rows" @click="total()"` calls the
+        // iteration variable), so it is collected before any directive here is
+        // scanned.
+        for prop in element.props.iter() {
+            if let PropNode::Directive(directive) = prop
+                && directive.name.as_str() == "for"
+            {
+                push_for_aliases(directive, &mut self.shadowed);
+            }
+        }
+
+        for prop in element.props.iter() {
+            if let PropNode::Directive(directive) = prop
+                && let Some(exp) = directive.exp.as_ref()
+                // `v-for`'s expression is `item in items`, not JavaScript, and
+                // `v-slot`'s is a binding pattern rather than a reference.
+                && !matches!(directive.name.as_str(), "for" | "slot")
+            {
+                self.scan(exp, visit);
+            }
+        }
+
+        // A slot variable, by contrast, scopes the slot *content*, so it is
+        // collected only after this element's own directives are scanned.
+        for prop in element.props.iter() {
+            if let PropNode::Directive(directive) = prop
+                && directive.name.as_str() == "slot"
+                && let Some(exp) = directive.exp.as_ref()
+            {
+                push_identifier_tokens(expression_source(exp), &mut self.shadowed);
+            }
+        }
+
+        self.walk(&element.children, visit);
+        self.shadowed.truncate(depth);
+    }
+
+    fn scan(&self, exp: &ExpressionNode<'_>, visit: &mut impl FnMut(TemplateCall<'_>)) {
+        let shadowed = &self.shadowed;
+        calls::for_each_call(
+            expression_source(exp),
+            exp.loc().start.offset,
+            &mut |call| {
+                if shadowed.iter().any(|name| name.as_str() == call.callee) {
+                    return;
+                }
+                visit(call);
+            },
+        );
+    }
+}
+
+/// Push the value / key / index aliases of a `v-for` directive.
+///
+/// The parsed aliases are preferred; a `v-for` the parser could not split falls
+/// back to the whole expression, whose identifier tokens include the source as
+/// well as the aliases. Over-collecting only suppresses calls.
+fn push_for_aliases(directive: &DirectiveNode<'_>, out: &mut Vec<String>) {
+    if let Some(parsed) = directive.for_parse_result.as_ref() {
+        for alias in [
+            parsed.value.as_ref(),
+            parsed.key.as_ref(),
+            parsed.index.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            push_identifier_tokens(expression_source(alias), out);
+        }
+        return;
+    }
+    if let Some(exp) = directive.exp.as_ref() {
+        push_identifier_tokens(expression_source(exp), out);
+    }
+}
+
+fn expression_source<'a>(exp: &'a ExpressionNode<'a>) -> &'a str {
+    match exp {
+        ExpressionNode::Simple(simple) => simple.content.as_str(),
+        ExpressionNode::Compound(compound) => compound.loc.source.as_str(),
+    }
+}
+
+/// Push every identifier-shaped token of `source` onto `out`.
+fn push_identifier_tokens(source: &str, out: &mut Vec<String>) {
+    let bytes = source.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if !is_identifier_start(bytes[index]) {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        while index < bytes.len() && is_identifier_byte(bytes[index]) {
+            index += 1;
+        }
+        out.push(String::new(&source[start..index]));
+    }
+}
+
+#[inline]
+fn is_identifier_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_' || byte == b'$'
+}
+
+#[inline]
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+}

--- a/crates/vize_patina/src/rules/script/template_scan/calls.rs
+++ b/crates/vize_patina/src/rules/script/template_scan/calls.rs
@@ -1,0 +1,77 @@
+//! One template expression, parsed with oxc, yielding its identifier-callee
+//! calls.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{CallExpression, Expression};
+use oxc_ast_visit::{Visit, walk::walk_call_expression};
+use oxc_parser::Parser;
+use oxc_span::{SourceType, Span};
+
+/// A call the template performs, with a plain identifier callee.
+pub(in crate::rules::script) struct TemplateCall<'a> {
+    /// The callee identifier, e.g. `total`.
+    pub(in crate::rules::script) callee: &'a str,
+    /// Byte range of the call expression, relative to the template block.
+    pub(in crate::rules::script) start: u32,
+    /// Exclusive end of [`TemplateCall::start`].
+    pub(in crate::rules::script) end: u32,
+}
+
+/// Call `visit` for every identifier-callee call in `source`, a single
+/// template expression whose first byte sits at `base` in the template block.
+///
+/// A template expression may be a statement list rather than a single
+/// expression (`@click="a(); b()"` is valid), so it is parsed as a program.
+/// Sources oxc rejects are skipped: a call invented from a mis-parse would be a
+/// false positive, and a template that does not compile has larger problems.
+pub(super) fn for_each_call(source: &str, base: u32, visit: &mut impl FnMut(TemplateCall<'_>)) {
+    // Cheap reject for the overwhelmingly common expression (`{{ msg }}`,
+    // `:class="cls"`): no call syntax, nothing to parse.
+    if !source.contains('(') {
+        return;
+    }
+    let allocator = Allocator::default();
+    let parsed = Parser::new(
+        &allocator,
+        source,
+        SourceType::default().with_typescript(true),
+    )
+    .parse();
+    if parsed.panicked || !parsed.errors.is_empty() {
+        return;
+    }
+    let mut collector = CallCollector { calls: Vec::new() };
+    collector.visit_program(&parsed.program);
+    for call in collector.calls {
+        visit(TemplateCall {
+            callee: call.callee,
+            start: base + call.span.start,
+            end: base + call.span.end,
+        });
+    }
+}
+
+struct CollectedCall<'a> {
+    callee: &'a str,
+    span: Span,
+}
+
+struct CallCollector<'a> {
+    calls: Vec<CollectedCall<'a>>,
+}
+
+impl<'a> Visit<'a> for CallCollector<'a> {
+    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+        // Only a plain identifier callee: a member call (`bus.emit('x')`,
+        // `child.$emit('x')`) dispatches on another object, which is a
+        // different thing entirely and is deliberately not tracked.
+        if let Expression::Identifier(callee) = &it.callee {
+            self.calls.push(CollectedCall {
+                callee: callee.name.as_str(),
+                span: it.span,
+            });
+        }
+        // Keep walking: an argument can hold further calls (`a(b())`).
+        walk_call_expression(self, it);
+    }
+}


### PR DESCRIPTION
## Defect (#3414 A)

`script/no-use-computed-property-like-method` is documented as *"scoped
conservatively to the Options API: only `this.<computedName>(...)` member calls
are flagged"* — because a `script/*` rule could not observe the `<template>`.
That left the highest-value call site unchecked.

## Minimal reproduction

```vue
<script>
export default {
  computed: {
    total() { return 1; },
  },
};
</script>

<template>
  <div>{{ total() }}</div>
</template>
```

`Linter::new().with_enabled_rules(Some(vec!["script/no-use-computed-property-like-method"])).lint_sfc(sfc, "Probe.vue")`

- Actual: 0 findings.
- Expected: 1. `{{ total() }}` evaluates the computed *value* and immediately
  calls it, which throws at runtime unless the computed happens to return a
  function.

Moving the same call into `methods: { go() { return this.total() } }` already
reported, so only the template call sites were missing.

## Over-match / under-match analysis

This is the direction #3223 calls dangerous: template evidence that **creates** a
finding. The existing raw scan in `props_emits/template_emits.rs` is explicitly
one-directional — over-matching there only suppresses an "unused" report — so it
could not be reused. A substring sweep for `total(` over the raw template would
fire on all of these, none of which call the computed:

| case | why it must not report |
| --- | --- |
| `<!-- total() -->` | HTML comment |
| `<p title="total()">total()</p>` | plain attribute and text node |
| `@click="console.log('total()')"` | inside a string literal |
| `{{ subtotal() }}` | a longer identifier ending in the name |
| `<pre v-pre>{{ total() }}</pre>` | region Vue never compiles |
| `{{ bus.total() }}` | a member callee dispatches on another object |
| `<Child v-slot="{ total }">{{ total() }}</Child>` | the name is a slot variable |
| `<li v-for="total in rows">{{ total() }}</li>` | the name is the iteration variable |

So the evidence is taken from the **template AST** — a `DirectiveNode` carrying
an expression, or an `InterpolationNode`'s content, which structurally excludes
comments, text nodes, plain attributes and `v-pre` regions (the parser rewrites
a `v-pre` region's directives to attributes and its interpolations to text) —
and each expression is then **parsed with oxc**, so only a genuine
`CallExpression` with a plain `Identifier` callee counts. An occurrence inside a
string literal parses to a `StringLiteral` and can never be a callee, and
`subtotal` is a different `IdentifierReference`.

Every row above has a test asserting **exactly zero** findings, plus one
asserting that a name *stops* being shadowed when the `v-for` subtree ends.

**Where over-matching is still possible it suppresses rather than reports.**
Shadowing names are collected as bare identifier tokens out of the `v-for` alias
/ slot expression rather than by parsing the binding pattern, so
`v-slot="{ total: sum }"` shadows both `total` and `sum`. Over-collecting only
ever removes a report.

**Under-matching loses a report**, the tolerable direction: an expression oxc
cannot parse is skipped, as is a member callee and a dynamic directive argument
(`:[key]="…"`). `v-for`'s own expression (`item in items`) and `v-slot`'s
binding pattern are not JavaScript references and are not scanned.

All of this is written into the module docs of
`crates/vize_patina/src/rules/script/template_scan.rs`.

## Shared infrastructure

The walk-plus-parse machinery lands as `rules/script/template_scan`, not inside
this rule, because #3413 needs exactly the same evidence for template `$emit`
calls:

```rust
for_each_template_call(root, |call| { /* call.callee, call.start, call.end */ });
```

Only calls with a plain identifier callee are yielded, already filtered for
shadowing, with the span mapped into template-block coordinates. Each expression
is parsed at most once, and only when it contains a `(` at all — the
overwhelmingly common `{{ msg }}` / `:class="cls"` never reaches oxc.

## Location

Reported at the **call expression** inside the template expression, mapped into
whole-SFC coordinates through `template_offset` — the same granularity upstream
uses. The script half keeps reporting at the `this.total()` call, unchanged. The
two halves carry the same message and different help text (`{{ name }}` vs
`this.<name>`), since the fix differs.

## How the new tests fail before the fix

With the `check_template` call short-circuited (the pre-fix behaviour),
`cargo test -p vize_patina --lib no_use_computed_property_like_method::tests::template`
fails exactly the six positive-direction tests and passes all twelve others,
including every over-match probe and the script-half regression test:

```
reports_a_computed_called_in_an_interpolation_issue_3414 ... FAILED
reports_a_computed_called_in_a_bound_attribute ... FAILED
reports_a_computed_called_in_an_inline_handler ... FAILED
reports_a_computed_called_inside_a_v_for_body ... FAILED
reports_a_computed_called_as_a_nested_argument ... FAILED
still_reports_a_computed_after_a_shadowing_subtree_ends ... FAILED
test result: FAILED. 12 passed; 6 failed
```

With the fix: `20 passed; 0 failed` for the whole rule (18 template + 2
pre-existing script-only tests, both unchanged — including the `diagnostic_shape`
snapshot, which is byte-identical).

## File split

`no_use_computed_property_like_method.rs` was 255 lines. It becomes 190, plus
`computed_names.rs` (142, the options + `computed` resolution moved verbatim) and
`tests/template.rs` (233); `tests.rs` grows 100 → 136. The shared
`template_scan.rs` is 214 and `template_scan/calls.rs` 77.
`rules/script.rs` grows 344 → 345.

## Gates run

- `nix develop -c vp run fmt:check` — pass
- `nix develop -c vp run lint:rust` (clippy `-D warnings`) — pass
- `nix develop -c vp run check:rust` — pass
- `nix develop -c cargo test -p vize_patina` — 2290 passed, 0 failed (rebased on
  `d4986fb5c`)

Refs #3414
Refs #3223


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Extended the computed-property method lint rule to analyze Vue template expressions, including interpolations, bound attributes, event handlers, loops, and nested calls.
  - Added support for resolving computed properties from component options and common component definitions.
  - Improved diagnostics with template-specific guidance.

- **Bug Fixes**
  - Avoids false positives for member calls, shadowed variables, comments, strings, `v-pre` content, and non-call expressions.
  - Preserves existing script analysis behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->