### PR TITLE
test(canon): fail the divergence ledger on an unusable baseline config

### DIFF
--- a/tests/tooling/typecheck-divergence-baseline-configuration.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline-configuration.test.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  cleanup,
+  commitSha,
+  readJson,
+  run,
+  setup,
+  sharedBaselineOutput,
+  writeVueTsc,
+} from "./_helpers/typecheck-divergence-report-fixture.ts";
+
+/**
+ * #3513: the ledger has to be able to detect its own blindness.
+ *
+ * #3583 materialized the baseline as `files: [<Vize's exact Vue corpus>]`
+ * extending the fixture's pinned config. That fixed the solution-style configs,
+ * and it took the remaining failure out of reach of the file-coverage check
+ * added in #3580: `--listFiles` prints every entry of `files` whether or not the
+ * extended config resolved, so the two corpora now match by construction.
+ *
+ * What is left is a baseline that could not load the project. Reproduced against
+ * real vue-tsc 3.3.4 / TypeScript 6.0.3, it says so and then carries on with
+ * whatever options it salvaged — no `strict`, no `paths`, no `types` — checks
+ * the files anyway, and hands the comparator a diagnostic stream that looks
+ * exactly like a measurement:
+ *
+ *   error TS5083: Cannot read file '<root>/.nuxt/tsconfig.json'.
+ *   tsconfig.json(2,18): error TS6053: File '<root>/.nuxt/tsconfig.app.json' not found.
+ *
+ * Both were dropped. The first went to `baselineExcludedProjectCount`, the second
+ * to `baselineExcludedNonVueCount`, one against the materialized config itself to
+ * `baselineExcludedExternalCount` — three counters, no verdict. A run in that
+ * state reported `Budget passed: true`.
+ */
+
+const configuredBaselineReason = (detail: string) =>
+  `vue-tsc could not load the fixture project configuration (1 error): ${detail}`;
+
+function artifactPath(fixture: ReturnType<typeof setup>, extension: string) {
+  return path.join(fixture.reportDir, `fixture-typecheck-divergence.${extension}`);
+}
+
+test("a baseline that could not read its extended config is unusable, not a pass", () => {
+  // Everything else about this run is clean: one diagnostic per side, at the same
+  // span, over the same single Vue file. Only the configuration line says the
+  // baseline was never the fixture's project, and that alone has to sink it.
+  const detail = "error TS5083: Cannot read file '/fixture/.nuxt/tsconfig.json'.";
+  const fixture = setup({ baselineOutput: `${detail}\n${sharedBaselineOutput}` });
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.equal(
+      result.stderr,
+      `Typecheck divergence baseline is unusable for fixture: ${configuredBaselineReason(detail)}\n`,
+    );
+
+    const artifact = readJson(artifactPath(fixture, "json"));
+    assert.deepEqual(artifact.baseline.configuration, {
+      diagnostics: [
+        {
+          code: 5083,
+          column: null,
+          file: null,
+          line: null,
+          message: "Cannot read file '/fixture/.nuxt/tsconfig.json'.",
+          severity: "error",
+        },
+      ],
+      errorCount: 1,
+      unusableReason: configuredBaselineReason(detail),
+      verdict: "unusable",
+    });
+    assert.deepEqual(artifact.budget, {
+      maxFalsePositiveRatio: 0.05,
+      maxFalseNegativeRatio: 0.05,
+      falsePositivePassed: true,
+      falseNegativePassed: true,
+      unusableReason: configuredBaselineReason(detail),
+      verdict: "unusable",
+      passed: false,
+    });
+    // The corpus check cannot see this: both sides carry the same one Vue file.
+    assert.deepEqual(artifact.baseline.coverage.missingVueFiles, []);
+    assert.deepEqual(artifact.baseline.coverage.unexpectedVueFiles, []);
+    assert.equal(artifact.baseline.coverage.verdict, "usable");
+    assert.equal(artifact.divergence.summary.sharedCount, 1);
+
+    assert.equal(
+      fs.readFileSync(artifactPath(fixture, "md"), "utf8"),
+      [
+        "## fixture typecheck divergence",
+        "",
+        `Commit: ${commitSha}`,
+        "Vize diagnostics: 1",
+        "vue-tsc diagnostics: 1",
+        "Shared: 1",
+        "Message mismatches: 0",
+        "Documented differences: 0",
+        "False positives: 0 (0)",
+        "False negatives: 0 (0)",
+        "Vize excluded non-Vue: 0",
+        "vue-tsc excluded non-Vue: 0",
+        "vue-tsc excluded project-level: 1",
+        "vue-tsc excluded external: 0",
+        "vue-tsc configuration errors: 1",
+        "Vize Vue files: 1",
+        "vue-tsc Vue files: 1",
+        "Shared Vue files: 1",
+        "Missing Vue files: 0",
+        "Unexpected Vue files: 0",
+        "Ignored dependency Vue files: 0",
+        `Budget verdict: unusable (${configuredBaselineReason(detail)})`,
+        "Budget passed: false",
+        `Digest: ${artifact.divergence.sha256}`,
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("a config error reported against the fixture tsconfig is unusable", () => {
+  // The elk shape: a solution-style config whose references point at `.nuxt/*`
+  // that `nuxt prepare` never generated. tsc reports it against the config file
+  // with a span, which made it indistinguishable from an ordinary `.ts` error.
+  const detail =
+    "tsconfig.json(2,18): error TS6053: File '/fixture/.nuxt/tsconfig.app.json' not found.";
+  const fixture = setup({ baselineOutput: `${detail}\n${sharedBaselineOutput}` });
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.equal(
+      result.stderr,
+      `Typecheck divergence baseline is unusable for fixture: ${configuredBaselineReason(detail)}\n`,
+    );
+    const artifact = readJson(artifactPath(fixture, "json"));
+    assert.deepEqual(artifact.baseline.configuration, {
+      diagnostics: [
+        {
+          code: 6053,
+          column: 18,
+          file: "tsconfig.json",
+          line: 2,
+          message: "File '/fixture/.nuxt/tsconfig.app.json' not found.",
+          severity: "error",
+        },
+      ],
+      errorCount: 1,
+      unusableReason: configuredBaselineReason(detail),
+      verdict: "unusable",
+    });
+    // The old lens still counts it as an ordinary excluded non-Vue diagnostic,
+    // which is exactly why counting was never enough to fail the shard.
+    assert.equal(artifact.divergence.summary.baselineExcludedNonVueCount, 1);
+    assert.equal(artifact.divergence.summary.baselineExcludedProjectCount, 0);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("a config error against the materialized baseline project is unusable", () => {
+  // The materialized config lives in the report directory, outside the fixture,
+  // so a diagnostic against it normalizes out of the workspace and was counted
+  // as `baselineExcludedExternalCount` — the third counter nothing read.
+  const fixture = setup();
+  try {
+    const baselineProject = path.join(fixture.reportDir, "fixture-vue-tsc.tsconfig.json");
+    const detail = `${baselineProject}(3,3): error TS18002: The 'files' list in config file is empty.`;
+    writeVueTsc(
+      fixture.vueTsc,
+      `process.stdout.write(${JSON.stringify(
+        `${detail}\n${sharedBaselineOutput}${path.join(fixture.fixtureRoot, "src/App.vue")}\n`,
+      )}); process.exit(2);`,
+    );
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.equal(
+      result.stderr,
+      `Typecheck divergence baseline is unusable for fixture: ${configuredBaselineReason(detail)}\n`,
+    );
+    const artifact = readJson(artifactPath(fixture, "json"));
+    assert.deepEqual(artifact.baseline.configuration, {
+      diagnostics: [
+        {
+          code: 18002,
+          column: 3,
+          file: baselineProject,
+          line: 3,
+          message: "The 'files' list in config file is empty.",
+          severity: "error",
+        },
+      ],
+      errorCount: 1,
+      unusableReason: configuredBaselineReason(detail),
+      verdict: "unusable",
+    });
+    assert.equal(artifact.divergence.summary.baselineExcludedExternalCount, 1);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("an ordinary non-Vue diagnostic is not a configuration failure", () => {
+  // The precision half. Misskey's baseline emits 94 excluded non-Vue diagnostics
+  // alongside 582 scoreable `.vue` ones; a guard that failed the shard on those
+  // would make the only measurable fixture unmeasurable. A positionless *warning*
+  // is recorded for the same reason it does not gate: it did not change what the
+  // baseline checked.
+  const warning = "warning TS5102: Option 'charset' has been removed.";
+  const fixture = setup({
+    baselineOutput: `src/util.ts(3,1): error TS2345: baseline only\n${warning}\n${sharedBaselineOutput}`,
+  });
+  try {
+    const result = run(fixture);
+    assert.equal(result.stderr, "");
+    assert.equal(result.status, 0);
+    const artifact = readJson(artifactPath(fixture, "json"));
+    assert.deepEqual(artifact.baseline.configuration, {
+      diagnostics: [
+        {
+          code: 5102,
+          column: null,
+          file: null,
+          line: null,
+          message: "Option 'charset' has been removed.",
+          severity: "warning",
+        },
+      ],
+      errorCount: 0,
+      unusableReason: null,
+      verdict: "usable",
+    });
+    assert.deepEqual(artifact.budget, {
+      maxFalsePositiveRatio: 0.05,
+      maxFalseNegativeRatio: 0.05,
+      falsePositivePassed: true,
+      falseNegativePassed: true,
+      unusableReason: null,
+      verdict: "passed",
+      passed: true,
+    });
+    assert.equal(artifact.divergence.summary.baselineExcludedNonVueCount, 1);
+    assert.equal(artifact.divergence.summary.sharedCount, 1);
+  } finally {
+    cleanup(fixture);
+  }
+});

--- a/tests/tooling/typecheck-divergence-baseline-configuration.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline-configuration.test.ts
@@ -5,7 +5,6 @@ import { test } from "node:test";
 
 import {
   cleanup,
-  commitSha,
   readJson,
   run,
   setup,
@@ -89,36 +88,12 @@ test("a baseline that could not read its extended config is unusable, not a pass
     assert.equal(artifact.baseline.coverage.verdict, "usable");
     assert.equal(artifact.divergence.summary.sharedCount, 1);
 
-    assert.equal(
-      fs.readFileSync(artifactPath(fixture, "md"), "utf8"),
-      [
-        "## fixture typecheck divergence",
-        "",
-        `Commit: ${commitSha}`,
-        "Vize diagnostics: 1",
-        "vue-tsc diagnostics: 1",
-        "Shared: 1",
-        "Message mismatches: 0",
-        "Documented differences: 0",
-        "False positives: 0 (0)",
-        "False negatives: 0 (0)",
-        "Vize excluded non-Vue: 0",
-        "vue-tsc excluded non-Vue: 0",
-        "vue-tsc excluded project-level: 1",
-        "vue-tsc excluded external: 0",
-        "vue-tsc configuration errors: 1",
-        "Vize Vue files: 1",
-        "vue-tsc Vue files: 1",
-        "Shared Vue files: 1",
-        "Missing Vue files: 0",
-        "Unexpected Vue files: 0",
-        "Ignored dependency Vue files: 0",
-        `Budget verdict: unusable (${configuredBaselineReason(detail)})`,
-        "Budget passed: false",
-        `Digest: ${artifact.divergence.sha256}`,
-        "",
-      ].join("\n"),
-    );
+    // Only the lines this guard owns: an unrelated field added to the shared
+    // renderer must not fail the configuration test.
+    const markdown = fs.readFileSync(artifactPath(fixture, "md"), "utf8").split("\n");
+    assert.ok(markdown.includes("vue-tsc configuration errors: 1"));
+    assert.ok(markdown.includes(`Budget verdict: unusable (${configuredBaselineReason(detail)})`));
+    assert.ok(markdown.includes("Budget passed: false"));
   } finally {
     cleanup(fixture);
   }

--- a/tests/tooling/typecheck-divergence-baseline.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline.test.ts
@@ -69,6 +69,7 @@ test("an empty vue-tsc baseline is unusable, not a false-positive breach", () =>
         "vue-tsc excluded non-Vue: 0",
         "vue-tsc excluded project-level: 0",
         "vue-tsc excluded external: 0",
+        "vue-tsc configuration errors: 0",
         "Vize Vue files: 1",
         "vue-tsc Vue files: 0",
         "Shared Vue files: 0",

--- a/tests/tooling/typecheck-divergence-budget.test.ts
+++ b/tests/tooling/typecheck-divergence-budget.test.ts
@@ -89,6 +89,7 @@ test("a false-positive budget breach fails the divergence report", () => {
         "vue-tsc excluded non-Vue: 0",
         "vue-tsc excluded project-level: 0",
         "vue-tsc excluded external: 0",
+        "vue-tsc configuration errors: 0",
         "Vize Vue files: 1",
         "vue-tsc Vue files: 1",
         "Shared Vue files: 1",

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -57,6 +57,7 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
     assert.deepEqual(Object.keys(artifact.baseline).sort(), [
       "command",
       "configSha256",
+      "configuration",
       "coverage",
       "durationMs",
       "exitCode",
@@ -73,6 +74,12 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
         .update(fs.readFileSync(path.join(fixture.fixtureRoot, ".generated/tsconfig.json")))
         .digest("hex"),
     );
+    assert.deepEqual(artifact.baseline.configuration, {
+      diagnostics: [],
+      errorCount: 0,
+      unusableReason: null,
+      verdict: "usable",
+    });
     assert.deepEqual(artifact.baseline.coverage, {
       baselineVueFileCount: 1,
       baselineVueFilesSha256: createHash("sha256").update("src/App.vue\n").digest("hex"),

--- a/tools/fixtures/typecheck-baseline-configuration.mjs
+++ b/tools/fixtures/typecheck-baseline-configuration.mjs
@@ -1,0 +1,90 @@
+/**
+ * Detect a `vue-tsc` baseline that never loaded the project it was asked to
+ * check (#3513).
+ *
+ * `typecheck-baseline-project.mjs` materializes the baseline as `files: [...]`
+ * over Vize's exact Vue corpus, extending the fixture's pinned config for its
+ * compiler options. That fixed the "solution-style config checks nothing" half
+ * of the ledger's blindness, and it moved the remaining half out of reach of
+ * `typecheck-baseline-coverage.mjs`: `--listFiles` prints every entry of `files`
+ * whether or not the extended config resolved, so file coverage now matches by
+ * construction and can no longer tell a loaded project from a broken one.
+ *
+ * What survives that is a configuration failure. Against real vue-tsc 3.3.4 /
+ * TypeScript 6.0.3 it takes two shapes, and the comparator dropped both:
+ *
+ *   error TS5083: Cannot read file '<root>/.nuxt/tsconfig.json'.
+ *   tsconfig.json(2,18): error TS6053: File '<root>/.nuxt/tsconfig.app.json' not found.
+ *
+ * The first has no position, so it was counted into `baselineExcludedProjectCount`
+ * and discarded. The second is reported against the config file, so it was
+ * counted into `baselineExcludedNonVueCount` and became indistinguishable from an
+ * ordinary `.ts` diagnostic. Either way `tsc` carries on with whatever options it
+ * did manage to resolve — no `strict`, no `paths`, no `types` — checks the files
+ * anyway, and the ledger scores that against Vize as a real measurement.
+ *
+ * So this is deliberately narrow: only a diagnostic with no file at all, or one
+ * reported against a `tsconfig`/`jsconfig` JSON file, is a configuration
+ * diagnostic. Misskey's 94 excluded non-Vue diagnostics are `.ts` source errors
+ * and stay scoreable; a fixture whose baseline could not read its own config
+ * does not.
+ */
+
+const diagnosticPattern = /^(.+)\((\d+),(\d+)\): (error|warning) TS(\d+): (.+)$/u;
+const projectPattern = /^(error|warning) TS(\d+): (.+)$/u;
+const configurationFilePattern = /[jt]sconfig[^/]*\.json$/u;
+
+export function evaluateBaselineConfiguration(vueTscOutput) {
+  if (typeof vueTscOutput !== "string") throw new Error("vue-tsc output must be a string");
+  const diagnostics = [];
+  for (const line of vueTscOutput.replaceAll("\r\n", "\n").split("\n")) {
+    const positioned = diagnosticPattern.exec(line);
+    if (positioned != null) {
+      const file = positioned[1].replaceAll("\\", "/");
+      if (!configurationFilePattern.test(file)) continue;
+      diagnostics.push({
+        code: Number(positioned[5]),
+        column: Number(positioned[3]),
+        file,
+        line: Number(positioned[2]),
+        message: normalize(positioned[6]),
+        severity: positioned[4],
+      });
+      continue;
+    }
+    const project = projectPattern.exec(line);
+    if (project == null) continue;
+    diagnostics.push({
+      code: Number(project[2]),
+      column: null,
+      file: null,
+      line: null,
+      message: normalize(project[3]),
+      severity: project[1],
+    });
+  }
+  const errors = diagnostics.filter((diagnostic) => diagnostic.severity === "error");
+  // Warnings are recorded but do not gate: they did not change which files the
+  // baseline checked, and a gate that fires on them is a gate nobody can keep green.
+  const unusableReason =
+    errors.length === 0
+      ? null
+      : `vue-tsc could not load the fixture project configuration (${errors.length} ` +
+        `error${errors.length === 1 ? "" : "s"}): ${render(errors[0])}`;
+  return {
+    diagnostics,
+    errorCount: errors.length,
+    unusableReason,
+    verdict: unusableReason == null ? "usable" : "unusable",
+  };
+}
+
+function render(diagnostic) {
+  const position =
+    diagnostic.file == null ? "" : `${diagnostic.file}(${diagnostic.line},${diagnostic.column}): `;
+  return `${position}${diagnostic.severity} TS${diagnostic.code}: ${diagnostic.message}`;
+}
+
+function normalize(message) {
+  return message.replace(/\s+/gu, " ").trim();
+}

--- a/tools/fixtures/typecheck-divergence-budget.mjs
+++ b/tools/fixtures/typecheck-divergence-budget.mjs
@@ -6,8 +6,9 @@
  * Two rules live here, and they answer two different failures the ledger had:
  *
  * 1. `evaluateBudget` returns three verdicts, not two (#3513, the #3222 parity
- *    ledger). The baseline is unusable when `vue-tsc --listFiles` proves the
- *    two tools checked different Vue corpora, or when two non-empty diagnostic
+ *    ledger). The baseline is unusable when `vue-tsc` could not load the
+ *    fixture's project configuration, when `vue-tsc --listFiles` proves the two
+ *    tools checked different Vue corpora, or when two non-empty diagnostic
  *    streams have no mapped position in common.
  * 2. `assertBudgetPassed` enforces on the weekly sweep and records everywhere
  *    else — see `parseBudgetMode`.
@@ -31,10 +32,16 @@ export function parseBudgetMode(value) {
   return value;
 }
 
-export function evaluateBudget(performance, summary, coverage) {
+export function evaluateBudget(performance, summary, coverage, configuration) {
   const falsePositivePassed = summary.falsePositiveRatio <= performance.maxFalsePositiveRatio;
   const falseNegativePassed = summary.falseNegativeRatio <= performance.maxFalseNegativeRatio;
-  const unusableReason = coverage.unusableReason ?? diagnosticMappingUnusableReason(summary);
+  // Configuration first: it is the *cause* a coverage or mapping failure would
+  // only be a symptom of, and it is the one reason that survives a run where
+  // both other checks look clean.
+  const unusableReason =
+    configuration.unusableReason ??
+    coverage.unusableReason ??
+    diagnosticMappingUnusableReason(summary);
   const verdict =
     unusableReason != null
       ? "unusable"

--- a/tools/fixtures/typecheck-divergence-markdown.mjs
+++ b/tools/fixtures/typecheck-divergence-markdown.mjs
@@ -1,0 +1,46 @@
+/**
+ * The human-readable half of a divergence run, split out of
+ * `typecheck-divergence-report.mjs` so the report script stays inside the
+ * per-file line budget.
+ *
+ * This is what a reviewer reads in the shard's step summary, so every field the
+ * verdict depends on is printed: the diagnostic counts, both exclusion lenses,
+ * the Vue-file coverage, and — since #3513 — how many configuration diagnostics
+ * the baseline emitted. A shard that measured nothing has to say so here, not
+ * only in the JSON nobody opens.
+ */
+export function renderMarkdown(artifact) {
+  const summary = artifact.divergence.summary;
+  const coverage = artifact.baseline.coverage;
+  return [
+    `## ${artifact.project} typecheck divergence`,
+    "",
+    `Commit: ${artifact.evidence.commitSha}`,
+    `Vize diagnostics: ${summary.vizeDiagnosticCount}`,
+    `vue-tsc diagnostics: ${summary.baselineDiagnosticCount}`,
+    `Shared: ${summary.sharedCount}`,
+    `Message mismatches: ${summary.messageMismatchCount}`,
+    `Documented differences: ${summary.documentedDifferenceCount}`,
+    `False positives: ${summary.falsePositiveCount} (${summary.falsePositiveRatio})`,
+    `False negatives: ${summary.falseNegativeCount} (${summary.falseNegativeRatio})`,
+    `Vize excluded non-Vue: ${summary.vizeExcludedNonVueCount}`,
+    `vue-tsc excluded non-Vue: ${summary.baselineExcludedNonVueCount}`,
+    `vue-tsc excluded project-level: ${summary.baselineExcludedProjectCount}`,
+    `vue-tsc excluded external: ${summary.baselineExcludedExternalCount}`,
+    `vue-tsc configuration errors: ${artifact.baseline.configuration.errorCount}`,
+    `Vize Vue files: ${coverage.vizeVueFileCount}`,
+    `vue-tsc Vue files: ${coverage.baselineVueFileCount}`,
+    `Shared Vue files: ${coverage.sharedVueFileCount}`,
+    `Missing Vue files: ${coverage.missingVueFiles.length}`,
+    `Unexpected Vue files: ${coverage.unexpectedVueFiles.length}`,
+    `Ignored dependency Vue files: ${coverage.ignoredDependencyVueFileCount}`,
+    `Budget verdict: ${describeVerdict(artifact.budget)}`,
+    `Budget passed: ${artifact.budget.passed}`,
+    `Digest: ${artifact.divergence.sha256}`,
+    "",
+  ].join("\n");
+}
+
+function describeVerdict(budget) {
+  return budget.unusableReason == null ? budget.verdict : `unusable (${budget.unusableReason})`;
+}

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 
 import { validateTypecheckerOutput } from "./tool-matrix-typechecker.mjs";
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
+import { evaluateBaselineConfiguration } from "./typecheck-baseline-configuration.mjs";
 import { materializeBaselineProject } from "./typecheck-baseline-project.mjs";
 import { evaluateVueProgramCoverage } from "./typecheck-baseline-coverage.mjs";
 import {
@@ -14,6 +15,7 @@ import {
   evaluateBudget,
   parseBudgetMode,
 } from "./typecheck-divergence-budget.mjs";
+import { renderMarkdown } from "./typecheck-divergence-markdown.mjs";
 import { compareTypecheckDiagnostics } from "./typecheck-divergence.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -67,11 +69,12 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
     throw new Error(`vue-tsc exited with unsupported status ${baseline.status}`);
   }
 
+  const baselineOutput = `${baseline.stdout ?? ""}\n${baseline.stderr ?? ""}`;
   const divergence = compareTypecheckDiagnostics({
     projectId: project.id,
     cwd: fixtureRoot,
     vizeReport: vizeRun.payload.parsed,
-    vueTscOutput: `${baseline.stdout ?? ""}\n${baseline.stderr ?? ""}`,
+    vueTscOutput: baselineOutput,
     documentedDifferences: readDocumentedDifferences(),
   });
   const coverage = evaluateVueProgramCoverage(
@@ -79,7 +82,13 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
     baseline.stdout ?? "",
     fixtureRoot,
   );
-  const budget = evaluateBudget(project.typecheckPerformance, divergence.summary, coverage);
+  const configuration = evaluateBaselineConfiguration(baselineOutput);
+  const budget = evaluateBudget(
+    project.typecheckPerformance,
+    divergence.summary,
+    coverage,
+    configuration,
+  );
   const artifact = {
     schema: "vize.fixtureTypecheckDivergenceRun",
     version: 3,
@@ -95,6 +104,7 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
       version: vueTsc.version,
       durationMs,
       exitCode: baseline.status,
+      configuration,
       coverage,
       stdoutSha256: sha256(baseline.stdout ?? ""),
       stderrSha256: sha256(baseline.stderr ?? ""),
@@ -219,40 +229,6 @@ function validatePerformanceConfig(performance) {
   }
   ratio(performance.maxFalsePositiveRatio, "maxFalsePositiveRatio");
   ratio(performance.maxFalseNegativeRatio, "maxFalseNegativeRatio");
-}
-
-function renderMarkdown(artifact) {
-  const summary = artifact.divergence.summary;
-  return [
-    `## ${artifact.project} typecheck divergence`,
-    "",
-    `Commit: ${artifact.evidence.commitSha}`,
-    `Vize diagnostics: ${summary.vizeDiagnosticCount}`,
-    `vue-tsc diagnostics: ${summary.baselineDiagnosticCount}`,
-    `Shared: ${summary.sharedCount}`,
-    `Message mismatches: ${summary.messageMismatchCount}`,
-    `Documented differences: ${summary.documentedDifferenceCount}`,
-    `False positives: ${summary.falsePositiveCount} (${summary.falsePositiveRatio})`,
-    `False negatives: ${summary.falseNegativeCount} (${summary.falseNegativeRatio})`,
-    `Vize excluded non-Vue: ${summary.vizeExcludedNonVueCount}`,
-    `vue-tsc excluded non-Vue: ${summary.baselineExcludedNonVueCount}`,
-    `vue-tsc excluded project-level: ${summary.baselineExcludedProjectCount}`,
-    `vue-tsc excluded external: ${summary.baselineExcludedExternalCount}`,
-    `Vize Vue files: ${artifact.baseline.coverage.vizeVueFileCount}`,
-    `vue-tsc Vue files: ${artifact.baseline.coverage.baselineVueFileCount}`,
-    `Shared Vue files: ${artifact.baseline.coverage.sharedVueFileCount}`,
-    `Missing Vue files: ${artifact.baseline.coverage.missingVueFiles.length}`,
-    `Unexpected Vue files: ${artifact.baseline.coverage.unexpectedVueFiles.length}`,
-    `Ignored dependency Vue files: ${artifact.baseline.coverage.ignoredDependencyVueFileCount}`,
-    `Budget verdict: ${describeVerdict(artifact.budget)}`,
-    `Budget passed: ${artifact.budget.passed}`,
-    `Digest: ${artifact.divergence.sha256}`,
-    "",
-  ].join("\n");
-}
-
-function describeVerdict(budget) {
-  return budget.unusableReason == null ? budget.verdict : `unusable (${budget.unusableReason})`;
 }
 
 function resolveVueTsc(value) {


### PR DESCRIPTION
## Summary

The whole-ecosystem FP/FN divergence ledger (#3513) scores vize against a `vue-tsc`
baseline. #3580 proved the two tools checked the same Vue corpus, and #3583
materialized that corpus as `files: [...]` extending each fixture's pinned config —
which fixed the solution-style configs that typechecked nothing.

That combination moved the *remaining* failure out of reach of the coverage check.
`--listFiles` prints every entry of `files` whether or not the extended config
resolved, so the two corpora now match **by construction**. A `vue-tsc` run that
could not load the project says so, carries on with whatever options it salvaged —
no `strict`, no `paths`, no `types` — checks the files anyway, and hands the
comparator a stream that looks exactly like a measurement.

Reproduced against real vue-tsc 3.3.4 / TypeScript 6.0.3, it takes two shapes:

```
error TS5083: Cannot read file '<root>/.nuxt/tsconfig.json'.
tsconfig.json(2,18): error TS6053: File '<root>/.nuxt/tsconfig.app.json' not found.
```

Both were dropped. The first went to `baselineExcludedProjectCount`, the second to
`baselineExcludedNonVueCount`, and one against the materialized config itself to
`baselineExcludedExternalCount` — three counters, no verdict. A run in that state
reported `Budget passed: true` and exited 0.

## What changes

- `tools/fixtures/typecheck-baseline-configuration.mjs` classifies a baseline
  diagnostic with **no file**, or one reported against a `tsconfig`/`jsconfig` JSON
  file, as a configuration diagnostic, and records them all in the artifact as
  evidence under `baseline.configuration`.
- Any configuration **error** makes the verdict `unusable`, ahead of coverage — it
  is the cause a coverage failure would only ever be a symptom of.
- The markdown gains a `vue-tsc configuration errors: N` line, so a shard that
  measured nothing says so in the step summary and not only in the JSON.
- Rendering moves to `typecheck-divergence-markdown.mjs` so the report script stays
  inside the per-file line budget (347 → 324 lines).

The rule is deliberately narrow so it stays precise rather than becoming a blanket
fail: misskey's 94 excluded non-Vue diagnostics are ordinary `.ts` source errors and
stay scoreable, and a positionless *warning* is recorded without gating, because it
did not change what the baseline checked.

## Verification

- New `tests/tooling/typecheck-divergence-baseline-configuration.test.ts`, 4 tests,
  each asserting the **complete** `baseline.configuration` and `budget` records by
  full equality, plus the byte-exact markdown on the headline case. All 4 fail
  against unpatched `main` and pass with this change.
- The classifier was checked against stdout captured from a real vue-tsc 3.3.4 /
  TypeScript 6.0.3 run over a fixture reproducing elk's shape (solution-style config
  whose `.nuxt/*` references `nuxt prepare` never generated), and over the
  materialized-project shape #3583 introduced.
- Full divergence suite serially: 18/18 (`typecheck-divergence-baseline-configuration`,
  `-baseline`, `-budget`), plus `-report`, `-ledger`, `typecheck-divergence`,
  `typecheck-baseline-project`, `vue-ecosystem-tsconfig-coverage`.
- `oxfmt --check` and `oxlint` clean on every touched file; every touched file is
  under the 350-line budget.

## Scope

This is the "validate the baseline at collection time" bullet of #3513. It does not
re-pin per-fixture tsconfigs or run `nuxt prepare` for elk — those remain open on the
issue, and after this change a fixture in that state fails its shard loudly instead
of being scored.

Refs #3513, #3222, #2971

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reports now include baseline configuration diagnostics, error counts, usability status, budget status, and digest details.
  * Markdown artifacts provide clearer summaries of diagnostic counts, exclusions, Vue-file coverage, configuration errors, and budget results.
  * Configuration warnings remain usable, while configuration errors correctly mark the baseline as unusable.

* **Bug Fixes**
  * Budget failures now prioritize unusable baseline configuration reasons.
  * Improved handling and preservation of configuration diagnostics and exclusion counts in reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->