### PR TITLE
fix(canon): honor exactOptionalPropertyTypes for component props

### DIFF
--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_component_prop_checks_respect_same_element_vif_guard.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_component_prop_checks_respect_same_element_vif_guard.snap
@@ -120,7 +120,7 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
-  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: Required<Pick<P, K>>[K] | {} | null };
   // @vize-map: component -> 0:40
   type __LinkComp_Props_0 = typeof LinkComp extends { __vizeCheck: any } ? Record<string, unknown> : (typeof LinkComp extends { new (): { $props: infer __P } } ? __P : (typeof LinkComp extends (props: infer __P) => any ? __P : {}));
   type __LinkComp_0_prop_to = __VizePropValue<__LinkComp_Props_0, 'to'>;

--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_component_prop_checks_respect_same_element_vif_guard.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_component_prop_checks_respect_same_element_vif_guard.snap
@@ -120,11 +120,11 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
   // @vize-map: component -> 0:40
   type __LinkComp_Props_0 = typeof LinkComp extends { __vizeCheck: any } ? Record<string, unknown> : (typeof LinkComp extends { new (): { $props: infer __P } } ? __P : (typeof LinkComp extends (props: infer __P) => any ? __P : {}));
   type __LinkComp_0_prop_to = __VizePropValue<__LinkComp_Props_0, 'to'>;
-  type __LinkComp_CheckProps_0 = {
-  };
+  type __LinkComp_CheckProps_0 = __VizeExactOptionalProps<__LinkComp_Props_0>;
   type __LinkComp_Check_0 = __VizePropChecker<typeof LinkComp, __LinkComp_CheckProps_0>;
 
   // Component template navigation references

--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_reserved_prop_and_hyphenated_slot_names.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_reserved_prop_and_hyphenated_slot_names.snap
@@ -124,11 +124,11 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
   // @vize-map: component -> 0:27
   type __TrendChart_Props_0 = typeof TrendChart extends { __vizeCheck: any } ? Record<string, unknown> : (typeof TrendChart extends { new (): { $props: infer __P } } ? __P : (typeof TrendChart extends (props: infer __P) => any ? __P : {}));
   type __TrendChart_0_prop_class = __VizePropValue<__TrendChart_Props_0, 'class'>;
-  type __TrendChart_CheckProps_0 = {
-  };
+  type __TrendChart_CheckProps_0 = __VizeExactOptionalProps<__TrendChart_Props_0>;
   type __TrendChart_Check_0 = __VizePropChecker<typeof TrendChart, __TrendChart_CheckProps_0>;
 
   // Component template navigation references

--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_reserved_prop_and_hyphenated_slot_names.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_reserved_prop_and_hyphenated_slot_names.snap
@@ -124,7 +124,7 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
-  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: Required<Pick<P, K>>[K] | {} | null };
   // @vize-map: component -> 0:27
   type __TrendChart_Props_0 = typeof TrendChart extends { __vizeCheck: any } ? Record<string, unknown> : (typeof TrendChart extends { new (): { $props: infer __P } } ? __P : (typeof TrendChart extends (props: infer __P) => any ? __P : {}));
   type __TrendChart_0_prop_class = __VizePropValue<__TrendChart_Props_0, 'class'>;

--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_scoped_slot_expressions.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_scoped_slot_expressions.snap
@@ -113,7 +113,7 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
-  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: Required<Pick<P, K>>[K] | {} | null };
   // @vize-map: component -> 0:23
   type __MyList_Props_0 = typeof MyList extends { __vizeCheck: any } ? Record<string, unknown> : (typeof MyList extends { new (): { $props: infer __P } } ? __P : (typeof MyList extends (props: infer __P) => any ? __P : {}));
   type __MyList_0_prop_items = __VizePropValue<__MyList_Props_0, 'items'>;

--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_scoped_slot_expressions.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_scoped_slot_expressions.snap
@@ -113,11 +113,11 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
   // @vize-map: component -> 0:23
   type __MyList_Props_0 = typeof MyList extends { __vizeCheck: any } ? Record<string, unknown> : (typeof MyList extends { new (): { $props: infer __P } } ? __P : (typeof MyList extends (props: infer __P) => any ? __P : {}));
   type __MyList_0_prop_items = __VizePropValue<__MyList_Props_0, 'items'>;
-  type __MyList_CheckProps_0 = {
-  };
+  type __MyList_CheckProps_0 = __VizeExactOptionalProps<__MyList_Props_0>;
   type __MyList_Check_0 = __VizePropChecker<typeof MyList, __MyList_CheckProps_0>;
 
   // Component template navigation references

