### PR TITLE
fix(canon): preserve authored vue ts substitutions

### DIFF
--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -45,7 +45,9 @@ pub use virtual_project::{
 pub use virtual_specifier_message::restore_virtual_vue_specifiers;
 pub use virtual_ts::VirtualTsGenerator;
 
-pub(crate) use virtual_specifier_message::AUTHORED_VUE_TS_SENTINEL;
+pub(crate) use virtual_specifier_message::{
+    AUTHORED_VUE_TS_ALIAS_SENTINEL, AUTHORED_VUE_TS_SENTINEL,
+};
 
 use vize_carton::String;
 

--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -8,11 +8,11 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_carton::{String, ToCompactString, cstr};
 
-use super::AUTHORED_VUE_TS_SENTINEL;
+use super::{AUTHORED_VUE_TS_ALIAS_SENTINEL, AUTHORED_VUE_TS_SENTINEL};
 
 #[path = "import_rewriter_authored_vue_ts.rs"]
 mod authored_vue_ts;
-use authored_vue_ts::unresolved_authored_vue_ts_collides_with_sfc;
+use authored_vue_ts::{VueTsCollision, authored_vue_ts_collides_with_sfc};
 
 #[path = "import_rewriter_collect.rs"]
 mod collect;
@@ -240,8 +240,12 @@ impl ImportRewriter {
     }
 
     fn rewrite_module_specifier(&self, path: &str, source_dir: Option<&Path>) -> Option<String> {
-        if unresolved_authored_vue_ts_collides_with_sfc(path, source_dir) {
-            return Some(cstr!("{path}{AUTHORED_VUE_TS_SENTINEL}"));
+        if let Some(collision) = authored_vue_ts_collides_with_sfc(path, source_dir) {
+            let marker = match collision {
+                VueTsCollision::Unresolved => AUTHORED_VUE_TS_SENTINEL,
+                VueTsCollision::Authored => AUTHORED_VUE_TS_ALIAS_SENTINEL,
+            };
+            return Some(cstr!("{path}{marker}"));
         }
         if is_rewritable_vue_specifier(path) {
             Some(cstr!("{path}.ts"))
@@ -256,8 +260,12 @@ impl ImportRewriter {
         roots: (&std::path::Path, &std::path::Path),
         source_dir: Option<&std::path::Path>,
     ) -> Option<String> {
-        if unresolved_authored_vue_ts_collides_with_sfc(path, source_dir) {
-            return Some(cstr!("{path}{AUTHORED_VUE_TS_SENTINEL}"));
+        if let Some(collision) = authored_vue_ts_collides_with_sfc(path, source_dir) {
+            let marker = match collision {
+                VueTsCollision::Unresolved => AUTHORED_VUE_TS_SENTINEL,
+                VueTsCollision::Authored => AUTHORED_VUE_TS_ALIAS_SENTINEL,
+            };
+            return Some(cstr!("{path}{marker}"));
         }
         if let Some(source_dir) = source_dir
             && let Some(rewritten) = rewrite_relative_dts_specifier(path, source_dir, roots.0)

--- a/crates/vize_canon/src/batch/import_rewriter_authored_vue_ts.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_authored_vue_ts.rs
@@ -4,18 +4,25 @@ use std::path::Path;
 
 use super::virtual_rewrite::append_extension;
 
-/// Whether an explicit `.vue.ts`/`.vue.tsx` specifier is proven to resolve only
-/// because Vize materializes the sibling `.vue` file at that exact path.
-pub(super) fn unresolved_authored_vue_ts_collides_with_sfc(
+pub(super) enum VueTsCollision {
+    /// No authored candidate exists; use the child-path poison from #3482.
+    Unresolved,
+    /// TypeScript has an authored candidate that needs a collision-free alias.
+    Authored,
+}
+
+/// Whether an explicit `.vue.ts`/`.vue.tsx` specifier shares its virtual path
+/// with the generated mirror for a sibling SFC.
+pub(super) fn authored_vue_ts_collides_with_sfc(
     specifier: &str,
     source_dir: Option<&Path>,
-) -> bool {
+) -> Option<VueTsCollision> {
     let suffix = if specifier.ends_with(".vue.tsx") {
         ".tsx"
     } else if specifier.ends_with(".vue.ts") {
         ".ts"
     } else {
-        return false;
+        return None;
     };
 
     let relative = specifier.starts_with("./") || specifier.starts_with("../");
@@ -23,43 +30,38 @@ pub(super) fn unresolved_authored_vue_ts_collides_with_sfc(
     let candidate = if path.is_absolute() {
         path.to_path_buf()
     } else if relative {
-        let Some(source_dir) = source_dir else {
-            return false;
-        };
+        let source_dir = source_dir?;
         source_dir.join(path)
     } else {
         // Bare and aliased paths need the project resolver. Absence cannot be
         // established from the authored directory alone.
-        return false;
+        return None;
     };
 
-    let Some(name) = candidate.file_name().and_then(|name| name.to_str()) else {
-        return false;
-    };
-    let Some(sfc_name) = name.strip_suffix(suffix) else {
-        return false;
-    };
+    let name = candidate.file_name().and_then(|name| name.to_str())?;
+    let sfc_name = name.strip_suffix(suffix)?;
     let sfc_path = candidate.with_file_name(sfc_name);
     if !sfc_path.is_file() {
-        return false;
+        return None;
     }
 
-    // TypeScript first substitutes the explicit TS/TSX suffix, then appends
-    // the standard candidate set to the full spelling, and finally tries the
-    // full spelling as a directory. Poison only when every native candidate is
-    // proven absent; permission/metadata errors stay conservatively untouched.
     let stripped_extensions: &[&str] = if suffix == ".tsx" {
         &[".tsx", ".ts", ".d.ts", ".jsx", ".js"]
     } else {
         &[".ts", ".tsx", ".d.ts", ".js", ".jsx"]
     };
-    stripped_extensions
+    let missing = stripped_extensions
         .iter()
         .all(|extension| path_is_proven_absent(&append_extension(&sfc_path, extension)))
         && [".ts", ".tsx", ".d.ts", ".js", ".jsx"]
             .iter()
             .all(|extension| path_is_proven_absent(&append_extension(&candidate, extension)))
-        && path_is_proven_absent(&candidate)
+        && path_is_proven_absent(&candidate);
+    Some(if missing {
+        VueTsCollision::Unresolved
+    } else {
+        VueTsCollision::Authored
+    })
 }
 
 fn path_is_proven_absent(path: &Path) -> bool {

--- a/crates/vize_canon/src/batch/import_rewriter_authored_vue_ts_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_authored_vue_ts_tests.rs
@@ -1,7 +1,9 @@
 use oxc_span::SourceType;
 use tempfile::TempDir;
 
-use super::{AUTHORED_VUE_TS_SENTINEL, import_rewriter::ImportRewriter};
+use super::{
+    AUTHORED_VUE_TS_ALIAS_SENTINEL, AUTHORED_VUE_TS_SENTINEL, import_rewriter::ImportRewriter,
+};
 
 #[test]
 fn authored_vue_ts_specifiers_cannot_resolve_generated_mirrors() {
@@ -68,26 +70,17 @@ fn authored_vue_ts_specifiers_cannot_resolve_generated_mirrors() {
     let expected = format!(
         "import './Mirror.vue.ts{AUTHORED_VUE_TS_SENTINEL}';\n\
          import './MirrorJsx.vue.tsx{AUTHORED_VUE_TS_SENTINEL}';\n\
-         import './Real.vue.ts';\n\
-         import './RealJsx.vue.tsx';\n\
-         import './Directory.vue.ts';\n\
-         import './Declaration.vue.ts';\n\
-         import './Runtime.vue.ts';\n\
-         import './FullDeclaration.vue.ts';\n\
-         import './FullSource.vue.ts';\n\
+         import './Real.vue.ts{AUTHORED_VUE_TS_ALIAS_SENTINEL}';\n\
+         import './RealJsx.vue.tsx{AUTHORED_VUE_TS_ALIAS_SENTINEL}';\n\
+         import './Directory.vue.ts{AUTHORED_VUE_TS_ALIAS_SENTINEL}';\n\
+         import './Declaration.vue.ts{AUTHORED_VUE_TS_ALIAS_SENTINEL}';\n\
+         import './Runtime.vue.ts{AUTHORED_VUE_TS_ALIAS_SENTINEL}';\n\
+         import './FullDeclaration.vue.ts{AUTHORED_VUE_TS_ALIAS_SENTINEL}';\n\
+         import './FullSource.vue.ts{AUTHORED_VUE_TS_ALIAS_SENTINEL}';\n\
          import '@/Alias.vue.ts';\n\
          import '{absent_absolute}{AUTHORED_VUE_TS_SENTINEL}';\n\
          import './Generated.vue.ts';\n"
     );
-    let full_declaration = source_dir
-        .join("FullDeclaration.vue.ts")
-        .to_string_lossy()
-        .replace('\\', "/");
-    let virtual_expected = expected.replace(
-        "import './FullDeclaration.vue.ts';",
-        &format!("import '{full_declaration}';"),
-    );
-
     let rewriter = ImportRewriter::new();
     assert_eq!(
         rewriter
@@ -104,7 +97,7 @@ fn authored_vue_ts_specifiers_cannot_resolve_generated_mirrors() {
                 Some(&source_dir),
             )
             .code,
-        virtual_expected
+        expected
     );
 
     // Callers without an authored directory cannot prove that a relative

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
@@ -7,6 +7,7 @@ mod native_prop_anchors;
 mod sequence_prop_expressions;
 mod spread_props;
 mod spread_scope_bindings;
+mod ts_extension_substitution;
 
 #[test]
 fn issue_2645_infers_generic_sfc_props_in_tsx() {

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/ts_extension_substitution.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/ts_extension_substitution.rs
@@ -1,0 +1,177 @@
+use super::super::{
+    BatchTypeChecker, TypeChecker, create_project_case, relative_path, resolve_test_tsgo_binary,
+};
+use vize_carton::{String, cstr};
+
+const SFC: &str = "<script setup lang=\"ts\">\nconst local = 1\n</script>\n<template><div>{{ local }}</div></template>\n";
+
+#[test]
+fn explicit_vue_ts_imports_follow_typescript_extension_substitution() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    for sfc_first in [false, true] {
+        let case_name = if sfc_first {
+            "vue-ts-extension-substitution-sfc-first"
+        } else {
+            "vue-ts-extension-substitution-authored-first"
+        };
+        let project_root = create_project_case(
+            case_name,
+            &[
+                (
+                    "src/App.vue",
+                    r#"<script setup lang="ts">
+import { typed } from "./Typed.vue.ts";
+import { runtime } from "./Runtime.vue.ts";
+import { full } from "./Full.vue.ts";
+import { directory } from "./Directory.vue.ts";
+import { direct } from "./Direct.vue.ts";
+import { packaged } from "./Packaged.vue.ts";
+import { main } from "./Main.vue.ts";
+
+const typedNumber: number = typed;
+const runtimeNumber: number = runtime;
+const fullNumber: number = full;
+const directoryNumber: number = directory;
+const directNumber: number = direct;
+const packagedNumber: number = packaged;
+const mainNumber: number = main;
+</script>
+"#,
+                ),
+                (
+                    "src/Typed.vue.d.ts",
+                    "export declare const typed: string;\n",
+                ),
+                ("src/Runtime.vue.js", "export const runtime = 'runtime';\n"),
+                (
+                    "src/Full.vue.ts.ts",
+                    "export const full: string = 'full';\n",
+                ),
+                (
+                    "src/Directory.vue.ts/index.ts",
+                    "export const directory: string = 'directory';\n",
+                ),
+                (
+                    "src/Direct.vue.ts",
+                    "export const direct: string = 'direct';\n",
+                ),
+                (
+                    "src/Packaged.vue.ts/package.json",
+                    r#"{"types":"./types.d.ts"}"#,
+                ),
+                (
+                    "src/Packaged.vue.ts/types.d.ts",
+                    "export declare const packaged: string;\n",
+                ),
+                ("src/Main.vue.ts/package.json", r#"{"main":"./entry.js"}"#),
+                (
+                    "src/Main.vue.ts/entry.d.ts",
+                    "export declare const main: string;\n",
+                ),
+                ("src/Main.vue.ts/entry.js", "export const main = 'main';\n"),
+                ("src/Typed.vue", SFC),
+                ("src/Runtime.vue", SFC),
+                ("src/Full.vue", SFC),
+                ("src/Directory.vue", SFC),
+                ("src/Direct.vue", SFC),
+                ("src/Packaged.vue", SFC),
+                ("src/Main.vue", SFC),
+            ],
+        );
+
+        let app = project_root.join("src/App.vue");
+        let mut scan_paths = [
+            "Typed.vue",
+            "Runtime.vue",
+            "Full.vue",
+            "Directory.vue",
+            "Direct.vue",
+            "Packaged.vue",
+            "Main.vue",
+        ]
+        .map(|name| project_root.join("src").join(name))
+        .to_vec();
+        let authored_direct = project_root.join("src/Direct.vue.ts");
+        if sfc_first {
+            scan_paths.push(authored_direct);
+            scan_paths.push(app);
+        } else {
+            scan_paths.insert(0, authored_direct);
+            scan_paths.insert(0, app);
+        }
+
+        let mut checker = BatchTypeChecker::new(&project_root).unwrap();
+        checker.scan_paths(&scan_paths).unwrap();
+        let result = checker.check_project().unwrap();
+        let virtual_root = project_root.join("node_modules/.vize/canon");
+        let virtual_root = virtual_root.to_string_lossy();
+        let mut snapshot: Vec<_> = result
+            .diagnostics
+            .into_iter()
+            .map(|diagnostic| {
+                let message = diagnostic
+                    .message
+                    .replace(virtual_root.as_ref(), "<virtual>");
+                (
+                    relative_path(&project_root, &diagnostic.file),
+                    diagnostic.code,
+                    cstr!(
+                        "{}:{} {}",
+                        diagnostic.line + 1,
+                        diagnostic.column + 1,
+                        message
+                    ),
+                )
+            })
+            .collect();
+        snapshot.sort();
+
+        assert_eq!(
+            snapshot,
+            vec![
+                (
+                    String::from("src/App.vue"),
+                    Some(2322),
+                    String::from("10:7 Type 'string' is not assignable to type 'number'."),
+                ),
+                (
+                    String::from("src/App.vue"),
+                    Some(2322),
+                    String::from("12:7 Type 'string' is not assignable to type 'number'."),
+                ),
+                (
+                    String::from("src/App.vue"),
+                    Some(2322),
+                    String::from("13:7 Type 'string' is not assignable to type 'number'."),
+                ),
+                (
+                    String::from("src/App.vue"),
+                    Some(2322),
+                    String::from("14:7 Type 'string' is not assignable to type 'number'."),
+                ),
+                (
+                    String::from("src/App.vue"),
+                    Some(2322),
+                    String::from("15:7 Type 'string' is not assignable to type 'number'."),
+                ),
+                (
+                    String::from("src/App.vue"),
+                    Some(2322),
+                    String::from("16:7 Type 'string' is not assignable to type 'number'."),
+                ),
+                (
+                    String::from("src/App.vue"),
+                    Some(7016),
+                    String::from(
+                        "3:25 Could not find a declaration file for module './Runtime.vue.ts'. '<virtual>/src/Runtime.vue.ts.__vize_authored_vue_ts_alias__.js' implicitly has an 'any' type."
+                    ),
+                ),
+            ]
+        );
+
+        let _ = std::fs::remove_dir_all(&project_root);
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/passthrough.rs
+++ b/crates/vize_canon/src/batch/virtual_project/passthrough.rs
@@ -7,7 +7,13 @@ use std::path::{Path, PathBuf};
 
 use vize_carton::{FxHashSet, String as CompactString, ToCompactString, cstr};
 
+use crate::batch::AUTHORED_VUE_TS_ALIAS_SENTINEL;
+
 use super::{VirtualProject, build::mirrored_virtual_path};
+
+#[path = "passthrough_resolution.rs"]
+mod resolution;
+use resolution::resolve_relative_passthrough_module;
 
 impl VirtualProject {
     pub(super) fn javascript_passthrough_files(&self) -> impl Iterator<Item = &Path> {
@@ -34,26 +40,51 @@ pub(super) fn collect_passthrough_modules(
         let Some(original_path) = resolve_relative_passthrough_module(dir, &specifier) else {
             continue;
         };
-        let Ok(virtual_path) = mirrored_virtual_path(project_root, virtual_root, &original_path)
-        else {
-            continue;
-        };
         let declaration_path = adjacent_declaration_path(&original_path);
-        if seen.insert(virtual_path.clone()) {
-            files.push((virtual_path, original_path));
-        }
-        if let Some(declaration_path) = declaration_path {
-            let Ok(virtual_path) =
-                mirrored_virtual_path(project_root, virtual_root, &declaration_path)
-            else {
-                continue;
-            };
-            if seen.insert(virtual_path.clone()) {
-                files.push((virtual_path, declaration_path));
+        for original_path in std::iter::once(original_path).chain(declaration_path) {
+            let virtual_path = authored_collision_alias(
+                dir,
+                &specifier,
+                &original_path,
+                project_root,
+                virtual_root,
+            )
+            .or_else(|| mirrored_virtual_path(project_root, virtual_root, &original_path).ok());
+            if let Some(virtual_path) = virtual_path
+                && seen.insert(virtual_path.clone())
+            {
+                files.push((virtual_path, original_path));
             }
         }
     }
     files
+}
+
+fn authored_collision_alias(
+    dir: &Path,
+    specifier: &str,
+    original: &Path,
+    project_root: &Path,
+    virtual_root: &Path,
+) -> Option<PathBuf> {
+    let suffix = specifier
+        .strip_suffix(".vue.tsx")
+        .or_else(|| specifier.strip_suffix(".vue.ts"))?;
+    let sfc = dir.join(cstr!("{suffix}.vue").as_str());
+    if !sfc.is_file() {
+        return None;
+    }
+    let name = original.file_name()?.to_str()?;
+    let extension = if name.ends_with(".d.ts") {
+        "d.ts"
+    } else {
+        original.extension()?.to_str()?
+    };
+    let base = dir.join(specifier);
+    let parent = normalize_existing_path(base.parent()?);
+    let name = base.file_name()?.to_str()?;
+    let alias = parent.join(cstr!("{name}{AUTHORED_VUE_TS_ALIAS_SENTINEL}.{extension}").as_str());
+    mirrored_virtual_path(project_root, virtual_root, &alias).ok()
 }
 
 fn extract_relative_module_specifiers(source: &str) -> Vec<CompactString> {
@@ -124,45 +155,6 @@ fn is_identifier_byte(byte: u8) -> bool {
 
 fn is_relative_specifier(specifier: &str) -> bool {
     specifier.starts_with("./") || specifier.starts_with("../")
-}
-
-const PASSTHROUGH_EXTENSIONS: &[&str] = &["js", "jsx", "mjs", "cjs", "json"];
-
-fn resolve_relative_passthrough_module(dir: &Path, specifier: &str) -> Option<PathBuf> {
-    let base = dir.join(specifier);
-
-    if specifier_has_passthrough_extension(specifier) && base.is_file() {
-        return Some(normalize_existing_path(&base));
-    }
-
-    for extension in PASSTHROUGH_EXTENSIONS {
-        let candidate = append_extension(&base, extension);
-        if candidate.is_file() {
-            return Some(normalize_existing_path(&candidate));
-        }
-    }
-
-    for extension in PASSTHROUGH_EXTENSIONS {
-        let candidate = base.join(cstr!("index.{extension}").as_str());
-        if candidate.is_file() {
-            return Some(normalize_existing_path(&candidate));
-        }
-    }
-
-    None
-}
-
-fn append_extension(base: &Path, extension: &str) -> PathBuf {
-    match base.file_name().and_then(|name| name.to_str()) {
-        Some(name) => base.with_file_name(cstr!("{name}.{extension}")),
-        None => base.to_path_buf(),
-    }
-}
-
-fn specifier_has_passthrough_extension(specifier: &str) -> bool {
-    PASSTHROUGH_EXTENSIONS
-        .iter()
-        .any(|extension| specifier.ends_with(cstr!(".{extension}").as_str()))
 }
 
 fn normalize_existing_path(path: &Path) -> PathBuf {

--- a/crates/vize_canon/src/batch/virtual_project/passthrough_resolution.rs
+++ b/crates/vize_canon/src/batch/virtual_project/passthrough_resolution.rs
@@ -1,0 +1,184 @@
+//! TypeScript-compatible probing for relative modules copied into the mirror.
+
+use std::path::{Path, PathBuf};
+
+use vize_carton::cstr;
+
+const PASSTHROUGH_EXTENSIONS: &[&str] = &["js", "jsx", "mjs", "cjs", "json"];
+const TYPESCRIPT_EXTENSIONS: &[&str] = &["ts", "tsx", "d.ts", "js", "jsx"];
+const PACKAGE_ENTRY_FIELDS: &[&str] = &["types", "typings", "main"];
+
+pub(super) fn resolve_relative_passthrough_module(dir: &Path, specifier: &str) -> Option<PathBuf> {
+    let base = dir.join(specifier);
+    if let Some((stripped, extensions)) = explicit_typescript_substitution(&base, specifier) {
+        if let Some(path) = first_existing_with_extensions(&stripped, extensions) {
+            return Some(path);
+        }
+        if let Some(path) = first_existing_with_extensions(&base, TYPESCRIPT_EXTENSIONS) {
+            return Some(path);
+        }
+        return first_existing_directory_module(&base, TYPESCRIPT_EXTENSIONS);
+    }
+
+    if specifier_has_passthrough_extension(specifier) && base.is_file() {
+        return Some(normalize_existing_path(&base));
+    }
+    first_existing_with_extensions(&base, PASSTHROUGH_EXTENSIONS)
+        .or_else(|| first_existing_directory_module(&base, PASSTHROUGH_EXTENSIONS))
+}
+
+fn explicit_typescript_substitution<'a>(
+    base: &Path,
+    specifier: &str,
+) -> Option<(PathBuf, &'a [&'a str])> {
+    let (suffix, extensions): (&str, &[&str]) = if specifier.ends_with(".vue.tsx") {
+        (".tsx", &["tsx", "ts", "d.ts", "jsx", "js"])
+    } else if specifier.ends_with(".vue.ts") {
+        (".ts", &["ts", "tsx", "d.ts", "js", "jsx"])
+    } else {
+        return None;
+    };
+    let name = base.file_name()?.to_str()?;
+    Some((base.with_file_name(name.strip_suffix(suffix)?), extensions))
+}
+
+fn first_existing_with_extensions(base: &Path, extensions: &[&str]) -> Option<PathBuf> {
+    extensions
+        .iter()
+        .map(|extension| append_extension(base, extension))
+        .find(|candidate| candidate.is_file())
+        .map(|candidate| normalize_existing_path(&candidate))
+}
+
+fn first_existing_index(base: &Path, extensions: &[&str]) -> Option<PathBuf> {
+    extensions
+        .iter()
+        .map(|extension| base.join(cstr!("index.{extension}").as_str()))
+        .find(|candidate| candidate.is_file())
+        .map(|candidate| normalize_existing_path(&candidate))
+}
+
+fn first_existing_directory_module(base: &Path, extensions: &[&str]) -> Option<PathBuf> {
+    package_entry(base, extensions).or_else(|| first_existing_index(base, extensions))
+}
+
+fn package_entry(base: &Path, extensions: &[&str]) -> Option<PathBuf> {
+    let manifest = std::fs::read_to_string(base.join("package.json")).ok()?;
+    let package: serde_json::Value = serde_json::from_str(&manifest).ok()?;
+    for field in PACKAGE_ENTRY_FIELDS {
+        let Some(relative) = package.get(field).and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let target = base.join(relative);
+        if let Some(resolved) = resolve_package_target(&target, extensions) {
+            return Some(resolved);
+        }
+    }
+    None
+}
+
+fn resolve_package_target(target: &Path, extensions: &[&str]) -> Option<PathBuf> {
+    let substituted = target
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| {
+            [".js", ".jsx"]
+                .into_iter()
+                .find_map(|suffix| name.strip_suffix(suffix))
+        })
+        .map(|name| target.with_file_name(name))
+        .and_then(|base| first_existing_with_extensions(&base, extensions));
+    substituted
+        .or_else(|| target.is_file().then(|| normalize_existing_path(target)))
+        .or_else(|| first_existing_with_extensions(target, extensions))
+        .or_else(|| first_existing_index(target, extensions))
+}
+
+fn append_extension(base: &Path, extension: &str) -> PathBuf {
+    match base.file_name().and_then(|name| name.to_str()) {
+        Some(name) => base.with_file_name(cstr!("{name}.{extension}")),
+        None => base.to_path_buf(),
+    }
+}
+
+fn specifier_has_passthrough_extension(specifier: &str) -> bool {
+    PASSTHROUGH_EXTENSIONS
+        .iter()
+        .any(|extension| specifier.ends_with(cstr!(".{extension}").as_str()))
+}
+
+fn normalize_existing_path(path: &Path) -> PathBuf {
+    vize_carton::path::canonicalize_non_verbatim(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::resolve_relative_passthrough_module;
+
+    #[test]
+    fn explicit_vue_ts_uses_typescript_candidate_order() {
+        let case = tempfile::tempdir().expect("temp project");
+        let root = &std::fs::canonicalize(case.path()).unwrap();
+        for path in [
+            "Direct.vue.ts",
+            "Direct.vue.tsx",
+            "Direct.vue.d.ts",
+            "Direct.vue.js",
+            "Direct.vue.jsx",
+            "Full.vue.ts.d.ts",
+            "Directory.vue.ts/index.ts",
+            "Packaged.vue.ts/types.d.ts",
+            "Main.vue.ts/entry.d.ts",
+            "Main.vue.ts/entry.js",
+        ] {
+            let path = root.join(path);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, "export {}\n").unwrap();
+        }
+        std::fs::write(
+            root.join("Packaged.vue.ts/package.json"),
+            r#"{"types":"./types.d.ts"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("Main.vue.ts/package.json"),
+            r#"{"main":"./entry.js"}"#,
+        )
+        .unwrap();
+
+        let resolve = |specifier| {
+            resolve_relative_passthrough_module(root, specifier)
+                .unwrap()
+                .strip_prefix(root)
+                .unwrap()
+                .to_path_buf()
+        };
+        assert_eq!(resolve("./Direct.vue.ts"), Path::new("Direct.vue.ts"));
+        assert_eq!(resolve("./Full.vue.ts"), Path::new("Full.vue.ts.d.ts"));
+        assert_eq!(
+            resolve("./Directory.vue.ts"),
+            Path::new("Directory.vue.ts/index.ts")
+        );
+        assert_eq!(
+            resolve("./Packaged.vue.ts"),
+            Path::new("Packaged.vue.ts/types.d.ts")
+        );
+        assert_eq!(
+            resolve("./Main.vue.ts"),
+            Path::new("Main.vue.ts/entry.d.ts")
+        );
+    }
+
+    #[test]
+    fn explicit_vue_tsx_prefers_tsx_then_ts() {
+        let case = tempfile::tempdir().expect("temp project");
+        let root = &std::fs::canonicalize(case.path()).unwrap();
+        std::fs::write(root.join("Component.vue.ts"), "export {}\n").unwrap();
+        std::fs::write(root.join("Component.vue.tsx"), "export {}\n").unwrap();
+
+        let resolved = resolve_relative_passthrough_module(root, "./Component.vue.tsx").unwrap();
+        assert!(resolved.ends_with("Component.vue.tsx"));
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/paths.rs
+++ b/crates/vize_canon/src/batch/virtual_project/paths.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use vize_carton::cstr;
 
+use crate::batch::AUTHORED_VUE_TS_ALIAS_SENTINEL;
 use crate::batch::error::{CorsaError, CorsaResult};
 
 pub(super) fn script_virtual_path(
@@ -16,6 +17,20 @@ pub(super) fn script_virtual_path(
             path: path.to_path_buf(),
         });
     };
+    let source_file_name = path.file_name().and_then(|name| name.to_str());
+    let authored_vue_ts_extension = source_file_name.and_then(|name| {
+        name.strip_suffix(".vue.ts")
+            .map(|stem| (stem, "ts"))
+            .or_else(|| name.strip_suffix(".vue.tsx").map(|stem| (stem, "tsx")))
+    });
+    if let Some((stem, extension)) = authored_vue_ts_extension
+        && path.with_file_name(cstr!("{stem}.vue").as_str()).is_file()
+    {
+        virtual_path.set_file_name(
+            cstr!("{file_name}{AUTHORED_VUE_TS_ALIAS_SENTINEL}.{extension}").as_str(),
+        );
+        return Ok(virtual_path);
+    }
     if let Some(stem) = file_name.strip_suffix(".d.ts") {
         virtual_path.set_file_name(cstr!("{stem}.d.cts").as_str());
     }

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -331,11 +331,15 @@ impl VirtualProject {
                 .insert(registered.file.virtual_path.clone());
         }
         for (virtual_path, original_path) in registered.passthrough_files {
-            self.passthrough_files.insert(virtual_path, original_path);
+            if !self.virtual_files.contains_key(&virtual_path) {
+                self.passthrough_files.insert(virtual_path, original_path);
+            }
         }
         for file in registered.extra_virtual_files {
+            self.passthrough_files.remove(&file.virtual_path);
             self.virtual_files.insert(file.virtual_path.clone(), file);
         }
+        self.passthrough_files.remove(&registered.file.virtual_path);
         self.virtual_files
             .insert(registered.file.virtual_path.clone(), registered.file);
     }

--- a/crates/vize_canon/src/batch/virtual_specifier_message.rs
+++ b/crates/vize_canon/src/batch/virtual_specifier_message.rs
@@ -5,6 +5,7 @@ use vize_carton::{String, ToCompactString, cstr};
 /// Suffix added to an unresolved authored `.vue.ts`/`.vue.tsx` import so
 /// TypeScript cannot accidentally resolve the generated SFC mirror.
 pub(crate) const AUTHORED_VUE_TS_SENTINEL: &str = "/__vize_authored_vue_ts__";
+pub(crate) const AUTHORED_VUE_TS_ALIAS_SENTINEL: &str = ".__vize_authored_vue_ts_alias__";
 
 const QUOTE_PAIRS: [(char, char); 3] = [('\'', '\''), ('"', '"'), ('\u{2018}', '\u{2019}')];
 
@@ -37,10 +38,12 @@ pub fn restore_virtual_vue_specifiers(message: &str, authored_source: &str) -> S
 }
 
 fn authored_specifier(reported: &str) -> Option<&str> {
-    if let Some(authored) = reported.strip_suffix(AUTHORED_VUE_TS_SENTINEL)
-        && (authored.ends_with(".vue.ts") || authored.ends_with(".vue.tsx"))
-    {
-        return Some(authored);
+    for marker in [AUTHORED_VUE_TS_SENTINEL, AUTHORED_VUE_TS_ALIAS_SENTINEL] {
+        if let Some(authored) = reported.strip_suffix(marker)
+            && (authored.ends_with(".vue.ts") || authored.ends_with(".vue.tsx"))
+        {
+            return Some(authored);
+        }
     }
     reported
         .strip_suffix(".ts")
@@ -76,19 +79,23 @@ fn is_specifier_shaped(candidate: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{AUTHORED_VUE_TS_SENTINEL, restore_virtual_vue_specifiers};
+    use super::{
+        AUTHORED_VUE_TS_ALIAS_SENTINEL, AUTHORED_VUE_TS_SENTINEL, restore_virtual_vue_specifiers,
+    };
 
     #[test]
     fn restores_generated_mirrors_and_authored_collision_markers() {
         let marker = AUTHORED_VUE_TS_SENTINEL;
-        let message =
-            format!("Module '\"./Panel.vue.ts\"' failed; cannot find '../Missing.vue.ts{marker}'.");
+        let alias = AUTHORED_VUE_TS_ALIAS_SENTINEL;
+        let message = format!(
+            "Module '\"./Panel.vue.ts\"' failed; cannot find '../Missing.vue.ts{marker}' or './Typed.vue.ts{alias}'."
+        );
         assert_eq!(
             restore_virtual_vue_specifiers(
                 &message,
                 "import './Panel.vue'; import '../Missing.vue.ts'"
             ),
-            "Module '\"./Panel.vue\"' failed; cannot find '../Missing.vue.ts'."
+            "Module '\"./Panel.vue\"' failed; cannot find '../Missing.vue.ts' or './Typed.vue.ts'."
         );
     }
 


### PR DESCRIPTION
Closes #3564

## Summary
- preserve TypeScript extension substitution candidates for explicit `.vue.ts` and `.vue.tsx` imports
- isolate authored same-stem modules from generated SFC mirrors with collision-free aliases
- resolve declaration, runtime, directory, and package entry candidates in TypeScript order

## Verification
- exact Corsa E2E across authored-first and generated-first scan orders
- focused alias, unresolved-poison, candidate-order, and diagnostic-restoration tests
- `cargo clippy -p vize_canon --all-features --lib -- -D warnings`
- `cargo fmt --all -- --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Vue TypeScript import collisions, including `.vue.ts` and `.vue.tsx` files.
  * Fixed module resolution for relative imports, package entries, extension substitutions, and directory indexes.
  * Ensured generated virtual files take precedence over passthrough files.
  * Preserved correct virtual-path restoration for authored Vue TypeScript modules.

* **Tests**
  * Added regression coverage for TypeScript extension substitution and expanded virtual module resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->