### PR TITLE
perf: gate long-term benchmark drift

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,13 +1,14 @@
 name: Benchmark
 
 on:
+  schedule:
+    - cron: "29 5 * * 2"
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
-  # GitHub records a workflow_dispatch run's head_sha from the branch or tag
-  # passed via --ref, not from a later checkout. Dispatch with a ref whose tip
-  # is exactly head_sha; the first step rejects mismatches so release evidence
-  # cannot be attributed to the wrong commit.
+  # The schedule compares main against the exact SHA below until a reviewed PR
+  # deliberately refreshes it. Dispatch runs keep accepting an explicit range;
+  # GitHub records their head SHA from --ref, so validation rejects mismatches.
   workflow_dispatch:
     inputs:
       base_sha:
@@ -19,17 +20,17 @@ on:
         required: true
         type: string
 
-run-name: "Benchmark ${{ github.event_name == 'workflow_dispatch' && format('{0}...{1}', inputs.base_sha, inputs.head_sha) || format('PR #{0}', github.event.pull_request.number) }}"
+run-name: "Benchmark ${{ github.event_name == 'schedule' && format('long baseline...{0}', github.sha) || github.event_name == 'workflow_dispatch' && format('{0}...{1}', inputs.base_sha, inputs.head_sha) || format('PR #{0}', github.event.pull_request.number) }}"
 
 concurrency:
-  group: benchmark-${{ github.event_name == 'workflow_dispatch' && format('dispatch-{0}-{1}', inputs.base_sha, inputs.head_sha) || github.event.pull_request.number }}
+  group: benchmark-${{ github.event_name == 'schedule' && 'long-baseline' || github.event_name == 'workflow_dispatch' && format('dispatch-{0}-{1}', inputs.base_sha, inputs.head_sha) || github.event.pull_request.number }}
   cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  BENCHMARK_BASE_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.base_sha || github.event.pull_request.base.sha }}
-  BENCHMARK_HEAD_SHA: ${{ github.event_name == 'workflow_dispatch' && inputs.head_sha || github.event.pull_request.head.sha }}
+  BENCHMARK_BASE_SHA: ${{ github.event_name == 'schedule' && 'cea92c7994b4b84c1e42ed74c023b17c0c54090d' || github.event_name == 'workflow_dispatch' && inputs.base_sha || github.event.pull_request.base.sha }}
+  BENCHMARK_HEAD_SHA: ${{ github.event_name == 'schedule' && github.sha || github.event_name == 'workflow_dispatch' && inputs.head_sha || github.event.pull_request.head.sha }}
   # 1000 files keeps the fastest lane (compile, ~200us/file single-threaded)
   # above ~200ms so runner thermal drift between interleaved runs stays well
   # under the 5% threshold; at 300 files the lane ran ~65ms and perf-neutral
@@ -51,8 +52,8 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Validate dispatch SHAs
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+      - name: Validate benchmark SHAs
+        if: ${{ github.event_name != 'pull_request' }}
         env:
           RUN_HEAD_SHA: ${{ github.sha }}
         run: |
@@ -70,7 +71,7 @@ jobs:
             exit 1
           fi
           if [[ "$RUN_HEAD_SHA" != "$BENCHMARK_HEAD_SHA" ]]; then
-            echo "::error title=Dispatch ref mismatch::run head_sha comes from --ref; dispatch with a branch or tag at $BENCHMARK_HEAD_SHA (got $RUN_HEAD_SHA)"
+            echo "::error title=Workflow ref mismatch::run head_sha must match $BENCHMARK_HEAD_SHA (got $RUN_HEAD_SHA)"
             exit 1
           fi
 
@@ -79,7 +80,7 @@ jobs:
         with:
           path: head
           ref: ${{ env.BENCHMARK_HEAD_SHA }}
-          fetch-depth: ${{ github.event_name == 'workflow_dispatch' && '0' || '1' }}
+          fetch-depth: ${{ github.event_name != 'pull_request' && '0' || '1' }}
 
       - name: Checkout base
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -95,7 +96,7 @@ jobs:
           HEAD_SHA: ${{ env.BENCHMARK_HEAD_SHA }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]] && \
+          if [[ "$EVENT_NAME" != "pull_request" ]] && \
              ! git -C "$GITHUB_WORKSPACE/head" merge-base --is-ancestor "$BASE_SHA" "$HEAD_SHA"; then
             echo "::error title=Invalid benchmark range::base_sha must be an ancestor of head_sha"
             exit 1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,9 +6,8 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
