### PR TITLE
fix(canon): distinguish direct callback props

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/generic_props/inline_callback_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_props/inline_callback_props.rs
@@ -83,3 +83,157 @@ import Child from './Child.vue'
         ]
     );
 }
+
+/// A parameter type may contain an arrow before the callback's outer arrow.
+/// The prop classifier must find the outer arrow so the standalone per-prop
+/// check contextually types the following `value` parameter instead of
+/// reporting `TS7006` on code the generic child's checker types.
+#[test]
+fn inline_callback_prop_with_nested_type_arrow_is_contextually_typed() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "generic-inline-callback-prop-with-nested-type-arrow",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts" generic="T">
+defineProps<{ value: T; apply: (fn: (value: T) => T, value: T) => T }>()
+</script>
+
+<template><span /></template>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child :value="1" :apply="(fn: (x: number) => number, value) => fn(value)" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else {
+        return;
+    };
+
+    assert_eq!(snapshot, Vec::new());
+}
+
+/// Delimiters inside a regex default value are not parameter-list structure.
+/// The direct callback must still receive generic-prop contextual typing for
+/// its following untyped parameter.
+#[test]
+fn inline_callback_prop_with_regex_default_is_contextually_typed() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "generic-inline-callback-prop-with-regex-default",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts" generic="T">
+defineProps<{
+  value: T
+  apply: (pattern: RegExp, value: T) => T
+  calculate: (pattern: number, value: T) => T
+  inspect: (fn: () => void, value: T) => T
+  choose: (value: T) => T
+  sequence: (value: T) => T
+}>()
+</script>
+
+<template><span /></template>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+let foo = 1
+const bar = 2
+const ok = true
+const target = ')'
+</script>
+
+<template>
+  <Child
+    :value="1"
+    :apply="(pattern = /* default */ /\)/, value) /* callback */ => value"
+    :calculate="(pattern = foo++ / bar, value) => value"
+    :inspect="(fn = () => { if (ok) /\)/.test(target) }, value) => value"
+    :choose="ok ? (value) => value : (value) => value"
+    :sequence="(void 0, (value) => value)"
+  />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else {
+        return;
+    };
+
+    assert_eq!(snapshot, Vec::new());
+}
+
+/// A nested arrow does not make the prop value itself callable. This is the
+/// shape used by Misskey's `<MkTl :events="jobs.map((job) => …)" />`: treating
+/// the inner `map` callback as the prop value made the array fail against the
+/// callable fallback added for genuine inline callback props.
+#[test]
+fn array_expression_with_nested_callback_is_not_classified_as_a_callback_prop() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "generic-array-prop-with-nested-callback",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts" generic="T extends { id: number }">
+defineProps<{ events: T[] }>()
+</script>
+
+<template><span /></template>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+const jobs = [{ id: 1, timestamp: 2 }]
+</script>
+
+<template>
+  <Child :events="jobs.map((job) => ({ id: job.id }))" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else {
+        return;
+    };
+
+    assert_eq!(
+        snapshot,
+        Vec::new(),
+        "nested callbacks must keep the array prop type"
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope.rs
@@ -15,8 +15,10 @@ mod context;
 mod emit;
 mod event_handler;
 mod event_scope;
+mod expression_scanner;
 mod globals;
 mod handler_shape;
+mod inline_callback_classifier;
 mod vif_guard;
 
 pub(crate) use closures::generate_scope_closures;

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
@@ -1,6 +1,7 @@
 use vize_carton::{FxHashSet, String, append, cstr};
 use vize_croquis::croquis::{ComponentUsage, PassedProp};
 
+use super::inline_callback_classifier::is_direct_inline_function_prop_value;
 use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier_fragment};
 
 /// Whether this prop's authored value is an inline function, which is the only
@@ -17,10 +18,13 @@ pub(super) fn is_inline_callback_prop(prop: &PassedProp) -> bool {
         && prop
             .value
             .as_ref()
-            .is_some_and(|value| is_inline_function_prop_value(value.as_str()))
+            .is_some_and(|value| is_direct_inline_function_prop_value(value.as_str()))
 }
 
