### PR TITLE
fix(patina): give no-unused-properties a real template-usage signal

### DIFF
--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -7,10 +7,12 @@
 //! - [`template_extract`]: ultra-fast `<template>` block extraction
 //! - [`ecosystem_hint`]: source heuristics for ecosystem template rules
 //! - [`tag_scan`]: shared byte-oriented tag scanning primitives
+//! - [`rule_sets`]: rule-name sets gating shared analysis work
 
 mod ecosystem_hint;
 mod offset;
 mod parse_diagnostics;
+mod rule_sets;
 mod script;
 mod tag_scan;
 mod template_extract;
@@ -35,6 +37,8 @@ use super::config::{LintResult, Linter};
 
 use ecosystem_hint::source_may_contain_ecosystem_template_rule;
 pub(crate) use offset::offset_result;
+use rule_sets::{SEMANTIC_TEMPLATE_RULES, SHARED_SFC_DESCRIPTOR_RULES};
+
 pub(crate) enum TemplateAnalysis<'a> {
     Disabled,
     Precomputed(&'a Croquis),
@@ -60,28 +64,6 @@ pub(crate) struct TemplateRuleEnv<'a> {
     pub sfc_descriptor: Option<&'a vize_atelier_sfc::SfcDescriptor<'a>>,
     pub dialect: VueDialect,
 }
