### PR TITLE
test(canon): pin resolved callback props under a narrowing guard

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_props.rs
@@ -3,6 +3,7 @@ use super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diag
 mod declaration_emit;
 mod emit_only;
 mod inherited_boolean;
+mod inline_callback_guarded_props;
 mod inline_callback_props;
 mod inline_callback_union_props;
 

--- a/crates/vize_canon/src/batch/type_checker/tests/generic_props/inline_callback_guarded_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/generic_props/inline_callback_guarded_props.rs
@@ -1,0 +1,111 @@
+//! The resolved-props binding under a narrowing `v-if`, and under
+//! `noUnusedLocals` (#3446, #3590).
+//!
+//! `inline_callback_props` already pins the callback anchors in a guarded and a
+//! looped scope, but leaves two properties of the resolution untested:
+//!
+//! * its guard is `v-if="visible"` over a `const visible = true`, so no checked
+//!   value's type depends on the guard holding. `generate_component_prop_checks`
+//!   groups the resolver call and the per-prop checks into one `if (guard)`
+//!   block precisely so that a sibling prop narrowed by the guard keeps its
+//!   narrowed type in both — `rows` here is `{ id: number }[] | null`, and an
+//!   empty diagnostic for `:items="rows"` is what shows the grouping held;
+//! * every local the resolution emits — the resolved and selected bindings, and
+//!   the `__VizePropsResolver`/`__VizePropsSelector`/`__VizeResolvedProp`
+//!   aliases — is read only through `typeof`. If one ever stops being read,
+//!   `noUnusedLocals` turns it into a `TS6133`/`TS6196` on a clean SFC, which
+//!   reaches check-server clients as an unmapped hint the same way the native
+//!   element aliases did before #3443. No other test checks the prop-check path
+//!   with that option on.
+
+use super::super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+use vize_carton::String;
+
+/// vue-tsc 3.3.4 with TypeScript 6.0.3, on this fixture and this tsconfig:
+///
+/// ```text
+/// src/Parent.vue(9,53): error TS2322: Type 'number' is not assignable to type 'string'.
+/// src/Parent.vue(10,85): error TS2322: Type 'number' is not assignable to type 'string'.
+/// src/Parent.vue(11,39): error TS2322: Type 'string' is not assignable to type 'number'.
+/// ```
+///
+/// Line 9 column 53 is the `item` of `item.id` inside the guarded usage's
+/// callback. Nothing is reported for `:items="rows"` on that line, because the
+/// `v-if` narrows `rows` away from `null` — so an equal list also proves the
+/// resolution reads the narrowed type. The list is asserted whole under
+/// `noUnusedLocals`, so an unread generated local fails here too.
+#[test]
+fn a_narrowing_guard_keeps_resolved_callback_props_and_leaves_no_unused_locals() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "generic-inline-callback-prop-narrowing-guard",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts" generic="T extends { id: number }">
+defineProps<{ items: T[]; pick: (item: T) => string }>()
+</script>
+
+<template><span /></template>
+"#,
+            ),
+            (
+                "src/CallbackOnly.vue",
+                r#"<script setup lang="ts" generic="T extends string = string">
+defineProps<{ transform: (item: T) => number }>()
+</script>
+
+<template><span /></template>
+"#,
+            ),
+            (
+                "src/Parent.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+import CallbackOnly from './CallbackOnly.vue'
+const groups = [[{ id: 1 }]]
+const rows = Math.random() > 0.5 ? [{ id: 1 }] : null
+</script>
+
+<template>
+  <Child v-if="rows" :items="rows" :pick="(item) => item.id" />
+  <Child v-for="group in groups" :key="group[0].id" :items="group" :pick="(item) => item.id" />
+  <CallbackOnly :transform="(item) => item.toUpperCase()" />
+</template>
+"#,
+            ),
+        ],
+    );
+    super::super::no_unused::write_no_unused_tsconfig(&project_root);
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let Some(snapshot) = snapshot else {
+        return;
+    };
+
+    assert_eq!(
+        snapshot,
+        // The helper sorts the rendered `line:column` strings, so the
+        // double-digit line numbers come before line 9.
+        vec![
+            (
+                String::from("src/Parent.vue"),
+                Some(2322),
+                String::from("10:85:error Type 'number' is not assignable to type 'string'."),
+            ),
+            (
+                String::from("src/Parent.vue"),
+                Some(2322),
+                String::from("11:39:error Type 'string' is not assignable to type 'number'."),
+            ),
+            (
+                String::from("src/Parent.vue"),
+                Some(2322),
+                String::from("9:53:error Type 'number' is not assignable to type 'string'."),
+            ),
+        ]
+    );
+}

--- a/crates/vize_canon/src/batch/type_checker/tests/no_unused.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/no_unused.rs
@@ -311,7 +311,10 @@ fn snapshot_project_diagnostics_without_template_checks(
     Some(snapshot)
 }
 
