### PR TITLE
feat(cli): add an interactive `vize init` that configures the lint file the lint command reads

### DIFF
--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -58,7 +58,7 @@
     "check:fix": "vp check --fix src tests vite.config.ts",
     "fmt": "vp fmt --write src tests vite.config.ts",
     "generate:rule-types": "vp run --workspace-root generate:rule-types",
-    "test": "vp pack && vp test run tests/setup.test.ts"
+    "test": "vp pack && vp test run tests/setup.test.ts tests/init.test.ts tests/init-frameworks.test.ts tests/init-prompt.test.ts"
   },
   "dependencies": {
     "@vizejs/native": "workspace:*",

--- a/npm/cli/src/cli.ts
+++ b/npm/cli/src/cli.ts
@@ -1,19 +1,28 @@
 import { createRequire } from "node:module";
 
+import { runInitCli } from "./init.js";
 import { runSetupCli } from "./setup.js";
 
 const require = createRequire(import.meta.url);
+
+function fail(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`[vize] ${message}\n`);
+  process.exitCode = 1;
+}
 
 try {
   const args = process.argv.slice(2);
   if (args[0] === "setup") {
     runSetupCli(args.slice(1));
+  } else if (args[0] === "init") {
+    // `init` prompts, so it is the one command that has to be async. Failures
+    // land in the same reporter as the synchronous commands.
+    runInitCli(args.slice(1)).catch(fail);
   } else {
     const native = require("@vizejs/native") as typeof import("@vizejs/native");
     native.runCli(args);
   }
 } catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  process.stderr.write(`[vize] ${message}\n`);
-  process.exitCode = 1;
+  fail(error);
 }

--- a/npm/cli/src/init.ts
+++ b/npm/cli/src/init.ts
@@ -1,0 +1,189 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { atomicWriteFile } from "./setup/config.js";
+import { initHelp, parseInitArgs, type InitArgs } from "./init/args.js";
+import { detectProject, withFramework, type ProjectDetection } from "./init/detect.js";
+import { planInit, type InitCommand, type InitPlan } from "./init/plan.js";
+import {
+  confirm,
+  createPromptDeps,
+  isNonInteractive,
+  selectFeatures,
+  type PromptDeps,
+} from "./init/prompt.js";
+import {
+  renderBlocked,
+  renderCancelled,
+  renderDetection,
+  renderEditors,
+  renderNonInteractiveRefusal,
+  renderPlan,
+} from "./init/report.js";
+import { defaultSelection, offerFeatures, type FeatureSelection } from "./init/select.js";
+
+export type { InitCommand, InitPlan } from "./init/plan.js";
+export type { ProjectDetection } from "./init/detect.js";
+
+export interface InitOptions {
+  readonly root: string;
+  readonly args?: readonly string[];
+  readonly runCommand?: (command: InitCommand) => void;
+  readonly writeFile?: (filename: string, source: string) => void;
+  readonly output?: (chunk: string) => void;
+  readonly promptDeps?: PromptDeps;
+  readonly stdin?: NodeJS.ReadableStream;
+}
+
+/**
+ * Resolves the feature selection from detection, flags, and -- when the terminal
+ * allows it -- the user.
+ *
+ * A non-TTY stdin without `--yes` returns `null`: refusing is the only correct
+ * answer, because prompting would hang a CI job forever.
+ */
+export async function resolveSelection(
+  detection: ProjectDetection,
+  args: InitArgs,
+  deps: {
+    readonly output: (chunk: string) => void;
+    readonly stdin: NodeJS.ReadableStream;
+    readonly promptDeps?: PromptDeps;
+  },
+): Promise<FeatureSelection | null> {
+  const offers = offerFeatures(detection);
+  const base = defaultSelection(offers);
+  // An explicit flag survives even when detection says the feature is
+  // unavailable: the planner then reports it as blocked, with the reason. That
+  // is more useful than dropping the flag the user typed.
+  const withOverrides: Record<string, boolean> = { ...base };
+  for (const [id, enabled] of Object.entries(args.overrides)) {
+    withOverrides[id] = enabled;
+  }
+  const selection = withOverrides as FeatureSelection;
+
+  if (args.yes) {
+    return selection;
+  }
+  if (deps.promptDeps === undefined && isNonInteractive(deps.stdin)) {
+    deps.output(renderNonInteractiveRefusal());
+    return null;
+  }
+  // Only a prompt this function created may be closed here; an injected one
+  // belongs to the caller.
+  const owned =
+    deps.promptDeps === undefined
+      ? createPromptDeps({ input: deps.stdin, output: process.stdout as NodeJS.WritableStream })
+      : null;
+  const promptDeps = deps.promptDeps ?? owned!;
+  try {
+    const chosen = await selectFeatures(offers, selection, promptDeps);
+    if (chosen !== null && (await confirm("Apply this selection?", promptDeps))) {
+      return chosen;
+    }
+    deps.output(renderCancelled());
+    return null;
+  } finally {
+    owned?.close?.();
+  }
+}
+
+/**
+ * Runs `init` end to end.
+ *
+ * Detection is reported before anything is decided, the plan is reported before
+ * anything is written, and a blocked feature is reported as NOT configured
+ * rather than quietly downgraded.
+ */
+export async function initProject(options: InitOptions): Promise<InitPlan | null> {
+  const args = parseInitArgs(options.args ?? []);
+  const output = options.output ?? ((chunk: string) => process.stdout.write(chunk));
+  const root = path.resolve(args.root ?? options.root);
+  const detection = withFramework(detectProject(root), args.bundlerOverride);
+  output(renderDetection(detection));
+
+  const selection = await resolveSelection(detection, args, {
+    output,
+    stdin: options.stdin ?? process.stdin,
+    promptDeps: options.promptDeps,
+  });
+  if (selection === null) {
+    return null;
+  }
+
+  const plan = planInit({
+    detection,
+    selection,
+    install: args.install,
+    packageManager: args.packageManager ?? undefined,
+  });
+  output(renderPlan(plan, args.dryRun));
+  output(renderBlocked(plan));
+  if (args.dryRun) {
+    return plan;
+  }
+
+  writePlannedFiles(plan, options.writeFile ?? writeProjectFile);
+  const runCommand = options.runCommand ?? runInitCommand;
+  for (const command of plan.commands) {
+    runCommand(command);
+  }
+  if (selection.editor) {
+    output(renderEditors());
+  }
+  return plan;
+}
+
+export async function runInitCli(args: readonly string[]): Promise<void> {
+  if (parseInitArgs(args).help) {
+    process.stdout.write(initHelp());
+    return;
+  }
+  const plan = await initProject({ root: process.cwd(), args });
+  if (plan === null) {
+    process.exitCode = 1;
+    return;
+  }
+  if (plan.features.some((feature) => feature.outcome === "blocked")) {
+    process.exitCode = 1;
+  }
+}
+
+/**
+ * Default writer.
+ *
+ * Creates the parent directory first so `.vscode/extensions.json` works in a
+ * project that has never had a `.vscode` folder, then reuses `setup`'s atomic
+ * write so a crash mid-run cannot leave a half-written config behind.
+ */
+function writeProjectFile(filename: string, source: string): void {
+  fs.mkdirSync(path.dirname(filename), { recursive: true });
+  atomicWriteFile(filename, source);
+}
+
+function writePlannedFiles(
+  plan: InitPlan,
+  writeFile: (filename: string, source: string) => void,
+): void {
+  const written: string[] = [];
+  for (const file of plan.files) {
+    try {
+      writeFile(file.filename, file.source);
+    } catch (error) {
+      if (written.length === 0) {
+        throw error;
+      }
+      throw new Error(
+        `init partially completed: wrote ${written.join(", ")} before ` +
+          `${path.relative(plan.root, file.filename)} failed. Run init again to finish.`,
+        { cause: error },
+      );
+    }
+    written.push(path.relative(plan.root, file.filename));
+  }
+}
+
+function runInitCommand(command: InitCommand): void {
+  execFileSync(command.command, [...command.args], { cwd: command.cwd, stdio: "inherit" });
+}

--- a/npm/cli/src/init/args.ts
+++ b/npm/cli/src/init/args.ts
@@ -1,0 +1,135 @@
+import { FEATURE_IDS, type FeatureId } from "./select.js";
+
+export type BundlerOverride = "vite" | "nuxt" | null;
+
+export interface InitArgs {
+  readonly root: string | null;
+  /** Explicit per-feature choices. Absent entries fall back to detection. */
+  readonly overrides: Readonly<Partial<Record<FeatureId, boolean>>>;
+  readonly bundlerOverride: BundlerOverride;
+  readonly yes: boolean;
+  readonly dryRun: boolean;
+  readonly install: boolean;
+  readonly packageManager: string | null;
+  readonly help: boolean;
+}
+
+const PACKAGE_MANAGERS = ["pnpm", "npm", "yarn", "bun", "vp"] as const;
+
+/**
+ * Parses `vize init` arguments.
+ *
+ * `--yes` is the only switch that disables prompting. Per-feature flags without
+ * it still prompt, using the flags as the pre-ticked defaults, which keeps a
+ * half-typed command from silently writing files.
+ */
+export function parseInitArgs(args: readonly string[]): InitArgs {
+  const overrides: Partial<Record<FeatureId, boolean>> = {};
+  let root: string | null = null;
+  let bundlerOverride: BundlerOverride = null;
+  let yes = false;
+  let dryRun = false;
+  let install = true;
+  let packageManager: string | null = null;
+  let help = false;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]!;
+    if (arg === "-h" || arg === "--help") {
+      help = true;
+      continue;
+    }
+    if (arg === "-y" || arg === "--yes") {
+      yes = true;
+      continue;
+    }
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (arg === "--no-install") {
+      install = false;
+      continue;
+    }
+    if (arg === "--package-manager") {
+      packageManager = requirePackageManager(args[index + 1]);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--package-manager=")) {
+      packageManager = requirePackageManager(arg.slice("--package-manager=".length));
+      continue;
+    }
+    if (arg === "--vite" || arg === "--nuxt") {
+      bundlerOverride = arg === "--vite" ? "vite" : "nuxt";
+      overrides.bundler = true;
+      continue;
+    }
+    const feature = matchFeatureFlag(arg);
+    if (feature !== null) {
+      overrides[feature.id] = feature.enabled;
+      continue;
+    }
+    if (arg.startsWith("-")) {
+      throw new Error(`Unknown init option: ${arg}`);
+    }
+    if (root !== null) {
+      throw new Error(`Unexpected init argument: ${arg}`);
+    }
+    root = arg;
+  }
+
+  return { root, overrides, bundlerOverride, yes, dryRun, install, packageManager, help };
+}
+
+function matchFeatureFlag(arg: string): { id: FeatureId; enabled: boolean } | null {
+  for (const id of FEATURE_IDS) {
+    if (arg === `--${id}`) {
+      return { id, enabled: true };
+    }
+    if (arg === `--no-${id}`) {
+      return { id, enabled: false };
+    }
+  }
+  return null;
+}
+
+function requirePackageManager(value: string | undefined): string {
+  if (value === undefined || value.startsWith("-")) {
+    throw new Error("--package-manager requires a value");
+  }
+  if (!(PACKAGE_MANAGERS as readonly string[]).includes(value)) {
+    throw new Error(
+      `Unknown package manager: ${value}. Expected one of ${PACKAGE_MANAGERS.join(", ")}`,
+    );
+  }
+  return value;
+}
+
+export function initHelp(): string {
+  return `Select, install, and configure Vize in an existing project
+
+Usage: vize init [ROOT] [OPTIONS]
+
+Arguments:
+  [ROOT]  Project root containing package.json (default: current directory)
+
+Options:
+  -y, --yes                  Accept the detected selection without prompting
+      --lint / --no-lint     oxlint plugin
+      --vite                 vite plugin (forces the Vite target)
+      --nuxt                 nuxt module (forces the Nuxt target)
+      --bundler/--no-bundler vite plugin or nuxt module, auto-detected
+      --fmt / --no-fmt       vize fmt
+      --typecheck            vize check (needs a tsconfig.json)
+      --no-typecheck
+      --editor / --no-editor .vscode/extensions.json recommendation
+      --dry-run              Print the plan without writing anything
+      --no-install           Write configuration without installing dependencies
+      --package-manager <PM> One of ${PACKAGE_MANAGERS.join(", ")} (default: detected)
+  -h, --help                 Print help
+
+Without --yes, init prompts. A non-TTY stdin is detected and refused rather than
+hung, so CI must pass --yes together with the per-feature flags it wants.
+`;
+}

