### PR TITLE
feat(atelier): forward an opaque slots object from JSX v-slots={slots}

### DIFF
--- a/crates/vize_atelier_core/src/codegen/slots.rs
+++ b/crates/vize_atelier_core/src/codegen/slots.rs
@@ -2,6 +2,7 @@
 //!
 //! Generates slot objects for component children.
 
+mod create_slots;
 mod detect;
 mod generate;
 mod name;

--- a/crates/vize_atelier_core/src/codegen/slots/create_slots.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/create_slots.rs
@@ -1,0 +1,310 @@
+//! `createSlots` generation for conditional and looped slot templates.
+//!
+//! When a component carries `<template v-if #name>` / `<template v-for #name>`
+//! children the slot *set* is decided at runtime, so the slots object cannot be
+//! an object literal. Vue's `createSlots(base, dynamicEntries)` merges the
+//! statically known entries with the conditional/looped ones; this module emits
+//! that call. The plain object-literal path lives in `generate.rs`.
+
+use crate::steps::v_slot::{get_slot_name, has_v_slot};
+use crate::{ElementNode, ForNode, IfNode, PropNode, RuntimeHelper, TemplateChildNode};
+use vize_carton::{String, ToCompactString};
+
+use super::super::context::CodegenContext;
+use super::super::expression::generate_expression;
+use super::detect::{child_is_slot_template, slot_children_have_meaningful_content, slots_spread};
+use super::generate::{generate_slot_child_node, generate_slot_children};
+use super::name::generate_slot_entry_name;
+use super::params::{extract_slot_params, get_slot_props, prefix_slot_defaults};
+
+/// Generate slots using createSlots for conditional/looped slot templates
+pub(super) fn generate_create_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
+    ctx.use_helper(RuntimeHelper::CreateSlots);
+    ctx.push(ctx.helper(RuntimeHelper::CreateSlots));
+    ctx.push("(");
+    generate_create_slots_base(ctx, el);
+    ctx.push(", [");
+    ctx.indent();
+
+    let mut first = true;
+    for child in &el.children {
+        match child {
+            TemplateChildNode::If(if_node) => {
+                // v-if on slot template: generate conditional slot entry
+                if !first {
+                    ctx.push(",");
+                }
+                first = false;
+                ctx.newline();
+                generate_conditional_slot(ctx, if_node);
+            }
+            TemplateChildNode::For(for_node) => {
+                // v-for on slot template: generate looped slot entries
+                if !first {
+                    ctx.push(",");
+                }
+                first = false;
+                ctx.newline();
+                generate_looped_slot(ctx, for_node);
+            }
+            TemplateChildNode::Element(template_el)
+                if template_el.tag.as_str() == "template" && has_v_slot(template_el) =>
+            {
+                // Regular named slot (no v-if/v-for)
+                if !first {
+                    ctx.push(",");
+                }
+                first = false;
+                ctx.newline();
+                // Generate as static slot entry
+                generate_static_slot_entry(ctx, template_el);
+            }
+            _ => {}
+        }
+    }
+
+    ctx.deindent();
+    ctx.newline();
+    ctx.push("])");
+}
+
+fn generate_create_slots_base(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
+    let default_children: Vec<_> = el
+        .children
+        .iter()
+        .filter(|child| !child_is_slot_template(child))
+        .collect();
+    let has_default_children = slot_children_have_meaningful_content(&default_children);
+    // A `v-slots` spread combined with `v-if`/`v-for` slot templates keeps the
+    // `createSlots` shape: the forwarded entries go into the base object, which
+    // `createSlots` then extends with the conditional/looped ones. `_: 2` stays
+    // because the conditional entries need it, so a forwarded entry that is not
+    // already `withCtx`-wrapped is bound to the wrong instance here. The JSX
+    // lowering cannot produce this combination (its slot bodies carry their own
+    // control flow); it is reachable only from a template, and dropping the
+    // spread instead would be silent.
+    let spread = slots_spread(el);
+
+    if !has_default_children && spread.is_none() {
+        ctx.push("{ _: 2 /* DYNAMIC */ }");
+        return;
+    }
+
+    ctx.push("{");
+    ctx.indent();
+
+    if has_default_children {
+        ctx.newline();
+        ctx.push("default: ");
+        ctx.use_helper(RuntimeHelper::WithCtx);
+        ctx.push(ctx.helper(RuntimeHelper::WithCtx));
+        ctx.push("(() => [");
+        ctx.indent();
+        for (i, child) in default_children.iter().enumerate() {
+            if i > 0 {
+                ctx.push(",");
+            }
+            ctx.newline();
+            generate_slot_child_node(ctx, child);
+        }
+        ctx.deindent();
+        ctx.newline();
+        ctx.push("]),");
+    }
+
+    if let Some(exp) = spread {
+        ctx.newline();
+        ctx.push("...");
+        generate_expression(ctx, exp);
+        ctx.push(",");
+    }
+
+    ctx.newline();
+    ctx.push("_: 2 /* DYNAMIC */");
+
+    ctx.deindent();
+    ctx.newline();
+    ctx.push("}");
+}
+
+/// Generate a conditional slot entry (v-if on slot template)
+fn generate_conditional_slot(ctx: &mut CodegenContext, if_node: &IfNode<'_>) {
+    // For each branch: condition ? { name, fn, key } : undefined
+    for (i, branch) in if_node.branches.iter().enumerate() {
+        if i > 0 {
+            ctx.newline();
+            ctx.push(": ");
+        }
+
+        // Generate condition
+        if let Some(condition) = &branch.condition {
+            ctx.push("(");
+            generate_expression(ctx, condition);
+            ctx.push(")");
+            ctx.indent();
+            ctx.newline();
+            ctx.push("? ");
+        }
+
+        // Find the slot template in this branch
+        let slot_template = branch.children.iter().find_map(|child| {
+            if let TemplateChildNode::Element(el) = child
+                && el.tag.as_str() == "template"
+                && has_v_slot(el)
+            {
+                return Some(el.as_ref());
+            }
+            None
+        });
+
+        if let Some(template_el) = slot_template {
+            generate_slot_object_entry(ctx, template_el, Some(i));
+        } else {
+            ctx.push("undefined");
+        }
+
+        if branch.condition.is_some() {
+            ctx.deindent();
+        }
+    }
+    if if_node
+        .branches
+        .last()
+        .is_none_or(|branch| branch.condition.is_some())
+    {
+        ctx.newline();
+        ctx.push(": undefined");
+    }
+}
+
+/// Generate a looped slot entry (v-for on slot template)
+fn generate_looped_slot(ctx: &mut CodegenContext, for_node: &ForNode<'_>) {
+    ctx.use_helper(RuntimeHelper::RenderList);
+    ctx.push(ctx.helper(RuntimeHelper::RenderList));
+    ctx.push("(");
+    generate_expression(ctx, &for_node.source);
+    ctx.push(", (");
+
+    // Collect callback parameter names for scope registration
+    let mut callback_params: Vec<String> = Vec::new();
+
+    if let Some(value) = &for_node.value_alias {
+        generate_expression(ctx, value);
+        super::super::v_for::helpers::extract_for_params(value, &mut callback_params);
+    }
+    if let Some(key) = &for_node.key_alias {
+        ctx.push(", ");
+        generate_expression(ctx, key);
+        super::super::v_for::helpers::extract_for_params(key, &mut callback_params);
+    }
+    if let Some(index) = &for_node.object_index_alias {
+        ctx.push(", ");
+        generate_expression(ctx, index);
+        super::super::v_for::helpers::extract_for_params(index, &mut callback_params);
+    }
+
+    ctx.add_slot_params(&callback_params);
+
+    ctx.push(") => {");
+    ctx.indent();
+    ctx.newline();
+    ctx.push("return ");
+
+    // Find the slot template in the for body
+    let slot_template = for_node.children.iter().find_map(|child| {
+        if let TemplateChildNode::Element(el) = child
+            && el.tag.as_str() == "template"
+            && has_v_slot(el)
+        {
+            return Some(el.as_ref());
+        }
+        None
+    });
+
+    if let Some(template_el) = slot_template {
+        generate_slot_object_entry(ctx, template_el, None);
+    }
+
+    ctx.remove_slot_params(&callback_params);
+
+    ctx.deindent();
+    ctx.newline();
+    ctx.push("})");
+}
+
+/// Generate a slot object entry: { name: "slotName", fn: _withCtx(() => [...]), key: "N" }
+fn generate_slot_object_entry(
+    ctx: &mut CodegenContext,
+    template_el: &ElementNode<'_>,
+    key_index: Option<usize>,
+) {
+    let slot_dir = template_el.props.iter().find_map(|p| {
+        if let PropNode::Directive(dir) = p
+            && dir.name.as_str() == "slot"
+        {
+            return Some(dir.as_ref());
+        }
+        None
+    });
+
+    if let Some(dir) = slot_dir {
+        let slot_name = get_slot_name(dir);
+
+        ctx.push("{");
+        ctx.indent();
+        ctx.newline();
+
+        // name
+        ctx.push("name: ");
+        generate_slot_entry_name(ctx, dir, &slot_name);
+        ctx.push(",");
+        ctx.newline();
+
+        // fn
+        ctx.push("fn: ");
+        ctx.use_helper(RuntimeHelper::WithCtx);
+        ctx.push(ctx.helper(RuntimeHelper::WithCtx));
+        ctx.push("(");
+
+        // Slot props
+        let params = if let Some(props_str) = get_slot_props(dir) {
+            let processed = prefix_slot_defaults(&props_str);
+            ctx.push("(");
+            ctx.push(&processed);
+            ctx.push(")");
+            extract_slot_params(&props_str)
+        } else {
+            ctx.push("()");
+            vec![]
+        };
+
+        ctx.add_slot_params(&params);
+
+        ctx.push(" => [");
+        ctx.indent();
+        generate_slot_children(ctx, &template_el.children);
+        ctx.deindent();
+        ctx.newline();
+        ctx.push("])");
+
+        ctx.remove_slot_params(&params);
+
+        // key (for v-if branches)
+        if let Some(key) = key_index {
+            ctx.push(",");
+            ctx.newline();
+            ctx.push("key: \"");
+            ctx.push(&key.to_compact_string());
+            ctx.push("\"");
+        }
+
+        ctx.deindent();
+        ctx.newline();
+        ctx.push("}");
+    }
+}
+
+/// Generate a static slot entry for createSlots context
+fn generate_static_slot_entry(ctx: &mut CodegenContext, template_el: &ElementNode<'_>) {
+    generate_slot_object_entry(ctx, template_el, None);
+}

--- a/crates/vize_atelier_core/src/codegen/slots/detect.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/detect.rs
@@ -1,20 +1,76 @@
 //! Slot detection predicates (which children form slots, dynamic/forwarded checks).
 
 use crate::steps::v_slot::{collect_slots, has_v_slot};
