### PR TITLE
fix(atelier): reject dynamic JSX v-model arguments

### DIFF
--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -14,14 +14,19 @@ use oxc_ast::ast::{
 };
 use oxc_span::{GetSpan, Span};
 use vize_carton::{Box, String, Vec, is_builtin_directive};
-use vize_relief::SourceLocation;
-use vize_relief::{AttributeNode, DirectiveNode, PropNode, TextNode};
-
-use vize_relief::SimpleExpressionNode;
+use vize_relief::{
+    AttributeNode, DirectiveNode, PropNode, SimpleExpressionNode, SourceLocation, TextNode,
+};
 
 use super::Lowerer;
 use super::expr::container_expr_span;
-use super::v_model::split_underscore_model_modifiers;
+use super::v_model::{ModelArrayLowering, split_underscore_model_modifiers};
+
+enum DirectiveAttributeLowering<'a> {
+    NotDirective,
+    Lowered(PropNode<'a>),
+    Rejected,
+}
 
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Lower a JSX opening element's attribute list into Vize props.
@@ -85,8 +90,10 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         }
 
         // Directive forms: `v-model`, `v-show`, `v-on:click`, custom `v-foo:arg`.
-        if let Some(directive) = self.try_directive_attribute(attr, &loc) {
-            return Some(directive);
+        match self.try_directive_attribute(attr, &loc) {
+            DirectiveAttributeLowering::Lowered(directive) => return Some(directive),
+            DirectiveAttributeLowering::Rejected => return None,
+            DirectiveAttributeLowering::NotDirective => {}
         }
 
         let name = String::from(self.mapper().slice(attr.name.span()));
@@ -187,21 +194,26 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     }
 
     fn try_directive_attribute(
-        &self,
+        &mut self,
         attr: &JSXAttribute<'_>,
         loc: &SourceLocation,
-    ) -> Option<PropNode<'a>> {
+    ) -> DirectiveAttributeLowering<'a> {
         let (raw_name, arg) = match &attr.name {
             JSXAttributeName::NamespacedName(named) => {
-                let raw_name = self
+                let Some(raw_name) = self
                     .mapper()
                     .slice(named.namespace.span())
-                    .strip_prefix("v-")?;
+                    .strip_prefix("v-")
+                else {
+                    return DirectiveAttributeLowering::NotDirective;
+                };
                 let arg_name = self.mapper().slice(named.name.span());
                 (raw_name, Some((arg_name, named.name.span())))
             }
             JSXAttributeName::Identifier(id) => {
-                let raw_name = self.mapper().slice(id.span()).strip_prefix("v-")?;
+                let Some(raw_name) = self.mapper().slice(id.span()).strip_prefix("v-") else {
+                    return DirectiveAttributeLowering::NotDirective;
+                };
                 (raw_name, None)
             }
         };
@@ -221,7 +233,10 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
                     .modifiers
                     .push(SimpleExpressionNode::new(modifier, false, loc.clone()));
             }
-            return Some(PropNode::Directive(Box::new_in(directive, self.bump())));
+            return DirectiveAttributeLowering::Lowered(PropNode::Directive(Box::new_in(
+                directive,
+                self.bump(),
+            )));
         }
 
         // `v-model={[value, ['trim']]}` — babel-plugin-jsx encodes the model
@@ -232,9 +247,14 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         if raw_name == "model"
             && arg.is_none()
             && let Some(array) = self.array_literal_value(attr.value.as_ref())
-            && let Some(prop) = self.lower_model_array(array, loc)
         {
-            return Some(prop);
+            match self.lower_model_array(array, loc) {
+                ModelArrayLowering::Lowered(prop) => {
+                    return DirectiveAttributeLowering::Lowered(prop);
+                }
+                ModelArrayLowering::Rejected => return DirectiveAttributeLowering::Rejected,
+                ModelArrayLowering::Unrecognized => {}
+            }
         }
 
         // `v-custom={[value, 'arg', ['a','b']]}` — babel-plugin-jsx's array
@@ -250,7 +270,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             && let Some(array) = self.array_literal_value(attr.value.as_ref())
             && let Some(prop) = self.lower_custom_directive_array(array, raw_name, loc)
         {
-            return Some(prop);
+            return DirectiveAttributeLowering::Lowered(prop);
         }
 
         let mut directive = DirectiveNode::new(self.bump(), raw_name, loc.clone());
