### PR TITLE
fix(canon): report the user's tsconfig option diagnostics

### DIFF
--- a/crates/vize/tests/check_ambient_export_assignment_cli.rs
+++ b/crates/vize/tests/check_ambient_export_assignment_cli.rs
@@ -57,7 +57,7 @@ fn check_allows_export_assignment_inside_ambient_module_declaration() {
     "strict": true,
     "target": "ES2022",
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "noEmit": true
   },
   "include": ["src/**/*.d.ts"]

--- a/crates/vize/tests/check_canon_graphql_cli.rs
+++ b/crates/vize/tests/check_canon_graphql_cli.rs
@@ -137,7 +137,6 @@ fn check_explicit_vue_keeps_generated_graphql_schema_out_of_canon() {
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "baseUrl": ".",
     "paths": {
       "~/*": ["*"]
     },
@@ -243,7 +242,6 @@ fn check_barrel_reexport_preserves_generated_graphql_identity() {
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "baseUrl": ".",
     "paths": {
       "~/*": ["*"],
       "@/*": ["*"]

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -1183,7 +1183,6 @@ const configs: AliasConfig[] = [{ key: "a", label: "A" }];
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noEmit": true,
-    "baseUrl": ".",
     "paths": { "@/*": ["src/*"] }
   },
   "include": ["src/**/*"]
@@ -1483,7 +1482,6 @@ const same: Registry["home"] = entry;
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "#registry": ["./registry"]
     }
@@ -3106,6 +3104,7 @@ fn check_declaration_emit_uses_tsconfig_options() {
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noEmit": true,
+    "declaration": true,
     "declarationDir": "types-from-tsconfig",
     "declarationMap": true
   },
@@ -3211,7 +3210,6 @@ fn check_json_handles_monorepo_tsconfig_extends_paths_and_excludes() {
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "baseUrl": ".",
     "paths": {
       "@shared/*": ["packages/shared/src/*"]
     },

--- a/crates/vize/tests/check_declaration_emit_cli.rs
+++ b/crates/vize/tests/check_declaration_emit_cli.rs
@@ -240,6 +240,7 @@ defineProps<PublicProps>()
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
     "inlineSources": true,

--- a/crates/vize/tests/check_nuxt2_plugin_injections_cli.rs
+++ b/crates/vize/tests/check_nuxt2_plugin_injections_cli.rs
@@ -20,7 +20,6 @@ fn check_nuxt2_use_context_sees_plugin_injections() {
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "baseUrl": ".",
     "noEmit": true
   },
   "include": ["pages/**/*.vue", "plugins/**/*.ts", "types/**/*.d.ts"]

--- a/crates/vize/tests/check_nuxt_tsconfig_paths_cli.rs
+++ b/crates/vize/tests/check_nuxt_tsconfig_paths_cli.rs
@@ -20,7 +20,6 @@ fn check_nuxt_sfc_virtual_ts_prefers_explicit_tsconfig_paths_over_fallback_modul
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "baseUrl": ".",
     "noEmit": true,
     "paths": {
       "#imports": ["types/vize/imports.ts"],
@@ -178,7 +177,6 @@ fn check_nuxt2_options_api_component_event_payloads_resolve_through_aliases() {
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "baseUrl": ".",
     "noEmit": true,
     "noUnusedLocals": true,
     "paths": {

--- a/crates/vize/tests/check_package_cwd_cli.rs
+++ b/crates/vize/tests/check_package_cwd_cli.rs
@@ -76,7 +76,6 @@ fn check_from_package_cwd_uses_package_local_tsconfig_inputs() {
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "baseUrl": ".",
     "paths": {
       "~/*": ["*"]
     },

--- a/crates/vize/tests/check_vue_reexports_cli.rs
+++ b/crates/vize/tests/check_vue_reexports_cli.rs
@@ -70,7 +70,6 @@ fn check_preserves_named_exports_from_vue_reexported_through_symlinked_absolute_
     "module": "ESNext",
     "moduleResolution": "bundler",
     "noEmit": true,
-    "baseUrl": ".",
     "paths": {
       "#design": [".nuxt/design.ts"]
     }

--- a/crates/vize_canon/src/batch/executor.rs
+++ b/crates/vize_canon/src/batch/executor.rs
@@ -27,9 +27,12 @@ const DECLARATION_HELPERS_FILE: &str = crate::virtual_ts::SHARED_PREAMBLE_FILE_N
 mod cli;
 mod declaration_maps;
 mod diagnostics;
+mod fallback;
+mod option_probe;
 mod session;
 
 use cli::{auto_server_count, check_with_cli, check_with_cli_sharded};
+use fallback::{FallbackStep, warn_fallback};
 use session::IncrementalSessionState;
 #[cfg(test)]
 use session::collect_virtual_file_uris;
@@ -87,6 +90,26 @@ impl CorsaExecutor {
         let _materialize_lock = MaterializeLock::acquire(project.virtual_root())?;
         profile!("canon.executor.materialize", project.materialize())?;
 
+        let mut result = self.check_program(project, servers)?;
+        // The generated config is sanitized, so it cannot carry the user's own
+        // `compilerOptions` diagnostics; a separate input-less program does
+        // (#3448). Errors it finds must fail the check exactly as `tsc`'s do.
+        let options = option_probe::option_diagnostics(&self.corsa_path, project);
+        if options.iter().any(|diagnostic| diagnostic.severity == 1) {
+            result.success = false;
+            result.exit_code = result.exit_code.max(1);
+        }
+        result.diagnostics.extend(options);
+        Ok(result)
+    }
+
+    /// Type-check the materialized project, walking the fallback ladder. The
+    /// caller holds the materialize lock.
+    fn check_program(
+        &self,
+        project: &VirtualProject,
+        servers: Option<usize>,
+    ) -> CorsaResult<TypeCheckResult> {
         let servers = servers.unwrap_or_else(|| auto_server_count(project));
         if servers > 1 {
             match profile!(
@@ -273,142 +296,6 @@ fn should_fallback_to_cli(error: &str) -> bool {
         || error.contains("process is closed: jsonrpc reader")
         || error.contains("Broken pipe")
         || error.contains("broken pipe")
-}
-
-/// A degradation step on the Corsa fallback ladder. Each variant names the
-/// faster/stronger path that failed and the slower/weaker path taken instead,
-/// so an operator can tell from a single signal which capability was lost.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FallbackStep {
-    /// Parallel sharded CLI check failed; degraded to a single CLI program
-    /// (doubles work on wide machines).
-    ShardedCliToSingleCli,
-    /// The CLI fast path failed; degraded to the much slower project-session
-    /// API.
-    CliToSession,
-    /// The project-session API could not be spawned/handshaken; degraded back
-    /// to a single CLI program.
-    SessionToCli,
-}
-
-impl FallbackStep {
-    const fn description(self) -> &'static str {
-        match self {
-            FallbackStep::ShardedCliToSingleCli => {
-                "sharded Corsa CLI check failed; degraded to a single CLI program"
-            }
-            FallbackStep::CliToSession => {
-                "Corsa CLI fast path unavailable; degraded to the slower project-session API"
-            }
-            FallbackStep::SessionToCli => {
-                "Corsa project-session API unavailable; degraded to a single CLI program"
-            }
-        }
-    }
-}
-
-/// Coarse cause of a ladder degradation, so the signal distinguishes a dead
-/// process from an unparseable runtime from a real type-check failure.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum FallbackCause {
-    /// The Corsa process could not be spawned or died (IO error, broken pipe,
-    /// closed reader, panic).
-    Spawn,
-    /// The Corsa process ran but its output could not be decoded/parsed.
-    Parse,
-    /// The Corsa process produced a usable error that is neither a spawn nor a
-    /// parse problem.
-    Check,
-}
-
-impl FallbackCause {
-    const fn label(self) -> &'static str {
-        match self {
-            FallbackCause::Spawn => "spawn",
-            FallbackCause::Parse => "parse",
-            FallbackCause::Check => "check",
-        }
-    }
-}
-
-/// Classify a ladder error as a spawn, parse, or check failure from its kind
-/// and message, without depending on any single error variant.
-fn classify_fallback_cause(error: &CorsaError) -> FallbackCause {
-    match error {
-        CorsaError::Io(_) => FallbackCause::Spawn,
-        CorsaError::JsonParse(_) => FallbackCause::Parse,
-        _ => {
-            let message = cstr!("{error}");
-            if message.contains("Broken pipe")
-                || message.contains("broken pipe")
-                || message.contains("process is closed")
-                || message.contains("jsonrpc reader")
-                || message.contains("worker panicked")
-                || message.contains("No such file")
-                || message.contains("not found")
-            {
-                FallbackCause::Spawn
-            } else if message.contains("marker")
-                || message.contains("decode")
-                || message.contains("parse")
-                || message.contains("unexpected")
-            {
-                FallbackCause::Parse
-            } else {
-                FallbackCause::Check
-            }
-        }
-    }
-}
-
-/// Whether the once-per-run fallback signal has already been emitted to stderr.
-/// The structured `tracing` event fires on every degradation (subscribers can
-/// dedup/aggregate), but the human-facing stderr line is emitted at most once
-/// per process so a large project's repeated fallbacks stay quiet.
-static FALLBACK_NOTICE_EMITTED: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-
-/// Emit an observable signal that the Corsa integration degraded to a
-/// slower/weaker path. Always records a structured `tracing::warn!` event
-/// (consumed by the LSP and CI which install a subscriber); additionally prints
-/// a single human-readable stderr warning per process for the `vize check` CLI,
-/// which installs no subscriber. The happy path never reaches this function, so
-/// a fully fast-path run stays silent.
-fn warn_fallback(step: FallbackStep, error: &CorsaError) {
-    let cause = classify_fallback_cause(error);
-    tracing::warn!(
-        target: "vize_canon::corsa::fallback",
-        fallback = ?step,
-        cause = cause.label(),
-        error = %error,
-        "{}",
-        step.description(),
-    );
-
-    if let Some(notice) = fallback_stderr_notice(step, cause) {
-        eprintln!("{notice}");
-    }
-}
-
-/// Build the human-facing stderr warning for a ladder degradation, claiming the
-/// once-per-process slot as a side effect. Returns `None` when the notice is
-/// suppressed (`VIZE_SILENCE_CORSA_FALLBACK`) or already emitted this run, so a
-/// large project's repeated fallbacks stay quiet. Separated from `eprintln!` so
-/// the once/suppression policy is unit-testable without capturing real stderr.
-fn fallback_stderr_notice(step: FallbackStep, cause: FallbackCause) -> Option<String> {
-    // Noise-sensitive embedders can suppress only the stderr line; the
-    // structured `tracing` event still fires for observability.
-    if std::env::var_os("VIZE_SILENCE_CORSA_FALLBACK").is_some() {
-        return None;
-    }
-    if FALLBACK_NOTICE_EMITTED.swap(true, std::sync::atomic::Ordering::Relaxed) {
-        return None;
-    }
-    Some(cstr!(
-        "\x1b[33mwarning:\x1b[0m corsa: {} ({} failure). Type checking continues on a slower path.",
-        step.description(),
-        cause.label(),
-    ))
 }
 
 #[cfg(test)]

--- a/crates/vize_canon/src/batch/executor/fallback.rs
+++ b/crates/vize_canon/src/batch/executor/fallback.rs
@@ -1,0 +1,142 @@
+//! The Corsa fallback ladder: how a degradation from a faster/stronger check
+//! path to a slower/weaker one is classified and signalled.
+
+use vize_carton::{String, cstr};
+
+use super::super::error::CorsaError;
+
+/// A degradation step on the Corsa fallback ladder. Each variant names the
+/// faster/stronger path that failed and the slower/weaker path taken instead,
+/// so an operator can tell from a single signal which capability was lost.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FallbackStep {
+    /// Parallel sharded CLI check failed; degraded to a single CLI program
+    /// (doubles work on wide machines).
+    ShardedCliToSingleCli,
+    /// The CLI fast path failed; degraded to the much slower project-session
+    /// API.
+    CliToSession,
+    /// The project-session API could not be spawned/handshaken; degraded back
+    /// to a single CLI program.
+    SessionToCli,
+}
+
+impl FallbackStep {
+    pub(super) const fn description(self) -> &'static str {
+        match self {
+            FallbackStep::ShardedCliToSingleCli => {
+                "sharded Corsa CLI check failed; degraded to a single CLI program"
+            }
+            FallbackStep::CliToSession => {
+                "Corsa CLI fast path unavailable; degraded to the slower project-session API"
+            }
+            FallbackStep::SessionToCli => {
+                "Corsa project-session API unavailable; degraded to a single CLI program"
+            }
+        }
+    }
+}
+
+/// Coarse cause of a ladder degradation, so the signal distinguishes a dead
+/// process from an unparseable runtime from a real type-check failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FallbackCause {
+    /// The Corsa process could not be spawned or died (IO error, broken pipe,
+    /// closed reader, panic).
+    Spawn,
+    /// The Corsa process ran but its output could not be decoded/parsed.
+    Parse,
+    /// The Corsa process produced a usable error that is neither a spawn nor a
+    /// parse problem.
+    Check,
+}
+
+impl FallbackCause {
+    pub(super) const fn label(self) -> &'static str {
+        match self {
+            FallbackCause::Spawn => "spawn",
+            FallbackCause::Parse => "parse",
+            FallbackCause::Check => "check",
+        }
+    }
+}
+
+/// Classify a ladder error as a spawn, parse, or check failure from its kind
+/// and message, without depending on any single error variant.
+pub(super) fn classify_fallback_cause(error: &CorsaError) -> FallbackCause {
+    match error {
+        CorsaError::Io(_) => FallbackCause::Spawn,
+        CorsaError::JsonParse(_) => FallbackCause::Parse,
+        _ => {
+            let message = cstr!("{error}");
+            if message.contains("Broken pipe")
+                || message.contains("broken pipe")
+                || message.contains("process is closed")
+                || message.contains("jsonrpc reader")
+                || message.contains("worker panicked")
+                || message.contains("No such file")
+                || message.contains("not found")
+            {
+                FallbackCause::Spawn
+            } else if message.contains("marker")
+                || message.contains("decode")
+                || message.contains("parse")
+                || message.contains("unexpected")
+            {
+                FallbackCause::Parse
+            } else {
+                FallbackCause::Check
+            }
+        }
+    }
+}
+
+/// Whether the once-per-run fallback signal has already been emitted to stderr.
+/// The structured `tracing` event fires on every degradation (subscribers can
+/// dedup/aggregate), but the human-facing stderr line is emitted at most once
+/// per process so a large project's repeated fallbacks stay quiet.
+pub(super) static FALLBACK_NOTICE_EMITTED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Emit an observable signal that the Corsa integration degraded to a
+/// slower/weaker path. Always records a structured `tracing::warn!` event
+/// (consumed by the LSP and CI which install a subscriber); additionally prints
+/// a single human-readable stderr warning per process for the `vize check` CLI,
+/// which installs no subscriber. The happy path never reaches this function, so
+/// a fully fast-path run stays silent.
+pub(super) fn warn_fallback(step: FallbackStep, error: &CorsaError) {
+    let cause = classify_fallback_cause(error);
+    tracing::warn!(
+        target: "vize_canon::corsa::fallback",
+        fallback = ?step,
+        cause = cause.label(),
+        error = %error,
+        "{}",
+        step.description(),
+    );
+
+    if let Some(notice) = fallback_stderr_notice(step, cause) {
+        eprintln!("{notice}");
+    }
+}
+
+/// Build the human-facing stderr warning for a ladder degradation, claiming the
+/// once-per-process slot as a side effect. Returns `None` when the notice is
+/// suppressed (`VIZE_SILENCE_CORSA_FALLBACK`) or already emitted this run, so a
+/// large project's repeated fallbacks stay quiet. Separated from `eprintln!` so
+/// the once/suppression policy is unit-testable without capturing real stderr.
+pub(super) fn fallback_stderr_notice(step: FallbackStep, cause: FallbackCause) -> Option<String> {
+    // Noise-sensitive embedders can suppress only the stderr line; the
+    // structured `tracing` event still fires for observability.
+    if std::env::var_os("VIZE_SILENCE_CORSA_FALLBACK").is_some() {
+        return None;
+    }
+    if FALLBACK_NOTICE_EMITTED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+        return None;
+    }
+    Some(cstr!(
+        "\x1b[33mwarning:\x1b[0m corsa: {} ({} failure). Type checking continues on a slower path.",
+        step.description(),
+        cause.label(),
+    ))
+}

