### PR TITLE
test(typecheck): tighten vue-element-admin parity baseline

### DIFF
--- a/tests/_fixtures/compat-baseline.json
+++ b/tests/_fixtures/compat-baseline.json
@@ -84,14 +84,14 @@
     "vue-element-admin": {
       "revision": "6858a9ad67483025f6a9432a926beb9327037be3",
       "accepted": true,
-      "vizeDiagnosticCount": 1,
+      "vizeDiagnosticCount": 0,
       "baselineDiagnosticCount": 0,
       "sharedCount": 0,
       "messageMismatchCount": 0,
       "documentedDifferenceCount": 0,
-      "falsePositiveCount": 1,
+      "falsePositiveCount": 0,
       "falseNegativeCount": 0,
-      "falsePositiveRatio": 1,
+      "falsePositiveRatio": 0,
       "falseNegativeRatio": 0
     },
     "vue-router": {

--- a/tests/_helpers/compat-ratchet.ts
+++ b/tests/_helpers/compat-ratchet.ts
@@ -79,6 +79,12 @@ export type CompatProbeResult = {
   vueTscDurationMs: number;
 };
 
+export type TypecheckPerformanceBudget = {
+  enabled?: boolean;
+  maxFalsePositiveRatio?: number;
+  maxFalseNegativeRatio?: number;
+};
+
 export const compatBaselinePath = path.join(repoRoot, "tests/_fixtures/compat-baseline.json");
 
 export const compatDocumentedDifferencesPath = path.join(
@@ -315,17 +321,22 @@ function isAcceptedByRegistryBudget(fixtureId: string, summary: CompatSummary): 
   ) as {
     projects: Array<{
       id: string;
-      typecheckPerformance?: {
-        enabled?: boolean;
-        maxFalsePositiveRatio?: number;
-        maxFalseNegativeRatio?: number;
-      };
+      typecheckPerformance?: TypecheckPerformanceBudget;
     }>;
   };
   const performance = registry.projects.find(
     (project) => project.id === fixtureId,
   )?.typecheckPerformance;
-  if (performance?.enabled !== true) return true;
+  return isAcceptedByTypecheckBudget(summary, performance);
+}
+
+export function isAcceptedByTypecheckBudget(
+  summary: CompatSummary,
+  performance: TypecheckPerformanceBudget | undefined,
+): boolean {
+  if (performance?.enabled !== true) {
+    return summary.falsePositiveCount === 0 && summary.falseNegativeCount === 0;
+  }
   return (
     summary.falsePositiveRatio <= (performance.maxFalsePositiveRatio ?? 1) &&
     summary.falseNegativeRatio <= (performance.maxFalseNegativeRatio ?? 1)

--- a/tests/tooling/compat-ratchet.test.ts
+++ b/tests/tooling/compat-ratchet.test.ts
@@ -33,6 +33,7 @@ import {
   type CompatSummary,
   compatBaselinePath,
   compatProbes,
+  isAcceptedByTypecheckBudget,
   isFixtureHydrated,
   readCompatBaseline,
   readCompatDocumentedDifferences,
@@ -48,6 +49,18 @@ const refreshInstruction =
   "regenerate it in this PR with: UPDATE_COMPAT_BASELINE=1 VIZE_TEST_BIN=target/release/vize " +
   "node --test tests/tooling/compat-ratchet.test.ts (hydrate the vue-parity fixtures first)";
 const updatedEntries = new Map<string, CompatBaselineEntry>();
+
+const exactParity: CompatSummary = {
+  vizeDiagnosticCount: 0,
+  baselineDiagnosticCount: 0,
+  sharedCount: 0,
+  messageMismatchCount: 0,
+  documentedDifferenceCount: 0,
+  falsePositiveCount: 0,
+  falseNegativeCount: 0,
+  falsePositiveRatio: 0,
+  falseNegativeRatio: 0,
+};
 
 type RatchetRule = {
   metric: keyof CompatSummary;
@@ -161,6 +174,32 @@ for (const probe of compatProbes) {
     },
   );
 }
+
+test("compat probes without a configured budget accept only exact parity", () => {
+  assert.equal(isAcceptedByTypecheckBudget(exactParity, undefined), true);
+  assert.equal(isAcceptedByTypecheckBudget(exactParity, { enabled: false }), true);
+  assert.equal(
+    isAcceptedByTypecheckBudget(
+      { ...exactParity, documentedDifferenceCount: 1 },
+      { enabled: false },
+    ),
+    true,
+  );
+  assert.equal(
+    isAcceptedByTypecheckBudget(
+      { ...exactParity, vizeDiagnosticCount: 1, falsePositiveCount: 1, falsePositiveRatio: 1 },
+      undefined,
+    ),
+    false,
+  );
+  assert.equal(
+    isAcceptedByTypecheckBudget(
+      { ...exactParity, baselineDiagnosticCount: 1, falseNegativeCount: 1, falseNegativeRatio: 1 },
+      undefined,
+    ),
+    false,
+  );
+});
 
 test(
   "compat baseline is pinned to the workspace vue-tsc",

--- a/tests/tooling/compat-ratchet.test.ts
+++ b/tests/tooling/compat-ratchet.test.ts
@@ -180,7 +180,12 @@ test("compat probes without a configured budget accept only exact parity", () =>
   assert.equal(isAcceptedByTypecheckBudget(exactParity, { enabled: false }), true);
   assert.equal(
     isAcceptedByTypecheckBudget(
-      { ...exactParity, documentedDifferenceCount: 1 },
+      {
+        ...exactParity,
+        vizeDiagnosticCount: 1,
+        baselineDiagnosticCount: 1,
+        documentedDifferenceCount: 1,
+      },
       { enabled: false },
     ),
     true,


### PR DESCRIPTION
Closes #3492.

## Summary

- update the pinned vue-element-admin compatibility result after #3351 removed the JavaScript SFC false positive
- require exact false-positive and false-negative parity when a fixture has no enabled performance budget
- cover missing and disabled budgets, documented differences, and both divergence directions

## Root cause evidence

A binary built from the parent of #3351 reports src/components/Breadcrumb/index.vue at 13:26 with TS2307 for the path-to-regexp import. The project does not enable checkJs, so vue-tsc correctly reports nothing for that JavaScript SFC. Current main suppresses that unrequested JavaScript diagnostic and both tools now report zero.

## Verification

- exact vue-element-admin probe: Vize 0, vue-tsc 0, false positives 0, false negatives 0
- node --test tests/tooling/compat-ratchet.test.ts
- oxfmt on changed files
- oxlint --deny-warnings on changed TypeScript files
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a compatibility baseline entry that incorrectly counted a diagnostic as a false positive.
  - Updated compatibility results to accurately report zero false positives for the affected scenario.

- **Tests**
  - Expanded compatibility checks to validate exact parity and both false-positive and false-negative outcomes.
  - Added safeguards ensuring compatibility differences meet configured performance thresholds before acceptance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->