### PR TITLE
fix(patina): anchor unused props at declarations

### DIFF
--- a/crates/vize_croquis/src/drawer/tests/snapshots/vize_croquis__drawer__tests__script__drawer_script_bindings.snap
+++ b/crates/vize_croquis/src/drawer/tests/snapshots/vize_croquis__drawer__tests__script__drawer_script_bindings.snap
@@ -1199,6 +1199,7 @@ Croquis {
     macros: MacroTracker {
         calls: [],
         props: [],
+        prop_declarations: {},
         emits: [],
         emit_calls: [],
         models: [],

--- a/crates/vize_croquis/src/macros.rs
+++ b/crates/vize_croquis/src/macros.rs
@@ -3,6 +3,8 @@
 //! Tracks Vue compiler macros (defineProps, defineEmits, etc.)
 //! and provides a plugin interface for custom macros.
 
+mod tracker;
+
 use vize_carton::{CompactString, FxHashMap};
 
 pub const DEFINE_PROPS: &str = "defineProps";
@@ -360,10 +362,12 @@ pub enum MacroBindingKind {
 }
 
 /// Tracks compiler macros during analysis
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct MacroTracker {
     calls: Vec<MacroCall>,
     props: Vec<PropDefinition>,
+    /// Written prop declarations, relative to the parsed script block.
+    prop_declarations: FxHashMap<CompactString, (u32, u32)>,
     emits: Vec<EmitDefinition>,
     /// Actual emit() calls in the code (not declarations)
     emit_calls: Vec<EmitCall>,
@@ -478,18 +482,6 @@ impl MacroTracker {
     #[inline]
     pub fn define_art(&self) -> Option<&ArtDefinition> {
         self.art.as_ref()
-    }
-
-    /// Add a prop definition
-    #[inline]
-    pub fn add_prop(&mut self, prop: PropDefinition) {
-        self.props.push(prop);
-    }
-
-    /// Get all props
-    #[inline]
-    pub fn props(&self) -> &[PropDefinition] {
-        &self.props
     }
 
     /// Add an emit definition
@@ -619,22 +611,6 @@ impl MacroTracker {
     #[inline]
     pub fn is_async(&self) -> bool {
         self.has_top_level_await()
-    }
-
-    /// Shift all stored source offsets by `delta`.
-    pub fn shift_offsets(&mut self, delta: u32) {
-        for call in &mut self.calls {
-            call.start = call.start.saturating_add(delta);
-            call.end = call.end.saturating_add(delta);
-        }
-        for call in &mut self.emit_calls {
-            call.start = call.start.saturating_add(delta);
-            call.end = call.end.saturating_add(delta);
-        }
-        for await_expr in &mut self.top_level_awaits {
-            await_expr.start = await_expr.start.saturating_add(delta);
-            await_expr.end = await_expr.end.saturating_add(delta);
-        }
     }
 }
 

--- a/crates/vize_croquis/src/macros/tracker.rs
+++ b/crates/vize_croquis/src/macros/tracker.rs
@@ -1,0 +1,76 @@
+//! Focused [`MacroTracker`](super::MacroTracker) implementations.
+
+use super::{MacroTracker, PropDefinition};
+
+impl std::fmt::Debug for MacroTracker {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MacroTracker")
+            .field("calls", &self.calls)
+            .field("props", &self.props)
+            .field("prop_declarations", &self.prop_declarations)
+            .field("emits", &self.emits)
+            .field("emit_calls", &self.emit_calls)
+            .field("models", &self.models)
+            .field("exposes", &self.exposes)
+            .field("slots", &self.slots)
+            .field("art", &self.art)
+            .field("props_destructure", &self.props_destructure)
+            .field("top_level_awaits", &self.top_level_awaits)
+            .field("next_id", &self.next_id)
+            .field("define_props_idx", &self.define_props_idx)
+            .field("define_emits_idx", &self.define_emits_idx)
+            .field("define_expose_idx", &self.define_expose_idx)
+            .field("define_slots_idx", &self.define_slots_idx)
+            .field("define_art_idx", &self.define_art_idx)
+            .finish()
+    }
+}
+
+impl MacroTracker {
+    /// Add a prop definition.
+    #[inline]
+    pub fn add_prop(&mut self, prop: PropDefinition) {
+        self.props.push(prop);
+    }
+
+    /// Add a prop together with the range of its written declaration.
+    #[inline]
+    pub fn add_prop_with_declaration(&mut self, prop: PropDefinition, start: u32, end: u32) {
+        self.prop_declarations
+            .insert(prop.name.clone(), (start, end));
+        self.props.push(prop);
+    }
+
+    /// Get all props.
+    #[inline]
+    pub fn props(&self) -> &[PropDefinition] {
+        &self.props
+    }
+
+    /// Get a prop's written declaration range, relative to its script block.
+    #[inline]
+    pub fn prop_declaration(&self, name: &str) -> Option<(u32, u32)> {
+        self.prop_declarations.get(name).copied()
+    }
+
+    /// Shift every stored script-relative source offset by `delta`.
+    pub fn shift_offsets(&mut self, delta: u32) {
+        for call in &mut self.calls {
+            call.start = call.start.saturating_add(delta);
+            call.end = call.end.saturating_add(delta);
+        }
+        for range in self.prop_declarations.values_mut() {
+            range.0 = range.0.saturating_add(delta);
+            range.1 = range.1.saturating_add(delta);
+        }
+        for call in &mut self.emit_calls {
+            call.start = call.start.saturating_add(delta);
+            call.end = call.end.saturating_add(delta);
+        }
+        for await_expr in &mut self.top_level_awaits {
+            await_expr.start = await_expr.start.saturating_add(delta);
+            await_expr.end = await_expr.end.saturating_add(delta);
+        }
+    }
+}

--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -47,6 +47,9 @@ mod legacy_vue2_tests;
 mod props_destructure_tests;
 
 #[cfg(test)]
+mod props_ranges_tests;
+
+#[cfg(test)]
 mod runtime_props_tests;
 
 #[cfg(test)]

--- a/crates/vize_croquis/src/script_parser/extract/props.rs
+++ b/crates/vize_croquis/src/script_parser/extract/props.rs
@@ -1,5 +1,6 @@
 use oxc_ast::ast::{
-    Argument, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey, TSType,
+    Argument, ArrayExpression, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey,
+    TSSignature, TSType,
 };
 use oxc_span::GetSpan;
 
@@ -18,12 +19,20 @@ pub fn extract_props_from_type(
     for tp in type_params.iter() {
         let type_source = tp.span().source_text(source);
         for prop in result.types.extract_properties(type_source) {
-            result.macros.add_prop(PropDefinition {
+            let declaration = type_prop_declaration(tp, prop.name.as_str());
+            let definition = PropDefinition {
                 name: prop.name.clone(),
                 required: !prop.optional,
                 prop_type: prop.prop_type,
                 default_value: None,
-            });
+            };
+            if let Some((start, end)) = declaration {
+                result
+                    .macros
+                    .add_prop_with_declaration(definition, start, end);
+            } else {
+                result.macros.add_prop(definition);
+            }
             result.bindings.add(prop.name.as_str(), BindingType::Props);
         }
     }
@@ -35,20 +44,7 @@ pub fn extract_props_from_runtime(
     source: &str,
 ) {
     match arg {
-        Argument::ArrayExpression(arr) => {
-            for elem in arr.elements.iter() {
-                if let oxc_ast::ast::ArrayExpressionElement::StringLiteral(s) = elem {
-                    let name = s.value.as_str();
-                    result.macros.add_prop(PropDefinition {
-                        name: CompactString::new(name),
-                        required: false,
-                        prop_type: None,
-                        default_value: None,
-                    });
-                    result.bindings.add(name, BindingType::Props);
-                }
-            }
-        }
+        Argument::ArrayExpression(arr) => extract_props_from_array(result, arr),
 
         Argument::ObjectExpression(obj) => {
             extract_props_from_object(result, obj, source);
@@ -77,20 +73,7 @@ fn extract_props_from_runtime_expression(
     source: &str,
 ) {
     match expr {
-        Expression::ArrayExpression(arr) => {
-            for elem in arr.elements.iter() {
-                if let oxc_ast::ast::ArrayExpressionElement::StringLiteral(s) = elem {
-                    let name = s.value.as_str();
-                    result.macros.add_prop(PropDefinition {
-                        name: CompactString::new(name),
-                        required: false,
-                        prop_type: None,
-                        default_value: None,
-                    });
-                    result.bindings.add(name, BindingType::Props);
-                }
-            }
-        }
+        Expression::ArrayExpression(arr) => extract_props_from_array(result, arr),
         Expression::ObjectExpression(obj) => extract_props_from_object(result, obj, source),
         Expression::TSAsExpression(ts_as) => {
             extract_props_from_runtime_expression(result, &ts_as.expression, source);
@@ -108,6 +91,25 @@ fn extract_props_from_runtime_expression(
     }
 }
 
+fn extract_props_from_array(result: &mut ScriptParseResult, arr: &ArrayExpression<'_>) {
+    for elem in arr.elements.iter() {
+        if let oxc_ast::ast::ArrayExpressionElement::StringLiteral(s) = elem {
+            let name = s.value.as_str();
+            result.macros.add_prop_with_declaration(
+                PropDefinition {
+                    name: CompactString::new(name),
+                    required: false,
+                    prop_type: None,
+                    default_value: None,
+                },
+                s.span.start,
+                s.span.end,
+            );
+            result.bindings.add(name, BindingType::Props);
+        }
+    }
+}
+
 fn extract_props_from_object(
     result: &mut ScriptParseResult,
     obj: &ObjectExpression<'_>,
@@ -119,7 +121,7 @@ fn extract_props_from_object(
                 let Some(name) = runtime_object_property_name(&p.key) else {
                     continue;
                 };
-                add_runtime_prop(
+                add_runtime_prop_with_declaration(
                     result,
                     PropDefinition {
                         name: CompactString::new(name),
@@ -127,6 +129,8 @@ fn extract_props_from_object(
                         prop_type: extract_runtime_prop_type(&p.value, source),
                         default_value: extract_runtime_prop_default(&p.value, source),
                     },
+                    p.key.span().start,
+                    p.span.end,
                 );
             }
             ObjectPropertyKind::SpreadProperty(spread) => {
@@ -148,9 +152,35 @@ fn extract_props_from_object(
     }
 }
 
+/// Locate an inline type-literal prop at its written name and cover the rest of
+/// its property signature. Referenced types do not declare a name inside the
+/// `defineProps` call, so callers fall back to the macro span for those forms.
+fn type_prop_declaration(type_param: &TSType<'_>, name: &str) -> Option<(u32, u32)> {
+    let TSType::TSTypeLiteral(literal) = type_param else {
+        return None;
+    };
+    literal.members.iter().find_map(|member| {
+        let TSSignature::TSPropertySignature(property) = member else {
+            return None;
+        };
+        (runtime_object_property_name(&property.key) == Some(name))
+            .then(|| (property.key.span().start, property.span.end))
+    })
+}
+
 fn add_runtime_prop(result: &mut ScriptParseResult, prop: PropDefinition) {
     result.bindings.add(prop.name.as_str(), BindingType::Props);
     result.macros.add_prop(prop);
+}
+
+fn add_runtime_prop_with_declaration(
+    result: &mut ScriptParseResult,
+    prop: PropDefinition,
+    start: u32,
+    end: u32,
+) {
+    result.bindings.add(prop.name.as_str(), BindingType::Props);
+    result.macros.add_prop_with_declaration(prop, start, end);
 }
 
 pub(super) fn runtime_object_property_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {

--- a/crates/vize_croquis/src/script_parser/props_ranges_tests.rs
+++ b/crates/vize_croquis/src/script_parser/props_ranges_tests.rs
@@ -1,0 +1,65 @@
+use super::parse_script_setup;
+
+#[test]
+fn type_props_retain_their_written_declaration_ranges() {
+    let source = r#"
+            const props = defineProps<{
+                msg: string
+                count?: number
+            }>()
+        "#;
+    let result = parse_script_setup(source);
+
+    assert_eq!(result.macros.all_calls().len(), 1);
+    assert_eq!(result.macros.props().len(), 2);
+    for (name, declaration) in [("msg", "msg: string"), ("count", "count?: number")] {
+        let (start, end) = result
+            .macros
+            .prop_declaration(name)
+            .expect("inline prop declaration range");
+        assert_eq!(&source[start as usize..end as usize], declaration);
+    }
+}
+
+#[test]
+fn runtime_array_props_retain_their_literal_ranges() {
+    let source = r#"
+            const props = defineProps(['foo', 'bar'])
+        "#;
+    let result = parse_script_setup(source);
+
+    assert_eq!(result.macros.props().len(), 2);
+    for (name, declaration) in [("foo", "'foo'"), ("bar", "'bar'")] {
+        let (start, end) = result
+            .macros
+            .prop_declaration(name)
+            .expect("runtime prop declaration range");
+        assert_eq!(&source[start as usize..end as usize], declaration);
+    }
+}
+
+#[test]
+fn shifting_macros_keeps_calls_and_prop_declarations_in_one_coordinate_space() {
+    let source = "defineProps<{ msg: string }>()";
+    let mut result = parse_script_setup(source);
+    let call_before = result
+        .macros
+        .define_props()
+        .expect("defineProps call")
+        .start;
+    let declaration_before = result
+        .macros
+        .prop_declaration("msg")
+        .expect("prop declaration");
+
+    result.macros.shift_offsets(17);
+
+    assert_eq!(
+        result.macros.define_props().expect("shifted call").start,
+        call_before + 17
+    );
+    assert_eq!(
+        result.macros.prop_declaration("msg"),
+        Some((declaration_before.0 + 17, declaration_before.1 + 17))
+    );
+}

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
@@ -15,6 +15,7 @@ ScriptParseResult {
     macros: MacroTracker {
         calls: [],
         props: [],
+        prop_declarations: {},
         emits: [],
         emit_calls: [],
         models: [],

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
@@ -15,6 +15,7 @@ ScriptParseResult {
     macros: MacroTracker {
         calls: [],
         props: [],
+        prop_declarations: {},
         emits: [],
         emit_calls: [],
         models: [],

--- a/crates/vize_croquis/src/script_parser/tests.rs
+++ b/crates/vize_croquis/src/script_parser/tests.rs
@@ -54,41 +54,6 @@ const run = async () => {
 }
 
 #[test]
-fn test_parse_define_props_type() {
-    let result = parse_script_setup(
-        r#"
-            const props = defineProps<{
-                msg: string
-                count?: number
-            }>()
-        "#,
-    );
-
-    assert_eq!(result.macros.all_calls().len(), 1);
-    assert_eq!(result.macros.props().len(), 2);
-
-    let prop_names: Vec<_> = result
-        .macros
-        .props()
-        .iter()
-        .map(|p| p.name.as_str())
-        .collect();
-    assert!(prop_names.contains(&"msg"));
-    assert!(prop_names.contains(&"count"));
-}
-
-#[test]
-fn test_parse_define_props_runtime() {
-    let result = parse_script_setup(
-        r#"
-            const props = defineProps(['foo', 'bar'])
-        "#,
-    );
-
-    assert_eq!(result.macros.props().len(), 2);
-}
-
-#[test]
 fn test_parse_define_props_runtime_object_spread_local_literal() {
     let result = parse_script_setup(
         r#"

--- a/crates/vize_patina/src/context.rs
+++ b/crates/vize_patina/src/context.rs
@@ -7,8 +7,11 @@
 mod directives;
 mod eslint_directive;
 mod helpers;
+mod reporting;
+mod sfc_directives;
 mod state;
 
+pub(crate) use reporting::offset_diagnostic;
 pub use state::{DisabledRange, ElementContext, SsrMode};
 
 use crate::diagnostic::{HelpLevel, LintDiagnostic, Severity};
@@ -24,6 +27,8 @@ use vize_carton::{
 };
 use vize_croquis::Croquis;
 
+use sfc_directives::SfcDirectiveState;
+
 /// Lint context provides utilities for rules during execution.
 ///
 /// Uses arena allocation for efficient memory management during lint traversal.
@@ -32,6 +37,8 @@ pub struct LintContext<'a> {
     allocator: &'a Allocator,
     /// Source code being linted.
     pub source: &'a str,
+    /// Byte offset of `source` within the containing SFC.
+    source_offset: u32,
     /// Filename for diagnostics.
     pub filename: &'a str,
     /// Locale for i18n (default: English).
@@ -76,6 +83,10 @@ pub struct LintContext<'a> {
     expected_error_lines: FxHashSet<u32>,
     /// Severity overrides from `@vize:level(...)` keyed by next-line number.
     severity_overrides: FxHashMap<u32, DirectiveSeverity>,
+    /// Directive state whose line numbers address the complete SFC source.
+    sfc_directives: Option<SfcDirectiveState>,
+    /// Whether SFC directives were inspected for an absolute-range report.
+    sfc_directives_scanned: bool,
 }
 
 impl<'a> LintContext<'a> {
@@ -101,6 +112,7 @@ impl<'a> LintContext<'a> {
         let mut ctx = Self {
             allocator,
             source,
+            source_offset: 0,
             filename,
             locale,
             diagnostics: Vec::with_capacity(Self::INITIAL_DIAGNOSTICS_CAPACITY),
@@ -123,6 +135,8 @@ impl<'a> LintContext<'a> {
             help_level: HelpLevel::default(),
             expected_error_lines: FxHashSet::default(),
             severity_overrides: FxHashMap::default(),
+            sfc_directives: None,
+            sfc_directives_scanned: false,
         };
         ctx.prescan_eslint_disable_comments();
         ctx
@@ -139,6 +153,7 @@ impl<'a> LintContext<'a> {
         let mut ctx = Self {
             allocator,
             source,
+            source_offset: 0,
             filename,
             locale: Locale::default(),
             diagnostics: Vec::with_capacity(Self::INITIAL_DIAGNOSTICS_CAPACITY),
@@ -161,6 +176,8 @@ impl<'a> LintContext<'a> {
             help_level: HelpLevel::default(),
             expected_error_lines: FxHashSet::default(),
             severity_overrides: FxHashMap::default(),
+            sfc_directives: None,
+            sfc_directives_scanned: false,
         };
         ctx.prescan_eslint_disable_comments();
         ctx
@@ -339,48 +356,5 @@ impl<'a> LintContext<'a> {
     #[inline]
     pub fn alloc_str(&self, s: &str) -> &'a str {
         self.allocator.alloc_str(s)
-    }
-
-    /// Report a lint diagnostic.
-    #[inline]
-    pub fn report(&mut self, mut diagnostic: LintDiagnostic) {
-        // Check if this rule is enabled
-        if !self.is_rule_enabled(diagnostic.rule_name) {
-            return;
-        }
-
-        // Check if this diagnostic is disabled via comments
-        let line = self.offset_to_line(diagnostic.start);
-        if self.is_disabled_at(diagnostic.rule_name, line) {
-            return;
-        }
-
-        // Check if this line has an @vize:expected directive. Use
-        // `contains`, not `remove`, so a line that legitimately emits
-        // multiple diagnostics has them all suppressed (#968).
-        if self.expected_error_lines.contains(&line) {
-            return;
-        }
-
-        if let Some(severity) = self.config_rule_severities.get(diagnostic.rule_name) {
-            diagnostic.severity = *severity;
-        }
-
-        // Apply @vize:level severity override. Same reasoning: the directive
-        // applies to every diagnostic on the targeted line, not just the
-        // first one we happen to report. (#968)
-        if let Some(override_severity) = self.severity_overrides.get(&line).copied() {
-            match override_severity {
-                DirectiveSeverity::Off => return,
-                DirectiveSeverity::Warn => diagnostic.severity = Severity::Warning,
-                DirectiveSeverity::Error => diagnostic.severity = Severity::Error,
-            }
-        }
-
-        match diagnostic.severity {
-            Severity::Error => self.error_count += 1,
-            Severity::Warning => self.warning_count += 1,
-        }
-        self.diagnostics.push(diagnostic);
     }
 }

--- a/crates/vize_patina/src/context/reporting.rs
+++ b/crates/vize_patina/src/context/reporting.rs
@@ -73,12 +73,15 @@ impl<'a> LintContext<'a> {
                 self.expected_error_lines.contains(&line),
                 self.severity_overrides.get(&line).copied(),
             ),
+            // Read through the lazy accessor so a caller that reports an
+            // SFC-absolute range without resolving directives first still
+            // honours full-document comments.
             DirectiveDomain::Sfc => {
-                self.sfc_directives
-                    .as_ref()
+                let rule_name = diagnostic.rule_name;
+                self.sfc_directives()
                     .map_or((false, false, None), |directives| {
                         (
-                            directives.is_disabled_at(diagnostic.rule_name, line),
+                            directives.is_disabled_at(rule_name, line),
                             directives.is_expected_at(line),
                             directives.severity_at(line),
                         )

--- a/crates/vize_patina/src/context/reporting.rs
+++ b/crates/vize_patina/src/context/reporting.rs
@@ -1,0 +1,128 @@
+//! Diagnostic reporting shared by template-local and SFC-absolute ranges.
+
+use crate::diagnostic::{LintDiagnostic, Severity};
+use vize_atelier_sfc::SfcDescriptor;
+use vize_carton::directive::DirectiveSeverity;
+
+use super::{LintContext, SfcDirectiveState};
+
+#[derive(Clone, Copy)]
+enum DirectiveDomain {
+    Template,
+    Sfc,
+}
+
+impl<'a> LintContext<'a> {
+    /// Attach an SFC descriptor to a template context and prepare its absolute
+    /// source position. Full-document directives remain lazy until needed.
+    pub fn set_sfc_template_descriptor(&mut self, descriptor: &'a SfcDescriptor<'a>) {
+        self.source_offset = descriptor
+            .template
+            .as_ref()
+            .map_or(0, |template| template.loc.start as u32);
+        self.sfc_directives = None;
+        self.sfc_directives_scanned = false;
+        self.set_sfc_descriptor(descriptor);
+    }
+
+    /// Report a diagnostic whose range addresses the context's local source.
+    #[inline]
+    pub fn report(&mut self, diagnostic: LintDiagnostic) {
+        let line = self.offset_to_line(diagnostic.start);
+        self.report_at_line(
+            diagnostic,
+            line,
+            DirectiveDomain::Template,
+            self.source_offset,
+        );
+    }
+
+    /// Report a diagnostic whose range already addresses the containing SFC.
+    #[inline]
+    pub fn report_in_sfc(&mut self, diagnostic: LintDiagnostic) {
+        let line = self
+            .sfc_directives()
+            .map_or(0, |directives| directives.offset_to_line(diagnostic.start));
+        self.report_at_line(diagnostic, line, DirectiveDomain::Sfc, 0);
+    }
+
+    fn sfc_directives(&mut self) -> Option<&SfcDirectiveState> {
+        if !self.sfc_directives_scanned {
+            self.sfc_directives_scanned = true;
+            self.sfc_directives = self
+                .sfc_descriptor
+                .and_then(|descriptor| SfcDirectiveState::scan_if_present(&descriptor.source));
+        }
+        self.sfc_directives.as_ref()
+    }
+
+    fn report_at_line(
+        &mut self,
+        mut diagnostic: LintDiagnostic,
+        line: u32,
+        domain: DirectiveDomain,
+        output_offset: u32,
+    ) {
+        if !self.is_rule_enabled(diagnostic.rule_name) {
+            return;
+        }
+
+        let (disabled, expected, override_severity) = match domain {
+            DirectiveDomain::Template => (
+                self.is_disabled_at(diagnostic.rule_name, line),
+                self.expected_error_lines.contains(&line),
+                self.severity_overrides.get(&line).copied(),
+            ),
+            DirectiveDomain::Sfc => {
+                self.sfc_directives
+                    .as_ref()
+                    .map_or((false, false, None), |directives| {
+                        (
+                            directives.is_disabled_at(diagnostic.rule_name, line),
+                            directives.is_expected_at(line),
+                            directives.severity_at(line),
+                        )
+                    })
+            }
+        };
+        if disabled || expected {
+            return;
+        }
+
+        if let Some(severity) = self.config_rule_severities.get(diagnostic.rule_name) {
+            diagnostic.severity = *severity;
+        }
+        match override_severity {
+            Some(DirectiveSeverity::Off) => return,
+            Some(DirectiveSeverity::Warn) => diagnostic.severity = Severity::Warning,
+            Some(DirectiveSeverity::Error) => diagnostic.severity = Severity::Error,
+            None => {}
+        }
+
+        match diagnostic.severity {
+            Severity::Error => self.error_count += 1,
+            Severity::Warning => self.warning_count += 1,
+        }
+        offset_diagnostic(&mut diagnostic, output_offset);
+        self.diagnostics.push(diagnostic);
+    }
+}
+
+/// Shift every range carried by a diagnostic into its containing source.
+pub(crate) fn offset_diagnostic(diagnostic: &mut LintDiagnostic, byte_offset: u32) {
+    if byte_offset == 0 {
+        return;
+    }
+    diagnostic.start += byte_offset;
+    diagnostic.end += byte_offset;
+    for label in &mut diagnostic.labels {
+        label.start += byte_offset;
+        label.end += byte_offset;
+    }
+    if let Some(fix) = diagnostic.fix.as_mut() {
+        for edit in &mut fix.edits {
+            edit.start += byte_offset;
+            edit.end += byte_offset;
+        }
+    }
+}

--- a/crates/vize_patina/src/context/reporting.rs
+++ b/crates/vize_patina/src/context/reporting.rs
@@ -51,7 +51,7 @@ impl<'a> LintContext<'a> {
             self.sfc_directives_scanned = true;
             self.sfc_directives = self
                 .sfc_descriptor
-                .and_then(|descriptor| SfcDirectiveState::scan_if_present(&descriptor.source));
+                .and_then(SfcDirectiveState::scan_if_present);
         }
         self.sfc_directives.as_ref()
     }

--- a/crates/vize_patina/src/context/reporting.rs
+++ b/crates/vize_patina/src/context/reporting.rs
@@ -81,9 +81,9 @@ impl<'a> LintContext<'a> {
                 self.sfc_directives()
                     .map_or((false, false, None), |directives| {
                         (
-                            directives.is_disabled_at(rule_name, line),
-                            directives.is_expected_at(line),
-                            directives.severity_at(line),
+                            directives.is_disabled_at(rule_name, line, diagnostic.start),
+                            directives.is_expected_at(line, diagnostic.start),
+                            directives.severity_at(line, diagnostic.start),
                         )
                     })
             }

--- a/crates/vize_patina/src/context/sfc_directives.rs
+++ b/crates/vize_patina/src/context/sfc_directives.rs
@@ -15,18 +15,25 @@ use lexer::{DirectiveLexer, StyleDirectiveLexer};
 
 #[derive(Clone, Copy)]
 enum BlockDomain<'a> {
-    Script,
+    Script { jsx: bool },
     Style(Option<&'a str>),
 }
 
 #[derive(Default)]
 pub(super) struct SfcDirectiveState {
+    blocks: Vec<BlockDirectiveState>,
+    line_offsets: Vec<u32>,
+}
+
+#[derive(Default)]
+struct BlockDirectiveState {
+    start: u32,
+    end: u32,
     disabled_all: Vec<DisabledRange>,
     disabled_rules: FxHashMap<CompactString, Vec<DisabledRange>>,
     ignored_regions: Vec<DisabledRange>,
     expected_error_lines: FxHashSet<u32>,
     severity_overrides: FxHashMap<u32, DirectiveSeverity>,
-    line_offsets: Vec<u32>,
 }
 
 impl SfcDirectiveState {
@@ -44,69 +51,60 @@ impl SfcDirectiveState {
 
         let source = descriptor.source.as_ref();
         let mut state = Self {
+            blocks: Vec::new(),
             line_offsets: std::iter::once(0)
                 .chain(memchr_iter(b'\n', source.as_bytes()).map(|offset| (offset + 1) as u32))
                 .collect(),
-            ..Self::default()
         };
         let mut blocks = descriptor
             .script
             .iter()
             .chain(descriptor.script_setup.iter())
-            .map(|block| (block.loc.start, block.content.as_ref(), BlockDomain::Script))
+            .map(|block| {
+                let jsx = matches!(block.lang.as_deref(), Some("jsx" | "tsx"));
+                (
+                    block.loc.start,
+                    block.loc.end,
+                    block.content.as_ref(),
+                    BlockDomain::Script { jsx },
+                )
+            })
             .chain(descriptor.styles.iter().map(|block| {
                 (
                     block.loc.start,
+                    block.loc.end,
                     block.content.as_ref(),
                     BlockDomain::Style(block.lang.as_deref()),
                 )
             }))
             .collect::<Vec<_>>();
-        blocks.sort_unstable_by_key(|(start, _, _)| *start);
+        blocks.sort_unstable_by_key(|(start, _, _, _)| *start);
 
-        for (start, content, domain) in blocks {
+        for (start, end, content, domain) in blocks {
             if !has_directive_marker(content) {
                 continue;
             }
             let first_line = state.offset_to_line(start as u32);
+            let mut block = BlockDirectiveState {
+                start: start as u32,
+                end: end as u32,
+                ..BlockDirectiveState::default()
+            };
             match domain {
-                BlockDomain::Script => {
-                    let mut lexer = DirectiveLexer::default();
-                    state.scan_block(content, first_line, |line| lexer.scan_line(line));
+                BlockDomain::Script { jsx } => {
+                    let mut lexer = DirectiveLexer::new(jsx);
+                    block.scan(content, first_line, |line| lexer.scan_line(line));
                 }
                 BlockDomain::Style(lang) => {
                     let allow_line_comments =
                         matches!(lang, Some("scss" | "sass" | "less" | "stylus"));
                     let mut lexer = StyleDirectiveLexer::new(allow_line_comments);
-                    state.scan_block(content, first_line, |line| lexer.scan_line(line));
+                    block.scan(content, first_line, |line| lexer.scan_line(line));
                 }
             }
+            state.blocks.push(block);
         }
         Some(state)
-    }
-
-    fn scan_block<F>(&mut self, source: &str, first_line: u32, mut scan_line: F)
-    where
-        F: FnMut(&str) -> lexer::CommentMarkers,
-    {
-        let mut last_line = first_line;
-        for (line_number, line) in (first_line..).zip(source.lines()) {
-            last_line = line_number;
-            let markers = scan_line(line);
-            self.scan_eslint_directive(line, line_number, markers.eslint);
-            self.scan_vize_directive(line, line_number, markers.vize);
-        }
-        self.finish_block(last_line);
-    }
-
-    fn finish_block(&mut self, last_line: u32) {
-        close_ranges(&mut self.disabled_all, last_line);
-        for ranges in self.disabled_rules.values_mut() {
-            close_ranges(ranges, last_line);
-        }
-        close_ranges(&mut self.ignored_regions, last_line);
-        self.expected_error_lines.retain(|line| *line <= last_line);
-        self.severity_overrides.retain(|line, _| *line <= last_line);
     }
 
     pub(super) fn offset_to_line(&self, offset: u32) -> u32 {
@@ -116,7 +114,41 @@ impl SfcDirectiveState {
         }
     }
 
-    pub(super) fn is_disabled_at(&self, rule_name: &str, line: u32) -> bool {
+    pub(super) fn is_disabled_at(&self, rule_name: &str, line: u32, offset: u32) -> bool {
+        self.block_at(offset)
+            .is_some_and(|block| block.is_disabled_at(rule_name, line))
+    }
+
+    pub(super) fn is_expected_at(&self, line: u32, offset: u32) -> bool {
+        self.block_at(offset)
+            .is_some_and(|block| block.expected_error_lines.contains(&line))
+    }
+
+    pub(super) fn severity_at(&self, line: u32, offset: u32) -> Option<DirectiveSeverity> {
+        self.block_at(offset)
+            .and_then(|block| block.severity_overrides.get(&line).copied())
+    }
+
+    fn block_at(&self, offset: u32) -> Option<&BlockDirectiveState> {
+        self.blocks
+            .iter()
+            .find(|block| block.start <= offset && offset < block.end)
+    }
+}
+
+impl BlockDirectiveState {
+    fn scan<F>(&mut self, source: &str, first_line: u32, mut scan_line: F)
+    where
+        F: FnMut(&str) -> lexer::CommentMarkers,
+    {
+        for (line_number, line) in (first_line..).zip(source.lines()) {
+            let markers = scan_line(line);
+            self.scan_eslint_directive(line, line_number, markers.eslint);
+            self.scan_vize_directive(line, line_number, markers.vize);
+        }
+    }
+
+    fn is_disabled_at(&self, rule_name: &str, line: u32) -> bool {
         self.disabled_all
             .iter()
             .any(|range| range_contains(range, line))
@@ -128,14 +160,6 @@ impl SfcDirectiveState {
                 .disabled_rules
                 .get(rule_name)
                 .is_some_and(|ranges| ranges.iter().any(|range| range_contains(range, line)))
-    }
-
-    pub(super) fn is_expected_at(&self, line: u32) -> bool {
-        self.expected_error_lines.contains(&line)
-    }
-
-    pub(super) fn severity_at(&self, line: u32) -> Option<DirectiveSeverity> {
-        self.severity_overrides.get(&line).copied()
     }
 
     fn scan_eslint_directive(&mut self, line: &str, line_number: u32, index: Option<usize>) {
@@ -152,9 +176,7 @@ impl SfcDirectiveState {
             EslintDisableKind::DisableLine => {
                 self.disable_rules(directive.rules, line_number, Some(line_number));
             }
-            EslintDisableKind::Disable => {
-                self.disable_rules(directive.rules, line_number, None);
-            }
+            EslintDisableKind::Disable => self.disable_rules(directive.rules, line_number, None),
             EslintDisableKind::Enable => self.enable_rules(directive.rules, line_number),
         }
     }
@@ -164,11 +186,8 @@ impl SfcDirectiveState {
             return;
         };
         let content = line[index..]
-            .split_once("-->")
-            .map_or(&line[index..], |(content, _)| content);
-        let content = content
             .split_once("*/")
-            .map_or(content, |(content, _)| content);
+            .map_or(&line[index..], |(content, _)| content);
         let Some(directive) = parse_vize_directive(content, line_number, 0) else {
             return;
         };

--- a/crates/vize_patina/src/context/sfc_directives.rs
+++ b/crates/vize_patina/src/context/sfc_directives.rs
@@ -15,7 +15,7 @@ use lexer::{DirectiveLexer, StyleDirectiveLexer};
 
 #[derive(Clone, Copy)]
 enum BlockDomain<'a> {
-    Script { jsx: bool },
+    Script { jsx: bool, tsx: bool },
     Style(Option<&'a str>),
 }
 
@@ -61,12 +61,16 @@ impl SfcDirectiveState {
             .iter()
             .chain(descriptor.script_setup.iter())
             .map(|block| {
-                let jsx = matches!(block.lang.as_deref(), Some("jsx" | "tsx"));
+                let (jsx, tsx) = match block.lang.as_deref() {
+                    Some("tsx") => (true, true),
+                    Some("jsx") => (true, false),
+                    _ => (false, false),
+                };
                 (
                     block.loc.start,
                     block.loc.end,
                     block.content.as_ref(),
-                    BlockDomain::Script { jsx },
+                    BlockDomain::Script { jsx, tsx },
                 )
             })
             .chain(descriptor.styles.iter().map(|block| {
@@ -91,8 +95,8 @@ impl SfcDirectiveState {
                 ..BlockDirectiveState::default()
             };
             match domain {
-                BlockDomain::Script { jsx } => {
-                    let mut lexer = DirectiveLexer::new(jsx);
+                BlockDomain::Script { jsx, tsx } => {
+                    let mut lexer = DirectiveLexer::new(jsx, tsx);
                     block.scan(content, first_line, |line| lexer.scan_line(line));
                 }
                 BlockDomain::Style(lang) => {

--- a/crates/vize_patina/src/context/sfc_directives.rs
+++ b/crates/vize_patina/src/context/sfc_directives.rs
@@ -1,0 +1,327 @@
+//! Directive state whose offsets and line numbers address a complete SFC.
+
+use memchr::memchr_iter;
+use vize_carton::directive::{
+    DirectiveKind, DirectiveSeverity, parse_level_severity, parse_vize_directive,
+};
+use vize_carton::{CompactString, FxHashMap, FxHashSet, String};
+
+use super::DisabledRange;
+use super::eslint_directive::{EslintDisableKind, parse_eslint_disable_comment};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum LexicalContext {
+    Code,
+    Interpolation(u32),
+    SingleQuote,
+    DoubleQuote,
+    Template,
+    BlockComment,
+    HtmlComment,
+    LineComment,
+}
+
+struct DirectiveLexer {
+    stack: Vec<LexicalContext>,
+}
+
+impl Default for DirectiveLexer {
+    fn default() -> Self {
+        Self {
+            stack: vec![LexicalContext::Code],
+        }
+    }
+}
+
+#[derive(Default)]
+struct CommentMarkers {
+    eslint: Option<usize>,
+    vize: Option<usize>,
+}
+
+#[derive(Default)]
+pub(super) struct SfcDirectiveState {
+    disabled_all: Vec<DisabledRange>,
+    disabled_rules: FxHashMap<CompactString, Vec<DisabledRange>>,
+    ignored_regions: Vec<DisabledRange>,
+    expected_error_lines: FxHashSet<u32>,
+    severity_overrides: FxHashMap<u32, DirectiveSeverity>,
+    line_offsets: Vec<u32>,
+}
+
+impl SfcDirectiveState {
+    pub(super) fn scan_if_present(source: &str) -> Option<Self> {
+        if !source.contains("eslint-") && !source.contains("@vize:") {
+            return None;
+        }
+
+        let mut state = Self {
+            line_offsets: std::iter::once(0)
+                .chain(memchr_iter(b'\n', source.as_bytes()).map(|offset| (offset + 1) as u32))
+                .collect(),
+            ..Self::default()
+        };
+        let mut lexer = DirectiveLexer::default();
+        for (line_number, line) in (1u32..).zip(source.lines()) {
+            let markers = lexer.scan_line(line);
+            state.scan_eslint_directive(line, line_number, markers.eslint);
+            state.scan_vize_directive(line, line_number, markers.vize);
+        }
+        Some(state)
+    }
+
+    pub(super) fn offset_to_line(&self, offset: u32) -> u32 {
+        match self.line_offsets.binary_search(&offset) {
+            Ok(line) => (line + 1) as u32,
+            Err(line) => line as u32,
+        }
+    }
+
+    pub(super) fn is_disabled_at(&self, rule_name: &str, line: u32) -> bool {
+        self.disabled_all
+            .iter()
+            .any(|range| range_contains(range, line))
+            || self
+                .ignored_regions
+                .iter()
+                .any(|range| range_contains(range, line))
+            || self
+                .disabled_rules
+                .get(rule_name)
+                .is_some_and(|ranges| ranges.iter().any(|range| range_contains(range, line)))
+    }
+
+    pub(super) fn is_expected_at(&self, line: u32) -> bool {
+        self.expected_error_lines.contains(&line)
+    }
+
+    pub(super) fn severity_at(&self, line: u32) -> Option<DirectiveSeverity> {
+        self.severity_overrides.get(&line).copied()
+    }
+
+    fn scan_eslint_directive(&mut self, line: &str, line_number: u32, index: Option<usize>) {
+        let Some(index) = index else {
+            return;
+        };
+        let Some(directive) = parse_eslint_disable_comment(&line[index..]) else {
+            return;
+        };
+        match directive.kind {
+            EslintDisableKind::DisableNextLine => {
+                self.disable_rules(directive.rules, line_number + 1, Some(line_number + 1))
+            }
+            EslintDisableKind::DisableLine => {
+                self.disable_rules(directive.rules, line_number, Some(line_number));
+            }
+            EslintDisableKind::Disable => {
+                self.disable_rules(directive.rules, line_number, None);
+            }
+            EslintDisableKind::Enable => self.enable_rules(directive.rules, line_number),
+        }
+    }
+
+    fn scan_vize_directive(&mut self, line: &str, line_number: u32, index: Option<usize>) {
+        let Some(index) = index else {
+            return;
+        };
+        let content = line[index..]
+            .split_once("-->")
+            .map_or(&line[index..], |(content, _)| content);
+        let content = content
+            .split_once("*/")
+            .map_or(content, |(content, _)| content);
+        let Some(directive) = parse_vize_directive(content, line_number, 0) else {
+            return;
+        };
+        match directive.kind {
+            DirectiveKind::Expected => {
+                self.expected_error_lines.insert(line_number + 1);
+            }
+            DirectiveKind::Level => {
+                if let Some(severity) = parse_level_severity(&directive.payload) {
+                    self.severity_overrides.insert(line_number + 1, severity);
+                }
+            }
+            DirectiveKind::IgnoreStart => self.ignored_regions.push(DisabledRange {
+                start_line: line_number,
+                end_line: None,
+            }),
+            DirectiveKind::IgnoreEnd => close_last_range(&mut self.ignored_regions, line_number),
+            _ => {}
+        }
+    }
+
+    fn disable_rules(&mut self, rules: Vec<String>, start_line: u32, end_line: Option<u32>) {
+        if rules.is_empty() {
+            self.disabled_all.push(DisabledRange {
+                start_line,
+                end_line,
+            });
+            return;
+        }
+        for rule in rules {
+            self.disabled_rules
+                .entry(CompactString::new(rule.as_str()))
+                .or_default()
+                .push(DisabledRange {
+                    start_line,
+                    end_line,
+                });
+        }
+    }
+
+    fn enable_rules(&mut self, rules: Vec<String>, line: u32) {
+        if rules.is_empty() {
+            close_ranges(&mut self.disabled_all, line);
+            for ranges in self.disabled_rules.values_mut() {
+                close_ranges(ranges, line);
+            }
+            return;
+        }
+        for rule in rules {
+            if let Some(ranges) = self.disabled_rules.get_mut(rule.as_str()) {
+                close_ranges(ranges, line);
+            }
+        }
+    }
+}
+
+fn range_contains(range: &DisabledRange, line: u32) -> bool {
+    line >= range.start_line && range.end_line.is_none_or(|end| line <= end)
+}
+
+fn close_ranges(ranges: &mut [DisabledRange], line: u32) {
+    for range in ranges {
+        if range.end_line.is_none() {
+            range.end_line = Some(line);
+        }
+    }
+}
+
+fn close_last_range(ranges: &mut [DisabledRange], line: u32) {
+    if let Some(range) = ranges
+        .iter_mut()
+        .rev()
+        .find(|range| range.end_line.is_none())
+    {
+        range.end_line = Some(line);
+    }
+}
+
+impl DirectiveLexer {
+    fn scan_line(&mut self, line: &str) -> CommentMarkers {
+        let bytes = line.as_bytes();
+        let mut markers = CommentMarkers::default();
+        let mut index = 0;
+        while index < bytes.len() {
+            let context = *self.stack.last().expect("lexer always has a root context");
+            if matches!(
+                context,
+                LexicalContext::BlockComment
+                    | LexicalContext::HtmlComment
+                    | LexicalContext::LineComment
+            ) {
+                if markers.eslint.is_none() && bytes[index..].starts_with(b"eslint-") {
+                    markers.eslint = Some(index);
+                }
+                if markers.vize.is_none() && bytes[index..].starts_with(b"@vize:") {
+                    markers.vize = Some(index);
+                }
+            }
+
+            let current = bytes[index];
+            let next = bytes.get(index + 1).copied();
+            match context {
+                LexicalContext::Code | LexicalContext::Interpolation(_) => match (current, next) {
+                    (b'/', Some(b'/')) => {
+                        self.stack.push(LexicalContext::LineComment);
+                        index += 1;
+                    }
+                    (b'/', Some(b'*')) => {
+                        self.stack.push(LexicalContext::BlockComment);
+                        index += 1;
+                    }
+                    (b'<', Some(b'!'))
+                        if bytes
+                            .get(index..index + 4)
+                            .is_some_and(|slice| slice == b"<!--") =>
+                    {
+                        self.stack.push(LexicalContext::HtmlComment);
+                        index += 3;
+                    }
+                    (b'\'', _) => self.stack.push(LexicalContext::SingleQuote),
+                    (b'"', _) => self.stack.push(LexicalContext::DoubleQuote),
+                    (b'`', _) => self.stack.push(LexicalContext::Template),
+                    (b'{', _) => {
+                        if let Some(LexicalContext::Interpolation(depth)) = self.stack.last_mut() {
+                            *depth += 1;
+                        }
+                    }
+                    (b'}', _) => {
+                        if let Some(LexicalContext::Interpolation(depth)) = self.stack.last_mut() {
+                            if *depth == 0 {
+                                self.stack.pop();
+                            } else {
+                                *depth -= 1;
+                            }
+                        }
+                    }
+                    _ => {}
+                },
+                LexicalContext::SingleQuote => match (current, next) {
+                    (b'\\', Some(_)) => index += 1,
+                    (b'\'', _) => {
+                        self.stack.pop();
+                    }
+                    _ => {}
+                },
+                LexicalContext::DoubleQuote => match (current, next) {
+                    (b'\\', Some(_)) => index += 1,
+                    (b'"', _) => {
+                        self.stack.pop();
+                    }
+                    _ => {}
+                },
+                LexicalContext::Template => match (current, next) {
+                    (b'\\', Some(_)) => index += 1,
+                    (b'`', _) => {
+                        self.stack.pop();
+                    }
+                    (b'$', Some(b'{')) => {
+                        self.stack.push(LexicalContext::Interpolation(0));
+                        index += 1;
+                    }
+                    _ => {}
+                },
+                LexicalContext::BlockComment => {
+                    if (current, next) == (b'*', Some(b'/')) {
+                        self.stack.pop();
+                        index += 1;
+                    }
+                }
+                LexicalContext::HtmlComment => {
+                    if bytes
+                        .get(index..index + 3)
+                        .is_some_and(|slice| slice == b"-->")
+                    {
+                        self.stack.pop();
+                        index += 2;
+                    }
+                }
+                LexicalContext::LineComment => {}
+            }
+            index += 1;
+        }
+
+        if matches!(self.stack.last(), Some(LexicalContext::LineComment)) {
+            self.stack.pop();
+        }
+        while matches!(
+            self.stack.last(),
+            Some(LexicalContext::SingleQuote | LexicalContext::DoubleQuote)
+        ) {
+            self.stack.pop();
+        }
+        markers
+    }
+}

--- a/crates/vize_patina/src/context/sfc_directives.rs
+++ b/crates/vize_patina/src/context/sfc_directives.rs
@@ -97,13 +97,15 @@ impl SfcDirectiveState {
             match domain {
                 BlockDomain::Script { jsx, tsx } => {
                     let mut lexer = DirectiveLexer::new(jsx, tsx);
-                    block.scan(content, first_line, |line| lexer.scan_line(line));
+                    block.scan(content, first_line, |line, remaining| {
+                        lexer.scan_line(line, remaining)
+                    });
                 }
                 BlockDomain::Style(lang) => {
                     let allow_line_comments =
                         matches!(lang, Some("scss" | "sass" | "less" | "stylus"));
                     let mut lexer = StyleDirectiveLexer::new(allow_line_comments);
-                    block.scan(content, first_line, |line| lexer.scan_line(line));
+                    block.scan(content, first_line, |line, _| lexer.scan_line(line));
                 }
             }
             state.blocks.push(block);
@@ -143,12 +145,17 @@ impl SfcDirectiveState {
 impl BlockDirectiveState {
     fn scan<F>(&mut self, source: &str, first_line: u32, mut scan_line: F)
     where
-        F: FnMut(&str) -> lexer::CommentMarkers,
+        F: FnMut(&str, &str) -> lexer::CommentMarkers,
     {
-        for (line_number, line) in (first_line..).zip(source.lines()) {
-            let markers = scan_line(line);
+        let mut offset = 0;
+        for (line_number, raw_line) in (first_line..).zip(source.split_inclusive('\n')) {
+            let line = raw_line
+                .strip_suffix('\n')
+                .map_or(raw_line, |line| line.strip_suffix('\r').unwrap_or(line));
+            let markers = scan_line(line, &source[offset..]);
             self.scan_eslint_directive(line, line_number, markers.eslint);
             self.scan_vize_directive(line, line_number, markers.vize);
+            offset += raw_line.len();
         }
     }
 

--- a/crates/vize_patina/src/context/sfc_directives.rs
+++ b/crates/vize_patina/src/context/sfc_directives.rs
@@ -1,6 +1,9 @@
 //! Directive state whose offsets and line numbers address a complete SFC.
 
+mod lexer;
+
 use memchr::memchr_iter;
+use vize_atelier_sfc::SfcDescriptor;
 use vize_carton::directive::{
     DirectiveKind, DirectiveSeverity, parse_level_severity, parse_vize_directive,
 };
@@ -8,35 +11,12 @@ use vize_carton::{CompactString, FxHashMap, FxHashSet, String};
 
 use super::DisabledRange;
 use super::eslint_directive::{EslintDisableKind, parse_eslint_disable_comment};
+use lexer::{DirectiveLexer, StyleDirectiveLexer};
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum LexicalContext {
-    Code,
-    Interpolation(u32),
-    SingleQuote,
-    DoubleQuote,
-    Template,
-    BlockComment,
-    HtmlComment,
-    LineComment,
-}
-
-struct DirectiveLexer {
-    stack: Vec<LexicalContext>,
-}
-
-impl Default for DirectiveLexer {
-    fn default() -> Self {
-        Self {
-            stack: vec![LexicalContext::Code],
-        }
-    }
-}
-
-#[derive(Default)]
-struct CommentMarkers {
-    eslint: Option<usize>,
-    vize: Option<usize>,
+#[derive(Clone, Copy)]
+enum BlockDomain<'a> {
+    Script,
+    Style(Option<&'a str>),
 }
 
 #[derive(Default)]
@@ -50,24 +30,83 @@ pub(super) struct SfcDirectiveState {
 }
 
 impl SfcDirectiveState {
-    pub(super) fn scan_if_present(source: &str) -> Option<Self> {
-        if !source.contains("eslint-") && !source.contains("@vize:") {
+    pub(super) fn scan_if_present(descriptor: &SfcDescriptor<'_>) -> Option<Self> {
+        let has_markers = descriptor
+            .script
+            .iter()
+            .chain(descriptor.script_setup.iter())
+            .map(|block| block.content.as_ref())
+            .chain(descriptor.styles.iter().map(|block| block.content.as_ref()))
+            .any(has_directive_marker);
+        if !has_markers {
             return None;
         }
 
+        let source = descriptor.source.as_ref();
         let mut state = Self {
             line_offsets: std::iter::once(0)
                 .chain(memchr_iter(b'\n', source.as_bytes()).map(|offset| (offset + 1) as u32))
                 .collect(),
             ..Self::default()
         };
-        let mut lexer = DirectiveLexer::default();
-        for (line_number, line) in (1u32..).zip(source.lines()) {
-            let markers = lexer.scan_line(line);
-            state.scan_eslint_directive(line, line_number, markers.eslint);
-            state.scan_vize_directive(line, line_number, markers.vize);
+        let mut blocks = descriptor
+            .script
+            .iter()
+            .chain(descriptor.script_setup.iter())
+            .map(|block| (block.loc.start, block.content.as_ref(), BlockDomain::Script))
+            .chain(descriptor.styles.iter().map(|block| {
+                (
+                    block.loc.start,
+                    block.content.as_ref(),
+                    BlockDomain::Style(block.lang.as_deref()),
+                )
+            }))
+            .collect::<Vec<_>>();
+        blocks.sort_unstable_by_key(|(start, _, _)| *start);
+
+        for (start, content, domain) in blocks {
+            if !has_directive_marker(content) {
+                continue;
+            }
+            let first_line = state.offset_to_line(start as u32);
+            match domain {
+                BlockDomain::Script => {
+                    let mut lexer = DirectiveLexer::default();
+                    state.scan_block(content, first_line, |line| lexer.scan_line(line));
+                }
+                BlockDomain::Style(lang) => {
+                    let allow_line_comments =
+                        matches!(lang, Some("scss" | "sass" | "less" | "stylus"));
+                    let mut lexer = StyleDirectiveLexer::new(allow_line_comments);
+                    state.scan_block(content, first_line, |line| lexer.scan_line(line));
+                }
+            }
         }
         Some(state)
+    }
+
+    fn scan_block<F>(&mut self, source: &str, first_line: u32, mut scan_line: F)
+    where
+        F: FnMut(&str) -> lexer::CommentMarkers,
+    {
+        let mut last_line = first_line;
+        for (line_number, line) in (first_line..).zip(source.lines()) {
+            last_line = line_number;
+            let markers = scan_line(line);
+            self.scan_eslint_directive(line, line_number, markers.eslint);
+            self.scan_vize_directive(line, line_number, markers.vize);
+        }
+        self.finish_block(last_line);
+    }
+
+    fn finish_block(&mut self, last_line: u32) {
+        close_ranges(&mut self.disabled_all, last_line);
+        for ranges in self.disabled_rules.values_mut() {
+            close_ranges(ranges, last_line);
+        }
+        close_ranges(&mut self.ignored_regions, last_line);
+        self.expected_error_lines.retain(|line| *line <= last_line);
+        self.severity_overrides.retain(|line, _| *line <= last_line);
     }
 
     pub(super) fn offset_to_line(&self, offset: u32) -> u32 {
@@ -186,6 +225,10 @@ impl SfcDirectiveState {
     }
 }
 
+fn has_directive_marker(source: &str) -> bool {
+    source.contains("eslint-") || source.contains("@vize:")
+}
+
 fn range_contains(range: &DisabledRange, line: u32) -> bool {
     line >= range.start_line && range.end_line.is_none_or(|end| line <= end)
 }
@@ -205,123 +248,5 @@ fn close_last_range(ranges: &mut [DisabledRange], line: u32) {
         .find(|range| range.end_line.is_none())
     {
         range.end_line = Some(line);
-    }
-}
-
-impl DirectiveLexer {
-    fn scan_line(&mut self, line: &str) -> CommentMarkers {
-        let bytes = line.as_bytes();
-        let mut markers = CommentMarkers::default();
-        let mut index = 0;
-        while index < bytes.len() {
-            let context = *self.stack.last().expect("lexer always has a root context");
-            if matches!(
-                context,
-                LexicalContext::BlockComment
-                    | LexicalContext::HtmlComment
-                    | LexicalContext::LineComment
-            ) {
-                if markers.eslint.is_none() && bytes[index..].starts_with(b"eslint-") {
-                    markers.eslint = Some(index);
-                }
-                if markers.vize.is_none() && bytes[index..].starts_with(b"@vize:") {
-                    markers.vize = Some(index);
-                }
-            }
-
-            let current = bytes[index];
-            let next = bytes.get(index + 1).copied();
-            match context {
-                LexicalContext::Code | LexicalContext::Interpolation(_) => match (current, next) {
-                    (b'/', Some(b'/')) => {
-                        self.stack.push(LexicalContext::LineComment);
-                        index += 1;
-                    }
-                    (b'/', Some(b'*')) => {
-                        self.stack.push(LexicalContext::BlockComment);
-                        index += 1;
-                    }
-                    (b'<', Some(b'!'))
-                        if bytes
-                            .get(index..index + 4)
-                            .is_some_and(|slice| slice == b"<!--") =>
-                    {
-                        self.stack.push(LexicalContext::HtmlComment);
-                        index += 3;
-                    }
-                    (b'\'', _) => self.stack.push(LexicalContext::SingleQuote),
-                    (b'"', _) => self.stack.push(LexicalContext::DoubleQuote),
-                    (b'`', _) => self.stack.push(LexicalContext::Template),
-                    (b'{', _) => {
-                        if let Some(LexicalContext::Interpolation(depth)) = self.stack.last_mut() {
-                            *depth += 1;
-                        }
-                    }
-                    (b'}', _) => {
-                        if let Some(LexicalContext::Interpolation(depth)) = self.stack.last_mut() {
-                            if *depth == 0 {
-                                self.stack.pop();
-                            } else {
-                                *depth -= 1;
-                            }
-                        }
-                    }
-                    _ => {}
-                },
-                LexicalContext::SingleQuote => match (current, next) {
-                    (b'\\', Some(_)) => index += 1,
-                    (b'\'', _) => {
-                        self.stack.pop();
-                    }
-                    _ => {}
-                },
-                LexicalContext::DoubleQuote => match (current, next) {
-                    (b'\\', Some(_)) => index += 1,
-                    (b'"', _) => {
-                        self.stack.pop();
-                    }
-                    _ => {}
-                },
-                LexicalContext::Template => match (current, next) {
-                    (b'\\', Some(_)) => index += 1,
-                    (b'`', _) => {
-                        self.stack.pop();
-                    }
-                    (b'$', Some(b'{')) => {
-                        self.stack.push(LexicalContext::Interpolation(0));
-                        index += 1;
-                    }
-                    _ => {}
-                },
-                LexicalContext::BlockComment => {
-                    if (current, next) == (b'*', Some(b'/')) {
-                        self.stack.pop();
-                        index += 1;
-                    }
-                }
-                LexicalContext::HtmlComment => {
-                    if bytes
-                        .get(index..index + 3)
-                        .is_some_and(|slice| slice == b"-->")
-                    {
-                        self.stack.pop();
-                        index += 2;
-                    }
-                }
-                LexicalContext::LineComment => {}
-            }
-            index += 1;
-        }
-
-        if matches!(self.stack.last(), Some(LexicalContext::LineComment)) {
-            self.stack.pop();
-        }
-        while matches!(
-            self.stack.last(),
-            Some(LexicalContext::SingleQuote | LexicalContext::DoubleQuote)
-        ) {
-            self.stack.pop();
-        }
-        markers
     }
 }

--- a/crates/vize_patina/src/context/sfc_directives/lexer.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer.rs
@@ -1,13 +1,15 @@
 //! Lightweight comment lexers for SFC script and style block contents.
 
+mod brace;
 mod style;
 mod token;
 
 pub(super) use style::StyleDirectiveLexer;
 
+use brace::DelimiterState;
 use token::{
-    ParenContext, ends_with_unescaped_backslash, identifier_allows_expression, identifier_end,
-    identifier_opens_control_paren, is_identifier_start, is_jsx_start,
+    ends_with_unescaped_backslash, identifier_allows_expression, identifier_end,
+    is_identifier_start, is_jsx_start,
 };
 
 #[derive(Default)]
@@ -37,8 +39,7 @@ pub(super) struct DirectiveLexer {
     jsx_depth: u32,
     can_start_expression: bool,
     after_dot: bool,
-    parens: Vec<ParenContext>,
-    next_paren_is_control: bool,
+    delimiters: DelimiterState,
 }
 
 impl Default for DirectiveLexer {
@@ -56,8 +57,7 @@ impl DirectiveLexer {
             jsx_depth: 0,
             can_start_expression: true,
             after_dot: false,
-            parens: Vec::new(),
-            next_paren_is_control: false,
+            delimiters: DelimiterState::default(),
         }
     }
 
@@ -79,21 +79,14 @@ impl DirectiveLexer {
             let current = bytes[index];
             let next = bytes.get(index + 1).copied();
             let had_code_token = has_code_token;
-            let starts_comment = matches!(
+            let in_code = matches!(
                 context,
                 ScriptContext::Code | ScriptContext::Interpolation(_)
-            ) && matches!((current, next), (b'/', Some(b'/' | b'*')));
-            if self.next_paren_is_control
-                && matches!(
-                    context,
-                    ScriptContext::Code | ScriptContext::Interpolation(_)
-                )
-                && !current.is_ascii_whitespace()
-                && !is_identifier_start(current)
-                && current != b'('
-                && !starts_comment
-            {
-                self.next_paren_is_control = false;
+            );
+            let starts_comment = in_code && matches!((current, next), (b'/', Some(b'/' | b'*')));
+            if in_code && !is_identifier_start(current) {
+                self.delimiters
+                    .before_non_identifier(current, starts_comment);
             }
             match context {
                 ScriptContext::Code | ScriptContext::Interpolation(_) => match (current, next) {
@@ -125,46 +118,44 @@ impl DirectiveLexer {
                         if let Some(ScriptContext::Interpolation(depth)) = self.stack.last_mut() {
                             *depth += 1;
                         }
+                        self.delimiters.open_brace();
                         self.can_start_expression = true;
                         self.after_dot = false;
                     }
                     (b'}', _) => {
+                        let mut closes_interpolation = false;
                         if let Some(ScriptContext::Interpolation(depth)) = self.stack.last_mut() {
                             if *depth == 0 {
+                                closes_interpolation = true;
                                 self.stack.pop();
                             } else {
                                 *depth -= 1;
                             }
                         }
-                        self.can_start_expression = false;
+                        self.can_start_expression = if closes_interpolation {
+                            false
+                        } else {
+                            self.delimiters.close_brace()
+                        };
                         self.after_dot = false;
                     }
                     (byte, _) if is_identifier_start(byte) => {
                         let end = identifier_end(bytes, index);
                         let identifier = &bytes[index..end];
                         let after_dot = self.after_dot;
-                        let keeps_control_paren =
-                            self.next_paren_is_control && identifier == b"await" && !after_dot;
-                        self.next_paren_is_control = keeps_control_paren
-                            || (!after_dot && identifier_opens_control_paren(identifier));
+                        self.delimiters.observe_identifier(identifier, after_dot);
                         self.can_start_expression =
                             !after_dot && identifier_allows_expression(identifier);
                         self.after_dot = false;
                         index = end - 1;
                     }
                     (b'(', _) => {
-                        let context = if std::mem::take(&mut self.next_paren_is_control) {
-                            ParenContext::Control
-                        } else {
-                            ParenContext::Expression
-                        };
-                        self.parens.push(context);
+                        self.delimiters.open_paren();
                         self.can_start_expression = true;
                         self.after_dot = false;
                     }
                     (b')', _) => {
-                        self.can_start_expression =
-                            matches!(self.parens.pop(), Some(ParenContext::Control));
+                        self.can_start_expression = self.delimiters.close_paren();
                         self.after_dot = false;
                     }
                     (b']' | b'0'..=b'9', _) => {
@@ -175,10 +166,18 @@ impl DirectiveLexer {
                     (b'+', Some(b'+')) | (b'-', Some(b'-')) => {
                         // Preserve the incoming token state: prefix ++/-- still
                         // expects an operand, while postfix ++/-- finishes one.
+                        self.delimiters.observe_operator(current);
+                        self.after_dot = false;
+                        index += 1;
+                    }
+                    (b'=', Some(b'>')) => {
+                        self.delimiters.observe_arrow();
+                        self.can_start_expression = true;
                         self.after_dot = false;
                         index += 1;
                     }
                     (b'!', Some(b'=')) => {
+                        self.delimiters.observe_operator(current);
                         self.can_start_expression = true;
                         self.after_dot = false;
                     }
@@ -186,6 +185,7 @@ impl DirectiveLexer {
                         // At an expression boundary `!` is logical-not. After
                         // an operand on this line it is TypeScript's postfix
                         // non-null assertion and must keep the operand complete.
+                        self.delimiters.observe_operator(current);
                         self.can_start_expression = self.can_start_expression || !had_code_token;
                         self.after_dot = false;
                     }
@@ -194,6 +194,7 @@ impl DirectiveLexer {
                         | b'&' | b'|' | b'^' | b'~' | b'<' | b'>',
                         _,
                     ) => {
+                        self.delimiters.observe_operator(current);
                         self.can_start_expression = true;
                         self.after_dot = false;
                     }
@@ -325,6 +326,7 @@ impl DirectiveLexer {
                 self.can_start_expression = false;
             }
         }
+        self.delimiters.finish_line(self.can_start_expression);
         markers
     }
 

--- a/crates/vize_patina/src/context/sfc_directives/lexer.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer.rs
@@ -57,7 +57,7 @@ impl DirectiveLexer {
         let mut markers = CommentMarkers::default();
         let mut index = 0;
         while index < bytes.len() {
-            let context = *self.stack.last().expect("lexer always has a root context");
+            let context = self.stack.last().copied().unwrap_or(ScriptContext::Code);
             if matches!(
                 context,
                 ScriptContext::BlockComment | ScriptContext::LineComment
@@ -226,6 +226,16 @@ impl DirectiveLexer {
 
         if matches!(self.stack.last(), Some(ScriptContext::LineComment)) {
             self.stack.pop();
+        }
+        let mut popped_regex = false;
+        while matches!(self.stack.last(), Some(ScriptContext::Regex(_))) {
+            self.stack.pop();
+            popped_regex = true;
+        }
+        if popped_regex {
+            // Regex literals never span lines, so an unterminated one means the
+            // opening `/` was a division operator (or the source is mid-edit).
+            self.can_start_expression = true;
         }
         if !ends_with_unescaped_backslash(bytes) {
             let mut popped_string = false;

--- a/crates/vize_patina/src/context/sfc_directives/lexer.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer.rs
@@ -1,6 +1,9 @@
 //! Lightweight comment lexers for SFC script and style block contents.
 
+mod style;
 mod token;
+
+pub(super) use style::StyleDirectiveLexer;
 
 use token::{
     ends_with_unescaped_backslash, identifier_allows_expression, identifier_end,
@@ -262,91 +265,7 @@ impl DirectiveLexer {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum StyleContext {
-    Code,
-    SingleQuote,
-    DoubleQuote,
-    BlockComment,
-    LineComment,
-}
-
-pub(super) struct StyleDirectiveLexer {
-    context: StyleContext,
-    allow_line_comments: bool,
-}
-
-impl StyleDirectiveLexer {
-    pub(super) fn new(allow_line_comments: bool) -> Self {
-        Self {
-            context: StyleContext::Code,
-            allow_line_comments,
-        }
-    }
-
-    pub(super) fn scan_line(&mut self, line: &str) -> CommentMarkers {
-        let bytes = line.as_bytes();
-        let mut markers = CommentMarkers::default();
-        let mut index = 0;
-        while index < bytes.len() {
-            if matches!(
-                self.context,
-                StyleContext::BlockComment | StyleContext::LineComment
-            ) {
-                record_markers(bytes, index, &mut markers);
-            }
-            let current = bytes[index];
-            let next = bytes.get(index + 1).copied();
-            match self.context {
-                StyleContext::Code => match (current, next) {
-                    (b'/', Some(b'*')) => {
-                        self.context = StyleContext::BlockComment;
-                        index += 1;
-                    }
-                    (b'/', Some(b'/')) if self.allow_line_comments => {
-                        self.context = StyleContext::LineComment;
-                        index += 1;
-                    }
-                    (b'\'', _) => self.context = StyleContext::SingleQuote,
-                    (b'"', _) => self.context = StyleContext::DoubleQuote,
-                    _ => {}
-                },
-                StyleContext::SingleQuote => match (current, next) {
-                    (b'\\', Some(_)) => index += 1,
-                    (b'\'', _) => self.context = StyleContext::Code,
-                    _ => {}
-                },
-                StyleContext::DoubleQuote => match (current, next) {
-                    (b'\\', Some(_)) => index += 1,
-                    (b'"', _) => self.context = StyleContext::Code,
-                    _ => {}
-                },
-                StyleContext::BlockComment => {
-                    if (current, next) == (b'*', Some(b'/')) {
-                        self.context = StyleContext::Code;
-                        index += 1;
-                    }
-                }
-                StyleContext::LineComment => {}
-            }
-            index += 1;
-        }
-        if self.context == StyleContext::LineComment {
-            self.context = StyleContext::Code;
-        }
-        if !ends_with_unescaped_backslash(bytes)
-            && matches!(
-                self.context,
-                StyleContext::SingleQuote | StyleContext::DoubleQuote
-            )
-        {
-            self.context = StyleContext::Code;
-        }
-        markers
-    }
-}
-
-fn record_markers(bytes: &[u8], index: usize, markers: &mut CommentMarkers) {
+pub(super) fn record_markers(bytes: &[u8], index: usize, markers: &mut CommentMarkers) {
     if markers.eslint.is_none() && bytes[index..].starts_with(b"eslint-") {
         markers.eslint = Some(index);
     }

--- a/crates/vize_patina/src/context/sfc_directives/lexer.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer.rs
@@ -1,5 +1,12 @@
 //! Lightweight comment lexers for SFC script and style block contents.
 
+mod token;
+
+use token::{
+    ends_with_unescaped_backslash, identifier_allows_expression, identifier_end,
+    is_identifier_start, is_jsx_start,
+};
+
 #[derive(Default)]
 pub(super) struct CommentMarkers {
     pub(super) eslint: Option<usize>,
@@ -24,6 +31,8 @@ pub(super) struct DirectiveLexer {
     stack: Vec<ScriptContext>,
     jsx: bool,
     jsx_depth: u32,
+    can_start_expression: bool,
+    after_dot: bool,
 }
 
 impl Default for DirectiveLexer {
@@ -38,6 +47,8 @@ impl DirectiveLexer {
             stack: vec![ScriptContext::Code],
             jsx,
             jsx_depth: 0,
+            can_start_expression: true,
+            after_dot: false,
         }
     }
 
@@ -66,13 +77,16 @@ impl DirectiveLexer {
                         self.stack.push(ScriptContext::BlockComment);
                         index += 1;
                     }
-                    (b'/', _) if can_start_literal(bytes, index) => {
+                    (b'/', _) if self.can_start_expression => {
                         self.stack.push(ScriptContext::Regex(false));
                     }
-                    (b'<', _) if self.jsx && can_start_jsx(bytes, index) => {
+                    (b'<', _)
+                        if self.jsx && self.can_start_expression && is_jsx_start(bytes, index) =>
+                    {
                         self.jsx_depth += 1;
                         self.stack.push(ScriptContext::JsxText);
                         self.stack.push(ScriptContext::JsxTag { closing: false });
+                        self.after_dot = false;
                     }
                     (b'\'', _) => self.stack.push(ScriptContext::SingleQuote),
                     (b'"', _) => self.stack.push(ScriptContext::DoubleQuote),
@@ -81,6 +95,8 @@ impl DirectiveLexer {
                         if let Some(ScriptContext::Interpolation(depth)) = self.stack.last_mut() {
                             *depth += 1;
                         }
+                        self.can_start_expression = true;
+                        self.after_dot = false;
                     }
                     (b'}', _) => {
                         if let Some(ScriptContext::Interpolation(depth)) = self.stack.last_mut() {
@@ -90,6 +106,28 @@ impl DirectiveLexer {
                                 *depth -= 1;
                             }
                         }
+                        self.can_start_expression = false;
+                        self.after_dot = false;
+                    }
+                    (byte, _) if is_identifier_start(byte) => {
+                        let end = identifier_end(bytes, index);
+                        self.can_start_expression =
+                            !self.after_dot && identifier_allows_expression(&bytes[index..end]);
+                        self.after_dot = false;
+                        index = end - 1;
+                    }
+                    (b')' | b']' | b'0'..=b'9', _) => {
+                        self.can_start_expression = false;
+                        self.after_dot = false;
+                    }
+                    (b'.', _) => self.after_dot = true,
+                    (
+                        b'(' | b'[' | b'/' | b'=' | b':' | b',' | b'!' | b'?' | b';' | b'+' | b'-'
+                        | b'*' | b'%' | b'&' | b'|' | b'^' | b'~' | b'<' | b'>',
+                        _,
+                    ) => {
+                        self.can_start_expression = true;
+                        self.after_dot = false;
                     }
                     _ => {}
                 },
@@ -97,6 +135,7 @@ impl DirectiveLexer {
                     (b'\\', Some(_)) => index += 1,
                     (b'\'', _) => {
                         self.stack.pop();
+                        self.can_start_expression = false;
                     }
                     _ => {}
                 },
@@ -104,6 +143,7 @@ impl DirectiveLexer {
                     (b'\\', Some(_)) => index += 1,
                     (b'"', _) => {
                         self.stack.pop();
+                        self.can_start_expression = false;
                     }
                     _ => {}
                 },
@@ -111,9 +151,11 @@ impl DirectiveLexer {
                     (b'\\', Some(_)) => index += 1,
                     (b'`', _) => {
                         self.stack.pop();
+                        self.can_start_expression = false;
                     }
                     (b'$', Some(b'{')) => {
                         self.stack.push(ScriptContext::Interpolation(0));
+                        self.can_start_expression = true;
                         index += 1;
                     }
                     _ => {}
@@ -132,6 +174,7 @@ impl DirectiveLexer {
                     }
                     (b'/', _) if !in_class => {
                         self.stack.pop();
+                        self.can_start_expression = false;
                     }
                     _ => {}
                 },
@@ -144,13 +187,19 @@ impl DirectiveLexer {
                         self.jsx_depth += 1;
                         self.stack.push(ScriptContext::JsxTag { closing: false });
                     }
-                    (b'{', _) => self.stack.push(ScriptContext::Interpolation(0)),
+                    (b'{', _) => {
+                        self.stack.push(ScriptContext::Interpolation(0));
+                        self.can_start_expression = true;
+                    }
                     _ => {}
                 },
                 ScriptContext::JsxTag { closing } => match (current, next) {
                     (b'\'', _) => self.stack.push(ScriptContext::SingleQuote),
                     (b'"', _) => self.stack.push(ScriptContext::DoubleQuote),
-                    (b'{', _) => self.stack.push(ScriptContext::Interpolation(0)),
+                    (b'{', _) => {
+                        self.stack.push(ScriptContext::Interpolation(0));
+                        self.can_start_expression = true;
+                    }
                     (b'/', Some(b'>')) if !closing => {
                         self.stack.pop();
                         self.finish_jsx_element();
@@ -179,11 +228,16 @@ impl DirectiveLexer {
             self.stack.pop();
         }
         if !ends_with_unescaped_backslash(bytes) {
+            let mut popped_string = false;
             while matches!(
                 self.stack.last(),
                 Some(ScriptContext::SingleQuote | ScriptContext::DoubleQuote)
             ) {
                 self.stack.pop();
+                popped_string = true;
+            }
+            if popped_string {
+                self.can_start_expression = false;
             }
         }
         markers
@@ -193,6 +247,7 @@ impl DirectiveLexer {
         self.jsx_depth = self.jsx_depth.saturating_sub(1);
         if self.jsx_depth == 0 && matches!(self.stack.last(), Some(ScriptContext::JsxText)) {
             self.stack.pop();
+            self.can_start_expression = false;
         }
     }
 }
@@ -288,51 +343,4 @@ fn record_markers(bytes: &[u8], index: usize, markers: &mut CommentMarkers) {
     if markers.vize.is_none() && bytes[index..].starts_with(b"@vize:") {
         markers.vize = Some(index);
     }
-}
-
-fn ends_with_unescaped_backslash(bytes: &[u8]) -> bool {
-    bytes
-        .iter()
-        .rev()
-        .take_while(|&&byte| byte == b'\\')
-        .count()
-        % 2
-        == 1
-}
-
-fn can_start_literal(bytes: &[u8], index: usize) -> bool {
-    let previous = bytes[..index]
-        .iter()
-        .rfind(|&&byte| !byte.is_ascii_whitespace())
-        .copied();
-    previous.is_none_or(|byte| {
-        matches!(
-            byte,
-            b'(' | b'['
-                | b'{'
-                | b'='
-                | b':'
-                | b','
-                | b'!'
-                | b'?'
-                | b';'
-                | b'+'
-                | b'-'
-                | b'*'
-                | b'%'
-                | b'&'
-                | b'|'
-                | b'^'
-                | b'~'
-                | b'<'
-                | b'>'
-        )
-    })
-}
-
-fn can_start_jsx(bytes: &[u8], index: usize) -> bool {
-    let Some(next) = bytes.get(index + 1).copied() else {
-        return false;
-    };
-    (next == b'>' || next.is_ascii_alphabetic()) && can_start_literal(bytes, index)
 }

--- a/crates/vize_patina/src/context/sfc_directives/lexer.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer.rs
@@ -124,6 +124,12 @@ impl DirectiveLexer {
                         self.after_dot = false;
                     }
                     (b'.', _) => self.after_dot = true,
+                    (b'+', Some(b'+')) | (b'-', Some(b'-')) => {
+                        // Preserve the incoming token state: prefix ++/-- still
+                        // expects an operand, while postfix ++/-- finishes one.
+                        self.after_dot = false;
+                        index += 1;
+                    }
                     (
                         b'(' | b'[' | b'/' | b'=' | b':' | b',' | b'!' | b'?' | b';' | b'+' | b'-'
                         | b'*' | b'%' | b'&' | b'|' | b'^' | b'~' | b'<' | b'>',

--- a/crates/vize_patina/src/context/sfc_directives/lexer.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer.rs
@@ -58,6 +58,7 @@ impl DirectiveLexer {
     pub(super) fn scan_line(&mut self, line: &str) -> CommentMarkers {
         let bytes = line.as_bytes();
         let mut markers = CommentMarkers::default();
+        let mut has_code_token = false;
         let mut index = 0;
         while index < bytes.len() {
             let context = self.stack.last().copied().unwrap_or(ScriptContext::Code);
@@ -70,6 +71,7 @@ impl DirectiveLexer {
 
             let current = bytes[index];
             let next = bytes.get(index + 1).copied();
+            let had_code_token = has_code_token;
             match context {
                 ScriptContext::Code | ScriptContext::Interpolation(_) => match (current, next) {
                     (b'/', Some(b'/')) => {
@@ -130,9 +132,20 @@ impl DirectiveLexer {
                         self.after_dot = false;
                         index += 1;
                     }
+                    (b'!', Some(b'=')) => {
+                        self.can_start_expression = true;
+                        self.after_dot = false;
+                    }
+                    (b'!', _) => {
+                        // At an expression boundary `!` is logical-not. After
+                        // an operand on this line it is TypeScript's postfix
+                        // non-null assertion and must keep the operand complete.
+                        self.can_start_expression = self.can_start_expression || !had_code_token;
+                        self.after_dot = false;
+                    }
                     (
-                        b'(' | b'[' | b'/' | b'=' | b':' | b',' | b'!' | b'?' | b';' | b'+' | b'-'
-                        | b'*' | b'%' | b'&' | b'|' | b'^' | b'~' | b'<' | b'>',
+                        b'(' | b'[' | b'/' | b'=' | b':' | b',' | b'?' | b';' | b'+' | b'-' | b'*'
+                        | b'%' | b'&' | b'|' | b'^' | b'~' | b'<' | b'>',
                         _,
                     ) => {
                         self.can_start_expression = true;
@@ -229,6 +242,17 @@ impl DirectiveLexer {
                     }
                 }
                 ScriptContext::LineComment => {}
+            }
+            let in_comment = matches!(
+                context,
+                ScriptContext::BlockComment | ScriptContext::LineComment
+            );
+            let starts_comment = matches!(
+                context,
+                ScriptContext::Code | ScriptContext::Interpolation(_)
+            ) && matches!((current, next), (b'/', Some(b'/' | b'*')));
+            if !in_comment && !current.is_ascii_whitespace() && !starts_comment {
+                has_code_token = true;
             }
             index += 1;
         }

--- a/crates/vize_patina/src/context/sfc_directives/lexer.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer.rs
@@ -61,8 +61,9 @@ impl DirectiveLexer {
         }
     }
 
-    pub(super) fn scan_line(&mut self, line: &str) -> CommentMarkers {
+    pub(super) fn scan_line(&mut self, line: &str, remaining: &str) -> CommentMarkers {
         let bytes = line.as_bytes();
+        let remaining_bytes = remaining.as_bytes();
         let mut markers = CommentMarkers::default();
         let mut has_code_token = false;
         let mut index = 0;
@@ -110,7 +111,7 @@ impl DirectiveLexer {
                     (b'<', _)
                         if self.jsx
                             && self.can_start_expression
-                            && is_jsx_start(bytes, index, self.tsx) =>
+                            && is_jsx_start(remaining_bytes, index, self.tsx) =>
                     {
                         self.jsx_depth += 1;
                         self.stack.push(ScriptContext::JsxText);

--- a/crates/vize_patina/src/context/sfc_directives/lexer.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer.rs
@@ -1,0 +1,229 @@
+//! Lightweight comment lexers for SFC script and style block contents.
+
+#[derive(Default)]
+pub(super) struct CommentMarkers {
+    pub(super) eslint: Option<usize>,
+    pub(super) vize: Option<usize>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ScriptContext {
+    Code,
+    Interpolation(u32),
+    SingleQuote,
+    DoubleQuote,
+    Template,
+    BlockComment,
+    LineComment,
+}
+
+pub(super) struct DirectiveLexer {
+    stack: Vec<ScriptContext>,
+}
+
+impl Default for DirectiveLexer {
+    fn default() -> Self {
+        Self {
+            stack: vec![ScriptContext::Code],
+        }
+    }
+}
+
+impl DirectiveLexer {
+    pub(super) fn scan_line(&mut self, line: &str) -> CommentMarkers {
+        let bytes = line.as_bytes();
+        let mut markers = CommentMarkers::default();
+        let mut index = 0;
+        while index < bytes.len() {
+            let context = *self.stack.last().expect("lexer always has a root context");
+            if matches!(
+                context,
+                ScriptContext::BlockComment | ScriptContext::LineComment
+            ) {
+                record_markers(bytes, index, &mut markers);
+            }
+
+            let current = bytes[index];
+            let next = bytes.get(index + 1).copied();
+            match context {
+                ScriptContext::Code | ScriptContext::Interpolation(_) => match (current, next) {
+                    (b'/', Some(b'/')) => {
+                        self.stack.push(ScriptContext::LineComment);
+                        index += 1;
+                    }
+                    (b'/', Some(b'*')) => {
+                        self.stack.push(ScriptContext::BlockComment);
+                        index += 1;
+                    }
+                    (b'\'', _) => self.stack.push(ScriptContext::SingleQuote),
+                    (b'"', _) => self.stack.push(ScriptContext::DoubleQuote),
+                    (b'`', _) => self.stack.push(ScriptContext::Template),
+                    (b'{', _) => {
+                        if let Some(ScriptContext::Interpolation(depth)) = self.stack.last_mut() {
+                            *depth += 1;
+                        }
+                    }
+                    (b'}', _) => {
+                        if let Some(ScriptContext::Interpolation(depth)) = self.stack.last_mut() {
+                            if *depth == 0 {
+                                self.stack.pop();
+                            } else {
+                                *depth -= 1;
+                            }
+                        }
+                    }
+                    _ => {}
+                },
+                ScriptContext::SingleQuote => match (current, next) {
+                    (b'\\', Some(_)) => index += 1,
+                    (b'\'', _) => {
+                        self.stack.pop();
+                    }
+                    _ => {}
+                },
+                ScriptContext::DoubleQuote => match (current, next) {
+                    (b'\\', Some(_)) => index += 1,
+                    (b'"', _) => {
+                        self.stack.pop();
+                    }
+                    _ => {}
+                },
+                ScriptContext::Template => match (current, next) {
+                    (b'\\', Some(_)) => index += 1,
+                    (b'`', _) => {
+                        self.stack.pop();
+                    }
+                    (b'$', Some(b'{')) => {
+                        self.stack.push(ScriptContext::Interpolation(0));
+                        index += 1;
+                    }
+                    _ => {}
+                },
+                ScriptContext::BlockComment => {
+                    if (current, next) == (b'*', Some(b'/')) {
+                        self.stack.pop();
+                        index += 1;
+                    }
+                }
+                ScriptContext::LineComment => {}
+            }
+            index += 1;
+        }
+
+        if matches!(self.stack.last(), Some(ScriptContext::LineComment)) {
+            self.stack.pop();
+        }
+        if !ends_with_unescaped_backslash(bytes) {
+            while matches!(
+                self.stack.last(),
+                Some(ScriptContext::SingleQuote | ScriptContext::DoubleQuote)
+            ) {
+                self.stack.pop();
+            }
+        }
+        markers
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StyleContext {
+    Code,
+    SingleQuote,
+    DoubleQuote,
+    BlockComment,
+    LineComment,
+}
+
+pub(super) struct StyleDirectiveLexer {
+    context: StyleContext,
+    allow_line_comments: bool,
+}
+
+impl StyleDirectiveLexer {
+    pub(super) fn new(allow_line_comments: bool) -> Self {
+        Self {
+            context: StyleContext::Code,
+            allow_line_comments,
+        }
+    }
+
+    pub(super) fn scan_line(&mut self, line: &str) -> CommentMarkers {
+        let bytes = line.as_bytes();
+        let mut markers = CommentMarkers::default();
+        let mut index = 0;
+        while index < bytes.len() {
+            if matches!(
+                self.context,
+                StyleContext::BlockComment | StyleContext::LineComment
+            ) {
+                record_markers(bytes, index, &mut markers);
+            }
+            let current = bytes[index];
+            let next = bytes.get(index + 1).copied();
+            match self.context {
+                StyleContext::Code => match (current, next) {
+                    (b'/', Some(b'*')) => {
+                        self.context = StyleContext::BlockComment;
+                        index += 1;
+                    }
+                    (b'/', Some(b'/')) if self.allow_line_comments => {
+                        self.context = StyleContext::LineComment;
+                        index += 1;
+                    }
+                    (b'\'', _) => self.context = StyleContext::SingleQuote,
+                    (b'"', _) => self.context = StyleContext::DoubleQuote,
+                    _ => {}
+                },
+                StyleContext::SingleQuote => match (current, next) {
+                    (b'\\', Some(_)) => index += 1,
+                    (b'\'', _) => self.context = StyleContext::Code,
+                    _ => {}
+                },
+                StyleContext::DoubleQuote => match (current, next) {
+                    (b'\\', Some(_)) => index += 1,
+                    (b'"', _) => self.context = StyleContext::Code,
+                    _ => {}
+                },
+                StyleContext::BlockComment => {
+                    if (current, next) == (b'*', Some(b'/')) {
+                        self.context = StyleContext::Code;
+                        index += 1;
+                    }
+                }
+                StyleContext::LineComment => {}
+            }
+            index += 1;
+        }
+        if self.context == StyleContext::LineComment {
+            self.context = StyleContext::Code;
+        }
+        if !ends_with_unescaped_backslash(bytes)
+            && matches!(
+                self.context,
+                StyleContext::SingleQuote | StyleContext::DoubleQuote
+            )
+        {
+            self.context = StyleContext::Code;
+        }
+        markers
+    }
+}
+
+fn record_markers(bytes: &[u8], index: usize, markers: &mut CommentMarkers) {
+    if markers.eslint.is_none() && bytes[index..].starts_with(b"eslint-") {
+        markers.eslint = Some(index);
+    }
+    if markers.vize.is_none() && bytes[index..].starts_with(b"@vize:") {
+        markers.vize = Some(index);
+    }
+}
+
+fn ends_with_unescaped_backslash(bytes: &[u8]) -> bool {
+    bytes
+        .iter()
+        .rev()
+        .take_while(|&&byte| byte == b'\\')
+        .count()
+        % 2
+        == 1
+}

--- a/crates/vize_patina/src/context/sfc_directives/lexer.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer.rs
@@ -6,8 +6,8 @@ mod token;
 pub(super) use style::StyleDirectiveLexer;
 
 use token::{
-    ends_with_unescaped_backslash, identifier_allows_expression, identifier_end,
-    is_identifier_start, is_jsx_start,
+    ParenContext, ends_with_unescaped_backslash, identifier_allows_expression, identifier_end,
+    identifier_opens_control_paren, is_identifier_start, is_jsx_start,
 };
 
 #[derive(Default)]
@@ -33,25 +33,31 @@ enum ScriptContext {
 pub(super) struct DirectiveLexer {
     stack: Vec<ScriptContext>,
     jsx: bool,
+    tsx: bool,
     jsx_depth: u32,
     can_start_expression: bool,
     after_dot: bool,
+    parens: Vec<ParenContext>,
+    next_paren_is_control: bool,
 }
 
 impl Default for DirectiveLexer {
     fn default() -> Self {
-        Self::new(false)
+        Self::new(false, false)
     }
 }
 
 impl DirectiveLexer {
-    pub(super) fn new(jsx: bool) -> Self {
+    pub(super) fn new(jsx: bool, tsx: bool) -> Self {
         Self {
             stack: vec![ScriptContext::Code],
             jsx,
+            tsx,
             jsx_depth: 0,
             can_start_expression: true,
             after_dot: false,
+            parens: Vec::new(),
+            next_paren_is_control: false,
         }
     }
 
@@ -72,6 +78,22 @@ impl DirectiveLexer {
             let current = bytes[index];
             let next = bytes.get(index + 1).copied();
             let had_code_token = has_code_token;
+            let starts_comment = matches!(
+                context,
+                ScriptContext::Code | ScriptContext::Interpolation(_)
+            ) && matches!((current, next), (b'/', Some(b'/' | b'*')));
+            if self.next_paren_is_control
+                && matches!(
+                    context,
+                    ScriptContext::Code | ScriptContext::Interpolation(_)
+                )
+                && !current.is_ascii_whitespace()
+                && !is_identifier_start(current)
+                && current != b'('
+                && !starts_comment
+            {
+                self.next_paren_is_control = false;
+            }
             match context {
                 ScriptContext::Code | ScriptContext::Interpolation(_) => match (current, next) {
                     (b'/', Some(b'/')) => {
@@ -86,7 +108,9 @@ impl DirectiveLexer {
                         self.stack.push(ScriptContext::Regex(false));
                     }
                     (b'<', _)
-                        if self.jsx && self.can_start_expression && is_jsx_start(bytes, index) =>
+                        if self.jsx
+                            && self.can_start_expression
+                            && is_jsx_start(bytes, index, self.tsx) =>
                     {
                         self.jsx_depth += 1;
                         self.stack.push(ScriptContext::JsxText);
@@ -116,12 +140,33 @@ impl DirectiveLexer {
                     }
                     (byte, _) if is_identifier_start(byte) => {
                         let end = identifier_end(bytes, index);
+                        let identifier = &bytes[index..end];
+                        let after_dot = self.after_dot;
+                        let keeps_control_paren =
+                            self.next_paren_is_control && identifier == b"await" && !after_dot;
+                        self.next_paren_is_control = keeps_control_paren
+                            || (!after_dot && identifier_opens_control_paren(identifier));
                         self.can_start_expression =
-                            !self.after_dot && identifier_allows_expression(&bytes[index..end]);
+                            !after_dot && identifier_allows_expression(identifier);
                         self.after_dot = false;
                         index = end - 1;
                     }
-                    (b')' | b']' | b'0'..=b'9', _) => {
+                    (b'(', _) => {
+                        let context = if std::mem::take(&mut self.next_paren_is_control) {
+                            ParenContext::Control
+                        } else {
+                            ParenContext::Expression
+                        };
+                        self.parens.push(context);
+                        self.can_start_expression = true;
+                        self.after_dot = false;
+                    }
+                    (b')', _) => {
+                        self.can_start_expression =
+                            matches!(self.parens.pop(), Some(ParenContext::Control));
+                        self.after_dot = false;
+                    }
+                    (b']' | b'0'..=b'9', _) => {
                         self.can_start_expression = false;
                         self.after_dot = false;
                     }
@@ -144,8 +189,8 @@ impl DirectiveLexer {
                         self.after_dot = false;
                     }
                     (
-                        b'(' | b'[' | b'/' | b'=' | b':' | b',' | b'?' | b';' | b'+' | b'-' | b'*'
-                        | b'%' | b'&' | b'|' | b'^' | b'~' | b'<' | b'>',
+                        b'[' | b'/' | b'=' | b':' | b',' | b'?' | b';' | b'+' | b'-' | b'*' | b'%'
+                        | b'&' | b'|' | b'^' | b'~' | b'<' | b'>',
                         _,
                     ) => {
                         self.can_start_expression = true;
@@ -247,10 +292,6 @@ impl DirectiveLexer {
                 context,
                 ScriptContext::BlockComment | ScriptContext::LineComment
             );
-            let starts_comment = matches!(
-                context,
-                ScriptContext::Code | ScriptContext::Interpolation(_)
-            ) && matches!((current, next), (b'/', Some(b'/' | b'*')));
             if !in_comment && !current.is_ascii_whitespace() && !starts_comment {
                 has_code_token = true;
             }

--- a/crates/vize_patina/src/context/sfc_directives/lexer.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer.rs
@@ -118,7 +118,7 @@ impl DirectiveLexer {
                         if let Some(ScriptContext::Interpolation(depth)) = self.stack.last_mut() {
                             *depth += 1;
                         }
-                        self.delimiters.open_brace();
+                        self.delimiters.open_brace(!self.can_start_expression);
                         self.can_start_expression = true;
                         self.after_dot = false;
                     }

--- a/crates/vize_patina/src/context/sfc_directives/lexer.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer.rs
@@ -13,23 +13,34 @@ enum ScriptContext {
     SingleQuote,
     DoubleQuote,
     Template,
+    Regex(bool),
+    JsxText,
+    JsxTag { closing: bool },
     BlockComment,
     LineComment,
 }
 
 pub(super) struct DirectiveLexer {
     stack: Vec<ScriptContext>,
+    jsx: bool,
+    jsx_depth: u32,
 }
 
 impl Default for DirectiveLexer {
     fn default() -> Self {
-        Self {
-            stack: vec![ScriptContext::Code],
-        }
+        Self::new(false)
     }
 }
 
 impl DirectiveLexer {
+    pub(super) fn new(jsx: bool) -> Self {
+        Self {
+            stack: vec![ScriptContext::Code],
+            jsx,
+            jsx_depth: 0,
+        }
+    }
+
     pub(super) fn scan_line(&mut self, line: &str) -> CommentMarkers {
         let bytes = line.as_bytes();
         let mut markers = CommentMarkers::default();
@@ -54,6 +65,14 @@ impl DirectiveLexer {
                     (b'/', Some(b'*')) => {
                         self.stack.push(ScriptContext::BlockComment);
                         index += 1;
+                    }
+                    (b'/', _) if can_start_literal(bytes, index) => {
+                        self.stack.push(ScriptContext::Regex(false));
+                    }
+                    (b'<', _) if self.jsx && can_start_jsx(bytes, index) => {
+                        self.jsx_depth += 1;
+                        self.stack.push(ScriptContext::JsxText);
+                        self.stack.push(ScriptContext::JsxTag { closing: false });
                     }
                     (b'\'', _) => self.stack.push(ScriptContext::SingleQuote),
                     (b'"', _) => self.stack.push(ScriptContext::DoubleQuote),
@@ -99,6 +118,52 @@ impl DirectiveLexer {
                     }
                     _ => {}
                 },
+                ScriptContext::Regex(in_class) => match (current, next) {
+                    (b'\\', Some(_)) => index += 1,
+                    (b'[', _) if !in_class => {
+                        if let Some(ScriptContext::Regex(in_class)) = self.stack.last_mut() {
+                            *in_class = true;
+                        }
+                    }
+                    (b']', _) if in_class => {
+                        if let Some(ScriptContext::Regex(in_class)) = self.stack.last_mut() {
+                            *in_class = false;
+                        }
+                    }
+                    (b'/', _) if !in_class => {
+                        self.stack.pop();
+                    }
+                    _ => {}
+                },
+                ScriptContext::JsxText => match (current, next) {
+                    (b'<', Some(b'/')) => {
+                        self.stack.push(ScriptContext::JsxTag { closing: true });
+                        index += 1;
+                    }
+                    (b'<', Some(next)) if next == b'>' || next.is_ascii_alphabetic() => {
+                        self.jsx_depth += 1;
+                        self.stack.push(ScriptContext::JsxTag { closing: false });
+                    }
+                    (b'{', _) => self.stack.push(ScriptContext::Interpolation(0)),
+                    _ => {}
+                },
+                ScriptContext::JsxTag { closing } => match (current, next) {
+                    (b'\'', _) => self.stack.push(ScriptContext::SingleQuote),
+                    (b'"', _) => self.stack.push(ScriptContext::DoubleQuote),
+                    (b'{', _) => self.stack.push(ScriptContext::Interpolation(0)),
+                    (b'/', Some(b'>')) if !closing => {
+                        self.stack.pop();
+                        self.finish_jsx_element();
+                        index += 1;
+                    }
+                    (b'>', _) => {
+                        self.stack.pop();
+                        if closing {
+                            self.finish_jsx_element();
+                        }
+                    }
+                    _ => {}
+                },
                 ScriptContext::BlockComment => {
                     if (current, next) == (b'*', Some(b'/')) {
                         self.stack.pop();
@@ -122,6 +187,13 @@ impl DirectiveLexer {
             }
         }
         markers
+    }
+
+    fn finish_jsx_element(&mut self) {
+        self.jsx_depth = self.jsx_depth.saturating_sub(1);
+        if self.jsx_depth == 0 && matches!(self.stack.last(), Some(ScriptContext::JsxText)) {
+            self.stack.pop();
+        }
     }
 }
 
@@ -226,4 +298,41 @@ fn ends_with_unescaped_backslash(bytes: &[u8]) -> bool {
         .count()
         % 2
         == 1
+}
+
+fn can_start_literal(bytes: &[u8], index: usize) -> bool {
+    let previous = bytes[..index]
+        .iter()
+        .rfind(|&&byte| !byte.is_ascii_whitespace())
+        .copied();
+    previous.is_none_or(|byte| {
+        matches!(
+            byte,
+            b'(' | b'['
+                | b'{'
+                | b'='
+                | b':'
+                | b','
+                | b'!'
+                | b'?'
+                | b';'
+                | b'+'
+                | b'-'
+                | b'*'
+                | b'%'
+                | b'&'
+                | b'|'
+                | b'^'
+                | b'~'
+                | b'<'
+                | b'>'
+        )
+    })
+}
+
+fn can_start_jsx(bytes: &[u8], index: usize) -> bool {
+    let Some(next) = bytes.get(index + 1).copied() else {
+        return false;
+    };
+    (next == b'>' || next.is_ascii_alphabetic()) && can_start_literal(bytes, index)
 }

--- a/crates/vize_patina/src/context/sfc_directives/lexer/brace.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer/brace.rs
@@ -244,7 +244,6 @@ impl DelimiterState {
         if !can_start_expression {
             self.expression_required = false;
             self.brace_expression_required = false;
-            self.possible_label = false;
         }
     }
 }
@@ -252,8 +251,7 @@ impl DelimiterState {
 fn identifier_can_be_label(identifier: &[u8]) -> bool {
     !matches!(
         identifier,
-        b"async"
-            | b"await"
+        b"await"
             | b"break"
             | b"case"
             | b"catch"

--- a/crates/vize_patina/src/context/sfc_directives/lexer/brace.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer/brace.rs
@@ -1,0 +1,128 @@
+//! Lightweight delimiter roles used to distinguish regex from division.
+
+use super::token::identifier_opens_control_paren;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ParenContext {
+    Expression,
+    Control,
+    Function(BraceContext),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum BraceContext {
+    Expression,
+    FunctionExpression,
+    Statement,
+}
+
+#[derive(Default)]
+pub(super) struct DelimiterState {
+    parens: Vec<ParenContext>,
+    braces: Vec<BraceContext>,
+    next_paren_is_control: bool,
+    next_paren_is_function: Option<BraceContext>,
+    function_type_depth: u32,
+    next_brace: Option<BraceContext>,
+    function_expression_required: bool,
+}
+
+impl DelimiterState {
+    pub(super) fn before_non_identifier(&mut self, byte: u8, starts_comment: bool) {
+        if byte.is_ascii_whitespace() || starts_comment {
+            return;
+        }
+        if byte != b'(' {
+            self.next_paren_is_control = false;
+        }
+        if self.next_paren_is_function.is_some() {
+            match byte {
+                b'(' | b'*' => {}
+                b'<' => self.function_type_depth += 1,
+                b'>' if self.function_type_depth > 0 => self.function_type_depth -= 1,
+                _ if self.function_type_depth > 0 => {}
+                _ => self.next_paren_is_function = None,
+            }
+        }
+        if byte != b'{' {
+            self.next_brace = None;
+        }
+    }
+
+    pub(super) fn observe_identifier(&mut self, identifier: &[u8], after_dot: bool) {
+        let keeps_control = self.next_paren_is_control && identifier == b"await" && !after_dot;
+        self.next_paren_is_control =
+            keeps_control || (!after_dot && identifier_opens_control_paren(identifier));
+        if after_dot {
+            self.next_paren_is_function = None;
+            self.function_type_depth = 0;
+        } else if identifier == b"function" {
+            self.next_paren_is_function = Some(if self.function_expression_required {
+                BraceContext::FunctionExpression
+            } else {
+                BraceContext::Statement
+            });
+            self.function_type_depth = 0;
+        }
+        self.next_brace = (!after_dot
+            && matches!(identifier, b"catch" | b"do" | b"else" | b"finally" | b"try"))
+        .then_some(BraceContext::Statement);
+        if self.function_expression_required
+            || !matches!(identifier, b"async" | b"declare" | b"default" | b"export")
+        {
+            self.function_expression_required = true;
+        }
+    }
+
+    pub(super) fn open_paren(&mut self) {
+        let context = if std::mem::take(&mut self.next_paren_is_control) {
+            ParenContext::Control
+        } else if let Some(body) = self.next_paren_is_function.take() {
+            self.function_type_depth = 0;
+            ParenContext::Function(body)
+        } else {
+            ParenContext::Expression
+        };
+        self.next_brace = None;
+        self.function_expression_required = true;
+        self.parens.push(context);
+    }
+
+    pub(super) fn close_paren(&mut self) -> bool {
+        let context = self.parens.pop();
+        self.next_brace = match context {
+            Some(ParenContext::Control) => Some(BraceContext::Statement),
+            Some(ParenContext::Function(body)) => Some(body),
+            _ => None,
+        };
+        self.function_expression_required = true;
+        matches!(context, Some(ParenContext::Control))
+    }
+
+    pub(super) fn open_brace(&mut self) {
+        let context = self.next_brace.take().unwrap_or(BraceContext::Expression);
+        self.function_expression_required = matches!(context, BraceContext::Expression);
+        self.braces.push(context);
+    }
+
+    pub(super) fn close_brace(&mut self) -> bool {
+        let closes_statement = matches!(self.braces.pop(), Some(BraceContext::Statement));
+        self.function_expression_required = !closes_statement;
+        closes_statement
+    }
+
+    pub(super) fn observe_arrow(&mut self) {
+        self.next_brace = Some(BraceContext::FunctionExpression);
+        self.function_expression_required = true;
+    }
+
+    pub(super) fn observe_operator(&mut self, operator: u8) {
+        self.function_expression_required = operator != b';';
+    }
+
+    pub(super) fn finish_line(&mut self, can_start_expression: bool) {
+        if !can_start_expression {
+            self.function_expression_required = false;
+        }
+    }
+}

--- a/crates/vize_patina/src/context/sfc_directives/lexer/brace.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer/brace.rs
@@ -12,8 +12,15 @@ enum ParenContext {
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum BraceContext {
     Expression,
-    FunctionExpression,
+    ExpressionBody,
     Statement,
+    TypeExpression,
+}
+
+#[derive(Default)]
+struct ReturnTypeState {
+    brace_depth: u32,
+    can_end: bool,
 }
 
 #[derive(Default)]
@@ -24,7 +31,10 @@ pub(super) struct DelimiterState {
     next_paren_is_function: Option<BraceContext>,
     function_type_depth: u32,
     next_brace: Option<BraceContext>,
-    function_expression_required: bool,
+    pending_function_body: Option<BraceContext>,
+    return_type: Option<ReturnTypeState>,
+    pending_class_body: Option<(BraceContext, usize)>,
+    expression_required: bool,
 }
 
 impl DelimiterState {
@@ -34,6 +44,9 @@ impl DelimiterState {
         }
         if byte != b'(' {
             self.next_paren_is_control = false;
+        }
+        if byte == b':' && self.pending_function_body.is_some() && self.return_type.is_none() {
+            self.return_type = Some(ReturnTypeState::default());
         }
         if self.next_paren_is_function.is_some() {
             match byte {
@@ -50,79 +63,145 @@ impl DelimiterState {
     }
 
     pub(super) fn observe_identifier(&mut self, identifier: &[u8], after_dot: bool) {
+        if let Some(return_type) = self.return_type.as_mut() {
+            return_type.can_end = true;
+        }
         let keeps_control = self.next_paren_is_control && identifier == b"await" && !after_dot;
         self.next_paren_is_control =
             keeps_control || (!after_dot && identifier_opens_control_paren(identifier));
         if after_dot {
-            self.next_paren_is_function = None;
-            self.function_type_depth = 0;
+            if self.function_type_depth == 0 {
+                self.next_paren_is_function = None;
+                self.pending_class_body = None;
+            }
         } else if identifier == b"function" {
-            self.next_paren_is_function = Some(if self.function_expression_required {
-                BraceContext::FunctionExpression
+            self.next_paren_is_function = Some(if self.expression_required {
+                BraceContext::ExpressionBody
             } else {
                 BraceContext::Statement
             });
             self.function_type_depth = 0;
+        } else if identifier == b"class" {
+            let body = if self.expression_required {
+                BraceContext::ExpressionBody
+            } else {
+                BraceContext::Statement
+            };
+            self.pending_class_body = Some((body, self.parens.len()));
         }
         self.next_brace = (!after_dot
             && matches!(identifier, b"catch" | b"do" | b"else" | b"finally" | b"try"))
         .then_some(BraceContext::Statement);
-        if self.function_expression_required
+        if self.expression_required
             || !matches!(identifier, b"async" | b"declare" | b"default" | b"export")
         {
-            self.function_expression_required = true;
+            self.expression_required = true;
         }
     }
 
     pub(super) fn open_paren(&mut self) {
         let context = if std::mem::take(&mut self.next_paren_is_control) {
             ParenContext::Control
-        } else if let Some(body) = self.next_paren_is_function.take() {
+        } else if self.function_type_depth == 0 && self.next_paren_is_function.is_some() {
+            let body = self.next_paren_is_function.take().unwrap();
             self.function_type_depth = 0;
             ParenContext::Function(body)
         } else {
             ParenContext::Expression
         };
+        if let Some(return_type) = self.return_type.as_mut() {
+            return_type.can_end = false;
+        }
         self.next_brace = None;
-        self.function_expression_required = true;
+        self.expression_required = true;
         self.parens.push(context);
     }
 
     pub(super) fn close_paren(&mut self) -> bool {
         let context = self.parens.pop();
-        self.next_brace = match context {
-            Some(ParenContext::Control) => Some(BraceContext::Statement),
-            Some(ParenContext::Function(body)) => Some(body),
-            _ => None,
-        };
-        self.function_expression_required = true;
+        self.next_brace = None;
+        match context {
+            Some(ParenContext::Control) => self.next_brace = Some(BraceContext::Statement),
+            Some(ParenContext::Function(body)) => self.pending_function_body = Some(body),
+            Some(ParenContext::Expression) => {
+                if let Some(return_type) = self.return_type.as_mut() {
+                    return_type.can_end = true;
+                }
+            }
+            None => {}
+        }
+        self.expression_required = true;
         matches!(context, Some(ParenContext::Control))
     }
 
-    pub(super) fn open_brace(&mut self) {
-        let context = self.next_brace.take().unwrap_or(BraceContext::Expression);
-        self.function_expression_required = matches!(context, BraceContext::Expression);
+    pub(super) fn open_brace(&mut self, expression_complete: bool) {
+        let function_body_starts = self.return_type.as_ref().is_none_or(|return_type| {
+            return_type.brace_depth == 0 && (return_type.can_end || expression_complete)
+        });
+        let context = if self.pending_function_body.is_some() && function_body_starts {
+            self.return_type = None;
+            self.pending_function_body.take().unwrap()
+        } else if self.pending_function_body.is_some() {
+            self.return_type.as_mut().unwrap().brace_depth += 1;
+            BraceContext::TypeExpression
+        } else if self
+            .pending_class_body
+            .is_some_and(|(_, depth)| depth == self.parens.len())
+        {
+            self.pending_class_body.take().unwrap().0
+        } else if let Some(context) = self.next_brace.take() {
+            context
+        } else if self.expression_required {
+            BraceContext::Expression
+        } else {
+            BraceContext::Statement
+        };
+        self.expression_required = matches!(context, BraceContext::Expression);
         self.braces.push(context);
     }
 
     pub(super) fn close_brace(&mut self) -> bool {
-        let closes_statement = matches!(self.braces.pop(), Some(BraceContext::Statement));
-        self.function_expression_required = !closes_statement;
+        let context = self.braces.pop();
+        let closes_statement = matches!(context, Some(BraceContext::Statement));
+        if matches!(context, Some(BraceContext::TypeExpression))
+            && let Some(return_type) = self.return_type.as_mut()
+        {
+            return_type.brace_depth = return_type.brace_depth.saturating_sub(1);
+            return_type.can_end = true;
+        }
+        self.expression_required = !closes_statement;
         closes_statement
     }
 
     pub(super) fn observe_arrow(&mut self) {
-        self.next_brace = Some(BraceContext::FunctionExpression);
-        self.function_expression_required = true;
+        if let Some(return_type) = self.return_type.as_mut() {
+            return_type.can_end = false;
+        } else {
+            self.next_brace = Some(BraceContext::ExpressionBody);
+        }
+        self.expression_required = true;
     }
 
     pub(super) fn observe_operator(&mut self, operator: u8) {
-        self.function_expression_required = operator != b';';
+        if let Some(return_type) = self.return_type.as_mut() {
+            return_type.can_end = operator == b'>';
+        }
+        if operator == b';'
+            && self
+                .return_type
+                .as_ref()
+                .is_none_or(|return_type| return_type.brace_depth == 0)
+        {
+            self.pending_function_body = None;
+            self.return_type = None;
+            self.pending_class_body = None;
+        }
+        self.expression_required = operator != b';';
     }
 
     pub(super) fn finish_line(&mut self, can_start_expression: bool) {
         if !can_start_expression {
-            self.function_expression_required = false;
+            self.expression_required = false;
         }
     }
 }

--- a/crates/vize_patina/src/context/sfc_directives/lexer/brace.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer/brace.rs
@@ -23,6 +23,12 @@ struct ReturnTypeState {
     can_end: bool,
 }
 
+struct ClassHeaderState {
+    body: BraceContext,
+    paren_depth: usize,
+    angle_depth: u32,
+}
+
 #[derive(Default)]
 pub(super) struct DelimiterState {
     parens: Vec<ParenContext>,
@@ -33,14 +39,19 @@ pub(super) struct DelimiterState {
     next_brace: Option<BraceContext>,
     pending_function_body: Option<BraceContext>,
     return_type: Option<ReturnTypeState>,
-    pending_class_body: Option<(BraceContext, usize)>,
+    class_headers: Vec<ClassHeaderState>,
     expression_required: bool,
+    brace_expression_required: bool,
+    possible_label: bool,
 }
 
 impl DelimiterState {
     pub(super) fn before_non_identifier(&mut self, byte: u8, starts_comment: bool) {
         if byte.is_ascii_whitespace() || starts_comment {
             return;
+        }
+        if byte != b':' {
+            self.possible_label = false;
         }
         if byte != b'(' {
             self.next_paren_is_control = false;
@@ -57,12 +68,26 @@ impl DelimiterState {
                 _ => self.next_paren_is_function = None,
             }
         }
+        if let Some(class_header) = self
+            .class_headers
+            .last_mut()
+            .filter(|class_header| class_header.paren_depth == self.parens.len())
+        {
+            match byte {
+                b'<' => class_header.angle_depth += 1,
+                b'>' if class_header.angle_depth > 0 => class_header.angle_depth -= 1,
+                _ => {}
+            }
+        }
         if byte != b'{' {
             self.next_brace = None;
         }
     }
 
     pub(super) fn observe_identifier(&mut self, identifier: &[u8], after_dot: bool) {
+        let at_statement_start = !self.expression_required && !self.brace_expression_required;
+        self.possible_label =
+            !after_dot && at_statement_start && identifier_can_be_label(identifier);
         if let Some(return_type) = self.return_type.as_mut() {
             return_type.can_end = true;
         }
@@ -72,7 +97,6 @@ impl DelimiterState {
         if after_dot {
             if self.function_type_depth == 0 {
                 self.next_paren_is_function = None;
-                self.pending_class_body = None;
             }
         } else if identifier == b"function" {
             self.next_paren_is_function = Some(if self.expression_required {
@@ -87,7 +111,11 @@ impl DelimiterState {
             } else {
                 BraceContext::Statement
             };
-            self.pending_class_body = Some((body, self.parens.len()));
+            self.class_headers.push(ClassHeaderState {
+                body,
+                paren_depth: self.parens.len(),
+                angle_depth: 0,
+            });
         }
         self.next_brace = (!after_dot
             && matches!(identifier, b"catch" | b"do" | b"else" | b"finally" | b"try"))
@@ -96,6 +124,9 @@ impl DelimiterState {
             || !matches!(identifier, b"async" | b"declare" | b"default" | b"export")
         {
             self.expression_required = true;
+        }
+        if self.brace_expression_required || !matches!(identifier, b"declare" | b"export") {
+            self.brace_expression_required = true;
         }
     }
 
@@ -114,6 +145,7 @@ impl DelimiterState {
         }
         self.next_brace = None;
         self.expression_required = true;
+        self.brace_expression_required = true;
         self.parens.push(context);
     }
 
@@ -131,6 +163,7 @@ impl DelimiterState {
             None => {}
         }
         self.expression_required = true;
+        self.brace_expression_required = true;
         matches!(context, Some(ParenContext::Control))
     }
 
@@ -144,19 +177,19 @@ impl DelimiterState {
         } else if self.pending_function_body.is_some() {
             self.return_type.as_mut().unwrap().brace_depth += 1;
             BraceContext::TypeExpression
-        } else if self
-            .pending_class_body
-            .is_some_and(|(_, depth)| depth == self.parens.len())
-        {
-            self.pending_class_body.take().unwrap().0
+        } else if self.class_headers.last().is_some_and(|class_header| {
+            class_header.angle_depth == 0 && class_header.paren_depth == self.parens.len()
+        }) {
+            self.class_headers.pop().unwrap().body
         } else if let Some(context) = self.next_brace.take() {
             context
-        } else if self.expression_required {
+        } else if self.brace_expression_required {
             BraceContext::Expression
         } else {
             BraceContext::Statement
         };
         self.expression_required = matches!(context, BraceContext::Expression);
+        self.brace_expression_required = self.expression_required;
         self.braces.push(context);
     }
 
@@ -170,6 +203,7 @@ impl DelimiterState {
             return_type.can_end = true;
         }
         self.expression_required = !closes_statement;
+        self.brace_expression_required = self.expression_required;
         closes_statement
     }
 
@@ -180,9 +214,11 @@ impl DelimiterState {
             self.next_brace = Some(BraceContext::ExpressionBody);
         }
         self.expression_required = true;
+        self.brace_expression_required = true;
     }
 
     pub(super) fn observe_operator(&mut self, operator: u8) {
+        let is_label = operator == b':' && std::mem::take(&mut self.possible_label);
         if let Some(return_type) = self.return_type.as_mut() {
             return_type.can_end = operator == b'>';
         }
@@ -194,14 +230,57 @@ impl DelimiterState {
         {
             self.pending_function_body = None;
             self.return_type = None;
-            self.pending_class_body = None;
+            if self.class_headers.last().is_some_and(|class_header| {
+                class_header.angle_depth == 0 && class_header.paren_depth == self.parens.len()
+            }) {
+                self.class_headers.pop();
+            }
         }
-        self.expression_required = operator != b';';
+        self.expression_required = !is_label && operator != b';';
+        self.brace_expression_required = self.expression_required;
     }
 
     pub(super) fn finish_line(&mut self, can_start_expression: bool) {
         if !can_start_expression {
             self.expression_required = false;
+            self.brace_expression_required = false;
+            self.possible_label = false;
         }
     }
+}
+
+fn identifier_can_be_label(identifier: &[u8]) -> bool {
+    !matches!(
+        identifier,
+        b"async"
+            | b"await"
+            | b"break"
+            | b"case"
+            | b"catch"
+            | b"class"
+            | b"const"
+            | b"continue"
+            | b"debugger"
+            | b"declare"
+            | b"default"
+            | b"do"
+            | b"else"
+            | b"export"
+            | b"extends"
+            | b"finally"
+            | b"for"
+            | b"function"
+            | b"if"
+            | b"import"
+            | b"let"
+            | b"new"
+            | b"return"
+            | b"switch"
+            | b"throw"
+            | b"try"
+            | b"var"
+            | b"while"
+            | b"with"
+            | b"yield"
+    )
 }

--- a/crates/vize_patina/src/context/sfc_directives/lexer/style.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer/style.rs
@@ -1,0 +1,88 @@
+//! Comment lexer for SFC style block contents.
+
+use super::token::ends_with_unescaped_backslash;
+use super::{CommentMarkers, record_markers};
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StyleContext {
+    Code,
+    SingleQuote,
+    DoubleQuote,
+    BlockComment,
+    LineComment,
+}
+
+pub(crate) struct StyleDirectiveLexer {
+    context: StyleContext,
+    allow_line_comments: bool,
+}
+
+impl StyleDirectiveLexer {
+    pub(crate) fn new(allow_line_comments: bool) -> Self {
+        Self {
+            context: StyleContext::Code,
+            allow_line_comments,
+        }
+    }
+
+    pub(crate) fn scan_line(&mut self, line: &str) -> CommentMarkers {
+        let bytes = line.as_bytes();
+        let mut markers = CommentMarkers::default();
+        let mut index = 0;
+        while index < bytes.len() {
+            if matches!(
+                self.context,
+                StyleContext::BlockComment | StyleContext::LineComment
+            ) {
+                record_markers(bytes, index, &mut markers);
+            }
+            let current = bytes[index];
+            let next = bytes.get(index + 1).copied();
+            match self.context {
+                StyleContext::Code => match (current, next) {
+                    (b'/', Some(b'*')) => {
+                        self.context = StyleContext::BlockComment;
+                        index += 1;
+                    }
+                    (b'/', Some(b'/')) if self.allow_line_comments => {
+                        self.context = StyleContext::LineComment;
+                        index += 1;
+                    }
+                    (b'\'', _) => self.context = StyleContext::SingleQuote,
+                    (b'"', _) => self.context = StyleContext::DoubleQuote,
+                    _ => {}
+                },
+                StyleContext::SingleQuote => match (current, next) {
+                    (b'\\', Some(_)) => index += 1,
+                    (b'\'', _) => self.context = StyleContext::Code,
+                    _ => {}
+                },
+                StyleContext::DoubleQuote => match (current, next) {
+                    (b'\\', Some(_)) => index += 1,
+                    (b'"', _) => self.context = StyleContext::Code,
+                    _ => {}
+                },
+                StyleContext::BlockComment => {
+                    if (current, next) == (b'*', Some(b'/')) {
+                        self.context = StyleContext::Code;
+                        index += 1;
+                    }
+                }
+                StyleContext::LineComment => {}
+            }
+            index += 1;
+        }
+        if self.context == StyleContext::LineComment {
+            self.context = StyleContext::Code;
+        }
+        if !ends_with_unescaped_backslash(bytes)
+            && matches!(
+                self.context,
+                StyleContext::SingleQuote | StyleContext::DoubleQuote
+            )
+        {
+            self.context = StyleContext::Code;
+        }
+        markers
+    }
+}

--- a/crates/vize_patina/src/context/sfc_directives/lexer/token.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer/token.rs
@@ -1,11 +1,5 @@
 //! Token-boundary helpers for the script directive lexer.
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub(super) enum ParenContext {
-    Expression,
-    Control,
-}
-
 pub(super) fn ends_with_unescaped_backslash(bytes: &[u8]) -> bool {
     bytes
         .iter()

--- a/crates/vize_patina/src/context/sfc_directives/lexer/token.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer/token.rs
@@ -57,7 +57,13 @@ fn is_generic_arrow_start(bytes: &[u8], start: usize) -> bool {
         return false;
     }
     let Some(parameters_end) = matching_close(bytes, parameters_start, b'(', b')') else {
-        return false;
+        // `<T,>(` is the standard TSX spelling that disambiguates a generic
+        // arrow from JSX. The parameter list may continue on later lines, so
+        // the current line cannot always contain its closing `)` and `=>`.
+        return bytes[start + 1..type_end]
+            .iter()
+            .rfind(|byte| !byte.is_ascii_whitespace())
+            == Some(&b',');
     };
     bytes[parameters_end + 1..]
         .windows(2)

--- a/crates/vize_patina/src/context/sfc_directives/lexer/token.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer/token.rs
@@ -1,0 +1,105 @@
+//! Token-boundary helpers for the script directive lexer.
+
+pub(super) fn ends_with_unescaped_backslash(bytes: &[u8]) -> bool {
+    bytes
+        .iter()
+        .rev()
+        .take_while(|&&byte| byte == b'\\')
+        .count()
+        % 2
+        == 1
+}
+
+pub(super) fn is_identifier_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || matches!(byte, b'_' | b'$') || byte >= 0x80
+}
+
+pub(super) fn identifier_end(bytes: &[u8], start: usize) -> usize {
+    bytes[start..]
+        .iter()
+        .position(|byte| {
+            !(byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$') || *byte >= 0x80)
+        })
+        .map_or(bytes.len(), |relative| start + relative)
+}
+
+pub(super) fn identifier_allows_expression(identifier: &[u8]) -> bool {
+    matches!(
+        identifier,
+        b"await"
+            | b"case"
+            | b"delete"
+            | b"in"
+            | b"instanceof"
+            | b"new"
+            | b"of"
+            | b"return"
+            | b"throw"
+            | b"typeof"
+            | b"void"
+            | b"yield"
+    )
+}
+
+pub(super) fn is_jsx_start(bytes: &[u8], start: usize) -> bool {
+    let Some(next) = bytes.get(start + 1).copied() else {
+        return false;
+    };
+    (next == b'>' || is_identifier_start(next)) && !is_generic_arrow_start(bytes, start)
+}
+
+fn is_generic_arrow_start(bytes: &[u8], start: usize) -> bool {
+    let Some(type_end) = matching_close(bytes, start, b'<', b'>') else {
+        return false;
+    };
+    let parameters_start = skip_whitespace(bytes, type_end + 1);
+    if bytes.get(parameters_start) != Some(&b'(') {
+        return false;
+    }
+    let Some(parameters_end) = matching_close(bytes, parameters_start, b'(', b')') else {
+        return false;
+    };
+    bytes[parameters_end + 1..]
+        .windows(2)
+        .any(|candidate| candidate == b"=>")
+}
+
+fn matching_close(bytes: &[u8], start: usize, open: u8, close: u8) -> Option<usize> {
+    let mut depth = 0usize;
+    let mut quote = None;
+    let mut cursor = start;
+    while cursor < bytes.len() {
+        let byte = bytes[cursor];
+        if let Some(active_quote) = quote {
+            match byte {
+                b'\\' => cursor += 1,
+                byte if byte == active_quote => quote = None,
+                _ => {}
+            }
+        } else {
+            match byte {
+                b'\'' | b'"' | b'`' => quote = Some(byte),
+                byte if byte == open => depth += 1,
+                byte if byte == close
+                    && !(close == b'>' && bytes.get(cursor.wrapping_sub(1)) == Some(&b'=')) =>
+                {
+                    depth = depth.checked_sub(1)?;
+                    if depth == 0 {
+                        return Some(cursor);
+                    }
+                }
+                _ => {}
+            }
+        }
+        cursor += 1;
+    }
+    None
+}
+
+fn skip_whitespace(bytes: &[u8], start: usize) -> usize {
+    start
+        + bytes[start..]
+            .iter()
+            .take_while(|byte| byte.is_ascii_whitespace())
+            .count()
+}

--- a/crates/vize_patina/src/context/sfc_directives/lexer/token.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer/token.rs
@@ -64,10 +64,13 @@ pub(super) fn is_jsx_start(bytes: &[u8], start: usize, tsx: bool) -> bool {
 }
 
 fn is_generic_arrow_start(bytes: &[u8], start: usize) -> bool {
+    const LOOKAHEAD_LIMIT: usize = 4 * 1024;
+
+    let bytes = &bytes[..bytes.len().min(start.saturating_add(LOOKAHEAD_LIMIT))];
     let Some(type_end) = matching_close(bytes, start, b'<', b'>') else {
         return false;
     };
-    let parameters_start = skip_whitespace(bytes, type_end + 1);
+    let parameters_start = skip_trivia(bytes, type_end + 1);
     if bytes.get(parameters_start) != Some(&b'(') {
         return false;
     }
@@ -76,9 +79,70 @@ fn is_generic_arrow_start(bytes: &[u8], start: usize) -> bool {
         // the type-parameter grammar itself disambiguates it from JSX.
         return disambiguates_type_parameters(&bytes[start + 1..type_end]);
     };
-    bytes[parameters_end + 1..]
-        .windows(2)
-        .any(|candidate| candidate == b"=>")
+    let arrow_start = skip_trivia(bytes, parameters_end + 1);
+    has_arrow_after_parameters(bytes, arrow_start)
+}
+
+fn has_arrow_after_parameters(bytes: &[u8], start: usize) -> bool {
+    if bytes
+        .get(start..)
+        .is_some_and(|remaining| remaining.starts_with(b"=>"))
+    {
+        return true;
+    }
+    if bytes.get(start) != Some(&b':') {
+        return false;
+    }
+
+    let mut depths = [0usize; 4];
+    let mut quote = None;
+    let mut line_comment = false;
+    let mut block_comment = false;
+    let mut cursor = start + 1;
+    while cursor < bytes.len() {
+        let byte = bytes[cursor];
+        let next = bytes.get(cursor + 1).copied();
+        if line_comment {
+            line_comment = byte != b'\n';
+        } else if block_comment {
+            if (byte, next) == (b'*', Some(b'/')) {
+                block_comment = false;
+                cursor += 1;
+            }
+        } else if let Some(active_quote) = quote {
+            match byte {
+                b'\\' => cursor += 1,
+                byte if byte == active_quote => quote = None,
+                _ => {}
+            }
+        } else {
+            let at_top_level = depths.iter().all(|depth| *depth == 0);
+            match (byte, next) {
+                (b'=', Some(b'>')) if at_top_level => return true,
+                (b';', _) if at_top_level => return false,
+                (b'/', Some(b'/')) => {
+                    line_comment = true;
+                    cursor += 1;
+                }
+                (b'/', Some(b'*')) => {
+                    block_comment = true;
+                    cursor += 1;
+                }
+                (b'\'' | b'"' | b'`', _) => quote = Some(byte),
+                (b'<', _) => depths[0] += 1,
+                (b'>', _) => depths[0] = depths[0].saturating_sub(1),
+                (b'(', _) => depths[1] += 1,
+                (b')', _) => depths[1] = depths[1].saturating_sub(1),
+                (b'[', _) => depths[2] += 1,
+                (b']', _) => depths[2] = depths[2].saturating_sub(1),
+                (b'{', _) => depths[3] += 1,
+                (b'}', _) => depths[3] = depths[3].saturating_sub(1),
+                _ => {}
+            }
+        }
+        cursor += 1;
+    }
+    false
 }
 
 fn disambiguates_type_parameters(bytes: &[u8]) -> bool {
@@ -128,10 +192,22 @@ fn disambiguates_type_parameters(bytes: &[u8]) -> bool {
 fn matching_close(bytes: &[u8], start: usize, open: u8, close: u8) -> Option<usize> {
     let mut depth = 0usize;
     let mut quote = None;
+    let mut line_comment = false;
+    let mut block_comment = false;
     let mut cursor = start;
     while cursor < bytes.len() {
         let byte = bytes[cursor];
-        if let Some(active_quote) = quote {
+        let next = bytes.get(cursor + 1).copied();
+        if line_comment {
+            if byte == b'\n' {
+                line_comment = false;
+            }
+        } else if block_comment {
+            if (byte, next) == (b'*', Some(b'/')) {
+                block_comment = false;
+                cursor += 1;
+            }
+        } else if let Some(active_quote) = quote {
             match byte {
                 b'\\' => cursor += 1,
                 byte if byte == active_quote => quote = None,
@@ -139,6 +215,14 @@ fn matching_close(bytes: &[u8], start: usize, open: u8, close: u8) -> Option<usi
             }
         } else {
             match byte {
+                b'/' if next == Some(b'/') => {
+                    line_comment = true;
+                    cursor += 1;
+                }
+                b'/' if next == Some(b'*') => {
+                    block_comment = true;
+                    cursor += 1;
+                }
                 b'\'' | b'"' | b'`' => quote = Some(byte),
                 byte if byte == open => depth += 1,
                 byte if byte == close
@@ -163,4 +247,30 @@ fn skip_whitespace(bytes: &[u8], start: usize) -> usize {
             .iter()
             .take_while(|byte| byte.is_ascii_whitespace())
             .count()
+}
+
+fn skip_trivia(bytes: &[u8], start: usize) -> usize {
+    let mut cursor = skip_whitespace(bytes, start);
+    loop {
+        match (bytes.get(cursor), bytes.get(cursor + 1)) {
+            (Some(b'/'), Some(b'/')) => {
+                cursor += 2;
+                cursor += bytes[cursor..]
+                    .iter()
+                    .position(|byte| *byte == b'\n')
+                    .unwrap_or(bytes.len() - cursor);
+            }
+            (Some(b'/'), Some(b'*')) => {
+                let Some(end) = bytes[cursor + 2..]
+                    .windows(2)
+                    .position(|candidate| candidate == b"*/")
+                else {
+                    return bytes.len();
+                };
+                cursor += end + 4;
+            }
+            _ => return cursor,
+        }
+        cursor = skip_whitespace(bytes, cursor);
+    }
 }

--- a/crates/vize_patina/src/context/sfc_directives/lexer/token.rs
+++ b/crates/vize_patina/src/context/sfc_directives/lexer/token.rs
@@ -1,5 +1,11 @@
 //! Token-boundary helpers for the script directive lexer.
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum ParenContext {
+    Expression,
+    Control,
+}
+
 pub(super) fn ends_with_unescaped_backslash(bytes: &[u8]) -> bool {
     bytes
         .iter()
@@ -29,6 +35,8 @@ pub(super) fn identifier_allows_expression(identifier: &[u8]) -> bool {
         b"await"
             | b"case"
             | b"delete"
+            | b"do"
+            | b"else"
             | b"in"
             | b"instanceof"
             | b"new"
@@ -41,11 +49,18 @@ pub(super) fn identifier_allows_expression(identifier: &[u8]) -> bool {
     )
 }
 
-pub(super) fn is_jsx_start(bytes: &[u8], start: usize) -> bool {
+pub(super) fn identifier_opens_control_paren(identifier: &[u8]) -> bool {
+    matches!(
+        identifier,
+        b"catch" | b"for" | b"if" | b"switch" | b"while" | b"with"
+    )
+}
+
+pub(super) fn is_jsx_start(bytes: &[u8], start: usize, tsx: bool) -> bool {
     let Some(next) = bytes.get(start + 1).copied() else {
         return false;
     };
-    (next == b'>' || is_identifier_start(next)) && !is_generic_arrow_start(bytes, start)
+    (next == b'>' || is_identifier_start(next)) && !(tsx && is_generic_arrow_start(bytes, start))
 }
 
 fn is_generic_arrow_start(bytes: &[u8], start: usize) -> bool {
@@ -57,17 +72,57 @@ fn is_generic_arrow_start(bytes: &[u8], start: usize) -> bool {
         return false;
     }
     let Some(parameters_end) = matching_close(bytes, parameters_start, b'(', b')') else {
-        // `<T,>(` is the standard TSX spelling that disambiguates a generic
-        // arrow from JSX. The parameter list may continue on later lines, so
-        // the current line cannot always contain its closing `)` and `=>`.
-        return bytes[start + 1..type_end]
-            .iter()
-            .rfind(|byte| !byte.is_ascii_whitespace())
-            == Some(&b',');
+        // TSX accepts a generic arrow before its closing `) =>` is visible when
+        // the type-parameter grammar itself disambiguates it from JSX.
+        return disambiguates_type_parameters(&bytes[start + 1..type_end]);
     };
     bytes[parameters_end + 1..]
         .windows(2)
         .any(|candidate| candidate == b"=>")
+}
+
+fn disambiguates_type_parameters(bytes: &[u8]) -> bool {
+    let mut angle_depth = 0usize;
+    let mut paren_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut brace_depth = 0usize;
+    let mut quote = None;
+    let mut cursor = 0;
+    while cursor < bytes.len() {
+        let byte = bytes[cursor];
+        if let Some(active_quote) = quote {
+            match byte {
+                b'\\' => cursor += 1,
+                byte if byte == active_quote => quote = None,
+                _ => {}
+            }
+        } else {
+            let at_top_level =
+                angle_depth == 0 && paren_depth == 0 && bracket_depth == 0 && brace_depth == 0;
+            match byte {
+                b'\'' | b'"' | b'`' => quote = Some(byte),
+                b',' | b'=' if at_top_level => return true,
+                byte if at_top_level && is_identifier_start(byte) => {
+                    let end = identifier_end(bytes, cursor);
+                    if matches!(&bytes[cursor..end], b"const" | b"extends") {
+                        return true;
+                    }
+                    cursor = end - 1;
+                }
+                b'<' => angle_depth += 1,
+                b'>' => angle_depth = angle_depth.saturating_sub(1),
+                b'(' => paren_depth += 1,
+                b')' => paren_depth = paren_depth.saturating_sub(1),
+                b'[' => bracket_depth += 1,
+                b']' => bracket_depth = bracket_depth.saturating_sub(1),
+                b'{' => brace_depth += 1,
+                b'}' => brace_depth = brace_depth.saturating_sub(1),
+                _ => {}
+            }
+        }
+        cursor += 1;
+    }
+    false
 }
 
 fn matching_close(bytes: &[u8], start: usize, open: u8, close: u8) -> Option<usize> {

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -231,7 +231,7 @@ impl Linter {
         ctx.set_help_level(self.help_level);
         ctx.set_dialect(env.dialect);
         if let Some(descriptor) = env.sfc_descriptor {
-            ctx.set_sfc_descriptor(descriptor);
+            ctx.set_sfc_template_descriptor(descriptor);
         }
         #[cfg(not(target_arch = "wasm32"))]
         let has_analysis = analysis.is_some();
@@ -738,7 +738,7 @@ impl Linter {
     }
 
     pub(crate) fn lint_sfc_template_root<'a>(&self, input: SfcTemplateLintInput<'a>) -> LintResult {
-        let mut result = self.lint_template_root(
+        self.lint_template_root(
             input.allocator,
             &input.template.content,
             input.filename,
@@ -748,9 +748,7 @@ impl Linter {
                 sfc_descriptor: input.descriptor,
                 dialect: VueDialect::Vue,
             },
-        );
-        offset_result(&mut result, input.template.loc.start as u32);
-        result
+        )
     }
 
     pub(crate) fn lint_sfc_template_with_descriptor<'a>(

--- a/crates/vize_patina/src/linter/engine/offset.rs
+++ b/crates/vize_patina/src/linter/engine/offset.rs
@@ -1,6 +1,7 @@
 //! Diagnostic offset adjustment for extracted template lint results.
 
 use super::super::config::LintResult;
+use crate::context::offset_diagnostic;
 
 pub(crate) fn offset_result(result: &mut LintResult, byte_offset: u32) {
     if byte_offset == 0 {
@@ -8,17 +9,6 @@ pub(crate) fn offset_result(result: &mut LintResult, byte_offset: u32) {
     }
 
     for diag in &mut result.diagnostics {
-        diag.start += byte_offset;
-        diag.end += byte_offset;
-        for label in &mut diag.labels {
-            label.start += byte_offset;
-            label.end += byte_offset;
-        }
-        if let Some(fix) = diag.fix.as_mut() {
-            for edit in &mut fix.edits {
-                edit.start += byte_offset;
-                edit.end += byte_offset;
-            }
-        }
+        offset_diagnostic(diag, byte_offset);
     }
 }

--- a/crates/vize_patina/src/linter/native_type_aware/snapshots/vize_patina__linter__native_type_aware__tests__type_aware_diagnostics_snapshot.snap
+++ b/crates/vize_patina/src/linter/native_type_aware/snapshots/vize_patina__linter__native_type_aware__tests__type_aware_diagnostics_snapshot.snap
@@ -6,8 +6,8 @@ expression: diagnostics
     (
         "vue/no-unused-properties",
         "Prop 'msg' is defined but never used",
-        336,
-        336,
+        64,
+        69,
         Some(
             "Remove unused prop or use it in your template/script",
         ),

--- a/crates/vize_patina/src/linter/tests/directives.rs
+++ b/crates/vize_patina/src/linter/tests/directives.rs
@@ -128,6 +128,30 @@ fn test_eslint_disable_next_line_suppresses_template_rule() {
 }
 
 #[test]
+fn test_template_apostrophe_does_not_hide_a_same_line_eslint_directive() {
+    // An apostrophe in prose is not a string delimiter, so the directive that
+    // follows it on the same line must still be read.
+    let linter = Linter::new();
+    let result = linter.lint_sfc(
+        r#"<template>
+  <p>Don't forget: <!-- eslint-disable-next-line vue/require-v-for-key --></p>
+  <ul><li v-for="item in items">{{ item }}</li></ul>
+</template>"#,
+        "test.vue",
+    );
+
+    assert_eq!(
+        result
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.rule_name == "vue/require-v-for-key")
+            .count(),
+        0,
+        "an unmatched apostrophe must not suppress the directive that follows it"
+    );
+}
+
+#[test]
 fn test_eslint_disable_line_suppresses_template_rule() {
     let linter = Linter::new();
     let result = linter.lint_template(

--- a/crates/vize_patina/src/rules/vue/no_unused_properties.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties.rs
@@ -34,11 +34,10 @@
 //!
 //! ## Report location
 //!
-//! Every diagnostic a `vue/*` rule produces is offset into the `<template>`
-//! block, so a location inside `<script setup>` cannot be expressed from here.
-//! The report is anchored at the start of the template block and names the prop
-//! in its message; upstream anchors at the prop declaration instead. That is a
-//! location divergence for the parity ledger, not a coverage one.
+//! A diagnostic starts at the prop's written name and covers its declaration.
+//! Inline type-literal members and runtime declarations carry their exact OXC
+//! source range through Croquis; an indirect type reference falls back to the
+//! `defineProps` call because the member is declared outside the macro.
 //!
 //! ## Examples
 //!
@@ -146,23 +145,31 @@ impl Rule for NoUnusedProperties {
         let Some(descriptor) = ctx.sfc_descriptor() else {
             return;
         };
-        let script_setup = descriptor
-            .script_setup
-            .as_ref()
-            .map(|block| block.content.as_ref());
-        let plain_script = descriptor
-            .script
-            .as_ref()
-            .map(|block| block.content.as_ref());
+        let script_setup = descriptor.script_setup.as_ref();
+        let plain_script = descriptor.script.as_ref();
+        let declaring_block = script_setup.or(plain_script);
+        let declaring_script = declaring_block
+            .map(|block| block.content.as_ref())
+            .unwrap_or_default();
+        let declaring_offset = declaring_block.map_or(0, |block| block.loc.start as u32);
+        // Lint analysis merges a sibling plain script before script setup and
+        // shifts every setup macro range into that combined view. This rule
+        // scans and reports against the original setup block, so normalize all
+        // macro-owned ranges back into its coordinate space together.
+        let setup_shift = match (plain_script, script_setup) {
+            (Some(plain), Some(_)) => plain.content.len() as u32 + 1,
+            _ => 0,
+        };
 
         // Collect unused props first (to avoid borrow conflicts).
-        let unused_props: Vec<String> = {
+        let unused_props: Vec<(String, u32, u32)> = {
             let Some(analysis) = ctx.analysis() else {
                 return;
             };
             let Some(call) = analysis.macros.define_props() else {
                 return;
             };
+            let call_span = unshift_span((call.start, call.end), setup_shift);
             let props = analysis.macros.props();
             if props.is_empty() {
                 return;
@@ -170,18 +177,17 @@ impl Rule for NoUnusedProperties {
 
             // `defineProps` is a `<script setup>` macro, so its span addresses
             // that block; fall back to a lone `<script>` for robustness.
-            let declaring_script = script_setup.or(plain_script).unwrap_or_default();
             if matches!(
-                classify_props_access(declaring_script, (call.start, call.end)),
+                classify_props_access(declaring_script, call_span),
                 PropsAccess::Captured
             ) {
                 return;
             }
 
             let mut referenced = template_references(root);
-            push_script_tokens(declaring_script, (call.start, call.end), &mut referenced);
+            push_script_tokens(declaring_script, call_span, &mut referenced);
             if let Some(plain) = plain_script.filter(|_| script_setup.is_some()) {
-                push_identifier_tokens(plain, &mut referenced);
+                push_identifier_tokens(&plain.content, &mut referenced);
             }
 
             let destructured = analysis.macros.props_destructure();
@@ -196,22 +202,37 @@ impl Rule for NoUnusedProperties {
                     // follow, so it is left alone.
                     destructured.is_none_or(|bindings| bindings.get(name).is_none())
                 })
-                .map(|prop| prop.name.to_compact_string())
+                .map(|prop| {
+                    let (start, end) = analysis
+                        .macros
+                        .prop_declaration(prop.name.as_str())
+                        .unwrap_or((call.start, call.end));
+                    let (start, end) = unshift_span((start, end), setup_shift);
+                    (
+                        prop.name.to_compact_string(),
+                        declaring_offset + start,
+                        declaring_offset + end,
+                    )
+                })
                 .collect()
         };
 
-        for prop_name in unused_props {
-            ctx.report(
+        for (prop_name, start, end) in unused_props {
+            ctx.report_in_sfc(
                 crate::diagnostic::LintDiagnostic::warn(
                     ctx.current_rule,
                     format!("Prop '{}' is defined but never used", prop_name),
-                    0,
-                    0,
+                    start,
+                    end,
                 )
                 .with_help("Remove unused prop or use it in your template/script"),
             );
         }
     }
+}
+
+fn unshift_span((start, end): (u32, u32), delta: u32) -> (u32, u32) {
+    (start.saturating_sub(delta), end.saturating_sub(delta))
 }
 
 /// Push the identifier tokens of `script`, minus the `defineProps` call.

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests.rs
@@ -5,6 +5,7 @@ use crate::rule::{Rule, RuleCategory};
 
 // The positive direction (a prop that must be reported) lives in the `reports`
 // submodule; this file keeps the helpers and the silent-direction cases.
+mod directive_lexer_reports;
 mod reports;
 
 /// Lint a full SFC with only this rule enabled.
@@ -39,14 +40,18 @@ fn none() -> Vec<(&'static str, Severity, u32, u32, &'static str)> {
     Vec::new()
 }
 
-/// The finding an unused `name` produces, anchored at the template block.
-fn unused(sfc: &str, name: &str) -> (&'static str, Severity, u32, u32, std::string::String) {
-    let anchor = sfc.find("<template>").expect("template block") + "<template>".len();
+/// The finding an unused `name` produces at its exact written declaration.
+fn unused(
+    sfc: &str,
+    name: &str,
+    declaration: &str,
+) -> (&'static str, Severity, u32, u32, std::string::String) {
+    let start = sfc.find(declaration).expect("prop declaration") as u32;
     (
         "vue/no-unused-properties",
         Severity::Warning,
-        anchor as u32,
-        anchor as u32,
+        start,
+        start + declaration.len() as u32,
         format!("Prop '{name}' is defined but never used"),
     )
 }

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests.rs
@@ -290,3 +290,35 @@ defineProps<{ msg: string; rows: string[] }>();
 "#;
     assert_eq!(findings(&lint_sfc(sfc)), none());
 }
+
+#[test]
+fn ignores_a_non_ascii_prop_named_by_a_sibling_options_api_block() {
+    // Identifiers are not ASCII-only, so a byte-wise token scan drops this
+    // reference entirely and reports the prop as unused.
+    let sfc = r#"<script>
+export default { methods: { show() { return this.ラベル; } } };
+</script>
+
+<script setup>
+defineProps({ ラベル: String });
+</script>
+
+<template>
+  <div>hi</div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_non_ascii_prop_read_in_an_interpolation() {
+    let sfc = r#"<script setup>
+defineProps({ étiquette: String });
+</script>
+
+<template>
+  <div>{{ étiquette }}</div>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests.rs
@@ -6,6 +6,7 @@ use crate::rule::{Rule, RuleCategory};
 // The positive direction (a prop that must be reported) lives in the `reports`
 // submodule; this file keeps the helpers and the silent-direction cases.
 mod directive_lexer_reports;
+mod directive_lexer_tsx_multiline;
 mod reports;
 
 /// Lint a full SFC with only this rule enabled.

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests.rs
@@ -46,6 +46,13 @@ fn unused(
     name: &str,
     declaration: &str,
 ) -> (&'static str, Severity, u32, u32, std::string::String) {
+    // A declaration that appears twice would make the expected range ambiguous,
+    // so the first match is only trustworthy when it is the only one.
+    assert_eq!(
+        sfc.matches(declaration).count(),
+        1,
+        "declaration {declaration:?} must occur exactly once"
+    );
     let start = sfc.find(declaration).expect("prop declaration") as u32;
     (
         "vue/no-unused-properties",

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests.rs
@@ -6,6 +6,7 @@ use crate::rule::{Rule, RuleCategory};
 // The positive direction (a prop that must be reported) lives in the `reports`
 // submodule; this file keeps the helpers and the silent-direction cases.
 mod directive_lexer_reports;
+mod directive_lexer_statement_blocks;
 mod directive_lexer_tsx_multiline;
 mod reports;
 

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
@@ -103,3 +103,43 @@ defineProps<{ msg: string }>();
 "#;
     assert_msg_reported(sfc);
 }
+
+#[test]
+fn division_at_the_start_of_a_line_does_not_hide_a_real_directive() {
+    let sfc = r#"<script setup lang="ts">
+const half = 10
+  / 2
+// eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>hi</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
+fn tsx_generic_arrow_does_not_hide_a_real_directive() {
+    let sfc = r#"<script setup lang="tsx">
+const identity = <T,>(value: T) => value
+// eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>hi</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
+fn jsx_after_return_keeps_raw_text_out_of_comment_directives() {
+    let sfc = r#"<script setup lang="tsx">
+function render() {
+  return <div>
+    // eslint-disable-next-line vue/no-unused-properties
+  </div>
+}
+defineProps<{ msg: string }>();
+</script>
+<template><div>hi</div></template>
+"#;
+    assert_msg_reported(sfc);
+}

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
@@ -235,6 +235,105 @@ defineProps<{{ msg: string }}>();
 }
 
 #[test]
+fn constrained_multiline_tsx_generic_arrow_does_not_hide_a_real_directive() {
+    let sfc = r#"<script setup lang="tsx">
+const identity = <T extends unknown>(
+  value: T,
+) => value
+// eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>{{ identity('ok') }}</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+fn assert_regex_marker_is_not_a_directive(statement: &str) {
+    let sfc = format!(
+        r#"<script setup lang="ts">
+declare const ok: boolean
+declare const input: string
+{statement}
+defineProps<{{ msg: string }}>();
+</script>
+<template><div>hi</div></template>
+"#
+    );
+    assert_msg_reported(&sfc);
+}
+
+#[test]
+fn regex_after_control_condition_stays_out_of_comment_directives() {
+    assert_regex_marker_is_not_a_directive("if (ok) /[/*] @vize:expected */.test(input)");
+}
+
+#[test]
+fn control_paren_survives_an_intervening_comment() {
+    assert_regex_marker_is_not_a_directive(
+        "if /* keep control state */ (ok) /[/*] @vize:expected */.test(input)",
+    );
+}
+
+#[test]
+fn for_await_control_paren_starts_a_regex_statement() {
+    assert_regex_marker_is_not_a_directive(
+        "for await (const value of input) /[/*] @vize:expected */.test(value)",
+    );
+}
+
+#[test]
+fn regex_after_else_stays_out_of_comment_directives() {
+    assert_regex_marker_is_not_a_directive(
+        "if (ok) input\nelse /[/*] @vize:expected */.test(input)",
+    );
+}
+
+#[test]
+fn regex_after_do_stays_out_of_comment_directives() {
+    assert_regex_marker_is_not_a_directive("do /[/*] @vize:expected */.test(input); while (ok)");
+}
+
+#[test]
+fn division_after_an_expression_paren_does_not_hide_a_real_directive() {
+    let sfc = r#"<script setup lang="ts">
+declare const input: number
+const half = Number(input)
+  / 2 // eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>{{ half }}</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
+fn jsx_after_control_condition_keeps_raw_text_out_of_comment_directives() {
+    let sfc = r#"<script setup lang="tsx">
+declare const ok: boolean
+if (ok) <div>
+  // eslint-disable-next-line vue/no-unused-properties
+</div>
+defineProps<{ msg: string }>();
+</script>
+<template><div>hi</div></template>
+"#;
+    assert_msg_reported(sfc);
+}
+
+#[test]
+fn constrained_jsx_tag_is_not_a_typescript_generic_arrow() {
+    let sfc = r#"<script setup lang="jsx">
+const vnode = <T extends unknown>(
+  // eslint-disable vue/no-unused-properties
+)</T>
+defineProps(['msg']);
+</script>
+<template><div>{{ vnode }}</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), vec![unused(sfc, "msg", "'msg'")]);
+}
+
+#[test]
 fn jsx_after_return_keeps_raw_text_out_of_comment_directives() {
     let sfc = r#"<script setup lang="tsx">
 function render() {

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
@@ -66,3 +66,40 @@ defineProps<{ msg: string }>();
 "#;
     assert_msg_reported(sfc);
 }
+
+#[test]
+fn same_line_style_directive_cannot_leak_into_script_setup() {
+    let sfc = r#"<style>/* eslint-disable vue/no-unused-properties */</style><script setup lang="ts">defineProps<{ msg: string }>();</script><template><div>hi</div></template>"#;
+    assert_msg_reported(sfc);
+}
+
+#[test]
+fn same_line_plain_script_directive_cannot_leak_into_script_setup() {
+    let sfc = r#"<script>/* eslint-disable vue/no-unused-properties */</script><script setup lang="ts">defineProps<{ msg: string }>();</script><template><div>hi</div></template>"#;
+    assert_msg_reported(sfc);
+}
+
+#[test]
+fn regex_braces_do_not_hide_a_following_real_directive() {
+    let sfc = r#"<script setup lang="ts">
+const marker = `${/\{/.test('{')}`
+// eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>hi</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
+fn tsx_raw_text_marker_is_not_a_comment_directive() {
+    let sfc = r#"<script setup lang="tsx">
+const vnode = <div>
+// eslint-disable-next-line vue/no-unused-properties
+</div>
+defineProps<{ msg: string }>();
+</script>
+<template><div>hi</div></template>
+"#;
+    assert_msg_reported(sfc);
+}

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
@@ -153,6 +153,46 @@ defineProps<{ msg: string }>();
 }
 
 #[test]
+fn multiline_tsx_generic_arrow_does_not_hide_a_real_directive() {
+    let sfc = r#"<script setup lang="tsx">
+const identity = <T,>(
+  value: T,
+) => value
+// eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>hi</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
+fn division_after_postfix_increment_does_not_hide_a_real_directive() {
+    let sfc = r#"<script setup lang="ts">
+let value = 10
+value++
+  / 2 // eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>hi</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
+fn division_after_postfix_decrement_does_not_hide_a_real_directive() {
+    let sfc = r#"<script setup lang="ts">
+let value = 10
+value--
+  / 2 // eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>hi</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
 fn jsx_after_return_keeps_raw_text_out_of_comment_directives() {
     let sfc = r#"<script setup lang="tsx">
 function render() {

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
@@ -118,6 +118,29 @@ defineProps<{ msg: string }>();
 }
 
 #[test]
+fn directive_on_the_script_tag_line_disables_the_next_line() {
+    let sfc = r#"<script setup lang="ts">// eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>hi</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
+fn division_after_a_postfix_increment_does_not_hide_a_real_directive() {
+    let sfc = r#"<script setup lang="ts">
+let index = 1
+const half = index++ / 2
+// eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>{{ half }}</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
 fn tsx_generic_arrow_does_not_hide_a_real_directive() {
     let sfc = r#"<script setup lang="tsx">
 const identity = <T,>(value: T) => value

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
@@ -193,6 +193,48 @@ defineProps<{ msg: string }>();
 }
 
 #[test]
+fn division_after_typescript_non_null_assertion_does_not_hide_a_real_directive() {
+    let sfc = r#"<script setup lang="ts">
+declare const value: number
+const half = value!
+  / 2 // eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>{{ half }}</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
+fn line_initial_logical_not_starts_an_expression() {
+    let sfc = r#"<script setup lang="ts">
+declare const input: string
+const previous = input
+!/[/*] @vize:expected */.test(input)
+defineProps<{ msg: string }>();
+</script>
+<template><div>{{ previous }}</div></template>
+"#;
+    assert_msg_reported(sfc);
+}
+
+#[test]
+fn inequality_operators_keep_regex_literals_out_of_comment_directives() {
+    for operator in ["!=", "!=="] {
+        let sfc = format!(
+            r#"<script setup lang="ts">
+declare const input: string
+const differs = input {operator} /[/*] @vize:expected */.source
+defineProps<{{ msg: string }}>();
+</script>
+<template><div>{{{{ differs }}}}</div></template>
+"#
+        );
+        assert_msg_reported(&sfc);
+    }
+}
+
+#[test]
 fn jsx_after_return_keeps_raw_text_out_of_comment_directives() {
     let sfc = r#"<script setup lang="tsx">
 function render() {

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
@@ -1,0 +1,30 @@
+//! SFC directive lexer coverage for JavaScript template interpolation.
+
+use super::{lint_sfc, owned, unused};
+
+#[test]
+fn nested_template_marker_is_not_a_comment_directive() {
+    let sfc = r#"<script setup lang="ts">
+const marker = `outer ${`// eslint-disable-next-line vue/no-unused-properties`}`
+defineProps<{ msg: string }>();
+</script>
+
+<template><div>hi</div></template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(sfc, "msg", "msg: string")]
+    );
+}
+
+#[test]
+fn interpolation_comment_remains_a_real_directive() {
+    let sfc = r#"<script setup lang="ts">
+const marker = `outer ${ /* eslint-disable-next-line vue/no-unused-properties */ 1 }`
+defineProps<{ msg: string }>();
+</script>
+
+<template><div>hi</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_reports.rs
@@ -2,6 +2,13 @@
 
 use super::{lint_sfc, owned, unused};
 
+fn assert_msg_reported(sfc: &str) {
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(sfc, "msg", "msg: string")]
+    );
+}
+
 #[test]
 fn nested_template_marker_is_not_a_comment_directive() {
     let sfc = r#"<script setup lang="ts">
@@ -11,10 +18,7 @@ defineProps<{ msg: string }>();
 
 <template><div>hi</div></template>
 "#;
-    assert_eq!(
-        owned(&lint_sfc(sfc)),
-        vec![unused(sfc, "msg", "msg: string")]
-    );
+    assert_msg_reported(sfc);
 }
 
 #[test]
@@ -27,4 +31,38 @@ defineProps<{ msg: string }>();
 <template><div>hi</div></template>
 "#;
     assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
+fn template_text_marker_cannot_disable_a_script_diagnostic() {
+    let sfc = r#"<template><div>// eslint-disable vue/no-unused-properties</div></template>
+<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+"#;
+    assert_msg_reported(sfc);
+}
+
+#[test]
+fn multiline_html_attribute_marker_is_not_a_comment_directive() {
+    let sfc = r#"<template><div title="prefix
+// eslint-disable vue/no-unused-properties
+suffix"></div></template>
+<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+"#;
+    assert_msg_reported(sfc);
+}
+
+#[test]
+fn escaped_newline_keeps_the_marker_inside_a_script_string() {
+    let sfc = r#"<script setup lang="ts">
+const marker = "prefix\
+// eslint-disable-next-line vue/no-unused-properties"
+defineProps<{ msg: string }>();
+</script>
+<template><div>hi</div></template>
+"#;
+    assert_msg_reported(sfc);
 }

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_statement_blocks.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_statement_blocks.rs
@@ -1,0 +1,95 @@
+//! Statement-block and expression-brace boundaries for script directives.
+
+use super::{lint_sfc, owned, unused};
+
+fn assert_regex_marker_is_not_a_directive(statement: &str) {
+    let sfc = format!(
+        r#"<script setup lang="ts">
+declare const ok: boolean
+declare const input: string
+{statement}
+defineProps<{{ msg: string }}>();
+</script>
+<template><div>hi</div></template>
+"#
+    );
+    assert_eq!(
+        owned(&lint_sfc(&sfc)),
+        vec![unused(&sfc, "msg", "msg: string")]
+    );
+}
+
+#[test]
+fn regex_after_if_statement_block_is_not_a_directive() {
+    assert_regex_marker_is_not_a_directive("if (ok) {}\n/[/*] @vize:expected */.test(input)");
+}
+
+#[test]
+fn regex_after_function_statement_block_is_not_a_directive() {
+    assert_regex_marker_is_not_a_directive(
+        "function check() {}\n/[/*] @vize:expected */.test(input)",
+    );
+    assert_regex_marker_is_not_a_directive(
+        "function check<T>() {}\n/[/*] @vize:expected */.test(input)",
+    );
+}
+
+#[test]
+fn regex_after_loop_statement_blocks_is_not_a_directive() {
+    assert_regex_marker_is_not_a_directive(
+        "while (ok) { break }\n/[/*] @vize:expected */.test(input)",
+    );
+    assert_regex_marker_is_not_a_directive(
+        "for (let index = 0; index < 1; index++) {}\n/[/*] @vize:expected */.test(input)",
+    );
+}
+
+#[test]
+fn regex_after_try_statement_blocks_is_not_a_directive() {
+    assert_regex_marker_is_not_a_directive("try {} catch {}\n/[/*] @vize:expected */.test(input)");
+    assert_regex_marker_is_not_a_directive(
+        "try {} finally {}\n/[/*] @vize:expected */.test(input)",
+    );
+}
+
+#[test]
+fn division_after_object_literal_keeps_a_real_directive() {
+    let sfc = r#"<script setup lang="ts">
+const object = { value: 10 }
+  / 2 // eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>{{ object }}</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
+fn division_inside_destructuring_default_keeps_a_real_directive() {
+    let sfc = r#"<script setup lang="ts">
+declare const source: { value?: unknown }
+const { value = { nested: 10 }
+  / 2 // eslint-disable vue/no-unused-properties
+} = source
+defineProps<{ msg: string }>();
+</script>
+<template><div>{{ value }}</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
+fn division_after_function_expressions_keeps_a_real_directive() {
+    for expression in ["function check() {}", "() => {}"] {
+        let sfc = format!(
+            r#"<script setup lang="ts">
+const check = {expression}
+  / 2 // eslint-disable-next-line vue/no-unused-properties
+defineProps<{{ msg: string }}>();
+</script>
+<template><div>{{{{ check }}}}</div></template>
+"#
+        );
+        assert_eq!(owned(&lint_sfc(&sfc)), Vec::new(), "{expression}");
+    }
+}

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_statement_blocks.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_statement_blocks.rs
@@ -15,7 +15,8 @@ defineProps<{{ msg: string }}>();
     );
     assert_eq!(
         owned(&lint_sfc(&sfc)),
-        vec![unused(&sfc, "msg", "msg: string")]
+        vec![unused(&sfc, "msg", "msg: string")],
+        "{statement}"
     );
 }
 
@@ -26,12 +27,17 @@ fn regex_after_if_statement_block_is_not_a_directive() {
 
 #[test]
 fn regex_after_function_statement_block_is_not_a_directive() {
-    assert_regex_marker_is_not_a_directive(
-        "function check() {}\n/[/*] @vize:expected */.test(input)",
-    );
-    assert_regex_marker_is_not_a_directive(
-        "function check<T>() {}\n/[/*] @vize:expected */.test(input)",
-    );
+    for declaration in [
+        "function check() {}",
+        "function check<T>() {}",
+        "function check(): void {}",
+        "function check<T>(): { value: T } {}",
+        "function check<T extends (...args: never[]) => unknown>(): boolean {}",
+    ] {
+        assert_regex_marker_is_not_a_directive(&format!(
+            "{declaration}\n/[/*] @vize:expected */.test(input)"
+        ));
+    }
 }
 
 #[test]
@@ -50,6 +56,15 @@ fn regex_after_try_statement_blocks_is_not_a_directive() {
     assert_regex_marker_is_not_a_directive(
         "try {} finally {}\n/[/*] @vize:expected */.test(input)",
     );
+}
+
+#[test]
+fn regex_after_standalone_and_class_blocks_is_not_a_directive() {
+    for statement in ["{}", "class Check {}"] {
+        assert_regex_marker_is_not_a_directive(&format!(
+            "{statement}\n/[/*] @vize:expected */.test(input)"
+        ));
+    }
 }
 
 #[test]
@@ -79,8 +94,13 @@ defineProps<{ msg: string }>();
 }
 
 #[test]
-fn division_after_function_expressions_keeps_a_real_directive() {
-    for expression in ["function check() {}", "() => {}"] {
+fn division_after_function_and_class_expressions_keeps_a_real_directive() {
+    for expression in [
+        "function check() {}",
+        "function check(): void {}",
+        "() => {}",
+        "class {}",
+    ] {
         let sfc = format!(
             r#"<script setup lang="ts">
 const check = {expression}

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_statement_blocks.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_statement_blocks.rs
@@ -63,6 +63,9 @@ fn regex_after_standalone_and_class_blocks_is_not_a_directive() {
     for statement in [
         "{}",
         "label: {}",
+        "label\n: {}",
+        "label\n/* comment */\n: {}",
+        "async: {}",
         "class Check {}",
         "class Check extends Foo.Bar {}",
         "class Check extends mixin(foo < bar) {}",

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_statement_blocks.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_statement_blocks.rs
@@ -60,7 +60,14 @@ fn regex_after_try_statement_blocks_is_not_a_directive() {
 
 #[test]
 fn regex_after_standalone_and_class_blocks_is_not_a_directive() {
-    for statement in ["{}", "class Check {}"] {
+    for statement in [
+        "{}",
+        "label: {}",
+        "class Check {}",
+        "class Check extends Foo.Bar {}",
+        "class Check extends mixin(foo < bar) {}",
+        "class Check<T extends { value: string }> {}",
+    ] {
         assert_regex_marker_is_not_a_directive(&format!(
             "{statement}\n/[/*] @vize:expected */.test(input)"
         ));
@@ -100,6 +107,8 @@ fn division_after_function_and_class_expressions_keeps_a_real_directive() {
         "function check(): void {}",
         "() => {}",
         "class {}",
+        "class extends Foo.Bar {}",
+        "class<T extends { value: string }> {}",
     ] {
         let sfc = format!(
             r#"<script setup lang="ts">
@@ -112,4 +121,16 @@ defineProps<{{ msg: string }}>();
         );
         assert_eq!(owned(&lint_sfc(&sfc)), Vec::new(), "{expression}");
     }
+}
+
+#[test]
+fn division_after_default_exported_object_keeps_a_real_directive() {
+    let sfc = r#"<script setup lang="ts">
+export default { value: 1 }
+  / 2 // eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>hi</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
 }

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_tsx_multiline.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/directive_lexer_tsx_multiline.rs
@@ -1,0 +1,69 @@
+//! TSX generic-arrow lookahead coverage for script directive scanning.
+
+use super::{lint_sfc, owned, unused};
+
+fn assert_msg_reported(sfc: &str) {
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(sfc, "msg", "msg: string")]
+    );
+}
+
+#[test]
+fn type_parameter_close_on_a_later_line_is_not_jsx() {
+    let sfc = r#"<script setup lang="tsx">
+const identity = <T
+  extends unknown
+>(value: T) => value
+// eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>{{ identity('ok') }}</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
+fn multiline_constraint_and_default_are_not_jsx() {
+    let sfc = r#"<script setup lang="tsx">
+const identity = <T
+  extends { value: string } = { value: string }
+>(value: T): T => value
+// eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>{{ identity({ value: 'ok' }) }}</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}
+
+#[test]
+fn jsx_with_a_constraint_shaped_attribute_stays_jsx() {
+    let sfc = r#"<script setup lang="tsx">
+const vnode = <T
+  extends="unknown"
+>(
+  // eslint-disable vue/no-unused-properties
+)</T>
+defineProps<{ msg: string }>();
+</script>
+<template><div>{{ vnode }}</div></template>
+"#;
+    assert_msg_reported(sfc);
+}
+
+#[test]
+fn relational_less_than_does_not_start_jsx_lookahead() {
+    let sfc = r#"<script setup lang="tsx">
+declare const value: number
+declare const T: number
+const compared = value < T
+  ? value
+  : T
+// eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+<template><div>{{ compared }}</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+}

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/tests/reports.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/tests/reports.rs
@@ -5,7 +5,7 @@ use super::{lint_sfc, owned, unused};
 // --- The recovered case: an unassigned defineProps -------------------------
 
 #[test]
-fn reports_a_prop_referenced_nowhere_issue_3416() {
+fn anchors_an_unused_prop_at_its_declaration_issue_3520() {
     let sfc = r#"<script setup lang="ts">
 defineProps<{ msg: string }>();
 </script>
@@ -14,7 +14,233 @@ defineProps<{ msg: string }>();
   <div>hi</div>
 </template>
 "#;
-    assert_eq!(owned(&lint_sfc(sfc)), vec![unused(sfc, "msg")]);
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(sfc, "msg", "msg: string")]
+    );
+}
+
+#[test]
+fn anchors_after_a_template_that_precedes_script_setup() {
+    let sfc = r#"<template>
+  <div>🦀</div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ trailing: string }>();
+</script>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(sfc, "trailing", "trailing: string")]
+    );
+}
+
+#[test]
+fn anchors_a_split_script_prop_after_normalizing_merged_macro_offsets() {
+    let sfc = r#"<script>
+export const moduleValue = 1;
+</script>
+
+<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template><div>hi</div></template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(sfc, "msg", "msg: string")]
+    );
+}
+
+#[test]
+fn split_script_indirect_type_falls_back_to_the_normalized_macro_call() {
+    let sfc = r#"<script>
+export const moduleValue = 1;
+</script>
+
+<script setup lang="ts">
+defineProps<Pick<{ msg: string }, 'msg'>>();
+</script>
+
+<template><div>hi</div></template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(
+            sfc,
+            "msg",
+            "defineProps<Pick<{ msg: string }, 'msg'>>()"
+        )]
+    );
+}
+
+#[test]
+fn split_script_runtime_spread_falls_back_to_the_normalized_macro_call() {
+    let sfc = r#"<script>
+export const moduleValue = 1;
+</script>
+
+<script setup>
+const common = { 'msg-prop': String }
+defineProps({ ...common })
+</script>
+
+<template><div>hi</div></template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(sfc, "msg-prop", "defineProps({ ...common })")]
+    );
+}
+
+#[test]
+fn split_script_usage_scan_excludes_the_normalized_macro_call() {
+    let sfc = r#"<script>
+export default { computed: { used() { return this.used } } }
+</script>
+
+<script setup lang="ts">
+defineProps<{ used: string; unused: string }>();
+</script>
+
+<template><div>hi</div></template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(sfc, "unused", "unused: string")]
+    );
+}
+
+#[test]
+fn split_script_prop_honors_eslint_disable_forms() {
+    for sfc in [
+        r#"<script>
+export const moduleValue = 1;
+</script>
+
+<script setup lang="ts">
+// eslint-disable-next-line vue/no-unused-properties
+defineProps<{ msg: string }>();
+</script>
+
+<template><div>hi</div></template>
+"#,
+        r#"<script>
+export const moduleValue = 1;
+</script>
+
+<script setup lang="ts">
+defineProps<{ msg: string }>(); // eslint-disable-line vue/no-unused-properties
+</script>
+
+<template><div>hi</div></template>
+"#,
+        r#"<script>
+export const moduleValue = 1;
+</script>
+
+<script setup lang="ts">
+// eslint-disable vue/no-unused-properties
+defineProps<{ msg: string }>();
+// eslint-enable vue/no-unused-properties
+</script>
+
+<template><div>hi</div></template>
+"#,
+    ] {
+        assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+    }
+}
+
+#[test]
+fn sfc_absolute_prop_ignores_eslint_markers_in_strings() {
+    let sfc = r#"<script setup lang="ts">
+const marker = "eslint-disable-next-line vue/no-unused-properties"
+defineProps<{ msg: string }>();
+</script>
+
+<template><div>hi</div></template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(sfc, "msg", "msg: string")]
+    );
+}
+
+#[test]
+fn sfc_absolute_prop_honors_vize_expected() {
+    for sfc in [
+        r#"<script setup lang="ts">
+// @vize:expected
+defineProps<{ msg: string }>();
+</script>
+
+<template><div>hi</div></template>
+"#,
+        r#"<script setup lang="ts">
+/* @vize:expected */
+defineProps<{ msg: string }>();
+</script>
+
+<template><div>hi</div></template>
+"#,
+    ] {
+        assert_eq!(owned(&lint_sfc(sfc)), Vec::new());
+    }
+}
+
+#[test]
+fn sfc_absolute_prop_honors_vize_ignore_region_but_not_string_contents() {
+    let ignored = r#"<script setup lang="ts">
+// @vize:ignore-start
+defineProps<{ msg: string }>();
+// @vize:ignore-end
+</script>
+
+<template><div>hi</div></template>
+"#;
+    assert_eq!(owned(&lint_sfc(ignored)), Vec::new());
+
+    let string = r#"<script setup lang="ts">
+const marker = "@vize:expected"
+defineProps<{ msg: string }>();
+</script>
+
+<template><div>hi</div></template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(string)),
+        vec![unused(string, "msg", "msg: string")]
+    );
+}
+
+#[test]
+fn sfc_absolute_prop_honors_every_vize_level() {
+    for (level, severity) in [
+        ("off", None),
+        ("warn", Some(crate::diagnostic::Severity::Warning)),
+        ("error", Some(crate::diagnostic::Severity::Error)),
+    ] {
+        let sfc = format!(
+            r#"<script setup lang="ts">
+// @vize:level({level})
+defineProps<{{ msg: string }}>();
+</script>
+
+<template><div>hi</div></template>
+"#
+        );
+        let result = lint_sfc(&sfc);
+        let Some(severity) = severity else {
+            assert_eq!(owned(&result), Vec::new(), "@vize:level({level})");
+            continue;
+        };
+        let mut expected = unused(&sfc, "msg", "msg: string");
+        expected.1 = severity;
+        assert_eq!(owned(&result), vec![expected], "@vize:level({level})");
+    }
 }
 
 #[test]
@@ -27,7 +253,10 @@ defineProps<{ msg: string; unused: number }>();
   <div>{{ msg }}</div>
 </template>
 "#;
-    assert_eq!(owned(&lint_sfc(sfc)), vec![unused(sfc, "unused")]);
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(sfc, "unused", "unused: number")]
+    );
 }
 
 #[test]
@@ -40,7 +269,23 @@ defineProps(['msg'])
   <div>hi</div>
 </template>
 "#;
-    assert_eq!(owned(&lint_sfc(sfc)), vec![unused(sfc, "msg")]);
+    assert_eq!(owned(&lint_sfc(sfc)), vec![unused(sfc, "msg", "'msg'")]);
+}
+
+#[test]
+fn reports_a_prop_of_a_runtime_object_declaration() {
+    let sfc = r#"<script setup>
+defineProps({ msg: String })
+</script>
+
+<template>
+  <div>hi</div>
+</template>
+"#;
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(sfc, "msg", "msg: String")]
+    );
 }
 
 #[test]
@@ -54,7 +299,10 @@ const upper = msg.toUpperCase();
   <div>{{ upper }}</div>
 </template>
 "#;
-    assert_eq!(owned(&lint_sfc(sfc)), vec![unused(sfc, "other")]);
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(sfc, "other", "other: number")]
+    );
 }
 
 // --- A name that is not a reference must still report ---------------------
@@ -71,7 +319,10 @@ defineProps<{ msg: string }>();
   <p title="msg">msg</p>
 </template>
 "#;
-    assert_eq!(owned(&lint_sfc(sfc)), vec![unused(sfc, "msg")]);
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(sfc, "msg", "msg: string")]
+    );
 }
 
 #[test]
@@ -85,5 +336,8 @@ defineProps<{ msg: string }>();
   <pre v-pre>{{ msg }}</pre>
 </template>
 "#;
-    assert_eq!(owned(&lint_sfc(sfc)), vec![unused(sfc, "msg")]);
+    assert_eq!(
+        owned(&lint_sfc(sfc)),
+        vec![unused(sfc, "msg", "msg: string")]
+    );
 }

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/usage.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/usage.rs
@@ -126,27 +126,31 @@ fn expression_source<'a>(exp: &'a ExpressionNode<'a>) -> &'a str {
 
 /// Push every identifier-shaped token of `source` onto `names`.
 pub(super) fn push_identifier_tokens(source: &str, names: &mut FxHashSet<CompactString>) {
-    let bytes = source.as_bytes();
-    let mut index = 0;
-    while index < bytes.len() {
-        if !is_identifier_start(bytes[index]) {
-            index += 1;
+    let mut chars = source.char_indices().peekable();
+    while let Some((offset, ch)) = chars.next() {
+        if !is_identifier_start(ch) {
             continue;
         }
-        let start = index;
-        while index < bytes.len() && is_identifier_byte(bytes[index]) {
-            index += 1;
+        let mut end = offset + ch.len_utf8();
+        while let Some(&(next_offset, next_ch)) = chars.peek() {
+            if !is_identifier_char(next_ch) {
+                break;
+            }
+            end = next_offset + next_ch.len_utf8();
+            chars.next();
         }
-        names.insert(CompactString::new(&source[start..index]));
+        names.insert(CompactString::new(&source[offset..end]));
     }
 }
 
+/// Identifiers may be non-ASCII (`ラベル`, `día`), so scan by character rather
+/// than by byte; otherwise such references read as absent.
 #[inline]
-fn is_identifier_start(byte: u8) -> bool {
-    byte.is_ascii_alphabetic() || byte == b'_' || byte == b'$'
+fn is_identifier_start(ch: char) -> bool {
+    ch.is_alphabetic() || ch == '_' || ch == '$'
 }
 
 #[inline]
-fn is_identifier_byte(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+fn is_identifier_char(ch: char) -> bool {
+    ch.is_alphanumeric() || ch == '_' || ch == '$'
 }

--- a/tests/snapshots/lint/__snapshots__/elk-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/elk-lint.snap
@@ -1056,10 +1056,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unused-properties] Prop 'noOverflowHidden' is defined but never used",
-        "line": 41,
-        "column": 11,
-        "endLine": 41,
-        "endColumn": 11,
+        "line": 11,
+        "column": 3,
+        "endLine": 11,
+        "endColumn": 29,
         "help": "Remove unused prop or use it in your template/script"
       },
       {
@@ -1888,10 +1888,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unused-properties] Prop 'alt' is defined but never used",
-        "line": 28,
-        "column": 11,
-        "endLine": 28,
-        "endColumn": 11,
+        "line": 6,
+        "column": 3,
+        "endLine": 6,
+        "endColumn": 15,
         "help": "Remove unused prop or use it in your template/script"
       },
       {
@@ -2015,10 +2015,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unused-properties] Prop 'inReplyToVisibility' is defined but never used",
-        "line": 394,
-        "column": 11,
-        "endLine": 394,
-        "endColumn": 11,
+        "line": 22,
+        "column": 3,
+        "endLine": 22,
+        "endColumn": 53,
         "help": "Remove unused prop or use it in your template/script"
       },
       {
@@ -2785,10 +2785,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unused-properties] Prop 'inNotification' is defined but never used",
-        "line": 37,
-        "column": 11,
-        "endLine": 37,
-        "endColumn": 11,
+        "line": 9,
+        "column": 3,
+        "endLine": 9,
+        "endColumn": 27,
         "help": "Remove unused prop or use it in your template/script"
       }
     ],

--- a/tests/snapshots/lint/__snapshots__/misskey-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/misskey-lint.snap
@@ -10517,28 +10517,6 @@
     "file": "src/components/MkPushNotificationAllowButton.vue",
     "messages": [
       {
-        "ruleId": "vue/no-unused-properties",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unused-properties] Prop 'danger' is defined but never used",
-        "line": 6,
-        "column": 11,
-        "endLine": 6,
-        "endColumn": 11,
-        "help": "Remove unused prop or use it in your template/script"
-      },
-      {
-        "ruleId": "vue/no-unused-properties",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unused-properties] Prop 'link' is defined but never used",
-        "line": 6,
-        "column": 11,
-        "endLine": 6,
-        "endColumn": 11,
-        "help": "Remove unused prop or use it in your template/script"
-      },
-      {
         "ruleId": "vue/sfc-element-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -10548,6 +10526,28 @@
         "endLine": 196,
         "endColumn": 10,
         "help": "Recommended order: <script> -> <template> -> <style>"
+      },
+      {
+        "ruleId": "vue/no-unused-properties",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-properties] Prop 'link' is defined but never used",
+        "line": 59,
+        "column": 2,
+        "endLine": 59,
+        "endColumn": 17,
+        "help": "Remove unused prop or use it in your template/script"
+      },
+      {
+        "ruleId": "vue/no-unused-properties",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unused-properties] Prop 'danger' is defined but never used",
+        "line": 63,
+        "column": 2,
+        "endLine": 63,
+        "endColumn": 19,
+        "help": "Remove unused prop or use it in your template/script"
       }
     ],
     "errorCount": 0,

--- a/tests/snapshots/lint/__snapshots__/npmx.dev-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/npmx.dev-lint.snap
@@ -1775,10 +1775,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unused-properties] Prop 'packageName' is defined but never used",
-        "line": 13,
-        "column": 11,
-        "endLine": 13,
-        "endColumn": 11,
+        "line": 6,
+        "column": 3,
+        "endLine": 6,
+        "endColumn": 22,
         "help": "Remove unused prop or use it in your template/script"
       },
       {
@@ -1786,10 +1786,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unused-properties] Prop 'version' is defined but never used",
-        "line": 13,
-        "column": 11,
-        "endLine": 13,
-        "endColumn": 11,
+        "line": 7,
+        "column": 3,
+        "endLine": 7,
+        "endColumn": 19,
         "help": "Remove unused prop or use it in your template/script"
       },
       {

--- a/tests/snapshots/lint/__snapshots__/nuxt-ui-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/nuxt-ui-lint.snap
@@ -2365,10 +2365,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unused-properties] Prop 'src' is defined but never used",
-        "line": 9,
-        "column": 11,
-        "endLine": 9,
-        "endColumn": 11,
+        "line": 3,
+        "column": 3,
+        "endLine": 3,
+        "endColumn": 14,
         "help": "Remove unused prop or use it in your template/script"
       }
     ],

--- a/tests/snapshots/lint/__snapshots__/vuefes-2025-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/vuefes-2025-lint.snap
@@ -140,10 +140,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unused-properties] Prop 'gapSp' is defined but never used",
-        "line": 21,
-        "column": 11,
-        "endLine": 21,
-        "endColumn": 11,
+        "line": 14,
+        "column": 3,
+        "endLine": 14,
+        "endColumn": 18,
         "help": "Remove unused prop or use it in your template/script"
       },
       {
@@ -151,10 +151,10 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-unused-properties] Prop 'linkPath' is defined but never used",
-        "line": 21,
-        "column": 11,
-        "endLine": 21,
-        "endColumn": 11,
+        "line": 15,
+        "column": 3,
+        "endLine": 15,
+        "endColumn": 21,
         "help": "Remove unused prop or use it in your template/script"
       },
       {


### PR DESCRIPTION
## Summary

- retain exact OXC ranges for inline and runtime prop declarations
- report SFC-absolute diagnostics without applying the template offset twice
- pin byte ranges and real-project lint snapshots, including template-first UTF-8 input

## Tests

- `cargo test -p vize_croquis --lib`
- `cargo test -p vize_patina --lib`
- `cargo clippy -p vize_croquis -p vize_patina --lib -- -D warnings`
- lint snapshots: elk, misskey, npmx.dev, nuxt-ui, vuefes-2025

Closes #3520

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved unused-property diagnostics by highlighting exact prop declarations.
  - Added prop usage detection across multiple script blocks and corrected merged source positions.
  - Corrected diagnostic locations and fix ranges for complete single-file components.
  - Improved handling of non-ASCII prop names.

- **New Features**
  - Added support for ESLint and Vize directives, including disabled rules, expected errors, and severity overrides.
  - Improved directive recognition across script, style, JSX, and template content.

- **Tests**
  - Expanded coverage for prop declarations, source ranges, directives, split scripts, spreads, and template ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->