-
-const SEMANTIC_TEMPLATE_RULES: &[&str] = &[
-    "vue/no-unused-vars",
-    "vue/no-unused-components",
-    "vue/require-component-registration",
-    "vue/no-undefined-refs",
-    "vue/no-mutating-props",
-    "vue/no-unused-properties",
-    "a11y/no-refer-to-non-existent-id",
-    "ecosystem/router-link-require-to",
-];
-const SHARED_SFC_DESCRIPTOR_RULES: &[&str] = &[
-    "vue/no-reserved-component-names",
-    "vue/no-unused-properties",
-    "vue/no-unused-refs",
-    "vue/sfc-element-order",
-    "vue/require-scoped-style",
-    "vue/single-style-block",
-    "vue/warn-custom-block",
-    "ecosystem/void-link-require-href",
-    "ecosystem/void-link-valid-method",
-];
 
 pub(crate) fn analyze_descriptor_for_lint(
     descriptor: &vize_atelier_sfc::SfcDescriptor<'_>,

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -67,11 +67,13 @@ const SEMANTIC_TEMPLATE_RULES: &[&str] = &[
     "vue/require-component-registration",
     "vue/no-undefined-refs",
     "vue/no-mutating-props",
+    "vue/no-unused-properties",
     "a11y/no-refer-to-non-existent-id",
     "ecosystem/router-link-require-to",
 ];
 const SHARED_SFC_DESCRIPTOR_RULES: &[&str] = &[
     "vue/no-reserved-component-names",
+    "vue/no-unused-properties",
     "vue/no-unused-refs",
     "vue/sfc-element-order",
     "vue/require-scoped-style",

--- a/crates/vize_patina/src/linter/engine/rule_sets.rs
+++ b/crates/vize_patina/src/linter/engine/rule_sets.rs
@@ -1,0 +1,33 @@
+//! Rule-name sets that gate shared analysis work in the lint engine.
+//!
+//! A rule must appear in a set to receive the work that set unlocks:
+//!
+//! - [`SEMANTIC_TEMPLATE_RULES`]: rules whose `run_on_template` pass needs the
+//!   template semantic analysis (`LintContext::has_analysis`). Omitting a rule
+//!   here means its template pass returns before the rule body runs.
+//! - [`SHARED_SFC_DESCRIPTOR_RULES`]: rules that consume SFC descriptor
+//!   metadata, so the outer SFC path parses the descriptor once up front
+//!   instead of letting each rule re-parse the file.
+
+pub(super) const SEMANTIC_TEMPLATE_RULES: &[&str] = &[
+    "vue/no-unused-vars",
+    "vue/no-unused-components",
+    "vue/require-component-registration",
+    "vue/no-undefined-refs",
+    "vue/no-mutating-props",
+    "vue/no-unused-properties",
+    "a11y/no-refer-to-non-existent-id",
+    "ecosystem/router-link-require-to",
+];
+
+pub(super) const SHARED_SFC_DESCRIPTOR_RULES: &[&str] = &[
+    "vue/no-reserved-component-names",
+    "vue/no-unused-properties",
+    "vue/no-unused-refs",
+    "vue/sfc-element-order",
+    "vue/require-scoped-style",
+    "vue/single-style-block",
+    "vue/warn-custom-block",
+    "ecosystem/void-link-require-href",
+    "ecosystem/void-link-valid-method",
+];

--- a/crates/vize_patina/src/linter/native_type_aware/snapshots/vize_patina__linter__native_type_aware__tests__type_aware_diagnostics_snapshot.snap
+++ b/crates/vize_patina/src/linter/native_type_aware/snapshots/vize_patina__linter__native_type_aware__tests__type_aware_diagnostics_snapshot.snap
@@ -4,6 +4,15 @@ expression: diagnostics
 ---
 [
     (
+        "vue/no-unused-properties",
+        "Prop 'msg' is defined but never used",
+        336,
+        336,
+        Some(
+            "Remove unused prop or use it in your template/script",
+        ),
+    ),
+    (
         "vue/html-button-has-type",
         "'<button>' is missing a 'type' attribute; add type=\"button\", \"submit\", or \"reset\"",
         372,

--- a/crates/vize_patina/src/rules/vue/no_unused_properties.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties.rs
@@ -1,13 +1,51 @@
 //! vue/no-unused-properties
 //!
-//! Disallow unused properties (props, data, computed, etc.).
+//! Disallow props that are declared but referenced nowhere.
+//!
+//! ## How usage is decided
+//!
+//! A prop is reported only when its name appears in **none** of the places it
+//! could be referenced from:
+//!
+//! * a compiled template expression — a directive's expression or argument, an
+//!   interpolation, a `v-for` source (an HTML comment, a text node, a plain
+//!   attribute and a `v-pre` region are not expressions and do not count);
+//! * the `<script setup>` block, outside the `defineProps(...)` call itself;
+//! * a sibling Options API `<script>` block, which can reach props via `this`.
+//!
+//! The scan deliberately over-approximates in every direction except the
+//! template AST; see [`usage`] for why that is the *sound* direction for a rule
+//! that reports the absence of a reference.
+//!
+//! ## What stays silent
+//!
+//! * `const props = defineProps(...)`, and `withDefaults(...)`. The script holds
+//!   the props object and can index it in ways no scan can see (`props[key]`),
+//!   so nothing is reported for the component. That is the blanket suppression
+//!   the rule has always applied; what is recovered here is the unassigned
+//!   (`defineProps<{ … }>()`, `defineProps([…])`) and destructured spellings.
+//! * Any name a `const { … } = defineProps(...)` pattern binds: it becomes a
+//!   script binding this does not follow. A prop the pattern does *not* name is
+//!   still checked.
+//! * The Options API `props:` option. Croquis exposes only `defineProps` props
+//!   through `macros.props()`, so that spelling declares nothing here and is out
+//!   of scope.
+//! * Names matched by `ignore_pattern`, and any name starting with `_`.
+//!
+//! ## Report location
+//!
+//! Every diagnostic a `vue/*` rule produces is offset into the `<template>`
+//! block, so a location inside `<script setup>` cannot be expressed from here.
+//! The report is anchored at the start of the template block and names the prop
+//! in its message; upstream anchors at the prop declaration instead. That is a
+//! location divergence for the parity ledger, not a coverage one.
 //!
 //! ## Examples
 //!
 //! ### Invalid
 //! ```vue
 //! <script setup lang="ts">
-//! const props = defineProps<{
+//! defineProps<{
 //!   msg: string
 //!   unused: number  // defined but never used
 //! }>()
@@ -21,7 +59,7 @@
 //! ### Valid
 //! ```vue
 //! <script setup lang="ts">
-//! const props = defineProps<{
+//! defineProps<{
 //!   msg: string
 //!   count: number
 //! }>()
@@ -34,12 +72,21 @@
 
 #![allow(clippy::disallowed_macros)]
 
+#[cfg(test)]
+mod tests;
+mod usage;
+
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_carton::String;
 use vize_carton::ToCompactString;
+use vize_carton::{CompactString, FxHashSet};
 use vize_relief::RootNode;
+
+use self::usage::{
+    PropsAccess, classify_props_access, push_identifier_tokens, template_references,
+};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-unused-properties",
@@ -90,74 +137,76 @@ impl Rule for NoUnusedProperties {
         &META
     }
 
-    fn run_on_template<'a>(&self, ctx: &mut LintContext<'a>, _root: &RootNode<'a>) {
-        // Skip if no analysis available
-        if !ctx.has_analysis() {
+    fn run_on_template<'a>(&self, ctx: &mut LintContext<'a>, root: &RootNode<'a>) {
+        if !self.check_props || !ctx.has_analysis() {
             return;
         }
+        // The script blocks are needed to see references the template cannot
+        // hold, so without a descriptor there is no sound way to decide.
+        let Some(descriptor) = ctx.sfc_descriptor() else {
+            return;
+        };
+        let script_setup = descriptor
+            .script_setup
+            .as_ref()
+            .map(|block| block.content.as_ref());
+        let plain_script = descriptor
+            .script
+            .as_ref()
+            .map(|block| block.content.as_ref());
 
-        // Collect unused props first (to avoid borrow conflicts)
-        let (unused_props, define_props_loc): (Vec<String>, (u32, u32)) = {
+        // Collect unused props first (to avoid borrow conflicts).
+        let unused_props: Vec<String> = {
             let Some(analysis) = ctx.analysis() else {
                 return;
             };
-
-            if !self.check_props {
+            let Some(call) = analysis.macros.define_props() else {
+                return;
+            };
+            let props = analysis.macros.props();
+            if props.is_empty() {
                 return;
             }
 
-            let props = analysis.macros.props();
+            // `defineProps` is a `<script setup>` macro, so its span addresses
+            // that block; fall back to a lone `<script>` for robustness.
+            let declaring_script = script_setup.or(plain_script).unwrap_or_default();
+            if matches!(
+                classify_props_access(declaring_script, (call.start, call.end)),
+                PropsAccess::Captured
+            ) {
+                return;
+            }
 
-            // Get defineProps call location for error reporting
-            let loc = analysis
-                .macros
-                .define_props()
-                .map(|call| (call.start, call.end))
-                .unwrap_or((0, 0));
+            let mut referenced = template_references(root);
+            push_script_tokens(declaring_script, (call.start, call.end), &mut referenced);
+            if let Some(plain) = plain_script.filter(|_| script_setup.is_some()) {
+                push_identifier_tokens(plain, &mut referenced);
+            }
 
-            let unused: Vec<String> = props
+            let destructured = analysis.macros.props_destructure();
+            props
                 .iter()
                 .filter(|prop| {
-                    // Skip ignored properties
-                    if self.should_ignore(prop.name.as_str()) {
+                    let name = prop.name.as_str();
+                    if self.should_ignore(name) || referenced.contains(name) {
                         return false;
                     }
-
-                    let prop_name = prop.name.as_str();
-
-                    // Check if prop is used in template scope chain
-                    let is_used_in_scope = analysis.scopes.is_used(prop_name);
-
-                    // Check if prop is accessed via props object in bindings
-                    let has_props_binding = analysis.bindings.contains("props");
-                    let is_prop_destructured = analysis.bindings.get(prop_name).is_some_and(|bt| {
-                        matches!(
-                            bt,
-                            vize_relief::BindingType::Props
-                                | vize_relief::BindingType::PropsAliased
-                        )
-                    });
-
-                    // If props object exists and is used, we can't easily track individual prop usage
-                    // in script, so we only report if not used in template AND not destructured
-                    let is_used = is_used_in_scope || is_prop_destructured || has_props_binding;
-
-                    !is_used
+                    // A destructured name is a script binding this does not
+                    // follow, so it is left alone.
+                    destructured.is_none_or(|bindings| bindings.get(name).is_none())
                 })
                 .map(|prop| prop.name.to_compact_string())
-                .collect();
-
-            (unused, loc)
+                .collect()
         };
 
-        // Report unused props
         for prop_name in unused_props {
             ctx.report(
                 crate::diagnostic::LintDiagnostic::warn(
                     ctx.current_rule,
                     format!("Prop '{}' is defined but never used", prop_name),
-                    define_props_loc.0,
-                    define_props_loc.1,
+                    0,
+                    0,
                 )
                 .with_help("Remove unused prop or use it in your template/script"),
             );
@@ -165,22 +214,17 @@ impl Rule for NoUnusedProperties {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::NoUnusedProperties;
-    use crate::rule::{Rule, RuleCategory};
-
-    #[test]
-    fn test_meta() {
-        let rule = NoUnusedProperties::default();
-        assert_eq!(rule.meta().name, "vue/no-unused-properties");
-        assert_eq!(rule.meta().category, RuleCategory::StronglyRecommended);
+/// Push the identifier tokens of `script`, minus the `defineProps` call.
+///
+/// The call always spells every prop name, so leaving it in would mark them all
+/// used. Everything around it counts, including a destructuring pattern and a
+/// `withDefaults` defaults object.
+fn push_script_tokens(script: &str, span: (u32, u32), names: &mut FxHashSet<CompactString>) {
+    let (start, end) = (span.0 as usize, span.1 as usize);
+    if let Some(before) = script.get(..start) {
+        push_identifier_tokens(before, names);
     }
-
-    #[test]
-    fn test_should_ignore() {
-        let rule = NoUnusedProperties::default();
-        assert!(rule.should_ignore("_internal"));
-        assert!(!rule.should_ignore("count"));
+    if let Some(after) = script.get(end..) {
+        push_identifier_tokens(after, names);
     }
 }

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests.rs
@@ -1,0 +1,280 @@
+use super::NoUnusedProperties;
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleCategory};
+
+// The positive direction (a prop that must be reported) lives in the `reports`
+// submodule; this file keeps the helpers and the silent-direction cases.
+mod reports;
+
+/// Lint a full SFC with only this rule enabled.
+///
+/// `vue/no-unused-properties` is a member of `SEMANTIC_TEMPLATE_RULES` and of
+/// `SHARED_SFC_DESCRIPTOR_RULES`, so enabling it alone still produces both the
+/// croquis analysis and the SFC descriptor the rule reads.
+fn lint_sfc(sfc: &str) -> LintResult {
+    Linter::new()
+        .with_enabled_rules(Some(vec!["vue/no-unused-properties".into()]))
+        .lint_sfc(sfc, "Probe.vue")
+}
+
+/// The full identity of every finding: rule, severity, byte range, message.
+fn findings(result: &LintResult) -> Vec<(&'static str, Severity, u32, u32, &str)> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            (
+                diagnostic.rule_name,
+                diagnostic.severity,
+                diagnostic.start,
+                diagnostic.end,
+                diagnostic.message.as_str(),
+            )
+        })
+        .collect()
+}
+
+fn none() -> Vec<(&'static str, Severity, u32, u32, &'static str)> {
+    Vec::new()
+}
+
+/// The finding an unused `name` produces, anchored at the template block.
+fn unused(sfc: &str, name: &str) -> (&'static str, Severity, u32, u32, std::string::String) {
+    let anchor = sfc.find("<template>").expect("template block") + "<template>".len();
+    (
+        "vue/no-unused-properties",
+        Severity::Warning,
+        anchor as u32,
+        anchor as u32,
+        format!("Prop '{name}' is defined but never used"),
+    )
+}
+
+/// [`findings`] with owned messages, so it compares against [`unused`].
+fn owned(result: &LintResult) -> Vec<(&'static str, Severity, u32, u32, std::string::String)> {
+    findings(result)
+        .into_iter()
+        .map(|(rule, severity, start, end, message)| {
+            (rule, severity, start, end, message.to_string())
+        })
+        .collect()
+}
+
+#[test]
+fn test_meta() {
+    let rule = NoUnusedProperties::default();
+    assert_eq!(rule.meta().name, "vue/no-unused-properties");
+    assert_eq!(rule.meta().category, RuleCategory::StronglyRecommended);
+}
+
+#[test]
+fn test_should_ignore() {
+    let rule = NoUnusedProperties::default();
+    assert!(rule.should_ignore("_internal"));
+    assert!(!rule.should_ignore("count"));
+}
+
+// --- The prop is referenced: exactly zero findings -------------------------
+
+#[test]
+fn ignores_a_prop_read_in_an_interpolation() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <div>{{ msg }}</div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_prop_read_in_a_directive_expression() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <div :title="msg"></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_prop_read_only_inside_a_v_for_body() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string; rows: string[] }>();
+</script>
+
+<template>
+  <ul><li v-for="row in rows" :key="row">{{ msg }}</li></ul>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_prop_read_through_dollar_props() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <div>{{ $props.msg }}</div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_prop_read_in_a_dynamic_directive_argument() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <div :[msg]="1"></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+// --- The blanket suppressors must survive ---------------------------------
+
+#[test]
+fn ignores_everything_when_the_props_object_is_captured() {
+    // `props[key]` is invisible to any scan, so a captured props object
+    // suppresses the whole component. This is the issue's headline repro, and
+    // staying silent on it is the sound direction.
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <div>hi</div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_everything_when_define_props_is_wrapped() {
+    let sfc = r#"<script setup lang="ts">
+const props = withDefaults(defineProps<{ msg?: string }>(), { msg: 'x' });
+</script>
+
+<template>
+  <div>hi</div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_prop_used_only_in_the_script() {
+    let sfc = r#"<script setup lang="ts">
+const { msg } = defineProps<{ msg: string }>();
+const upper = msg.toUpperCase();
+</script>
+
+<template>
+  <div>{{ upper }}</div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_prop_named_by_a_sibling_options_api_block() {
+    let sfc = r#"<script>
+export default { methods: { show() { return this.msg; } } };
+</script>
+
+<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <div>hi</div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_an_underscore_prefixed_prop() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ _internal: string }>();
+</script>
+
+<template>
+  <div>hi</div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_the_options_api_props_spelling() {
+    // Croquis exposes only `defineProps` props, so this spelling declares
+    // nothing here and is documented as out of scope.
+    let sfc = r#"<script>
+export default { props: { msg: String } };
+</script>
+
+<template>
+  <div>hi</div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_component_with_no_props_at_all() {
+    let sfc = r#"<script setup lang="ts">
+const a = 1;
+</script>
+
+<template>
+  <div>{{ a }}</div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+// --- Under-match probes: a reference the scan must not miss ---------------
+//
+// This rule reports the *absence* of a reference, so an under-match is the
+// false positive. Each of these keeps the rule silent.
+
+#[test]
+fn ignores_a_prop_named_only_inside_a_template_string_literal() {
+    // Over-approximating within an expression only suppresses a report.
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <div :title="'msg'"></div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_prop_whose_name_a_v_for_alias_reuses() {
+    // Shadowing is deliberately not honoured: treating the alias as a
+    // reference only suppresses.
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string; rows: string[] }>();
+</script>
+
+<template>
+  <ul><li v-for="msg in rows" :key="msg">{{ msg }}</li></ul>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/reports.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/reports.rs
@@ -1,0 +1,89 @@
+//! The positive direction: a declared prop referenced nowhere.
+
+use super::{lint_sfc, owned, unused};
+
+// --- The recovered case: an unassigned defineProps -------------------------
+
+#[test]
+fn reports_a_prop_referenced_nowhere_issue_3416() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <div>hi</div>
+</template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), vec![unused(sfc, "msg")]);
+}
+
+#[test]
+fn reports_only_the_prop_the_template_never_reads() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string; unused: number }>();
+</script>
+
+<template>
+  <div>{{ msg }}</div>
+</template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), vec![unused(sfc, "unused")]);
+}
+
+#[test]
+fn reports_a_prop_of_a_runtime_array_declaration() {
+    let sfc = r#"<script setup>
+defineProps(['msg'])
+</script>
+
+<template>
+  <div>hi</div>
+</template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), vec![unused(sfc, "msg")]);
+}
+
+#[test]
+fn reports_a_prop_the_destructuring_pattern_omits() {
+    let sfc = r#"<script setup lang="ts">
+const { msg } = defineProps<{ msg: string; other: number }>();
+const upper = msg.toUpperCase();
+</script>
+
+<template>
+  <div>{{ upper }}</div>
+</template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), vec![unused(sfc, "other")]);
+}
+
+// --- A name that is not a reference must still report ---------------------
+
+#[test]
+fn reports_a_prop_named_only_in_an_html_comment_or_text() {
+    // Neither is a compiled expression, so neither is a reference.
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <!-- msg -->
+  <p title="msg">msg</p>
+</template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), vec![unused(sfc, "msg")]);
+}
+
+#[test]
+fn reports_a_prop_named_only_inside_a_v_pre_region() {
+    // Vue never compiles a `v-pre` region, so `{{ msg }}` there is literal text.
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <pre v-pre>{{ msg }}</pre>
+</template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), vec![unused(sfc, "msg")]);
+}

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/usage.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/usage.rs
@@ -1,0 +1,152 @@
+//! Where a prop name can be referenced, and how `defineProps` is consumed.
+//!
+//! # Direction of error
+//!
+//! `vue/no-unused-properties` reports the **absence** of a reference, so the
+//! usage scan is the mirror image of the evidence scans in
+//! [`crate::rules::script::template_scan`]: here an **under-match is the false
+//! positive** (a reference this misses becomes an "unused" report on a prop the
+//! component does use), and an over-match only costs a missed finding.
+//!
+//! Every step therefore over-approximates on purpose:
+//!
+//! * Identifier-shaped **tokens** are collected, not resolved references. So
+//!   `props.msg`, `msg.length` and even `'msg'` inside a template expression all
+//!   count as a reference to `msg`.
+//! * Shadowing is **not** honoured. `v-for="msg in rows"` binds an iteration
+//!   variable rather than the prop, but treating it as a reference only
+//!   suppresses a report.
+//! * The whole script block is scanned, minus the `defineProps` call itself —
+//!   which must be excluded, since the declaration always spells the name and
+//!   would otherwise mark every prop used.
+//!
+//! The one place precision is used is the template *AST*: a name that appears
+//! only in an HTML comment, a text node or a plain attribute is genuinely not a
+//! reference, and Vue never compiles a `v-pre` region. Every position Vue does
+//! compile is scanned — a directive's expression *and* its argument, an
+//! interpolation's content, and a `v-for`'s source and aliases.
+
+use vize_carton::{CompactString, FxHashSet};
+use vize_relief::{ExpressionNode, PropNode, RootNode, TemplateChildNode};
+
+/// How the `defineProps(...)` return value is consumed.
+pub(super) enum PropsAccess {
+    /// A bare `defineProps(...)` statement. The props are reachable only from
+    /// the template (and from an Options API sibling block through `this`), so
+    /// a name referenced nowhere is genuinely unused.
+    Discarded,
+    /// `const { msg } = defineProps(...)`. Each destructured name becomes a
+    /// script binding this cannot follow, so those are left alone; a prop the
+    /// pattern does *not* name is still only reachable from the template.
+    Destructured,
+    /// `const props = defineProps(...)`, or the call wrapped in another call
+    /// (`withDefaults(...)`). The script holds the props object and can index it
+    /// in ways no scan can see (`props[key]`), so nothing may be reported.
+    Captured,
+}
+
+/// Classify how the `defineProps` call at `span` inside `script` is consumed.
+///
+/// Decided from the text immediately before the call, which is enough to tell
+/// the three cases apart and resolves every ambiguity towards
+/// [`PropsAccess::Captured`] — the outcome that reports nothing.
+pub(super) fn classify_props_access(script: &str, span: (u32, u32)) -> PropsAccess {
+    let Some(prefix) = script.get(..span.0 as usize) else {
+        return PropsAccess::Captured;
+    };
+    let prefix = prefix.trim_end();
+    match prefix.as_bytes().last() {
+        // `const <pattern> = defineProps(...)`.
+        Some(b'=') => match prefix[..prefix.len() - 1].trim_end().as_bytes().last() {
+            Some(b'}') => PropsAccess::Destructured,
+            _ => PropsAccess::Captured,
+        },
+        // Wrapped in a call, e.g. `withDefaults(defineProps(...), { ... })`.
+        Some(b'(') => PropsAccess::Captured,
+        // A statement of its own: nothing consumes the return value.
+        _ => PropsAccess::Discarded,
+    }
+}
+
+/// Every identifier-shaped token referenced by a compiled template expression.
+pub(super) fn template_references(root: &RootNode<'_>) -> FxHashSet<CompactString> {
+    let mut names = FxHashSet::default();
+    collect_children(&root.children, &mut names);
+    names
+}
+
+fn collect_children(children: &[TemplateChildNode<'_>], names: &mut FxHashSet<CompactString>) {
+    for child in children {
+        match child {
+            TemplateChildNode::Element(element) => {
+                for prop in element.props.iter() {
+                    if let PropNode::Directive(directive) = prop {
+                        // A directive's argument is an expression too when it is
+                        // dynamic (`:[key]="x"`); a static one is a plain name
+                        // and contributes nothing harmful.
+                        for exp in [directive.exp.as_ref(), directive.arg.as_ref()]
+                            .into_iter()
+                            .flatten()
+                        {
+                            push_identifier_tokens(expression_source(exp), names);
+                        }
+                    }
+                }
+                collect_children(&element.children, names);
+            }
+            TemplateChildNode::Interpolation(interpolation) => {
+                push_identifier_tokens(expression_source(&interpolation.content), names);
+            }
+            // `v-if` / `v-for` are still plain directives in the parse this
+            // reads, so these arms only matter if a transformed AST is ever
+            // passed in. Walking them keeps that case correct.
+            TemplateChildNode::If(if_node) => {
+                for branch in if_node.branches.iter() {
+                    if let Some(condition) = branch.condition.as_ref() {
+                        push_identifier_tokens(expression_source(condition), names);
+                    }
+                    collect_children(&branch.children, names);
+                }
+            }
+            TemplateChildNode::For(for_node) => {
+                push_identifier_tokens(expression_source(&for_node.source), names);
+                collect_children(&for_node.children, names);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn expression_source<'a>(exp: &'a ExpressionNode<'a>) -> &'a str {
+    match exp {
+        ExpressionNode::Simple(simple) => simple.content.as_str(),
+        ExpressionNode::Compound(compound) => compound.loc.source.as_str(),
+    }
+}
+
+/// Push every identifier-shaped token of `source` onto `names`.
+pub(super) fn push_identifier_tokens(source: &str, names: &mut FxHashSet<CompactString>) {
+    let bytes = source.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        if !is_identifier_start(bytes[index]) {
+            index += 1;
+            continue;
+        }
+        let start = index;
+        while index < bytes.len() && is_identifier_byte(bytes[index]) {
+            index += 1;
+        }
+        names.insert(CompactString::new(&source[start..index]));
+    }
+}
+
+#[inline]
+fn is_identifier_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_' || byte == b'$'
+}
+
+#[inline]
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+}

--- a/tests/tooling/lsp-template-completion.test.ts
+++ b/tests/tooling/lsp-template-completion.test.ts
@@ -29,12 +29,16 @@ test("vize lsp surfaces template completion contexts", async (t) => {
 defineProps<{ diskOnly: string }>()
 </script>
 `;
+    // Both props are read in the template: `vue/no-unused-properties` is
+    // enabled here, and the assertions below expect a clean child document.
     const openChildSource = `<script setup lang="ts">
 defineProps<{ label: string; disabled?: boolean }>()
 </script>
-<template><button></button></template>
+<template><button>{{ label }}{{ disabled }}</button></template>
 `;
-    const changedChildSource = openChildSource.replace("disabled?: boolean", "loading?: number");
+    const changedChildSource = openChildSource
+      .replaceAll("disabled", "loading")
+      .replace("loading?: boolean", "loading?: number");
     fs.writeFileSync(path.join(workspaceDir, "Child.vue"), childSource, "utf8");
 
     // Two spaces after <Child so the cursor sits inside the opening tag,


### PR DESCRIPTION
## Defect (#3416 B)

`vue/no-unused-properties` could not report under **any** input. It is a member
of both `happy_path` and `opinionated`, so this was a genuine defect, not preset
membership.

```vue
<script setup lang="ts">
defineProps<{ msg: string }>();
</script>

<template>
  <div>hi</div>
</template>
```

`Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-properties"])).lint_sfc(sfc, "Probe.vue")`

- Actual: 0 findings. Expected: 1 — `msg` is used in neither block.

## The four stacked causes

1. **Not in `SEMANTIC_TEMPLATE_RULES`.** `run_on_template` opens with
   `if !ctx.has_analysis() { return; }`, and the analysis is only computed when
   one of those rules is active — so enabling this rule alone never reached the
   rule body at all.
2. **`BindingType::Props` was treated as usage**, and *every* declared prop
   carries it (that is how props reach the template), so `is_prop_destructured`
   was unconditionally true.
3. **`analysis.bindings.contains("props")`** blanket-suppressed on top of that.
4. **`analysis.scopes.is_used()` is not a template-usage oracle.** It tracks
   template *scope* variables (`v-for` / `v-slot` aliases), not references to
   top-level bindings, so it was `false` even for `<div>{{ msg }}</div>`.

(4) is why loosening (2) and (3) alone would have been strictly worse than
silence: with no usage signal the rule would have reported *everything*.

## The usage signal

The rule already received `root: &RootNode` and ignored it (`_root`). It now
builds a reference set from:

- every **compiled template expression** — a directive's expression *and* its
  argument, an interpolation's content, a `v-for` source;
- the **`<script setup>` block minus the `defineProps(...)` call**. The call
  always spells every prop name, so leaving it in would mark them all used;
  everything around it (a destructuring pattern, a `withDefaults` defaults
  object, a watcher) counts;
- a sibling Options API **`<script>` block**, which can reach props via `this`.

## Direction of error — the mirror image of #3451

This rule reports the **absence** of a reference, so the arithmetic is inverted:
an **under-match is the false positive** (a reference the scan misses becomes an
"unused" report on a prop the component does use), and an over-match only costs
a missed finding. Every step therefore over-approximates on purpose:

| step | why it over-approximates |
| --- | --- |
| identifier **tokens**, not resolved references | `props.msg`, `msg.length`, even `'msg'` in an expression all count |
| shadowing **not** honoured | `v-for="msg in rows"` binds an alias, but treating it as a reference only suppresses |
| whole script block scanned | a reference this cannot resolve is still a token |

Both of the first two have a test asserting the rule stays **silent**.

The one place precision is used is the template **AST**, because a name that
appears only in an HTML comment, a text node or a plain attribute genuinely is
not a reference, and Vue never compiles a `v-pre` region. Those have tests
asserting the rule **does** report — the AST is what makes that safe.

## What stays silent

- `const props = defineProps(...)` and `withDefaults(...)`: the script holds the
  props object and can index it invisibly (`props[key]`), so nothing is reported
  for the component. **This leaves the issue's headline repro correctly silent**,
  which the issue itself calls the sound direction. Classification is decided
  from the text immediately before the call, and every ambiguity resolves to
  "captured", the outcome that reports nothing.
- Any name a `const { … } = defineProps(...)` pattern binds. A prop the pattern
  does *not* name is still checked — that is a recovered case, with a test.
- The Options API `props:` option: croquis exposes only `defineProps` props
  through `macros.props()`, so that spelling declares nothing here. Documented as
  out of scope (option 4b in the issue's "what a correct fix needs").

The recovered coverage is therefore the **unassigned, runtime-array and
destructured** spellings, exactly as the issue scoped it.

## Corpus check

Because the dangerous direction here is a false positive, the rule was run over
real code as well as fixtures. `vue/no-unused-properties` alone over all **168**
tracked `.vue` files in the repo:

```
FILES 168 TOTAL findings: 2
tests/fixtures/sfc/imported_types/ReExportedChild.vue: Prop 'as' is defined but never used
tests/fixtures/sfc/imported_types/ReExportedChild.vue: Prop 'asChild' is defined but never used
```

Both are true positives — that fixture declares `as` and `asChild` and renders
`<div />`. No false positive anywhere in the corpus.

The one existing snapshot that changed,
`type_aware_diagnostics_snapshot`, is the same shape: its fixture has
`defineProps(['msg'])` and never reads `msg`.

## Engine changes

`vue/no-unused-properties` is added to two lists:

- `SEMANTIC_TEMPLATE_RULES`, so the croquis analysis exists when the rule is
  enabled alone (cause 1). Inside a preset the analysis was already being
  computed for `vue/no-unused-vars`, so this costs nothing there.
- `SHARED_SFC_DESCRIPTOR_RULES`, so the rule can read the script blocks. Without
  a descriptor it reports nothing, since half the reference set would be
  invisible.

## Report location

A `vue/*` rule's diagnostics are offset into the `<template>` block, so a
location inside `<script setup>` cannot be expressed from here. The report is
anchored at the start of the template block and names the prop in its message;
upstream anchors at the prop declaration. A location divergence for the parity
ledger, not a coverage one — noted in the module docs.

## How the new tests fail before the fix

With `run_on_template` short-circuited (the pre-fix behaviour — the rule could
not report under any input), `cargo test -p vize_patina --lib no_unused_properties`
fails exactly the six positive-direction tests and passes all sixteen others,
including both blanket-suppressor tests and both under-match probes:

```
reports_a_prop_referenced_nowhere_issue_3416 ... FAILED
reports_only_the_prop_the_template_never_reads ... FAILED
reports_a_prop_of_a_runtime_array_declaration ... FAILED
reports_a_prop_the_destructuring_pattern_omits ... FAILED
reports_a_prop_named_only_in_an_html_comment_or_text ... FAILED
reports_a_prop_named_only_inside_a_v_pre_region ... FAILED
test result: FAILED. 16 passed; 6 failed
```

With the fix: `22 passed; 0 failed`.

## File split

`no_unused_properties.rs` was 186 lines (inline tests included). It becomes 230,
plus `usage.rs` (152), `tests.rs` (280) and `tests/reports.rs` (89).

## Gates run

- `nix develop -c vp run fmt:check` — pass
- `nix develop -c vp run lint:rust` (clippy `-D warnings`) — pass
- `nix develop -c vp run check:rust` — pass
- `nix develop -c cargo test -p vize_patina` — 2343 passed, 0 failed
- `nix develop -c cargo test -p vize --lib` — 398 passed, 0 failed (the rule is
  preset-enabled, so the CLI suite is the blast-radius check)

Closes #3416
Refs #3223

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->