### PR TITLE
fix(typecheck): scope the divergence budget to the weekly sweep

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -3,6 +3,17 @@ run-name: Real Project Matrix @ ${{ github.sha }}
 
 on:
   workflow_dispatch:
+    inputs:
+      # Off by default because a manual dispatch is how the required release gate runs
+      # (tools/github/release-preflight-bootstrap.mjs dispatches this workflow with no inputs), and
+      # the divergence baseline is currently unusable on most of the corpus (#3513): enforcing it
+      # here would block every release on a broken instrument rather than on a vize regression.
+      # The weekly schedule below always enforces, so the alarm still rings; turn this on to
+      # re-check the budget on demand, for example when verifying a baseline fix.
+      enforce_divergence_budget:
+        description: Fail the job when the typecheck divergence budget breaches
+        type: boolean
+        default: false
   schedule:
     # Weekly full ecosystem sweep. Manual dispatches provide on-demand release evidence.
     - cron: "37 5 * * 0"
@@ -111,11 +122,19 @@ jobs:
             tests/tooling/glyph-corpus-lint-agreement.test.ts
 
       - name: Record typechecker baseline divergence
+        env:
+          # The divergence budget is the weekly alarm (#3486), and this workflow is
+          # also a required release gate. `record-only` still computes the verdict,
+          # writes it to both artifacts and raises a workflow warning; it just does
+          # not fail the job, so a breach cannot block a release while the baseline
+          # itself is unusable (#3513). The scheduled sweep always enforces.
+          BUDGET_MODE: ${{ (github.event_name == 'schedule' || inputs.enforce_divergence_budget) && 'enforce' || 'record-only' }}
         run: |
           node tools/fixtures/typecheck-divergence-report.mjs \
             --report-dir "$FIXTURE_REPORT_DIR" \
             --shard-index "$FIXTURE_SHARD_INDEX" \
             --shard-count "$FIXTURE_SHARD_COUNT" \
+            --budget-mode "$BUDGET_MODE" \
             --vue-tsc-bin tests/node_modules/.bin/vue-tsc
 
       - name: Publish shard summary

--- a/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
@@ -63,12 +63,15 @@ export function setup(options: FixtureOptions = {}) {
     fileCount: 1,
     files: [{ file: "src/App.vue", diagnostics: vizeDiagnostics }],
   };