--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_component_props_in_scope.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_component_props_in_scope.snap
@@ -122,7 +122,7 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
-  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: Required<Pick<P, K>>[K] | {} | null };
   // @vize-map: component -> 8:70
   type __TodoItem_Props_0 = typeof TodoItem extends { __vizeCheck: any } ? Record<string, unknown> : (typeof TodoItem extends { new (): { $props: infer __P } } ? __P : (typeof TodoItem extends (props: infer __P) => any ? __P : {}));
   type __TodoItem_0_prop_item = __VizePropValue<__TodoItem_Props_0, 'item'>;

--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_component_props_in_scope.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_component_props_in_scope.snap
@@ -122,11 +122,11 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
   // @vize-map: component -> 8:70
   type __TodoItem_Props_0 = typeof TodoItem extends { __vizeCheck: any } ? Record<string, unknown> : (typeof TodoItem extends { new (): { $props: infer __P } } ? __P : (typeof TodoItem extends (props: infer __P) => any ? __P : {}));
   type __TodoItem_0_prop_item = __VizePropValue<__TodoItem_Props_0, 'item'>;
-  type __TodoItem_CheckProps_0 = {
-  };
+  type __TodoItem_CheckProps_0 = __VizeExactOptionalProps<__TodoItem_Props_0>;
   type __TodoItem_Check_0 = __VizePropChecker<typeof TodoItem, __TodoItem_CheckProps_0>;
 
   // Component template navigation references

--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_component_props_source_nested_in_vif_is_wrapped_for_narrowing.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_component_props_source_nested_in_vif_is_wrapped_for_narrowing.snap
@@ -129,7 +129,7 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
-  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: Required<Pick<P, K>>[K] | {} | null };
   // @vize-map: component -> 81:105
   type __Test_Props_0 = typeof Test extends { __vizeCheck: any } ? Record<string, unknown> : (typeof Test extends { new (): { $props: infer __P } } ? __P : (typeof Test extends (props: infer __P) => any ? __P : {}));
   type __Test_0_prop_value1 = __VizePropValue<__Test_Props_0, 'value1'>;

--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_component_props_source_nested_in_vif_is_wrapped_for_narrowing.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_component_props_source_nested_in_vif_is_wrapped_for_narrowing.snap
@@ -129,11 +129,11 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
   // @vize-map: component -> 81:105
   type __Test_Props_0 = typeof Test extends { __vizeCheck: any } ? Record<string, unknown> : (typeof Test extends { new (): { $props: infer __P } } ? __P : (typeof Test extends (props: infer __P) => any ? __P : {}));
   type __Test_0_prop_value1 = __VizePropValue<__Test_Props_0, 'value1'>;
-  type __Test_CheckProps_0 = {
-  };
+  type __Test_CheckProps_0 = __VizeExactOptionalProps<__Test_Props_0>;
   type __Test_Check_0 = __VizePropChecker<typeof Test, __Test_CheckProps_0>;
 
   // Component template navigation references

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
@@ -1,6 +1,7 @@
 use super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
 mod directive_anchors;
 mod directive_values;