-pub(super) fn is_inline_function_prop_value(value: &str) -> bool {
+/// Whether the value contains an inline callback whose standalone generation
+/// would lose contextual typing. Legacy Vue 2 globals use this broader shape
+/// to avoid reporting `TS7006` for values such as `[(value) => !!value]`.
+pub(super) fn contains_inline_function_prop_value(value: &str) -> bool {
     let value = value.trim();
     value.contains("=>") || value.starts_with("function") || value.starts_with("async function")
 }

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_expressions.rs
@@ -1,7 +1,7 @@
 use vize_carton::FxHashSet;
 use vize_croquis::{Croquis, TemplateExpressionKind};
 
-use super::component_prop_checker::is_inline_function_prop_value;
+use super::component_prop_checker::contains_inline_function_prop_value;
 use super::component_props::component_usage_has_checkable_binding;
 use super::context::ScopeGenerationOptions;
 use crate::virtual_ts::types::VirtualTsOptions;
@@ -43,7 +43,7 @@ pub(super) fn collect_component_prop_expression_ranges(
                 continue;
             }
             let value = value.as_str().trim();
-            if !is_inline_function_prop_value(value) {
+            if !contains_inline_function_prop_value(value) {
                 continue;
             }
             // Checkable components validate inline function props through the

--- a/crates/vize_canon/src/virtual_ts/scope/expression_scanner.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/expression_scanner.rs
@@ -1,0 +1,188 @@
+//! Allocation-free lexical helpers for classifying template expressions.
+//!
+//! This intentionally skips quoted and commented text without attempting to
+//! parse JavaScript. Callers only need structural delimiters and arrows.
+
+struct StructuralBytes<'a> {
+    bytes: &'a [u8],
+    index: usize,
+}
+
+impl<'a> StructuralBytes<'a> {
+    fn new(input: &'a str, index: usize) -> Self {
+        Self {
+            bytes: input.as_bytes(),
+            index,
+        }
+    }
+}
+
+impl Iterator for StructuralBytes<'_> {
+    type Item = (usize, u8);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.index < self.bytes.len() {
+            let index = self.index;
+            let byte = self.bytes[index];
+            if byte.is_ascii_whitespace() {
+                self.index += 1;
+                continue;
+            }
+            if matches!(byte, b'\'' | b'"' | b'`') {
+                self.index += 1;
+                let mut escaped = false;
+                while let Some(&quoted) = self.bytes.get(self.index) {
+                    self.index += 1;
+                    if escaped {
+                        escaped = false;
+                    } else if quoted == b'\\' {
+                        escaped = true;
+                    } else if quoted == byte {
+                        break;
+                    }
+                }
+                continue;
+            }
+            if byte == b'/' && self.bytes.get(index + 1) == Some(&b'/') {
+                self.index += 2;
+                while self
+                    .bytes
+                    .get(self.index)
+                    .is_some_and(|byte| *byte != b'\n')
+                {
+                    self.index += 1;
+                }
+                continue;
+            }
+            if byte == b'/' && self.bytes.get(index + 1) == Some(&b'*') {
+                self.index += 2;
+                while self.index + 1 < self.bytes.len()
+                    && (self.bytes[self.index] != b'*' || self.bytes[self.index + 1] != b'/')
+                {
+                    self.index += 1;
+                }
+                self.index = (self.index + 2).min(self.bytes.len());
+                continue;
+            }
+            self.index += 1;
+            return Some((index, byte));
+        }
+        None
+    }
+}
+
+pub(super) fn skip_js_trivia(input: &str, mut index: usize) -> usize {
+    let bytes = input.as_bytes();
+    loop {
+        while bytes
+            .get(index)
+            .is_some_and(|byte| byte.is_ascii_whitespace())
+        {
+            index += 1;
+        }
+        if bytes
+            .get(index..index + 2)
+            .is_some_and(|trivia| trivia == b"//")
+        {
+            index += 2;
+            while bytes.get(index).is_some_and(|byte| *byte != b'\n') {
+                index += 1;
+            }
+            continue;
+        }
+        if bytes
+            .get(index..index + 2)
+            .is_some_and(|trivia| trivia == b"/*")
+        {
+            index += 2;
+            while index + 1 < bytes.len() && (bytes[index] != b'*' || bytes[index + 1] != b'/') {
+                index += 1;
+            }
+            index = (index + 2).min(bytes.len());
+            continue;
+        }
+        return index;
+    }
+}
+
+pub(super) fn matching_paren_index(input: &str, open_index: usize) -> Option<usize> {
+    if input.as_bytes().get(open_index) != Some(&b'(') {
+        return None;
+    }
+
+    let mut depth = 0u32;
+    for (index, byte) in StructuralBytes::new(input, open_index) {
+        match byte {
+            b'(' => depth += 1,
+            b')' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Finds only an arrow that forms the outer callable. Nested callbacks in
+/// parameter types, defaults, calls, arrays, and objects do not qualify.
+pub(super) fn top_level_arrow_index(input: &str) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let (mut parens, mut brackets, mut braces) = (0u32, 0u32, 0u32);
+    for (index, byte) in StructuralBytes::new(input, 0) {
+        match byte {
+            b'(' => parens += 1,
+            b')' => parens = parens.checked_sub(1)?,
+            b'[' => brackets += 1,
+            b']' => brackets = brackets.checked_sub(1)?,
+            b'{' => braces += 1,
+            b'}' => braces = braces.checked_sub(1)?,
+            b'=' if bytes.get(index + 1) == Some(&b'>')
+                && parens == 0
+                && brackets == 0
+                && braces == 0 =>
+            {
+                return Some(index);
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Cheaply recognizes a possible sequence-expression separator. If lexical
+/// ambiguity makes the delimiter balance invalid, prefer the exact parser
+/// fallback over rejecting a valid callback shape.
+pub(super) fn has_top_level_comma(input: &str) -> bool {
+    let (mut parens, mut brackets, mut braces) = (0u32, 0u32, 0u32);
+    for (_, byte) in StructuralBytes::new(input, 0) {
+        match byte {
+            b'(' => parens += 1,
+            b')' => {
+                let Some(next) = parens.checked_sub(1) else {
+                    return input.contains(',');
+                };
+                parens = next;
+            }
+            b'[' => brackets += 1,
+            b']' => {
+                let Some(next) = brackets.checked_sub(1) else {
+                    return input.contains(',');
+                };
+                brackets = next;
+            }
+            b'{' => braces += 1,
+            b'}' => {
+                let Some(next) = braces.checked_sub(1) else {
+                    return input.contains(',');
+                };
+                braces = next;
+            }
+            b',' if parens == 0 && brackets == 0 && braces == 0 => return true,
+            _ => {}
+        }
+    }
+    (parens != 0 || brackets != 0 || braces != 0) && input.contains(',')
+}

--- a/crates/vize_canon/src/virtual_ts/scope/handler_shape.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/handler_shape.rs
@@ -6,13 +6,29 @@
 //! this scanning decides which; it deliberately stays a scanner rather than a
 //! parser, matching only the spellings a template attribute can hold.
 
+use super::expression_scanner::{matching_paren_index, skip_js_trivia, top_level_arrow_index};
+
 pub(super) fn inline_callback_event_argument(content: &str) -> Option<&'static str> {
-    let trimmed = content.trim_start();
+    let trimmed = strip_outer_parentheses(content.trim());
     if trimmed.is_empty() {
         return None;
     }
 
-    if let Some(arrow_idx) = trimmed.find("=>") {
+    let function = strip_async_prefix(trimmed);
+    if let Some(rest) = function.strip_prefix("function")
+        && !rest.chars().next().is_some_and(is_identifier_continue)
+    {
+        let paren_start = function.len() - rest.len() + rest.find('(')?;
+        let paren_end = matching_paren_index(function, paren_start)?;
+        let inner = &function[paren_start + 1..paren_end];
+        return Some(if inner.trim().is_empty() {
+            ""
+        } else {
+            "$event"
+        });
+    }
+
+    if let Some(arrow_idx) = top_level_arrow_index(trimmed) {
         let before_arrow = strip_async_prefix(trimmed[..arrow_idx].trim_end()).trim();
         if before_arrow.is_empty() {
             return None;
@@ -24,31 +40,31 @@ pub(super) fn inline_callback_event_argument(content: &str) -> Option<&'static s
 
         return is_identifier_segment(before_arrow).then_some("$event");
     }
+    None
+}
 
-    let rest = trimmed.strip_prefix("function")?;
-    // `functionalHandler(evt)` only starts with the keyword's letters; the
-    // keyword has to end there for this to be a function expression.
-    if rest.chars().next().is_some_and(is_identifier_continue) {
-        return None;
+fn strip_outer_parentheses(mut input: &str) -> &str {
+    while input.starts_with('(')
+        && matching_paren_index(input, 0).is_some_and(|close| close == input.len() - 1)
+    {
+        input = input[1..input.len() - 1].trim();
     }
-    let paren_start = trimmed.len() - rest.len() + rest.find('(')?;
-    let paren_end = matching_paren_index(trimmed, paren_start)?;
-    let inner = &trimmed[paren_start + 1..paren_end];
-    Some(if inner.trim().is_empty() {
-        ""
-    } else {
-        "$event"
-    })
+    input
 }
 
 fn strip_async_prefix(input: &str) -> &str {
     let Some(rest) = input.strip_prefix("async") else {
         return input;
     };
-    if rest.chars().next().is_some_and(char::is_whitespace) {
-        rest.trim_start()
-    } else {
+    if rest.chars().next().is_some_and(is_identifier_continue) {
         input
+    } else {
+        let content_start = skip_js_trivia(rest, 0);
+        if content_start == 0 {
+            input
+        } else {
+            &rest[content_start..]
+        }
     }
 }
 
@@ -57,33 +73,11 @@ fn parenthesized_params_are_empty(input: &str) -> Option<bool> {
         return None;
     }
     let close = matching_paren_index(input, 0)?;
-    if !input[close + 1..].trim().is_empty() {
+    let suffix = &input[close + 1..];
+    if skip_js_trivia(suffix, 0) != suffix.len() {
         return None;
     }
     Some(input[1..close].trim().is_empty())
-}
-
-fn matching_paren_index(input: &str, open_index: usize) -> Option<usize> {
-    let bytes = input.as_bytes();
-    if bytes.get(open_index) != Some(&b'(') {
-        return None;
-    }
-
-    let mut depth = 0u32;
-    for (idx, byte) in bytes.iter().enumerate().skip(open_index) {
-        match byte {
-            b'(' => depth += 1,
-            b')' => {
-                depth = depth.checked_sub(1)?;
-                if depth == 0 {
-                    return Some(idx);
-                }
-            }
-            _ => {}
-        }
-    }
-
-    None
 }
 
 pub(super) fn is_callable_handler_reference(content: &str) -> bool {
@@ -231,11 +225,23 @@ mod tests {
             ("v => f(v)", Some("$event")),
             ("async (v) => f(v)", Some("$event")),
             ("async v => f(v)", Some("$event")),
+            ("((v) => f(v))", Some("$event")),
+            (r#"((x = ")") => x)"#, Some("$event")),
+            ("(value) /* callback */ => value", Some("$event")),
+            ("async /* callback */ (value) => value", Some("$event")),
+            ("(fn: (x: string) => string) => fn(\"x\")", Some("$event")),
+            ("(fn = (x) => x) => fn(1)", Some("$event")),
             ("function () {}", Some("")),
             ("function (v) { f(v) }", Some("$event")),
+            ("function (v) { return () => v }", Some("$event")),
             ("function named(v) { f(v) }", Some("$event")),
+            ("async function (v) { f(v) }", Some("$event")),
+            ("(async function (v) { f(v) })", Some("$event")),
             ("handler", None),
             ("handlers[key]", None),
+            ("jobs.map((job) => job.id)", None),
+            ("jobs.map(function (job) { return job.id })", None),
+            ("/=>/.test(value)", None),
             // Starts with the `function` keyword's letters but is a call.
             ("functionalHandler(evt)", None),
         ];

--- a/crates/vize_canon/src/virtual_ts/scope/inline_callback_classifier.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/inline_callback_classifier.rs
@@ -1,0 +1,126 @@
+//! Direct inline-function classification for generic component props.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Expression;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+use super::expression_scanner::{has_top_level_comma, skip_js_trivia};
+use super::handler_shape::inline_callback_event_argument;
+
+/// Whether the value itself is a callback, rather than an expression that only
+/// contains one (for example `items.map((item) => item.id)`).
+pub(super) fn is_direct_inline_function_prop_value(value: &str) -> bool {
+    inline_callback_event_argument(value).is_some() || parsed_direct_inline_function(value)
+}
+
+/// Fall back to the TypeScript parser only for callback-shaped values the
+/// allocation-free scanner cannot settle. JavaScript's regex/division lexical
+/// goal depends on full grammar context, so duplicating it here would make
+/// rare valid defaults less reliable than the parser already used by Canon.
+fn parsed_direct_inline_function(value: &str) -> bool {
+    let value = value.trim();
+    if !value.contains("=>") || !looks_like_inline_callback_start(value) {
+        return false;
+    }
+    let allocator = Allocator::new();
+    let Ok(expression) = Parser::new(&allocator, value, SourceType::ts()).parse_expression() else {
+        return false;
+    };
+    expression_is_inline_function(&expression)
+}
+
+fn looks_like_inline_callback_start(value: &str) -> bool {
+    if value.starts_with(['(', '<'])
+        || value.starts_with("async")
+        || value.contains('?')
+        || has_top_level_comma(value)
+    {
+        return true;
+    }
+    let mut end = 0;
+    for (index, ch) in value.char_indices() {
+        if index == 0 {
+            if !(ch == '_' || ch == '$' || ch.is_alphabetic()) {
+                return false;
+            }
+        } else if !(ch == '_' || ch == '$' || ch.is_alphanumeric()) {
+            break;
+        }
+        end = index + ch.len_utf8();
+    }
+    let after_identifier = skip_js_trivia(value, end);
+    value[after_identifier..].starts_with("=>")
+}
+
+fn expression_is_inline_function(expression: &Expression<'_>) -> bool {
+    match expression {
+        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => true,
+        Expression::ParenthesizedExpression(parenthesized) => {
+            expression_is_inline_function(&parenthesized.expression)
+        }
+        Expression::TSAsExpression(assertion) => {
+            expression_is_inline_function(&assertion.expression)
+        }
+        Expression::TSSatisfiesExpression(assertion) => {
+            expression_is_inline_function(&assertion.expression)
+        }
+        Expression::TSTypeAssertion(assertion) => {
+            expression_is_inline_function(&assertion.expression)
+        }
+        Expression::TSNonNullExpression(non_null) => {
+            expression_is_inline_function(&non_null.expression)
+        }
+        Expression::ConditionalExpression(conditional) => {
+            expression_is_inline_function(&conditional.consequent)
+                && expression_is_inline_function(&conditional.alternate)
+        }
+        Expression::SequenceExpression(sequence) => sequence
+            .expressions
+            .last()
+            .is_some_and(expression_is_inline_function),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_direct_inline_function_prop_value;
+
+    #[test]
+    fn distinguishes_direct_callbacks_from_nested_callbacks() {
+        let direct = [
+            "(fn: (x: string) => string) => fn('x')",
+            r"(pattern = /* default */ /\)/, value) /* callback */ => value",
+            "(pattern = foo++ / bar, value) => value",
+            "(pattern = foo! / bar, value) => value",
+            r"(fn = () => { if (ok) /\)/.test(value) }, value) => value",
+            "value /* callback */ => value",
+            "ok ? (value) => value : (value) => value",
+            "(0, (value) => value)",
+            "void 0, (value) => value",
+        ];
+        for value in direct {
+            assert!(
+                is_direct_inline_function_prop_value(value),
+                "expected a direct callback: {value}"
+            );
+        }
+
+        let nested = [
+            "jobs.map((job) => job.id)",
+            "[() => true]",
+            "{ apply: (value) => value }",
+            "ok ? (value) => value : fallback",
+            "(0, jobs.map((job) => job.id))",
+            "void 0, jobs.map((job) => job.id)",
+            "/=>/.test(value)",
+        ];
+        for value in nested {
+            assert!(
+                !is_direct_inline_function_prop_value(value),
+                "expected only a nested callback: {value}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- classify only function-valued generic prop expressions as callable fallbacks
- keep nested callbacks such as `jobs.map((job) => ...)` on their authored array/object type
- use an allocation-free fast path with a bounded TypeScript parser fallback for grammar-sensitive edge cases

Closes #3541.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [x] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

- #3541
- TypeScript contextual typing for function-valued component props

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [x] Fuzzing target or crash-reproducer coverage considered
- [x] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

Commands and evidence:

- `cargo test -p vize_canon --lib` — 708 passed
- focused classifier and generic-prop tsgo regressions passed
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- independent review covered regex/division grammar, comments, nested arrows, conditional/sequence values, and nested non-function expressions

No snapshots change in this PR. The Misskey snapshot correction remains a separately audited data change after the engine fixes merge.

## Risk

The parser fallback is limited to values that contain an arrow, look callback-shaped, and were not settled by the allocation-free scanner. Nested map/array/object callbacks stay on the fast rejection path. Function-valued conditionals require both branches to be functions; sequences require the final expression to be a function.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contextual typing for inline callback props on generic components.
  * Correctly handles callbacks with nested arrows, defaults, comments, regex literals, type annotations, async/function syntax, and wrapped expressions.
  * Prevents array expressions and nested callbacks from being incorrectly classified as callable props.
* **Tests**
  * Added regression coverage for complex callback expressions and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->