### PR TITLE
test(infra): skip unavailable vue2-elm fixture

### DIFF
--- a/tests/snapshots/check/vue2-elm.ts
+++ b/tests/snapshots/check/vue2-elm.ts
@@ -1,9 +1,10 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
-import { withPinnedFixtureWorkspace } from "../../_helpers/realworld-patch.ts";
+import { repoRoot, withPinnedFixtureWorkspace } from "../../_helpers/realworld-patch.ts";
 import {
   resolveTsgoBinary,
   runVizeCheck,
@@ -12,6 +13,8 @@ import {
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const SNAPSHOT_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "__snapshots__");
+const VUE2_ELM_SRC = path.join(repoRoot, "tests/_fixtures/_git/vue2-elm/src");
+const fixtureSkip = fs.existsSync(VUE2_ELM_SRC) ? false : "vue2-elm fixture checkout unavailable";
 
 // First suite to exercise the pinned vue2-elm fixture (#2971 audit item 7).
 // The snapshot pins the exact `vize check` surface over the untouched Vue 2
@@ -21,7 +24,7 @@ const SNAPSHOT_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), "__
 // and for vendor modules that are intentionally not installed. Behavior
 // changes on legacy input must land as reviewed snapshot updates
 // (UPDATE_SNAPSHOTS=1), never as silent drift.
-test("vue2-elm vize check surface over the pinned Vue 2 app stays exact", async () => {
+async function verifyVue2ElmSnapshot(): Promise<void> {
   const corsaPath = resolveTsgoBinary();
 
   await withPinnedFixtureWorkspace(
@@ -67,7 +70,13 @@ test("vue2-elm vize check surface over the pinned Vue 2 app stays exact", async 
       assertSnapshot(SNAPSHOT_DIR, "vue2-elm-check", `${JSON.stringify(first.report, null, 2)}\n`);
     },
   );
-});
+}
+
+test(
+  "vue2-elm vize check surface over the pinned Vue 2 app stays exact",
+  { skip: fixtureSkip },
+  verifyVue2ElmSnapshot,
+);
 
 function json(value: unknown): string {
   return `${JSON.stringify(value, null, 2)}\n`;


### PR DESCRIPTION
Closes #3417.

The vue2-elm snapshot now registers with an explicit skip reason when its pinned submodule is not hydrated, which lets the check fixture suite run from ordinary git worktrees. Hydrated checkouts still execute the unchanged strict byte-stability and snapshot assertions.

Validation:
- fresh worktree without the submodule: skipped with `vue2-elm fixture checkout unavailable`
- hydrated pinned fixture: snapshot matched
- hydrated snapshot test: 10 consecutive passes
- oxfmt check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->