--- a/npm/cli/src/init/detect.ts
+++ b/npm/cli/src/init/detect.ts
@@ -1,0 +1,221 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  dependencyNames,
+  OXLINT_CONFIG_FILES,
+  parsePackageJson,
+  readRequiredFile,
+  VIZE_CONFIG_FILES,
+} from "../setup/config.js";
+
+export const NUXT_CONFIG_FILES = [
+  "nuxt.config.ts",
+  "nuxt.config.mts",
+  "nuxt.config.js",
+  "nuxt.config.mjs",
+] as const;
+
+export const VITE_CONFIG_FILES = [
+  "vite.config.ts",
+  "vite.config.mts",
+  "vite.config.js",
+  "vite.config.mjs",
+] as const;
+
+export type PackageManager = "pnpm" | "npm" | "yarn" | "bun";
+
+/**
+ * Bundler integration `init` can wire up.
+ *
+ * Nuxt outranks Vite because a Nuxt project owns its own Vite instance: adding
+ * `@vizejs/vite-plugin` to a Nuxt-managed Vite config would fight the module.
+ */
+export type Framework = "nuxt" | "vite" | "none";
+
+export interface ProjectDetection {
+  readonly root: string;
+  readonly packageManager: PackageManager | null;
+  readonly framework: Framework;
+  readonly nuxtConfig: string | null;
+  readonly viteConfigs: readonly string[];
+  readonly usesVitePlus: boolean;
+  readonly typescript: boolean;
+  readonly tsconfig: string | null;
+  readonly vizeConfig: string | null;
+  readonly oxlintConfig: string | null;
+  readonly hasVitePlusLintBlock: boolean;
+  readonly hasVizeVitePlugin: boolean;
+  readonly hasVizeNuxtModule: boolean;
+  readonly dependencies: ReadonlySet<string>;
+  readonly scripts: Readonly<Record<string, string>>;
+  readonly vscodeRecommendsVize: boolean;
+}
+
+/**
+ * Package-manager detection.
+ *
+ * Deliberately mirrors `detect_package_manager` in
+ * `crates/vize_canon/src/batch/error.rs`, including the lockfile priority order
+ * and the `packageManager` prefix fallback. The Rust side suggests an install
+ * command in its corsa-not-found message; if the two ever disagreed, a user
+ * would be told to run `pnpm add` by one half of the toolchain and `npm install`
+ * by the other.
+ */
+export function detectPackageManager(root: string): PackageManager | null {
+  const exists = (name: string): boolean => fs.existsSync(path.join(root, name));
+  if (exists("pnpm-lock.yaml")) {
+    return "pnpm";
+  }
+  if (exists("bun.lockb") || exists("bun.lock")) {
+    return "bun";
+  }
+  if (exists("yarn.lock")) {
+    return "yarn";
+  }
+  if (exists("package-lock.json")) {
+    return "npm";
+  }
+  return detectPackageManagerField(root);
+}
+
+function detectPackageManagerField(root: string): PackageManager | null {
+  let source: string;
+  try {
+    source = fs.readFileSync(path.join(root, "package.json"), "utf8");
+  } catch {
+    return null;
+  }
+  let field: unknown;
+  try {
+    field = (JSON.parse(source) as { packageManager?: unknown }).packageManager;
+  } catch {
+    return null;
+  }
+  if (typeof field !== "string") {
+    return null;
+  }
+  for (const candidate of ["pnpm", "yarn", "bun", "npm"] as const) {
+    if (field.startsWith(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Applies an explicit `--vite` / `--nuxt` choice over what detection concluded.
+ *
+ * Overriding the framework rather than branching later keeps one code path: the
+ * planner, the prompt and the printed detection summary all see the same answer,
+ * so the summary cannot claim Vite while the plan configures Nuxt.
+ */
+export function withFramework(
+  detection: ProjectDetection,
+  framework: Framework | null,
+): ProjectDetection {
+  return framework === null || framework === detection.framework
+    ? detection
+    : { ...detection, framework };
+}
+
+export function detectProject(root: string): ProjectDetection {
+  const packagePath = path.join(root, "package.json");
+  const packageSource = readRequiredFile(packagePath, "No package.json found");
+  const packageJson = parsePackageJson(packagePath, packageSource);
+  const dependencies = dependencyNames(packageJson);
+  const scripts = readScripts(packageJson);
+
+  const nuxtConfig = findExisting(root, NUXT_CONFIG_FILES);
+  const viteConfigs = VITE_CONFIG_FILES.filter((candidate) =>
+    fs.existsSync(path.join(root, candidate)),
+  );
+  const viteSource = viteConfigs.length === 1 ? readFile(root, viteConfigs[0]!) : null;
+  const nuxtSource = nuxtConfig === null ? null : readFile(root, nuxtConfig);
+
+  return {
+    root,
+    packageManager: detectPackageManager(root),
+    framework: detectFramework(nuxtConfig, viteConfigs, dependencies),
+    nuxtConfig,
+    viteConfigs,
+    usesVitePlus: detectVitePlus(dependencies, viteSource, scripts),
+    typescript: dependencies.has("typescript") || fs.existsSync(path.join(root, "tsconfig.json")),
+    tsconfig: fs.existsSync(path.join(root, "tsconfig.json")) ? "tsconfig.json" : null,
+    vizeConfig: findExisting(root, VIZE_CONFIG_FILES),
+    oxlintConfig: findExisting(root, OXLINT_CONFIG_FILES),
+    hasVitePlusLintBlock: viteSource !== null && viteSource.includes("oxlint-plugin-vize"),
+    hasVizeVitePlugin: viteSource !== null && viteSource.includes("@vizejs/vite-plugin"),
+    hasVizeNuxtModule: nuxtSource !== null && nuxtSource.includes("@vizejs/nuxt"),
+    dependencies,
+    scripts,
+    vscodeRecommendsVize: detectVscodeRecommendation(root),
+  };
+}
+
+function detectFramework(
+  nuxtConfig: string | null,
+  viteConfigs: readonly string[],
+  dependencies: ReadonlySet<string>,
+): Framework {
+  if (nuxtConfig !== null || dependencies.has("nuxt")) {
+    return "nuxt";
+  }
+  return viteConfigs.length > 0 ? "vite" : "none";
+}
+
+/**
+ * Whether the project's lint command is `vp lint` rather than the `oxlint` binary.
+ *
+ * This single boolean decides which file `init` must write the Oxlint
+ * configuration into, so it is deliberately generous: a project is treated as a
+ * Vite+ project if the dependency is declared, if its Vite config imports from
+ * `vite-plus`, or if any script invokes `vp`. Guessing "plain Oxlint" for a
+ * Vite+ project is the failure that #3389 documented — `vp lint` would ignore
+ * `.oxlintrc.json` and report zero Vize diagnostics while exiting 0.
+ */
+function detectVitePlus(
+  dependencies: ReadonlySet<string>,
+  viteSource: string | null,
+  scripts: Readonly<Record<string, string>>,
+): boolean {
+  if (dependencies.has("vite-plus")) {
+    return true;
+  }
+  if (viteSource !== null && /from\s+["']vite-plus["']/u.test(viteSource)) {
+    return true;
+  }
+  return Object.values(scripts).some((command) => /(?:^|[\s&|;])vpx?(?:\s|$)/u.test(command));
+}
+
+function detectVscodeRecommendation(root: string): boolean {
+  let source: string;
+  try {
+    source = fs.readFileSync(path.join(root, ".vscode", "extensions.json"), "utf8");
+  } catch {
+    return false;
+  }
+  return source.includes("ubugeeei.vize");
+}
+
+function readScripts(packageJson: Record<string, unknown>): Record<string, string> {
+  const scripts = packageJson.scripts;
+  if (typeof scripts !== "object" || scripts === null || Array.isArray(scripts)) {
+    return {};
+  }
+  const entries: Record<string, string> = {};
+  for (const [name, command] of Object.entries(scripts)) {
+    if (typeof command === "string") {
+      entries[name] = command;
+    }
+  }
+  return entries;
+}
+
+function findExisting(root: string, candidates: readonly string[]): string | null {
+  return candidates.find((candidate) => fs.existsSync(path.join(root, candidate))) ?? null;
+}
+
+function readFile(root: string, relative: string): string {
+  return fs.readFileSync(path.join(root, relative), "utf8");
+}

--- a/npm/cli/src/init/edit-config.ts
+++ b/npm/cli/src/init/edit-config.ts
@@ -1,0 +1,161 @@
+import { VITE_LINT_BLOCK, VITE_LINT_IMPORT, VITE_PLUGIN_IMPORT } from "./templates.js";
+import { countConfigCalls, findTopLevelKey, readTopLevelArray } from "./top-level.js";
+
+/**
+ * Conservative source edits for user-owned `vite.config.*` and `nuxt.config.*`.
+ *
+ * Every function here returns `null` rather than guessing. A wrong edit to a
+ * build config breaks the project; a `null` costs the user one paste of a
+ * snippet `init` prints for them.
+ */
+
+const VITE_CALLEE = "defineConfig";
+const NUXT_CALLEE = "defineNuxtConfig";
+
+/**
+ * `defineConfig({` plus the newline that usually follows it.
+ *
+ * The trailing newline is consumed and re-emitted by the injectors so an
+ * inserted key does not leave a stray blank line behind in the user's file.
+ */
+const VITE_OPENING = /\bdefineConfig\s*\(\s*\{[^\S\r\n]*(?:\r?\n)?/u;
+const NUXT_OPENING = /\bdefineNuxtConfig\s*\(\s*\{[^\S\r\n]*(?:\r?\n)?/u;
+
+/**
+ * Whether a Vite config is a single plain `defineConfig({ ... })` call that a
+ * new top-level key can be inserted into.
+ *
+ * Anything else -- several `defineConfig` calls, a config built from a variable,
+ * or a config that already declares the key -- is left alone.
+ */
+export function canInjectViteKey(source: string, key: string): boolean {
+  if (hasTopLevelKey(source, key)) {
+    return false;
+  }
+  return countConfigCalls(source, VITE_CALLEE) === 1;
+}
+
+/** Whether the Vite config declares `key` at the top level of its `defineConfig` call. */
+export function hasTopLevelKey(source: string, key: string): boolean {
+  return findTopLevelKey(source, VITE_CALLEE, key) !== null;
+}
+
+/** Whether the Vite+ `lint` block can be injected into this source. */
+export function canInjectViteLint(source: string): boolean {
+  if (source.includes("oxlint-plugin-vize")) {
+    return false;
+  }
+  return canInjectViteKey(source, "lint");
+}
+
+/**
+ * Inserts the `lint` block, and its import, into a Vite config.
+ *
+ * Returns `null` when the source does not have the shape `canInjectViteLint`
+ * accepts, so callers cannot inject blindly.
+ */
+export function injectViteLint(source: string): string | null {
+  if (!canInjectViteLint(source)) {
+    return null;
+  }
+  const withImport = insertImport(source, VITE_LINT_IMPORT);
+  if (withImport === null) {
+    return null;
+  }
+  return withImport.replace(VITE_OPENING, () => `defineConfig({\n${VITE_LINT_BLOCK}`);
+}
+
+/**
+ * Adds `vize()` to a Vite config's top-level `plugins` array, importing the
+ * plugin.
+ *
+ * The array is located by depth-aware scan rather than by regex: a Vite+ config
+ * can carry a second `plugins` key inside its `lint` block, and appending Vize's
+ * Vite plugin to Oxlint's plugin list would corrupt both.
+ */
+export function injectVitePlugin(source: string): string | null {
+  if (source.includes("@vizejs/vite-plugin")) {
+    return null;
+  }
+  const withImport = insertImport(source, VITE_PLUGIN_IMPORT);
+  if (withImport === null) {
+    return null;
+  }
+  const plugins = readTopLevelArray(withImport, VITE_CALLEE, "plugins");
+  if (plugins !== null) {
+    return insertArrayEntry(withImport, plugins.contentStart, "vize()", plugins.empty);
+  }
+  if (findTopLevelKey(withImport, VITE_CALLEE, "plugins") !== null) {
+    // `plugins` exists but is not an array literal; inserting would change what
+    // the config evaluates to.
+    return null;
+  }
+  if (!canInjectViteKey(withImport, "plugins")) {
+    return null;
+  }
+  return withImport.replace(VITE_OPENING, () => `defineConfig({\n  plugins: [vize()],\n`);
+}
+
+/**
+ * Adds `"@vizejs/nuxt"` to a Nuxt config's top-level `modules` array.
+ *
+ * Nuxt owns its own Vite instance, so the module is the supported integration
+ * point; adding `@vizejs/vite-plugin` to a Nuxt-managed Vite config would fight
+ * it.
+ */
+export function injectNuxtModule(source: string): string | null {
+  if (source.includes("@vizejs/nuxt")) {
+    return null;
+  }
+  if (countConfigCalls(source, NUXT_CALLEE) !== 1) {
+    return null;
+  }
+  const modules = readTopLevelArray(source, NUXT_CALLEE, "modules");
+  if (modules !== null) {
+    return insertArrayEntry(source, modules.contentStart, '"@vizejs/nuxt"', modules.empty);
+  }
+  if (findTopLevelKey(source, NUXT_CALLEE, "modules") !== null) {
+    return null;
+  }
+  return source.replace(NUXT_OPENING, () => `defineNuxtConfig({\n  modules: ["@vizejs/nuxt"],\n`);
+}
+
+/**
+ * Inserts `entry` as the first element of an array literal.
+ *
+ * Prepending keeps the user's existing entries in their original order and
+ * leaves their formatting alone.
+ */
+function insertArrayEntry(
+  source: string,
+  contentStart: number,
+  entry: string,
+  empty: boolean,
+): string {
+  const suffix = empty ? "" : ", ";
+  const tail = empty ? source.slice(contentStart).replace(/^\s*/u, "") : source.slice(contentStart);
+  return `${source.slice(0, contentStart)}${entry}${suffix}${tail}`;
+}
+
+/**
+ * Inserts an import after the last existing top-level import.
+ *
+ * A config with no imports at all returns `null`: the safe insertion point is
+ * not obvious, and the file is unusual enough to be worth a human look.
+ */
+function insertImport(source: string, importLine: string): string | null {
+  if (source.includes(importLine.trimEnd())) {
+    return source;
+  }
+  const imports = [
+    ...source.matchAll(
+      /^import[^\r\n]*(?:from\s+["'][^"']+["']|["'][^"']+["'])\s*;?[^\S\r\n]*(?:\r?\n|$)/gmu,
+    ),
+  ];
+  const lastImport = imports.at(-1);
+  if (lastImport === undefined || lastImport.index === undefined) {
+    return null;
+  }
+  const end = lastImport.index + lastImport[0].length;
+  return source.slice(0, end) + importLine + source.slice(end);
+}

--- a/npm/cli/src/init/lint-target.ts
+++ b/npm/cli/src/init/lint-target.ts
@@ -1,0 +1,202 @@
+import type { ProjectDetection } from "./detect.js";
+import { canInjectViteLint, hasTopLevelKey } from "./edit-config.js";
+import { VITE_LINT_MERGE_SNIPPET, VITE_LINT_SNIPPET } from "./templates.js";
+
+/**
+ * Oxlint config filenames the `oxlint` binary actually auto-discovers.
+ *
+ * Verified against oxlint 1.64: `.oxlintrc.json`, `.oxlintrc.jsonc` and
+ * `oxlint.config.ts` are read; `oxlint.config.mts`, `.js`, `.mjs`, `.cjs` and
+ * `.cts` produce a run byte-identical to having no config at all. The wider list
+ * in `setup/config.ts` treats all eight as configuration, which is #3474. `init`
+ * uses this narrower list so it never reports an unread file as configured.
+ */
+export const DISCOVERED_OXLINT_CONFIG_FILES = [
+  ".oxlintrc.json",
+  ".oxlintrc.jsonc",
+  "oxlint.config.ts",
+] as const;
+
+/** Filename `init` writes when the `oxlint` binary is the lint entry point. */
+export const INIT_OXLINT_CONFIG_FILE = "oxlint.config.ts";
+
+/**
+ * Where a project's Oxlint configuration has to live to be read.
+ *
+ * `vp lint` and `vp check` read the `lint` block of `vite.config.ts` and never
+ * read `.oxlintrc.json`; the `oxlint` and `oxlint-vize` binaries read
+ * `.oxlintrc.json` and never read `vite.config.ts`. Writing the wrong one leaves
+ * a project that looks configured, reports zero `vize/*` diagnostics and exits
+ * `0` -- the defect #3389 recorded and #3407 fixed. Every branch below therefore
+ * follows the command the project will actually run, not the file that is
+ * easiest to write.
+ */
+export type LintTargetKind =
+  /** Vite+ project: the `lint` block in the Vite config is the only readable place. */
+  | "vite-plus"
+  /** No Vite+: the `oxlint` binary reads its own config file. */
+  | "oxlint"
+  /** Both entry points are in use; both files get written from one settings object. */
+  | "both"
+  /** Vite+ project whose Vite config cannot be edited safely. Nothing is written. */
+  | "manual";
+
+export interface LintTarget {
+  readonly kind: LintTargetKind;
+  /** Vite config to receive the `lint` block, when one can be edited. */
+  readonly viteConfig: string | null;
+  /** Oxlint config file to write, when the `oxlint` binary is an entry point. */
+  readonly oxlintConfig: string | null;
+  /** Existing Oxlint config left untouched, if any. */
+  readonly preservedOxlintConfig: string | null;
+  /** Why this target was chosen. Always shown to the user. */
+  readonly reason: string;
+  /**
+   * Set when the project needs a Vite+ `lint` block that `init` will not write.
+   * The caller must print the snippet and must not claim lint is configured.
+   */
+  readonly blockedReason: string | null;
+  /** Snippet to paste when `blockedReason` is set. */
+  readonly blockedSnippet: string | null;
+}
+
+export interface LintTargetInput {
+  readonly detection: ProjectDetection;
+  /** Source of the single Vite config, or `null` when there is not exactly one. */
+  readonly viteSource: string | null;
+}
+
+/**
+ * Chooses which Oxlint configuration file(s) the project needs.
+ *
+ * The `oxlint` binary is treated as an entry point whenever the project already
+ * carries a discovered Oxlint config or runs `oxlint` from a script. A Vite+
+ * project that also does either gets both files, generated from the same preset
+ * and help level, because keeping one of them silently stale is the same class
+ * of bug as writing the wrong one.
+ */
+export function resolveLintTarget(input: LintTargetInput): LintTarget {
+  const { detection } = input;
+  const existing = discoveredOxlintConfig(detection);
+  const runsOxlintBinary = existing !== null || hasOxlintScript(detection);
+
+  if (!detection.usesVitePlus) {
+    return {
+      kind: "oxlint",
+      viteConfig: null,
+      oxlintConfig: existing === null ? INIT_OXLINT_CONFIG_FILE : null,
+      preservedOxlintConfig: existing,
+      reason:
+        "no Vite+ detected, so `oxlint` is the lint entry point and reads " +
+        `${existing ?? INIT_OXLINT_CONFIG_FILE}`,
+      blockedReason: null,
+      blockedSnippet: null,
+    };
+  }
+
+  const viteConfig = detection.viteConfigs.length === 1 ? detection.viteConfigs[0]! : null;
+  const injectable = input.viteSource !== null && canInjectViteLint(input.viteSource);
+  if (!detection.hasVitePlusLintBlock && !injectable) {
+    const blocked = describeBlocked(detection, input.viteSource);
+    return {
+      kind: "manual",
+      viteConfig: null,
+      oxlintConfig: null,
+      preservedOxlintConfig: existing,
+      reason: "Vite+ detected, so `vp lint` reads the `lint` block in the Vite config",
+      blockedReason: blocked.reason,
+      blockedSnippet: blocked.snippet,
+    };
+  }
+
+  if (!runsOxlintBinary) {
+    return {
+      kind: "vite-plus",
+      viteConfig,
+      oxlintConfig: null,
+      preservedOxlintConfig: null,
+      reason:
+        "Vite+ detected, so `vp lint` reads the `lint` block in " +
+        `${viteConfig ?? "the Vite config"} and never reads .oxlintrc.json`,
+      blockedReason: null,
+      blockedSnippet: null,
+    };
+  }
+
+  return {
+    kind: "both",
+    viteConfig,
+    oxlintConfig: existing === null ? INIT_OXLINT_CONFIG_FILE : null,
+    preservedOxlintConfig: existing,
+    reason:
+      "Vite+ and the `oxlint` binary are both in use, so the `lint` block in " +
+      `${viteConfig ?? "the Vite config"} and ${existing ?? INIT_OXLINT_CONFIG_FILE} ` +
+      "are written from the same preset",
+    blockedReason: null,
+    blockedSnippet: null,
+  };
+}
+
+/**
+ * The existing Oxlint config, restricted to names Oxlint actually reads.
+ *
+ * A project holding only `oxlint.config.mjs` is deliberately treated as having
+ * no Oxlint config, because that is how Oxlint treats it.
+ */
+export function discoveredOxlintConfig(detection: ProjectDetection): string | null {
+  const existing = detection.oxlintConfig;
+  if (existing === null) {
+    return null;
+  }
+  return (DISCOVERED_OXLINT_CONFIG_FILES as readonly string[]).includes(existing) ? existing : null;
+}
+
+/** An Oxlint config file that is present but which Oxlint will never read. */
+export function unreadOxlintConfig(detection: ProjectDetection): string | null {
+  const existing = detection.oxlintConfig;
+  if (existing === null || discoveredOxlintConfig(detection) !== null) {
+    return null;
+  }
+  return existing;
+}
+
+function hasOxlintScript(detection: ProjectDetection): boolean {
+  return Object.values(detection.scripts).some((command) =>
+    /(?:^|[\s&|;])oxlint(?:-vize)?(?:\s|$)/u.test(command),
+  );
+}
+
+/**
+ * Why the `lint` block will not be written.
+ *
+ * The message is the whole value of a blocked result, so it names the specific
+ * obstacle instead of a generic "could not edit". An existing `lint` block in
+ * particular is a merge the user has to make, not a failure of the file.
+ */
+function describeBlocked(
+  detection: ProjectDetection,
+  viteSource: string | null,
+): { readonly reason: string; readonly snippet: string } {
+  if (detection.viteConfigs.length === 0) {
+    return { reason: "no vite.config file to hold the `lint` block", snippet: VITE_LINT_SNIPPET };
+  }
+  if (detection.viteConfigs.length > 1) {
+    return {
+      reason: `several Vite configs (${detection.viteConfigs.join(", ")}), so the target is ambiguous`,
+      snippet: VITE_LINT_SNIPPET,
+    };
+  }
+  const filename = detection.viteConfigs[0]!;
+  if (viteSource !== null && hasTopLevelKey(viteSource, "lint")) {
+    return {
+      reason:
+        `${filename} already has a \`lint\` block and merging into it would risk dropping ` +
+        "settings, so spread createVizeLintConfig() into it by hand",
+      snippet: VITE_LINT_MERGE_SNIPPET,
+    };
+  }
+  return {
+    reason: `${filename} is not a single plain defineConfig({ ... }) call`,
+    snippet: VITE_LINT_SNIPPET,
+  };
+}

--- a/npm/cli/src/init/plan-bundler.ts
+++ b/npm/cli/src/init/plan-bundler.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { ProjectDetection } from "./detect.js";
+import { injectNuxtModule, injectVitePlugin } from "./edit-config.js";
+import { skipped, type PlanDraft } from "./plan-types.js";
+
+/**
+ * Plans the bundler integration: the Vite plugin, or the Nuxt module.
+ *
+ * Nuxt outranks Vite because a Nuxt project owns its own Vite instance --
+ * adding `@vizejs/vite-plugin` to a Nuxt-managed Vite config would fight the
+ * module rather than complement it.
+ *
+ * @returns the possibly-edited Vite config source, or the input unchanged.
+ */
+export function planBundler(
+  detection: ProjectDetection,
+  viteDraft: string | null,
+  draft: PlanDraft,
+): string | null {
+  if (detection.framework === "nuxt") {
+    planNuxtModule(detection, draft);
+    return viteDraft;
+  }
+  if (detection.framework !== "vite" || detection.viteConfigs.length !== 1) {
+    draft.features.push(skipped("bundler", "no single vite.config or nuxt.config to configure"));
+    return viteDraft;
+  }
+  draft.dependencies.add("@vizejs/vite-plugin");
+  const filename = detection.viteConfigs[0]!;
+  if (detection.hasVizeVitePlugin) {
+    draft.features.push({
+      id: "bundler",
+      outcome: "unchanged",
+      detail: `${filename} already uses @vizejs/vite-plugin`,
+      snippet: null,
+    });
+    return viteDraft;
+  }
+  const injected = viteDraft === null ? null : injectVitePlugin(viteDraft);
+  if (injected === null) {
+    draft.features.push({
+      id: "bundler",
+      outcome: "blocked",
+      detail: `${filename} has no plugins array this tool can extend safely`,
+      snippet: "plugins: [vize()]",
+    });
+    return viteDraft;
+  }
+  draft.features.push({
+    id: "bundler",
+    outcome: "configured",
+    detail: `adds vize() to ${filename}`,
+    snippet: null,
+  });
+  return injected;
+}
+
+function planNuxtModule(detection: ProjectDetection, draft: PlanDraft): void {
+  draft.dependencies.add("@vizejs/nuxt");
+  if (detection.nuxtConfig === null) {
+    draft.features.push(skipped("bundler", "no nuxt.config file to add @vizejs/nuxt to"));
+    return;
+  }
+  if (detection.hasVizeNuxtModule) {
+    draft.features.push({
+      id: "bundler",
+      outcome: "unchanged",
+      detail: `${detection.nuxtConfig} already lists @vizejs/nuxt`,
+      snippet: null,
+    });
+    return;
+  }
+  const source = fs.readFileSync(path.join(detection.root, detection.nuxtConfig), "utf8");
+  const injected = injectNuxtModule(source);
+  if (injected === null) {
+    draft.features.push({
+      id: "bundler",
+      outcome: "blocked",
+      detail: `${detection.nuxtConfig} is not a single plain defineNuxtConfig({ ... }) call`,
+      snippet: 'modules: ["@vizejs/nuxt"]',
+    });
+    return;
+  }
+  draft.files.push({
+    filename: path.join(detection.root, detection.nuxtConfig),
+    source: injected,
+  });
+  draft.updatedFiles.push(detection.nuxtConfig);
+  draft.features.push({
+    id: "bundler",
+    outcome: "configured",
+    detail: `adds @vizejs/nuxt to ${detection.nuxtConfig}`,
+    snippet: null,
+  });
+}

--- a/npm/cli/src/init/plan-editor.ts
+++ b/npm/cli/src/init/plan-editor.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { detectJsonIndent, type PlannedFile } from "../setup/config.js";
+import type { ProjectDetection } from "./detect.js";
+import type { FeatureResult } from "./plan-types.js";
+import { renderVscodeExtensions, VSCODE_EXTENSION_ID } from "./templates.js";
+
+const EXTENSIONS_FILE = path.join(".vscode", "extensions.json");
+
+/**
+ * Plans the editor recommendation.
+ *
+ * `.vscode/extensions.json` is preferred over `code --install-extension` because
+ * it is checked in, applies to everyone on the project, and changes nothing on
+ * the machine running `init`. An existing file is merged, never replaced: it
+ * usually carries the team's other recommendations.
+ */
+export function planEditorFile(
+  detection: ProjectDetection,
+  files: PlannedFile[],
+  createdFiles: string[],
+  updatedFiles: string[],
+): FeatureResult {
+  const filename = path.join(detection.root, ".vscode", "extensions.json");
+  let source: string;
+  try {
+    source = fs.readFileSync(filename, "utf8");
+  } catch {
+    files.push({ filename, source: renderVscodeExtensions(2) });
+    createdFiles.push(EXTENSIONS_FILE);
+    return {
+      id: "editor",
+      outcome: "configured",
+      detail: `writes ${EXTENSIONS_FILE} recommending ${VSCODE_EXTENSION_ID}`,
+      snippet: null,
+    };
+  }
+
+  const merged = mergeRecommendation(source);
+  if (merged === null) {
+    return {
+      id: "editor",
+      outcome: "blocked",
+      detail: `${EXTENSIONS_FILE} is not a plain JSON object this tool can extend safely`,
+      snippet: `"recommendations": ["${VSCODE_EXTENSION_ID}"]`,
+    };
+  }
+  if (merged === source) {
+    return {
+      id: "editor",
+      outcome: "unchanged",
+      detail: `${EXTENSIONS_FILE} already recommends ${VSCODE_EXTENSION_ID}`,
+      snippet: null,
+    };
+  }
+  files.push({ filename, source: merged });
+  updatedFiles.push(EXTENSIONS_FILE);
+  return {
+    id: "editor",
+    outcome: "configured",
+    detail: `adds ${VSCODE_EXTENSION_ID} to ${EXTENSIONS_FILE}`,
+    snippet: null,
+  };
+}
+
+/**
+ * Adds the recommendation to an existing file, preserving its other keys and its
+ * indentation. Returns the input unchanged when the id is already listed, and
+ * `null` when the file is not a JSON object with an array of string
+ * recommendations.
+ */
+function mergeRecommendation(source: string): string | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(source);
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+  const document = parsed as Record<string, unknown>;
+  const existing = document.recommendations;
+  if (existing !== undefined && !isStringArray(existing)) {
+    return null;
+  }
+  const recommendations = existing ?? [];
+  if (recommendations.includes(VSCODE_EXTENSION_ID)) {
+    return source;
+  }
+  document.recommendations = [...recommendations, VSCODE_EXTENSION_ID];
+  return `${JSON.stringify(document, null, detectJsonIndent(source))}\n`;
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}

--- a/npm/cli/src/init/plan-lint.ts
+++ b/npm/cli/src/init/plan-lint.ts
@@ -1,0 +1,68 @@
+import path from "node:path";
+
+import type { ProjectDetection } from "./detect.js";
+import { injectViteLint } from "./edit-config.js";
+import { INIT_OXLINT_CONFIG_FILE, type LintTarget } from "./lint-target.js";
+import type { PlanDraft } from "./plan-types.js";
+import { INIT_OXLINT_CONFIG } from "./templates.js";
+
+/**
+ * Plans the Oxlint wiring into whichever file the project's lint command reads.
+ *
+ * The single rule this function exists to enforce: never write an Oxlint config
+ * the project's own lint command ignores. `vp lint` and `vp check` read only the
+ * `lint` block of the Vite config; `oxlint` and `oxlint-vize` read only their own
+ * config file. Writing the wrong one produces a project that looks configured,
+ * reports zero `vize/*` diagnostics and exits `0` -- #3389, fixed in #3407.
+ *
+ * When the required file cannot be edited safely this returns a `blocked`
+ * result and writes nothing at all. Falling back to the *other* file would be
+ * the bug: the user would see a success message and get silence from the linter.
+ *
+ * @returns the possibly-edited Vite config source, or the input unchanged.
+ */
+export function planLint(
+  detection: ProjectDetection,
+  lintTarget: LintTarget,
+  viteDraft: string | null,
+  draft: PlanDraft,
+): string | null {
+  if (lintTarget.blockedReason !== null) {
+    draft.features.push({
+      id: "lint",
+      outcome: "blocked",
+      detail:
+        `vp lint reads the \`lint\` block in the Vite config, but ${lintTarget.blockedReason}. ` +
+        "Nothing was written: an unconfigured project fails loudly, while an Oxlint config vp " +
+        "lint never reads reports zero Vize diagnostics and exits 0",
+      snippet: lintTarget.blockedSnippet,
+    });
+    return viteDraft;
+  }
+
+  let source = viteDraft;
+  const wrote: string[] = [];
+  if (lintTarget.viteConfig !== null && !detection.hasVitePlusLintBlock && source !== null) {
+    const injected = injectViteLint(source);
+    if (injected !== null) {
+      source = injected;
+      wrote.push(lintTarget.viteConfig);
+    }
+  }
+  if (lintTarget.oxlintConfig !== null) {
+    draft.files.push({
+      filename: path.join(detection.root, INIT_OXLINT_CONFIG_FILE),
+      source: INIT_OXLINT_CONFIG,
+    });
+    draft.createdFiles.push(INIT_OXLINT_CONFIG_FILE);
+    wrote.push(INIT_OXLINT_CONFIG_FILE);
+  }
+  draft.features.push({
+    id: "lint",
+    outcome: wrote.length > 0 ? "configured" : "unchanged",
+    detail:
+      wrote.length > 0 ? `${lintTarget.reason}; writes ${wrote.join(" and ")}` : lintTarget.reason,
+    snippet: null,
+  });
+  return source;
+}

--- a/npm/cli/src/init/plan-project.ts
+++ b/npm/cli/src/init/plan-project.ts
@@ -1,0 +1,114 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { DEFAULT_SCRIPTS, detectJsonIndent, parsePackageJson } from "../setup/config.js";
+import type { ProjectDetection } from "./detect.js";
+import { skipped, type PlanDraft } from "./plan-types.js";
+import type { FeatureId, FeatureSelection } from "./select.js";
+import { renderVizeConfig } from "./templates.js";
+
+/** Scripts each feature contributes, reusing the command strings `setup` ships. */
+const FEATURE_SCRIPTS: Readonly<Record<FeatureId, readonly string[]>> = {
+  lint: ["vize:lint"],
+  bundler: [],
+  fmt: ["vize:fmt", "vize:fmt:fix"],
+  typecheck: ["vize:check"],
+  editor: [],
+};
+
+/**
+ * Plans `vize.config.ts` and the fmt/typecheck feature results.
+ *
+ * Only selected features contribute a block, so asking for the formatter alone
+ * does not hand the project a type checker it never opted into. An existing Vize
+ * config is never rewritten: merging into a user's config is exactly the kind of
+ * guess that loses their settings.
+ */
+export function planVizeConfig(
+  detection: ProjectDetection,
+  selection: FeatureSelection,
+  draft: PlanDraft,
+): void {
+  for (const id of ["fmt", "typecheck"] as const) {
+    if (!selection[id]) {
+      draft.features.push(
+        id === "typecheck" && detection.tsconfig === null
+          ? skipped(id, "no tsconfig.json, so vize check has nothing to check")
+          : skipped(id),
+      );
+      continue;
+    }
+    if (id === "typecheck" && detection.tsconfig === null) {
+      draft.features.push({
+        id,
+        outcome: "blocked",
+        detail: "vize check needs a tsconfig.json; none was found",
+        snippet: null,
+      });
+      continue;
+    }
+    draft.features.push({
+      id,
+      outcome: detection.vizeConfig === null ? "configured" : "unchanged",
+      detail:
+        detection.vizeConfig === null
+          ? "writes vize.config.ts"
+          : `${detection.vizeConfig} already exists and was left unchanged`,
+      snippet: null,
+    });
+  }
+
+  const needsConfig = selection.lint || selection.fmt || selection.typecheck;
+  if (!needsConfig || detection.vizeConfig !== null) {
+    return;
+  }
+  draft.files.push({
+    filename: path.join(detection.root, "vize.config.ts"),
+    source: renderVizeConfig({
+      lint: selection.lint,
+      fmt: selection.fmt,
+      typecheck: selection.typecheck && detection.tsconfig !== null,
+      vite: detection.framework === "vite",
+    }),
+  });
+  draft.createdFiles.push("vize.config.ts");
+}
+
+/**
+ * Adds the scripts the selected features need.
+ *
+ * A script the project already defines is left alone, whatever its value: the
+ * user's version of `vize:lint` outranks the default, and rewriting it would
+ * make a second `init` run destructive.
+ */
+export function planScripts(
+  detection: ProjectDetection,
+  selection: FeatureSelection,
+  draft: PlanDraft,
+): readonly string[] {
+  const wanted: string[] = [];
+  for (const id of ["lint", "fmt", "typecheck"] as const) {
+    if (!selection[id] || (id === "typecheck" && detection.tsconfig === null)) {
+      continue;
+    }
+    wanted.push(...FEATURE_SCRIPTS[id]);
+  }
+  const missing = wanted.filter((name) => !(name in detection.scripts));
+  if (missing.length === 0) {
+    return [];
+  }
+  const packagePath = path.join(detection.root, "package.json");
+  const source = fs.readFileSync(packagePath, "utf8");
+  const packageJson = parsePackageJson(packagePath, source);
+  const scripts = { ...detection.scripts } as Record<string, string>;
+  for (const name of missing) {
+    scripts[name] = DEFAULT_SCRIPTS[name as keyof typeof DEFAULT_SCRIPTS];
+  }
+  packageJson.scripts = scripts;
+  draft.files.push({
+    filename: packagePath,
+    source: `${JSON.stringify(packageJson, null, detectJsonIndent(source))}\n`,
+  });
+  draft.updatedFiles.push("package.json");
+  return missing;
+}

--- a/npm/cli/src/init/plan-types.ts
+++ b/npm/cli/src/init/plan-types.ts
@@ -1,0 +1,77 @@
+import type { PlannedFile } from "../setup/config.js";
+import type { ProjectDetection } from "./detect.js";
+import type { LintTarget } from "./lint-target.js";
+import type { FeatureId, FeatureSelection } from "./select.js";
+
+/**
+ * Shared plan vocabulary.
+ *
+ * Lives apart from `plan.ts` so the per-feature planners can name these types
+ * without importing the orchestrator that calls them.
+ */
+
+export type FeatureOutcome =
+  /** The feature was selected and something was written for it. */
+  | "configured"
+  /** The feature was selected and is already wired up. A re-run lands here. */
+  | "unchanged"
+  /** The feature was not selected, or the project cannot support it. */
+  | "skipped"
+  /** Selected, but a user-owned file has to be edited by hand. Nothing written. */
+  | "blocked";
+
+export interface FeatureResult {
+  readonly id: FeatureId;
+  readonly outcome: FeatureOutcome;
+  readonly detail: string;
+  /** Snippet the user must paste when `outcome` is `blocked`. */
+  readonly snippet: string | null;
+}
+
+export interface InitCommand {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd: string;
+}
+
+export interface InitPlan {
+  readonly root: string;
+  readonly detection: ProjectDetection;
+  readonly lintTarget: LintTarget;
+  readonly features: readonly FeatureResult[];
+  readonly files: readonly PlannedFile[];
+  readonly createdFiles: readonly string[];
+  readonly updatedFiles: readonly string[];
+  readonly addedScripts: readonly string[];
+  readonly commands: readonly InitCommand[];
+}
+
+export interface PlanInitOptions {
+  readonly detection: ProjectDetection;
+  readonly selection: FeatureSelection;
+  readonly install: boolean;
+  readonly packageManager?: string;
+}
+
+/** Mutable accumulators the per-feature planners append to. */
+export interface PlanDraft {
+  readonly files: PlannedFile[];
+  readonly createdFiles: string[];
+  readonly updatedFiles: string[];
+  readonly features: FeatureResult[];
+  readonly dependencies: Set<string>;
+}
+
+export function createPlanDraft(): PlanDraft {
+  return {
+    files: [],
+    createdFiles: [],
+    updatedFiles: [],
+    features: [],
+    dependencies: new Set<string>(),
+  };
+}
+
+export function skipped(id: FeatureId, detail = "not selected"): FeatureResult {
+  return { id, outcome: "skipped", detail, snippet: null };
+}

--- a/npm/cli/src/init/plan.ts
+++ b/npm/cli/src/init/plan.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { ProjectDetection } from "./detect.js";
+import { resolveLintTarget } from "./lint-target.js";
+import { planBundler } from "./plan-bundler.js";
+import { planEditorFile } from "./plan-editor.js";
+import { planLint } from "./plan-lint.js";
+import { planScripts, planVizeConfig } from "./plan-project.js";
+import {
+  createPlanDraft,
+  skipped,
+  type FeatureResult,
+  type InitCommand,
+  type InitPlan,
+  type PlanInitOptions,
+} from "./plan-types.js";
+import type { FeatureId } from "./select.js";
+
+export type {
+  FeatureOutcome,
+  FeatureResult,
+  InitCommand,
+  InitPlan,
+  PlanInitOptions,
+} from "./plan-types.js";
+
+/** Dev dependencies each feature needs. */
+const FEATURE_DEPENDENCIES: Readonly<Record<FeatureId, readonly string[]>> = {
+  lint: ["oxlint", "oxlint-plugin-vize"],
+  bundler: [],
+  fmt: ["vize"],
+  typecheck: ["vize"],
+  editor: [],
+};
+
+const INSTALL_ARGS: Readonly<Record<string, readonly string[]>> = {
+  pnpm: ["add", "-D"],
+  yarn: ["add", "-D"],
+  bun: ["add", "-D"],
+  npm: ["install", "-D"],
+  vp: ["add", "-D"],
+};
+
+const FEATURE_ORDER: readonly FeatureId[] = ["lint", "bundler", "fmt", "typecheck", "editor"];
+
+/**
+ * Builds the full plan without touching the filesystem.
+ *
+ * Planning is separated from execution so `--dry-run`, the interactive
+ * confirmation and the tests all inspect the same object the writer consumes;
+ * a plan that is correct in `--dry-run` and wrong on disk is not possible.
+ */
+export function planInit(options: PlanInitOptions): InitPlan {
+  const { detection, selection } = options;
+  const draft = createPlanDraft();
+
+  const viteSource = readSingleViteConfig(detection);
+  const lintTarget = resolveLintTarget({ detection, viteSource });
+
+  let viteDraft = viteSource;
+  if (selection.lint) {
+    viteDraft = planLint(detection, lintTarget, viteDraft, draft);
+    addAll(draft.dependencies, FEATURE_DEPENDENCIES.lint);
+  } else {
+    draft.features.push(skipped("lint"));
+  }
+
+  if (selection.bundler) {
+    viteDraft = planBundler(detection, viteDraft, draft);
+  } else {
+    draft.features.push(skipped("bundler"));
+  }
+
+  // One write for the Vite config, however many features touched it, so the
+  // plugin edit and the lint edit cannot overwrite one another.
+  if (viteSource !== null && viteDraft !== null && viteDraft !== viteSource) {
+    const filename = detection.viteConfigs[0]!;
+    draft.files.push({ filename: path.join(detection.root, filename), source: viteDraft });
+    draft.updatedFiles.push(filename);
+  }
+
+  planVizeConfig(detection, selection, draft);
+  for (const id of ["fmt", "typecheck"] as const) {
+    if (selection[id]) {
+      addAll(draft.dependencies, FEATURE_DEPENDENCIES[id]);
+    }
+  }
+
+  draft.features.push(
+    selection.editor
+      ? planEditorFile(detection, draft.files, draft.createdFiles, draft.updatedFiles)
+      : skipped("editor"),
+  );
+
+  const addedScripts = planScripts(detection, selection, draft);
+  return {
+    root: detection.root,
+    detection,
+    lintTarget,
+    features: sortFeatures(draft.features),
+    files: draft.files,
+    createdFiles: draft.createdFiles,
+    updatedFiles: draft.updatedFiles,
+    addedScripts,
+    commands: planCommands(detection, draft.dependencies, options),
+  };
+}
+
+/**
+ * The install commands, as a list so callers can assert on them.
+ *
+ * Exactly one command is emitted, or none when every dependency is already
+ * declared -- which is what makes a second `init` run a no-op.
+ */
+function planCommands(
+  detection: ProjectDetection,
+  dependencies: ReadonlySet<string>,
+  options: PlanInitOptions,
+): readonly InitCommand[] {
+  if (!options.install) {
+    return [];
+  }
+  const missing = [...dependencies].filter((name) => !detection.dependencies.has(name)).sort();
+  if (missing.length === 0) {
+    return [];
+  }
+  const command = resolveInstaller(detection, options.packageManager);
+  return [{ command, args: [...INSTALL_ARGS[command]!, ...missing], cwd: detection.root }];
+}
+
+/**
+ * Installer used for the one install command.
+ *
+ * A Vite+ project gets `vp add`, matching `setup` and the project's own
+ * workflow. Otherwise the package manager comes from the same lockfile rules
+ * `detect_package_manager` uses on the Rust side, defaulting to npm when
+ * nothing identifies one.
+ */
+export function resolveInstaller(detection: ProjectDetection, override?: string): string {
+  if (override !== undefined) {
+    return override;
+  }
+  if (detection.usesVitePlus) {
+    return "vp";
+  }
+  return detection.packageManager ?? "npm";
+}
+
+function readSingleViteConfig(detection: ProjectDetection): string | null {
+  if (detection.viteConfigs.length !== 1) {
+    return null;
+  }
+  return fs.readFileSync(path.join(detection.root, detection.viteConfigs[0]!), "utf8");
+}
+
+function addAll(target: Set<string>, values: readonly string[]): void {
+  for (const value of values) {
+    target.add(value);
+  }
+}
+
+function sortFeatures(features: readonly FeatureResult[]): readonly FeatureResult[] {
+  return [...features].sort(
+    (left, right) => FEATURE_ORDER.indexOf(left.id) - FEATURE_ORDER.indexOf(right.id),
+  );
+}

--- a/npm/cli/src/init/prompt.ts
+++ b/npm/cli/src/init/prompt.ts
@@ -1,0 +1,161 @@
+import readline from "node:readline";
+
+import type { FeatureId, FeatureOffer, FeatureSelection } from "./select.js";
+
+/**
+ * Interactive multi-select for the five features.
+ *
+ * Implemented on `node:readline` rather than a prompt package: `vize` is a
+ * published CLI whose install cost every user pays, and a numbered toggle list
+ * needs no raw-mode handling, no terminal restore path, and no dependency in the
+ * runtime path. It is a real multi-select -- numbers toggle, Enter accepts.
+ */
+
+export interface PromptIo {
+  readonly input: NodeJS.ReadableStream;
+  readonly output: NodeJS.WritableStream;
+}
+
+export interface PromptDeps extends PromptIo {
+  /** Resolves to `null` when the input ended before an answer arrived. */
+  readonly question: (query: string) => Promise<string | null>;
+  /**
+   * Releases the terminal. Required for readline-backed deps: an open interface
+   * keeps stdin referenced and the process never exits.
+   */
+  readonly close?: () => void;
+}
+
+/** True when stdin cannot answer a prompt, so `init` must not ask one. */
+export function isNonInteractive(stream: NodeJS.ReadableStream): boolean {
+  return (stream as NodeJS.ReadStream).isTTY !== true;
+}
+
+/**
+ * Wraps `node:readline` so a closed input resolves instead of hanging.
+ *
+ * `rl.question` never invokes its callback when stdin reaches EOF first. Left
+ * alone that leaves `init`'s promise permanently pending, and the process exits
+ * `0` having written nothing -- a silent no-op that looks like success. Resolving
+ * to `null` on close turns that into an explicit cancellation.
+ */
+export function createPromptDeps(io: PromptIo): PromptDeps {
+  const rl = readline.createInterface({ input: io.input, output: io.output });
+  let closed = false;
+  rl.on("close", () => {
+    closed = true;
+  });
+  return {
+    ...io,
+    question: (query) =>
+      new Promise<string | null>((resolve) => {
+        if (closed) {
+          resolve(null);
+          return;
+        }
+        let settled = false;
+        const onClose = (): void => {
+          if (!settled) {
+            settled = true;
+            resolve(null);
+          }
+        };
+        rl.once("close", onClose);
+        rl.question(query, (answer) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          rl.removeListener("close", onClose);
+          resolve(answer);
+        });
+      }),
+    close: () => {
+      rl.close();
+    },
+  };
+}
+
+/** Runs the checklist. Returns `null` when the input ended before confirmation. */
+export async function selectFeatures(
+  offers: readonly FeatureOffer[],
+  initial: FeatureSelection,
+  deps: PromptDeps,
+): Promise<FeatureSelection | null> {
+  const selection: Record<FeatureId, boolean> = { ...initial };
+  const toggleable = offers.filter((offer) => offer.available);
+  for (;;) {
+    deps.output.write(renderChecklist(offers, selection));
+    const raw = await deps.question("> ");
+    if (raw === null) {
+      return null;
+    }
+    const answer = raw.trim();
+    if (answer === "") {
+      return selection;
+    }
+    const indexes = parseIndexes(answer, toggleable.length);
+    if (indexes === null) {
+      deps.output.write(
+        `Enter numbers between 1 and ${toggleable.length}, or press Enter to accept.\n`,
+      );
+      continue;
+    }
+    for (const index of indexes) {
+      const offer = toggleable[index]!;
+      selection[offer.id] = !selection[offer.id];
+    }
+  }
+}
+
+/** Yes/no confirmation. A closed input counts as "no", never as "yes". */
+export async function confirm(query: string, deps: PromptDeps): Promise<boolean> {
+  const raw = await deps.question(`${query} [Y/n] `);
+  if (raw === null) {
+    return false;
+  }
+  const answer = raw.trim().toLowerCase();
+  return answer === "" || answer === "y" || answer === "yes";
+}
+
+function renderChecklist(
+  offers: readonly FeatureOffer[],
+  selection: Readonly<Record<FeatureId, boolean>>,
+): string {
+  const lines = [
+    "",
+    "Select the features to configure.",
+    "Type the numbers to toggle (space or comma separated), then press Enter.",
+    "",
+  ];
+  let position = 0;
+  for (const offer of offers) {
+    if (!offer.available) {
+      lines.push(`     -  ${offer.label}${offer.note === "" ? "" : ` (${offer.note})`}`);
+      continue;
+    }
+    position += 1;
+    const mark = selection[offer.id] ? "x" : " ";
+    const note = offer.note === "" ? "" : ` (${offer.note})`;
+    lines.push(`  ${position}. [${mark}] ${offer.label}${note}`);
+  }
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+/** Parses a toggle answer into zero-based indexes, or `null` when any entry is out of range. */
+function parseIndexes(answer: string, count: number): readonly number[] | null {
+  const tokens = answer.split(/[\s,]+/u).filter((token) => token !== "");
+  const indexes: number[] = [];
+  for (const token of tokens) {
+    if (!/^\d+$/u.test(token)) {
+      return null;
+    }
+    const value = Number.parseInt(token, 10);
+    if (value < 1 || value > count) {
+      return null;
+    }
+    indexes.push(value - 1);
+  }
+  return indexes.length === 0 ? null : indexes;
+}

--- a/npm/cli/src/init/report.ts
+++ b/npm/cli/src/init/report.ts
@@ -1,0 +1,136 @@
+import type { ProjectDetection } from "./detect.js";
+import { unreadOxlintConfig } from "./lint-target.js";
+import type { InitPlan } from "./plan.js";
+import { EDITOR_INTEGRATIONS } from "./templates.js";
+
+const PREFIX = "[vize init]";
+
+/**
+ * Detection summary, printed before any prompt.
+ *
+ * Users need to see what `init` concluded before they are asked to act on it;
+ * an unexpected line here is the cheapest place to catch a wrong root or a
+ * missing lockfile.
+ */
+export function renderDetection(detection: ProjectDetection): string {
+  const lines = [
+    `${PREFIX} detected in ${detection.root}:`,
+    `  framework:       ${describeFramework(detection)}`,
+    `  package manager: ${detection.packageManager ?? "none detected (defaulting to npm)"}`,
+    `  language:        ${detection.typescript ? "TypeScript" : "JavaScript"}${
+      detection.tsconfig === null ? " (no tsconfig.json)" : " (tsconfig.json)"
+    }`,
+    `  lint command:    ${detection.usesVitePlus ? "vp lint" : "oxlint"}`,
+    `  vize config:     ${detection.vizeConfig ?? "none"}`,
+    `  oxlint config:   ${describeOxlintConfig(detection)}`,
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+function describeFramework(detection: ProjectDetection): string {
+  if (detection.framework === "nuxt") {
+    return `Nuxt (${detection.nuxtConfig ?? "nuxt dependency, no nuxt.config"})`;
+  }
+  if (detection.framework === "vite") {
+    const configs = detection.viteConfigs.join(", ");
+    return detection.usesVitePlus ? `Vite+ (${configs})` : `Vite (${configs})`;
+  }
+  return "none (no vite.config or nuxt.config)";
+}
+
+function describeOxlintConfig(detection: ProjectDetection): string {
+  const unread = unreadOxlintConfig(detection);
+  if (unread !== null) {
+    return `${unread} — present but oxlint does not read this name (#3474)`;
+  }
+  return detection.oxlintConfig ?? "none";
+}
+
+/**
+ * The full plan.
+ *
+ * Printed before anything is written in both modes, so the wording is what the
+ * run is about to do, not what it has done. `--dry-run` differs only in stopping
+ * afterwards.
+ */
+export function renderPlan(plan: InitPlan, dryRun: boolean): string {
+  const verb = dryRun ? "would" : "will";
+  const lines: string[] = [`${PREFIX} plan:`];
+  for (const feature of plan.features) {
+    lines.push(`  ${feature.id.padEnd(9)} ${feature.outcome.padEnd(10)} ${feature.detail}`);
+  }
+  for (const filename of plan.createdFiles) {
+    lines.push(`${PREFIX} ${verb} create ${filename}`);
+  }
+  for (const filename of plan.updatedFiles) {
+    lines.push(`${PREFIX} ${verb} update ${filename}`);
+  }
+  if (plan.addedScripts.length > 0) {
+    lines.push(`${PREFIX} ${verb} add scripts: ${plan.addedScripts.join(", ")}`);
+  }
+  for (const command of plan.commands) {
+    lines.push(`${PREFIX} ${verb} run: ${command.command} ${command.args.join(" ")}`);
+  }
+  if (plan.createdFiles.length + plan.updatedFiles.length + plan.commands.length === 0) {
+    lines.push(`${PREFIX} nothing to do; the project is already configured`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Snippets for anything `init` refused to edit.
+ *
+ * A blocked feature is deliberately loud. The alternative for the lint feature
+ * would be writing an Oxlint config the project's lint command never reads,
+ * which reports zero Vize diagnostics and exits 0 (#3389).
+ */
+export function renderBlocked(plan: InitPlan): string {
+  const blocked = plan.features.filter((feature) => feature.outcome === "blocked");
+  if (blocked.length === 0) {
+    return "";
+  }
+  const lines: string[] = [];
+  for (const feature of blocked) {
+    lines.push(`${PREFIX} ${feature.id}: NOT configured — ${feature.detail}`);
+    if (feature.snippet !== null) {
+      lines.push("", indent(feature.snippet), "");
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export function renderEditors(): string {
+  const lines = [`${PREFIX} editor integrations shipped with Vize:`];
+  for (const integration of EDITOR_INTEGRATIONS) {
+    lines.push(`  ${integration}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Printed when the prompt ends without a confirmation.
+ *
+ * Covers both a declined confirmation and an input stream that closed
+ * mid-prompt. Saying so is what keeps a closed stdin from looking like a
+ * successful run that happened to change nothing.
+ */
+export function renderCancelled(): string {
+  return `${PREFIX} cancelled; nothing was written.\n`;
+}
+
+export function renderNonInteractiveRefusal(): string {
+  return (
+    `${PREFIX} stdin is not a TTY, so init will not prompt.\n` +
+    `${PREFIX} pass --yes with the features you want, for example:\n` +
+    `${PREFIX}   vize init --yes --lint --vite --fmt --typecheck --editor\n` +
+    `${PREFIX} or run with --dry-run to print the plan without writing.\n`
+  );
+}
+
+function indent(source: string): string {
+  return source
+    .split("\n")
+    .map((line) => (line === "" ? line : `    ${line}`))
+    .join("\n")
+    .trimEnd();
+}

--- a/npm/cli/src/init/select.ts
+++ b/npm/cli/src/init/select.ts
@@ -1,0 +1,153 @@
+import type { ProjectDetection } from "./detect.js";
+import { discoveredOxlintConfig, unreadOxlintConfig } from "./lint-target.js";
+
+export const FEATURE_IDS = ["lint", "bundler", "fmt", "typecheck", "editor"] as const;
+
+export type FeatureId = (typeof FEATURE_IDS)[number];
+
+export type FeatureSelection = Readonly<Record<FeatureId, boolean>>;
+
+export interface FeatureOffer {
+  readonly id: FeatureId;
+  /** Label shown in the prompt and in the plan. Reflects what detection found. */
+  readonly label: string;
+  /** False when the project cannot support the feature at all. */
+  readonly available: boolean;
+  /** True when the project already has this feature wired up. */
+  readonly configured: boolean;
+  /** Why the feature is unavailable or already configured. Empty when neither. */
+  readonly note: string;
+  readonly defaultSelected: boolean;
+}
+
+/**
+ * Turns detection into the five offers `init` presents.
+ *
+ * Already-configured features stay selected by default so a re-run is a no-op
+ * the user can confirm rather than a set of boxes they have to re-tick.
+ */
+export function offerFeatures(detection: ProjectDetection): readonly FeatureOffer[] {
+  return [
+    lintOffer(detection),
+    bundlerOffer(detection),
+    fmtOffer(detection),
+    typecheckOffer(detection),
+    editorOffer(detection),
+  ];
+}
+
+/** Selection implied by detection alone, used by `--yes` and as the prompt default. */
+export function defaultSelection(offers: readonly FeatureOffer[]): FeatureSelection {
+  const selection: Record<FeatureId, boolean> = {
+    lint: false,
+    bundler: false,
+    fmt: false,
+    typecheck: false,
+    editor: false,
+  };
+  for (const offer of offers) {
+    selection[offer.id] = offer.defaultSelected;
+  }
+  return selection;
+}
+
+function lintOffer(detection: ProjectDetection): FeatureOffer {
+  const configured = detection.usesVitePlus
+    ? detection.hasVitePlusLintBlock
+    : discoveredOxlintConfig(detection) !== null;
+  const unread = unreadOxlintConfig(detection);
+  const label = detection.usesVitePlus
+    ? "oxlint plugin (vp lint reads the `lint` block in the Vite config)"
+    : "oxlint plugin (the oxlint binary reads oxlint.config.ts)";
+  return {
+    id: "lint",
+    label,
+    available: true,
+    configured,
+    note: configured
+      ? "already configured"
+      : unread === null
+        ? ""
+        : `${unread} exists but oxlint never reads it (#3474)`,
+    defaultSelected: true,
+  };
+}
+
+function bundlerOffer(detection: ProjectDetection): FeatureOffer {
+  if (detection.framework === "nuxt") {
+    return {
+      id: "bundler",
+      label: "nuxt module (@vizejs/nuxt)",
+      available: detection.nuxtConfig !== null,
+      configured: detection.hasVizeNuxtModule,
+      note: detection.hasVizeNuxtModule
+        ? "already configured"
+        : detection.nuxtConfig === null
+          ? "no nuxt.config file to add @vizejs/nuxt to"
+          : "",
+      defaultSelected: detection.nuxtConfig !== null,
+    };
+  }
+  if (detection.framework === "vite") {
+    const single = detection.viteConfigs.length === 1;
+    return {
+      id: "bundler",
+      label: "vite plugin (@vizejs/vite-plugin)",
+      available: single,
+      configured: detection.hasVizeVitePlugin,
+      note: detection.hasVizeVitePlugin
+        ? "already configured"
+        : single
+          ? ""
+          : `several Vite configs (${detection.viteConfigs.join(", ")})`,
+      defaultSelected: single,
+    };
+  }
+  return {
+    id: "bundler",
+    label: "vite plugin or nuxt module",
+    available: false,
+    configured: false,
+    note: "no vite.config or nuxt.config found; the other features work without one",
+    defaultSelected: false,
+  };
+}
+
+function fmtOffer(detection: ProjectDetection): FeatureOffer {
+  const configured = detection.vizeConfig !== null && "vize:fmt" in detection.scripts;
+  return {
+    id: "fmt",
+    label: "fmt (vize fmt)",
+    available: true,
+    configured,
+    note: configured ? "already configured" : "",
+    defaultSelected: true,
+  };
+}
+
+function typecheckOffer(detection: ProjectDetection): FeatureOffer {
+  const configured = detection.vizeConfig !== null && "vize:check" in detection.scripts;
+  return {
+    id: "typecheck",
+    label: "typecheck (vize check)",
+    available: detection.tsconfig !== null,
+    configured,
+    note: configured
+      ? "already configured"
+      : detection.tsconfig === null
+        ? "needs a tsconfig.json"
+        : "",
+    defaultSelected: detection.tsconfig !== null,
+  };
+}
+
+function editorOffer(detection: ProjectDetection): FeatureOffer {
+  return {
+    id: "editor",
+    label: "editor extension (.vscode/extensions.json recommendation)",
+    available: true,
+    configured: detection.vscodeRecommendsVize,
+    note: detection.vscodeRecommendsVize ? "already recommended" : "",
+    defaultSelected: true,
+  };
+}

--- a/npm/cli/src/init/templates.ts
+++ b/npm/cli/src/init/templates.ts
@@ -1,0 +1,175 @@
+/**
+ * Config sources `vize init` writes.
+ *
+ * Every Oxlint-facing template here is derived from one settings object so the
+ * `vp lint` block and the `oxlint` config can never describe different presets.
+ * See `lint-target.ts` for why writing the wrong one of the two is silent.
+ */
+
+/** Preset both Oxlint entry points run with. The bridge's own default. */
+export const INIT_LINT_PRESET = "general-recommended";
+
+/** `settings.vize.helpLevel` both Oxlint entry points run with. */
+export const INIT_LINT_HELP_LEVEL = "short";
+
+/** VS Code extension id published from `editors/vscode`. */
+export const VSCODE_EXTENSION_ID = "ubugeeei.vize";
+
+export interface VizeConfigFeatures {
+  readonly lint: boolean;
+  readonly fmt: boolean;
+  readonly typecheck: boolean;
+  readonly vite: boolean;
+}
+
+/**
+ * Builds `vize.config.ts` from the selected features.
+ *
+ * Only selected features contribute a block, so a project that asked for the
+ * formatter alone does not silently get a type checker it never opted into.
+ */
+export function renderVizeConfig(features: VizeConfigFeatures): string {
+  const blocks: string[] = [
+    `  compiler: {
+    templateSyntax: "standard",
+  },`,
+  ];
+  if (features.lint) {
+    blocks.push(`  linter: {
+    enabled: true,
+    preset: "${INIT_LINT_PRESET}",
+  },`);
+  }
+  if (features.fmt) {
+    blocks.push(`  formatter: {
+    singleAttributePerLine: false,
+    sortBlocks: true,
+  },`);
+  }
+  if (features.typecheck) {
+    blocks.push(`  typeChecker: {
+    enabled: true,
+    strict: true,
+  },`);
+  }
+  if (features.vite) {
+    blocks.push(`  vite: {
+    scanPatterns: ["src/**/*.vue"],
+  },`);
+  }
+  return `import { defineConfig } from "vize";
+
+export default defineConfig({
+${blocks.join("\n")}
+});
+`;
+}
+
+/**
+ * Config for the `oxlint` binary.
+ *
+ * `.oxlintrc.json` cannot import `configs.recommended`, and the bridge only runs
+ * `vize/*` rules that appear in `rules`, so a JSON config would need every rule
+ * id inlined and would rot on the next rule addition. `oxlint.config.ts` is
+ * Oxlint's TypeScript config format and is auto-discovered (verified against
+ * oxlint 1.64; `oxlint.config.mjs`, `.js`, `.cjs`, `.mts` and `.cts` are not --
+ * see #3474), so it is the only form that stays correct over time.
+ */
+export const INIT_OXLINT_CONFIG = `import { defineConfig } from "oxlint";
+import { configs } from "oxlint-plugin-vize";
+
+export default defineConfig({
+  plugins: ["vue"],
+  jsPlugins: ["oxlint-plugin-vize"],
+  settings: {
+    vize: {
+      preset: "${INIT_LINT_PRESET}",
+      helpLevel: "${INIT_LINT_HELP_LEVEL}",
+    },
+  },
+  rules: configs.recommended,
+});
+`;
+
+/** Import line the Vite+ `lint` block needs. */
+export const VITE_LINT_IMPORT =
+  'import { createVizeLintConfig } from "oxlint-plugin-vize";\n' as const;
+
+/**
+ * The Vite+ `lint` block, the only Oxlint configuration `vp lint` and `vp check`
+ * read.
+ *
+ * `createVizeLintConfig()` returns the whole block rather than fragments, which
+ * is what makes the `jsPlugins` entry impossible to omit. Hand-assembling the
+ * block is how a config ends up looking wired while reporting nothing.
+ */
+export const VITE_LINT_BLOCK = `  lint: createVizeLintConfig({
+    preset: "${INIT_LINT_PRESET}",
+    settings: {
+      helpLevel: "${INIT_LINT_HELP_LEVEL}",
+    },
+  }),
+`;
+
+/** Snippet printed when a Vite config has no `lint` block and cannot be edited safely. */
+export const VITE_LINT_SNIPPET = `import { createVizeLintConfig } from "oxlint-plugin-vize";
+
+export default defineConfig({
+${VITE_LINT_BLOCK}});
+`;
+
+/**
+ * Snippet printed when the Vite config already has a `lint` block.
+ *
+ * Spreading is the documented way to keep an existing block's other keys while
+ * still taking the whole Vize block, `jsPlugins` included.
+ */
+export const VITE_LINT_MERGE_SNIPPET = `import { createVizeLintConfig } from "oxlint-plugin-vize";
+
+export default defineConfig({
+  lint: {
+    ...createVizeLintConfig({
+      preset: "${INIT_LINT_PRESET}",
+      settings: {
+        helpLevel: "${INIT_LINT_HELP_LEVEL}",
+      },
+    }),
+    // keep your existing lint keys here
+  },
+});
+`;
+
+export const VITE_PLUGIN_IMPORT = 'import vize from "@vizejs/vite-plugin";\n' as const;
+
+export const VITE_PLUGIN_SNIPPET = `import vize from "@vizejs/vite-plugin";
+
+export default defineConfig({
+  plugins: [vize()],
+});
+`;
+
+export const NUXT_MODULE_SNIPPET = `export default defineNuxtConfig({
+  modules: ["@vizejs/nuxt"],
+});
+`;
+
+/**
+ * `.vscode/extensions.json` written when no file exists yet.
+ *
+ * Recommendations are chosen over `code --install-extension` because they are
+ * checked in, apply to the whole team, and change nothing on the machine that
+ * runs `init`.
+ */
+export function renderVscodeExtensions(indent: string | number): string {
+  return `${JSON.stringify({ recommendations: [VSCODE_EXTENSION_ID] }, null, indent)}\n`;
+}
+
+/** Editor integrations shipped from this repo, reported alongside the VS Code one. */
+export const EDITOR_INTEGRATIONS = [
+  "VS Code: ubugeeei.vize (recommended in .vscode/extensions.json)",
+  "Zed: tools/zed-vize",
+  "Neovim: tools/nvim-vize",
+  "Vim: tools/vim-vize",
+  "Helix: tools/helix-vize",
+  "Emacs: tools/emacs-vize",
+] as const;

--- a/npm/cli/src/init/top-level.ts
+++ b/npm/cli/src/init/top-level.ts
@@ -1,0 +1,143 @@
+/**
+ * Depth-aware lookup of a top-level key in a `defineConfig({ ... })` call.
+ *
+ * A plain regex cannot tell the config's own `plugins` key from the `plugins`
+ * key inside a `lint: { ... }` block, and picking the wrong one rewrites a part
+ * of the user's config they never asked to change. This scanner tracks bracket
+ * depth and skips strings, template literals and comments, so a key only matches
+ * at depth 0 of the config object.
+ *
+ * It is not a JavaScript parser and does not try to be: template-literal
+ * substitutions and regex literals are treated as ordinary text. Both make the
+ * scan give up or miss, which turns into a refusal to edit -- the safe direction.
+ */
+
+const IDENTIFIER = /^[$A-Z_a-z][$\w]*/u;
+const KEY_SEPARATOR = /^\s*:/u;
+
+export interface TopLevelKey {
+  /** Index of the first character of the key. */
+  readonly keyStart: number;
+  /** Index of the first character after the `:`. */
+  readonly valueStart: number;
+}
+
+/** Finds `key` at the top level of `callee({ ... })`, or `null`. */
+export function findTopLevelKey(source: string, callee: string, key: string): TopLevelKey | null {
+  const opening = new RegExp(`\\b${callee}\\s*\\(\\s*\\{`, "u").exec(source);
+  if (opening === null) {
+    return null;
+  }
+  let index = opening.index + opening[0].length;
+  let depth = 0;
+  while (index < source.length) {
+    const char = source[index]!;
+    const skipped = skipNonCode(source, index);
+    if (skipped !== index) {
+      index = skipped;
+      continue;
+    }
+    if (char === "{" || char === "[" || char === "(") {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+    if (char === "}" || char === "]" || char === ")") {
+      if (depth === 0) {
+        // Closing brace of the config object itself: the key is not here.
+        return null;
+      }
+      depth -= 1;
+      index += 1;
+      continue;
+    }
+    const identifier = IDENTIFIER.exec(source.slice(index));
+    if (identifier === null) {
+      index += 1;
+      continue;
+    }
+    const separator = KEY_SEPARATOR.exec(source.slice(index + identifier[0].length));
+    if (depth === 0 && identifier[0] === key && separator !== null) {
+      return {
+        keyStart: index,
+        valueStart: index + identifier[0].length + separator[0].length,
+      };
+    }
+    index += identifier[0].length;
+  }
+  return null;
+}
+
+/** Number of `callee({` openings in the source. */
+export function countConfigCalls(source: string, callee: string): number {
+  return [...source.matchAll(new RegExp(`\\b${callee}\\s*\\(\\s*\\{`, "gu"))].length;
+}
+
+export interface ArrayValue {
+  /** Index just after the opening `[`. */
+  readonly contentStart: number;
+  /** True when the array holds nothing but whitespace. */
+  readonly empty: boolean;
+}
+
+/**
+ * Reads the array literal a top-level key is assigned to.
+ *
+ * Returns `null` when the value is not an array literal -- a spread from a
+ * variable, or a helper call -- because inserting into those would change what
+ * the config evaluates to.
+ */
+export function readTopLevelArray(source: string, callee: string, key: string): ArrayValue | null {
+  const found = findTopLevelKey(source, callee, key);
+  if (found === null) {
+    return null;
+  }
+  const rest = source.slice(found.valueStart);
+  const leading = /^\s*/u.exec(rest)![0];
+  if (rest[leading.length] !== "[") {
+    return null;
+  }
+  const contentStart = found.valueStart + leading.length + 1;
+  return { contentStart, empty: /^\s*\]/u.test(source.slice(contentStart)) };
+}
+
+/**
+ * Advances past a string, template literal or comment starting at `index`.
+ *
+ * Returns `index` unchanged when nothing at that position needs skipping.
+ */
+function skipNonCode(source: string, index: number): number {
+  const char = source[index]!;
+  if (char === '"' || char === "'" || char === "`") {
+    return skipQuoted(source, index, char);
+  }
+  if (char !== "/") {
+    return index;
+  }
+  const next = source[index + 1];
+  if (next === "/") {
+    const end = source.indexOf("\n", index);
+    return end === -1 ? source.length : end;
+  }
+  if (next === "*") {
+    const end = source.indexOf("*/", index + 2);
+    return end === -1 ? source.length : end + 2;
+  }
+  return index;
+}
+
+function skipQuoted(source: string, index: number, quote: string): number {
+  let cursor = index + 1;
+  while (cursor < source.length) {
+    const char = source[cursor]!;
+    if (char === "\\") {
+      cursor += 2;
+      continue;
+    }
+    if (char === quote) {
+      return cursor + 1;
+    }
+    cursor += 1;
+  }
+  return source.length;
+}

--- a/npm/cli/tests/init-frameworks.test.ts
+++ b/npm/cli/tests/init-frameworks.test.ts
@@ -1,0 +1,287 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+
+import {
+  ALL_FEATURES,
+  exists,
+  read,
+  readAll,
+  runInit,
+  temporaryProject,
+  write,
+  writeManifest,
+} from "./init-support.ts";
+
+test("a Nuxt project is configured through the Nuxt module, not the Vite plugin", async () => {
+  const root = temporaryProject("nuxt");
+  writeManifest(root, {
+    name: "fixture",
+    private: true,
+    type: "module",
+    scripts: { dev: "nuxt dev" },
+    devDependencies: { nuxt: "^4.0.0" },
+  });
+  write(
+    root,
+    "nuxt.config.ts",
+    `export default defineNuxtConfig({
+  modules: ["@nuxt/image"],
+  devtools: { enabled: true },
+});
+`,
+  );
+  write(root, "tsconfig.json", "{}\n");
+  write(root, "yarn.lock", "# yarn lockfile v1\n");
+
+  const result = await runInit(root, ALL_FEATURES);
+
+  assert.deepEqual(result.commands, [
+    {
+      command: "yarn",
+      args: ["add", "-D", "@vizejs/nuxt", "oxlint", "oxlint-plugin-vize", "vize"],
+      cwd: root,
+    },
+  ]);
+  assert.deepEqual(result.written, [
+    "oxlint.config.ts",
+    "nuxt.config.ts",
+    "vize.config.ts",
+    ".vscode/extensions.json",
+    "package.json",
+  ]);
+  assert.equal(
+    read(root, "nuxt.config.ts"),
+    `export default defineNuxtConfig({
+  modules: ["@vizejs/nuxt", "@nuxt/image"],
+  devtools: { enabled: true },
+});
+`,
+  );
+  // Nuxt owns its Vite instance, so no Vite config is created for it.
+  assert.equal(exists(root, "vite.config.ts"), false);
+  assert.equal(result.plan?.lintTarget.kind, "oxlint");
+});
+
+test("Nuxt wins when both configs exist, and --vite overrides that", async () => {
+  const root = temporaryProject("bundler-override");
+  writeManifest(root, {
+    name: "fixture",
+    private: true,
+    type: "module",
+    scripts: { dev: "nuxt dev" },
+    devDependencies: { nuxt: "^4.0.0" },
+  });
+  write(
+    root,
+    "vite.config.ts",
+    `import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [],
+});
+`,
+  );
+  write(root, "nuxt.config.ts", "export default defineNuxtConfig({});\n");
+  write(root, "pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
+
+  const bundlerOnly = ["--yes", "--no-lint", "--no-fmt", "--no-typecheck", "--no-editor"] as const;
+
+  // Nuxt owns the Vite instance, so it wins over the Vite config that is also
+  // present.
+  const detected = await runInit(root, [...bundlerOnly, "--bundler", "--dry-run"]);
+  assert.deepEqual(detected.plan?.commands, [
+    { command: "pnpm", args: ["add", "-D", "@vizejs/nuxt"], cwd: root },
+  ]);
+  assert.deepEqual(detected.plan?.updatedFiles, ["nuxt.config.ts"]);
+  assert.equal(detected.output.split("\n")[1], "  framework:       Nuxt (nuxt.config.ts)");
+
+  const overridden = await runInit(root, [...bundlerOnly, "--vite", "--dry-run"]);
+  assert.deepEqual(overridden.plan?.commands, [
+    { command: "pnpm", args: ["add", "-D", "@vizejs/vite-plugin"], cwd: root },
+  ]);
+  assert.deepEqual(overridden.plan?.updatedFiles, ["vite.config.ts"]);
+  assert.equal(overridden.output.split("\n")[1], "  framework:       Vite (vite.config.ts)");
+});
+
+test("a JavaScript-only project skips typecheck and still configures the rest", async () => {
+  const root = temporaryProject("javascript");
+  writeManifest(root, {
+    name: "fixture",
+    private: true,
+    type: "module",
+    scripts: { dev: "vite" },
+    devDependencies: { vite: "^7.0.0" },
+  });
+  write(
+    root,
+    "vite.config.js",
+    `import { defineConfig } from "vite";
+
+export default defineConfig({});
+`,
+  );
+  write(root, "bun.lock", "{}\n");
+
+  const result = await runInit(root, ALL_FEATURES);
+
+  assert.deepEqual(result.commands, [
+    {
+      command: "bun",
+      args: ["add", "-D", "@vizejs/vite-plugin", "oxlint", "oxlint-plugin-vize", "vize"],
+      cwd: root,
+    },
+  ]);
+  assert.deepEqual(
+    result.plan?.features.map((feature) => [feature.id, feature.outcome]),
+    [
+      ["lint", "configured"],
+      ["bundler", "configured"],
+      ["fmt", "configured"],
+      ["typecheck", "blocked"],
+      ["editor", "configured"],
+    ],
+  );
+  assert.deepEqual(result.plan?.addedScripts, ["vize:lint", "vize:fmt", "vize:fmt:fix"]);
+  assert.deepEqual(readAll(root, ["vite.config.js", "vize.config.ts"]), {
+    "vite.config.js": `import { defineConfig } from "vite";
+import vize from "@vizejs/vite-plugin";
+
+export default defineConfig({
+  plugins: [vize()],
+});
+`,
+    "vize.config.ts": `import { defineConfig } from "vize";
+
+export default defineConfig({
+  compiler: {
+    templateSyntax: "standard",
+  },
+  linter: {
+    enabled: true,
+    preset: "general-recommended",
+  },
+  formatter: {
+    singleAttributePerLine: false,
+    sortBlocks: true,
+  },
+  vite: {
+    scanPatterns: ["src/**/*.vue"],
+  },
+});
+`,
+  });
+});
+
+test("a hand-written lint block is never overwritten and never silently bypassed", async () => {
+  const root = temporaryProject("hand-written");
+  writeManifest(root, {
+    name: "fixture",
+    private: true,
+    type: "module",
+    scripts: { dev: "vp dev" },
+    devDependencies: { "vite-plus": "^0.1.0" },
+  });
+  const handWritten = `import { defineConfig } from "vite-plus";
+import legacy from "@vitejs/plugin-legacy";
+import inspect from "vite-plugin-inspect";
+
+export default defineConfig({
+  lint: {
+    plugins: ["eslint", "typescript"],
+    rules: {
+      "no-console": "warn",
+    },
+  },
+  plugins: [legacy(), inspect()],
+});
+`;
+  write(root, "vite.config.ts", handWritten);
+  write(root, "tsconfig.json", "{}\n");
+  write(root, "pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
+
+  const result = await runInit(root, ALL_FEATURES);
+
+  assert.equal(result.plan?.lintTarget.kind, "manual");
+  assert.deepEqual(
+    result.plan?.features.map((feature) => [feature.id, feature.outcome]),
+    [
+      ["lint", "blocked"],
+      ["bundler", "configured"],
+      ["fmt", "configured"],
+      ["typecheck", "configured"],
+      ["editor", "configured"],
+    ],
+  );
+  // The lint block is untouched; only the plugin list gained an entry, and the
+  // project's own plugins keep their order.
+  assert.equal(
+    read(root, "vite.config.ts"),
+    `import { defineConfig } from "vite-plus";
+import legacy from "@vitejs/plugin-legacy";
+import inspect from "vite-plugin-inspect";
+import vize from "@vizejs/vite-plugin";
+
+export default defineConfig({
+  lint: {
+    plugins: ["eslint", "typescript"],
+    rules: {
+      "no-console": "warn",
+    },
+  },
+  plugins: [vize(), legacy(), inspect()],
+});
+`,
+  );
+  // The bug this guards: falling back to an Oxlint config file would leave
+  // `vp lint` reading the untouched hand-written block and reporting zero
+  // vize/* diagnostics while exiting 0.
+  assert.equal(exists(root, "oxlint.config.ts"), false);
+  assert.equal(exists(root, ".oxlintrc.json"), false);
+  assert.equal(
+    result.plan?.features.find((feature) => feature.id === "lint")?.snippet,
+    `import { createVizeLintConfig } from "oxlint-plugin-vize";
+
+export default defineConfig({
+  lint: {
+    ...createVizeLintConfig({
+      preset: "general-recommended",
+      settings: {
+        helpLevel: "short",
+      },
+    }),
+    // keep your existing lint keys here
+  },
+});
+`,
+  );
+});
+
+test("an oxlint config name oxlint never reads is reported, not counted as configured", async () => {
+  const root = temporaryProject("unread-oxlint");
+  writeManifest(root, {
+    name: "fixture",
+    private: true,
+    type: "module",
+    scripts: { lint: "oxlint src" },
+    devDependencies: { vite: "^7.0.0" },
+  });
+  write(root, "oxlint.config.mjs", "export default {};\n");
+  write(root, "package-lock.json", '{"lockfileVersion":3}\n');
+
+  const result = await runInit(root, [
+    "--yes",
+    "--lint",
+    "--no-fmt",
+    "--no-typecheck",
+    "--no-editor",
+  ]);
+
+  assert.equal(result.plan?.lintTarget.kind, "oxlint");
+  assert.deepEqual(result.plan?.createdFiles, ["oxlint.config.ts", "vize.config.ts"]);
+  assert.equal(read(root, "oxlint.config.mjs"), "export default {};\n");
+  assert.equal(
+    result.output.split("\n")[6],
+    "  oxlint config:   oxlint.config.mjs — present but oxlint does not read this name (#3474)",
+  );
+});

--- a/npm/cli/tests/init-prompt.test.ts
+++ b/npm/cli/tests/init-prompt.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+
+import {
+  exists,
+  runInit,
+  scriptedPrompt,
+  temporaryProject,
+  write,
+  writeManifest,
+} from "./init-support.ts";
+
+function vitePlusProject(name: string): string {
+  const root = temporaryProject(name);
+  writeManifest(root, {
+    name: "fixture",
+    private: true,
+    type: "module",
+    scripts: { dev: "vp dev" },
+    devDependencies: { "vite-plus": "^0.1.0" },
+  });
+  write(
+    root,
+    "vite.config.ts",
+    `import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  plugins: [],
+});
+`,
+  );
+  write(root, "tsconfig.json", "{}\n");
+  write(root, "pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
+  return root;
+}
+
+const CHECKLIST_HEADER = `
+Select the features to configure.
+Type the numbers to toggle (space or comma separated), then press Enter.
+`;
+
+test("the checklist pre-ticks what detection found and reports what it cannot offer", async () => {
+  const root = vitePlusProject("prompt-defaults");
+  const prompt = scriptedPrompt(["", "y"]);
+
+  const result = await runInit(root, [], prompt);
+
+  assert.deepEqual(prompt.asked(), ["> ", "Apply this selection? [Y/n] "]);
+  assert.equal(
+    prompt.transcript(),
+    `${CHECKLIST_HEADER}
+  1. [x] oxlint plugin (vp lint reads the \`lint\` block in the Vite config)
+  2. [x] vite plugin (@vizejs/vite-plugin)
+  3. [x] fmt (vize fmt)
+  4. [x] typecheck (vize check)
+  5. [x] editor extension (.vscode/extensions.json recommendation)
+
+`,
+  );
+  assert.deepEqual(
+    result.plan?.features.map((feature) => [feature.id, feature.outcome]),
+    [
+      ["lint", "configured"],
+      ["bundler", "configured"],
+      ["fmt", "configured"],
+      ["typecheck", "configured"],
+      ["editor", "configured"],
+    ],
+  );
+});
+
+test("toggling a number off removes exactly that feature from the plan", async () => {
+  const root = vitePlusProject("prompt-toggle");
+  // Toggle 4 (typecheck) and 5 (editor) off, accept, confirm.
+  const prompt = scriptedPrompt(["4 5", "", ""]);
+
+  const result = await runInit(root, ["--no-install"], prompt);
+
+  assert.deepEqual(prompt.asked(), ["> ", "> ", "Apply this selection? [Y/n] "]);
+  assert.deepEqual(
+    result.plan?.features.map((feature) => [feature.id, feature.outcome]),
+    [
+      ["lint", "configured"],
+      ["bundler", "configured"],
+      ["fmt", "configured"],
+      ["typecheck", "skipped"],
+      ["editor", "skipped"],
+    ],
+  );
+  assert.deepEqual(result.plan?.addedScripts, ["vize:lint", "vize:fmt", "vize:fmt:fix"]);
+  assert.equal(exists(root, ".vscode/extensions.json"), false);
+  assert.deepEqual(result.commands, []);
+});
+
+test("an out-of-range answer is rejected without changing the selection", async () => {
+  const root = vitePlusProject("prompt-invalid");
+  const prompt = scriptedPrompt(["9", "", "y"]);
+
+  await runInit(root, ["--no-install"], prompt);
+
+  const checklist = `${CHECKLIST_HEADER}
+  1. [x] oxlint plugin (vp lint reads the \`lint\` block in the Vite config)
+  2. [x] vite plugin (@vizejs/vite-plugin)
+  3. [x] fmt (vize fmt)
+  4. [x] typecheck (vize check)
+  5. [x] editor extension (.vscode/extensions.json recommendation)
+
+`;
+  // The rejected answer is reported and the checklist is re-rendered unchanged.
+  assert.equal(
+    prompt.transcript(),
+    `${checklist}Enter numbers between 1 and 5, or press Enter to accept.\n${checklist}`,
+  );
+  assert.deepEqual(prompt.asked(), ["> ", "> ", "Apply this selection? [Y/n] "]);
+});
+
+test("declining the confirmation writes nothing at all", async () => {
+  const root = vitePlusProject("prompt-decline");
+  const prompt = scriptedPrompt(["", "n"]);
+
+  const result = await runInit(root, [], prompt);
+
+  assert.equal(result.plan, null);
+  assert.deepEqual(result.written, []);
+  assert.deepEqual(result.commands, []);
+  assert.equal(exists(root, "vize.config.ts"), false);
+  assert.equal(result.output.split("\n").at(-2), "[vize init] cancelled; nothing was written.");
+});
+
+test("an input that ends mid-prompt cancels instead of silently doing nothing", async () => {
+  const root = vitePlusProject("prompt-eof");
+  // No answers at all: the first question sees a closed input.
+  const prompt = scriptedPrompt([]);
+
+  const result = await runInit(root, [], prompt);
+
+  assert.deepEqual(prompt.asked(), ["> "]);
+  assert.equal(result.plan, null);
+  assert.deepEqual(result.written, []);
+  assert.deepEqual(result.commands, []);
+  assert.equal(exists(root, "vize.config.ts"), false);
+  assert.equal(result.output.split("\n").at(-2), "[vize init] cancelled; nothing was written.");
+});
+
+test("an unavailable feature is listed without a number and cannot be toggled", async () => {
+  const root = temporaryProject("prompt-unavailable");
+  writeManifest(root, { name: "fixture", private: true, type: "module" });
+  const prompt = scriptedPrompt(["", "y"]);
+
+  const result = await runInit(root, ["--no-install"], prompt);
+
+  assert.equal(
+    prompt.transcript(),
+    `${CHECKLIST_HEADER}
+  1. [x] oxlint plugin (the oxlint binary reads oxlint.config.ts)
+     -  vite plugin or nuxt module (no vite.config or nuxt.config found; the other features work without one)
+  2. [x] fmt (vize fmt)
+     -  typecheck (vize check) (needs a tsconfig.json)
+  3. [x] editor extension (.vscode/extensions.json recommendation)
+
+`,
+  );
+  assert.deepEqual(
+    result.plan?.features.map((feature) => [feature.id, feature.outcome]),
+    [
+      ["lint", "configured"],
+      ["bundler", "skipped"],
+      ["fmt", "configured"],
+      ["typecheck", "skipped"],
+      ["editor", "configured"],
+    ],
+  );
+});

--- a/npm/cli/tests/init-support.ts
+++ b/npm/cli/tests/init-support.ts
@@ -1,0 +1,169 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { initProject, type InitCommand, type InitPlan } from "../src/init.ts";
+import type { PromptDeps } from "../src/init/prompt.ts";
+
+/**
+ * Harness for the non-interactive `init` path.
+ *
+ * Every run writes to a real temporary project under `os.tmpdir()` and records
+ * what it wrote, so the same helper serves both the "assert the exact bytes"
+ * tests and the idempotence test, where the second run has to observe the first
+ * run's output on disk.
+ */
+
+export interface RunResult {
+  readonly plan: InitPlan | null;
+  readonly commands: readonly InitCommand[];
+  readonly output: string;
+  /** Files the run wrote, relative to the project root, in write order. */
+  readonly written: readonly string[];
+}
+
+export function temporaryProject(name: string): string {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `vize-init-${name}-`)));
+}
+
+export function write(root: string, filename: string, source: string): void {
+  const target = path.join(root, filename);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, source);
+}
+
+export function read(root: string, filename: string): string {
+  return fs.readFileSync(path.join(root, filename), "utf8");
+}
+
+export function exists(root: string, filename: string): boolean {
+  return fs.existsSync(path.join(root, filename));
+}
+
+/** Reads several files at once so a test can `deepEqual` the whole result set. */
+export function readAll(root: string, filenames: readonly string[]): Record<string, string> {
+  const contents: Record<string, string> = {};
+  for (const filename of filenames) {
+    contents[filename] = read(root, filename);
+  }
+  return contents;
+}
+
+/**
+ * Runs `init` against a fixture project.
+ *
+ * The install command is simulated rather than executed: it appends the
+ * requested dev dependencies to `package.json` exactly as a package manager
+ * would, which is what makes the second run of the idempotence test see them.
+ */
+export async function runInit(
+  root: string,
+  args: readonly string[],
+  prompt?: ScriptedPrompt,
+): Promise<RunResult> {
+  const commands: InitCommand[] = [];
+  const written: string[] = [];
+  let output = "";
+
+  const plan = await initProject({
+    root,
+    args,
+    stdin: prompt === undefined ? nonTtyStdin() : ttyStdin(),
+    promptDeps: prompt?.deps,
+    output(chunk) {
+      output += chunk;
+    },
+    writeFile(filename, source) {
+      fs.mkdirSync(path.dirname(filename), { recursive: true });
+      fs.writeFileSync(filename, source);
+      written.push(path.relative(root, filename));
+    },
+    runCommand(command) {
+      commands.push(command);
+      applyInstall(root, command);
+    },
+  });
+
+  return { plan, commands, output, written };
+}
+
+/** A stdin stand-in that is explicitly not a TTY, matching a CI environment. */
+export function nonTtyStdin(): NodeJS.ReadableStream {
+  return { isTTY: false } as unknown as NodeJS.ReadableStream;
+}
+
+/** A stdin stand-in that reports itself as a TTY without being one. */
+export function ttyStdin(): NodeJS.ReadableStream {
+  return { isTTY: true } as unknown as NodeJS.ReadableStream;
+}
+
+export interface ScriptedPrompt {
+  readonly deps: PromptDeps;
+  /** Everything the checklist rendered, in order. */
+  readonly transcript: () => string;
+  /** The prompts the run asked for, in order. */
+  readonly asked: () => readonly string[];
+}
+
+/**
+ * A prompt that replays a fixed list of answers.
+ *
+ * Drives the real `selectFeatures` / `confirm` code rather than a stand-in for
+ * it, so the checklist rendering and the toggle parsing are both covered. Once
+ * the script runs out the prompt reports a closed input, matching what readline
+ * does at EOF.
+ */
+export function scriptedPrompt(answers: readonly (string | null)[]): ScriptedPrompt {
+  const asked: string[] = [];
+  let transcript = "";
+  let index = 0;
+  const deps: PromptDeps = {
+    input: ttyStdin(),
+    output: {
+      write(chunk: string): boolean {
+        transcript += chunk;
+        return true;
+      },
+    } as unknown as NodeJS.WritableStream,
+    question(query: string): Promise<string | null> {
+      asked.push(query);
+      const answer = index < answers.length ? answers[index]! : null;
+      index += 1;
+      return Promise.resolve(answer);
+    },
+  };
+  return { deps, transcript: () => transcript, asked: () => asked };
+}
+
+function applyInstall(root: string, command: InitCommand): void {
+  const packagePath = path.join(root, "package.json");
+  const manifest = JSON.parse(fs.readFileSync(packagePath, "utf8")) as {
+    devDependencies?: Record<string, string>;
+  };
+  const devDependencies = manifest.devDependencies ?? {};
+  for (const dependency of command.args.slice(2)) {
+    devDependencies[dependency] = "^0.306.0";
+  }
+  manifest.devDependencies = devDependencies;
+  fs.writeFileSync(packagePath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+export function manifest(
+  overrides: Readonly<Record<string, unknown>> = {},
+): Readonly<Record<string, unknown>> {
+  return { name: "fixture", private: true, type: "module", ...overrides };
+}
+
+export function writeManifest(root: string, value: Readonly<Record<string, unknown>>): void {
+  write(root, "package.json", `${JSON.stringify(value, null, 2)}\n`);
+}
+
+/** All five features on, no prompting. The flags CI would pass. */
+export const ALL_FEATURES = [
+  "--yes",
+  "--lint",
+  "--bundler",
+  "--fmt",
+  "--typecheck",
+  "--editor",
+] as const;

--- a/npm/cli/tests/init.test.ts
+++ b/npm/cli/tests/init.test.ts
@@ -1,0 +1,298 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+
+import {
+  ALL_FEATURES,
+  exists,
+  read,
+  readAll,
+  runInit,
+  temporaryProject,
+  write,
+  writeManifest,
+} from "./init-support.ts";
+
+const VITE_PLUS_CONFIG = `import { defineConfig } from "vite-plus";
+
+export default defineConfig({
+  plugins: [],
+});
+`;
+
+const EXPECTED_VITE_PLUS_CONFIG = `import { defineConfig } from "vite-plus";
+import { createVizeLintConfig } from "oxlint-plugin-vize";
+import vize from "@vizejs/vite-plugin";
+
+export default defineConfig({
+  lint: createVizeLintConfig({
+    preset: "general-recommended",
+    settings: {
+      helpLevel: "short",
+    },
+  }),
+  plugins: [vize()],
+});
+`;
+
+const EXPECTED_VIZE_CONFIG = `import { defineConfig } from "vize";
+
+export default defineConfig({
+  compiler: {
+    templateSyntax: "standard",
+  },
+  linter: {
+    enabled: true,
+    preset: "general-recommended",
+  },
+  formatter: {
+    singleAttributePerLine: false,
+    sortBlocks: true,
+  },
+  typeChecker: {
+    enabled: true,
+    strict: true,
+  },
+  vite: {
+    scanPatterns: ["src/**/*.vue"],
+  },
+});
+`;
+
+const EXPECTED_OXLINT_CONFIG = `import { defineConfig } from "oxlint";
+import { configs } from "oxlint-plugin-vize";
+
+export default defineConfig({
+  plugins: ["vue"],
+  jsPlugins: ["oxlint-plugin-vize"],
+  settings: {
+    vize: {
+      preset: "general-recommended",
+      helpLevel: "short",
+    },
+  },
+  rules: configs.recommended,
+});
+`;
+
+const EXPECTED_EXTENSIONS = `{
+  "recommendations": [
+    "ubugeeei.vize"
+  ]
+}
+`;
+
+function vitePlusProject(name: string): string {
+  const root = temporaryProject(name);
+  writeManifest(root, {
+    name: "fixture",
+    private: true,
+    type: "module",
+    scripts: { dev: "vp dev" },
+    devDependencies: { "vite-plus": "^0.1.0" },
+  });
+  write(root, "vite.config.ts", VITE_PLUS_CONFIG);
+  write(root, "tsconfig.json", "{}\n");
+  write(root, "pnpm-lock.yaml", "lockfileVersion: '9.0'\n");
+  return root;
+}
+
+test("a Vite+ project is configured through the vite.config lint block", async () => {
+  const root = vitePlusProject("vite-plus");
+  const result = await runInit(root, ALL_FEATURES);
+
+  assert.deepEqual(result.commands, [
+    {
+      command: "vp",
+      args: ["add", "-D", "@vizejs/vite-plugin", "oxlint", "oxlint-plugin-vize", "vize"],
+      cwd: root,
+    },
+  ]);
+  assert.deepEqual(result.written, [
+    "vite.config.ts",
+    "vize.config.ts",
+    ".vscode/extensions.json",
+    "package.json",
+  ]);
+  assert.deepEqual(readAll(root, ["vite.config.ts", "vize.config.ts", ".vscode/extensions.json"]), {
+    "vite.config.ts": EXPECTED_VITE_PLUS_CONFIG,
+    "vize.config.ts": EXPECTED_VIZE_CONFIG,
+    ".vscode/extensions.json": EXPECTED_EXTENSIONS,
+  });
+  assert.equal(
+    read(root, "package.json"),
+    `${JSON.stringify(
+      {
+        name: "fixture",
+        private: true,
+        type: "module",
+        scripts: {
+          dev: "vp dev",
+          "vize:lint": "vize lint --preset happy-path --max-warnings 0 src",
+          "vize:fmt": "vize fmt --check src",
+          "vize:fmt:fix": "vize fmt --write src",
+          "vize:check": "vize check src",
+        },
+        devDependencies: {
+          "vite-plus": "^0.1.0",
+          "@vizejs/vite-plugin": "^0.306.0",
+          oxlint: "^0.306.0",
+          "oxlint-plugin-vize": "^0.306.0",
+          vize: "^0.306.0",
+        },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  // The trap: a Vite+ project must not be handed an Oxlint config file, because
+  // `vp lint` never reads one.
+  assert.equal(exists(root, "oxlint.config.ts"), false);
+  assert.equal(exists(root, ".oxlintrc.json"), false);
+  assert.equal(result.plan?.lintTarget.kind, "vite-plus");
+});
+
+test("a second run of an already-configured project writes and runs nothing", async () => {
+  const root = vitePlusProject("idempotent");
+  const first = await runInit(root, ALL_FEATURES);
+  const before = readAll(root, [
+    "package.json",
+    "vite.config.ts",
+    "vize.config.ts",
+    ".vscode/extensions.json",
+  ]);
+
+  const second = await runInit(root, ALL_FEATURES);
+
+  assert.deepEqual(second.written, []);
+  assert.deepEqual(second.commands, []);
+  assert.deepEqual(second.plan?.createdFiles, []);
+  assert.deepEqual(second.plan?.updatedFiles, []);
+  assert.deepEqual(second.plan?.addedScripts, []);
+  assert.deepEqual(
+    readAll(root, ["package.json", "vite.config.ts", "vize.config.ts", ".vscode/extensions.json"]),
+    before,
+  );
+  assert.deepEqual(
+    second.plan?.features.map((feature) => [feature.id, feature.outcome]),
+    [
+      ["lint", "unchanged"],
+      ["bundler", "unchanged"],
+      ["fmt", "unchanged"],
+      ["typecheck", "unchanged"],
+      ["editor", "unchanged"],
+    ],
+  );
+  assert.notEqual(first.written.length, 0);
+});
+
+test("a plain Vite project gets the Oxlint config its lint command reads", async () => {
+  const root = temporaryProject("plain-vite");
+  writeManifest(root, {
+    name: "fixture",
+    private: true,
+    type: "module",
+    scripts: { dev: "vite", lint: "oxlint src" },
+    devDependencies: { vite: "^7.0.0" },
+  });
+  write(
+    root,
+    "vite.config.ts",
+    `import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [],
+});
+`,
+  );
+  write(root, "tsconfig.json", "{}\n");
+  write(root, "package-lock.json", '{"lockfileVersion":3}\n');
+
+  const result = await runInit(root, ALL_FEATURES);
+
+  assert.deepEqual(result.commands, [
+    {
+      command: "npm",
+      args: ["install", "-D", "@vizejs/vite-plugin", "oxlint", "oxlint-plugin-vize", "vize"],
+      cwd: root,
+    },
+  ]);
+  assert.deepEqual(result.written, [
+    "oxlint.config.ts",
+    "vite.config.ts",
+    "vize.config.ts",
+    ".vscode/extensions.json",
+    "package.json",
+  ]);
+  assert.deepEqual(readAll(root, ["oxlint.config.ts", "vite.config.ts"]), {
+    "oxlint.config.ts": EXPECTED_OXLINT_CONFIG,
+    "vite.config.ts": `import { defineConfig } from "vite";
+import vize from "@vizejs/vite-plugin";
+
+export default defineConfig({
+  plugins: [vize()],
+});
+`,
+  });
+  assert.equal(result.plan?.lintTarget.kind, "oxlint");
+});
+
+test("a Vite+ project that also runs oxlint gets both configs from one preset", async () => {
+  const root = vitePlusProject("both-targets");
+  writeManifest(root, {
+    name: "fixture",
+    private: true,
+    type: "module",
+    scripts: { dev: "vp dev", "lint:ci": "oxlint-vize -f stylish src" },
+    devDependencies: { "vite-plus": "^0.1.0" },
+  });
+
+  const result = await runInit(root, ALL_FEATURES);
+
+  assert.equal(result.plan?.lintTarget.kind, "both");
+  assert.deepEqual(readAll(root, ["oxlint.config.ts", "vite.config.ts"]), {
+    "oxlint.config.ts": EXPECTED_OXLINT_CONFIG,
+    "vite.config.ts": EXPECTED_VITE_PLUS_CONFIG,
+  });
+});
+
+test("--dry-run reports the plan and writes nothing", async () => {
+  const root = vitePlusProject("dry-run");
+  const before = readAll(root, ["package.json", "vite.config.ts"]);
+
+  const result = await runInit(root, [...ALL_FEATURES, "--dry-run"]);
+
+  assert.deepEqual(result.written, []);
+  assert.deepEqual(result.commands, []);
+  assert.deepEqual(readAll(root, ["package.json", "vite.config.ts"]), before);
+  assert.equal(exists(root, "vize.config.ts"), false);
+  assert.deepEqual(result.plan?.createdFiles, ["vize.config.ts", ".vscode/extensions.json"]);
+  assert.deepEqual(result.plan?.updatedFiles, ["vite.config.ts", "package.json"]);
+});
+
+test("a non-TTY stdin without --yes refuses to prompt instead of hanging", async () => {
+  const root = vitePlusProject("non-tty");
+  const before = readAll(root, ["package.json", "vite.config.ts"]);
+
+  const result = await runInit(root, ["--lint", "--fmt"]);
+
+  assert.equal(result.plan, null);
+  assert.deepEqual(result.written, []);
+  assert.deepEqual(result.commands, []);
+  assert.deepEqual(readAll(root, ["package.json", "vite.config.ts"]), before);
+  assert.equal(
+    result.output,
+    `[vize init] detected in ${root}:
+  framework:       Vite+ (vite.config.ts)
+  package manager: pnpm
+  language:        TypeScript (tsconfig.json)
+  lint command:    vp lint
+  vize config:     none
+  oxlint config:   none
+[vize init] stdin is not a TTY, so init will not prompt.
+[vize init] pass --yes with the features you want, for example:
+[vize init]   vize init --yes --lint --vite --fmt --typecheck --editor
+[vize init] or run with --dry-run to print the plan without writing.
+`,
+  );
+});


### PR DESCRIPTION
Adds `vize init` (`vpx vize init`): an interactive, one-shot command that selects, installs and
configures the oxlint plugin, the vite plugin or nuxt module, fmt, typecheck, and the editor
extension.

## Which layer this builds on, and why

**`setup` stays the non-interactive core; `init` is a second entry point over the same planning
layer.** One planning layer, two entry points, as suggested.

`init` reuses `atomicWriteFile`, `parsePackageJson`, `detectJsonIndent`, `dependencyNames`,
`readRequiredFile`, `PlannedFile`, `VIZE_CONFIG_FILES`, `OXLINT_CONFIG_FILES` and — importantly —
`DEFAULT_SCRIPTS`, so the `vize:lint` / `vize:fmt` / `vize:check` command strings cannot drift
between the two commands. It adds the parts `setup` has no concept of: per-feature selection, Nuxt,
package-manager detection, a dry run, and a plan object that is built before anything is written.

It lives next to `setup` on the JS side rather than in `crates/vize/src/cli.rs`. The planning layer
it has to reuse is JS, and prompts plus `package.json` / `vite.config.ts` editing are all better
served there. Putting `init` in the Rust CLI would have meant a second, diverging planning layer —
which is how the `.oxlintrc.json` vs `vite.config.ts` split became a silent bug in the first place.

## The trap: writing the config the user's actual lint command reads

#3389 (fixed in #3407) established the split:

| Command                 | Reads                                |
| ----------------------- | ------------------------------------ |
| `vp lint`, `vp check`   | the `lint` block in `vite.config.ts` |
| `oxlint`, `oxlint-vize` | `.oxlintrc.json` / `oxlint.config.ts` |

Vite+ never reads `.oxlintrc.json`. A project wired the documented way looked configured, `vp lint`
ignored the file, Oxlint never saw a `vize/*` rule id, and the run reported **zero** Vize
diagnostics while exiting `0`.

`init` picks its target from the command the project will run, never from what is easiest to write.
`src/init/lint-target.ts` is the whole decision:

| Detection                                        | Written                                                             |
| ------------------------------------------------ | ------------------------------------------------------------------- |
| Vite+ present                                     | the `lint` block in `vite.config.*`, via `createVizeLintConfig()`     |
| no Vite+ (plain Vite, Nuxt, or no bundler)        | `oxlint.config.ts`                                                    |
| Vite+ **and** the `oxlint` binary both in use     | **both**, from one preset and one help level                          |
| Vite+ but the Vite config cannot be edited safely | **nothing** — the exact snippet is printed with the reason, exit 1     |

Three details that matter:

- The `lint` block is emitted with **`createVizeLintConfig()`**, the API #3407 added, not a
  hand-assembled block. It returns the whole block, so `jsPlugins` cannot go missing.
- "Both in use" is detected (an existing discovered Oxlint config, or a script invoking
  `oxlint`/`oxlint-vize`) and both files are generated from the same `INIT_LINT_PRESET` /
  `INIT_LINT_HELP_LEVEL` constants, so they cannot drift apart.
- **The blocked branch writes nothing.** Falling back to an Oxlint config file when the Vite+ `lint`
  block is unavailable is precisely the #3389 bug: `vp lint` would keep reading the untouched Vite
  config and keep reporting nothing. An unconfigured project that fails loudly is correct; a
  configured-looking project that is silent is not. There is a test asserting no Oxlint config file
  appears in that case.

## A second instance of the same bug class, found on the way

Of the eight names in `OXLINT_CONFIG_FILES`, oxlint 1.64 auto-discovers only three. Probing each
name with a project containing `console.log(1);` and a config enabling `no-console`:

```
DISCOVERED   .oxlintrc.json
DISCOVERED   .oxlintrc.jsonc
DISCOVERED   oxlint.config.ts
IGNORED      oxlint.config.mts
IGNORED      oxlint.config.js
IGNORED      oxlint.config.mjs
IGNORED      oxlint.config.cjs
IGNORED      oxlint.config.cts
```

"IGNORED" is byte-identical to running with no config at all — `Found 0 warnings and 0 errors`,
exit `0`, and 95 rules enabled instead of 96, confirming the file was never loaded.

`setup` treats all eight as configuration and will print `preserved existing oxlint.config.mjs` for
a project Oxlint reads nothing for. That is filed separately as **#3474** rather than widened into
this PR. `init` does not inherit it: it counts only the three discovered names, writes
`oxlint.config.ts`, and reports the others as `present but oxlint does not read this name (#3474)`.

## Detection matrix

Reported before any prompt (`[vize init] detected in …`).

| Signal          | Rule                                                                                                                 |
| --------------- | -------------------------------------------------------------------------------------------------------------------- |
| Framework       | `nuxt.config.{ts,mts,js,mjs}` or a `nuxt` dependency → Nuxt; else `vite.config.*` → Vite; else none                     |
| Both            | **Nuxt wins** — it owns its own Vite instance, so `@vizejs/vite-plugin` would fight the module. `--vite` overrides.     |
| Neither         | the bundler feature is offered as unavailable and the other four still work; nothing is invented                        |
| Package manager | `pnpm-lock.yaml` → pnpm, `bun.lockb`/`bun.lock` → bun, `yarn.lock` → yarn, `package-lock.json` → npm, then the `packageManager` prefix. Identical rules to `detect_package_manager` in `crates/vize_canon/src/batch/error.rs`, so the two halves of the toolchain cannot suggest different install commands. A Vite+ project gets `vp add -D`, matching `setup`. |
| Language        | `tsconfig.json` and/or a `typescript` dependency; typecheck requires a `tsconfig.json` and is reported `blocked` when explicitly requested without one |
| Lint entry point | `vite-plus` dependency, a `vite-plus` import in the Vite config, or a script invoking `vp` — deliberately generous, because guessing "plain Oxlint" for a Vite+ project is the failure mode |
| Already done    | existing Vize config, discovered Oxlint config, existing `lint` block, `@vizejs/vite-plugin` / `@vizejs/nuxt` already wired, `ubugeeei.vize` already recommended, installed deps |

### Files written per combination

| Feature   | Vite+                                    | plain Vite          | Nuxt                | no bundler         |
| --------- | ---------------------------------------- | ------------------- | ------------------- | ------------------ |
| lint      | `lint` block in `vite.config.*` (+ `oxlint.config.ts` if the binary is also used) | `oxlint.config.ts` | `oxlint.config.ts` | `oxlint.config.ts` |
| bundler   | `vize()` in `vite.config.*`               | same                | `@vizejs/nuxt` in `nuxt.config.*` | offered as unavailable |
| fmt       | `vize.config.ts` + `vize:fmt`, `vize:fmt:fix` | same            | same                | same               |
| typecheck | `vize.config.ts` + `vize:check`           | same                | same                | same               |
| editor    | `.vscode/extensions.json`                 | same                | same                | same               |

`vize.config.ts` is assembled from the selected features only, so asking for the formatter alone does
not hand the project a type checker it never opted into.

## Never clobbering user config

Editing `vite.config.ts` / `nuxt.config.ts` is the risky part, and a regex was not good enough. A
Vite+ config carries a **second `plugins` key inside its `lint` block**; a naive `plugins: [` match
appends Vize's Vite plugin to Oxlint's plugin list and corrupts both. The first version of this PR
did exactly that, and the hand-written-config test caught it:

```diff
-   plugins: ["eslint", "typescript"],
+   plugins: [vize(), "eslint", "typescript"],
```

`src/init/top-level.ts` is a small depth-aware scanner that skips strings, template literals and
comments and only matches a key at depth 0 of the config object. It is not a JS parser and does not
try to be — anything it cannot read turns into a refusal to edit, which is the safe direction. Every
injector returns `null` rather than guessing, and a `null` becomes a printed snippet.

`--dry-run` prints the full plan and writes nothing.

## Interactive and non-interactive

The prompt is a numbered multi-select on `node:readline`. **No new dependency**: `@clack/prompts`
and `@inquirer/prompts` are in the lockfile only as transitive deps of `@nuxt/cli`,
`@nuxt/devtools-wizard` and `@napi-rs/cli`, never as workspace deps, and `vize` is a published CLI
whose install cost every user pays. A numbered toggle list also needs no raw-mode handling and no
terminal-restore path.

Already-configured features are pre-checked and labelled `(already configured)`; unavailable ones are
listed without a number and cannot be toggled.

Non-interactive mode: `--yes` plus `--lint`/`--no-lint`, `--vite`/`--nuxt`/`--bundler`/`--no-bundler`,
`--fmt`, `--typecheck`, `--editor` and their `--no-` forms, `--dry-run`, `--no-install`,
`--package-manager`. **A non-TTY stdin is detected and refused** rather than hung, naming the flags to
pass. An explicit feature flag survives even when detection says the feature is unavailable — the
planner then reports it as `blocked` with the reason, which beats dropping a flag the user typed.

The pty run also surfaced a bug worth calling out: `rl.question` never fires its callback when stdin
reaches EOF first, so `init` would sit on a permanently pending promise and the process would exit
`0` having written nothing — a silent no-op that looks like success. `question` now resolves to
`null` on close and that becomes an explicit `cancelled; nothing was written` with exit 1.

## Editor extension

`.vscode/extensions.json` recommendations, not `code --install-extension`: checked in, applies to the
whole team, changes nothing on the machine running `init`. An existing file is merged (other
recommendations and the file's indentation preserved), never replaced. The output also lists the Zed,
Neovim, Vim, Helix and Emacs integrations this repo ships, rather than pretending VS Code is the only
editor.

## Tests

25 tests across `npm/cli/tests/init{,-frameworks,-prompt}.test.ts`, all over temporary projects under
`os.tmpdir()`, all driving the real code, no build artifact assumed. `assert.deepEqual` on complete
file contents and on the complete command list — no substring matching.

Fixtures: Vite+ TS, plain Vite TS, Nuxt, JS-only, a fully configured project, a hand-written
`vite.config.ts` with an existing `lint` block and unrelated plugins, a Vite+ project that also runs
`oxlint-vize`, a project holding an `oxlint.config.mjs`, and a bare project with no bundler.

Cases the brief called out explicitly:

- **Idempotence** — run twice, assert the second run's `written`, `commands`, `createdFiles`,
  `updatedFiles` and `addedScripts` are all empty, every file is byte-identical to before, and all
  five features report `unchanged`.
- **Non-TTY refusal** — asserts the complete stdout, and that the fixture is byte-identical after.
- **Prompt** — the scripted prompt drives the real `selectFeatures`/`confirm`, asserting the complete
  rendered checklist, the exact list of questions asked, toggling, out-of-range rejection, decline,
  and EOF cancellation.

### How the tests fail without the fix

This is a new command, so the regression evidence is per-behaviour rather than one pre-fix run:

- The `plugins`-inside-`lint` corruption above is a real defect the hand-written-config test caught
  during development, before `top-level.ts` existed. Reverting to the regex reproduces the diff shown.
- The EOF hang was caught by the pty run and reproduces by removing the `rl.once("close", …)` handler:
  the process exits `0` with nothing written instead of cancelling.
- The `oxlint.config.mjs` test fails against the wider `OXLINT_CONFIG_FILES` list — it would report
  the file as existing configuration and write no readable Oxlint config at all.

## Gates run

```
$ cd npm/cli && vp run test        # vp pack && vp test run tests/{setup,init,init-frameworks,init-prompt}.test.ts
  Test Files  4 passed (4)
       Tests  25 passed (25)

$ cd npm/cli && vp run check       # vp check src tests vite.config.ts
  pass: All 34 files are correctly formatted
  pass: Found no warnings or lint errors in 34 files

$ vp run check:repo
  pass: All 1838 files are correctly formatted (13476ms, 12 threads)
  pass: Found no warnings or lint errors in 1257 files (4.3s, 12 threads)
```

No Rust was touched. Longest new file is 298 lines (a test); every new source file is well inside the
350-line budget and no over-limit file grew.

End-to-end, against the packed `dist/cli.mjs`: `--help`, the non-TTY refusal (exit 1, nothing
written), `--dry-run` (nothing written), a real run, a second run (`nothing to do; the project is
already configured`), and an `expect`-driven pty run toggling typecheck off — which correctly omitted
both the `typeChecker` block and the `vize:check` script.

## Deliberately left out

- **Docs.** `docs/content/guide/` and the README getting-started pointer follow in a second PR, so
  this one stays reviewable.
- **`setup` is unchanged.** Narrowing `OXLINT_CONFIG_FILES` is #3474's job, not this PR's.
- **Merging into an existing `vize.config.*`.** `init` leaves it alone and says so. Merging a user's
  config is the kind of guess that loses settings.
- **`code --install-extension`.** Recommendations cover the team case; shelling out to a `code` binary
  can follow if anyone asks.
- **Creating a `vite.config.ts` for a project that has none.** `init` reports the bundler feature as
  unavailable and configures the other four rather than inventing a build setup.

Closes #3473


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `vize init` command for configuring projects interactively or through command-line options.
  * Detects project frameworks, package managers, existing configurations, and available integrations.
  * Supports dry runs, feature selection, dependency installation, formatting, type checking, linting, bundler integration, and editor recommendations.
  * Safely updates supported configuration files while preserving existing settings.
  * Provides clear plans, cancellation messages, blocked-action guidance, and consistent error reporting.

* **Tests**
  * Expanded coverage for initialization workflows, prompts, framework detection, dry runs, cancellations, and configuration preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->