### PR TITLE
test(canon): anchor an empty prop check after multibyte text

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/empty_required_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/empty_required_props.rs
@@ -74,6 +74,7 @@ const propName = 'count' as string
   <External />
   <Transition />
   <UnknownWidget />
+  <p>日本語の見出し</p><Required />
 </template>
 "#,
             ),
@@ -96,12 +97,17 @@ const propName = 'count' as string
         })
         .collect();
 
+    // Line 20 anchors after multibyte text: `  <p>日本語の見出し</p><` is 17
+    // UTF-16 units but 31 UTF-8 bytes, so a byte/char confusion anywhere between
+    // the parser's byte spans and the reported column would move the component
+    // name from column 18 to column 32 instead of failing outright.
     assert_eq!(
         positions,
         [
             ("src/Parent.vue", Some(2345), "12:4".to_string()),
             ("src/Parent.vue", Some(2345), "13:4".to_string()),
             ("src/Parent.vue", Some(2345), "17:4".to_string()),
+            ("src/Parent.vue", Some(2345), "20:18".to_string()),
         ],
         "exact required-prop diagnostics only: {snapshot:#?}"
     );


### PR DESCRIPTION
Follow-up to the review of #3567, which merged before the comment could be addressed there.

The empty-usage required-prop test asserted component-name columns only on an ASCII-only template, so a UTF-8/UTF-16 confusion between the parser's byte spans and the reported column could still return a wrong location without failing the test. The fixture now places an empty usage after multibyte text on the same line:

```rust
  <UnknownWidget />
  <p>日本語の見出し</p><Required />
</template>
```

```rust
("src/Parent.vue", Some(2345), "20:18".to_string()),
```

Column 18 is the `R` counted in UTF-16 code units, matching `LineIndex::offset_to_line_col`; a byte-indexed column would report 32, so the expectation now discriminates the two. The existing ASCII expectations are unchanged.

The mixin/runtime extraction gap noted in the same review stays tracked in #3571, and the statically empty `v-bind` spread contract is already asserted by `recent_issues::spread_props` (`<Child v-bind="$attrs" />` at `10:4`), so neither needed a change here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->