### PR TITLE
feat(maestro): scope rangeFormatting to the selection and advertise it

### DIFF
--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -90,9 +90,11 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
         // Document formatting
         document_formatting_provider: features.formatting.then_some(OneOf::Left(true)),
 
-        // Range formatting is intentionally not advertised until the handler
-        // can produce edits scoped to the requested range.
-        document_range_formatting_provider: None,
+        // Range formatting ("Format Selection"). Rides the `formatting` flag
+        // with `document_formatting_provider`: the handler projects the
+        // whole-document format back onto the SFC blocks the selection
+        // intersects, so the two commands can never disagree.
+        document_range_formatting_provider: features.formatting.then_some(OneOf::Left(true)),
 
         // Signature help is not implemented yet.
         signature_help_provider: None,

--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -109,7 +109,12 @@ fn individual_feature_flags_gate_matching_providers() {
         (
             "formatting",
             |features| features.formatting = false,
-            |capabilities| capabilities.document_formatting_provider.is_some(),
+            // Range formatting rides the same flag: "Format Selection" is the
+            // same formatter scoped to the blocks a selection touches.
+            |capabilities| {
+                capabilities.document_formatting_provider.is_some()
+                    && capabilities.document_range_formatting_provider.is_some()
+            },
         ),
         (
             "code_lens",
@@ -245,6 +250,7 @@ fn default_features_advertise_non_opinionated_providers() {
     assert!(capabilities.definition_provider.is_some());
     assert!(capabilities.document_link_provider.is_some());
     assert!(capabilities.document_formatting_provider.is_none());
+    assert!(capabilities.document_range_formatting_provider.is_none());
 }
 
 #[test]
@@ -273,7 +279,7 @@ fn all_features_skip_unimplemented_providers_and_keep_implemented_ones() {
     assert!(capabilities.code_action_provider.is_some());
     assert!(capabilities.rename_provider.is_some());
     assert!(capabilities.document_formatting_provider.is_some());
-    assert!(capabilities.document_range_formatting_provider.is_none());
+    assert!(capabilities.document_range_formatting_provider.is_some());
     assert!(capabilities.code_lens_provider.is_some());
     assert!(capabilities.semantic_tokens_provider.is_some());
     assert!(capabilities.document_link_provider.is_some());

--- a/crates/vize_maestro/src/server/format.rs
+++ b/crates/vize_maestro/src/server/format.rs
@@ -3,6 +3,12 @@
 //! Provides SFC document formatting via the vize_glyph formatter.
 
 #[cfg(feature = "glyph")]
+mod range;
+
+#[cfg(feature = "glyph")]
+pub(crate) use range::format_range;
+
+#[cfg(feature = "glyph")]
 use tower_lsp::lsp_types::{Position, Range, TextEdit};
 
 /// Format a document and return TextEdits for the LSP client.

--- a/crates/vize_maestro/src/server/format/range.rs
+++ b/crates/vize_maestro/src/server/format/range.rs
@@ -1,0 +1,131 @@
+//! `textDocument/rangeFormatting`: format only the blocks the selection touches.
+//!
+//! # Why this is not "format the document and return that"
+//!
+//! The handler used to ignore `params.range` and return the whole-document
+//! edit, which is why the capability was never advertised: "Format Selection"
+//! would have silently reformatted the entire file, and a user who selected ten
+//! lines would get a diff over a thousand (#3456).
+//!
+//! # Why it is not "format the selected text on its own"
+//!
+//! Handing the selected substring to a formatter loses the context that decides
+//! its shape — the block's language, its base indentation, whether it is inside
+//! `<script>` or `<template>`. The result would not match what Format Document
+//! produces for the same lines, so the two commands would fight.
+//!
+//! Instead the whole document is formatted once and the result is *projected*
+//! back per SFC block: only blocks whose content the requested range intersects
+//! contribute a `TextEdit`. Format Selection is therefore always a subset of
+//! Format Document, by construction.
+//!
+//! Block *tags* are never rewritten, only block content, so a selection can
+//! never reorder or retag the file.
+
+use tower_lsp::lsp_types::{Position, Range, TextEdit};
+
+use crate::ide::position_to_offset;
+
+/// Byte span of one block's content, in discovery order.
+type BlockSpan = (usize, usize);
+
+pub(crate) fn format_range(
+    content: &str,
+    filename: &str,
+    range: Range,
+    options: &vize_glyph::FormatOptions,
+) -> Option<Vec<TextEdit>> {
+    let start = position_to_offset(content, range.start.line, range.start.character)?;
+    let end = position_to_offset(content, range.end.line, range.end.character)?;
+    // A client is allowed to send an inverted range (selecting backwards).
+    let (selection_start, selection_end) = if start <= end {
+        (start, end)
+    } else {
+        (end, start)
+    };
+
+    let allocator = vize_glyph::Allocator::with_capacity(content.len());
+    let formatted = vize_glyph::format_sfc_with_allocator(content, options, &allocator).ok()?;
+    if !formatted.changed {
+        return Some(Vec::new());
+    }
+
+    let authored = block_spans(content, filename)?;
+    let target = block_spans(&formatted.code, filename)?;
+    // A formatter must not add, drop or reorder blocks. If it did, the two
+    // lists cannot be paired and there is no safe partial edit to make.
+    if authored.len() != target.len() {
+        return None;
+    }
+
+    let mut edits = Vec::new();
+    for (&(authored_start, authored_end), &(target_start, target_end)) in
+        authored.iter().zip(target.iter())
+    {
+        if selection_start > authored_end || authored_start > selection_end {
+            continue;
+        }
+        let new_text = &formatted.code[target_start..target_end];
+        if new_text == &content[authored_start..authored_end] {
+            continue;
+        }
+        edits.push(TextEdit {
+            range: Range {
+                start: offset_position(content, authored_start),
+                end: offset_position(content, authored_end),
+            },
+            #[allow(clippy::disallowed_methods)]
+            new_text: new_text.to_string(),
+        });
+    }
+
+    // Block content spans are disjoint, so sorting by start is enough to make
+    // the list non-overlapping and ascending, which is what clients apply.
+    edits.sort_by_key(|edit| (edit.range.start.line, edit.range.start.character));
+    Some(edits)
+}
+
+/// Content spans of every SFC block, in a fixed discovery order so the authored
+/// and formatted documents pair up positionally.
+fn block_spans(source: &str, filename: &str) -> Option<Vec<BlockSpan>> {
+    let options = vize_atelier_sfc::SfcParseOptions {
+        filename: filename.into(),
+        ..Default::default()
+    };
+    let descriptor = vize_atelier_sfc::parse_sfc(source, options).ok()?;
+
+    Some(
+        descriptor
+            .template
+            .as_ref()
+            .map(|block| (block.loc.start, block.loc.end))
+            .into_iter()
+            .chain(
+                descriptor
+                    .script_setup
+                    .as_ref()
+                    .map(|block| (block.loc.start, block.loc.end)),
+            )
+            .chain(
+                descriptor
+                    .script
+                    .as_ref()
+                    .map(|block| (block.loc.start, block.loc.end)),
+            )
+            .chain(
+                descriptor
+                    .styles
+                    .iter()
+                    .map(|block| (block.loc.start, block.loc.end)),
+            )
+            .collect(),
+    )
+}
+
+fn offset_position(content: &str, offset: usize) -> Position {
+    let (line, character) = crate::ide::offset_to_position(content, offset);
+    Position { line, character }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_maestro/src/server/format/range/tests.rs
+++ b/crates/vize_maestro/src/server/format/range/tests.rs
@@ -1,0 +1,153 @@
+use tower_lsp::lsp_types::{Position, Range, TextEdit};
+
+use super::format_range;
+
+/// Two badly formatted blocks, so "only the selected one changes" is visible.
+///
+/// ```text
+/// 0  <script setup lang="ts">
+/// 1  const   a=1
+/// 2  const   b=2
+/// 3  </script>
+/// 4
+/// 5  <template>
+/// 6    <div   class="x"   >{{ a }}</div>
+/// 7  </template>
+/// ```
+const SOURCE: &str = "<script setup lang=\"ts\">\nconst   a=1\nconst   b=2\n</script>\n\n<template>\n  <div   class=\"x\"   >{{ a }}</div>\n</template>\n";
+
+/// Whole-document `vize fmt` output for SOURCE, as the block contents it
+/// rewrites. Recorded by running `vize fmt --write` on the fixture.
+const FORMATTED_SCRIPT: &str = "\nconst a = 1;\nconst b = 2;\n";
+const FORMATTED_TEMPLATE: &str = "\n  <div class=\"x\">\n    {{ a }}\n  </div>\n";
+
+/// `<template>`'s content, from just after the open tag to just before
+/// `</template>`.
+const TEMPLATE_CONTENT: Range = Range {
+    start: Position {
+        line: 5,
+        character: 10,
+    },
+    end: Position {
+        line: 7,
+        character: 0,
+    },
+};
+/// `<script setup>`'s content, on the same terms.
+const SCRIPT_CONTENT: Range = Range {
+    start: Position {
+        line: 0,
+        character: 24,
+    },
+    end: Position {
+        line: 3,
+        character: 0,
+    },
+};
+
+fn edits(source: &str, range: Range) -> Option<Vec<TextEdit>> {
+    format_range(
+        source,
+        "/App.vue",
+        range,
+        &vize_glyph::FormatOptions::default(),
+    )
+}
+
+fn selection(start: (u32, u32), end: (u32, u32)) -> Range {
+    Range {
+        start: Position {
+            line: start.0,
+            character: start.1,
+        },
+        end: Position {
+            line: end.0,
+            character: end.1,
+        },
+    }
+}
+
+#[test]
+fn a_selection_inside_one_block_leaves_every_other_block_untouched() {
+    // Lines 1-2: entirely inside `<script setup>`. The equally badly formatted
+    // template must not appear in the response at all — before #3456 this
+    // handler returned a single whole-document edit, so "Format Selection"
+    // rewrote the template too.
+    assert_eq!(
+        edits(SOURCE, selection((1, 0), (2, 11))),
+        Some(vec![TextEdit {
+            range: SCRIPT_CONTENT,
+            new_text: FORMATTED_SCRIPT.to_string(),
+        }])
+    );
+
+    // Line 6: entirely inside `<template>`.
+    assert_eq!(
+        edits(SOURCE, selection((6, 0), (6, 35))),
+        Some(vec![TextEdit {
+            range: TEMPLATE_CONTENT,
+            new_text: FORMATTED_TEMPLATE.to_string(),
+        }])
+    );
+}
+
+#[test]
+fn a_selection_spanning_both_blocks_edits_both_in_document_order() {
+    assert_eq!(
+        edits(SOURCE, selection((0, 0), (7, 11))),
+        Some(vec![
+            TextEdit {
+                range: SCRIPT_CONTENT,
+                new_text: FORMATTED_SCRIPT.to_string(),
+            },
+            TextEdit {
+                range: TEMPLATE_CONTENT,
+                new_text: FORMATTED_TEMPLATE.to_string(),
+            },
+        ])
+    );
+}
+
+#[test]
+fn an_inverted_range_selects_the_same_blocks() {
+    // A backwards selection is a legal range; the client sends the anchor last.
+    assert_eq!(
+        edits(SOURCE, selection((2, 11), (1, 0))),
+        edits(SOURCE, selection((1, 0), (2, 11)))
+    );
+}
+
+#[test]
+fn a_caret_with_no_selection_formats_the_block_it_sits_in() {
+    assert_eq!(
+        edits(SOURCE, selection((1, 5), (1, 5))),
+        Some(vec![TextEdit {
+            range: SCRIPT_CONTENT,
+            new_text: FORMATTED_SCRIPT.to_string(),
+        }])
+    );
+}
+
+#[test]
+fn an_already_formatted_document_produces_no_edits() {
+    // `Some(vec![])`, not `None`: the request succeeded and there is nothing to
+    // change, which is a different answer from "this document cannot be
+    // formatted".
+    let formatted = "<script setup lang=\"ts\">\nconst a = 1;\n</script>\n\n<template>\n  <div class=\"x\">\n    {{ a }}\n  </div>\n</template>\n";
+    assert_eq!(
+        edits(formatted, selection((0, 0), (8, 11))),
+        Some(Vec::new())
+    );
+}
+
+#[test]
+fn a_selection_between_blocks_edits_nothing() {
+    // Line 4 is the blank line separating the two blocks: it is inside no
+    // block's content, so no block is reformatted.
+    assert_eq!(edits(SOURCE, selection((4, 0), (4, 0))), Some(Vec::new()));
+}
+
+#[test]
+fn an_out_of_bounds_range_is_refused_rather_than_guessed() {
+    assert_eq!(edits(SOURCE, selection((0, 0), (900, 0))), None);
+}

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -17,18 +17,19 @@ use tower_lsp::{
         DocumentSymbolParams, DocumentSymbolResponse, FoldingRange, FoldingRangeParams,
         GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams, InitializeParams,
         InitializeResult, InitializedParams, InlayHint, InlayHintParams, LinkedEditingRangeParams,
-        LinkedEditingRanges, Location, Position, PrepareRenameResponse, ReferenceParams,
-        RenameFilesParams, RenameParams, SelectionRange, SelectionRangeParams,
-        SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
-        SemanticTokensResult, ServerInfo, SymbolInformation, TextDocumentPositionParams, TextEdit,
-        WorkspaceEdit, WorkspaceSymbolParams,
+        LinkedEditingRanges, Location, PrepareRenameResponse, ReferenceParams, RenameFilesParams,
+        RenameParams, SelectionRange, SelectionRangeParams, SemanticTokensParams,
+        SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, ServerInfo,
+        SymbolInformation, TextDocumentPositionParams, TextEdit, WorkspaceEdit,
+        WorkspaceSymbolParams,
     },
 };
 
-// Only the test modules below construct ranges now that `document_symbol` moved
-// into `server::document_structure`; they reach it through `use super::*`.
+// Only the test modules below construct positions and ranges now that
+// `document_symbol` moved into `server::document_structure` and range
+// formatting into `server::format`; they reach these through `use super::*`.
 #[cfg(test)]
-use tower_lsp::lsp_types::Range;
+use tower_lsp::lsp_types::{Position, Range};
 
 use super::{MaestroServer, server_capabilities};
 use crate::ide::{
@@ -751,6 +752,8 @@ impl LanguageServer for MaestroServer {
         Ok(None)
     }
 
+    /// Format only the SFC blocks the selection touches — see
+    /// `server::format::range` for why this is not the whole-document edit.
     async fn range_formatting(
         &self,
         params: DocumentRangeFormattingParams,
@@ -760,6 +763,7 @@ impl LanguageServer for MaestroServer {
         }
 
         let uri = &params.text_document.uri;
+        let _range = params.range;
 
         // See `formatting`: standalone HTML must not go through the SFC formatter.
         if crate::utils::is_standalone_html_path(uri.path()) {
@@ -769,17 +773,13 @@ impl LanguageServer for MaestroServer {
         let Some(_content) = self.state.documents.text(uri) else {
             return Ok(None);
         };
-        let valid_position =
-            |position: Position| position_to_offset(&_content, position.line, position.character);
-        if valid_position(params.range.start).is_none()
-            || valid_position(params.range.end).is_none()
-        {
-            return Ok(None);
-        }
         #[cfg(feature = "glyph")]
         {
             let options = self.state.get_format_options();
-            return Ok(super::format::format_document(&_content, &options));
+            let path = uri.path();
+            return Ok(super::format::format_range(
+                &_content, path, _range, &options,
+            ));
         }
         #[cfg(not(feature = "glyph"))]
         Ok(None)

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -89,9 +89,12 @@ test("vize lsp advertises the full editor-feature provider set with exact shapes
     // Selection ranges ship with the document-structure group.
     assert.equal(capabilities.selectionRangeProvider, true);
 
+    // Formatting is opt-in, so neither formatting provider is here.
+    assert.equal(capabilities.documentFormattingProvider, undefined);
+    assert.equal(capabilities.documentRangeFormattingProvider, undefined);
+
     // Providers that are intentionally not yet advertised stay absent.
     assert.equal(capabilities.signatureHelpProvider, undefined);
-    assert.equal(capabilities.documentRangeFormattingProvider, undefined);
   });
 });
 
@@ -189,4 +192,15 @@ test("vize lsp per-feature init flags toggle individual providers independently"
     assert.equal(capabilities.codeLensProvider?.resolveProvider, false);
     assert.ok(capabilities.semanticTokensProvider, "semanticTokensProvider should remain");
   });
+
+  await withCapabilities(
+    "granular-formatting-on",
+    { editor: true, formatting: true },
+    (capabilities) => {
+      // Opting into formatting brings both commands: "Format Selection" is the
+      // same formatter scoped to the SFC blocks a selection touches (#3456).
+      assert.equal(capabilities.documentFormattingProvider, true);
+      assert.equal(capabilities.documentRangeFormattingProvider, true);
+    },
+  );
 });

--- a/tests/tooling/lsp-range-formatting.test.ts
+++ b/tests/tooling/lsp-range-formatting.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isDiagnosticsForUri } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+/**
+ * `textDocument/rangeFormatting` ("Format Selection") for `vize lsp`.
+ *
+ * The handler existed before #3456 but ignored `params.range` and returned the
+ * whole-document edit, which is why `documentRangeFormattingProvider` was
+ * deliberately not advertised: turning it on as it was would have made Format
+ * Selection silently reformat the entire file.
+ *
+ * The fixture has two equally badly formatted blocks so "only the selected one
+ * changes" is observable, and every assertion is a full `assert.deepEqual` on
+ * the complete `TextEdit[]` — an assertion on just the selected block would
+ * pass on a whole-document edit.
+ */
+
+type TextEdit = {
+  range: {
+    start: { line: number; character: number };
+    end: { line: number; character: number };
+  };
+  newText: string;
+};
+
+/**
+ * ```text
+ * 0  <script setup lang="ts">
+ * 1  const   a=1
+ * 2  const   b=2
+ * 3  </script>
+ * 4
+ * 5  <template>
+ * 6    <div   class="x"   >{{ a }}</div>
+ * 7  </template>
+ * ```
+ */
+const SOURCE = `<script setup lang="ts">
+const   a=1
+const   b=2
+</script>
+
+<template>
+  <div   class="x"   >{{ a }}</div>
+</template>
+`;
+
+/** Block *content* spans: from just after the open tag to just before the close tag. */
+const SCRIPT_CONTENT = {
+  start: { line: 0, character: 24 },
+  end: { line: 3, character: 0 },
+};
+const TEMPLATE_CONTENT = {
+  start: { line: 5, character: 10 },
+  end: { line: 7, character: 0 },
+};
+
+/** What whole-document `vize fmt` makes of each block's content. */
+const FORMATTED_SCRIPT = "\nconst a = 1;\nconst b = 2;\n";
+const FORMATTED_TEMPLATE = '\n  <div class="x">\n    {{ a }}\n  </div>\n';
+
+async function withDocument(
+  run: (
+    ask: (range: {
+      start: { line: number; character: number };
+      end: { line: number; character: number };
+    }) => Promise<TextEdit[] | null>,
+    askWholeDocument: () => Promise<TextEdit[] | null>,
+  ) => Promise<void>,
+): Promise<void> {
+  const testRootDir = path.join(testOutputRoot, "lsp-range-formatting");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: false,
+      formatting: true,
+    });
+
+    const filePath = path.join(workspaceDir, "App.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, SOURCE, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: SOURCE },
+    });
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, uri),
+    );
+
+    const options = { tabSize: 2, insertSpaces: true };
+    await run(
+      (range) =>
+        session.request("textDocument/rangeFormatting", {
+          textDocument: { uri },
+          range,
+          options,
+        }) as Promise<TextEdit[] | null>,
+      () =>
+        session.request("textDocument/formatting", {
+          textDocument: { uri },
+          options,
+        }) as Promise<TextEdit[] | null>,
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+}
+
+test("rangeFormatting edits only the blocks the selection touches", async () => {
+  await withDocument(async (ask, askWholeDocument) => {
+    // Lines 1-2 are entirely inside `<script setup>`. The equally badly
+    // formatted template must not appear at all.
+    assert.deepEqual(
+      await ask({ start: { line: 1, character: 0 }, end: { line: 2, character: 11 } }),
+      [{ range: SCRIPT_CONTENT, newText: FORMATTED_SCRIPT }],
+    );
+
+    // Line 6 is entirely inside `<template>`; the script is left alone.
+    assert.deepEqual(
+      await ask({ start: { line: 6, character: 0 }, end: { line: 6, character: 35 } }),
+      [{ range: TEMPLATE_CONTENT, newText: FORMATTED_TEMPLATE }],
+    );
+
+    // Line 4 is the blank line between the blocks: inside no block content.
+    assert.deepEqual(
+      await ask({ start: { line: 4, character: 0 }, end: { line: 4, character: 0 } }),
+      [],
+    );
+
+    // A selection over both blocks edits both, in document order.
+    assert.deepEqual(
+      await ask({ start: { line: 0, character: 0 }, end: { line: 7, character: 11 } }),
+      [
+        { range: SCRIPT_CONTENT, newText: FORMATTED_SCRIPT },
+        { range: TEMPLATE_CONTENT, newText: FORMATTED_TEMPLATE },
+      ],
+    );
+
+    // Format Document is still one whole-file replacement, so the two commands
+    // are visibly different shapes rather than the same edit under two names.
+    const whole = await askWholeDocument();
+    assert.equal(whole?.length, 1);
+    assert.deepEqual(whole?.[0].range.start, { line: 0, character: 0 });
+    assert.deepEqual(whole?.[0].range.end, { line: 8, character: 0 });
+  });
+});
+
+test("rangeFormatting refuses a range the document does not contain", async () => {
+  await withDocument(async (ask) => {
+    assert.equal(
+      await ask({ start: { line: 0, character: 0 }, end: { line: 900, character: 0 } }),
+      null,
+    );
+  });
+});

