### PR TITLE
feat(patina): close the template $emit gap in the emits rules

### DIFF
--- a/crates/vize_patina/src/rules/script/custom_event_name_casing.rs
+++ b/crates/vize_patina/src/rules/script/custom_event_name_casing.rs
@@ -8,12 +8,29 @@
 //! recommended casing and is reported.
 //!
 //! This walks the emit call sites and checks the string-literal event name (the
-//! first argument): a call to the captured `defineEmits` binding
-//! (`const emit = defineEmits(...)` then `emit('my-event')`), or a member call
-//! whose property is `emit`/`$emit` (`ctx.emit('my-event')`,
-//! `this.$emit('my-event')`). Only string-literal event names are checked; a
-//! dynamic name (`emit(eventName)`) carries no literal to inspect and is skipped.
-//! The `update:` prefix used by `v-model` (`'update:modelValue'`) is permitted.
+//! first argument). Only string-literal event names are checked; a dynamic name
+//! (`emit(eventName)`) carries no literal to inspect and is skipped. The
+//! `update:` prefix used by `v-model` (`'update:modelValue'`) is permitted.
+//!
+//! ## Script call sites
+//!
+//! A call to the captured `defineEmits` binding (`const emit = defineEmits(...)`
+//! then `emit('my-event')`), or a member call whose property is `emit`/`$emit`
+//! (`ctx.emit('my-event')`, `this.$emit('my-event')`).
+//!
+//! ## Template call sites
+//!
+//! A template dispatches the same events, through the built-in `$emit` helper
+//! (`@click="$emit('foo-bar')"`) or through the captured binding, which is
+//! template-visible as a top-level `<script setup>` binding. Recovering them
+//! *creates* findings from template evidence, so they come from the template
+//! AST and an oxc parse of each expression; see [`super::template_scan`] for the
+//! over-match analysis and the shadowing rules.
+//!
+//! The template half additionally requires the SFC to have a single script
+//! block. The rule is invoked once per block, and unlike the script half — whose
+//! call sites live in the block being linted — a template `$emit` is visible to
+//! every block, so two blocks would report it twice.
 //!
 //! Mirrors [`vue/custom-event-name-casing`](https://eslint.vuejs.org/rules/custom-event-name-casing.html)
 //! with the Vue 3 default (`camelCase`).
@@ -32,7 +49,8 @@
 //! emit('myEvent')
 //! ```
 
-use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
+use super::template_scan::{DOLLAR_EMIT, for_each_template_call};
+use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta, SfcScriptContext};
 use crate::diagnostic::{LintDiagnostic, Severity};
 use oxc_ast::ast::{
     Argument, BindingPattern, CallExpression, Expression, Program, Statement, StringLiteral,
@@ -60,11 +78,29 @@ impl ScriptRule for CustomEventNameCasing {
     }
 
     #[inline]
+    fn uses_template_ast(&self) -> bool {
+        true
+    }
+
+    #[inline]
     fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        // Keep the parse-owning `check` path functional: without SFC context
+        // only the script call sites are observable.
+        self.check_program_with_sfc(program, source, offset, SfcScriptContext::default(), result);
+    }
+
+    fn check_program_with_sfc<'a>(
         &self,
         program: &'a Program<'a>,
         _source: &str,
         offset: usize,
+        sfc: SfcScriptContext<'_>,
         result: &mut ScriptLintResult,
     ) {
         // The `<script setup>` emit function captured from `defineEmits(...)`, if
@@ -77,7 +113,40 @@ impl ScriptRule for CustomEventNameCasing {
             emit_binding,
         };
         visitor.visit_program(program);
+
+        check_template(emit_binding, sfc, result);
     }
+}
+
+/// The template half: `$emit('foo-bar')`, or a call of the captured binding.
+fn check_template(
+    emit_binding: Option<&str>,
+    sfc: SfcScriptContext<'_>,
+    result: &mut ScriptLintResult,
+) {
+    if !sfc.sole_script_block {
+        return;
+    }
+    let Some((root, template_offset)) = sfc.template_ast() else {
+        return;
+    };
+    for_each_template_call(root, |call| {
+        if call.callee != DOLLAR_EMIT && Some(call.callee) != emit_binding {
+            return;
+        }
+        let Some(event) = call.first_string_argument else {
+            return;
+        };
+        if is_camel_case_event(event.value) {
+            return;
+        }
+        report(
+            event.value,
+            template_offset + event.start,
+            template_offset + event.end,
+            result,
+        );
+    });
 }
 
 struct CustomEventNameCasingVisitor<'a, 'result> {
@@ -118,23 +187,28 @@ impl<'a> CustomEventNameCasingVisitor<'a, '_> {
         if is_camel_case_event(value) {
             return;
         }
-
-        let start = self.offset as u32 + literal.span.start;
-        let end = self.offset as u32 + literal.span.end;
-
-        let mut message = CompactString::with_capacity(value.len() + 40);
-        message.push_str("Custom event name '");
-        message.push_str(value);
-        message.push_str("' is not camelCase.");
-
-        let diagnostic = LintDiagnostic::error(META.name, message, start, end)
-            .with_label("expected camelCase", start, end)
-            .with_help(
-                "Vue 3 recommends camelCase for emitted event names; rename this event \
-                 to camelCase (e.g. `myEvent`).",
-            );
-        self.result.add_diagnostic(diagnostic);
+        report(
+            value,
+            self.offset as u32 + literal.span.start,
+            self.offset as u32 + literal.span.end,
+            self.result,
+        );
     }
+}
+
+fn report(value: &str, start: u32, end: u32, result: &mut ScriptLintResult) {
+    let mut message = CompactString::with_capacity(value.len() + 40);
+    message.push_str("Custom event name '");
+    message.push_str(value);
+    message.push_str("' is not camelCase.");
+
+    let diagnostic = LintDiagnostic::error(META.name, message, start, end)
+        .with_label("expected camelCase", start, end)
+        .with_help(
+            "Vue 3 recommends camelCase for emitted event names; rename this event \
+             to camelCase (e.g. `myEvent`).",
+        );
+    result.add_diagnostic(diagnostic);
 }
 
 /// Whether `value` is an acceptable camelCase event name. Each `:`-separated