+mod exact_optional_props;
 
 #[test]
 fn issue_2645_infers_generic_sfc_props_in_tsx() {

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/exact_optional_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/exact_optional_props.rs
@@ -1,0 +1,245 @@
+//! `exactOptionalPropertyTypes` is honored for component props (#3450).
+//!
+//! Passing an explicitly `undefined` value to an optional child prop is an error
+//! under the option and was silent in vize. The per-prop check cannot express
+//! it: it extracts `label?: string` to `string | undefined` and assigns to that,
+//! which is legal whatever the option says. The distinction between "absent" and
+//! "present and `undefined`" only exists when a whole object literal is assigned
+//! at once, so the usage's props literal is now checked against
+//! `__VizeExactOptionalProps<__Child_Props_N>`.
+//!
+//! Every case below is a guard on that check reporting *only* what the per-prop
+//! path cannot, because anything else it reports is a second diagnostic for a
+//! defect already flagged at a better anchor.
+
+use super::super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+use std::path::Path;
+use vize_carton::String;
+
+const CHILD: &str = r#"<script setup lang="ts">
+defineProps<{ label?: string }>()
+</script>
+
+<template><span /></template>
+"#;
+
+fn write_tsconfig(project_root: &Path, exact_optional: bool) {
+    let exact = if exact_optional {
+        "\n    \"exactOptionalPropertyTypes\": true,"
+    } else {
+        ""
+    };
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        vize_carton::cstr!(
+            r#"{{
+  "compilerOptions": {{
+    "strict": true,{exact}
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": [],
+    "noEmit": true
+  }},
+  "include": ["src/**/*"]
+}}"#
+        )
+        .as_str(),
+    )
+    .unwrap();
+}
+
+fn diagnostics_of(
+    name: &str,
+    parent: &str,
+    exact_optional: bool,
+) -> Option<Vec<(String, Option<u32>, String)>> {
+    let project_root = create_project_case(
+        name,
+        &[("src/Child.vue", CHILD), ("src/Parent.vue", parent)],
+    );
+    write_tsconfig(&project_root, exact_optional);
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    snapshot
+}
+
+/// vue-tsc 3.3.4:
+///
+/// ```text
+/// src/Parent.vue(6,12): error TS2379: Argument of type '{ label: undefined; }' is not assignable to parameter of type '{ readonly label?: string; } & VNodeProps & AllowedComponentProps & ComponentCustomProps & Record<string, unknown>' with 'exactOptionalPropertyTypes: true'.
+/// ```
+///
+/// vize reports the same defect at the same place with a different **code**:
+/// `TS2345`, not `TS2379`. That is a compiler-version difference, not a mapping
+/// one — `tsc 6.0.3` (which `vue-tsc` pins) answers `TS2379` and the
+/// `@typescript/native-preview` build vize runs answers `TS2345` for identical
+/// code against an identical target, across every target shape tried including
+/// `vue-tsc`'s own. The assertion is therefore on the position and the defect,
+/// not on the code the runtime chose.
+#[test]
+fn an_explicitly_undefined_optional_prop_is_reported() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let Some(snapshot) = diagnostics_of(
+        "exact-optional-props",
+        r#"<script setup lang="ts">
+import Child from './Child.vue'
+const maybe: string | undefined = undefined
+</script>
+
+<template>
+  <Child :label="maybe" />
+</template>
+"#,
+        true,
+    ) else {
+        return;
+    };
+
+    assert_eq!(
+        snapshot.len(),
+        1,
+        "expected exactly one diagnostic: {snapshot:?}"
+    );
+    let (file, _, message) = &snapshot[0];
+    assert_eq!(file.as_str(), "src/Parent.vue");
+    // Column 4 is the `C` of `<Child`, one byte right of the `<`. vue-tsc
+    // anchors a whole-props failure on the element name: its oracle reads
+    // `src/Parent.vue(6,12)` for `<template><Child …`, where 12 is the `C`.
+    assert!(
+        message.starts_with("7:4:error"),
+        "the diagnostic anchors on the element name, got: {message}"
+    );
+    assert!(
+        message.contains("exactOptionalPropertyTypes"),
+        "the diagnostic must name the option that caused it, got: {message}"
+    );
+}
+
+/// Without the option the check is inert, because an optional property accepts
+/// `undefined` implicitly. `vue-tsc` reports nothing here either.
+#[test]
+fn the_same_binding_is_clean_without_the_option() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let Some(snapshot) = diagnostics_of(
+        "exact-optional-props-off",
+        r#"<script setup lang="ts">
+import Child from './Child.vue'
+const maybe: string | undefined = undefined
+</script>
+
+<template>
+  <Child :label="maybe" />
+</template>
+"#,
+        false,
+    ) else {
+        return;
+    };
+
+    assert_eq!(
+        snapshot,
+        vec![],
+        "the option is off, so nothing is reported"
+    );
+}
+
+/// The shapes that must stay silent under the option. Each one would be a false
+/// positive on correct code, and the last two are the reason this check widens
+/// every property rather than using the child's props type:
+///
+/// * a prop the template did not pass — `Child` declares only optional props
+///   here, but the widening is what keeps the missing-required-prop class off in
+///   general;
+/// * `class`, `style` and `data-*` fallthrough attributes the child never
+///   declares;
+/// * a prop whose declared type includes `null`, passed `null`;
+/// * a prop whose declared type includes `undefined` explicitly — the child
+///   opted into it.
+#[test]
+fn correct_usages_stay_silent_under_the_option() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "exact-optional-props-no-false-positive",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts">
+defineProps<{
+  label?: string
+  nullish?: string | null
+  explicit?: string | undefined
+}>()
+</script>
+
+<template><span /></template>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+const maybe: string | undefined = undefined
+const orNull: string | null = null
+</script>
+
+<template>
+  <Child />
+  <Child :label="'ok'" class="a" style="color: red" data-id="1" />
+  <Child :nullish="orNull" />
+  <Child :explicit="maybe" />
+</template>
+"#,
+            ),
+        ],
+    );
+    write_tsconfig(&project_root, true);
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else {
+        return;
+    };
+
+    assert_eq!(snapshot, vec![], "no correct usage may be reported");
+}
+
+/// An ordinary type mismatch stays the per-prop check's to report, at its own
+/// anchor, and is **not** reported a second time by the whole-object check. This
+/// is the case that ruled out checking against the child's props type or
+/// `Partial<>` of it: both reported every wrongly-typed prop twice, one byte
+/// apart, with an identical code and message that `dedup_diagnostics` could not
+/// collapse because the positions differ.
+#[test]
+fn a_wrongly_typed_prop_is_reported_exactly_once() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let Some(snapshot) = diagnostics_of(
+        "exact-optional-props-single-report",
+        r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child :label="42" />
+</template>
+"#,
+        true,
+    ) else {
+        return;
+    };
+
+    assert_eq!(
+        snapshot.len(),
+        1,
+        "a wrongly typed prop must be reported once, not once per check: {snapshot:?}"
+    );
+    assert_eq!(snapshot[0].1, Some(2322));
+}

