### PR TITLE
fix(canon): reject authored SFC mirror paths

### DIFF
--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -10,6 +10,8 @@ mod error;
 mod executor;
 mod import_rewriter;
 #[cfg(test)]
+mod import_rewriter_authored_vue_ts_tests;
+#[cfg(test)]
 mod import_rewriter_dts_tests;
 #[cfg(test)]
 mod import_rewriter_tests;
@@ -23,6 +25,7 @@ mod runtime_deps;
 mod source_map;
 mod type_checker;
 mod virtual_project;
+mod virtual_specifier_message;
 mod virtual_ts;
 
 pub use error::{CorsaError, CorsaNotFoundError, CorsaResult, PackageManager};
@@ -39,7 +42,10 @@ pub use virtual_project::{
     generate_vue_content_mapper_transform, generate_vue_document_virtual_ts,
     generate_vue_document_virtual_ts_with_options,
 };
+pub use virtual_specifier_message::restore_virtual_vue_specifiers;
 pub use virtual_ts::VirtualTsGenerator;
+
+pub(crate) use virtual_specifier_message::AUTHORED_VUE_TS_SENTINEL;
 
 use vize_carton::String;
 

--- a/crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs
@@ -15,6 +15,7 @@
 //! mirror spelling themselves.
 
 use super::{DiagnosticMapper, OriginalPosition};
+use crate::batch::restore_virtual_vue_specifiers;
 use vize_carton::{String, cstr};
 
 /// The authored `.vue` spelling behind a generated mirror-module specifier, or
