### PR TITLE
test(patina): re-pin the five app lint snapshots to no-unused-properties' real usage signal

### DIFF
--- a/tests/snapshots/lint/__snapshots__/elk-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/elk-lint.snap
@@ -1052,6 +1052,17 @@
     "file": "app/components/main/MainContent.vue",
     "messages": [
       {
+        "ruleId": "vue/no-unused-properties",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-properties] Prop 'noOverflowHidden' is defined but never used",
+        "line": 41,
+        "column": 11,
+        "endLine": 41,
+        "endColumn": 11,
+        "help": "Remove unused prop or use it in your template/script"
+      },
+      {
         "ruleId": "html/deprecated-attr",
         "ruleDocsPath": "docs/content/rules/html.md",
         "severity": 1,
@@ -1064,7 +1075,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 2
   },
   {
     "file": "app/components/main/MainTitle.vue",
@@ -1873,6 +1884,17 @@
     "file": "app/components/publish/PublishAttachment.vue",
     "messages": [
       {
+        "ruleId": "vue/no-unused-properties",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-properties] Prop 'alt' is defined but never used",
+        "line": 28,
+        "column": 11,
+        "endLine": 28,
+        "endColumn": 11,
+        "help": "Remove unused prop or use it in your template/script"
+      },
+      {
         "ruleId": "a11y/click-events-have-key-events",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -1907,7 +1929,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 4
   },
   {
     "file": "app/components/publish/PublishCharacterCounter.vue",
@@ -1987,6 +2009,17 @@
         "endLine": 457,
         "endColumn": 42,
         "help": "Element IDs must be unique within a document. Duplicate IDs break label associations, ARIA references, and getElementById()."
+      },
+      {
+        "ruleId": "vue/no-unused-properties",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-properties] Prop 'inReplyToVisibility' is defined but never used",
+        "line": 394,
+        "column": 11,
+        "endLine": 394,
+        "endColumn": 11,
+        "help": "Remove unused prop or use it in your template/script"
       },
       {
         "ruleId": "html/deprecated-attr",
@@ -2141,7 +2174,7 @@
       }
     ],
     "errorCount": 4,
-    "warningCount": 11
+    "warningCount": 12
   },
   {
     "file": "app/components/publish/PublishWidgetFull.client.vue",
@@ -2746,9 +2779,21 @@
   },
   {
     "file": "app/components/status/StatusContent.vue",
-    "messages": [],
+    "messages": [
+      {
+        "ruleId": "vue/no-unused-properties",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-properties] Prop 'inNotification' is defined but never used",
+        "line": 37,
+        "column": 11,
+        "endLine": 37,
+        "endColumn": 11,
+        "help": "Remove unused prop or use it in your template/script"
+      }
+    ],
     "errorCount": 0,