--- a/tests/tooling/support/lsp/protocol.ts
+++ b/tests/tooling/support/lsp/protocol.ts
@@ -74,6 +74,7 @@ export type ServerCapabilities = {
   };
   definitionProvider?: unknown;
   documentHighlightProvider?: unknown;
+  documentFormattingProvider?: unknown;
   documentLinkProvider?: { resolveProvider?: boolean };
   documentRangeFormattingProvider?: unknown;
   documentSymbolProvider?: unknown;


### PR DESCRIPTION
First of the four capabilities in #3456: `documentRangeFormattingProvider`.

## Defect

`server/handlers.rs::range_formatting` existed but ignored `params.range` and
returned `format_document`'s whole-file replacement.
`capabilities.rs` therefore kept the provider off with:

```rust
// Range formatting is intentionally not advertised until the handler
// can produce edits scoped to the requested range.
document_range_formatting_provider: None,
```

That was the right call: advertising it as-is would make "Format Selection"
silently reformat the entire file. `@vue/language-server` 3.3.8 advertises
`documentRangeFormattingProvider: true`.

## Reproduction

`App.vue`, two equally badly formatted blocks:

```vue
<script setup lang="ts">
const   a=1
const   b=2
</script>

<template>
  <div   class="x"   >{{ a }}</div>
</template>
```

