### PR TITLE
fix(release): preserve docs build evidence

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,139 @@
+name: Docs build
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+permissions:
+  contents: read
+
+# Release preflight consumes this workflow as immutable evidence for github.sha.
+# A later main push must build independently instead of cancelling an older SHA.
+concurrency:
+  group: docs-build-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-docs:
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Setup Wild linker
+        uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
+        with:
+          wild-version: "0.9.0"
+
+      - uses: ./.github/actions/setup-rust-sticky-cache
+        with:
+          key: docs-napi
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+
+      - name: Setup Vite+ and Node.js
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+      - uses: ./.github/actions/setup-moonbit
+
+      - name: Install JS dependencies
+        run: moon run --target native tools/moon/cmd/github/vp_install -- --filter './docs...' --filter './npm/builder/vite...' --filter './npm/cli...' --filter './npm/native...'
+
+      - name: Build @vizejs/vite-plugin
+        run: moon run --target native tools/moon/cmd/github/run_many -- vp run --filter './npm/native' build:ci -- vp run --filter './npm/cli' build -- vp run --filter './npm/builder/vite' build
+
+      - name: Build docs
+        run: vp run --filter './docs' build
+
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docs
+          path: docs/dist
+          if-no-files-found: error
+
+  build-playground:
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Setup Wild linker
+        uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
+        with:
+          wild-version: "0.9.0"
+
+      - uses: ./.github/actions/setup-moonbit
+
+      - uses: ./.github/actions/setup-rust-sticky-cache
+        with:
+          key: docs-wasm
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+
+      - name: Cache WASM build
+        id: cache-wasm
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            npm/wasm
+            playground/src/wasm
+          key: ${{ runner.os }}-docs-wasm-${{ hashFiles('crates/**/*.rs', 'Cargo.lock', 'npm/wasm/package.json') }}
+
+      - name: Install wasm-bindgen-cli
+        if: steps.cache-wasm.outputs.cache-hit != 'true'
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        with:
+          tool: wasm-bindgen-cli@0.2.121
+
+      - name: Build WASM
+        if: steps.cache-wasm.outputs.cache-hit != 'true'
+        run: moon run --target native tools/moon/cmd/github/build_vitrine_wasm -- npm/wasm playground/src/wasm
+
+      - name: Setup Vite+ and Node.js
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+
+      - name: Install JS dependencies
+        run: moon run --target native tools/moon/cmd/github/vp_install -- --filter './playground...' --filter './examples/vite-musea...' --filter './npm/builder/vite-musea...' --filter './npm/builder/vite...' --filter './npm/cli...' --filter './npm/native...'
+
+      - name: Build npm packages
+        run: moon run --target native tools/moon/cmd/github/run_many -- vp run --filter './npm/native' build:ci -- vp run --filter './npm/cli' build -- vp run --filter './npm/builder/vite' build -- vp run --filter './npm/builder/vite-musea' build
+
+      - name: Build playground
+        run: vp run --filter './playground' build
+
+      - name: Clean musea example Rust target
+        run: cargo clean --target-dir target/docs-example
+
+      - name: Build musea-examples
+        run: vp run --filter './examples/vite-musea' build
+
+      - name: Upload playground artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playground
+          path: playground/dist
+          if-no-files-found: error
+
+      - name: Upload musea-examples artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: musea-examples
+          path: examples/vite-musea/dist
+          if-no-files-found: error

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,142 +1,33 @@
 name: Deploy docs
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - Docs build
+    types:
+      - completed
     branches:
       - main
-  workflow_dispatch:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 permissions:
+  actions: read
   contents: read
 
