### PR TITLE
docs: split getting started into an orientation page

### DIFF
--- a/docs/content/fr/getting-started.md
+++ b/docs/content/fr/getting-started.md
@@ -1,414 +1,91 @@
 ---
-title: Commencer
+title: Bien démarrer
 ---
 
 <!-- Generated translation; source: getting-started.md -->
 
-# Commencer
+# Bien démarrer
 
-> **⚠️ Travaux en cours :** Vize est en développement actif et n’est pas encore prêt pour une utilisation en production. Les API et les limites des paquets peuvent changer sans préavis.
+> **⚠️ En cours de développement :** Vize évolue activement et n’est pas encore prêt pour la
+> production. Les API et les frontières entre paquets peuvent changer sans préavis.
 
-## Qu’est-ce que Vize ?
+Vize (_/viːz/_) est une chaîne d’outils Vue.js native en Rust. Elle réunit la compilation, le lint,
+le formatage, la vérification de types, les diagnostics dans l’éditeur et l’exploration de composants
+dans un même workspace, tout en proposant chaque fonction via des paquets et commandes spécialisés.
 
-Vize (_/viːz/_) est une chaîne d’outils Vue.js écrite en Rust. L’espace de travail contient des blocs de construction
-partagés pour :
+| Besoin                                                                                | Point d’entrée recommandé   |
+| ------------------------------------------------------------------------------------- | --------------------------- |
+| Compiler des SFC Vue avec Vite                                                        | `@vizejs/vite-plugin`       |
+| Compiler des SFC Vue avec Nuxt                                                        | `@vizejs/nuxt`              |
+| Lancer le lint, le formatage et la vérification de types depuis les scripts du projet | `vize`                      |
+| Combiner les diagnostics Vize avec Oxlint                                             | `oxlint-plugin-vize`        |
+| Explorer et tester les composants                                                     | `@vizejs/vite-plugin-musea` |
+| Évaluer les fonctions d’édition                                                       | VS Code, Zed ou `vize lsp`  |
 
-| Superficie               | Caisse principale de rouille                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Point d’entrée orienté utilisateur             |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| Compilation              | [`vize_atelier_core`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_core), [`vize_atelier_dom`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_dom), [`vize_atelier_vapor`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_vapor), [`vize_atelier_ssr`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_ssr), [`vize_atelier_sfc`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_sfc) | `@vizejs/vite-plugin`, npm `vize:build` script |
-| Peluches                 | [`vize_patina`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_patina)                                                                                                                                                                                                                                                                                                                                                                                                             | NPM `vize:lint` script, `oxlint-plugin-vize`   |
-| Format                   | [`vize_glyph`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_glyph)                                                                                                                                                                                                                                                                                                                                                                                                               | Script `vize:fmt` NPM                          |
-| Contrôle de type         | [`vize_canon`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_canon)                                                                                                                                                                                                                                                                                                                                                                                                               | NPM `vize:check` script                        |
-| Support des éditeurs     | [`vize_maestro`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_maestro)                                                                                                                                                                                                                                                                                                                                                                                                           | VS Code, Zed, Rust `vize lsp`                  |
-| Outils d’art de la musea | [`vize_musea`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_musea)                                                                                                                                                                                                                                                                                                                                                                                                               | `@vizejs/vite-plugin-musea`                    |
-| Reliures                 | [`vize_vitrine`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_vitrine)                                                                                                                                                                                                                                                                                                                                                                                                           | `@vizejs/native`, `@vizejs/wasm`               |
+## Configurer un projet existant
 
