### PR TITLE
fix(atelier): unpack the custom-directive array form in JSX

### DIFF
--- a/crates/vize_atelier_jsx/src/lower.rs
+++ b/crates/vize_atelier_jsx/src/lower.rs
@@ -15,6 +15,7 @@ mod name;
 mod slot;
 mod style;
 mod text;
+mod v_custom;
 mod v_model;
 mod v_models;
 mod v_slots;

--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -13,7 +13,7 @@ use oxc_ast::ast::{
     JSXAttribute, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXSpreadAttribute,
 };
 use oxc_span::{GetSpan, Span};
-use vize_carton::{Box, String, Vec};
+use vize_carton::{Box, String, Vec, is_builtin_directive};
 use vize_relief::SourceLocation;
 use vize_relief::{AttributeNode, DirectiveNode, PropNode, TextNode};
 
@@ -231,8 +231,24 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         // malformed `$event => ($event => (...))` chain).
         if raw_name == "model"
             && arg.is_none()
-            && let Some(array) = self.model_array_value(attr.value.as_ref())
+            && let Some(array) = self.array_literal_value(attr.value.as_ref())
             && let Some(prop) = self.lower_model_array(array, loc)
+        {
+            return Some(prop);
+        }
+
+        // `v-custom={[value, 'arg', ['a','b']]}` — babel-plugin-jsx's array
+        // encoding for a custom directive's value, argument and modifiers.
+        // Restricted to custom directives with no JSX-namespace argument: the
+        // built-ins carry their own array meanings (`v-model` just above,
+        // `v-models` before `lower_attribute` even runs), and when the argument
+        // is already spelled `v-custom:arg` there is no positional slot for the
+        // array to fill.
+        if arg.is_none()
+            && !is_builtin_directive(raw_name)
+            && raw_name != "models"
+            && let Some(array) = self.array_literal_value(attr.value.as_ref())
+            && let Some(prop) = self.lower_custom_directive_array(array, raw_name, loc)
         {
             return Some(prop);
         }

--- a/crates/vize_atelier_jsx/src/lower/v_custom.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_custom.rs
@@ -1,0 +1,95 @@
+//! `v-custom={[value, 'arg', ['a','b']]}` — babel-plugin-jsx's array encoding
+//! for a *custom* directive's value, argument and modifiers (#3421).
+//!
+//! The built-in encodings live next door: `v_model.rs` destructures
+//! `v-model={[value, ['trim']]}`, and `v_models.rs` the two-dimensional
+//! `v-models` form. This module handles everything else that is not a built-in.
+
+use oxc_ast::ast::{ArrayExpressionElement, Expression};
+use oxc_span::GetSpan;
+use vize_carton::Box;
+use vize_relief::SourceLocation;
+use vize_relief::{DirectiveNode, PropNode, SimpleExpressionNode};
+
+use super::Lowerer;
+
+impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// Unpack babel-plugin-jsx's array encoding for a custom directive.
+    ///
+    /// Babel places the elements positionally, so `[val, 'arg', ['a','b']]`
+    /// becomes `[dir, val, 'arg', { a: true, b: true }]`. Only the shapes babel
+    /// actually encodes are unpacked:
+    ///
+    /// - `[value]`
+    /// - `[value, 'arg']`
+    /// - `[value, ['a', 'b']]`
+    /// - `[value, 'arg', ['a', 'b']]`
+    ///
+    /// Every other shape returns `None` and keeps the whole array as the bound
+    /// value, which is what vize did before this existed. That fallback is the
+    /// point rather than a limitation: a partial unpack would place the elements
+    /// it recognizes and silently drop the rest, which is exactly the
+    /// degrade-instead-of-diagnose failure #3421 is about. A non-literal value
+    /// (`v-custom={someArray}`) never reaches here at all, so a user passing an
+    /// array-valued directive keeps passing it.
+    pub(crate) fn lower_custom_directive_array(
+        &self,
+        array: &oxc_ast::ast::ArrayExpression<'_>,
+        name: &str,
+        loc: &SourceLocation,
+    ) -> Option<PropNode<'a>> {
+        let mut elements = std::vec::Vec::new();
+        for element in &array.elements {
+            match element {
+                ArrayExpressionElement::SpreadElement(_) | ArrayExpressionElement::Elision(_) => {
+                    return None;
+                }
+                _ => elements.push(element.as_expression()?),
+            }
+        }
+
+        let value_expr = *elements.first()?;
+        let (arg, modifiers) = match elements.len() {
+            1 => (None, None),
+            2 => match elements[1] {
+                Expression::StringLiteral(argument) => (Some(argument), None),
+                Expression::ArrayExpression(modifiers) => (None, Some(modifiers)),
+                _ => return None,
+            },
+            3 => match (elements[1], elements[2]) {
+                (Expression::StringLiteral(argument), Expression::ArrayExpression(modifiers)) => {
+                    (Some(argument), Some(modifiers))
+                }
+                _ => return None,
+            },
+            _ => return None,
+        };
+
+        // Validate before building: a modifiers list holding anything but string
+        // literals is not babel's encoding, and dropping those entries would be
+        // the same silent degradation.
+        let modifier_names = match modifiers {
+            None => std::vec::Vec::new(),
+            Some(modifiers) => modifiers
+                .elements
+                .iter()
+                .map(|element| match element.as_expression() {
+                    Some(Expression::StringLiteral(name)) => Some(name.value.as_str()),
+                    _ => None,
+                })
+                .collect::<Option<std::vec::Vec<_>>>()?,
+        };
+
+        let mut directive = DirectiveNode::new(self.bump(), name, loc.clone());
+        directive.exp = Some(self.dyn_expr(value_expr.span()));
+        if let Some(argument) = arg {
+            directive.arg = Some(self.static_expr(argument.value.as_str(), argument.span));
+        }
+        for modifier in modifier_names {
+            directive
+                .modifiers
+                .push(SimpleExpressionNode::new(modifier, false, loc.clone()));
+        }
+        Some(PropNode::Directive(Box::new_in(directive, self.bump())))
+    }
+}

