### PR TITLE
fix(canon): preserve relative paths in option probes

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/option_probe.rs
+++ b/crates/vize_canon/src/batch/virtual_project/option_probe.rs
@@ -54,7 +54,7 @@ impl VirtualProject {
         let Some(tsconfig_path) = self.resolved_tsconfig_path() else {
             return Ok(None);
         };
-        let declared = self.load_compiler_options(Some(tsconfig_path.as_path()))?;
+        let declared = self.load_compiler_options_verbatim(Some(tsconfig_path.as_path()))?;
         if declared.is_empty() || !option_probe_is_needed(&declared, &self.generated_options()) {
             return Ok(None);
         }

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -1,3 +1,4 @@
+mod compiler_options;
 mod native_options;
 mod path_rebase;
 mod vue_alias;
@@ -5,14 +6,11 @@ mod vue_alias;
 use std::path::{Path, PathBuf};
 
 use serde_json::{Map, Value};
-use vize_carton::{FxHashSet, String as CompactString, ToCompactString, cstr, profile};
+use vize_carton::{String as CompactString, ToCompactString, cstr};
 
 use crate::batch::error::CorsaResult;
 use crate::batch::materialize_fs::write_if_changed;
 
-use super::tsconfig_paths::{
-    normalize_path_lexically, parse_jsonc_value, resolve_extended_tsconfig_path,
-};
 use super::{SHARED_HELPERS_FILE, VirtualProject};
 use native_options::normalize_native_removed_options;
 use vue_alias::remap_path_targets;
@@ -269,70 +267,6 @@ impl VirtualProject {
         }
         includes.sort();
         includes
-    }
-    #[allow(clippy::disallowed_types)]
-    pub(super) fn load_compiler_options(
-        &self,
-        tsconfig_path: Option<&Path>,
-    ) -> CorsaResult<Map<std::string::String, Value>> {
-        let Some(tsconfig_path) = tsconfig_path else {
-            return Ok(Map::new());
-        };
-
-        let mut seen = FxHashSet::default();
-        self.load_compiler_options_inner(tsconfig_path, &mut seen)
-    }
-
-    #[allow(clippy::disallowed_types)]
-    fn load_compiler_options_inner(
-        &self,
-        tsconfig_path: &Path,
-        seen: &mut FxHashSet<PathBuf>,
-    ) -> CorsaResult<Map<std::string::String, Value>> {
-        if !tsconfig_path.exists() {
-            return Ok(Map::new());
-        }
-        let normalized = normalize_path_lexically(tsconfig_path);
-        if !seen.insert(normalized.clone()) {
-            return Ok(Map::new());
-        }
-
-        let content = profile!("canon.tsconfig.read", std::fs::read_to_string(&normalized))?;
-        let config = profile!("canon.tsconfig.parse", parse_jsonc_value(&content))?;
-        let mut compiler_options = config
-            .get("compilerOptions")
-            .and_then(Value::as_object)
-            .cloned()
-            .unwrap_or_default();
-        let base_dir = normalized.parent().unwrap_or(self.project_root.as_path());
-        path_rebase::onto_project_root(&mut compiler_options, base_dir, &self.project_root);
-
-        // `extends` may be a single specifier or an array; array entries are
-        // applied in order, with later entries overriding earlier ones, and
-        // the extending file overriding them all.
-        let mut inherited = Map::new();
-        match config.get("extends") {
-            Some(Value::String(extends)) => {
-                if let Some(parent_path) = resolve_extended_tsconfig_path(&normalized, extends) {
-                    inherited = self.load_compiler_options_inner(&parent_path, seen)?;
-                }
-            }
-            Some(Value::Array(entries)) => {
-                for extends in entries.iter().filter_map(Value::as_str) {
-                    if let Some(parent_path) = resolve_extended_tsconfig_path(&normalized, extends)
-                    {
-                        inherited.extend(self.load_compiler_options_inner(&parent_path, seen)?);
-                    }
-                }
-            }
-            _ => {}
-        }
-        if inherited.is_empty() {
-            return Ok(compiler_options);
-        }
-
-        inherited.extend(compiler_options);
-        Ok(inherited)
     }
 
     /// Re-anchor tsconfig `paths` targets into the virtual mirror. Each relative

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen/compiler_options.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen/compiler_options.rs
@@ -1,0 +1,114 @@
+//! Loading and flattening effective `compilerOptions` from a tsconfig chain.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+use vize_carton::{FxHashSet, profile};
+
+use crate::batch::error::CorsaResult;
+
+use super::super::VirtualProject;
+use super::super::tsconfig_paths::{
+    normalize_path_lexically, parse_jsonc_value, resolve_extended_tsconfig_path,
+};
+use super::path_rebase;
+
+#[derive(Clone, Copy)]
+enum PathOptions {
+    Rebase,
+    Verbatim,
+}
+
+impl VirtualProject {
+    #[allow(clippy::disallowed_types)]
+    pub(in super::super) fn load_compiler_options(
+        &self,
+        tsconfig_path: Option<&Path>,
+    ) -> CorsaResult<Map<std::string::String, Value>> {
+        self.load_compiler_options_with_paths(tsconfig_path, PathOptions::Rebase)
+    }
+
+    /// Flatten the effective options without changing path spellings. The
+    /// input-less option probe validates syntax only, so its paths stay inert.
+    #[allow(clippy::disallowed_types)]
+    pub(in super::super) fn load_compiler_options_verbatim(
+        &self,
+        tsconfig_path: Option<&Path>,
+    ) -> CorsaResult<Map<std::string::String, Value>> {
+        self.load_compiler_options_with_paths(tsconfig_path, PathOptions::Verbatim)
+    }
+
+    #[allow(clippy::disallowed_types)]
+    fn load_compiler_options_with_paths(
+        &self,
+        tsconfig_path: Option<&Path>,
+        path_options: PathOptions,
+    ) -> CorsaResult<Map<std::string::String, Value>> {
+        let Some(tsconfig_path) = tsconfig_path else {
+            return Ok(Map::new());
+        };
+
+        let mut seen = FxHashSet::default();
+        self.load_compiler_options_inner(tsconfig_path, &mut seen, path_options)
+    }
+
+    #[allow(clippy::disallowed_types)]
+    fn load_compiler_options_inner(
+        &self,
+        tsconfig_path: &Path,
+        seen: &mut FxHashSet<PathBuf>,
+        path_options: PathOptions,
+    ) -> CorsaResult<Map<std::string::String, Value>> {
+        if !tsconfig_path.exists() {
+            return Ok(Map::new());
+        }
+        let normalized = normalize_path_lexically(tsconfig_path);
+        if !seen.insert(normalized.clone()) {
+            return Ok(Map::new());
+        }
+
+        let content = profile!("canon.tsconfig.read", std::fs::read_to_string(&normalized))?;
+        let config = profile!("canon.tsconfig.parse", parse_jsonc_value(&content))?;
+        let mut compiler_options = config
+            .get("compilerOptions")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        if matches!(path_options, PathOptions::Rebase) {
+            let base_dir = normalized.parent().unwrap_or(self.project_root.as_path());
+            path_rebase::onto_project_root(&mut compiler_options, base_dir, &self.project_root);
+        }
+
+        // `extends` may be a single specifier or an array; array entries are
+        // applied in order, with later entries overriding earlier ones, and
+        // the extending file overriding them all.
+        let mut inherited = Map::new();
+        match config.get("extends") {
+            Some(Value::String(extends)) => {
+                if let Some(parent_path) = resolve_extended_tsconfig_path(&normalized, extends) {
+                    inherited =
+                        self.load_compiler_options_inner(&parent_path, seen, path_options)?;
+                }
+            }
+            Some(Value::Array(entries)) => {
+                for extends in entries.iter().filter_map(Value::as_str) {
+                    if let Some(parent_path) = resolve_extended_tsconfig_path(&normalized, extends)
+                    {
+                        inherited.extend(self.load_compiler_options_inner(
+                            &parent_path,
+                            seen,
+                            path_options,
+                        )?);
+                    }
+                }
+            }
+            _ => {}
+        }
+        if inherited.is_empty() {
+            return Ok(compiler_options);
+        }
+
+        inherited.extend(compiler_options);
+        Ok(inherited)
+    }
+}

