### PR TITLE
feat(maestro): support CSS named colours

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3829,6 +3829,7 @@ dependencies = [
  "ropey",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "tower-lsp",
  "tracing",

--- a/crates/vize_maestro/Cargo.toml
+++ b/crates/vize_maestro/Cargo.toml
@@ -61,4 +61,5 @@ vize_musea.workspace = true
 
 [dev-dependencies]
 insta.workspace = true
+sha2.workspace = true
 tempfile.workspace = true

--- a/crates/vize_maestro/src/server/annotations/document_color.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color.rs
@@ -15,6 +15,7 @@
 //! Ranges are authored `.vue` coordinates, never virtual TypeScript.
 #![allow(clippy::disallowed_macros, clippy::disallowed_types)]
 
+mod named;
 mod scan;
 
 use tower_lsp::lsp_types::{Color, ColorInformation, ColorPresentation, Position, Range};
@@ -28,7 +29,7 @@ impl DocumentColorService {
     pub(super) fn colors(content: &str, filename: &str) -> Vec<ColorInformation> {
         let mut colors = Vec::new();
         for region in css_regions(content, filename) {
-            for literal in scan::colors_in(content, region) {
+            for literal in scan::colors_in(content, region.range, region.mode) {
                 colors.push(ColorInformation {
                     range: Range {
                         start: position_at(content, literal.start),
@@ -82,8 +83,14 @@ impl DocumentColorService {
     }
 }
 
+#[derive(Clone, Copy)]
+struct CssRegion {
+    range: (usize, usize),
+    mode: scan::CssMode,
+}
+
 /// Byte regions of the document that hold CSS.
-fn css_regions(content: &str, filename: &str) -> Vec<(usize, usize)> {
+fn css_regions(content: &str, filename: &str) -> Vec<CssRegion> {
     let options = vize_atelier_sfc::SfcParseOptions {
         filename: filename.into(),
         ..Default::default()
@@ -92,20 +99,31 @@ fn css_regions(content: &str, filename: &str) -> Vec<(usize, usize)> {
         return Vec::new();
     };
 
-    let mut regions: Vec<(usize, usize)> = descriptor
+    let mut regions: Vec<CssRegion> = descriptor
         .styles
         .iter()
-        .map(|block| (block.loc.start, block.loc.end))
+        .map(|block| CssRegion {
+            range: (block.loc.start, block.loc.end),
+            mode: match block.lang.as_deref() {
+                Some("sass") => scan::CssMode::IndentedSass,
+                Some("css") | None => scan::CssMode::Stylesheet,
+                Some(_) => scan::CssMode::Preprocessor,
+            },
+        })
         .collect();
 
     if let Some(template) = descriptor.template.as_ref() {
-        regions.extend(static_style_attributes(
-            content,
-            (template.loc.start, template.loc.end),
-        ));
+        regions.extend(
+            static_style_attributes(content, (template.loc.start, template.loc.end))
+                .into_iter()
+                .map(|range| CssRegion {
+                    range,
+                    mode: scan::CssMode::DeclarationList,
+                }),
+        );
     }
 
-    regions.sort_unstable();
+    regions.sort_unstable_by_key(|region| region.range);
     regions
 }
 

--- a/crates/vize_maestro/src/server/annotations/document_color/named.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color/named.rs
@@ -1,0 +1,251 @@
+//! CSS named colours from CSS Color Module Level 4, section 6.1.
+//!
+//! Source: <https://www.w3.org/TR/css-color-4/#named-colors>. The 148 opaque
+//! entries are kept in the specification's ASCII order; `transparent` is the
+//! transparent black defined by section 6.3.
+
+/// Resolve an ASCII case-insensitive CSS colour keyword to RGBA bytes.
+#[cfg(test)]
+pub(super) fn rgba(name: &str) -> Option<[u8; 4]> {
+    rgba_bytes(name.as_bytes())
+}
+
+pub(super) fn rgba_bytes(name: &[u8]) -> Option<[u8; 4]> {
+    let index = CSS_NAMED_COLORS
+        .binary_search_by(|(candidate, _)| {
+            candidate
+                .bytes()
+                .cmp(name.iter().map(|byte| byte.to_ascii_lowercase()))
+        })
+        .ok()?;
+    Some(CSS_NAMED_COLORS[index].1.to_be_bytes())
+}
+
+/// Packed as `0xRRGGBBAA` so every table row stays visually auditable against
+/// the hexadecimal value in the specification.
+const CSS_NAMED_COLORS: [(&str, u32); 149] = [
+    ("aliceblue", 0xf0f8ffff),
+    ("antiquewhite", 0xfaebd7ff),
+    ("aqua", 0x00ffffff),
+    ("aquamarine", 0x7fffd4ff),
+    ("azure", 0xf0ffffff),
+    ("beige", 0xf5f5dcff),
+    ("bisque", 0xffe4c4ff),
+    ("black", 0x000000ff),
+    ("blanchedalmond", 0xffebcdff),
+    ("blue", 0x0000ffff),
+    ("blueviolet", 0x8a2be2ff),
+    ("brown", 0xa52a2aff),
+    ("burlywood", 0xdeb887ff),
+    ("cadetblue", 0x5f9ea0ff),
+    ("chartreuse", 0x7fff00ff),
+    ("chocolate", 0xd2691eff),
+    ("coral", 0xff7f50ff),
+    ("cornflowerblue", 0x6495edff),
+    ("cornsilk", 0xfff8dcff),
+    ("crimson", 0xdc143cff),
+    ("cyan", 0x00ffffff),
+    ("darkblue", 0x00008bff),
+    ("darkcyan", 0x008b8bff),
+    ("darkgoldenrod", 0xb8860bff),
+    ("darkgray", 0xa9a9a9ff),
+    ("darkgreen", 0x006400ff),
+    ("darkgrey", 0xa9a9a9ff),
+    ("darkkhaki", 0xbdb76bff),
+    ("darkmagenta", 0x8b008bff),
+    ("darkolivegreen", 0x556b2fff),
+    ("darkorange", 0xff8c00ff),
+    ("darkorchid", 0x9932ccff),
+    ("darkred", 0x8b0000ff),
+    ("darksalmon", 0xe9967aff),
+    ("darkseagreen", 0x8fbc8fff),
+    ("darkslateblue", 0x483d8bff),
+    ("darkslategray", 0x2f4f4fff),
+    ("darkslategrey", 0x2f4f4fff),
+    ("darkturquoise", 0x00ced1ff),
+    ("darkviolet", 0x9400d3ff),
+    ("deeppink", 0xff1493ff),
+    ("deepskyblue", 0x00bfffff),
+    ("dimgray", 0x696969ff),
+    ("dimgrey", 0x696969ff),
+    ("dodgerblue", 0x1e90ffff),
+    ("firebrick", 0xb22222ff),
+    ("floralwhite", 0xfffaf0ff),
+    ("forestgreen", 0x228b22ff),
+    ("fuchsia", 0xff00ffff),
+    ("gainsboro", 0xdcdcdcff),
+    ("ghostwhite", 0xf8f8ffff),
+    ("gold", 0xffd700ff),
+    ("goldenrod", 0xdaa520ff),
+    ("gray", 0x808080ff),
+    ("green", 0x008000ff),
+    ("greenyellow", 0xadff2fff),
+    ("grey", 0x808080ff),
+    ("honeydew", 0xf0fff0ff),
+    ("hotpink", 0xff69b4ff),
+    ("indianred", 0xcd5c5cff),
+    ("indigo", 0x4b0082ff),
+    ("ivory", 0xfffff0ff),
+    ("khaki", 0xf0e68cff),
+    ("lavender", 0xe6e6faff),
+    ("lavenderblush", 0xfff0f5ff),
+    ("lawngreen", 0x7cfc00ff),
+    ("lemonchiffon", 0xfffacdff),
+    ("lightblue", 0xadd8e6ff),
+    ("lightcoral", 0xf08080ff),
+    ("lightcyan", 0xe0ffffff),
+    ("lightgoldenrodyellow", 0xfafad2ff),
+    ("lightgray", 0xd3d3d3ff),
+    ("lightgreen", 0x90ee90ff),
+    ("lightgrey", 0xd3d3d3ff),
+    ("lightpink", 0xffb6c1ff),
+    ("lightsalmon", 0xffa07aff),
+    ("lightseagreen", 0x20b2aaff),
+    ("lightskyblue", 0x87cefaff),
+    ("lightslategray", 0x778899ff),
+    ("lightslategrey", 0x778899ff),
+    ("lightsteelblue", 0xb0c4deff),
+    ("lightyellow", 0xffffe0ff),
+    ("lime", 0x00ff00ff),
+    ("limegreen", 0x32cd32ff),
+    ("linen", 0xfaf0e6ff),
+    ("magenta", 0xff00ffff),
+    ("maroon", 0x800000ff),
+    ("mediumaquamarine", 0x66cdaaff),
+    ("mediumblue", 0x0000cdff),
+    ("mediumorchid", 0xba55d3ff),
+    ("mediumpurple", 0x9370dbff),
+    ("mediumseagreen", 0x3cb371ff),
+    ("mediumslateblue", 0x7b68eeff),
+    ("mediumspringgreen", 0x00fa9aff),
+    ("mediumturquoise", 0x48d1ccff),
+    ("mediumvioletred", 0xc71585ff),
+    ("midnightblue", 0x191970ff),
+    ("mintcream", 0xf5fffaff),
+    ("mistyrose", 0xffe4e1ff),
+    ("moccasin", 0xffe4b5ff),
+    ("navajowhite", 0xffdeadff),
+    ("navy", 0x000080ff),
+    ("oldlace", 0xfdf5e6ff),
+    ("olive", 0x808000ff),
+    ("olivedrab", 0x6b8e23ff),
+    ("orange", 0xffa500ff),
+    ("orangered", 0xff4500ff),
+    ("orchid", 0xda70d6ff),
+    ("palegoldenrod", 0xeee8aaff),
+    ("palegreen", 0x98fb98ff),
+    ("paleturquoise", 0xafeeeeff),
+    ("palevioletred", 0xdb7093ff),
+    ("papayawhip", 0xffefd5ff),
+    ("peachpuff", 0xffdab9ff),
+    ("peru", 0xcd853fff),
+    ("pink", 0xffc0cbff),
+    ("plum", 0xdda0ddff),
+    ("powderblue", 0xb0e0e6ff),
+    ("purple", 0x800080ff),
+    ("rebeccapurple", 0x663399ff),
+    ("red", 0xff0000ff),
+    ("rosybrown", 0xbc8f8fff),
+    ("royalblue", 0x4169e1ff),
+    ("saddlebrown", 0x8b4513ff),
+    ("salmon", 0xfa8072ff),
+    ("sandybrown", 0xf4a460ff),
+    ("seagreen", 0x2e8b57ff),
+    ("seashell", 0xfff5eeff),
+    ("sienna", 0xa0522dff),
+    ("silver", 0xc0c0c0ff),
+    ("skyblue", 0x87ceebff),
+    ("slateblue", 0x6a5acdff),
+    ("slategray", 0x708090ff),
+    ("slategrey", 0x708090ff),
+    ("snow", 0xfffafaff),
+    ("springgreen", 0x00ff7fff),
+    ("steelblue", 0x4682b4ff),
+    ("tan", 0xd2b48cff),
+    ("teal", 0x008080ff),
+    ("thistle", 0xd8bfd8ff),
+    ("tomato", 0xff6347ff),
+    ("transparent", 0x00000000),
+    ("turquoise", 0x40e0d0ff),
+    ("violet", 0xee82eeff),
+    ("wheat", 0xf5deb3ff),
+    ("white", 0xffffffff),
+    ("whitesmoke", 0xf5f5f5ff),
+    ("yellow", 0xffff00ff),
+    ("yellowgreen", 0x9acd32ff),
+];
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Write;
+
+    use sha2::{Digest, Sha256};
+
+    use super::{CSS_NAMED_COLORS, rgba};
+
+    #[test]
+    fn table_is_complete_sorted_and_ascii_case_insensitive() {
+        assert_eq!(CSS_NAMED_COLORS.len(), 149);
+        assert!(
+            CSS_NAMED_COLORS
+                .windows(2)
+                .all(|pair| pair[0].0 < pair[1].0)
+        );
+        for &(name, expected) in &CSS_NAMED_COLORS {
+            assert_eq!(rgba(name), Some(expected.to_be_bytes()), "{name}");
+            assert_eq!(
+                rgba(&name.to_ascii_uppercase()),
+                Some(expected.to_be_bytes()),
+                "{name}"
+            );
+        }
+        assert_eq!(rgba("transparent"), Some([0, 0, 0, 0]));
+    }
+
+    #[test]
+    fn every_gray_grey_alias_has_the_same_value() {
+        for (gray, grey) in [
+            ("gray", "grey"),
+            ("darkgray", "darkgrey"),
+            ("darkslategray", "darkslategrey"),
+            ("dimgray", "dimgrey"),
+            ("lightgray", "lightgrey"),
+            ("lightslategray", "lightslategrey"),
+            ("slategray", "slategrey"),
+        ] {
+            assert_eq!(rgba(gray), rgba(grey), "{gray}/{grey}");
+        }
+    }
+
+    #[test]
+    fn table_matches_the_pinned_css_color_4_oracle() {
+        let mut serialization = String::new();
+        for (name, packed) in CSS_NAMED_COLORS {
+            writeln!(serialization, "{name}=#{packed:08x}").unwrap();
+        }
+
+        // SHA-256 of the 149 sorted W3C rows serialized as
+        // `name=#rrggbbaa\n`; transparent is the section 6.3 transparent black.
+        // Expected: 8c7caee2456a1cab1e378b1009475d38bd04be7b95726da9f976f140d3fb3b93.
+        let digest: [u8; 32] = Sha256::digest(serialization).into();
+        assert_eq!(
+            digest,
+            [
+                0x8c, 0x7c, 0xae, 0xe2, 0x45, 0x6a, 0x1c, 0xab, 0x1e, 0x37, 0x8b, 0x10, 0x09, 0x47,
+                0x5d, 0x38, 0xbd, 0x04, 0xbe, 0x7b, 0x95, 0x72, 0x6d, 0xa9, 0xf9, 0x76, 0xf1, 0x40,
+                0xd3, 0xfb, 0x3b, 0x93,
+            ]
+        );
+        for (name, expected) in [
+            ("aliceblue", [0xf0, 0xf8, 0xff, 0xff]),
+            ("aqua", [0x00, 0xff, 0xff, 0xff]),
+            ("darkslategray", [0x2f, 0x4f, 0x4f, 0xff]),
+            ("green", [0x00, 0x80, 0x00, 0xff]),
+            ("rebeccapurple", [0x66, 0x33, 0x99, 0xff]),
+            ("transparent", [0x00, 0x00, 0x00, 0x00]),
+            ("yellowgreen", [0x9a, 0xcd, 0x32, 0xff]),
+        ] {
+            assert_eq!(rgba(name), Some(expected), "{name}");
+        }
+    }
+}

--- a/crates/vize_maestro/src/server/annotations/document_color/scan.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color/scan.rs
@@ -2,21 +2,17 @@
 //!
 //! # Coverage
 //!
-//! CSS named colours, `#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`, and the `rgb()` /
-//! `rgba()` functional notation in both the legacy comma form
-//! (`rgb(255, 0, 0)`) and the modern space form (`rgb(255 0 0 / 50%)`).
+//! CSS named colours, hex forms, and legacy/modern `rgb()` / `rgba()`.
 //!
-//! `hsl()` is **not** recognised yet: see #3502. A missing swatch is invisible;
-//! a wrong one is not, so nothing is guessed.
+//! `hsl()` is not recognised yet: see #3502.
 //!
-//! CSS comments are skipped, because a swatch rendered inside `/* ... */` would
-//! offer to rewrite text the stylesheet never reads.
+//! CSS comments are skipped so the picker never rewrites inactive text.
 
 mod lex;
 
 use self::lex::{
     decode_identifier, identifier_end, is_declaration_name, is_identifier_boundary,
-    is_identifier_byte, pair_at, skip_comment, skip_string, skipped_function_end,
+    is_identifier_byte, pair_at, skip_comment, skip_function, skip_string, skipped_function_end,
 };
 use super::named;
 
@@ -24,6 +20,12 @@ use super::named;
 std::thread_local! {
     static SCAN_STEPS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
     static RGB_PROBES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static DECLARATION_NAME_WORK: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn record_declaration_name_work(bytes: usize) {
+    DECLARATION_NAME_WORK.set(DECLARATION_NAME_WORK.get() + bytes);
 }
 
 /// A colour literal: `(start, end, red, green, blue, alpha)` with the channels
@@ -120,7 +122,8 @@ pub(crate) fn colors_in(content: &str, region: (usize, usize), mode: CssMode) ->
                 statement_start = cursor;
                 continue;
             }
-            b':' if parenthesis_depth == 0
+            b':' if !in_value
+                && parenthesis_depth == 0
                 && (mode.accepts_root_declarations() || block_depth > 0)
                 && is_declaration_name(
                     bytes,
@@ -148,18 +151,6 @@ pub(crate) fn colors_in(content: &str, region: (usize, usize), mode: CssMode) ->
             _ => {}
         }
 
-        if !in_value {
-            cursor += 1;
-            continue;
-        }
-        if (bytes[cursor].is_ascii_alphabetic() || bytes[cursor] == b'\\')
-            && is_identifier_boundary(bytes, cursor, region_start)
-            && let Some(end) = skipped_function_end(content, cursor, region_end)
-        {
-            cursor = end;
-            continue;
-        }
-
         let mut identifier_token_end = None;
         let literal = if bytes[cursor] == b'#' {
             hex_literal(content, cursor, region_end)
@@ -168,7 +159,24 @@ pub(crate) fn colors_in(content: &str, region: (usize, usize), mode: CssMode) ->
         {
             let end = identifier_end(bytes, cursor, region_end);
             identifier_token_end = Some(end);
-            identifier_color_literal(content, cursor, end, region_end)
+            if let Some(skipped_end) = skipped_function_end(content, cursor, region_end) {
+                cursor = skipped_end;
+                continue;
+            }
+            if bytes.get(end) == Some(&b'(') {
+                if !is_rgb_function_name(content, cursor, end) {
+                    None
+                } else if let Some(literal) = rgb_literal(content, cursor, end, region_end) {
+                    Some(literal)
+                } else {
+                    cursor = skip_function(bytes, end, region_end);
+                    continue;
+                }
+            } else if in_value {
+                named_color_literal(content, cursor, end)
+            } else {
+                None
+            }
         } else {
             None
         };
@@ -185,18 +193,8 @@ pub(crate) fn colors_in(content: &str, region: (usize, usize), mode: CssMode) ->
     found
 }
 
-/// Parse one complete identifier before deciding whether it is a function or a
-/// keyword. In particular, a named `red` never searches the rest of the file
-/// for a later `(` while probing for `rgb()`.
-fn identifier_color_literal(
-    content: &str,
-    start: usize,
-    end: usize,
-    limit: usize,
-) -> Option<ColorLiteral> {
-    if content.as_bytes().get(end) == Some(&b'(') {
-        return rgb_literal(content, start, end, limit);
-    }
+/// Parse one complete identifier before deciding whether it is a colour.
+fn named_color_literal(content: &str, start: usize, end: usize) -> Option<ColorLiteral> {
     let mut decoded = [0u8; 32];
     let decoded_len = decode_identifier(content.as_bytes(), start, end, &mut decoded)?;
     let [red, green, blue, alpha] = named::rgba_bytes(&decoded[..decoded_len])?;
@@ -208,6 +206,14 @@ fn identifier_color_literal(
         blue: blue as f32 / 255.0,
         alpha: alpha as f32 / 255.0,
     })
+}
+
+fn is_rgb_function_name(content: &str, start: usize, end: usize) -> bool {
+    let mut decoded = [0u8; 4];
+    let Some(len) = decode_identifier(content.as_bytes(), start, end, &mut decoded) else {
+        return false;
+    };
+    decoded[..len].eq_ignore_ascii_case(b"rgb") || decoded[..len].eq_ignore_ascii_case(b"rgba")
 }
 
 /// `#` followed by exactly 3, 4, 6 or 8 hex digits and nothing that could
@@ -273,10 +279,6 @@ fn rgb_literal(
 ) -> Option<ColorLiteral> {
     #[cfg(test)]
     RGB_PROBES.set(RGB_PROBES.get() + 1);
-    let name = &content[start..identifier_end];
-    if !name.eq_ignore_ascii_case("rgb") && !name.eq_ignore_ascii_case("rgba") {
-        return None;
-    }
     let arguments_start = identifier_end + 1;
     let close = content[arguments_start..limit].find(')')? + arguments_start;
     let end = close + 1;
@@ -314,13 +316,18 @@ pub(super) fn colors_in_with_metrics(
 ) -> (Vec<ColorLiteral>, usize, usize) {
     SCAN_STEPS.set(0);
     RGB_PROBES.set(0);
+    DECLARATION_NAME_WORK.set(0);
     let mode = if declaration_list {
         CssMode::DeclarationList
     } else {
         CssMode::Stylesheet
     };
     let colors = colors_in(content, region, mode);
-    (colors, SCAN_STEPS.get(), RGB_PROBES.get())
+    (
+        colors,
+        SCAN_STEPS.get() + DECLARATION_NAME_WORK.get(),
+        RGB_PROBES.get(),
+    )
 }
 
 /// One component, normalised to 0.0..=1.0. `full` is the value that maps to 1.0

--- a/crates/vize_maestro/src/server/annotations/document_color/scan.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color/scan.rs
@@ -2,15 +2,29 @@
 //!
 //! # Coverage
 //!
-//! `#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`, and the `rgb()` / `rgba()`
-//! functional notation in both the legacy comma form (`rgb(255, 0, 0)`) and the
-//! modern space form (`rgb(255 0 0 / 50%)`).
+//! CSS named colours, `#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`, and the `rgb()` /
+//! `rgba()` functional notation in both the legacy comma form
+//! (`rgb(255, 0, 0)`) and the modern space form (`rgb(255 0 0 / 50%)`).
 //!
-//! Named colours (`red`) and `hsl()` are **not** recognised: see #3502. A
-//! missing swatch is invisible; a wrong one is not, so nothing is guessed.
+//! `hsl()` is **not** recognised yet: see #3502. A missing swatch is invisible;
+//! a wrong one is not, so nothing is guessed.
 //!
 //! CSS comments are skipped, because a swatch rendered inside `/* ... */` would
 //! offer to rewrite text the stylesheet never reads.
+
+mod lex;
+
+use self::lex::{
+    decode_identifier, identifier_end, is_declaration_name, is_identifier_boundary,
+    is_identifier_byte, pair_at, skip_comment, skip_string, skipped_function_end,
+};
+use super::named;
+
+#[cfg(test)]
+std::thread_local! {
+    static SCAN_STEPS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static RGB_PROBES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
 
 /// A colour literal: `(start, end, red, green, blue, alpha)` with the channels
 /// already normalised to 0.0..=1.0, which is what LSP's `Color` carries.
@@ -23,28 +37,138 @@ pub(crate) struct ColorLiteral {
     pub(crate) alpha: f32,
 }
 
-pub(crate) fn colors_in(content: &str, region: (usize, usize)) -> Vec<ColorLiteral> {
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum CssMode {
+    Stylesheet,
+    DeclarationList,
+    Preprocessor,
+    IndentedSass,
+}
+
+impl CssMode {
+    fn accepts_root_declarations(self) -> bool {
+        self != Self::Stylesheet
+    }
+
+    fn accepts_variable_names(self) -> bool {
+        matches!(self, Self::Preprocessor | Self::IndentedSass)
+    }
+
+    fn has_line_comments(self) -> bool {
+        matches!(self, Self::Preprocessor | Self::IndentedSass)
+    }
+}
+
+pub(crate) fn colors_in(content: &str, region: (usize, usize), mode: CssMode) -> Vec<ColorLiteral> {
     let (region_start, region_end) = region;
     let bytes = content.as_bytes();
     let mut found = Vec::new();
     let mut cursor = region_start;
+    let mut block_depth = 0usize;
+    let mut parenthesis_depth = 0usize;
+    let mut in_value = false;
+    let mut statement_start = region_start;
+    let mut tentative_value = None;
 
     while cursor < region_end {
-        if content[cursor..region_end].starts_with("/*") {
-            cursor = content[cursor..region_end]
-                .find("*/")
-                .map_or(region_end, |relative| cursor + relative + 2);
+        #[cfg(test)]
+        SCAN_STEPS.set(SCAN_STEPS.get() + 1);
+        if pair_at(bytes, cursor, b"/*") {
+            cursor = skip_comment(bytes, cursor, region_end);
+            continue;
+        }
+        if mode.has_line_comments() && pair_at(bytes, cursor, b"//") {
+            cursor = bytes[cursor..region_end]
+                .iter()
+                .position(|byte| matches!(byte, b'\r' | b'\n'))
+                .map_or(region_end, |offset| cursor + offset);
+            continue;
+        }
+        if matches!(bytes[cursor], b'\'' | b'"') {
+            cursor = skip_string(bytes, cursor, region_end);
+            continue;
+        }
+        if mode == CssMode::IndentedSass
+            && parenthesis_depth == 0
+            && matches!(bytes[cursor], b'\r' | b'\n')
+        {
+            tentative_value = None;
+            in_value = false;
+            cursor += 1;
+            statement_start = cursor;
             continue;
         }
 
-        // `rgb(` only starts a colour at a token boundary: the `r` in
-        // `border-radius` is not the start of a function call.
+        match bytes[cursor] {
+            b'{' => {
+                if let Some(checkpoint) = tentative_value.take() {
+                    found.truncate(checkpoint);
+                }
+                block_depth += 1;
+                parenthesis_depth = 0;
+                in_value = false;
+                cursor += 1;
+                statement_start = cursor;
+                continue;
+            }
+            b'}' => {
+                tentative_value = None;
+                block_depth = block_depth.saturating_sub(1);
+                parenthesis_depth = 0;
+                in_value = false;
+                cursor += 1;
+                statement_start = cursor;
+                continue;
+            }
+            b':' if parenthesis_depth == 0
+                && (mode.accepts_root_declarations() || block_depth > 0)
+                && is_declaration_name(
+                    bytes,
+                    statement_start,
+                    cursor,
+                    mode.accepts_variable_names(),
+                ) =>
+            {
+                if mode != CssMode::DeclarationList {
+                    tentative_value.get_or_insert(found.len());
+                }
+                in_value = true;
+                cursor += 1;
+                continue;
+            }
+            b';' if parenthesis_depth == 0 => {
+                tentative_value = None;
+                in_value = false;
+                cursor += 1;
+                statement_start = cursor;
+                continue;
+            }
+            b'(' => parenthesis_depth += 1,
+            b')' => parenthesis_depth = parenthesis_depth.saturating_sub(1),
+            _ => {}
+        }
+
+        if !in_value {
+            cursor += 1;
+            continue;
+        }
+        if (bytes[cursor].is_ascii_alphabetic() || bytes[cursor] == b'\\')
+            && is_identifier_boundary(bytes, cursor, region_start)
+            && let Some(end) = skipped_function_end(content, cursor, region_end)
+        {
+            cursor = end;
+            continue;
+        }
+
+        let mut identifier_token_end = None;
         let literal = if bytes[cursor] == b'#' {
             hex_literal(content, cursor, region_end)
-        } else if (bytes[cursor] | 0x20) == b'r'
-            && !is_ident_byte(bytes.get(cursor.wrapping_sub(1)))
+        } else if (bytes[cursor].is_ascii_alphabetic() || bytes[cursor] == b'\\')
+            && is_identifier_boundary(bytes, cursor, region_start)
         {
-            rgb_literal(content, cursor, region_end)
+            let end = identifier_end(bytes, cursor, region_end);
+            identifier_token_end = Some(end);
+            identifier_color_literal(content, cursor, end, region_end)
         } else {
             None
         };
@@ -54,16 +178,36 @@ pub(crate) fn colors_in(content: &str, region: (usize, usize)) -> Vec<ColorLiter
                 cursor = literal.end;
                 found.push(literal);
             }
-            None => cursor += 1,
+            None => cursor = identifier_token_end.unwrap_or(cursor + 1),
         }
     }
 
     found
 }
 
-#[inline]
-fn is_ident_byte(byte: Option<&u8>) -> bool {
-    byte.is_some_and(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+/// Parse one complete identifier before deciding whether it is a function or a
+/// keyword. In particular, a named `red` never searches the rest of the file
+/// for a later `(` while probing for `rgb()`.
+fn identifier_color_literal(
+    content: &str,
+    start: usize,
+    end: usize,
+    limit: usize,
+) -> Option<ColorLiteral> {
+    if content.as_bytes().get(end) == Some(&b'(') {
+        return rgb_literal(content, start, end, limit);
+    }
+    let mut decoded = [0u8; 32];
+    let decoded_len = decode_identifier(content.as_bytes(), start, end, &mut decoded)?;
+    let [red, green, blue, alpha] = named::rgba_bytes(&decoded[..decoded_len])?;
+    Some(ColorLiteral {
+        start,
+        end,
+        red: red as f32 / 255.0,
+        green: green as f32 / 255.0,
+        blue: blue as f32 / 255.0,
+        alpha: alpha as f32 / 255.0,
+    })
 }
 
 /// `#` followed by exactly 3, 4, 6 or 8 hex digits and nothing that could
@@ -75,7 +219,7 @@ fn hex_literal(content: &str, start: usize, limit: usize) -> Option<ColorLiteral
         end += 1;
     }
     let digits = &content[start + 1..end];
-    if !matches!(digits.len(), 3 | 4 | 6 | 8) || is_ident_byte(bytes.get(end)) {
+    if !matches!(digits.len(), 3 | 4 | 6 | 8) || is_identifier_byte(bytes.get(end)) {
         return None;
     }
 
@@ -121,17 +265,23 @@ fn hex_value(byte: u8) -> Option<u32> {
 
 /// `rgb(...)` / `rgba(...)`, comma- or space-separated, with an optional alpha
 /// after `,` or `/`. Components may be numbers or percentages.
-fn rgb_literal(content: &str, start: usize, limit: usize) -> Option<ColorLiteral> {
-    let head = &content[start..limit];
-    let open = head.find('(')?;
-    let name = &head[..open];
+fn rgb_literal(
+    content: &str,
+    start: usize,
+    identifier_end: usize,
+    limit: usize,
+) -> Option<ColorLiteral> {
+    #[cfg(test)]
+    RGB_PROBES.set(RGB_PROBES.get() + 1);
+    let name = &content[start..identifier_end];
     if !name.eq_ignore_ascii_case("rgb") && !name.eq_ignore_ascii_case("rgba") {
         return None;
     }
-    let close = head[open..].find(')')? + open;
-    let end = start + close + 1;
+    let arguments_start = identifier_end + 1;
+    let close = content[arguments_start..limit].find(')')? + arguments_start;
+    let end = close + 1;
 
-    let mut components = head[open + 1..close]
+    let mut components = content[arguments_start..close]
         .split(|ch: char| ch == ',' || ch == '/' || ch.is_ascii_whitespace())
         .filter(|part| !part.is_empty());
 
@@ -154,6 +304,23 @@ fn rgb_literal(content: &str, start: usize, limit: usize) -> Option<ColorLiteral
         blue,
         alpha,
     })
+}
+
+#[cfg(test)]
+pub(super) fn colors_in_with_metrics(
+    content: &str,
+    region: (usize, usize),
+    declaration_list: bool,
+) -> (Vec<ColorLiteral>, usize, usize) {
+    SCAN_STEPS.set(0);
+    RGB_PROBES.set(0);
+    let mode = if declaration_list {
+        CssMode::DeclarationList
+    } else {
+        CssMode::Stylesheet
+    };
+    let colors = colors_in(content, region, mode);
+    (colors, SCAN_STEPS.get(), RGB_PROBES.get())
 }
 
 /// One component, normalised to 0.0..=1.0. `full` is the value that maps to 1.0

--- a/crates/vize_maestro/src/server/annotations/document_color/scan/lex.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color/scan/lex.rs
@@ -1,0 +1,257 @@
+//! Small CSS lexical helpers used by the colour scanner.
+
+#[inline]
+pub(super) fn pair_at(bytes: &[u8], start: usize, pair: &[u8; 2]) -> bool {
+    bytes.get(start) == Some(&pair[0]) && bytes.get(start + 1) == Some(&pair[1])
+}
+
+#[inline]
+pub(super) fn is_identifier_byte(byte: Option<&u8>) -> bool {
+    byte.is_some_and(|&byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'\\') || byte >= 0x80
+    })
+}
+
+pub(super) fn is_identifier_boundary(bytes: &[u8], start: usize, region_start: usize) -> bool {
+    if is_identifier_byte(bytes.get(start.wrapping_sub(1)))
+        || bytes
+            .get(start.wrapping_sub(1))
+            .is_some_and(|byte| matches!(byte, b'$' | b'@' | b'#' | b'.'))
+    {
+        return false;
+    }
+    let Some(prefix) = bytes.get(region_start..start.wrapping_sub(1)) else {
+        return true;
+    };
+    if !bytes[start - 1].is_ascii_whitespace() {
+        return true;
+    }
+    let hex_digits = prefix
+        .iter()
+        .rev()
+        .take(6)
+        .take_while(|byte| byte.is_ascii_hexdigit())
+        .count();
+    hex_digits == 0
+        || prefix
+            .len()
+            .checked_sub(hex_digits + 1)
+            .and_then(|escape| prefix.get(escape))
+            != Some(&b'\\')
+}
+
+pub(super) fn is_declaration_name(
+    bytes: &[u8],
+    start: usize,
+    end: usize,
+    allow_variable_prefix: bool,
+) -> bool {
+    let mut cursor = skip_trivia(bytes, start, end);
+    if allow_variable_prefix
+        && bytes
+            .get(cursor)
+            .is_some_and(|byte| matches!(byte, b'$' | b'@'))
+    {
+        cursor += 1;
+    }
+    let name_start = cursor;
+    cursor = identifier_end(bytes, cursor, end);
+    cursor > name_start && skip_trivia(bytes, cursor, end) == end
+}
+
+fn skip_trivia(bytes: &[u8], mut cursor: usize, limit: usize) -> usize {
+    loop {
+        while cursor < limit && bytes[cursor].is_ascii_whitespace() {
+            cursor += 1;
+        }
+        if pair_at(bytes, cursor, b"/*") {
+            cursor = skip_comment(bytes, cursor, limit);
+        } else {
+            return cursor;
+        }
+    }
+}
+
+pub(super) fn skip_comment(bytes: &[u8], start: usize, limit: usize) -> usize {
+    let mut cursor = start + 2;
+    while cursor + 1 < limit {
+        if pair_at(bytes, cursor, b"*/") {
+            return cursor + 2;
+        }
+        cursor += 1;
+    }
+    limit
+}
+
+pub(super) fn skip_string(bytes: &[u8], start: usize, limit: usize) -> usize {
+    let quote = bytes[start];
+    let mut cursor = start + 1;
+    while cursor < limit {
+        match bytes[cursor] {
+            b'\\' => cursor = (cursor + 2).min(limit),
+            byte if byte == quote => return cursor + 1,
+            _ => cursor += 1,
+        }
+    }
+    limit
+}
+
+pub(super) fn identifier_end(bytes: &[u8], start: usize, limit: usize) -> usize {
+    let mut cursor = start;
+    while cursor < limit {
+        if bytes[cursor] == b'\\' {
+            cursor = escape_end(bytes, cursor, limit);
+        } else if is_identifier_byte(bytes.get(cursor)) {
+            cursor += 1;
+        } else {
+            break;
+        }
+    }
+    cursor
+}
+
+/// Decode one complete CSS identifier into a caller-provided buffer. The raw
+/// token end is found separately, so a non-ASCII or overlong result can fail
+/// lookup without exposing a suffix as a second identifier.
+pub(super) fn decode_identifier(
+    bytes: &[u8],
+    start: usize,
+    end: usize,
+    output: &mut [u8],
+) -> Option<usize> {
+    let mut cursor = start;
+    let mut output_len = 0;
+    while cursor < end {
+        let (byte, next) = if bytes[cursor] == b'\\' {
+            decoded_escape(bytes, cursor, end)
+        } else {
+            (Some(bytes[cursor]), cursor + 1)
+        };
+        let byte = byte?;
+        *output.get_mut(output_len)? = byte;
+        output_len += 1;
+        cursor = next;
+    }
+    Some(output_len)
+}
+
+/// Functions whose arguments cannot contain a CSS colour value. URLs need
+/// opaque treatment; math functions only accept numeric calculations.
+pub(super) fn skipped_function_end(content: &str, start: usize, limit: usize) -> Option<usize> {
+    const SKIPPED: &[&[u8]] = &[
+        b"url", b"calc", b"min", b"max", b"clamp", b"round", b"mod", b"rem", b"sin", b"cos",
+        b"tan", b"asin", b"acos", b"atan", b"atan2", b"pow", b"sqrt", b"hypot", b"log", b"exp",
+        b"abs", b"sign",
+    ];
+    let bytes = content.as_bytes();
+    let identifier_end = identifier_end(bytes, start, limit);
+    if bytes.get(identifier_end) != Some(&b'(')
+        || !SKIPPED
+            .iter()
+            .any(|expected| identifier_eq(bytes, start, identifier_end, expected))
+    {
+        return None;
+    }
+    Some(skip_function(bytes, identifier_end, limit))
+}
+
+fn escape_end(bytes: &[u8], slash: usize, limit: usize) -> usize {
+    let mut cursor = slash + 1;
+    let mut digits = 0;
+    while cursor < limit && digits < 6 && bytes[cursor].is_ascii_hexdigit() {
+        cursor += 1;
+        digits += 1;
+    }
+    if digits > 0 {
+        cursor = css_escape_whitespace_end(bytes, cursor, limit);
+    } else {
+        cursor = (cursor + 1).min(limit);
+    }
+    cursor
+}
+
+fn identifier_eq(bytes: &[u8], start: usize, end: usize, expected: &[u8]) -> bool {
+    let mut cursor = start;
+    let mut expected_cursor = 0;
+    while cursor < end {
+        let (byte, next) = if bytes[cursor] == b'\\' {
+            decoded_escape(bytes, cursor, end)
+        } else {
+            (Some(bytes[cursor]), cursor + 1)
+        };
+        let Some(byte) = byte else {
+            return false;
+        };
+        if expected.get(expected_cursor) != Some(&byte.to_ascii_lowercase()) {
+            return false;
+        }
+        expected_cursor += 1;
+        cursor = next;
+    }
+    expected_cursor == expected.len()
+}
+
+fn decoded_escape(bytes: &[u8], slash: usize, limit: usize) -> (Option<u8>, usize) {
+    let mut cursor = slash + 1;
+    let mut value = 0u32;
+    let mut digits = 0;
+    while cursor < limit && digits < 6 && bytes[cursor].is_ascii_hexdigit() {
+        value = value * 16 + u32::from(hex_value(bytes[cursor]));
+        cursor += 1;
+        digits += 1;
+    }
+    if digits > 0 {
+        cursor = css_escape_whitespace_end(bytes, cursor, limit);
+        (u8::try_from(value).ok(), cursor)
+    } else {
+        (bytes.get(cursor).copied(), (cursor + 1).min(limit))
+    }
+}
+
+fn css_escape_whitespace_end(bytes: &[u8], cursor: usize, limit: usize) -> usize {
+    match bytes.get(cursor).copied() {
+        Some(b'\r') if bytes.get(cursor + 1) == Some(&b'\n') => (cursor + 2).min(limit),
+        Some(b'\t' | b'\n' | b'\x0c' | b'\r' | b' ') => cursor + 1,
+        _ => cursor,
+    }
+}
+
+fn hex_value(byte: u8) -> u8 {
+    match byte {
+        b'0'..=b'9' => byte - b'0',
+        b'a'..=b'f' => byte - b'a' + 10,
+        b'A'..=b'F' => byte - b'A' + 10,
+        _ => 0,
+    }
+}
+
+fn skip_function(bytes: &[u8], open: usize, limit: usize) -> usize {
+    let mut cursor = open;
+    let mut depth = 0usize;
+    while cursor < limit {
+        if pair_at(bytes, cursor, b"/*") {
+            cursor = skip_comment(bytes, cursor, limit);
+            continue;
+        }
+        if matches!(bytes[cursor], b'\'' | b'"') {
+            cursor = skip_string(bytes, cursor, limit);
+            continue;
+        }
+        match bytes[cursor] {
+            b'\\' => cursor = escape_end(bytes, cursor, limit),
+            b'(' => {
+                depth += 1;
+                cursor += 1;
+            }
+            b')' => {
+                depth = depth.saturating_sub(1);
+                cursor += 1;
+                if depth == 0 {
+                    return cursor;
+                }
+            }
+            _ => cursor += 1,
+        }
+    }
+    limit
+}

--- a/crates/vize_maestro/src/server/annotations/document_color/scan/lex.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color/scan/lex.rs
@@ -20,12 +20,17 @@ pub(super) fn is_identifier_boundary(bytes: &[u8], start: usize, region_start: u
     {
         return false;
     }
-    let Some(prefix) = bytes.get(region_start..start.wrapping_sub(1)) else {
+    let Some(previous) = start.checked_sub(1) else {
         return true;
     };
-    if !bytes[start - 1].is_ascii_whitespace() {
+    let whitespace_start = match bytes[previous] {
+        b'\n' if previous > region_start && bytes[previous - 1] == b'\r' => previous - 1,
+        b'\t' | b'\n' | b'\x0c' | b'\r' | b' ' => previous,
+        _ => return true,
+    };
+    let Some(prefix) = bytes.get(region_start..whitespace_start) else {
         return true;
-    }
+    };
     let hex_digits = prefix
         .iter()
         .rev()
@@ -46,6 +51,8 @@ pub(super) fn is_declaration_name(
     end: usize,
     allow_variable_prefix: bool,
 ) -> bool {
+    #[cfg(test)]
+    super::record_declaration_name_work(end.saturating_sub(start));
     let mut cursor = skip_trivia(bytes, start, end);
     if allow_variable_prefix
         && bytes
@@ -225,7 +232,7 @@ fn hex_value(byte: u8) -> u8 {
     }
 }
 
-fn skip_function(bytes: &[u8], open: usize, limit: usize) -> usize {
+pub(super) fn skip_function(bytes: &[u8], open: usize, limit: usize) -> usize {
     let mut cursor = open;
     let mut depth = 0usize;
     while cursor < limit {

--- a/crates/vize_maestro/src/server/annotations/document_color/tests.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color/tests.rs
@@ -1,4 +1,4 @@
-use tower_lsp::lsp_types::Color;
+use tower_lsp::lsp_types::{Color, ColorInformation, Position, Range};
 
 use super::DocumentColorService;
 
@@ -86,6 +86,170 @@ fn functional_notation_is_recognised_in_both_syntaxes() {
             (1, 76, 97, 255, 0, 0, 50),
         ]
     );
+}
+
+#[test]
+fn named_colours_report_the_complete_exact_output() {
+    let source = "<style>\n.a { color: red; background: ReBeCcApUrPlE; border-color: transparent; outline: gray; caret-color: grey; --h: hsl(0 100% 50%); --ha: hsla(0, 100%, 50%, .5) }\n</style>\n";
+    assert_eq!(
+        colors(source),
+        vec![
+            (1, 12, 15, 255, 0, 0, 100),
+            (1, 29, 42, 102, 51, 153, 100),
+            (1, 58, 69, 0, 0, 0, 0),
+            (1, 80, 84, 128, 128, 128, 100),
+            (1, 99, 103, 128, 128, 128, 100),
+        ]
+    );
+}
+
+#[test]
+fn preprocessor_variables_keep_named_and_existing_colour_forms() {
+    let source = "<style lang=\"scss\">\n$named: red;\n$hex: #0f0;\n$rgb: rgb(0, 0, 255);\n// red #f00 rgb(255, 0, 0)\n</style>\n<style lang=\"less\">\n@named: blue;\n@hex: #fff;\n@rgb: rgb(255, 0, 0);\n// red #f00 rgb(255, 0, 0)\n</style>\n";
+    assert_eq!(
+        colors(source),
+        vec![
+            (1, 8, 11, 255, 0, 0, 100),
+            (2, 6, 10, 0, 255, 0, 100),
+            (3, 6, 20, 0, 0, 255, 100),
+            (7, 8, 12, 0, 0, 255, 100),
+            (8, 6, 10, 255, 255, 255, 100),
+            (9, 6, 20, 255, 0, 0, 100),
+        ]
+    );
+}
+
+#[test]
+fn indented_sass_keeps_named_and_existing_colour_forms() {
+    let source = "<style lang=\"sass\">\n.a\n  color: red\n  background: #0f0\n  border-color: rgb(0, 0, 255)\n  // red #f00 rgb(255, 0, 0)\n</style>\n";
+    assert_eq!(
+        colors(source),
+        vec![
+            (2, 9, 12, 255, 0, 0, 100),
+            (3, 14, 18, 0, 255, 0, 100),
+            (4, 16, 30, 0, 0, 255, 100),
+        ]
+    );
+}
+
+#[test]
+fn css_escape_whitespace_follows_css_input_preprocessing() {
+    let source = "<style>\r\n.a { color: r\\65\r\nd; outline: r\\65\u{000b}d }\r\n</style>\r\n";
+    assert_eq!(
+        DocumentColorService::colors(source, "/App.vue"),
+        vec![ColorInformation {
+            range: Range {
+                start: Position {
+                    line: 1,
+                    character: 12,
+                },
+                end: Position {
+                    line: 2,
+                    character: 1,
+                },
+            },
+            color: Color {
+                red: 1.0,
+                green: 0.0,
+                blue: 0.0,
+                alpha: 1.0,
+            },
+        }]
+    );
+}
+
+#[test]
+fn named_colours_require_identifier_boundaries_and_skip_comments() {
+    let source = r#"<style>
+/* red BLUE transparent */
+.reddish { --redish: 1; border-red: 2; color: redish; --a: éred; --b: redé; --c: \ red; --d: red\ish; --e: x\20 red }
+</style>
+"#;
+    assert_eq!(colors(source), Vec::new());
+}
+
+#[test]
+fn named_colours_are_limited_to_css_value_tokens() {
+    let source = "<style>\n.red, #red { content: \"red /*\"; background-image: url(red); width: tan(red); color: blue }\n</style>\n";
+    assert_eq!(colors(source), vec![(1, 84, 88, 0, 0, 255, 100)]);
+}
+
+#[test]
+fn nested_pseudo_selectors_are_not_colour_values() {
+    let source = "<style>\n.outer {\n  :deep(.red) { color: blue }\n  :is(.red) { color: blue }\n  :global(.red) { color: blue }\n  a:is(.red) { color: blue }\n  &:global(.red) { color: blue }\n}\n</style>\n";
+    assert_eq!(
+        colors(source),
+        vec![
+            (2, 23, 27, 0, 0, 255, 100),
+            (3, 21, 25, 0, 0, 255, 100),
+            (4, 25, 29, 0, 0, 255, 100),
+            (5, 22, 26, 0, 0, 255, 100),
+            (6, 26, 30, 0, 0, 255, 100),
+        ]
+    );
+}
+
+#[test]
+fn escaped_urls_and_preprocessor_or_hash_tokens_are_not_colours() {
+    let source = r#"<style>
+.a { background: u\72l(red), \75rl(blue), u\000072 l(tan); --scss: $red; --less: @blue; --hash: #red; color: green }
+</style>
+"#;
+    assert_eq!(colors(source), vec![(1, 109, 114, 0, 128, 0, 100)]);
+}
+
+#[test]
+fn comment_trivia_before_a_declaration_colon_keeps_value_context() {
+    let source = "<style>\n.a { color/* red */: blue }\n</style>\n";
+    assert_eq!(colors(source), vec![(1, 21, 25, 0, 0, 255, 100)]);
+}
+
+#[test]
+fn escaped_named_colours_use_the_complete_authored_identifier_range() {
+    let source = r#"<style>
+.a { color: r\65 d; background: \72 ed }
+.b { --a: \ red; --b: x\ red; color: blue }
+</style>
+"#;
+    assert_eq!(
+        colors(source),
+        vec![
+            (1, 12, 18, 255, 0, 0, 100),
+            (1, 32, 38, 255, 0, 0, 100),
+            (2, 37, 41, 0, 0, 255, 100),
+        ]
+    );
+}
+
+#[test]
+fn named_colour_scanning_has_linear_work_at_1k_through_8k() {
+    let mut previous_steps = 0;
+    for count in [1_000, 2_000, 4_000, 8_000] {
+        let mut source = String::from("--colours: ");
+        source.reserve(count * 4);
+        for _ in 0..count {
+            source.push_str("red ");
+        }
+        let source_len = source.len();
+        let (found, steps, rgb_probes) =
+            super::scan::colors_in_with_metrics(&source, (0, source_len), true);
+        assert_eq!(found.len(), count);
+        assert_eq!(
+            rgb_probes, 0,
+            "named tokens must never probe the rgb parser"
+        );
+        assert!(
+            steps <= source_len,
+            "scanner revisited input at {count} tokens"
+        );
+        if previous_steps > 0 {
+            assert!(
+                steps <= previous_steps * 2 + 16,
+                "scanner work grew faster than input at {count} tokens"
+            );
+        }
+        previous_steps = steps;
+    }
 }
 
 #[test]

--- a/crates/vize_maestro/src/server/annotations/document_color/tests.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color/tests.rs
@@ -2,8 +2,7 @@ use tower_lsp::lsp_types::{Color, ColorInformation, Position, Range};
 
 use super::DocumentColorService;
 
-/// One colour as `(line, start_character, end_character, r, g, b, a)` with the
-/// channels back in 0..=255 / 0..=100 so a test reads like the CSS it pins.
+/// `(line, start, end, r, g, b, a)`, with byte channels and percent alpha.
 type FlatColor = (u32, u32, u32, u32, u32, u32, u32);
 
 fn colors(source: &str) -> Vec<FlatColor> {
@@ -69,23 +68,42 @@ fn every_hex_form_is_recognised_with_its_exact_span() {
 
 #[test]
 fn a_hex_run_that_is_not_a_colour_is_not_one() {
-    // 5 and 7 digits are not CSS colours, and `#abcdef0` must not be read as
-    // `#abcdef` with a stray `0`.
+    // `#abcdef0` must not be read as `#abcdef` with a stray `0`.
     let source = "<style>\n.a { --x: #abcde; --y: #abcdef0; --z: #ffgg }\n</style>\n";
     assert_eq!(colors(source), Vec::new());
 }
 
 #[test]
 fn functional_notation_is_recognised_in_both_syntaxes() {
-    let source = "<style>\n.a { color: rgb(255, 0, 0); background: rgba(255, 0, 0, 0.5); border-color: rgb(100% 0% 0% / 50%) }\n</style>\n";
+    let source = "<style>\n.a { color: rgb(255, 0, 0); background: rgba(255, 0, 0, 0.5); border-color: rgb(100% 0% 0% / 50%); outline-color: r\\67 b(0 0 255) }\n</style>\n";
     assert_eq!(
         colors(source),
         vec![
             (1, 12, 26, 255, 0, 0, 100),
             (1, 40, 60, 255, 0, 0, 50),
             (1, 76, 97, 255, 0, 0, 50),
+            (1, 114, 129, 0, 0, 255, 100),
         ]
     );
+}
+
+#[test]
+fn existing_colour_forms_remain_visible_in_supports_conditions() {
+    let source = "<style>\n@supports (color: #f00) and (background: rgb(0, 255, 0)) { .a { color: blue } }\n</style>\n";
+    assert_eq!(
+        colors(source),
+        vec![
+            (1, 18, 22, 255, 0, 0, 100),
+            (1, 41, 55, 0, 255, 0, 100),
+            (1, 71, 75, 0, 0, 255, 100),
+        ]
+    );
+}
+
+#[test]
+fn invalid_rgb_functions_do_not_expose_named_arguments() {
+    let source = "<style>\n.a { --a: rgb(red 0 0); --b: r\\67 b(red 0 0); --c: RGBA(blue, 0, 0, 1); --d: \\72 gba(blue, 0, 0, 1); color: green }\n</style>\n";
+    assert_eq!(colors(source), vec![(1, 108, 113, 0, 128, 0, 100)]);
 }
 
 #[test]
@@ -155,6 +173,15 @@ fn css_escape_whitespace_follows_css_input_preprocessing() {
                 alpha: 1.0,
             },
         }]
+    );
+}
+
+#[test]
+fn escaped_hash_tokens_consume_crlf_but_not_vertical_tab() {
+    let source = "<style>\r\n.a { --crlf: #x\\20\r\nred; --vt: #x\\20\u{000b}red; color: blue }\r\n</style>\r\n";
+    assert_eq!(
+        colors(source),
+        vec![(2, 17, 20, 255, 0, 0, 100), (2, 29, 33, 0, 0, 255, 100),]
     );
 }
 
@@ -253,6 +280,31 @@ fn named_colour_scanning_has_linear_work_at_1k_through_8k() {
 }
 
 #[test]
+fn declaration_context_scanning_counts_internal_work_linearly() {
+    let mut previous_work = 0;
+    for count in [1_000, 2_000, 4_000, 8_000] {
+        let source = format!(
+            ".a {{ /*{}*/ --chain: {}red; }}",
+            "x".repeat(count),
+            "a:".repeat(count)
+        );
+        let source_len = source.len();
+        let (found, work, rgb_probes) =
+            super::scan::colors_in_with_metrics(&source, (0, source_len), false);
+        assert_eq!(found.len(), 1);
+        assert_eq!(rgb_probes, 0);
+        assert!(work <= source_len * 2, "too much work at {count}: {work}");
+        if previous_work > 0 {
+            assert!(
+                work <= previous_work * 2 + 32,
+                "internal work grew faster than input at {count}: {work}"
+            );
+        }
+        previous_work = work;
+    }
+}
+
+#[test]
 fn a_colour_inside_a_css_comment_is_not_offered() {
     // A swatch there would offer to rewrite text the stylesheet never reads.
     let source = "<style>\n/* #f00 */\n.a { color: #0f0 }\n</style>\n";
@@ -286,8 +338,7 @@ fn presentations_offer_hex_first_then_the_functional_form() {
         labels(1.0, 0.0, 0.0, 1.0),
         vec!["#ff0000".to_string(), "rgb(255, 0, 0)".to_string()]
     );
-    // A translucent colour needs the 8-digit hex and `rgba()`; the alpha is
-    // written the way CSS writes it, not as `0.500000`.
+    // CSS alpha is trimmed rather than written as `0.500000`.
     assert_eq!(
         labels(1.0, 0.0, 0.0, 0.5),
         vec!["#ff000080".to_string(), "rgba(255, 0, 0, 0.5)".to_string()]


### PR DESCRIPTION
## Summary

- recognise all 148 CSS Color 4 named colours plus transparent
- preserve existing hex and rgb scanning across CSS and preprocessors
- handle escaped identifiers and invalid colour functions without false swatches
- keep scanner work linear with an internal-work oracle

## Verification

- exact pinned W3C 149-entry table digest
- focused documentColor: 26 passed
- full vize_maestro all-features: 652 unit + 3 integration + 1 doc passed; 1 runtime-dependent ignored
- clippy library, fmt, diff check
- five mutation oracles confirmed RED

Refs #3502

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->