### PR TITLE
fix(canon): parenthesize sequence prop expressions

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
@@ -2,6 +2,7 @@ use super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diag
 mod directive_anchors;
 mod directive_values;
 mod exact_optional_props;
+mod sequence_prop_expressions;
 mod spread_props;
 
 #[test]

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/sequence_prop_expressions.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/sequence_prop_expressions.rs
@@ -1,0 +1,76 @@
+//! Sequence expressions passed to component props (#3547).
+//!
+//! The generated per-prop initializer and generic props object both place a
+//! prop value next to comma-delimited syntax. An authored top-level sequence
+//! must stay one expression at both boundaries, and its final callback must
+//! retain the child's contextual parameter type.
+
+use super::super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+
+#[test]
+fn non_generic_sequence_callback_prop_is_contextually_typed() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "non-generic-sequence-callback-prop",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts">
+defineProps<{ transform: (value: number) => number }>()
+</script>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child :transform="void 0, (value) => value" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    assert_eq!(snapshot, Some(Vec::new()));
+}
+
+#[test]
+fn generic_sequence_callback_prop_is_contextually_typed() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "generic-sequence-callback-prop",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts" generic="T">
+defineProps<{ value: T; transform: (value: T) => T }>()
+</script>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child :value="1" :transform="void 0, (value) => value" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    assert_eq!(snapshot, Some(Vec::new()));
+}

--- a/crates/vize_canon/src/virtual_ts/expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions.rs
@@ -15,6 +15,8 @@ mod native_props;
 mod native_props_tests;
 mod prop_sources;
 mod reserved_props;
+#[cfg(test)]
+mod sequence_prop_tests;
 mod statements;
 mod value_checks;
 mod vif_chain;

--- a/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
@@ -7,7 +7,9 @@
 
 use super::super::helpers::to_safe_identifier_fragment;
 use super::super::types::{VizeMapping, VizeSubSpan};
-use super::prop_sources::{generated_prop_value, prop_name_source_range, prop_value_source_range};
+use super::prop_sources::{
+    append_prop_value, generated_prop_value, prop_name_source_range, prop_value_source_range,
+};
 use vize_carton::FxHashMap;
 use vize_carton::FxHashSet;
 use vize_carton::String;
@@ -57,7 +59,7 @@ pub(super) fn merged_class_binding_value(bindings: &[(&PassedProp, String)]) -> 
                 if index > 0 {
                     value.push_str(", ");
                 }
-                value.push_str(binding_value.as_str());
+                append_prop_value(&mut value, binding_value.as_str());
             }
             value.push(']');
             Some(value)
@@ -129,9 +131,7 @@ pub(crate) fn generate_component_prop_checks(
                 *ts,
                 ": __{component_type_name}_{idx}_prop_{safe_prop_name} = ",
             );
-            let value_gen_start = ts.len();
-            ts.push_str(generated_value.as_str());
-            let value_gen_end = ts.len();
+            let value_gen_range = append_prop_value(ts, generated_value.as_str());
             ts.push_str(";\n");
             let gen_stmt_end = ts.len();
             append!(*ts, "{expr_indent}void {check_name};\n");
@@ -150,7 +150,7 @@ pub(crate) fn generate_component_prop_checks(
             }
             if let Some(src_range) = value_src_range {
                 sub_spans.push(VizeSubSpan {
-                    gen_range: value_gen_start..value_gen_end,
+                    gen_range: value_gen_range,
                     src_range,
                 });
             }

--- a/crates/vize_canon/src/virtual_ts/expressions/generic_props_call.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/generic_props_call.rs
@@ -10,7 +10,9 @@ use super::component_props::{
     ComponentPropSource, collect_generated_class_bindings, is_checkable_prop,
     merged_class_binding_value,
 };