--- a/crates/vize_canon/src/batch/virtual_project/snapshots/vize_canon__batch__virtual_project__tests__reexported_vue_interface_props_virtual_ts.snap
+++ b/crates/vize_canon/src/batch/virtual_project/snapshots/vize_canon__batch__virtual_project__tests__reexported_vue_interface_props_virtual_ts.snap
@@ -73,7 +73,7 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
-  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: Required<Pick<P, K>>[K] | {} | null };
   // @vize-map: component -> 258:302
   type __Child_Props_0 = typeof Child extends { __vizeCheck: any } ? Record<string, unknown> : (typeof Child extends { new (): { $props: infer __P } } ? __P : (typeof Child extends (props: infer __P) => any ? __P : {}));
   type __Child_0_prop_as = __VizePropValue<__Child_Props_0, 'as'>;

--- a/crates/vize_canon/src/batch/virtual_project/snapshots/vize_canon__batch__virtual_project__tests__reexported_vue_interface_props_virtual_ts.snap
+++ b/crates/vize_canon/src/batch/virtual_project/snapshots/vize_canon__batch__virtual_project__tests__reexported_vue_interface_props_virtual_ts.snap
@@ -73,12 +73,12 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
   // @vize-map: component -> 258:302
   type __Child_Props_0 = typeof Child extends { __vizeCheck: any } ? Record<string, unknown> : (typeof Child extends { new (): { $props: infer __P } } ? __P : (typeof Child extends (props: infer __P) => any ? __P : {}));
   type __Child_0_prop_as = __VizePropValue<__Child_Props_0, 'as'>;
   type __Child_0_prop_as_child = __VizePropValue<__Child_Props_0, 'asChild'>;
-  type __Child_CheckProps_0 = {
-  };
+  type __Child_CheckProps_0 = __VizeExactOptionalProps<__Child_Props_0>;
   type __Child_Check_0 = __VizePropChecker<typeof Child, __Child_CheckProps_0>;
 
   // Component template navigation references

--- a/crates/vize_canon/src/batch/virtual_project/snapshots/vize_canon__batch__virtual_project__tests__register_vue_file_rewrites_child_imports.snap
+++ b/crates/vize_canon/src/batch/virtual_project/snapshots/vize_canon__batch__virtual_project__tests__register_vue_file_rewrites_child_imports.snap
@@ -54,11 +54,11 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
   // @vize-map: component -> 97:121
   type __Child_Props_0 = typeof Child extends { __vizeCheck: any } ? Record<string, unknown> : (typeof Child extends { new (): { $props: infer __P } } ? __P : (typeof Child extends (props: infer __P) => any ? __P : {}));
   type __Child_0_prop_count = __VizePropValue<__Child_Props_0, 'count'>;
-  type __Child_CheckProps_0 = {
-  };
+  type __Child_CheckProps_0 = __VizeExactOptionalProps<__Child_Props_0>;
   type __Child_Check_0 = __VizePropChecker<typeof Child, __Child_CheckProps_0>;
 
   // Component template navigation references

--- a/crates/vize_canon/src/batch/virtual_project/snapshots/vize_canon__batch__virtual_project__tests__register_vue_file_rewrites_child_imports.snap
+++ b/crates/vize_canon/src/batch/virtual_project/snapshots/vize_canon__batch__virtual_project__tests__register_vue_file_rewrites_child_imports.snap
@@ -54,7 +54,7 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
-  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: Required<Pick<P, K>>[K] | {} | null };
   // @vize-map: component -> 97:121
   type __Child_Props_0 = typeof Child extends { __vizeCheck: any } ? Record<string, unknown> : (typeof Child extends { new (): { $props: infer __P } } ? __P : (typeof Child extends (props: infer __P) => any ? __P : {}));
   type __Child_0_prop_count = __VizePropValue<__Child_Props_0, 'count'>;

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_scoped_slots.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_scoped_slots.snap
@@ -133,11 +133,11 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
   // @vize-map: component -> 145:168
   type __MyList_Props_0 = typeof MyList extends { __vizeCheck: any } ? Record<string, unknown> : (typeof MyList extends { new (): { $props: infer __P } } ? __P : (typeof MyList extends (props: infer __P) => any ? __P : {}));
   type __MyList_0_prop_items = __VizePropValue<__MyList_Props_0, 'items'>;
