### PR TITLE
test(canon): re-pin the five app check snapshots to the landed diagnostic fixes

### DIFF
--- a/tests/snapshots/check/__snapshots__/elk-check.snap
+++ b/tests/snapshots/check/__snapshots__/elk-check.snap
@@ -247,7 +247,9 @@
     },
     {
       "file": "app/components/common/CommonTabs.vue",
-      "diagnostics": []
+      "diagnostics": [
+        "error:40:39 [TS2322] Type '{ name: string; icon?: string | undefined; display: string; }' is not assignable to type 'PropertyKey | undefined'."
+      ]
     },
     {
       "file": "app/components/common/CommonTooltip.vue",
@@ -1427,7 +1429,7 @@
       "diagnostics": []
     }
   ],
-  "errorCount": 280,
+  "errorCount": 281,
   "warningCount": 0,
   "fileCount": 253
 }

--- a/tests/snapshots/check/__snapshots__/misskey-check.snap
+++ b/tests/snapshots/check/__snapshots__/misskey-check.snap
@@ -735,7 +735,6 @@
     {
       "file": "src/components/MkTabs.vue",
       "diagnostics": [
-        "error:11:11 [TS7006] Parameter 'el' implicitly has an 'any' type.",
         "error:33:14 [TS2345] Argument of type '(el: Element) => Promise<void>' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
         "error:34:19 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
         "error:35:14 [TS2345] Argument of type '(el: Element) => Promise<void>' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
@@ -973,7 +972,6 @@
     {
       "file": "src/components/global/MkPageHeader.tabs.vue",
       "diagnostics": [
-        "error:11:11 [TS7006] Parameter 'el' implicitly has an 'any' type.",
         "error:31:35 [TS2345] Argument of type '(el: Element) => Promise<void>' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
         "error:31:55 [TS2345] Argument of type '(el: Element) => void' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
         "error:31:75 [TS2345] Argument of type '(el: Element) => Promise<void>' is not assignable to parameter of type '(_e: Event) => unknown'.\nTypes of parameters 'el' and '_e' are incompatible.\nType 'Event' is missing the following properties from type 'Element': attributes, classList, className, clientHeight, and 183 more.",
@@ -2391,7 +2389,7 @@
       "diagnostics": []
     }
   ],
-  "errorCount": 39,
+  "errorCount": 37,
   "warningCount": 0,
   "fileCount": 583
 }

--- a/tests/snapshots/check/__snapshots__/npmx.dev-check.snap
+++ b/tests/snapshots/check/__snapshots__/npmx.dev-check.snap
@@ -355,7 +355,7 @@
     {
       "file": "app/components/Package/SkillsModal.vue",
       "diagnostics": [
-        "error:206:75 [TS2367] This comparison appears to be unintentional because the types '\"skills-cli\"' and '\"skills-npm\"' have no overlap."
+        "error:217:18 [TS2367] This comparison appears to be unintentional because the types '\"skills-cli\"' and '\"skills-npm\"' have no overlap."
       ]
     },
     {

--- a/tests/snapshots/check/__snapshots__/nuxt-ui-check.snap
+++ b/tests/snapshots/check/__snapshots__/nuxt-ui-check.snap
@@ -594,7 +594,7 @@
         "error:3:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:5:19 [TS2307] Cannot find module '#build/ui/input-tags' or its corresponding type declarations.",
         "error:73:7 [TS2307] Cannot find module '#imports' or its corresponding type declarations.\nType '\"type\"' is not assignable to type 'keyof Props<T>'.\nType '\"type\"' is not assignable to type 'keyof Props<T>'.\nType '\"type\"' is not assignable to type 'keyof Props<T>'.",
-        "error:167:26 [TS2345] Argument of type '(value: T[]) => void' is not assignable to parameter of type '(payload: AcceptableInputValue[]) => unknown'.\nTypes of parameters 'value' and 'args' are incompatible.\nType 'AcceptableInputValue[]' is not assignable to type 'T[]'.\nType 'AcceptableInputValue' is not assignable to type 'T'.\n'AcceptableInputValue' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'AcceptableInputValue'.\nType 'string' is not assignable to type 'T'.\n'string' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'AcceptableInputValue'."
+        "error:167:6 [TS2322] Type '(value: T[]) => void' is not assignable to type '(payload: AcceptableInputValue[]) => unknown'.\nTypes of parameters 'value' and 'args' are incompatible.\nType 'AcceptableInputValue[]' is not assignable to type 'T[]'.\nType 'AcceptableInputValue' is not assignable to type 'T'.\n'AcceptableInputValue' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'AcceptableInputValue'.\nType 'string' is not assignable to type 'T'.\n'string' is assignable to the constraint of type 'T', but 'T' could be instantiated with a different subtype of constraint 'AcceptableInputValue'."
       ]
     },
     {
@@ -817,7 +817,7 @@
         "error:3:32 [TS2307] Cannot find module '@nuxt/schema' or its corresponding type declarations.",
         "error:4:19 [TS2307] Cannot find module '#build/ui/pricing-plan' or its corresponding type declarations.",
         "error:115:50 [TS2307] Cannot find module '#imports' or its corresponding type declarations.",
-        "error:231:155 [TS2345] Argument of type '((event: MouseEvent) => void | Promise<void>)[] | ((event: MouseEvent) => void | Promise<void>) | undefined' is not assignable to parameter of type '((...args: any[]) => unknown) | null | undefined'.\nType '((event: MouseEvent) => void | Promise<void>)[]' is not assignable to type '(...args: any[]) => unknown'.\nType '((event: MouseEvent) => void | Promise<void>)[]' provides no match for the signature '(...args: any[]): unknown'."
+        "error:231:148 [TS2322] Type '((event: MouseEvent) => void | Promise<void>)[] | ((event: MouseEvent) => void | Promise<void>) | undefined' is not assignable to type '((...args: any[]) => unknown) | null | undefined'.\nType '((event: MouseEvent) => void | Promise<void>)[]' is not assignable to type '(...args: any[]) => unknown'.\nType '((event: MouseEvent) => void | Promise<void>)[]' provides no match for the signature '(...args: any[]): unknown'."
       ]
     },
     {

--- a/tests/snapshots/check/__snapshots__/reka-ui-check.snap
+++ b/tests/snapshots/check/__snapshots__/reka-ui-check.snap
@@ -251,7 +251,7 @@
       "diagnostics": [
         "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.",
         "error:3:69 [TS2307] Cannot find module '@internationalized/date' or its corresponding type declarations.",
-        "error:65:32 [TS2345] Argument of type '(newLocale: string) => void' is not assignable to parameter of type '(value: AcceptableValue) => unknown'.\nTypes of parameters 'newLocale' and 'args' are incompatible.\nType 'AcceptableValue' is not assignable to type 'string'.\nType 'null' is not assignable to type 'string'."
+        "error:65:12 [TS2322] Type '(newLocale: string) => void' is not assignable to type '(value: AcceptableValue) => unknown'.\nTypes of parameters 'newLocale' and 'args' are incompatible.\nType 'AcceptableValue' is not assignable to type 'string'.\nType 'null' is not assignable to type 'string'."
       ]
     },
     {
@@ -570,7 +570,7 @@
     {
       "file": "packages/core/src/Combobox/story/ComboboxCustom.story.vue",
       "diagnostics": [
-        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.\nType '\"as\"' is not assignable to type 'never'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'asChild' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'height' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'rounded' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'width' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'defer' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'disabled' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'forceMount' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'to' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'."
+        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations."
       ]
     },
     {
@@ -588,7 +588,7 @@
     {
       "file": "packages/core/src/Combobox/story/ComboboxReactive.story.vue",
       "diagnostics": [
-        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations."
+        "error:2:22 [TS2307] Cannot find module '@iconify/vue' or its corresponding type declarations.\nType '\"as\"' is not assignable to type 'never'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'as' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'asChild' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'height' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'rounded' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nProperty 'width' does not exist on type 'Omit<__LooseRequired<ContextMenuArrowProps>, \"as\" | \"height\" | \"width\"> & {}'.\nType '\"as\"' is not assignable to type 'never'.\nProperty 'defer' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'disabled' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'forceMount' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'.\nProperty 'to' does not exist on type '__DefineProps<ContextMenuPortalProps, never>'."
       ]
     },
     {
@@ -2081,7 +2081,9 @@
     },
     {
       "file": "packages/core/src/Popper/PopperArrow.vue",
-      "diagnostics": []
+      "diagnostics": [
+        "error:42:6 [TS2322] Type '(el: HTMLElement) => undefined' is not assignable to type 'VNodeRef | undefined'.\nType '(el: HTMLElement) => undefined' is not assignable to type '(ref: Element | ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, string, ComponentProvideOptions>, ... 4 more ..., any> | null, refs: Record<...>) => void'.\nTypes of parameters 'el' and 'ref' are incompatible.\nType 'Element | ComponentPublicInstance<{}, {}, {}, {}, {}, {}, {}, {}, false, ComponentOptionsBase<any, any, any, any, any, any, any, any, any, {}, {}, string, {}, {}, {}, string, ComponentProvideOptions>, ... 4 more ..., any> | null' is not assignable to type 'HTMLElement'.\nType 'null' is not assignable to type 'HTMLElement'."
+      ]
     },
     {
       "file": "packages/core/src/Popper/PopperContent.vue",
@@ -3338,7 +3340,7 @@
       "diagnostics": []
     }
   ],
-  "errorCount": 329,
+  "errorCount": 330,
   "warningCount": 0,
   "fileCount": 700
 }