-    "warningCount": 0
+    "warningCount": 1
   },
   {
     "file": "app/components/status/StatusDetails.vue",

--- a/tests/snapshots/lint/__snapshots__/misskey-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/misskey-lint.snap
@@ -10517,6 +10517,28 @@
     "file": "src/components/MkPushNotificationAllowButton.vue",
     "messages": [
       {
+        "ruleId": "vue/no-unused-properties",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-properties] Prop 'danger' is defined but never used",
+        "line": 6,
+        "column": 11,
+        "endLine": 6,
+        "endColumn": 11,
+        "help": "Remove unused prop or use it in your template/script"
+      },
+      {
+        "ruleId": "vue/no-unused-properties",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-properties] Prop 'link' is defined but never used",
+        "line": 6,
+        "column": 11,
+        "endLine": 6,
+        "endColumn": 11,
+        "help": "Remove unused prop or use it in your template/script"
+      },
+      {
         "ruleId": "vue/sfc-element-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -10529,7 +10551,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 3
   },
   {
     "file": "src/components/MkRadios.vue",

--- a/tests/snapshots/lint/__snapshots__/npmx.dev-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/npmx.dev-lint.snap
@@ -286,21 +286,9 @@
   },
   {
     "file": "app/components/BuildEnvironment.vue",
-    "messages": [
-      {
-        "ruleId": "vue/no-unused-properties",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unused-properties] Prop 'buildInfo' is defined but never used",
-        "line": 16,
-        "column": 95,
-        "endLine": 17,
-        "endColumn": 30,
-        "help": "Remove unused prop or use it in your template/script"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "app/components/Button/Base.vue",
@@ -1783,6 +1771,28 @@
     "file": "app/components/Package/SkillsCard.vue",
     "messages": [
       {
+        "ruleId": "vue/no-unused-properties",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-properties] Prop 'packageName' is defined but never used",
+        "line": 13,
+        "column": 11,
+        "endLine": 13,
+        "endColumn": 11,
+        "help": "Remove unused prop or use it in your template/script"
+      },
+      {
+        "ruleId": "vue/no-unused-properties",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-properties] Prop 'version' is defined but never used",
+        "line": 13,
+        "column": 11,
+        "endLine": 13,
+        "endColumn": 11,
+        "help": "Remove unused prop or use it in your template/script"
+      },
+      {
         "ruleId": "vue/attribute-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1795,7 +1805,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 3
   },
   {
     "file": "app/components/Package/SkillsModal.vue",

--- a/tests/snapshots/lint/__snapshots__/nuxt-ui-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/nuxt-ui-lint.snap
@@ -2359,9 +2359,21 @@
   },
   {
     "file": "src/runtime/components/prose/Script.vue",
-    "messages": [],
+    "messages": [
+      {
+        "ruleId": "vue/no-unused-properties",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-properties] Prop 'src' is defined but never used",
+        "line": 9,
+        "column": 11,
+        "endLine": 9,
+        "endColumn": 11,
+        "help": "Remove unused prop or use it in your template/script"
+      }
+    ],
     "errorCount": 0,
-    "warningCount": 0
+    "warningCount": 1
   },
   {
     "file": "src/runtime/components/prose/Steps.vue",

--- a/tests/snapshots/lint/__snapshots__/vuefes-2025-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/vuefes-2025-lint.snap
@@ -136,6 +136,28 @@
     "file": "app/components/SponsorGrid.vue",
     "messages": [
       {
+        "ruleId": "vue/no-unused-properties",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-properties] Prop 'gapSp' is defined but never used",
+        "line": 21,
+        "column": 11,
+        "endLine": 21,
+        "endColumn": 11,
+        "help": "Remove unused prop or use it in your template/script"
+      },
+      {
+        "ruleId": "vue/no-unused-properties",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-properties] Prop 'linkPath' is defined but never used",
+        "line": 21,
+        "column": 11,
+        "endLine": 21,
+        "endColumn": 11,
+        "help": "Remove unused prop or use it in your template/script"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -148,7 +170,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 3
   },
   {
     "file": "app/components/button/VFButton.vue",


### PR DESCRIPTION
Second half of the v0.308.0 release unblock. #3515 re-pinned the five **check**
snapshots; this does the same for the five **lint** snapshots, which failed in
the same run and are still red on `main`.

Closes #3518.

## The failure

`App E2E (lint)` failed on `83343426f`
([run 30602594088](https://github.com/ubugeeei-prod/vize/actions/runs/30602594088))
for elk, misskey, npmx.dev, nuxt-ui and vuefes-2025 — `vize lint does not crash
and snapshot matches`.

Same structural cause as #3515 and #3516: `App E2E` `lint` only runs on
tag / nightly / dispatch, so #3508 (`fix(patina): give no-unused-properties a
real template-usage signal`) was green on its own PR and the drift surfaced at
release time.

## Every hunk, attributed

The drift is **entirely `vue/no-unused-properties`**: twelve message objects
change in total — eleven added, one removed — spread over the nine files below.
Each was checked against the fixture source at its pinned submodule commit.

Verified strictly: comparing the global multiset of **full** message objects
(every field, including `ruleDocsPath` and `help`) per snapshot, keyed by file,
the only differences are those twelve. No other rule changes count anywhere, no
retained message moves or is reworded, and the file-entry list is identical in
all seven snapshots.

| snapshot | file | prop | verdict |
| --- | --- | --- | --- |
| elk | `main/MainContent.vue` | `noOverflowHidden` | **+** true positive |
| elk | `publish/PublishAttachment.vue` | `alt` | **+** true positive |
| elk | `publish/PublishWidget.vue` | `inReplyToVisibility` | **+** true positive |
| elk | `status/StatusContent.vue` | `inNotification` | **+** true positive |
| misskey | `MkPushNotificationAllowButton.vue` | `danger`, `link` | **+** true positive |
| npmx.dev | `Package/SkillsCard.vue` | `packageName`, `version` | **+** true positive |
| npmx.dev | `BuildEnvironment.vue` | `buildInfo` | **−** false positive removed |
| nuxt-ui | `prose/Script.vue` | `src` | **+** true positive |
| vuefes-2025 | `SponsorGrid.vue` | `gapSp`, `linkPath` | **+** true positive |

For every added finding, the prop name occurs **exactly once** in the file — in
the `defineProps<{…}>()` type literal — and is not among the names the component
destructures. `nuxt-ui`'s `prose/Script.vue` is the clearest case; that is the
entire component:

```vue
<script setup lang="ts">
defineProps<{
  src: string
}>()

const isDev = import.meta.dev
</script>

<template>
  <div v-if="isDev">
    Rendering the <code>script</code> element is dangerous and is disabled by default. …
  </div>
</template>
```

`vuefes-2025`'s `SponsorGrid.vue` is the one that could have been a trap and is
not — it *does* destructure, but only `imageOnly`, `columns` and `gap`, leaving
`gapSp` and `linkPath` genuinely unreferenced.

### The one removal, in detail

`npmx.dev` `app/components/BuildEnvironment.vue` is the only place a finding
disappears, so it got the same scrutiny as misskey's two vanishing `TS7006`s in
#3515. It is a false positive going away.

```ts
const { footer = false, buildInfo: buildInfoProp } = defineProps<{
  footer?: boolean
  buildInfo?: BuildInfo
}>()

const appConfig = useAppConfig()
const buildInfo = computed(() => buildInfoProp || appConfig.buildInfo)
```

The prop `buildInfo` is destructured **under a different name** and used on the
line below as `buildInfoProp`. Separately, `buildInfo` is rebound as a local
`computed`, and that is what the template reads. The old name-based signal did
not follow the rename, saw no use of a binding called `buildInfo` that came from
the props, and reported it unused. #3508 resolves the aliased binding, so the
warning correctly stops firing — the prop is used.

That the same PR both *adds* findings for genuinely dead props and *removes* one
for an aliased-but-used prop is the signature of a rule that stopped guessing
from names and started reading real usage, which is exactly what #3508 says it
does.

## How these were generated

Re-run with snapshot writing forced on a throwaway branch based on **this exact
`main` (`60754bd38`)** — not the earlier probe branch — inside the App E2E `lint`
environment: same Linux runner, same pinned fixture commits, same misskey
worktree setup. Probe branch deleted.

**Determinism.** The run rewrote all seven lint snapshots from scratch. Every one
of the seven is byte-identical to the same file produced by an independent
earlier run on a *different* base commit — 2.9 MB reproduced exactly, run to run.
Of those seven, `ant-design-vue-lint.snap` (580 KB) and `reka-ui-lint.snap`
(292 KB) also come back byte-identical to what is committed, so exactly the five
expected files move and nothing else drifts.

## Verification

`App E2E` dispatched with `suite=lint` against this branch — the same job that
failed on the release commit.

Local gates: `nix develop -c vp run fmt:check`, `check:js`, `source:lengths` all
exit 0.

## Noted, not fixed here

Every new `vue/no-unused-properties` message anchors at the `<template>` tag
rather than at the prop declaration — `MainContent.vue` reports `41:11`,
`SkillsCard.vue` `13:11`, `prose/Script.vue` `9:11`, and in each case that line
is the file's `<template>` and column 11 is the character just past the
ten-character `<template>` tag. The findings are correct; only the location is
unhelpful. Filed separately rather than widened into a release-unblocking PR.
