### PR TITLE
test(editor): run real host smoke from packaged VSIX

### DIFF
--- a/editors/vscode/test/packaged-host-contract.mjs
+++ b/editors/vscode/test/packaged-host-contract.mjs
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export function createPackagedHostInstallArgs({ extensionsPath, userDataPath, vsixPath }) {
+  return [
+    "--install-extension",
+    vsixPath,
+    "--force",
+    `--extensions-dir=${extensionsPath}`,
+    `--user-data-dir=${userDataPath}`,
+  ];
+}
+
+// VS Code only executes --extensionTestsPath for an extension development
+// host. Point that protocol requirement at the extracted VSIX itself; using
+// the repository source path here would silently stop testing the artifact.
+export function createPackagedHostLaunchArgs({
+  extensionsPath,
+  extensionTestsPath,
+  installedExtensionPath,
+  userDataPath,
+  workspacePath,
+}) {
+  return [
+    "--no-sandbox",
+    "--disable-gpu-sandbox",
+    "--disable-updates",
+    "--disable-workspace-trust",
+    "--skip-welcome",
+    "--skip-release-notes",
+    `--extensions-dir=${extensionsPath}`,
+    `--user-data-dir=${userDataPath}`,
+    `--extensionDevelopmentPath=${installedExtensionPath}`,
+    `--extensionTestsPath=${extensionTestsPath}`,
+    workspacePath,
+  ];
+}
+
+export function resolveInstalledExtensionPath(extensionsPath, extensionId) {
+  const matches = fs
+    .readdirSync(extensionsPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(extensionsPath, entry.name))
+    .filter((candidate) => readExtensionId(candidate) === extensionId);
+
+  if (matches.length !== 1) {
+    throw new Error(
+      `expected exactly one installed ${extensionId} extension, found ${matches.length}: ${matches.join(", ")}`,
+    );
+  }
+
+  return fs.realpathSync(matches[0]);
+}
+
+export async function runVSCodeCommandWithTimeout(runCommand, args, { environment, timeoutMs }) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await runCommand(args, {
+      spawn: { env: environment, signal: controller.signal },
+    });
+  } catch (error) {
+    if (controller.signal.aborted) {
+      throw new Error(`VS Code command timed out after ${timeoutMs}ms`, { cause: error });
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function readExtensionId(extensionPath) {
+  try {
+    const manifest = JSON.parse(fs.readFileSync(path.join(extensionPath, "package.json"), "utf8"));
+    return `${manifest.publisher}.${manifest.name}`;
+  } catch {
+    return undefined;
+  }
+}

--- a/editors/vscode/test/run-extension-host-real.mjs
+++ b/editors/vscode/test/run-extension-host-real.mjs
@@ -4,24 +4,32 @@ import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { runTests } from "@vscode/test-electron";
+import { runVSCodeCommand } from "@vscode/test-electron";
 
-const extensionDevelopmentPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const repositoryRoot = path.resolve(extensionDevelopmentPath, "..", "..");
+import {
+  createPackagedHostInstallArgs,
+  createPackagedHostLaunchArgs,
+  resolveInstalledExtensionPath,
+  runVSCodeCommandWithTimeout,
+} from "./packaged-host-contract.mjs";
+
+const sourceExtensionPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repositoryRoot = path.resolve(sourceExtensionPath, "..", "..");
 const fixtureWorkspacePath = path.join(
-  extensionDevelopmentPath,
+  sourceExtensionPath,
   "test-fixtures",
   "extension-host",
   "real-vue",
 );
-const testDataPath = path.join(extensionDevelopmentPath, ".vscode-test", "host-smoke-real");
+const testDataPath = path.join(sourceExtensionPath, ".vscode-test", "host-smoke-real");
 const workspacePath = path.join(testDataPath, "workspaces", "real-vue");
 const extensionTestsPath = path.join(
-  extensionDevelopmentPath,
+  sourceExtensionPath,
   "test",
   "suite",
   "extension-host-real.cjs",
 );
+const vsixPath = path.join(sourceExtensionPath, "dist", "vize.vsix");
 
 const serverPath = resolveRealServerPath();
 const corsaPath = resolveCorsaPath();
@@ -40,26 +48,46 @@ fs.writeFileSync(
 // singleton socket inside the user-data directory. Deep checkouts overflow the
 // default `.vscode-test/user-data` location, so keep user data in a short
 // temporary directory instead.
-const userDataPath = fs.mkdtempSync(path.join(os.tmpdir(), "vize-host-real-"));
+const profilePath = fs.mkdtempSync(path.join(os.tmpdir(), "vize-host-real-"));
+const extensionsPath = path.join(profilePath, "extensions");
+const userDataPath = path.join(profilePath, "user-data");
 
 try {
-  await runTests({
-    extensionDevelopmentPath,
-    extensionTestsPath,
-    extensionTestsEnv: {
-      VIZE_TEST_SERVER_PATH: serverPath,
-    },
-    launchArgs: [
-      "--disable-extensions",
-      "--disable-workspace-trust",
-      "--skip-welcome",
-      "--skip-release-notes",
-      `--user-data-dir=${userDataPath}`,
-      workspacePath,
-    ],
+  if (!fs.existsSync(vsixPath)) {
+    throw new Error(`missing packaged VS Code extension: ${vsixPath}`);
+  }
+
+  const installArgs = createPackagedHostInstallArgs({ extensionsPath, userDataPath, vsixPath });
+  const installation = await runVSCodeCommandWithTimeout(runVSCodeCommand, installArgs, {
+    environment: process.env,
+    timeoutMs: 120_000,
   });
+  writeCommandOutput(installation);
+  const installedExtensionPath = resolveInstalledExtensionPath(extensionsPath, "ubugeeei.vize");
+  const launchArgs = createPackagedHostLaunchArgs({
+    extensionsPath,
+    extensionTestsPath,
+    installedExtensionPath,
+    userDataPath,
+    workspacePath,
+  });
+  const host = await runVSCodeCommandWithTimeout(runVSCodeCommand, launchArgs, {
+    environment: {
+      ...process.env,
+      VIZE_TEST_PACKAGED_EXTENSIONS_DIR: extensionsPath,
+      VIZE_TEST_SERVER_PATH: serverPath,
+      VIZE_TEST_SOURCE_EXTENSION_PATH: sourceExtensionPath,
+    },
+    timeoutMs: 300_000,
+  });
+  writeCommandOutput(host);
 } finally {
-  fs.rmSync(userDataPath, { force: true, recursive: true });
+  fs.rmSync(profilePath, { force: true, recursive: true });
+}
+
+function writeCommandOutput({ stderr, stdout }) {
+  if (stdout) process.stdout.write(stdout);
+  if (stderr) process.stderr.write(stderr);
 }
 
 /**
@@ -95,7 +123,7 @@ function resolveRealServerPath() {
  * resolve the platform package from the meta package's real location.
  */
 function resolveCorsaPath() {
-  const extensionRequire = createRequire(path.join(extensionDevelopmentPath, "package.json"));
+  const extensionRequire = createRequire(path.join(sourceExtensionPath, "package.json"));
   const metaManifestPath = fs.realpathSync(
     extensionRequire.resolve("@typescript/native-preview/package.json"),
   );

--- a/editors/vscode/test/suite/extension-host-real.cjs
+++ b/editors/vscode/test/suite/extension-host-real.cjs
@@ -61,6 +61,7 @@ exports.run = async function run() {
   const serverPath = getRealServer();
   const extension = vscode.extensions.getExtension(extensionId);
   assert.ok(extension, `missing extension: ${extensionId}`);
+  assertPackagedExtension(extension);
   await extension.activate();
   assert.equal(extension.isActive, true);
 
@@ -80,6 +81,39 @@ exports.run = async function run() {
   await vscode.commands.executeCommand("vize.disable");
   assert.equal(vscode.workspace.getConfiguration("vize").get("enable"), false);
 };
+
+function assertPackagedExtension(extension) {
+  const extensionsPath = getRequiredPath(
+    "VIZE_TEST_PACKAGED_EXTENSIONS_DIR",
+    "packaged extension directory",
+  );
+  const sourceExtensionPath = getRequiredPath(
+    "VIZE_TEST_SOURCE_EXTENSION_PATH",
+    "source extension directory",
+  );
+  const installedPath = fs.realpathSync(extension.extensionPath);
+  const relativeToInstallRoot = path.relative(extensionsPath, installedPath);
+
+  assert.ok(
+    relativeToInstallRoot &&
+      !relativeToInstallRoot.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relativeToInstallRoot),
+    `extension must load from the isolated install directory: ${installedPath}`,
+  );
+  assert.notEqual(installedPath, sourceExtensionPath, "extension must not load from repo source");
+  assert.equal(extension.packageJSON.main, "./dist/extension.cjs");
+  assert.ok(
+    fs.existsSync(path.resolve(installedPath, extension.packageJSON.main)),
+    "installed extension must contain its packaged entrypoint",
+  );
+}
+
+function getRequiredPath(environmentName, label) {
+  const value = process.env[environmentName];
+  assert.ok(value, `${environmentName} must be set`);
+  assert.ok(fs.existsSync(value), `missing ${label}: ${value}`);
+  return fs.realpathSync(value);
+}
 
 async function runRealDiagnosticSmoke(mismatchDocument, cleanDocument) {
   const diagnostics = await waitForDiagnostics(

--- a/tests/tooling/vscode-packaged-host-smoke.test.ts
+++ b/tests/tooling/vscode-packaged-host-smoke.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  createPackagedHostInstallArgs,
+  createPackagedHostLaunchArgs,
+  resolveInstalledExtensionPath,
+  runVSCodeCommandWithTimeout,
+} from "../../editors/vscode/test/packaged-host-contract.mjs";
+import { root } from "./support/github-workflows.ts";
+
+test("packaged VS Code host smoke installs the VSIX before launching its tests", () => {
+  const installArgs = createPackagedHostInstallArgs({
+    extensionsPath: "/tmp/vize-extensions",
+    userDataPath: "/tmp/vize-user-data",
+    vsixPath: "/repo/editors/vscode/dist/vize.vsix",
+  });
+  const launchArgs = createPackagedHostLaunchArgs({
+    extensionsPath: "/tmp/vize-extensions",
+    extensionTestsPath: "/repo/editors/vscode/test/suite/extension-host-real.cjs",
+    installedExtensionPath: "/tmp/vize-extensions/ubugeeei.vize-0.311.0",
+    userDataPath: "/tmp/vize-user-data",
+    workspacePath: "/repo/editors/vscode/.vscode-test/workspaces/real-vue",
+  });
+
+  assert.deepEqual(installArgs, [
+    "--install-extension",
+    "/repo/editors/vscode/dist/vize.vsix",
+    "--force",
+    "--extensions-dir=/tmp/vize-extensions",
+    "--user-data-dir=/tmp/vize-user-data",
+  ]);
+  assert.deepEqual(launchArgs, [
+    "--no-sandbox",
+    "--disable-gpu-sandbox",
+    "--disable-updates",
+    "--disable-workspace-trust",
+    "--skip-welcome",
+    "--skip-release-notes",
+    "--extensions-dir=/tmp/vize-extensions",
+    "--user-data-dir=/tmp/vize-user-data",
+    "--extensionDevelopmentPath=/tmp/vize-extensions/ubugeeei.vize-0.311.0",
+    "--extensionTestsPath=/repo/editors/vscode/test/suite/extension-host-real.cjs",
+    "/repo/editors/vscode/.vscode-test/workspaces/real-vue",
+  ]);
+  assert.equal(launchArgs.includes("--extensionDevelopmentPath=/repo/editors/vscode"), false);
+  assert.equal(launchArgs.includes("--disable-extensions"), false);
+});
+
+test("packaged host resolves exactly one installed Vize extension", () => {
+  const extensionsPath = fs.mkdtempSync(path.join(os.tmpdir(), "vize-installed-extension-"));
+  try {
+    writeManifest(path.join(extensionsPath, "other.extension-1.0.0"), "other", "extension");
+    const installedPath = path.join(extensionsPath, "ubugeeei.vize-0.311.0");
+    writeManifest(installedPath, "ubugeeei", "vize");
+
+    assert.equal(
+      resolveInstalledExtensionPath(extensionsPath, "ubugeeei.vize"),
+      fs.realpathSync(installedPath),
+    );
+    writeManifest(path.join(extensionsPath, "ubugeeei.vize-duplicate"), "ubugeeei", "vize");
+    assert.throws(
+      () => resolveInstalledExtensionPath(extensionsPath, "ubugeeei.vize"),
+      /expected exactly one installed ubugeeei\.vize extension, found 2/,
+    );
+  } finally {
+    fs.rmSync(extensionsPath, { force: true, recursive: true });
+  }
+});
+
+test("packaged host aborts a stuck VS Code command", async () => {
+  let receivedSignal;
+  const stuckCommand = (_args, options) => {
+    receivedSignal = options.spawn.signal;
+    return new Promise((_resolve, reject) => {
+      receivedSignal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+    });
+  };
+
+  await assert.rejects(
+    runVSCodeCommandWithTimeout(stuckCommand, ["--version"], {
+      environment: {},
+      timeoutMs: 5,
+    }),
+    /VS Code command timed out after 5ms/,
+  );
+  assert.equal(receivedSignal.aborted, true);
+});
+
+test("real host task packages and statically validates the same VSIX that it runs", () => {
+  const tasks = read("tools/vite-plus/tasks/test-benchmark.ts");
+  const taskBody = tasks.match(
+    /"test:vscode-extension:host-real": noCacheTask\(([\s\S]*?)\n  \),\n  "test:zed-extension/,
+  )?.[1];
+  assert.ok(taskBody, "missing test:vscode-extension:host-real task");
+
+  const packageAt = taskBody.indexOf("packageVscodeExtension");
+  const staticAssertAt = taskBody.indexOf(
+    "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
+  );
+  const hostAt = taskBody.indexOf("node test/run-extension-host-real.mjs");
+  assert.ok(packageAt >= 0, "real host smoke must build the production VSIX");
+  assert.ok(staticAssertAt > packageAt, "the packaged VSIX must retain its static allowlist check");
+  assert.ok(hostAt > staticAssertAt, "the validated VSIX must run in the real host");
+});
+
+test("real host runner cannot fall back to loading the source extension", () => {
+  const runner = read("editors/vscode/test/run-extension-host-real.mjs");
+  assert.match(runner, /import \{ runVSCodeCommand \} from "@vscode\/test-electron"/);
+  assert.doesNotMatch(runner, /\brunTests\b/);
+  assert.match(runner, /resolveInstalledExtensionPath\(extensionsPath, "ubugeeei\.vize"\)/);
+  assert.match(runner, /runVSCodeCommandWithTimeout\(runVSCodeCommand, installArgs/);
+  assert.match(runner, /runVSCodeCommandWithTimeout\(runVSCodeCommand, launchArgs/);
+
+  const suite = read("editors/vscode/test/suite/extension-host-real.cjs");
+  assert.match(suite, /VIZE_TEST_PACKAGED_EXTENSIONS_DIR/);
+  assert.match(suite, /VIZE_TEST_SOURCE_EXTENSION_PATH/);
+  assert.match(suite, /fs\.realpathSync\(extension\.extensionPath\)/);
+  assert.match(suite, /assertPackagedExtension\(extension\);/);
+});
+
+function read(...segments: string[]): string {
+  return fs.readFileSync(path.join(root, ...segments), "utf8");
+}
+
+function writeManifest(directory: string, publisher: string, name: string): void {
+  fs.mkdirSync(directory);
+  fs.writeFileSync(path.join(directory, "package.json"), JSON.stringify({ name, publisher }));
+}

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -112,8 +112,8 @@ export const testAndBenchmarkTasks = defineTasks({
   ),
   "test:vscode-extension:host-real": noCacheTask(
     runInVscodeExtension(
-      stageVscodeTypeScriptPlugin,
-      "pnpm exec vp pack",
+      packageVscodeExtension,
+      "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
       "node test/run-extension-host-real.mjs",
     ),
   ),


### PR DESCRIPTION
## Summary

- build and statically validate the production VSIX before the real VS Code host smoke
- install the VSIX into an isolated extension profile and run the test protocol from its extracted package, never the repository source tree
- reject ambiguous installs and bound install/host commands with abort timeouts
- assert the active extension path and packaged entrypoint inside the extension host

## Root cause

The real host smoke loaded `editors/vscode` directly, so package-only failures in `.vscodeignore`, bundling, and the published manifest could not fail the test. VS Code requires an extension development path to execute an extension test path, so the runner now supplies the isolated VSIX extraction directory for that protocol field.

## Validation

- `node --test --test-concurrency=1 tests/tooling/vscode-*.test.ts tests/tooling/editor-integrations.test.ts tests/tooling/editor-integrations-consistency.test.ts tests/tooling/github-workflows-check.test.ts` (263 passed)
- VS Code extension `tsgo --noEmit` and `vp check`
- focused format and lint checks
- VSIX static package validation (16 files)
- packaged real-host diagnostics, completion, hover, and unsaved `didChange` repair smoke (exit 0)
- independent review: approved

Closes #3493

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added smoke tests for packaged VS Code extension installation, launching, path resolution, and timeout handling.
  * Strengthened extension-host integration checks to confirm tests run against the packaged extension rather than source files.
  * Added validation for extension manifests, entrypoints, required paths, and isolated test environments.

* **Bug Fixes**
  * Improved handling of invalid extension manifests and interrupted or timed-out VS Code commands.
  * Updated the real extension-host test to validate and run the packaged VSIX before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->