@@ -258,7 +278,10 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             directive.arg = Some(self.static_expr(arg_name, arg_span));
         }
         directive.exp = self.directive_value_expr(attr.value.as_ref());
-        Some(PropNode::Directive(Box::new_in(directive, self.bump())))
+        DirectiveAttributeLowering::Lowered(PropNode::Directive(Box::new_in(
+            directive,
+            self.bump(),
+        )))
     }
 
     fn directive_value_expr(

--- a/crates/vize_atelier_jsx/src/lower/v_model.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_model.rs
@@ -21,6 +21,16 @@ use vize_relief::{DirectiveNode, PropNode, SimpleExpressionNode};
 use super::Lowerer;
 use crate::diagnostics::JsxDiagnostic;
 
+/// Result of parsing babel-plugin-jsx's positional `v-model` array form.
+pub(crate) enum ModelArrayLowering<'a> {
+    /// The array was lowered into a model directive.
+    Lowered(PropNode<'a>),
+    /// The array shape was not recognizable and may use the generic fallback.
+    Unrecognized,
+    /// The array was recognized but rejected with a diagnostic.
+    Rejected,
+}
+
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Reject a `v-model` whose bound target cannot be assigned to.
     ///
@@ -113,28 +123,32 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     ///   - a trailing array-literal element: modifiers  -> `directive.modifiers`
     ///   - an intermediate string-literal element: arg  -> `directive.arg`
     ///
-    /// Returns `None` (fall back to default handling) for shapes we cannot
+    /// Returns [`ModelArrayLowering::Unrecognized`] for shapes we cannot
     /// confidently destructure (e.g. empty array, spread/hole elements).
+    /// Recognized dynamic arguments are rejected instead of being silently
+    /// discarded: representing them requires computed prop codegen (#3466).
     pub(crate) fn lower_model_array(
-        &self,
+        &mut self,
         array: &oxc_ast::ast::ArrayExpression<'_>,
         loc: &SourceLocation,
-    ) -> Option<PropNode<'a>> {
+    ) -> ModelArrayLowering<'a> {
         // Collect the plain (non-hole, non-spread) expression elements.
         let mut elems: std::vec::Vec<&Expression<'_>> = std::vec::Vec::new();
         for element in &array.elements {
             match element {
                 ArrayExpressionElement::SpreadElement(_) | ArrayExpressionElement::Elision(_) => {
-                    return None;
+                    return ModelArrayLowering::Unrecognized;
                 }
                 _ => match element.as_expression() {
                     Some(expr) => elems.push(expr),
-                    None => return None,
+                    None => return ModelArrayLowering::Unrecognized,
                 },
             }
         }
 
-        let value_expr = *elems.first()?;
+        let Some(value_expr) = elems.first().copied() else {
+            return ModelArrayLowering::Unrecognized;
+        };
 
         // A trailing array-literal element is the modifiers list. Its index marks
         // the boundary so a middle string element can be recognized as the arg.
@@ -143,15 +157,33 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             _ => None,
         };
 
-        let mut directive = DirectiveNode::new(self.bump(), "model", loc.clone());
-        directive.exp = Some(self.dyn_expr(value_expr.span()));
-
         // An intermediate string-literal element (index 1, before any modifiers
         // array) is the arg: the bound prop name for component v-model.
-        if let Some(Expression::StringLiteral(s)) = elems.get(1).copied()
-            && modifiers_idx != Some(1)
-        {
-            directive.arg = Some(self.static_expr(s.value.as_str(), s.span));
+        let arg = if modifiers_idx == Some(1) {
+            None
+        } else {
+            match elems.get(1).copied() {
+                Some(Expression::StringLiteral(string)) => Some(string),
+                Some(expression) => {
+                    let span = expression.span();
+                    let source = self.mapper().slice(span);
+                    self.reject_at(
+                        span,
+                        format_args!(
+                            "v-model argument `{source}` must be a string literal; dynamic \
+                             arguments are not supported."
+                        ),
+                    );
+                    return ModelArrayLowering::Rejected;
+                }
+                None => None,
+            }
+        };
+
+        let mut directive = DirectiveNode::new(self.bump(), "model", loc.clone());
+        directive.exp = Some(self.dyn_expr(value_expr.span()));
+        if let Some(string) = arg {
+            directive.arg = Some(self.static_expr(string.value.as_str(), string.span));
         }
 
         if let Some(idx) = modifiers_idx
@@ -169,7 +201,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             }
         }
 
