### PR TITLE
fix(canon): reject a call that only starts with the function keyword

### DIFF
--- a/crates/vize_canon/src/virtual_ts/scope/event_handler.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/event_handler.rs
@@ -127,13 +127,20 @@ pub(super) fn generate_event_handler_expressions(
             // range entirely, so the mapping has to widen to the whole statement
             // for the identifier to be inside it — the diagnostic path looks the
             // mapping up by `gen_range` before narrowing to a sub-span.
-            let (gen_range, sub_spans) = match (listener_spans, ctx.event_name_src_range.clone()) {
-                (Some((stmt_gen_range, name_gen_range)), Some(name_src_range)) => (
+            // When the event name cannot be located in the source the bound
+            // expression is the next best anchor, so the identifier's error
+            // still maps back instead of being dropped for want of a sub-span
+            // (same fallback as a component prop's name/value ranges).
+            let (gen_range, sub_spans) = match listener_spans {
+                Some((stmt_gen_range, name_gen_range)) => (
                     stmt_gen_range,
                     vec![
                         VizeSubSpan {
                             gen_range: name_gen_range,
-                            src_range: name_src_range,
+                            src_range: ctx
+                                .event_name_src_range
+                                .clone()
+                                .unwrap_or(src_start..src_end),
                         },
                         VizeSubSpan {
                             gen_range,
@@ -141,7 +148,7 @@ pub(super) fn generate_event_handler_expressions(
                         },
                     ],
                 ),
-                _ => (gen_range, Vec::new()),
+                None => (gen_range, Vec::new()),
             };
             mappings.push(VizeMapping {
                 gen_range,

--- a/crates/vize_canon/src/virtual_ts/scope/handler_shape.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/handler_shape.rs
@@ -26,6 +26,11 @@ pub(super) fn inline_callback_event_argument(content: &str) -> Option<&'static s
     }
 
     let rest = trimmed.strip_prefix("function")?;
+    // `functionalHandler(evt)` only starts with the keyword's letters; the
+    // keyword has to end there for this to be a function expression.
+    if rest.chars().next().is_some_and(is_identifier_continue) {
+        return None;
+    }
     let paren_start = trimmed.len() - rest.len() + rest.find('(')?;
     let paren_end = matching_paren_index(trimmed, paren_start)?;
     let inner = &trimmed[paren_start + 1..paren_end];
@@ -215,7 +220,34 @@ fn parse_bracket_member(input: &str, open_index: usize) -> Option<usize> {
 
 #[cfg(test)]
 mod tests {
-    use super::is_callable_handler_reference;
+    use super::{inline_callback_event_argument, is_callable_handler_reference};
+
+    #[test]
+    fn inline_callbacks_report_the_event_argument_they_accept() {
+        // (handler body, argument the generated call must pass)
+        let cases = [
+            ("() => f()", Some("")),
+            ("(v) => f(v)", Some("$event")),
+            ("v => f(v)", Some("$event")),
+            ("async (v) => f(v)", Some("$event")),
+            ("async v => f(v)", Some("$event")),
+            ("function () {}", Some("")),
+            ("function (v) { f(v) }", Some("$event")),
+            ("function named(v) { f(v) }", Some("$event")),
+            ("handler", None),
+            ("handlers[key]", None),
+            // Starts with the `function` keyword's letters but is a call.
+            ("functionalHandler(evt)", None),
+        ];
+
+        for (content, expected) in cases {
+            assert_eq!(
+                inline_callback_event_argument(content),
+                expected,
+                "unexpected inline-callback classification for {content:?}"
+            );
+        }
+    }
 
     #[test]
     fn undefined_is_not_a_callable_handler_reference() {

--- a/crates/vize_canon/tests/component_event_arity.rs
+++ b/crates/vize_canon/tests/component_event_arity.rs
@@ -32,10 +32,13 @@ function handleSelect(key: string, path: string[]) {
             "<script setup lang=\"ts\"></script>\n<template><div /></template>\n",
         ),
     ]);
+    // The listener type annotates the synthetic const, so a rejected handler
+    // would surface as an assignment error (`TS2322`) at the declared name
+    // rather than the call-argument `TS2345` this used to watch for (#3462).
     assert_no_diagnostic(
         project.path(),
         "App.vue",
-        2345,
+        2322,
         "an unresolved component emit must not reject a valid multi-argument handler",
     );
 }


### PR DESCRIPTION
Review follow-ups to #3509, which merged before they could land.

`inline_callback_event_argument` only checked `strip_prefix("function")`, so `@click="functionalHandler(evt)"` was classified as a function expression and the generated wrapper invoked it with `$event`. The keyword now has to actually end:

```rust
let rest = trimmed.strip_prefix("function")?;
// `functionalHandler(evt)` only starts with the keyword's letters; the
// keyword has to end there for this to be a function expression.
if rest.chars().next().is_some_and(is_identifier_continue) {
    return None;
}
```

A table-driven test pins the whole classification surface: `() =>`, `(v) =>`, bare-parameter and `async` arrows, anonymous and named function expressions, plain references, and the `functionalHandler(evt)` regression.

The `@event` sub-spans also collapsed to `Vec::new()` whenever `ctx.event_name_src_range` was `None`, which dropped the `TS2322` anchor on the declared identifier instead of degrading it. It now falls back to the bound expression, mirroring how a component prop falls back from its name range to its value range in `expressions/component_props.rs`.

Finally, `unresolved_component_events_accept_multi_argument_handlers` still asserted the absence of `TS2345`. Since #3509 the listener type is an annotation on the synthetic const, so a rejected handler is an assignment error; the test watches `TS2322` and no longer passes vacuously.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->