### PR TITLE
test(canon): cover each CLI continuation reset path

### DIFF
--- a/crates/vize_canon/src/batch/executor/cli/tests.rs
+++ b/crates/vize_canon/src/batch/executor/cli/tests.rs
@@ -233,70 +233,48 @@ fn drops_continuations_of_unmapped_diagnostics() {
     project.register_path(&source).unwrap();
     project.materialize().unwrap();
 
-    let output = cstr!(
-        "{}(1,7): error TS2322: kept primary\n  kept continuation\nerror TS2666: dropped global\n  dropped global continuation\n{}(1,1): error TS2304: dropped primary\n  dropped continuation",
-        project.virtual_root().join("src").join("main.ts").display(),
+    let kept = cstr!(
+        "{}(1,7): error TS2322: kept primary\n  kept continuation",
+        project.virtual_root().join("src").join("main.ts").display()
+    );
+    let dropped_global = "error TS2666: dropped global\n  dropped global continuation";
+    let dropped_positioned = cstr!(
+        "{}(1,1): error TS2304: dropped primary\n  dropped continuation",
         project
             .virtual_root()
             .join("src")
             .join("unmapped.vue.ts")
             .display()
     );
-    let mut diagnostics = Vec::new();
+
     let mut mapper = DiagnosticMapper::new(&project);
-    parse_cli_diagnostics(output.as_str(), &project, &mut mapper, &mut diagnostics);
+    let mut parse = |output: &str| {
+        let mut diagnostics = Vec::new();
+        parse_cli_diagnostics(output, &project, &mut mapper, &mut diagnostics);
+        diagnostics
+    };
 
-    assert_eq!(diagnostics.len(), 1);
-    assert_eq!(diagnostics[0].message, "kept primary\nkept continuation");
+    // Each kind of dropped header must reset continuation state on its own, so
+    // every dropped header is also exercised directly after a kept diagnostic.
+    for output in [
+        cstr!("{kept}\n{dropped_global}\n{dropped_positioned}"),
+        cstr!("{kept}\n{dropped_positioned}"),
+        cstr!("{kept}\n{dropped_global}"),
+    ] {
+        let diagnostics = parse(output.as_str());
+        assert_eq!(diagnostics.len(), 1, "{output}");
+        assert_eq!(
+            diagnostics[0].message, "kept primary\nkept continuation",
+            "{output}"
+        );
+    }
 
-    let mut global_diagnostics = Vec::new();
-    parse_cli_diagnostics(
-        "error TS2688: kept global\n  kept global continuation",
-        &project,
-        &mut mapper,
-        &mut global_diagnostics,
-    );
+    let global_diagnostics = parse("error TS2688: kept global\n  kept global continuation");
     assert_eq!(global_diagnostics.len(), 1);
     assert_eq!(
         global_diagnostics[0].message,
         "kept global\nkept global continuation"
     );
-
-    // An unmapped positioned header must reset continuation state on its own,
-    // without a preceding dropped global header doing it first.
-    let unmapped_after_kept = cstr!(
-        "{}(1,7): error TS2322: kept primary\n  kept continuation\n{}(1,1): error TS2304: dropped primary\n  dropped continuation",
-        project.virtual_root().join("src").join("main.ts").display(),
-        project
-            .virtual_root()
-            .join("src")
-            .join("unmapped.vue.ts")
-            .display()
-    );
-    let mut diagnostics = Vec::new();
-    parse_cli_diagnostics(
-        unmapped_after_kept.as_str(),
-        &project,
-        &mut mapper,
-        &mut diagnostics,
-    );
-    assert_eq!(diagnostics.len(), 1);
-    assert_eq!(diagnostics[0].message, "kept primary\nkept continuation");
-
-    // A suppressed file-less global header resets continuation state too.
-    let suppressed_global_after_kept = cstr!(
-        "{}(1,7): error TS2322: kept primary\n  kept continuation\nerror TS2666: dropped global\n  dropped global continuation",
-        project.virtual_root().join("src").join("main.ts").display()
-    );
-    let mut diagnostics = Vec::new();
-    parse_cli_diagnostics(
-        suppressed_global_after_kept.as_str(),
-        &project,
-        &mut mapper,
-        &mut diagnostics,
-    );
-    assert_eq!(diagnostics.len(), 1);
-    assert_eq!(diagnostics[0].message, "kept primary\nkept continuation");
 
     let _ = fs::remove_dir_all(&case_dir);
 }

--- a/crates/vize_canon/src/batch/executor/cli/tests.rs
+++ b/crates/vize_canon/src/batch/executor/cli/tests.rs
@@ -262,6 +262,42 @@ fn drops_continuations_of_unmapped_diagnostics() {
         "kept global\nkept global continuation"
     );
 
+    // An unmapped positioned header must reset continuation state on its own,
+    // without a preceding dropped global header doing it first.
+    let unmapped_after_kept = cstr!(
+        "{}(1,7): error TS2322: kept primary\n  kept continuation\n{}(1,1): error TS2304: dropped primary\n  dropped continuation",
+        project.virtual_root().join("src").join("main.ts").display(),
+        project
+            .virtual_root()
+            .join("src")
+            .join("unmapped.vue.ts")
+            .display()
+    );
+    let mut diagnostics = Vec::new();
+    parse_cli_diagnostics(
+        unmapped_after_kept.as_str(),
+        &project,
+        &mut mapper,
+        &mut diagnostics,
+    );
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message, "kept primary\nkept continuation");
+
+    // A suppressed file-less global header resets continuation state too.
+    let suppressed_global_after_kept = cstr!(
+        "{}(1,7): error TS2322: kept primary\n  kept continuation\nerror TS2666: dropped global\n  dropped global continuation",
+        project.virtual_root().join("src").join("main.ts").display()
+    );
+    let mut diagnostics = Vec::new();
+    parse_cli_diagnostics(
+        suppressed_global_after_kept.as_str(),
+        &project,
+        &mut mapper,
+        &mut diagnostics,
+    );
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].message, "kept primary\nkept continuation");
+
     let _ = fs::remove_dir_all(&case_dir);
 }
 


### PR DESCRIPTION
Follow-up to a review comment on #3548 (merged before it could be addressed). The existing `drops_continuations_of_unmapped_diagnostics` case put the suppressed global header *before* the unmapped positioned header, so the global header already cleared `last_was_kept` and the positioned-header reset in `parse_cli_diagnostics` was never exercised on its own: the test would still pass if that branch did not reset.

This adds two sequences where a retained diagnostic is immediately followed by each kind of dropped header, so both resets are covered independently:

```rust
// An unmapped positioned header must reset continuation state on its own,
// without a preceding dropped global header doing it first.
let unmapped_after_kept = cstr!(
    "{}(1,7): error TS2322: kept primary
  kept continuation
{}(1,1): error TS2304: dropped primary
  dropped continuation",
    // ...
);
// ...
assert_eq!(diagnostics[0].message, "kept primary
kept continuation");
```

Test-only change; no production behavior touched. `cargo test -p vize_canon --lib batch::executor::cli::tests::drops_continuations_of_unmapped_diagnostics` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3550"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded diagnostic handling coverage for dropped headers following retained diagnostics.
  * Verified that only the retained diagnostic and its continuation are emitted in global and positioned scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->