### PR TITLE
fix(release): accept former main tips in preflight

### DIFF
--- a/tests/tooling/release-preflight-core.test.ts
+++ b/tests/tooling/release-preflight-core.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
-  assertReleaseCommitIsCurrentMain,
+  assertReleaseCommitIsOnMainFirstParent,
   assertReleaseMetadata,
   findReleaseBlockers,
   remoteTagCommit,
@@ -86,11 +86,15 @@ test("release metadata rejects private manifests in the publish inventory", () =
   );
 });
 
-test("release commit must remain the exact current main tip", () => {
-  assert.doesNotThrow(() => assertReleaseCommitIsCurrentMain(sha, sha));
+test("release commit may remain on main's first-parent history when main advances", () => {
+  assert.doesNotThrow(() => assertReleaseCommitIsOnMainFirstParent(sha, sha, true));
+  assert.doesNotThrow(() => assertReleaseCommitIsOnMainFirstParent(sha, "b".repeat(40), true));
+});
+
+test("release commit rejects ancestry that exists only through a merge's second parent", () => {
   assert.throws(
-    () => assertReleaseCommitIsCurrentMain(sha, "b".repeat(40)),
-    /not the current origin\/main/,
+    () => assertReleaseCommitIsOnMainFirstParent("c".repeat(40), "b".repeat(40), false),
+    /not on the first-parent history of current origin\/main/,
   );
 });
 

--- a/tests/tooling/release-preflight-runner.test.ts
+++ b/tests/tooling/release-preflight-runner.test.ts
@@ -23,7 +23,7 @@ test("release preflight CLI fails closed on unknown or ambiguous modes", () => {
   assert.throws(() => parseReleasePreflightMode(["--verify-only", "--target-only"]), /Usage:/);
 });
 
-test("target-only mode verifies HEAD, current main, and the peeled remote tag", () => {
+test("target-only mode verifies HEAD, main first-parent history, and the peeled remote tag", () => {
   const tempDir = fs.mkdtempSync(path.join(tmpdir(), "vize-release-target-"));
   const binDir = path.join(tempDir, "bin");
   const version = workspaceVersionFromCargoToml(
@@ -41,14 +41,15 @@ test("target-only mode verifies HEAD, current main, and the peeled remote tag", 
     [
       "const args = process.argv.slice(2);",
       "const command = args.join(' ');",
-      "if (command === 'rev-parse HEAD') console.log(process.env.TEST_RELEASE_SHA);",
+      "if (command === 'rev-parse HEAD') console.log(process.env.TEST_HEAD_SHA);",
       "else if (command === 'rev-parse refs/remotes/origin/main') console.log(process.env.TEST_MAIN_SHA);",
       "else if (args[0] === 'fetch') process.exit(0);",
       "else if (args[0] === 'ls-files') process.stdout.write(JSON.parse(process.env.TEST_PACKAGE_MANIFESTS).join('\\0') + '\\0');",
       "else if (args[0] === 'ls-remote') {",
       "  console.log(`${process.env.TEST_TAG_OBJECT}\\trefs/tags/${process.env.TEST_TAG}`);",
       "  console.log(`${process.env.TEST_TAG_SHA}\\trefs/tags/${process.env.TEST_TAG}^{}`);",
-      "} else if (args[0] === 'rev-list') console.log(`${process.env.TEST_RELEASE_SHA} ${process.env.TEST_BASE_SHA}`);",
+      "} else if (command === 'rev-list --first-parent refs/remotes/origin/main') console.log(process.env.TEST_MAIN_FIRST_PARENT_HISTORY);",
+      "else if (args[0] === 'rev-list') console.log(`${process.env.TEST_RELEASE_SHA} ${process.env.TEST_BASE_SHA}`);",
       "else if (args[0] === 'merge-base') process.exit(0);",
       "else process.exit(2);",
     ].join("\n"),
@@ -63,8 +64,10 @@ test("target-only mode verifies HEAD, current main, and the peeled remote tag", 
         GITHUB_REF_TYPE: "tag",
         GITHUB_REF_NAME: `v${version}`,
         GITHUB_SHA: sha,
+        TEST_HEAD_SHA: sha,
         TEST_RELEASE_SHA: sha,
         TEST_MAIN_SHA: sha,
+        TEST_MAIN_FIRST_PARENT_HISTORY: [sha, "b".repeat(40)].join("\n"),
         TEST_TAG: `v${version}`,
         TEST_TAG_OBJECT: "c".repeat(40),
         TEST_TAG_SHA: sha,
@@ -77,9 +80,20 @@ test("target-only mode verifies HEAD, current main, and the peeled remote tag", 
   try {
     const success = run();
     assert.equal(success.status, 0, `${success.stderr}\n${success.stdout}`.trim());
-    const mainMismatch = run({ TEST_MAIN_SHA: "d".repeat(40) });
-    assert.equal(mainMismatch.status, 1);
-    assert.match(mainMismatch.stderr, /not the current origin\/main/);
+    const advancedMain = run({ TEST_MAIN_SHA: "d".repeat(40) });
+    assert.equal(advancedMain.status, 0, `${advancedMain.stderr}\n${advancedMain.stdout}`.trim());
+    const headMismatch = run({ TEST_HEAD_SHA: "f".repeat(40) });
+    assert.equal(headMismatch.status, 1);
+    assert.match(headMismatch.stderr, /Checked out HEAD .* does not match release event SHA/);
+    const secondParentOnly = run({
+      TEST_MAIN_SHA: "d".repeat(40),
+      TEST_MAIN_FIRST_PARENT_HISTORY: ["d".repeat(40), "b".repeat(40)].join("\n"),
+    });
+    assert.equal(secondParentOnly.status, 1);
+    assert.match(
+      secondParentOnly.stderr,
+      /not on the first-parent history of current origin\/main/,
+    );
     const tagMismatch = run({ TEST_TAG_SHA: "e".repeat(40) });
     assert.equal(tagMismatch.status, 1);
     assert.match(tagMismatch.stderr, /Remote tag .* points to/);

--- a/tools/github/release-preflight-core.mjs
+++ b/tools/github/release-preflight-core.mjs
@@ -56,9 +56,11 @@ export function assertReleaseMetadata({ tag, sha, cargoToml, packageManifests })
   return version;
 }
 
-export function assertReleaseCommitIsCurrentMain(sha, mainSha) {
-  if (sha !== mainSha) {
-    throw new Error(`Release commit ${sha} is not the current origin/main ${mainSha}`);
+export function assertReleaseCommitIsOnMainFirstParent(sha, mainSha, isOnFirstParent) {
+  if (!isOnFirstParent) {
+    throw new Error(
+      `Release commit ${sha} is not on the first-parent history of current origin/main ${mainSha}`,
+    );
   }
 }
 

--- a/tools/github/release-preflight.mjs
+++ b/tools/github/release-preflight.mjs
@@ -11,7 +11,7 @@ import {
   releaseGateRunQualifiers,
 } from "./release-preflight-bootstrap.mjs";
 import {
-  assertReleaseCommitIsCurrentMain,
+  assertReleaseCommitIsOnMainFirstParent,
   assertReleaseMetadata,
   findReleaseBlockers,
   remoteTagCommit,
@@ -56,7 +56,14 @@ function verifyGitReleaseTarget(tag, sha) {
   }
   runGit(["fetch", "--quiet", "--no-tags", "origin", "+refs/heads/main:refs/remotes/origin/main"]);
   const mainSha = runGit(["rev-parse", "refs/remotes/origin/main"]).stdout.trim();
-  assertReleaseCommitIsCurrentMain(sha, mainSha);
+  // The local release guard requires an exact main tip before creating the
+  // immutable tag. Once the tag exists, later main commits must not invalidate
+  // long-running exact-SHA gates for that release. Requiring the first-parent
+  // chain rejects commits that only entered main through a merge's side parent.
+  const mainFirstParentHistory = runGit(["rev-list", "--first-parent", "refs/remotes/origin/main"])
+    .stdout.trim()
+    .split(/\r?\n/);
+  assertReleaseCommitIsOnMainFirstParent(sha, mainSha, mainFirstParentHistory.includes(sha));
 
   const remoteTag = runGit([
     "ls-remote",


### PR DESCRIPTION
## Summary

- allow a tagged release commit after `main` advances to a direct descendant
- require the release SHA to appear in `origin/main`'s first-parent history
- reject second-parent-only side commits and preserve exact HEAD/tag/gate checks
- add runner regressions for advanced main, side history, and HEAD mismatch

## Context

The v0.309.0 release passed all eight exact-SHA gates, but failed the final target check after `main` advanced while the workflow was waiting:

https://github.com/ubugeeei-prod/vize/actions/runs/30607798766

The local pre-tag guard still requires the exact current `main` tip. Once that immutable tag exists, the server-side preflight now accepts only commits that were genuine first-parent `main` revisions.

## Verification

- release preflight and local guard tests: 43/43
- real-history proof: v0.309 `0f0f418b` is on the first-parent chain; side commit `d01f6b1d` is not
- formatter and lint checks on the four touched files
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->