--- a/crates/vize_canon/src/batch/executor/option_probe.rs
+++ b/crates/vize_canon/src/batch/executor/option_probe.rs
@@ -1,0 +1,143 @@
+//! Running the `compilerOptions` probe and turning its output into project
+//! diagnostics (#3448).
+//!
+//! See [`crate::batch::virtual_project::option_probe`] for why the probe config
+//! exists and what it contains. Here it is executed and read back: only
+//! diagnostics the checker positions *on the probe config itself* are kept, and
+//! only those in TypeScript's 5xxx range — the codes reserved for command-line
+//! and config-file option problems. Everything else the input-less program can
+//! say is noise for this purpose, most visibly `TS18002` ("the 'files' list in
+//! config file is empty"), which is the price of building no program at all.
+//!
+//! Diagnostics are anchored on the project exactly as
+//! `cli::project_diagnostics::config` anchors the main run's config errors, so an
+//! option that survives sanitization and is therefore reported by *both* runs
+//! collapses in `dedup_diagnostics` instead of being reported twice.
+
+use std::path::Path;
+use std::process::Command;
+
+use vize_carton::profile;
+
+use super::super::{Diagnostic, VirtualProject};
+use super::diagnostics::dedup_diagnostics;
+
+/// TypeScript reserves 5000-5999 for command-line and config option messages.
+const OPTION_DIAGNOSTIC_CODES: std::ops::Range<u32> = 5000..6000;
+
+/// Option diagnostics for the user's own `compilerOptions`.
+///
+/// Best-effort: a probe that cannot be written or run leaves the main run's
+/// diagnostics untouched rather than failing the check, because the probe adds
+/// diagnostics and never gates any.
+pub(super) fn option_diagnostics(corsa_path: &Path, project: &VirtualProject) -> Vec<Diagnostic> {
+    let Ok(Some(config_path)) = project.write_option_probe_tsconfig() else {
+        return Vec::new();
+    };
+
+    let Ok(output) = profile!("canon.corsa.cli.option_probe", {
+        Command::new(corsa_path)
+            .current_dir(project.virtual_root())
+            .arg("--pretty")
+            .arg("false")
+            .arg("--project")
+            .arg(&config_path)
+            .output()
+    }) else {
+        return Vec::new();
+    };
+
+    let anchor = project.project_diagnostics_anchor();
+    let mut diagnostics = Vec::new();
+    #[allow(clippy::disallowed_types)]
+    for stream in [&output.stdout, &output.stderr] {
+        let text = std::string::String::from_utf8_lossy(stream);
+        collect_option_diagnostics(text.as_ref(), &config_path, &anchor, &mut diagnostics);
+    }
+    dedup_diagnostics(diagnostics)
+}
+
+/// Parse `output` into anchored option diagnostics.
+///
+/// A diagnostic's message can continue on following indented lines, so the
+/// parser tracks whether the last header line was kept: continuations of a
+/// dropped diagnostic must be dropped with it rather than appended to the
+/// previous kept one.
+fn collect_option_diagnostics(
+    output: &str,
+    config_path: &Path,
+    anchor: &Path,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let mut last_was_kept = false;
+    for line in output.lines() {
+        match parse_option_diagnostic_line(line, config_path) {
+            Some(Some((code, message, severity))) => {
+                diagnostics.push(Diagnostic {
+                    file: anchor.to_path_buf(),
+                    line: 0,
+                    column: 0,
+                    message,
+                    code: Some(code),
+                    severity,
+                    block_type: None,
+                });
+                last_was_kept = true;
+            }
+            // A diagnostic header this probe does not report.
+            Some(None) => last_was_kept = false,
+            None => {
+                let continuation = line.trim();
+                if last_was_kept
+                    && !continuation.is_empty()
+                    && let Some(last) = diagnostics.last_mut()
+                {
+                    last.message.push('\n');
+                    last.message.push_str(continuation);
+                }
+            }
+        }
+    }
+}
+
+/// `Some(Some(..))` for an option diagnostic on the probe config, `Some(None)`
+/// for any other diagnostic header on it, `None` when the line is not a
+/// diagnostic header for that file at all.
+#[allow(clippy::type_complexity)]
+fn parse_option_diagnostic_line(
+    line: &str,
+    config_path: &Path,
+) -> Option<Option<(u32, vize_carton::String, u8)>> {
+    let (prefix, suffix) = line.split_once("): ")?;
+    let open = prefix.rfind('(')?;
+    if !names_probe_config(&prefix[..open], config_path) {
+        return None;
+    }
+
+    let (severity, rest) = suffix.split_once(' ')?;
+    let severity = match severity {
+        "error" => 1,
+        "warning" => 2,
+        "info" => 3,
+        _ => return None,
+    };
+    let (code, message) = rest.split_once(": ")?;
+    let Some(code) = code
+        .strip_prefix("TS")
+        .and_then(|code| code.parse::<u32>().ok())
+        .filter(|code| OPTION_DIAGNOSTIC_CODES.contains(code))
+    else {
+        return Some(None);
+    };
+    Some(Some((code, message.into(), severity)))
+}
+
+/// The checker reports the probe config by whatever path the invocation used —
+/// a bare file name from `current_dir`, or the absolute path it was given.
+fn names_probe_config(reported: &str, config_path: &Path) -> bool {
+    let reported = Path::new(reported);
+    reported == config_path || reported.file_name() == config_path.file_name()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_canon/src/batch/executor/option_probe/tests.rs
+++ b/crates/vize_canon/src/batch/executor/option_probe/tests.rs
@@ -1,0 +1,135 @@
+use std::path::{Path, PathBuf};
+
+use super::collect_option_diagnostics;
+use crate::batch::Diagnostic;
+
+/// Verbatim `tsgo --pretty false` output for a probe config declaring
+/// `baseUrl`, `target: ES5`, `moduleResolution: node`, `downlevelIteration` and
+/// an unknown option, captured from
+/// `@typescript/native-preview 7.0.0-dev.20260602.1`.
+const PROBE_OUTPUT: &str = "\
+tsconfig.options.json(6,5): error TS5102: Option 'baseUrl' has been removed. Please remove it from your configuration.
+  Use '\"paths\": {\"*\": [\"./*\"]}' instead.
+tsconfig.options.json(7,15): error TS5108: Option 'target=ES5' has been removed. Please remove it from your configuration.
+tsconfig.options.json(8,25): error TS5108: Option 'moduleResolution=node10' has been removed. Please remove it from your configuration.
+tsconfig.options.json(9,5): error TS5102: Option 'downlevelIteration' has been removed. Please remove it from your configuration.
+tsconfig.options.json(11,5): error TS5023: Unknown compiler option 'importsNotUsedAsValues'.
+tsconfig.options.json(14,12): error TS18002: The 'files' list in config file '/tmp/p/tsconfig.options.json' is empty.
+";
+
+fn collected(output: &str) -> Vec<(Option<u32>, u8, String)> {
+    let mut diagnostics = Vec::new();
+    collect_option_diagnostics(
+        output,
+        Path::new("tsconfig.options.json"),
+        &PathBuf::from("/project/tsconfig.json"),
+        &mut diagnostics,
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(
+                |diagnostic: &Diagnostic| diagnostic.file == Path::new("/project/tsconfig.json")
+                    && diagnostic.line == 0
+                    && diagnostic.column == 0
+            ),
+        "option diagnostics are anchored on the project: {diagnostics:?}"
+    );
+    diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+            (
+                diagnostic.code,
+                diagnostic.severity,
+                diagnostic.message.to_string(),
+            )
+        })
+        .collect()
+}
+
+#[test]
+fn every_option_code_is_reported_with_its_continuation_line() {
+    assert_eq!(
+        collected(PROBE_OUTPUT),
+        vec![
+            (
+                Some(5102),
+                1,
+                "Option 'baseUrl' has been removed. Please remove it from your configuration.\n\
+                 Use '\"paths\": {\"*\": [\"./*\"]}' instead."
+                    .to_owned()
+            ),
+            (
+                Some(5108),
+                1,
+                "Option 'target=ES5' has been removed. Please remove it from your configuration."
+                    .to_owned()
+            ),
+            (
+                Some(5108),
+                1,
+                "Option 'moduleResolution=node10' has been removed. Please remove it from your \
+                 configuration."
+                    .to_owned()
+            ),
+            (
+                Some(5102),
+                1,
+                "Option 'downlevelIteration' has been removed. Please remove it from your \
+                 configuration."
+                    .to_owned()
+            ),
+            (
+                Some(5023),
+                1,
+                "Unknown compiler option 'importsNotUsedAsValues'.".to_owned()
+            ),
+        ]
+    );
+}
+
+#[test]
+fn a_continuation_of_a_dropped_diagnostic_is_dropped_with_it() {
+    // TS18002 is the price of building no program; its follow-on lines must not
+    // be glued onto the option diagnostic above it.
+    assert_eq!(
+        collected(
+            "tsconfig.options.json(6,5): error TS5102: Option 'baseUrl' has been removed.\n\
+             tsconfig.options.json(14,12): error TS18002: The 'files' list is empty.\n  \
+             and here is a continuation of the dropped one\n"
+        ),
+        vec![(
+            Some(5102),
+            1,
+            "Option 'baseUrl' has been removed.".to_owned()
+        )]
+    );
+}
+
+#[test]
+fn diagnostics_on_any_other_file_are_ignored() {
+    // The probe only speaks for its own config; anything the input-less program
+    // says about a source file or a lib belongs to the main run.
+    assert_eq!(
+        collected(
+            "src/App.vue.ts(5,23): error TS2345: Argument of type 'number' is not assignable.\n\
+             tsconfig.json(6,5): error TS5102: Option 'baseUrl' has been removed.\n"
+        ),
+        Vec::new()
+    );
+}
+
+#[test]
+fn an_absolute_config_path_is_recognized() {
+    let mut diagnostics = Vec::new();
+    collect_option_diagnostics(
+        "/virtual/root/tsconfig.options.json(6,5): error TS5102: Option 'baseUrl' has been \
+         removed.\n",
+        Path::new("/virtual/root/tsconfig.options.json"),
+        &PathBuf::from("/project/tsconfig.json"),
+        &mut diagnostics,
+    );
+
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+    assert_eq!(diagnostics[0].code, Some(5102));
+}

