### PR TITLE
fix(canon): isolate CLI diagnostic continuations

### DIFF
--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -501,25 +501,25 @@ fn parse_cli_diagnostics(
     mapper: &mut DiagnosticMapper<'_>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
+    let mut last_was_kept = false;
     for line in output.lines() {
-        if let Some(diagnostic) = parse_cli_diagnostic_line(line, project, mapper) {
-            diagnostics.push(diagnostic);
-            continue;
-        }
         // Project-level diagnostics carry no file position (`error TS2688:
         // Cannot find type definition file for 'x'.`). They are real,
         // user-actionable problems — tsc and vue-tsc report them and the
         // runtime may skip the semantic pass because of them — so they are
         // attributed to the project's tsconfig instead of being dropped.
-        if let Some(diagnostic) = project_diagnostics::global(line, project) {
+        let diagnostic = parse_cli_diagnostic_line(line, project, mapper)
+            .or_else(|| project_diagnostics::global(line, project));
+        if let Some(diagnostic) = diagnostic {
             diagnostics.push(diagnostic);
+            last_was_kept = true;
             continue;
         }
-        if is_cli_diagnostic_line(line) {
+        if is_cli_diagnostic_line(line) || is_global_diagnostic_line(line) {
+            last_was_kept = false;
             continue;
         }
-
-        let Some(last) = diagnostics.last_mut() else {
+        let Some(last) = diagnostics.last_mut().filter(|_| last_was_kept) else {
             continue;
         };
         let line = line.trim();

--- a/crates/vize_canon/src/batch/executor/cli/tests.rs
+++ b/crates/vize_canon/src/batch/executor/cli/tests.rs
@@ -222,6 +222,50 @@ fn parses_cli_diagnostics_back_to_original_files() {
 }
 
 #[test]
+fn drops_continuations_of_unmapped_diagnostics() {
+    let case_dir = unique_case_dir("diagnostic-continuations");
+    let _ = fs::remove_dir_all(&case_dir);
+    let source = case_dir.join("src").join("main.ts");
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    fs::write(&source, "const value: number = 'x';\n").unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_path(&source).unwrap();
+    project.materialize().unwrap();
+
+    let output = cstr!(
+        "{}(1,7): error TS2322: kept primary\n  kept continuation\nerror TS2666: dropped global\n  dropped global continuation\n{}(1,1): error TS2304: dropped primary\n  dropped continuation",
+        project.virtual_root().join("src").join("main.ts").display(),
+        project
+            .virtual_root()
+            .join("src")
+            .join("unmapped.vue.ts")
+            .display()
+    );
+    let mut diagnostics = Vec::new();
+    let mut mapper = DiagnosticMapper::new(&project);
+    parse_cli_diagnostics(output.as_str(), &project, &mut mapper, &mut diagnostics);
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message, "kept primary\nkept continuation");
+
+    let mut global_diagnostics = Vec::new();
+    parse_cli_diagnostics(
+        "error TS2688: kept global\n  kept global continuation",
+        &project,
+        &mut mapper,
+        &mut global_diagnostics,
+    );
+    assert_eq!(global_diagnostics.len(), 1);
+    assert_eq!(
+        global_diagnostics[0].message,
+        "kept global\nkept global continuation"
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
 fn parses_cli_diagnostics_with_relative_dotdot_paths() {
     let case_dir = unique_case_dir("diagnostics-dotdot");
     let _ = fs::remove_dir_all(&case_dir);


### PR DESCRIPTION
## Summary

- bind continuation lines only to the immediately preceding retained diagnostic header
- reset continuation state for unmapped positioned headers and suppressed file-less global headers
- preserve continuations for retained positioned and global diagnostics

Closes #3545.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [x] Semantic analysis, lint, and cross-file analysis
- [x] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

- #3545
- tsgo plain-text diagnostic header/continuation grouping

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [x] Fuzzing target or crash-reproducer coverage considered
- [x] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

Commands and evidence:

- CLI parser tests — 8 passed
- `cargo test -p vize_canon --lib` — 705 passed on the independent review base
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- retained/unmapped/suppressed-global/kept-global transitions are covered in one regression
- `cli.rs` remains 659 lines; test module is 335 lines

No snapshot changes are included. The Reka UI snapshot will be regenerated only after this and the option-probe fix merge.

## Risk

The state is local to each stdout/stderr parse call, so continuation text cannot cross streams. Non-header informational lines retain the existing behavior when the immediately preceding header was kept.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line diagnostic parsing to prevent unrelated continuation text from appearing under earlier diagnostics.
  * Ensured continuation details are retained for applicable file and global diagnostics while excluding diagnostics from unmapped files.
* **Tests**
  * Added regression coverage for diagnostic continuation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->