-fn write_no_unused_tsconfig(project_root: &std::path::Path) {
+/// Shared with `generic_props::inline_callback_guarded_props`: every synthetic
+/// local the prop checks emit has to be read somewhere, or a clean SFC gains an
+/// unmapped `TS6133`/`TS6196` hint.
+pub(super) fn write_no_unused_tsconfig(project_root: &std::path::Path) {
     std::fs::write(
         project_root.join("tsconfig.json"),
         r#"{

--- a/crates/vize_canon/src/virtual_ts/expressions/sequence_prop_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/sequence_prop_tests.rs
@@ -2,6 +2,17 @@ use vize_croquis::{Analyzer, AnalyzerOptions};
 
 use crate::virtual_ts::generate_virtual_ts;
 
+/// Every generated line that re-emits `void 0, (value) => value`, trimmed, in
+/// emission order: the generic child's props resolver, then the per-prop check
+/// that reads its instantiated type. The selector call and the whole-props
+/// checker call both replace an inline callback with `undefined as any`, so
+/// they are deliberately absent — an entry appearing here for either of them
+/// would mean the callback is checked, and reported, twice (#3446).
+const SEQUENCE_VALUE_LINES: [&str; 2] = [
+    r#""transform": (void 0, (value) => value),"#,
+    "const __vize_prop_check_0_transform: __VizeResolvedProp<typeof __vize_resolved_Child_props_0, typeof __vize_selected_Child_props_0, 'transform', __Child_0_prop_transform> = (void 0, (value) => value);",
+];
+
 #[test]
 fn sequence_prop_values_are_grouped_without_mapping_synthetic_parentheses() {
     let script = r#"import Child from "./Child.vue"
@@ -17,21 +28,16 @@ fn sequence_prop_values_are_grouped_without_mapping_synthetic_parentheses() {
     let summary = analyzer.finish();
 
     let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
-    assert!(
-        output
-            .code
-            .contains("__vize_prop_check_0_transform: __VizeResolvedProp<")
-            && output.code.contains(" = (void 0, (value) => value);"),
-        "per-prop initializer must group the sequence expression:\n{}",
-        output.code
-    );
-    assert!(
-        output
-            .code
-            .contains(r#""transform": (void 0, (value) => value),"#),
-        "generic props object must group the sequence expression:\n{}",
-        output.code
-    );
+    // Asserted as whole lines rather than as substrings: a sequence has to be
+    // grouped at *every* site that re-emits the authored value, and only an
+    // exhaustive list can show that none was missed.
+    let emitted_value_lines: Vec<&str> = output
+        .code
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.contains(expression))
+        .collect();
+    assert_eq!(emitted_value_lines, SEQUENCE_VALUE_LINES, "{}", output.code);
 
     let value_start = template.find(expression).expect("bound expression present");
     let value_range = value_start..value_start + expression.len();


### PR DESCRIPTION
## Surface

Canon test coverage for the resolved-props binding #3590 introduced for inline
callback props on a generic child (`crates/vize_canon`). Tests only — no
generated-code change, no snapshot change.

## Why

#3590 closed #3446 by resolving a generic child's instantiated props once per
usage and annotating the inline callback's per-prop check with the result. It
emits two new locals per usage — `__vize_resolved_X_props_N` and
`__vize_selected_X_props_N` — plus the `__VizePropsResolver`,
`__VizePropsSelector` and `__VizeResolvedProp` aliases, and every one of them is
read **only** through `typeof`.

Nothing in the suite checks the prop-check path under `noUnusedLocals`. If one
of those locals ever stops being read — a prop the classifier accepts but the
check loop skips, a usage whose alias is emitted and never referenced — the
result is a `TS6133`/`TS6196` that reaches check-server clients as an unmapped
hint on an otherwise clean SFC. That is the exact failure #3443 fixed for the
native element aliases, and the code comments in `component_prop_checker` name
it as the reason those helpers are gated; the gate itself is untested.

The existing `resolved_callback_props_match_vue_tsc_in_guarded_and_loop_scopes`
also guards with `v-if="visible"` over a `const visible = true`, so the resolver
call never sees a value whose type depends on the guard holding.

## Added

`generic_props/inline_callback_guarded_props.rs`, one test over the same three
scopes but with a guard over a nullable binding, checked with `noUnusedLocals`:

```vue
const rows = Math.random() > 0.5 ? [{ id: 1 }] : null
...
  <Child v-if="rows" :items="rows" :pick="(item) => item.id" />
  <Child v-for="group in groups" :key="group[0].id" :items="group" :pick="(item) => item.id" />
  <CallbackOnly :transform="(item) => item.toUpperCase()" />
```

The complete diagnostic list is asserted by equality against the vue-tsc 3.3.4 /
TypeScript 6.0.3 oracle, run on these sources with this tsconfig:

```
src/Parent.vue(9,53): error TS2322: Type 'number' is not assignable to type 'string'.
src/Parent.vue(10,85): error TS2322: Type 'number' is not assignable to type 'string'.
src/Parent.vue(11,39): error TS2322: Type 'string' is not assignable to type 'number'.
```

Because the list is complete and `noUnusedLocals` is on, an unread generated
local fails this assertion; because nothing is reported for `:items="rows"`, it
also pins that the guarded usage is checked against the narrowed type.

`no_unused::write_no_unused_tsconfig` becomes `pub(super)` so both modules share
one definition of that tsconfig.

## Also

`sequence_prop_values_are_grouped_without_mapping_synthetic_parentheses`
asserted grouping with two `.contains()` substring checks. A substring cannot
show that no *other* emission site dropped the parentheses, which is the
property the test exists for — and #3590 changed how many sites there are. It
now collects every generated line that re-emits the authored sequence and
compares the complete list with `assert_eq!`.

That also makes the second half of #3590 visible in a test for the first time:
the list is exactly the resolver call and the per-prop check. The selector call
and the whole-props checker call both replace an inline callback with
`undefined as any`, and an entry appearing for either of them would mean the
callback is checked — and reported — twice, which is the duplicate #3446 was
about. The old assertion could not tell those apart, because its substring was
satisfied by the resolver call alone; its message still claimed it was pinning
the checker call, which by then no longer emitted the value at all.

Refs #3446, #3590.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3591"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type-checking reliability for generic inline callback properties used with conditional and loop-based narrowing.
  * Prevented misleading unused-variable diagnostics and false errors in narrowed data scenarios.

* **Tests**
  * Added coverage for generic callback props and strict unused-local checks.
  * Strengthened validation of generated type-checking output to ensure only relevant property checks are emitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->