### PR DESCRIPTION
## The failure

`App E2E (check)` failed on the v0.308.0 release commit `83343426f`
([run 30602594088](https://github.com/ubugeeei-prod/vize/actions/runs/30602594088)):
elk, misskey, npmx.dev, nuxt-ui and reka-ui all failed
`vize check does not crash and snapshot matches`.

That suite only runs on tag / nightly / dispatch. It last ran green at v0.306.0
(`8c2509a23`), and five PRs that each intentionally change diagnostics have
merged since, so the drift accumulated invisibly and landed on the release.

This is drift, not a regression, and it is re-pinned here — not accepted blind.

## Every hunk, attributed

The whole diff is 10 semantic hunks plus 3 `errorCount` lines.

| snapshot | hunk | cause |
| --- | --- | --- |
| elk | `CommonTabs.vue` **+** `40:39 [TS2322]` — `:key="option"` binds an object where Vue needs a `PropertyKey` | #3443 |
| misskey | `MkTabs.vue` **−** `11:11 [TS7006] Parameter 'el' implicitly has an 'any' type` on `:ref="(el) => tabRefs[t.key] = (el as HTMLElement)"` | #3443 |
| misskey | `MkPageHeader.tabs.vue` **−** the same `11:11 [TS7006]` on the same construct | #3443 |
| npmx.dev | `SkillsModal.vue` `[TS2367]` moves `206:75` → `217:18` | #3509/#3512, then #3510 |
| nuxt-ui | `InputTags.vue` `167:26 [TS2345]` → `167:6 [TS2322]` on `@update:model-value` | #3509 |
| nuxt-ui | `PricingPlan.vue` `231:155 [TS2345]` → `231:148 [TS2322]` | #3509 |
| reka-ui | `CalendarSelect.story.vue` `65:32 [TS2345]` → `65:12 [TS2322]` on `@update:model-value` | #3509 |
| reka-ui | the unanchored `ContextMenu*` message block moves from `ComboboxCustom.story.vue` to `ComboboxReactive.story.vue` | #3443/#3509 |
| reka-ui | `PopperArrow.vue` **+** `42:6 [TS2322]` — `:ref="(el: HTMLElement) => …"` against `VNodeRef` | #3443 |

`errorCount`: elk 280 → 281, misskey 39 → 37, npmx.dev 161 → 161,
nuxt-ui 646 → 646, reka-ui 329 → 330. `fileCount` is unchanged everywhere.

### The two disappearing diagnostics are a false positive going away

misskey is the only snapshot that loses diagnostics, so it got the most
scrutiny. Both removals are `TS7006` on the `el` parameter of
`:ref="(el) => …"` on a **native** `<button>`.

Before #3443 a native-element `v-bind` was only checked when the attribute name
was in a hard-coded boolean-ish list, so `:ref` was not checked at all, the
inline arrow got no contextual type, and its parameter was implicitly `any`.
#3443 checks the binding against the element's `ref` prop type (`VNodeRef`),
which contextually types the parameter — so `TS7006` correctly no longer fires.
`vue-tsc` does not report it either.

reka-ui's `PopperArrow.vue` is the same construct with an explicit
`(el: HTMLElement)` annotation instead of an inferred parameter, which is
exactly why it **gains** a `TS2322` (`VNodeRef` may be handed `null` on unmount)
where misskey loses a `TS7006`. The two directions corroborate each other.

### No message text is lost in the reka-ui relocation

The Combobox hunk moves a block of unanchored `ContextMenu*` messages between
two sibling story files that both carry a `2:22 [TS2307]` for `@iconify/vue`.
Comparing the **global multiset** of diagnostic strings for `reka-ui-check.snap`,
old vs new, the only differences are the `CalendarSelect` recode and the new
`PopperArrow` error — the relocated block's count is unchanged, so nothing was
dropped.

### npmx.dev moved twice, which pins #3510

The failing run at v0.307.0 (`0409c6ade`,
[run 30599680680](https://github.com/ubugeeei-prod/vize/actions/runs/30599680680))
is a free bisect point: it is after #3512 and before #3510. It reported this
`TS2367` at `225:24`, so the position moved `206:75` → `225:24` (the #3509/#3512
handler-codegen reshape) → `217:18` (#3510 hoisting the ref-widening helpers out
of the per-file preamble). The diagnostic has no authored anchor — neither
`206:75`, `225:24` nor `217:18` points at a comparison — so its reported
position tracks generated-module layout, which both PRs changed by design. Every
other hunk in all five snapshots is byte-identical at v0.307.0 and v0.308.0.

## How these were generated

Not locally. The suite was re-run with snapshot writing forced on a throwaway
branch, in the App E2E `check` environment itself — same Linux runner, same
pinned fixture submodule commits, same `corsa` build, same misskey worktree
setup — and the resulting files were taken verbatim.

**Determinism evidence.** That run rewrote every asserted snapshot in the
directory from scratch, not just the failing five. `vuefes-2025-check.snap` came
back byte-identical, as did `ant-design-vue-lint.snap` and `reka-ui-lint.snap`
(~880 KB together) from the companion `lint` dispatch. Exactly the five expected
files changed and nothing else moved.

(`ant-design-vue-check.snap` is not evidence either way — its `assertSnapshot`
is gated behind `VIZE_CHECK_ASSERT_SNAPSHOT=1` pending #510.)

## Verification

`App E2E` dispatched with `suite=check` against this branch — the same job that
failed on the release commit, now green.

Local gates: `nix develop -c vp run fmt:check`, `check:js`, `source:lengths` all
exit 0.

## Not part of this PR

- **`App E2E (lint)` is a second, independent release blocker.** It failed in
  the same run for elk, misskey, npmx.dev, nuxt-ui and vuefes-2025. That drift is
  entirely `vue/no-unused-properties` (+4/+2/+1/+1/+2, and one removal in
  npmx.dev), which is #3508 doing what it says on the tin. The release stays
  blocked until those five are re-pinned too; this PR does not touch them.
- `vize check: no generated `.nuxt` types found` in the run log is unrelated
  pre-existing stderr noise. It appears 8 times in the last fully green run
  (v0.306.0, run 30567979170); it belongs to the Nuxt fixtures — elk,
  frontend-phpcon, npmx.dev, vuefes-2025 — not to nuxt-ui, which never emits it;
  and vuefes-2025 emits it while matching its snapshot byte for byte.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->