### PR TITLE
test(canon): prove empty prop check isolation

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/empty_required_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/empty_required_props.rs
@@ -1,6 +1,8 @@
 //! Empty component usages still check required props (#3527).
 
-use super::super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+use super::super::{
+    BatchTypeChecker, create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics,
+};
 
 /// Supported required-prop shapes report at the component name, while optional
 /// runtime/mixin props, framework, and unresolved components stay clean.
@@ -116,16 +118,19 @@ fn many_empty_usages_do_not_exhaust_typescript_control_flow() {
         return;
     }
 
-    const USAGE_COUNT: usize = 1_200;
+    // Mutation oracle: 600 guarded calls trigger TS2563 when emitted directly,
+    // while unguarded calls remain below TypeScript's control-flow threshold.
+    const USAGE_COUNT: usize = 600;
     let mut parent = std::string::String::from(
         r#"<script setup lang="ts">
 import Required from './Required.vue'
+const flag = true
 </script>
 <template>
 "#,
     );
     for _ in 0..USAGE_COUNT {
-        parent.push_str("  <Required />\n");
+        parent.push_str("  <Required v-if=\"flag\" />\n");
     }
     parent.push_str("</template>\n");
 
@@ -164,30 +169,24 @@ defineProps<{ count: number }>()
     );
 }
 
-/// Closure scopes need the same isolation as root siblings: every component in
-/// a `v-for` is otherwise emitted into one generated callback.
+/// Closure scopes need the same isolation as root siblings. Inspect the emitted
+/// callback directly because TypeScript's TS2563 threshold for a `v-for` body
+/// is reached by the surrounding loop before empty-call isolation differs.
 #[test]
-fn many_v_for_empty_usages_do_not_exhaust_typescript_control_flow() {
-    if resolve_test_tsgo_binary().is_none() {
-        return;
-    }
-
-    const USAGE_COUNT: usize = 1_200;
-    let mut parent = std::string::String::from(
-        r#"<script setup lang="ts">
+fn v_for_empty_usages_are_isolated_inside_the_callback() {
+    let parent = r#"<script setup lang="ts">
 import Required from './Required.vue'
 </script>
 <template>
   <div v-for="item in [1]" :key="item">
-"#,
-    );
-    for _ in 0..USAGE_COUNT {
-        parent.push_str("    <Required />\n");
-    }
-    parent.push_str("  </div>\n</template>\n");
+    <Required />
+    <Required />
+  </div>
+</template>
+"#;
 
     let project_root = create_project_case(
-        "many-v-for-empty-component-required-props",
+        "v-for-empty-component-required-props-isolation",
         &[
             (
                 "src/Required.vue",
@@ -197,26 +196,28 @@ defineProps<{ count: number }>()
 <template><span /></template>
 "#,
             ),
-            ("src/Parent.vue", parent.as_str()),
+            ("src/Parent.vue", parent),
         ],
     );
 
-    let snapshot = snapshot_project_diagnostics(&project_root);
-    let _ = std::fs::remove_dir_all(&project_root);
-    let Some(snapshot) = snapshot else {
-        return;
-    };
+    let mut checker = BatchTypeChecker::new(&project_root).unwrap();
+    checker.scan_project().unwrap();
+    let generated = checker
+        .virtual_files()
+        .into_iter()
+        .find(|file| file.original_path.ends_with("src/Parent.vue"))
+        .expect("Parent.vue virtual file")
+        .content
+        .as_str();
+    let callback = generated
+        .split_once("// Component props in v-for scope:")
+        .expect("component props v-for section")
+        .1
+        .split_once("__vForList([1]).forEach(([item]) => {")
+        .expect("v-for callback")
+        .1;
 
-    assert!(
-        snapshot.iter().all(|(_, code, _)| *code != Some(2563)),
-        "v-for empty usages must not make a closure too large: {snapshot:#?}"
-    );
-    assert_eq!(
-        snapshot
-            .iter()
-            .filter(|(_, code, _)| *code == Some(2345))
-            .count(),
-        USAGE_COUNT,
-        "every v-for empty usage must retain its required-prop diagnostic"
-    );
+    assert!(callback.contains("    void [\n"), "{callback}");
+    assert_eq!(callback.matches("      () => {").count(), 2, "{callback}");
+    let _ = std::fs::remove_dir_all(&project_root);
 }


### PR DESCRIPTION
## Summary

- replace an ineffective unguarded stress fixture with the 600-use guarded mutation oracle
- prove the pre-isolation implementation fails with TS2563 while the current implementation retains all 600 TS2345 diagnostics
- inspect generated v-for code directly so closure isolation cannot regress behind TypeScript threshold noise

## Validation

- `VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --lib` (737 passed)
- `cargo clippy -p vize_canon --all-features --lib -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `git diff --check`

Refs #3527

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->