### PR TITLE
test(canon): re-pin the vue2-elm directive-value diagnostic position

### DIFF
--- a/tests/snapshots/check/__snapshots__/vue2-elm-check.snap
+++ b/tests/snapshots/check/__snapshots__/vue2-elm-check.snap
@@ -547,7 +547,7 @@
         "error:649:61 [TS2339] Property 'timer' does not exist on type '__VizeThis'.",
         "error:650:33 [TS2339] Property 'timer' does not exist on type '__VizeThis'.",
         "error:687:78 [TS2339] Property '$router' does not exist on type '__VizeThis'.",
-        "error:1353:17 [TS2304] Cannot find name 'attribute'."
+        "error:1359:11 [TS2304] Cannot find name 'attribute'."
       ]
     },
     {


### PR DESCRIPTION
`vue-parity` is red on `main` (`375b0fb5b`), blocking the release.

## Cause

#3521 (`fix(canon)!: type-check custom directive values against Directive<El, Value>`) collects custom directive value expressions as template expressions for the first time. The generated virtual TypeScript for the pinned Vue 2 app therefore places them differently, and one diagnostic moves:

```
- "error:1353:17 [TS2304] Cannot find name 'attribute'."
+ "error:1359:11 [TS2304] Cannot find name 'attribute'."
```

Same code, same message, same file, same diagnostic count — only the generated-module position moves. That is the expected consequence of emitting an expression that was previously not emitted at all.

## Why main went red rather than the PR

`App E2E`'s check suite and this `vue2-elm` snapshot run on different lanes: `vue-parity` (in `check.yml`) owns this one and runs on every push to `main`, while the ecosystem check snapshots only run on tag/release commits. #3521 was green on its own PR because `vue-parity` there compared against a pre-#3521 baseline.

This is the same structural shape recorded in #3516 — snapshot suites that validate on a different cadence than the change that moves them.

## Verification

The position change is attributable and the surrounding entries are untouched. CI's `vue-parity` job is the check that matters here; it hydrates the pinned `vue2-elm` submodule, which a local worktree cannot (the suite asserts the pinned fixture SHA before invoking vize, and worktrees do not get submodules checked out — see #3417).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->