### PR TITLE
fix(atelier): keep non-JSX render-prop slot bodies and report the JSX children that cannot be lowered

### DIFF
--- a/crates/vize_atelier_jsx/src/lower/child.rs
+++ b/crates/vize_atelier_jsx/src/lower/child.rs
@@ -7,6 +7,18 @@ use vize_relief::{InterpolationNode, TemplateChildNode, TextNode};
 
 use super::Lowerer;
 
+/// `<div><><i/></></div>`. A nested fragment is lowered as an element tagged
+/// `Fragment`, and the DOM backend turns a component tag into
+/// `resolveComponent("Fragment")`, which resolves to nothing at runtime.
+/// A fragment used as the whole render root is fine — its children become the
+/// root children — so only the nested case reports.
+const NESTED_FRAGMENT_UNSUPPORTED: &str = "a JSX fragment nested inside an element is not supported; it lowers to an unresolvable `Fragment` component";
+
+/// `<div>{...items}</div>`. `@vue/babel-plugin-jsx` spreads the value into the
+/// children array; the lowering has no spread child, so the array used to be
+/// stringified into a single text node through `toDisplayString`.
+const SPREAD_CHILD_UNSUPPORTED: &str = "spread children (`{...items}`) are not supported; the value would be stringified instead of spread";
+
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Lower a list of JSX children, dropping whitespace-only text.
     pub(crate) fn lower_children(
@@ -37,10 +49,13 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
                     self.bump(),
                 )))
             }
-            JSXChild::Fragment(fragment) => Some(TemplateChildNode::Element(Box::new_in(
-                self.lower_fragment_node(fragment),
-                self.bump(),
-            ))),
+            JSXChild::Fragment(fragment) => {
+                self.reject(fragment.span, NESTED_FRAGMENT_UNSUPPORTED);
+                Some(TemplateChildNode::Element(Box::new_in(
+                    self.lower_fragment_node(fragment),
+                    self.bump(),
+                )))
+            }
             JSXChild::ExpressionContainer(container) => self.lower_child_container(container),
             JSXChild::Spread(spread) => Some(self.lower_spread_child(spread)),
         }
@@ -73,13 +88,15 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         }
     }
 