-concurrency:
-  group: pages-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  build-docs:
-    runs-on: blacksmith-32vcpu-ubuntu-2404
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-
-      - name: Setup Wild linker
-        uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
-        with:
-          wild-version: "0.9.0"
-
-      - uses: ./.github/actions/setup-rust-sticky-cache
-        with:
-          key: docs-napi
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
-
-      - name: Setup Vite+ and Node.js
-        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
-        with:
-          node-version-file: ".node-version"
-          cache: true
-          run-install: false
-      - uses: ./.github/actions/setup-moonbit
-
-      - name: Install JS dependencies
-        run: moon run --target native tools/moon/cmd/github/vp_install -- --filter './docs...' --filter './npm/builder/vite...' --filter './npm/cli...' --filter './npm/native...'
-
-      - name: Build @vizejs/vite-plugin
-        run: moon run --target native tools/moon/cmd/github/run_many -- vp run --filter './npm/native' build:ci -- vp run --filter './npm/cli' build -- vp run --filter './npm/builder/vite' build
-
-      - name: Build docs
-        run: vp run --filter './docs' build
-
-      - name: Upload docs artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: docs
-          path: docs/dist
-
-  build-playground:
-    runs-on: blacksmith-32vcpu-ubuntu-2404
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          targets: wasm32-unknown-unknown
-
-      - name: Setup Wild linker
-        uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
-        with:
-          wild-version: "0.9.0"
-
-      - uses: ./.github/actions/setup-moonbit
-
-      - uses: ./.github/actions/setup-rust-sticky-cache
-        with:
-          key: docs-wasm
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
-
-      - name: Cache WASM build
-        id: cache-wasm
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: |
-            npm/wasm
-            playground/src/wasm
-          key: ${{ runner.os }}-docs-wasm-${{ hashFiles('crates/**/*.rs', 'Cargo.lock', 'npm/wasm/package.json') }}
-
-      - name: Install wasm-bindgen-cli
-        if: steps.cache-wasm.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
-        with:
-          tool: wasm-bindgen-cli@0.2.121
-
-      - name: Build WASM
-        if: steps.cache-wasm.outputs.cache-hit != 'true'
-        run: moon run --target native tools/moon/cmd/github/build_vitrine_wasm -- npm/wasm playground/src/wasm
-
-      - name: Setup Vite+ and Node.js
-        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
-        with:
-          node-version-file: ".node-version"
-          cache: true
-          run-install: false
-
-      - name: Install JS dependencies
-        run: moon run --target native tools/moon/cmd/github/vp_install -- --filter './playground...' --filter './examples/vite-musea...' --filter './npm/builder/vite-musea...' --filter './npm/builder/vite...' --filter './npm/cli...' --filter './npm/native...'
-
-      - name: Build npm packages
-        run: moon run --target native tools/moon/cmd/github/run_many -- vp run --filter './npm/native' build:ci -- vp run --filter './npm/cli' build -- vp run --filter './npm/builder/vite' build -- vp run --filter './npm/builder/vite-musea' build
-
-      - name: Build playground
-        run: vp run --filter './playground' build
-
-      - name: Clean musea example Rust target
-        run: cargo clean --target-dir target/docs-example
-
-      - name: Build musea-examples
-        run: vp run --filter './examples/vite-musea' build
-
-      - name: Upload playground artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: playground
-          path: playground/dist
-
-      - name: Upload musea-examples artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: musea-examples
-          path: examples/vite-musea/dist
-
   deploy:
+    name: Deploy current docs build
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: blacksmith-32vcpu-ubuntu-2404
-    needs: [build-docs, build-playground]
+    concurrency:
+      group: pages-main
+      # Preserve newer pending deploys when an older build finishes late.
+      queue: max
+      cancel-in-progress: false
     permissions:
+      actions: read
       contents: read
       pages: write
       id-token: write
@@ -144,22 +35,60 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout current main
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: main
+          fetch-depth: 1
+          persist-credentials: false
 
