### PR TITLE
fix(canon): preserve runtime and mixin props

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/component_prop_regressions.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/component_prop_regressions.rs
@@ -4,3 +4,5 @@ mod attribute_only_required_props;
 mod attribute_only_required_props_edges;
 #[path = "generic_emit_guard.rs"]
 mod generic_emit_guard;
+#[path = "runtime_mixin_props.rs"]
+mod runtime_mixin_props;

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/runtime_mixin_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/runtime_mixin_props.rs
@@ -1,0 +1,130 @@
+//! Runtime and mixin props keep Vue's public requiredness across SFC imports.
+
+use super::super::super::{
+    BatchTypeChecker, TypeChecker, create_project_case, relative_path, resolve_test_tsgo_binary,
+};
+
+#[test]
+fn imported_runtime_and_mixin_props_preserve_requiredness() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "imported-runtime-mixin-required-props",
+        &[
+            (
+                "src/RuntimeRequired.vue",
+                r#"<script lang="ts">
+import { defineComponent } from 'vue'
+export default defineComponent({
+  props: { count: { type: Number, required: true } },
+})
+</script>
+"#,
+            ),
+            (
+                "src/RuntimeOptional.vue",
+                r#"<script lang="ts">
+import { defineComponent } from 'vue'
+export default defineComponent({ props: { count: Number } })
+</script>
+"#,
+            ),
+            (
+                "src/MixinRequired.vue",
+                r#"<script lang="ts">
+import { defineComponent } from 'vue'
+const base = defineComponent({
+  props: { count: { type: Number, required: true } },
+})
+export default defineComponent({ mixins: [base] })
+</script>
+"#,
+            ),
+            (
+                "src/MixinOptional.vue",
+                r#"<script lang="ts">
+import { defineComponent } from 'vue'
+const base = defineComponent({ props: { count: Number } })
+export default defineComponent({ mixins: [base] })
+</script>
+"#,
+            ),
+            (
+                "src/DirectDefault.vue",
+                r#"<script lang="ts">
+import { defineComponent } from 'vue'
+export default defineComponent({
+  props: { label: { type: String, default: 'x' } },
+})
+</script>
+"#,
+            ),
+            (
+                "src/DirectAndMixin.vue",
+                r#"<script lang="ts">
+import { defineComponent } from 'vue'
+const base = defineComponent({
+  props: { inherited: { type: Number, required: true } },
+})
+export default defineComponent({
+  mixins: [base],
+  props: { own: String },
+})
+</script>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import RuntimeRequired from './RuntimeRequired.vue'
+import RuntimeOptional from './RuntimeOptional.vue'
+import MixinRequired from './MixinRequired.vue'
+import MixinOptional from './MixinOptional.vue'
+import DirectDefault from './DirectDefault.vue'
+import DirectAndMixin from './DirectAndMixin.vue'
+</script>
+<template>
+  <RuntimeRequired />
+  <RuntimeOptional />
+  <MixinRequired />
+  <MixinOptional />
+  <DirectDefault />
+  <DirectAndMixin />
+</template>
+"#,
+            ),
+        ],
+    );
+    if !project_root.join("node_modules/vue/dist").exists() {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    }
+
+    let mut checker = BatchTypeChecker::new(&project_root).unwrap();
+    checker.enable_options_api();
+    checker.scan_project().unwrap();
+    let snapshot = checker.check_project().unwrap();
+    let _ = std::fs::remove_dir_all(&project_root);
+    let actual: Vec<_> = snapshot
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            (
+                relative_path(&project_root, &diagnostic.file).to_string(),
+                diagnostic.code,
+                diagnostic.line + 1,
+                diagnostic.column + 1,
+            )
+        })
+        .collect();
+    assert_eq!(
+        actual,
+        [
+            ("src/Parent.vue".to_string(), Some(2345), 10, 4),
+            ("src/Parent.vue".to_string(), Some(2345), 12, 4),
+            ("src/Parent.vue".to_string(), Some(2345), 15, 4),
+        ],
+        "required runtime and mixin props must cross the SFC boundary: {snapshot:#?}"
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -28,10 +28,10 @@ use self::imports::{
 };
 pub use self::legacy_vue2::generate_virtual_ts_with_offsets_legacy_vue2;
 use self::options_api::{
-    find_default_export_targets, find_options_api_props, generate_options_api_bridge,
-    generate_options_api_variables,
+    find_default_export_targets, generate_options_api_bridge, generate_options_api_variables,
 };
 use self::options_api_props_identifiers::PropsConstAssertions;
+use self::options_api_support::find_options_api_props;
 use self::props_anchors::emit_setup_scope_prop_anchors;
 use self::setup_helpers::emit_setup_helpers;
 use self::setup_props::generate_setup_props;

--- a/crates/vize_canon/src/virtual_ts/generator/options_api.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api.rs
@@ -10,9 +10,7 @@ use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
 use vize_croquis::{BindingType, Croquis};
 
-use super::options_api_support::{
-    extend_options_api_descriptor_names, is_safe_value_identifier, props_source_from_object,
-};
+use super::options_api_support::{extend_options_api_descriptor_names, is_safe_value_identifier};
 use crate::virtual_ts::types::VirtualTsOptions;
 use vize_carton::{CompactString, FxHashSet, String, append};
 
@@ -666,71 +664,6 @@ pub(super) fn find_default_export_targets(script: &str) -> DefaultExportTargets 
     targets
 }
 
