### PR TITLE
test(carton): isolate corsa wrapper normalization

### DIFF
--- a/crates/vize_carton/src/corsa_resolver.rs
+++ b/crates/vize_carton/src/corsa_resolver.rs
@@ -38,6 +38,9 @@
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
+#[cfg(test)]
+mod normalize_tests;
+
 /// Environment variables honored by the resolver, in precedence order.
 pub const CORSA_ENV_VARS: [&str; 4] = [
     "CORSA_PATH",
@@ -549,8 +552,7 @@ fn push_unique(paths: &mut Vec<PathBuf>, candidate: PathBuf) {
 mod tests {
     use super::{
         CORSA_ENV_VARS, CorsaResolveError, CorsaResolveRequest, discover_in_walk,
-        normalize_corsa_path, normalize_corsa_path_with_discovery, platform_suffix,
-        resolve_with_env,
+        normalize_corsa_path, platform_suffix, resolve_with_env,
     };
     use std::ffi::OsString;
     use std::fs;
@@ -706,24 +708,6 @@ mod tests {
         write_file(&cache);
 
         assert_eq!(normalize_corsa_path(&wrapper), cache);
-    }
-
-    #[test]
-    fn normalize_keeps_wrapper_when_nothing_better_exists() {
-        let temp_dir = TempDir::new().unwrap();
-        let wrapper = temp_dir
-            .path()
-            .join("node_modules")
-            .join(".bin")
-            .join("tsgo");
-        write_file(&wrapper);
-
-        let normalized = normalize_corsa_path_with_discovery(&wrapper, |project_root| {
-            assert_eq!(project_root, temp_dir.path());
-            None
-        });
-
-        assert_eq!(normalized, wrapper);
     }
 
     #[test]

--- a/crates/vize_carton/src/corsa_resolver.rs
+++ b/crates/vize_carton/src/corsa_resolver.rs
@@ -115,10 +115,19 @@ pub fn discover_corsa_in_ancestors(start: &Path) -> Option<PathBuf> {
 /// shadows, when one can be discovered from the wrapper's project root.
 /// Non-wrapper paths are returned unchanged.
 pub fn normalize_corsa_path(path: &Path) -> PathBuf {
+    normalize_corsa_path_with_discovery(path, |project_root| {
+        discover_in_walk(&[project_root.to_path_buf()], dev_paths_enabled())
+    })
+}
+
+fn normalize_corsa_path_with_discovery(
+    path: &Path,
+    discover: impl FnOnce(&Path) -> Option<PathBuf>,
+) -> PathBuf {
     let Some(project_root) = wrapper_project_root(path) else {
         return path.to_path_buf();
     };
-    match discover_in_walk(&[project_root.to_path_buf()], dev_paths_enabled()) {
+    match discover(project_root) {
         Some(resolved) if resolved != path => resolved,
         _ => path.to_path_buf(),
     }
@@ -540,7 +549,8 @@ fn push_unique(paths: &mut Vec<PathBuf>, candidate: PathBuf) {
 mod tests {
     use super::{
         CORSA_ENV_VARS, CorsaResolveError, CorsaResolveRequest, discover_in_walk,
-        normalize_corsa_path, platform_suffix, resolve_with_env,
+        normalize_corsa_path, normalize_corsa_path_with_discovery, platform_suffix,
+        resolve_with_env,
     };
     use std::ffi::OsString;
     use std::fs;
@@ -708,7 +718,12 @@ mod tests {
             .join("tsgo");
         write_file(&wrapper);
 
-        assert_eq!(normalize_corsa_path(&wrapper), wrapper);
+        let normalized = normalize_corsa_path_with_discovery(&wrapper, |project_root| {
+            assert_eq!(project_root, temp_dir.path());
+            None
+        });
+
+        assert_eq!(normalized, wrapper);
     }
 
     #[test]

--- a/crates/vize_carton/src/corsa_resolver/normalize_tests.rs
+++ b/crates/vize_carton/src/corsa_resolver/normalize_tests.rs
@@ -1,0 +1,24 @@
+use std::fs;
+
+use tempfile::TempDir;
+
+use super::normalize_corsa_path_with_discovery;
+
+#[test]
+fn normalize_keeps_wrapper_when_nothing_better_exists() {
+    let temp_dir = TempDir::new().unwrap();
+    let wrapper = temp_dir
+        .path()
+        .join("node_modules")
+        .join(".bin")
+        .join("tsgo");
+    fs::create_dir_all(wrapper.parent().unwrap()).unwrap();
+    fs::write(&wrapper, "binary").unwrap();
+
+    let normalized = normalize_corsa_path_with_discovery(&wrapper, |project_root| {
+        assert_eq!(project_root, temp_dir.path());
+        None
+    });
+
+    assert_eq!(normalized, wrapper);
+}


### PR DESCRIPTION
## Summary

- inject project-scoped Corsa discovery into wrapper normalization tests
- keep the public normalization path unchanged
- prevent the negative test from resolving through host-level developer paths

## Verification

- `cargo test -p vize_carton --lib corsa_resolver::tests::normalize_keeps_wrapper_when_nothing_better_exists -- --exact`
- `cargo test -p vize_carton --lib corsa_resolver`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #3504

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->