@@ -194,151 +268,4 @@ fn is_define_emits_call(expression: &Expression<'_>) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::CustomEventNameCasing;
-    use crate::rules::script::ScriptLinter;
-
-    fn create_linter() -> ScriptLinter {
-        let mut linter = ScriptLinter::new();
-        linter.add_rule(Box::new(CustomEventNameCasing));
-        linter
-    }
-
-    #[test]
-    fn test_valid_camel_case_setup_emit() {
-        let source = r#"
-const emit = defineEmits(['myEvent'])
-emit('myEvent')
-"#;
-        let result = create_linter().lint(source, 0);
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_valid_single_word_event() {
-        let source = r#"
-const emit = defineEmits(['change'])
-emit('change')
-"#;
-        let result = create_linter().lint(source, 0);
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_valid_update_model_value() {
-        // The `update:` prefix used by `v-model` is permitted.
-        let result = create_linter().lint("this.$emit('update:modelValue', value)", 0);
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_invalid_kebab_case_setup_emit() {
-        let source = r#"
-const emit = defineEmits(['my-event'])
-emit('my-event')
-"#;
-        let result = create_linter().lint(source, 0);
-        assert_eq!(result.error_count, 1);
-        insta::assert_debug_snapshot!(result.diagnostics);
-    }
-
-    #[test]
-    fn test_invalid_pascal_case_dollar_emit() {
-        let result = create_linter().lint("this.$emit('MyEvent')", 0);
-        assert_eq!(result.error_count, 1);
-        insta::assert_debug_snapshot!(result.diagnostics);
-    }
-
-    #[test]
-    fn test_invalid_kebab_case_dollar_emit() {
-        let result = create_linter().lint("this.$emit('my-event')", 0);
-        assert_eq!(result.error_count, 1);
-    }
-
-    #[test]
-    fn test_invalid_context_emit_kebab() {
-        // A setup-context member call (`ctx.emit('...')`) is checked too.
-        let result = create_linter().lint("ctx.emit('my-event')", 0);
-        assert_eq!(result.error_count, 1);
-    }
-
-    #[test]
-    fn test_valid_context_emit_camel() {
-        let result = create_linter().lint("ctx.emit('myEvent')", 0);
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_dynamic_event_name_not_checked() {
-        // A non-string-literal event name carries no literal to inspect.
-        let source = r#"
-const emit = defineEmits(['myEvent'])
-const name = 'my-event'
-emit(name)
-"#;
-        let result = create_linter().lint(source, 0);
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_unassigned_define_emits_call_not_tracked() {
-        // Without a binding the `emit(...)` identifier cannot be resolved, so the
-        // bare `emit` identifier call is not treated as an emit.
-        let source = r#"
-defineEmits(['my-event'])
-emit('my-event')
-"#;
-        let result = create_linter().lint(source, 0);
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_custom_emit_binding_name() {
-        let source = r#"
-const myEmit = defineEmits(['change'])
-myEmit('my-event')
-"#;
-        let result = create_linter().lint(source, 0);
-        assert_eq!(result.error_count, 1);
-    }
-
-    #[test]
-    fn test_options_api_this_emit_in_method() {
-        let source = r#"
-export default {
-  methods: {
-    submit() {
-      this.$emit('my-event')
-    }
-  }
-}
-"#;
-        let result = create_linter().lint(source, 0);
-        assert_eq!(result.error_count, 1);
-    }
-
-    #[test]
-    fn test_plain_identifier_call_not_emit() {
-        // A call to some other function is not an emit, even with a kebab string.
-        let result = create_linter().lint("notify('my-event')", 0);
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_multiple_invalid_events() {
-        let source = r#"
-const emit = defineEmits(['my-event', 'OtherEvent'])
-emit('my-event')
-emit('OtherEvent')
-"#;
-        let result = create_linter().lint(source, 0);
-        assert_eq!(result.error_count, 2);
-    }
-
-    #[test]
-    fn test_offset_applied() {
-        let result = create_linter().lint("this.$emit('my-event')", 30);
-        assert_eq!(result.error_count, 1);
-        assert_eq!(result.diagnostics[0].start, 30 + 11);
-    }
-}
+mod tests;

--- a/crates/vize_patina/src/rules/script/custom_event_name_casing/snapshots/vize_patina__rules__script__custom_event_name_casing__tests__invalid_kebab_case_setup_emit.snap
+++ b/crates/vize_patina/src/rules/script/custom_event_name_casing/snapshots/vize_patina__rules__script__custom_event_name_casing__tests__invalid_kebab_case_setup_emit.snap
@@ -1,22 +1,22 @@
 ---
-source: crates/vize_patina/src/rules/script/custom_event_name_casing.rs
+source: crates/vize_patina/src/rules/script/custom_event_name_casing/tests.rs
 expression: result.diagnostics
 ---
 [
     LintDiagnostic {
         rule_name: "script/custom-event-name-casing",
         severity: Error,
-        message: "Custom event name 'MyEvent' is not camelCase.",
-        start: 11,
-        end: 20,
+        message: "Custom event name 'my-event' is not camelCase.",
+        start: 45,
+        end: 55,
         help: Some(
             "Vue 3 recommends camelCase for emitted event names; rename this event to camelCase (e.g. `myEvent`).",
         ),
         labels: [
             Label {
                 message: "expected camelCase",
-                start: 11,
-                end: 20,
+                start: 45,
+                end: 55,
             },
         ],
         fix: None,

--- a/crates/vize_patina/src/rules/script/custom_event_name_casing/snapshots/vize_patina__rules__script__custom_event_name_casing__tests__invalid_pascal_case_dollar_emit.snap
+++ b/crates/vize_patina/src/rules/script/custom_event_name_casing/snapshots/vize_patina__rules__script__custom_event_name_casing__tests__invalid_pascal_case_dollar_emit.snap
@@ -1,22 +1,22 @@
 ---
-source: crates/vize_patina/src/rules/script/custom_event_name_casing.rs
+source: crates/vize_patina/src/rules/script/custom_event_name_casing/tests.rs
 expression: result.diagnostics
 ---
 [
     LintDiagnostic {
         rule_name: "script/custom-event-name-casing",
         severity: Error,
-        message: "Custom event name 'my-event' is not camelCase.",
-        start: 45,
-        end: 55,
+        message: "Custom event name 'MyEvent' is not camelCase.",
+        start: 11,
+        end: 20,
         help: Some(
             "Vue 3 recommends camelCase for emitted event names; rename this event to camelCase (e.g. `myEvent`).",
         ),
         labels: [
             Label {
                 message: "expected camelCase",
-                start: 45,
-                end: 55,
+                start: 11,
+                end: 20,
             },
         ],
         fix: None,

--- a/crates/vize_patina/src/rules/script/custom_event_name_casing/tests.rs
+++ b/crates/vize_patina/src/rules/script/custom_event_name_casing/tests.rs
@@ -1,0 +1,180 @@
+use super::CustomEventNameCasing;
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rules::script::ScriptLinter;
+
+// Template-half tests (#3413 B) live in the `template` submodule.
+mod template;
+
+fn create_linter() -> ScriptLinter {
+    let mut linter = ScriptLinter::new();
+    linter.add_rule(Box::new(CustomEventNameCasing));
+    linter
+}
+
+/// Lint a full SFC end-to-end with only this rule enabled, exercising the
+/// engine path that supplies the parsed `<template>` AST to the rule.
+fn lint_sfc(sfc: &str) -> LintResult {
+    Linter::new()
+        .with_enabled_rules(Some(vec!["script/custom-event-name-casing".into()]))
+        .lint_sfc(sfc, "Probe.vue")
+}
+
+/// The full identity of every finding: rule, severity, byte range, message.
+fn findings(result: &LintResult) -> Vec<(&'static str, Severity, u32, u32, &str)> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            (
+                diagnostic.rule_name,
+                diagnostic.severity,
+                diagnostic.start,
+                diagnostic.end,
+                diagnostic.message.as_str(),
+            )
+        })
+        .collect()
+}
+
+fn none() -> Vec<(&'static str, Severity, u32, u32, &'static str)> {
+    Vec::new()
+}
+
+#[test]
+fn test_valid_camel_case_setup_emit() {
+    let source = r#"
+const emit = defineEmits(['myEvent'])
+emit('myEvent')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_single_word_event() {
+    let source = r#"
+const emit = defineEmits(['change'])
+emit('change')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_update_model_value() {
+    // The `update:` prefix used by `v-model` is permitted.
+    let result = create_linter().lint("this.$emit('update:modelValue', value)", 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_invalid_kebab_case_setup_emit() {
+    let source = r#"
+const emit = defineEmits(['my-event'])
+emit('my-event')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+    insta::assert_debug_snapshot!(result.diagnostics);
+}
+
+#[test]
+fn test_invalid_pascal_case_dollar_emit() {
+    let result = create_linter().lint("this.$emit('MyEvent')", 0);
+    assert_eq!(result.error_count, 1);
+    insta::assert_debug_snapshot!(result.diagnostics);
+}
+
+#[test]
+fn test_invalid_kebab_case_dollar_emit() {
+    let result = create_linter().lint("this.$emit('my-event')", 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_invalid_context_emit_kebab() {
+    // A setup-context member call (`ctx.emit('...')`) is checked too.
+    let result = create_linter().lint("ctx.emit('my-event')", 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_valid_context_emit_camel() {
+    let result = create_linter().lint("ctx.emit('myEvent')", 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_dynamic_event_name_not_checked() {
+    // A non-string-literal event name carries no literal to inspect.
+    let source = r#"
+const emit = defineEmits(['myEvent'])
+const name = 'my-event'
+emit(name)
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_unassigned_define_emits_call_not_tracked() {
+    // Without a binding the `emit(...)` identifier cannot be resolved, so the
+    // bare `emit` identifier call is not treated as an emit.
+    let source = r#"
+defineEmits(['my-event'])
+emit('my-event')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_custom_emit_binding_name() {
+    let source = r#"
+const myEmit = defineEmits(['change'])
+myEmit('my-event')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_options_api_this_emit_in_method() {
+    let source = r#"
+export default {
+  methods: {
+submit() {
+  this.$emit('my-event')
+}
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_plain_identifier_call_not_emit() {
+    // A call to some other function is not an emit, even with a kebab string.
+    let result = create_linter().lint("notify('my-event')", 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_multiple_invalid_events() {
+    let source = r#"
+const emit = defineEmits(['my-event', 'OtherEvent'])
+emit('my-event')
+emit('OtherEvent')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 2);
+}
+
+#[test]
+fn test_offset_applied() {
+    let result = create_linter().lint("this.$emit('my-event')", 30);
+    assert_eq!(result.error_count, 1);
+    assert_eq!(result.diagnostics[0].start, 30 + 11);
+}

--- a/crates/vize_patina/src/rules/script/custom_event_name_casing/tests/template.rs
+++ b/crates/vize_patina/src/rules/script/custom_event_name_casing/tests/template.rs
@@ -1,0 +1,285 @@
+//! Template half (#3413 B): a template `$emit` with a non-camelCase name.
+//!
+//! Because this half *creates* findings from template evidence, the over-match
+//! probes are as load-bearing as the positive cases: each asserts the full
+//! finding set, and the negative ones assert it is exactly empty.
+
+use super::{findings, lint_sfc, none};
+use crate::diagnostic::Severity;
+
+/// The finding the quoted event name `literal` produces, located inside the
+/// `<template>` block.
+fn not_camel_case(
+    sfc: &str,
+    literal: &str,
+    name: &str,
+) -> (&'static str, Severity, u32, u32, std::string::String) {
+    let template = sfc.find("<template>").expect("template block");
+    let start = template + sfc[template..].find(literal).expect("event literal");
+    (
+        "script/custom-event-name-casing",
+        Severity::Error,
+        start as u32,
+        (start + literal.len()) as u32,
+        format!("Custom event name '{name}' is not camelCase."),
+    )
+}
+
+/// [`findings`] with owned messages, so it compares against [`not_camel_case`].
+fn owned(
+    result: &crate::linter::LintResult,
+) -> Vec<(&'static str, Severity, u32, u32, std::string::String)> {
+    findings(result)
+        .into_iter()
+        .map(|(rule, severity, start, end, message)| {
+            (rule, severity, start, end, message.to_string())
+        })
+        .collect()
+}
+
+// --- The recovered case: a template `$emit` with a bad name ----------------
+
+#[test]
+fn reports_a_kebab_case_dollar_emit_issue_3413() {
+    // Exact reproduction from #3413 B.
+    let sfc = r#"<script setup lang="ts">
+const a = 1;
+</script>
+
+<template>
+  <button @click="$emit('foo-bar')">{{ a }}</button>
+</template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![not_camel_case(sfc, "'foo-bar'", "foo-bar")]
+    );
+}
+
+#[test]
+fn reports_a_pascal_case_dollar_emit() {
+    let sfc = r#"<script setup lang="ts">
+const a = 1;
+</script>
+
+<template>
+  <button @click="$emit('FooBar')">{{ a }}</button>
+</template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![not_camel_case(sfc, "'FooBar'", "FooBar")]
+    );
+}
+
+#[test]
+fn reports_a_kebab_case_call_of_the_captured_binding() {
+    // The captured binding is template-visible and dispatches the same events.
+    let sfc = r#"<script setup lang="ts">
+const emit = defineEmits<{ 'foo-bar': [] }>();
+</script>
+
+<template>
+  <button @click="emit('foo-bar')">go</button>
+</template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![not_camel_case(sfc, "'foo-bar'", "foo-bar")]
+    );
+}
+
+#[test]
+fn reports_a_dollar_emit_in_an_interpolation() {
+    let sfc = r#"<script setup lang="ts">
+const a = 1;
+</script>
+
+<template>
+  <span>{{ $emit('foo-bar') || a }}</span>
+</template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![not_camel_case(sfc, "'foo-bar'", "foo-bar")]
+    );
+}
+
+// --- Well-named events: exactly zero findings ------------------------------
+
+#[test]
+fn ignores_a_camel_case_dollar_emit() {
+    let sfc = r#"<script setup lang="ts">
+const a = 1;
+</script>
+
+<template>
+  <button @click="$emit('fooBar')">{{ a }}</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_the_v_model_update_prefix() {
+    let sfc = r#"<script setup lang="ts">
+const a = 1;
+</script>
+
+<template>
+  <input @input="$emit('update:modelValue', a)" />
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_dynamic_event_name() {
+    let sfc = r#"<script setup lang="ts">
+const name = 'foo-bar';
+</script>
+
+<template>
+  <button @click="$emit(name)">go</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+// --- Over-match probes: none of these may manufacture a finding ------------
+
+#[test]
+fn ignores_a_dollar_emit_inside_an_html_comment() {
+    let sfc = r#"<script setup lang="ts">
+const a = 1;
+</script>
+
+<template>
+  <div>{{ a }}<!-- $emit('foo-bar') --></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_dollar_emit_in_a_text_node_or_plain_attribute() {
+    let sfc = r#"<script setup lang="ts">
+const a = 1;
+</script>
+
+<template>
+  <p title="$emit('foo-bar')">$emit('foo-bar') {{ a }}</p>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_dollar_emit_inside_a_string_literal() {
+    let sfc = r#"<script setup lang="ts">
+const a = 1;
+</script>
+
+<template>
+  <button @click="console.log('$emit(\'foo-bar\')')">{{ a }}</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_dollar_emit_inside_a_v_pre_region() {
+    let sfc = r#"<script setup lang="ts">
+const a = 1;
+</script>
+
+<template>
+  <pre v-pre>{{ $emit('foo-bar') }}</pre>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_an_identifier_that_merely_ends_with_emit() {
+    let sfc = r#"<script setup lang="ts">
+const myEmit = (name: string) => name;
+</script>
+
+<template>
+  <button @click="myEmit('foo-bar')">go</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_member_dollar_emit_on_another_instance() {
+    let sfc = r#"<script setup lang="ts">
+const a = 1;
+</script>
+
+<template>
+  <Child ref="child" @click="child.$emit('foo-bar')">{{ a }}</Child>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_slot_variable_that_shadows_the_captured_binding() {
+    let sfc = r#"<script setup lang="ts">
+const emit = defineEmits<{ 'foo-bar': [] }>();
+</script>
+
+<template>
+  <Child v-slot="{ emit }"><button @click="emit('foo-bar')">go</button></Child>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_template_dollar_emit_when_a_sibling_script_block_exists() {
+    // Each block is linted separately and a template `$emit` is visible to
+    // both, so reporting it from either would double the diagnostic.
+    let sfc = r#"<script>
+export default { name: 'Probe' };
+</script>
+
+<script setup lang="ts">
+const a = 1;
+</script>
+
+<template>
+  <button @click="$emit('foo-bar')">{{ a }}</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+// --- The pre-existing script-only subset must keep working -----------------
+
+#[test]
+fn still_reports_a_script_side_emit_through_the_sfc_path() {
+    let sfc = r#"<script setup lang="ts">
+const emit = defineEmits<{ 'foo-bar': [] }>();
+emit('foo-bar');
+</script>
+
+<template>
+  <div>ok</div>
+</template>
+"#;
+    let literal = sfc.rfind("'foo-bar'").expect("emit literal");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![(
+            "script/custom-event-name-casing",
+            Severity::Error,
+            literal as u32,
+            (literal + "'foo-bar'".len()) as u32,
+            "Custom event name 'foo-bar' is not camelCase.",
+        )]
+    );
+}

--- a/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs
@@ -10,9 +10,7 @@
 //!
 //! ## Sound subset
 //!
-//! Upstream also scans the template (`@evt` / `v-on:evt`), which a `script/*`
-//! rule cannot observe. This implementation only decides what is sound from the
-//! script alone:
+//! The rule reports only what it can prove:
 //!
 //! * It reports only when a declaration **exists** and is **fully known**. With
 //!   no declaration, nothing is reported (the emits may be declared elsewhere, or
@@ -23,9 +21,23 @@
 //! * Only string-literal emit names are checked; a dynamic name (`emit(name)`)
 //!   is skipped.
 //!
-//! Emit call sites are the captured `defineEmits` binding (`emit('change')`) and
-//! `this.$emit('change')`. The declaration-resolution logic lives in the
+//! Script call sites are the captured `defineEmits` binding (`emit('change')`)
+//! and `this.$emit('change')`. The declaration-resolution logic lives in the
 //! [`declared`] submodule.
+//!
+//! ## Template call sites
+//!
+//! A template dispatches the same events, through the built-in `$emit` helper
+//! (`@click="$emit('cancel')"`) or through the captured binding, which is
+//! template-visible as a top-level `<script setup>` binding. Both are checked.
+//! Recovering them *creates* findings from template evidence, so they come from
+//! the template AST and an oxc parse of each expression; see
+//! [`crate::rules::script::template_scan`] for the over-match analysis and the
+//! shadowing rules.
+//!
+//! The template half additionally requires the SFC to have a single script
+//! block: the declared set is a property of the whole component, and with both
+//! a `<script>` and a `<script setup>` each invocation sees only half of it.
 //!
 //! ```ts
 //! const emit = defineEmits(['change'])
@@ -42,7 +54,8 @@ use oxc_span::Span;
 use vize_carton::{CompactString, FxHashSet};
 
 use self::declared::{Declared, resolve_declared_emits};
-use super::super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
+use super::super::template_scan::{DOLLAR_EMIT, for_each_template_call};
+use super::super::{ScriptLintResult, ScriptRule, ScriptRuleMeta, SfcScriptContext};
 use crate::diagnostic::{LintDiagnostic, Severity};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
@@ -64,11 +77,29 @@ impl ScriptRule for RequireExplicitEmits {
         true
     }
 
+    #[inline]
+    fn uses_template_ast(&self) -> bool {
+        true
+    }
+
     fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        // Keep the parse-owning `check` path functional: without SFC context
+        // only the script call sites are observable.
+        self.check_program_with_sfc(program, source, offset, SfcScriptContext::default(), result);
+    }
+
+    fn check_program_with_sfc<'a>(
         &self,
         program: &'a Program<'a>,
         _source: &str,
         offset: usize,
+        sfc: SfcScriptContext<'_>,
         result: &mut ScriptLintResult,
     ) {
         // Bail unless a declaration exists AND is fully known; a missing or
@@ -88,7 +119,42 @@ impl ScriptRule for RequireExplicitEmits {
             result,
         };
         visitor.visit_program(program);
+
+        check_template(&declared, binding, sfc, result);
     }
+}
+
+/// The template half: `$emit('x')` — or a call of the captured binding — naming
+/// an event the declaration does not contain.
+fn check_template(
+    declared: &FxHashSet<CompactString>,
+    binding: Option<&str>,
+    sfc: SfcScriptContext<'_>,
+    result: &mut ScriptLintResult,
+) {
+    if !sfc.sole_script_block {
+        return;
+    }
+    let Some((root, template_offset)) = sfc.template_ast() else {
+        return;
+    };
+    for_each_template_call(root, |call| {
+        if call.callee != DOLLAR_EMIT && Some(call.callee) != binding {
+            return;
+        }
+        let Some(event) = call.first_string_argument else {
+            return;
+        };
+        if declared.contains(event.value) {
+            return;
+        }
+        report(
+            event.value,
+            template_offset + event.start,
+            template_offset + event.end,
+            result,
+        );
+    });
 }
 
 /// Walks the program reporting every string-literal emit whose name is absent
@@ -114,22 +180,28 @@ impl<'a> Visit<'a> for EmitCallVisitor<'_, '_> {
 
 impl EmitCallVisitor<'_, '_> {
     fn report(&mut self, name: &str, span: Span) {
-        let start = self.offset as u32 + span.start;
-        let end = self.offset as u32 + span.end;
-
-        let mut message = CompactString::with_capacity(name.len() + 48);
-        message.push_str("The emitted event '");
-        message.push_str(name);
-        message.push_str("' is not declared in defineEmits or the emits option.");
-
-        let diagnostic = LintDiagnostic::warn(META.name, message, start, end)
-            .with_label("undeclared emitted event", start, end)
-            .with_help(
-                "Add this event to the defineEmits declaration (or the Options API `emits` \
-                 option) so the component's event surface is explicit.",
-            );
-        self.result.add_diagnostic(diagnostic);
+        report(
+            name,
+            self.offset as u32 + span.start,
+            self.offset as u32 + span.end,
+            self.result,
+        );
     }
+}
+
+fn report(name: &str, start: u32, end: u32, result: &mut ScriptLintResult) {
+    let mut message = CompactString::with_capacity(name.len() + 48);
+    message.push_str("The emitted event '");
+    message.push_str(name);
+    message.push_str("' is not declared in defineEmits or the emits option.");
+
+    let diagnostic = LintDiagnostic::warn(META.name, message, start, end)
+        .with_label("undeclared emitted event", start, end)
+        .with_help(
+            "Add this event to the defineEmits declaration (or the Options API `emits` \
+             option) so the component's event surface is explicit.",
+        );
+    result.add_diagnostic(diagnostic);
 }
 
 /// The string-literal event name of an emit call, if `call` is one we track.

--- a/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/tests.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/tests.rs
@@ -1,6 +1,10 @@
 use crate::rules::script::RequireExplicitEmits;
 use crate::rules::script::ScriptLinter;
 
+// Template-half tests (#3413 A) live in the `template` submodule, helpers and
+// all: this file is already close to the 350-line budget.
+mod template;
+
 fn create_linter() -> ScriptLinter {
     let mut linter = ScriptLinter::new();
     linter.add_rule(Box::new(RequireExplicitEmits));

--- a/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/tests/template.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/tests/template.rs
@@ -1,0 +1,333 @@
+//! Template half (#3413 A): a template `$emit` of an undeclared event.
+//!
+//! Because this half *creates* findings from template evidence, the over-match
+//! probes are as load-bearing as the positive cases: each asserts the full
+//! finding set, and the negative ones assert it is exactly empty.
+
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+
+/// Lint a full SFC end-to-end with only this rule enabled, exercising the
+/// engine path that supplies the parsed `<template>` AST to the rule.
+fn lint_sfc(sfc: &str) -> LintResult {
+    Linter::new()
+        .with_enabled_rules(Some(vec!["script/require-explicit-emits".into()]))
+        .lint_sfc(sfc, "Probe.vue")
+}
+
+/// The full identity of every finding: rule, severity, byte range, message.
+fn findings(result: &LintResult) -> Vec<(&'static str, Severity, u32, u32, &str)> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            (
+                diagnostic.rule_name,
+                diagnostic.severity,
+                diagnostic.start,
+                diagnostic.end,
+                diagnostic.message.as_str(),
+            )
+        })
+        .collect()
+}
+
+fn none() -> Vec<(&'static str, Severity, u32, u32, &'static str)> {
+    Vec::new()
+}
+
+/// The finding the quoted event name `literal` produces, located inside the
+/// `<template>` block.
+fn undeclared(
+    sfc: &str,
+    literal: &str,
+    name: &str,
+) -> (&'static str, Severity, u32, u32, std::string::String) {
+    let template = sfc.find("<template>").expect("template block");
+    let start = template + sfc[template..].find(literal).expect("event literal");
+    (
+        "script/require-explicit-emits",
+        Severity::Warning,
+        start as u32,
+        (start + literal.len()) as u32,
+        format!("The emitted event '{name}' is not declared in defineEmits or the emits option."),
+    )
+}
+
+/// [`findings`] with owned messages, so it compares against [`undeclared`].
+fn owned(result: &LintResult) -> Vec<(&'static str, Severity, u32, u32, std::string::String)> {
+    findings(result)
+        .into_iter()
+        .map(|(rule, severity, start, end, message)| {
+            (rule, severity, start, end, message.to_string())
+        })
+        .collect()
+}
+
+// --- The recovered case: a template `$emit` of an undeclared event ---------
+
+#[test]
+fn reports_an_undeclared_dollar_emit_issue_3413() {
+    // Exact reproduction from #3413 A.
+    let sfc = r#"<script setup lang="ts">
+const emit = defineEmits<{ save: [] }>();
+</script>
+
+<template>
+  <button @click="$emit('cancel')">x</button>
+</template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![undeclared(sfc, "'cancel'", "cancel")]
+    );
+}
+
+#[test]
+fn reports_an_undeclared_call_of_the_captured_binding() {
+    let sfc = r#"<script setup>
+const emit = defineEmits(['save'])
+</script>
+
+<template>
+  <button @click="emit('cancel')">x</button>
+</template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![undeclared(sfc, "'cancel'", "cancel")]
+    );
+}
+
+#[test]
+fn reports_an_undeclared_dollar_emit_against_the_options_api_emits() {
+    let sfc = r#"<script>
+export default { emits: ['save'] };
+</script>
+
+<template>
+  <button @click="$emit('cancel')">x</button>
+</template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![undeclared(sfc, "'cancel'", "cancel")]
+    );
+}
+
+#[test]
+fn reports_an_undeclared_dollar_emit_in_an_interpolation() {
+    let sfc = r#"<script setup lang="ts">
+const emit = defineEmits<{ save: [] }>();
+</script>
+
+<template>
+  <span>{{ $emit('cancel') }}</span>
+</template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![undeclared(sfc, "'cancel'", "cancel")]
+    );
+}
+
+// --- The event is declared: exactly zero findings --------------------------
+
+#[test]
+fn ignores_a_declared_dollar_emit() {
+    let sfc = r#"<script setup lang="ts">
+const emit = defineEmits<{ save: [] }>();
+</script>
+
+<template>
+  <button @click="$emit('save')">x</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_dynamic_event_name() {
+    let sfc = r#"<script setup>
+const emit = defineEmits(['save'])
+const name = 'cancel'
+</script>
+
+<template>
+  <button @click="$emit(name)">x</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+// --- The soundness guard: no declaration means no report ------------------
+
+#[test]
+fn ignores_a_dollar_emit_when_nothing_is_declared() {
+    // The rule reports only when a declaration exists and is fully known;
+    // otherwise the events may be declared elsewhere, or intentionally not at
+    // all, and flagging would be a false positive.
+    let sfc = r#"<script setup lang="ts">
+const a = 1;
+</script>
+
+<template>
+  <button @click="$emit('cancel')">{{ a }}</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_dollar_emit_when_the_declaration_is_not_enumerable() {
+    let sfc = r#"<script setup lang="ts">
+const names = ['save'];
+const emit = defineEmits([...names]);
+</script>
+
+<template>
+  <button @click="$emit('cancel')">x</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+// --- Over-match probes: none of these may manufacture a finding ------------
+
+#[test]
+fn ignores_a_dollar_emit_inside_an_html_comment() {
+    let sfc = r#"<script setup lang="ts">
+const emit = defineEmits<{ save: [] }>();
+</script>
+
+<template>
+  <div><!-- $emit('cancel') --></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_dollar_emit_in_a_text_node_or_plain_attribute() {
+    let sfc = r#"<script setup lang="ts">
+const emit = defineEmits<{ save: [] }>();
+</script>
+
+<template>
+  <p title="$emit('cancel')">$emit('cancel')</p>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_dollar_emit_inside_a_string_literal() {
+    let sfc = r#"<script setup lang="ts">
+const emit = defineEmits<{ save: [] }>();
+</script>
+
+<template>
+  <button @click="console.log('$emit(\'cancel\')')">x</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_dollar_emit_inside_a_v_pre_region() {
+    let sfc = r#"<script setup lang="ts">
+const emit = defineEmits<{ save: [] }>();
+</script>
+
+<template>
+  <pre v-pre>{{ $emit('cancel') }}</pre>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_an_identifier_that_merely_ends_with_the_binding_name() {
+    let sfc = r#"<script setup>
+const emit = defineEmits(['save'])
+const myemit = (name) => name
+</script>
+
+<template>
+  <button @click="myemit('cancel')">x</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_member_dollar_emit_on_another_instance() {
+    let sfc = r#"<script setup>
+const emit = defineEmits(['save'])
+</script>
+
+<template>
+  <Child ref="child" @click="child.$emit('cancel')" />
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_slot_variable_that_shadows_the_captured_binding() {
+    let sfc = r#"<script setup>
+const emit = defineEmits(['save'])
+</script>
+
+<template>
+  <Child v-slot="{ emit }"><button @click="emit('cancel')">x</button></Child>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_template_dollar_emit_when_a_sibling_script_block_exists() {
+    // Each block is linted separately, so neither sees the whole declared set.
+    let sfc = r#"<script>
+export default { emits: ['cancel'] };
+</script>
+
+<script setup>
+const emit = defineEmits(['save'])
+</script>
+
+<template>
+  <button @click="$emit('cancel')">x</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+// --- The pre-existing script-only subset must keep working -----------------
+
+#[test]
+fn still_reports_a_script_side_emit_through_the_sfc_path() {
+    let sfc = r#"<script setup>
+const emit = defineEmits(['save'])
+function onClick() {
+  emit('cancel')
+}
+</script>
+
+<template>
+  <button @click="onClick">x</button>
+</template>
+"#;
+    let literal = sfc.find("'cancel'").expect("emit literal");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![(
+            "script/require-explicit-emits",
+            Severity::Warning,
+            literal as u32,
+            (literal + "'cancel'".len()) as u32,
+            "The emitted event 'cancel' is not declared in defineEmits or the emits option.",
+        )]
+    );
+}

--- a/crates/vize_patina/src/rules/script/template_scan.rs
+++ b/crates/vize_patina/src/rules/script/template_scan.rs
@@ -45,6 +45,11 @@ use vize_relief::{
 
 pub(super) use calls::TemplateCall;
 
+/// The template-visible emit helper. Available in every template expression and
+/// dispatching this component's own events, unlike a member call such as
+/// `child.$emit('x')`.
+pub(super) const DOLLAR_EMIT: &str = "$emit";
+
 /// Visit every call with a plain identifier callee that the template performs.
 ///
 /// Calls whose callee is shadowed by an enclosing `v-for` alias or slot

--- a/crates/vize_patina/src/rules/script/template_scan/calls.rs
+++ b/crates/vize_patina/src/rules/script/template_scan/calls.rs
@@ -2,18 +2,33 @@
 //! calls.
 
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{CallExpression, Expression};
+use oxc_ast::ast::{Argument, CallExpression, Expression};
 use oxc_ast_visit::{Visit, walk::walk_call_expression};
 use oxc_parser::Parser;
 use oxc_span::{SourceType, Span};
 
 /// A call the template performs, with a plain identifier callee.
 pub(in crate::rules::script) struct TemplateCall<'a> {
-    /// The callee identifier, e.g. `total`.
+    /// The callee identifier, e.g. `total` or `$emit`.
     pub(in crate::rules::script) callee: &'a str,
+    /// The first argument, when it is a string literal. `None` for a dynamic
+    /// argument (`$emit(name)`) or no arguments at all — a value only the
+    /// runtime knows cannot be checked against a declared set or a casing rule.
+    pub(in crate::rules::script) first_string_argument: Option<TemplateStringArgument<'a>>,
     /// Byte range of the call expression, relative to the template block.
     pub(in crate::rules::script) start: u32,
     /// Exclusive end of [`TemplateCall::start`].
+    pub(in crate::rules::script) end: u32,
+}
+
+/// A string-literal argument, with the range of the literal itself so a rule
+/// can report there rather than at the whole call.
+pub(in crate::rules::script) struct TemplateStringArgument<'a> {
+    pub(in crate::rules::script) value: &'a str,
+    /// Byte range of the literal *including* its quotes, relative to the
+    /// template block — matching how the script halves span a `StringLiteral`.
+    pub(in crate::rules::script) start: u32,
+    /// Exclusive end of [`TemplateStringArgument::start`].
     pub(in crate::rules::script) end: u32,
 }
 
@@ -45,6 +60,13 @@ pub(super) fn for_each_call(source: &str, base: u32, visit: &mut impl FnMut(Temp
     for call in collector.calls {
         visit(TemplateCall {
             callee: call.callee,
+            first_string_argument: call.first_string_argument.map(|(value, span)| {
+                TemplateStringArgument {
+                    value,
+                    start: base + span.start,
+                    end: base + span.end,
+                }
+            }),
             start: base + call.span.start,
             end: base + call.span.end,
         });
@@ -53,6 +75,7 @@ pub(super) fn for_each_call(source: &str, base: u32, visit: &mut impl FnMut(Temp
 
 struct CollectedCall<'a> {
     callee: &'a str,
+    first_string_argument: Option<(&'a str, Span)>,
     span: Span,
 }
 
@@ -68,6 +91,12 @@ impl<'a> Visit<'a> for CallCollector<'a> {
         if let Expression::Identifier(callee) = &it.callee {
             self.calls.push(CollectedCall {
                 callee: callee.name.as_str(),
+                first_string_argument: match it.arguments.first() {
+                    Some(Argument::StringLiteral(literal)) => {
+                        Some((literal.value.as_str(), literal.span))
+                    }
+                    _ => None,
+                },
                 span: it.span,
             });
         }


### PR DESCRIPTION
## Defect (#3413)

Two `script/*` emit rules resolved call sites from the script AST only, so the
`$emit(...)` a template performs was invisible to both.

### A — `script/require-explicit-emits`

```vue
<script setup lang="ts">
const emit = defineEmits<{ save: [] }>();
</script>

<template>
  <button @click="$emit('cancel')">x</button>
</template>
```

- Actual: 0 findings. Expected: 1 — `cancel` is not declared.

A *documented* scope decision rather than a regression: the module doc said
upstream "also scans the template … which a `script/*` rule cannot observe".
That premise no longer holds.

### B — `script/custom-event-name-casing`

```vue
<script setup lang="ts">
const a = 1;
</script>

<template>
  <button @click="$emit('foo-bar')">{{ a }}</button>
</template>
```

- Actual: 0 findings. Expected: 1 — the Vue 3 default casing is camelCase.

Unlike A this gap was undocumented: the module doc enumerated the call sites
without noting the template exclusion.

Both run through
`Linter::new().with_enabled_rules(Some(vec![<rule>])).lint_sfc(sfc, "Probe.vue")`.

## Over-match / under-match analysis

This is the direction #3223 calls dangerous: template evidence that **creates** a
finding. The existing raw scan in `props_emits/template_emits.rs` is explicitly
one-directional — a recovered name there only ever *suppresses* an "unused"
report, so its tolerated over-matches are harmless — and it fires on all of
these, none of which emit anything:

| case | why it must not report |
| --- | --- |
| `<!-- $emit('foo-bar') -->` | HTML comment |
| `<p title="$emit('x')">$emit('x')</p>` | plain attribute and text node |
| `@click="console.log('$emit(\'x\')')"` | inside a string literal |
| `<pre v-pre>{{ $emit('x') }}</pre>` | region Vue never compiles |
| `@click="myEmit('foo-bar')"` | a longer identifier ending in the binding name |
| `@click="child.$emit('x')"` | a member call dispatches on another instance |
| `<Child v-slot="{ emit }">…emit('x')…</Child>` | the name is a slot variable |

The evidence therefore comes from the **template AST** plus an **oxc parse** of
each expression, through the `template_scan` module added in #3491: only a
directive expression or an interpolation's content is scanned (which excludes
comments, text nodes, plain attributes and `v-pre`, whose directives the parser
rewrites to attributes and whose interpolations become text), and only a genuine
`CallExpression` with a plain `Identifier` callee and a `StringLiteral` first
argument counts.

Every row above has a test asserting **exactly zero** findings, in *both* rules.

**Where over-matching is still possible it suppresses rather than reports** —
shadowing names are over-collected from the `v-for` alias / slot pattern.

**Under-matching loses a report**, the tolerable direction: a dynamic event name
(`$emit(name)`), an expression oxc cannot parse, and a member callee are all
skipped.

## The soundness guards survive

- `require-explicit-emits` still reports **only** when a declaration exists and
  is fully known. A template `$emit('cancel')` in a component with no
  `defineEmits` at all, or with `defineEmits([...names])`, reports nothing —
  tested both ways. Without that, the fix would trade a false negative for a
  much louder false positive.
- `custom-event-name-casing` keeps permitting the `v-model` `update:` prefix and
  skipping dynamic names.

## Single-script-block requirement

Both template halves require the SFC to have a single script block
(`SfcScriptContext::sole_script_block`, added in #3485). The rule is invoked once
per block, and unlike the script halves — whose call sites live in the block
being linted — a template `$emit` is visible to every block. With both a
`<script>` and a `<script setup>` the declared set is split across them, so each
invocation would judge on half the information and both would report the same
call. Each rule has a test for that shape asserting zero findings. This is an
under-match, the tolerable direction.

## Coverage beyond `$emit`

The captured `defineEmits` binding is also template-visible as a top-level
`<script setup>` binding, so `@click="emit('cancel')"` dispatches the same
events and is checked too — symmetric with `props_emits/template_emits.rs`,
which already treats it as usage in the suppressing direction.

## Location

Reported at the **string literal** naming the event, mapped into whole-SFC
coordinates through `template_offset` — the same node both script halves span.

## How the new tests fail before the fix

With the `check_template` call short-circuited in both rules (the pre-fix
behaviour):

```
custom_event_name_casing::tests::template::reports_a_kebab_case_dollar_emit_issue_3413 ... FAILED
custom_event_name_casing::tests::template::reports_a_pascal_case_dollar_emit ... FAILED
custom_event_name_casing::tests::template::reports_a_kebab_case_call_of_the_captured_binding ... FAILED
custom_event_name_casing::tests::template::reports_a_dollar_emit_in_an_interpolation ... FAILED
require_explicit_emits::tests::template::reports_an_undeclared_dollar_emit_issue_3413 ... FAILED
require_explicit_emits::tests::template::reports_an_undeclared_call_of_the_captured_binding ... FAILED
require_explicit_emits::tests::template::reports_an_undeclared_dollar_emit_against_the_options_api_emits ... FAILED
require_explicit_emits::tests::template::reports_an_undeclared_dollar_emit_in_an_interpolation ... FAILED
test result: FAILED. 25 passed; 8 failed
```

Exactly the eight positive-direction tests fail; all 25 others pass, including
every over-match probe, both soundness-guard tests, both sibling-block tests and
both script-half regression tests.

With the fix: `73 passed; 0 failed` across the two rules.

## File split

`custom_event_name_casing.rs` was 344 lines, one edit from the budget. Its
inline `mod tests` moves verbatim to `custom_event_name_casing/tests.rs`,
leaving 271 + 180 + 285 (`tests/template.rs`).
`require_explicit_emits.rs` grows 181 → 253, and its `tests.rs` (already 339)
gains only the two-line `mod template;` — the template helpers live in
`tests/template.rs` (333) precisely so that file does not grow past 350.
`template_scan/calls.rs` grows 77 → 106 (the string-literal argument channel,
with the literal's own span).

## Gates run

- `nix develop -c vp run fmt:check` — pass
- `nix develop -c vp run lint:rust` (clippy `-D warnings`) — pass
- `nix develop -c vp run check:rust` — pass
- `nix develop -c cargo test -p vize_patina` — 2323 passed, 0 failed (rebased on
  `545d893ac`)

Closes #3413
Refs #3223
