### PR TITLE
ci(release): preserve exact-sha gate evidence

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ on:
     - cron: "11 3 * * *"
 
 concurrency:
-  group: check-v2-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: check-v2-${{ github.workflow }}-${{ github.event.pull_request.number || format('{0}-{1}', github.event_name, github.sha) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: miri-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: miri-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 permissions:

--- a/tests/tooling/release-gate-concurrency.test.ts
+++ b/tests/tooling/release-gate-concurrency.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parse } from "yaml";
+
+import { readRepoFile } from "./support/github-workflows.ts";
+
+type Workflow = {
+  concurrency?: {
+    "cancel-in-progress"?: boolean;
+    group?: string;
+  };
+};
+
+const exactShaGates = [
+  [
+    "check.yml",
+    "check-v2-${{ github.workflow }}-${{ github.event.pull_request.number || format('{0}-{1}', github.event_name, github.sha) }}",
+  ],
+  ["miri.yml", "miri-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}"],
+] as const;
+
+test("release gates preserve completed evidence for each pushed main SHA", () => {
+  for (const [file, expectedGroup] of exactShaGates) {
+    const workflow = parse(readRepoFile(".github", "workflows", file)) as Workflow;
+
+    assert.deepEqual(workflow.concurrency, {
+      group: expectedGroup,
+      "cancel-in-progress": true,
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- key push Check evidence by event type and exact commit SHA
- key Miri push evidence by exact commit SHA
- keep pull-request supersession keyed by PR number
- pin the release-gate concurrency contract in a focused workflow test

## Context

The v0.304.0 release lost exact-SHA `Check` evidence when a later `main` push reused the ref-scoped concurrency group and cancelled it. Check's scheduled runs also need a distinct event key because release preflight accepts push evidence only.

This is the first small part of #3538. Docs build evidence and latest-only Pages deployment remain intentionally separate follow-up work.

## Verification

- release gate concurrency contract test
- release preflight workflow tests
- repository-wide workflow tests
- `vp check .github/workflows/check.yml .github/workflows/miri.yml tests/tooling/release-gate-concurrency.test.ts`
- `git diff --check`

Refs #3538

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->