-    /// `{...children}` keeps the spread argument as an interpolation expression.
+    /// `{...children}` keeps the spread argument as an interpolation expression,
+    /// which is not what a spread means; report before doing so.
     fn lower_spread_child(&mut self, spread: &JSXSpreadChild<'_>) -> TemplateChildNode<'a> {
+        self.reject(spread.span, SPREAD_CHILD_UNSUPPORTED);
         let content = self.dyn_expr(spread.expression.span());
         self.interpolation(content, spread.span)
     }
 
-    fn interpolation(
+    pub(crate) fn interpolation(
         &self,
         content: vize_relief::ExpressionNode<'a>,
         span: oxc_span::Span,

--- a/crates/vize_atelier_jsx/src/lower/slot.rs
+++ b/crates/vize_atelier_jsx/src/lower/slot.rs
@@ -19,7 +19,7 @@ use oxc_ast::ast::{
 use oxc_span::{GetSpan, Span};
 use vize_carton::{Box, Vec};
 use vize_relief::ElementType;
-use vize_relief::{DirectiveNode, ElementNode, PropNode, TemplateChildNode};
+use vize_relief::{DirectiveNode, ElementNode, PropNode, TemplateChildNode, TextNode};
 
 use super::Lowerer;
 use crate::diagnostics::JsxDiagnostic;
@@ -185,8 +185,11 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// JSX element/fragment becomes the slot content directly; a control-flow
     /// expression (`(rows) => rows.map(...)`, a conditional, or `&&`) reuses the
     /// shared control-flow lowering so a list/conditional rendered inside a slot
-    /// works the same as one rendered as an ordinary child. Anything else
-    /// produces an empty body.
+    /// works the same as one rendered as an ordinary child.
+    ///
+    /// Anything else is rendered as the slot's content, exactly as the same
+    /// expression would be as an ordinary child. This used to produce an empty
+    /// body instead, so `<B>{() => 'foo'}</B>` silently rendered nothing.
     fn extract_fn_slot_body(&mut self, slot_fn: &SlotFn<'_>) -> Vec<'a, TemplateChildNode<'a>> {
         let mut out = Vec::new_in(self.bump());
         let Some(expr) = slot_fn.return_expr else {
@@ -210,10 +213,26 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             other => {
                 if let Some(child) = self.lower_control_flow_expr(other, other.span()) {
                     out.push(child);
+                } else {
+                    out.push(self.slot_body_value(other));
                 }
             }
         }
         out
+    }
+
+    /// Render a plain-expression slot body the way the same expression renders
+    /// as an ordinary child: a string literal becomes text, anything else an
+    /// interpolation.
+    fn slot_body_value(&mut self, expr: &Expression<'_>) -> TemplateChildNode<'a> {
+        if let Expression::StringLiteral(string) = expr {
+            return TemplateChildNode::Text(Box::new_in(
+                TextNode::new(string.value.as_str(), self.mapper().location(string.span)),
+                self.bump(),
+            ));
+        }
+        let content = self.dyn_expr(expr.span());
+        self.interpolation(content, expr.span())
     }
 }
 

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   70 |
-| divergent  |   25 |
+| equivalent |   71 |
+| divergent  |   24 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -118,7 +118,7 @@ deliberate answer, recorded here so it is not relitigated.
 | `elements/member_tag`            | `createVNode(a.b.c, …)`                                          | `resolveComponent("a.b.c")` — a name string              | emit the member expression                   | ❌      |
 | `elements/namespaced_tag`        | rejects: `getTag: JSXNamespacedName is not supported`            | silently emits tag `a:b`                                 | reject with a diagnostic                     | ❌      |
 | `elements/fragment`              | `createVNode(Fragment, null, […])`                               | `createElementBlock(Fragment, …, STABLE_FRAGMENT)`       | no change                                    | ✅      |
-| `elements/nested_fragment_child` | nested `Fragment` vnode                                          | `resolveComponent("Fragment")` — unresolvable at runtime | use the `Fragment` symbol                    | ❌      |
+| `elements/nested_fragment_child` | nested `Fragment` vnode                                          | `resolveComponent("Fragment")`, now reported as an error | use the `Fragment` symbol                    | ❌      |
 
 ## Props and attributes
 
@@ -194,7 +194,7 @@ it classifies as an intrinsic element but the DOM backend still resolves with
 | Case                                 | Babel                                 | Vize today                                  | Compat mode                           | Verdict |
 | ------------------------------------ | ------------------------------------- | ------------------------------------------- | ------------------------------------- | ------- |
 | `slots/object_children`              | object child becomes the slots object | `withCtx` slots + `_: 1`                    | no change                             | ✅      |
-| `slots/render_prop_child`            | `{default: () => 'foo'}`              | empty default slot — the value is dropped   | keep the non-JSX body                 | ❌      |
+| `slots/render_prop_child`            | `{default: () => 'foo'}`              | `default: () => [createTextVNode("foo")]`   | no change                             | ✅      |
 | `slots/scoped_param`                 | `default: s => …`                     | `default: withCtx((s) => […])`              | no change                             | ✅      |
 | `slots/v_slots_with_children`        | `{default: () => […], ...slots}`      | diagnosed: opaque slots value (#3418)       | forward the object; needs #3467       | ❌      |
 | `slots/v_slots_only`                 | slots object passed as children       | diagnosed: opaque slots value (#3418)       | forward the object; needs #3467       | ❌      |
@@ -228,7 +228,7 @@ here so the choice is not implicit (#3418, `src/lower/v_slots.rs`):
 | `children/text_interp_mix` | three children                | one concatenated `TEXT` child     | no change                      | ✅      |
 | `children/comment_only`    | children `null`               | no children                       | no change                      | ✅      |
 | `children/empty_expr`      | children `null`               | no children                       | no change                      | ✅      |
-| `children/spread_child`    | `[...items]`                  | `toDisplayString(items)`          | spread into the children array | ❌      |
+| `children/spread_child`    | `[...items]`                  | `toDisplayString(items)`, reported | spread into the children array | ❌      |
 | `children/logical_and`     | `[c && vnode]`                | `v-if` with a comment placeholder | no change                      | ✅      |
 | `children/ternary`         | `[c ? a : b]`                 | two-branch `v-if` with keys       | no change                      | ✅      |
 | `children/map_list`        | raw `list.map(…)` array child | `renderList` + `KEYED_FRAGMENT`   | no change                      | ✅      |

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -222,16 +222,16 @@ here so the choice is not implicit (#3418, `src/lower/v_slots.rs`):
 
 ## Children
 
-| Case                       | Babel                         | Vize today                        | Compat mode                    | Verdict |
-| -------------------------- | ----------------------------- | --------------------------------- | ------------------------------ | ------- |
-| `children/static_text`     | `[createTextVNode("x")]`      | `"x"` as the children argument    | no change                      | ✅      |
-| `children/text_interp_mix` | three children                | one concatenated `TEXT` child     | no change                      | ✅      |
-| `children/comment_only`    | children `null`               | no children                       | no change                      | ✅      |
-| `children/empty_expr`      | children `null`               | no children                       | no change                      | ✅      |
+| Case                       | Babel                         | Vize today                         | Compat mode                    | Verdict |
+| -------------------------- | ----------------------------- | ---------------------------------- | ------------------------------ | ------- |
+| `children/static_text`     | `[createTextVNode("x")]`      | `"x"` as the children argument     | no change                      | ✅      |
+| `children/text_interp_mix` | three children                | one concatenated `TEXT` child      | no change                      | ✅      |
+| `children/comment_only`    | children `null`               | no children                        | no change                      | ✅      |
+| `children/empty_expr`      | children `null`               | no children                        | no change                      | ✅      |
 | `children/spread_child`    | `[...items]`                  | `toDisplayString(items)`, reported | spread into the children array | ❌      |
-| `children/logical_and`     | `[c && vnode]`                | `v-if` with a comment placeholder | no change                      | ✅      |
-| `children/ternary`         | `[c ? a : b]`                 | two-branch `v-if` with keys       | no change                      | ✅      |
-| `children/map_list`        | raw `list.map(…)` array child | `renderList` + `KEYED_FRAGMENT`   | no change                      | ✅      |
+| `children/logical_and`     | `[c && vnode]`                | `v-if` with a comment placeholder  | no change                      | ✅      |
+| `children/ternary`         | `[c ? a : b]`                 | two-branch `v-if` with keys        | no change                      | ✅      |
+| `children/map_list`        | raw `list.map(…)` array child | `renderList` + `KEYED_FRAGMENT`    | no change                      | ✅      |
 
 ## `optimize: true` (patch flags and dynamic prop keys)
 

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -56,7 +56,7 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("elements/fragment", Same),
     (
         "elements/nested_fragment_child",
-        Diff("nested fragment resolved by name"),
+        Diff("nested fragment resolved by name, now reported"),
     ),
     // -- props -----------------------------------------------------------
     ("props/static_attr", Same),
@@ -120,10 +120,7 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("directives/v_dashed_custom", Same),
     // -- slots -----------------------------------------------------------
     ("slots/object_children", Same),
-    (
-        "slots/render_prop_child",
-        Diff("non-JSX render-prop body dropped"),
-    ),
+    ("slots/render_prop_child", Same),
     ("slots/scoped_param", Same),
     // #3418 lowers the object-literal form; an opaque slots value is diagnosed
     // rather than forwarded, which needs the slots spread tracked by #3467.
@@ -147,7 +144,10 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("children/text_interp_mix", Same),
     ("children/comment_only", Same),
     ("children/empty_expr", Same),
-    ("children/spread_child", Diff("spread child stringified")),
+    (
+        "children/spread_child",
+        Diff("spread child stringified, now reported"),
+    ),
     ("children/logical_and", Same),
     ("children/ternary", Same),
     ("children/map_list", Same),

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (70, 25, 2));
+    assert_eq!((equivalent, divergent, deferred), (71, 24, 2));
     assert_eq!(VERDICTS.len(), 97);
 }
 

--- a/crates/vize_atelier_jsx/tests/components.rs
+++ b/crates/vize_atelier_jsx/tests/components.rs
@@ -2,9 +2,12 @@
 
 mod common;
 
-use common::{as_element, find_directive, is_static, lower_all, lower_one, root_element};
+use common::{
+    as_element, as_text, find_directive, is_static, lower_all, lower_one, root_element,
+    simple_content,
+};
 use vize_carton::Bump;
-use vize_relief::ElementType;
+use vize_relief::{ElementType, TemplateChildNode};
 
 #[test]
 fn multiple_top_level_roots_are_each_lowered() {
@@ -91,4 +94,30 @@ fn jsx_in_ternary_finds_both_branches() {
     let bump = Bump::new();
     let out = lower_all(&bump, "const a = ok ? <yes/> : <no/>;");
     assert_eq!(out.roots.len(), 2);
+}
+
+#[test]
+fn render_prop_child_with_a_plain_body_keeps_its_value() {
+    let bump = Bump::new();
+    // `<B>{() => 'foo'}</B>` used to produce an empty default slot: the slot
+    // body was only lowered for JSX and control-flow shapes, and anything else
+    // was dropped (#3421).
+    let root = lower_one(&bump, "const a = <B>{() => 'foo'}</B>;");
+    let component = root_element(&root);
+    let template = as_element(&component.children[0]);
+    assert_eq!(template.tag.as_str(), "template");
+    assert_eq!(template.children.len(), 1);
+    assert_eq!(as_text(&template.children[0]).content.as_str(), "foo");
+}
+
+#[test]
+fn render_prop_child_with_an_expression_body_keeps_its_value() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <B>{() => label}</B>;");
+    let component = root_element(&root);
+    let template = as_element(&component.children[0]);
+    let TemplateChildNode::Interpolation(interpolation) = &template.children[0] else {
+        panic!("expected an interpolation slot body");
+    };
+    assert_eq!(simple_content(&interpolation.content), "label");
 }

--- a/crates/vize_atelier_jsx/tests/diagnostics.rs
+++ b/crates/vize_atelier_jsx/tests/diagnostics.rs
@@ -73,3 +73,63 @@ fn line_and_column_are_one_indexed() {
     assert_eq!(loc.start.line, 2);
     assert_eq!(loc.start.column, 1);
 }
+
+/// The shapes below all used to lower to something meaningless with no signal
+/// at all: the component rendered wrong and nothing said so (#3421).
+fn diagnostic_texts<'d>(
+    out: &'d vize_atelier_jsx::LowerOutput<'_>,
+) -> std::vec::Vec<(bool, &'d str)> {
+    out.diagnostics
+        .iter()
+        .map(|diagnostic| (diagnostic.is_error(), diagnostic.message.as_str()))
+        .collect()
+}
+
+#[test]
+fn nested_fragment_child_is_reported() {
+    let bump = Bump::new();
+    let src = "const a = <div><><i/></></div>;";
+    let out = lower_all(&bump, src);
+
+    assert_eq!(
+        diagnostic_texts(&out),
+        vec![(
+            true,
+            "a JSX fragment nested inside an element is not supported; it lowers to an unresolvable `Fragment` component"
+        )]
+    );
+    // The span covers exactly the nested fragment.
+    let diagnostic = &out.diagnostics[0];
+    assert_eq!(
+        &src[diagnostic.start as usize..diagnostic.end as usize],
+        "<><i/></>"
+    );
+}
+
+#[test]
+fn a_fragment_used_as_the_whole_root_is_not_reported() {
+    let bump = Bump::new();
+    let out = lower_all(&bump, "const a = <><i/><b/></>;");
+
+    assert_eq!(diagnostic_texts(&out), vec![]);
+}
+
+#[test]
+fn spread_child_is_reported() {
+    let bump = Bump::new();
+    let src = "const a = <div>{...items}</div>;";
+    let out = lower_all(&bump, src);
+
+    assert_eq!(
+        diagnostic_texts(&out),
+        vec![(
+            true,
+            "spread children (`{...items}`) are not supported; the value would be stringified instead of spread"
+        )]
+    );
+    let diagnostic = &out.diagnostics[0];
+    assert_eq!(
+        &src[diagnostic.start as usize..diagnostic.end as usize],
+        "{...items}"
+    );
+}

--- a/crates/vize_atelier_jsx/tests/fragments.rs
+++ b/crates/vize_atelier_jsx/tests/fragments.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use common::{as_element, as_text, lower_one, root_element};
+use common::{as_element, as_text, lower_all, lower_one, root_element};
 use vize_carton::Bump;
 use vize_relief::ElementType;
 
@@ -25,14 +25,28 @@ fn fragment_with_text_and_elements() {
 }
 
 #[test]
-fn nested_fragment_becomes_fragment_component() {
+fn nested_fragment_becomes_fragment_component_and_is_reported() {
     let bump = Bump::new();
-    let root = lower_one(&bump, "const a = <div><><p/></></div>;");
-    let div = root_element(&root);
+    let out = lower_all(&bump, "const a = <div><><p/></></div>;");
+    let div = root_element(&out.roots[0].root);
     let fragment = as_element(&div.children[0]);
     assert_eq!(fragment.tag.as_str(), "Fragment");
     assert_eq!(fragment.tag_type, ElementType::Component);
     assert_eq!(as_element(&fragment.children[0]).tag.as_str(), "p");
+    // The shape above is what the lowering produces, and it is wrong: the DOM
+    // backend turns a component tag into `resolveComponent("Fragment")`, which
+    // resolves to nothing. Until the IR can carry the `Fragment` symbol the
+    // shape stays, but it no longer degrades silently (#3421).
+    assert_eq!(
+        out.diagnostics
+            .iter()
+            .map(|diagnostic| (diagnostic.is_error(), diagnostic.message.as_str()))
+            .collect::<std::vec::Vec<_>>(),
+        vec![(
+            true,
+            "a JSX fragment nested inside an element is not supported; it lowers to an unresolvable `Fragment` component"
+        )]
+    );
 }
 
 #[test]

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__children.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__children.snap
@@ -68,7 +68,7 @@ export function render(_ctx, _cache) {
 
 ## children/spread_child
 ### verdict
-divergent: spread child stringified
+divergent: spread child stringified, now reported
 ### source (jsx)
 const A = () => <div>{...items}</div>;
 ### babel options
@@ -77,6 +77,7 @@ const A = () => <div>{...items}</div>;
 import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [...items]);
 ### vize (vdom, default config)
+<Error> spread children (`{...items}`) are not supported; the value would be stringified instead of spread
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, _toDisplayString(items), 1 /* TEXT */))

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__elements.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__elements.snap
@@ -162,7 +162,7 @@ export function render(_ctx, _cache) {
 
 ## elements/nested_fragment_child
 ### verdict
-divergent: nested fragment resolved by name
+divergent: nested fragment resolved by name, now reported
 ### source (jsx)
 const A = () => <div><><i/></></div>;
 ### babel options
@@ -171,6 +171,7 @@ const A = () => <div><><i/></></div>;
 import { Fragment as _Fragment, createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [_createVNode(_Fragment, null, [_createVNode("i", null, null)])]);
 ### vize (vdom, default config)
+<Error> a JSX fragment nested inside an element is not supported; it lowers to an unresolvable `Fragment` component
 import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, createVNode as _createVNode, openBlock as _openBlock, createElementBlock as _createElementBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_Fragment = _resolveComponent("Fragment")

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__slots.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__slots.snap
@@ -33,7 +33,7 @@ export function render(_ctx, _cache) {
 
 ## slots/render_prop_child
 ### verdict
-divergent: non-JSX render-prop body dropped
+equivalent
 ### source (jsx)
 const A = () => <B>{() => 'foo'}</B>;
 ### babel options
@@ -44,12 +44,13 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
   default: () => 'foo'
 });
 ### vize (vdom, default config)
-import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock, createTextVNode as _createTextVNode, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
   
   return (_openBlock(), _createBlock(_component_B, null, {
     default: _withCtx(() => [
+      _createTextVNode("foo")
     ]),
     _: 1 /* STABLE */
   }))


### PR DESCRIPTION
Part of #3421: the lowering layer has no "I don't handle this" path, so anything it does not
recognize falls through to a nearest-neighbour lowering instead of a diagnostic. This closes three
of the inventory rows — one by fixing it, two by reporting.

## Fixed: `<B>{() => 'foo'}</B>` dropped the value

`extract_fn_slot_body` lowered a slot body only when it was a JSX element, a JSX fragment, or a
control-flow expression. Every other expression produced an **empty** body, so a render prop that
returned anything else rendered nothing.

It now renders the same way the same expression renders as an ordinary child: text for a string
literal, an interpolation otherwise.

```
### babel
_createVNode(_resolveComponent("B"), null, { default: () => 'foo' });
### vize, before                              ### vize, after
default: _withCtx(() => [                     default: _withCtx(() => [
]),                                             _createTextVNode("foo")
                                              ]),
```

`slots/render_prop_child` goes from divergent to equivalent.

## Reported: two shapes the IR cannot represent

Both keep their current output — this PR does not change what is emitted for them — but they no
longer degrade silently.

| Input | Before | Now |
| --- | --- | --- |
| `<div><><i/></></div>` | `resolveComponent("Fragment")`, unresolvable at runtime, no diagnostic | same output + `<Error> a JSX fragment nested inside an element is not supported; it lowers to an unresolvable Fragment component` |
| `<div>{...items}</div>` | `toDisplayString(items)` — the array stringified into one text node, no diagnostic | same output + `<Error> spread children ({...items}) are not supported; the value would be stringified instead of spread` |

A fragment used as the **whole render root** is unaffected: its children become the root children,
which is already equivalent to babel (`elements/fragment` is ✅), and
`a_fragment_used_as_the_whole_root_is_not_reported` pins that.

## Deliberately not in this PR

Three of the issue's rows need a semantics decision rather than a diagnostic, and two of them are
pinned by existing tests that encode the opposite intent. Detail and per-row direction are in a
comment on #3421:

- `<a:b/>` and `<a.b.c/>` — `namespaced_element_name_is_preserved` (`<svg:circle/>`),
  `member_expression_tag_keeps_dotted_path` and `this_member_tag_is_a_component` assert today's
  behaviour on purpose. `<svg:circle/>` in particular is more useful than babel's outright
  rejection, so a blanket diagnostic would be a regression.
- `<B>{slots}</B>` — cannot be told apart statically from an ordinary interpolation child
  (`<B>{count}</B>`); babel decides it at runtime with `_isSlot`.
- `v-custom={[val, 'arg', ['a','b']]}` — needs the literal-array form unpacked, which is an
  implementation, not a report.

## Tests fail before the fix

New: `diagnostics.rs::nested_fragment_child_is_reported`, `::spread_child_is_reported`,
`::a_fragment_used_as_the_whole_root_is_not_reported`,
`components.rs::render_prop_child_with_a_plain_body_keeps_its_value`,
`::render_prop_child_with_an_expression_body_keeps_its_value`. Each asserts the **full** diagnostic
list (`(is_error, message)` pairs) and, for the two reports, that the span slices exactly the
offending source. Updated: `fragments.rs::nested_fragment_becomes_fragment_component_and_is_reported`
keeps its shape assertions and adds the diagnostic.

With `crates/vize_atelier_jsx/src` checked out at the parent commit and the tests from this branch:

```
$ cargo test -p vize_atelier_jsx --test diagnostics --test components --test fragments
test nested_fragment_child_is_reported ... FAILED
  left: []
 right: [(true, "a JSX fragment nested inside an element is not supported; …")]
test spread_child_is_reported ... FAILED
  left: []
 right: [(true, "spread children (`{...items}`) are not supported; …")]
test render_prop_child_with_a_plain_body_keeps_its_value ... FAILED
test render_prop_child_with_an_expression_body_keeps_its_value ... FAILED
  left: 0
 right: 1
```

All pass with the fix.

## Inventory

`babel_compat_verdict_totals` pins the headline number, so `BABEL_COMPAT_INVENTORY.md` and
`babel_compat/verdicts.rs` move together: **70/25/2 -> 71/24/2**.

## Gates

```
$ cargo test -p vize_atelier_jsx                                     # 31 suites, 0 failed
$ cargo clippy -p vize_atelier_jsx -- -D warnings -D clippy::wildcard_imports   # clean
$ rustfmt --edition 2024 --config style_edition=2024 --check <changed>          # clean
$ node --test tests/tooling/babel-jsx-oracle.test.ts                 # 3 pass
```

Refs #3421

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->