--- a/crates/vize_canon/tests/tsconfig_option_diagnostics.rs
+++ b/crates/vize_canon/tests/tsconfig_option_diagnostics.rs
@@ -233,6 +233,42 @@ fn a_non_relative_paths_target_under_base_url_is_not_reported() {
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// The option probe must not turn an explicitly relative `paths` target into a
+/// non-relative one. `rootDir` makes the probe necessary without adding a
+/// `baseUrl`; before #3544 the probe rewrote `./src/*` to `src/*` and invented
+/// TS5090 even though the authored config is valid.
+#[test]
+fn an_explicit_relative_paths_target_stays_valid_without_base_url() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let root = write_case(
+        "explicit-relative-paths",
+        ",\n    \"rootDir\": \"./src\",\n    \"paths\": { \"@/*\": [\"./src/*\"] }",
+    );
+
+    let Some(diagnostics) = project_diagnostics(&root) else {
+        let _ = std::fs::remove_dir_all(&root);
+        return;
+    };
+    assert_eq!(
+        diagnostics,
+        Vec::new(),
+        "an authored relative path must not produce TS5090: {diagnostics:?}"
+    );
+
+    let probe =
+        std::fs::read_to_string(root.join("node_modules/.vize/canon/tsconfig.options.json"))
+            .expect("rootDir should require an option probe");
+    let probe: serde_json::Value = serde_json::from_str(&probe).unwrap();
+    assert_eq!(
+        probe["compilerOptions"]["paths"]["@/*"],
+        serde_json::json!(["./src/*"])
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 /// `ignoreDeprecations` is what TypeScript 6 tells the user to set, and it
 /// silences 6's deprecation errors. TypeScript 7 has nothing to silence, so it
 /// reports the removal regardless — leaving a project that did exactly what


### PR DESCRIPTION
## Summary

- preserve authored relative path spelling in the input-less compiler-option probe
- keep normal virtual-project materialization and declaration path rebasing unchanged
- split the shared config-chain loader into a cohesive submodule with explicit rebase/verbatim modes

Closes #3544.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [x] Semantic analysis, lint, and cross-file analysis
- [x] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

- #3544
- TypeScript 7 relative `paths` target requirement (TS5090)

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [x] Fuzzing target or crash-reproducer coverage considered
- [x] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

Commands and evidence:

- `tsconfig_option_diagnostics` — 6 passed
- materialized direct/inherited path rebasing — 2 passed
- declaration rootDir coverage — 4 passed
- full `cargo test -p vize_canon` passed in author verification
- `cargo test -p vize_canon --lib` — 704 passed in independent review
- production and changed-target clippy passed
- `cargo fmt --all -- --check`
- `git diff --check`
- regression proves no TS5090 and inspects generated probe JSON for `./src/*`

No snapshots change in this PR. Reka UI is regenerated after this and the continuation parser fix merge.

## Risk

Only the input-less option probe selects verbatim paths. Config inheritance order and cycle handling are shared with the existing loader, and normal materialized/declaration flows remain on the rebase mode.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript configuration handling for virtual projects, including inherited settings and path-based options.
  * Preserved explicitly configured relative path targets during diagnostics.
  * Prevented false diagnostics when probing configurations that require a `rootDir`.

* **Tests**
  * Added regression coverage for relative `paths` targets and option probing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->