### PR TITLE
fix(croquis)!: type-check the v-bind="object" prop spread

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
@@ -2,6 +2,7 @@ use super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diag
 mod directive_anchors;
 mod directive_values;
 mod exact_optional_props;
+mod spread_props;
 
 #[test]
 fn issue_2645_infers_generic_sfc_props_in_tsx() {

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/spread_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/spread_props.rs
@@ -1,0 +1,173 @@
+//! `v-bind="object"` prop spreads are type-checked (#3444).
+//!
+//! A spread contributes no `PassedProp`, so a usage that only spreads had no
+//! checkable prop, emitted no check, and passed a wrongly typed bag silently.
+//! The spread is now folded into the same props object literal the generic
+//! inference call already assembles.
+//!
+//! Oracles below are `vue-tsc@3.3.4` with `vue@3.6.0-beta.10`, run against a
+//! byte-identical workspace.
+
+use super::super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+
+const CHILD: &str = r#"<script setup lang="ts">
+defineProps<{ count: number }>()
+</script>
+
+<template><span /></template>
+"#;
+
+/// vue-tsc, on the fixture below:
+///
+/// ```text
+/// src/Parent.vue(8,4):  error TS2345: Argument of type '{ count: string; }' is not assignable ...
+/// src/Parent.vue(10,4): error TS2345: Argument of type '{}' is not assignable ... Property 'count' is missing.
+/// ```
+///
+/// Line 9 — a bag that satisfies the child — is clean in both tools.
+///
+/// Column 4 is the `C` of `<Child`, the element name, which is where vue-tsc
+/// anchors a whole-props failure. The message text diverges: vize names its own
+/// generated props type where vue-tsc names
+/// `{ readonly count: number; } & VNodeProps & …`. That is a message-only
+/// divergence of the kind the ledger scores separately.
+#[test]
+fn a_wrongly_typed_spread_is_reported_and_a_correct_one_is_not() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "vbind-spread-props",
+        &[
+            ("src/Child.vue", CHILD),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+const bag = { count: 'oops' }
+const good = { count: 1 }
+</script>
+
+<template>
+  <Child v-bind="bag" />
+  <Child v-bind="good" />
+  <Child v-bind="$attrs" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else {
+        return;
+    };
+
+    // `snapshot_project_diagnostics` sorts, so the expectation is sorted too.
+    let mut positions: Vec<_> = snapshot
+        .iter()
+        .map(|(file, code, message)| {
+            (
+                file.as_str(),
+                *code,
+                message.split(':').take(2).collect::<Vec<_>>().join(":"),
+            )
+        })
+        .collect();
+    positions.sort();
+    assert_eq!(
+        positions,
+        vec![
+            ("src/Parent.vue", Some(2345), "10:4".to_string()),
+            ("src/Parent.vue", Some(2345), "8:4".to_string()),
+        ],
+        "positions byte-identical with vue-tsc: {snapshot:?}"
+    );
+}
+
+/// A spread beside named bindings keeps the named ones on the per-prop path,
+/// which owns their anchors, and folds the spread into the same literal so an
+/// error *inside* the spread expression still lands on the authored bytes.
+#[test]
+fn a_spread_beside_named_props_keeps_both_paths() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "vbind-spread-mixed",
+        &[
+            ("src/Child.vue", CHILD),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+const rest = { extra: 1 }
+</script>
+
+<template>
+  <Child v-bind="rest" :count="'nope'" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else {
+        return;
+    };
+
+    assert_eq!(
+        snapshot.len(),
+        1,
+        "the named prop is reported once, by the per-prop check: {snapshot:?}"
+    );
+    assert_eq!(snapshot[0].1, Some(2322));
+    assert!(
+        snapshot[0].2.starts_with("7:25"),
+        "anchored on the `count` attribute name, one byte right of the `:`, got: {}",
+        snapshot[0].2
+    );
+}
+
+/// An undefined name inside the spread expression is reported on the authored
+/// bytes, not on the generated literal.
+#[test]
+fn an_error_inside_the_spread_expression_lands_on_the_source() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "vbind-spread-inner-error",
+        &[
+            ("src/Child.vue", CHILD),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+const bag = { count: 1 }
+</script>
+
+<template>
+  <Child v-bind="bag.missing" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else {
+        return;
+    };
+
+    assert!(
+        snapshot
+            .iter()
+            .any(|(_, code, message)| *code == Some(2339) && message.starts_with("7:")),
+        "the property error should anchor inside the template: {snapshot:?}"
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
@@ -20,6 +20,12 @@ fn has_inference_props(usage: &ComponentUsage) -> bool {
     usage.props.iter().any(is_checkable_prop)
 }
 
+/// A `v-bind="obj"` spread contributes no [`PassedProp`], so a usage that only
+/// spreads has no inference props and emitted no check at all before #3444.
+fn has_checkable_props_or_spread(usage: &ComponentUsage) -> bool {
+    has_inference_props(usage) || !usage.spread_props.is_empty()
+}
+
 fn is_checkable_prop(prop: &PassedProp) -> bool {
     !prop.name_is_dynamic && prop.name.as_str() != "key" && prop.name.as_str() != "ref"
 }
@@ -198,7 +204,7 @@ fn generate_generic_props_call(
     template_offset: u32,
     indent: &str,
 ) {
-    if !has_inference_props(usage) {
+    if !has_checkable_props_or_spread(usage) {
         return;
     }
 
@@ -229,6 +235,25 @@ fn generate_generic_props_call(
     // reports about the literal as a whole.
     let literal_gen_start = ts.len();
     ts.push_str("{\n");
+
+    // `v-bind="obj"` becomes a spread in the same literal, so the child's props
+    // type sees the whole bag: `({ ...bag, "label": maybe })`. vue-tsc checks the
+    // spread's contribution the same way, which is what makes a wrongly typed
+    // bag `TS2345` rather than silence (#3444). Each spread maps back to its own
+    // directive so an error *inside* the expression lands on the authored bytes.
+    for spread in &usage.spread_props {
+        append!(*ts, "{expr_indent}  ...");
+        let spread_gen_start = ts.len();
+        ts.push_str(spread.expression.as_str());
+        let spread_gen_end = ts.len();
+        ts.push_str(",\n");
+        mappings.push(VizeMapping {
+            gen_range: spread_gen_start..spread_gen_end,
+            src_range: (template_offset + spread.start) as usize
+                ..(template_offset + spread.end) as usize,
+            sub_spans: Vec::new(),
+        });
+    }
 
     let class_bindings = collect_generated_class_bindings(usage, template_prop_names);
     let merge_class_bindings = class_bindings.len() > 1;

--- a/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
@@ -8,23 +8,14 @@
 use super::super::helpers::{to_camel_case, to_safe_identifier_fragment};
 use super::super::types::{VizeMapping, VizeSubSpan};
 use super::prop_sources::{generated_prop_value, prop_name_source_range, prop_value_source_range};
+use crate::virtual_ts::scope::has_checkable_props_or_spread;
 use vize_carton::FxHashMap;
 use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::append;
 use vize_carton::cstr;
 use vize_carton::profile;
-use vize_croquis::croquis::{ComponentUsage, PassedProp};
-
-fn has_inference_props(usage: &ComponentUsage) -> bool {
-    usage.props.iter().any(is_checkable_prop)
-}
-
-/// A `v-bind="obj"` spread contributes no [`PassedProp`], so a usage that only
-/// spreads has no inference props and emitted no check at all before #3444.
-fn has_checkable_props_or_spread(usage: &ComponentUsage) -> bool {
-    has_inference_props(usage) || !usage.spread_props.is_empty()
-}
+use vize_croquis::croquis::{ComponentUsage, PassedProp, SpreadProp};
 
 fn is_checkable_prop(prop: &PassedProp) -> bool {
     !prop.name_is_dynamic && prop.name.as_str() != "key" && prop.name.as_str() != "ref"
@@ -236,31 +227,26 @@ fn generate_generic_props_call(
     let literal_gen_start = ts.len();
     ts.push_str("{\n");
 
-    // `v-bind="obj"` becomes a spread in the same literal, so the child's props
-    // type sees the whole bag: `({ ...bag, "label": maybe })`. vue-tsc checks the
-    // spread's contribution the same way, which is what makes a wrongly typed
-    // bag `TS2345` rather than silence (#3444). Each spread maps back to its own
-    // directive so an error *inside* the expression lands on the authored bytes.
-    for spread in &usage.spread_props {
-        append!(*ts, "{expr_indent}  ...");
-        let spread_gen_start = ts.len();
-        ts.push_str(spread.expression.as_str());
-        let spread_gen_end = ts.len();
-        ts.push_str(",\n");
-        mappings.push(VizeMapping {
-            gen_range: spread_gen_start..spread_gen_end,
-            src_range: (template_offset + spread.start) as usize
-                ..(template_offset + spread.end) as usize,
-            sub_spans: Vec::new(),
-        });
-    }
-
     let class_bindings = collect_generated_class_bindings(usage, template_prop_names);
     let merge_class_bindings = class_bindings.len() > 1;
     let mut emitted_merged_class = false;
+    // `v-bind="obj"` becomes a spread in the same literal, so the child's props
+    // type sees the whole bag: `({ ...bag, "label": maybe })`. vue-tsc checks the
+    // spread's contribution the same way, which is what makes a wrongly typed
+    // bag `TS2345` rather than silence (#3444).
+    //
+    // Entries follow template order, because Vue 3 resolves an overlapping key
+    // by source order (last binding wins), exactly as an object literal does.
+    // Spreading first unconditionally would check `1` for the `count` of
+    // `:count="1" v-bind="bag"`, a key the runtime takes from `bag` instead.
+    // Both lists are already sorted, so walking them together is enough.
+    let mut spreads = usage.spread_props.iter().peekable();
     for prop in &usage.props {
         if !is_checkable_prop(prop) {
             continue;
+        }
+        while let Some(spread) = spreads.next_if(|spread| spread.start < prop.start) {
+            append_spread_entry(ts, mappings, spread, template_offset, expr_indent.as_str());
         }
 
         let generated_value = if merge_class_bindings && prop.name.as_str() == "class" {
@@ -315,6 +301,9 @@ fn generate_generic_props_call(
             sub_spans: Vec::new(),
         });
     }
+    for spread in spreads {
+        append_spread_entry(ts, mappings, spread, template_offset, expr_indent.as_str());
+    }
 
     append!(*ts, "{expr_indent}}}");
     let literal_gen_end = ts.len();
@@ -334,4 +323,26 @@ fn generate_generic_props_call(
     if usage.vif_guard.is_some() {
         append!(*ts, "{indent}}}\n");
     }
+}
+
+/// Emit one `...expr` entry of the props literal, mapped back to its own
+/// directive so an error *inside* the expression lands on the authored bytes.
+fn append_spread_entry(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    spread: &SpreadProp,
+    template_offset: u32,
+    expr_indent: &str,
+) {
+    append!(*ts, "{expr_indent}  ...");
+    let gen_start = ts.len();
+    ts.push_str(spread.expression.as_str());
+    let gen_end = ts.len();
+    ts.push_str(",\n");
+    mappings.push(VizeMapping {
+        gen_range: gen_start..gen_end,
+        src_range: (template_offset + spread.start) as usize
+            ..(template_offset + spread.end) as usize,
+        sub_spans: Vec::new(),
+    });
 }

--- a/crates/vize_canon/src/virtual_ts/scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope.rs
@@ -20,5 +20,6 @@ mod handler_shape;
 mod vif_guard;
 
 pub(crate) use closures::generate_scope_closures;
+pub(crate) use component_prop_checker::has_checkable_props_or_spread;
 pub(crate) use context::ScopeGenerationOptions;
 pub(crate) use vif_guard::remove_enclosing_vif_guard_prefix;

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
@@ -30,7 +30,11 @@ pub(super) fn has_inference_props(usage: &ComponentUsage) -> bool {
 /// A `v-bind="obj"` spread contributes no `PassedProp`, so a usage that only
 /// spreads has no inference props and used to be skipped entirely — which is
 /// why `<Child v-bind="bag" />` was unchecked (#3444).
-pub(super) fn has_checkable_props_or_spread(usage: &ComponentUsage) -> bool {
+///
+/// Shared with `expressions::component_props`, which gates the call this
+/// module's aliases type. Two copies of the rule could disagree and leave the
+/// generated TypeScript calling a type that was never declared.
+pub(crate) fn has_checkable_props_or_spread(usage: &ComponentUsage) -> bool {
     has_inference_props(usage) || !usage.spread_props.is_empty()
 }
 

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
@@ -1,4 +1,4 @@
-use vize_carton::{String, append};
+use vize_carton::{String, append, cstr};
 use vize_croquis::croquis::ComponentUsage;
 
 pub(super) fn is_inline_function_prop_value(value: &str) -> bool {
@@ -23,6 +23,15 @@ pub(super) fn has_inference_props(usage: &ComponentUsage) -> bool {
     usage.props.iter().any(|prop| {
         !prop.name_is_dynamic && prop.name.as_str() != "key" && prop.name.as_str() != "ref"
     })
+}
+
+/// Whether the usage has anything for the whole-props check to look at.
+///
+/// A `v-bind="obj"` spread contributes no `PassedProp`, so a usage that only
+/// spreads has no inference props and used to be skipped entirely — which is
+/// why `<Child v-bind="bag" />` was unchecked (#3444).
+pub(super) fn has_checkable_props_or_spread(usage: &ComponentUsage) -> bool {
+    has_inference_props(usage) || !usage.spread_props.is_empty()
 }
 
 /// The target the usage's whole props object literal is checked against.
@@ -92,13 +101,28 @@ pub(super) fn has_inference_props(usage: &ComponentUsage) -> bool {
 /// compiler-version difference, not something the generated code can steer.
 pub(super) fn append_prop_checker_alias(
     ts: &mut String,
+    usage: &ComponentUsage,
     component_type_name: &str,
     component_ref: &str,
     idx: usize,
 ) {
+    // A usage that spreads and binds nothing by name is checked against the
+    // child's props type *unmodified*. Nothing on that element is covered by the
+    // per-prop path, so nothing can be reported twice, and it is the only shape
+    // that catches a wrongly typed value *inside* the spread — #3444's oracle,
+    // where `<Child v-bind="bag" />` with a string `count` is `TS2345`.
+    //
+    // Any usage that also binds by name keeps the widened target: its named
+    // props belong to the per-prop check, and the full type there would
+    // duplicate every one of them.
+    let target = if has_inference_props(usage) {
+        cstr!("__VizeExactOptionalProps<__{component_type_name}_Props_{idx}>")
+    } else {
+        cstr!("__{component_type_name}_Props_{idx}")
+    };
     append!(
         *ts,
-        "  type __{component_type_name}_CheckProps_{idx} = __VizeExactOptionalProps<__{component_type_name}_Props_{idx}>;\n",
+        "  type __{component_type_name}_CheckProps_{idx} = {target};\n",
     );
     append!(
         *ts,

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -290,22 +290,7 @@ fn generate_closure_component_props_recursive(
             }
 
             // Emit component prop checks for this scope
-            if let Some(usages) = ctx.components_by_scope.get(&scope_id) {
-                for &(idx, usage) in usages {
-                    profile!(
-                        "canon.virtual_ts.component_prop_checks",
-                        generate_component_prop_checks(
-                            ts,
-                            mappings,
-                            usage,
-                            idx,
-                            ctx.template_prop_names,
-                            ctx.source_context,
-                            &vfor_inner_indent,
-                        )
-                    );
-                }
-            }
+            emit_scope_component_prop_checks(ts, mappings, ctx, scope_id, &vfor_inner_indent);
 
             // Recursively handle child closure scopes (v-for and v-slot)
             recurse_child_closure_scopes(ts, mappings, ctx, scope_id, &vfor_inner_indent);
@@ -347,22 +332,7 @@ fn generate_closure_component_props_recursive(
                 }
             }
             // Emit component prop checks for this scope
-            if let Some(usages) = ctx.components_by_scope.get(&scope_id) {
-                for &(idx, usage) in usages {
-                    profile!(
-                        "canon.virtual_ts.component_prop_checks",
-                        generate_component_prop_checks(
-                            ts,
-                            mappings,
-                            usage,
-                            idx,
-                            ctx.template_prop_names,
-                            ctx.source_context,
-                            &inner_indent,
-                        )
-                    );
-                }
-            }
+            emit_scope_component_prop_checks(ts, mappings, ctx, scope_id, &inner_indent);
 
             // Recursively handle child closure scopes (v-for and v-slot)
             recurse_child_closure_scopes(ts, mappings, ctx, scope_id, &inner_indent);
@@ -371,6 +341,33 @@ fn generate_closure_component_props_recursive(
             ts.push_str("};\n");
         }
         _ => {}
+    }
+}
+
+/// Emit the prop checks for every component usage bound to a closure scope.
+fn emit_scope_component_prop_checks(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    ctx: &VForPropsContext<'_>,
+    scope_id: u32,
+    indent: &str,
+) {
+    let Some(usages) = ctx.components_by_scope.get(&scope_id) else {
+        return;
+    };
+    for &(idx, usage) in usages {
+        profile!(
+            "canon.virtual_ts.component_prop_checks",
+            generate_component_prop_checks(
+                ts,
+                mappings,
+                usage,
+                idx,
+                ctx.template_prop_names,
+                ctx.source_context,
+                indent,
+            )
+        );
     }
 }
 

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -15,7 +15,8 @@ use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier, to_safe_iden
 use crate::virtual_ts::types::VizeMapping;
 
 use super::component_prop_checker::{
-    append_prop_check_helpers, append_prop_checker_alias, has_inference_props, has_value_props,
+    append_prop_check_helpers, append_prop_checker_alias, has_checkable_props_or_spread,
+    has_value_props,
 };
 use super::component_prop_navigation;
 use super::context::{ComponentPropsContext, VForPropsContext};
@@ -75,7 +76,7 @@ pub(super) fn generate_component_props(
     // typing is limited to inline function props to avoid duplicate errors.
     let any_inference_props = checkable_usages
         .iter()
-        .any(|(_, usage)| has_inference_props(usage));
+        .any(|(_, usage)| has_checkable_props_or_spread(usage));
     if any_inference_props {
         append_prop_check_helpers(ts);
     }
@@ -86,7 +87,7 @@ pub(super) fn generate_component_props(
 
         let has_value_props = has_value_props(usage);
         let has_navigable_props = component_prop_navigation::has_navigable_props(ctx, usage);
-        if !has_value_props && !has_navigable_props {
+        if !has_value_props && !has_navigable_props && usage.spread_props.is_empty() {
             continue;
         }
 
@@ -119,10 +120,11 @@ pub(super) fn generate_component_props(
             }
         }
 
-        if has_inference_props(usage) {
+        if has_checkable_props_or_spread(usage) {
             // Generic functional prop-checker for this component (#775).
             append_prop_checker_alias(
                 ts,
+                usage,
                 component_type_name.as_str(),
                 component_ref.as_str(),
                 idx,

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -7,6 +7,7 @@ use super::{
 use vize_carton::config::VueVersion;
 mod auto_import_shadowing;
 mod component_navigation;
+mod component_spread_prop_order;
 mod define_props_scope;
 mod generic_module_type_exports;
 mod legacy_nuxt2_page_context;

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -179,55 +179,6 @@ export default defineComponent({
 }
 
 #[test]
-fn test_options_api_virtual_ts_emits_typed_shape_for_pinia_spread_helpers() {
-    let script = r#"import { defineComponent } from 'vue'
-import { mapState, mapActions } from 'pinia'
-
-function useFakeStore() {
-    return {
-        ready: false,
-        items: [] as Array<{ id: number; label: string }>,
-        setReady(_v: boolean) {},
-    }
-}
-
-export default defineComponent({
-    computed: {
-        ...mapState(useFakeStore, ['items', 'ready']),
-        localComputed() { return 1 },
-    },
-    methods: {
-        ...mapActions(useFakeStore, ['setReady']),
-    },
-})
-"#;
-    let summary = analyze_options_api_script(script);
-    let output = generate_virtual_ts_with_offsets_options_api(
-        &summary,
-        Some(script),
-        None,
-        0,
-        0,
-        &Default::default(),
-    );
-
-    assert!(
-        output
-            .code
-            .contains("[K in 'items' | 'ready']: ReturnType<typeof useFakeStore>[K]"),
-        "expected precise mapped type for mapState spread keys:\n{}",
-        output.code
-    );
-    assert!(
-        output
-            .code
-            .contains("[K in 'setReady']: ReturnType<typeof useFakeStore>[K]"),
-        "expected precise mapped type for mapActions spread keys:\n{}",
-        output.code
-    );
-}
-
-#[test]
 fn test_options_api_unresolved_extends_exposes_template_refs_as_inherited_any() {
     use vize_croquis::{Analyzer, AnalyzerOptions};
 

--- a/crates/vize_canon/src/virtual_ts/tests/component_spread_prop_order.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/component_spread_prop_order.rs
@@ -1,0 +1,46 @@
+//! The props literal emits `v-bind="obj"` spreads in template order (#3444).
+//!
+//! Vue 3 resolves an overlapping key by source order, last binding wins, and so
+//! does an object literal. Emitting every spread first would type-check the
+//! named value for a key the runtime takes from the spread instead.
+
+use super::generate_virtual_ts;
+use vize_croquis::{Analyzer, AnalyzerOptions};
+
+fn generated_props_literal(template: &str) -> vize_carton::String {
+    let script = r#"import Child from "./Child.vue"
+const bag = { count: 1 }
+"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    generate_virtual_ts(&summary, Some(script), Some(&root), 0).code
+}
+
+#[test]
+fn a_spread_after_a_named_prop_is_emitted_after_it() {
+    let code = generated_props_literal(r#"<Child :count="2" v-bind="bag" />"#);
+
+    let named = code.find("\"count\": 2").expect("named prop emitted");
+    let spread = code.find("...bag").expect("spread emitted");
+    assert!(
+        named < spread,
+        "the spread is authored last, so it must win the key: {code}"
+    );
+}
+
+#[test]
+fn a_spread_before_a_named_prop_is_emitted_before_it() {
+    let code = generated_props_literal(r#"<Child v-bind="bag" :count="2" />"#);
+
+    let spread = code.find("...bag").expect("spread emitted");
+    let named = code.find("\"count\": 2").expect("named prop emitted");
+    assert!(
+        spread < named,
+        "the named prop is authored last, so it must win the key: {code}"
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs
@@ -276,3 +276,52 @@ export default defineComponent({
         output.code
     );
 }
+
+#[test]
+fn test_options_api_virtual_ts_emits_typed_shape_for_pinia_spread_helpers() {
+    let script = r#"import { defineComponent } from 'vue'
+import { mapState, mapActions } from 'pinia'
+
+function useFakeStore() {
+    return {
+        ready: false,
+        items: [] as Array<{ id: number; label: string }>,
+        setReady(_v: boolean) {},
+    }
+}
+
+export default defineComponent({
+    computed: {
+        ...mapState(useFakeStore, ['items', 'ready']),
+        localComputed() { return 1 },
+    },
+    methods: {
+        ...mapActions(useFakeStore, ['setReady']),
+    },
+})
+"#;
+    let summary = analyze_options_api_script(script);
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        None,
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        output
+            .code
+            .contains("[K in 'items' | 'ready']: ReturnType<typeof useFakeStore>[K]"),
+        "expected precise mapped type for mapState spread keys:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("[K in 'setReady']: ReturnType<typeof useFakeStore>[K]"),
+        "expected precise mapped type for mapActions spread keys:\n{}",
+        output.code
+    );
+}

--- a/crates/vize_croquis/src/croquis.rs
+++ b/crates/vize_croquis/src/croquis.rs
@@ -62,7 +62,7 @@ pub use snapshot::{
 pub use summary::CroquisSemanticSummary;
 pub use template::{
     ComponentRegistration, ComponentUsage, ElementIdInfo, ElementIdKind, EventListener, PassedProp,
-    SlotUsage, TemplateExpression, TemplateExpressionKind, TemplateInfo,
+    SlotUsage, SpreadProp, TemplateExpression, TemplateExpressionKind, TemplateInfo,
 };
 
 use crate::hoist::HoistTracker;

--- a/crates/vize_croquis/src/croquis/snapshot_tests.rs
+++ b/crates/vize_croquis/src/croquis/snapshot_tests.rs
@@ -156,6 +156,7 @@ fn semantic_snapshot_is_deterministic_for_manual_croquis_facts() {
             has_scope: false,
         }],
         has_spread_attrs: false,
+        spread_props: vize_carton::SmallVec::new(),
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     });

--- a/crates/vize_croquis/src/croquis/summary_template_tests.rs
+++ b/crates/vize_croquis/src/croquis/summary_template_tests.rs
@@ -56,6 +56,7 @@ fn semantic_summary_collects_template_and_export_counts() {
             has_scope: true,
         }],
         has_spread_attrs: true,
+        spread_props: vize_carton::SmallVec::new(),
         scope_id: ScopeId::ROOT,
         vif_guard: Some(CompactString::new("visible")),
     });

--- a/crates/vize_croquis/src/croquis/template.rs
+++ b/crates/vize_croquis/src/croquis/template.rs
@@ -183,10 +183,28 @@ pub struct ComponentUsage {
     pub slots: SmallVec<[SlotUsage; 2]>,
     /// Whether v-bind="$attrs" or similar spread is used
     pub has_spread_attrs: bool,
+    /// The argument-less `v-bind="expr"` spreads on this usage, in source order.
+    ///
+    /// [`Self::has_spread_attrs`] answers "is there one"; this carries *what*
+    /// was spread, which is what a whole-props type check needs. A spread
+    /// contributes no [`PassedProp`], so without this the expression is not
+    /// recoverable from the usage at all (#3444).
+    pub spread_props: SmallVec<[SpreadProp; 1]>,
     /// The scope this component usage is in (for v-for prop checking)
     pub scope_id: crate::scope::ScopeId,
     /// Combined v-if / v-else-if guard active for this component usage.
     pub vif_guard: Option<CompactString>,
+}
+
+/// An argument-less `v-bind="expr"` spread on a component usage.
+#[derive(Debug, Clone)]
+pub struct SpreadProp {
+    /// The spread expression as authored, e.g. `bag` or `$attrs`.
+    pub expression: CompactString,
+    /// Start offset of the whole directive, at the `v` of `v-bind` or the `:`.
+    pub start: u32,
+    /// End offset of the whole directive.
+    pub end: u32,
 }
 
 /// A prop passed to a component in template.

--- a/crates/vize_croquis/src/drawer/template/components.rs
+++ b/crates/vize_croquis/src/drawer/template/components.rs
@@ -3,7 +3,7 @@
 //! Collects props, events, and slots passed to child components
 //! during template traversal.
 
-use crate::croquis::{ComponentUsage, EventListener, PassedProp, SlotUsage};
+use crate::croquis::{ComponentUsage, EventListener, PassedProp, SlotUsage, SpreadProp};
 use crate::drawer::helpers::extract_slot_props;
 use vize_carton::{CompactString, SmallVec, cstr};
 use vize_relief::{ElementNode, ExpressionNode, PropNode, TemplateChildNode};
@@ -51,8 +51,18 @@ impl Drawer {
                                 end: dir.loc.end.offset,
                                 is_dynamic: true,
                             });
-                        } else if dir.exp.is_some() {
+                        } else if let Some(ref exp) = dir.exp {
                             usage.has_spread_attrs = true;
+                            usage.spread_props.push(SpreadProp {
+                                expression: match exp {
+                                    ExpressionNode::Simple(s) => s.content.clone(),
+                                    ExpressionNode::Compound(c) => {
+                                        CompactString::new(c.loc.source.as_str())
+                                    }
+                                },
+                                start: dir.loc.start.offset,
+                                end: dir.loc.end.offset,
+                            });
                         }
                     }
                     "on" => {

--- a/crates/vize_croquis/src/drawer/template/visit_element.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element.rs
@@ -122,6 +122,7 @@ impl Drawer {
             events: SmallVec::new(),
             slots: SmallVec::new(),
             has_spread_attrs: false,
+            spread_props: SmallVec::new(),
             scope_id: crate::scope::ScopeId::ROOT,
             vif_guard: None,
         })

--- a/crates/vize_croquis_cf/src/analyzer/tests_basic.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_basic.rs
@@ -344,6 +344,7 @@ fn component_usage_with_on_prefixed_prop(component: &str) -> ComponentUsage {
         events: smallvec![event_listener("click")],
         slots: smallvec![],
         has_spread_attrs: false,
+        spread_props: smallvec![],
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     }
@@ -358,6 +359,7 @@ fn component_usage_with_spread_and_extra_prop(component: &str) -> ComponentUsage
         events: smallvec![],
         slots: smallvec![],
         has_spread_attrs: true,
+        spread_props: smallvec![],
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     }
@@ -383,6 +385,7 @@ fn component_usage_with_extra_prop_at(
         events: smallvec![],
         slots: smallvec![],
         has_spread_attrs: false,
+        spread_props: smallvec![],
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     }
@@ -408,6 +411,7 @@ fn component_usage_with_count_string_at(
         events: smallvec![],
         slots: smallvec![],
         has_spread_attrs: false,
+        spread_props: smallvec![],
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     }
@@ -427,6 +431,7 @@ fn component_usage_with_prop(
         events: smallvec![],
         slots: smallvec![],
         has_spread_attrs: false,
+        spread_props: smallvec![],
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     }

--- a/crates/vize_croquis_cf/src/analyzer/tests_basic.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_basic.rs
@@ -332,16 +332,15 @@ fn unregistered_components(result: &CrossFileResult) -> Vec<&str> {
         .collect()
 }
 
-fn component_usage_with_on_prefixed_prop(component: &str) -> ComponentUsage {
+/// A usage of `component` that binds nothing; every helper below overrides only
+/// the fields its case is about.
+fn component_usage_base(component: &str) -> ComponentUsage {
     ComponentUsage {
         name: CompactString::new(component),
         start: 0,
         end: 0,
-        props: smallvec![
-            passed_prop("title", Some("x"), false),
-            passed_prop("online", Some("true"), false),
-        ],
-        events: smallvec![event_listener("click")],
+        props: smallvec![],
+        events: smallvec![],
         slots: smallvec![],
         has_spread_attrs: false,
         spread_props: smallvec![],
@@ -350,18 +349,22 @@ fn component_usage_with_on_prefixed_prop(component: &str) -> ComponentUsage {
     }
 }
 
+fn component_usage_with_on_prefixed_prop(component: &str) -> ComponentUsage {
+    ComponentUsage {
+        props: smallvec![
+            passed_prop("title", Some("x"), false),
+            passed_prop("online", Some("true"), false),
+        ],
+        events: smallvec![event_listener("click")],
+        ..component_usage_base(component)
+    }
+}
+
 fn component_usage_with_spread_and_extra_prop(component: &str) -> ComponentUsage {
     ComponentUsage {
-        name: CompactString::new(component),
-        start: 0,
-        end: 0,
         props: smallvec![passed_prop("extra", Some("true"), false)],
-        events: smallvec![],
-        slots: smallvec![],
         has_spread_attrs: true,
-        spread_props: smallvec![],
-        scope_id: ScopeId::ROOT,
-        vif_guard: None,
+        ..component_usage_base(component)
     }
 }
 
@@ -372,7 +375,6 @@ fn component_usage_with_extra_prop_at(
     prop_end: u32,
 ) -> ComponentUsage {
     ComponentUsage {
-        name: CompactString::new(component),
         start: usage_start,
         end: prop_end,
         props: smallvec![passed_prop_at(
@@ -382,12 +384,7 @@ fn component_usage_with_extra_prop_at(
             prop_start,
             prop_end
         )],
-        events: smallvec![],
-        slots: smallvec![],
-        has_spread_attrs: false,
-        spread_props: smallvec![],
-        scope_id: ScopeId::ROOT,
-        vif_guard: None,
+        ..component_usage_base(component)
     }
 }
 
@@ -398,7 +395,6 @@ fn component_usage_with_count_string_at(
     prop_end: u32,
 ) -> ComponentUsage {
     ComponentUsage {
-        name: CompactString::new(component),
         start: usage_start,
         end: prop_end,
         props: smallvec![passed_prop_at(
@@ -408,12 +404,7 @@ fn component_usage_with_count_string_at(
             prop_start,
             prop_end,
         )],
-        events: smallvec![],
-        slots: smallvec![],
-        has_spread_attrs: false,
-        spread_props: smallvec![],
-        scope_id: ScopeId::ROOT,
-        vif_guard: None,
+        ..component_usage_base(component)
     }
 }
 
@@ -424,16 +415,8 @@ fn component_usage_with_prop(
     is_dynamic: bool,
 ) -> ComponentUsage {
     ComponentUsage {
-        name: CompactString::new(component),
-        start: 0,
-        end: 0,
         props: smallvec![passed_prop(prop_name, value, is_dynamic)],
-        events: smallvec![],
-        slots: smallvec![],
-        has_spread_attrs: false,
-        spread_props: smallvec![],
-        scope_id: ScopeId::ROOT,
-        vif_guard: None,
+        ..component_usage_base(component)
     }
 }
 

--- a/crates/vize_croquis_cf/src/analyzer/tests_fallthrough/base.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_fallthrough/base.rs
@@ -52,6 +52,7 @@ fn fallthrough_component_facts_are_populated_from_analyzer() {
         }],
         slots: smallvec![],
         has_spread_attrs: false,
+        spread_props: smallvec![],
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     });

--- a/crates/vize_croquis_cf/src/analyzer/tests_provide_inject/tree.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_provide_inject/tree.rs
@@ -253,6 +253,7 @@ fn component_usage_with_span(
         events: vize_carton::SmallVec::new(),
         slots: vize_carton::SmallVec::new(),
         has_spread_attrs: false,
+        spread_props: vize_carton::SmallVec::new(),
         scope_id: vize_croquis::ScopeId::ROOT,
         vif_guard: None,
     }

--- a/crates/vize_croquis_cf/src/analyzer/tests_race_conditions.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_race_conditions.rs
@@ -32,6 +32,7 @@ fn component_usage(component: &str) -> ComponentUsage {
         events: SmallVec::new(),
         slots: SmallVec::new(),
         has_spread_attrs: false,
+        spread_props: SmallVec::new(),
         scope_id: vize_croquis::ScopeId::ROOT,
         vif_guard: None,
     }

--- a/crates/vize_croquis_cf/src/analyzer/tests_reactivity_props.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_reactivity_props.rs
@@ -43,6 +43,7 @@ fn component_usage(component: &str, props: &[(&str, &str)]) -> ComponentUsage {
         events: SmallVec::new(),
         slots: SmallVec::new(),
         has_spread_attrs: false,
+        spread_props: SmallVec::new(),
         scope_id: vize_croquis::ScopeId::ROOT,
         vif_guard: None,
     }

--- a/crates/vize_croquis_cf/src/analyzer/tests_snapshots/fallthrough.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_snapshots/fallthrough.rs
@@ -42,6 +42,7 @@ fn usage(
         events: events.into_iter().collect(),
         slots: smallvec![],
         has_spread_attrs,
+        spread_props: smallvec![],
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     }

--- a/crates/vize_croquis_cf/src/rules/complexity_hotspots_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity_hotspots_tests.rs
@@ -45,6 +45,7 @@ fn ranks_hotspots_with_dimension_inputs_and_json_shape() {
             has_scope: true,
         }],
         has_spread_attrs: false,
+        spread_props: smallvec![],
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     });
@@ -198,6 +199,7 @@ fn analyzer_result_stores_complexity_hotspots() {
         events: smallvec![],
         slots: smallvec![],
         has_spread_attrs: false,
+        spread_props: smallvec![],
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     });

--- a/crates/vize_croquis_cf/src/rules/complexity_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/complexity_tests.rs
@@ -126,6 +126,7 @@ fn summarizes_complexity_from_registry_and_result() {
             has_scope: true,
         }],
         has_spread_attrs: false,
+        spread_props: smallvec![],
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     });
@@ -271,6 +272,7 @@ fn summarizes_component_tree_template_nesting() {
             has_scope: true,
         }],
         has_spread_attrs: false,
+        spread_props: smallvec![],
         scope_id: parent_loop,
         vif_guard: Some(CompactString::new("ready")),
     });

--- a/crates/vize_croquis_cf/src/rules/component_resolution/tests.rs
+++ b/crates/vize_croquis_cf/src/rules/component_resolution/tests.rs
@@ -57,6 +57,7 @@ fn unregistered_component_uses_template_usage_offset() {
         events: smallvec![],
         slots: smallvec![],
         has_spread_attrs: false,
+        spread_props: smallvec![],
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     });

--- a/crates/vize_croquis_cf/src/rules/fallthrough/diagnostics_tests.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough/diagnostics_tests.rs
@@ -38,6 +38,7 @@ fn diagnostics_include_parent_usage_related_locations() {
             events: smallvec![],
             slots: smallvec![],
             has_spread_attrs: false,
+            spread_props: smallvec![],
             scope_id: ScopeId::ROOT,
             vif_guard: None,
         });
@@ -102,6 +103,7 @@ fn spread_attrs_report_multi_root_with_parent_usage_location() {
             events: smallvec![],
             slots: smallvec![],
             has_spread_attrs: true,
+            spread_props: smallvec![],
             scope_id: ScopeId::ROOT,
             vif_guard: None,
         });
@@ -156,6 +158,7 @@ fn spread_attrs_are_safe_when_multi_root_component_binds_attrs() {
         events: smallvec![],
         slots: smallvec![],
         has_spread_attrs: true,
+        spread_props: smallvec![],
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     });
@@ -199,6 +202,7 @@ fn declared_emit_listener_does_not_create_fallthrough_diagnostics() {
         }],
         slots: smallvec![],
         has_spread_attrs: false,