-  type __MyList_CheckProps_0 = {
-  };
+  type __MyList_CheckProps_0 = __VizeExactOptionalProps<__MyList_Props_0>;
   type __MyList_Check_0 = __VizePropChecker<typeof MyList, __MyList_CheckProps_0>;
 
   // Component template navigation references

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_scoped_slots.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_scoped_slots.snap
@@ -133,7 +133,7 @@ function __setup() {
   type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;
   type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;
   type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;
-  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };
+  type __VizeExactOptionalProps<P> = { [K in keyof P]?: Required<Pick<P, K>>[K] | {} | null };
   // @vize-map: component -> 145:168
   type __MyList_Props_0 = typeof MyList extends { __vizeCheck: any } ? Record<string, unknown> : (typeof MyList extends { new (): { $props: infer __P } } ? __P : (typeof MyList extends (props: infer __P) => any ? __P : {}));
   type __MyList_0_prop_items = __VizePropValue<__MyList_Props_0, 'items'>;

--- a/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
@@ -215,8 +215,20 @@ fn generate_generic_props_call(
 
     append!(
         *ts,
-        "{expr_indent}(undefined as unknown as __{component_type_name}_Check_{idx})({{\n",
+        "{expr_indent}(undefined as unknown as __{component_type_name}_Check_{idx})(",
     );
+    // TypeScript anchors an *argument* assignability failure — `TS2345` — at the
+    // argument expression, which here is the whole object literal and not any
+    // one property. Without a mapping over that range the diagnostic has no
+    // authored position and the diagnostics path drops it silently, which is
+    // what made the `exactOptionalPropertyTypes` check (#3450) fire in the
+    // generated program and report nothing to the user.
+    //
+    // The per-entry mappings pushed below stay inside this range and remain the
+    // anchor for a per-property failure; this one only catches what TypeScript
+    // reports about the literal as a whole.
+    let literal_gen_start = ts.len();
+    ts.push_str("{\n");
 
     let class_bindings = collect_generated_class_bindings(usage, template_prop_names);
     let merge_class_bindings = class_bindings.len() > 1;
@@ -279,7 +291,20 @@ fn generate_generic_props_call(
         });
     }
 
-    append!(*ts, "{expr_indent}}});\n");
+    append!(*ts, "{expr_indent}}}");
+    let literal_gen_end = ts.len();
+    ts.push_str(");\n");
+    // Anchored on the tag *name*, not on `usage.start`, which is the `<` one
+    // byte to its left. `vue-tsc` puts a whole-props failure on the name — the
+    // #3450 oracle reads `src/Parent.vue(6,12)` for `<template><Child …`, where
+    // column 12 is the `C`. Same derivation as the navigation references in
+    // `scope::component_prop_navigation`.
+    let tag_src_start = (template_offset + usage.start + 1) as usize;
+    mappings.push(VizeMapping {
+        gen_range: literal_gen_start..literal_gen_end,
+        src_range: tag_src_start..tag_src_start + usage.name.len(),
+        sub_spans: Vec::new(),
+    });
 
     if usage.vif_guard.is_some() {
         append!(*ts, "{indent}}}\n");

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
@@ -1,8 +1,6 @@
 use vize_carton::{String, append};
 use vize_croquis::croquis::ComponentUsage;
 
-use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier_fragment};
-
 pub(super) fn is_inline_function_prop_value(value: &str) -> bool {
     let value = value.trim();
     value.contains("=>") || value.starts_with("function") || value.starts_with("async function")
@@ -27,38 +25,92 @@ pub(super) fn has_inference_props(usage: &ComponentUsage) -> bool {
     })
 }
 