-use super::prop_sources::{generated_prop_value, prop_name_source_range, prop_value_source_range};
+use super::prop_sources::{
+    append_prop_value, generated_prop_value, prop_name_source_range, prop_value_source_range,
+};
 use crate::virtual_ts::scope::has_checkable_props_or_spread;
 use vize_carton::FxHashSet;
 use vize_carton::String;
@@ -136,8 +138,7 @@ pub(super) fn generate_generic_props_call(
         append!(*ts, "\"{camel_prop_name}\"");
         let key_gen_end = ts.len();
         ts.push_str(": ");
-        let value_gen_start = ts.len();
-        ts.push_str(generated_value.as_str());
+        let value_gen_range = append_prop_value(ts, generated_value.as_str());
         let entry_gen_end = ts.len();
         ts.push_str(",\n");
         // Without sub-spans the whole entry maps proportionally onto the whole
@@ -152,7 +153,7 @@ pub(super) fn generate_generic_props_call(
                 source_context,
                 prop,
                 entry_gen_start..key_gen_end,
-                value_gen_start..entry_gen_end,
+                value_gen_range,
             ),
         };
         mappings.push(VizeMapping {
@@ -195,12 +196,10 @@ fn append_spread_entry(
     expr_indent: &str,
 ) {
     append!(*ts, "{expr_indent}  ...");
-    let gen_start = ts.len();
-    ts.push_str(spread.expression.as_str());
-    let gen_end = ts.len();
+    let gen_range = append_prop_value(ts, spread.expression.as_str());
     ts.push_str(",\n");
     mappings.push(VizeMapping {
-        gen_range: gen_start..gen_end,
+        gen_range,
         src_range: (template_offset + spread.start) as usize
             ..(template_offset + spread.end) as usize,
         sub_spans: Vec::new(),

--- a/crates/vize_canon/src/virtual_ts/expressions/prop_sources.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/prop_sources.rs
@@ -8,6 +8,11 @@
 
 use super::component_props::ComponentPropSource;
 use super::reserved_props::rewrite_reserved_template_prop;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Expression;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use std::ops::Range;
 use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_croquis::croquis::PassedProp;
@@ -49,6 +54,36 @@ pub(super) fn generated_prop_value(
         || String::from(value.as_ref()),
         |s| String::from(s.as_str()),
     ))
+}
+
+/// Append one generated prop value and return its range without synthetic
+/// grouping bytes.
+///
+/// A top-level sequence needs grouping wherever a prop value sits beside
+/// comma-delimited generated syntax (a declaration, object property, array
+/// element, or spread). OXC distinguishes that shape from commas nested in a
+/// call, array, object, or already-parenthesized sequence. The cheap byte check
+/// only skips parsing expressions that cannot possibly be sequences.
+pub(super) fn append_prop_value(ts: &mut String, value: &str) -> Range<usize> {
+    let needs_grouping = value.as_bytes().contains(&b',') && is_top_level_sequence(value);
+    if needs_grouping {
+        ts.push('(');
+    }
+    let value_start = ts.len();
+    ts.push_str(value);
+    let value_end = ts.len();
+    if needs_grouping {
+        ts.push(')');
+    }
+    value_start..value_end
+}
+
+fn is_top_level_sequence(value: &str) -> bool {
+    let allocator = Allocator::default();
+    matches!(
+        Parser::new(&allocator, value, SourceType::ts()).parse_expression(),
+        Ok(Expression::SequenceExpression(_))
+    )
 }
 
 pub(super) fn prop_value_source_range(
@@ -118,7 +153,25 @@ fn anchor_token(name_region: &str, name: &str) -> Option<(usize, usize)> {
 
 #[cfg(test)]
 mod tests {
-    use super::anchor_token;
+    use super::{anchor_token, append_prop_value};
+
+    #[test]
+    fn groups_only_unparenthesized_top_level_sequences() {
+        let cases = [
+            ("void 0, callback", "(void 0, callback)", 1..17),
+            ("(void 0, callback)", "(void 0, callback)", 0..18),
+            ("invoke(value, other)", "invoke(value, other)", 0..20),
+            ("[value, other]", "[value, other]", 0..14),
+        ];
+
+        for (source, expected, expected_range) in cases {
+            let mut generated = vize_carton::String::default();
+            let range = append_prop_value(&mut generated, source);
+            assert_eq!(generated, expected, "unexpected grouping for `{source}`");
+            assert_eq!(range, expected_range, "unexpected range for `{source}`");
+            assert_eq!(&generated[range], source);
+        }
+    }
 
     #[test]
     fn prop_anchor_tokens_match_the_authored_binding() {

--- a/crates/vize_canon/src/virtual_ts/expressions/sequence_prop_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/sequence_prop_tests.rs
@@ -1,0 +1,108 @@
+use vize_croquis::{Analyzer, AnalyzerOptions};
+
+use crate::virtual_ts::generate_virtual_ts;
+
+#[test]
+fn sequence_prop_values_are_grouped_without_mapping_synthetic_parentheses() {
+    let script = r#"import Child from "./Child.vue"
+"#;
+    let expression = "void 0, (value) => value";
+    let template = r#"<Child :transform="void 0, (value) => value" />"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+    assert!(
+        output
+            .code
+            .contains("__Child_0_prop_transform = (void 0, (value) => value);"),
+        "per-prop initializer must group the sequence expression:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains(r#""transform": (void 0, (value) => value),"#),
+        "generic props object must group the sequence expression:\n{}",
+        output.code
+    );
+
+    let value_start = template.find(expression).expect("bound expression present");
+    let value_range = value_start..value_start + expression.len();
+    let value_spans: Vec<_> = output
+        .mappings
+        .iter()
+        .flat_map(|mapping| &mapping.sub_spans)
+        .filter(|span| span.src_range == value_range)
+        .collect();
+    assert_eq!(
+        value_spans.len(),
+        2,
+        "both prop-check boundaries must map the authored expression"
+    );
+    for span in value_spans {
+        assert_eq!(
+            &output.code[span.gen_range.clone()],
+            expression,
+            "synthetic parentheses must stay outside the exact value sub-span"
+        );
+        assert_eq!(output.code.as_bytes()[span.gen_range.start - 1], b'(');
+        assert_eq!(output.code.as_bytes()[span.gen_range.end], b')');
+    }
+}
+
+#[test]
+fn already_parenthesized_sequence_prop_values_are_not_double_wrapped() {
+    let script = r#"import Child from "./Child.vue"
+"#;
+    let template = r#"<Child :transform="(void 0, (value) => value)" />"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+    assert!(
+        !output.code.contains("((void 0, (value) => value))"),
+        "authored grouping should not gain redundant parentheses:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn sequence_values_stay_single_in_merged_class_and_spread_entries() {
+    let script = r#"import Child from "./Child.vue"
+const classes = { active: true }
+const props = { id: "child" }
+"#;
+    let template = r#"<Child class="base" :class="void 0, classes" v-bind="void 0, props" />"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+    assert!(
+        output
+            .code
+            .contains(r#""class": ["base", (void 0, classes)]"#),
+        "a sequence class binding must remain one merged array element:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains("...(void 0, props),"),
+        "a sequence spread binding must remain one spread operand:\n{}",
+        output.code
+    );
+}


### PR DESCRIPTION
## Summary
- preserve top-level sequence expressions as one value at generated prop boundaries
- keep synthetic grouping parentheses outside authored source mappings
- cover generic and non-generic contextual callback typing, merged class values, and spreads

## Tests
- `VIZE_TEST_REQUIRE_TSGO=1 cargo +1.95.0 test -p vize_canon --lib sequence_prop` (5 passed)
- `cargo +1.95.0 fmt --all -- --check`
- full `vize_canon` library suite (715 passed before final rebase)
- workspace clippy with warnings denied (before final rebase)

Closes #3547

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->