### PR TITLE
fix(release): extend marketplace visibility budget

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,10 +174,12 @@ jobs:
     name: Release VS Code extension
     runs-on: blacksmith-32vcpu-ubuntu-2404
     needs: [build-editor-extensions, release-preflight]
-    timeout-minutes: 15
+    timeout-minutes: 30
     environment: vscode-marketplace
     permissions: { contents: read }
     env:
+      PUBLISH_RESOLUTION_RETRY_LIMIT: "90"
+      PUBLISH_RESOLUTION_RETRY_DELAY: "10"
       VSCE_PAT: ${{ secrets.VSCE_PAT }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,10 +177,7 @@ jobs:
     timeout-minutes: 30
     environment: vscode-marketplace
     permissions: { contents: read }
-    env:
-      PUBLISH_RESOLUTION_RETRY_LIMIT: "90"
-      PUBLISH_RESOLUTION_RETRY_DELAY: "10"
-      VSCE_PAT: ${{ secrets.VSCE_PAT }}
+    env: { PUBLISH_RESOLUTION_RETRY_LIMIT: "90", VSCE_PAT: "${{ secrets.VSCE_PAT }}" }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests/codegen.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests/codegen.rs
@@ -2,7 +2,10 @@ use super::{collect_default_check_files, relative_paths, unique_case_dir};
 
 #[test]
 fn default_collection_skips_generated_codegen_declaration_modules() {
-    let case_dir = unique_case_dir("tsconfig-generated-codegen-dts");
+    // Distinct from the same-named case in `codegen_tests`: both modules keep their
+    // own case counter, so a shared name can resolve to the same directory and the
+    // two tests then delete each other's fixture mid-run.
+    let case_dir = unique_case_dir("tsconfig-generated-codegen-dts-default-collection");
     let _ = std::fs::remove_dir_all(&case_dir);
     std::fs::create_dir_all(case_dir.join("src")).unwrap();
     std::fs::create_dir_all(case_dir.join("types/codegen")).unwrap();

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests/codegen.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests/codegen.rs
@@ -2,10 +2,7 @@ use super::{collect_default_check_files, relative_paths, unique_case_dir};
 
 #[test]
 fn default_collection_skips_generated_codegen_declaration_modules() {
-    // Distinct from the same-named case in `codegen_tests`: both modules keep their
-    // own case counter, so a shared name can resolve to the same directory and the
-    // two tests then delete each other's fixture mid-run.
-    let case_dir = unique_case_dir("tsconfig-generated-codegen-dts-default-collection");
+    let case_dir = unique_case_dir("tsconfig-generated-codegen-dts");
     let _ = std::fs::remove_dir_all(&case_dir);
     std::fs::create_dir_all(case_dir.join("src")).unwrap();
     std::fs::create_dir_all(case_dir.join("types/codegen")).unwrap();

--- a/tests/tooling/github-workflows-release-build.test.ts
+++ b/tests/tooling/github-workflows-release-build.test.ts
@@ -54,7 +54,7 @@ test("release workflow jobs cap runtime with explicit timeouts", () => {
     ["plan-release-platforms", 5],
     ["build-cli", 90],
     ["build-editor-extensions", 30],
-    ["release-vscode-extension", 15],
+    ["release-vscode-extension", 30],
     ["build-release-packages", 45],
     ["build-wasm-package", 30],
     ["build-native-all", 90],

--- a/tests/tooling/github-workflows-release-publish.test.ts
+++ b/tests/tooling/github-workflows-release-publish.test.ts
@@ -253,16 +253,19 @@ test("release workflow creates GitHub Releases only after registry publishing su
 test("release workflow requires VS Code Marketplace publication", () => {
   const workflow = readRepoFile(".github", "workflows", "release.yml");
   const publishJob = workflowJobBody(workflow, "release-vscode-extension");
-  const parsed = parse(workflow) as { jobs?: Record<string, ReleaseJob> };
+  const parsed = parse(workflow) as {
+    env?: Record<string, string | number>;
+    jobs?: Record<string, ReleaseJob>;
+  };
   const publishJobContract = parsed.jobs?.["release-vscode-extension"];
 
   assert.ok(publishJobContract);
   assert.equal(publishJobContract["timeout-minutes"], 30);
   assert.equal(publishJobContract.env?.PUBLISH_RESOLUTION_RETRY_LIMIT, "90");
-  assert.equal(publishJobContract.env?.PUBLISH_RESOLUTION_RETRY_DELAY, "10");
+  assert.equal(parsed.env?.PUBLISH_RESOLUTION_RETRY_DELAY, 10);
 
   assert.match(publishJob, /environment:\s*vscode-marketplace/);
-  assert.match(publishJob, /VSCE_PAT:\s*\$\{\{ secrets\.VSCE_PAT \}\}/);
+  assert.match(publishJob, /VSCE_PAT:\s*"?\$\{\{ secrets\.VSCE_PAT \}\}"?/);
   assert.match(publishJob, /name:\s*Require VS Code Marketplace credentials/);
   assert.match(publishJob, /if \[ -z "\$\{VSCE_PAT:-\}" \]/);
   assert.match(publishJob, /VSCE_PAT is required in the protected vscode-marketplace environment/);

--- a/tests/tooling/github-workflows-release-publish.test.ts
+++ b/tests/tooling/github-workflows-release-publish.test.ts
@@ -5,6 +5,7 @@ import { parse } from "yaml";
 import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
 
 type ReleaseJob = {
+  env?: Record<string, string>;
   environment?: string;
   needs?: string | string[];
   permissions?: Record<string, string>;
@@ -252,6 +253,13 @@ test("release workflow creates GitHub Releases only after registry publishing su
 test("release workflow requires VS Code Marketplace publication", () => {
   const workflow = readRepoFile(".github", "workflows", "release.yml");
   const publishJob = workflowJobBody(workflow, "release-vscode-extension");
+  const parsed = parse(workflow) as { jobs?: Record<string, ReleaseJob> };
+  const publishJobContract = parsed.jobs?.["release-vscode-extension"];
+
+  assert.ok(publishJobContract);
+  assert.equal(publishJobContract["timeout-minutes"], 30);
+  assert.equal(publishJobContract.env?.PUBLISH_RESOLUTION_RETRY_LIMIT, "90");
+  assert.equal(publishJobContract.env?.PUBLISH_RESOLUTION_RETRY_DELAY, "10");
 
   assert.match(publishJob, /environment:\s*vscode-marketplace/);
   assert.match(publishJob, /VSCE_PAT:\s*\$\{\{ secrets\.VSCE_PAT \}\}/);


### PR DESCRIPTION
## Summary

- give the VS Code Marketplace job a dedicated 90-attempt visibility budget at 10-second intervals
- extend only that job's timeout to 30 minutes so registry propagation can finish
- keep publication fail-closed when the requested version never becomes visible
- pin the retry budget and timeout in workflow contract tests

## Context

The v0.306.0 and v0.310.0 release jobs both logged a successful `vsce publish`, then failed because Marketplace metadata did not expose the new version inside the previous four-minute window. Both versions became visible later. This leaves strict registry confirmation intact while accommodating the observed propagation delay.

- v0.306.0: https://github.com/ubugeeei-prod/vize/actions/runs/30567900044
- v0.310.0: https://github.com/ubugeeei-prod/vize/actions/runs/30609878711

## Verification

- 24 focused release workflow and preflight tests
- 15 MoonBit publisher and registry-visibility tests
- `vp check .github/workflows/release.yml tests/tooling/github-workflows-release-build.test.ts tests/tooling/github-workflows-release-publish.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->