### PR TITLE
feat(maestro): support hsl document colours

### DIFF
--- a/crates/vize_maestro/src/server/annotations/document_color.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color.rs
@@ -71,8 +71,25 @@ impl DocumentColorService {
         } else {
             format!("rgba({red}, {green}, {blue}, {})", trim_alpha(color.alpha))
         };
+        let [hue, saturation, lightness] = rgb_to_hsl(color.red, color.green, color.blue);
+        let hsl = if opaque {
+            format!(
+                "hsl({} {}% {}%)",
+                trim_decimal(hue),
+                trim_decimal(saturation * 100.0),
+                trim_decimal(lightness * 100.0)
+            )
+        } else {
+            format!(
+                "hsl({} {}% {}% / {})",
+                trim_decimal(hue),
+                trim_decimal(saturation * 100.0),
+                trim_decimal(lightness * 100.0),
+                trim_alpha(color.alpha)
+            )
+        };
 
-        [hex, functional]
+        [hex, functional, hsl]
             .into_iter()
             .map(|label| ColorPresentation {
                 label,
@@ -178,16 +195,46 @@ fn to_byte(channel: f32) -> u32 {
     (channel.clamp(0.0, 1.0) * 255.0).round() as u32
 }
 
+fn rgb_to_hsl(red: f32, green: f32, blue: f32) -> [f32; 3] {
+    let red = f64::from(red.clamp(0.0, 1.0));
+    let green = f64::from(green.clamp(0.0, 1.0));
+    let blue = f64::from(blue.clamp(0.0, 1.0));
+    let maximum = red.max(green).max(blue);
+    let minimum = red.min(green).min(blue);
+    let delta = maximum - minimum;
+    let lightness = (maximum + minimum) / 2.0;
+    if delta == 0.0 {
+        return [0.0, 0.0, lightness as f32];
+    }
+
+    let saturation = delta / (1.0 - (2.0 * lightness - 1.0).abs());
+    let sector = if maximum == red {
+        (green - blue) / delta
+    } else if maximum == green {
+        (blue - red) / delta + 2.0
+    } else {
+        (red - green) / delta + 4.0
+    };
+    [
+        (sector * 60.0).rem_euclid(360.0) as f32,
+        saturation as f32,
+        lightness as f32,
+    ]
+}
+
+fn trim_decimal(value: f32) -> String {
+    let text = format!("{:.2}", value);
+    text.trim_end_matches('0').trim_end_matches('.').to_string()
+}
+
 /// Alpha as CSS writes it: `1`, `0.5`, `0.35` — never `0.500000`.
 fn trim_alpha(alpha: f32) -> String {
-    let text = format!("{:.2}", alpha.clamp(0.0, 1.0));
-    let trimmed = text.trim_end_matches('0').trim_end_matches('.');
-    if trimmed.is_empty() {
-        "0".to_string()
-    } else {
-        trimmed.to_string()
-    }
+    trim_decimal(alpha.clamp(0.0, 1.0))
 }
+
+#[cfg(test)]
+#[path = "document_color/hsl_presentation_tests.rs"]
+mod hsl_presentation_tests;
 
 #[cfg(test)]
 mod tests;

--- a/crates/vize_maestro/src/server/annotations/document_color/hsl_presentation_tests.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color/hsl_presentation_tests.rs
@@ -1,0 +1,44 @@
+//! Exact HSL colour-presentation output.
+
+use tower_lsp::lsp_types::Color;
+
+use super::DocumentColorService;
+
+fn labels(red: f32, green: f32, blue: f32, alpha: f32) -> Vec<String> {
+    DocumentColorService::presentations(Color {
+        red,
+        green,
+        blue,
+        alpha,
+    })
+    .into_iter()
+    .map(|presentation| {
+        assert!(presentation.text_edit.is_none());
+        presentation.label
+    })
+    .collect()
+}
+
+#[test]
+fn presentations_offer_hex_rgb_and_hsl_forms() {
+    assert_eq!(
+        labels(1.0, 0.0, 0.0, 1.0),
+        ["#ff0000", "rgb(255, 0, 0)", "hsl(0 100% 50%)"]
+    );
+    assert_eq!(
+        labels(1.0, 0.0, 0.0, 0.5),
+        ["#ff000080", "rgba(255, 0, 0, 0.5)", "hsl(0 100% 50% / 0.5)",]
+    );
+    assert_eq!(
+        labels(0.0, 0.0, 0.0, 0.0),
+        ["#00000000", "rgba(0, 0, 0, 0)", "hsl(0 0% 0% / 0)"]
+    );
+    assert_eq!(
+        labels(0.25, 0.5, 0.75, 1.0),
+        ["#4080bf", "rgb(64, 128, 191)", "hsl(210 50% 50%)"]
+    );
+    assert_eq!(
+        labels(1.0, 0.999_999_94, 1.0, 1.0),
+        ["#ffffff", "rgb(255, 255, 255)", "hsl(300 100% 100%)"]
+    );
+}

--- a/crates/vize_maestro/src/server/annotations/document_color/scan.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color/scan.rs
@@ -4,11 +4,14 @@
 //!
 //! CSS named colours, hex forms, and legacy/modern `rgb()` / `rgba()`.
 //!
-//! `hsl()` is not recognised yet: see #3502.
+//! `hsl()` / `hsla()` accept legacy comma and modern space syntax. Functional
+//! colours are emitted only when every component is valid; nothing is guessed.
 //!
 //! CSS comments are skipped so the picker never rewrites inactive text.
 
+mod hsl;
 mod lex;
+mod rgb;
 
 use self::lex::{
     decode_identifier, identifier_end, is_declaration_name, is_identifier_boundary,
@@ -164,13 +167,21 @@ pub(crate) fn colors_in(content: &str, region: (usize, usize), mode: CssMode) ->
                 continue;
             }
             if bytes.get(end) == Some(&b'(') {
-                if !is_rgb_function_name(content, cursor, end) {
-                    None
-                } else if let Some(literal) = rgb_literal(content, cursor, end, region_end) {
+                let (recognized, literal) = if rgb::is_function_name(content, cursor, end) {
+                    (true, rgb::literal(content, cursor, end, region_end))
+                } else if is_hsl_function_name(content, cursor, end) {
+                    (true, hsl::literal(content, cursor, end, region_end))
+                } else {
+                    (false, None)
+                };
+                if let Some(literal) = literal {
                     Some(literal)
                 } else {
-                    cursor = skip_function(bytes, end, region_end);
-                    continue;
+                    if recognized {
+                        cursor = skip_function(bytes, end, region_end);
+                        continue;
+                    }
+                    None
                 }
             } else if in_value {
                 named_color_literal(content, cursor, end)
@@ -208,12 +219,12 @@ fn named_color_literal(content: &str, start: usize, end: usize) -> Option<ColorL
     })
 }
 
-fn is_rgb_function_name(content: &str, start: usize, end: usize) -> bool {
+fn is_hsl_function_name(content: &str, start: usize, end: usize) -> bool {
     let mut decoded = [0u8; 4];
     let Some(len) = decode_identifier(content.as_bytes(), start, end, &mut decoded) else {
         return false;
     };
-    decoded[..len].eq_ignore_ascii_case(b"rgb") || decoded[..len].eq_ignore_ascii_case(b"rgba")
+    decoded[..len].eq_ignore_ascii_case(b"hsl") || decoded[..len].eq_ignore_ascii_case(b"hsla")
 }
 
 /// `#` followed by exactly 3, 4, 6 or 8 hex digits and nothing that could
@@ -269,45 +280,6 @@ fn hex_value(byte: u8) -> Option<u32> {
     (byte as char).to_digit(16)
 }
 
-/// `rgb(...)` / `rgba(...)`, comma- or space-separated, with an optional alpha
-/// after `,` or `/`. Components may be numbers or percentages.
-fn rgb_literal(
-    content: &str,
-    start: usize,
-    identifier_end: usize,
-    limit: usize,
-) -> Option<ColorLiteral> {
-    #[cfg(test)]
-    RGB_PROBES.set(RGB_PROBES.get() + 1);
-    let arguments_start = identifier_end + 1;
-    let close = content[arguments_start..limit].find(')')? + arguments_start;
-    let end = close + 1;
-
-    let mut components = content[arguments_start..close]
-        .split(|ch: char| ch == ',' || ch == '/' || ch.is_ascii_whitespace())
-        .filter(|part| !part.is_empty());
-
-    let red = channel(components.next()?, 255.0)?;
-    let green = channel(components.next()?, 255.0)?;
-    let blue = channel(components.next()?, 255.0)?;
-    let alpha = match components.next() {
-        Some(part) => channel(part, 1.0)?,
-        None => 1.0,
-    };
-    if components.next().is_some() {
-        return None;
-    }
-
-    Some(ColorLiteral {
-        start,
-        end,
-        red,
-        green,
-        blue,
-        alpha,
-    })
-}
-
 #[cfg(test)]
 pub(super) fn colors_in_with_metrics(
     content: &str,
@@ -328,15 +300,4 @@ pub(super) fn colors_in_with_metrics(
         SCAN_STEPS.get() + DECLARATION_NAME_WORK.get(),
         RGB_PROBES.get(),
     )
-}
-
-/// One component, normalised to 0.0..=1.0. `full` is the value that maps to 1.0
-/// for the plain-number form: 255 for a colour channel, 1 for alpha.
-fn channel(part: &str, full: f32) -> Option<f32> {
-    let part = part.trim();
-    let value = match part.strip_suffix('%') {
-        Some(percent) => percent.trim().parse::<f32>().ok()? / 100.0,
-        None => part.parse::<f32>().ok()? / full,
-    };
-    value.is_finite().then(|| value.clamp(0.0, 1.0))
 }

--- a/crates/vize_maestro/src/server/annotations/document_color/scan/hsl.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color/scan/hsl.rs
@@ -1,0 +1,225 @@
+//! `hsl()` / `hsla()` parsing and HSL-to-sRGB conversion.
+
+use super::ColorLiteral;
+
+pub(super) fn literal(
+    content: &str,
+    start: usize,
+    identifier_end: usize,
+    limit: usize,
+) -> Option<ColorLiteral> {
+    let arguments_start = identifier_end + 1;
+    let end = super::lex::function_end(content.as_bytes(), identifier_end, limit)?;
+    let arguments = normalize_comments(&content[arguments_start..end - 1])?;
+    let (hue, saturation, lightness, alpha) = components(&arguments)?;
+    let [red, green, blue] = to_rgb(hue, saturation, lightness);
+    Some(ColorLiteral {
+        start,
+        end,
+        red,
+        green,
+        blue,
+        alpha,
+    })
+}
+
+fn components(arguments: &str) -> Option<(f32, f32, f32, f32)> {
+    if arguments.contains(',') {
+        if arguments.contains('/') {
+            return None;
+        }
+        let mut parts = arguments.split(',').map(super::rgb::trim_css_whitespace);
+        let hue = hue(parts.next()?)?;
+        let saturation = percentage(parts.next()?)?;
+        let lightness = percentage(parts.next()?)?;
+        let alpha = parts
+            .next()
+            .map_or(Some(1.0), |part| super::rgb::channel(part, 1.0))?;
+        if parts.next().is_some() {
+            return None;
+        }
+        return Some((hue, saturation, lightness, alpha));
+    }
+
+    let (channels, alpha) = match arguments.split_once('/') {
+        Some((channels, alpha)) if !alpha.contains('/') => (channels, Some(alpha.trim())),
+        Some(_) => return None,
+        None => (arguments, None),
+    };
+    let mut parts = channels
+        .split(is_css_whitespace)
+        .filter(|part| !part.is_empty());
+    let hue = modern_hue(parts.next()?)?;
+    let saturation = modern_saturation(parts.next()?)?;
+    let lightness = modern_lightness(parts.next()?)?;
+    if parts.next().is_some() {
+        return None;
+    }
+    let alpha = alpha.map_or(Some(1.0), modern_alpha)?;
+    Some((hue, saturation, lightness, alpha))
+}
+
+fn hue(part: &str) -> Option<f32> {
+    let part = super::rgb::trim_css_whitespace(part);
+    let (number, factor) = [
+        ("turn", 360.0),
+        ("grad", 0.9),
+        ("rad", 180.0 / std::f32::consts::PI),
+        ("deg", 1.0),
+    ]
+    .into_iter()
+    .find_map(|(unit, factor)| {
+        part.get(part.len().checked_sub(unit.len())?..)
+            .is_some_and(|suffix| suffix.eq_ignore_ascii_case(unit))
+            .then(|| (&part[..part.len() - unit.len()], factor))
+    })
+    .unwrap_or((part, 1.0));
+    let degrees = super::rgb::parse_css_number(number)? * factor;
+    degrees.is_finite().then(|| degrees.rem_euclid(360.0))
+}
+
+fn modern_hue(part: &str) -> Option<f32> {
+    if super::rgb::trim_css_whitespace(part).eq_ignore_ascii_case("none") {
+        return Some(0.0);
+    }
+    hue(part)
+}
+
+fn percentage(part: &str) -> Option<f32> {
+    let value =
+        super::rgb::parse_css_number(super::rgb::trim_css_whitespace(part).strip_suffix('%')?)?
+            / 100.0;
+    value.is_finite().then(|| value.clamp(0.0, 1.0))
+}
+
+fn modern_component(part: &str) -> Option<f32> {
+    let part = super::rgb::trim_css_whitespace(part);
+    if part.eq_ignore_ascii_case("none") {
+        return Some(0.0);
+    }
+    let number = part.strip_suffix('%').unwrap_or(part);
+    let value = super::rgb::parse_css_number(number)? / 100.0;
+    value.is_finite().then_some(value)
+}
+
+fn modern_saturation(part: &str) -> Option<f32> {
+    modern_component(part).map(|value| value.max(0.0))
+}
+
+fn modern_lightness(part: &str) -> Option<f32> {
+    modern_component(part)
+}
+
+fn modern_alpha(part: &str) -> Option<f32> {
+    if super::rgb::trim_css_whitespace(part).eq_ignore_ascii_case("none") {
+        return Some(0.0);
+    }
+    super::rgb::channel(part, 1.0)
+}
+
+fn is_css_whitespace(character: char) -> bool {
+    matches!(character, ' ' | '\t' | '\n' | '\r' | '\u{000c}')
+}
+
+fn normalize_comments(arguments: &str) -> Option<String> {
+    let mut normalized = String::with_capacity(arguments.len());
+    let mut cursor = 0;
+    while cursor < arguments.len() {
+        if arguments[cursor..].starts_with("/*") {
+            let close = arguments[cursor + 2..].find("*/")? + cursor + 2;
+            normalized.push(' ');
+            cursor = close + 2;
+            continue;
+        }
+        let character = arguments[cursor..].chars().next()?;
+        normalized.push(character);
+        cursor += character.len_utf8();
+    }
+    Some(normalized)
+}
+
+fn to_rgb(hue: f32, saturation: f32, lightness: f32) -> [f32; 3] {
+    let hue = f64::from(hue);
+    let saturation = f64::from(saturation);
+    let lightness = f64::from(lightness);
+    let chroma = (1.0 - (2.0 * lightness - 1.0).abs()) * saturation;
+    let sector = hue / 60.0;
+    let secondary = chroma * (1.0 - (sector.rem_euclid(2.0) - 1.0).abs());
+    let [red, green, blue] = match sector as u8 {
+        0 => [chroma, secondary, 0.0],
+        1 => [secondary, chroma, 0.0],
+        2 => [0.0, chroma, secondary],
+        3 => [0.0, secondary, chroma],
+        4 => [secondary, 0.0, chroma],
+        _ => [chroma, 0.0, secondary],
+    };
+    let match_value = lightness - chroma / 2.0;
+    [red + match_value, green + match_value, blue + match_value]
+        .map(|channel| channel.clamp(0.0, 1.0) as f32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{components, normalize_comments, to_rgb};
+
+    #[test]
+    fn accepts_modern_legacy_and_hue_units() {
+        assert_eq!(components("0 100% 50%"), Some((0.0, 1.0, 0.5, 1.0)));
+        assert_eq!(components("0 100 50"), Some((0.0, 1.0, 0.5, 1.0)));
+        assert_eq!(components("0 1 0.5"), Some((0.0, 0.01, 0.005, 1.0)));
+        assert_eq!(components("30 300% 75%"), Some((30.0, 3.0, 0.75, 1.0)));
+        assert_eq!(components("30 -100% -25%"), Some((30.0, 0.0, -0.25, 1.0)));
+        assert_eq!(
+            components("none none none / none"),
+            Some((0.0, 0.0, 0.0, 0.0))
+        );
+        assert_eq!(
+            normalize_comments("0/**/100%/**/50%")
+                .as_deref()
+                .and_then(components),
+            Some((0.0, 1.0, 0.5, 1.0))
+        );
+        assert_eq!(
+            components("120, 100%, 25%, 50%"),
+            Some((120.0, 1.0, 0.25, 0.5))
+        );
+        assert_eq!(
+            components("0.5turn 100% 50% / .25"),
+            Some((180.0, 1.0, 0.5, 0.25))
+        );
+        assert_eq!(components("200grad 100% 50%"), Some((180.0, 1.0, 0.5, 1.0)));
+        assert_eq!(
+            components("3.1415927rad 100% 50%"),
+            Some((180.0, 1.0, 0.5, 1.0))
+        );
+    }
+
+    #[test]
+    fn rejects_mixed_or_malformed_component_syntax() {
+        assert_eq!(components("0, 100%, 50% / .5"), None);
+        assert_eq!(components("0, 100, 50"), None);
+        assert_eq!(components("none, 100%, 50%"), None);
+        assert_eq!(components("0\u{000b}100%\u{000b}50%"), None);
+        assert_eq!(components("0,\u{00a0}100%,\u{00a0}50%"), None);
+        assert_eq!(components("0 100% 50% .5"), None);
+        assert_eq!(components("0 100% 50% // .5"), None);
+        assert_eq!(components("0 100% 50% extra"), None);
+        assert_eq!(components("NaN 100% 50%"), None);
+    }
+
+    #[test]
+    fn converts_each_hue_sector_and_achromatic_values() {
+        assert_eq!(to_rgb(0.0, 1.0, 0.5), [1.0, 0.0, 0.0]);
+        assert_eq!(to_rgb(120.0, 1.0, 0.5), [0.0, 1.0, 0.0]);
+        assert_eq!(to_rgb(240.0, 1.0, 0.5), [0.0, 0.0, 1.0]);
+        assert_eq!(to_rgb(30.0, 0.0, 0.25), [0.25, 0.25, 0.25]);
+        assert_eq!(to_rgb(30.0, 3.0, 0.75), [1.0, 0.75, 0.0]);
+        assert!(
+            components("30 3e38 3e38")
+                .map(|(hue, saturation, lightness, _)| to_rgb(hue, saturation, lightness))
+                .is_some_and(|channels| channels
+                    .into_iter()
+                    .all(|channel| channel.is_finite() && (0.0..=1.0).contains(&channel)))
+        );
+    }
+}

--- a/crates/vize_maestro/src/server/annotations/document_color/scan/lex.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color/scan/lex.rs
@@ -80,14 +80,18 @@ fn skip_trivia(bytes: &[u8], mut cursor: usize, limit: usize) -> usize {
 }
 
 pub(super) fn skip_comment(bytes: &[u8], start: usize, limit: usize) -> usize {
+    comment_end(bytes, start, limit).unwrap_or(limit)
+}
+
+fn comment_end(bytes: &[u8], start: usize, limit: usize) -> Option<usize> {
     let mut cursor = start + 2;
     while cursor + 1 < limit {
         if pair_at(bytes, cursor, b"*/") {
-            return cursor + 2;
+            return Some(cursor + 2);
         }
         cursor += 1;
     }
-    limit
+    None
 }
 
 pub(super) fn skip_string(bytes: &[u8], start: usize, limit: usize) -> usize {
@@ -233,11 +237,15 @@ fn hex_value(byte: u8) -> u8 {
 }
 
 pub(super) fn skip_function(bytes: &[u8], open: usize, limit: usize) -> usize {
+    function_end(bytes, open, limit).unwrap_or(limit)
+}
+
+pub(super) fn function_end(bytes: &[u8], open: usize, limit: usize) -> Option<usize> {
     let mut cursor = open;
     let mut depth = 0usize;
     while cursor < limit {
         if pair_at(bytes, cursor, b"/*") {
-            cursor = skip_comment(bytes, cursor, limit);
+            cursor = comment_end(bytes, cursor, limit)?;
             continue;
         }
         if matches!(bytes[cursor], b'\'' | b'"') {
@@ -254,11 +262,11 @@ pub(super) fn skip_function(bytes: &[u8], open: usize, limit: usize) -> usize {
                 depth = depth.saturating_sub(1);
                 cursor += 1;
                 if depth == 0 {
-                    return cursor;
+                    return Some(cursor);
                 }
             }
             _ => cursor += 1,
         }
     }
-    limit
+    None
 }

--- a/crates/vize_maestro/src/server/annotations/document_color/scan/rgb.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color/scan/rgb.rs
@@ -1,0 +1,119 @@
+//! `rgb()` / `rgba()` recognition and component parsing.
+
+use super::{ColorLiteral, lex::decode_identifier};
+
+pub(super) fn is_function_name(content: &str, start: usize, end: usize) -> bool {
+    let mut decoded = [0u8; 4];
+    let Some(len) = decode_identifier(content.as_bytes(), start, end, &mut decoded) else {
+        return false;
+    };
+    decoded[..len].eq_ignore_ascii_case(b"rgb") || decoded[..len].eq_ignore_ascii_case(b"rgba")
+}
+
+/// Comma- or space-separated notation with an optional alpha after `,` or `/`.
+pub(super) fn literal(
+    content: &str,
+    start: usize,
+    identifier_end: usize,
+    limit: usize,
+) -> Option<ColorLiteral> {
+    #[cfg(test)]
+    super::RGB_PROBES.set(super::RGB_PROBES.get() + 1);
+    let arguments_start = identifier_end + 1;
+    let close = content[arguments_start..limit].find(')')? + arguments_start;
+    let end = close + 1;
+
+    let mut components = content[arguments_start..close]
+        .split(|ch: char| ch == ',' || ch == '/' || ch.is_ascii_whitespace())
+        .filter(|part| !part.is_empty());
+    let red = channel(components.next()?, 255.0)?;
+    let green = channel(components.next()?, 255.0)?;
+    let blue = channel(components.next()?, 255.0)?;
+    let alpha = components
+        .next()
+        .map_or(Some(1.0), |part| channel(part, 1.0))?;
+    if components.next().is_some() {
+        return None;
+    }
+
+    Some(ColorLiteral {
+        start,
+        end,
+        red,
+        green,
+        blue,
+        alpha,
+    })
+}
+
+/// One component normalised to `0.0..=1.0`; `full` maps a number to one.
+pub(super) fn channel(part: &str, full: f32) -> Option<f32> {
+    let part = trim_css_whitespace(part);
+    let value = match part.strip_suffix('%') {
+        Some(percent) => parse_css_number(percent)? / 100.0,
+        None => parse_css_number(part)? / full,
+    };
+    value.is_finite().then(|| value.clamp(0.0, 1.0))
+}
+
+pub(super) fn trim_css_whitespace(part: &str) -> &str {
+    part.trim_matches(|character| matches!(character, ' ' | '\t' | '\n' | '\r' | '\u{000c}'))
+}
+
+/// CSS Syntax's `<number>` spelling, excluding delimiters Rust also accepts
+/// (for example the trailing dot in `1.`).
+pub(super) fn parse_css_number(part: &str) -> Option<f32> {
+    let bytes = part.as_bytes();
+    let mut cursor = usize::from(matches!(bytes.first(), Some(b'+') | Some(b'-')));
+    let integer_start = cursor;
+    while bytes.get(cursor).is_some_and(u8::is_ascii_digit) {
+        cursor += 1;
+    }
+    let integer_digits = cursor - integer_start;
+
+    let mut fraction_digits = 0;
+    if bytes.get(cursor) == Some(&b'.') && bytes.get(cursor + 1).is_some_and(u8::is_ascii_digit) {
+        cursor += 1;
+        let fraction_start = cursor;
+        while bytes.get(cursor).is_some_and(u8::is_ascii_digit) {
+            cursor += 1;
+        }
+        fraction_digits = cursor - fraction_start;
+    }
+    if integer_digits + fraction_digits == 0 {
+        return None;
+    }
+
+    if matches!(bytes.get(cursor), Some(b'e') | Some(b'E')) {
+        cursor += 1;
+        if matches!(bytes.get(cursor), Some(b'+') | Some(b'-')) {
+            cursor += 1;
+        }
+        let exponent_start = cursor;
+        while bytes.get(cursor).is_some_and(u8::is_ascii_digit) {
+            cursor += 1;
+        }
+        if cursor == exponent_start {
+            return None;
+        }
+    }
+    if cursor != bytes.len() {
+        return None;
+    }
+    part.parse::<f32>().ok().filter(|value| value.is_finite())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_css_number;
+
+    #[test]
+    fn css_number_spelling_requires_digits_after_dot_and_exponent() {
+        for accepted in ["0", "+1", "-.5", "1.25", "1e2", "1E-2"] {
+            assert!(parse_css_number(accepted).is_some(), "{accepted}");
+        }
+        for rejected in ["", ".", "1.", "1.e2", "1e", "1e+", " 1", "1 "] {
+            assert_eq!(parse_css_number(rejected), None, "{rejected}");
+        }
+    }
+}

--- a/crates/vize_maestro/src/server/annotations/document_color/tests.rs
+++ b/crates/vize_maestro/src/server/annotations/document_color/tests.rs
@@ -34,24 +34,6 @@ fn percent(alpha: f32) -> u32 {
     (alpha * 100.0).round() as u32
 }
 
-fn labels(red: f32, green: f32, blue: f32, alpha: f32) -> Vec<String> {
-    DocumentColorService::presentations(Color {
-        red,
-        green,
-        blue,
-        alpha,
-    })
-    .into_iter()
-    .map(|presentation| {
-        assert!(
-            presentation.text_edit.is_none(),
-            "the label is the inserted text; a textEdit would override the client's own range"
-        );
-        presentation.label
-    })
-    .collect()
-}
-
 #[test]
 fn every_hex_form_is_recognised_with_its_exact_span() {
     let source = "<style>\n.a { color: #f00; background: #ff0000; border-color: #f00c; outline-color: #ff0000cc }\n</style>\n";
@@ -117,8 +99,42 @@ fn named_colours_report_the_complete_exact_output() {
             (1, 58, 69, 0, 0, 0, 0),
             (1, 80, 84, 128, 128, 128, 100),
             (1, 99, 103, 128, 128, 128, 100),
+            (1, 110, 125, 255, 0, 0, 100),
+            (1, 133, 155, 255, 0, 0, 50),
         ]
     );
+}
+
+#[test]
+fn hsl_supports_modern_legacy_units_wrapping_and_alpha() {
+    let source = "<style>\n.a { --a: hsl(120deg 100% 25%); --b: hsl(240 100% 50% / 25%); --c: hsla(.5turn, 100%, 50%, .5); --d: hsl(200grad 100% 50%); --e: hsl(-120 100% 50%); --f: hsl(30 0% 25%); --g: h\\73l(60 100% 50%); --h: hsl(0 100 50); --i: hsl(none none none / none); --j: hsl(0/**/100%/**/50%); --k: hsl(30 300% 75%) }\n</style>\n";
+    let found = colors(source);
+    assert_eq!(found.len(), 11, "{found:?}");
+    assert_eq!(
+        found
+            .into_iter()
+            .map(|(_, _, _, red, green, blue, alpha)| (red, green, blue, alpha))
+            .collect::<Vec<_>>(),
+        vec![
+            (0, 128, 0, 100),
+            (0, 0, 255, 25),
+            (0, 255, 255, 50),
+            (0, 255, 255, 100),
+            (0, 0, 255, 100),
+            (64, 64, 64, 100),
+            (255, 255, 0, 100),
+            (255, 0, 0, 100),
+            (0, 0, 0, 0),
+            (255, 0, 0, 100),
+            (255, 191, 0, 100),
+        ]
+    );
+}
+
+#[test]
+fn malformed_hsl_is_not_offered_as_a_colour() {
+    let source = "<style>\n.a { --a: hsl(0, 100, 50); --b: hsl(0, 100%, 50% / .5); --c: hsl(0 100%); --d: hsl(NaN 100% 50%); --e: hsl(0 100% 50% extra); --f: hsl(red 100% 50%); --g: hsl(0. 100% 50%); --h: hsl(0 100.% 50%); --i: hsl(0 100% 50% / 1.); --j: hsl(0\u{000b}100%\u{000b}50%); --k: hsl(0,\u{00a0}100%,\u{00a0}50%) }\n</style>\n";
+    assert_eq!(colors(source), Vec::new());
 }
 
 #[test]
@@ -330,21 +346,4 @@ fn script_and_template_text_are_never_scanned_for_colours() {
     // `#f00` in a script body or a text node is not CSS.
     let source = "<script setup lang=\"ts\">\nconst tag = '#f00'\n</script>\n\n<template>\n  <div>#00ff00</div>\n</template>\n";
     assert_eq!(colors(source), Vec::new());
-}
-
-#[test]
-fn presentations_offer_hex_first_then_the_functional_form() {
-    assert_eq!(
-        labels(1.0, 0.0, 0.0, 1.0),
-        vec!["#ff0000".to_string(), "rgb(255, 0, 0)".to_string()]
-    );
-    // CSS alpha is trimmed rather than written as `0.500000`.
-    assert_eq!(
-        labels(1.0, 0.0, 0.0, 0.5),
-        vec!["#ff000080".to_string(), "rgba(255, 0, 0, 0.5)".to_string()]
-    );
-    assert_eq!(
-        labels(0.0, 0.0, 0.0, 0.0),
-        vec!["#00000000".to_string(), "rgba(0, 0, 0, 0)".to_string()]
-    );
 }

--- a/crates/vize_maestro/src/server/annotations/tests.rs
+++ b/crates/vize_maestro/src/server/annotations/tests.rs
@@ -6,7 +6,7 @@ use tower_lsp::lsp_types::{
 use super::{color_presentation, document_color};
 use crate::server::ServerState;
 
-const SFC: &str = "<template>\n  <div style=\"color: #f00\" />\n</template>\n\n<style scoped>\n.a { background: rgba(0, 0, 255, 0.5) }\n</style>\n";
+const SFC: &str = "<template>\n  <div style=\"color: #f00\" />\n</template>\n\n<style scoped>\n.a { background: rgba(0, 0, 255, 0.5) }\n.b { color: hsl(120 100% 25%) }\n</style>\n";
 
 fn state_with(uri: &Url, source: &str) -> ServerState {
     let state = ServerState::new();
@@ -40,8 +40,8 @@ fn document_color_reports_every_css_literal_in_document_order() {
         })
         .collect();
 
-    // The inline `style` attribute on line 1, then the `<style>` rule on line 5.
-    assert_eq!(colors, vec![(1, 21, 25), (5, 17, 37)]);
+    // The inline attribute on line 1, then rgba() and hsl() in the style block.
+    assert_eq!(colors, vec![(1, 21, 25), (5, 17, 37), (6, 12, 29)]);
 }
 
 #[test]
@@ -77,5 +77,8 @@ fn color_presentation_does_not_consult_the_document() {
         .iter()
         .map(|presentation| presentation.label.as_str())
         .collect();
-    assert_eq!(labels, vec!["#00ff00", "rgb(0, 255, 0)"]);
+    assert_eq!(
+        labels,
+        vec!["#00ff00", "rgb(0, 255, 0)", "hsl(120 100% 50%)"]
+    );
 }

--- a/tests/tooling/lsp-document-color.test.ts
+++ b/tests/tooling/lsp-document-color.test.ts
@@ -43,7 +43,8 @@ type ColorPresentation = { label: string; textEdit?: unknown };
  * 8
  * 9  <style scoped>
  * 10 .a { background: rgba(0, 0, 255, 0.5) }
- * 11 </style>
+ * 11 .b { color: hsl(120 100% 25%) }
+ * 12 </style>
  * ```
  */
 const SOURCE = `<script setup lang="ts">
@@ -57,6 +58,7 @@ const tag = '#123456'
 
 <style scoped>
 .a { background: rgba(0, 0, 255, 0.5) }
+.b { color: hsl(120 100% 25%) }
 </style>
 `;
 
@@ -103,9 +105,9 @@ async function withDocument(
   }
 }
 
-test("documentColor reports CSS colour literals and nothing else", async () => {
+test("documentColor reports every supported CSS colour and nothing else", async () => {
   await withDocument(async (colors) => {
-    // Exactly two: the static `style` attribute and the `<style>` rule.
+    // Exactly three: the static attribute, rgba(), and hsl() in `<style>`.
     // Deliberately absent, and the reason this is a full-list assertion:
     //   - `'#123456'` on line 1 is a string in the script body,
     //   - `#00ff00` on line 5 is a text node,
@@ -125,15 +127,23 @@ test("documentColor reports CSS colour literals and nothing else", async () => {
         },
         color: { red: 0, green: 0, blue: 1, alpha: 0.5 },
       },
+      {
+        range: {
+          start: { line: 11, character: 12 },
+          end: { line: 11, character: 29 },
+        },
+        color: { red: 0, green: 0.5, blue: 0, alpha: 1 },
+      },
     ]);
   });
 });
 