+        spread_props: smallvec![],
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     });

--- a/crates/vize_croquis_cf/src/rules/fallthrough/tests.rs
+++ b/crates/vize_croquis_cf/src/rules/fallthrough/tests.rs
@@ -33,6 +33,7 @@ fn usage_with_prop(name: &str, prop: &str) -> ComponentUsage {
         events: smallvec![],
         slots: smallvec![],
         has_spread_attrs: false,
+        spread_props: smallvec![],
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     }
@@ -88,6 +89,7 @@ fn usage_facts_keep_parent_source_ranges_and_attr_classification() {
             events: smallvec![event_listener_at("click", 60, 76)],
             slots: smallvec![],
             has_spread_attrs: true,
+            spread_props: smallvec![],
             scope_id: ScopeId::ROOT,
             vif_guard: None,
         });
@@ -165,6 +167,7 @@ fn usage_facts_feed_listener_attrs_into_component_aggregates() {
             events: smallvec![event_listener_at("close", 12, 28)],
             slots: smallvec![],
             has_spread_attrs: false,
+            spread_props: smallvec![],
             scope_id: ScopeId::ROOT,
             vif_guard: None,
         });

--- a/crates/vize_maestro/src/ide/hover/component_tag/items.rs
+++ b/crates/vize_maestro/src/ide/hover/component_tag/items.rs
@@ -131,6 +131,7 @@ mod tests {
             events: smallvec![],
             slots: smallvec![],
             has_spread_attrs: false,
+            spread_props: smallvec![],
             scope_id: ScopeId::ROOT,
             vif_guard: None,
         };