-  # The schedule compares main against the exact SHA below until a reviewed PR
-  # deliberately refreshes it. Dispatch runs keep accepting an explicit range;
-  # GitHub records their head SHA from --ref, so validation rejects mismatches.
+  # Schedule compares main against the exact SHA below until a reviewed refresh.
+  # Dispatch records its head SHA from --ref, so validation rejects mismatches.
   workflow_dispatch:
     inputs:
       base_sha:
@@ -31,18 +30,12 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   BENCHMARK_BASE_SHA: ${{ github.event_name == 'schedule' && 'cea92c7994b4b84c1e42ed74c023b17c0c54090d' || github.event_name == 'workflow_dispatch' && inputs.base_sha || github.event.pull_request.base.sha }}
   BENCHMARK_HEAD_SHA: ${{ github.event_name == 'schedule' && github.sha || github.event_name == 'workflow_dispatch' && inputs.head_sha || github.event.pull_request.head.sha }}
-  # 1000 files keeps the fastest lane (compile, ~200us/file single-threaded)
-  # above ~200ms so runner thermal drift between interleaved runs stays well
-  # under the 5% threshold; at 300 files the lane ran ~65ms and perf-neutral
-  # PRs tripped the budget on drift alone (#1411: +5.27%).
+  # Keep the fastest lane above the runner's noise floor (#1411).
   VIZE_BENCH_FILE_COUNT: 1000
-  # Optimized (ci-opt) binaries run fast enough that 5 runs / 1 warmup left the
-  # gate's noise floor above the 5% threshold: an identical-source PR (#1395)
-  # tripped the budget at +5.12% on the compile lane. More samples tighten the
-  # median instead of weakening the threshold.
   VIZE_BENCH_RUNS: 10
   VIZE_BENCH_WARMUPS: 2
   VIZE_BENCH_REGRESSION_THRESHOLD_PERCENT: 5
+  VIZE_BENCH_BUILD_PROFILE_KEY: ci-opt-release-thin-lto-cgu16
 
 jobs:
   pr-benchmark:
@@ -116,7 +109,9 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Install Rust toolchain
+        id: rust-toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:
@@ -170,11 +165,10 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: base/target/ci-opt/vize
-          key: ${{ runner.os }}-benchmark-base-cli-ci-opt-${{ env.BENCHMARK_BASE_SHA }}
+          key: ${{ runner.os }}-${{ runner.arch }}-benchmark-base-${{ env.VIZE_BENCH_BUILD_PROFILE_KEY }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ env.BENCHMARK_BASE_SHA }}
 
-      # The ci-opt profile is also injected via --config so the base checkout
-      # builds even when it predates the profile's Cargo.toml definition, and
-      # both sides are guaranteed to measure under identical settings.
+      # Inject ci-opt so old bases build and both sides use identical settings.
+      # This exact configuration is represented by the cache/profile key above.
       - name: Build base CLI
         id: build-base
         if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.cache-base-cli.outputs.cache-hit != 'true'
@@ -185,8 +179,7 @@ jobs:
           --config 'profile.ci-opt.lto="thin"'
           --config 'profile.ci-opt.codegen-units=16'
 
-      # A base that does not compile (e.g. a hotfix PR for a broken main) cannot
-      # be benchmarked; skip the comparison instead of hard-failing the gate.
+      # Skip an unbuildable base instead of hard-failing a hotfix PR.
       - name: Skip benchmark when base CLI cannot be built
         if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.build-base.outcome == 'failure'
         run: |
@@ -210,7 +203,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: head/target/ci-opt/vize
-          key: ${{ runner.os }}-benchmark-head-cli-ci-opt-${{ env.BENCHMARK_HEAD_SHA }}
+          key: ${{ runner.os }}-${{ runner.arch }}-benchmark-head-${{ env.VIZE_BENCH_BUILD_PROFILE_KEY }}-${{ steps.rust-toolchain.outputs.cachekey }}-${{ env.BENCHMARK_HEAD_SHA }}
 
       - name: Build head CLI
         if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.cache-head-cli.outputs.cache-hit != 'true' && steps.build-base.outcome != 'failure'
@@ -240,6 +233,15 @@ jobs:
             --out "$GITHUB_WORKSPACE/benchmark-summary.md" \
             --json "$GITHUB_WORKSPACE/benchmark-results.json"
 