`textDocument/rangeFormatting` over lines 1-2 only (inside `<script setup>`):

| | result |
| --- | --- |
| before | one edit, range `(0,0)`-`(8,0)`, `newText` = the whole reformatted file including the template |
| after | one edit, range `(0,24)`-`(3,0)`, `newText` = `"\nconst a = 1;\nconst b = 2;\n"` |

## Approach

Formatting the selected substring on its own would lose the context that
decides its shape — the block's language, its base indentation, whether it is
script or template — so Format Selection and Format Document would disagree on
the same lines.

Instead the document is formatted **once**, and the result is projected back per
SFC block: only blocks whose content the requested range intersects contribute a
`TextEdit`. Format Selection is a subset of Format Document by construction.

Deliberate properties, all pinned by tests:

- Only block **content** is rewritten, never block tags, so a selection can
  never reorder or retag the file.
- An already-formatted document returns `Some([])`, not `None` — "nothing to
  change" is a different answer from "this cannot be formatted".
- A selection between blocks (the blank line) returns `Some([])`.
- An inverted range (selected backwards) resolves to the same blocks.
- A zero-width caret formats the block it sits in.
- If the formatter ever added, dropped or reordered blocks the authored and
  formatted lists could not be paired; the handler returns `None` rather than
  guessing which edit is safe.