### PR DESCRIPTION
Closes #3444. #3525 (#3450) has landed, so this PR now targets `main` directly and the diff shows only the spread work.

## The defect

`v-bind="obj"` was not type-checked at all. A spread contributes no `PassedProp`, so a usage that only spreads had no checkable prop, `has_inference_props` was false, and no check was emitted for it anywhere.

croquis now records the spread expression and its span (`ComponentUsage::has_spread_attrs` answered "is there one" but not *what*), and canon folds it into the same props object literal the generic inference call already assembles: `({ ...bag, "label": maybe })`.

## The target depends on what else the usage binds

This is what keeps the diagnostics from doubling:

| usage | target | why |
| --- | --- | --- |
| spreads, binds nothing by name | the child's props type **unmodified** | nothing on that element is covered by the per-prop path, so nothing doubles — and it is the only shape that catches a wrongly typed value *inside* the spread, which is this issue's oracle |
| also binds by name | #3450's widened target | the named props belong to the per-prop check at anchors it already owns; the full type there would duplicate every one |

## Measured against vue-tsc, not assumed

`vue-tsc@3.3.4` + `vue@3.6.0-beta.10`, byte-identical workspace. Both tools now report the same two positions, column 4 being the element name:

```
Parent.vue(8,4)   <Child v-bind="bag" />      bag.count is a string
Parent.vue(10,4)  <Child v-bind="$attrs" />   contributes no `count`
Parent.vue(9)     <Child v-bind="good" />     clean in both
```