+      - name: Record benchmark build provenance
+        if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.build-base.outcome != 'failure'
+        run: |
+          {
+            printf 'profile=%s\n' "$VIZE_BENCH_BUILD_PROFILE_KEY"
+            rustc --version --verbose
+            sha256sum base/target/ci-opt/vize head/target/ci-opt/vize
+          } > benchmark-provenance.txt
+
       - name: Write job summary
         run: cat benchmark-summary.md >> "$GITHUB_STEP_SUMMARY"
 
@@ -250,6 +252,7 @@ jobs:
           path: |
             benchmark-summary.md
             benchmark-results.json
+            benchmark-provenance.txt
           if-no-files-found: warn
           retention-days: 14
 

--- a/tests/tooling/github-workflows-benchmark.test.ts
+++ b/tests/tooling/github-workflows-benchmark.test.ts
@@ -25,11 +25,11 @@ test("benchmark workflow comments from trusted code after a read-only benchmark 
   assert.match(benchmarkJob, /path:\s*base[\s\S]*ref:\s*\$\{\{\s*env\.BENCHMARK_BASE_SHA\s*\}\}/);
   assert.match(
     workflow,
-    /BENCHMARK_HEAD_SHA:\s*\$\{\{\s*github\.event_name == 'workflow_dispatch' && inputs\.head_sha \|\| github\.event\.pull_request\.head\.sha\s*\}\}/,
+    /BENCHMARK_HEAD_SHA:\s*\$\{\{[^\n]*github\.event_name == 'workflow_dispatch' && inputs\.head_sha \|\| github\.event\.pull_request\.head\.sha\s*\}\}/,
   );
   assert.match(
     workflow,
-    /BENCHMARK_BASE_SHA:\s*\$\{\{\s*github\.event_name == 'workflow_dispatch' && inputs\.base_sha \|\| github\.event\.pull_request\.base\.sha\s*\}\}/,
+    /BENCHMARK_BASE_SHA:\s*\$\{\{[^\n]*github\.event_name == 'workflow_dispatch' && inputs\.base_sha \|\| github\.event\.pull_request\.base\.sha\s*\}\}/,
   );
   assert.match(benchmarkJob, /name:\s*pr-benchmark/);
   assert.doesNotMatch(benchmarkJob, /node base\/bench\/comment-pr\.mjs/);
@@ -86,7 +86,7 @@ test("benchmark dispatch validates exact SHA evidence and runs the existing budg
   const benchmarkJob = workflowJobBody(workflow, "pr-benchmark");
   const budgetJob = workflowJobBody(workflow, "pr-benchmark-budget");
   const commentJob = workflowJobBody(workflow, "pr-benchmark-comment");
-  const validateDispatchStep = workflowStepBody(benchmarkJob, "Validate dispatch SHAs");
+  const validateDispatchStep = workflowStepBody(benchmarkJob, "Validate benchmark SHAs");
   const checkoutHeadStep = workflowStepBody(benchmarkJob, "Checkout head");
   const checkBaseStep = workflowStepBody(benchmarkJob, "Check base checkout");
 
@@ -105,13 +105,10 @@ test("benchmark dispatch validates exact SHA evidence and runs the existing budg
     /group:[^\n]*dispatch-\{0\}-\{1\}[^\n]*inputs\.base_sha[^\n]*inputs\.head_sha/,
   );
   assert.match(workflow, /group:[^\n]*\|\| github\.event\.pull_request\.number[^\n]*\}\}/);
-  assert.match(workflow, /head_sha from the branch or tag/);
-  assert.match(workflow, /passed via --ref, not from a later checkout/);
+  assert.match(workflow, /head SHA from --ref/);
+  assert.match(workflow, /validation rejects mismatches/);
 
-  assert.match(
-    validateDispatchStep,
-    /if:\s*\$\{\{\s*github\.event_name == 'workflow_dispatch'\s*\}\}/,
-  );
+  assert.match(validateDispatchStep, /if:\s*\$\{\{\s*github\.event_name != 'pull_request'\s*\}\}/);
   assert.match(validateDispatchStep, /full_sha='\^\[0-9a-f\]\{40\}\$'/);
   assert.match(validateDispatchStep, /! "\$BENCHMARK_BASE_SHA" =~ \$full_sha/);
   assert.match(validateDispatchStep, /! "\$BENCHMARK_HEAD_SHA" =~ \$full_sha/);