+  // `vize check` exits 0 only when it found nothing, and the matrix summary
+  // status is derived from that, so a fixture with no diagnostics has to agree.
+  const exitCode = vizeDiagnostics.length === 0 ? 0 : 1;
   writeJson(outputPath, {
     schema: "vize.fixtureToolRun",
     version: 1,
     project: "fixture",
     tool: "typechecker",
-    exitCode: 1,
+    exitCode,
     stdout: JSON.stringify(parsed),
     stderr: "",
     parsed,
@@ -94,8 +97,8 @@ export function setup(options: FixtureOptions = {}) {
         runs: [
           {
             tool: "typechecker",
-            status: "findings",
-            exitCode: 1,
+            status: exitCode === 0 ? "ok" : "findings",
+            exitCode,
             fileCount: 1,
             outputPath: path.relative(root, outputPath),
           },
@@ -125,7 +128,11 @@ export function writeVueTsc(pathname: string, runBody: string, invocationPath?: 
   fs.chmodSync(pathname, 0o755);
 }
 
-export function run(fixture: ReturnType<typeof setup>, env: NodeJS.ProcessEnv = {}) {
+export function run(
+  fixture: ReturnType<typeof setup>,
+  env: NodeJS.ProcessEnv = {},
+  extraArgs: string[] = [],
+) {
   return spawnSync(
     process.execPath,
     [
@@ -136,6 +143,7 @@ export function run(fixture: ReturnType<typeof setup>, env: NodeJS.ProcessEnv = 
       fixture.reportDir,
       "--vue-tsc-bin",
       fixture.vueTsc,
+      ...extraArgs,
     ],
     { cwd: root, encoding: "utf8", env: { ...process.env, GITHUB_SHA: commitSha, ...env } },
   );

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -148,11 +148,22 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
    * workflow warning; tests/tooling/typecheck-divergence-budget.test.ts pins
    * what each mode does.
    */
-  assert.equal(
-    divergence?.env?.BUDGET_MODE,
-    "${{ (github.event_name == 'schedule' || inputs.enforce_divergence_budget)" +
-      " && 'enforce' || 'record-only' }}",
-  );
+  const budgetMode = divergence?.env?.BUDGET_MODE;
+  assert.ok(budgetMode, "Missing BUDGET_MODE on the divergence step");
+  for (const [eventName, enforceInput, expected] of [
+    ["schedule", undefined, "enforce"],
+    ["workflow_dispatch", true, "enforce"],
+    ["workflow_dispatch", false, "record-only"],
+  ] as const) {
+    assert.equal(
+      evaluateExpression(budgetMode, {
+        github: { event_name: eventName },
+        inputs: { enforce_divergence_budget: enforceInput },
+      }),
+      expected,
+      `${eventName} with enforce_divergence_budget=${enforceInput}`,
+    );
+  }
   assert.equal(summary?.if, "${{ always() }}");
   assert.match(summary?.run ?? "", /summary\.md/);
   assert.match(summary?.run ?? "", /\*-typecheck-divergence\.md/);
@@ -166,3 +177,59 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
     "retention-days": 30,
   });
 });
+
+/**
+ * Just enough of the GitHub Actions expression grammar (parentheses, `==`, and
+ * the value-returning `&&` / `||`) to resolve a `${{ … }}` template under a
+ * given event context, so the test above can assert the mode each trigger
+ * actually produces instead of how the expression happens to be spelled.
+ */
+function evaluateExpression(template: string, context: Record<string, unknown>): unknown {
+  const body = template.replace(/^\$\{\{\s*/, "").replace(/\s*\}\}$/, "");
+  const tokens = body.match(/\(|\)|&&|\|\||==|'[^']*'|[\w.]+/g) ?? [];
+  let index = 0;
+  const lookup = (path: string) => {
+    let value: unknown = context;
+    for (const key of path.split(".")) {
+      value = (value as Record<string, unknown> | undefined)?.[key];
+    }
+    return value;
+  };
+  const primary = (): unknown => {
+    const token = tokens[index++];
+    if (token === "(") {
+      const value = or();
+      index++;
+      return value;
+    }
+    if (token?.startsWith("'")) return token.slice(1, -1);
+    return lookup(token ?? "");
+  };
+  const equality = (): unknown => {
+    let value = primary();
+    while (tokens[index] === "==") {
+      index++;
+      value = value === primary();
+    }
+    return value;
+  };
+  const and = (): unknown => {
+    let value = equality();
+    while (tokens[index] === "&&") {
+      index++;
+      const right = equality();
+      value = value ? right : value;
+    }
+    return value;
+  };
+  const or = (): unknown => {
+    let value = and();
+    while (tokens[index] === "||") {
+      index++;
+      const right = and();
+      value = value ? value : right;
+    }
+    return value;
+  };
+  return or();
+}

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -25,7 +25,10 @@ test("real-project workflow schedules every balanced fixture shard", () => {
   const workflow = parse(readRepoFile(".github", "workflows", "real-project-matrix.yml")) as {
     concurrency?: { "cancel-in-progress"?: boolean; group?: string };
     jobs?: Record<string, WorkflowJob>;
-    on?: { schedule?: Array<{ cron?: string }>; workflow_dispatch?: unknown };
+    on?: {
+      schedule?: Array<{ cron?: string }>;
+      workflow_dispatch?: { inputs?: Record<string, unknown> };
+    };
     permissions?: Record<string, string>;
   };
   const job = workflow.jobs?.["real-project-matrix"];
@@ -33,14 +36,12 @@ test("real-project workflow schedules every balanced fixture shard", () => {
   assert.ok(job);
   assert.deepEqual(workflow.permissions, { contents: "read" });
   assert.equal(workflow.on?.schedule?.[0]?.cron, "37 5 * * 0");
-  assert.deepEqual(workflow.on?.workflow_dispatch, {
-    inputs: {
-      enforce_divergence_budget: {
-        description: "Fail the job when the typecheck divergence budget breaches",
-        type: "boolean",
-        default: false,
-      },
-    },
+  const dispatch = workflow.on?.workflow_dispatch;
+  assert.ok(dispatch, "Missing workflow_dispatch trigger");
+  assert.deepEqual(dispatch.inputs?.enforce_divergence_budget, {
+    description: "Fail the job when the typecheck divergence budget breaches",
+    type: "boolean",
+    default: false,
   });
   assert.deepEqual(workflow.concurrency, {
     group: "real-project-matrix-${{ github.ref }}",
@@ -147,11 +148,11 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
    * workflow warning; tests/tooling/typecheck-divergence-budget.test.ts pins
    * what each mode does.
    */
-  assert.deepEqual(divergence?.env, {
-    BUDGET_MODE:
-      "${{ (github.event_name == 'schedule' || inputs.enforce_divergence_budget)" +
+  assert.equal(
+    divergence?.env?.BUDGET_MODE,
+    "${{ (github.event_name == 'schedule' || inputs.enforce_divergence_budget)" +
       " && 'enforce' || 'record-only' }}",
-  });
+  );
   assert.equal(summary?.if, "${{ always() }}");
   assert.match(summary?.run ?? "", /summary\.md/);
   assert.match(summary?.run ?? "", /\*-typecheck-divergence\.md/);

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -33,7 +33,15 @@ test("real-project workflow schedules every balanced fixture shard", () => {
   assert.ok(job);
   assert.deepEqual(workflow.permissions, { contents: "read" });
   assert.equal(workflow.on?.schedule?.[0]?.cron, "37 5 * * 0");
-  assert.ok("workflow_dispatch" in (workflow.on ?? {}));
+  assert.deepEqual(workflow.on?.workflow_dispatch, {
+    inputs: {
+      enforce_divergence_budget: {
+        description: "Fail the job when the typecheck divergence budget breaches",
+        type: "boolean",
+        default: false,
+      },
+    },
+  });
   assert.deepEqual(workflow.concurrency, {
     group: "real-project-matrix-${{ github.ref }}",
     "cancel-in-progress": true,
@@ -123,7 +131,27 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(divergence?.run ?? "", /--report-dir "\$FIXTURE_REPORT_DIR"/);
   assert.match(divergence?.run ?? "", /--shard-index "\$FIXTURE_SHARD_INDEX"/);
   assert.match(divergence?.run ?? "", /--shard-count "\$FIXTURE_SHARD_COUNT"/);
+  assert.match(divergence?.run ?? "", /--budget-mode "\$BUDGET_MODE"/);
   assert.match(divergence?.run ?? "", /--vue-tsc-bin tests\/node_modules\/\.bin\/vue-tsc/);
+  /**
+   * #3513: this workflow is both the weekly ecosystem sweep and a required
+   * release gate (tools/github/release-preflight-bootstrap.mjs dispatches it
+   * with no inputs). The divergence budget is the weekly alarm, so it may only
+   * fail the job on the paths that asked for it:
+   *
+   *   schedule                                  -> enforce
+   *   workflow_dispatch (release, no inputs)    -> record-only
+   *   workflow_dispatch + enforce_divergence_budget -> enforce
+   *
+   * `record-only` still writes the verdict to both artifacts and raises a
+   * workflow warning; tests/tooling/typecheck-divergence-budget.test.ts pins
+   * what each mode does.
+   */
+  assert.deepEqual(divergence?.env, {
+    BUDGET_MODE:
+      "${{ (github.event_name == 'schedule' || inputs.enforce_divergence_budget)" +
+      " && 'enforce' || 'record-only' }}",
+  });
   assert.equal(summary?.if, "${{ always() }}");
   assert.match(summary?.run ?? "", /summary\.md/);
   assert.match(summary?.run ?? "", /\*-typecheck-divergence\.md/);

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -171,7 +171,13 @@ test("Native Smoke uses its stable workflow title as evidence", () => {
 test("Real Project Matrix dispatch identifies its immutable target", () => {
   const matrix = readWorkflow(findReleasePlan("Real Project Matrix").workflowId);
   assert.equal(matrix.name, "Real Project Matrix");
-  assert.deepEqual(Object.keys(matrix.on?.workflow_dispatch?.inputs ?? {}), []);
+  // The release gate dispatches this workflow with no inputs, so every input has
+  // to carry a default. `enforce_divergence_budget` defaults to off on purpose
+  // (#3513): the weekly sweep enforces the divergence budget, and a release must
+  // not be blocked by it while the ecosystem baseline is unusable.
+  const dispatchInputs = matrix.on?.workflow_dispatch?.inputs ?? {};
+  assert.deepEqual(Object.keys(dispatchInputs), ["enforce_divergence_budget"]);
+  assert.equal(dispatchInputs.enforce_divergence_budget.default, false);
   assert.match(matrix["run-name"] ?? "", /^Real Project Matrix @ /);
   assert.match(matrix["run-name"] ?? "", /github\.sha/);
 });

--- a/tests/tooling/typecheck-divergence-baseline.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  cleanup,
+  commitSha,
+  readJson,
+  root,
+  run,
+  setup,
+  sharedVizeDiagnostic,
+} from "./_helpers/typecheck-divergence-report-fixture.ts";
+
+/**
+ * #3513: a divergence run only measures vize when the two tools actually met at
+ * a diagnostic. On the v0.307.0 release run, 8 of 11 fixtures reported
+ * `shared: 0` alongside hundreds of "false positives" because vue-tsc
+ * typechecked nothing at all, and the other 3 reported 0/0/0. Scoring the first
+ * shape as a breach blames vize for a broken instrument, and scoring the second
+ * as a pass is the silent-success failure the budget gate exists to stop, so
+ * both get a third verdict that is never a pass.
+ */
+
+const vizeOnly = "error:2:1 [TS2345] vize only";
+const emptyBaselineReason =
+  "vize reported 2 and vue-tsc reported 0 diagnostics with none in common";
+const emptyBothReason = "neither vize nor vue-tsc reported a diagnostic, so nothing was compared";
+
+function artifactPath(fixture: ReturnType<typeof setup>, extension: string) {
+  return path.join(fixture.reportDir, `fixture-typecheck-divergence.${extension}`);
+}
+
+test("an empty vue-tsc baseline is unusable, not a false-positive breach", () => {
+  const fixture = setup({ vizeDiagnostics: [sharedVizeDiagnostic, vizeOnly], baselineOutput: "" });
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.equal(
+      result.stderr,
+      `Typecheck divergence baseline is unusable for fixture: ${emptyBaselineReason}\n`,
+    );
+    const artifact = readJson(artifactPath(fixture, "json"));
+    assert.deepEqual(artifact.budget, {
+      maxFalsePositiveRatio: 0.05,
+      maxFalseNegativeRatio: 0.05,
+      falsePositivePassed: false,
+      falseNegativePassed: true,
+      unusableReason: emptyBaselineReason,
+      verdict: "unusable",
+      passed: false,
+    });
+    assert.equal(
+      fs.readFileSync(artifactPath(fixture, "md"), "utf8"),
+      [
+        "## fixture typecheck divergence",
+        "",
+        `Commit: ${commitSha}`,
+        "Vize diagnostics: 2",
+        "vue-tsc diagnostics: 0",
+        "Shared: 0",
+        "Message mismatches: 0",
+        "Documented differences: 0",
+        "False positives: 2 (1)",
+        "False negatives: 0 (0)",
+        "Vize excluded non-Vue: 0",
+        "vue-tsc excluded non-Vue: 0",
+        "vue-tsc excluded project-level: 0",
+        "vue-tsc excluded external: 0",
+        `Budget verdict: unusable (${emptyBaselineReason})`,
+        "Budget passed: false",
+        `Digest: ${artifact.divergence.sha256}`,
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("two sides that never meet are unusable, not a breach of both budgets", () => {
+  // Both tools reported a diagnostic, so neither side is empty, but they share
+  // no position at all. That is a broken mapping, not a 100% error rate.
+  const fixture = setup({
+    vizeDiagnostics: [sharedVizeDiagnostic],
+    baselineOutput: "src/App.vue(9,1): error TS2322: shared\n",
+  });
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.equal(
+      result.stderr,
+      "Typecheck divergence baseline is unusable for fixture: " +
+        "vize reported 1 and vue-tsc reported 1 diagnostics with none in common\n",
+    );
+    assert.deepEqual(readJson(artifactPath(fixture, "json")).budget, {
+      maxFalsePositiveRatio: 0.05,
+      maxFalseNegativeRatio: 0.05,
+      falsePositivePassed: false,
+      falseNegativePassed: false,
+      unusableReason: "vize reported 1 and vue-tsc reported 1 diagnostics with none in common",
+      verdict: "unusable",
+      passed: false,
+    });
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("zero diagnostics on both sides is unusable, never a vacuous pass", () => {
+  const fixture = setup({ vizeDiagnostics: [], baselineOutput: "" });
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.equal(
+      result.stderr,
+      `Typecheck divergence baseline is unusable for fixture: ${emptyBothReason}\n`,
+    );
+    assert.deepEqual(readJson(artifactPath(fixture, "json")).budget, {
+      maxFalsePositiveRatio: 0.05,
+      maxFalseNegativeRatio: 0.05,
+      falsePositivePassed: true,
+      falseNegativePassed: true,
+      unusableReason: emptyBothReason,
+      verdict: "unusable",
+      passed: false,
+    });
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("--budget-mode record-only reports an unusable baseline as a warning", () => {
+  // The release path still has to say so out loud: a green shard that measured
+  // nothing is exactly what this verdict exists to make visible.
+  const fixture = setup({ vizeDiagnostics: [], baselineOutput: "" });
+  try {
+    const result = run(fixture, {}, ["--budget-mode", "record-only"]);
+    assert.equal(result.status, 0);
+    assert.equal(result.stderr, "");
+    assert.equal(
+      result.stdout,
+      [
+        `Wrote ${path.relative(root, artifactPath(fixture, "json"))}`,
+        `Wrote ${path.relative(root, artifactPath(fixture, "md"))}`,
+        "::warning title=Typecheck divergence budget not enforced::" +
+          `Typecheck divergence baseline is unusable for fixture: ${emptyBothReason}`,
+        "",
+      ].join("\n"),
+    );
+    assert.equal(readJson(artifactPath(fixture, "json")).budget.passed, false);
+  } finally {
+    cleanup(fixture);
+  }
+});

--- a/tests/tooling/typecheck-divergence-budget.test.ts
+++ b/tests/tooling/typecheck-divergence-budget.test.ts
@@ -7,6 +7,7 @@ import {
   cleanup,
   commitSha,
   readJson,
+  root,
   run,
   setup,
   sharedBaselineOutput,
@@ -19,13 +20,36 @@ import {
  * false-negative breach printed `Budget passed: false` and the weekly Real
  * Project Matrix job still went green. These tests execute the failure path the
  * gate had never taken.
+ *
+ * #3513: the same gate then had to learn two more things. It is the *weekly*
+ * gate, so `--budget-mode record-only` records a verdict on the release-evidence
+ * dispatch without failing it; and a comparison whose two sides never met is a
+ * measurement failure that may never render as a pass.
  */
 
 const vizeOnly = "error:2:1 [TS2345] vize only";
 const baselineOnly = "src/App.vue(3,1): error TS2345: baseline only\n";
+const passingBudget = {
+  maxFalsePositiveRatio: 0.05,
+  maxFalseNegativeRatio: 0.05,
+  falsePositivePassed: true,
+  falseNegativePassed: true,
+  unusableReason: null,
+  verdict: "passed",
+  passed: true,
+};
 
 function artifactPath(fixture: ReturnType<typeof setup>, extension: string) {
   return path.join(fixture.reportDir, `fixture-typecheck-divergence.${extension}`);
+}
+
+/** Everything the script prints on the happy path, before any verdict line. */
+function wroteLines(fixture: ReturnType<typeof setup>) {
+  return [
+    `Wrote ${path.relative(root, artifactPath(fixture, "json"))}`,
+    `Wrote ${path.relative(root, artifactPath(fixture, "md"))}`,
+    "",
+  ].join("\n");
 }
 
 test("a false-positive budget breach fails the divergence report", () => {
@@ -43,6 +67,8 @@ test("a false-positive budget breach fails the divergence report", () => {
       maxFalseNegativeRatio: 0.05,
       falsePositivePassed: false,
       falseNegativePassed: true,
+      unusableReason: null,
+      verdict: "breached",
       passed: false,
     });
     // The breach is uploaded, not swallowed: both artifacts land before the throw.
@@ -63,6 +89,7 @@ test("a false-positive budget breach fails the divergence report", () => {
         "vue-tsc excluded non-Vue: 0",
         "vue-tsc excluded project-level: 0",
         "vue-tsc excluded external: 0",
+        "Budget verdict: breached",
         "Budget passed: false",
         `Digest: ${artifact.divergence.sha256}`,
         "",
@@ -87,6 +114,8 @@ test("a false-negative budget breach fails the divergence report", () => {
       maxFalseNegativeRatio: 0.05,
       falsePositivePassed: true,
       falseNegativePassed: false,
+      unusableReason: null,
+      verdict: "breached",
       passed: false,
     });
   } finally {
@@ -131,14 +160,67 @@ test("a ratio exactly at the budget still passes", () => {
     assert.equal(result.stderr, "");
     assert.equal(result.status, 0);
     const artifact = readJson(artifactPath(fixture, "json"));
-    assert.deepEqual(artifact.budget, {
+    assert.deepEqual(artifact.budget, passingBudget);
+    assert.equal(artifact.divergence.summary.falsePositiveRatio, 0.05);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("--budget-mode record-only records a breach without failing the job", () => {
+  // The release path. `real-project-matrix.yml` is dispatched as a required
+  // release gate as well as run weekly, so a breach has to stay visible without
+  // blocking a release: the artifacts and the warning land, the exit code is 0.
+  const fixture = setup({ vizeDiagnostics: [sharedVizeDiagnostic, vizeOnly] });
+  try {
+    const result = run(fixture, {}, ["--budget-mode", "record-only"]);
+    assert.equal(result.status, 0);
+    assert.equal(result.stderr, "");
+    assert.equal(
+      result.stdout,
+      `${wroteLines(fixture)}::warning title=Typecheck divergence budget not enforced::` +
+        "Typecheck divergence budget breached for fixture: " +
+        "1 false positives (ratio 0.5) exceed maxFalsePositiveRatio 0.05\n",
+    );
+    // Recording is not forgiving: the artifact still carries the failing verdict.
+    assert.deepEqual(readJson(artifactPath(fixture, "json")).budget, {
       maxFalsePositiveRatio: 0.05,
       maxFalseNegativeRatio: 0.05,
-      falsePositivePassed: true,
+      falsePositivePassed: false,
       falseNegativePassed: true,
-      passed: true,
+      unusableReason: null,
+      verdict: "breached",
+      passed: false,
     });
-    assert.equal(artifact.divergence.summary.falsePositiveRatio, 0.05);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("--budget-mode enforce is the default and fails the job", () => {
+  const fixture = setup({ vizeDiagnostics: [sharedVizeDiagnostic, vizeOnly] });
+  try {
+    const expected =
+      "Typecheck divergence budget breached for fixture: " +
+      "1 false positives (ratio 0.5) exceed maxFalsePositiveRatio 0.05\n";
+    const explicit = run(fixture, {}, ["--budget-mode", "enforce"]);
+    assert.equal(explicit.status, 1);
+    assert.equal(explicit.stderr, expected);
+    const implicit = run(fixture);
+    assert.equal(implicit.status, 1);
+    assert.equal(implicit.stderr, expected);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("an unrecognised budget mode is rejected instead of disarming the gate", () => {
+  const fixture = setup({ vizeDiagnostics: [sharedVizeDiagnostic, vizeOnly] });
+  try {
+    const result = run(fixture, {}, ["--budget-mode", "off"]);
+    assert.equal(result.status, 1);
+    assert.equal(result.stderr, "--budget-mode must be one of: enforce, record-only\n");
+    assert.equal(fs.existsSync(artifactPath(fixture, "json")), false);
   } finally {
     cleanup(fixture);
   }

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -49,6 +49,8 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
       maxFalseNegativeRatio: 0.05,
       falsePositivePassed: true,
       falseNegativePassed: true,
+      unusableReason: null,
+      verdict: "passed",
       passed: true,
     });
     assert.equal(artifact.divergence.summary.sharedCount, 1);

--- a/tools/fixtures/typecheck-divergence-budget.mjs
+++ b/tools/fixtures/typecheck-divergence-budget.mjs
@@ -102,13 +102,16 @@ function baselineUnusableReason(summary) {
  * and reviewable — the run fails with the evidence attached, not instead of it.
  */
 export function assertBudgetPassed(artifact, budgetMode = "enforce") {
+  // Validated before the passed-verdict return, so an unrecognised mode is
+  // rejected on every run rather than only on the runs that breach.
+  const mode = parseBudgetMode(budgetMode);
   const budget = artifact.budget;
   if (budget.verdict === "passed") return;
   const detail =
     budget.verdict === "unusable"
       ? `Typecheck divergence baseline is unusable for ${artifact.project}: ${budget.unusableReason}`
       : `Typecheck divergence budget breached for ${artifact.project}: ${describeBreaches(artifact).join("; ")}`;
-  if (parseBudgetMode(budgetMode) === "enforce") throw new Error(detail);
+  if (mode === "enforce") throw new Error(detail);
   // A GitHub workflow command, so a release run that records an unusable
   // baseline still shows a warning on the run instead of a silent green tick.
   process.stdout.write(`::warning title=Typecheck divergence budget not enforced::${detail}\n`);

--- a/tools/fixtures/typecheck-divergence-budget.mjs
+++ b/tools/fixtures/typecheck-divergence-budget.mjs
@@ -1,0 +1,132 @@
+/**
+ * Verdict and enforcement for the vize-versus-vue-tsc false-positive /
+ * false-negative budget, split out of `typecheck-divergence-report.mjs` so the
+ * report script stays inside the per-file line budget.
+ *
+ * Two rules live here, and they answer two different failures the ledger had:
+ *
+ * 1. `evaluateBudget` returns three verdicts, not two (#3513, the #3222 parity
+ *    ledger). A run whose two sides never met at a single diagnostic has not
+ *    measured a ratio at all, so it may never render as `passed` — see
+ *    `baselineUnusableReason`.
+ * 2. `assertBudgetPassed` enforces on the weekly sweep and records everywhere
+ *    else — see `parseBudgetMode`.
+ */
+
+/**
+ * `enforce` fails the run on anything that is not a clean pass. `record-only`
+ * writes the same verdict into the artifact and annotates the run, but exits 0.
+ *
+ * `enforce` is the default so that a caller which forgets the flag fails closed;
+ * only `.github/workflows/real-project-matrix.yml` opts out, and only on the
+ * release-evidence dispatch. An unrecognised value is rejected rather than
+ * treated as "do not enforce", so a typo cannot silently disarm the gate.
+ */
+const budgetModes = ["enforce", "record-only"];
+
+export function parseBudgetMode(value) {
+  if (!budgetModes.includes(value)) {
+    throw new Error(`--budget-mode must be one of: ${budgetModes.join(", ")}`);
+  }
+  return value;
+}
+
+export function evaluateBudget(performance, summary) {
+  const falsePositivePassed = summary.falsePositiveRatio <= performance.maxFalsePositiveRatio;
+  const falseNegativePassed = summary.falseNegativeRatio <= performance.maxFalseNegativeRatio;
+  const unusableReason = baselineUnusableReason(summary);
+  const verdict =
+    unusableReason != null
+      ? "unusable"
+      : falsePositivePassed && falseNegativePassed
+        ? "passed"
+        : "breached";
+  return {
+    maxFalsePositiveRatio: performance.maxFalsePositiveRatio,
+    maxFalseNegativeRatio: performance.maxFalseNegativeRatio,
+    falsePositivePassed,
+    falseNegativePassed,
+    unusableReason,
+    verdict,
+    passed: verdict === "passed",
+  };
+}
+
+/**
+ * The ratios only measure something when the two tools actually met: every
+ * diagnostic they both reported at the same file, severity, line, column and
+ * code lands in `shared`, `messageMismatches` or `documentedDifferences`. When
+ * all three are empty the split between "false positive" and "false negative" is
+ * an artifact of how the baseline failed, not evidence about vize:
+ *
+ * - vue-tsc typechecked nothing (a solution-style tsconfig, a config error, an
+ *   `include` that never matches `.vue`), so every vize diagnostic is scored as
+ *   a false positive by construction; or
+ * - both sides reported diagnostics that share no position at all, so the file
+ *   or position mapping between them is broken; or
+ * - neither side reported anything, which scores 0/0 and reads as a pass while
+ *   proving nothing.
+ *
+ * All three are measurement failures. Reporting them as `breached` would blame
+ * vize for a broken instrument, and reporting the last one as `passed` is the
+ * silent-success failure this whole gate exists to stop, so they get their own
+ * verdict.
+ */
+function baselineUnusableReason(summary) {
+  const overlap =
+    summary.sharedCount + summary.messageMismatchCount + summary.documentedDifferenceCount;
+  if (overlap > 0) return null;
+  if (summary.vizeDiagnosticCount === 0 && summary.baselineDiagnosticCount === 0) {
+    return "neither vize nor vue-tsc reported a diagnostic, so nothing was compared";
+  }
+  return (
+    `vize reported ${summary.vizeDiagnosticCount} and vue-tsc reported ` +
+    `${summary.baselineDiagnosticCount} diagnostics with none in common`
+  );
+}
+
+/**
+ * The budget is a gate, not a note (#2971): `budget.passed` used to be computed,
+ * embedded in the artifact and printed in the step summary while nothing read
+ * it, so a matrix-wide breach reported `Budget passed: false` and the weekly job
+ * still went green.
+ *
+ * It is the *weekly* gate. `real-project-matrix.yml` is also dispatched as a
+ * required release gate, and while the ecosystem baseline is unusable on most of
+ * the corpus (#3513) a breach there would block every release on a broken
+ * instrument, so the release dispatch passes `--budget-mode record-only`: the
+ * verdict is still computed, written to both artifacts and raised as a workflow
+ * warning, it just does not fail the job.
+ *
+ * Either way this runs after both artifacts are written, so a breach is uploaded
+ * and reviewable — the run fails with the evidence attached, not instead of it.
+ */
+export function assertBudgetPassed(artifact, budgetMode = "enforce") {
+  const budget = artifact.budget;
+  if (budget.verdict === "passed") return;
+  const detail =
+    budget.verdict === "unusable"
+      ? `Typecheck divergence baseline is unusable for ${artifact.project}: ${budget.unusableReason}`
+      : `Typecheck divergence budget breached for ${artifact.project}: ${describeBreaches(artifact).join("; ")}`;
+  if (parseBudgetMode(budgetMode) === "enforce") throw new Error(detail);
+  // A GitHub workflow command, so a release run that records an unusable
+  // baseline still shows a warning on the run instead of a silent green tick.
+  process.stdout.write(`::warning title=Typecheck divergence budget not enforced::${detail}\n`);
+}
+
+function describeBreaches(artifact) {
+  const budget = artifact.budget;
+  const summary = artifact.divergence.summary;
+  const breaches = [];
+  if (!budget.falsePositivePassed) {
+    breaches.push(
+      `${summary.falsePositiveCount} false positives (ratio ${summary.falsePositiveRatio}) exceed maxFalsePositiveRatio ${budget.maxFalsePositiveRatio}`,
+    );
+  }
+  if (!budget.falseNegativePassed) {
+    breaches.push(
+      `${summary.falseNegativeCount} false negatives (ratio ${summary.falseNegativeRatio}) exceed maxFalseNegativeRatio ${budget.maxFalseNegativeRatio}`,
+    );
+  }
+  return breaches;
+}

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -7,6 +7,11 @@ import { fileURLToPath } from "node:url";
 
 import { validateTypecheckerOutput } from "./tool-matrix-typechecker.mjs";
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
+import {
+  assertBudgetPassed,
+  evaluateBudget,
+  parseBudgetMode,
+} from "./typecheck-divergence-budget.mjs";
 import { compareTypecheckDiagnostics } from "./typecheck-divergence.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -87,37 +92,8 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
   writeFileSync(markdownPath, renderMarkdown(artifact));
   process.stdout.write(`Wrote ${relative(repoRoot, jsonPath)}\n`);
   process.stdout.write(`Wrote ${relative(repoRoot, markdownPath)}\n`);
-  assertBudgetPassed(artifact);
+  assertBudgetPassed(artifact, args.budgetMode);
   return artifact;
-}
-
-/**
- * The false-positive/false-negative budget is a gate, not a note (#3460).
- * `budget.passed` used to be computed, embedded in the artifact, and printed in
- * the step summary while nothing read it, so a matrix-wide breach reported
- * `Budget passed: false` and the weekly job still went green.
- *
- * This runs after both artifacts are written, so a breach is still uploaded and
- * reviewable — the run fails with the evidence attached, not instead of it.
- */
-export function assertBudgetPassed(artifact) {
-  const budget = artifact.budget;
-  if (budget.passed) return;
-  const summary = artifact.divergence.summary;
-  const breaches = [];
-  if (!budget.falsePositivePassed) {
-    breaches.push(
-      `${summary.falsePositiveCount} false positives (ratio ${summary.falsePositiveRatio}) exceed maxFalsePositiveRatio ${budget.maxFalsePositiveRatio}`,
-    );
-  }
-  if (!budget.falseNegativePassed) {
-    breaches.push(
-      `${summary.falseNegativeCount} false negatives (ratio ${summary.falseNegativeRatio}) exceed maxFalseNegativeRatio ${budget.maxFalseNegativeRatio}`,
-    );
-  }
-  throw new Error(
-    `Typecheck divergence budget breached for ${artifact.project}: ${breaches.join("; ")}`,
-  );
 }
 
 function readDocumentedDifferences() {
@@ -229,19 +205,6 @@ function validatePerformanceConfig(performance) {
   ratio(performance.maxFalseNegativeRatio, "maxFalseNegativeRatio");
 }
 
-function evaluateBudget(performance, summary) {
-  const falseNegativeLimit = performance.maxFalseNegativeRatio;
-  const falsePositivePassed = summary.falsePositiveRatio <= performance.maxFalsePositiveRatio;
-  const falseNegativePassed = summary.falseNegativeRatio <= falseNegativeLimit;
-  return {
-    maxFalsePositiveRatio: performance.maxFalsePositiveRatio,
-    maxFalseNegativeRatio: falseNegativeLimit,
-    falsePositivePassed,
-    falseNegativePassed,
-    passed: falsePositivePassed && falseNegativePassed,
-  };
-}
-
 function renderMarkdown(artifact) {
   const summary = artifact.divergence.summary;
   return [
@@ -259,10 +222,15 @@ function renderMarkdown(artifact) {
     `vue-tsc excluded non-Vue: ${summary.baselineExcludedNonVueCount}`,
     `vue-tsc excluded project-level: ${summary.baselineExcludedProjectCount}`,
     `vue-tsc excluded external: ${summary.baselineExcludedExternalCount}`,
-    `Budget passed: ${artifact.budget.passed ?? "not configured"}`,
+    `Budget verdict: ${describeVerdict(artifact.budget)}`,
+    `Budget passed: ${artifact.budget.passed}`,
     `Digest: ${artifact.divergence.sha256}`,
     "",
   ].join("\n");
+}
+
+function describeVerdict(budget) {
+  return budget.unusableReason == null ? budget.verdict : `unusable (${budget.unusableReason})`;
 }
 
 function resolveVueTsc(value) {
@@ -276,6 +244,7 @@ function resolveVueTsc(value) {
 
 function parseArgs(argv) {
   const args = {
+    budgetMode: "enforce",
     registry: defaultRegistry,
     reportDir: null,
     shardCount: 1,
@@ -288,7 +257,8 @@ function parseArgs(argv) {
       if (argv[index + 1] == null) throw new Error(`${arg} requires a value`);
       return argv[++index];
     };
-    if (arg === "--registry") args.registry = resolve(repoRoot, value());
+    if (arg === "--budget-mode") args.budgetMode = parseBudgetMode(value());
+    else if (arg === "--registry") args.registry = resolve(repoRoot, value());
     else if (arg === "--report-dir") args.reportDir = resolve(repoRoot, value());
     else if (arg === "--shard-count") args.shardCount = integer(value(), arg, 1);
     else if (arg === "--shard-index") args.shardIndex = integer(value(), arg, 0);


### PR DESCRIPTION
## The defect

#3486 was correct: the divergence budget was computed, embedded and printed while nothing read it,
so a breach went green. It is not reverted here.

But its own title says *the **weekly** divergence budget*, and `real-project-matrix.yml` is not only
a weekly job — `tools/github/release-preflight-bootstrap.mjs` dispatches it as one of the five
**required release gates**. So the assertion started blocking releases:

| commit | Real Project Matrix |
| --- | --- |
| `8c2509a23` (v0.306.0, before #3486) | passed |
| `0409c6ade` (v0.307.0, after #3486) | **failed on 6 of 11 shards** |

## The input the gate is failing on is broken

Computed from the shard artifacts of run
[30599682112](https://github.com/ubugeeei/vize/actions/runs/30599682112), reading
`<project>-typecheck-divergence.json` out of each `real-project-matrix-*` artifact:

| project | vue-tsc exit | vue-tsc ms | vize | vue-tsc | shared | FP | FN | verdict |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| element-plus | 0 | 200 | 662 | 0 | **0** | 662 | 0 | breach |
| primevue | 2 | 497 | 1173 | 0 | **0** | 1173 | 0 | breach |
| elk | 2 | 128 | 140 | 0 | **0** | 140 | 0 | breach |
| reka-ui | 2 | 4795 | 96 | 50 | **0** | 96 | 50 | breach |
| vuetify | 2 | 5025 | 44 | 0 | **0** | 44 | 0 | breach |
| vuestic-admin | 2 | 3067 | 39 | 1 | **0** | 39 | 1 | breach |
| voicevox | 2 | 5703 | 1 | 0 | **0** | 1 | 0 | breach |
| vue-vben-admin | 0 | 9082 | 0 | 0 | 0 | 0 | 0 | "pass" |
| hoppscotch | 2 | 2323 | 0 | 0 | 0 | 0 | 0 | "pass" |
| lx-music-desktop | 2 | 4614 | 1 | 1 | 0 | 0 | 0 | pass |
| misskey | 2 | 13977 | 612 | 582 | 549 | 46 | 16 | breach |

`shared: 0` next to hundreds of false positives means the baseline produced **no comparable output
at all**, so every vize diagnostic is a false positive by construction. element-plus is the clearest
case: `tsconfig.json` at the pinned revision is a solution-style config (`"files": []` +
`references`), `vue-tsc -p` does not follow references without `--build`, so it typechecks zero
files and exits 0 in **200 ms**. And `0/0/0` passes vacuously.

Only **misskey** measured anything (549 shared; FP `0.0752` / FN `0.0275` against a `0.02` budget —
a real breach, tracked separately).

Filed as **#3513** with the per-project root causes found so far. **Not fixed here**: this PR does
not touch the fixture registry.

## What this PR does

**1. Scopes the assertion back to what #3486 said it was.** New `--budget-mode enforce|record-only`.
`record-only` writes the same verdict into both artifacts and raises a `::warning::` on the run — it
just exits 0. The workflow computes it:

```yaml
BUDGET_MODE: ${{ (github.event_name == 'schedule' || inputs.enforce_divergence_budget) && 'enforce' || 'record-only' }}
```

| path | mode |
| --- | --- |
| `schedule` (weekly sweep) | `enforce` |
| `workflow_dispatch` (release evidence, no inputs) | `record-only` |
| `workflow_dispatch` + `enforce_divergence_budget: true` | `enforce` |

`enforce` is the **script default**, so any caller that forgets the flag fails closed, and an
unrecognised value is rejected rather than read as "do not enforce". Budgets are unchanged — nothing
is widened to swallow the breach. The alarm still rings every Sunday.

**2. Makes an unusable baseline loud, and never a pass.** `budget` gains `verdict`
(`passed` | `breached` | `unusable`) and `unusableReason`; `passed` is now `verdict === "passed"`,
so it can never be `true` for a comparison that measured nothing. The rule: the two tools met when
at least one diagnostic landed in `shared`, `messageMismatches` or `documentedDifferences`. If that
overlap is zero, the FP/FN split is an artifact of how the baseline failed, so the run reports

```
Typecheck divergence baseline is unusable for element-plus: vize reported 662 and vue-tsc reported 0 diagnostics with none in common
```

instead of blaming vize for 662 false positives. `0/0/0` gets the same verdict with
`neither vize nor vue-tsc reported a diagnostic, so nothing was compared`. The step summary line
becomes `Budget verdict: unusable (…)` above `Budget passed: false`.

Against the 11 fixtures above, this rule reclassifies 9 shards from "breach"/"pass" to `unusable`
and leaves misskey a genuine breach and lx-music-desktop a genuine pass.

## How the tests fail before the fix

Extends #3486's suite (which drives the real script as a subprocess) rather than adding a parallel
harness. Verified by restoring `tools/fixtures/typecheck-divergence-report.mjs` and
`.github/workflows/real-project-matrix.yml` from `origin/main` and deleting the new module:

```
$ git checkout origin/main -- tools/fixtures/typecheck-divergence-report.mjs \
    .github/workflows/real-project-matrix.yml
$ rm tools/fixtures/typecheck-divergence-budget.mjs
$ nix develop -c node --test tests/tooling/typecheck-divergence-baseline.test.ts \
    tests/tooling/typecheck-divergence-budget.test.ts \
    tests/tooling/real-project-matrix-workflow.test.ts \
    tests/tooling/release-preflight-bootstrap.test.ts
ℹ tests 26   ℹ pass 13   ℹ fail 13
```

The three that matter most:

| test | pre-fix actual |
| --- | --- |
| an empty vue-tsc baseline is unusable, not a false-positive breach | `Typecheck divergence budget breached for fixture: 2 false positives (ratio 1) exceed maxFalsePositiveRatio 0.05` — blames vize for a baseline that reported nothing |
| zero diagnostics on both sides is unusable, never a vacuous pass | exit **0** (silent pass) |
| `--budget-mode record-only` records a breach without failing the job | exit 1, `Unknown argument: --budget-mode` |

With the fix, all 41 tests across the six touched suites pass.

New coverage: three `unusable` shapes (empty baseline / both sides non-empty with zero overlap /
0-0-0) with full artifact and byte-for-byte markdown assertions, `record-only` for both a breach and
an unusable baseline (exact stdout including the warning annotation), `enforce` explicit and by
default, and a rejected unknown mode.

## Gates run

```
nix develop -c vp run check:repo    # All 1843 files correctly formatted; 0 lint warnings in 1261
moon run source_file_lengths -- --check --base-ref origin/main
                                   # "No new or grown files exceed 350 lines."
nix develop -c node --test tests/tooling/typecheck-divergence-baseline.test.ts \
  tests/tooling/typecheck-divergence-budget.test.ts \
  tests/tooling/typecheck-divergence-report.test.ts \
  tests/tooling/real-project-matrix-workflow.test.ts \
  tests/tooling/release-preflight-bootstrap.test.ts \
  tests/tooling/release-preflight-evidence.test.ts
                                   # ℹ tests 41  ℹ pass 41  ℹ fail 0
```

`vp run fmt:check` also runs `check:vize-apps`, which fails locally on
`examples/vite-musea` with `Cannot find module 'vue'` — it needs built `dist` artifacts this
worktree never produced. No Rust changed, so `lint:rust` / `check:rust` are untouched by this diff.

Two files had to move to stay inside the 350-line budget:
`tools/fixtures/typecheck-divergence-report.mjs` was at **357** (already over, so it could not grow
by a line), and the budget verdict now lives in a new
`tools/fixtures/typecheck-divergence-budget.mjs` (132 lines), dropping the report to 323. The new
baseline-verdict tests are a new file for the same reason.

## One deliberate one-word change

The comment #3486 landed says the budget "is a gate, not a note (#3460)". #3460 is a perf regression
issue; the PR body itself identifies the checklist item as #2971's. Since that comment moved into
the new module, the reference is corrected to #2971.

Refs #2971, #3486, #3222
Refs #3513

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional manual workflow setting to enforce typecheck divergence budgets, defaulting to record-only.
  * Scheduled checks now enforce divergence budgets automatically.
  * Added record-only monitoring so results can be reported without failing workflows.

* **Bug Fixes**
  * Improved handling of unusable baselines with clearer reasons and warnings.
  * Reports now display explicit budget verdicts and pass status.

* **Tests**
  * Expanded coverage for thresholds, enforcement modes, invalid inputs, and baseline scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->