+/// The target the usage's whole props object literal is checked against.
+///
+/// `__VizeExactOptionalProps<__X_Props_N>` reports **only** what the per-prop
+/// check structurally cannot: the `exactOptionalPropertyTypes` distinction
+/// between "the property is absent" and "the property is present and
+/// `undefined`" (#3450). That distinction only exists when a whole object
+/// literal is assigned at once, which is why the per-prop path cannot express
+/// it — it extracts `label?: string` to `string | undefined` through
+/// `__VizePropValue` and assigns to that, legal whatever the option says.
+///
+/// Every property is widened to `{} | null`, which accepts any value except
+/// `undefined`. That is the whole trick: an ordinary type mismatch stays the
+/// per-prop check's to report, at its own well-anchored position, and is not
+/// reported a second time here. Checking against the child's props type
+/// unmodified — or against `Partial<>` of it — reports every wrongly-typed prop
+/// twice, one byte apart, with an identical code and message that
+/// `dedup_diagnostics` cannot collapse because the positions differ.
+///
+/// `null` has to be in the widened type, not just `{}`: a child prop declared
+/// `LinkBehavior | null` is legitimately passed `null`, and `{}` alone rejects
+/// it. Only `undefined` is this check's business.
+///
+/// `Required<Pick<P, K>>[K]` rather than `P[K]` because indexed access on an
+/// optional property already includes `undefined`, so `P[K]` cannot tell
+/// `label?: string` from `label?: string | undefined`. Stripping the modifier
+/// first leaves only an *explicitly* declared `undefined`, which the child opted
+/// into and which must stay silent.
+///
+/// Consequences, each a case in `component_props_tests.rs`:
+///
+/// * a prop the template did not pass is not reported — every property is
+///   optional, so the missing-required-prop class stays off. That is also what
+///   keeps this independent of #3444, whose spread needs the full type.
+/// * `class`, `style`, `data-*`, `aria-*` and anything else the child does not
+///   declare are absorbed by the `Record<string, unknown>` intersection
+///   `__VizePropChecker` applies, which also suppresses object-literal excess
+///   property checking.
+/// * the alias does not have to agree with the literal's key set. The literal
+///   skips props whose value does not generate; a `Pick<>` over the authored
+///   names would have had to reproduce that filtering exactly or report phantom
+///   missing properties.
+/// * with `exactOptionalPropertyTypes` off the check is inert, because an
+///   optional property accepts `undefined` implicitly — which is also what
+///   `vue-tsc` does.
+///
+/// Only the **non-generic** branch of `__VizePropChecker` uses this type; a
+/// generic child resolves through its own `__vizeCheck` signature and ignores
+/// it, so the generic inference path is untouched.
+///
+/// Note the code divergence. TypeScript 6, which `vue-tsc` pins, reports this as
+/// `TS2379`; the `@typescript/native-preview` build vize runs reports the
+/// identical code against the identical target as `TS2345` with the same
+/// explanation nested one level down. Confirmed by running both compilers over
+/// the same file across five target shapes, including `vue-tsc`'s own. It is a
+/// compiler-version difference, not something the generated code can steer.
 pub(super) fn append_prop_checker_alias(
     ts: &mut String,
-    usage: &ComponentUsage,
     component_type_name: &str,
     component_ref: &str,
     idx: usize,
 ) {
     append!(
         *ts,
-        "  type __{component_type_name}_CheckProps_{idx} = {{\n",
+        "  type __{component_type_name}_CheckProps_{idx} = __VizeExactOptionalProps<__{component_type_name}_Props_{idx}>;\n",
     );
-    for prop in &usage.props {
-        if prop.name_is_dynamic || prop.name.as_str() == "key" || prop.name.as_str() == "ref" {
-            continue;
-        }
-        if let Some(value) = prop.value.as_ref()
-            && prop.is_dynamic
-        {
-            if !is_inline_function_prop_value(value.as_str()) {
-                continue;
-            }
-            let camel_prop_name = to_camel_case(prop.name.as_str());
-            let safe_prop_name = to_safe_identifier_fragment(prop.name.as_str());
-            append!(
-                *ts,
-                "    \"{camel_prop_name}\": __{component_type_name}_{idx}_prop_{safe_prop_name};\n",
-            );
-        }
-    }
-    ts.push_str("  };\n");
     append!(
         *ts,
         "  type __{component_type_name}_Check_{idx} = __VizePropChecker<typeof {component_ref}, __{component_type_name}_CheckProps_{idx}>;\n",
+    );
+}
+
+/// The shared type helpers every per-usage prop check resolves through, emitted
+/// once per template scope that has at least one checkable component usage.
+///
+/// They live here rather than at the call site because
+/// [`append_prop_checker_alias`] is what names them, and the reasoning for
+/// `__VizeExactOptionalProps` in particular belongs beside the alias it builds.
+pub(super) fn append_prop_check_helpers(ts: &mut String) {
+    ts.push_str("  type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;\n");
+    ts.push_str(
+        "  type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;\n",
+    );
+    ts.push_str(
+        "  type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;\n",
+    );
+    ts.push_str(
+        "  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };\n",
     );
 }

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
@@ -35,13 +35,21 @@ pub(super) fn has_inference_props(usage: &ComponentUsage) -> bool {
 /// it — it extracts `label?: string` to `string | undefined` through
 /// `__VizePropValue` and assigns to that, legal whatever the option says.
 ///
-/// Every property is widened to `{} | null`, which accepts any value except
-/// `undefined`. That is the whole trick: an ordinary type mismatch stays the
-/// per-prop check's to report, at its own well-anchored position, and is not
+/// Every property is widened *with* `{} | null`, a union that accepts any value
+/// except `undefined`. That is the whole trick: an ordinary type mismatch stays
+/// the per-prop check's to report, at its own well-anchored position, and is not
 /// reported a second time here. Checking against the child's props type
 /// unmodified — or against `Partial<>` of it — reports every wrongly-typed prop
 /// twice, one byte apart, with an identical code and message that
 /// `dedup_diagnostics` cannot collapse because the positions differ.
+///
+/// The declared type stays in the union rather than being replaced by `{} | null`
+/// because it is the only thing that contextually types an inline callback prop.
+/// Against a bare `{} | null` the parameters of `:textConverter="(value) => …"`
+/// have no contextual signature to draw from and become implicit `any`, a
+/// `TS7006` on correct code, which is what `check_function_props_cli` guards.
+/// Since a function is assignable to `{}`, keeping the declared member adds
+/// contextual typing without adding a single rejection.
 ///
 /// `null` has to be in the widened type, not just `{}`: a child prop declared
 /// `LinkBehavior | null` is legitimately passed `null`, and `{}` alone rejects
@@ -49,9 +57,11 @@ pub(super) fn has_inference_props(usage: &ComponentUsage) -> bool {
 ///
 /// `Required<Pick<P, K>>[K]` rather than `P[K]` because indexed access on an
 /// optional property already includes `undefined`, so `P[K]` cannot tell
-/// `label?: string` from `label?: string | undefined`. Stripping the modifier
-/// first leaves only an *explicitly* declared `undefined`, which the child opted
-/// into and which must stay silent.
+/// `label?: string` from `label?: string | undefined` and would make the check
+/// inert. Stripping the modifier first leaves only an *explicitly* declared
+/// `undefined`, which the child opted into and which must stay silent, and it
+/// leaves that `undefined` *in the union*, so no conditional branch is needed to
+/// allow it.
 ///
 /// Consequences, each a case in `component_props_tests.rs`:
 ///
@@ -111,6 +121,6 @@ pub(super) fn append_prop_check_helpers(ts: &mut String) {
         "  type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;\n",
     );
     ts.push_str(
-        "  type __VizeExactOptionalProps<P> = { [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null };\n",
+        "  type __VizeExactOptionalProps<P> = { [K in keyof P]?: Required<Pick<P, K>>[K] | {} | null };\n",
     );
 }

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -15,7 +15,7 @@ use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier, to_safe_iden
 use crate::virtual_ts::types::VizeMapping;
 
 use super::component_prop_checker::{
-    append_prop_checker_alias, has_inference_props, has_value_props,
+    append_prop_check_helpers, append_prop_checker_alias, has_inference_props, has_value_props,
 };
 use super::component_prop_navigation;
 use super::context::{ComponentPropsContext, VForPropsContext};
@@ -77,13 +77,7 @@ pub(super) fn generate_component_props(
         .iter()
         .any(|(_, usage)| has_inference_props(usage));
     if any_inference_props {
-        ts.push_str("  type __VizeIsAny<T> = 0 extends (1 & T) ? true : false;\n");
-        ts.push_str(
-            "  type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: P & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: P & Record<string, unknown>) => void) : (props: P & Record<string, unknown>) => void;\n",
-        );
-        ts.push_str(
-            "  type __VizePropValue<P, K extends PropertyKey, __V = P extends unknown ? (K extends keyof P ? P[K] : never) : never> = [__V] extends [never] ? unknown : __V;\n",
-        );
+        append_prop_check_helpers(ts);
     }
 
     for &(idx, usage) in &checkable_usages {
@@ -129,7 +123,6 @@ pub(super) fn generate_component_props(
             // Generic functional prop-checker for this component (#775).
             append_prop_checker_alias(
                 ts,
-                usage,
                 component_type_name.as_str(),
                 component_ref.as_str(),
                 idx,


### PR DESCRIPTION
Closes #3450. Splits cleanly from #3444 — see below for why the two turned out to be separable after all.

## The defect

Passing an explicitly `undefined` value to an optional child prop is an error under `exactOptionalPropertyTypes` and was silent in vize. The per-prop check *structurally cannot* express it: it extracts `label?: string` to `string | undefined` through `__VizePropValue` and assigns to that, legal whatever the option says. The distinction between "absent" and "present and `undefined`" only exists when a whole object literal is assigned at once.

## Why the target is widened rather than the child's props type

The usage's props literal — already assembled for generic inference — is now checked against:

```ts
type __VizeExactOptionalProps<P> = {
  [K in keyof P]?: undefined extends Required<Pick<P, K>>[K] ? unknown : {} | null
};
```

Every property widened to `{} | null`: anything except `undefined`. **That widening is the whole design**, not a shortcut. Checking against the child's props type unmodified — or against `Partial<>` of it — reports every wrongly-typed prop **twice**, one byte apart, with an identical code and message that `dedup_diagnostics` cannot collapse because the positions differ:

```
6:10:error Type 'string' is not assignable to type 'number'.   <- whole-object
6:11:error Type 'string' is not assignable to type 'number'.   <- per-prop
```

10 canon tests fail that way; it is not snapshot churn, and re-pinning would have doubled every prop diagnostic in the ecosystem. Widening leaves ordinary mismatches to the per-prop check at its own well-anchored position and reports only what that path cannot.

Two details that are load-bearing:

- **`null` must be in the widened type.** A prop declared `LinkBehavior | null` is legitimately passed `null`, and `{}` alone rejects it. Caught by the existing `batch_type_checker_accepts_forwarded_optional_component_props`.
- **`Required<Pick<P, K>>[K]`, not `P[K]`.** Indexed access on an optional property already includes `undefined`, so `P[K]` cannot tell `label?: string` from `label?: string | undefined`. Stripping the modifier first leaves only an *explicitly* declared `undefined`, which the child opted into and which must stay silent.

## A missing mapping, not just a missing type

The check fired in the generated program and reported nothing. TypeScript anchors an *argument* assignability failure at the argument expression — the whole object literal, not any property — so the diagnostic landed on generated bytes with no authored range and the diagnostics path dropped it. Confirmed by running tsgo directly against the materialized virtual project.

The literal's range now maps to the tag name (`usage.start + 1`), which is where vue-tsc anchors a whole-props failure — its oracle reads `src/Parent.vue(6,12)`, column 12 being the `C` of `Child` — and the same derivation `scope::component_prop_navigation` already uses.

## Separable from #3444 after all

The earlier analysis said the two could not be split, because turning the whole-object check on would report a missing required prop on every `v-bind="obj"` usage. That holds for the child's props type unmodified, not for a target whose properties are all optional. A usage carrying only `v-bind="obj"` contributes no entries to `usage.props`, so `has_inference_props` is already false and no call is emitted for it at all.

#3444 still needs the full type, and still needs an answer for `v-bind="$attrs"`, which against the full type is a false positive:

```ts
declare const attrs: Record<string, unknown>;
check({ ...attrs });
// error TS2345: '{ [x: string]: unknown; }' is not assignable to 'ChildProps & Record<string, unknown>'
```

Recorded on #3444.

## The code is `TS2345`, not `TS2379`

The issue's oracle expects `TS2379`. vize cannot produce it. Running **both** compilers over the same file with the same target:

```
tsc 6.0.3 (what vue-tsc pins)  -> error TS2379
tsgo 7.0.0-dev (what vize runs) -> error TS2345   (same text, nested one level down)
```

Five target shapes were tried — bare object type, intersected with `Record<string, unknown>`, through `Pick<>`, and vue-tsc's exact `{ readonly label?: string } & VNodeProps & AllowedComponentProps & ComponentCustomProps & Record<string, unknown>` — all five give `TS2379` under 6 and `TS2345` under 7. A compiler-version difference, the same shape as the `TS5101`/`TS5102` pair in #3448. The test asserts the position and the defect, not the code.

## Verification

- 4 end-to-end tests: the oracle case, the same binding clean with the option off, four correct-usage shapes silent under the option (omitted prop, fallthrough `class`/`style`/`data-*`, a `null`-declaring prop passed `null`, an `undefined`-declaring prop passed `undefined`), and a wrongly-typed prop reported **exactly once**
- Full `vize_canon` suite: 23 binaries, 698 lib tests
- Hydrated vue-parity fixtures: `vue2-elm` and all five `vue-element-admin` oracles pass **unchanged, no re-pins**
- `vize check --declaration` vue-floor and `check-server` consumers green
- Source-length gate green (`component_props.rs` was already over budget, so the shared helper emission moved next to the alias it serves — it now shrinks 404 → 397)

The 8 snapshot updates are the alias text and the new helper line only; no behavioral output moved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue component prop validation with TypeScript’s `exactOptionalPropertyTypes` setting.
  * Explicit `undefined` values are now correctly accepted or rejected according to compiler configuration.
  * Improved diagnostics for whole-object prop mismatches while preserving precise per-property errors.

* **Tests**
  * Added regression coverage for valid props, invalid optional values, and standard type mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->