-Ce guide recommande [Vite+](https://viteplus.dev/) (`vp`) pour la gestion de paquets JavaScript et les commandes de projet. Cela maintient la cohérence du flux d’installation et d’exécutif entre les gestionnaires de paquets tout en utilisant l’outil sous-jacent de l’espace de travail.
-
-Si vous n’avez pas encore `vp` , installez-le une fois et ouvrez un nouveau shell :
-
-```bash
-curl -fsSL https://vite.plus | bash
-```
-
-Consultez les [Vite+ docs](https://viteplus.dev/) et les [Installing Dependencies guide](https://viteplus.dev/guide/install) pour en savoir plus.
-
-## Ce que fait Vize
-
-À un niveau général, Vize est divisé en quelques voies réutilisables :
-
-| Voie                  | Paquet ou script                         | Ce que tu obtiens                                                                                           |
-| --------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Compiler              | `@vizejs/vite-plugin`, `vize:build`      | Compilation SFC Vue native Rust, sortie SSR, mode Vapor, gestion CSS à portée portée                        |
-| Analyse statique      | `vize:lint`, `oxlint-plugin-vize`        | Modèle Vue, script, CSS, a11y, SSR, Vapor, Musea, diagnostics cross-file et sensibles aux types             |
-| Contrôle de type      | `vize:check`                             | Génération de Virtual TypeScript, diagnostic de projet, mappage de diagnostic Vue vers la source            |
-| Format                | `vize:fmt`                               | Mise en page SFC Vue avec options de projet et de CLI                                                       |
-| Galerie de composants | `@vizejs/vite-plugin-musea`, `musea-vrt` | Fichiers artistiques, variantes composantes, configuration de prévisualisation, jetons de design, a11y, VRT |
-| Support des éditeurs  | VS Code, Zed, Rust `vize lsp`            | Diagnostics et fonctionnalités d’éditeur en option                                                          |
-
-Voir [Static Analysis](./guide/static-analysis.md) pour le modèle de vérification de lint et de type,
-[Rules](./rules/index.md) pour la sortie de règles concrètes, et
-[Configuration](./guide/configuration.md) pour les options partagées de configuration et de compilateur.
-
-Créer des composants dans JSX/TSX au lieu de `.vue` SFC ? Consultez le guide [JSX & TSX](./guide/jsx.md) —
-`.jsx`/`.tsx` composants Vue se compilent dans la même voie Rust.
-
-## Choisissez votre point d’entrée
-
-### 1. Projets Vite
-
-Utilisez le plugin Vite si vous voulez une compilation native de Vue dans un projet Vite existant.
+Lancez l’initialisation interactive à la racine du projet :
 
 ```bash
-vp install -D @vizejs/vite-plugin
+vpx vize init
 ```
 
-Installez `vize` comme dépendance directe uniquement lorsque vous souhaitez importer des assistants de configuration partagés depuis
-`"vize"` ou ajouter des scripts de paquets Vize comme `vize:lint` et `vize:check`.
+`vpx` est fourni avec [Vite+](https://viteplus.dev/guide/install). Installez d’abord Vite+ si la
+commande n’est pas disponible dans votre shell.
 
-```ts
-// vite.config.ts
-import { defineConfig } from "vite";
-import vize from "@vizejs/vite-plugin";
+Avant toute écriture, `vize init` détecte Vite, Vite+ ou Nuxt, le gestionnaire de paquets,
+TypeScript, la commande de lint active et la configuration Vize existante. Vous choisissez les
+éléments à configurer :
 
-export default defineConfig({
-  plugins: [vize()],
-});
-```
+- le plugin Vite ou le module Nuxt
+- le plugin Oxlint, dans le fichier réellement lu par la commande de lint active
+- les scripts de projet `vize fmt` et `vize check`
+- les réglages partagés `vize.config.*`
+- une recommandation d’extension VS Code
 
-Ajoutez des options de compilateur dans `vize.config.ts` lorsque vous souhaitez avoir les mêmes réglages pour intégrer
-scripts et le plugin :
-
-```ts
-import { defineConfig } from "vize";
-
-export default defineConfig({
-  compiler: {
-    sourceMap: true,
-    vapor: false,
-    customRenderer: false,
-  },
-  vite: {
-    scanPatterns: ["src/**/*.vue"],
-  },
-});
-```
-
-### 2. Projets Nuxt
-
-Utilisez le module Nuxt lorsque vous voulez que Vize tourne dans le pipeline Vite de Nuxt.
+Prévisualisez toutes les modifications de fichiers et de dépendances sans rien écrire :
 
 ```bash
-vp install @vizejs/nuxt
+vpx vize init --dry-run
 ```
 
-Ajoutez le module à `nuxt.config.ts`:
-
-```ts
-export default defineNuxtConfig({
-  modules: ["@vizejs/nuxt"],
-  vize: {
-    compiler: true,
-  },
-});
-```
-
-Faites tourner votre serveur de développement Nuxt comme d’habitude. Les registres du module `@vizejs/vite-plugin` pour la compilation de
-SFC Vue tout en préservant les importations automatiques Nuxt, les composants, les middlewares et les transformations SSR.
-
-Consultez le guide [Nuxt Integration](./integrations/nuxt.md) pour l’installation de Musea et les notes spécifiques à Nuxt.
-
-### 3. scripts de paquet npm + configuration partagée
-
-Utilisez le package `vize` npm lorsque vous voulez des utilitaires de configuration partagés et des commandes natives disponibles via
-scripts de projet.
+Dans la CI ou tout autre environnement non interactif, sélectionnez explicitement les fonctions :
 
 ```bash
-vp install -D vize
+vpx vize init --yes --lint --bundler --fmt --typecheck --editor
 ```
 
-Scripts de paquets recommandés :
+Consultez [Project Setup (en anglais)](../guide/init.md) pour les règles de détection, toutes les
+options, les garanties d’idempotence et les cas où l’initialiseur refuse volontairement de modifier
+un fichier.
 
-```json
-{
-  "scripts": {
-    "vize:build": "vize build src",
-    "vize:fmt": "vize fmt --write src",
-    "vize:lint": "vize lint --preset happy-path src",
-    "vize:check": "vize check src",
-    "vize:ready": "vize ready src"
-  }
-}
-```
+## Choisir une configuration manuelle
 
-```bash
-vp run vize:fmt
-vp run vize:lint
-vp run vize:check
-vp run vize:build
-vp run vize:ready
-```
+Préférez la configuration manuelle pour préserver une configuration existante ou adopter une seule
+partie de Vize à la fois :
 
-La commande `vize check` du package npm utilise le vérificateur NAPI empaqueté et peut émettre des déclarations de composantes Vue
-avec `--declaration --declaration-dir dist/types`. Utilisez la ligne de commande Rust lorsque vous avez besoin de
-`check-server`, LSP, gestion de l’IDE ou de diagnostics de projet via Vue, TS, TSX et `.d.ts` entrées.
+- [Plugin Vite](./guide/vite-plugin.md) — compilation native des SFC Vue dans Vite
+- [Intégration Nuxt](./integrations/nuxt.md) — voie prise en charge dans le pipeline Vite de Nuxt
+- [Scripts de paquet et CLI](./guide/cli.md) — `vize build`, `fmt`, `lint`, `check`, `ready` et la CLI
+  Rust complète
 
-### 4. CLI complet de rouille
+Vite est l’intégration de bundler recommandée. Les paquets unplugin et Rspack restent expérimentaux ;
+leur périmètre actuel est décrit dans [Autres bundlers](./guide/unplugin.md).
 
-La plupart des flux de travail applicatifs devraient utiliser les scripts de paquet npm ci-dessus. Utilisez le binaire Rust lorsque vous
-besoin de la CLI native complète aujourd’hui : LSP, gestion de l’IDE, profilage ou `check-server`. Pour l’alpha v1, les canaux publics
-pris en charge sont les binaires de publication GitHub et le point d’entrée Nix ; le CLI Rust n’est pas encore
-publié via crates.io.
+## Consulter les guides spécialisés
 
-```bash
-nix run github:ubugeeei-prod/vize#vize -- --help
-```
+Cette page sert volontairement de point d’orientation. Pour les détails de configuration et
+d’intégration, les guides spécialisés constituent la source de référence :
 
-```bash
-vize build src/**/*.vue
-vize fmt --check src
-vize lint --profile src
-vize check --profile src
-vize ready src
-vize lsp
-```
+- [Configuration](./guide/configuration.md) — `vize.config.*`, options du compilateur, vérification
+  de types et réglages Musea
+- [Analyse statique](./guide/static-analysis.md) — modèle de lint et de vérification de types
+- [Documentation des règles](./rules/index.md) — diagnostics concrets et exemples
+- [Plugin Oxlint](./guide/oxlint.md) — préréglages, options et fichier de configuration réellement lu
+  par chaque commande
+- [VS Code et autres éditeurs](./integrations/vscode.md) — profil d’édition optionnel et configuration LSP
+- [JSX et TSX](./guide/jsx.md) — composants Vue écrits hors des SFC `.vue`
+- [Musea](./guide/musea.md) — exemples, documentation, jetons, a11y et VRT des composants
 
-## Vérification de type native
-
-`vize check` est alimenté par `vize_canon`, qui s’appuie désormais sur [`corsa-bind`](https://github.com/ubugeeei/corsa-bind) sessions de projet pour des diagnostics natifs TypeScript. Vize génère un TypeScript virtuel pour les SFC Vue, demande à Corsa des diagnostics conscients du projet, puis remappe les résultats sur les fichiers originaux `.vue`, `.ts`, `.tsx`et `.d.ts`.
-
-Cette voie est encore en train de mûrir, donc la vérification des types d’éditeurs reste une option volontaire pour l’instant. La pile d’exécution
-est le paquet `@typescript/native-preview`, Corsa/corsa-bind est la couche API avec laquelle Vize
-communique, et l’exécutable installé par l’aperçu natif TypeScript est encore couramment nommé
-`tsgo`. Utilisez `typeChecker.corsaPath`, ou un script package qui s’exécute
-`vize check --corsa-path /path/to/tsgo`, lorsque vous souhaitez épingler ce runtime.
-`typeChecker.tsgoPath` reste un alias de compatibilité obsolète.
-
-Cibles utiles pour scripts de paquets :
-
-```json
-{
-  "scripts": {
-    "vize:check": "vize check",
-    "vize:check:app": "vize check --tsconfig tsconfig.app.json",
-    "vize:check:virtual-ts": "vize check --show-virtual-ts src/components/App.vue",
-    "vize:check:declarations": "vize check --declaration --declaration-dir dist/types"
-  }
-}
-```
-
-```bash
-vp run vize:check
-vp run vize:check:app
-vp run vize:check:virtual-ts
-vp run vize:check:declarations
-```
-
-## Partagé `vize.config.*`
-
-Les commandes de paquet npm et `@vizejs/vite-plugin` partagent la découverte de configuration :
-
-- `vize.config.pkl`
-- `vize.config.ts`
-- `vize.config.js`
-- `vize.config.mjs`
-- `vize.config.json`
-
-Configuration TypeScript :
-
-```ts
-import { defineConfig } from "vize";
-
-export default defineConfig({
-  compiler: {
-    sourceMap: true,
-    vapor: false,
-    customRenderer: false,
-  },
-  linter: {
-    preset: "opinionated",
-  },
-  typeChecker: {
-    enabled: true,
-    strict: true,
-    corsaPath: "./node_modules/.bin/tsgo",
-  },
-  formatter: {
-    printWidth: 100,
-  },
-  musea: {
-    include: ["src/**/*.art.vue"],
-    basePath: "/__musea__",
-  },
-  lsp: {
-    lint: true,
-    typecheck: false,
-    editor: false,
-    formatting: false,
-  },
-});
-```
-
-Configuration PKL :
-
-```pkl
-amends "node_modules/vize/pkl/vize.pkl"
-
-linter {
-  preset = "opinionated"
-}
-
-typeChecker {
-  enabled = true
-  strict = true
-}
-
-lsp {
-  lint = true
-  typecheck = false
-  editor = false
-  formatting = false
-}
-```
-
-Configuration JSON avec schéma :
-
-```json
-{
-  "$schema": "./node_modules/vize/schemas/vize.config.schema.json",
-  "linter": {
-    "preset": "opinionated"
-  }
-}
-```
-
-## Paquets
-
-```bash
-vp install -D @vizejs/vite-plugin
-vp install @vizejs/native
-vp install @vizejs/wasm
-vp install @vizejs/unplugin
-vp install @vizejs/rspack-plugin @rspack/core
-vp install @vizejs/nuxt
-vp install @vizejs/vite-plugin-musea
-vp install @vizejs/musea-mcp-server
-vp install -D oxlint oxlint-plugin-vize
-```
-
-Notes :
-
-- `@vizejs/vite-plugin` 'est l’intégration recommandée du bundler aujourd’hui.
-- `@vizejs/unplugin` et `@vizejs/rspack-plugin` sont encore expérimentaux.
-- `@vizejs/native` et `@vizejs/wasm` exposent directement les fixations Rust.
-- `@vizejs/vite-plugin-musea` fournit la galerie et le flux de travail dev-server pour Musea.
-
-## Galerie des composantes de la Musea
-
-Utilisez Musea lorsque vous souhaitez des exemples de composants natifs Vue, de la documentation, des jetons, des vérifications VRT et a11y :
-
-```bash
-vp install -D @vizejs/vite-plugin @vizejs/vite-plugin-musea vize
-```
-
-```ts
-// vite.config.ts
-import { defineConfig } from "vite";
-import vize from "@vizejs/vite-plugin";
-import { musea } from "@vizejs/vite-plugin-musea";
-
-export default defineConfig({
-  plugins: [
-    vize(),
-    musea({
-      include: ["src/**/*.art.vue"],
-      basePath: "/__musea__",
-      previewCss: ["src/styles/main.css"],
-    }),
-  ],
-});
-```
-
-Faites tourner votre serveur de développement Vite et ouvrez `/__musea__`. Voir [Musea](./guide/musea.md) pour les fichiers d’art, la configuration
-aperçu, les jetons de design, la VRT et les variantes générées.
-
-## Intégration Oxlint
-
-Exécutez les diagnostics Vue de Vize à l’intérieur d’Oxlint :
-
-```bash
-vp install -D oxlint oxlint-plugin-vize
-```
-
-```json
-{
-  "plugins": ["vue"],
-  "jsPlugins": ["oxlint-plugin-vize"],
-  "rules": {
-    "eqeqeq": "error",
-    "vize/vue/require-v-for-key": "error",
-    "vize/vue/no-v-html": "warn"
-  },
-  "settings": {
-    "vize": {
-      "preset": "general-recommended",
-      "helpLevel": "short"
-    }
-  }
-}
-```
-
-Pour une utilisation terminale d’abord, préférez :
-
-```bash
-vp exec oxlint-vize -c .oxlintrc.json -f stylish src
-```
-
-## Support des éditeurs
-
-Pour le montage quotidien de Vue, continuez à utiliser `vuejs/language-tools` pour l’instant.
-fonctionnalités de l’éditeur Vize sont conçues pour l’adhésion incrémentale.
-
-Point de départ de VS Code :
-
-```json
-{
-  "vize.enable": true,
-  "vize.lint.enable": true,
-  "vize.typecheck.enable": false,
-  "vize.editor.enable": false,
-  "vize.formatting.enable": false
-}
-```
-
-Point de départ de Zed :
-
-```json
-{
-  "languages": {
-    "Vue": {
-      "language_servers": ["vize", "..."]
-    }
-  },
-  "lsp": {
-    "vize": {
-      "initialization_options": {
-        "lint": true
-      }
-    }
-  }
-}
-```
-
-## Développement local
-
-Les tâches locales restent locales ; [CI parity](./contributing.md#common-checks) utilise `nix develop .#testbox`.
-
-```bash
-nix develop
-vp install --frozen-lockfile
-vp check
-vp fmt
-vp dev
-vp build
-```
+Tant que l’intégration de Vize aux éditeurs reste expérimentale, continuez à utiliser l’outil
+officiel [`vuejs/language-tools`](https://github.com/vuejs/language-tools) au quotidien.

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -4,409 +4,85 @@ title: Getting Started
 
 # Getting Started
 
-> **⚠️ Work in Progress:** Vize is under active development and is not yet ready for production use. APIs and package boundaries may change without notice.
+> **⚠️ Work in Progress:** Vize is under active development and is not yet ready for production use.
+> APIs and package boundaries may change without notice.
 
-## What is Vize?
+Vize (_/viːz/_) is a Rust-native Vue.js toolchain. It brings compilation, linting, formatting,
+type checking, editor diagnostics, and component exploration into one workspace while keeping each
+capability available through focused packages and commands.
 
-Vize (_/viːz/_) is a Vue.js toolchain written in Rust. The workspace contains shared
-building blocks for:
+| Need                                              | Recommended entry point     |
+| ------------------------------------------------- | --------------------------- |
+| Compile Vue SFCs in Vite                          | `@vizejs/vite-plugin`       |
+| Compile Vue SFCs in Nuxt                          | `@vizejs/nuxt`              |
+| Lint, format, and type-check from project scripts | `vize`                      |
+| Combine Vize diagnostics with Oxlint              | `oxlint-plugin-vize`        |
+| Explore and test components                       | `@vizejs/vite-plugin-musea` |
+| Evaluate editor features                          | VS Code, Zed, or `vize lsp` |
 
-| Area            | Main Rust crate(s)                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | User-facing entry point                        |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| Compilation     | [`vize_atelier_core`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_core), [`vize_atelier_dom`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_dom), [`vize_atelier_vapor`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_vapor), [`vize_atelier_ssr`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_ssr), [`vize_atelier_sfc`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_sfc) | `@vizejs/vite-plugin`, npm `vize:build` script |
-| Lint            | [`vize_patina`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_patina)                                                                                                                                                                                                                                                                                                                                                                                                             | npm `vize:lint` script, `oxlint-plugin-vize`   |
-| Format          | [`vize_glyph`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_glyph)                                                                                                                                                                                                                                                                                                                                                                                                               | npm `vize:fmt` script                          |
-| Type check      | [`vize_canon`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_canon)                                                                                                                                                                                                                                                                                                                                                                                                               | npm `vize:check` script                        |
-| Editor support  | [`vize_maestro`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_maestro)                                                                                                                                                                                                                                                                                                                                                                                                           | VS Code, Zed, Rust `vize lsp`                  |
-| Musea art tools | [`vize_musea`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_musea)                                                                                                                                                                                                                                                                                                                                                                                                               | `@vizejs/vite-plugin-musea`                    |
-| Bindings        | [`vize_vitrine`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_vitrine)                                                                                                                                                                                                                                                                                                                                                                                                           | `@vizejs/native`, `@vizejs/wasm`               |
+## Set Up an Existing Project
 
-This guide recommends [Vite+](https://viteplus.dev/) (`vp`) for JavaScript package management and project commands. It keeps the install and exec flow consistent across package managers while still using the workspace's underlying tool.
-
-If you do not have `vp` yet, install it once and open a new shell:
-
-```bash
-curl -fsSL https://vite.plus | bash
-```
-
-See the [Vite+ docs](https://viteplus.dev/) and the [Installing Dependencies guide](https://viteplus.dev/guide/install) for more.
-
-## What Vize Does
-
-At a high level, Vize is split into a few reusable lanes:
-
-| Lane              | Package or script                        | What you get                                                                               |
-| ----------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------ |
-| Compile           | `@vizejs/vite-plugin`, `vize:build`      | Rust-native Vue SFC compilation, SSR output, Vapor mode, scoped CSS handling               |
-| Static analysis   | `vize:lint`, `oxlint-plugin-vize`        | Vue template, script, CSS, a11y, SSR, Vapor, Musea, cross-file, and type-aware diagnostics |
-| Type check        | `vize:check`                             | Virtual TypeScript generation, project diagnostics, Vue-to-source diagnostic mapping       |
-| Format            | `vize:fmt`                               | Vue SFC formatting with project and CLI options                                            |
-| Component gallery | `@vizejs/vite-plugin-musea`, `musea-vrt` | Art files, component variants, preview setup, design tokens, a11y, VRT                     |
-| Editor support    | VS Code, Zed, Rust `vize lsp`            | Opt-in diagnostics and editor features                                                     |
-
-See [Static Analysis](./guide/static-analysis.md) for the lint and type-checking model,
-[Rules](./rules/index.md) for concrete rule output, and
-[Configuration](./guide/configuration.md) for shared config and compiler options.
-
-Authoring components in JSX/TSX instead of `.vue` SFCs? See the [JSX & TSX](./guide/jsx.md) guide —
-`.jsx`/`.tsx` Vue components compile through the same Rust lane.
-
-## Choose Your Entry Point
-
-### 1. Vite Projects
-
-Use the Vite plugin if you want native Vue compilation in an existing Vite project.
+Run the interactive initializer from the project root:
 
 ```bash
-vp install -D @vizejs/vite-plugin
+vpx vize init
 ```
 
-Install `vize` as a direct dependency only when you want to import shared config helpers from
-`"vize"` or add Vize package scripts such as `vize:lint` and `vize:check`.
+`vpx` is included with [Vite+](https://viteplus.dev/guide/install). Install Vite+ first if the
+command is not available in your shell.
 
-```ts
-// vite.config.ts
-import { defineConfig } from "vite";
-import vize from "@vizejs/vite-plugin";
+`vize init` detects Vite, Vite+, or Nuxt; the package manager; TypeScript; the active lint command;
+and existing Vize configuration before it writes anything. You choose which parts to configure:
 
-export default defineConfig({
-  plugins: [vize()],
-});
-```
+- the Vite plugin or Nuxt module
+- the Oxlint plugin, in the configuration file the active lint command reads
+- `vize fmt` and `vize check` project scripts
+- shared `vize.config.*` settings
+- a VS Code extension recommendation
 
-Add compiler options in `vize.config.ts` when you want the same settings available to package
-scripts and the plugin:
-
-```ts
-import { defineConfig } from "vize";
-
-export default defineConfig({
-  compiler: {
-    sourceMap: true,
-    vapor: false,
-    customRenderer: false,
-  },
-  vite: {
-    scanPatterns: ["src/**/*.vue"],
-  },
-});
-```
-
-### 2. Nuxt Projects
-
-Use the Nuxt module when you want Vize to run inside Nuxt's own Vite pipeline.
+Preview every proposed file and dependency change without writing it:
 
 ```bash
-vp install @vizejs/nuxt
+vpx vize init --dry-run
 ```
 
-Add the module to `nuxt.config.ts`:
-
-```ts
-export default defineNuxtConfig({
-  modules: ["@vizejs/nuxt"],
-  vize: {
-    compiler: true,
-  },
-});
-```
-
-Run your Nuxt dev server as usual. The module registers `@vizejs/vite-plugin` for Vue SFC
-compilation while preserving Nuxt auto-imports, components, middleware, and SSR transforms.
-
-See the [Nuxt Integration](./integrations/nuxt.md) guide for Musea setup and Nuxt-specific notes.
-
-### 3. npm Package Scripts + Shared Config
-
-Use the `vize` npm package when you want shared config utilities and native commands available from
-project scripts.
+For CI or another non-interactive environment, select the features explicitly:
 
 ```bash
-vp install -D vize
+vpx vize init --yes --lint --bundler --fmt --typecheck --editor
 ```
 
-Recommended package scripts:
+See [Project Setup](./guide/init.md) for detection rules, all flags, idempotency guarantees, and the
+cases where the initializer deliberately refuses to edit a file.
 
-```json
-{
-  "scripts": {
-    "vize:build": "vize build src",
-    "vize:fmt": "vize fmt --write src",
-    "vize:lint": "vize lint --preset happy-path src",
-    "vize:check": "vize check src",
-    "vize:ready": "vize ready src"
-  }
-}
-```
+## Choose a Manual Path
 
-```bash
-vp run vize:fmt
-vp run vize:lint
-vp run vize:check
-vp run vize:build
-vp run vize:ready
-```
+Prefer a manual setup when you need to preserve an established configuration or adopt one Vize
+surface at a time:
 
-The npm package's `vize check` command uses the packaged NAPI checker and can emit Vue component
-declarations with `--declaration --declaration-dir dist/types`. Use the Rust CLI when you need
-`check-server`, LSP, IDE management, or project diagnostics across Vue, TS, TSX, and `.d.ts` inputs.
+- [Vite Plugin](./guide/vite-plugin.md) — native Vue SFC compilation in Vite
+- [Nuxt Integration](./integrations/nuxt.md) — the supported path through Nuxt's Vite pipeline
+- [Package Scripts and CLI](./guide/cli.md) — `vize build`, `fmt`, `lint`, `check`, `ready`, and the
+  full Rust CLI
 
-### 4. Full Rust CLI
+Vite is the recommended bundler integration. The unplugin and Rspack packages remain experimental;
+their current scope is documented in [Other Bundlers](./guide/unplugin.md).
 
-Most application workflows should use the npm package scripts above. Use the Rust binary when you
-need the full native CLI today: LSP, IDE management, profiling, or `check-server`. For v1 alpha, the
-supported public channels are GitHub release binaries and the Nix entry point; the Rust CLI is not
-published through crates.io yet.
+## Continue with the Focused Guides
 
-```bash
-nix run github:ubugeeei-prod/vize#vize -- --help
-```
+Getting Started is intentionally an orientation page. Use the focused guides as the source of truth
+for configuration and integration details:
 
-```bash
-vize build src/**/*.vue
-vize fmt --check src
-vize lint --profile src
-vize check --profile src
-vize ready src
-vize lsp
-```
+- [Configuration](./guide/configuration.md) — `vize.config.*`, compiler options, type-checking, and
+  Musea settings
+- [Static Analysis](./guide/static-analysis.md) — the lint and type-checking model
+- [Rule Documentation](./rules/index.md) — concrete diagnostics and examples
+- [Oxlint Plugin](./guide/oxlint.md) — presets, settings, and the configuration file each command
+  actually reads
+- [VS Code and Other Editors](./integrations/vscode.md) — the opt-in editor profile and LSP setup
+- [JSX & TSX](./guide/jsx.md) — Vue components authored outside `.vue` SFCs
+- [Musea](./guide/musea.md) — component examples, documentation, tokens, a11y, and VRT
 
-## Native Type Checking
-
-`vize check` is powered by `vize_canon`, which now leans on [`corsa-bind`](https://github.com/ubugeeei/corsa-bind) project sessions for native TypeScript diagnostics. Vize generates virtual TypeScript for Vue SFCs, asks Corsa for project-aware diagnostics, and then maps the results back onto the original `.vue`, `.ts`, `.tsx`, and `.d.ts` files.
-
-This path is still maturing, so editor type checking remains an opt-in capability for now. The
-runtime stack is the `@typescript/native-preview` package, Corsa/corsa-bind is the API layer Vize
-talks to, and the executable installed by the TypeScript native preview is still commonly named
-`tsgo`. Use `typeChecker.corsaPath`, or a package script that runs
-`vize check --corsa-path /path/to/tsgo`, when you want to pin that runtime.
-`typeChecker.tsgoPath` remains a deprecated compatibility alias.
-
-Useful package-script targets:
-
-```json
-{
-  "scripts": {
-    "vize:check": "vize check",
-    "vize:check:app": "vize check --tsconfig tsconfig.app.json",
-    "vize:check:virtual-ts": "vize check --show-virtual-ts src/components/App.vue",
-    "vize:check:declarations": "vize check --declaration --declaration-dir dist/types"
-  }
-}
-```
-
-```bash
-vp run vize:check
-vp run vize:check:app
-vp run vize:check:virtual-ts
-vp run vize:check:declarations
-```
-
-## Shared `vize.config.*`
-
-The npm package commands and `@vizejs/vite-plugin` share config discovery:
-
-- `vize.config.pkl`
-- `vize.config.ts`
-- `vize.config.js`
-- `vize.config.mjs`
-- `vize.config.json`
-
-TypeScript config:
-
-```ts
-import { defineConfig } from "vize";
-
-export default defineConfig({
-  compiler: {
-    sourceMap: true,
-    vapor: false,
-    customRenderer: false,
-  },
-  linter: {
-    preset: "opinionated",
-  },
-  typeChecker: {
-    enabled: true,
-    strict: true,
-    corsaPath: "./node_modules/.bin/tsgo",
-  },
-  formatter: {
-    printWidth: 100,
-  },
-  musea: {
-    include: ["src/**/*.art.vue"],
-    basePath: "/__musea__",
-  },
-  lsp: {
-    lint: true,
-    typecheck: false,
-    editor: false,
-    formatting: false,
-  },
-});
-```
-
-PKL config:
-
-```pkl
-amends "node_modules/vize/pkl/vize.pkl"
-
-linter {
-  preset = "opinionated"
-}
-
-typeChecker {
-  enabled = true
-  strict = true
-}
-
-lsp {
-  lint = true
-  typecheck = false
-  editor = false
-  formatting = false
-}
-```
-
-JSON config with schema:
-
-```json
-{
-  "$schema": "./node_modules/vize/schemas/vize.config.schema.json",
-  "linter": {
-    "preset": "opinionated"
-  }
-}
-```
-
-## Packages
-
-```bash
-vp install -D @vizejs/vite-plugin
-vp install @vizejs/native
-vp install @vizejs/wasm
-vp install @vizejs/unplugin
-vp install @vizejs/rspack-plugin @rspack/core
-vp install @vizejs/nuxt
-vp install @vizejs/vite-plugin-musea
-vp install @vizejs/musea-mcp-server
-vp install -D oxlint oxlint-plugin-vize
-```
-
-Notes:
-
-- `@vizejs/vite-plugin` is the recommended bundler integration today.
-- `@vizejs/unplugin` and `@vizejs/rspack-plugin` are still experimental.
-- `@vizejs/native` and `@vizejs/wasm` expose the Rust bindings directly.
-- `@vizejs/vite-plugin-musea` provides the gallery and dev-server workflow for Musea.
-
-## Musea Component Gallery
-
-Use Musea when you want Vue-native component examples, documentation, tokens, VRT, and a11y checks:
-
-```bash
-vp install -D @vizejs/vite-plugin @vizejs/vite-plugin-musea vize
-```
-
-```ts
-// vite.config.ts
-import { defineConfig } from "vite";
-import vize from "@vizejs/vite-plugin";
-import { musea } from "@vizejs/vite-plugin-musea";
-
-export default defineConfig({
-  plugins: [
-    vize(),
-    musea({
-      include: ["src/**/*.art.vue"],
-      basePath: "/__musea__",
-      previewCss: ["src/styles/main.css"],
-    }),
-  ],
-});
-```
-
-Run your Vite dev server and open `/__musea__`. See [Musea](./guide/musea.md) for art files,
-preview setup, design tokens, VRT, and generated variants.
-
-## Oxlint Integration
-
-Run Vize's Vue diagnostics inside Oxlint:
-
-```bash
-vp install -D oxlint oxlint-plugin-vize
-```
-
-```json
-{
-  "plugins": ["vue"],
-  "jsPlugins": ["oxlint-plugin-vize"],
-  "rules": {
-    "eqeqeq": "error",
-    "vize/vue/require-v-for-key": "error",
-    "vize/vue/no-v-html": "warn"
-  },
-  "settings": {
-    "vize": {
-      "preset": "general-recommended",
-      "helpLevel": "short"
-    }
-  }
-}
-```
-
-For terminal-first usage, prefer:
-
-```bash
-vp exec oxlint-vize -c .oxlintrc.json -f stylish src
-```
-
-## Editor Support
-
-For day-to-day Vue editing, keep using `vuejs/language-tools` for now.
-Vize editor features are designed for incremental opt-in.
-
-VS Code starting point:
-
-```json
-{
-  "vize.enable": true,
-  "vize.lint.enable": true,
-  "vize.typecheck.enable": false,
-  "vize.editor.enable": false,
-  "vize.formatting.enable": false
-}
-```
-
-Zed starting point:
-
-```json
-{
-  "languages": {
-    "Vue": {
-      "language_servers": ["vize", "..."]
-    }
-  },
-  "lsp": {
-    "vize": {
-      "initialization_options": {
-        "lint": true
-      }
-    }
-  }
-}
-```
-
-## Local Development
-
-Local tasks stay local; [CI parity](./contributing.md#common-checks) uses `nix develop .#testbox`.
-
-```bash
-nix develop
-vp install --frozen-lockfile
-vp check
-vp fmt
-vp dev
-vp build
-```
+For day-to-day Vue editor support, keep using the official
+[`vuejs/language-tools`](https://github.com/vuejs/language-tools) while Vize's editor integration is
+experimental.

--- a/docs/content/guide/init.md
+++ b/docs/content/guide/init.md
@@ -231,11 +231,11 @@ This is checked in, applies to everyone on the project, and changes nothing on t
 | Helix   | `tools/helix-vize` |
 | Emacs   | `tools/emacs-vize` |
 
-See [Editor Support](../getting-started.md#editor-support) for per-editor instructions.
+See [VS Code and Other Editors](../integrations/vscode.md) for per-editor instructions.
 
 ## Relationship To `vize setup`
 
-[`vize setup`](../getting-started.md) is the older, all-or-nothing command for a Vite or Vite+
+`vize setup` is the older, all-or-nothing command for a Vite or Vite+
 project. It still works and is unchanged. `init` covers the same ground plus feature selection, Nuxt,
 package-manager detection, a dry run, and a non-interactive mode, over the same planning layer. Prefer
 `vize init` for new projects.

--- a/docs/content/ja/getting-started.md
+++ b/docs/content/ja/getting-started.md
@@ -6,409 +6,81 @@ title: はじめる
 
 # はじめる
 
-> **⚠️ 進行中の作業:**Vize は積極的に開発中であり、まだ運用環境で使用する準備ができていません。 API とパッケージの境界は予告なく変更される場合があります。
+> **⚠️ 開発中:** Vize は活発に開発されており、まだ本番環境向けではありません。
+> API やパッケージの境界は予告なく変更される可能性があります。
 
-## ヴィゼとは何ですか?
+Vize (_/viːz/_) は Rust ネイティブな Vue.js ツールチェーンです。コンパイル、lint、
+フォーマット、型チェック、エディター診断、コンポーネントの検証を 1 つのワークスペースに
+まとめつつ、それぞれの機能を用途別のパッケージとコマンドから利用できます。
 
-Vize (_/viːz/_) は、Rust で書かれた Vue.js ツールチェーンです。ワークスペースには共有が含まれています
-以下の構成要素:
+| やりたいこと                                                    | 推奨される入口                  |
+| --------------------------------------------------------------- | ------------------------------- |
+| Vite で Vue SFC をコンパイルする                                | `@vizejs/vite-plugin`           |
+| Nuxt で Vue SFC をコンパイルする                                | `@vizejs/nuxt`                  |
+| プロジェクトスクリプトから lint・フォーマット・型チェックを行う | `vize`                          |
+| Vize の診断を Oxlint と組み合わせる                             | `oxlint-plugin-vize`            |
+| コンポーネントを検証・閲覧する                                  | `@vizejs/vite-plugin-musea`     |
+| エディター機能を試す                                            | VS Code、Zed、または `vize lsp` |
 
-| エリア               | メイン Rust クレート                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | ユーザー向けのエントリ ポイント                    |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
-| 編集                 | [`vize_atelier_core`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_core)、[`vize_atelier_dom`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_dom)、[`vize_atelier_vapor`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_vapor)、[`vize_atelier_ssr`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_ssr)、 [`vize_atelier_sfc`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_sfc) | `@vizejs/vite-plugin`、npm `vize:build` スクリプト |
-| 糸くず               | [`vize_patina`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_patina)                                                                                                                                                                                                                                                                                                                                                                                                              | npm `vize:lint` スクリプト、`oxlint-plugin-vize`   |
-| フォーマット         | [`vize_glyph`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_glyph)                                                                                                                                                                                                                                                                                                                                                                                                                | npm `vize:fmt` スクリプト                          |
-| タイプチェック       | [`vize_canon`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_canon)                                                                                                                                                                                                                                                                                                                                                                                                                | npm `vize:check` スクリプト                        |
-| エディターのサポート | [`vize_maestro`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_maestro)                                                                                                                                                                                                                                                                                                                                                                                                            | VS コード、ゼッド、ラスト `vize lsp`               |
-| 美術館の美術道具     | [`vize_musea`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_musea)                                                                                                                                                                                                                                                                                                                                                                                                                | `@vizejs/vite-plugin-musea`                        |
-| バインディング       | [`vize_vitrine`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_vitrine)                                                                                                                                                                                                                                                                                                                                                                                                            | `@vizejs/native`、`@vizejs/wasm`                   |
+## 既存プロジェクトをセットアップする
 
-このガイドでは、JavaScript パッケージ管理とプロジェクト コマンドに [Vite+](https://viteplus.dev/) (`vp`) を推奨します。ワークスペースの基礎となるツールを使用しながら、パッケージ マネージャー間でインストールと実行のフローの一貫性を保ちます。
-
-`vp` をまだ持っていない場合は、一度インストールして新しいシェルを開きます。
-
-```bash
-curl -fsSL https://vite.plus | bash
-```
-
-詳細については、[Vite+ ドキュメント](https://viteplus.dev/) および [依存関係のインストール ガイド](https://viteplus.dev/guide/install) を参照してください。
-
-## Vize の機能
-
-大まかに言うと、Vize はいくつかの再利用可能なレーンに分割されています。
-
-| レーン                   | パッケージまたはスクリプト               | 得られるもの                                                                                      |
-| ------------------------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| コンパイル               | `@vizejs/vite-plugin`、`vize:build`      | Rust ネイティブ Vue SFC コンパイル、SSR 出力、Vapor モード、スコープ付き CSS 処理                 |
-| 静的解析                 | `vize:lint`、`oxlint-plugin-vize`        | Vue テンプレート、スクリプト、CSS、a11y、SSR、Vapor、Musea、クロスファイル、およびタイプ認識診断  |
-| タイプチェック           | `vize:check`                             | 仮想 TypeScript の生成、プロジェクト診断、Vue からソースへの診断マッピング                        |
-| フォーマット             | `vize:fmt`                               | プロジェクトおよび CLI オプションを使用した Vue SFC フォーマット                                  |
-| コンポーネントギャラリー | `@vizejs/vite-plugin-musea`、`musea-vrt` | アート ファイル、コンポーネント バリアント、プレビュー セットアップ、デザイン トークン、a11y、VRT |
-| エディターのサポート     | VS コード、ゼッド、ラスト `vize lsp`     | オプトイン診断とエディター機能                                                                    |
-
-lint および型チェック モデルについては、[静的解析](./guide/static-analysis.md) を参照してください。
-具体的なルール出力の [ルール](./rules/index.md)、および
-[構成](./guide/configuration.md) 共有構成およびコンパイラ オプション用。
-
-`.vue` SFC ではなく JSX/TSX でコンポーネントをオーサリングしますか? [JSX & TSX](./guide/jsx.md) ガイドを参照してください。
-`.jsx`/`.tsx` Vue コンポーネントは同じ Rust レーンを通じてコンパイルされます。
-
-## エントリーポイントを選択してください
-
-### 1. Vite プロジェクト
-
-既存の Vite プロジェクトでネイティブ Vue コンパイルが必要な場合は、Vite プラグインを使用します。
+プロジェクトのルートで対話形式の初期化コマンドを実行します。
 
 ```bash
-vp install -D @vizejs/vite-plugin
+vpx vize init
 ```
 
-共有構成ヘルパーをインポートする場合にのみ、`vize` を直接の依存関係としてインストールします。
-`"vize"` または `vize:lint` や `vize:check` などの Vize パッケージ スクリプトを追加します。
+`vpx` は [Vite+](https://viteplus.dev/guide/install) に含まれています。シェルでこのコマンドを
+利用できない場合は、先に Vite+ をインストールしてください。
 
-```ts
-// vite.config.ts
-import { defineConfig } from "vite";
-import vize from "@vizejs/vite-plugin";
+`vize init` は、ファイルを書き換える前に Vite、Vite+、Nuxt、パッケージマネージャー、
+TypeScript、有効な lint コマンド、既存の Vize 設定を検出します。設定する機能は個別に選べます。
 
-export default defineConfig({
-  plugins: [vize()],
-});
-```
+- Vite プラグインまたは Nuxt モジュール
+- 実際の lint コマンドが読み込む設定ファイル内の Oxlint プラグイン
+- `vize fmt` と `vize check` のプロジェクトスクリプト
+- 共有の `vize.config.*` 設定
+- VS Code 拡張機能の推奨設定
 
-同じ設定をパッケージ化する場合は、`vize.config.ts` にコンパイラ オプションを追加します。
-スクリプトとプラグイン:
-
-```ts
-import { defineConfig } from "vize";
-
-export default defineConfig({
-  compiler: {
-    sourceMap: true,
-    vapor: false,
-    customRenderer: false,
-  },
-  vite: {
-    scanPatterns: ["src/**/*.vue"],
-  },
-});
-```
-
-### 2. Nuxt プロジェクト
-
-Nuxt 独自の Vite パイプライン内で Vize を実行する場合は、Nuxt モジュールを使用します。
+ファイルや依存関係を変更せず、予定されている処理をすべて確認できます。
 
 ```bash
-vp install @vizejs/nuxt
+vpx vize init --dry-run
 ```
 
-モジュールを `nuxt.config.ts` に追加します。
-
-```ts
-export default defineNuxtConfig({
-  modules: ["@vizejs/nuxt"],
-  vize: {
-    compiler: true,
-  },
-});
-```
-
-通常どおり Nuxt 開発サーバーを実行します。モジュールは Vue SFC 用に `@vizejs/vite-plugin` を登録します
-Nuxt の自動インポート、コンポーネント、ミドルウェア、SSR 変換を保持しながらコンパイルします。
-
-Musea のセットアップと Nuxt 固有の注意事項については、[Nuxt Integration](./integrations/nuxt.md) ガイドを参照してください。
-
-### 3. npm パッケージ スクリプト + 共有設定
-
-共有設定ユーティリティとネイティブ コマンドを次から利用できるようにしたい場合は、`vize` npm パッケージを使用します。
-プロジェクトのスクリプト。
+CI などの非対話環境では、必要な機能を明示します。
 
 ```bash
-vp install -D vize
+vpx vize init --yes --lint --bundler --fmt --typecheck --editor
 ```
 
-推奨されるパッケージ スクリプト:
+検出規則、全オプション、冪等性の保証、編集を意図的に拒否する条件については、
+[Project Setup（英語）](../guide/init.md)を参照してください。
 
-```json
-{
-  "scripts": {
-    "vize:build": "vize build src",
-    "vize:fmt": "vize fmt --write src",
-    "vize:lint": "vize lint --preset happy-path src",
-    "vize:check": "vize check src",
-    "vize:ready": "vize ready src"
-  }
-}
-```
+## 手動で導入する
 
-```bash
-vp run vize:fmt
-vp run vize:lint
-vp run vize:check
-vp run vize:build
-vp run vize:ready
-```
+既存の設定を維持したい場合や、Vize の機能を 1 つずつ導入したい場合は手動設定が適しています。
 
-npm パッケージの `vize check` コマンドは、パッケージ化された NAPI チェッカーを使用し、Vue コンポーネントを出力できます
-`--declaration --declaration-dir dist/types` で宣言します。必要な場合は Rust CLI を使用してください
-`check-server`、LSP、IDE 管理、または Vue、TS、TSX、および `.d.ts` 入力にわたるプロジェクト診断。
+- [Vite プラグイン](./guide/vite-plugin.md) — Vite でのネイティブ Vue SFC コンパイル
+- [Nuxt 統合](./integrations/nuxt.md) — Nuxt の Vite パイプラインを通すサポート済みの方法
+- [パッケージスクリプトと CLI](./guide/cli.md) — `vize build`、`fmt`、`lint`、`check`、
+  `ready`、および完全な Rust CLI
 
-### 4. 完全な Rust CLI
+Vite が推奨されるバンドラー統合です。unplugin と Rspack のパッケージはまだ実験的です。
+現在の対応範囲は[その他のバンドラー](./guide/unplugin.md)を参照してください。
 
-ほとんどのアプリケーション ワークフローでは、上記の npm パッケージ スクリプトを使用する必要があります。次の場合には Rust バイナリを使用してください。
-今すぐ完全なネイティブ CLI (LSP、IDE 管理、プロファイリング、または `check-server`) が必要です。 v1 アルファの場合、
-サポートされているパブリック チャネルは、GitHub リリース バイナリと Nix エントリ ポイントです。 Rust CLIはそうではありません
-crates.io を通じてまだ公開されていません。
+## 目的別ガイドへ進む
 
-```bash
-nix run github:ubugeeei-prod/vize#vize -- --help
-```
+このページは入口の案内に役割を絞っています。設定と統合の詳細については、次のガイドを
+信頼できる情報源として参照してください。
 
-```bash
-vize build src/**/*.vue
-vize fmt --check src
-vize lint --profile src
-vize check --profile src
-vize ready src
-vize lsp
-```
+- [設定](./guide/configuration.md) — `vize.config.*`、コンパイラ、型チェック、Musea の設定
+- [静的解析](./guide/static-analysis.md) — lint と型チェックのモデル
+- [ルール一覧](./rules/index.md) — 診断と具体例
+- [Oxlint プラグイン](./guide/oxlint.md) — プリセット、設定、各コマンドが実際に読み込むファイル
+- [VS Code とその他のエディター](./integrations/vscode.md) — オプトインのエディタープロファイルと LSP 設定
+- [JSX & TSX](./guide/jsx.md) — `.vue` SFC 以外で記述する Vue コンポーネント
+- [Musea](./guide/musea.md) — コンポーネント例、ドキュメント、トークン、a11y、VRT
 
-## ネイティブ型チェック
-
-`vize check` は `vize_canon` を利用しており、ネイティブ TypeScript 診断用に [`corsa-bind`](https://github.com/ubugeeei/corsa-bind) プロジェクト セッションを利用するようになりました。 Vize は Vue SFC 用の仮想 TypeScript を生成し、Corsa にプロジェクト対応の診断を要求し、その結果を元の `.vue`、`.ts`、`.tsx`、および `.d.ts` ファイルにマッピングし直します。
-
-このパスはまだ成熟しているため、エディターのタイプ チェックは現時点ではオプトイン機能のままです。の
-ランタイム スタックは `@typescript/native-preview` パッケージ、Corsa/corsa-bind は API レイヤー Vize
-と対話し、TypeScript ネイティブ プレビューによってインストールされる実行可能ファイルには依然として一般的な名前が付けられています。
-`tsgo`。 `typeChecker.corsaPath`、または実行されるパッケージ スクリプトを使用します。
-`vize check --corsa-path /path/to/tsgo`、そのランタイムを固定したい場合。
-`typeChecker.tsgoPath` は、非推奨の互換性エイリアスのままです。
-
-便利なパッケージ スクリプト ターゲット:
-
-```json
-{
-  "scripts": {
-    "vize:check": "vize check",
-    "vize:check:app": "vize check --tsconfig tsconfig.app.json",
-    "vize:check:virtual-ts": "vize check --show-virtual-ts src/components/App.vue",
-    "vize:check:declarations": "vize check --declaration --declaration-dir dist/types"
-  }
-}
-```
-
-```bash
-vp run vize:check
-vp run vize:check:app
-vp run vize:check:virtual-ts
-vp run vize:check:declarations
-```
-
-## 共有 `vize.config.*`
-
-npm package コマンドと `@vizejs/vite-plugin` は構成検出を共有します。
-
-- `vize.config.pkl`
-- `vize.config.ts`
-- `vize.config.js`
-- `vize.config.mjs`
-- `vize.config.json`
-
-TypeScript 構成:
-
-```ts
-import { defineConfig } from "vize";
-
-export default defineConfig({
-  compiler: {
-    sourceMap: true,
-    vapor: false,
-    customRenderer: false,
-  },
-  linter: {
-    preset: "opinionated",
-  },
-  typeChecker: {
-    enabled: true,
-    strict: true,
-    corsaPath: "./node_modules/.bin/tsgo",
-  },
-  formatter: {
-    printWidth: 100,
-  },
-  musea: {
-    include: ["src/**/*.art.vue"],
-    basePath: "/__musea__",
-  },
-  lsp: {
-    lint: true,
-    typecheck: false,
-    editor: false,
-    formatting: false,
-  },
-});
-```
-
-PKL 構成:
-
-```pkl
-amends "node_modules/vize/pkl/vize.pkl"
-
-linter {
-  preset = "opinionated"
-}
-
-typeChecker {
-  enabled = true
-  strict = true
-}
-
-lsp {
-  lint = true
-  typecheck = false
-  editor = false
-  formatting = false
-}
-```
-
-スキーマを含む JSON 構成:
-
-```json
-{
-  "$schema": "./node_modules/vize/schemas/vize.config.schema.json",
-  "linter": {
-    "preset": "opinionated"
-  }
-}
-```
-
-## パッケージ
-
-```bash
-vp install -D @vizejs/vite-plugin
-vp install @vizejs/native
-vp install @vizejs/wasm
-vp install @vizejs/unplugin
-vp install @vizejs/rspack-plugin @rspack/core
-vp install @vizejs/nuxt
-vp install @vizejs/vite-plugin-musea
-vp install @vizejs/musea-mcp-server
-vp install -D oxlint oxlint-plugin-vize
-```
-
-注:
-
-- `@vizejs/vite-plugin` は現在推奨されるバンドラー統合です。
-- `@vizejs/unplugin` および `@vizejs/rspack-plugin` はまだ実験段階です。
-- `@vizejs/native` および `@vizejs/wasm` は Rust バインディングを直接公開します。
-- `@vizejs/vite-plugin-musea` は、Musea のギャラリーと開発サーバーのワークフローを提供します。
-
-## Musea コンポーネント ギャラリー
-
-Vue ネイティブ コンポーネントのサンプル、ドキュメント、トークン、VRT、および a11y チェックが必要な場合は、Musea を使用します。
-
-```bash
-vp install -D @vizejs/vite-plugin @vizejs/vite-plugin-musea vize
-```
-
-```ts
-// vite.config.ts
-import { defineConfig } from "vite";
-import vize from "@vizejs/vite-plugin";
-import { musea } from "@vizejs/vite-plugin-musea";
-
-export default defineConfig({
-  plugins: [
-    vize(),
-    musea({
-      include: ["src/**/*.art.vue"],
-      basePath: "/__musea__",
-      previewCss: ["src/styles/main.css"],
-    }),
-  ],
-});
-```
-
-Vite 開発サーバーを実行し、`/__musea__` を開きます。アート ファイルについては [Musea](./guide/musea.md) を参照してください。
-プレビュー設定、デザイントークン、VRT、生成されたバリアント。
-
-## Oxlint の統合
-
-Oxlint 内で Vize の Vue 診断を実行します。
-
-```bash
-vp install -D oxlint oxlint-plugin-vize
-```
-
-```json
-{
-  "plugins": ["vue"],
-  "jsPlugins": ["oxlint-plugin-vize"],
-  "rules": {
-    "eqeqeq": "error",
-    "vize/vue/require-v-for-key": "error",
-    "vize/vue/no-v-html": "warn"
-  },
-  "settings": {
-    "vize": {
-      "preset": "general-recommended",
-      "helpLevel": "short"
-    }
-  }
-}
-```
-
-ターミナルファーストで使用する場合は、次のことを優先します。
-
-```bash
-vp exec oxlint-vize -c .oxlintrc.json -f stylish src
-```
-
-## エディターのサポート
-
-日常の Vue 編集には、今のところ `vuejs/language-tools` を使用し続けてください。
-Vize エディターの機能は、段階的なオプトイン用に設計されています。
-
-VS コードの開始点:
-
-```json
-{
-  "vize.enable": true,
-  "vize.lint.enable": true,
-  "vize.typecheck.enable": false,
-  "vize.editor.enable": false,
-  "vize.formatting.enable": false
-}
-```
-
-ゼッドの出発点:
-
-```json
-{
-  "languages": {
-    "Vue": {
-      "language_servers": ["vize", "..."]
-    }
-  },
-  "lsp": {
-    "vize": {
-      "initialization_options": {
-        "lint": true
-      }
-    }
-  }
-}
-```
-
-## 地域開発
-
-ローカルタスクはローカルのままです。 [CIパリティ](./contributing.md#common-checks)は`nix develop .#testbox`を使用します。
-
-```bash
-nix develop
-vp install --frozen-lockfile
-vp check
-vp fmt
-vp dev
-vp build
-```
+Vize のエディター統合が実験段階にある間、日常的な Vue 開発では公式の
+[`vuejs/language-tools`](https://github.com/vuejs/language-tools)を引き続き使用してください。

--- a/docs/content/pt-BR/getting-started.md
+++ b/docs/content/pt-BR/getting-started.md
@@ -1,414 +1,92 @@
 ---
-title: Começando
+title: Primeiros passos
 ---
 
 <!-- Generated translation; source: getting-started.md -->
 
-# Começando
+# Primeiros passos
 
-> **⚠️ Trabalho em andamento:** O Vize está em desenvolvimento ativo e ainda não está pronto para uso em produção. APIs e limites de pacotes podem mudar sem aviso prévio.
+> **⚠️ Em desenvolvimento:** o Vize está em desenvolvimento ativo e ainda não está pronto para uso
+> em produção. As APIs e os limites entre pacotes podem mudar sem aviso prévio.
 
-## O que é Vize?
+O Vize (_/viːz/_) é uma cadeia de ferramentas Vue.js nativa em Rust. Ele reúne compilação, lint,
+formatação, verificação de tipos, diagnósticos no editor e exploração de componentes em um único
+workspace, mantendo cada recurso disponível por meio de pacotes e comandos específicos.
 
-Vize (_/viːz/_) é uma Vue.js cadeia de ferramentas escrita em Rust. O espaço de trabalho contém blocos de construção
-compartilhados para:
+| Necessidade                                                             | Ponto de entrada recomendado |
+| ----------------------------------------------------------------------- | ---------------------------- |
+| Compilar SFCs Vue no Vite                                               | `@vizejs/vite-plugin`        |
+| Compilar SFCs Vue no Nuxt                                               | `@vizejs/nuxt`               |
+| Executar lint, formatação e verificação de tipos por scripts do projeto | `vize`                       |
+| Combinar os diagnósticos do Vize com o Oxlint                           | `oxlint-plugin-vize`         |
+| Explorar e testar componentes                                           | `@vizejs/vite-plugin-musea`  |
+| Avaliar recursos de editor                                              | VS Code, Zed ou `vize lsp`   |
 
-| Área                      | Caixa(s) principal(es) de ferrugem                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Ponto de entrada voltado para o usuário         |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| Compilação                | [`vize_atelier_core`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_core), [`vize_atelier_dom`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_dom), [`vize_atelier_vapor`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_vapor), [`vize_atelier_ssr`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_ssr), [`vize_atelier_sfc`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_sfc) | `@vizejs/vite-plugin`, npm `vize:build` script  |
-| Fiapos                    | [`vize_patina`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_patina)                                                                                                                                                                                                                                                                                                                                                                                                             | O NPM `vize:lint` roteiro, `oxlint-plugin-vize` |
-| Formato                   | [`vize_glyph`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_glyph)                                                                                                                                                                                                                                                                                                                                                                                                               | Roteiro `vize:fmt` NPM                          |
-| Verificação de tipo       | [`vize_canon`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_canon)                                                                                                                                                                                                                                                                                                                                                                                                               | NPM `vize:check` roteiro                        |
-| Suporte ao editor         | [`vize_maestro`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_maestro)                                                                                                                                                                                                                                                                                                                                                                                                           | VS Code, Zed, Rust `vize lsp`                   |
-| Ferramentas de arte musea | [`vize_musea`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_musea)                                                                                                                                                                                                                                                                                                                                                                                                               | `@vizejs/vite-plugin-musea`                     |
-| Encadernações             | [`vize_vitrine`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_vitrine)                                                                                                                                                                                                                                                                                                                                                                                                           | `@vizejs/native`, `@vizejs/wasm`                |
+## Configurar um projeto existente
 
-Este guia recomenda [Vite+](https://viteplus.dev/) (`vp`) para gerenciamento de pacotes em JavaScript e comandos de projeto. Ela mantém o fluxo de instalação e exec consistente entre gerenciadores de pacotes, enquanto ainda usa a ferramenta subjacente do workspace.
-
-Se você ainda não tem `vp` , instale uma vez e abra uma nova carcaça:
-
-```bash
-curl -fsSL https://vite.plus | bash
-```
-
-Veja o [Vite+ docs](https://viteplus.dev/) e o [Installing Dependencies guide](https://viteplus.dev/guide/install) para mais informações.
-
-## O que o Vize faz
-
-Em um nível geral, o Vize é dividido em algumas rotas reutilizáveis:
-
-| Lane                   | Pacote ou script                         | O que você ganha                                                                                          |
-| ---------------------- | ---------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| Compilar               | `@vizejs/vite-plugin`, `vize:build`      | Compilação Vue SFC nativa de ferrugem, saída SSR, modo Vapor, manuseio de CSS com escopo                  |
-| Análise estática       | `vize:lint`, `oxlint-plugin-vize`        | Template Vue, script, CSS, a11y, SSR, Vapor, Musea, cross-file e diagnósticos conscientes de tipos        |
-| Verificação de tipo    | `vize:check`                             | Geração Virtual TypeScript, diagnóstico de projetos, mapeamento de diagnóstico Vue-to-source              |
-| Formato                | `vize:fmt`                               | Formatação SFC do Vue com opções de projeto e CLI                                                         |
-| Galeria de componentes | `@vizejs/vite-plugin-musea`, `musea-vrt` | arquivos de arte, variantes de componentes, configuração de pré-visualização, tokens de design, a11y, VRT |
-| Suporte ao editor      | VS Code, Zed, Rust `vize lsp`            | Diagnósticos e recursos do editor com opção de participação                                               |
-
-Veja [Static Analysis](./guide/static-analysis.md) para o modelo de verificação de lint e tipo,
-[Rules](./rules/index.md) para saída concreta de regras e
-[Configuration](./guide/configuration.md) para opções compartilhadas de configuração e compilador.
-
-Autoria de componentes em JSX/TSX em vez de `.vue` SFCs? Veja o guia [JSX & TSX](./guide/jsx.md) —
-`.jsx`/`.tsx` componentes do Vue se compilam pela mesma faixa Rust.
-
-## Escolha seu ponto de entrada
-
-### 1. Projetos Vite
-
-Use o plugin Vite se quiser compilação nativa do Vue em um projeto Vite existente.
+Execute o inicializador interativo na raiz do projeto:
 
 ```bash
-vp install -D @vizejs/vite-plugin
+vpx vize init
 ```
 
-Instale `vize` como uma dependência direta apenas quando quiser importar ajudantes de configuração compartilhados da
-`"vize"` ou adicionar scripts de pacote Vize como `vize:lint` e `vize:check`.
+O `vpx` faz parte do [Vite+](https://viteplus.dev/guide/install). Instale o Vite+ primeiro se o
+comando não estiver disponível no shell.
 
-```ts
-// vite.config.ts
-import { defineConfig } from "vite";
-import vize from "@vizejs/vite-plugin";
+Antes de escrever qualquer arquivo, o `vize init` detecta Vite, Vite+ ou Nuxt, o gerenciador de
+pacotes, TypeScript, o comando de lint ativo e a configuração existente do Vize. Você escolhe quais
+partes serão configuradas:
 
-export default defineConfig({
-  plugins: [vize()],
-});
-```
+- o plugin do Vite ou o módulo do Nuxt
+- o plugin do Oxlint, no arquivo de configuração realmente lido pelo comando de lint ativo
+- scripts de projeto para `vize fmt` e `vize check`
+- configurações compartilhadas em `vize.config.*`
+- uma recomendação de extensão para o VS Code
 
-Adicionar opções de compilador em `vize.config.ts` quando quiser as mesmas configurações disponíveis para empacotar scripts
-e o plugin:
-
-```ts
-import { defineConfig } from "vize";
-
-export default defineConfig({
-  compiler: {
-    sourceMap: true,
-    vapor: false,
-    customRenderer: false,
-  },
-  vite: {
-    scanPatterns: ["src/**/*.vue"],
-  },
-});
-```
-
-### 2. Projetos Nuxt
-
-Use o módulo Nuxt quando quiser que o Vize rode dentro do próprio pipeline Vite da Nuxt.
+Visualize todas as alterações propostas em arquivos e dependências sem gravá-las:
 
 ```bash
-vp install @vizejs/nuxt
+vpx vize init --dry-run
 ```
 
-Adicione o módulo ao `nuxt.config.ts`:
-
-```ts
-export default defineNuxtConfig({
-  modules: ["@vizejs/nuxt"],
-  vize: {
-    compiler: true,
-  },
-});
-```
-
-Gerencie seu servidor de desenvolvimento Nuxt normalmente. Os registradores do módulo `@vizejs/vite-plugin` para compilação de
-SFC do Vue, preservando as autoimportações Nuxt, componentes, middleware e transformações SSR.
-
-Veja o guia [Nuxt Integration](./integrations/nuxt.md) para a configuração do Musea e notas específicas do Nuxt.
-
-### 3. Scripts de Pacote npm + Configuração Compartilhada
-
-Use o pacote `vize` npm quando quiser utilidades de configuração compartilhadas e comandos nativos disponíveis
-scripts de projeto.
+Em CI ou outro ambiente não interativo, selecione os recursos explicitamente:
 
 ```bash
-vp install -D vize
+vpx vize init --yes --lint --bundler --fmt --typecheck --editor
 ```
 
-Scripts recomendados para pacotes:
+Consulte [Project Setup (em inglês)](../guide/init.md) para conhecer as regras de detecção, todas as
+opções, as garantias de idempotência e os casos em que o inicializador se recusa deliberadamente a
+editar um arquivo.
 
-```json
-{
-  "scripts": {
-    "vize:build": "vize build src",
-    "vize:fmt": "vize fmt --write src",
-    "vize:lint": "vize lint --preset happy-path src",
-    "vize:check": "vize check src",
-    "vize:ready": "vize ready src"
-  }
-}
-```
+## Escolher uma configuração manual
 
-```bash
-vp run vize:fmt
-vp run vize:lint
-vp run vize:check
-vp run vize:build
-vp run vize:ready
-```
+Prefira a configuração manual quando precisar preservar uma configuração existente ou adotar uma
+parte do Vize por vez:
 
-O comando `vize check` do pacote npm usa o verificador NAPI empacotado e pode emitir declarações de
-componentes Vue com `--declaration --declaration-dir dist/types`. Use a CLI do Rust quando precisar de
-`check-server`, LSP, gerenciamento de IDE ou diagnósticos de projetos em entradas do Vue, TS, TSX e `.d.ts`.
+- [Plugin do Vite](./guide/vite-plugin.md) — compilação nativa de SFCs Vue no Vite
+- [Integração com Nuxt](./integrations/nuxt.md) — caminho compatível pelo pipeline Vite do Nuxt
+- [Scripts de pacote e CLI](./guide/cli.md) — `vize build`, `fmt`, `lint`, `check`, `ready` e a CLI
+  Rust completa
 
-### 4. CLI Full Rust
+O Vite é a integração recomendada com bundlers. Os pacotes unplugin e Rspack continuam
+experimentais; o escopo atual está em [Outros bundlers](./guide/unplugin.md).
 
-A maioria dos fluxos de trabalho de aplicação deve usar os scripts de pacote npm acima. Use o binário Rust quando
-precisar da CLI nativa completa hoje: LSP, gerenciamento de IDE, perfilamento ou `check-server`. Para a versão alfa da v1, os canais públicos
-suportados são os binários de lançamento do GitHub e o ponto de entrada do Nix; a CLI Rust ainda não
-foi publicada pela crates.io.
+## Continuar pelos guias específicos
 
-```bash
-nix run github:ubugeeei-prod/vize#vize -- --help
-```
+Esta página é intencionalmente apenas uma orientação. Para detalhes de configuração e integração,
+use os guias específicos como fonte de referência:
 
-```bash
-vize build src/**/*.vue
-vize fmt --check src
-vize lint --profile src
-vize check --profile src
-vize ready src
-vize lsp
-```
+- [Configuração](./guide/configuration.md) — `vize.config.*`, opções do compilador, verificação de
+  tipos e configurações do Musea
+- [Análise estática](./guide/static-analysis.md) — modelo de lint e verificação de tipos
+- [Documentação de regras](./rules/index.md) — diagnósticos concretos e exemplos
+- [Plugin do Oxlint](./guide/oxlint.md) — predefinições, opções e o arquivo de configuração que cada
+  comando realmente lê
+- [VS Code e outros editores](./integrations/vscode.md) — perfil opcional do editor e configuração LSP
+- [JSX e TSX](./guide/jsx.md) — componentes Vue escritos fora de SFCs `.vue`
+- [Musea](./guide/musea.md) — exemplos de componentes, documentação, tokens, a11y e VRT
 
-## Verificação de Tipos Nativa
-
-`vize check` é alimentado pelo `vize_canon`, que agora se apoia em sessões de projeto [`corsa-bind`](https://github.com/ubugeeei/corsa-bind) para diagnósticos nativos de TypeScript. O Vize gera TypeScript virtual para SFCs do Vue, pede ao Corsa diagnósticos conscientes do projeto e então mapeia os resultados de volta para os arquivos originais `.vue`, `.ts`, `.tsx`e `.d.ts`.
-
-Esse caminho ainda está amadurecendo, então a verificação de tipos de editor continua sendo uma opção opcional por enquanto. A
-pilha de runtime é o pacote `@typescript/native-preview`, Corsa/corsa-bind é a camada API com a qual o Vize
-se comunica, e o executável instalado pela prévia nativa do TypeScript ainda é comumente chamado
-`tsgo`. Use `typeChecker.corsaPath`, ou um script de pacote que rode
-`vize check --corsa-path /path/to/tsgo`, quando quiser fixar esse tempo de execução.
-`typeChecker.tsgoPath` permanece um apelido de compatibilidade obsoleto.
-
-Alvos úteis para scripts de pacotes:
-
-```json
-{
-  "scripts": {
-    "vize:check": "vize check",
-    "vize:check:app": "vize check --tsconfig tsconfig.app.json",
-    "vize:check:virtual-ts": "vize check --show-virtual-ts src/components/App.vue",
-    "vize:check:declarations": "vize check --declaration --declaration-dir dist/types"
-  }
-}
-```
-
-```bash
-vp run vize:check
-vp run vize:check:app
-vp run vize:check:virtual-ts
-vp run vize:check:declarations
-```
-
-## Compartilhado `vize.config.*`
-
-Os comandos de pacote npm e `@vizejs/vite-plugin` compartilham descoberta de configuração:
-
-- `vize.config.pkl`
-- `vize.config.ts`
-- `vize.config.js`
-- `vize.config.mjs`
-- `vize.config.json`
-
-Configuração do TypeScript:
-
-```ts
-import { defineConfig } from "vize";
-
-export default defineConfig({
-  compiler: {
-    sourceMap: true,
-    vapor: false,
-    customRenderer: false,
-  },
-  linter: {
-    preset: "opinionated",
-  },
-  typeChecker: {
-    enabled: true,
-    strict: true,
-    corsaPath: "./node_modules/.bin/tsgo",
-  },
-  formatter: {
-    printWidth: 100,
-  },
-  musea: {
-    include: ["src/**/*.art.vue"],
-    basePath: "/__musea__",
-  },
-  lsp: {
-    lint: true,
-    typecheck: false,
-    editor: false,
-    formatting: false,
-  },
-});
-```
-
-Configuração PKL:
-
-```pkl
-amends "node_modules/vize/pkl/vize.pkl"
-
-linter {
-  preset = "opinionated"
-}
-
-typeChecker {
-  enabled = true
-  strict = true
-}
-
-lsp {
-  lint = true
-  typecheck = false
-  editor = false
-  formatting = false
-}
-```
-
-Configuração JSON com esquema:
-
-```json
-{
-  "$schema": "./node_modules/vize/schemas/vize.config.schema.json",
-  "linter": {
-    "preset": "opinionated"
-  }
-}
-```
-
-## Pacotes
-
-```bash
-vp install -D @vizejs/vite-plugin
-vp install @vizejs/native
-vp install @vizejs/wasm
-vp install @vizejs/unplugin
-vp install @vizejs/rspack-plugin @rspack/core
-vp install @vizejs/nuxt
-vp install @vizejs/vite-plugin-musea
-vp install @vizejs/musea-mcp-server
-vp install -D oxlint oxlint-plugin-vize
-```
-
-Notas:
-
-- `@vizejs/vite-plugin` é a integração recomendada para bundlers hoje.
-- `@vizejs/unplugin` e `@vizejs/rspack-plugin` ainda são experimentais.
-- `@vizejs/native` e `@vizejs/wasm` expõem diretamente as fixações de ferrugem.
-- `@vizejs/vite-plugin-musea` fornece a galeria e o fluxo de trabalho do dev-server para o Musea.
-
-## Galeria de Componentes Musea
-
-Use o Musea quando quiser exemplos de componentes nativos do Vue, documentação, tokens, VRT e verificações a11y:
-
-```bash
-vp install -D @vizejs/vite-plugin @vizejs/vite-plugin-musea vize
-```
-
-```ts
-// vite.config.ts
-import { defineConfig } from "vite";
-import vize from "@vizejs/vite-plugin";
-import { musea } from "@vizejs/vite-plugin-musea";
-
-export default defineConfig({
-  plugins: [
-    vize(),
-    musea({
-      include: ["src/**/*.art.vue"],
-      basePath: "/__musea__",
-      previewCss: ["src/styles/main.css"],
-    }),
-  ],
-});
-```
-
-Execute seu servidor de desenvolvimento Vite e abra `/__musea__`. Veja [Musea](./guide/musea.md) para arquivos de arte, configuração de pré-visualização
-, tokens de design, VRT e variantes geradas.
-
-## Integração Oxlint
-
-Execute o diagnóstico do Vue da Vize dentro do Oxlint:
-
-```bash
-vp install -D oxlint oxlint-plugin-vize
-```
-
-```json
-{
-  "plugins": ["vue"],
-  "jsPlugins": ["oxlint-plugin-vize"],
-  "rules": {
-    "eqeqeq": "error",
-    "vize/vue/require-v-for-key": "error",
-    "vize/vue/no-v-html": "warn"
-  },
-  "settings": {
-    "vize": {
-      "preset": "general-recommended",
-      "helpLevel": "short"
-    }
-  }
-}
-```
-
-Para uso terminal primeiro, prefira:
-
-```bash
-vp exec oxlint-vize -c .oxlintrc.json -f stylish src
-```
-
-## Suporte ao Editor
-
-Para a edição diária do Vue, continue usando `vuejs/language-tools` por enquanto.
-recursos do editor Vize são projetados para opt-in incremental.
-
-Ponto de partida do VS Code:
-
-```json
-{
-  "vize.enable": true,
-  "vize.lint.enable": true,
-  "vize.typecheck.enable": false,
-  "vize.editor.enable": false,
-  "vize.formatting.enable": false
-}
-```
-
-Ponto de partida do Zed:
-
-```json
-{
-  "languages": {
-    "Vue": {
-      "language_servers": ["vize", "..."]
-    }
-  },
-  "lsp": {
-    "vize": {
-      "initialization_options": {
-        "lint": true
-      }
-    }
-  }
-}
-```
-
-## Desenvolvimento Local
-
-As tarefas locais permanecem locais; [CI parity](./contributing.md#common-checks) usa `nix develop .#testbox`.
-
-```bash
-nix develop
-vp install --frozen-lockfile
-vp check
-vp fmt
-vp dev
-vp build
-```
+Enquanto a integração do Vize com editores for experimental, continue usando o
+[`vuejs/language-tools`](https://github.com/vuejs/language-tools) oficial no desenvolvimento Vue do
+dia a dia.

--- a/docs/content/zh-CN/getting-started.md
+++ b/docs/content/zh-CN/getting-started.md
@@ -4,411 +4,82 @@ title: 入门指南
 
 <!-- Generated translation; source: getting-started.md -->
 
-# 开始
+# 入门指南
 
-> **⚠️ 正在开发中：**Vize正在积极开发中，尚未准备好投入生产使用。API 和包边界可能会在没有预告的情况下发生变化。
+> **⚠️ 开发中：** Vize 正在积极开发，目前尚未准备好用于生产环境。
+> API 和软件包边界可能会随时更改，恕不另行通知。
 
-## 什么是Vize？
+Vize (_/viːz/_) 是一个用 Rust 原生实现的 Vue.js 工具链。它将编译、代码检查、格式化、
+类型检查、编辑器诊断和组件浏览整合在同一个工作区中，同时仍可通过专用的软件包和命令
+单独使用每项功能。
 
-Vize（_/viːz/_）是用Rust编写的Vue.js工具链。工作区包含共享
-以下构件：
+| 需求                                     | 推荐入口                    |
+| ---------------------------------------- | --------------------------- |
+| 在 Vite 中编译 Vue SFC                   | `@vizejs/vite-plugin`       |
+| 在 Nuxt 中编译 Vue SFC                   | `@vizejs/nuxt`              |
+| 从项目脚本运行代码检查、格式化和类型检查 | `vize`                      |
+| 将 Vize 诊断与 Oxlint 组合使用           | `oxlint-plugin-vize`        |
+| 浏览和测试组件                           | `@vizejs/vite-plugin-musea` |
+| 试用编辑器功能                           | VS Code、Zed 或 `vize lsp`  |
 
-| 面积          | 主锈箱                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          | 面向用户的入口                               |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
-| 合辑          | [`vize_atelier_core`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_core)、[`vize_atelier_dom`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_dom)、[`vize_atelier_vapor`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_vapor)、[`vize_atelier_ssr`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_ssr)、[`vize_atelier_sfc`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_sfc) | `@vizejs/vite-plugin`，NPM `vize:build` 脚本 |
-| 绒毛          | [`vize_patina`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_patina)                                                                                                                                                                                                                                                                                                                                                                                                             | NPM `vize:lint`脚本，`oxlint-plugin-vize`    |
-| 格式          | [`vize_glyph`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_glyph)                                                                                                                                                                                                                                                                                                                                                                                                               | NPM `vize:fmt`脚本                           |
-| 类型检查      | [`vize_canon`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_canon)                                                                                                                                                                                                                                                                                                                                                                                                               | NPM `vize:check`脚本                         |
-| 编辑支持      | [`vize_maestro`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_maestro)                                                                                                                                                                                                                                                                                                                                                                                                           | VS Code、Zed、Rust `vize lsp`                |
-| Musea艺术工具 | [`vize_musea`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_musea)                                                                                                                                                                                                                                                                                                                                                                                                               | `@vizejs/vite-plugin-musea`                  |
-| 装订          | [`vize_vitrine`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_vitrine)                                                                                                                                                                                                                                                                                                                                                                                                           | `@vizejs/native`，`@vizejs/wasm`             |
+## 设置现有项目
 
-本指南推荐使用 [Vite+](https://viteplus.dev/)（`vp`）来管理 JavaScript 包和项目命令。它保持了安装和执行流程在不同包管理器之间的一致性，同时仍使用工作区底层工具。
-
-如果你还没有`vp`，先安装一次并重新开启一个外壳：
-
-```bash
-curl -fsSL https://vite.plus | bash
-```
-
-详情请参见[Vite+文档](https://viteplus.dev/)和[安装依赖指南](https://viteplus.dev/guide/install)。
-
-## 维兹的行为
-
-从大层面来看，Vice被划分为几个可重复使用的通道：
-
-| 莱恩     | 包或脚本                                 | 你得到了什么                                                      |
-| -------- | ---------------------------------------- | ----------------------------------------------------------------- |
-| 编译     | `@vizejs/vite-plugin`，`vize:build`      | Rust原生的Vue SFC编译，SSR输出，Vapor模式，Scoped CSS处理         |
-| 静态分析 | `vize:lint`，`oxlint-plugin-vize`        | Vue模板、脚本、CSS、a11y、SSR、Vapor、Musea、跨文件和类型感知诊断 |
-| 类型检查 | `vize:check`                             | 虚拟TypeScript生成、项目诊断、Vue到源的诊断映射                   |
-| 格式     | `vize:fmt`                               | Vue SFC 格式化及项目和 CLI 选项                                   |
-| 组件画廊 | `@vizejs/vite-plugin-musea`，`musea-vrt` | 艺术文件、组件变体、预览设置、设计标记、a11y、VRT                 |
-| 编辑支持 | VS Code、Zed、Rust `vize lsp`            | 选择加入的诊断和编辑器功能                                        |
-
-关于lint和类型检查模型，请参见[静态分析](./guide/static-analysis.md)
-[规则](./rules/index.md) 用于具体规则输出，且
-[配置](./guide/configuration.md)用于共享配置和编译器选项。
-
-在JSX/TSX中编写组件而不是`.vue` SFC吗？请参阅[JSX与多伦多](./guide/jsx.md)指南——
-`.jsx`/`.tsx` Vue组件通过同一条Rust通道编译。
-
-## 选择你的入口
-
-### 1.Vite项目
-
-如果你想在现有的 Vite 项目中实现原生 Vue 编译，可以使用 Vite 插件。
+在项目根目录运行交互式初始化命令：
 
 ```bash
-vp install -D @vizejs/vite-plugin
+vpx vize init
 ```
 
-只有当你想导入共享配置助手时，才会直接安装`vize`依赖
-`"vize"`或添加 Vize 的包脚本，如 `vize:lint` 和 `vize:check`。
+`vpx` 随 [Vite+](https://viteplus.dev/guide/install) 一起提供。如果当前 shell 中没有此命令，
+请先安装 Vite+。
 
-```ts
-// vite.config.ts
-import { defineConfig } from "vite";
-import vize from "@vizejs/vite-plugin";
+写入任何文件之前，`vize init` 会检测 Vite、Vite+ 或 Nuxt、软件包管理器、TypeScript、
+当前使用的 lint 命令以及已有的 Vize 配置。你可以单独选择要配置的功能：
 
-export default defineConfig({
-  plugins: [vize()],
-});
-```
+- Vite 插件或 Nuxt 模块
+- Oxlint 插件，并写入当前 lint 命令实际读取的配置文件
+- `vize fmt` 和 `vize check` 项目脚本
+- 共享的 `vize.config.*` 设置
+- VS Code 扩展推荐
 
-当你想打包使用相同的设置时，可以在`vize.config.ts`添加编译器选项
-脚本和插件：
-
-```ts
-import { defineConfig } from "vize";
-
-export default defineConfig({
-  compiler: {
-    sourceMap: true,
-    vapor: false,
-    customRenderer: false,
-  },
-  vite: {
-    scanPatterns: ["src/**/*.vue"],
-  },
-});
-```
-
-### 2.Nuxt 项目
-
-当你想让 Vize 在 Nuxt 自己的 Vite 流水线内运行时，可以使用 Nuxt 模块。
+不写入任何内容，预览所有计划中的文件和依赖项更改：
 
 ```bash
-vp install @vizejs/nuxt
+vpx vize init --dry-run
 ```
 
-将模块添加到`nuxt.config.ts`：
-
-```ts
-export default defineNuxtConfig({
-  modules: ["@vizejs/nuxt"],
-  vize: {
-    compiler: true,
-  },
-});
-```
-
-像平时一样运行你的Nuxt开发服务器。该模块为 Vue SFC 注册 `@vizejs/vite-plugin`
-编译过程中保留了 Nuxt 自动导入、组件、中间件和 SSR 转换。
-
-请参阅 [Nuxt 集成](./integrations/nuxt.md)指南，了解 Musea 的设置和 Nuxt 专用笔记。
-
-### 3.npm Package Scripts + Shared Config
-
-当你想获得共享配置工具和原生命令时，可以使用`vize` npm包
-项目脚本。
+在 CI 或其他非交互环境中，请明确选择所需功能：
 
 ```bash
-vp install -D vize
+vpx vize init --yes --lint --bundler --fmt --typecheck --editor
 ```
 
-推荐的包脚本：
+有关检测规则、全部选项、幂等性保证，以及初始化程序会主动拒绝编辑文件的情况，
+请参阅 [Project Setup（英文）](../guide/init.md)。
 
-```json
-{
-  "scripts": {
-    "vize:build": "vize build src",
-    "vize:fmt": "vize fmt --write src",
-    "vize:lint": "vize lint --preset happy-path src",
-    "vize:check": "vize check src",
-    "vize:ready": "vize ready src"
-  }
-}
-```
+## 选择手动配置
 
-```bash
-vp run vize:fmt
-vp run vize:lint
-vp run vize:check
-vp run vize:build
-vp run vize:ready
-```
+如果需要保留现有配置，或希望逐步采用 Vize 的单项功能，请使用手动配置：
 
-npm包的`vize check`命令使用打包的NAPI检查器，并可以输出Vue组件
-与`--declaration --declaration-dir dist/types`的宣言。需要时用Rust CLI吧
-`check-server`、LSP、IDE管理，或跨Vue、TS、TSX和`.d.ts`输入的项目诊断。
+- [Vite 插件](./guide/vite-plugin.md) — 在 Vite 中原生编译 Vue SFC
+- [Nuxt 集成](./integrations/nuxt.md) — 通过 Nuxt 自身 Vite 管线的受支持方式
+- [软件包脚本和 CLI](./guide/cli.md) — `vize build`、`fmt`、`lint`、`check`、`ready`
+  以及完整的 Rust CLI
 
-### 4.完整的Rust CLI系统
+Vite 是推荐的打包器集成。unplugin 和 Rspack 软件包仍处于实验阶段；请参阅
+[其他打包器](./guide/unplugin.md)了解当前范围。
 
-大多数应用工作流程应该使用上述的 npm 包脚本。使用 Rust 二进制文件
-今天需要完整的原生CLI：LSP、IDE管理、配置文件或`check-server`。对于v1 alpha，
-支持的公开渠道包括GitHub发布二进制文件和Nix入口;Rust CLI 则不是
-已通过 crates.io 出版。
+## 继续阅读专题指南
 
-```bash
-nix run github:ubugeeei-prod/vize#vize -- --help
-```
+本页有意只提供入门导览。有关配置和集成的详细信息，请以以下专题指南为准：
 
-```bash
-vize build src/**/*.vue
-vize fmt --check src
-vize lint --profile src
-vize check --profile src
-vize ready src
-vize lsp
-```
+- [配置](./guide/configuration.md) — `vize.config.*`、编译器选项、类型检查和 Musea 设置
+- [静态分析](./guide/static-analysis.md) — 代码检查和类型检查模型
+- [规则文档](./rules/index.md) — 具体诊断及示例
+- [Oxlint 插件](./guide/oxlint.md) — 预设、设置以及每个命令实际读取的配置文件
+- [VS Code 和其他编辑器](./integrations/vscode.md) — 选择启用的编辑器配置和 LSP 设置
+- [JSX 与 TSX](./guide/jsx.md) — 在 `.vue` SFC 之外编写 Vue 组件
+- [Musea](./guide/musea.md) — 组件示例、文档、设计令牌、a11y 和 VRT
 
-## 本地类型检查
-
-`vize check` 由 `vize_canon` 驱动，现在 依赖于 [`corsa-bind`](https://github.com/ubugeeei/corsa-bind) 项目会话来实现原生 TypeScript 诊断。Vize为Vue SFC生成虚拟TypeScript，向Corsa请求项目感知诊断，然后将结果映射到原始的`.vue`、`.ts`、`.tsx`和`.d.ts`文件上。
-
-这条路径仍在成熟中，因此编辑器类型检查目前仍是选择加入的功能。该
-运行时栈是`@typescript/native-preview`包，Corsa/corsa-bind 是 API 层 Vize。
-与 对话，而 TypeScript 原生预览版安装的可执行文件仍然通常被命名为
-`tsgo`。用`typeChecker.corsaPath`，或者运行的包脚本
-`vize check --corsa-path /path/to/tsgo`，当你想固定那个运行时。
-`typeChecker.tsgoPath`仍是一个已废弃的兼容性别名。
-
-有用的包脚本目标：
-
-```json
-{
-  "scripts": {
-    "vize:check": "vize check",
-    "vize:check:app": "vize check --tsconfig tsconfig.app.json",
-    "vize:check:virtual-ts": "vize check --show-virtual-ts src/components/App.vue",
-    "vize:check:declarations": "vize check --declaration --declaration-dir dist/types"
-  }
-}
-```
-
-```bash
-vp run vize:check
-vp run vize:check:app
-vp run vize:check:virtual-ts
-vp run vize:check:declarations
-```
-
-## 共享的`vize.config.*`
-
-npm 包命令和`@vizejs/vite-plugin` 共享配置发现：
-
-- `vize.config.pkl`
-- `vize.config.ts`
-- `vize.config.js`
-- `vize.config.mjs`
-- `vize.config.json`
-
-TypeScript 配置：
-
-```ts
-import { defineConfig } from "vize";
-
-export default defineConfig({
-  compiler: {
-    sourceMap: true,
-    vapor: false,
-    customRenderer: false,
-  },
-  linter: {
-    preset: "opinionated",
-  },
-  typeChecker: {
-    enabled: true,
-    strict: true,
-    corsaPath: "./node_modules/.bin/tsgo",
-  },
-  formatter: {
-    printWidth: 100,
-  },
-  musea: {
-    include: ["src/**/*.art.vue"],
-    basePath: "/__musea__",
-  },
-  lsp: {
-    lint: true,
-    typecheck: false,
-    editor: false,
-    formatting: false,
-  },
-});
-```
-
-PKL 配置：
-
-```pkl
-amends "node_modules/vize/pkl/vize.pkl"
-
-linter {
-  preset = "opinionated"
-}
-
-typeChecker {
-  enabled = true
-  strict = true
-}
-
-lsp {
-  lint = true
-  typecheck = false
-  editor = false
-  formatting = false
-}
-```
-
-带模式的JSON配置：
-
-```json
-{
-  "$schema": "./node_modules/vize/schemas/vize.config.schema.json",
-  "linter": {
-    "preset": "opinionated"
-  }
-}
-```
-
-## 包裹
-
-```bash
-vp install -D @vizejs/vite-plugin
-vp install @vizejs/native
-vp install @vizejs/wasm
-vp install @vizejs/unplugin
-vp install @vizejs/rspack-plugin @rspack/core
-vp install @vizejs/nuxt
-vp install @vizejs/vite-plugin-musea
-vp install @vizejs/musea-mcp-server
-vp install -D oxlint oxlint-plugin-vize
-```
-
-注释：
-
-- `@vizejs/vite-plugin` 是目前推荐的捆绑器集成。
-- `@vizejs/unplugin`和`@vizejs/rspack-plugin`还在实验阶段。
-- `@vizejs/native`和`@vizejs/wasm`直接暴露Rust装帧。
-- `@vizejs/vite-plugin-musea` 为 Musa 提供画廊和开发服务器的工作流程。
-
-## 博物馆组件画廊
-
-当你想要Vue原生组件示例、文档、令牌、VRT和a11y检查时，可以使用Musea：
-
-```bash
-vp install -D @vizejs/vite-plugin @vizejs/vite-plugin-musea vize
-```
-
-```ts
-// vite.config.ts
-import { defineConfig } from "vite";
-import vize from "@vizejs/vite-plugin";
-import { musea } from "@vizejs/vite-plugin-musea";
-
-export default defineConfig({
-  plugins: [
-    vize(),
-    musea({
-      include: ["src/**/*.art.vue"],
-      basePath: "/__musea__",
-      previewCss: ["src/styles/main.css"],
-    }),
-  ],
-});
-```
-
-运行你的Vite开发服务器并打开`/__musea__`。有关艺术文件，请参见[Musea](./guide/musea.md)
-预览设置、设计标记、VRT和生成变体。
-
-## Oxlint 整合
-
-在Oxlint内部运行Vize的Vue诊断：
-
-```bash
-vp install -D oxlint oxlint-plugin-vize
-```
-
-```json
-{
-  "plugins": ["vue"],
-  "jsPlugins": ["oxlint-plugin-vize"],
-  "rules": {
-    "eqeqeq": "error",
-    "vize/vue/require-v-for-key": "error",
-    "vize/vue/no-v-html": "warn"
-  },
-  "settings": {
-    "vize": {
-      "preset": "general-recommended",
-      "helpLevel": "short"
-    }
-  }
-}
-```
-
-对于终端优先使用，优先使用：
-
-```bash
-vp exec oxlint-vize -c .oxlintrc.json -f stylish src
-```
-
-## 编辑支持
-
-日常编辑Vue时，暂时继续用`vuejs/language-tools`。
-Vize编辑器的功能设计支持增量选择。
-
-VS Code 起点：
-
-```json
-{
-  "vize.enable": true,
-  "vize.lint.enable": true,
-  "vize.typecheck.enable": false,
-  "vize.editor.enable": false,
-  "vize.formatting.enable": false
-}
-```
-
-Zed起始点：
-
-```json
-{
-  "languages": {
-    "Vue": {
-      "language_servers": ["vize", "..."]
-    }
-  },
-  "lsp": {
-    "vize": {
-      "initialization_options": {
-        "lint": true
-      }
-    }
-  }
-}
-```
-
-## 地方发展
-
-本地任务保持本地;[CI平权](./contributing.md#common-checks)用`nix develop .#testbox`。
-
-```bash
-nix develop
-vp install --frozen-lockfile
-vp check
-vp fmt
-vp dev
-vp build
-```
+在 Vize 编辑器集成仍处于实验阶段时，日常 Vue 开发请继续使用官方的
+[`vuejs/language-tools`](https://github.com/vuejs/language-tools)。


### PR DESCRIPTION
Closes #3496

## Summary
- reduce Getting Started to the shortest supported setup path
- route detailed configuration, lint, editor, and integration guidance to focused guides
- keep English, Japanese, Chinese, Portuguese, and French pages structurally aligned

## Validation
- `vp fmt --check`
- local link and anchor validation for all changed pages
- search index validation for all five locales
- `VIZE_ALLOW_NATIVE_VERSION_MISMATCH=1 vp run --no-cache --filter "./docs" build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->