-use crate::virtual_ts::props::OptionsApiPropsSource;
-
-/// Parse a plain `<script>` and extract its Options API `props:` declaration.
-///
-/// Returns `None` when there is no resolvable component options object or no
-/// `props:` option (or it is an unrecognized expression form). Object and array
-/// literals are recognized directly. Identifier props are deferred through setup
-/// scope so local/imported runtime prop declarations stay in value position
-/// before `__RuntimePropShape<...>` reads them.
-///
-/// The result feeds canon's real `export type Props` for Options API
-/// components: object form maps through the shared `__RuntimePropShape<...>`
-/// machinery (runtime ctors and `{ type, required }` shapes resolve to TS prop
-/// types with correct optionality), while the array form has no runtime type
-/// info so each prop is emitted as optional `unknown`.
-pub(super) fn find_options_api_props(script: &str) -> Option<OptionsApiPropsSource> {
-    if !script.contains("export default") {
-        return None;
-    }
-    let allocator = Allocator::default();
-    let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
-    if parsed.panicked {
-        return None;
-    }
-    let options = component_options_from_program(&parsed.program)?;
-    let props = option_expression_property(options, "props")?;
-    options_api_props_from_expression(script, props)
-}
-
-fn options_api_props_from_expression(
-    script: &str,
-    expression: &Expression<'_>,
-) -> Option<OptionsApiPropsSource> {
-    match expression {
-        Expression::ObjectExpression(object) => {
-            let source = source_slice(script, object.span())?;
-            Some(props_source_from_object(source))
-        }
-        Expression::ArrayExpression(array) => {
-            let mut names = Vec::new();
-            for element in &array.elements {
-                if let ArrayExpressionElement::StringLiteral(literal) = element {
-                    names.push(String::from(literal.value.as_str()));
-                }
-            }
-            (!names.is_empty()).then_some(OptionsApiPropsSource::Names(names))
-        }
-        Expression::Identifier(identifier) => is_safe_value_identifier(identifier.name.as_str())
-            .then(|| OptionsApiPropsSource::DeferredObject(String::from(identifier.name.as_str()))),
-        Expression::ParenthesizedExpression(parenthesized) => {
-            options_api_props_from_expression(script, &parenthesized.expression)
-        }
-        Expression::TSAsExpression(ts_as) => {
-            options_api_props_from_expression(script, &ts_as.expression)
-        }
-        Expression::TSSatisfiesExpression(ts_satisfies) => {
-            options_api_props_from_expression(script, &ts_satisfies.expression)
-        }
-        Expression::TSNonNullExpression(ts_non_null) => {
-            options_api_props_from_expression(script, &ts_non_null.expression)
-        }
-        _ => None,
-    }
-}
-
 pub(super) fn option_expression_property<'a>(
     object: &'a ObjectExpression<'a>,
     key_name: &str,