@@ -40,25 +41,10 @@ pub(crate) fn mirror_module_specifier_source(specifier: &str) -> Option<&str> {
 /// specifier — no whitespace and no quote characters — so an unbalanced pairing
 /// can never yield a run of prose that happens to end in `.vue.ts`.
 fn quoted_mirror_specifiers(message: &str) -> Vec<&str> {
-    let mut found: Vec<&str> = Vec::new();
-    for (open, close) in QUOTE_PAIRS {
-        let mut rest = message;
-        while let Some(start) = rest.find(open) {
-            let after_open = &rest[start + open.len_utf8()..];
-            let Some(end) = after_open.find(close) else {
-                break;
-            };
-            let candidate = &after_open[..end];
-            if is_specifier_shaped(candidate)
-                && mirror_module_specifier_source(candidate).is_some()
-                && !found.contains(&candidate)
-            {
-                found.push(candidate);
-            }
-            rest = &after_open[end + close.len_utf8()..];
-        }
-    }
-    found
+    quoted_specifiers(message)
+        .into_iter()
+        .filter(|candidate| mirror_module_specifier_source(candidate).is_some())
+        .collect()
 }
 
 fn is_specifier_shaped(candidate: &str) -> bool {
@@ -83,7 +69,12 @@ impl DiagnosticMapper<'_> {
         original: &OriginalPosition,
         message: String,
     ) -> String {
-        let rewrites: Vec<(String, String)> = quoted_mirror_specifiers(&message)
+        let mut rewritten = if let Some(source) = self.original_source(&original.path) {
+            restore_virtual_vue_specifiers(&message, &source.content)
+        } else {
+            message
+        };
+        let rewrites: Vec<(String, String)> = quoted_mirror_specifiers(&rewritten)
             .into_iter()
             .filter_map(|reported| {
                 let authored = mirror_module_specifier_source(reported)?;
@@ -91,7 +82,6 @@ impl DiagnosticMapper<'_> {
                     .then(|| (String::from(reported), String::from(authored)))
             })
             .collect();
-        let mut rewritten = message;
         for (reported, authored) in rewrites {
             for (open, close) in QUOTE_PAIRS {
                 let quoted = cstr!("{open}{reported}{close}");
@@ -139,6 +129,25 @@ impl DiagnosticMapper<'_> {
             .and_then(string_literal_at);
         literal_at_position == Some(authored) || !content.contains(reported)
     }
+}
+
+fn quoted_specifiers(message: &str) -> Vec<&str> {
+    let mut found = Vec::new();
+    for (open, close) in QUOTE_PAIRS {
+        let mut rest = message;
+        while let Some(start) = rest.find(open) {
+            let after_open = &rest[start + open.len_utf8()..];
+            let Some(end) = after_open.find(close) else {
+                break;
+            };
+            let candidate = &after_open[..end];
+            if is_specifier_shaped(candidate) && !found.contains(&candidate) {
+                found.push(candidate);
+            }
+            rest = &after_open[end + close.len_utf8()..];
+        }
+    }
+    found
 }
 
 /// The contents of the string literal starting at the beginning of `rest`, or

--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -8,6 +8,12 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_carton::{String, ToCompactString, cstr};
 
+use super::AUTHORED_VUE_TS_SENTINEL;
+
+#[path = "import_rewriter_authored_vue_ts.rs"]
+mod authored_vue_ts;
+use authored_vue_ts::unresolved_authored_vue_ts_collides_with_sfc;
+
 #[path = "import_rewriter_collect.rs"]
 mod collect;
 use collect::ModuleSpecifierCollector;
@@ -100,7 +106,7 @@ impl ImportRewriter {
         }
 
         self.rewrite_with(source, source_type, |path| {
-            self.rewrite_module_specifier(path)
+            self.rewrite_module_specifier(path, source_dir)
                 .or_else(|| source_dir.and_then(|dir| rewrite_relative_vue_specifier(path, dir)))
         })
     }
@@ -233,7 +239,10 @@ impl ImportRewriter {
         specifiers
     }
 
-    fn rewrite_module_specifier(&self, path: &str) -> Option<String> {
+    fn rewrite_module_specifier(&self, path: &str, source_dir: Option<&Path>) -> Option<String> {
+        if unresolved_authored_vue_ts_collides_with_sfc(path, source_dir) {
+            return Some(cstr!("{path}{AUTHORED_VUE_TS_SENTINEL}"));
+        }
         if is_rewritable_vue_specifier(path) {
             Some(cstr!("{path}.ts"))
         } else {
@@ -247,6 +256,9 @@ impl ImportRewriter {
         roots: (&std::path::Path, &std::path::Path),
         source_dir: Option<&std::path::Path>,
     ) -> Option<String> {
+        if unresolved_authored_vue_ts_collides_with_sfc(path, source_dir) {
+            return Some(cstr!("{path}{AUTHORED_VUE_TS_SENTINEL}"));
+        }
         if let Some(source_dir) = source_dir
             && let Some(rewritten) = rewrite_relative_dts_specifier(path, source_dir, roots.0)
                 .or_else(|| rewrite_relative_vue_specifier(path, source_dir))

--- a/crates/vize_canon/src/batch/import_rewriter_authored_vue_ts.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_authored_vue_ts.rs
@@ -1,0 +1,67 @@
+//! Distinguishes an authored `.vue.ts` import from an SFC mirror collision.
+
+use std::path::Path;
+
+use super::virtual_rewrite::append_extension;
+
+/// Whether an explicit `.vue.ts`/`.vue.tsx` specifier is proven to resolve only
+/// because Vize materializes the sibling `.vue` file at that exact path.
+pub(super) fn unresolved_authored_vue_ts_collides_with_sfc(
+    specifier: &str,
+    source_dir: Option<&Path>,
+) -> bool {
+    let suffix = if specifier.ends_with(".vue.tsx") {
+        ".tsx"
+    } else if specifier.ends_with(".vue.ts") {
+        ".ts"
+    } else {
+        return false;
+    };
+
+    let relative = specifier.starts_with("./") || specifier.starts_with("../");
+    let path = Path::new(specifier);
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else if relative {
+        let Some(source_dir) = source_dir else {
+            return false;
+        };
+        source_dir.join(path)
+    } else {
+        // Bare and aliased paths need the project resolver. Absence cannot be
+        // established from the authored directory alone.
+        return false;
+    };
+
+    let Some(name) = candidate.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let Some(sfc_name) = name.strip_suffix(suffix) else {
+        return false;
+    };
+    let sfc_path = candidate.with_file_name(sfc_name);
+    if !sfc_path.is_file() {
+        return false;
+    }
+
+    // TypeScript first substitutes the explicit TS/TSX suffix, then appends
+    // the standard candidate set to the full spelling, and finally tries the
+    // full spelling as a directory. Poison only when every native candidate is
+    // proven absent; permission/metadata errors stay conservatively untouched.
+    let stripped_extensions: &[&str] = if suffix == ".tsx" {
+        &[".tsx", ".ts", ".d.ts", ".jsx", ".js"]
+    } else {
+        &[".ts", ".tsx", ".d.ts", ".js", ".jsx"]
+    };
+    stripped_extensions
+        .iter()
+        .all(|extension| path_is_proven_absent(&append_extension(&sfc_path, extension)))
+        && [".ts", ".tsx", ".d.ts", ".js", ".jsx"]
+            .iter()
+            .all(|extension| path_is_proven_absent(&append_extension(&candidate, extension)))
+        && path_is_proven_absent(&candidate)
+}
+
+fn path_is_proven_absent(path: &Path) -> bool {
+    matches!(path.try_exists(), Ok(false))
+}

--- a/crates/vize_canon/src/batch/import_rewriter_authored_vue_ts_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_authored_vue_ts_tests.rs
@@ -6,7 +6,7 @@ use super::{AUTHORED_VUE_TS_SENTINEL, import_rewriter::ImportRewriter};
 #[test]
 fn authored_vue_ts_specifiers_cannot_resolve_generated_mirrors() {
     let case = TempDir::new().expect("temp project");
-    let project = case.path();
+    let project = std::fs::canonicalize(case.path()).expect("canonical temp project");
     let source_dir = project.join("src");
     let virtual_root = project.join("node_modules/.vize/canon");
     std::fs::create_dir_all(&source_dir).expect("source directory");
@@ -79,6 +79,14 @@ fn authored_vue_ts_specifiers_cannot_resolve_generated_mirrors() {
          import '{absent_absolute}{AUTHORED_VUE_TS_SENTINEL}';\n\
          import './Generated.vue.ts';\n"
     );
+    let full_declaration = source_dir
+        .join("FullDeclaration.vue.ts")
+        .to_string_lossy()
+        .replace('\\', "/");
+    let virtual_expected = expected.replace(
+        "import './FullDeclaration.vue.ts';",
+        &format!("import '{full_declaration}';"),
+    );
 
     let rewriter = ImportRewriter::new();
     assert_eq!(
@@ -92,11 +100,11 @@ fn authored_vue_ts_specifiers_cannot_resolve_generated_mirrors() {
             .rewrite_for_virtual_project(
                 &source,
                 SourceType::ts(),
-                (project, &virtual_root),
+                (&project, &virtual_root),
                 Some(&source_dir),
             )
             .code,
-        expected
+        virtual_expected
     );
 
     // Callers without an authored directory cannot prove that a relative

--- a/crates/vize_canon/src/batch/import_rewriter_authored_vue_ts_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_authored_vue_ts_tests.rs
@@ -1,0 +1,110 @@
+use oxc_span::SourceType;
+use tempfile::TempDir;
+
+use super::{AUTHORED_VUE_TS_SENTINEL, import_rewriter::ImportRewriter};
+
+#[test]
+fn authored_vue_ts_specifiers_cannot_resolve_generated_mirrors() {
+    let case = TempDir::new().expect("temp project");
+    let project = case.path();
+    let source_dir = project.join("src");
+    let virtual_root = project.join("node_modules/.vize/canon");
+    std::fs::create_dir_all(&source_dir).expect("source directory");
+    std::fs::write(source_dir.join("Mirror.vue"), "<template />").expect("SFC mirror");
+    std::fs::write(source_dir.join("MirrorJsx.vue"), "<template />").expect("TSX SFC mirror");
+    std::fs::write(source_dir.join("Real.vue.ts"), "export const real = true")
+        .expect("real authored vue.ts");
+    std::fs::write(
+        source_dir.join("RealJsx.vue.tsx"),
+        "export const real = true",
+    )
+    .expect("real authored vue.tsx");
+    std::fs::create_dir_all(source_dir.join("Directory.vue.ts")).expect("directory module");
+    std::fs::write(
+        source_dir.join("Directory.vue.ts/index.ts"),
+        "export const real = true",
+    )
+    .expect("directory module index");
+    for path in [
+        "Declaration.vue.d.ts",
+        "Runtime.vue.js",
+        "FullDeclaration.vue.ts.d.ts",
+        "FullSource.vue.ts.ts",
+    ] {
+        std::fs::write(source_dir.join(path), "export const real = true")
+            .expect("extension-substituted module");
+    }
+    for path in [
+        "Real.vue",
+        "RealJsx.vue",
+        "Directory.vue",
+        "Declaration.vue",
+        "Runtime.vue",
+        "FullDeclaration.vue",
+        "FullSource.vue",
+    ] {
+        std::fs::write(source_dir.join(path), "<template />").expect("colliding SFC mirror");
+    }
+
+    let absent_absolute = project.join("absent/Absolute.vue.ts");
+    std::fs::create_dir_all(absent_absolute.parent().unwrap()).expect("absolute source directory");
+    std::fs::write(project.join("absent/Absolute.vue"), "<template />")
+        .expect("absolute SFC mirror");
+    let absent_absolute = absent_absolute.to_string_lossy().replace('\\', "/");
+    let source = format!(
+        "import './Mirror.vue.ts';\n\
+         import './MirrorJsx.vue.tsx';\n\
+         import './Real.vue.ts';\n\
+         import './RealJsx.vue.tsx';\n\
+         import './Directory.vue.ts';\n\
+         import './Declaration.vue.ts';\n\
+         import './Runtime.vue.ts';\n\
+         import './FullDeclaration.vue.ts';\n\
+         import './FullSource.vue.ts';\n\
+         import '@/Alias.vue.ts';\n\
+         import '{absent_absolute}';\n\
+         import './Generated.vue';\n"
+    );
+    let expected = format!(
+        "import './Mirror.vue.ts{AUTHORED_VUE_TS_SENTINEL}';\n\
+         import './MirrorJsx.vue.tsx{AUTHORED_VUE_TS_SENTINEL}';\n\
+         import './Real.vue.ts';\n\
+         import './RealJsx.vue.tsx';\n\
+         import './Directory.vue.ts';\n\
+         import './Declaration.vue.ts';\n\
+         import './Runtime.vue.ts';\n\
+         import './FullDeclaration.vue.ts';\n\
+         import './FullSource.vue.ts';\n\
+         import '@/Alias.vue.ts';\n\
+         import '{absent_absolute}{AUTHORED_VUE_TS_SENTINEL}';\n\
+         import './Generated.vue.ts';\n"
+    );
+
+    let rewriter = ImportRewriter::new();
+    assert_eq!(
+        rewriter
+            .rewrite(&source, SourceType::ts(), Some(&source_dir))
+            .code,
+        expected
+    );
+    assert_eq!(
+        rewriter
+            .rewrite_for_virtual_project(
+                &source,
+                SourceType::ts(),
+                (project, &virtual_root),
+                Some(&source_dir),
+            )
+            .code,
+        expected
+    );
+
+    // Callers without an authored directory cannot prove that a relative
+    // `.vue.ts` is the generated mirror rather than a real source file.
+    assert_eq!(
+        rewriter
+            .rewrite("import './Mirror.vue.ts';", SourceType::ts(), None,)
+            .code,
+        "import './Mirror.vue.ts';"
+    );
+}

--- a/crates/vize_canon/src/batch/type_checker/tests/package_exports_types.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/package_exports_types.rs
@@ -76,10 +76,9 @@ import Literal from "./Literal.vue.ts";
 /// src/pages/LocalConsumer.vue(2,10): error TS2614: Module '"../components/Local.vue"' has no exported member 'Bare'. Did you mean to use 'import Bare from "../components/Local.vue"' instead?
 /// ```
 ///
-/// The second consumer pins the other direction: it hand-writes the `.vue.ts`
-/// specifier, so that spelling really is the author's and must survive
-/// verbatim. (vize resolves that import where `vue-tsc` reports `TS2307` for
-/// it; that resolution difference is not what this test covers.)
+/// The second consumer pins the other direction: a hand-written `.vue.ts`
+/// specifier must not resolve through the generated mirror, and its `TS2307`
+/// must keep the exact spelling the author wrote (#3482).
 #[test]
 fn module_member_diagnostics_report_the_authored_specifier() {
     if resolve_test_tsgo_binary().is_none() {
@@ -112,10 +111,29 @@ const label: string = Bare.label;
                 "src/pages/LiteralConsumer.vue",
                 r#"<script setup lang="ts">
 import { Bare } from "../components/Local.vue.ts";
+import { real } from "../components/Authored.vue.ts";
+import "../components/Missing.vue.ts/__vize_authored_vue_ts__";
+import { directory } from "../components/Directory.vue.ts";
 
-const label: string = Bare.label;
+const label: string = Bare.label + real + directory;
 </script>
 "#,
+            ),
+            (
+                "src/components/Authored.vue.ts",
+                r#"export const real: string = "authored";
+"#,
+            ),
+            (
+                "src/components/Directory.vue.ts/index.ts",
+                "export const directory: string = 'directory';\n",
+            ),
+            // With `allowArbitraryExtensions`, the old sibling suffix poison
+            // resolved this declaration instead of reporting TS2307. The
+            // child-path poison cannot traverse the generated mirror file.
+            (
+                "src/components/Local.vue.ts.d.__vize_authored_vue_ts__.ts",
+                "export declare const Bare: { label: number };\n",
             ),
         ],
     );
@@ -131,9 +149,16 @@ const label: string = Bare.label;
         vec![
             (
                 String::from("src/pages/LiteralConsumer.vue"),
-                Some(2614),
+                Some(2307),
                 String::from(
-                    "2:10:error Module '\"../components/Local.vue.ts\"' has no exported member 'Bare'. Did you mean to use 'import Bare from \"../components/Local.vue.ts\"' instead?"
+                    "2:22:error Cannot find module '../components/Local.vue.ts' or its corresponding type declarations."
+                ),
+            ),
+            (
+                String::from("src/pages/LiteralConsumer.vue"),
+                Some(2882),
+                String::from(
+                    "4:8:error Cannot find module or type declarations for side-effect import of '../components/Missing.vue.ts/__vize_authored_vue_ts__'."
                 ),
             ),
             (

--- a/crates/vize_canon/src/batch/virtual_specifier_message.rs
+++ b/crates/vize_canon/src/batch/virtual_specifier_message.rs
@@ -1,0 +1,109 @@
+//! Restores authored Vue module specifiers in TypeScript diagnostics.
+
+use vize_carton::{String, ToCompactString, cstr};
+
+/// Suffix added to an unresolved authored `.vue.ts`/`.vue.tsx` import so
+/// TypeScript cannot accidentally resolve the generated SFC mirror.
+pub(crate) const AUTHORED_VUE_TS_SENTINEL: &str = "/__vize_authored_vue_ts__";
+
+const QUOTE_PAIRS: [(char, char); 3] = [('\'', '\''), ('"', '"'), ('\u{2018}', '\u{2019}')];
+
+/// Restore virtual Vue module specifiers quoted in a TypeScript diagnostic.
+///
+/// Replacement requires proof that the reported spelling is absent from the
+/// authored source. This preserves diagnostics for real `.vue.ts` files and
+/// even for a deliberately authored sentinel-like module name.
+pub fn restore_virtual_vue_specifiers(message: &str, authored_source: &str) -> String {
+    let mut rewrites = Vec::new();
+    for reported in quoted_specifiers(message) {
+        if authored_source.contains(reported) {
+            continue;
+        }
+        let Some(authored) = authored_specifier(reported) else {
+            continue;
+        };
+        rewrites.push((reported.to_compact_string(), authored.to_compact_string()));
+    }
+
+    let mut rewritten = message.to_compact_string();
+    for (reported, authored) in rewrites {
+        for (open, close) in QUOTE_PAIRS {
+            let quoted = cstr!("{open}{reported}{close}");
+            let restored = cstr!("{open}{authored}{close}");
+            rewritten = rewritten.replace(quoted.as_str(), restored.as_str()).into();
+        }
+    }
+    rewritten
+}
+
+fn authored_specifier(reported: &str) -> Option<&str> {
+    if let Some(authored) = reported.strip_suffix(AUTHORED_VUE_TS_SENTINEL)
+        && (authored.ends_with(".vue.ts") || authored.ends_with(".vue.tsx"))
+    {
+        return Some(authored);
+    }
+    reported
+        .strip_suffix(".ts")
+        .or_else(|| reported.strip_suffix(".tsx"))
+        .filter(|authored| authored.ends_with(".vue"))
+}
+
+fn quoted_specifiers(message: &str) -> Vec<&str> {
+    let mut found = Vec::new();
+    for (open, close) in QUOTE_PAIRS {
+        let mut rest = message;
+        while let Some(start) = rest.find(open) {
+            let after_open = &rest[start + open.len_utf8()..];
+            let Some(end) = after_open.find(close) else {
+                break;
+            };
+            let candidate = &after_open[..end];
+            if is_specifier_shaped(candidate) && !found.contains(&candidate) {
+                found.push(candidate);
+            }
+            rest = &after_open[end + close.len_utf8()..];
+        }
+    }
+    found
+}
+
+fn is_specifier_shaped(candidate: &str) -> bool {
+    !candidate.is_empty()
+        && !candidate
+            .chars()
+            .any(|character| character.is_whitespace() || matches!(character, '\'' | '"' | '`'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AUTHORED_VUE_TS_SENTINEL, restore_virtual_vue_specifiers};
+
+    #[test]
+    fn restores_generated_mirrors_and_authored_collision_markers() {
+        let marker = AUTHORED_VUE_TS_SENTINEL;
+        let message =
+            format!("Module '\"./Panel.vue.ts\"' failed; cannot find '../Missing.vue.ts{marker}'.");
+        assert_eq!(
+            restore_virtual_vue_specifiers(
+                &message,
+                "import './Panel.vue'; import '../Missing.vue.ts'"
+            ),
+            "Module '\"./Panel.vue\"' failed; cannot find '../Missing.vue.ts'."
+        );
+    }
+
+    #[test]
+    fn preserves_authored_typescript_and_marker_like_specifiers() {
+        let marker = AUTHORED_VUE_TS_SENTINEL;
+        let reported = format!("./Literal.vue.ts{marker}");
+        let message = format!("Cannot find module '{reported}'. Also './Authored.vue.ts'.");
+        let source = format!("import '{reported}'; import './Authored.vue.ts';");
+        assert_eq!(restore_virtual_vue_specifiers(&message, &source), message);
+    }
+
+    #[test]
+    fn ignores_unquoted_suffixes_and_unrelated_modules() {
+        let message = "Generated ./Panel.vue.ts; cannot find './util.ts'.";
+        assert_eq!(restore_virtual_vue_specifiers(message, ""), message);
+    }
+}

--- a/crates/vize_canon/src/corsa_server/diagnostics.rs
+++ b/crates/vize_canon/src/corsa_server/diagnostics.rs
@@ -1,4 +1,5 @@
 use super::{CorsaServer, Diagnostic};
+use crate::batch::restore_virtual_vue_specifiers;
 use crate::corsa_bridge::CorsaVueVirtualProject;
 use crate::corsa_client::LspDiagnostic;
 use vize_carton::{String, cstr, line_index::LineIndex};
@@ -35,7 +36,13 @@ impl CorsaServer {
         Ok(corsa_diagnostics
             .into_iter()
             .filter_map(|diagnostic| {
-                map_corsa_diagnostic(project, &virtual_line_index, &source_line_index, diagnostic)
+                map_corsa_diagnostic(
+                    project,
+                    source,
+                    &virtual_line_index,
+                    &source_line_index,
+                    diagnostic,
+                )
             })
             .collect())
     }
@@ -43,6 +50,7 @@ impl CorsaServer {
 
 fn map_corsa_diagnostic(
     project: &CorsaVueVirtualProject,
+    source: &str,
     virtual_line_index: &LineIndex<'_>,
     source_line_index: &LineIndex<'_>,
     diagnostic: LspDiagnostic,
@@ -67,7 +75,7 @@ fn map_corsa_diagnostic(
         _ => cstr!("{code:?}"),
     });
     Some(Diagnostic {
-        message: diagnostic.message,
+        message: restore_virtual_vue_specifiers(&diagnostic.message, source),
         severity,
         line: one_based(line),
         column: one_based(column),
@@ -163,6 +171,7 @@ mod tests {
         let project = project();
         map_corsa_diagnostic(
             &project,
+            SOURCE,
             &LineIndex::new(&project.host.code),
             &LineIndex::new(SOURCE),
             diagnostic,
@@ -188,5 +197,30 @@ mod tests {
         assert_eq!(mapped.line, 1);
         assert_eq!(mapped.column, 1);
         assert_eq!(mapped.code.as_deref(), Some("TS6196"));
+    }
+
+    #[test]
+    fn restores_an_unresolved_authored_vue_ts_specifier() {
+        let marker = crate::batch::AUTHORED_VUE_TS_SENTINEL;
+        let mut raw = diagnostic(1, 0, 1);
+        raw.message = format!(
+            "Cannot find module './Missing.vue.ts{marker}' or its corresponding type declarations."
+        )
+        .into();
+        let source = "import Missing from './Missing.vue.ts';\n";
+        let project = project();
+        let mapped = map_corsa_diagnostic(
+            &project,
+            source,
+            &LineIndex::new(&project.host.code),
+            &LineIndex::new(source),
+            raw,
+        )
+        .expect("mapped diagnostic");
+
+        assert_eq!(
+            mapped.message,
+            "Cannot find module './Missing.vue.ts' or its corresponding type declarations."
+        );
     }
 }

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
@@ -183,7 +183,7 @@ pub(super) async fn collect_synced_virtual_result_diagnostics(
                 }),
                 code: diag.code.map(corsa_diagnostic_code),
                 source: Some(sources::TYPE_CHECKER.to_string()),
-                message: rewrite_corsa_message(&diag.message),
+                message: rewrite_corsa_message(&diag.message, content),
                 ..Default::default()
             })
         })

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/message.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/message.rs
@@ -1,5 +1,6 @@
 //! Vue-flavored rewriting of raw Corsa/TypeScript diagnostic messages.
 
+use vize_canon::batch::restore_virtual_vue_specifiers;
 use vize_carton::cstr;
 
 /// Rewrite a Corsa diagnostic message with a Vue-flavored hint when the
@@ -8,16 +9,9 @@ use vize_carton::cstr;
 /// The original wording is preserved as the prefix so the user can still see
 /// what TypeScript reported. The added hint points at the most common Vue
 /// cause for that error shape.
-pub(super) fn rewrite_corsa_message(message: &str) -> String {
-    let normalized_message;
-    let message = if message.contains(".vue.ts") {
-        normalized_message = message
-            .replace(".vue.tsx", ".vue")
-            .replace(".vue.ts", ".vue");
-        normalized_message.as_str()
-    } else {
-        message
-    };
+pub(super) fn rewrite_corsa_message(message: &str, authored_source: &str) -> String {
+    let normalized_message = restore_virtual_vue_specifiers(message, authored_source);
+    let message = normalized_message.as_str();
 
     if let Some(prop) = property_does_not_exist_property(message)
         && prop != "value"
@@ -55,7 +49,7 @@ mod hint_tests {
     #[test]
     fn rewrites_property_does_not_exist_with_value_hint() {
         let original = "Property 'toFixed' does not exist on type 'Ref<number>'.";
-        let rewritten = rewrite_corsa_message(original);
+        let rewritten = rewrite_corsa_message(original, "");
         assert!(rewritten.contains(original));
         assert!(
             rewritten.contains(".value"),
@@ -68,14 +62,14 @@ mod hint_tests {
         // We don't want to suggest `.value` on a `.value` access — that's
         // already what the user wrote.
         let original = "Property 'value' does not exist on type 'unknown'.";
-        let rewritten = rewrite_corsa_message(original);
+        let rewritten = rewrite_corsa_message(original, "");
         assert_eq!(rewritten, original);
     }
 
     #[test]
     fn rewrites_ref_assignment_with_unwrap_hint() {
         let original = "Type 'Ref<number>' is not assignable to type 'number'.";
-        let rewritten = rewrite_corsa_message(original);
+        let rewritten = rewrite_corsa_message(original, "");
         assert!(rewritten.contains(original));
         assert!(rewritten.contains("Did you forget `.value`"));
     }
@@ -83,7 +77,7 @@ mod hint_tests {
     #[test]
     fn rewrites_internal_vue_ts_imports_back_to_vue() {
         let original = "Cannot find module '../logo/MfMatesLogo.vue.ts' or its corresponding type declarations.";
-        let rewritten = rewrite_corsa_message(original);
+        let rewritten = rewrite_corsa_message(original, "import '../logo/MfMatesLogo.vue';");
 
         assert_eq!(
             rewritten,
@@ -96,7 +90,7 @@ mod hint_tests {
     fn rewrites_internal_vue_tsx_imports_back_to_vue() {
         let original =
             "Cannot find module './Panel.vue.tsx' or its corresponding type declarations.";
-        let rewritten = rewrite_corsa_message(original);
+        let rewritten = rewrite_corsa_message(original, "import './Panel.vue';");
 
         assert_eq!(
             rewritten,
@@ -108,7 +102,7 @@ mod hint_tests {
     #[test]
     fn rewrites_every_internal_vue_virtual_suffix_in_message() {
         let original = "Cannot find module '../logo/MfMatesLogo.vue.ts'. Related import './Panel.vue.tsx' also failed.";
-        let rewritten = rewrite_corsa_message(original);
+        let rewritten = rewrite_corsa_message(original, "");
 
         assert_eq!(
             rewritten,
@@ -122,7 +116,7 @@ mod hint_tests {
     fn rewrites_internal_vue_suffix_before_adding_value_hint() {
         let original =
             "Property 'toFixed' does not exist on type 'typeof import(\"./Panel.vue.ts\")'.";
-        let rewritten = rewrite_corsa_message(original);
+        let rewritten = rewrite_corsa_message(original, "");
 
         assert!(rewritten.contains("./Panel.vue"));
         assert!(!rewritten.contains(".vue.ts"));
@@ -132,7 +126,7 @@ mod hint_tests {
     #[test]
     fn passes_through_unrelated_messages() {
         let original = "Expected 1 argument, but got 0.";
-        assert_eq!(rewrite_corsa_message(original), original);
+        assert_eq!(rewrite_corsa_message(original, ""), original);
     }
 
     #[test]
@@ -144,6 +138,22 @@ mod hint_tests {
         assert_eq!(
             property_does_not_exist_property("Cannot find name 'foo'."),
             None
+        );
+    }
+
+    #[test]
+    fn preserves_authored_vue_ts_and_restores_collision_marker() {
+        let marker = "/__vize_authored_vue_ts__";
+        let original = format!("Cannot find module './Missing.vue.ts{marker}'.");
+        assert_eq!(
+            rewrite_corsa_message(&original, "import './Missing.vue.ts';"),
+            "Cannot find module './Missing.vue.ts'."
+        );
+
+        let authored = "Cannot find module './Authored.vue.ts'.";
+        assert_eq!(
+            rewrite_corsa_message(authored, "import './Authored.vue.ts';"),
+            authored
         );
     }
 }


### PR DESCRIPTION
## Summary

- prevent explicit missing `.vue.ts` and `.vue.tsx` imports from resolving generated SFC mirrors
- require a proven same-stem SFC collision and preserve TypeScript's native file, directory, and extension-substitution candidates
- restore authored module spellings across batch, check-server, and language-server diagnostics

## Validation

- `cargo test -p vize_canon --all-features`
- `cargo test -p vize_maestro --all-features`
- `cargo clippy -p vize_canon --all-features --lib -- -D warnings`
- `cargo clippy -p vize_maestro --all-features --lib -- -D warnings`
- exact tsgo resolver-collision and diagnostic snapshots
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #3482
Refs #3564

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue TypeScript import resolution when authored `.vue.ts` or `.vue.tsx` files conflict with generated Vue modules.
  * Diagnostics now restore readable `.vue` specifiers while preserving genuine authored TypeScript paths.
  * Fixed consistency between physical and virtual projects, including absolute, relative, and unresolved imports.

* **Tests**
  * Added coverage for collision handling, module resolution, diagnostic messages, and supported quote styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->