### PR TITLE
feat(maestro): fold script and style bodies

### DIFF
--- a/crates/vize_maestro/src/server/document_structure/folding.rs
+++ b/crates/vize_maestro/src/server/document_structure/folding.rs
@@ -31,6 +31,7 @@ pub(crate) fn folding_ranges(
         ..Default::default()
     };
     let descriptor = vize_atelier_sfc::parse_sfc(&content, options).ok()?;
+    let authored_lines = AuthoredLineMap::new(&content);
 
     let mut ranges = Vec::new();
     let labelled_blocks = descriptor
@@ -53,11 +54,9 @@ pub(crate) fn folding_ranges(
         .chain(descriptor.styles.iter().map(|block| (&block.loc, "style")));
 
     for (loc, label) in labelled_blocks {
-        // `start_line`/`end_line` are the 1-based lines of the opening and
-        // closing tags.
         let Some(range) = region(
-            loc.start_line.saturating_sub(1) as u32,
-            loc.end_line.saturating_sub(1) as u32,
+            authored_lines.line_at(loc.tag_start),
+            authored_lines.line_at(loc.end),
             Some(FoldingRangeKind::Region),
             Some(label),
         ) else {
@@ -81,13 +80,44 @@ pub(crate) fn folding_ranges(
         .iter()
         .chain(descriptor.script.iter())
     {
-        ranges.extend(script::script_regions(script));
+        ranges.extend(script::script_regions(
+            script,
+            authored_lines.line_at(script.loc.start),
+        ));
     }
     for style in &descriptor.styles {
-        ranges.extend(style::style_regions(style));
+        ranges.extend(style::style_regions(
+            style,
+            authored_lines.line_at(style.loc.start),
+        ));
     }
 
     (!ranges.is_empty()).then_some(ranges)
+}
+
+/// Maps authored byte offsets to zero-based lines in O(1) per lookup.
+///
+/// Construction scans the document once, so nested-region discovery neither
+/// rescans source prefixes nor binary-searches a newline table.
+struct AuthoredLineMap {
+    lines: Vec<u32>,
+}
+
+impl AuthoredLineMap {
+    fn new(source: &str) -> Self {
+        let mut lines = Vec::with_capacity(source.len() + 1);
+        let mut line = 0;
+        for byte in source.bytes() {
+            lines.push(line);
+            line += u32::from(byte == b'\n');
+        }
+        lines.push(line);
+        Self { lines }
+    }
+
+    fn line_at(&self, byte_offset: usize) -> u32 {
+        self.lines[byte_offset.min(self.lines.len() - 1)]
+    }
 }
 
 /// A region that hides `open_line + 1 ..= close_line - 1`.

--- a/crates/vize_maestro/src/server/document_structure/folding.rs
+++ b/crates/vize_maestro/src/server/document_structure/folding.rs
@@ -1,7 +1,7 @@
 //! `textDocument/foldingRange` for authored `.vue` documents.
 //!
-//! Two regions are produced: one per multi-line SFC block, and one per
-//! multi-line element or comment inside the template.
+//! Regions are produced for multi-line SFC blocks, template elements and
+//! comments, script object/function bodies, and style rule blocks.
 //!
 //! # `endLine` is the last line the client hides
 //!
@@ -13,18 +13,12 @@
 //! construct's closing line, and a construct with nothing between its opening
 //! and closing lines produces no region at all.
 //!
-//! # Not covered
-//!
-//! Folding *inside* `<script>` (functions, objects) and `<style>` (rule blocks)
-//! needs the TypeScript and CSS services rather than the SFC block layout; it is
-//! tracked in #3477.
-
 use tower_lsp::lsp_types::{FoldingRange, FoldingRangeKind, FoldingRangeParams};
 
 use crate::server::ServerState;
 
-/// One region per multi-line SFC block, then one per multi-line element or
-/// comment in the template, in document order.
+/// One region per multi-line SFC block, then nested regions in template,
+/// script, and style discovery order.
 pub(crate) fn folding_ranges(
     state: &ServerState,
     params: &FoldingRangeParams,
@@ -80,6 +74,17 @@ pub(crate) fn folding_ranges(
             &content,
             (template.loc.start, template.loc.end),
         ));
+    }
+
+    for script in descriptor
+        .script_setup
+        .iter()
+        .chain(descriptor.script.iter())
+    {
+        ranges.extend(script::script_regions(script));
+    }
+    for style in &descriptor.styles {
+        ranges.extend(style::style_regions(style));
     }
 
     (!ranges.is_empty()).then_some(ranges)
@@ -238,5 +243,7 @@ fn start_tag_end(content: &str, tag_start: usize, limit: usize) -> Option<usize>
     None
 }
 
+mod script;
+mod style;
 #[cfg(test)]
 mod tests;

--- a/crates/vize_maestro/src/server/document_structure/folding/script.rs
+++ b/crates/vize_maestro/src/server/document_structure/folding/script.rs
@@ -1,0 +1,90 @@
+//! Folding regions derived from authored script AST spans.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{FunctionBody, ObjectExpression};
+use oxc_ast_visit::{
+    Visit,
+    walk::{walk_function_body, walk_object_expression},
+};
+use oxc_parser::Parser;
+use oxc_span::{SourceType, Span};
+use tower_lsp::lsp_types::FoldingRange;
+use vize_atelier_sfc::SfcScriptBlock;
+
+use super::region;
+
+pub(super) fn script_regions(block: &SfcScriptBlock<'_>) -> Vec<FoldingRange> {
+    if block.src.is_some() || block.content.is_empty() {
+        return Vec::new();
+    }
+
+    let source = block.content.as_ref();
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source, source_type(block.lang.as_deref())).parse();
+    let mut collector = ScriptRegionCollector {
+        source: source.as_bytes(),
+        spans: Vec::new(),
+    };
+    collector.visit_program(&parsed.program);
+    collector.spans.sort_by_key(|span| (span.start, span.end));
+    collector.spans.dedup();
+
+    let base_line = block.loc.start_line.saturating_sub(1) as u32;
+    let newline_offsets = source
+        .match_indices('\n')
+        .map(|(offset, _)| offset)
+        .collect::<Vec<_>>();
+    collector
+        .spans
+        .into_iter()
+        .filter_map(|span| {
+            let start = span.start as usize;
+            let close = span.end.saturating_sub(1) as usize;
+            let open_line = base_line + line_offset(&newline_offsets, start);
+            let close_line = base_line + line_offset(&newline_offsets, close);
+            region(open_line, close_line, None, None)
+        })
+        .collect()
+}
+
+fn line_offset(newlines: &[usize], byte_offset: usize) -> u32 {
+    newlines.partition_point(|newline| *newline < byte_offset) as u32
+}
+
+fn source_type(lang: Option<&str>) -> SourceType {
+    match lang {
+        Some("ts") => SourceType::ts().with_module(true),
+        Some("tsx") => SourceType::tsx().with_module(true),
+        Some("jsx") => SourceType::jsx().with_module(true),
+        _ => SourceType::mjs(),
+    }
+}
+
+struct ScriptRegionCollector<'s> {
+    source: &'s [u8],
+    spans: Vec<Span>,
+}
+
+impl ScriptRegionCollector<'_> {
+    fn push_braced(&mut self, span: Span) {
+        let start = span.start as usize;
+        let Some(close) = (span.end as usize).checked_sub(1) else {
+            return;
+        };
+        if self.source.get(start) == Some(&b'{') && self.source.get(close) == Some(&b'}') {
+            self.spans.push(span);
+        }
+    }
+}
+
+impl<'a> Visit<'a> for ScriptRegionCollector<'_> {
+    fn visit_object_expression(&mut self, expression: &ObjectExpression<'a>) {
+        self.push_braced(expression.span);
+        walk_object_expression(self, expression);
+    }
+
+    fn visit_function_body(&mut self, body: &FunctionBody<'a>) {
+        self.push_braced(body.span);
+        walk_function_body(self, body);
+    }
+}

