### PR TITLE
refactor(atelier): split the template-only case out of compile.rs

### DIFF
--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -10,6 +10,7 @@ mod helpers;
 mod normal_script;
 pub(crate) mod output_module;
 mod styles;
+mod template_only;
 #[cfg(test)]
 mod tests;
 
@@ -238,99 +239,24 @@ fn compile_sfc_inner(
 
     // Case 1: Template only - just output render function
     if !has_script && !has_script_setup && has_template {
-        let template = descriptor.template.as_ref().unwrap();
-        let template_result = if is_vapor {
-            profile!(
-                "atelier.sfc.template.vapor",
-                compile_template_block_vapor(
-                    template,
-                    &scope_id,
-                    has_scoped,
-                    None,
-                    &options.template,
-                    template_syntax,
-                    &codegen_options,
-                )
-            )
-        } else {
-            // Enable hoisting for template-only SFCs (hoisted consts go at module level)
-            let mut template_opts = options.template.clone();
-            let mut dom_opts = template_opts.compiler_options.take().unwrap_or_default();
-            dom_opts.hoist_static = true;
-            template_opts.compiler_options = Some(dom_opts);
-            // Also pass scope IDs to the client template compiler. Vue's runtime
-            // normally propagates __scopeId, but wrapper components such as NuxtLink
-            // can otherwise lose parent scoped attrs before the final DOM root.
-            profile!(
-                "atelier.sfc.template.compile",
-                compile_template_block(
-                    template,
-                    &template_opts,
-                    TemplateBlockCompileContext {
-                        scope_id: &scope_id,
-                        apply_scope_id: has_scoped,
-                        has_scoped,
-                        is_ts: template_is_ts,
-                        inline: false,
-                        component_name: Some(&component_name),
-                        bindings: None,
-                        croquis: None,
-                    },
-                    template_syntax,
-                    &codegen_options,
-                )
-            )
-        };
-
-        match template_result {
-            Ok(template_output) => {
-                warnings.extend(template_output.warnings);
-                code = template_output.code;
-                if is_vapor {
-                    code.push_str("const _sfc_main = { __vapor: true }\n");
-                    append_component_render_export(
-                        &mut code,
-                        "_sfc_main",
-                        RenderFunctionName::Render,
-                        &compiled_styles.css_modules,
-                    );
-                } else if options.template.ssr {
-                    code.push_str("const _sfc_main = {}\n");
-                    append_component_render_export(
-                        &mut code,
-                        "_sfc_main",
-                        RenderFunctionName::SsrRender,
-                        &compiled_styles.css_modules,
-                    );
-                } else if !compiled_styles.css_modules.is_empty() {
-                    code.push_str("const _sfc_main = {}\n");
-                    append_component_render_export(
-                        &mut code,
-                        "_sfc_main",
-                        RenderFunctionName::Render,
-                        &compiled_styles.css_modules,
-                    );
-                }
-            }
-            // Previously this just collected the error into a local vec
-            // and continued, returning Ok with empty code — so callers
-            // wrote a 0-byte module and exited 0 (#958). Propagate the
-            // template error up so the build/CLI surfaces it.
-            Err(e) => return Err(e),
-        }
-
-        finalize_output_mode(&mut code, &mut warnings, &options, &codegen_options);
-        trim_trailing_newlines(&mut code);
-
-        return Ok(SfcCompileResult {
-            code,
+        return template_only::compile_template_only(
+            template_only::TemplateOnlyInput {
+                descriptor,
+                options: &options,
+                template_syntax,
+                codegen_options: &codegen_options,
+                compiled_styles: &compiled_styles,
+                component_name: &component_name,
+                scope_id: &scope_id,
+                has_scoped,
+                is_vapor,
+                template_is_ts,
+            },
             css,
-            map: None,
             errors,
             warnings,
-            bindings: None,
             macro_artifacts,
-        });
+        );
     }
 
     // Case 2: Script (non-setup) + Template - rewrite default and compile template

--- a/crates/vize_atelier_sfc/src/compile/template_only.rs
+++ b/crates/vize_atelier_sfc/src/compile/template_only.rs
@@ -130,7 +130,7 @@ pub(super) fn compile_template_only(
     );
     trim_trailing_newlines(&mut code);
 
-    return Ok(SfcCompileResult {
+    Ok(SfcCompileResult {
         code,
         css,
         map: None,
@@ -138,5 +138,5 @@ pub(super) fn compile_template_only(
         warnings,
         bindings: None,
         macro_artifacts,
-    });
+    })
 }

--- a/crates/vize_atelier_sfc/src/compile/template_only.rs
+++ b/crates/vize_atelier_sfc/src/compile/template_only.rs
@@ -1,0 +1,142 @@
+//! Case 1 of SFC compilation: a template with no `<script>` of either kind.
+//!
+//! Split out of `super::compile_sfc_inner` so that function stays inside the
+//! per-file source-length budget while the other two cases keep their shape.
+
+use vize_atelier_core::{CodegenOptions, TemplateSyntaxMode};
+use vize_carton::{String, profile};
+
+use crate::compile_template::{
+    TemplateBlockCompileContext, compile_template_block, compile_template_block_vapor,
+};
+use crate::types::{
+    SfcCompileOptions, SfcCompileResult, SfcDescriptor, SfcError, SfcMacroArtifact,
+};
+
+use super::helpers::trim_trailing_newlines;
+use super::output_module::{
+    RenderFunctionName, append_component_render_export, finalize_output_mode,
+};
+use super::styles::CompiledStyles;
+
+/// Everything the template-only path reads from the shared prelude.
+pub(super) struct TemplateOnlyInput<'a> {
+    pub(super) descriptor: &'a SfcDescriptor<'a>,
+    pub(super) options: &'a SfcCompileOptions,
+    pub(super) template_syntax: TemplateSyntaxMode,
+    pub(super) codegen_options: &'a CodegenOptions,
+    pub(super) compiled_styles: &'a CompiledStyles,
+    pub(super) component_name: &'a str,
+    pub(super) scope_id: &'a str,
+    pub(super) has_scoped: bool,
+    pub(super) is_vapor: bool,
+    pub(super) template_is_ts: bool,
+}
+
+pub(super) fn compile_template_only(
+    input: TemplateOnlyInput<'_>,
+    css: Option<String>,
+    errors: Vec<SfcError>,
+    mut warnings: Vec<SfcError>,
+    macro_artifacts: Vec<SfcMacroArtifact>,
+) -> Result<SfcCompileResult, SfcError> {
+    let template = input.descriptor.template.as_ref().unwrap();
+    let template_result = if input.is_vapor {
+        profile!(
+            "atelier.sfc.template.vapor",
+            compile_template_block_vapor(
+                template,
+                input.scope_id,
+                input.has_scoped,
+                None,
+                &input.options.template,
+                input.template_syntax,
+                input.codegen_options,
+            )
+        )
+    } else {
+        // Enable hoisting for template-only SFCs (hoisted consts go at module level)
+        let mut template_opts = input.options.template.clone();
+        let mut dom_opts = template_opts.compiler_options.take().unwrap_or_default();
+        dom_opts.hoist_static = true;
+        template_opts.compiler_options = Some(dom_opts);
+        // Also pass scope IDs to the client template compiler. Vue's runtime
+        // normally propagates __scopeId, but wrapper components such as NuxtLink
+        // can otherwise lose parent scoped attrs before the final DOM root.
+        profile!(
+            "atelier.sfc.template.compile",
+            compile_template_block(
+                template,
+                &template_opts,
+                TemplateBlockCompileContext {
+                    scope_id: input.scope_id,
+                    apply_scope_id: input.has_scoped,
+                    has_scoped: input.has_scoped,
+                    is_ts: input.template_is_ts,
+                    inline: false,
+                    component_name: Some(input.component_name),
+                    bindings: None,
+                    croquis: None,
+                },
+                input.template_syntax,
+                input.codegen_options,
+            )
+        )
+    };
+
+    let mut code = match template_result {
+        Ok(template_output) => {
+            warnings.extend(template_output.warnings);
+            let mut code = template_output.code;
+            if input.is_vapor {
+                code.push_str("const _sfc_main = { __vapor: true }\n");
+                append_component_render_export(
+                    &mut code,
+                    "_sfc_main",
+                    RenderFunctionName::Render,
+                    &input.compiled_styles.css_modules,
+                );
+            } else if input.options.template.ssr {
+                code.push_str("const _sfc_main = {}\n");
+                append_component_render_export(
+                    &mut code,
+                    "_sfc_main",
+                    RenderFunctionName::SsrRender,
+                    &input.compiled_styles.css_modules,
+                );
+            } else if !input.compiled_styles.css_modules.is_empty() {
+                code.push_str("const _sfc_main = {}\n");
+                append_component_render_export(
+                    &mut code,
+                    "_sfc_main",
+                    RenderFunctionName::Render,
+                    &input.compiled_styles.css_modules,
+                );
+            }
+            code
+        }
+        // Previously this just collected the error into a local vec
+        // and continued, returning Ok with empty code — so callers
+        // wrote a 0-byte module and exited 0 (#958). Propagate the
+        // template error up so the build/CLI surfaces it.
+        Err(e) => return Err(e),
+    };
+
+    finalize_output_mode(
+        &mut code,
+        &mut warnings,
+        input.options,
+        input.codegen_options,
+    );
+    trim_trailing_newlines(&mut code);
+
+    return Ok(SfcCompileResult {
+        code,
+        css,
+        map: None,
+        errors,
+        warnings,
+        bindings: None,
+        macro_artifacts,
+    });
+}