--- a/crates/vize_canon/src/batch/executor/tests.rs
+++ b/crates/vize_canon/src/batch/executor/tests.rs
@@ -1,7 +1,5 @@
-use super::{
-    CorsaError, CorsaExecutor, FallbackCause, classify_fallback_cause, collect_declaration_outputs,
-    collect_virtual_file_uris,
-};
+use super::fallback::{FallbackCause, classify_fallback_cause};
+use super::{CorsaError, CorsaExecutor, collect_declaration_outputs, collect_virtual_file_uris};
 use crate::file_uri::path_to_file_uri;
 use std::{
     fs,
@@ -267,11 +265,11 @@ fn classifies_check_failures() {
 
 #[test]
 fn fallback_notice_is_observable_once_and_silenceable() {
-    use super::{FallbackCause, FallbackStep, fallback_stderr_notice};
+    use super::fallback::{FallbackCause, FallbackStep, fallback_stderr_notice};
 
     // Re-arm the once-per-run guard and ensure the notice is not suppressed,
     // regardless of earlier degradations in this process.
-    super::FALLBACK_NOTICE_EMITTED.store(false, std::sync::atomic::Ordering::Relaxed);
+    super::fallback::FALLBACK_NOTICE_EMITTED.store(false, std::sync::atomic::Ordering::Relaxed);
     // SAFETY: single-threaded test; the var is only read by the helper.
     unsafe { std::env::remove_var("VIZE_SILENCE_CORSA_FALLBACK") };
 
@@ -294,7 +292,7 @@ fn fallback_notice_is_observable_once_and_silenceable() {
     );
 
     // Opt-out suppresses the stderr notice without claiming the guard.
-    super::FALLBACK_NOTICE_EMITTED.store(false, std::sync::atomic::Ordering::Relaxed);
+    super::fallback::FALLBACK_NOTICE_EMITTED.store(false, std::sync::atomic::Ordering::Relaxed);
     // SAFETY: single-threaded test; restored immediately after the call.
     unsafe { std::env::set_var("VIZE_SILENCE_CORSA_FALLBACK", "1") };
     let suppressed = fallback_stderr_notice(FallbackStep::CliToSession, FallbackCause::Check);
@@ -305,7 +303,7 @@ fn fallback_notice_is_observable_once_and_silenceable() {
         "silenced fallback must not emit a notice"
     );
     assert!(
-        !super::FALLBACK_NOTICE_EMITTED.load(std::sync::atomic::Ordering::Relaxed),
+        !super::fallback::FALLBACK_NOTICE_EMITTED.load(std::sync::atomic::Ordering::Relaxed),
         "silenced fallback must not claim the once-per-run guard"
     );
 }

--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -1891,7 +1891,6 @@ export { answer } from '@/helper'
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
     },

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -44,6 +44,7 @@ mod jsx_codegen;
 mod mapping;
 mod materialize;
 mod materialize_stubs;
+mod option_probe;
 mod package_node_modules;
 mod passthrough;
 mod paths;

--- a/crates/vize_canon/src/batch/virtual_project/option_probe.rs
+++ b/crates/vize_canon/src/batch/virtual_project/option_probe.rs
@@ -1,0 +1,126 @@
+//! A second, input-less `tsconfig` whose only job is to make the checker report
+//! the user's `compilerOptions` diagnostics (#3448).
+//!
+//! [`super::tsconfig_gen`] deliberately writes a *sanitized* config: the
+//! path-sensitive options are stripped so they cannot resolve against the mirror,
+//! and the options the native checker removed are rewritten to their nearest
+//! working equivalent (`target: ES5` becomes `ES2015`, legacy `moduleResolution`
+//! becomes `bundler`). Every one of those edits also erases the diagnostic the
+//! option would have produced, so `vize check` silently accepted a config that
+//! `tsc` and `vue-tsc` reject:
+//!
+//! ```text
+//! vue-tsc  tsconfig.json(15,5): error TS5101: Option 'baseUrl' is deprecated ...
+//! vize     (nothing)
+//! ```
+//!
+//! Options the sanitizer leaves alone were never affected — an unknown option
+//! still reaches the checker inside the generated config and is already
+//! reported — so the gap is exactly the sanitizer's own edits, and
+//! [`option_probe_is_needed`] tests for exactly those.
+//!
+//! The probe config carries the *unsanitized* options with no inputs at all
+//! (`"files": []`, `"include": []`). Config options are validated before any
+//! program is built, so the checker still reports every one of them; measured
+//! with `tsgo` at ~45 ms against ~200 ms for the same options with a single
+//! source file. Nothing is resolved, so the unrebased path options are inert.
+
+use std::path::PathBuf;
+
+use serde_json::{Map, Value};
+use vize_carton::profile;
+
+use crate::batch::error::CorsaResult;
+use crate::batch::materialize_fs::write_if_changed;
+
+use super::VirtualProject;
+use super::tsconfig_paths::parse_jsonc_value;
+
+/// Name of the probe config inside the virtual root. Like the shard configs it
+/// is written after materialization and pruned by the next run, so it is not
+/// part of the expected materialized file set.
+const OPTION_PROBE_CONFIG: &str = "tsconfig.options.json";
+
+impl VirtualProject {
+    /// Write the option probe config, or `None` when the generated config
+    /// already carries every option the user declared and the main run
+    /// therefore reports their diagnostics on its own.
+    pub(crate) fn write_option_probe_tsconfig(&self) -> CorsaResult<Option<PathBuf>> {
+        let Some(tsconfig_path) = self.resolved_tsconfig_path() else {
+            return Ok(None);
+        };
+        let declared = self.load_compiler_options(Some(tsconfig_path.as_path()))?;
+        if declared.is_empty() || !option_probe_is_needed(&declared, &self.generated_options()) {
+            return Ok(None);
+        }
+
+        let path = self.virtual_root.join(OPTION_PROBE_CONFIG);
+        let content = serde_json::to_string_pretty(&option_probe_value(declared))?;
+        profile!(
+            "canon.project.write_option_probe",
+            write_if_changed(&path, content.as_bytes())
+        )?;
+        Ok(Some(path))
+    }
+
+    /// `compilerOptions` of the config `tsconfig_gen` wrote for this run. Read
+    /// back from disk rather than recomputed so the comparison can never drift
+    /// from what the checker actually sees.
+    #[allow(clippy::disallowed_types)]
+    fn generated_options(&self) -> Map<std::string::String, Value> {
+        let path = self.virtual_root.join("tsconfig.json");
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|content| parse_jsonc_value(&content).ok())
+            .and_then(|config| {
+                config
+                    .get("compilerOptions")
+                    .and_then(Value::as_object)
+                    .cloned()
+            })
+            .unwrap_or_default()
+    }
+}
+
+/// Whether the generated config lost or rewrote an option the user declared.
+///
+/// An option missing from the generated config can no longer produce its
+/// diagnostic. So can one whose value was rewritten, but only when the value is
+/// what the diagnostic is about — `TS5108: Option 'target=ES5' has been removed`
+/// names it, while the re-anchored `paths` map and `typeRoots` list keep their
+/// key and with it every diagnostic their presence triggers. Comparing only
+/// string-valued options draws exactly that line.
+#[allow(clippy::disallowed_types)]
+fn option_probe_is_needed(
+    declared: &Map<std::string::String, Value>,
+    generated: &Map<std::string::String, Value>,
+) -> bool {
+    declared
+        .iter()
+        .any(|(name, value)| match generated.get(name) {
+            None => true,
+            Some(written) => value.is_string() && written != value,
+        })
+}
+
+/// The probe config: the declared options verbatim, with no inputs.
+///
+/// Only `types` is overridden, and only to empty, so a `@types` package that
+/// resolves from the real tree alone cannot turn into a spurious `TS2688` here;
+/// the generated config still carries the user's `types` and reports that case
+/// itself. Nothing else is touched — an option added here could *invent* a
+/// diagnostic the user's own config does not have (`noEmit` alone conflicts with
+/// several emit options), and a program with no inputs emits nothing regardless.
+#[allow(clippy::disallowed_types)]
+fn option_probe_value(mut declared: Map<std::string::String, Value>) -> Value {
+    declared.insert("types".into(), Value::Array(Vec::new()));
+
+    let mut config = Map::new();
+    config.insert("compilerOptions".into(), Value::Object(declared));
+    config.insert("include".into(), Value::Array(Vec::new()));
+    config.insert("files".into(), Value::Array(Vec::new()));
+    Value::Object(config)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_canon/src/batch/virtual_project/option_probe/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/option_probe/tests.rs
@@ -1,0 +1,81 @@
+use serde_json::{Value, json};
+
+use super::{option_probe_is_needed, option_probe_value};
+
+#[allow(clippy::disallowed_types)]
+fn options(value: Value) -> serde_json::Map<std::string::String, Value> {
+    value.as_object().unwrap().clone()
+}
+
+#[test]
+fn an_option_the_generated_config_dropped_needs_the_probe() {
+    // `baseUrl` is stripped by `tsconfig_gen`, which also erases its
+    // `TS5101`/`TS5102`.
+    assert!(option_probe_is_needed(
+        &options(json!({ "strict": true, "baseUrl": "." })),
+        &options(json!({ "strict": true })),
+    ));
+}
+
+#[test]
+fn a_rewritten_string_option_needs_the_probe() {
+    // `normalize_native_removed_options` turns `ES5` into `ES2015`, and the
+    // diagnostic names the value: `TS5108: Option 'target=ES5' has been removed`.
+    assert!(option_probe_is_needed(
+        &options(json!({ "target": "ES5" })),
+        &options(json!({ "target": "ES2015" })),
+    ));
+}
+
+#[test]
+fn a_re_anchored_paths_map_does_not_need_the_probe() {
+    // `paths` and `typeRoots` keep their key, so every diagnostic their presence
+    // triggers still fires in the main run; only their targets are re-anchored.
+    assert!(!option_probe_is_needed(
+        &options(json!({
+            "paths": { "@/*": ["./src/*"] },
+            "typeRoots": ["./types"],
+        })),
+        &options(json!({
+            "paths": { "@/*": ["./src/*", "../../../src/*"] },
+            "typeRoots": ["./types", "../../../types"],
+        })),
+    ));
+}
+
+#[test]
+fn options_carried_through_unchanged_do_not_need_the_probe() {
+    assert!(!option_probe_is_needed(
+        &options(json!({ "strict": true, "target": "ES2022" })),
+        &options(json!({
+            "strict": true,
+            "target": "ES2022",
+            "allowImportingTsExtensions": true,
+            "noEmit": true,
+        })),
+    ));
+}
+
+#[test]
+fn the_probe_config_keeps_the_declared_options_and_takes_no_inputs() {
+    let config = option_probe_value(options(json!({
+        "baseUrl": ".",
+        "strict": true,
+        "types": ["node"],
+    })));
+
+    assert_eq!(
+        config,
+        json!({
+            "compilerOptions": {
+                "baseUrl": ".",
+                "strict": true,
+                // The only override: an unresolvable `@types` package must not
+                // turn into a spurious TS2688 in a program that resolves nothing.
+                "types": [],
+            },
+            "include": [],
+            "files": [],
+        })
+    );
+}

--- a/crates/vize_canon/tests/tsconfig_option_diagnostics.rs
+++ b/crates/vize_canon/tests/tsconfig_option_diagnostics.rs
@@ -1,0 +1,189 @@
+//! `vize check` must report the option diagnostics of the user's own
+//! `tsconfig.json` (#3448).
+//!
+//! The generated virtual config is deliberately sanitized — path-sensitive
+//! options are stripped so they cannot resolve against the mirror — which also
+//! erased the diagnostic those options produce. `vue-tsc` reports
+//! `tsconfig.json(15,5): error TS5101: Option 'baseUrl' is deprecated ...` for
+//! the config below and vize reported nothing, so the two tools disagreed about
+//! the whole diagnostic set from one unreported config error.
+
+use std::path::{Path, PathBuf};
+
+use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait};
+use vize_carton::cstr;
+
+fn resolve_test_tsgo_binary() -> Option<PathBuf> {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return None;
+    }
+    if let Ok(path) = std::env::var("CORSA_PATH")
+        && Path::new(&path).exists()
+    {
+        return Some(PathBuf::from(path));
+    }
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)?;
+    [
+        root.join("node_modules/.bin/tsgo"),
+        root.join("tests/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn case_dir(name: &str) -> PathBuf {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("vize-tests")
+        .join("tsconfig-option-diagnostics")
+        .join(cstr!("{name}-{}", std::process::id()).as_str());
+    let _ = std::fs::remove_dir_all(&dir);
+    dir
+}
+
+fn write(root: &Path, relative: &str, contents: &str) {
+    let path = root.join(relative);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, contents).unwrap();
+}
+
+/// Diagnostics of `project_root`, as `(relative path, code)` pairs.
+fn project_diagnostics(project_root: &Path) -> Option<Vec<(String, Option<u32>)>> {
+    let mut checker = BatchTypeChecker::new(project_root).ok()?;
+    checker.scan_project().ok()?;
+    let result = checker.check_project().ok()?;
+    let mut diagnostics: Vec<_> = result
+        .diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+            (
+                diagnostic
+                    .file
+                    .strip_prefix(project_root)
+                    .unwrap_or(&diagnostic.file)
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+                diagnostic.code,
+            )
+        })
+        .collect();
+    diagnostics.sort();
+    Some(diagnostics)
+}
+
+fn write_case(name: &str, extra_options: &str) -> PathBuf {
+    let root = case_dir(name);
+    std::fs::create_dir_all(root.join("node_modules")).unwrap();
+    write(&root, "src/main.ts", "export const answer = 42;\n");
+    write(
+        &root,
+        "tsconfig.json",
+        &cstr!(
+            r#"{{
+  "compilerOptions": {{
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": []{extra_options}
+  }},
+  "include": ["src"]
+}}
+"#
+        ),
+    );
+    root
+}
+
+#[test]
+fn a_stripped_path_sensitive_option_still_reports_its_diagnostic() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    // `baseUrl` never reaches the generated config, so before #3448 this
+    // project type-checked clean. The exact code is the runtime's own — TS5101
+    // (deprecated) under TypeScript 6, TS5102 (removed) under the native
+    // preview — so the assertion is that an option diagnostic is reported on
+    // the user's tsconfig, not which release names it.
+    let root = write_case("base-url", ",\n    \"baseUrl\": \".\"");
+
+    let Some(diagnostics) = project_diagnostics(&root) else {
+        let _ = std::fs::remove_dir_all(&root);
+        return;
+    };
+    let codes: Vec<_> = diagnostics
+        .iter()
+        .filter(|(file, _)| file == "tsconfig.json")
+        .filter_map(|(_, code)| *code)
+        .collect();
+
+    assert_eq!(
+        codes.len(),
+        1,
+        "expected one option diagnostic: {diagnostics:?}"
+    );
+    assert!(
+        (5000..6000).contains(&codes[0]),
+        "expected a config option diagnostic code: {diagnostics:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_config_the_generated_one_carries_through_reports_nothing_extra() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    // The probe must not invent diagnostics: nothing here is sanitized away, so
+    // the project stays clean and the probe is never even written.
+    let root = write_case("clean", "");
+
+    let Some(diagnostics) = project_diagnostics(&root) else {
+        let _ = std::fs::remove_dir_all(&root);
+        return;
+    };
+
+    assert_eq!(diagnostics, Vec::new());
+    assert!(
+        !root
+            .join("node_modules/.vize/canon/tsconfig.options.json")
+            .exists(),
+        "an unsanitized config needs no probe"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn an_option_diagnostic_is_reported_once_beside_the_file_diagnostics() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    // An unknown option survives sanitization, so the main run reports it too;
+    // the probe's copy must collapse into it rather than double it. The type
+    // error proves the program is still checked — `tsc` treats a config error
+    // as fatal and would report neither.
+    let root = write_case("both-runs", ",\n    \"nosuchoption\": true");
+    write(&root, "src/main.ts", "export const answer: string = 42;\n");
+
+    let Some(diagnostics) = project_diagnostics(&root) else {
+        let _ = std::fs::remove_dir_all(&root);
+        return;
+    };
+
+    assert_eq!(
+        diagnostics,
+        vec![
+            ("src/main.ts".to_owned(), Some(2322)),
+            ("tsconfig.json".to_owned(), Some(5023)),
+        ]
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/tests/_fixtures/_projects/ecosystem-products/tsconfig.json
+++ b/tests/_fixtures/_projects/ecosystem-products/tsconfig.json
@@ -10,7 +10,6 @@
     "allowSyntheticDefaultImports": true,
     "allowArbitraryExtensions": true,
     "jsx": "preserve",
-    "baseUrl": ".",
     "paths": {
       "@nuxt/ui/components/*.vue": ["src/vendors/nuxt-ui-component.ts"]
     }

--- a/tests/snapshots/check/vue-element-admin-legacy-lsp-oracle.ts
+++ b/tests/snapshots/check/vue-element-admin-legacy-lsp-oracle.ts
@@ -209,7 +209,6 @@ const tsconfig = {
     // Legacy vue-element-admin is plain JavaScript; checking it at all is the
     // `checkJs` opt-in TypeScript requires for a `lang="js"` block (#3322).
     checkJs: true,
-    baseUrl: ".",
     lib: ["ES2022", "DOM"],
     paths: { "@/*": ["src/*"] },
     skipLibCheck: true,

--- a/tests/snapshots/check/vue-element-admin-legacy-oracle.ts
+++ b/tests/snapshots/check/vue-element-admin-legacy-oracle.ts
@@ -561,7 +561,6 @@ const tsconfig = {
     // Legacy vue-element-admin is plain JavaScript; checking it at all is the
     // `checkJs` opt-in TypeScript requires for a `lang="js"` block (#3322).
     checkJs: true,
-    baseUrl: ".",
     lib: ["ES2022", "DOM"],
     paths: { "@/*": ["src/*"] },
     skipLibCheck: true,

--- a/tests/snapshots/check/vue-element-admin-unmapped-diagnostic-oracle.ts
+++ b/tests/snapshots/check/vue-element-admin-unmapped-diagnostic-oracle.ts
@@ -167,7 +167,6 @@ const tsconfig = {
     strict: false,
     skipLibCheck: true,
     noEmit: true,
-    baseUrl: ".",
     paths: { "@/*": ["src/*"] },
   },
   include: ["src/**/*"],

--- a/tests/snapshots/check/vue2-elm.ts
+++ b/tests/snapshots/check/vue2-elm.ts
@@ -37,7 +37,6 @@ test("vue2-elm vize check surface over the pinned Vue 2 app stays exact", async 
             // all is the `checkJs` opt-in, exactly as `tsc`/`vue-tsc` require
             // for a `lang="js"` script block (#3322).
             checkJs: true,
-            baseUrl: ".",
             lib: ["ES2022", "DOM"],
             paths: { "src/*": ["src/*"] },
             skipLibCheck: true,


### PR DESCRIPTION
## The false negative

`vize check` never reported a `compilerOptions` diagnostic for an option its own
`tsconfig` sanitizer touches. On the config from #3448:

```
vue-tsc  tsconfig.json(15,5): error TS5101: Option 'baseUrl' is deprecated and will stop
                              functioning in TypeScript 7.0. ...
vize     (nothing)
```

The cause is not which codes are forwarded — `project_diagnostics::config` already forwards
config errors, and an *unknown* option is reported today. It is that
`virtual_project::tsconfig_gen` writes a **sanitized** config: `PATH_SENSITIVE_COMPILER_OPTIONS`
(`baseUrl`, `rootDir`, `rootDirs`, `tsBuildInfoFile`, …) are stripped so they cannot resolve
against the mirror, and `normalize_native_removed_options` rewrites what the native checker
removed (`target: ES5` → `ES2015`, `moduleResolution: node` → `bundler`,
`downlevelIteration` dropped). The checker never sees those options, so it never reports
them. Measured on a build of `main`:

| tsconfig | `tsgo` on the real config | `vize check` before | `vize check` after |
| --- | --- | --- | --- |
| `"baseUrl": "."` | `TS5102` | *(nothing)* | `TS5102` |
| `"target": "ES5"` | `TS5108` | *(nothing)* | `TS5108` |
| `"moduleResolution": "node"` | `TS5108` | *(nothing)* | `TS5108` |
| `"downlevelIteration": true` | `TS5102` | *(nothing)* | `TS5102` |
| `"nosuchoption": true` | `TS5023` | `TS5023` | `TS5023` (once) |

Every one of these is an **error** in TypeScript 6.0.3 too — `tsc` 6.0.3 answers `TS5107`
for `target=ES5` and `moduleResolution=node10`, and `TS5101` for `baseUrl` and
`downlevelIteration` — so this is a real divergence and not a version artifact of the
native preview. The code numbers differ because vize's checker is one major ahead.

## The fix

Ask the checker about the *unsanitized* options in a second config that builds no program:

```json
{ "compilerOptions": { …the user's options verbatim, `types` emptied… },
  "include": [], "files": [] }
```

Config options are validated before any program is built, so every option diagnostic still
comes out. Measured with `tsgo`: **45 ms** for the input-less config against 190 ms for the
same options with a single source file, and it is only written when the generated config
actually lost or rewrote something the user declared — comparing what
`tsconfig_gen` *wrote to disk* against the loaded chain, so the test can never drift from
what the checker sees. `paths` and `typeRoots` keep their key (only their targets are
re-anchored), so they never trigger it.

Only diagnostics the checker positions on that config, in TypeScript's 5xxx option range,
are forwarded; they are anchored on the project exactly like the main run's config errors,
so an option reported by both runs collapses in `dedup_diagnostics`. `TS18002` — the price
of building no program — falls outside the range and is dropped along with its
continuation lines.

`types` is the only option overridden, and only to empty, so a `@types` package that
resolves from the real tree alone cannot become a spurious `TS2688`. Nothing else is
touched: adding `noEmit` here would invent conflicts with the user's own emit options, and
a program with no inputs emits nothing anyway.

Errors found this way fail the check, as they do in `tsc`. vize still checks the project —
`tsc` treats a config error as fatal and reports nothing else — which is the deliberate
remaining difference #3448 calls out as its own decision.

`executor.rs` gets the call; the fallback-ladder machinery moves verbatim to
`executor/fallback.rs`, which takes that file from 415 to 302 lines.

## Fixtures this changed

Eight existing tests asserted a clean check on a config `tsc` rejects. Each fixture is
fixed, not re-pinned:

* `"baseUrl": "."` removed from nine fixtures — every one pairs it with `paths`, which
  resolve relative to the tsconfig directory on their own, so the fixtures are unchanged in
  meaning;
* `"moduleResolution": "Node"` → `"Bundler"` in `check_ambient_export_assignment_cli`
  (the test is about `export =` in an ambient module and never resolves from disk);
* `"declaration": true` added beside `declarationMap` in the two declaration-emit fixtures,
  which were tripping `TS5069`.

## Tests

* `crates/vize_canon/tests/tsconfig_option_diagnostics.rs` — end to end through
  `BatchTypeChecker`: a stripped `baseUrl` now reports exactly one option diagnostic on the
  user's `tsconfig.json`; a config that survives sanitization reports nothing extra *and*
  writes no probe at all; an unknown option is reported **once** beside the file
  diagnostics, which also proves the program is still checked.
* `virtual_project/option_probe/tests.rs` — the gate (dropped option, rewritten string
  option, re-anchored `paths`, unchanged options) and the exact probe config.
* `executor/option_probe/tests.rs` — parsing verbatim `tsgo` output: every 5xxx code with
  its continuation line, a dropped `TS18002` taking its continuation with it, diagnostics on
  any other file ignored, and the absolute-path spelling of the config.

**Failing before the fix**: with the probe call in `check_with_servers` replaced by an empty
diagnostic list, `a_stripped_path_sensitive_option_still_reports_its_diagnostic` fails with
`expected one option diagnostic: []` / `left: 0, right: 1`. The other two end-to-end cases
assert an absence and a de-duplication, so they hold trivially without the probe and are
there to pin that it adds nothing it should not — as the eight fixture tests above, which
passed only because vize was silent, now demonstrate from the other side.

## Not fixed here

`"ignoreDeprecations": "6.0"` silences `TS5101`/`TS5107` in TypeScript 6 but does not
silence the native preview's `TS5102`/`TS5108`, because in TypeScript 7 those options are
gone rather than deprecated. A project that has correctly acknowledged the deprecation is
therefore clean under `vue-tsc` and reports an error under vize. Filed separately as
#3505.

Closes #3448

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->