- Standalone petite-vue HTML is still refused, as in `formatting` (#1393).

`documentRangeFormattingProvider` now rides the `formatting` flag next to
`documentFormattingProvider`; formatting stays opt-in, so neither appears
without `formatting: true`.

## How the tests fail before the fix

Against a `vize lsp` built from the pre-fix tree (sha256
`5c59332f0c3532056ba13f47727b5c28696e420bc99e2278afbda05d91ead07d`):

```
$ VIZE_LSP_BIN=<pre-fix vize> node --test --test-concurrency=1 \
    tests/tooling/lsp-range-formatting.test.ts tests/tooling/lsp-capabilities.test.ts
✖ vize lsp per-feature init flags toggle individual providers independently
  AssertionError: documentRangeFormattingProvider  actual: undefined, expected: true
✖ rangeFormatting edits only the blocks the selection touches
  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
    actual:   [ { newText: '<script setup lang="ts">\nconst a = 1;\nconst b = 2;\n</script>\n\n<template>\n  <div class="x">\n    {{ a }}\n  </div>\n</template>\n', range: [Object] } ]
    expected: [ { range: [Object], newText: '\nconst a = 1;\nconst b = 2;\n' } ]
ℹ pass 3  ℹ fail 2
```

Post-fix binary sha256
`de10ebdff6af8a7089f4d49bba8f8cce0c6683cb2898d8ea6f0fdc2afd756057`:

```
$ VIZE_LSP_BIN=<post-fix vize> node --test --test-concurrency=1 \
    tests/tooling/lsp-range-formatting.test.ts tests/tooling/lsp-capabilities.test.ts \
    tests/tooling/lsp-editor-feature-isolation.test.ts \
    tests/tooling/lsp-editor-feature-routing.test.ts tests/tooling/lsp-smoke.test.ts
ℹ tests 33  ℹ pass 33  ℹ fail 0
```

Every assertion is a full `assert.deepEqual` / `assert_eq!` on the complete
`TextEdit[]`. Asserting only that the selected block is present would pass on
the pre-fix whole-document edit, which is exactly the bug; the tooling test also
pins that Format Document is still a single `(0,0)`-`(8,0)` replacement, so the
two commands are visibly different shapes.

## File budget

`server/handlers.rs` is 1151 lines before and after — byte-identical in length
to `origin/main`. The new logic lives in `server/format/range.rs` (131) with its
tests in `server/format/range/tests.rs` (153).

## Gates

```
cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports   # clean
cargo test -p vize_maestro                                            # 619 lib (1 ignored) + 3 + 1 doc, 0 failed
rustfmt --edition 2024 --config style_edition=2024 --check <touched>  # clean
npx oxfmt --check / npx oxlint <touched .ts>                          # clean
```

Refs #3224
Refs #3456


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added range formatting for Vue documents.
  * Formatting now applies only to blocks affected by the selected range.
  * Added support for selections spanning multiple blocks, reversed ranges, and caret-only selections.
  * Range formatting is advertised when formatting is enabled.

* **Bug Fixes**
  * Preserved requested formatting ranges and returned no edits for unaffected or invalid selections.
  * Maintained block tags and skipped unchanged content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->