-      - name: Download all artifacts
+      - name: Compare docs build with current main
+        id: main
+        shell: bash
+        env:
+          DOCS_BUILD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$DOCS_BUILD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=Invalid docs build SHA::workflow_run.head_sha must be a full lowercase commit SHA"
+            exit 1
+          fi
+          CURRENT_MAIN_SHA="$(git rev-parse HEAD)"
+          if [[ "$DOCS_BUILD_SHA" == "$CURRENT_MAIN_SHA" ]]; then
+            echo "eligible=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping stale docs build $DOCS_BUILD_SHA; current main is $CURRENT_MAIN_SHA"
+          fi
+
+      - name: Checkout docs build
+        if: ${{ steps.main.outputs.eligible == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+
+      - name: Download docs build artifacts
+        if: ${{ steps.main.outputs.eligible == 'true' }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
           path: artifacts
 
-      - uses: ./.github/actions/setup-moonbit
+      - if: ${{ steps.main.outputs.eligible == 'true' }}
+        uses: ./.github/actions/setup-moonbit
 
       - name: Create site structure
+        if: ${{ steps.main.outputs.eligible == 'true' }}
         run: moon run --target native tools/moon/cmd/github/create_site_structure --
 
       - name: Setup Pages
+        if: ${{ steps.main.outputs.eligible == 'true' }}
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Upload pages artifact
+        if: ${{ steps.main.outputs.eligible == 'true' }}
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           name: github-pages-${{ github.run_attempt }}
@@ -167,6 +96,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
+        if: ${{ steps.main.outputs.eligible == 'true' }}
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
         with:
           artifact_name: github-pages-${{ github.run_attempt }}

--- a/.github/workflows/tool-benchmark.yml
+++ b/.github/workflows/tool-benchmark.yml
@@ -92,6 +92,7 @@ jobs:
               - '!.github/workflows/check-bench.yml'
               - '!.github/workflows/check.yml'
               - '!.github/workflows/criterion-bench.yml'
+              - '!.github/workflows/build-docs.yml'
               - '!.github/workflows/deploy-docs.yml'
               - '!.github/workflows/e2e.yml'
               - '!.github/workflows/fuzz.yml'

--- a/docs/release/v1-alpha-go-no-go.md
+++ b/docs/release/v1-alpha-go-no-go.md
@@ -21,7 +21,7 @@ they operate.
   - [Check](../../.github/workflows/check.yml)
   - [Benchmark](../../.github/workflows/benchmark.yml)
   - [App E2E](../../.github/workflows/e2e.yml) for `dev`, `preview`, and `build`
-  - [Deploy Docs](../../.github/workflows/deploy-docs.yml) on the target commit or a matching dry run
+  - [Docs Build](../../.github/workflows/build-docs.yml) evidence on the exact target commit
 - [ ] [Fuzz](../../.github/workflows/fuzz.yml) status, seeded corpus health, and uploaded
       reproducers are reviewed when parser/compiler surfaces changed.
 - [ ] No release-blocking draft PR, open P0/P1 fix request, or failing required workflow remains.
@@ -101,7 +101,8 @@ vp dlx vize@alpha --version
 vp install -D @vizejs/vite-plugin@alpha @vizejs/vite-plugin-musea@alpha
 ```
 
-- [ ] Docs owner verifies the docs site, search index, and release post after deploy.
+- [ ] Docs owner verifies the docs site, search index, and release post after
+      [Deploy Docs](../../.github/workflows/deploy-docs.yml) publishes current `main`.
 - [ ] npm owner verifies native optional dependency resolution on macOS, Linux, and Windows runners.
 - [ ] Release captain posts release communication with:
   - version and channel

--- a/tests/tooling/github-workflows-docs.test.ts
+++ b/tests/tooling/github-workflows-docs.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parse } from "yaml";
+
+import {
+  requiredReleaseWorkflowEvidence,
+  requiredReleaseWorkflows,
+  selectRequiredWorkflowRuns,
+} from "../../tools/github/release-preflight-evidence.mjs";
+import { readRepoFile } from "./support/github-workflows.ts";
+import { releaseSha, successfulReleaseRun } from "./support/release-preflight.ts";
+
+interface WorkflowStep {
+  name?: string;
+  id?: string;
+  if?: string;
+  uses?: string;
+  env?: Record<string, string>;
+  run?: string;
+  with?: Record<string, unknown>;
+}
+
+interface WorkflowJob {
+  if?: string;
+  needs?: string;
+  concurrency?: { group?: string; queue?: string; "cancel-in-progress"?: boolean };
+  permissions?: Record<string, string>;
+  outputs?: Record<string, string>;
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  name?: string;
+  on?: Record<string, unknown>;
+  concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+  permissions?: Record<string, string>;
+  jobs?: Record<string, WorkflowJob>;
+}
+
+function readWorkflow(file: string): Workflow {
+  return parse(readRepoFile(".github", "workflows", file)) as Workflow;
+}
+
+function workflowJob(workflow: Workflow, name: string): WorkflowJob {
+  const job = workflow.jobs?.[name];
+  assert.ok(job, `missing workflow job ${name}`);
+  return job;
+}
+
+function namedStep(job: WorkflowJob, name: string): WorkflowStep {
+  const step = job.steps?.find((candidate) => candidate.name === name);
+  assert.ok(step, `missing workflow step ${name}`);
+  return step;
+}
+
+test("docs build evidence is immutable per SHA and has no Pages authority", () => {
+  const workflow = readWorkflow("build-docs.yml");
+  const events = workflow.on as {
+    push?: { branches?: string[] };
+    workflow_dispatch?: unknown;
+  };
+
+  assert.equal(workflow.name, "Docs build");
+  assert.deepEqual(Object.keys(events).sort(), ["push", "workflow_dispatch"]);
+  assert.deepEqual(events.push?.branches, ["main"]);
+  assert.equal(workflow.concurrency?.group, "docs-build-${{ github.sha }}");
+  assert.equal(workflow.concurrency?.["cancel-in-progress"], true);
+  assert.deepEqual(Object.keys(workflow.jobs ?? {}).sort(), ["build-docs", "build-playground"]);
+  assert.equal(workflow.permissions?.contents, "read");
+
+  const source = readRepoFile(".github", "workflows", "build-docs.yml");
+  assert.doesNotMatch(source, /pages:\s*write|id-token:\s*write|actions\/deploy-pages/);
+  for (const artifact of ["docs", "playground", "musea-examples"]) {
+    const upload = Object.values(workflow.jobs ?? {})
+      .flatMap((job) => job.steps ?? [])
+      .find((step) => step.with?.name === artifact);
+    assert.ok(upload, `missing ${artifact} artifact upload`);
+    assert.match(upload.uses ?? "", /^actions\/upload-artifact@[0-9a-f]{40}$/);
+    assert.equal(upload.with?.["if-no-files-found"], "error");
+  }
+});
+
+test("docs deployment serializes before revalidating current main", () => {
+  const workflow = readWorkflow("deploy-docs.yml");
+  const events = workflow.on as {
+    workflow_run?: { workflows?: string[]; types?: string[]; branches?: string[] };
+  };
+  const deploy = workflowJob(workflow, "deploy");
+  const checkoutMain = namedStep(deploy, "Checkout current main");
+  const compare = namedStep(deploy, "Compare docs build with current main");
+
+  assert.equal(workflow.name, "Deploy docs");
+  assert.deepEqual(Object.keys(events), ["workflow_run"]);
+  assert.deepEqual(events.workflow_run?.workflows, ["Docs build"]);
+  assert.deepEqual(events.workflow_run?.types, ["completed"]);
+  assert.deepEqual(events.workflow_run?.branches, ["main"]);
+  assert.deepEqual(Object.keys(workflow.jobs ?? {}), ["deploy"]);
+  assert.equal(workflow.concurrency, undefined);
+  assert.equal(deploy.if, "${{ github.event.workflow_run.conclusion == 'success' }}");
+  assert.equal(deploy.concurrency?.group, "pages-main");
+  assert.equal(
+    deploy.concurrency?.queue,
+    "max",
+    "a stale late arrival must not replace a newer pending deployment",
+  );
+  assert.equal(
+    deploy.concurrency?.["cancel-in-progress"],
+    false,
+    "an older completed build must never cancel a newer deployment",
+  );
+  assert.equal(checkoutMain.with?.ref, "main");
+  assert.equal(
+    deploy.steps?.[0],
+    checkoutMain,
+    "main must be fetched after concurrency is acquired",
+  );
+  assert.equal(deploy.steps?.[1], compare, "the freshness check must open the deploy section");
+  assert.equal(compare.env?.DOCS_BUILD_SHA, "${{ github.event.workflow_run.head_sha }}");
+  assert.match(compare.run ?? "", /\^\[0-9a-f\]\{40\}\$/);
+  assert.match(compare.run ?? "", /CURRENT_MAIN_SHA="\$\(git rev-parse HEAD\)"/);
+  assert.match(compare.run ?? "", /\[\[ "\$DOCS_BUILD_SHA" == "\$CURRENT_MAIN_SHA" \]\]/);
+  assert.match(compare.run ?? "", /eligible=false/);
+});
+
+test("only the exact current-main build can download or deploy Pages", () => {
+  const workflow = readWorkflow("deploy-docs.yml");
+  const deploy = workflowJob(workflow, "deploy");
+  const download = namedStep(deploy, "Download docs build artifacts");
+  const checkout = namedStep(deploy, "Checkout docs build");
+  namedStep(deploy, "Deploy to GitHub Pages");
+  const eligibility = "${{ steps.main.outputs.eligible == 'true' }}";
+
+  assert.equal(deploy.permissions?.actions, "read");
+  assert.equal(deploy.permissions?.pages, "write");
+  assert.equal(deploy.permissions?.["id-token"], "write");
+  assert.equal(checkout?.with?.ref, "${{ github.event.workflow_run.head_sha }}");
+  for (const step of deploy.steps?.slice(2) ?? []) {
+    assert.equal(step.if, eligibility, `${step.name ?? step.uses} bypasses the freshness gate`);
+  }
+  assert.equal(download.with?.["run-id"], "${{ github.event.workflow_run.id }}");
+  assert.equal(download.with?.["github-token"], "${{ github.token }}");
+  assert.equal(download.with?.path, "artifacts");
+});
+
+test("release preflight requires docs build evidence, never mutable deployment", () => {
+  assert.ok(requiredReleaseWorkflows.includes("Docs build"));
+  assert.ok(!requiredReleaseWorkflows.includes("Deploy docs"));
+  assert.deepEqual(requiredReleaseWorkflowEvidence.get("Docs build"), {
+    path: ".github/workflows/build-docs.yml",
+    events: ["push", "workflow_dispatch"],
+    branches: { push: ["main"] },
+  });
+
+  const runs = requiredReleaseWorkflows.map((name, index) => successfulReleaseRun(name, index + 1));
+  const docsBuild = runs.find((run) => run.name === "Docs build");
+  assert.ok(docsBuild);
+  docsBuild.name = "Deploy docs";
+  docsBuild.path = ".github/workflows/deploy-docs.yml";
+  docsBuild.event = "workflow_run";
+  assert.throws(() => selectRequiredWorkflowRuns(runs, releaseSha), /Docs build: missing/);
+});

--- a/tests/tooling/github-workflows-setup.test.ts
+++ b/tests/tooling/github-workflows-setup.test.ts
@@ -6,7 +6,7 @@ import { hostedOrBlacksmith, readRepoFile, workflowJobBody } from "./support/git
 test("deploy-docs deploy job installs MoonBit before running command packages", () => {
   const workflow = readRepoFile(".github", "workflows", "deploy-docs.yml");
   const deployJob = workflow.slice(workflow.indexOf("\n  deploy:\n"));
-  const setupIndex = deployJob.indexOf("- uses: ./.github/actions/setup-moonbit");
+  const setupIndex = deployJob.indexOf("uses: ./.github/actions/setup-moonbit");
   const moonRunIndex = deployJob.indexOf(
     "run: moon run --target native tools/moon/cmd/github/create_site_structure --",
   );
@@ -20,7 +20,7 @@ test("deploy-docs deploy job keeps a full checkout so local actions and scripts 
   const workflow = readRepoFile(".github", "workflows", "deploy-docs.yml");
   const deployJob = workflow.slice(workflow.indexOf("\n  deploy:\n"));
 
-  assert.match(deployJob, /- uses: actions\/checkout@[0-9a-f]{40}\s*# v6/);
+  assert.match(deployJob, /uses: actions\/checkout@[0-9a-f]{40}\s*# v6/);
   assert.doesNotMatch(deployJob, /sparse-checkout:/);
 });
 
@@ -47,7 +47,7 @@ test("WASM build jobs install MoonBit before invoking moon run", () => {
         "run: moon run --target native tools/moon/cmd/github/build_vitrine_wasm -- playground/src/wasm",
     },
     {
-      workflowName: "deploy-docs.yml",
+      workflowName: "build-docs.yml",
       jobName: "build-playground",
       moonRun:
         "run: moon run --target native tools/moon/cmd/github/build_vitrine_wasm -- npm/wasm playground/src/wasm",

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -17,6 +17,7 @@ test("repo text helpers normalize line endings before workflow matching", () => 
 
 test("GitHub workflows opt JavaScript actions into Node 24", () => {
   for (const workflowName of [
+    "build-docs.yml",
     "check.yml",
     "deploy-docs.yml",
     "miri.yml",
@@ -37,6 +38,7 @@ test("GitHub workflows use the current cache action", () => {
     ".github/actions/setup-rust-sticky-cache/action.yml",
     ".github/actions/setup-moonbit/action.yml",
     ".github/workflows/benchmark.yml",
+    ".github/workflows/build-docs.yml",
     ".github/workflows/check.yml",
     ".github/workflows/deploy-docs.yml",
     ".github/workflows/e2e.yml",
@@ -179,9 +181,9 @@ test("App E2E workflow keeps Blacksmith Testbox dispatch hydration separate", ()
 test("Linux Rust CI installs Wild linker before cargo builds", () => {
   for (const workflowName of [
     "benchmark.yml",
+    "build-docs.yml",
     "check.yml",
     "criterion-bench.yml",
-    "deploy-docs.yml",
     "e2e.yml",
     "native-smoke.yml",
     "release-preflight.yml",
@@ -208,9 +210,9 @@ test("Blacksmith Rust CI uses sticky disks for Cargo and target caches", () => {
   assert.match(action, /secondary-target-path/);
 
   for (const workflowName of [
+    "build-docs.yml",
     "check.yml",
     "criterion-bench.yml",
-    "deploy-docs.yml",
     "e2e.yml",
     "fuzz.yml",
     "miri.yml",

--- a/tests/tooling/release-readiness.test.ts
+++ b/tests/tooling/release-readiness.test.ts
@@ -30,6 +30,7 @@ test("v1 alpha go/no-go checklist covers release gates and rollback", () => {
     "../../.github/workflows/benchmark.yml",
     "../../.github/workflows/fuzz.yml",
     "../../.github/workflows/e2e.yml",
+    "../../.github/workflows/build-docs.yml",
     "../../.github/workflows/deploy-docs.yml",
     "../../.github/workflows/release.yml",
   ]) {

--- a/tests/tooling/tool-benchmark-trigger.test.ts
+++ b/tests/tooling/tool-benchmark-trigger.test.ts
@@ -47,6 +47,7 @@ test("Tool Benchmark ignores only known non-runtime pull request paths", () => {
     "!.github/workflows/check-bench.yml",
     "!.github/workflows/check.yml",
     "!.github/workflows/criterion-bench.yml",
+    "!.github/workflows/build-docs.yml",
     "!.github/workflows/deploy-docs.yml",
     "!.github/workflows/e2e.yml",
     "!.github/workflows/fuzz.yml",

--- a/tools/github/release-preflight-evidence.mjs
+++ b/tools/github/release-preflight-evidence.mjs
@@ -6,7 +6,7 @@ export const requiredReleaseWorkflows = [
   "Miri",
   "App E2E",
   "Real Project Matrix",
-  "Deploy docs",
+  "Docs build",
 ];
 
 export const requiredReleaseWorkflowEvidence = new Map([
@@ -49,9 +49,9 @@ export const requiredReleaseWorkflowEvidence = new Map([
     },
   ],
   [
-    "Deploy docs",
+    "Docs build",
     {
-      path: ".github/workflows/deploy-docs.yml",
+      path: ".github/workflows/build-docs.yml",
       events: ["push", "workflow_dispatch"],
       branches: { push: ["main"] },
     },


### PR DESCRIPTION
## Summary
- split immutable docs builds from mutable Pages deployment
- require exact-SHA `Docs build` evidence during release preflight
- serialize Pages deployment, revalidate current `main`, and fail closed on missing artifacts
- keep release documentation and workflow contract tests in sync

## Tests
- `vp exec --filter './tests' -- node --test tooling/github-workflows-docs.test.ts tooling/github-workflows-setup.test.ts tooling/github-workflows.test.ts tooling/release-readiness.test.ts tooling/tool-benchmark-trigger.test.ts` (30 passed)\n- `git diff --check origin/main...HEAD`\n\nCloses #3538

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->