### PR TITLE
fix(cli): recognize only discovered oxlint configs

### DIFF
--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -58,7 +58,7 @@
     "check:fix": "vp check --fix src tests vite.config.ts",
     "fmt": "vp fmt --write src tests vite.config.ts",
     "generate:rule-types": "vp run --workspace-root generate:rule-types",
-    "test": "vp pack && vp test run tests/setup.test.ts tests/init.test.ts tests/init-frameworks.test.ts tests/init-prompt.test.ts"
+    "test": "vp pack && vp test run tests/setup.test.ts tests/setup-oxlint-config.test.ts tests/init.test.ts tests/init-frameworks.test.ts tests/init-prompt.test.ts"
   },
   "dependencies": {
     "@vizejs/native": "workspace:*",

--- a/npm/cli/src/init/lint-target.ts
+++ b/npm/cli/src/init/lint-target.ts
@@ -1,22 +1,17 @@
 import type { ProjectDetection } from "./detect.js";
+import { DISCOVERED_OXLINT_CONFIG_FILES } from "../setup/config.js";
 import { canInjectViteLint, hasTopLevelKey } from "./edit-config.js";
 import { VITE_LINT_MERGE_SNIPPET, VITE_LINT_SNIPPET } from "./templates.js";
+
+export { DISCOVERED_OXLINT_CONFIG_FILES } from "../setup/config.js";
 
 /**
  * Oxlint config filenames the `oxlint` binary actually auto-discovers.
  *
  * Verified against oxlint 1.64: `.oxlintrc.json`, `.oxlintrc.jsonc` and
  * `oxlint.config.ts` are read; `oxlint.config.mts`, `.js`, `.mjs`, `.cjs` and
- * `.cts` produce a run byte-identical to having no config at all. The wider list
- * in `setup/config.ts` treats all eight as configuration, which is #3474. `init`
- * uses this narrower list so it never reports an unread file as configured.
+ * `.cts` produce a run byte-identical to having no config at all.
  */
-export const DISCOVERED_OXLINT_CONFIG_FILES = [
-  ".oxlintrc.json",
-  ".oxlintrc.jsonc",
-  "oxlint.config.ts",
-] as const;
-
 /** Filename `init` writes when the `oxlint` binary is the lint entry point. */
 export const INIT_OXLINT_CONFIG_FILE = "oxlint.config.ts";
 

--- a/npm/cli/src/setup.ts
+++ b/npm/cli/src/setup.ts
@@ -9,7 +9,7 @@ import {
   DEFAULT_VIZE_CONFIG,
   dependencyNames,
   detectJsonIndent,
-  OXLINT_CONFIG_FILES,
+  DISCOVERED_OXLINT_CONFIG_FILES,
   parsePackageJson,
   planGeneratedConfig,
   readRequiredFile,
@@ -68,7 +68,7 @@ export function setupProject(options: SetupOptions): SetupResult {
     preservedFiles,
   );
 
-  const existingOxlintConfig = OXLINT_CONFIG_FILES.find((candidate) =>
+  const existingOxlintConfig = DISCOVERED_OXLINT_CONFIG_FILES.find((candidate) =>
     fs.existsSync(path.join(root, candidate)),
   );
   const viteMigration = planViteMigration(root, existingOxlintConfig === undefined);
@@ -90,7 +90,7 @@ export function setupProject(options: SetupOptions): SetupResult {
   } else if (!viteMigration.hasVitePlusLint && !viteMigration.usesVitePlus) {
     planGeneratedConfig(
       root,
-      OXLINT_CONFIG_FILES,
+      DISCOVERED_OXLINT_CONFIG_FILES,
       "oxlint.config.ts",
       DEFAULT_OXLINT_CONFIG,
       plannedFiles,

--- a/npm/cli/src/setup/config.ts
+++ b/npm/cli/src/setup/config.ts
@@ -9,10 +9,21 @@ export const VIZE_CONFIG_FILES = [
   "vize.config.json",
 ] as const;
 
-export const OXLINT_CONFIG_FILES = [
+/** Config filenames Oxlint 1.64 auto-discovers. */
+export const DISCOVERED_OXLINT_CONFIG_FILES = [
   ".oxlintrc.json",
   ".oxlintrc.jsonc",
   "oxlint.config.ts",
+] as const;
+
+/**
+ * All plausible Oxlint config filenames, including names the binary ignores.
+ *
+ * Project detection keeps the ignored names so `vize init` can explain why it
+ * will not preserve them. Setup must use `DISCOVERED_OXLINT_CONFIG_FILES`.
+ */
+export const OXLINT_CONFIG_FILES = [
+  ...DISCOVERED_OXLINT_CONFIG_FILES,
   "oxlint.config.mts",
   "oxlint.config.js",
   "oxlint.config.mjs",

--- a/npm/cli/tests/setup-oxlint-config.test.ts
+++ b/npm/cli/tests/setup-oxlint-config.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { test } from "vite-plus/test";
+
+import { setupProject } from "../src/setup.ts";
+
+test("does not treat Oxlint config filenames that the binary ignores as configured", () => {
+  const ignoredFilenames = [
+    "oxlint.config.mts",
+    "oxlint.config.js",
+    "oxlint.config.mjs",
+    "oxlint.config.cjs",
+    "oxlint.config.cts",
+  ] as const;
+
+  for (const filename of ignoredFilenames) {
+    const root = fs.mkdtempSync(
+      path.join(os.tmpdir(), `vize-setup-ignored-${path.extname(filename).slice(1)}-`),
+    );
+    try {
+      const ignoredConfig = `export default { rules: { "no-console": "error" } };\n`;
+      fs.writeFileSync(
+        path.join(root, "package.json"),
+        `{"name":"ignored-oxlint-config","private":true}\n`,
+      );
+      fs.writeFileSync(path.join(root, filename), ignoredConfig);
+
+      const result = setupProject({ root, install: false });
+
+      assert.ok(result.createdFiles.includes("oxlint.config.ts"), filename);
+      assert.ok(!result.preservedFiles.includes(filename), filename);
+      assert.equal(fs.readFileSync(path.join(root, filename), "utf8"), ignoredConfig, filename);
+      assert.match(
+        fs.readFileSync(path.join(root, "oxlint.config.ts"), "utf8"),
+        /from "oxlint-plugin-vize"/u,
+        filename,
+      );
+    } finally {
+      fs.rmSync(root, { force: true, recursive: true });
+    }
+  }
+});

--- a/npm/cli/tests/setup.test.ts
+++ b/npm/cli/tests/setup.test.ts
@@ -189,6 +189,34 @@ export default defineConfig({
   }
 });
 
+test("does not treat Oxlint config filenames that the binary ignores as configured", () => {
+  const ignoredFilenames = [
+    "oxlint.config.mts",
+    "oxlint.config.js",
+    "oxlint.config.mjs",
+    "oxlint.config.cjs",
+    "oxlint.config.cts",
+  ] as const;
+
+  for (const filename of ignoredFilenames) {
+    const root = temporaryProject(`ignored-${path.extname(filename).slice(1)}`);
+    try {
+      const ignoredConfig = `export default { rules: { "no-console": "error" } };\n`;
+      write(root, "package.json", `{"name":"ignored-oxlint-config","private":true}\n`);
+      write(root, filename, ignoredConfig);
+
+      const result = setupProject({ root, install: false });
+
+      assert.ok(result.createdFiles.includes("oxlint.config.ts"), filename);
+      assert.ok(!result.preservedFiles.includes(filename), filename);
+      assert.equal(read(root, filename), ignoredConfig, filename);
+      assert.match(read(root, "oxlint.config.ts"), /from "oxlint-plugin-vize"/u, filename);
+    } finally {
+      fs.rmSync(root, { force: true, recursive: true });
+    }
+  }
+});
+
 test("does not write any setup file when package.json is invalid", () => {
   const root = temporaryProject("invalid-package");
   try {

--- a/npm/cli/tests/setup.test.ts
+++ b/npm/cli/tests/setup.test.ts
@@ -189,34 +189,6 @@ export default defineConfig({
   }
 });
 
-test("does not treat Oxlint config filenames that the binary ignores as configured", () => {
-  const ignoredFilenames = [
-    "oxlint.config.mts",
-    "oxlint.config.js",
-    "oxlint.config.mjs",
-    "oxlint.config.cjs",
-    "oxlint.config.cts",
-  ] as const;
-
-  for (const filename of ignoredFilenames) {
-    const root = temporaryProject(`ignored-${path.extname(filename).slice(1)}`);
-    try {
-      const ignoredConfig = `export default { rules: { "no-console": "error" } };\n`;
-      write(root, "package.json", `{"name":"ignored-oxlint-config","private":true}\n`);
-      write(root, filename, ignoredConfig);
-
-      const result = setupProject({ root, install: false });
-
-      assert.ok(result.createdFiles.includes("oxlint.config.ts"), filename);
-      assert.ok(!result.preservedFiles.includes(filename), filename);
-      assert.equal(read(root, filename), ignoredConfig, filename);
-      assert.match(read(root, "oxlint.config.ts"), /from "oxlint-plugin-vize"/u, filename);
-    } finally {
-      fs.rmSync(root, { force: true, recursive: true });
-    }
-  }
-});
-
 test("does not write any setup file when package.json is invalid", () => {
   const root = temporaryProject("invalid-package");
   try {


### PR DESCRIPTION
## Summary

- separate Oxlint's three auto-discovered config filenames from the wider set used to diagnose plausible-but-unread files
- make `vize setup` generate `oxlint.config.ts` when only an unread filename is present
- cover all five ignored filenames while preserving their contents

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [x] Not language-facing

## Behavior Reference

Closes #3474.

Oxlint 1.64 auto-discovers `.oxlintrc.json`, `.oxlintrc.jsonc`, and `oxlint.config.ts`; the other five plausible names are retained only so `vize init` can explain that Oxlint does not read them.

## Verification Evidence

- `pnpm --dir npm/cli exec vp test run tests/setup.test.ts tests/init.test.ts tests/init-frameworks.test.ts tests/init-prompt.test.ts` — 26 tests passed
- `pnpm --dir npm/cli exec vp check src tests vite.config.ts` — 34 files formatted, no lint errors
- `pnpm --dir npm/cli exec vp pack` — packed CLI built successfully
- pre-fix regression run failed on `oxlint.config.mts`; the post-fix test passes all five ignored names
- full GitHub Actions package build/test remains the authoritative clean-environment gate

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — none
- [x] Parity or real-world fixture coverage considered — filename discovery is covered directly
- [x] Security/audit impact considered — no dependency or execution-path change
- [x] Performance status or PR benchmark impact considered — constant-size setup-only lookup
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed — existing `init` explanation remains accurate

## Risk

Low. The broader candidate list remains available to `vize init` for unread-file diagnostics; only `vize setup` now distinguishes actually discovered configs. Existing unread files are left byte-for-byte unchanged while a working `oxlint.config.ts` is added.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Oxlint setup handling for configuration filenames that Oxlint does not automatically recognize.
  * Setup now creates the recommended TypeScript configuration while preserving existing unrecognized configuration files.

* **Tests**
  * Added coverage for multiple unsupported Oxlint configuration extensions to ensure consistent setup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->