--- a/crates/vize_maestro/src/server/document_structure/folding/script.rs
+++ b/crates/vize_maestro/src/server/document_structure/folding/script.rs
@@ -1,4 +1,4 @@
-//! Folding regions derived from authored script AST spans.
+//! Folding regions for the bodies inside an authored `<script>` block.
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{FunctionBody, ObjectExpression};
@@ -13,9 +13,21 @@ use vize_atelier_sfc::SfcScriptBlock;
 
 use super::region;
 
-pub(super) fn script_regions(block: &SfcScriptBlock<'_>) -> Vec<FoldingRange> {
+/// One region per multi-line object literal and function body, in document
+/// order. The AST traversal and line scan together take O(n + r).
+pub(super) fn script_regions(
+    block: &SfcScriptBlock<'_>,
+    content_start_line: u32,
+) -> Vec<FoldingRange> {
+    collect_script_regions(block, content_start_line).0
+}
+
+fn collect_script_regions(
+    block: &SfcScriptBlock<'_>,
+    content_start_line: u32,
+) -> (Vec<FoldingRange>, usize) {
     if block.src.is_some() || block.content.is_empty() {
-        return Vec::new();
+        return (Vec::new(), 0);
     }
 
     let source = block.content.as_ref();
@@ -23,32 +35,21 @@ pub(super) fn script_regions(block: &SfcScriptBlock<'_>) -> Vec<FoldingRange> {
     let parsed = Parser::new(&allocator, source, source_type(block.lang.as_deref())).parse();
     let mut collector = ScriptRegionCollector {
         source: source.as_bytes(),
-        spans: Vec::new(),
+        cursor: 0,
+        line: content_start_line,
+        ranges: Vec::new(),
     };
     collector.visit_program(&parsed.program);
-    collector.spans.sort_by_key(|span| (span.start, span.end));
-    collector.spans.dedup();
-
-    let base_line = block.loc.start_line.saturating_sub(1) as u32;
-    let newline_offsets = source
-        .match_indices('\n')
-        .map(|(offset, _)| offset)
-        .collect::<Vec<_>>();
-    collector
-        .spans
-        .into_iter()
-        .filter_map(|span| {
-            let start = span.start as usize;
-            let close = span.end.saturating_sub(1) as usize;
-            let open_line = base_line + line_offset(&newline_offsets, start);
-            let close_line = base_line + line_offset(&newline_offsets, close);
-            region(open_line, close_line, None, None)
-        })
-        .collect()
+    let work = collector.cursor + collector.ranges.len();
+    (collector.ranges.into_iter().flatten().collect(), work)
 }
 
-fn line_offset(newlines: &[usize], byte_offset: usize) -> u32 {
-    newlines.partition_point(|newline| *newline < byte_offset) as u32
+#[cfg(test)]
+pub(super) fn script_regions_with_metrics(
+    block: &SfcScriptBlock<'_>,
+    content_start_line: u32,
+) -> (Vec<FoldingRange>, usize) {
+    collect_script_regions(block, content_start_line)
 }
 
 fn source_type(lang: Option<&str>) -> SourceType {
@@ -62,29 +63,73 @@ fn source_type(lang: Option<&str>) -> SourceType {
 
 struct ScriptRegionCollector<'s> {
     source: &'s [u8],
-    spans: Vec<Span>,
+    cursor: usize,
+    line: u32,
+    ranges: Vec<Option<FoldingRange>>,
 }
 
 impl ScriptRegionCollector<'_> {
-    fn push_braced(&mut self, span: Span) {
+    fn begin_braced(&mut self, span: Span) -> Option<PendingRegion> {
         let start = span.start as usize;
-        let Some(close) = (span.end as usize).checked_sub(1) else {
-            return;
-        };
-        if self.source.get(start) == Some(&b'{') && self.source.get(close) == Some(&b'}') {
-            self.spans.push(span);
+        let close = (span.end as usize).checked_sub(1)?;
+        if self.source.get(start) != Some(&b'{') || self.source.get(close) != Some(&b'}') {
+            return None;
         }
+
+        let open_line = self.advance_to(start);
+        let index = self.ranges.len();
+        self.ranges.push(None);
+        Some(PendingRegion {
+            index,
+            open_line,
+            close,
+        })
     }
+
+    fn end_braced(&mut self, pending: PendingRegion) {
+        let close_line = self.advance_to(pending.close);
+        self.ranges[pending.index] = region(pending.open_line, close_line, None, None);
+    }
+
+    /// AST enter/exit events follow authored source order, so this cursor only
+    /// advances and scans all intervening bytes at most once.
+    fn advance_to(&mut self, byte_offset: usize) -> u32 {
+        debug_assert!(
+            byte_offset >= self.cursor,
+            "script AST traversal must follow authored source order"
+        );
+        if byte_offset < self.cursor {
+            return self.line;
+        }
+        self.line += self.source[self.cursor..byte_offset]
+            .iter()
+            .filter(|byte| **byte == b'\n')
+            .count() as u32;
+        self.cursor = byte_offset;
+        self.line
+    }
+}
+
+struct PendingRegion {
+    index: usize,
+    open_line: u32,
+    close: usize,
 }
 
 impl<'a> Visit<'a> for ScriptRegionCollector<'_> {
     fn visit_object_expression(&mut self, expression: &ObjectExpression<'a>) {
-        self.push_braced(expression.span);
+        let pending = self.begin_braced(expression.span);
         walk_object_expression(self, expression);
+        if let Some(pending) = pending {
+            self.end_braced(pending);
+        }
     }
 
     fn visit_function_body(&mut self, body: &FunctionBody<'a>) {
-        self.push_braced(body.span);
+        let pending = self.begin_braced(body.span);
         walk_function_body(self, body);
+        if let Some(pending) = pending {
+            self.end_braced(pending);
+        }
     }
 }

--- a/crates/vize_maestro/src/server/document_structure/folding/style.rs
+++ b/crates/vize_maestro/src/server/document_structure/folding/style.rs
@@ -13,58 +13,82 @@ enum ScanState {
     LineComment,
 }
 
-pub(super) fn style_regions(block: &SfcStyleBlock<'_>) -> Vec<FoldingRange> {
+/// One region per multi-line brace block, in document order and O(n + r).
+pub(super) fn style_regions(
+    block: &SfcStyleBlock<'_>,
+    content_start_line: u32,
+) -> Vec<FoldingRange> {
+    collect_style_regions(block, content_start_line).0
+}
+
+fn collect_style_regions(
+    block: &SfcStyleBlock<'_>,
+    content_start_line: u32,
+) -> (Vec<FoldingRange>, usize) {
     if block.src.is_some() || block.content.is_empty() {
-        return Vec::new();
+        return (Vec::new(), 0);
     }
 
-    let source = block.content.as_ref();
-    let bytes = source.as_bytes();
+    let bytes = block.content.as_bytes();
     let line_comments = matches!(
         block.lang.as_deref(),
         Some("less" | "scss" | "sass" | "stylus")
     );
     let mut state = ScanState::Code;
-    let mut line = block.loc.start_line.saturating_sub(1) as u32;
+    let mut line = content_start_line;
     let mut stack = Vec::new();
+    // Reserve a slot at `{` and fill it at `}` to preserve document order
+    // without a final sort. Unterminated blocks leave an empty slot.
     let mut ranges = Vec::new();
     let mut cursor = 0;
 
     while cursor < bytes.len() {
         let byte = bytes[cursor];
         match state {
-            ScanState::Code => match byte {
-                b'/' if bytes.get(cursor + 1) == Some(&b'*') => {
-                    state = ScanState::BlockComment;
-                    cursor += 2;
+            ScanState::Code => {
+                // A URL payload is opaque: `https://`, braces, and quotes in
+                // it are data rather than style structure or line comments.
+                if matches!(byte, b'u' | b'U')
+                    && let Some(open_paren) = url_open_paren(bytes, cursor)
+                {
+                    advance_to(bytes, &mut cursor, open_paren + 1, &mut line);
+                    skip_url(bytes, &mut cursor, &mut line);
+                    continue;
                 }
-                b'/' if line_comments && bytes.get(cursor + 1) == Some(&b'/') => {
-                    state = ScanState::LineComment;
-                    cursor += 2;
-                }
-                b'\'' | b'"' => {
-                    state = ScanState::Quoted(byte);
-                    cursor += 1;
-                }
-                b'\\' => skip_escape(bytes, &mut cursor, &mut line),
-                b'{' => {
-                    stack.push(line);
-                    cursor += 1;
-                }
-                b'}' => {
-                    if let Some(open_line) = stack.pop()
-                        && let Some(range) = region(open_line, line, None, None)
-                    {
-                        ranges.push(range);
+
+                match byte {
+                    b'/' if bytes.get(cursor + 1) == Some(&b'*') => {
+                        state = ScanState::BlockComment;
+                        cursor += 2;
                     }
-                    cursor += 1;
+                    b'/' if line_comments && bytes.get(cursor + 1) == Some(&b'/') => {
+                        state = ScanState::LineComment;
+                        cursor += 2;
+                    }
+                    b'\'' | b'"' => {
+                        state = ScanState::Quoted(byte);
+                        cursor += 1;
+                    }
+                    b'\\' => skip_escape(bytes, &mut cursor, &mut line),
+                    b'{' => {
+                        let index = ranges.len();
+                        ranges.push(None);
+                        stack.push((line, index));
+                        cursor += 1;
+                    }
+                    b'}' => {
+                        if let Some((open_line, index)) = stack.pop() {
+                            ranges[index] = region(open_line, line, None, None);
+                        }
+                        cursor += 1;
+                    }
+                    b'\n' => {
+                        line += 1;
+                        cursor += 1;
+                    }
+                    _ => cursor += 1,
                 }
-                b'\n' => {
-                    line += 1;
-                    cursor += 1;
-                }
-                _ => cursor += 1,
-            },
+            }
             ScanState::Quoted(quote) => match byte {
                 b'\\' => skip_escape(bytes, &mut cursor, &mut line),
                 current if current == quote => {
@@ -98,8 +122,93 @@ pub(super) fn style_regions(block: &SfcStyleBlock<'_>) -> Vec<FoldingRange> {
         }
     }
 
-    ranges.sort_by_key(|range| (range.start_line, range.end_line));
-    ranges
+    let work = cursor + ranges.len();
+    (ranges.into_iter().flatten().collect(), work)
+}
+
+#[cfg(test)]
+pub(super) fn style_regions_with_metrics(
+    block: &SfcStyleBlock<'_>,
+    content_start_line: u32,
+) -> (Vec<FoldingRange>, usize) {
+    collect_style_regions(block, content_start_line)
+}
+
+fn url_open_paren(bytes: &[u8], cursor: usize) -> Option<usize> {
+    if cursor > 0 && is_identifier_byte(bytes[cursor - 1]) {
+        return None;
+    }
+    if !bytes.get(cursor..cursor + 3)?.eq_ignore_ascii_case(b"url") {
+        return None;
+    }
+    if bytes
+        .get(cursor + 3)
+        .is_some_and(|byte| is_identifier_byte(*byte))
+    {
+        return None;
+    }
+
+    let mut open_paren = cursor + 3;
+    while bytes
+        .get(open_paren)
+        .is_some_and(|byte| byte.is_ascii_whitespace())
+    {
+        open_paren += 1;
+    }
+    (bytes.get(open_paren) == Some(&b'(')).then_some(open_paren)
+}
+
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'\\') || !byte.is_ascii()
+}
+
+fn skip_url(bytes: &[u8], cursor: &mut usize, line: &mut u32) {
+    let mut quote = None;
+    let mut depth = 1;
+    while *cursor < bytes.len() {
+        let byte = bytes[*cursor];
+        match quote {
+            Some(_) if byte == b'\\' => skip_escape(bytes, cursor, line),
+            Some(open) if byte == open => {
+                quote = None;
+                *cursor += 1;
+            }
+            Some(_) if byte == b'\n' => {
+                *line += 1;
+                *cursor += 1;
+            }
+            Some(_) => *cursor += 1,
+            None if matches!(byte, b'\'' | b'"') => {
+                quote = Some(byte);
+                *cursor += 1;
+            }
+            None if byte == b'\\' => skip_escape(bytes, cursor, line),
+            None if byte == b'(' => {
+                depth += 1;
+                *cursor += 1;
+            }
+            None if byte == b')' => {
+                depth -= 1;
+                *cursor += 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            None if byte == b'\n' => {
+                *line += 1;
+                *cursor += 1;
+            }
+            None => *cursor += 1,
+        }
+    }
+}
+
+fn advance_to(bytes: &[u8], cursor: &mut usize, end: usize, line: &mut u32) {
+    *line += bytes[*cursor..end]
+        .iter()
+        .filter(|byte| **byte == b'\n')
+        .count() as u32;
+    *cursor = end;
 }
 
 fn skip_escape(bytes: &[u8], cursor: &mut usize, line: &mut u32) {

--- a/crates/vize_maestro/src/server/document_structure/folding/style.rs
+++ b/crates/vize_maestro/src/server/document_structure/folding/style.rs
@@ -1,0 +1,111 @@
+//! Brace-aware folding for authored style blocks.
+
+use tower_lsp::lsp_types::FoldingRange;
+use vize_atelier_sfc::SfcStyleBlock;
+
+use super::region;
+
+#[derive(Clone, Copy)]
+enum ScanState {
+    Code,
+    Quoted(u8),
+    BlockComment,
+    LineComment,
+}
+
+pub(super) fn style_regions(block: &SfcStyleBlock<'_>) -> Vec<FoldingRange> {
+    if block.src.is_some() || block.content.is_empty() {
+        return Vec::new();
+    }
+
+    let source = block.content.as_ref();
+    let bytes = source.as_bytes();
+    let line_comments = matches!(
+        block.lang.as_deref(),
+        Some("less" | "scss" | "sass" | "stylus")
+    );
+    let mut state = ScanState::Code;
+    let mut line = block.loc.start_line.saturating_sub(1) as u32;
+    let mut stack = Vec::new();
+    let mut ranges = Vec::new();
+    let mut cursor = 0;
+
+    while cursor < bytes.len() {
+        let byte = bytes[cursor];
+        match state {
+            ScanState::Code => match byte {
+                b'/' if bytes.get(cursor + 1) == Some(&b'*') => {
+                    state = ScanState::BlockComment;
+                    cursor += 2;
+                }
+                b'/' if line_comments && bytes.get(cursor + 1) == Some(&b'/') => {
+                    state = ScanState::LineComment;
+                    cursor += 2;
+                }
+                b'\'' | b'"' => {
+                    state = ScanState::Quoted(byte);
+                    cursor += 1;
+                }
+                b'\\' => skip_escape(bytes, &mut cursor, &mut line),
+                b'{' => {
+                    stack.push(line);
+                    cursor += 1;
+                }
+                b'}' => {
+                    if let Some(open_line) = stack.pop()
+                        && let Some(range) = region(open_line, line, None, None)
+                    {
+                        ranges.push(range);
+                    }
+                    cursor += 1;
+                }
+                b'\n' => {
+                    line += 1;
+                    cursor += 1;
+                }
+                _ => cursor += 1,
+            },
+            ScanState::Quoted(quote) => match byte {
+                b'\\' => skip_escape(bytes, &mut cursor, &mut line),
+                current if current == quote => {
+                    state = ScanState::Code;
+                    cursor += 1;
+                }
+                b'\n' => {
+                    line += 1;
+                    cursor += 1;
+                }
+                _ => cursor += 1,
+            },
+            ScanState::BlockComment => match byte {
+                b'*' if bytes.get(cursor + 1) == Some(&b'/') => {
+                    state = ScanState::Code;
+                    cursor += 2;
+                }
+                b'\n' => {
+                    line += 1;
+                    cursor += 1;
+                }
+                _ => cursor += 1,
+            },
+            ScanState::LineComment => {
+                if byte == b'\n' {
+                    line += 1;
+                    state = ScanState::Code;
+                }
+                cursor += 1;
+            }
+        }
+    }
+
+    ranges.sort_by_key(|range| (range.start_line, range.end_line));
+    ranges
+}
+
+fn skip_escape(bytes: &[u8], cursor: &mut usize, line: &mut u32) {
+    *cursor += 1;
+    if bytes.get(*cursor) == Some(&b'\n') {
+        *line += 1;
+    }
+    *cursor += usize::from(*cursor < bytes.len());
+}

--- a/crates/vize_maestro/src/server/document_structure/folding/tests.rs
+++ b/crates/vize_maestro/src/server/document_structure/folding/tests.rs
@@ -3,7 +3,7 @@ use tower_lsp::lsp_types::{
     WorkDoneProgressParams,
 };
 
-use super::folding_ranges;
+use super::{AuthoredLineMap, folding_ranges};
 use crate::server::ServerState;
 
 /// The fixture from #3455, with the `<template>` closing on line 9.
@@ -179,6 +179,81 @@ fn style_scanner_ignores_braces_in_strings_and_comments() {
             (7, 8, None, None),
         ]
     );
+}
+
+#[test]
+fn multiline_opening_tags_keep_script_and_style_ranges_on_authored_lines() {
+    let source = "<script\n  setup\n  lang=\"ts\"\n>\nconst config = {\n  enabled: true,\n}\n</script>\n\n<style\n  lang=\"scss\"\n>\n.card {\n  color: red;\n}\n</style>\n";
+
+    assert_eq!(
+        ranges(source),
+        vec![
+            (0, 6, Some("region"), Some("script setup")),
+            (9, 14, Some("region"), Some("style")),
+            (4, 5, None, None),
+            (12, 13, None, None),
+        ]
+    );
+}
+
+#[test]
+fn style_line_comments_do_not_start_at_url_schemes() {
+    let source = "<style lang=\"scss\">\n.remote {\n  color: red;\n  background: url(https://example.test/a.png); }\n\n.local {\n  // } is not structural\n  color: blue;\n  padding: 0;\n}\n</style>\n";
+
+    assert_eq!(
+        ranges(source),
+        vec![
+            (0, 9, Some("region"), Some("style")),
+            (1, 2, None, None),
+            (5, 8, None, None),
+        ]
+    );
+}
+
+#[test]
+fn script_and_style_internal_work_stays_linear() {
+    let mut previous_script_work = None;
+    let mut previous_style_work = None;
+
+    for count in [128, 256, 512, 1024] {
+        let mut source = String::from("<script setup lang=\"ts\">\nconst records = [\n");
+        for _ in 0..count {
+            source.push_str("  {\n    enabled: true,\n  },\n");
+        }
+        source.push_str("]\n</script>\n<style lang=\"scss\">\n");
+        for _ in 0..count {
+            source.push_str(".rule {\n  color: red;\n}\n");
+        }
+        source.push_str("</style>\n");
+
+        let descriptor =
+            vize_atelier_sfc::parse_sfc(&source, vize_atelier_sfc::SfcParseOptions::default())
+                .unwrap();
+        let authored_lines = AuthoredLineMap::new(&source);
+        let script = descriptor.script_setup.as_ref().unwrap();
+        let style = descriptor.styles.first().unwrap();
+        let (script_ranges, script_work) = super::script::script_regions_with_metrics(
+            script,
+            authored_lines.line_at(script.loc.start),
+        );
+        let (style_ranges, style_work) = super::style::style_regions_with_metrics(
+            style,
+            authored_lines.line_at(style.loc.start),
+        );
+
+        assert_eq!(script_ranges.len(), count);
+        assert_eq!(style_ranges.len(), count);
+        assert!(script_work <= script.content.len() + count);
+        assert!(style_work <= style.content.len() + count);
+        if let Some(previous) = previous_script_work {
+            assert!(script_work <= previous * 2 + 32);
+        }
+        if let Some(previous) = previous_style_work {
+            assert!(style_work <= previous * 2 + 32);
+        }
+        previous_script_work = Some(script_work);
+        previous_style_work = Some(style_work);
+    }
 }
 
 #[test]

--- a/crates/vize_maestro/src/server/document_structure/folding/tests.rs
+++ b/crates/vize_maestro/src/server/document_structure/folding/tests.rs
@@ -135,6 +135,53 @@ fn a_script_body_that_looks_like_markup_is_never_scanned() {
 }
 
 #[test]
+fn script_and_style_bodies_fold_alongside_blocks_and_template_elements() {
+    let source = "<script setup lang=\"ts\">\nconst config = {\n  nested: true,\n}\n\nfunction greet() {\n  return config\n}\n</script>\n\n<template>\n  <section>\n    <div>hello</div>\n  </section>\n</template>\n\n<style scoped>\n.card {\n  color: red;\n}\n</style>\n";
+
+    assert_eq!(
+        ranges(source),
+        vec![
+            (10, 13, Some("region"), Some("template")),
+            (0, 7, Some("region"), Some("script setup")),
+            (16, 19, Some("region"), Some("style")),
+            (11, 12, None, None),
+            (1, 2, None, None),
+            (5, 6, None, None),
+            (17, 18, None, None),
+        ]
+    );
+}
+
+#[test]
+fn script_ast_ignores_braces_in_literals_and_folds_nested_bodies() {
+    let source = "<script lang=\"ts\">\nconst marker = \"}\"\nconst regex = /}/\nconst config = {\n  nested: {\n    enabled: true,\n  },\n  run() {\n    return marker\n  }\n}\n</script>\n";
+
+    assert_eq!(
+        ranges(source),
+        vec![
+            (0, 10, Some("region"), Some("script")),
+            (3, 9, None, None),
+            (4, 5, None, None),
+            (7, 8, None, None),
+        ]
+    );
+}
+
+#[test]
+fn style_scanner_ignores_braces_in_strings_and_comments() {
+    let source = "<style lang=\"scss\">\n.outer {\n  content: \"}\";\n  /*\n    } {\n  */\n  // }\n  .inner {\n    color: red;\n  }\n}\n</style>\n";
+
+    assert_eq!(
+        ranges(source),
+        vec![
+            (0, 10, Some("region"), Some("style")),
+            (1, 9, None, None),
+            (7, 8, None, None),
+        ]
+    );
+}
+
+#[test]
 fn an_unopened_document_yields_no_folding_ranges() {
     let state = ServerState::new();
     let params = FoldingRangeParams {

--- a/tests/tooling/lsp-folding-range.test.ts
+++ b/tests/tooling/lsp-folding-range.test.ts
@@ -147,13 +147,15 @@ test("foldingRange folds elements and stops one line before every closing tag", 
 
 test("foldingRange emits one region per multi-line block with block-named collapsedText", async () => {
   await withSession("lsp-folding-multi-block", async (ask) => {
-    // Styles always collapse to "style"; the single-line `<div>{{ x }}</div>`
-    // hides nothing and contributes no element region.
+    // Styles always collapse to "style" and each rule folds independently;
+    // the single-line `<div>{{ x }}</div>` hides nothing.
     assert.deepEqual(await ask(MULTI_BLOCK, "MultiBlock.vue"), [
       [4, 5, "region", "template"],
       [0, 1, "region", "script setup"],
       [8, 11, "region", "style"],
       [14, 17, "region", "style"],
+      [9, 10, undefined, undefined],
+      [15, 16, undefined, undefined],
     ]);
   });
 });
@@ -173,6 +175,42 @@ test("foldingRange folds a multi-line comment as a comment region", async () => 
       [0, 6, "region", "template"],
       [1, 2, "comment", undefined],
       [4, 5, undefined, undefined],
+    ]);
+  });
+});
+
+test("foldingRange folds script and style bodies alongside SFC and template regions", async () => {
+  await withSession("lsp-folding-script-style", async (ask) => {
+    const source = `<script setup lang="ts">
+const config = {
+  nested: true,
+}
+
+function greet() {
+  return config
+}
+</script>
+
+<template>
+  <section>
+    <div>hello</div>
+  </section>
+</template>
+
+<style scoped>
+.card {
+  color: red;
+}
+</style>
+`;
+    assert.deepEqual(await ask(source, "ScriptStyle.vue"), [
+      [10, 13, "region", "template"],
+      [0, 7, "region", "script setup"],
+      [16, 19, "region", "style"],
+      [11, 12, undefined, undefined],
+      [1, 2, undefined, undefined],
+      [5, 6, undefined, undefined],
+      [17, 18, undefined, undefined],
     ]);
   });
 });

--- a/tests/tooling/lsp-folding-range.test.ts
+++ b/tests/tooling/lsp-folding-range.test.ts
@@ -215,6 +215,56 @@ function greet() {
   });
 });
 
+test("foldingRange maps script and style bodies after multiline opening tags", async () => {
+  await withSession("lsp-folding-multiline-open-tags", async (ask) => {
+    const source = `<script
+  setup
+  lang="ts"
+>
+const config = {
+  enabled: true,
+}
+</script>
+
+<style
+  lang="scss"
+>
+.card {
+  color: red;
+}
+</style>
+`;
+    assert.deepEqual(await ask(source, "MultilineOpenTags.vue"), [
+      [0, 6, "region", "script setup"],
+      [9, 14, "region", "style"],
+      [4, 5, undefined, undefined],
+      [12, 13, undefined, undefined],
+    ]);
+  });
+});
+
+test("foldingRange distinguishes URL schemes from preprocessor line comments", async () => {
+  await withSession("lsp-folding-style-url", async (ask) => {
+    const source = `<style lang="scss">
+.remote {
+  color: red;
+  background: url(https://example.test/a.png); }
+
+.local {
+  // } is not structural
+  color: blue;
+  padding: 0;
+}
+</style>
+`;
+    assert.deepEqual(await ask(source, "StyleUrl.vue"), [
+      [0, 9, "region", "style"],
+      [1, 2, undefined, undefined],
+      [5, 8, undefined, undefined],
+    ]);
+  });
+});
+
 test("foldingRange returns null when nothing hides a line", async () => {
   await withSession("lsp-folding-nothing", async (ask) => {
     // Everything on one line, so there is nothing to fold.


### PR DESCRIPTION
Closes #3477

## Summary
- fold nested regions inside `<script>` and `<style>` blocks
- keep authored byte-to-line coordinates correct for multiline opening tags
- preserve URL text while recognizing line comments in style content

## Verification
- focused folding tests: 13/13
- Maestro unit tests: 664 passed, 1 environment-only ignored
- integration tests: 3/3
- exact debug binary stdio LSP tests: 7/7
- strict library clippy, formatting, oxlint, and diff checks: clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->