**`$attrs` is not special-cased.** vue-tsc types its contribution as `{}` and reports the required prop missing, so matching it is parity, not a false positive. My earlier note on the issue claimed the opposite — that was derived from a hand-written probe rather than from running vue-tsc, and is [corrected there](https://github.com/ubugeeei-prod/vize/issues/3444#issuecomment-5140769529).

The message text still diverges: vize names its own generated props type where vue-tsc names `{ readonly count: number; } & VNodeProps & …`. Message-only, which the ledger scores separately.

## Deliberately out of scope

`<Child />` binding nothing at all. vue-tsc reports a missing required prop there and vize does not — a real gap, but it is the **missing-required-prop diagnostic class** rather than this issue's spread, and it deserves its own blast-radius measurement across the ecosystem. Filed separately. The seam is visible and intentional: `<Child class="x" />` does report it (the widened target makes required keys non-optional once anything is bound), `<Child />` does not.

## A #3513 trap found on the way

The first three runs of this measurement produced **zero** vue-tsc diagnostics, including on a blatant `<Child :count="'definitely wrong'" />`, with all three `.vue` files listed in the program. The cause: vue-tsc could not resolve `vue`, because this repo's root `node_modules` is a pnpm store with no hoisted `vue`. With an unresolvable `vue`, template checking degrades to **silence** rather than erroring — a third way to get the empty baseline #3513 documents, invisible to both the exit code and a file-list check. Recorded on that issue.

## Verification

- 3 end-to-end tests: the wrongly-typed and `$attrs` spreads at vue-tsc-identical positions with the correct bag clean; a spread beside a named prop reported once by the per-prop path at the attribute name; an error inside the spread expression landing on the authored bytes
- `vize_canon` + `vize_croquis`: 27 test binaries green
- Hydrated vue-parity fixtures: `vue2-elm` and all five `vue-element-admin` oracles pass **unchanged, no re-pins**
- `vize check --declaration` vue-floor and `check-server` consumers green
- Source-length gate green

## Breaking

`ComponentUsage` gains a `spread_props` field and `SpreadProp` is a new public type. The struct has public fields and is not `#[non_exhaustive]`, so downstream struct-literal construction must add the field — hence the `!`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type checking for component props provided through `v-bind` spreads.
  * Preserved template order and Vue’s last-binding-wins behavior for mixed named props and spreads.
  * Errors in spread expressions now point to the relevant template locations.
  * Preserved named-prop diagnostics and avoided false errors for valid spreads and `$attrs`.

* **Tests**
  * Added regression coverage for spread-prop type checking, diagnostic locations, and binding order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->