### PR TITLE
refactor(canon): share the quoted specifier scanner

### DIFF
--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -42,12 +42,10 @@ pub use virtual_project::{
     generate_vue_content_mapper_transform, generate_vue_document_virtual_ts,
     generate_vue_document_virtual_ts_with_options,
 };
-pub use virtual_specifier_message::restore_virtual_vue_specifiers;
+pub use virtual_specifier_message::{AUTHORED_VUE_TS_SENTINEL, restore_virtual_vue_specifiers};
 pub use virtual_ts::VirtualTsGenerator;
 
-pub(crate) use virtual_specifier_message::{
-    AUTHORED_VUE_TS_ALIAS_SENTINEL, AUTHORED_VUE_TS_SENTINEL,
-};
+pub(crate) use virtual_specifier_message::AUTHORED_VUE_TS_ALIAS_SENTINEL;
 
 use vize_carton::String;
 

--- a/crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs
@@ -30,8 +30,7 @@ pub(crate) fn mirror_module_specifier_source(specifier: &str) -> Option<&str> {
         .filter(|source| source.ends_with(".vue"))
 }
 
-/// Every distinct mirror-module specifier quoted in `message`, in first-seen
-/// order.
+/// Every distinct mirror-module specifier quoted in `message`.
 ///
 /// A checker message quotes a module specifier either directly
 /// (`Cannot find module './Panel.vue.ts'`) or doubly, as a module symbol name

--- a/crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs
@@ -16,6 +16,7 @@
 
 use super::{DiagnosticMapper, OriginalPosition};
 use crate::batch::restore_virtual_vue_specifiers;
+use crate::batch::virtual_specifier_message::{QUOTE_PAIRS, quoted_specifiers};
 use vize_carton::{String, cstr};
 
 /// The authored `.vue` spelling behind a generated mirror-module specifier, or
@@ -35,27 +36,14 @@ pub(crate) fn mirror_module_specifier_source(specifier: &str) -> Option<&str> {
 /// A checker message quotes a module specifier either directly
 /// (`Cannot find module './Panel.vue.ts'`) or doubly, as a module symbol name
 /// inside a quoted sentence (`Module '"./Panel.vue.ts"' ...`,
-/// `... 'import Panel from "./Panel.vue.ts"' ...`). Single- and double-quoted
-/// runs are therefore scanned in independent passes so a specifier nested
-/// inside another quoted run is still found. A candidate must look like a
-/// specifier — no whitespace and no quote characters — so an unbalanced pairing
-/// can never yield a run of prose that happens to end in `.vue.ts`.
+/// `... 'import Panel from "./Panel.vue.ts"' ...`), both of which the shared
+/// [`quoted_specifiers`] scan covers.
 fn quoted_mirror_specifiers(message: &str) -> Vec<&str> {
     quoted_specifiers(message)
         .into_iter()
         .filter(|candidate| mirror_module_specifier_source(candidate).is_some())
         .collect()
 }
-
-fn is_specifier_shaped(candidate: &str) -> bool {
-    !candidate.is_empty()
-        && !candidate
-            .chars()
-            .any(|character| character.is_whitespace() || matches!(character, '\'' | '"' | '`'))
-}
-
-/// The quote pairs a checker message may wrap a specifier in.
-const QUOTE_PAIRS: [(char, char); 3] = [('\'', '\''), ('"', '"'), ('\u{2018}', '\u{2019}')];
 
 impl DiagnosticMapper<'_> {
     /// Rewrite every generated mirror-module specifier in `message` back to the
@@ -129,25 +117,6 @@ impl DiagnosticMapper<'_> {
             .and_then(string_literal_at);
         literal_at_position == Some(authored) || !content.contains(reported)
     }