--- a/crates/vize_atelier_jsx/src/lower/v_model.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_model.rs
@@ -94,7 +94,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
 
     /// The `[value, ...]` array literal backing a `v-model={[...]}` attribute,
     /// or `None` when the value is not an array-literal expression container.
-    pub(crate) fn model_array_value<'e>(
+    pub(crate) fn array_literal_value<'e>(
         &self,
         value: Option<&'e JSXAttributeValue<'e>>,
     ) -> Option<&'e oxc_ast::ast::ArrayExpression<'e>> {

--- a/crates/vize_atelier_jsx/src/lower/v_models.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_models.rs
@@ -109,7 +109,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             return true;
         }
 
-        let Some(entries) = self.model_array_value(attr.value.as_ref()) else {
+        let Some(entries) = self.array_literal_value(attr.value.as_ref()) else {
             self.reject(
                 span,
                 "v-models expects a two-dimensional array of `[value, arg?, modifiers?]` \

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   71 |
-| divergent  |   24 |
+| equivalent |   72 |
+| divergent  |   23 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -170,7 +170,7 @@ deliberate answer, recorded here so it is not relitigated.
 | `directives/v_html_with_children`       | keeps the children too                                         | same                                                            | no change               | ✅      |
 | `directives/v_text`                     | `{textContent: t}` raw                                         | `textContent: toDisplayString(t)`                               | assign raw              | ❌      |
 | `directives/v_custom_arg`               | `[[resolveDirective("custom"), val, "arg"]]`                   | same                                                            | no change               | ✅      |
-| `directives/v_custom_array`             | unpacks `[val, 'arg', ['a','b']]` into value / arg / modifiers | passes the whole array as the value                             | unpack the array form   | ❌      |
+| `directives/v_custom_array`             | unpacks `[val, 'arg', ['a','b']]` into value / arg / modifiers | same (#3421)                                                    | no change               | ✅      |
 | `directives/v_dashed_custom`            | `resolveDirective("unknown-thing")`                            | same                                                            | no change               | ✅      |
 
 ### `v-models` spellings Vize rejects and babel accepts

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -113,10 +113,7 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
         Diff("v-text wrapped in toDisplayString"),
     ),
     ("directives/v_custom_arg", Same),
-    (
-        "directives/v_custom_array",
-        Diff("custom-directive array form not unpacked"),
-    ),
+    ("directives/v_custom_array", Same),
     ("directives/v_dashed_custom", Same),
     // -- slots -----------------------------------------------------------
     ("slots/object_children", Same),

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (71, 24, 2));
+    assert_eq!((equivalent, divergent, deferred), (72, 23, 2));
     assert_eq!(VERDICTS.len(), 97);
 }
 

--- a/crates/vize_atelier_jsx/tests/directives.rs
+++ b/crates/vize_atelier_jsx/tests/directives.rs
@@ -78,3 +78,132 @@ fn directive_and_plain_attributes_coexist() {
     assert_eq!(attr.name.as_str(), "class");
     assert_eq!(attr.value.as_ref().unwrap().content.as_str(), "f");
 }
+
+// -- custom directive array form (#3421) -------------------------------------
+//
+// babel-plugin-jsx encodes a custom directive's value, argument and modifiers
+// positionally in an array literal. Vize used to pass the whole array through as
+// the bound value, so `[val, 'arg', ['a','b']]` reached the runtime as one
+// array argument instead of three.
+//
+// The unpack is deliberately restricted to the shapes babel actually encodes.
+// Everything else keeps the array intact, because a partial unpack would place
+// what it recognizes and silently drop the rest — the exact failure mode #3421
+// is about.
+
+fn modifier_names<'a>(directive: &'a vize_relief::DirectiveNode<'a>) -> Vec<&'a str> {
+    directive
+        .modifiers
+        .iter()
+        .map(|modifier| modifier.content.as_str())
+        .collect()
+}
+
+#[test]
+fn custom_directive_array_unpacks_value_arg_and_modifiers() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <a v-custom={[val, 'arg', ['a','b']]}/>;");
+    let directive = find_directive(root_element(&root), "custom").expect("v-custom directive");
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "val");
+    assert_eq!(simple_content(directive.arg.as_ref().unwrap()), "arg");
+    assert_eq!(modifier_names(directive), vec!["a", "b"]);
+}
+
+#[test]
+fn custom_directive_array_of_one_is_just_the_value() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <a v-custom={[val]}/>;");
+    let directive = find_directive(root_element(&root), "custom").expect("v-custom directive");
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "val");
+    assert!(directive.arg.is_none());
+    assert!(directive.modifiers.is_empty());
+}
+
+#[test]
+fn custom_directive_array_takes_a_trailing_modifiers_list_without_an_arg() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <a v-custom={[val, ['a']]}/>;");
+    let directive = find_directive(root_element(&root), "custom").expect("v-custom directive");
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "val");
+    assert!(directive.arg.is_none());
+    assert_eq!(modifier_names(directive), vec!["a"]);
+}
+
+#[test]
+fn custom_directive_array_takes_an_arg_without_modifiers() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <a v-custom={[val, 'arg']}/>;");
+    let directive = find_directive(root_element(&root), "custom").expect("v-custom directive");
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "val");
+    assert_eq!(simple_content(directive.arg.as_ref().unwrap()), "arg");
+    assert!(directive.modifiers.is_empty());
+}
+
+/// A non-literal value is not babel's encoding and never was: a user passing an
+/// array-valued directive must keep passing it.
+#[test]
+fn custom_directive_non_literal_array_value_is_passed_through() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <a v-custom={someArray}/>;");
+    let directive = find_directive(root_element(&root), "custom").expect("v-custom directive");
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "someArray");
+    assert!(directive.arg.is_none());
+    assert!(directive.modifiers.is_empty());
+}
+
+/// An unrecognized tail keeps the whole array rather than unpacking the part it
+/// understands. Placing `val` and dropping `other` would be a silent content
+/// loss, which is worse than the divergence.
+#[test]
+fn custom_directive_unrecognized_array_shape_keeps_the_whole_array() {
+    for source in [
+        "const a = <a v-custom={[val, other]}/>;",
+        "const a = <a v-custom={[val, 'arg', ['a'], extra]}/>;",
+        "const a = <a v-custom={[val, 'arg', [notAString]]}/>;",
+        "const a = <a v-custom={[...spread]}/>;",
+    ] {
+        let bump = Bump::new();
+        let root = lower_one(&bump, source);
+        let directive = find_directive(root_element(&root), "custom").expect("v-custom directive");
+        let value = simple_content(directive.exp.as_ref().unwrap());
+        assert!(
+            value.starts_with('['),
+            "{source} should keep the array as the bound value, got {value}"
+        );
+        assert!(directive.arg.is_none(), "{source} should have no argument");
+        assert!(
+            directive.modifiers.is_empty(),
+            "{source} should have no modifiers"
+        );
+    }
+}
+
+/// With the argument already spelled as a JSX namespace there is no positional
+/// slot for the array to fill, so it stays the bound value.
+#[test]
+fn custom_directive_with_namespaced_arg_keeps_an_array_value() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <a v-custom:arg={[val, ['a']]}/>;");
+    let directive = find_directive(root_element(&root), "custom").expect("v-custom directive");
+    assert_eq!(simple_content(directive.arg.as_ref().unwrap()), "arg");
+    assert!(
+        simple_content(directive.exp.as_ref().unwrap()).starts_with('['),
+        "the array stays the bound value"
+    );
+    assert!(directive.modifiers.is_empty());
+}
+
+/// Built-ins carry their own array meanings and must not be re-read as the
+/// custom-directive encoding. `v-model` is destructured by its own path just
+/// above this one; `v-show` and the rest take the array as their value.
+#[test]
+fn builtin_directives_do_not_use_the_custom_array_encoding() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div v-show={[visible, ['a']]}/>;");
+    let directive = find_directive(root_element(&root), "show").expect("v-show directive");
+    assert!(
+        simple_content(directive.exp.as_ref().unwrap()).starts_with('['),
+        "v-show keeps its array value"
+    );
+    assert!(directive.modifiers.is_empty());
+}

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
@@ -354,7 +354,7 @@ export function render(_ctx, _cache) {
 
 ## directives/v_custom_array
 ### verdict
-divergent: custom-directive array form not unpacked
+equivalent
 ### source (jsx)
 const A = () => <a v-custom={[val, 'arg', ['a','b']]}/>;
 ### babel options
@@ -371,7 +371,7 @@ export function render(_ctx, _cache) {
   const _directive_custom = _resolveDirective("custom")
   
   return _withDirectives((_openBlock(), _createElementBlock("a", null, null, 512 /* NEED_PATCH */)), [
-    [_directive_custom, [val, 'arg', ['a','b']]]
+    [_directive_custom, val, "arg", { a: true, b: true }]
   ])
 }
 


### PR DESCRIPTION
Refs #3421 — closes the `v-custom` array row from the maintainer triage. The remaining `{slots}` row needs a semantics decision (babel resolves it at runtime with `_isSlot`), so it stays open there.

## The defect

`@vue/babel-plugin-jsx` encodes a custom directive's value, argument and modifiers positionally in an array literal. Vize passed the whole array through as the bound value:

```jsx
const A = () => <a v-custom={[val, 'arg', ['a','b']]}/>;
```

| | output |
| --- | --- |
| babel | `[_resolveDirective("custom"), val, 'arg', { a: true, b: true }]` |
| vize (before) | `[_directive_custom, [val, 'arg', ['a','b']]]` |
| vize (after) | `[_directive_custom, val, "arg", { a: true, b: true }]` |

The directive received a value the author never wrote, with no diagnostic. Fixed unconditionally rather than behind the #3391 compat mode, per #3421's own framing: this is meaningless under *any* semantics, not a choice between two.

## Why the fallback matters more than the unpack

Only the shapes babel actually encodes are unpacked:

- `[value]`
- `[value, 'arg']`
- `[value, ['a', 'b']]`
- `[value, 'arg', ['a', 'b']]`

Everything else keeps the array intact. A partial unpack would place the elements it recognizes and **silently drop the rest** — which is precisely the degrade-instead-of-diagnose failure mode #3421 exists to close. Tested explicitly: `[val, other]`, `[val, 'arg', ['a'], extra]`, `[val, 'arg', [notAString]]` and `[...spread]` all keep the whole array.

`v-custom={someArray}` is not a literal and never reaches the unpack, so a user passing an array-valued directive keeps passing it.

## Not applied to

- **`v-model`** — destructured by its own path immediately above.
- **`v-models`** — consumed before `lower_attribute` runs.
- **Other built-ins** (`v-show`, `v-html`, …) — they take the array as their value; asserted.
- **`v-custom:arg={[…]}`** — the argument is already spelled as a JSX namespace, leaving no positional slot for the array to fill.

## Behavior note

`v-custom={[a, 'b']}` authored as a genuine two-element literal value now reads as value + argument. That is babel's reading of the same source, and matching it is what this row measures.

## Tests

8 new cases in `tests/directives.rs` covering each accepted shape, each rejected shape, the non-literal passthrough, the namespaced-arg case, and built-in exclusion. Verdict `directives/v_custom_array` moves `divergent` → `equivalent`; inventory totals 71/24/2 → 72/23/2, pinned by `babel_compat_verdict_totals`.

Full `vize_atelier_jsx` suite green. `tests/tooling/babel-jsx-oracle.test.ts` — "inventory markdown documents exactly the corpus cases" passes; `babel-output.json` is untouched.

`model_array_value` is renamed `array_literal_value`: it already served `v-models` as well as `v-model`, and now serves custom directives too. Crate-internal, no API change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for Babel-style custom directive arrays, including directive values, arguments, and string modifiers.
  * Preserved expected behavior for malformed arrays, spreads, non-string modifiers, built-in directives, and `v-models`.

* **Bug Fixes**
  * Custom directive array handling now matches Babel compatibility expectations.

* **Tests**
  * Added comprehensive coverage for valid and unsupported directive array formats.
  * Updated compatibility results to reflect the improved matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->