### PR DESCRIPTION
Refs #3425 — this is the prerequisite that issue names, nothing more.

## Why

`compile.rs` is **928 lines**, so the 350-line source budget forbids it from growing by even one line (`OverLimitFileGrew`). #3425's Rust half has to add a module-shape field to `SfcCompileResult` and therefore touch the three result literals in this file, so it cannot be written at all until there is headroom. The issue says as much:

> Threading a shape record through it therefore cannot be done additively — every `let shape = ...` has to be paid for by an extraction out of that file first […] Worth deciding before writing any of it, because it dictates whether this is one PR or two.

## What moved

`compile_sfc_inner` is 774 of the 928 lines and is three sequential cases: template only, non-setup script + template, and script setup. The first is the smallest and most self-contained — it reads eleven values from the shared prelude, consumes the four accumulators, and returns — so it moves out whole and leaves the other two untouched.

`compile.rs` goes **928 → 854**. That is enough headroom for #3425 to add its field and still shrink the file relative to base. Splitting the remaining two cases would be a much larger change for no additional benefit right now.

## How a pure refactor was verified without the snapshot tests

The 8 `vize_atelier_sfc` snapshot tests need a `pkl` binary that is not available in this environment — and those are precisely the tests that would catch an output change. Rather than rely on CI for the one check that matters, verification is byte-level over a real corpus.

**6064 SFCs compiled before and after, byte-identical**, compared as a sorted SHA-256 manifest:

| corpus | files |
| --- | ---: |
| `vue-element-admin` | 131 |
| `vue2-elm` | 55 |
| repo fixture projects | 58 |
| materialized ecosystem worktrees (misskey et al.) | 5820 |

Coverage across the three cases: 5857 script-setup, 533 template-only, the rest non-setup script + template — so the extracted case and both untouched ones are all exercised.

`cargo test -p vize_atelier_sfc`: 574 passed / 8 failed — the same counts as on clean `main`, where the 8 are the pkl-dependent snapshot tests. CI has `pkl` and will run them.

Source-length gate green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->