### PR TITLE
fix(canon): anchor generic callback return errors

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
@@ -4,6 +4,7 @@ mod declaration_emit;
 mod emit_only;
 mod inherited_boolean;
 mod inline_callback_props;
+mod inline_callback_union_props;
 
 #[test]
 fn batch_type_checker_exposes_generic_props_inherited_from_pick() {

--- a/crates/vize_canon/src/batch/type_checker/tests/generic_props/inline_callback_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_props/inline_callback_props.rs
@@ -1,10 +1,10 @@
 //! Inline callback props on a generic child (#3446).
 //!
-//! A generic child's props come from its `__vizeCheck<T>(props)` call, so the
-//! per-prop alias resolves to `unknown` and an inline arrow annotated with it
-//! has no contextual type at all. Under `strict` that produced a `TS7006` on a
-//! parameter vue-tsc infers from the child's generic — a new error on correct
-//! code — while the real check still ran in the checker call.
+//! A generic child's static per-prop alias resolves to `unknown`; the generic
+//! type is instantiated only by its whole-props call. Inline arrows therefore
+//! need the child's resolver result for both contextual typing and the same
+//! leaf diagnostic anchor as vue-tsc. The callable fallback remains for
+//! components that do not expose that resolver.
 
 use super::super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
 use vize_carton::String;
@@ -21,11 +21,6 @@ use vize_carton::String;
 /// the `id` key of the offending object literal, which vize used to anchor one
 /// byte to the right.
 ///
-/// The line 6 assignability error itself is still anchored differently: vize
-/// reports the whole signature at the `pick` attribute name (column 32) where
-/// vue-tsc reports the leaf inside the arrow body (column 48). That is the one
-/// part of #3446 this does not close, and it needs the generic child's prop
-/// type to be resolved per prop rather than only inside the checker call.
 #[test]
 fn inline_callback_prop_on_a_generic_child_is_contextually_typed() {
     if resolve_test_tsgo_binary().is_none() {
@@ -70,10 +65,7 @@ import Child from './Child.vue'
             (
                 String::from("src/Parent.vue"),
                 Some(2322),
-                String::from(
-                    "6:32:error Type '(item: { id: number; }) => number' is not assignable to type '(item: { id: number; }) => string'.\n\
-                     Type 'number' is not assignable to type 'string'."
-                ),
+                String::from("6:48:error Type 'number' is not assignable to type 'string'."),
             ),
             (
                 String::from("src/Parent.vue"),
@@ -235,5 +227,83 @@ const jobs = [{ id: 1, timestamp: 2 }]
         snapshot,
         Vec::new(),
         "nested callbacks must keep the array prop type"
+    );
+}
+
+/// vue-tsc 3.3.4 with TypeScript 6.0.3 reports the three callback-body errors
+/// below verbatim. This covers the two scopes where the resolved prop type must
+/// remain local and a generic inferred only through its callback constraint.
+#[test]
+fn resolved_callback_props_match_vue_tsc_in_guarded_and_loop_scopes() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "generic-inline-callback-prop-scopes",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts" generic="T extends { id: number }">
+defineProps<{ items: T[]; pick: (item: T) => string }>()
+</script>
+
+<template><span /></template>
+"#,
+            ),
+            (
+                "src/CallbackOnly.vue",
+                r#"<script setup lang="ts" generic="T extends string = string">
+defineProps<{ transform: (item: T) => number }>()
+</script>
+
+<template><span /></template>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+import CallbackOnly from './CallbackOnly.vue'
+const visible = true
+const groups = [[{ id: 1 }]]
+</script>
+
+<template>
+  <Child v-if="visible" :items="[{ id: 1 }]" :pick="(item) => item.id" />
+  <Child v-for="group in groups" :key="group[0].id" :items="group" :pick="(item) => item.id" />
+  <CallbackOnly :transform="(item) => item.toUpperCase()" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else {
+        return;
+    };
+
+    assert_eq!(
+        snapshot,
+        // The snapshot helper sorts the rendered `line:column` strings, so
+        // double-digit line numbers precede line 9 here.
+        vec![
+            (
+                String::from("src/Parent.vue"),
+                Some(2322),
+                String::from("10:85:error Type 'number' is not assignable to type 'string'."),
+            ),
+            (
+                String::from("src/Parent.vue"),
+                Some(2322),
+                String::from("11:39:error Type 'string' is not assignable to type 'number'."),
+            ),
+            (
+                String::from("src/Parent.vue"),
+                Some(2322),
+                String::from("9:63:error Type 'number' is not assignable to type 'string'."),
+            ),
+        ]
     );
 }

--- a/crates/vize_canon/src/batch/type_checker/tests/generic_props/inline_callback_union_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_props/inline_callback_union_props.rs
@@ -1,0 +1,252 @@
+//! Generic union props with a callback key present in only one branch.
+
+use super::super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+use vize_carton::String;
+
+/// A non-distributive `keyof Props<T>` omits the branch-only `pick` key and
+/// silently falls back to the permissive callable type. The resolved branch's
+/// callback must retain Vize's ordinary leaf-level return check.
+#[test]
+fn resolved_callback_prop_distributes_over_union_branches() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "generic-inline-callback-union-props",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts" generic="T extends { id: number }">
+type Props<T> =
+  | { kind: 'pick'; items: T[]; pick: (item: T) => string }
+  | { kind: 'plain'; items: T[] }
+defineProps<Props<T>>()
+</script>
+
+<template><span /></template>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child kind="pick" :items="[{ id: 1 }]" :pick="(item) => item.id" />
+  <Child kind="plain" :items="[{ id: 1 }]" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else { return };
+
+    assert_eq!(
+        snapshot,
+        vec![(
+            String::from("src/Parent.vue"),
+            Some(2322),
+            String::from("6:60:error Type 'number' is not assignable to type 'string'."),
+        )]
+    );
+}
+
+/// The callback key exists in both branches, so the authored discriminant must
+/// select its matching signature instead of checking against their union.
+#[test]
+fn resolved_callback_prop_preserves_discriminated_union_correlation() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "generic-inline-callback-discriminated-union",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts" generic="T extends { id: number }">
+type Props<T> =
+  | { kind: 'text'; items: T[]; pick: (item: T) => string }
+  | { kind: 'count'; items: T[]; pick: (item: T) => number }
+defineProps<Props<T>>()
+</script>
+
+<template><span /></template>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child kind="text" :items="[{ id: 1 }]" :pick="(item) => item.id" />
+  <Child kind="count" :items="[{ id: 1 }]" :pick="(item) => item.id" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else { return };
+
+    assert_eq!(
+        snapshot,
+        vec![(
+            String::from("src/Parent.vue"),
+            Some(2322),
+            String::from("6:60:error Type 'number' is not assignable to type 'string'."),
+        )]
+    );
+}
+
+/// A declared `never` is a real prop type, not the missing-key sentinel. The
+/// mapped callback owner must preserve it and report the authored binding.
+#[test]
+fn resolved_callback_prop_preserves_declared_never() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "generic-inline-callback-never-prop",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts" generic="T">
+defineProps<{ value: T; pick: never }>()
+</script>
+
+<template><span /></template>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child :value="1" :pick="() => 1" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else { return };
+
+    assert_eq!(
+        snapshot,
+        vec![(
+            String::from("src/Parent.vue"),
+            Some(2322),
+            String::from("6:22:error Type '() => number' is not assignable to type 'never'."),
+        )]
+    );
+}
+
+/// Selecting a branch which does not declare the authored callback must not
+/// borrow the callback type from a different branch.
+#[test]
+fn resolved_callback_prop_rejects_a_key_missing_from_the_selected_branch() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "generic-inline-callback-missing-selected-key",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts" generic="T extends { id: number }">
+type Props<T> =
+  | { kind: 'pick'; items: T[]; pick: (item: T) => string }
+  | { kind: 'plain'; items: T[] }
+defineProps<Props<T>>()
+</script>
+
+<template><span /></template>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child kind="plain" :items="[{ id: 1 }]" :pick="() => 'x'" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else { return };
+
+    assert_eq!(
+        snapshot,
+        vec![(
+            String::from("src/Parent.vue"),
+            Some(2322),
+            String::from("6:45:error Type '() => string' is not assignable to type 'never'."),
+        )]
+    );
+}
+
+/// A sibling inference failure already has its own mapped owner. Branch
+/// selection must fall back to a callable context instead of adding TS7006 on
+/// the callback parameter or a second callback mismatch.
+#[test]
+fn failed_sibling_inference_does_not_cascade_into_the_callback() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "generic-inline-callback-failed-sibling-inference",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts" generic="T extends { id: number }">
+defineProps<{ items: T[]; pick: (item: T) => string }>()
+</script>
+
+<template><span /></template>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+
+<template>
+  <Child :items="[{ id: 'x' }]" :pick="(item) => String(item.id)" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else { return };
+
+    assert_eq!(
+        snapshot,
+        vec![(
+            String::from("src/Parent.vue"),
+            Some(2322),
+            String::from("6:21:error Type 'string' is not assignable to type 'number'."),
+        )]
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions.rs
@@ -3,6 +3,9 @@
 //! Handles generating TypeScript code for template expressions (with optional
 //! v-if narrowing) and component prop value type assertions.
 
+mod callback_prop_resolution;
+#[cfg(test)]
+mod callback_prop_resolution_tests;
 mod component_props;
 #[cfg(test)]
 mod component_props_tests;

--- a/crates/vize_canon/src/virtual_ts/expressions/callback_prop_resolution.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/callback_prop_resolution.rs
@@ -1,0 +1,154 @@
+//! Resolve a generic child's instantiated props before checking inline callbacks.
+
+use super::component_props::{
+    ComponentPropSource, collect_generated_class_bindings, is_checkable_prop,
+    merged_class_binding_value,
+};
+use super::prop_sources::{append_prop_value, generated_prop_value};
+use super::spread_reserved_props::rewrite_reserved_spread_references;
+use crate::virtual_ts::helpers::{to_safe_identifier, to_safe_identifier_fragment};
+use crate::virtual_ts::scope::is_inline_callback_prop;
+use vize_carton::{FxHashSet, String, append, cstr};
+use vize_croquis::croquis::ComponentUsage;
+
+pub(super) struct CallbackPropsResolution {
+    pub(super) resolved_props: String,
+    pub(super) selected_props: String,
+}
+
+/// Invoke the child's props resolver solely to capture its instantiated return
+/// type, retaining inference from every authored prop and spread. This call has
+/// no source mapping, so the mapped whole-props and per-prop checks below remain
+/// the only user-facing diagnostic owners.
+///
+/// A second constrained identity call erases only the callbacks and captures
+/// the authored sibling-prop literals. The mapped owner can therefore select a
+/// discriminated-union branch after generic inference without letting an
+/// invalid callback choose a different branch or emit a coarse duplicate.
+pub(super) fn generate_callback_props_resolution(
+    ts: &mut String,
+    usage: &ComponentUsage,
+    idx: usize,
+    template_prop_names: &FxHashSet<String>,
+    source_context: ComponentPropSource<'_>,
+    indent: &str,
+) -> Option<CallbackPropsResolution> {
+    if !usage.props.iter().any(is_inline_callback_prop) {
+        return None;
+    }
+
+    let component_ref = to_safe_identifier(usage.name.as_str());
+    let component_type_name = to_safe_identifier_fragment(usage.name.as_str());
+    let resolved_props = cstr!("__vize_resolved_{component_type_name}_props_{idx}");
+    let selected_props = cstr!("__vize_selected_{component_type_name}_props_{idx}");
+    let expr_indent = String::from(indent);
+
+    append!(
+        *ts,
+        "{expr_indent}const {resolved_props} = (undefined as unknown as __VizePropsResolver<typeof {component_ref}>)({{\n",
+    );
+
+    append_props_object(
+        ts,
+        usage,
+        template_prop_names,
+        source_context,
+        expr_indent.as_str(),
+        false,
+    );
+    append!(*ts, "{expr_indent}}});\n");
+    append!(
+        *ts,
+        "{expr_indent}const {selected_props} = (undefined as unknown as __VizePropsSelector<typeof {resolved_props}>)({{\n",
+    );
+    append_props_object(
+        ts,
+        usage,
+        template_prop_names,
+        source_context,
+        expr_indent.as_str(),
+        true,
+    );
+    append!(*ts, "{expr_indent}}});\n");
+    Some(CallbackPropsResolution {
+        resolved_props,
+        selected_props,
+    })
+}
+
+fn append_props_object(
+    ts: &mut String,
+    usage: &ComponentUsage,
+    template_prop_names: &FxHashSet<String>,
+    source_context: ComponentPropSource<'_>,
+    expr_indent: &str,
+    erase_callbacks: bool,
+) {
+    let class_bindings = collect_generated_class_bindings(usage, template_prop_names);
+    let merge_class_bindings = class_bindings.len() > 1;
+    let mut emitted_merged_class = false;
+    let mut spreads = usage.spread_props.iter().peekable();
+    for prop in &usage.props {
+        if !is_checkable_prop(prop) {
+            continue;
+        }
+        while let Some(spread) = spreads.next_if(|spread| spread.start < prop.start) {
+            append!(*ts, "{expr_indent}  ...");
+            append_spread_value(
+                ts,
+                usage,
+                spread.expression.as_str(),
+                template_prop_names,
+                source_context,
+            );
+            ts.push_str(",\n");
+        }
+        let value = if merge_class_bindings && prop.name.as_str() == "class" {
+            if emitted_merged_class {
+                continue;
+            }
+            emitted_merged_class = true;
+            merged_class_binding_value(&class_bindings)
+        } else {
+            generated_prop_value(prop, template_prop_names)
+        };
+        let Some(mut value) = value else { continue };
+        if erase_callbacks && is_inline_callback_prop(prop) {
+            value = String::from("undefined as any");
+        }
+        let name = super::super::helpers::to_camel_case(prop.name.as_str());
+        append!(*ts, "{expr_indent}  \"{name}\": ");
+        append_prop_value(ts, value.as_str());
+        ts.push_str(",\n");
+    }
+    for spread in spreads {
+        append!(*ts, "{expr_indent}  ...");
+        append_spread_value(
+            ts,
+            usage,
+            spread.expression.as_str(),
+            template_prop_names,
+            source_context,
+        );
+        ts.push_str(",\n");
+    }
+}
+
+fn append_spread_value(
+    ts: &mut String,
+    usage: &ComponentUsage,
+    expression: &str,
+    template_prop_names: &FxHashSet<String>,
+    source_context: ComponentPropSource<'_>,
+) {
+    if let Some(rewritten) = rewrite_reserved_spread_references(
+        expression,
+        template_prop_names,
+        source_context.scopes,
+        usage.scope_id,
+    ) {
+        append_prop_value(ts, rewritten.code.as_str());
+    } else {
+        append_prop_value(ts, expression);
+    }
+}

--- a/crates/vize_canon/src/virtual_ts/expressions/callback_prop_resolution_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/callback_prop_resolution_tests.rs
@@ -1,0 +1,73 @@
+use vize_croquis::{Analyzer, AnalyzerOptions};
+
+use crate::virtual_ts::generate_virtual_ts;
+
+#[test]
+fn callback_resolution_keeps_inference_and_branch_selection_separate() {
+    let script = r#"import Child from "./Child.vue"
+"#;
+    let callback = "(item) => item.id";
+    let template = r#"<Child kind="text" :items="[{ id: 1 }]" :pick="(item) => item.id" />"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+    assert!(
+        output.code.contains(
+            "const __vize_resolved_Child_props_0 = (undefined as unknown as __VizePropsResolver<typeof Child>)({"
+        ),
+        "inference resolver must keep the authored callback:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains(
+            "const __vize_selected_Child_props_0 = (undefined as unknown as __VizePropsSelector<typeof __vize_resolved_Child_props_0>)({"
+        ),
+        "selector must be constrained by the inferred props union:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains(
+            "__VizeResolvedProp<typeof __vize_resolved_Child_props_0, typeof __vize_selected_Child_props_0, 'pick'"
+        ),
+        "mapped owner must use both inference and selected-branch types:\n{}",
+        output.code
+    );
+    assert_eq!(
+        output.code.matches(callback).count(),
+        2,
+        "only the inference call and mapped owner keep the callback"
+    );
+    assert_eq!(
+        output.code.matches(r#""pick": undefined as any"#).count(),
+        2,
+        "the selector and whole-props checker must erase the callback"
+    );
+    assert!(
+        output
+            .code
+            .contains("type __VizeMissingProp = { readonly __vizeMissingProp: unique symbol };")
+            && output
+                .code
+                .contains("K extends keyof R ? { value: R[K] } : __VizeMissingProp"),
+        "present `never` must remain distinguishable from a missing key"
+    );
+
+    let callback_start = template.find(callback).expect("callback present");
+    let callback_range = callback_start..callback_start + callback.len();
+    assert_eq!(
+        output
+            .mappings
+            .iter()
+            .flat_map(|mapping| &mapping.sub_spans)
+            .filter(|span| span.src_range == callback_range)
+            .count(),
+        1,
+        "the mapped per-prop owner must remain the sole diagnostic owner"
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/component_props.rs
@@ -90,6 +90,31 @@ pub(crate) fn generate_component_prop_checks(
     indent: &str,
 ) {
     let component_type_name = to_safe_identifier_fragment(usage.name.as_str());
+    let has_inline_callback = usage
+        .props
+        .iter()
+        .any(crate::virtual_ts::scope::is_inline_callback_prop);
+    let grouped_guard = has_inline_callback && usage.vif_guard.is_some();
+    if grouped_guard {
+        append!(
+            *ts,
+            "{indent}if ({}) {{\n",
+            usage.vif_guard.as_deref().unwrap()
+        );
+    }
+    let callback_indent = if grouped_guard {
+        cstr!("{indent}  ")
+    } else {
+        String::from(indent)
+    };
+    let resolved_props = super::callback_prop_resolution::generate_callback_props_resolution(
+        ts,
+        usage,
+        idx,
+        template_prop_names,
+        source_context,
+        callback_indent.as_str(),
+    );
     let mut name_occurrences: FxHashMap<String, u32> = FxHashMap::default();
     for prop in &usage.props {
         if !is_checkable_prop(prop) {
@@ -118,7 +143,7 @@ pub(crate) fn generate_component_prop_checks(
                 indent.into()
             };
 
-            if let Some(ref guard) = usage.vif_guard {
+            if !grouped_guard && let Some(ref guard) = usage.vif_guard {
                 append!(*ts, "{indent}if ({guard}) {{\n");
             }
 
@@ -139,10 +164,22 @@ pub(crate) fn generate_component_prop_checks(
             let check_name_start = ts.len();
             ts.push_str(check_name.as_str());
             let check_name_end = ts.len();
-            append!(
-                *ts,
-                ": __{component_type_name}_{idx}_prop_{safe_prop_name} = ",
-            );
+            if crate::virtual_ts::scope::is_inline_callback_prop(prop)
+                && let Some(resolution) = resolved_props.as_ref()
+            {
+                let camel_prop_name = super::super::helpers::to_camel_case(prop.name.as_str());
+                let resolved_props = resolution.resolved_props.as_str();
+                let selected_props = resolution.selected_props.as_str();
+                append!(
+                    *ts,
+                    ": __VizeResolvedProp<typeof {resolved_props}, typeof {selected_props}, '{camel_prop_name}', __{component_type_name}_{idx}_prop_{safe_prop_name}> = ",
+                );
+            } else {
+                append!(
+                    *ts,
+                    ": __{component_type_name}_{idx}_prop_{safe_prop_name} = ",
+                );
+            }
             let value_gen_range = append_prop_value(ts, generated_value.as_str());
             ts.push_str(";\n");
             let gen_stmt_end = ts.len();
@@ -172,10 +209,13 @@ pub(crate) fn generate_component_prop_checks(
                 sub_spans,
             });
 
-            if usage.vif_guard.is_some() {
+            if !grouped_guard && usage.vif_guard.is_some() {
                 append!(*ts, "{indent}}}\n");
             }
         }
+    }
+    if grouped_guard {
+        append!(*ts, "{indent}}}\n");
     }
 
     super::generic_props_call::generate_generic_props_call(

--- a/crates/vize_canon/src/virtual_ts/expressions/generic_props_call.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/generic_props_call.rs
@@ -31,6 +31,11 @@ use vize_croquis::{
 /// call reports nothing and the well-tested per-prop extraction above is the
 /// sole check. Each property value is mapped back to its source attribute so a
 /// `TS2322` from a wrongly-typed prop points at the offending binding.
+///
+/// Direct inline callbacks are the exception: their authored expression is
+/// checked separately against the resolver's instantiated prop type. This call
+/// receives `any` for that one entry so it keeps whole-object/required-prop
+/// validation without also reporting a coarse property-key error.
 pub(super) fn generate_generic_props_call(
     ts: &mut String,
     mappings: &mut Vec<VizeMapping>,
@@ -108,9 +113,15 @@ pub(super) fn generate_generic_props_call(
         } else {
             generated_prop_value(prop, template_prop_names)
         };
-        let Some(generated_value) = generated_value else {
+        let Some(mut generated_value) = generated_value else {
             continue;
         };
+        let inline_callback = crate::virtual_ts::scope::is_inline_callback_prop(prop);
+        if inline_callback {
+            // The authored callback is emitted by `callback_prop_resolution`
+            // for inference and by the mapped per-prop check for diagnostics.
+            generated_value = String::from("undefined as any");
+        }
 
         let (prop_src_start, prop_src_end) =
             if merge_class_bindings && prop.name.as_str() == "class" {
@@ -153,9 +164,19 @@ pub(super) fn generate_generic_props_call(
         // error inside the value (TypeScript anchors a nested object-literal
         // mismatch at the offending key) landed one byte to the right of where
         // vue-tsc puts it (#3446). Mapping the key and the value separately
-        // makes the value range verbatim, so offsets inside it are exact.
+        // makes the value range verbatim, so offsets inside it are exact. An
+        // inline callback has a synthetic `any` value here, so only its key is
+        // mapped; the separately emitted authored callback owns its value span.
         let sub_spans = match merge_class_bindings && prop.name.as_str() == "class" {
             true => Vec::new(),
+            false if inline_callback => {
+                prop_name_source_range(source_context, prop).map_or_else(Vec::new, |src_range| {
+                    vec![VizeSubSpan {
+                        gen_range: entry_gen_start..key_gen_end,
+                        src_range,
+                    }]
+                })
+            }
             false => entry_sub_spans(
                 source_context,
                 prop,

--- a/crates/vize_canon/src/virtual_ts/expressions/sequence_prop_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/sequence_prop_tests.rs
@@ -20,7 +20,8 @@ fn sequence_prop_values_are_grouped_without_mapping_synthetic_parentheses() {
     assert!(
         output
             .code
-            .contains("__Child_0_prop_transform = (void 0, (value) => value);"),
+            .contains("__vize_prop_check_0_transform: __VizeResolvedProp<")
+            && output.code.contains(" = (void 0, (value) => value);"),
         "per-prop initializer must group the sequence expression:\n{}",
         output.code
     );
@@ -42,8 +43,8 @@ fn sequence_prop_values_are_grouped_without_mapping_synthetic_parentheses() {
         .collect();
     assert_eq!(
         value_spans.len(),
-        2,
-        "both prop-check boundaries must map the authored expression"
+        1,
+        "the resolved per-prop check must own the authored expression mapping"
     );
     for span in value_spans {
         assert_eq!(

--- a/crates/vize_canon/src/virtual_ts/scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope.rs
@@ -23,5 +23,6 @@ mod inline_callback_classifier;
 mod vif_guard;
 
 pub(crate) use closures::generate_scope_closures;
+pub(crate) use component_prop_checker::is_inline_callback_prop;
 pub(crate) use context::ScopeGenerationOptions;
 pub(crate) use vif_guard::remove_enclosing_vif_guard_prefix;

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
@@ -10,7 +10,7 @@ use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier_fragment};
 /// The name filters mirror [`append_per_prop_aliases`] exactly, because the two
 /// must agree: emitting the helper for a prop the alias loop then skips leaves
 /// it unreferenced, which is `TS6196` on a clean SFC.
-pub(super) fn is_inline_callback_prop(prop: &PassedProp) -> bool {
+pub(crate) fn is_inline_callback_prop(prop: &PassedProp) -> bool {
     if prop.name_is_dynamic || prop.name.as_str() == "key" || prop.name.as_str() == "ref" {
         return false;
     }
@@ -240,8 +240,8 @@ pub(super) fn append_prop_check_helpers(ts: &mut String, usages: &[(usize, &Comp
         );
     }
     // Emitted only when a usage actually binds an inline callback, because
-    // nothing else references it and an unreferenced alias is `TS6196:
-    // '__VizeCallableProp' is declared but never used`. That reaches
+    // nothing else references these aliases and an unreferenced one is
+    // `TS6196`. That reaches
     // check-server clients as an unmapped hint on an otherwise clean SFC, the
     // same way the native element aliases did before #3443. The ambient
     // `declare function` trick those use is not available here: these helpers
@@ -252,11 +252,13 @@ pub(super) fn append_prop_check_helpers(ts: &mut String, usages: &[(usize, &Comp
     // resolves to `unknown`. An inline callback prop annotated `unknown` has
     // no contextual type, so `strict` reports TS7006 on parameters that are
     // in fact contextually typed by the checker call below — a new error on
-    // correct code (#3446). Falling back to a permissive callable gives
-    // those parameters a contextual `any` and reports nothing itself. `any`
-    // is excluded so a genuinely `any` prop stays assignable from a
-    // non-function value, and a resolved prop type is returned untouched so
-    // a real mismatch on a non-generic child still surfaces.
+    // correct code (#3446). `__VizeCallableProp` remains the safe fallback for
+    // components without Vize's resolver. A generic Vize child is invoked once
+    // through `__VizePropsResolver`; `__VizeResolvedProp` then selects the
+    // instantiated callback type so return errors surface inside the authored
+    // body, at the same leaf byte as vue-tsc. `any` is excluded from the
+    // fallback so a genuinely `any` prop stays assignable from a non-function
+    // value, and a resolved non-generic prop type is returned untouched.
     if usages
         .iter()
         .any(|(_, usage)| usage.props.iter().any(is_inline_callback_prop))
@@ -264,15 +266,31 @@ pub(super) fn append_prop_check_helpers(ts: &mut String, usages: &[(usize, &Comp
         ts.push_str(
             "  type __VizeCallableProp<T> = __VizeIsAny<T> extends true ? T : unknown extends T ? (...args: any[]) => any : T;\n",
         );
+        ts.push_str(
+            "  type __VizePropsResolver<C> = C extends { __vizeResolveProps?: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: any) => {}) : (props: any) => {};\n",
+        );
+        ts.push_str(
+            "  type __VizePropsSelector<R> = <A extends Partial<R> & Record<string, unknown>>(props: A) => A;\n",
+        );
+        ts.push_str("  type __VizeMissingProp = { readonly __vizeMissingProp: unique symbol };\n");
+        ts.push_str(
+            "  type __VizeResolvedPropEntry<R, K extends PropertyKey> = R extends unknown ? K extends keyof R ? { value: R[K] } : __VizeMissingProp : never;\n",
+        );
+        ts.push_str(
+            "  type __VizeSelectedProps<R, A> = R extends unknown ? A extends Partial<R> ? R : never : never;\n",
+        );
+        ts.push_str(
+            "  type __VizeResolvedProp<R, A, K extends PropertyKey, F, __S = __VizeSelectedProps<R, A>, __E = __VizeResolvedPropEntry<__S, K>, __A = __VizeResolvedPropEntry<R, K>, __P = Extract<__E, { value: unknown }>> = [__S] extends [never] ? F : [__P] extends [never] ? [Extract<__A, { value: unknown }>] extends [never] ? F : never : __P extends { value: infer V } ? V : never;\n",
+        );
     }
 }
 
 /// The type a per-prop check is annotated with.
 ///
-/// An inline callback prop gets the `__VizeCallableProp` fallback so a generic
-/// child — whose per-prop type resolves to `unknown`, its props coming from the
-/// `__vizeCheck<T>(props)` call instead — still contextually types the
-/// callback's parameters (#3446). Every other prop keeps the resolved type.
+/// An inline callback prop gets the `__VizeCallableProp` fallback for a child
+/// without `__vizeResolveProps`. Vize generic children replace it at the value
+/// check with their instantiated resolver result. Every other prop keeps the
+/// statically extracted type.
 pub(super) fn prop_alias_type(
     prop: &PassedProp,
     component_type_name: &str,


### PR DESCRIPTION
## Summary

- distinguish missing generic prop keys from present `never` callback props
- preserve discriminant-to-callback correlation for mapped owning checks
- reject branch-only callback keys while suppressing contextual-typing cascades

## Verification

- real-tsgo focused regressions: 12/12
- Canon unit tests: 753/753
- workspace clippy with warnings denied
- `cargo fmt --all -- --check`
- `git diff --check`
- independent exact-SHA review approved

Closes #3446

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type checking for inline callback props on generic components.
  * Added more accurate contextual typing within conditional and loop scopes.
  * Improved validation across union branches, including discriminated unions and `never` properties.
  * Prevented duplicate or cascading callback diagnostics when related prop inference fails.
  * Updated diagnostics and source mappings for clearer, more precise error locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->