@@ -119,14 +116,13 @@ test("benchmark dispatch validates exact SHA evidence and runs the existing budg
   assert.match(validateDispatchStep, /base_sha must differ from head_sha/);
   assert.match(validateDispatchStep, /RUN_HEAD_SHA:\s*\$\{\{\s*github\.sha\s*\}\}/);
   assert.match(validateDispatchStep, /"\$RUN_HEAD_SHA" != "\$BENCHMARK_HEAD_SHA"/);
-  assert.match(validateDispatchStep, /run head_sha comes from --ref/);
-  assert.match(validateDispatchStep, /dispatch with a branch or tag/);
+  assert.match(validateDispatchStep, /run head_sha must match/);
   assert.match(
     checkoutHeadStep,
-    /fetch-depth:\s*\$\{\{\s*github\.event_name == 'workflow_dispatch' && '0' \|\| '1'\s*\}\}/,
+    /fetch-depth:\s*\$\{\{\s*github\.event_name != 'pull_request' && '0' \|\| '1'\s*\}\}/,
   );
   assert.match(checkBaseStep, /EVENT_NAME:\s*\$\{\{\s*github\.event_name\s*\}\}/);
-  assert.match(checkBaseStep, /"\$EVENT_NAME" == "workflow_dispatch"/);
+  assert.match(checkBaseStep, /"\$EVENT_NAME" != "pull_request"/);
   assert.match(checkBaseStep, /merge-base --is-ancestor "\$BASE_SHA" "\$HEAD_SHA"/);
   assert.match(checkBaseStep, /base_sha must be an ancestor of head_sha/);
 
@@ -140,6 +136,44 @@ test("benchmark dispatch validates exact SHA evidence and runs the existing budg
   assert.match(budgetJob, /--labels-json "\$PR_LABELS_JSON"/);
   assert.match(budgetJob, /\|\| '\[\]'/);
   assert.doesNotMatch(commentJob, /github\.event_name == 'workflow_dispatch'/);
+});
+
+test("benchmark schedule gates long-term drift against a fixed commit", () => {
+  const workflow = readRepoFile(".github", "workflows", "benchmark.yml");
+  const benchmarkJob = workflowJobBody(workflow, "pr-benchmark");
+  const budgetJob = workflowJobBody(workflow, "pr-benchmark-budget");
+  const commentJob = workflowJobBody(workflow, "pr-benchmark-comment");
+  const validateStep = workflowStepBody(benchmarkJob, "Validate benchmark SHAs");
+  const checkoutHeadStep = workflowStepBody(benchmarkJob, "Checkout head");
+  const checkBaseStep = workflowStepBody(benchmarkJob, "Check base checkout");
+
+  assert.match(workflow, /\n  schedule:\n\s+- cron:\s*"29 5 \* \* 2"/);
+  assert.match(
+    workflow,
+    /BENCHMARK_BASE_SHA:\s*\$\{\{\s*github\.event_name == 'schedule' && '[0-9a-f]{40}' \|\| github\.event_name == 'workflow_dispatch'/,
+  );
+  const baseline = workflow.match(/github\.event_name == 'schedule' && '([0-9a-f]{40})'/)?.[1];
+  assert.ok(baseline, "missing exact scheduled benchmark baseline");
+  assert.equal(workflow.split(baseline).length - 1, 1, "baseline must have one refresh point");
+  assert.match(
+    workflow,
+    /BENCHMARK_HEAD_SHA:\s*\$\{\{\s*github\.event_name == 'schedule' && github\.sha \|\| github\.event_name == 'workflow_dispatch'/,
+  );
+  assert.match(validateStep, /github\.event_name != 'pull_request'/);
+  assert.match(checkoutHeadStep, /github\.event_name != 'pull_request' && '0' \|\| '1'/);
+  assert.match(checkBaseStep, /"\$EVENT_NAME" != "pull_request"/);
+  assert.match(checkBaseStep, /merge-base --is-ancestor "\$BASE_SHA" "\$HEAD_SHA"/);
+
+  // Scheduled runs cannot opt out of a missing or unbuildable baseline: the
+  // label reader is PR-only and every other event supplies an empty label set.
+  const budgetHeader = budgetJob.slice(0, budgetJob.indexOf("\n    steps:"));
+  assert.doesNotMatch(budgetHeader, /\n    if:/, "scheduled budget must always run");
+  assert.match(budgetJob, /if:\s*\$\{\{\s*github\.event_name == 'pull_request'\s*\}\}/);
+  assert.match(
+    budgetJob,
+    /github\.event_name == 'pull_request' && steps\.pr-labels\.outputs\.labels \|\| '\[\]'/,
+  );
+  assert.doesNotMatch(commentJob, /github\.event_name == 'schedule'/);
 });
 
 test("tool benchmark workflow produces docs artifacts, PR comments, and conventional commits", () => {

--- a/tests/tooling/github-workflows-benchmark.test.ts
+++ b/tests/tooling/github-workflows-benchmark.test.ts
@@ -126,9 +126,12 @@ test("benchmark dispatch validates exact SHA evidence and runs the existing budg
   assert.match(checkBaseStep, /merge-base --is-ancestor "\$BASE_SHA" "\$HEAD_SHA"/);
   assert.match(checkBaseStep, /base_sha must be an ancestor of head_sha/);
 
-  const validateIndex = benchmarkJob.indexOf("- name: Validate dispatch SHAs");
+  const validateIndex = benchmarkJob.indexOf("- name: Validate benchmark SHAs");
   const ancestryIndex = benchmarkJob.indexOf("- name: Check base checkout");
   const benchmarkIndex = benchmarkJob.indexOf("- name: Compare base and head");
+  assert.notEqual(validateIndex, -1, "missing SHA validation step");
+  assert.notEqual(ancestryIndex, -1, "missing ancestry validation step");
+  assert.notEqual(benchmarkIndex, -1, "missing benchmark step");
   assert.ok(validateIndex < ancestryIndex, "SHA equality must be validated before ancestry");
   assert.ok(ancestryIndex < benchmarkIndex, "ancestry must be validated before benchmarking");
 
@@ -146,6 +149,7 @@ test("benchmark schedule gates long-term drift against a fixed commit", () => {
   const validateStep = workflowStepBody(benchmarkJob, "Validate benchmark SHAs");
   const checkoutHeadStep = workflowStepBody(benchmarkJob, "Checkout head");
   const checkBaseStep = workflowStepBody(benchmarkJob, "Check base checkout");
+  const provenanceStep = workflowStepBody(benchmarkJob, "Record benchmark build provenance");
 
   assert.match(workflow, /\n  schedule:\n\s+- cron:\s*"29 5 \* \* 2"/);
   assert.match(
@@ -163,6 +167,18 @@ test("benchmark schedule gates long-term drift against a fixed commit", () => {
   assert.match(checkoutHeadStep, /github\.event_name != 'pull_request' && '0' \|\| '1'/);
   assert.match(checkBaseStep, /"\$EVENT_NAME" != "pull_request"/);
   assert.match(checkBaseStep, /merge-base --is-ancestor "\$BASE_SHA" "\$HEAD_SHA"/);
+  assert.match(
+    benchmarkJob,
+    /benchmark-base-\$\{\{ env\.VIZE_BENCH_BUILD_PROFILE_KEY \}\}-\$\{\{ steps\.rust-toolchain\.outputs\.cachekey \}\}/,
+  );
+  assert.match(
+    benchmarkJob,
+    /benchmark-head-\$\{\{ env\.VIZE_BENCH_BUILD_PROFILE_KEY \}\}-\$\{\{ steps\.rust-toolchain\.outputs\.cachekey \}\}/,
+  );
+  assert.match(provenanceStep, /rustc --version --verbose/);
+  assert.match(provenanceStep, /printf 'profile=%s\\n' "\$VIZE_BENCH_BUILD_PROFILE_KEY"/);
+  assert.match(provenanceStep, /sha256sum base\/target\/ci-opt\/vize head\/target\/ci-opt\/vize/);
+  assert.match(benchmarkJob, /benchmark-provenance\.txt/);
 
   // Scheduled runs cannot opt out of a missing or unbuildable baseline: the
   // label reader is PR-only and every other event supplies an empty label set.


### PR DESCRIPTION
Closes #3488

## Summary
- compare the current main benchmark against one fixed historical baseline on the weekly schedule
- bind both binaries to the same resolved Rust toolchain and ci-opt profile
- fail closed on invalid evidence and record rustc plus binary SHA-256 provenance

## Verification
- workflow tests: 6/6
- benchmark budget tests: 6/6
- actionlint/actrun strict lint
- schedule and dispatch dry-runs
- oxfmt, oxlint, git diff --check
- independent review of exact commit 7ff9e3ed4087c8a6ba912820f19cd533f5d7bf0d

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Benchmark runs now execute weekly on a fixed baseline and record build provenance.
  * Improved benchmark caching uses runner architecture, build profile, Rust toolchain, and commit details.
  * Added stronger commit validation and ancestry checks for benchmark runs.
  * Benchmark results and provenance are uploaded as downloadable artifacts.

* **Tests**
  * Expanded coverage for scheduled benchmarks, validation, caching, provenance, ancestry checks, and budget execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->