-use crate::{ElementNode, ElementType, PropNode, TemplateChildNode};
+use crate::{ElementNode, ElementType, ExpressionNode, PropNode, TemplateChildNode};
+
+/// The expression a component spreads into its slots object, if it carries a
+/// `v-slots` directive (#3467).
+///
+/// `v-slots` is the `@vue/babel-plugin-jsx` spelling for slot forwarding:
+/// `<B v-slots={slots}/>` hands `B` a slots object the compiler cannot see
+/// inside. The JSX lowering keeps the object-literal form as synthetic
+/// `<template v-slot:name>` children (#3418) and only reaches here for a value
+/// that stays opaque at compile time.
+pub(super) fn slots_spread<'a, 'b>(el: &'b ElementNode<'a>) -> Option<&'b ExpressionNode<'a>> {
+    el.props.iter().find_map(|prop| {
+        let PropNode::Directive(dir) = prop else {
+            return None;
+        };
+        // `v-slots` takes no argument -- the slot names are the forwarded
+        // object's own keys -- so an argument spelling is not this construct.
+        if dir.name.as_str() != "slots" || dir.arg.is_some() {
+            return None;
+        }
+        dir.exp.as_ref()
+    })
+}
+
+/// Whether the component's slots object is built **only** from a forwarded
+/// `v-slots` value: no `v-slot` on the component root, no slot templates, and
+/// no children to become the default slot.
+///
+/// `@vue/babel-plugin-jsx` passes the forwarded value straight through as the
+/// children argument in that shape (`createVNode(B, null, slots)`) rather than
+/// wrapping it in an object literal, and Vize matches it.
+pub(super) fn slots_are_only_forwarded(el: &ElementNode<'_>) -> bool {
+    slots_spread(el).is_some() && !has_authored_slots(el)
+}
+
+/// Whether the element contributes slots of its own: a `v-slot` on the
+/// component root, or any child that is not whitespace/comment filler.
+fn has_authored_slots(el: &ElementNode<'_>) -> bool {
+    if el
+        .props
+        .iter()
+        .any(|prop| matches!(prop, PropNode::Directive(dir) if dir.name.as_str() == "slot"))
+    {
+        return true;
+    }
+    el.children.iter().any(|child| match child {
+        TemplateChildNode::Text(t) => !t.content.trim().is_empty(),
+        TemplateChildNode::Comment(_) => false,
+        _ => true,
+    })
+}
 
 /// Check if component has slot children that need to be generated as slots object
 pub fn has_slot_children(el: &ElementNode<'_>) -> bool {
-    if el.children.is_empty() {
-        return false;
-    }
-
     // Teleport and KeepAlive consume raw children rather than a slot object.
     // KeepAlive still gets DYNAMIC_SLOTS at the vnode patch-flag layer.
     if matches!(
         el.tag.as_str(),
         "Teleport" | "teleport" | "KeepAlive" | "keep-alive"
     ) {
+        return false;
+    }
+
+    // A forwarded `v-slots` value is the component's slots even when it has no
+    // children of its own (`<B v-slots={slots}/>`).
+    if slots_spread(el).is_some() {
+        return true;
+    }
+
+    if el.children.is_empty() {
         return false;
     }
 
@@ -45,6 +101,15 @@ pub fn has_slot_children(el: &ElementNode<'_>) -> bool {
 
 /// Check if component has dynamic slots (requires DYNAMIC_SLOTS patch flag)
 pub fn has_dynamic_slots_flag(el: &ElementNode<'_>) -> bool {
+    // A forwarded slots object can change without anything on this vnode
+    // changing, and the emitted slots object carries no `_` stability flag (see
+    // `generate_slots`), so the child is only re-rendered if the parent forces
+    // it through DYNAMIC_SLOTS. `@vue/babel-plugin-jsx` gets the same forced
+    // update for free by emitting no patch flags at all: `shouldUpdateComponent`
+    // falls back to "any children means update" for unoptimized vnodes.
+    if slots_spread(el).is_some() {
+        return true;
+    }
     let collected_slots = collect_slots(el);
     if collected_slots.iter().any(|s| s.is_dynamic) {
         return true;

--- a/crates/vize_atelier_core/src/codegen/slots/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/generate.rs
@@ -1,26 +1,57 @@
 //! Slots object generation for component children.
 
 use crate::steps::v_slot::{collect_slots, get_slot_name, has_v_slot};
-use crate::{
-    ElementNode, ExpressionNode, ForNode, IfNode, PropNode, RuntimeHelper, TemplateChildNode,
-};
-use vize_carton::{String, ToCompactString};
+use crate::{ElementNode, ExpressionNode, PropNode, RuntimeHelper, TemplateChildNode};
+use vize_carton::String;
 
 use super::super::context::CodegenContext;
 use super::super::expression::generate_expression;
 use super::super::helpers::{escape_js_string, is_valid_js_identifier};
 use super::super::node::generate_node;
+use super::create_slots::generate_create_slots;
 use super::detect::{
-    child_is_slot_template, has_conditional_or_loop_slots, has_forwarded_slot_outlet,
-    slot_children_have_meaningful_content,
+    has_conditional_or_loop_slots, has_forwarded_slot_outlet, slots_are_only_forwarded,
+    slots_spread,
 };
-use super::name::generate_slot_entry_name;
 use super::params::{extract_slot_params, get_slot_props, prefix_slot_defaults};
 
 /// Generate slots object for component
+///
+/// # Forwarded slots (`v-slots`)
+///
+/// A `v-slots` directive carries an object the compiler cannot see inside, so
+/// it is emitted as a spread rather than expanded into entries (#3467). Two
+/// shapes, both matching `@vue/babel-plugin-jsx`:
+///
+/// - nothing else contributes slots — the forwarded value *is* the children
+///   argument: `createBlock(B, null, slots, 1024 /* DYNAMIC_SLOTS */)`;
+/// - otherwise the authored slots come first and `...expr` closes the object,
+///   so a forwarded entry overrides an authored one of the same name.
+///
+/// **No `_` stability flag is emitted alongside a spread**, and that is
+/// load-bearing rather than an omission. `initSlots`/`updateSlots` only run
+/// `normalizeObjectSlots` — which binds each raw slot to the owning instance
+/// and passes already-`withCtx`-wrapped entries through untouched via
+/// `rawSlot._n` — when the children object carries no `_`. Under `_: 2
+/// /* DYNAMIC */` `updateSlots` does a bare `extend(slots, children)` with no
+/// normalization at all, so an entry arriving through the spread unwrapped
+/// would render without the right instance context; under `_: 1 /* STABLE */`
+/// the child would never re-render when the forwarded slots change. The vnode
+/// instead carries `1024 /* DYNAMIC_SLOTS */` (see
+/// [`has_dynamic_slots_flag`](super::detect::has_dynamic_slots_flag)) to force
+/// that update.
 pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
     // Note: WithCtx helper is registered at each _withCtx() output site,
     // not here, to avoid importing it when slots don't actually use it.
+
+    // A `v-slots` value with nothing to merge it into is the children argument
+    // itself: `createVNode(B, null, slots)`, exactly as babel emits it.
+    if slots_are_only_forwarded(el)
+        && let Some(exp) = slots_spread(el)
+    {
+        generate_expression(ctx, exp);
+        return;
+    }
 
     // Check for v-slot on component root (shorthand for default slot)
     let root_slot = el.props.iter().find_map(|p| {
@@ -210,10 +241,16 @@ pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
         }
     }
 
-    // Add slot stability flag
     ctx.push(",");
     ctx.newline();
-    if has_forwarded_slots && !forwarded_slots_are_dynamic {
+    if let Some(exp) = slots_spread(el) {
+        // The forwarded object closes the literal so its entries override the
+        // authored ones, matching babel's `{default: () => […], ...slots}`. No
+        // `_` flag: see this function's docs for why the raw-slots path is the
+        // only one that normalizes spread entries correctly.
+        ctx.push("...");
+        generate_expression(ctx, exp);
+    } else if has_forwarded_slots && !forwarded_slots_are_dynamic {
         ctx.push("_: 3 /* FORWARDED */");
     } else if has_dynamic_slots {
         ctx.push("_: 2 /* DYNAMIC */");
@@ -226,282 +263,8 @@ pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
     ctx.push("}");
 }
 
-/// Generate slots using createSlots for conditional/looped slot templates
-fn generate_create_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
-    ctx.use_helper(RuntimeHelper::CreateSlots);
-    ctx.push(ctx.helper(RuntimeHelper::CreateSlots));
-    ctx.push("(");
-    generate_create_slots_base(ctx, el);
-    ctx.push(", [");
-    ctx.indent();
-
-    let mut first = true;
-    for child in &el.children {
-        match child {
-            TemplateChildNode::If(if_node) => {
-                // v-if on slot template: generate conditional slot entry
-                if !first {
-                    ctx.push(",");
-                }
-                first = false;
-                ctx.newline();
-                generate_conditional_slot(ctx, if_node);
-            }
-            TemplateChildNode::For(for_node) => {
-                // v-for on slot template: generate looped slot entries
-                if !first {
-                    ctx.push(",");
-                }
-                first = false;
-                ctx.newline();
-                generate_looped_slot(ctx, for_node);
-            }
-            TemplateChildNode::Element(template_el)
-                if template_el.tag.as_str() == "template" && has_v_slot(template_el) =>
-            {
-                // Regular named slot (no v-if/v-for)
-                if !first {
-                    ctx.push(",");
-                }
-                first = false;
-                ctx.newline();
-                // Generate as static slot entry
-                generate_static_slot_entry(ctx, template_el);
-            }
-            _ => {}
-        }
-    }
-
-    ctx.deindent();
-    ctx.newline();
-    ctx.push("])");
-}
-
-fn generate_create_slots_base(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
-    let default_children: Vec<_> = el
-        .children
-        .iter()
-        .filter(|child| !child_is_slot_template(child))
-        .collect();
-    let has_default_children = slot_children_have_meaningful_content(&default_children);
-
-    if !has_default_children {
-        ctx.push("{ _: 2 /* DYNAMIC */ }");
-        return;
-    }
-
-    ctx.push("{");
-    ctx.indent();
-
-    ctx.newline();
-    ctx.push("default: ");
-    ctx.use_helper(RuntimeHelper::WithCtx);
-    ctx.push(ctx.helper(RuntimeHelper::WithCtx));
-    ctx.push("(() => [");
-    ctx.indent();
-    for (i, child) in default_children.iter().enumerate() {
-        if i > 0 {
-            ctx.push(",");
-        }
-        ctx.newline();
-        generate_slot_child_node(ctx, child);
-    }
-    ctx.deindent();
-    ctx.newline();
-    ctx.push("]),");
-
-    ctx.newline();
-    ctx.push("_: 2 /* DYNAMIC */");
-
-    ctx.deindent();
-    ctx.newline();
-    ctx.push("}");
-}
-
-/// Generate a conditional slot entry (v-if on slot template)
-fn generate_conditional_slot(ctx: &mut CodegenContext, if_node: &IfNode<'_>) {
-    // For each branch: condition ? { name, fn, key } : undefined
-    for (i, branch) in if_node.branches.iter().enumerate() {
-        if i > 0 {
-            ctx.newline();
-            ctx.push(": ");
-        }
-
-        // Generate condition
-        if let Some(condition) = &branch.condition {
-            ctx.push("(");
-            generate_expression(ctx, condition);
-            ctx.push(")");
-            ctx.indent();
-            ctx.newline();
-            ctx.push("? ");
-        }
-
-        // Find the slot template in this branch
-        let slot_template = branch.children.iter().find_map(|child| {
-            if let TemplateChildNode::Element(el) = child
-                && el.tag.as_str() == "template"
-                && has_v_slot(el)
-            {
-                return Some(el.as_ref());
-            }
-            None
-        });
-
-        if let Some(template_el) = slot_template {
-            generate_slot_object_entry(ctx, template_el, Some(i));
-        } else {
-            ctx.push("undefined");
-        }
-
-        if branch.condition.is_some() {
-            ctx.deindent();
-        }
-    }
-    if if_node
-        .branches
-        .last()
-        .is_none_or(|branch| branch.condition.is_some())
-    {
-        ctx.newline();
-        ctx.push(": undefined");
-    }
-}
-
-/// Generate a looped slot entry (v-for on slot template)
-fn generate_looped_slot(ctx: &mut CodegenContext, for_node: &ForNode<'_>) {
-    ctx.use_helper(RuntimeHelper::RenderList);
-    ctx.push(ctx.helper(RuntimeHelper::RenderList));
-    ctx.push("(");
-    generate_expression(ctx, &for_node.source);
-    ctx.push(", (");
-
-    // Collect callback parameter names for scope registration
-    let mut callback_params: Vec<String> = Vec::new();
-
-    if let Some(value) = &for_node.value_alias {
-        generate_expression(ctx, value);
-        super::super::v_for::helpers::extract_for_params(value, &mut callback_params);
-    }
-    if let Some(key) = &for_node.key_alias {
-        ctx.push(", ");
-        generate_expression(ctx, key);
-        super::super::v_for::helpers::extract_for_params(key, &mut callback_params);
-    }
-    if let Some(index) = &for_node.object_index_alias {
-        ctx.push(", ");
-        generate_expression(ctx, index);
-        super::super::v_for::helpers::extract_for_params(index, &mut callback_params);
-    }
-
-    ctx.add_slot_params(&callback_params);
-
-    ctx.push(") => {");
-    ctx.indent();
-    ctx.newline();
-    ctx.push("return ");
-
-    // Find the slot template in the for body
-    let slot_template = for_node.children.iter().find_map(|child| {
-        if let TemplateChildNode::Element(el) = child
-            && el.tag.as_str() == "template"
-            && has_v_slot(el)
-        {
-            return Some(el.as_ref());
-        }
-        None
-    });
-
-    if let Some(template_el) = slot_template {
-        generate_slot_object_entry(ctx, template_el, None);
-    }
-
-    ctx.remove_slot_params(&callback_params);
-
-    ctx.deindent();
-    ctx.newline();
-    ctx.push("})");
-}
-
-/// Generate a slot object entry: { name: "slotName", fn: _withCtx(() => [...]), key: "N" }
-fn generate_slot_object_entry(
-    ctx: &mut CodegenContext,
-    template_el: &ElementNode<'_>,
-    key_index: Option<usize>,
-) {
-    let slot_dir = template_el.props.iter().find_map(|p| {
-        if let PropNode::Directive(dir) = p
-            && dir.name.as_str() == "slot"
-        {
-            return Some(dir.as_ref());
-        }
-        None
-    });
-
-    if let Some(dir) = slot_dir {
-        let slot_name = get_slot_name(dir);
-
-        ctx.push("{");
-        ctx.indent();
-        ctx.newline();
-
-        // name
-        ctx.push("name: ");
-        generate_slot_entry_name(ctx, dir, &slot_name);
-        ctx.push(",");
-        ctx.newline();
-
-        // fn
-        ctx.push("fn: ");
-        ctx.use_helper(RuntimeHelper::WithCtx);
-        ctx.push(ctx.helper(RuntimeHelper::WithCtx));
-        ctx.push("(");
-
-        // Slot props
-        let params = if let Some(props_str) = get_slot_props(dir) {
-            let processed = prefix_slot_defaults(&props_str);
-            ctx.push("(");
-            ctx.push(&processed);
-            ctx.push(")");
-            extract_slot_params(&props_str)
-        } else {
-            ctx.push("()");
-            vec![]
-        };
-
-        ctx.add_slot_params(&params);
-
-        ctx.push(" => [");
-        ctx.indent();
-        generate_slot_children(ctx, &template_el.children);
-        ctx.deindent();
-        ctx.newline();
-        ctx.push("])");
-
-        ctx.remove_slot_params(&params);
-
-        // key (for v-if branches)
-        if let Some(key) = key_index {
-            ctx.push(",");
-            ctx.newline();
-            ctx.push("key: \"");
-            ctx.push(&key.to_compact_string());
-            ctx.push("\"");
-        }
-
-        ctx.deindent();
-        ctx.newline();
-        ctx.push("}");
-    }
-}
-
-/// Generate a static slot entry for createSlots context
-fn generate_static_slot_entry(ctx: &mut CodegenContext, template_el: &ElementNode<'_>) {
-    generate_slot_object_entry(ctx, template_el, None);
-}
-
 /// Generate children for a slot
-fn generate_slot_children(ctx: &mut CodegenContext, children: &[TemplateChildNode<'_>]) {
+pub(super) fn generate_slot_children(ctx: &mut CodegenContext, children: &[TemplateChildNode<'_>]) {
     // Check if all children are text/interpolation - if so, concatenate into single _createTextVNode
     let all_text_or_interp = children.iter().all(|child| {
         matches!(
@@ -567,7 +330,7 @@ fn generate_slot_children(ctx: &mut CodegenContext, children: &[TemplateChildNod
 }
 
 /// Generate a single child node for slot content
-fn generate_slot_child_node(ctx: &mut CodegenContext, child: &TemplateChildNode<'_>) {
+pub(super) fn generate_slot_child_node(ctx: &mut CodegenContext, child: &TemplateChildNode<'_>) {
     match child {
         TemplateChildNode::Text(text) => {
             ctx.use_helper(RuntimeHelper::CreateText);

--- a/crates/vize_atelier_core/src/codegen/slots/tests.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/tests.rs
@@ -109,6 +109,45 @@ fn scoped_slot_default_expressions_prefix_context_only() {
 }
 
 #[test]
+fn v_slots_forwards_the_object_as_the_children_argument() {
+    // `v-slots` is a compiler built-in (#3467), so it never reaches the custom
+    // directive path: no `resolveDirective("slots")`, no `withDirectives`. With
+    // nothing else contributing slots the forwarded value *is* the children
+    // argument, matching `@vue/babel-plugin-jsx`.
+    let result = compile!(r#"<Comp v-slots="slots" />"#);
+    assert_eq!(
+        result_output(&result).as_str(),
+        "const { resolveComponent: _resolveComponent, openBlock: _openBlock, \
+         createBlock: _createBlock } = Vue\n\n\
+         function render(_ctx, _cache, $props, $setup, $data, $options) {\n  \
+         const _component_Comp = _resolveComponent(\"Comp\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_Comp, null, slots, \
+         1024 /* DYNAMIC_SLOTS */))\n}"
+    );
+}
+
+#[test]
+fn v_slots_spreads_after_the_authored_slots() {
+    // The spread closes the object so a forwarded entry overrides an authored
+    // one of the same name, and no `_` stability flag is emitted beside it.
+    let result = compile!(r#"<Comp v-slots="slots"><span></span></Comp>"#);
+    assert_eq!(
+        result_output(&result).as_str(),
+        "const { resolveComponent: _resolveComponent, createElementVNode: \
+         _createElementVNode, openBlock: _openBlock, createBlock: _createBlock, \
+         withCtx: _withCtx } = Vue\n\n\
+         function render(_ctx, _cache, $props, $setup, $data, $options) {\n  \
+         const _component_Comp = _resolveComponent(\"Comp\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_Comp, null, {\n    \
+         default: _withCtx(() => [\n      \
+         _createElementVNode(\"span\")\n    \
+         ]),\n    \
+         ...slots\n  \
+         }, 1024 /* DYNAMIC_SLOTS */))\n}"
+    );
+}
+
+#[test]
 fn slot_outlet_vbind_object_preserves_optional_chaining() {
     let result = compile!(
         r#"<slot v-bind="external ? { isActive: undefined } : { isActive: scope?.isActive }" />"#

--- a/crates/vize_atelier_core/src/codegen/v_for.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for.rs
@@ -5,6 +5,7 @@
 
 mod generate;
 pub(crate) mod helpers;
+mod slot_outlet;
 
 use crate::steps::v_memo::{get_memo_exp, has_v_memo};
 use crate::{ForNode, RuntimeHelper, TemplateChildNode};

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use super::super::{
-    children::{generate_children, generate_children_force_array, is_directive_comment},
+    children::{generate_children, generate_children_force_array},
     context::CodegenContext,
     element::helpers::{child_namespace, is_dynamic_component, is_is_prop},
     element::{
@@ -22,12 +22,10 @@ use super::super::{
     patch_flag::{
         calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
     },
-    slots::{
-        generate_slot_outlet_name, generate_slot_outlet_props, generate_slots, has_slot_children,
-        has_slot_outlet_props,
-    },
+    slots::{generate_slots, has_dynamic_slots_flag, has_slot_children},
 };
 use super::helpers::{get_element_key, has_other_props, should_skip_prop};
+use super::slot_outlet::generate_for_slot_outlet;
 use vize_carton::ToCompactString;
 
 fn strip_need_patch_for_v_for_item(patch_flag: Option<i32>) -> Option<i32> {
@@ -261,9 +259,13 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
 
                 // Children
                 let children_el = unwrapped_child.unwrap_or(el);
-                if !children_el.children.is_empty() {
+                // A component forwarding `v-slots` has slots without having any
+                // children of its own, so the slots argument is emitted on its
+                // own account rather than off the child list (#3467).
+                let component_slots = is_component && has_slot_children(children_el);
+                if !children_el.children.is_empty() || component_slots {
                     ctx.push(", ");
-                    if is_component && has_slot_children(children_el) {
+                    if component_slots {
                         // Component children must be compiled as slot functions,
                         // not raw children. Otherwise Vue warns:
                         // "Non-function value encountered for default slot"
@@ -328,12 +330,19 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
                     // slots inside v-for are dynamic by construction.
                     if matches!(el.tag.as_str(), "KeepAlive" | "keep-alive")
                         || (ctx.in_v_for && has_slot_children(el))
+                        || has_dynamic_slots_flag(el)
                     {
                         let dynamic_slots_flag = 1024;
                         patch_flag = Some(patch_flag.unwrap_or(0) | dynamic_slots_flag);
                     }
                     patch_flag = strip_need_patch_for_v_for_item(patch_flag);
-                    if el.children.is_empty() && (patch_flag.is_some() || dynamic_props.is_some()) {
+                    // The slots argument already occupies the children slot, so
+                    // the `null` placeholder is only for a component that
+                    // emitted no children at all.
+                    if el.children.is_empty()
+                        && !component_slots
+                        && (patch_flag.is_some() || dynamic_props.is_some())
+                    {
                         ctx.push(", null");
                     }
                     if let Some(flag) = patch_flag {
@@ -435,47 +444,6 @@ fn unwrap_template_single_element<'a>(el: &'a ElementNode<'a>) -> Option<&'a Ele
         Some(child_el)
     } else {
         None
-    }
-}
-
-fn generate_for_slot_outlet(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
-    ctx.use_helper(RuntimeHelper::RenderSlot);
-    ctx.push(ctx.helper(RuntimeHelper::RenderSlot));
-    ctx.push("(_ctx.$slots, ");
-    generate_slot_outlet_name(ctx, el);
-
-    let has_slot_props = has_slot_outlet_props(el);
-    let filtered: Vec<_> = el
-        .children
-        .iter()
-        .filter(|c| !is_directive_comment(c))
-        .collect();
-
-    if !filtered.is_empty() {
-        if has_slot_props {
-            ctx.push(", ");
-            generate_slot_outlet_props(ctx, el);
-        } else {
-            ctx.push(", {}");
-        }
-        ctx.push(", () => [");
-        ctx.indent();
-        for (i, child) in filtered.iter().enumerate() {
-            if i > 0 {
-                ctx.push(",");
-            }
-            ctx.newline();
-            generate_node(ctx, child);
-        }
-        ctx.deindent();
-        ctx.newline();
-        ctx.push("])");
-    } else if has_slot_props {
-        ctx.push(", ");
-        generate_slot_outlet_props(ctx, el);
-        ctx.push(")");
-    } else {
-        ctx.push(")");
     }
 }
 

--- a/crates/vize_atelier_core/src/codegen/v_for/slot_outlet.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/slot_outlet.rs
@@ -1,0 +1,58 @@
+//! `<slot/>` outlets that are themselves the `v-for` item.
+//!
+//! A slot outlet renders through `renderSlot` rather than as a vnode, so it
+//! never takes the element/component path in
+//! [`generate_for_item`](super::generate::generate_for_item). It is separated
+//! here for the same reason `slots/outlet.rs` is separate from
+//! `slots/generate.rs`: outlet rendering and vnode generation share nothing but
+//! the codegen context.
+
+use crate::{ElementNode, RuntimeHelper};
+
+use super::super::{
+    children::is_directive_comment,
+    context::CodegenContext,
+    node::generate_node,
+    slots::{generate_slot_outlet_name, generate_slot_outlet_props, has_slot_outlet_props},
+};
+
+pub(super) fn generate_for_slot_outlet(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
+    ctx.use_helper(RuntimeHelper::RenderSlot);
+    ctx.push(ctx.helper(RuntimeHelper::RenderSlot));
+    ctx.push("(_ctx.$slots, ");
+    generate_slot_outlet_name(ctx, el);
+
+    let has_slot_props = has_slot_outlet_props(el);
+    let filtered: Vec<_> = el
+        .children
+        .iter()
+        .filter(|c| !is_directive_comment(c))
+        .collect();
+
+    if !filtered.is_empty() {
+        if has_slot_props {
+            ctx.push(", ");
+            generate_slot_outlet_props(ctx, el);
+        } else {
+            ctx.push(", {}");
+        }
+        ctx.push(", () => [");
+        ctx.indent();
+        for (i, child) in filtered.iter().enumerate() {
+            if i > 0 {
+                ctx.push(",");
+            }
+            ctx.newline();
+            generate_node(ctx, child);
+        }
+        ctx.deindent();
+        ctx.newline();
+        ctx.push("])");
+    } else if has_slot_props {
+        ctx.push(", ");
+        generate_slot_outlet_props(ctx, el);
+        ctx.push(")");
+    } else {
+        ctx.push(")");
+    }
+}

--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -13,6 +13,7 @@ use vize_croquis::Croquis;
 
 use crate::compat::{JsxCompatMode, unsupported_with_vapor};
 use crate::diagnostics::JsxDiagnostic;
+use crate::forwarded_slots::{SlotsForwardingBackend, reject_forwarded_slots};
 use crate::ssr::compile_lowered_root_to_ssr;
 use crate::vapor::{VaporCompileOptions, compile_root_to_vapor};
 use crate::vdom::{VdomCompileOptions, compile_root_to_vdom};
@@ -218,6 +219,13 @@ pub fn compile_jsx(
     let mut components = Vec::with_capacity(lowered.roots.len());
     for lowered_root in lowered.roots {
         let component = if config.ssr {
+            // Only VDOM can forward an opaque slots object; the other backends
+            // name the gap rather than drop the directive (#3467).
+            reject_forwarded_slots(
+                &lowered_root.root,
+                SlotsForwardingBackend::Ssr,
+                &mut diagnostics,
+            );
             JsxComponent::Ssr(compile_lowered_root_to_ssr(
                 bump,
                 lowered_root,
@@ -226,6 +234,13 @@ pub fn compile_jsx(
             ))
         } else {
             let mode = resolve_mode(lowered_root.mode, config.default_mode);
+            if mode == JsxOutputMode::Vapor {
+                reject_forwarded_slots(
+                    &lowered_root.root,
+                    SlotsForwardingBackend::Vapor,
+                    &mut diagnostics,
+                );
+            }
             // Compat mode is a vdom-only contract: `@vue/babel-plugin-jsx` has
             // no Vapor output shape to be compatible with. Diagnose rather than
             // silently ignore the request, and keep compiling so the caller

--- a/crates/vize_atelier_jsx/src/forwarded_slots.rs
+++ b/crates/vize_atelier_jsx/src/forwarded_slots.rs
@@ -1,0 +1,89 @@
+//! Which backends can forward an opaque slots object (#3467).
+//!
+//! `v-slots={slots}` lowers to a relief `slots` directive that
+//! `vize_atelier_core`'s slot codegen emits as a spread, so the VDOM backend
+//! forwards it exactly as `@vue/babel-plugin-jsx` does. Vapor and SSR build
+//! their slots from `<template v-slot>` children and have no representation for
+//! an object that only exists at runtime: they would drop the directive and
+//! render the component with no slots, no error and no warning — the failure
+//! shape #3418 exists to remove. So they say so instead.
+
+use vize_relief::{ElementNode, PropNode, RootNode, SourceLocation, TemplateChildNode};
+
+use crate::diagnostics::JsxDiagnostic;
+
+/// The backend a component is being compiled to, for [`reject_forwarded_slots`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SlotsForwardingBackend {
+    Vapor,
+    Ssr,
+}
+
+impl SlotsForwardingBackend {
+    /// The message this backend reports, naming itself and the way out.
+    const fn message(self) -> &'static str {
+        match self {
+            Self::Vapor => {
+                "v-slots forwards a slots object the compiler cannot see inside, which Vapor \
+                 output cannot express: Vapor slots are built from the component's children. \
+                 Write the slots inline, e.g. v-slots={{ default: () => <div/> }}, or compile \
+                 this component to VDOM."
+            }
+            Self::Ssr => {
+                "v-slots forwards a slots object the compiler cannot see inside, which SSR \
+                 output cannot express: the server renderer inlines each slot's content. \
+                 Write the slots inline, e.g. v-slots={{ default: () => <div/> }}, or render \
+                 this component on the client."
+            }
+        }
+    }
+}
+
+/// Report every forwarded `v-slots` value in `root` as unsupported by `backend`.
+pub(crate) fn reject_forwarded_slots(
+    root: &RootNode<'_>,
+    backend: SlotsForwardingBackend,
+    diagnostics: &mut Vec<JsxDiagnostic>,
+) {
+    let mut locations = Vec::new();
+    for child in root.children.iter() {
+        collect_child(child, &mut locations);
+    }
+    for loc in locations {
+        diagnostics.push(JsxDiagnostic::error_at(backend.message(), loc));
+    }
+}
+
+fn collect_child<'b>(child: &'b TemplateChildNode<'_>, out: &mut Vec<&'b SourceLocation>) {
+    match child {
+        TemplateChildNode::Element(el) => collect_element(el, out),
+        TemplateChildNode::If(if_node) => {
+            for branch in if_node.branches.iter() {
+                for child in branch.children.iter() {
+                    collect_child(child, out);
+                }
+            }
+        }
+        TemplateChildNode::For(for_node) => {
+            for child in for_node.children.iter() {
+                collect_child(child, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_element<'b>(el: &'b ElementNode<'_>, out: &mut Vec<&'b SourceLocation>) {
+    for prop in el.props.iter() {
+        if let PropNode::Directive(dir) = prop
+            && dir.name.as_str() == "slots"
+            && dir.arg.is_none()
+            && dir.exp.is_some()
+        {
+            out.push(&dir.loc);
+        }
+    }
+    for child in el.children.iter() {
+        collect_child(child, out);
+    }
+}

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -43,6 +43,7 @@ pub mod vdom;
 
 mod analyze;
 mod finder;
+mod forwarded_slots;
 
 pub use analyze::analyze_program as analyze_jsx_program;
 

--- a/crates/vize_atelier_jsx/src/lower/v_slots.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_slots.rs
@@ -6,6 +6,27 @@
 //! same [`Lowerer::lower_object_slots`] into synthetic `<template v-slot:name>`
 //! children.
 //!
+//! # Forwarding an opaque slots object
+//!
+//! `v-slots={slots}` — the spelling the plugin README uses for slot forwarding —
+//! carries a value the compiler cannot see inside, so there are no entries to
+//! synthesize templates from. It lowers instead to a relief `slots` directive on
+//! the component, which `vize_atelier_core`'s slot codegen emits as a spread
+//! (#3467). Two shapes, both matching babel exactly:
+//!
+//! ```jsx
+//! const A = () => <B v-slots={slots}/>;
+//! const C = () => <B v-slots={slots}><div>A</div></B>;
+//! ```
+//!
+//! ```js
+//! const A = () => _createVNode(_resolveComponent("B"), null, slots);
+//! const C = () => _createVNode(_resolveComponent("B"), null, {
+//!   default: () => [_createVNode("div", null, [_createTextVNode("A")])],
+//!   ...slots
+//! });
+//! ```
+//!
 //! # Why this is a built-in and not a custom directive
 //!
 //! `v-slots` is a plugin built-in, not a user directive. Before #3418 any
@@ -34,13 +55,11 @@
 //!
 //! # Shapes that are diagnosed rather than lowered
 //!
-//! - `v-slots={slots}` and any other non-object-literal value. Vize builds the
-//!   slots object at compile time and has no IR for spreading an opaque value
-//!   into it; babel emits `{…, ...slots}` or passes the value straight through as
-//!   children. Tracked by #3467, which also records why implementing it needs a
-//!   runtime harness rather than just a codegen change.
-//! - `v-slots` with no value, or with a string value. Babel forwards these as
-//!   `null` / `"str"` children, which is meaningless for a component.
+//! - `v-slots` with no value, or with a literal value (`v-slots="str"`,
+//!   `v-slots={1}`, `v-slots={[…]}`). Babel forwards these as the component's
+//!   children, which is meaningless for a component: a slots object is either an
+//!   object literal to expand or an opaque expression to forward, never a
+//!   primitive.
 //! - `v-slots:arg={…}` — `v-slots` takes no argument; the slot names are the
 //!   object's keys.
 //! - `v-slots` on a plain element, which has no slots.
@@ -52,13 +71,30 @@
 //! `slot.rs`), not silence.
 
 use oxc_ast::ast::{
-    Expression, JSXAttribute, JSXAttributeItem, JSXAttributeName, JSXAttributeValue,
+    Expression, JSXAttribute, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXExpression,
+    ObjectExpression,
 };
 use oxc_span::{GetSpan, Span};
-use vize_relief::ElementNode;
+use vize_carton::Box;
+use vize_relief::{DirectiveNode, ElementNode, PropNode};
 
 use super::Lowerer;
 use super::expr::container_expr_span;
+
+/// What a `v-slots` attribute value is, once parentheses and TS wrappers are
+/// seen through.
+enum SlotsValue<'e> {
+    /// `v-slots={{ … }}` — entries the compiler expands into slot templates.
+    Object(&'e ObjectExpression<'e>),
+    /// `v-slots={slots}` — an expression that stays opaque at compile time and
+    /// is forwarded into the slots object as a spread. The span is the source to
+    /// emit, with any wrapper stripped.
+    Forwarded(Span),
+    /// A literal, an array, a lone function, or a quoted/missing value: babel
+    /// forwards these as the component's children, which is not a slots object.
+    /// The span names the offending source, the `&'static str` says why.
+    Rejected(Span, &'static str),
+}
 
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Whether `attr` is a `v-slots` attribute in any spelling.
@@ -128,54 +164,39 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             );
             return;
         };
-        let Some(object) = self.v_slots_object(value) else {
-            // Name the expression itself rather than the `{…}` container, so the
-            // message quotes `slots` and not `{slots}`.
-            let span = match value {
-                JSXAttributeValue::ExpressionContainer(container) => {
-                    container_expr_span(container).unwrap_or_else(|| value.span())
+        match classify_v_slots_value(value) {
+            SlotsValue::Object(object) => {
+                for template in self.lower_object_slots(object) {
+                    node.children.push(template);
                 }
-                other => other.span(),
-            };
-            let source = self.mapper().slice(span);
-            self.reject_at(
-                span,
-                format_args!(
-                    "v-slots value `{source}` is not an object literal: Vize builds the \
-                     slots object at compile time and cannot forward an opaque slots \
-                     value. Write the slots inline, e.g. \
-                     v-slots={{{{ default: () => <div/> }}}}. Forwarding a slots object \
-                     is tracked by #3467."
-                ),
-            );
-            return;
-        };
-
-        for template in self.lower_object_slots(object) {
-            node.children.push(template);
+            }
+            SlotsValue::Forwarded(span) => self.forward_slots(node, span),
+            SlotsValue::Rejected(span, reason) => {
+                let source = self.mapper().slice(span);
+                self.reject_at(
+                    span,
+                    format_args!(
+                        "v-slots value `{source}` {reason}. Write the slots inline, e.g. \
+                         v-slots={{{{ default: () => <div/> }}}}, or forward a slots \
+                         object, e.g. v-slots={{slots}}."
+                    ),
+                );
+            }
         }
     }
 
-    /// The object literal a `v-slots` attribute value carries, or `None` when it
-    /// is anything else.
-    fn v_slots_object<'e>(
-        &self,
-        value: &'e JSXAttributeValue<'e>,
-    ) -> Option<&'e oxc_ast::ast::ObjectExpression<'e>> {
-        let JSXAttributeValue::ExpressionContainer(container) = value else {
-            return None;
-        };
-        match &container.expression {
-            oxc_ast::ast::JSXExpression::ObjectExpression(object) => Some(object),
-            // `v-slots={({ … })}` — parentheses are transparent.
-            oxc_ast::ast::JSXExpression::ParenthesizedExpression(paren) => {
-                match paren.expression.get_inner_expression() {
-                    Expression::ObjectExpression(object) => Some(object),
-                    _ => None,
-                }
-            }
-            _ => None,
-        }
+    /// Record a forwarded slots object on `node` as a relief `slots` directive.
+    ///
+    /// The shared slot codegen turns it into `...expr` inside the slots object,
+    /// or into the whole children argument when nothing else contributes slots
+    /// (#3467). Keeping it a directive rather than a synthesized child is what
+    /// lets the value stay opaque: there are no entries to build templates from.
+    fn forward_slots(&mut self, node: &mut ElementNode<'a>, span: Span) {
+        let loc = self.mapper().location(span);
+        let mut directive = DirectiveNode::new(self.bump(), "slots", loc);
+        directive.exp = Some(self.dyn_expr(span));
+        node.props
+            .push(PropNode::Directive(Box::new_in(directive, self.bump())));
     }
 
     /// The span of the `v-slots` name itself, for any spelling, or `None` when
@@ -190,4 +211,69 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         };
         (raw == "v-slots").then_some(span)
     }
+}
+
+/// Classify a `v-slots` attribute value.
+///
+/// Spans always name the expression itself rather than its `{…}` container, so
+/// a diagnostic quotes `1` and not `{1}`, and a forwarded value is emitted
+/// without its wrapper (`slots as Slots` forwards as `slots`).
+fn classify_v_slots_value<'e>(value: &'e JSXAttributeValue<'e>) -> SlotsValue<'e> {
+    let JSXAttributeValue::ExpressionContainer(container) = value else {
+        // `v-slots="str"` and the JSX element/fragment value forms.
+        return SlotsValue::Rejected(value.span(), NOT_A_SLOTS_OBJECT);
+    };
+    if let JSXExpression::ObjectExpression(object) = &container.expression {
+        return SlotsValue::Object(object);
+    }
+    let Some(span) = container_expr_span(container) else {
+        // `v-slots={}` / `v-slots={/* … */}` carry no expression at all.
+        return SlotsValue::Rejected(container.span, NOT_A_SLOTS_OBJECT);
+    };
+    let Some(expression) = container.expression.as_expression() else {
+        return SlotsValue::Rejected(span, NOT_A_SLOTS_OBJECT);
+    };
+    // Parentheses and TS wrappers (`as`, `satisfies`, `!`) are transparent: what
+    // matters is the expression underneath, and forwarding its own span keeps
+    // TS-only syntax out of the emitted JavaScript.
+    let inner = expression.get_inner_expression();
+    match inner {
+        Expression::ObjectExpression(object) => SlotsValue::Object(object),
+        // A lone function is the *default slot*, not a slots object: babel
+        // forwards it as children and Vue's `normalizeChildren` wraps it as
+        // `{default: fn}`. Spreading it would yield `{}`, so name it instead.
+        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => {
+            SlotsValue::Rejected(inner.span(), IS_A_FUNCTION)
+        }
+        // The comma operator does not survive being emitted verbatim as a
+        // spread (`{...a, b}` is two properties, not one spread).
+        Expression::SequenceExpression(_) => SlotsValue::Rejected(inner.span(), NOT_A_SLOTS_OBJECT),
+        _ if is_literal_value(inner) => SlotsValue::Rejected(inner.span(), NOT_A_SLOTS_OBJECT),
+        _ => SlotsValue::Forwarded(inner.span()),
+    }
+}
+
+const NOT_A_SLOTS_OBJECT: &str = "is not a slots object: babel forwards it as the component's \
+                                  children, which leaves the component with no slots";
+const IS_A_FUNCTION: &str = "is a function, not a slots object: a lone function is the default \
+                             slot, so a spread of it contributes nothing";
+
+/// Whether an expression is a literal value that can never be a slots object.
+///
+/// Everything else — an identifier, a member/call expression, a conditional —
+/// stays opaque at compile time and is forwarded.
+fn is_literal_value(expression: &Expression<'_>) -> bool {
+    matches!(
+        expression,
+        Expression::ArrayExpression(_)
+            | Expression::BigIntLiteral(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::JSXElement(_)
+            | Expression::JSXFragment(_)
+            | Expression::NullLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::RegExpLiteral(_)
+            | Expression::StringLiteral(_)
+            | Expression::TemplateLiteral(_)
+    )
 }

--- a/crates/vize_atelier_jsx/src/ssr.rs
+++ b/crates/vize_atelier_jsx/src/ssr.rs
@@ -11,6 +11,7 @@ use vize_carton::{Bump, String};
 use vize_croquis::Croquis;
 
 use crate::diagnostics::JsxDiagnostic;
+use crate::forwarded_slots::{SlotsForwardingBackend, reject_forwarded_slots};
 use crate::scoped::{ScopedStyle, build_scoped_style};
 use crate::{ComponentSetupSpan, JsxLang, JsxOutputMode, LoweredRoot, lower_source};
 
@@ -62,12 +63,19 @@ pub fn compile_to_ssr(
     options: SsrCompileOptions,
 ) -> SsrOutput {
     let lowered = lower_source(bump, source, lang);
-    let diagnostics = lowered.diagnostics;
+    let mut diagnostics = lowered.diagnostics;
 
     let analysis: &Croquis = &*bump.alloc(lowered.analysis);
 
     let mut components = Vec::with_capacity(lowered.roots.len());
     for lowered_root in lowered.roots {
+        // The server renderer inlines each slot's content, so a forwarded slots
+        // object has nowhere to go; report it rather than drop it (#3467).
+        reject_forwarded_slots(
+            &lowered_root.root,
+            SlotsForwardingBackend::Ssr,
+            &mut diagnostics,
+        );
         components.push(compile_lowered_root_to_ssr(
             bump,
             lowered_root,

--- a/crates/vize_atelier_jsx/src/vapor.rs
+++ b/crates/vize_atelier_jsx/src/vapor.rs
@@ -19,6 +19,7 @@ use vize_carton::{Bump, String};
 use vize_croquis::Croquis;
 
 use crate::diagnostics::JsxDiagnostic;
+use crate::forwarded_slots::{SlotsForwardingBackend, reject_forwarded_slots};
 use crate::scoped::{ScopedStyle, build_scoped_style};
 use crate::{ComponentSetupSpan, JsxLang, JsxOutputMode, LoweredRoot, lower_source};
 
@@ -75,13 +76,21 @@ pub fn compile_to_vapor(
     options: VaporCompileOptions,
 ) -> VaporOutput {
     let lowered = lower_source(bump, source, lang);
-    let diagnostics = lowered.diagnostics;
+    let mut diagnostics = lowered.diagnostics;
 
     // Move the analysis into the arena so the transform can borrow it.
     let analysis: &Croquis = &*bump.alloc(lowered.analysis);
 
+    let backend = if options.ssr {
+        SlotsForwardingBackend::Ssr
+    } else {
+        SlotsForwardingBackend::Vapor
+    };
     let mut components = Vec::with_capacity(lowered.roots.len());
     for lowered_root in lowered.roots {
+        // Vapor slots are built from the component's children, so a forwarded
+        // slots object has nowhere to go; report it rather than drop it (#3467).
+        reject_forwarded_slots(&lowered_root.root, backend, &mut diagnostics);
         components.push(compile_root_to_vapor(
             bump,
             lowered_root,

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   72 |
-| divergent  |   24 |
+| equivalent |   75 |
+| divergent  |   21 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -197,20 +197,66 @@ it classifies as an intrinsic element but the DOM backend still resolves with
 | `slots/object_children`              | object child becomes the slots object | `withCtx` slots + `_: 1`                    | no change                             | ✅      |
 | `slots/render_prop_child`            | `{default: () => 'foo'}`              | `default: () => [createTextVNode("foo")]`   | no change                             | ✅      |
 | `slots/scoped_param`                 | `default: s => …`                     | `default: withCtx((s) => […])`              | no change                             | ✅      |
-| `slots/v_slots_with_children`        | `{default: () => […], ...slots}`      | diagnosed: opaque slots value (#3418)       | forward the object; needs #3467       | ❌      |
-| `slots/v_slots_only`                 | slots object passed as children       | diagnosed: opaque slots value (#3418)       | forward the object; needs #3467       | ❌      |
+| `slots/v_slots_with_children`        | `{default: () => […], ...slots}`      | same keys + `1024 /* DYNAMIC_SLOTS */` (#3467) | no change                          | ✅      |
+| `slots/v_slots_only`                 | slots object passed as children       | same + `1024 /* DYNAMIC_SLOTS */` (#3467)   | no change                             | ✅      |
 | `slots/v_slots_object_literal`       | object literal becomes the slots      | `withCtx` slots + `_: 1` (#3418)            | no change                             | ✅      |
 | `slots/v_slots_object_with_children` | `{default: () => […], bar: …}`        | same two slots, other literal order (#3418) | no change                             | ✅      |
 | `slots/element_children_default`     | `{default: () => […]}`                | `withCtx` default slot + `_: 1`             | no change                             | ✅      |
 | `slots/dynamic_slot_name`            | `{[n]: () => …}`                      | warns and drops the slot                    | deferred: needs dynamic-slot lowering | ⏸       |
 
+### Forwarding an opaque slots object (#3467)
+
+`v-slots={slots}` carries a value the compiler cannot see inside, so there are no
+entries to expand into slot templates. It lowers to a relief `slots` directive on
+the component, which `vize_atelier_core`'s slot codegen emits as a spread. Both
+babel shapes are reproduced exactly: the forwarded value **is** the children
+argument when nothing else contributes slots (`createVNode(B, null, slots)`), and
+otherwise closes the object literal (`{default: () => […], ...slots}`) so a
+forwarded entry overrides an authored one of the same name.
+
+The slot flag is the part that needed deciding, not the spread:
+
+- **No `_` flag is emitted beside a spread** — matching babel, and load-bearing.
+  Only the no-`_` path runs `normalizeObjectSlots`, which binds raw entries to
+  the owning instance and passes already-`withCtx`-wrapped ones through
+  untouched via `rawSlot._n`.
+- **Not `_: 2 /* DYNAMIC */`.** `updateSlots` then does a bare
+  `extend(slots, children)` with no normalization, so a forwarded entry that is
+  not already wrapped would render without the right instance context.
+- **Not `_: 1 /* STABLE */`.** The child would never re-render when the
+  forwarded slots change.
+- The vnode instead carries `1024 /* DYNAMIC_SLOTS */`, which is what forces
+  that update. Babel gets the same forced update for free by emitting no patch
+  flags at all: `shouldUpdateComponent` falls back to "any children means
+  update" for unoptimized vnodes, and Vize's output is always optimized.
+
+Like every other row, these three are asserted on the **emitted code** only:
+the compiled-output mount harness described above still does not exist, so the
+`equivalent` verdict here is review-checked in CI, not executed. The flag choice
+was confirmed once out of band by mounting both emitted shapes against
+`vue@3.5.35` under `happy-dom` — identical `innerHTML` after mount and after the
+forwarded slots changed, with `_: 1` and the no-patch-flag variants both going
+stale — but that check is not committed and does not run in CI (#3391).
+
+`v-slots` is therefore a compiler built-in
+(`vize_carton::BUILTIN_DIRECTIVES`), not a user directive: a component-level
+`v-slots` in a `.vue` template now spreads too, rather than compiling to the
+`resolveDirective("slots")` lookup #3418 removed. A user directive named `slots`
+collides with it exactly as one named `show` or `model` would.
+
 ### `v-slots` spellings Vize rejects and babel accepts
 
 Not corpus rows, because a compat mode is not expected to adopt them; recorded
-here so the choice is not implicit (#3418, `src/lower/v_slots.rs`):
+here so the choice is not implicit (#3418, #3467, `src/lower/v_slots.rs`):
 
-- `v-slots` with no value, and `v-slots="str"` — babel forwards `null` / `"str"`
-  as the component's children, which is meaningless for a component.
+- `v-slots` with no value, `v-slots="str"`, and any literal value
+  (`v-slots={1}`, `v-slots={[…]}`) — babel forwards these as the component's
+  children, which is meaningless for a component. A slots object is either an
+  object literal to expand or an opaque expression to forward, never a literal.
+- `v-slots={() => …}` — a lone function is the *default slot*, not a slots
+  object: babel forwards it as children and Vue wraps it as `{default: fn}`.
+  Spreading it would contribute nothing, so Vize names it and points at
+  `v-slots={{ default: … }}` (or the render-prop child form, which it supports).
 - `v-slots:arg={…}` — `v-slots` takes no argument; the slot names are the object's
   keys.
 - `v-slots` on a plain element — babel drops it silently and emits `[]` children.
@@ -253,7 +299,7 @@ Compared against Vize's default, which is already fully optimized.
 | `optimize/v_model_input`         | `8, ["onUpdate:modelValue"]` | same                                  | no change                       | ✅      |
 | `optimize/slots_stability`       | `_: 1`                       | `_: 1 /* STABLE */`                   | no change                       | ✅      |
 | `optimize/scoped_slot_stability` | `_: 1`                       | `_: 1 /* STABLE */`                   | no change                       | ✅      |
-| `optimize/v_slots_stability`     | slots object as children     | diagnosed: opaque slots value (#3418) | forward the object; needs #3467 | ❌      |
+| `optimize/v_slots_stability`     | slots object as children, no `_` flag | same, no `_` flag (#3467)    | no change                       | ✅      |
 | `optimize/fragment`              | no flag                      | `64 /* STABLE_FRAGMENT */`            | no change                       | ✅      |
 | `optimize/map_list`              | raw array child              | `renderList` + `KEYED_FRAGMENT`       | no change                       | ✅      |
 
@@ -268,4 +314,4 @@ accept it.
 | `errors/v_model_no_value`         | rejects: "You have to use JSX Expression inside your v-model"   | rejects: "v-model is missing expression."                         | no change      | ✅      |
 | `errors/v_models_not_array`       | rejects a non-array `v-models` value                            | rejects it too, naming the expected entry shape (closed by #3418) | no change      | ✅      |
 | `errors/v_models_entry_not_array` | rejects: "You should pass a Two-dimensional Arrays to v-models" | rejects it too, naming the offending entry (closed by #3418)      | no change      | ✅      |
-| `errors/v_slots_not_object`       | forwards the value as children                                  | rejects it, naming the offending value (#3418)                    | keep rejecting | ❌      |
+| `errors/v_slots_not_object`       | forwards the value as children                                  | rejects it, naming the offending value (#3418, #3467)             | keep rejecting | ❌      |

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -192,17 +192,17 @@ it classifies as an intrinsic element but the DOM backend still resolves with
 
 ## Slots
 
-| Case                                 | Babel                                 | Vize today                                  | Compat mode                           | Verdict |
-| ------------------------------------ | ------------------------------------- | ------------------------------------------- | ------------------------------------- | ------- |
-| `slots/object_children`              | object child becomes the slots object | `withCtx` slots + `_: 1`                    | no change                             | ✅      |
-| `slots/render_prop_child`            | `{default: () => 'foo'}`              | `default: () => [createTextVNode("foo")]`   | no change                             | ✅      |
-| `slots/scoped_param`                 | `default: s => …`                     | `default: withCtx((s) => […])`              | no change                             | ✅      |
-| `slots/v_slots_with_children`        | `{default: () => […], ...slots}`      | same keys + `1024 /* DYNAMIC_SLOTS */` (#3467) | no change                          | ✅      |
-| `slots/v_slots_only`                 | slots object passed as children       | same + `1024 /* DYNAMIC_SLOTS */` (#3467)   | no change                             | ✅      |
-| `slots/v_slots_object_literal`       | object literal becomes the slots      | `withCtx` slots + `_: 1` (#3418)            | no change                             | ✅      |
-| `slots/v_slots_object_with_children` | `{default: () => […], bar: …}`        | same two slots, other literal order (#3418) | no change                             | ✅      |
-| `slots/element_children_default`     | `{default: () => […]}`                | `withCtx` default slot + `_: 1`             | no change                             | ✅      |
-| `slots/dynamic_slot_name`            | `{[n]: () => …}`                      | warns and drops the slot                    | deferred: needs dynamic-slot lowering | ⏸       |
+| Case                                 | Babel                                 | Vize today                                     | Compat mode                           | Verdict |
+| ------------------------------------ | ------------------------------------- | ---------------------------------------------- | ------------------------------------- | ------- |
+| `slots/object_children`              | object child becomes the slots object | `withCtx` slots + `_: 1`                       | no change                             | ✅      |
+| `slots/render_prop_child`            | `{default: () => 'foo'}`              | `default: () => [createTextVNode("foo")]`      | no change                             | ✅      |
+| `slots/scoped_param`                 | `default: s => …`                     | `default: withCtx((s) => […])`                 | no change                             | ✅      |
+| `slots/v_slots_with_children`        | `{default: () => […], ...slots}`      | same keys + `1024 /* DYNAMIC_SLOTS */` (#3467) | no change                             | ✅      |
+| `slots/v_slots_only`                 | slots object passed as children       | same + `1024 /* DYNAMIC_SLOTS */` (#3467)      | no change                             | ✅      |
+| `slots/v_slots_object_literal`       | object literal becomes the slots      | `withCtx` slots + `_: 1` (#3418)               | no change                             | ✅      |
+| `slots/v_slots_object_with_children` | `{default: () => […], bar: …}`        | same two slots, other literal order (#3418)    | no change                             | ✅      |
+| `slots/element_children_default`     | `{default: () => […]}`                | `withCtx` default slot + `_: 1`                | no change                             | ✅      |
+| `slots/dynamic_slot_name`            | `{[n]: () => …}`                      | warns and drops the slot                       | deferred: needs dynamic-slot lowering | ⏸       |
 
 ### Forwarding an opaque slots object (#3467)
 
@@ -253,7 +253,7 @@ here so the choice is not implicit (#3418, #3467, `src/lower/v_slots.rs`):
   (`v-slots={1}`, `v-slots={[…]}`) — babel forwards these as the component's
   children, which is meaningless for a component. A slots object is either an
   object literal to expand or an opaque expression to forward, never a literal.
-- `v-slots={() => …}` — a lone function is the *default slot*, not a slots
+- `v-slots={() => …}` — a lone function is the _default slot_, not a slots
   object: babel forwards it as children and Vue wraps it as `{default: fn}`.
   Spreading it would contribute nothing, so Vize names it and points at
   `v-slots={{ default: … }}` (or the render-prop child form, which it supports).
@@ -284,24 +284,24 @@ here so the choice is not implicit (#3418, #3467, `src/lower/v_slots.rs`):
 
 Compared against Vize's default, which is already fully optimized.
 
-| Case                             | Babel                        | Vize today                            | Compat mode                     | Verdict |
-| -------------------------------- | ---------------------------- | ------------------------------------- | ------------------------------- | ------- |
-| `optimize/static`                | no flag                      | no flag                               | no change                       | ✅      |
-| `optimize/class_only`            | `2`                          | `2 /* CLASS */`                       | no change                       | ✅      |
-| `optimize/style_only`            | `4`                          | `4 /* STYLE */`                       | no change                       | ✅      |
-| `optimize/text_only`             | raw child, no flag           | `toDisplayString(t)` + `1 /* TEXT */` | emit the raw child              | ❌      |
-| `optimize/class_and_props`       | `10, ["id"]`                 | `11 /* TEXT, CLASS, PROPS */, ["id"]` | drop the TEXT child             | ❌      |
-| `optimize/spread`                | `16`                         | `16 /* FULL_PROPS */`                 | no change                       | ✅      |
-| `optimize/ref`                   | `512`                        | `512 /* NEED_PATCH */`                | no change                       | ✅      |
-| `optimize/key`                   | no flag                      | no flag                               | no change                       | ✅      |
-| `optimize/event`                 | `8, ["onClick"]`             | same                                  | no change                       | ✅      |
-| `optimize/component_props`       | `8, ["foo"]`                 | same                                  | no change                       | ✅      |
-| `optimize/v_model_input`         | `8, ["onUpdate:modelValue"]` | same                                  | no change                       | ✅      |
-| `optimize/slots_stability`       | `_: 1`                       | `_: 1 /* STABLE */`                   | no change                       | ✅      |
-| `optimize/scoped_slot_stability` | `_: 1`                       | `_: 1 /* STABLE */`                   | no change                       | ✅      |
-| `optimize/v_slots_stability`     | slots object as children, no `_` flag | same, no `_` flag (#3467)    | no change                       | ✅      |
-| `optimize/fragment`              | no flag                      | `64 /* STABLE_FRAGMENT */`            | no change                       | ✅      |
-| `optimize/map_list`              | raw array child              | `renderList` + `KEYED_FRAGMENT`       | no change                       | ✅      |
+| Case                             | Babel                                 | Vize today                            | Compat mode         | Verdict |
+| -------------------------------- | ------------------------------------- | ------------------------------------- | ------------------- | ------- |
+| `optimize/static`                | no flag                               | no flag                               | no change           | ✅      |
+| `optimize/class_only`            | `2`                                   | `2 /* CLASS */`                       | no change           | ✅      |
+| `optimize/style_only`            | `4`                                   | `4 /* STYLE */`                       | no change           | ✅      |
+| `optimize/text_only`             | raw child, no flag                    | `toDisplayString(t)` + `1 /* TEXT */` | emit the raw child  | ❌      |
+| `optimize/class_and_props`       | `10, ["id"]`                          | `11 /* TEXT, CLASS, PROPS */, ["id"]` | drop the TEXT child | ❌      |
+| `optimize/spread`                | `16`                                  | `16 /* FULL_PROPS */`                 | no change           | ✅      |
+| `optimize/ref`                   | `512`                                 | `512 /* NEED_PATCH */`                | no change           | ✅      |
+| `optimize/key`                   | no flag                               | no flag                               | no change           | ✅      |
+| `optimize/event`                 | `8, ["onClick"]`                      | same                                  | no change           | ✅      |
+| `optimize/component_props`       | `8, ["foo"]`                          | same                                  | no change           | ✅      |
+| `optimize/v_model_input`         | `8, ["onUpdate:modelValue"]`          | same                                  | no change           | ✅      |
+| `optimize/slots_stability`       | `_: 1`                                | `_: 1 /* STABLE */`                   | no change           | ✅      |
+| `optimize/scoped_slot_stability` | `_: 1`                                | `_: 1 /* STABLE */`                   | no change           | ✅      |
+| `optimize/v_slots_stability`     | slots object as children, no `_` flag | same, no `_` flag (#3467)             | no change           | ✅      |
+| `optimize/fragment`              | no flag                               | `64 /* STABLE_FRAGMENT */`            | no change           | ✅      |
+| `optimize/map_list`              | raw array child                       | `renderList` + `KEYED_FRAGMENT`       | no change           | ✅      |
 
 ## Inputs babel rejects
 

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -123,16 +123,11 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("slots/object_children", Same),
     ("slots/render_prop_child", Same),
     ("slots/scoped_param", Same),
-    // #3418 lowers the object-literal form; an opaque slots value is diagnosed
-    // rather than forwarded, which needs the slots spread tracked by #3467.
-    (
-        "slots/v_slots_with_children",
-        Diff("opaque v-slots value diagnosed; needs #3467"),
-    ),
-    (
-        "slots/v_slots_only",
-        Diff("opaque v-slots value diagnosed; needs #3467"),
-    ),
+    // #3418 lowers the object-literal form; #3467 forwards an opaque slots
+    // value as a spread (or as the whole children argument when nothing else
+    // contributes slots), with no `_` flag and a DYNAMIC_SLOTS vnode flag.
+    ("slots/v_slots_with_children", Same),
+    ("slots/v_slots_only", Same),
     ("slots/v_slots_object_literal", Same),
     ("slots/v_slots_object_with_children", Same),
     ("slots/element_children_default", Same),
@@ -172,10 +167,9 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("optimize/v_model_input", Same),
     ("optimize/slots_stability", Same),
     ("optimize/scoped_slot_stability", Same),
-    (
-        "optimize/v_slots_stability",
-        Diff("opaque v-slots value diagnosed; needs #3467"),
-    ),
+    // Babel emits no `_` flag beside a forwarded slots object even under
+    // `optimize: true`, and neither does Vize (#3467).
+    ("optimize/v_slots_stability", Same),
     ("optimize/fragment", Same),
     ("optimize/map_list", Same),
     // -- errors ----------------------------------------------------------

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (72, 24, 2));
+    assert_eq!((equivalent, divergent, deferred), (75, 21, 2));
     assert_eq!(VERDICTS.len(), 98);
 }
 

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
@@ -81,7 +81,7 @@ const A = () => <B v-slots={1}/>;
 import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_resolveComponent("B"), null, 1);
 ### vize (vdom, default config)
-<Error> v-slots value `1` is not an object literal: Vize builds the slots object at compile time and cannot forward an opaque slots value. Write the slots inline, e.g. v-slots={{ default: () => <div/> }}. Forwarding a slots object is tracked by #3467.
+<Error> v-slots value `1` is not a slots object: babel forwards it as the component's children, which leaves the component with no slots. Write the slots inline, e.g. v-slots={{ default: () => <div/> }}, or forward a slots object, e.g. v-slots={slots}.
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__optimize.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__optimize.snap
@@ -268,7 +268,7 @@ export function render(_ctx, _cache) {
 
 ## optimize/v_slots_stability
 ### verdict
-divergent: opaque v-slots value diagnosed; needs #3467
+equivalent
 ### source (jsx)
 const A = () => <B v-slots={slots}/>;
 ### babel options
@@ -277,12 +277,11 @@ const A = () => <B v-slots={slots}/>;
 import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_resolveComponent("B"), null, slots);
 ### vize (vdom, default config)
-<Error> v-slots value `slots` is not an object literal: Vize builds the slots object at compile time and cannot forward an opaque slots value. Write the slots inline, e.g. v-slots={{ default: () => <div/> }}. Forwarding a slots object is tracked by #3467.
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
   
-  return (_openBlock(), _createBlock(_component_B))
+  return (_openBlock(), _createBlock(_component_B, null, slots, 1024 /* DYNAMIC_SLOTS */))
 }
 
 ## optimize/fragment

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__slots.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__slots.snap
@@ -83,7 +83,7 @@ export function render(_ctx, _cache) {
 
 ## slots/v_slots_with_children
 ### verdict
-divergent: opaque v-slots value diagnosed; needs #3467
+equivalent
 ### source (jsx)
 const A = () => <B v-slots={slots}><div>A</div></B>;
 ### babel options
@@ -95,7 +95,6 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
   ...slots
 });
 ### vize (vdom, default config)
-<Error> v-slots value `slots` is not an object literal: Vize builds the slots object at compile time and cannot forward an opaque slots value. Write the slots inline, e.g. v-slots={{ default: () => <div/> }}. Forwarding a slots object is tracked by #3467.
 import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -104,13 +103,13 @@ export function render(_ctx, _cache) {
     default: _withCtx(() => [
       _createElementVNode("div", null, "A")
     ]),
-    _: 1 /* STABLE */
-  }))
+    ...slots
+  }, 1024 /* DYNAMIC_SLOTS */))
 }
 
 ## slots/v_slots_only
 ### verdict
-divergent: opaque v-slots value diagnosed; needs #3467
+equivalent
 ### source (jsx)
 const A = () => <B v-slots={slots}/>;
 ### babel options
@@ -119,12 +118,11 @@ const A = () => <B v-slots={slots}/>;
 import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_resolveComponent("B"), null, slots);
 ### vize (vdom, default config)
-<Error> v-slots value `slots` is not an object literal: Vize builds the slots object at compile time and cannot forward an opaque slots value. Write the slots inline, e.g. v-slots={{ default: () => <div/> }}. Forwarding a slots object is tracked by #3467.
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
   
-  return (_openBlock(), _createBlock(_component_B))
+  return (_openBlock(), _createBlock(_component_B, null, slots, 1024 /* DYNAMIC_SLOTS */))
 }
 
 ## slots/v_slots_object_literal

--- a/crates/vize_atelier_jsx/tests/v_slots.rs
+++ b/crates/vize_atelier_jsx/tests/v_slots.rs
@@ -10,8 +10,10 @@
 //!
 //! The object-literal form is pinned against the real plugin by the differential
 //! oracle (rows `slots/v_slots_object_literal` and
-//! `slots/v_slots_object_with_children`); forwarding an opaque slots object is
-//! still diagnosed and is tracked by #3467.
+//! `slots/v_slots_object_with_children`). Forwarding an **opaque** slots object
+//! (`v-slots={slots}`, #3467) has its own suite in `v_slots_forwarding.rs`;
+//! what stays here is the object-literal path plus the shapes both files agree
+//! are not a slots object at all.
 
 mod common;
 
@@ -201,63 +203,38 @@ fn v_slots_is_never_a_prop() {
 }
 
 #[test]
-fn an_opaque_slots_value_is_rejected() {
-    // Vize builds the slots object at compile time and has no IR for spreading
-    // an opaque value into it; implementing that is #3467.
-    let message = "v-slots value `slots` is not an object literal: Vize builds the slots \
-                   object at compile time and cannot forward an opaque slots value. Write \
-                   the slots inline, e.g. v-slots={{ default: () => <div/> }}. Forwarding \
-                   a slots object is tracked by #3467.";
-    assert_eq!(
-        errors("const A = () => <B v-slots={slots}/>;"),
-        vec![message.to_string()]
-    );
-    // No prop is contributed, so no `resolveDirective("slots")` is emitted.
-    assert_eq!(
-        render_code("const A = () => <B v-slots={slots}/>;"),
-        BARE_COMPONENT
-    );
-    // The element's own children are still lowered.
-    assert_eq!(
-        errors("const A = () => <B v-slots={slots}><div>A</div></B>;"),
-        vec![message.to_string()]
-    );
-    assert_eq!(
-        render_code("const A = () => <B v-slots={slots}><div>A</div></B>;"),
-        "export function render(_ctx, _cache) {\n  \
-         const _component_B = _resolveComponent(\"B\")\n  \n  \
-         return (_openBlock(), _createBlock(_component_B, null, {\n    \
-         default: _withCtx(() => [\n      \
-         _createElementVNode(\"div\", null, \"A\")\n    \
-         ]),\n    \
-         _: 1 /* STABLE */\n  \
-         }))\n}"
-    );
-}
-
-#[test]
-fn a_non_object_value_is_rejected() {
+fn a_literal_value_is_rejected() {
     // The corpus row `errors/v_slots_not_object`: babel forwards `1` as the
-    // component's children, which is meaningless.
+    // component's children, which is meaningless. An opaque *expression* is
+    // forwarded instead of rejected — see `v_slots_forwarding.rs` (#3467).
+    let suffix = "Write the slots inline, e.g. v-slots={{ default: () => <div/> }}, or \
+                  forward a slots object, e.g. v-slots={slots}.";
+    let not_slots = "is not a slots object: babel forwards it as the component's children, \
+                     which leaves the component with no slots.";
     assert_eq!(
         errors("const A = () => <B v-slots={1}/>;"),
-        vec![
-            "v-slots value `1` is not an object literal: Vize builds the slots object at \
-             compile time and cannot forward an opaque slots value. Write the slots \
-             inline, e.g. v-slots={{ default: () => <div/> }}. Forwarding a slots object \
-             is tracked by #3467."
-                .to_string()
-        ]
+        vec![format!("v-slots value `1` {not_slots} {suffix}")]
     );
     assert_eq!(
         errors("const A = () => <B v-slots=\"str\"/>;"),
-        vec![
-            "v-slots value `\"str\"` is not an object literal: Vize builds the slots \
-             object at compile time and cannot forward an opaque slots value. Write the \
-             slots inline, e.g. v-slots={{ default: () => <div/> }}. Forwarding a slots \
-             object is tracked by #3467."
-                .to_string()
-        ]
+        vec![format!("v-slots value `\"str\"` {not_slots} {suffix}")]
+    );
+    assert_eq!(
+        errors("const A = () => <B v-slots={[a, b]}/>;"),
+        vec![format!("v-slots value `[a, b]` {not_slots} {suffix}")]
+    );
+    assert_eq!(
+        render_code("const A = () => <B v-slots={1}/>;"),
+        BARE_COMPONENT
+    );
+    // A lone function is the default slot, not a slots object: spreading it
+    // would contribute nothing, so it is named rather than mis-lowered.
+    assert_eq!(
+        errors("const A = () => <B v-slots={() => <i/>}/>;"),
+        vec![format!(
+            "v-slots value `() => <i/>` is a function, not a slots object: a lone function \
+             is the default slot, so a spread of it contributes nothing. {suffix}"
+        )]
     );
 }
 

--- a/crates/vize_atelier_jsx/tests/v_slots_forwarding.rs
+++ b/crates/vize_atelier_jsx/tests/v_slots_forwarding.rs
@@ -1,0 +1,228 @@
+//! Forwarding an opaque slots object from `v-slots={slots}` (#3467).
+//!
+//! `v-slots={{ … }}` expands into synthetic `<template v-slot:name>` children
+//! (#3418, `v_slots.rs`). `v-slots={slots}` cannot: the value only exists at
+//! runtime, so there are no entries to expand. It lowers to a relief `slots`
+//! directive that `vize_atelier_core`'s slot codegen emits as a spread.
+//!
+//! Both babel shapes are asserted on the **complete** generated render function,
+//! against the recorded `@vue/babel-plugin-jsx` 2.0.1 output in the corpus rows
+//! `slots/v_slots_only`, `slots/v_slots_with_children` and
+//! `optimize/v_slots_stability`:
+//!
+//! ```js
+//! const A = () => _createVNode(_resolveComponent("B"), null, slots);
+//! const C = () => _createVNode(_resolveComponent("B"), null, {
+//!   default: () => [_createVNode("div", null, [_createTextVNode("A")])],
+//!   ...slots
+//! });
+//! ```
+//!
+//! # Why no `_` flag and why `1024 /* DYNAMIC_SLOTS */`
+//!
+//! Babel emits no slot-stability flag beside a forwarded object, even under
+//! `optimize: true`, and neither does Vize. Only the no-`_` path runs Vue's
+//! `normalizeObjectSlots`, which binds raw entries to the owning instance and
+//! passes already-`withCtx`-wrapped ones through untouched via `rawSlot._n`.
+//! `_: 2 /* DYNAMIC */` would `extend` without normalizing; `_: 1 /* STABLE */`
+//! would stop the child re-rendering when the forwarded slots change. Babel's
+//! unoptimized vnodes get that update for free (`shouldUpdateComponent` forces
+//! it for any children); Vize's are always optimized, so the vnode carries
+//! `1024 /* DYNAMIC_SLOTS */` to force it.
+
+mod common;
+
+use vize_atelier_jsx::{
+    JsxLang, SsrCompileOptions, VaporCompileOptions, VdomCompileOptions, compile_to_ssr,
+    compile_to_vapor, compile_to_vdom,
+};
+use vize_carton::Bump;
+
+fn render_code(source: &str) -> String {
+    let bump = Bump::new();
+    let out = compile_to_vdom(&bump, source, JsxLang::Jsx, VdomCompileOptions::default());
+    assert_eq!(
+        out.diagnostics
+            .iter()
+            .map(|d| d.message.as_str().to_string())
+            .collect::<Vec<_>>(),
+        Vec::<String>::new(),
+        "forwarding a slots object to VDOM is supported and must not diagnose"
+    );
+    out.components
+        .into_iter()
+        .map(|component| component.code.as_str().to_string())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn a_forwarded_slots_object_is_the_children_argument() {
+    // Corpus rows `slots/v_slots_only` and `optimize/v_slots_stability`: babel
+    // emits `_createVNode(_resolveComponent("B"), null, slots)` for both, with
+    // no `_` flag under either option set.
+    assert_eq!(
+        render_code("const A = () => <B v-slots={slots}/>;"),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, null, slots, \
+         1024 /* DYNAMIC_SLOTS */))\n}"
+    );
+}
+
+#[test]
+fn element_children_become_the_default_slot_and_the_spread_closes_the_object() {
+    // Corpus row `slots/v_slots_with_children`: babel emits
+    // `{default: () => [...], ...slots}` — authored slots first, spread last, so
+    // a forwarded entry overrides an authored one of the same name.
+    assert_eq!(
+        render_code("const A = () => <B v-slots={slots}><div>A</div></B>;"),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, null, {\n    \
+         default: _withCtx(() => [\n      \
+         _createElementVNode(\"div\", null, \"A\")\n    \
+         ]),\n    \
+         ...slots\n  \
+         }, 1024 /* DYNAMIC_SLOTS */))\n}"
+    );
+}
+
+#[test]
+fn named_slot_templates_keep_the_spread_last() {
+    assert_eq!(
+        render_code("const A = () => <B v-slots={slots}><template v-slot:foo>x</template></B>;"),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, null, {\n    \
+         foo: _withCtx(() => [\n      \
+         _createTextVNode(\"x\")\n    \
+         ]),\n    \
+         ...slots\n  \
+         }, 1024 /* DYNAMIC_SLOTS */))\n}"
+    );
+}
+
+#[test]
+fn whitespace_only_children_do_not_build_an_object() {
+    // Whitespace is not a default slot, so this is still the bare-value shape.
+    assert_eq!(
+        render_code("const A = () => <B v-slots={slots}>{' '}</B>;"),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, null, slots, \
+         1024 /* DYNAMIC_SLOTS */))\n}"
+    );
+}
+
+#[test]
+fn any_opaque_expression_is_forwarded_verbatim() {
+    // Parentheses and TS wrappers are transparent; what is emitted is the
+    // expression underneath, so no TS-only syntax reaches the JavaScript.
+    for (source, forwarded) in [
+        ("<B v-slots={p.slots}/>", "p.slots"),
+        ("<B v-slots={(slots)}/>", "slots"),
+        ("<B v-slots={getSlots()}/>", "getSlots()"),
+        ("<B v-slots={c ? a : b}/>", "c ? a : b"),
+    ] {
+        assert_eq!(
+            render_code(&format!("const A = () => {source};")),
+            format!(
+                "export function render(_ctx, _cache) {{\n  \
+                 const _component_B = _resolveComponent(\"B\")\n  \n  \
+                 return (_openBlock(), _createBlock(_component_B, null, {forwarded}, \
+                 1024 /* DYNAMIC_SLOTS */))\n}}"
+            ),
+            "{source}"
+        );
+    }
+}
+
+#[test]
+fn a_forwarded_slots_object_survives_v_for() {
+    // A component with no children of its own still needs the slots argument
+    // emitted inside `renderList`, where the children slot is otherwise skipped.
+    assert_eq!(
+        render_code("const A = () => <ul>{items.map(i => <B key={i} v-slots={slots}/>)}</ul>;"),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createElementBlock(\"ul\", null, [\n    \
+         (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(items, (i) => {\n      \
+         return (_openBlock(), _createBlock(_component_B, {\n        \
+         key: i\n      \
+         }, slots, 1024 /* DYNAMIC_SLOTS */))\n    \
+         }), 128 /* KEYED_FRAGMENT */))\n  \
+         ]))\n}"
+    );
+}
+
+#[test]
+fn v_slots_never_becomes_a_resolved_directive() {
+    // The #3418 regression: an unrecognized `v-*` fell through to the custom
+    // directive path. `slots` is a compiler built-in, so it contributes no prop,
+    // no `withDirectives` wrapper and no `resolveDirective("slots")`.
+    let bump = Bump::new();
+    let root = common::lower_one(&bump, "const A = () => <B class=\"c\" v-slots={slots}/>;");
+    let element = common::root_element(&root);
+    assert_eq!(element.props.len(), 2);
+    assert_eq!(
+        common::as_attribute(&element.props[0]).name.as_str(),
+        "class"
+    );
+    let forwarded =
+        common::find_directive(element, "slots").expect("v-slots lowers to a directive");
+    assert!(forwarded.arg.is_none());
+    let exp = forwarded.exp.as_ref().expect("forwarded expression");
+    assert_eq!(common::simple_content(exp), "slots");
+    assert!(!common::is_static(exp));
+}
+
+#[test]
+fn vapor_output_reports_the_gap_instead_of_dropping_the_slots() {
+    // Vapor builds its slots from the component's children and has no spread, so
+    // it must not silently render a component with no slots.
+    let bump = Bump::new();
+    let out = compile_to_vapor(
+        &bump,
+        "const A = () => <B v-slots={slots}/>;",
+        JsxLang::Jsx,
+        VaporCompileOptions::default(),
+    );
+    assert_eq!(
+        out.diagnostics
+            .iter()
+            .map(|d| d.message.as_str().to_string())
+            .collect::<Vec<_>>(),
+        vec![
+            "v-slots forwards a slots object the compiler cannot see inside, which Vapor \
+             output cannot express: Vapor slots are built from the component's children. \
+             Write the slots inline, e.g. v-slots={{ default: () => <div/> }}, or compile \
+             this component to VDOM."
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn ssr_output_reports_the_gap_instead_of_dropping_the_slots() {
+    let bump = Bump::new();
+    let out = compile_to_ssr(
+        &bump,
+        "const A = () => <B v-slots={slots}/>;",
+        JsxLang::Jsx,
+        SsrCompileOptions::default(),
+    );
+    assert_eq!(
+        out.diagnostics
+            .iter()
+            .map(|d| d.message.as_str().to_string())
+            .collect::<Vec<_>>(),
+        vec![
+            "v-slots forwards a slots object the compiler cannot see inside, which SSR \
+             output cannot express: the server renderer inlines each slot's content. \
+             Write the slots inline, e.g. v-slots={{ default: () => <div/> }}, or render \
+             this component on the client."
+                .to_string()
+        ]
+    );
+}

--- a/crates/vize_carton/src/general.rs
+++ b/crates/vize_carton/src/general.rs
@@ -17,9 +17,16 @@ pub static BUILTIN_TAGS: phf::Set<&'static str> = phf_set! {
 };
 
 /// Built-in directives
+///
+/// `slots` is the plural sibling of `slot`: it carries the object a component
+/// spreads into its slots object (`<B v-slots={slots}/>`, the
+/// `@vue/babel-plugin-jsx` spelling for slot forwarding, #3467).
+/// `vize_atelier_core`'s slot codegen consumes it, so — exactly like `slot` — it
+/// must never reach the custom-directive path and compile to a
+/// `resolveDirective("slots")` lookup for a directive that does not exist.
 pub static BUILTIN_DIRECTIVES: phf::Set<&'static str> = phf_set! {
     "bind", "cloak", "else-if", "else", "for", "html", "if",
-    "model", "on", "once", "pre", "show", "slot", "text", "memo"
+    "model", "on", "once", "pre", "show", "slot", "slots", "text", "memo"
 };
 
 /// Check if a property name is reserved


### PR DESCRIPTION
Closes #3467.

`v-slots={{ … }}` expands into synthetic `<template v-slot:name>` children
(#3418). `v-slots={slots}` cannot: the value only exists at runtime, so there
are no entries to expand — and it was diagnosed rather than forwarded, even
though it is the spelling the `@vue/babel-plugin-jsx` README uses for slot
forwarding.

## What it emits

A `v-slots` value that stays opaque now lowers to a relief `slots` directive on
the component, which `vize_atelier_core`'s slot codegen emits as a spread. Both
babel shapes are reproduced exactly, asserted on the complete generated render
function against the recorded `@vue/babel-plugin-jsx` 2.0.1 output:

```jsx
const A = () => <B v-slots={slots}/>;
const C = () => <B v-slots={slots}><div>A</div></B>;
```

```js
// babel
const A = () => _createVNode(_resolveComponent("B"), null, slots);
const C = () => _createVNode(_resolveComponent("B"), null, {
  default: () => [_createVNode("div", null, [_createTextVNode("A")])],
  ...slots
});
```

```js
// vize
return (_openBlock(), _createBlock(_component_B, null, slots, 1024 /* DYNAMIC_SLOTS */))

return (_openBlock(), _createBlock(_component_B, null, {
  default: _withCtx(() => [
    _createElementVNode("div", null, "A")
  ]),
  ...slots
}, 1024 /* DYNAMIC_SLOTS */))
```

With no children the forwarded value **is** the children argument; with children
it closes the object literal, so a forwarded entry overrides an authored one of
the same name — babel's key order.

## The slot flag, which is the part that needed deciding

**No `_` flag is emitted beside a spread**, matching babel under `optimize: true`
as well. That is load-bearing, not an omission:

- Only the no-`_` path runs `normalizeObjectSlots`, which binds raw entries to
  the owning instance and passes already-`withCtx`-wrapped ones through
  untouched via `rawSlot._n`.
- `_: 2 /* DYNAMIC */` would make `updateSlots` do a bare
  `extend(slots, children)` with no normalization, so a forwarded entry that is
  not already wrapped would render without the right instance context.
- `_: 1 /* STABLE */` would stop the child re-rendering when the forwarded slots
  change.

The vnode carries `1024 /* DYNAMIC_SLOTS */` instead, which is what forces that
update. Babel gets it for free by emitting no patch flags at all
(`shouldUpdateComponent` falls back to "any children means update" for
unoptimized vnodes); Vize's output is always optimized, so it has to be explicit.
`has_dynamic_slots_flag` is the single predicate the block / inline / `v-if`
vnode sites already share, so one change covers three of the four; the `v-for`
site needed its own edit because a forwarded component has slots without having
any children.

## Runtime check

The repo still has no harness that mounts compiled output (#3391), so CI asserts
the emitted code only. The flag choice was confirmed once out of band by mounting
both emitted shapes against `vue@3.5.35` under `happy-dom`: identical `innerHTML`
after mount and after the forwarded slots changed, while the `_: 1` and
no-patch-flag variants both went stale. That check is not committed and is called
out as not-executed in `BABEL_COMPAT_INVENTORY.md`.

## Corpus rows

`slots/v_slots_only`, `slots/v_slots_with_children` and
`optimize/v_slots_stability` move from divergent to equivalent; totals go
72/24/2 → 75/21/2, pinned by `babel_compat_verdict_totals` and the inventory.

## Also

- `slots` joins `vize_carton::BUILTIN_DIRECTIVES`, so it never reaches the
  custom-directive path — the `resolveDirective("slots")` lookup #3418 removed.
  A component-level `v-slots` in a `.vue` template therefore spreads too; a user
  directive named `slots` collides with it exactly as one named `show` would.
  Pinned by two new template-level tests in `codegen/slots/tests.rs`.
- Vapor and SSR build their slots from the component's children and have no
  spread. They report the gap rather than drop the directive, so this does not
  trade one silent degradation for another.
- Still rejected, with the message rewritten: a missing/quoted/literal value
  (`v-slots={1}`, `v-slots={[…]}`), and a lone function — that is the default
  slot, not a slots object, and spreading it would contribute nothing.
- `slots/generate.rs` (659) and `v_for/generate.rs` (952) are both over the
  350-line budget, so the `createSlots` family and the v-for slot-outlet path
  moved to their own files rather than growing them.

## Verification

```
cargo test -p vize_atelier_jsx                                    # all green
cargo test -p vize_atelier_core -p vize_carton -p vize_atelier_dom \
           -p vize_atelier_ssr -p vize_atelier_vapor -p vize_relief -p vize_croquis
rustfmt --edition 2024 --config style_edition=2024 --check <changed files>
cargo clippy -p vize_atelier_jsx -p vize_atelier_core -p vize_carton -- -D warnings
```

Regression proof: with `crates/*/src` reverted to the base and the new tests
kept, all 9 `tests/v_slots_forwarding.rs` tests fail, `v_slots::a_literal_value_is_rejected`
fails, and `babel_compat_matrix_snapshot` fails.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->