### PR TITLE
fix(tests): refresh vue2-elm check snapshot after continuation isolation

### DIFF
--- a/tests/snapshots/check/__snapshots__/vue2-elm-check.snap
+++ b/tests/snapshots/check/__snapshots__/vue2-elm-check.snap
@@ -574,14 +574,13 @@
       "file": "src/page/vipcard/vipcard.vue",
       "diagnostics": [
         "error:4:24 [TS2304] Cannot find name 'userInfo'.",
-        "error:4:24 [TS2304] Cannot find name 'userInfo'.\nType 'boolean' is not assignable to type 'number'.\nType '{ addClass: (e: any) => ...; removeClass: (e: any) => ...; hasClass: (e: any) => any; toggleClass: (e: any) => ...; attr: (e: any, a: any) => any; removeAttr: (e: any) => ...; data: (e: any, a: any) => any; ... 32 more ...; add: () => ...; }' is not assignable to type 'string'.\nType '{ addClass: (e: any) => ...; removeClass: (e: any) => ...; hasClass: (e: any) => any; toggleClass: (e: any) => ...; attr: (e: any, a: any) => any; removeAttr: (e: any) => ...; data: (e: any, a: any) => any; ... 32 more ...; add: () => ...; }' is not assignable to type 'string'.\nType '{ addClass: (e: any) => ...; removeClass: (e: any) => ...; hasClass: (e: any) => any; toggleClass: (e: any) => ...; attr: (e: any, a: any) => any; removeAttr: (e: any) => ...; data: (e: any, a: any) => any; ... 32 more ...; add: () => ...; }' is not assignable to type 'string'.\nType '{ addClass: (e: any) => ...; removeClass: (e: any) => ...; hasClass: (e: any) => any; toggleClass: (e: any) => ...; attr: (e: any, a: any) => any; removeAttr: (e: any) => ...; data: (e: any, a: any) => any; ... 32 more ...; add: () => ...; }' is not assignable to type 'string'.\nType '{ addClass: (e: any) => ...; removeClass: (e: any) => ...; hasClass: (e: any) => any; toggleClass: (e: any) => ...; attr: (e: any, a: any) => any; removeAttr: (e: any) => ...; data: (e: any, a: any) => any; ... 32 more ...; add: () => ...; }' is not assignable to type 'string'.\nType '{ addClass: (e: any) => ...; removeClass: (e: any) => ...; hasClass: (e: any) => any; toggleClass: (e: any) => ...; attr: (e: any, a: any) => any; removeAttr: (e: any) => ...; data: (e: any, a: any) => any; ... 32 more ...; add: () => ...; }' is not assignable to type 'string'.",
         "error:5:44 [TS2304] Cannot find name 'userInfo'.",
         "error:5:45 [TS2304] Cannot find name 'userInfo'.",
         "error:76:42 [TS2307] Cannot find module 'vuex' or its corresponding type declarations."
       ]
     }
   ],
-  "errorCount": 314,
+  "errorCount": 313,
   "warningCount": 0,
   "fileCount": 55
 }


### PR DESCRIPTION
The `vue-parity` job fails on `main` at `tests/snapshots/check/vue2-elm.ts` since #3548 landed: that PR stopped binding CLI continuation lines to unrelated diagnostic headers, but the baseline still records the old pre-fix output.

The stale entry was a duplicate of the `4:24` diagnostic carrying another diagnostic's continuation text (`Type 'boolean' is not assignable to type 'number'.` and the jQuery-ish helper object dump). With continuations isolated, that entry becomes an exact duplicate of the plain `4:24` one and `dedup_diagnostics` collapses it, so the file loses one line and `errorCount` drops by one:

```json
   "file": "src/page/vipcard/vipcard.vue",
   "diagnostics": [
     "error:4:24 [TS2304] Cannot find name 'userInfo'.",
-    "error:4:24 [TS2304] Cannot find name 'userInfo'.
Type 'boolean' is not assignable to type 'number'.
Type '{ addClass: ... }' ...",
     "error:5:44 [TS2304] Cannot find name 'userInfo'.",
```

```json
-  "errorCount": 314,
+  "errorCount": 313,
```

The new baseline matches the CI-reported actual output exactly (the only other multi-line entries in this snapshot are genuine TS2349 continuations and are unchanged). No production code is touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->