-}
-
-fn quoted_specifiers(message: &str) -> Vec<&str> {
-    let mut found = Vec::new();
-    for (open, close) in QUOTE_PAIRS {
-        let mut rest = message;
-        while let Some(start) = rest.find(open) {
-            let after_open = &rest[start + open.len_utf8()..];
-            let Some(end) = after_open.find(close) else {
-                break;
-            };
-            let candidate = &after_open[..end];
-            if is_specifier_shaped(candidate) && !found.contains(&candidate) {
-                found.push(candidate);
-            }
-            rest = &after_open[end + close.len_utf8()..];
-        }
-    }
-    found
 }
 
 /// The contents of the string literal starting at the beginning of `rest`, or

--- a/crates/vize_canon/src/batch/virtual_specifier_message.rs
+++ b/crates/vize_canon/src/batch/virtual_specifier_message.rs
@@ -4,10 +4,12 @@ use vize_carton::{String, ToCompactString, cstr};
 
 /// Suffix added to an unresolved authored `.vue.ts`/`.vue.tsx` import so
 /// TypeScript cannot accidentally resolve the generated SFC mirror.
-pub(crate) const AUTHORED_VUE_TS_SENTINEL: &str = "/__vize_authored_vue_ts__";
+pub const AUTHORED_VUE_TS_SENTINEL: &str = "/__vize_authored_vue_ts__";
 pub(crate) const AUTHORED_VUE_TS_ALIAS_SENTINEL: &str = ".__vize_authored_vue_ts_alias__";
 
-const QUOTE_PAIRS: [(char, char); 3] = [('\'', '\''), ('"', '"'), ('\u{2018}', '\u{2019}')];
+/// The quote pairs a checker message may wrap a specifier in.
+pub(crate) const QUOTE_PAIRS: [(char, char); 3] =
+    [('\'', '\''), ('"', '"'), ('\u{2018}', '\u{2019}')];
 
 /// Restore virtual Vue module specifiers quoted in a TypeScript diagnostic.
 ///
@@ -51,7 +53,15 @@ fn authored_specifier(reported: &str) -> Option<&str> {
         .filter(|authored| authored.ends_with(".vue"))
 }
 