-test("colorPresentation offers hex first, then the functional notation", async () => {
+test("colorPresentation offers hex, rgb, and hsl notation", async () => {
   await withDocument(async (_colors, presentations) => {
     assert.deepEqual(await presentations({ red: 1, green: 0, blue: 0, alpha: 1 }), [
       { label: "#ff0000" },
       { label: "rgb(255, 0, 0)" },
+      { label: "hsl(0 100% 50%)" },
     ]);
 
     // A translucent colour switches to the 8-digit hex and `rgba()`, with the
@@ -141,6 +151,7 @@ test("colorPresentation offers hex first, then the functional notation", async (
     assert.deepEqual(await presentations({ red: 0, green: 0, blue: 1, alpha: 0.5 }), [
       { label: "#0000ff80" },
       { label: "rgba(0, 0, 255, 0.5)" },
+      { label: "hsl(240 100% 50% / 0.5)" },
     ]);
   });
 });


### PR DESCRIPTION
Closes #3502

## Summary
- recognize CSS `hsl()` and `hsla()` in legacy and modern syntax
- implement current CSS Color 4 numbers, missing components, comments, hue units, and unbounded modern channels
- offer finite hex, RGB, and HSL color presentations

## Verification
- exact positive and must-exclude scanner assertions across CSS grammar boundaries
- all 659 Maestro tests, integration tests, and doc tests
- real `vize lsp` process documentColor/colorPresentation E2E
- `cargo clippy -p vize_maestro --all-features --lib -- -D warnings`
- independent exhaustive 8-bit RGB presentation round-trip review

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting HSL and HSLA colors in stylesheets.
  * Added HSL color presentations alongside hex and RGB/RGBA formats.
  * Supports modern and legacy CSS syntax, hue units, transparency, comments, escaped names, and value clamping.

* **Bug Fixes**
  * Improved handling of malformed color functions and unterminated comments.
  * Invalid color syntax is now safely ignored without disrupting subsequent color detection.

* **Tests**
  * Expanded coverage for HSL parsing, conversion, detection, and color presentations, including edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->