### PR TITLE
feat(maestro): complete native attribute values

### DIFF
--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -68,9 +68,7 @@ pub(crate) fn complete_template(ctx: &IdeContext) -> Vec<CompletionItem> {
                 return if is_expression_valued_attribute(name) {
                     analyzed_template_binding_completions(ctx, true)
                 } else {
-                    // A plain HTML attribute takes a literal, not an
-                    // expression. Its allowed values are not modelled (#3484).
-                    Vec::new()
+                    native::native_element_attribute_value_completions(&tag_ctx.tag_name, name)
                 };
             }
 

--- a/crates/vize_maestro/src/ide/completion/template/attribute_value_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/template/attribute_value_tests.rs
@@ -17,6 +17,7 @@ const label = 'x'
 function pick(n: number) { return n }
 </script>
 <template>
+  <input type= class= />
   <button :title= @click= v-if= type= class= />
 </template>
 "#;
@@ -57,14 +58,57 @@ fn a_bound_attribute_offers_the_template_bindings_right_after_the_equals() {
 }
 
 #[test]
-fn a_plain_html_attribute_offers_nothing_after_the_equals() {
-    // Its value is a literal, not an expression, so the bindings would be
-    // wrong. The set of allowed literals is not modelled (#3484).
-    for marker in ["type=", "class="] {
-        assert_eq!(
-            labels_after(marker),
-            Vec::<String>::new(),
-            "`{marker}` takes a literal, not an expression"
-        );
+fn plain_html_type_values_are_specific_to_the_element() {
+    assert_eq!(
+        labels_after("<button :title= @click= v-if= type="),
+        ["button", "reset", "submit"].map(str::to_string),
+    );
+    assert_eq!(
+        labels_after("<input type="),
+        [
+            "button",
+            "checkbox",
+            "color",
+            "date",
+            "datetime",
+            "datetime-local",
+            "email",
+            "file",
+            "hidden",
+            "image",
+            "month",
+            "number",
+            "password",
+            "radio",
+            "range",
+            "reset",
+            "search",
+            "submit",
+            "tel",
+            "text",
+            "time",
+            "url",
+            "week",
+        ]
+        .map(str::to_string),
+    );
+}
+
+#[test]
+fn literal_valued_attributes_never_offer_template_bindings() {
+    for marker in [
+        "<input type=",
+        "<button :title= @click= v-if= type=",
+        "class=",
+    ] {
+        let labels = labels_after(marker);
+        for binding in ["count", "label", "pick"] {
+            assert!(
+                !labels.iter().any(|label| label == binding),
+                "{marker}: {labels:?}"
+            );
+        }
     }
+
+    assert_eq!(labels_after("class="), Vec::<String>::new());
 }

--- a/crates/vize_maestro/src/ide/completion/template/native.rs
+++ b/crates/vize_maestro/src/ide/completion/template/native.rs
@@ -1,6 +1,6 @@
 //! Native HTML attribute completions for template opening tags.
 
-use tower_lsp::lsp_types::CompletionItem;
+use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
 
 use crate::ide::completion::items;
 use crate::ide::{IdeContext, is_component_tag};
@@ -21,6 +21,55 @@ pub(super) fn native_element_attribute_completions(ctx: &IdeContext) -> Vec<Comp
     let mut items = common_attribute_completions();
     items.extend(tag_attribute_completions(&tag_ctx.tag_name));
     items
+}
+
+pub(super) fn native_element_attribute_value_completions(
+    tag_name: &str,
+    attribute_name: &str,
+) -> Vec<CompletionItem> {
+    if is_component_tag(tag_name) || attribute_name != "type" {
+        return Vec::new();
+    }
+
+    let values: &[&str] = match tag_name {
+        "button" => &["button", "submit", "reset"],
+        "input" => &[
+            "hidden",
+            "text",
+            "search",
+            "tel",
+            "url",
+            "email",
+            "password",
+            "datetime",
+            "date",
+            "month",
+            "week",
+            "time",
+            "datetime-local",
+            "number",
+            "range",
+            "color",
+            "checkbox",
+            "radio",
+            "file",
+            "submit",
+            "image",
+            "reset",
+            "button",
+        ],
+        _ => return Vec::new(),
+    };
+
+    values
+        .iter()
+        .map(|value| CompletionItem {
+            label: (*value).to_string(),
+            kind: Some(CompletionItemKind::VALUE),
+            insert_text: Some((*value).to_string()),
+            ..Default::default()
+        })
+        .collect()
 }
 
 fn common_attribute_completions() -> Vec<CompletionItem> {


### PR DESCRIPTION
Closes #3484.

## Summary

- offer the HTML language data value set for input type immediately after the equals sign
- offer the element-specific button type value set instead of reusing input values
- keep arbitrary literal positions such as class free of template binding completions

## Verification

- exact sorted label assertions for input type and button type
- must-exclude assertions for all template bindings
- cargo test -p vize_maestro: 633 passed, 1 ignored
- cargo clippy -p vize_maestro --lib -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->