-fn quoted_specifiers(message: &str) -> Vec<&str> {
+/// Every distinct specifier-shaped run quoted in `message`, in first-seen
+/// order.
+///
+/// Single- and double-quoted runs are scanned in independent passes so a
+/// specifier nested inside another quoted run (`Module '"./Panel.vue.ts"' ...`)
+/// is still found. A candidate must look like a specifier — no whitespace and
+/// no quote characters — so an unbalanced pairing can never yield a run of
+/// prose.
+pub(crate) fn quoted_specifiers(message: &str) -> Vec<&str> {
     let mut found = Vec::new();
     for (open, close) in QUOTE_PAIRS {
         let mut rest = message;

--- a/crates/vize_canon/src/batch/virtual_specifier_message.rs
+++ b/crates/vize_canon/src/batch/virtual_specifier_message.rs
@@ -53,14 +53,17 @@ fn authored_specifier(reported: &str) -> Option<&str> {
         .filter(|authored| authored.ends_with(".vue"))
 }
 
-/// Every distinct specifier-shaped run quoted in `message`, in first-seen
-/// order.
+/// Every distinct specifier-shaped run quoted in `message`.
 ///
-/// Single- and double-quoted runs are scanned in independent passes so a
-/// specifier nested inside another quoted run (`Module '"./Panel.vue.ts"' ...`)
-/// is still found. A candidate must look like a specifier — no whitespace and
-/// no quote characters — so an unbalanced pairing can never yield a run of
-/// prose.
+/// Each quote pair is scanned in its own pass so a specifier nested inside
+/// another quoted run (`Module '"./Panel.vue.ts"' ...`) is still found. The
+/// result is therefore grouped by [`QUOTE_PAIRS`] order, not by position in
+/// `message`: a double-quoted specifier precedes a single-quoted one only if
+/// its quote pair comes first. Both callers rewrite every returned specifier
+/// across the whole message, so order carries no meaning beyond determinism.
+///
+/// A candidate must look like a specifier — no whitespace and no quote
+/// characters — so an unbalanced pairing can never yield a run of prose.
 pub(crate) fn quoted_specifiers(message: &str) -> Vec<&str> {
     let mut found = Vec::new();
     for (open, close) in QUOTE_PAIRS {
@@ -90,7 +93,8 @@ fn is_specifier_shaped(candidate: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        AUTHORED_VUE_TS_ALIAS_SENTINEL, AUTHORED_VUE_TS_SENTINEL, restore_virtual_vue_specifiers,
+        AUTHORED_VUE_TS_ALIAS_SENTINEL, AUTHORED_VUE_TS_SENTINEL, quoted_specifiers,
+        restore_virtual_vue_specifiers,
     };
 
     #[test]
@@ -122,5 +126,20 @@ mod tests {
     fn ignores_unquoted_suffixes_and_unrelated_modules() {
         let message = "Generated ./Panel.vue.ts; cannot find './util.ts'.";
         assert_eq!(restore_virtual_vue_specifiers(message, ""), message);
+    }
+
+    #[test]
+    fn scans_mixed_quote_styles_grouped_by_quote_pair() {
+        let message = "Module \"./First.vue.ts\" and './Second.vue.ts' differ.";
+        assert_eq!(
+            quoted_specifiers(message),
+            ["./Second.vue.ts", "./First.vue.ts"],
+            "runs are grouped by QUOTE_PAIRS order, not by position in the message"
+        );
+        assert_eq!(
+            restore_virtual_vue_specifiers(message, "import './First.vue'; import './Second.vue';"),
+            "Module \"./First.vue\" and './Second.vue' differ.",
+            "every returned specifier is rewritten regardless of scan order"
+        );
     }
 }

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/message.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/message.rs
@@ -143,7 +143,7 @@ mod hint_tests {
 
     #[test]
     fn preserves_authored_vue_ts_and_restores_collision_marker() {
-        let marker = "/__vize_authored_vue_ts__";
+        let marker = vize_canon::batch::AUTHORED_VUE_TS_SENTINEL;
         let original = format!("Cannot find module './Missing.vue.ts{marker}'.");
         assert_eq!(
             rewrite_corsa_message(&original, "import './Missing.vue.ts';"),


### PR DESCRIPTION
Follow-up to #3565 (already squash-merged as `5fda5ef`), addressing two CodeRabbit review comments that arrived after the merge.

`batch::executor::diagnostics::module_specifier` carried a byte-identical copy of `QUOTE_PAIRS`, `quoted_specifiers`, and `is_specifier_shaped` alongside the originals in `batch::virtual_specifier_message`, so any correction to the quote scan had to be made in two places. The scanner now has one home and the diagnostics mapper imports it:

```rust
use crate::batch::restore_virtual_vue_specifiers;
use crate::batch::virtual_specifier_message::{QUOTE_PAIRS, quoted_specifiers};
```

`is_specifier_shaped` stays private to `virtual_specifier_message`; only the two items the mapper actually uses are `pub(crate)`. The mapper is a descendant of `batch`, so it can reach into the private `virtual_specifier_message` module without widening its visibility.

`AUTHORED_VUE_TS_SENTINEL` also changes from `pub(crate) use` to `pub use` in `batch.rs`, so the Maestro test in `ide/diagnostics/corsa/message.rs` asserts against `vize_canon::batch::AUTHORED_VUE_TS_SENTINEL` instead of re-spelling `"/__vize_authored_vue_ts__"` — the test can no longer pass while the sentinel is renamed.

No behavior change: the moved function bodies are unchanged, and `devirtualized_module_message` still filters the shared scan through `mirror_module_specifier_source`.

## Validation

- `cargo check -p vize_canon --lib --tests`
- `cargo check -p vize_maestro --lib --tests`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Test binaries could not be linked in this sandbox (4 GB disk, `No space left on device` during link), so the `vize_canon` / `vize_maestro` test runs are left to CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module-specifier detection in diagnostics, including nested quoted specifiers.
  * Maintained filtering for mirror modules and valid specifier formats.
  * Preserved authored Vue TypeScript module handling.

* **Refactor**
  * Consolidated specifier scanning logic for more consistent diagnostic behavior.
  * Clarified and standardized internal handling of virtual specifier markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->