-        Some(PropNode::Directive(Box::new_in(directive, self.bump())))
+        ModelArrayLowering::Lowered(PropNode::Directive(Box::new_in(directive, self.bump())))
     }
 }
 

--- a/crates/vize_atelier_jsx/src/lower/v_models.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_models.rs
@@ -29,6 +29,8 @@
 //!   ("You should pass a Two-dimensional Arrays to v-models").
 //! - an entry whose target cannot be assigned to, for the same reason `v-model`
 //!   rejects one (#3420): the write-back compiles to `target = $event`.
+//! - an entry with a non-string argument. Dynamic argument support needs
+//!   computed prop and update-listener codegen, so it is diagnosed (#3466).
 //! - `v-models` on a plain element. Babel: "v-models can only use in custom
 //!   components".
 //!
@@ -46,7 +48,7 @@ use vize_carton::Vec;
 use vize_relief::PropNode;
 
 use super::Lowerer;
-use super::v_model::is_assignable_target;
+use super::v_model::{ModelArrayLowering, is_assignable_target};
 
 /// How a `v-models` attribute was spelled.
 enum Form {
@@ -194,8 +196,9 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             }
 
             match self.lower_model_array(entry, &loc) {
-                Some(prop) => lowered.push(prop),
-                None => {
+                ModelArrayLowering::Lowered(prop) => lowered.push(prop),
+                ModelArrayLowering::Rejected => rejected = true,
+                ModelArrayLowering::Unrecognized => {
                     let source = self.mapper().slice(element_span);
                     self.reject_at(
                         element_span,

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -153,26 +153,26 @@ deliberate answer, recorded here so it is not relitigated.
 
 ## Directives
 
-| Case                                    | Babel                                                          | Vize today                                                      | Compat mode             | Verdict |
-| --------------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------- | ----------------------- | ------- |
-| `directives/v_model_input`              | `withDirectives(…, [[vModelText, val]])`                       | same                                                            | no change               | ✅      |
-| `directives/v_model_arg`                | `[[vModelText, val, "foo"]]` + `onUpdate:foo`                  | rejected: "v-model argument is not supported on plain elements" | accept and pass the arg | ❌      |
-| `directives/v_model_modifier_array`     | `[[vModelText, val, void 0, {trim: true}]]`                    | same                                                            | no change               | ✅      |
-| `directives/v_model_underscore`         | `{lazy: true}` modifiers                                       | same                                                            | no change               | ✅      |
-| `directives/v_model_arg_underscore`     | `[[vModelText, val, "foo", {trim: true}]]`                     | rejected as above                                               | accept and pass the arg | ❌      |
-| `directives/v_model_component`          | `modelValue` + `onUpdate:modelValue` props                     | same                                                            | no change               | ✅      |
-| `directives/v_model_component_arg_mods` | `argument`, `argumentModifiers`, `onUpdate:argument`           | same props, different literal order                             | no change               | ✅      |
-| `directives/v_model_component_dynamic_arg` | computed prop + `"onUpdate:" + bar`                         | rejected: dynamic arguments need computed prop lowering (#3466) | add computed prop IR     | ❌      |
-| `directives/v_models`                   | expands to one prop pair per entry                             | same, via one `model` directive per entry (#3418)               | no change               | ✅      |
-| `directives/v_models_mods`              | adds `<arg>Modifiers` per entry                                | same props, different literal order (#3418)                     | no change               | ✅      |
-| `directives/v_show_element`             | `[[vShow, vis]]`                                               | same                                                            | no change               | ✅      |
-| `directives/v_show_component`           | `[[vShow, vis]]` on the component vnode                        | same                                                            | no change               | ✅      |
-| `directives/v_html`                     | `{innerHTML: h}`                                               | same                                                            | no change               | ✅      |
-| `directives/v_html_with_children`       | keeps the children too                                         | same                                                            | no change               | ✅      |
-| `directives/v_text`                     | `{textContent: t}` raw                                         | `textContent: toDisplayString(t)`                               | assign raw              | ❌      |
-| `directives/v_custom_arg`               | `[[resolveDirective("custom"), val, "arg"]]`                   | same                                                            | no change               | ✅      |
-| `directives/v_custom_array`             | unpacks `[val, 'arg', ['a','b']]` into value / arg / modifiers | same (#3421)                                                    | no change               | ✅      |
-| `directives/v_dashed_custom`            | `resolveDirective("unknown-thing")`                            | same                                                            | no change               | ✅      |
+| Case                                       | Babel                                                          | Vize today                                                      | Compat mode             | Verdict |
+| ------------------------------------------ | -------------------------------------------------------------- | --------------------------------------------------------------- | ----------------------- | ------- |
+| `directives/v_model_input`                 | `withDirectives(…, [[vModelText, val]])`                       | same                                                            | no change               | ✅      |
+| `directives/v_model_arg`                   | `[[vModelText, val, "foo"]]` + `onUpdate:foo`                  | rejected: "v-model argument is not supported on plain elements" | accept and pass the arg | ❌      |
+| `directives/v_model_modifier_array`        | `[[vModelText, val, void 0, {trim: true}]]`                    | same                                                            | no change               | ✅      |
+| `directives/v_model_underscore`            | `{lazy: true}` modifiers                                       | same                                                            | no change               | ✅      |
+| `directives/v_model_arg_underscore`        | `[[vModelText, val, "foo", {trim: true}]]`                     | rejected as above                                               | accept and pass the arg | ❌      |
+| `directives/v_model_component`             | `modelValue` + `onUpdate:modelValue` props                     | same                                                            | no change               | ✅      |
+| `directives/v_model_component_arg_mods`    | `argument`, `argumentModifiers`, `onUpdate:argument`           | same props, different literal order                             | no change               | ✅      |
+| `directives/v_model_component_dynamic_arg` | computed prop + `"onUpdate:" + bar`                            | rejected: dynamic arguments need computed prop lowering (#3466) | add computed prop IR    | ❌      |
+| `directives/v_models`                      | expands to one prop pair per entry                             | same, via one `model` directive per entry (#3418)               | no change               | ✅      |
+| `directives/v_models_mods`                 | adds `<arg>Modifiers` per entry                                | same props, different literal order (#3418)                     | no change               | ✅      |
+| `directives/v_show_element`                | `[[vShow, vis]]`                                               | same                                                            | no change               | ✅      |
+| `directives/v_show_component`              | `[[vShow, vis]]` on the component vnode                        | same                                                            | no change               | ✅      |
+| `directives/v_html`                        | `{innerHTML: h}`                                               | same                                                            | no change               | ✅      |
+| `directives/v_html_with_children`          | keeps the children too                                         | same                                                            | no change               | ✅      |
+| `directives/v_text`                        | `{textContent: t}` raw                                         | `textContent: toDisplayString(t)`                               | assign raw              | ❌      |
+| `directives/v_custom_arg`                  | `[[resolveDirective("custom"), val, "arg"]]`                   | same                                                            | no change               | ✅      |
+| `directives/v_custom_array`                | unpacks `[val, 'arg', ['a','b']]` into value / arg / modifiers | same (#3421)                                                    | no change               | ✅      |
+| `directives/v_dashed_custom`               | `resolveDirective("unknown-thing")`                            | same                                                            | no change               | ✅      |
 
 ### `v-models` spellings Vize rejects and babel accepts
 

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -13,7 +13,7 @@ opt-in compat mode (#3391) is expected to change.
 
 | Artifact                                  | Role                                                                                                       |
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `babel_compat/fixtures/corpus.json`       | the 97 inputs + the babel plugin options each is compiled with                                             |
+| `babel_compat/fixtures/corpus.json`       | the 98 inputs + the babel plugin options each is compiled with                                             |
 | `babel_compat/oracle.mjs`                 | runs the corpus through the real plugin; `--write` records, `--check` verifies                             |
 | `babel_compat/fixtures/babel-output.json` | committed ground truth (generated — do not hand-edit)                                                      |
 | `../babel_compat_oracle.rs`               | snapshots babel's output beside Vize's, per category, with a verdict per row                               |
@@ -56,7 +56,7 @@ numbers cannot drift from the verdict table.
 | Verdict    | Rows |
 | ---------- | ---: |
 | equivalent |   72 |
-| divergent  |   23 |
+| divergent  |   24 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -162,6 +162,7 @@ deliberate answer, recorded here so it is not relitigated.
 | `directives/v_model_arg_underscore`     | `[[vModelText, val, "foo", {trim: true}]]`                     | rejected as above                                               | accept and pass the arg | ❌      |
 | `directives/v_model_component`          | `modelValue` + `onUpdate:modelValue` props                     | same                                                            | no change               | ✅      |
 | `directives/v_model_component_arg_mods` | `argument`, `argumentModifiers`, `onUpdate:argument`           | same props, different literal order                             | no change               | ✅      |
+| `directives/v_model_component_dynamic_arg` | computed prop + `"onUpdate:" + bar`                         | rejected: dynamic arguments need computed prop lowering (#3466) | add computed prop IR     | ❌      |
 | `directives/v_models`                   | expands to one prop pair per entry                             | same, via one `model` directive per entry (#3418)               | no change               | ✅      |
 | `directives/v_models_mods`              | adds `<arg>Modifiers` per entry                                | same props, different literal order (#3418)                     | no change               | ✅      |
 | `directives/v_show_element`             | `[[vShow, vis]]`                                               | same                                                            | no change               | ✅      |

--- a/crates/vize_atelier_jsx/tests/babel_compat/fixtures/babel-output.json
+++ b/crates/vize_atelier_jsx/tests/babel_compat/fixtures/babel-output.json
@@ -199,6 +199,10 @@
       "status": "ok",
       "code": "import { resolveComponent as _resolveComponent, createVNode as _createVNode } from \"vue\";\nconst A = () => _createVNode(_resolveComponent(\"B\"), {\n  'argument': val,\n  \"argumentModifiers\": {\n    \"modifier\": true\n  },\n  \"onUpdate:argument\": $event => val = $event\n}, null);"
     },
+    "directives/v_model_component_dynamic_arg": {
+      "status": "ok",
+      "code": "import { resolveComponent as _resolveComponent, createVNode as _createVNode } from \"vue\";\nconst A = () => _createVNode(_resolveComponent(\"B\"), {\n  [bar]: foo,\n  [\"onUpdate:\" + bar]: $event => foo = $event\n}, null);"
+    },
     "directives/v_models": {
       "status": "ok",
       "code": "import { resolveComponent as _resolveComponent, createVNode as _createVNode } from \"vue\";\nconst A = () => _createVNode(_resolveComponent(\"B\"), {\n  \"modelValue\": foo,\n  \"onUpdate:modelValue\": $event => foo = $event,\n  'bar': bar,\n  \"onUpdate:bar\": $event => bar = $event\n}, null);"

--- a/crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json
+++ b/crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json
@@ -314,6 +314,12 @@
       "source": "const A = () => <B v-model={[val, 'argument', ['modifier']]}/>;"
     },
     {
+      "id": "directives/v_model_component_dynamic_arg",
+      "category": "directives",
+      "lang": "jsx",
+      "source": "const A = () => <B v-model={[foo, bar]}/>;"
+    },
+    {
       "id": "directives/v_models",
       "category": "directives",
       "lang": "jsx",

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -101,6 +101,10 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ),
     ("directives/v_model_component", Same),
     ("directives/v_model_component_arg_mods", Same),
+    (
+        "directives/v_model_component_dynamic_arg",
+        Diff("dynamic v-model argument diagnosed; needs computed prop lowering"),
+    ),
     // Closed by #3418: `v-models` expands to one model binding per entry.
     ("directives/v_models", Same),
     ("directives/v_models_mods", Same),

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,8 +80,8 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (72, 23, 2));
-    assert_eq!(VERDICTS.len(), 97);
+    assert_eq!((equivalent, divergent, deferred), (72, 24, 2));
+    assert_eq!(VERDICTS.len(), 98);
 }
 
 #[test]

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
@@ -174,6 +174,28 @@ export function render(_ctx, _cache) {
   }, null, 8 /* PROPS */, ["argument", "onUpdate:argument"]))
 }
 
+## directives/v_model_component_dynamic_arg
+### verdict
+divergent: dynamic v-model argument diagnosed; needs computed prop lowering
+### source (jsx)
+const A = () => <B v-model={[foo, bar]}/>;
+### babel options
+(defaults)
+### babel
+import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
+const A = () => _createVNode(_resolveComponent("B"), {
+  [bar]: foo,
+  ["onUpdate:" + bar]: $event => foo = $event
+}, null);
+### vize (vdom, default config)
+<Error> v-model argument `bar` must be a string literal; dynamic arguments are not supported.
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+export function render(_ctx, _cache) {
+  const _component_B = _resolveComponent("B")
+  
+  return (_openBlock(), _createBlock(_component_B))
+}
+
 ## directives/v_models
 ### verdict
 equivalent

--- a/crates/vize_atelier_jsx/tests/v_model_argument.rs
+++ b/crates/vize_atelier_jsx/tests/v_model_argument.rs
@@ -1,0 +1,42 @@
+//! `v-model` array-form argument validation (#3466).
+//!
+//! A non-literal argument needs computed prop keys and update-listener names.
+//! Until that codegen exists, lowering must reject the input instead of
+//! silently binding `modelValue` and changing the component contract.
+
+use vize_atelier_jsx::{JsxLang, VdomCompileOptions, compile_to_vdom, lower_source};
+use vize_carton::Bump;
+
+const SOURCE: &str = "const A = () => <B v-model={[foo, bar]}/>;";
+
+#[test]
+fn dynamic_array_argument_is_rejected_without_model_value_fallback() {
+    let bump = Bump::new();
+    let lowered = lower_source(&bump, SOURCE, JsxLang::Jsx);
+    let errors: Vec<_> = lowered
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.is_error())
+        .collect();
+
+    assert_eq!(errors.len(), 1);
+    assert_eq!(
+        errors[0].message.as_str(),
+        "v-model argument `bar` must be a string literal; dynamic arguments are not supported."
+    );
+    assert_eq!(
+        &SOURCE[errors[0].start as usize..errors[0].end as usize],
+        "bar"
+    );
+
+    let bump = Bump::new();
+    let compiled = compile_to_vdom(&bump, SOURCE, JsxLang::Jsx, VdomCompileOptions::default());
+    assert!(compiled.has_errors());
+    assert_eq!(compiled.components.len(), 1);
+    assert_eq!(
+        compiled.components[0].code.as_str(),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B))\n}"
+    );
+}

--- a/crates/vize_atelier_jsx/tests/v_models.rs
+++ b/crates/vize_atelier_jsx/tests/v_models.rs
@@ -241,6 +241,24 @@ fn a_non_assignable_entry_target_is_rejected() {
 }
 
 #[test]
+fn a_dynamic_entry_argument_rejects_the_whole_attribute() {
+    let source = "const A = () => <B v-models={[[ok], [foo, bar]]}/>;";
+    assert_eq!(
+        errors(source),
+        vec![
+            "v-model argument `bar` must be a string literal; dynamic arguments are not supported."
+                .to_string()
+        ]
+    );
+    assert_eq!(
+        render_code(source),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B))\n}"
+    );
+}
+
+#[test]
 fn the_argument_spelling_is_rejected() {
     // Babel accepts `v-models:x` but then ignores every entry's own argument:
     // `v-models:x={[[a], [b, "b"]]}` binds `x` and `modelValue`, never `b`.


### PR DESCRIPTION
## Summary

- reject non-string array-form v-model arguments with a hard diagnostic
- consume rejected attributes completely so no modelValue or generic prop fallback is emitted
- add focused regressions and a real Babel differential-oracle row

## Tests

- cargo test -p vize_atelier_jsx
- cargo clippy -p vize_atelier_jsx --lib -- -D warnings
- cargo fmt --all -- --check
- node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check
- node --test tests/tooling/babel-jsx-oracle.test.ts

Closes #3466

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->