### PR TITLE
test(typecheck): materialize vue-tsc corpus

### DIFF
--- a/tests/tooling/typecheck-baseline-project.test.ts
+++ b/tests/tooling/typecheck-baseline-project.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { materializeBaselineProject } from "../../tools/fixtures/typecheck-baseline-project.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const dependencyRoot =
+  process.env.VIZE_TEST_WORKSPACE_NODE_MODULES ?? path.join(root, "tests/node_modules");
+const vueTsc = path.join(dependencyRoot, ".bin/vue-tsc");
+
+test(
+  "materialized baseline checks Vue files omitted by a solution-style config",
+  { skip: !fs.existsSync(vueTsc) },
+  () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-project-"));
+    const fixtureRoot = path.join(temp, "fixture");
+    const reportDir = path.join(temp, "report");
+    const app = path.join(fixtureRoot, "src/App.vue");
+    fs.mkdirSync(path.dirname(app), { recursive: true });
+    fs.mkdirSync(reportDir);
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.json"),
+      `${JSON.stringify({ files: [], references: [{ path: "./tsconfig.app.json" }] })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.app.json"),
+      `${JSON.stringify({ compilerOptions: { composite: true }, include: ["src/**/*.vue"] })}\n`,
+    );
+    fs.writeFileSync(app, '<script setup lang="ts">const value: string = 1</script>\n');
+
+    try {
+      const direct = runVueTsc(path.join(fixtureRoot, "tsconfig.json"), fixtureRoot);
+      assert.doesNotMatch(direct.stdout, /App\.vue/u);
+
+      const project = materializeBaselineProject(
+        fixtureRoot,
+        reportDir,
+        { id: "fixture", tsconfig: "tsconfig.json" },
+        { fileCount: 1, files: [{ file: "src/App.vue" }] },
+      );
+      const materialized = runVueTsc(project.path, fixtureRoot);
+      assert.match(materialized.stdout, new RegExp(escapeRegExp(app)));
+      assert.equal(materialized.status, 2, materialized.stderr);
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  },
+);
+
+function runVueTsc(project: string, cwd: string) {
+  return spawnSync(vueTsc, ["--noEmit", "--pretty", "false", "--listFiles", "-p", project], {
+    cwd,
+    encoding: "utf8",
+  });
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -68,9 +68,23 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
     assert.equal(artifact.divergence.summary.sharedCount, 1);
     assert.equal(artifact.divergence.summary.falsePositiveCount, 0);
     assert.equal(artifact.divergence.summary.falseNegativeCount, 0);
-    assert.deepEqual(readJson(fixture.invocationPath), {
+    const invocation = readJson(fixture.invocationPath);
+    const baselineProject = path.join(fixture.reportDir, "fixture-vue-tsc.tsconfig.json");
+    assert.deepEqual(invocation, {
       cwd: fixture.fixtureRoot,
-      args: ["--noEmit", "--pretty", "false", "--listFiles", "-p", "tsconfig.json"],
+      args: ["--noEmit", "--pretty", "false", "--listFiles", "-p", baselineProject],
+    });
+    assert.deepEqual(readJson(baselineProject), {
+      extends: path
+        .relative(fixture.reportDir, path.join(fixture.fixtureRoot, "tsconfig.json"))
+        .replaceAll("\\", "/"),
+      files: [
+        path
+          .relative(fixture.reportDir, path.join(fixture.fixtureRoot, "src/App.vue"))
+          .replaceAll("\\", "/"),
+      ],
+      include: [],
+      references: [],
     });
     const markdown = fs.readFileSync(
       path.join(fixture.reportDir, "fixture-typecheck-divergence.md"),

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -1,0 +1,31 @@
+import { writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+
+/**
+ * Materialize the exact Vue corpus Vize checked as a vue-tsc project.
+ *
+ * The fixture's pinned tsconfig remains the source of compiler options, while
+ * `files` replaces solution-style or incomplete include lists. This makes the
+ * baseline compare the same authored SFCs instead of silently checking none.
+ */
+export function materializeBaselineProject(fixtureRoot, reportDir, project, vizeReport) {
+  const outputPath = join(reportDir, `${project.id}-vue-tsc.tsconfig.json`);
+  const configDir = dirname(outputPath);
+  const config = {
+    extends: configRelativePath(configDir, resolve(fixtureRoot, project.tsconfig)),
+    files: vizeReport.files
+      .slice(0, vizeReport.fileCount)
+      .map((entry) => configRelativePath(configDir, resolve(fixtureRoot, entry.file))),
+    include: [],
+    references: [],
+  };
+  const source = `${JSON.stringify(config, null, 2)}\n`;
+  writeFileSync(outputPath, source);
+  return { path: outputPath, source };
+}
+
+function configRelativePath(from, to) {
+  const path = relative(from, to).replaceAll("\\", "/");
+  if (isAbsolute(path) || /^[A-Za-z]:\//u.test(path)) return path;
+  return path.startsWith(".") ? path : `./${path}`;
+}

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 
 import { validateTypecheckerOutput } from "./tool-matrix-typechecker.mjs";
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
+import { materializeBaselineProject } from "./typecheck-baseline-project.mjs";
 import { evaluateVueProgramCoverage } from "./typecheck-baseline-coverage.mjs";
 import {
   assertBudgetPassed,
@@ -44,7 +45,13 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
   const summary = readAndValidateSummary(args.reportDir, project);
   const vizeRun = readAndValidateVizeRun(args.reportDir, project, summary);
   const vueTsc = resolveVueTsc(args.vueTscBin);
-  const baselineArgs = ["--noEmit", "--pretty", "false", "--listFiles", "-p", project.tsconfig];
+  const baselineProject = materializeBaselineProject(
+    fixtureRoot,
+    args.reportDir,
+    project,
+    vizeRun.payload.parsed,
+  );
+  const baselineArgs = ["--noEmit", "--pretty", "false", "--listFiles", "-p", baselineProject.path];
   const startedAt = Date.now();
   const baseline = spawnSync(vueTsc.path, baselineArgs, {
     cwd: fixtureRoot,
@@ -83,6 +90,7 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
     source: vizeRun.source,
     baseline: {
       command: displayCommand(vueTsc.path, baselineArgs),
+      configSha256: sha256(baselineProject.source),
       version: vueTsc.version,
       durationMs,
       exitCode: baseline.status,


### PR DESCRIPTION
## Summary

- materialize the validated Vize Vue file list as the vue-tsc baseline project
- preserve each fixture's pinned compiler options while overriding empty or incomplete project membership
- record the generated config digest and prove solution-style configs cannot yield an empty comparison

Refs #3513

## Verification

- real vue-tsc 3.3.4 / TypeScript 6.0.3 solution-style regression
- related divergence report and budget tests (26 passed)
- formatter, deny-warnings lint, diff, and source-length checks
- independent exact-SHA review: approved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->