### PR TITLE
test(typecheck): prepare generated baseline configs

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 3,
+  "schemaVersion": 4,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "projects": [
     {
@@ -334,6 +334,10 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "10.30.1",
         "lockfile": "pnpm-lock.yaml",
+        "baseline": {
+          "tsconfig": ".nuxt/tsconfig.app.json",
+          "prepare": ["pnpm", "exec", "nuxt", "prepare"]
+        },
         "hangTimeoutMs": 300000,
         "maxFalsePositiveRatio": 0.02,
         "maxFalseNegativeRatio": 0.02,

--- a/tests/tooling/fixture-tool-matrix-typecheck-target.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typecheck-target.test.ts
@@ -54,6 +54,38 @@ test("fixture tool matrix requires an exact baseline tsconfig for performance ta
     );
     assert.doesNotThrow(() =>
       validateTypecheckPerformanceTarget(
+        {
+          ...project,
+          typecheckPerformance: {
+            ...project.typecheckPerformance,
+            baseline: { tsconfig: project.tsconfig },
+          },
+        },
+        fixtureRoot,
+      ),
+    );
+    const generated = {
+      ...project,
+      typecheckPerformance: {
+        ...project.typecheckPerformance,
+        baseline: {
+          tsconfig: ".generated/tsconfig.json",
+          prepare: ["pnpm", "exec", "fixture", "prepare"],
+        },
+      },
+    };
+    assert.doesNotThrow(() => validateTypecheckPerformanceTarget(generated, fixtureRoot));
+    assert.throws(
+      () => validateTypecheckPerformanceTarget(generated, fixtureRoot, { requireBaseline: true }),
+      /baseline tsconfig does not exist/,
+    );
+    fs.mkdirSync(path.join(fixtureRoot, ".generated"));
+    fs.writeFileSync(path.join(fixtureRoot, ".generated/tsconfig.json"), "{}\n");
+    assert.doesNotThrow(() =>
+      validateTypecheckPerformanceTarget(generated, fixtureRoot, { requireBaseline: true }),
+    );
+    assert.doesNotThrow(() =>
+      validateTypecheckPerformanceTarget(
         { ...project, tsconfig: undefined, typecheckPerformance: { enabled: false } },
         fixtureRoot,
       ),
@@ -80,6 +112,16 @@ test("fixture tool matrix requires an exact baseline tsconfig for performance ta
           typecheckPerformance: { ...project.typecheckPerformance, lockfile: "yarn.lock" },
         },
         /lockfile must be pnpm-lock.yaml/,
+      ],
+      [
+        {
+          ...project,
+          typecheckPerformance: {
+            ...project.typecheckPerformance,
+            baseline: { tsconfig: "generated.json", prepare: ["npm", "run", "prepare"] },
+          },
+        },
+        /baseline prepare must be a pnpm command argument array/,
       ],
       [
         {

--- a/tests/tooling/typecheck-baseline-project.test.ts
+++ b/tests/tooling/typecheck-baseline-project.test.ts
@@ -52,6 +52,33 @@ test(
   },
 );
 
+test("materialized baseline extends an explicit generated project", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "vize-generated-baseline-project-"));
+  const fixtureRoot = path.join(temp, "fixture");
+  const reportDir = path.join(temp, "report");
+  fs.mkdirSync(path.join(fixtureRoot, ".generated"), { recursive: true });
+  fs.mkdirSync(path.join(fixtureRoot, "src"));
+  fs.mkdirSync(reportDir);
+  fs.writeFileSync(path.join(fixtureRoot, ".generated/tsconfig.json"), "{}\n");
+  fs.writeFileSync(path.join(fixtureRoot, "src/App.vue"), "<template />\n");
+  try {
+    const project = materializeBaselineProject(
+      fixtureRoot,
+      reportDir,
+      {
+        id: "fixture",
+        tsconfig: "tsconfig.json",
+        typecheckPerformance: { baseline: { tsconfig: ".generated/tsconfig.json" } },
+      },
+      { fileCount: 1, files: [{ file: "src/App.vue" }] },
+    );
+    assert.equal(project.sourceProject, ".generated/tsconfig.json");
+    assert.equal(JSON.parse(project.source).extends, "../fixture/.generated/tsconfig.json");
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
 function runVueTsc(project: string, cwd: string) {
   return spawnSync(vueTsc, ["--noEmit", "--pretty", "false", "--listFiles", "-p", project], {
     cwd,

--- a/tests/tooling/typecheck-dependency-prepare.test.ts
+++ b/tests/tooling/typecheck-dependency-prepare.test.ts
@@ -153,6 +153,7 @@ test("dependency prepare uses each pinned manager's immutable install command", 
       assert.equal(result.status, 0, result.stderr);
       const artifact = JSON.parse(fs.readFileSync(artifactPath(fixture), "utf8"));
       assert.deepEqual(Object.keys(artifact).sort(), [
+        "baselinePrepare",
         "evidence",
         "install",
         "lockfile",
@@ -163,6 +164,8 @@ test("dependency prepare uses each pinned manager's immutable install command", 
         "version",
       ]);
       assert.equal(artifact.schema, "vize.fixtureTypecheckDependencyInstall");
+      assert.equal(artifact.version, 2);
+      assert.equal(artifact.baselinePrepare, null);
       assert.equal(artifact.evidence.commitSha, commitSha);
       assert.deepEqual(artifact.packageManager, {
         name: packageManager.name,
@@ -200,6 +203,49 @@ test("dependency prepare rejects a mismatched detected package manager version",
     assert.match(result.stderr, /Detected pnpm version 9.0.0 does not match 10.0.0/);
     assert.equal(fs.existsSync(fixture.invocationPath), false);
     assert.equal(fs.existsSync(artifactPath(fixture)), false);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("dependency prepare materializes and records an explicit generated baseline config", () => {
+  const fixture = setup();
+  try {
+    const project = {
+      ...fixture.project,
+      typecheckPerformance: {
+        ...fixture.project.typecheckPerformance,
+        baseline: {
+          tsconfig: ".generated/tsconfig.json",
+          prepare: ["pnpm", "exec", "fixture", "prepare"],
+        },
+      },
+    };
+    writeJson(fixture.registryPath, { projects: [project] });
+    git(fixture.fixtureRoot, ["add", "registry.json"]);
+    git(fixture.fixtureRoot, ["commit", "-qm", "configure generated baseline"]);
+    writeManager(
+      fixture.manager,
+      fixture.invocationPath,
+      "10.0.0",
+      `if (process.argv[2] === "install") { ${successBody} } else process.exit(9);`,
+    );
+    const failed = run(fixture);
+    assert.equal(failed.status, 1);
+    assert.match(failed.stderr, /baseline prepare exited with status 9/);
+    writeManager(
+      fixture.manager,
+      fixture.invocationPath,
+      "10.0.0",
+      `if (process.argv[2] === "install") { ${successBody} } else { fs.mkdirSync(".generated", { recursive: true }); fs.writeFileSync(".generated/tsconfig.json", "{}\\n"); process.stdout.write("prepared"); }`,
+    );
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    const artifact = JSON.parse(fs.readFileSync(artifactPath(fixture), "utf8"));
+    assert.deepEqual(artifact.baselinePrepare.command, ["pnpm", "exec", "fixture", "prepare"]);
+    assert.equal(artifact.baselinePrepare.exitCode, 0);
+    assert.match(artifact.baselinePrepare.stdoutSha256, /^[0-9a-f]{64}$/);
+    assert.equal(fs.existsSync(path.join(fixture.fixtureRoot, ".generated/tsconfig.json")), true);
   } finally {
     cleanup(fixture);
   }

--- a/tests/tooling/typecheck-dependency-prepare.test.ts
+++ b/tests/tooling/typecheck-dependency-prepare.test.ts
@@ -70,15 +70,7 @@ function setup(packageManager: (typeof packageManagers)[number] = packageManager
   writeJson(registryPath, { projects: [project] });
   git(fixtureRoot, ["init", "-q"]);
   git(fixtureRoot, ["add", "."]);
-  git(fixtureRoot, [
-    "-c",
-    "user.name=Fixture",
-    "-c",
-    "user.email=fixture@example.com",
-    "commit",
-    "-qm",
-    "fixture",
-  ]);
+  commit(fixtureRoot, "fixture");
   const invocationPath = path.join(fakeDir, "invocation.json");
   const manager = path.join(fakeDir, packageManager.name);
   writeManager(manager, invocationPath, packageManager.version, successBody);
@@ -128,6 +120,19 @@ function run(fixture: ReturnType<typeof setup>, extraArgs: string[] = []) {
 function git(cwd: string, args: string[]) {
   const result = spawnSync("git", args, { cwd, encoding: "utf8" });
   assert.equal(result.status, 0, result.stderr);
+}
+
+// CI runners have no git identity, so every commit has to carry its own.
+function commit(cwd: string, message: string) {
+  git(cwd, [
+    "-c",
+    "user.name=Fixture",
+    "-c",
+    "user.email=fixture@example.com",
+    "commit",
+    "-qm",
+    message,
+  ]);
 }
 
 function artifactPath(fixture: ReturnType<typeof setup>) {
@@ -223,7 +228,7 @@ test("dependency prepare materializes and records an explicit generated baseline
     };
     writeJson(fixture.registryPath, { projects: [project] });
     git(fixture.fixtureRoot, ["add", "registry.json"]);
-    git(fixture.fixtureRoot, ["commit", "-qm", "configure generated baseline"]);
+    commit(fixture.fixtureRoot, "configure generated baseline");
     writeManager(
       fixture.manager,
       fixture.invocationPath,

--- a/tests/tooling/typecheck-divergence-baseline.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline.test.ts
@@ -74,6 +74,7 @@ test("an empty vue-tsc baseline is unusable, not a false-positive breach", () =>
         "Shared Vue files: 0",
         "Missing Vue files: 1",
         "Unexpected Vue files: 0",
+        "Ignored dependency Vue files: 0",
         `Budget verdict: unusable (${emptyBaselineReason})`,
         "Budget passed: false",
         `Digest: ${artifact.divergence.sha256}`,
@@ -216,6 +217,24 @@ test("same-sized but different Vue corpora are unusable", () => {
     const coverage = readJson(artifactPath(fixture, "json")).baseline.coverage;
     assert.deepEqual(coverage.missingVueFiles, ["src/App.vue"]);
     assert.deepEqual(coverage.unexpectedVueFiles, ["src/Other.vue"]);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("transitive Vue dependencies do not expand the authored fixture corpus", () => {
+  const fixture = setup({
+    baselineFiles: ["src/App.vue", "node_modules/pkg/RuntimeComponent.vue"],
+  });
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    const coverage = readJson(artifactPath(fixture, "json")).baseline.coverage;
+    assert.equal(coverage.verdict, "usable");
+    assert.equal(coverage.baselineVueFileCount, 1);
+    assert.equal(coverage.ignoredDependencyVueFileCount, 1);
+    assert.deepEqual(coverage.missingVueFiles, []);
+    assert.deepEqual(coverage.unexpectedVueFiles, []);
   } finally {
     cleanup(fixture);
   }

--- a/tests/tooling/typecheck-divergence-budget.test.ts
+++ b/tests/tooling/typecheck-divergence-budget.test.ts
@@ -94,6 +94,7 @@ test("a false-positive budget breach fails the divergence report", () => {
         "Shared Vue files: 1",
         "Missing Vue files: 0",
         "Unexpected Vue files: 0",
+        "Ignored dependency Vue files: 0",
         "Budget verdict: breached",
         "Budget passed: false",
         `Digest: ${artifact.divergence.sha256}`,

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -19,6 +19,18 @@ import {
 test("typecheck divergence report binds baseline evidence to the matrix artifact", () => {
   const fixture = setup();
   try {
+    fs.mkdirSync(path.join(fixture.fixtureRoot, ".generated"));
+    fs.writeFileSync(
+      path.join(fixture.fixtureRoot, ".generated/tsconfig.json"),
+      '{"compilerOptions":{"strict":true}}\n',
+    );
+    updateJson(
+      fixture.registryPath,
+      (registry) =>
+        (registry.projects[0].typecheckPerformance.baseline = {
+          tsconfig: ".generated/tsconfig.json",
+        }),
+    );
     const result = run(fixture);
     assert.equal(result.status, 0, result.stderr);
     const artifact = readJson(path.join(fixture.reportDir, "fixture-typecheck-divergence.json"));
@@ -35,14 +47,32 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
       "version",
     ]);
     assert.equal(artifact.schema, "vize.fixtureTypecheckDivergenceRun");
-    assert.equal(artifact.version, 2);
+    assert.equal(artifact.version, 3);
+    assert.equal(artifact.tsconfig, ".generated/tsconfig.json");
     assert.equal(artifact.evidence.commitSha, commitSha);
     assert.deepEqual(artifact.source, {
       payloadSha256: createHash("sha256").update(fs.readFileSync(fixture.outputPath)).digest("hex"),
       fileCount: 1,
     });
+    assert.deepEqual(Object.keys(artifact.baseline).sort(), [
+      "command",
+      "configSha256",
+      "coverage",
+      "durationMs",
+      "exitCode",
+      "sourceConfigSha256",
+      "stderrSha256",
+      "stdoutSha256",
+      "version",
+    ]);
     assert.equal(artifact.baseline.exitCode, 2);
     assert.equal(artifact.baseline.version, "3.3.4");
+    assert.equal(
+      artifact.baseline.sourceConfigSha256,
+      createHash("sha256")
+        .update(fs.readFileSync(path.join(fixture.fixtureRoot, ".generated/tsconfig.json")))
+        .digest("hex"),
+    );
     assert.deepEqual(artifact.baseline.coverage, {
       baselineVueFileCount: 1,
       baselineVueFilesSha256: createHash("sha256").update("src/App.vue\n").digest("hex"),
@@ -76,7 +106,7 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
     });
     assert.deepEqual(readJson(baselineProject), {
       extends: path
-        .relative(fixture.reportDir, path.join(fixture.fixtureRoot, "tsconfig.json"))
+        .relative(fixture.reportDir, path.join(fixture.fixtureRoot, ".generated/tsconfig.json"))
         .replaceAll("\\", "/"),
       files: [
         path

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -76,6 +76,8 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
     assert.deepEqual(artifact.baseline.coverage, {
       baselineVueFileCount: 1,
       baselineVueFilesSha256: createHash("sha256").update("src/App.vue\n").digest("hex"),
+      ignoredDependencyVueFileCount: 0,
+      ignoredDependencyVueFilesSha256: createHash("sha256").update("").digest("hex"),
       missingVueFiles: [],
       sharedVueFileCount: 1,
       unexpectedVueFiles: [],

--- a/tests/tooling/vue-ecosystem-fixtures.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures.test.ts
@@ -7,10 +7,8 @@ import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const registryPath = path.join(root, "tests", "_fixtures", "vue-ecosystem-fixtures.json");
-
 type FixtureKind = "application" | "component-library" | "library" | "tooling";
 type FixtureDiff = "e2e-vrt" | "curator-compare";
-
 interface FixtureProject {
   id: string;
   displayName: string;
@@ -18,10 +16,7 @@ interface FixtureProject {
   fixturePath: string;
   repository: string;
   revision: string;
-  license: {
-    spdx: string;
-    files: string[];
-  };
+  license: { spdx: string; files: string[] };
   vueGlobs: string[];
   expectedVueFileCount?: 0;
   tsconfig?: string;
@@ -33,6 +28,7 @@ interface FixtureProject {
     packageManager: "npm" | "pnpm" | "yarn";
     packageManagerVersion: string;
     lockfile: "pnpm-lock.yaml" | "yarn.lock";
+    baseline?: { tsconfig: string; prepare?: string[] };
     hangTimeoutMs: number;
     maxFalsePositiveRatio: number;
     maxFalseNegativeRatio: number;
@@ -168,7 +164,7 @@ test("Vue ecosystem registry covers the requested projects", () => {
   const registry = readRegistry();
   const ids = new Set(registry.projects.map((project) => project.id));
 
-  assert.equal(registry.schemaVersion, 3);
+  assert.equal(registry.schemaVersion, 4);
   for (const id of requestedFixtures) {
     assert.ok(ids.has(id), `${id} should be registered`);
   }
@@ -347,4 +343,8 @@ test("large typechecker fixtures have performance safeguards and bench wiring", 
     assert.ok((project?.typecheckPerformance?.maxFalseNegativeRatio ?? Infinity) <= 0.02);
     assert.match(benchCheck, new RegExp(`name:\\s*"${id}"`), `${id} should be in bench/check.ts`);
   }
+  const baseline = registry.projects.find((project) => project.id === "elk")?.typecheckPerformance
+    ?.baseline;
+  assert.equal(baseline?.tsconfig, ".nuxt/tsconfig.app.json");
+  assert.deepEqual(baseline?.prepare, ["pnpm", "exec", "nuxt", "prepare"]);
 });

--- a/tools/fixtures/tool-matrix-typecheck-target.mjs
+++ b/tools/fixtures/tool-matrix-typecheck-target.mjs
@@ -1,7 +1,11 @@
 import { statSync } from "node:fs";
 import { isAbsolute, resolve } from "node:path";
 
-export function validateTypecheckPerformanceTarget(project, fixtureRoot) {
+export function validateTypecheckPerformanceTarget(
+  project,
+  fixtureRoot,
+  { requireBaseline = false } = {},
+) {
   if (project.typecheckPerformance?.enabled !== true) return;
   if (project.typecheckPerformance.compareTo !== "vue-tsc") {
     invalid(project, "compareTo must be vue-tsc");
@@ -23,9 +27,40 @@ export function validateTypecheckPerformanceTarget(project, fixtureRoot) {
     invalid(project, `lockfile must be ${lockfiles[manager]} for ${manager}`);
   }
   requireFile(project, fixtureRoot, project.typecheckPerformance.lockfile, "lockfile");
+  const baseline = project.typecheckPerformance.baseline;
+  if (baseline == null) return;
+  requireRelativePath(project, baseline.tsconfig, "baseline tsconfig");
+  if (baseline.prepare == null) {
+    requireFile(project, fixtureRoot, baseline.tsconfig, "baseline tsconfig");
+    return;
+  }
+  if (requireBaseline) requireFile(project, fixtureRoot, baseline.tsconfig, "baseline tsconfig");
+  if (
+    !Array.isArray(baseline.prepare) ||
+    baseline.prepare.length < 2 ||
+    baseline.prepare[0] !== manager ||
+    baseline.prepare.some(
+      (argument) =>
+        typeof argument !== "string" || argument.length === 0 || argument.includes("\0"),
+    )
+  ) {
+    invalid(project, `baseline prepare must be a ${manager} command argument array`);
+  }
 }
 
 function requireFile(project, fixtureRoot, target, label) {
+  requireRelativePath(project, target, label);
+  const resolved = resolve(fixtureRoot, target);
+  let metadata;
+  try {
+    metadata = statSync(resolved);
+  } catch {
+    invalid(project, `${label} does not exist: ${target}`);
+  }
+  if (!metadata.isFile()) invalid(project, `${label} is not a file: ${target}`);
+}
+
+function requireRelativePath(project, target, label) {
   if (
     typeof target !== "string" ||
     target.length === 0 ||
@@ -37,14 +72,6 @@ function requireFile(project, fixtureRoot, target, label) {
   ) {
     invalid(project, `${label} must be a normalized relative path`);
   }
-  const resolved = resolve(fixtureRoot, target);
-  let metadata;
-  try {
-    metadata = statSync(resolved);
-  } catch {
-    invalid(project, `${label} does not exist: ${target}`);
-  }
-  if (!metadata.isFile()) invalid(project, `${label} is not a file: ${target}`);
 }
 
 function invalid(project, message) {

--- a/tools/fixtures/typecheck-baseline-coverage.mjs
+++ b/tools/fixtures/typecheck-baseline-coverage.mjs
@@ -12,7 +12,8 @@ export function evaluateVueProgramCoverage(vizeReport, vueTscOutput, cwd) {
     .slice(0, vizeReport.fileCount)
     .map((entry) => entry.file)
     .sort(byteOrder);
-  const baselineVueFiles = collectVueTscProgramFiles(vueTscOutput, cwd);
+  const { authoredFiles: baselineVueFiles, dependencyFiles: baselineDependencyVueFiles } =
+    collectVueTscProgramFiles(vueTscOutput, cwd);
   const vizeSet = new Set(vizeVueFiles);
   const baselineSet = new Set(baselineVueFiles);
   const missingVueFiles = vizeVueFiles.filter((file) => !baselineSet.has(file));
@@ -27,6 +28,8 @@ export function evaluateVueProgramCoverage(vizeReport, vueTscOutput, cwd) {
   return {
     baselineVueFileCount: baselineVueFiles.length,
     baselineVueFilesSha256: fileListHash(baselineVueFiles),
+    ignoredDependencyVueFileCount: baselineDependencyVueFiles.length,
+    ignoredDependencyVueFilesSha256: fileListHash(baselineDependencyVueFiles),
     missingVueFiles,
     sharedVueFileCount,
     unexpectedVueFiles,
@@ -39,6 +42,7 @@ export function evaluateVueProgramCoverage(vizeReport, vueTscOutput, cwd) {
 
 function collectVueTscProgramFiles(output, cwd) {
   const files = new Set();
+  const dependencyFiles = new Set();
   for (const rawLine of output.replaceAll("\r\n", "\n").split("\n")) {
     const line = rawLine.trimEnd();
     // `--listFiles` paths are absolute. Requiring that shape keeps diagnostic
@@ -53,9 +57,16 @@ function collectVueTscProgramFiles(output, cwd) {
     ) {
       continue;
     }
-    files.add(file);
+    if (file.split("/").includes("node_modules")) {
+      dependencyFiles.add(file);
+    } else {
+      files.add(file);
+    }
   }
-  return [...files].sort(byteOrder);
+  return {
+    authoredFiles: [...files].sort(byteOrder),
+    dependencyFiles: [...dependencyFiles].sort(byteOrder),
+  };
 }
 
 function fileListHash(files) {

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -11,8 +11,9 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 export function materializeBaselineProject(fixtureRoot, reportDir, project, vizeReport) {
   const outputPath = join(reportDir, `${project.id}-vue-tsc.tsconfig.json`);
   const configDir = dirname(outputPath);
+  const sourceProject = project.typecheckPerformance?.baseline?.tsconfig ?? project.tsconfig;
   const config = {
-    extends: configRelativePath(configDir, resolve(fixtureRoot, project.tsconfig)),
+    extends: configRelativePath(configDir, resolve(fixtureRoot, sourceProject)),
     files: vizeReport.files
       .slice(0, vizeReport.fileCount)
       .map((entry) => configRelativePath(configDir, resolve(fixtureRoot, entry.file))),
@@ -21,7 +22,7 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
   };
   const source = `${JSON.stringify(config, null, 2)}\n`;
   writeFileSync(outputPath, source);
-  return { path: outputPath, source };
+  return { path: outputPath, source, sourceProject };
 }
 
 function configRelativePath(from, to) {

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -76,9 +76,12 @@ export function runTypecheckDependencyPrepare(argv = process.argv.slice(2)) {
     throw new Error(`${manager} install modified frozen lockfile ${performance.lockfile}`);
   }
   requireCleanFixture(fixtureRoot, "after dependency installation");
+  const baselinePrepare = runBaselinePrepare(project, fixtureRoot, args.timeoutMs);
+  validateTypecheckPerformanceTarget(project, fixtureRoot, { requireBaseline: true });
+  requireCleanFixture(fixtureRoot, "after baseline preparation");
   const artifact = {
     schema: "vize.fixtureTypecheckDependencyInstall",
-    version: 1,
+    version: 2,
     project: project.id,
     revision: project.revision,
     evidence: {
@@ -98,11 +101,39 @@ export function runTypecheckDependencyPrepare(argv = process.argv.slice(2)) {
       stdoutSha256: sha256(install.stdout ?? ""),
       stderrSha256: sha256(install.stderr ?? ""),
     },
+    baselinePrepare,
   };
   const artifactPath = join(args.outputDir, `${project.id}-typecheck-dependencies.json`);
   writeFileSync(artifactPath, `${JSON.stringify(artifact, null, 2)}\n`);
   process.stdout.write(`Wrote ${relative(repoRoot, artifactPath)}\n`);
   return artifact;
+}
+
+function runBaselinePrepare(project, fixtureRoot, timeoutMs) {
+  const command = project.typecheckPerformance.baseline?.prepare;
+  if (command == null) return null;
+  const startedAt = Date.now();
+  const prepared = spawnSync(command[0], command.slice(1), {
+    cwd: fixtureRoot,
+    encoding: "utf8",
+    env: { ...process.env, CI: "true", NUXT_TELEMETRY_DISABLED: "1" },
+    maxBuffer: 1024 * 1024 * 1024,
+    timeout: timeoutMs,
+  });
+  const durationMs = Date.now() - startedAt;
+  if (prepared.error != null) {
+    throw new Error(`baseline prepare failed to run: ${errorMessage(prepared.error)}`);
+  }
+  if (prepared.status !== 0) {
+    throw new Error(`baseline prepare exited with status ${prepared.status}`);
+  }
+  return {
+    command,
+    durationMs,
+    exitCode: prepared.status,
+    stdoutSha256: sha256(prepared.stdout ?? ""),
+    stderrSha256: sha256(prepared.stderr ?? ""),
+  };
 }
 
 function installArguments(manager) {

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -243,6 +243,7 @@ function renderMarkdown(artifact) {
     `Shared Vue files: ${artifact.baseline.coverage.sharedVueFileCount}`,
     `Missing Vue files: ${artifact.baseline.coverage.missingVueFiles.length}`,
     `Unexpected Vue files: ${artifact.baseline.coverage.unexpectedVueFiles.length}`,
+    `Ignored dependency Vue files: ${artifact.baseline.coverage.ignoredDependencyVueFileCount}`,
     `Budget verdict: ${describeVerdict(artifact.budget)}`,
     `Budget passed: ${artifact.budget.passed}`,
     `Digest: ${artifact.divergence.sha256}`,

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -41,7 +41,7 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
   const project = selected[0];
   validatePerformanceConfig(project.typecheckPerformance);
   const fixtureRoot = resolve(repoRoot, project.fixturePath);
-  validateTypecheckPerformanceTarget(project, fixtureRoot);
+  validateTypecheckPerformanceTarget(project, fixtureRoot, { requireBaseline: true });
   const summary = readAndValidateSummary(args.reportDir, project);
   const vizeRun = readAndValidateVizeRun(args.reportDir, project, summary);
   const vueTsc = resolveVueTsc(args.vueTscBin);
@@ -82,15 +82,16 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
   const budget = evaluateBudget(project.typecheckPerformance, divergence.summary, coverage);
   const artifact = {
     schema: "vize.fixtureTypecheckDivergenceRun",
-    version: 2,
+    version: 3,
     project: project.id,
     revision: project.revision,
-    tsconfig: project.tsconfig,
+    tsconfig: baselineProject.sourceProject,
     evidence: summary.evidence,
     source: vizeRun.source,
     baseline: {
       command: displayCommand(vueTsc.path, baselineArgs),
       configSha256: sha256(baselineProject.source),
+      sourceConfigSha256: sha256(readFileSync(resolve(fixtureRoot, baselineProject.sourceProject))),
       version: vueTsc.version,
       durationMs,
       exitCode: baseline.status,


### PR DESCRIPTION
## Summary

- prepare generated Nuxt type configs before collecting the vue-tsc baseline
- fail closed on unpinned managers, failed preparation, missing configs, or tracked-source mutation
- compare only the authored fixture corpus while recording ignored dependency Vue files
- record generated-config provenance under fixture schema v4 and divergence artifact v3

## Verification

- focused Node tests: 19/19 for coverage/report plus 47/47 generated-config checks (1 expected unhydrated-fixture skip)
- `vp check` on every changed JS/TS file
- `git diff --check`
- independent exact-SHA review approved before the dependency-boundary follow-up
- [Real Project Matrix @ 41078b16b](https://github.com/ubugeeei-prod/vize/actions/runs/30676275965): all 11 baselines covered the exact authored Vue corpus; Elk is 253/253 with one hashed dependency Vue file ignored
- the enforced matrix now fails only on measured parity budgets or zero-overlap verdicts, not empty/mismatched file coverage

Closes #3513