@@ -880,7 +813,7 @@ fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
     }
 }
 
-fn source_slice(script: &str, span: oxc_span::Span) -> Option<&str> {
+pub(super) fn source_slice(script: &str, span: oxc_span::Span) -> Option<&str> {
     script.get(span.start as usize..span.end as usize)
 }
 

--- a/crates/vize_canon/src/virtual_ts/generator/options_api_support.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api_support.rs
@@ -1,7 +1,14 @@
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{ArrayExpressionElement, Expression};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
 use oxc_syntax::identifier::is_identifier_part;
 use vize_carton::String;
 use vize_croquis::{Croquis, OptionGroup};
 
+use super::options_api::{
+    component_options_from_program, option_expression_property, source_slice,
+};
 pub(super) use crate::options_api_setup_spread::is_safe_value_identifier;
 use crate::virtual_ts::props::OptionsApiPropsSource;
 
@@ -34,7 +41,67 @@ pub(super) fn extend_options_api_descriptor_names<'a>(
 }
 
 pub(super) fn props_source_from_object(source: &str) -> OptionsApiPropsSource {
-    OptionsApiPropsSource::DeferredObject(String::from(source))
+    OptionsApiPropsSource::deferred_object(String::from(source))
+}
+
+/// Extract direct runtime props or the inferred props of a mixin-only export.
+pub(super) fn find_options_api_props(script: &str) -> Option<OptionsApiPropsSource> {
+    if !script.contains("export default") {
+        return None;
+    }
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
+    if parsed.panicked {
+        return None;
+    }
+    let options = component_options_from_program(&parsed.program)?;
+    let direct = option_expression_property(options, "props")
+        .and_then(|props| props_from_expression(script, props));
+    if option_expression_property(options, "mixins").is_some() {
+        return Some(direct.map_or_else(
+            OptionsApiPropsSource::default_export,
+            OptionsApiPropsSource::with_default_export,
+        ));
+    }
+    direct
+}
+
+fn props_from_expression(
+    script: &str,
+    expression: &Expression<'_>,
+) -> Option<OptionsApiPropsSource> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(props_source_from_object(source_slice(
+            script,
+            object.span(),
+        )?)),
+        Expression::ArrayExpression(array) => {
+            let names = array
+                .elements
+                .iter()
+                .filter_map(|element| match element {
+                    ArrayExpressionElement::StringLiteral(literal) => {
+                        Some(String::from(literal.value.as_str()))
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            (!names.is_empty()).then(|| OptionsApiPropsSource::names(names))
+        }
+        Expression::Identifier(identifier) => is_safe_value_identifier(identifier.name.as_str())
+            .then(|| {
+                OptionsApiPropsSource::deferred_object(String::from(identifier.name.as_str()))
+            }),
+        Expression::ParenthesizedExpression(value) => {
+            props_from_expression(script, &value.expression)
+        }
+        Expression::TSAsExpression(value) => props_from_expression(script, &value.expression),
+        Expression::TSSatisfiesExpression(value) => {
+            props_from_expression(script, &value.expression)
+        }
+        Expression::TSNonNullExpression(value) => props_from_expression(script, &value.expression),
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
@@ -5,8 +5,9 @@ use super::generics::{
     generic_fallback_args, is_ident_byte, references_any_identifier, skip_ascii_ws,
 };
 use crate::virtual_ts::props::{
-    OptionsApiPropsSource, PropsTypeEmission, add_generic_defaults, extract_generic_names,
-    generate_props_type, generate_props_variables, generate_setup_scoped_props_artifact,
+    OptionsApiPropsSource, PropsTypeEmission, add_generic_defaults, append_default_props,
+    extract_generic_names, generate_props_type, generate_props_variables,
+    generate_setup_scoped_props_artifact,
 };
 
 fn is_identifier_start_byte(b: u8) -> bool {
@@ -112,6 +113,7 @@ pub(super) fn generate_setup_props(
 pub(super) struct SetupPropsPlan {
     defer: bool,
     defer_options_api_props: bool,
+    capture_options_api_default: bool,
     module_scope_declares_props: bool,
 }
 
@@ -135,9 +137,10 @@ impl SetupPropsPlan {
         Self {
             defer: define_props_type_requires_setup_scope(summary),
             defer_options_api_props: !module_scope_declares_props
-                && options_api_props.is_some_and(|source| {
-                    matches!(source, OptionsApiPropsSource::DeferredObject(_))
-                }),
+                && options_api_props
+                    .is_some_and(|source| source.deferred_object_source().is_some()),
+            capture_options_api_default: options_api_props
+                .is_some_and(OptionsApiPropsSource::captures_default),
             module_scope_declares_props,
         }
     }
@@ -237,6 +240,9 @@ impl SetupPropsPlan {
     }
 
     pub(super) fn push_return_field(&self, fields: &mut Vec<&'static str>) {
+        if self.capture_options_api_default {
+            fields.push("__default__");
+        }
         if self.defer {
             fields.push("__vize_setup_props");
         }
@@ -250,13 +256,23 @@ impl SetupPropsPlan {
         mut ts: &mut String,
         options_api_props: Option<&OptionsApiPropsSource>,
     ) {
-        let Some(OptionsApiPropsSource::DeferredObject(source)) = options_api_props else {
+        let Some(source) =
+            options_api_props.and_then(OptionsApiPropsSource::deferred_object_source)
+        else {
             return;
         };
         if self.module_scope_declares_props {
             return;
         }
-        append!(ts, "\n  const __vize_options_props = ({source});\n");
+        let const_assertion = if source.trim_start().starts_with('{') {
+            " as const"
+        } else {
+            ""
+        };
+        append!(
+            ts,
+            "\n  const __vize_options_props = ({source}{const_assertion});\n"
+        );
     }
 
     pub(super) fn emit_module_export(
@@ -279,14 +295,17 @@ impl SetupPropsPlan {
                     "export type Props = Awaited<ReturnType<typeof __setup>>[\"__vize_setup_props\"];\n\n",
                 );
             }
-        } else if matches!(
-            options_api_props,
-            Some(OptionsApiPropsSource::DeferredObject(_))
-        ) && !self.module_scope_declares_props
-        {
+        } else if !self.module_scope_declares_props {
+            let Some(source) =
+                options_api_props.filter(|source| source.deferred_object_source().is_some())
+            else {
+                return;
+            };
             ts.push_str(
-                "export type Props = __RuntimePropShape<Awaited<ReturnType<typeof __setup>>[\"__vize_options_props\"]>;\n\n",
+                "export type Props = __VizeOptionsPropShape<Awaited<ReturnType<typeof __setup>>[\"__vize_options_props\"]>",
             );
+            append_default_props(ts, source);
+            ts.push_str(";\n\n");
         }
     }
 

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -1,8 +1,12 @@
+mod options_api;
 mod setup_scoped;
 mod template_bindings;
 mod template_names;
 mod with_defaults;
 use super::helpers::{is_reserved_identifier, to_safe_identifier};
+pub(crate) use options_api::OptionsApiPropsSource;
+pub(crate) use options_api::append_default_props;
+use options_api::emit_options_api_props_type;
 pub(crate) use setup_scoped::{PropsTypeEmission, generate_setup_scoped_props_artifact};
 use setup_scoped::{props_type_ref, unused_generic_comment};
 use template_bindings::{emit_macro_template_prop_bindings, should_skip_template_prop_binding};
@@ -194,14 +198,6 @@ fn append_model_props_type_literal(ts: &mut String, models: &[ModelDefinition]) 
     ts.push('}');
 }
 
-/// Runtime `props:` source for Options API `export type Props` emission.
-/// Objects are routed through setup scope so JavaScript values never leak into
-/// TypeScript type position.
-pub(crate) enum OptionsApiPropsSource {
-    DeferredObject(String),
-    Names(Vec<String>),
-}
-
 /// Generate Props type definition at module level.
 /// When `generic_param` is present (e.g., `"T extends Foo, P extends Bar"`),
 /// the Props type is emitted with generic parameters: `export type Props<T, P> = ...;`
@@ -280,28 +276,6 @@ pub(crate) fn generate_props_type(
     }
 
     ts.push('\n');
-}
-
-/// Emit a real `export type Props` for an Options API component, derived from
-/// its runtime `props:` option. The object form reuses the shared
-/// `__RuntimePropShape<...>` mapped type (the same machinery `defineProps`
-/// runtime forms use), so runtime ctors and `{ type, required }` shapes resolve
-/// to real prop types with correct optionality.
-fn emit_options_api_props_type(
-    ts: &mut String,
-    generic_decl: &str,
-    options_api_props: &OptionsApiPropsSource,
-) {
-    match options_api_props {
-        OptionsApiPropsSource::DeferredObject(_) => {}
-        OptionsApiPropsSource::Names(names) => {
-            append!(*ts, "export type Props{generic_decl} = {{\n");
-            for name in names {
-                append!(*ts, "  \"{name}\"?: unknown;\n");
-            }
-            ts.push_str("};\n");
-        }
-    }
 }
 
 pub(crate) fn generate_props_variables(

--- a/crates/vize_canon/src/virtual_ts/props/options_api.rs
+++ b/crates/vize_canon/src/virtual_ts/props/options_api.rs
@@ -1,0 +1,92 @@
+use vize_carton::{String, append};
+
+/// Runtime prop source used to publish an Options API component's `Props`.
+pub(crate) struct OptionsApiPropsSource {
+    direct: Option<DirectOptionsApiPropsSource>,
+    captures_default: bool,
+}
+
+enum DirectOptionsApiPropsSource {
+    /// Runtime values that must remain in setup scope.
+    DeferredObject(String),
+    /// Array-form props, which carry names but no runtime types.
+    Names(Vec<String>),
+}
+
+impl OptionsApiPropsSource {
+    pub(crate) fn deferred_object(source: String) -> Self {
+        Self {
+            direct: Some(DirectOptionsApiPropsSource::DeferredObject(source)),
+            captures_default: false,
+        }
+    }
+
+    pub(crate) fn names(names: Vec<String>) -> Self {
+        Self {
+            direct: Some(DirectOptionsApiPropsSource::Names(names)),
+            captures_default: false,
+        }
+    }
+
+    pub(crate) fn default_export() -> Self {
+        Self {
+            direct: None,
+            captures_default: true,
+        }
+    }
+
+    pub(crate) fn with_default_export(mut self) -> Self {
+        self.captures_default = true;
+        self
+    }
+
+    pub(crate) fn deferred_object_source(&self) -> Option<&str> {
+        match self.direct.as_ref() {
+            Some(DirectOptionsApiPropsSource::DeferredObject(source)) => Some(source.as_str()),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn captures_default(&self) -> bool {
+        self.captures_default
+    }
+}
+
+/// Emit the public prop shape without moving runtime values into type position.
+pub(super) fn emit_options_api_props_type(
+    ts: &mut String,
+    generic_decl: &str,
+    source: &OptionsApiPropsSource,
+) {
+    if source.captures_default {
+        ts.push_str(
+            "type __VizeDefaultProps<T> = __VizeIsAny<T> extends true ? {} : T extends abstract new (...args: any[]) => { $props: infer P } ? P : {};\n",
+        );
+    }
+    match source.direct.as_ref() {
+        Some(DirectOptionsApiPropsSource::DeferredObject(_)) => ts.push_str(
+            "type __VizeOptionsPropRequired<T> = T extends { required: true } ? true : false;\ntype __VizeOptionsPropShape<T extends Record<string, any>> = { [K in keyof T as __VizeOptionsPropRequired<T[K]> extends true ? K : never]-?: __RuntimePropCtor<T[K]>; } & { [K in keyof T as __VizeOptionsPropRequired<T[K]> extends true ? never : K]?: __RuntimePropCtor<T[K]>; };\n",
+        ),
+        Some(DirectOptionsApiPropsSource::Names(names)) => {
+            append!(*ts, "export type Props{generic_decl} = {{\n");
+            for name in names {
+                append!(*ts, "  \"{name}\"?: unknown;\n");
+            }
+            ts.push('}');
+            append_default_props(ts, source);
+            ts.push_str(";\n");
+        }
+        None => {
+            append!(
+                *ts,
+                "export type Props{generic_decl} = __VizeDefaultProps<Awaited<ReturnType<typeof __setup>>[\"__default__\"]>;\n"
+            );
+        }
+    }
+}
+
+pub(crate) fn append_default_props(ts: &mut String, source: &OptionsApiPropsSource) {
+    if source.captures_default {
+        ts.push_str(" & __VizeDefaultProps<Awaited<ReturnType<typeof __setup>>[\"__default__\"]>");
+    }
+}

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -299,7 +299,7 @@ fn test_options_api_emits_real_props_type_from_object_option() {
 
     assert!(
         output.code.contains(
-            "const __vize_options_props = ({\n        initial: Number,\n        label: { type: String, required: true },\n    });"
+            "const __vize_options_props = ({\n        initial: Number,\n        label: { type: String, required: true },\n    } as const);"
         ),
         "expected the runtime props object to remain in value scope:\n{}",
         output.code

--- a/crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs
@@ -110,13 +110,13 @@ export default defineComponent({
     assert!(
         output
             .code
-            .contains("const __vize_options_props = ({ ...sharedProps });"),
+            .contains("const __vize_options_props = ({ ...sharedProps } as const);"),
         "spread props must be kept in setup scope where sharedProps resolves:\n{}",
         output.code
     );
     assert!(
         output.code.contains(
-            "export type Props = __RuntimePropShape<Awaited<ReturnType<typeof __setup>>[\"__vize_options_props\"]>;"
+            "export type Props = __VizeOptionsPropShape<Awaited<ReturnType<typeof __setup>>[\"__vize_options_props\"]>;"
         ),
         "Props should be derived from the setup-scoped runtime props artifact:\n{}",
         output.code
@@ -176,7 +176,7 @@ export default defineComponent({
     );
     assert!(
         output.code.contains(
-            "export type Props = __RuntimePropShape<Awaited<ReturnType<typeof __setup>>[\"__vize_options_props\"]>;"
+            "export type Props = __VizeOptionsPropShape<Awaited<ReturnType<typeof __setup>>[\"__vize_options_props\"]>;"
         ),
         "Props should be derived from the setup-scoped identifier props artifact:\n{}",
         output.code
@@ -230,7 +230,7 @@ export default defineComponent({
     );
     assert!(
         output.code.contains(
-            "export type Props = __RuntimePropShape<Awaited<ReturnType<typeof __setup>>[\"__vize_options_props\"]>;"
+            "export type Props = __VizeOptionsPropShape<Awaited<ReturnType<typeof __setup>>[\"__vize_options_props\"]>;"
         ),
         "Props should be derived from the setup-scoped runtime props artifact:\n{}",
         output.code

--- a/crates/vize_canon/tests/options_api_runtime_props_value_scope.rs
+++ b/crates/vize_canon/tests/options_api_runtime_props_value_scope.rs
@@ -41,7 +41,7 @@ fn options_api_runtime_props_stay_in_value_scope() {
     );
     assert!(
         virtual_ts.contains(
-            "export type Props = __RuntimePropShape<Awaited<ReturnType<typeof __setup>>[\"__vize_options_props\"]>;"
+            "export type Props = __VizeOptionsPropShape<Awaited<ReturnType<typeof __setup>>[\"__vize_options_props\"]>;"
         ),
         "Props must be derived from the captured runtime value:\n{virtual_ts}"
     );


### PR DESCRIPTION
## Summary

- publish direct Options API runtime props with Vue-compatible requiredness
- preserve inherited mixin props when a component also declares direct props
- keep defaulted public props optional and retain runtime values in setup scope

Closes #3571

## Verification

- real Vue/tsgo combined runtime, default, and mixin fixture
- Options API unit tests (30 passed)
- runtime value-scope integration tests (2 passed)
- `cargo test -p vize_canon --lib` (745 passed)
- strict clippy, rustfmt, diff, and source-length checks
- independent exact-SHA review: approved