### PR TITLE
fix(atelier): lower JSX member tags and nested fragments instead of naming them

### DIFF
--- a/crates/vize_atelier_jsx/src/lower/child.rs
+++ b/crates/vize_atelier_jsx/src/lower/child.rs
@@ -7,13 +7,6 @@ use vize_relief::{InterpolationNode, TemplateChildNode, TextNode};
 
 use super::Lowerer;
 
-/// `<div><><i/></></div>`. A nested fragment is lowered as an element tagged
-/// `Fragment`, and the DOM backend turns a component tag into
-/// `resolveComponent("Fragment")`, which resolves to nothing at runtime.
-/// A fragment used as the whole render root is fine — its children become the
-/// root children — so only the nested case reports.
-const NESTED_FRAGMENT_UNSUPPORTED: &str = "a JSX fragment nested inside an element is not supported; it lowers to an unresolvable `Fragment` component";
-
 /// `<div>{...items}</div>`. `@vue/babel-plugin-jsx` spreads the value into the
 /// children array; the lowering has no spread child, so the array used to be
 /// stringified into a single text node through `toDisplayString`.
@@ -27,37 +20,46 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     ) -> Vec<'a, TemplateChildNode<'a>> {
         let mut out = Vec::new_in(self.bump());
         for child in children {
-            if let Some(node) = self.lower_child(child) {
-                out.push(node);
-            }
+            self.push_child(child, &mut out);
         }
         out
     }
 
-    fn lower_child(&mut self, child: &JSXChild<'_>) -> Option<TemplateChildNode<'a>> {
+    /// Lower one JSX child, appending zero or more nodes to `out`. A child is
+    /// not one-to-one with a node: `<style scoped>` and `{}` contribute none,
+    /// and a fragment contributes its whole child list.
+    fn push_child(&mut self, child: &JSXChild<'_>, out: &mut Vec<'a, TemplateChildNode<'a>>) {
         match child {
-            JSXChild::Text(text) => self.lower_text(text),
+            // `<div><><i/><b/></></div>`. A fragment in child position carries
+            // no props and cannot be keyed, so its children *are* the parent's
+            // children at that position, in every backend. Splicing them in is
+            // therefore equivalent to the nested `Fragment` vnode
+            // `@vue/babel-plugin-jsx` emits, and it removes the node the DOM
+            // backend used to resolve by name as `resolveComponent("Fragment")`
+            // — an unresolvable component (#3421).
+            JSXChild::Fragment(fragment) => {
+                for nested in &fragment.children {
+                    self.push_child(nested, out);
+                }
+            }
+            JSXChild::Text(text) => out.extend(self.lower_text(text)),
             JSXChild::Element(element) => {
                 // A `<style scoped>` block is extracted at compile time (#1495)
                 // and must not become an element vnode; drop it from the
                 // rendered children once captured.
                 if self.try_extract_scoped_style(element) {
-                    return None;
+                    return;
                 }
-                Some(TemplateChildNode::Element(Box::new_in(
-                    self.lower_element_node(element),
-                    self.bump(),
-                )))
+                let node = self.lower_element_node(element);
+                out.push(TemplateChildNode::Element(Box::new_in(node, self.bump())));
             }
-            JSXChild::Fragment(fragment) => {
-                self.reject(fragment.span, NESTED_FRAGMENT_UNSUPPORTED);
-                Some(TemplateChildNode::Element(Box::new_in(
-                    self.lower_fragment_node(fragment),
-                    self.bump(),
-                )))
+            JSXChild::ExpressionContainer(container) => {
+                out.extend(self.lower_child_container(container));
             }
-            JSXChild::ExpressionContainer(container) => self.lower_child_container(container),
-            JSXChild::Spread(spread) => Some(self.lower_spread_child(spread)),
+            JSXChild::Spread(spread) => {
+                let node = self.lower_spread_child(spread);
+                out.push(node);
+            }
         }
     }
 

--- a/crates/vize_atelier_jsx/src/lower/element.rs
+++ b/crates/vize_atelier_jsx/src/lower/element.rs
@@ -1,16 +1,35 @@
 //! Lowering JSX elements and fragments into [`ElementNode`]s.
 
 use oxc_ast::ast::{JSXElement, JSXElementName, JSXFragment};
-use vize_relief::ElementNode;
-use vize_relief::ElementType;
+use oxc_span::Span;
+use vize_carton::{Box, String};
+use vize_relief::{DirectiveNode, ElementNode, ElementType, PropNode};
 
 use super::{Lowerer, name};
+
+/// Vue's dynamic-component tag.
+///
+/// `<a.b.c/>` names a component **value**, not a component name, so it lowers
+/// to `<component :is="a.b.c">`: the backends turn that into
+/// `resolveDynamicComponent(a.b.c)`, which passes a non-string straight
+/// through and so mounts exactly what `@vue/babel-plugin-jsx`'s
+/// `createVNode(a.b.c, …)` mounts. Emitting the dotted path as a *name*
+/// instead (`resolveComponent("a.b.c")`) looks up a component nobody
+/// registered, which resolves to nothing at runtime (#3421).
+const DYNAMIC_COMPONENT_TAG: &str = "component";
 
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Lower a JSX element into an [`ElementNode`] (tag, kind, props, children).
     pub(crate) fn lower_element_node(&mut self, element: &JSXElement<'_>) -> ElementNode<'a> {
         let opening = &element.opening_element;
-        let tag = name::element_tag(&opening.name);
+        self.reject_unsupported_namespace(&opening.name);
+        // A member-expression tag is a value, so it becomes the `:is` binding of
+        // a dynamic component rather than a tag string.
+        let expression_tag = name::expression_tag_span(&opening.name);
+        let tag = match expression_tag {
+            Some(_) => String::from(DYNAMIC_COMPONENT_TAG),
+            None => name::element_tag(&opening.name),
+        };
         let loc = self.mapper().location(element.span);
         let mut node = ElementNode::new(self.bump(), tag, loc);
         node.tag_type = element_type(&opening.name);
@@ -22,6 +41,12 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         // `@vue/babel-plugin-jsx`.
         let on_component = node.tag_type == ElementType::Component || node.tag.contains('-');
         node.props = self.lower_attributes(&opening.attributes, on_component);
+        if let Some(span) = expression_tag {
+            // First, so the emitted props object reads `<component :is="…" …>`
+            // like the template spelling it stands for. Codegen filters `is`
+            // out of the props object for a dynamic component.
+            node.props.insert(0, self.is_binding(span));
+        }
         // Components route through slot synthesis (object/render-prop children
         // become `<template v-slot>`s); intrinsic elements lower children
         // directly.
@@ -37,14 +62,50 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         node
     }
 
-    /// Lower a JSX fragment (`<>...</>`) used as a child into an [`ElementNode`]
-    /// tagged `Fragment`, matching `@vue/babel-plugin-jsx` semantics.
+    /// Lower a JSX fragment (`<>...</>`) that has to become a **single** node:
+    /// a `v-if` branch or a `v-for` body (`cond ? <><a/><b/></> : <c/>`).
+    /// Fragments in a child list or a slot body are spliced into that list
+    /// instead and never reach here.
+    ///
+    /// Lowered as an [`ElementType::Template`] node — Vize's IR for "these
+    /// children, with no element of their own", i.e. the `<template v-if>` /
+    /// `<template v-for>` shape every backend already handles, which the VDOM
+    /// backend emits as `createElementBlock(Fragment, …, STABLE_FRAGMENT)`.
+    /// Tagging it `Fragment` as a *component* instead produced
+    /// `resolveComponent("Fragment")`, a component nobody registers, so the
+    /// branch rendered nothing (#3421).
     pub(crate) fn lower_fragment_node(&mut self, fragment: &JSXFragment<'_>) -> ElementNode<'a> {
         let loc = self.mapper().location(fragment.span);
-        let mut node = ElementNode::new(self.bump(), "Fragment", loc);
-        node.tag_type = ElementType::Component;
+        let mut node = ElementNode::new(self.bump(), "template", loc);
+        node.tag_type = ElementType::Template;
         node.children = self.lower_children(&fragment.children);
         node
+    }
+
+    /// `:is="<source text of span>"`, the dynamic-component binding standing in
+    /// for a member-expression tag.
+    fn is_binding(&self, span: Span) -> PropNode<'a> {
+        let loc = self.mapper().location(span);
+        let mut directive = DirectiveNode::new(self.bump(), "bind", loc);
+        directive.arg = Some(self.static_expr("is", span));
+        directive.exp = Some(self.dyn_expr(span));
+        PropNode::Directive(Box::new_in(directive, self.bump()))
+    }
+
+    /// Report a JSX tag carrying a namespace no backend can resolve.
+    fn reject_unsupported_namespace(&mut self, name: &JSXElementName<'_>) {
+        let Some((namespace, span)) = name::unsupported_namespace(name) else {
+            return;
+        };
+        let tag = self.mapper().slice(span);
+        self.reject_at(
+            span,
+            format_args!(
+                "unsupported JSX tag namespace `{namespace}:`; only `svg:` and `math:` name a real \
+                 element namespace, so `{tag}` would be emitted verbatim as a tag name nothing \
+                 resolves (`@vue/babel-plugin-jsx` rejects every namespaced tag)"
+            ),
+        );
     }
 }
 

--- a/crates/vize_atelier_jsx/src/lower/name.rs
+++ b/crates/vize_atelier_jsx/src/lower/name.rs
@@ -1,12 +1,20 @@
 //! Resolving JSX element names into Vize tag strings and element kinds.
 
-use oxc_ast::ast::{JSXElementName, JSXMemberExpression, JSXMemberExpressionObject};
+use oxc_ast::ast::JSXElementName;
+use oxc_span::Span;
 use vize_carton::String;
 
-/// The Vize tag string for a JSX element name.
+/// The XML namespace prefixes a JSX tag may legitimately carry.
 ///
-/// Member expressions keep their full dotted path (`Foo.Bar`), namespaced names
-/// keep the `ns:name` form, and `this.X` resolves to `this.X`.
+/// `<svg:circle/>` and `<math:mi/>` are the qualified spellings of the only two
+/// foreign-content namespaces the HTML parser knows, and Vize keeps them
+/// verbatim. Every other prefix names a namespace nothing downstream resolves:
+/// `@vue/babel-plugin-jsx` rejects namespaced tags outright with
+/// `getTag: JSXNamespacedName is not supported`.
+const KNOWN_TAG_NAMESPACES: [&str; 2] = ["svg", "math"];
+
+/// The Vize tag string for a JSX element name. Namespaced names keep the
+/// `ns:name` form.
 pub(crate) fn element_tag(name: &JSXElementName<'_>) -> String {
     match name {
         JSXElementName::Identifier(id) => String::from(id.name.as_str()),
@@ -17,8 +25,16 @@ pub(crate) fn element_tag(name: &JSXElementName<'_>) -> String {
             tag.push_str(named.name.name.as_str());
             tag
         }
-        JSXElementName::MemberExpression(member) => member_to_string(member),
-        JSXElementName::ThisExpression(_) => String::from("this"),
+        // Panic path by lowering invariant: `lower_element_node` asks
+        // `expression_tag_span` first and routes these into a dynamic
+        // component's `:is` binding, because they name a *value*, not a
+        // component name. Reaching this arm would mean that guard was bypassed,
+        // and the dotted path would be emitted as a component name — the
+        // `resolveComponent("a.b.c")` lookup of a component nobody registers
+        // that #3421 removed.
+        JSXElementName::MemberExpression(_) | JSXElementName::ThisExpression(_) => {
+            unreachable!("member-expression tags lower to a dynamic component")
+        }
     }
 }
 
@@ -37,25 +53,36 @@ pub(crate) fn is_component(name: &JSXElementName<'_>) -> bool {
     }
 }
 
+/// The namespace prefix of a JSX tag Vize cannot lower, with the span to point
+/// a diagnostic at. `None` for an unprefixed tag or a known namespace.
+pub(crate) fn unsupported_namespace<'n>(name: &'n JSXElementName<'_>) -> Option<(&'n str, Span)> {
+    let JSXElementName::NamespacedName(named) = name else {
+        return None;
+    };
+    let namespace = named.namespace.name.as_str();
+    if KNOWN_TAG_NAMESPACES.contains(&namespace) {
+        return None;
+    }
+    Some((namespace, named.span))
+}
+
+/// The span of a JSX tag that names a **JavaScript expression** rather than a
+/// component name: `<a.b.c/>`, `<this.Dyn/>`, `<this/>`.
+///
+/// Slicing the span rather than rebuilding the path from the AST keeps the
+/// emitted expression byte-identical to what the author wrote.
+pub(crate) fn expression_tag_span(name: &JSXElementName<'_>) -> Option<Span> {
+    match name {
+        JSXElementName::MemberExpression(member) => Some(member.span),
+        JSXElementName::ThisExpression(this) => Some(this.span),
+        JSXElementName::Identifier(_)
+        | JSXElementName::IdentifierReference(_)
+        | JSXElementName::NamespacedName(_) => None,
+    }
+}
+
 fn is_intrinsic(name: &str) -> bool {
     name.chars()
         .next()
         .is_some_and(|ch| ch.is_ascii_lowercase())
-}
-
-fn member_to_string(member: &JSXMemberExpression<'_>) -> String {
-    let mut base = member_object_to_string(&member.object);
-    base.push('.');
-    base.push_str(member.property.name.as_str());
-    base
-}
-
-fn member_object_to_string(object: &JSXMemberExpressionObject<'_>) -> String {
-    match object {
-        JSXMemberExpressionObject::IdentifierReference(reference) => {
-            String::from(reference.name.as_str())
-        }
-        JSXMemberExpressionObject::MemberExpression(member) => member_to_string(member),
-        JSXMemberExpressionObject::ThisExpression(_) => String::from("this"),
-    }
 }

--- a/crates/vize_atelier_jsx/src/lower/slot.rs
+++ b/crates/vize_atelier_jsx/src/lower/slot.rs
@@ -202,11 +202,10 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
                     self.bump(),
                 )));
             }
+            // A slot body is already a child *list*, so a fragment body splices
+            // into it exactly as it does in element child position (#3421).
             Expression::JSXFragment(fragment) => {
-                out.push(TemplateChildNode::Element(Box::new_in(
-                    self.lower_fragment_node(fragment),
-                    self.bump(),
-                )));
+                out = self.lower_children(&fragment.children);
             }
             // `&&` / ternary / `.map(...)` slot bodies lower to the same
             // If/For relief children as control-flow expression children.

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   75 |
-| divergent  |   21 |
+| equivalent |   78 |
+| divergent  |   18 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -107,18 +107,41 @@ deliberate answer, recorded here so it is not relitigated.
 
 ## Elements and tags
 
-| Case                             | Babel                                                            | Vize today                                               | Compat mode                                  | Verdict |
-| -------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------- | ------- |
-| `elements/intrinsic`             | `createVNode("div", …)`                                          | `createElementBlock("div")`                              | no change                                    | ✅      |
-| `elements/component_pascal`      | `resolveComponent("B")`                                          | same                                                     | no change                                    | ✅      |
-| `elements/unknown_lowercase`     | `<foo/>` → `resolveComponent("foo")`                             | stays an intrinsic element                               | classify any non-HTML/SVG tag as a component | ❌      |
-| `elements/dashed_lowercase`      | `resolveComponent("my-el")`                                      | same                                                     | no change                                    | ✅      |
-| `elements/svg_tag`               | `createVNode("circle", …)`                                       | same                                                     | no change                                    | ✅      |
-| `elements/mathml_tag`            | `<mi/>` → `resolveComponent("mi")` (only HTML+SVG are intrinsic) | stays an intrinsic element                               | same fix as `unknown_lowercase`              | ❌      |
-| `elements/member_tag`            | `createVNode(a.b.c, …)`                                          | `resolveComponent("a.b.c")` — a name string              | emit the member expression                   | ❌      |
-| `elements/namespaced_tag`        | rejects: `getTag: JSXNamespacedName is not supported`            | silently emits tag `a:b`                                 | reject with a diagnostic                     | ❌      |
-| `elements/fragment`              | `createVNode(Fragment, null, […])`                               | `createElementBlock(Fragment, …, STABLE_FRAGMENT)`       | no change                                    | ✅      |
-| `elements/nested_fragment_child` | nested `Fragment` vnode                                          | `resolveComponent("Fragment")`, now reported as an error | use the `Fragment` symbol                    | ❌      |
+| Case                             | Babel                                                            | Vize today                                         | Compat mode                                  | Verdict |
+| -------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------- | -------------------------------------------- | ------- |
+| `elements/intrinsic`             | `createVNode("div", …)`                                          | `createElementBlock("div")`                        | no change                                    | ✅      |
+| `elements/component_pascal`      | `resolveComponent("B")`                                          | same                                               | no change                                    | ✅      |
+| `elements/unknown_lowercase`     | `<foo/>` → `resolveComponent("foo")`                             | stays an intrinsic element                         | classify any non-HTML/SVG tag as a component | ❌      |
+| `elements/dashed_lowercase`      | `resolveComponent("my-el")`                                      | same                                               | no change                                    | ✅      |
+| `elements/svg_tag`               | `createVNode("circle", …)`                                       | same                                               | no change                                    | ✅      |
+| `elements/mathml_tag`            | `<mi/>` → `resolveComponent("mi")` (only HTML+SVG are intrinsic) | stays an intrinsic element                         | same fix as `unknown_lowercase`              | ❌      |
+| `elements/member_tag`            | `createVNode(a.b.c, …)`                                          | `resolveDynamicComponent(a.b.c)` (#3421)           | no change                                    | ✅      |
+| `elements/namespaced_tag`        | rejects: `getTag: JSXNamespacedName is not supported`            | rejects it too, naming the namespace (#3421)       | no change                                    | ✅      |
+| `elements/fragment`              | `createVNode(Fragment, null, […])`                               | `createElementBlock(Fragment, …, STABLE_FRAGMENT)` | no change                                    | ✅      |
+| `elements/nested_fragment_child` | nested `Fragment` vnode                                          | children spliced into the parent (#3421)           | no change                                    | ✅      |
+
+### Tag shapes: what the three ✅ above are equivalent _up to_
+
+Recorded so the verdicts are not read as byte equality (#3421,
+`src/lower/element.rs`, `src/lower/name.rs`):
+
+- **Member tags.** `resolveDynamicComponent` returns a non-string argument
+  unchanged, so `<a.b.c/>` mounts exactly what babel's `createVNode(a.b.c, …)`
+  mounts. The two differ only when the member expression evaluates to a
+  **string**: babel makes it an element tag, Vize looks it up as a registered
+  component and falls back to the string. That is what `<component :is>` means
+  in a Vue template, so the divergence is Vue's own semantics rather than a
+  lowering gap.
+- **Nested fragments.** A JSX fragment in child position carries no props and
+  cannot be keyed, so Vize splices its children into the parent instead of
+  emitting a wrapper. Same DOM, same patch order, one vnode level fewer than
+  babel's nested `Fragment`.
+- **Namespaced tags.** Babel rejects _every_ `<ns:tag/>`. Vize rejects every
+  namespace except `svg:` and `math:`, the two that name a real element
+  namespace; `<svg:circle/>` stays a verbatim tag (pinned by
+  `elements.rs::known_namespaced_element_names_are_preserved`). This is the one
+  place Vize is deliberately more permissive than babel, and a compat mode is
+  not expected to narrow it.
 
 ## Props and attributes
 

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -45,19 +45,15 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("elements/dashed_lowercase", Same),
     ("elements/svg_tag", Same),
     ("elements/mathml_tag", Diff("unknown tag stays intrinsic")),
-    (
-        "elements/member_tag",
-        Diff("member tag resolved as a name string"),
-    ),
-    (
-        "elements/namespaced_tag",
-        Diff("namespaced tag accepted, babel rejects"),
-    ),
+    // Closed by #3421: a member tag names a component value, so it lowers to
+    // `resolveDynamicComponent`, which passes a non-string through unchanged.
+    ("elements/member_tag", Same),
+    // Closed by #3421: an unknown tag namespace is rejected, as babel does.
+    ("elements/namespaced_tag", Same),
     ("elements/fragment", Same),
-    (
-        "elements/nested_fragment_child",
-        Diff("nested fragment resolved by name, now reported"),
-    ),
+    // Closed by #3421: the nested fragment's children are spliced into the
+    // parent, mounting the same DOM as babel's nested `Fragment` vnode.
+    ("elements/nested_fragment_child", Same),
     // -- props -----------------------------------------------------------
     ("props/static_attr", Same),
     (

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (75, 21, 2));
+    assert_eq!((equivalent, divergent, deferred), (78, 18, 2));
     assert_eq!(VERDICTS.len(), 98);
 }
 

--- a/crates/vize_atelier_jsx/tests/diagnostics.rs
+++ b/crates/vize_atelier_jsx/tests/diagnostics.rs
@@ -85,33 +85,61 @@ fn diagnostic_texts<'d>(
         .collect()
 }
 
+/// `<a:b/>` names a namespace nothing downstream resolves, and the tag used to
+/// reach codegen verbatim as `createElementBlock("a:b")` with no signal.
+/// `@vue/babel-plugin-jsx` rejects every namespaced tag outright; Vize keeps the
+/// two prefixes that name a real element namespace and rejects the rest (#3421).
 #[test]
-fn nested_fragment_child_is_reported() {
+fn unsupported_tag_namespace_is_reported() {
     let bump = Bump::new();
-    let src = "const a = <div><><i/></></div>;";
+    let src = "const a = <a:b foo={1}/>;";
     let out = lower_all(&bump, src);
 
     assert_eq!(
         diagnostic_texts(&out),
         vec![(
             true,
-            "a JSX fragment nested inside an element is not supported; it lowers to an unresolvable `Fragment` component"
+            "unsupported JSX tag namespace `a:`; only `svg:` and `math:` name a real element \
+             namespace, so `a:b` would be emitted verbatim as a tag name nothing resolves \
+             (`@vue/babel-plugin-jsx` rejects every namespaced tag)"
         )]
     );
-    // The span covers exactly the nested fragment.
+    // The span covers exactly the tag name.
     let diagnostic = &out.diagnostics[0];
     assert_eq!(
         &src[diagnostic.start as usize..diagnostic.end as usize],
-        "<><i/></>"
+        "a:b"
     );
 }
 
 #[test]
-fn a_fragment_used_as_the_whole_root_is_not_reported() {
-    let bump = Bump::new();
-    let out = lower_all(&bump, "const a = <><i/><b/></>;");
+fn svg_and_math_namespaced_tags_are_not_reported() {
+    for source in [
+        "const a = <svg:circle/>;",
+        "const a = <math:mi/>;",
+        "const a = <div><svg:circle/></div>;",
+    ] {
+        let bump = Bump::new();
+        let out = lower_all(&bump, source);
+        assert_eq!(diagnostic_texts(&out), vec![], "for {source}");
+    }
+}
 
-    assert_eq!(diagnostic_texts(&out), vec![]);
+/// A fragment is lowered faithfully wherever it appears, so none of these
+/// positions reports. The nested case used to report because it produced an
+/// unresolvable `Fragment` component; it is now spliced into its parent.
+#[test]
+fn fragments_are_not_reported_at_any_depth() {
+    for source in [
+        "const a = <><i/><b/></>;",
+        "const a = <div><><i/></></div>;",
+        "const a = <B>{() => <><i/></>}</B>;",
+        "const a = <div>{cond ? <><i/></> : <b/>}</div>;",
+    ] {
+        let bump = Bump::new();
+        let out = lower_all(&bump, source);
+        assert_eq!(diagnostic_texts(&out), vec![], "for {source}");
+    }
 }
 
 #[test]

--- a/crates/vize_atelier_jsx/tests/edge_cases.rs
+++ b/crates/vize_atelier_jsx/tests/edge_cases.rs
@@ -45,14 +45,23 @@ fn fragment_preserves_mixed_child_order_exactly() {
         other => panic!("expected interpolation, got {:?}", other.node_type()),
     }
 
+    // `Widget.Panel` is a component *value*, so it lowers to a dynamic
+    // component whose `:is` binding is the member expression, ahead of the
+    // element's own props (#3421).
     let panel = as_element(&root.children[2]);
-    assert_eq!(panel.tag.as_str(), "Widget.Panel");
+    assert_eq!(panel.tag.as_str(), "component");
     assert_eq!(panel.tag_type, ElementType::Component);
-    assert_eq!(panel.props.len(), 2);
-    assert_eq!(as_attribute(&panel.props[0]).name.as_str(), "active");
-    assert_eq!(as_attribute(&panel.props[1]).name.as_str(), "data-id");
+    assert_eq!(panel.props.len(), 3);
+    let is_binding = as_directive(&panel.props[0]);
+    assert_eq!(simple_content(is_binding.arg.as_ref().unwrap()), "is");
     assert_eq!(
-        as_attribute(&panel.props[1])
+        simple_content(is_binding.exp.as_ref().unwrap()),
+        "Widget.Panel"
+    );
+    assert_eq!(as_attribute(&panel.props[1]).name.as_str(), "active");
+    assert_eq!(as_attribute(&panel.props[2]).name.as_str(), "data-id");
+    assert_eq!(
+        as_attribute(&panel.props[2])
             .value
             .as_ref()
             .unwrap()

--- a/crates/vize_atelier_jsx/tests/elements.rs
+++ b/crates/vize_atelier_jsx/tests/elements.rs
@@ -2,7 +2,8 @@
 
 mod common;
 
-use common::{as_element, lower_one, root_element};
+use common::{as_directive, as_element, lower_one, root_element, simple_content, vdom_code};
+use vize_atelier_jsx::JsxLang;
 use vize_carton::Bump;
 use vize_relief::ElementType;
 
@@ -40,22 +41,67 @@ fn capitalized_tag_is_a_component() {
     assert_eq!(element.tag_type, ElementType::Component);
 }
 
+/// `<Foo.Bar.Baz/>` names a component **value**. It used to lower to the tag
+/// string `"Foo.Bar.Baz"`, which the DOM backend emitted as
+/// `resolveComponent("Foo.Bar.Baz")` — a lookup of a component name nobody
+/// registers, so the element rendered as nothing with no diagnostic (#3421).
 #[test]
-fn member_expression_tag_keeps_dotted_path() {
+fn member_expression_tag_lowers_to_a_dynamic_component() {
     let bump = Bump::new();
     let root = lower_one(&bump, "const a = <Foo.Bar.Baz/>;");
     let element = root_element(&root);
-    assert_eq!(element.tag.as_str(), "Foo.Bar.Baz");
+    assert_eq!(element.tag.as_str(), "component");
     assert_eq!(element.tag_type, ElementType::Component);
+    assert_eq!(element.props.len(), 1);
+    let is_binding = as_directive(&element.props[0]);
+    assert_eq!(is_binding.name.as_str(), "bind");
+    assert_eq!(simple_content(is_binding.arg.as_ref().unwrap()), "is");
+    assert_eq!(
+        simple_content(is_binding.exp.as_ref().unwrap()),
+        "Foo.Bar.Baz"
+    );
 }
 
 #[test]
-fn this_member_tag_is_a_component() {
+fn this_member_tag_lowers_to_a_dynamic_component() {
     let bump = Bump::new();
     let root = lower_one(&bump, "const a = <this.Dynamic/>;");
     let element = root_element(&root);
-    assert_eq!(element.tag.as_str(), "this.Dynamic");
+    assert_eq!(element.tag.as_str(), "component");
     assert_eq!(element.tag_type, ElementType::Component);
+    assert_eq!(element.props.len(), 1);
+    assert_eq!(
+        simple_content(as_directive(&element.props[0]).exp.as_ref().unwrap()),
+        "this.Dynamic"
+    );
+}
+
+/// The whole emitted module for a member-expression tag. `resolveDynamicComponent`
+/// returns a non-string argument unchanged, so this mounts exactly what
+/// `@vue/babel-plugin-jsx`'s `createVNode(a.b.c, {"foo": 1}, null)` mounts.
+#[test]
+fn member_expression_tag_emits_resolve_dynamic_component() {
+    assert_eq!(
+        vdom_code("const A = () => <a.b.c foo={1}/>;", JsxLang::Jsx).as_str(),
+        "export function render(_ctx, _cache) {\n  \
+         return (_openBlock(), _createBlock(_resolveDynamicComponent(a.b.c), { foo: 1 }))\n}"
+    );
+}
+
+/// The member expression keeps its own props, and the `is` binding it is
+/// lowered through never leaks into the emitted props object.
+#[test]
+fn member_expression_tag_with_children_keeps_props_and_slots() {
+    assert_eq!(
+        vdom_code("const A = () => <a.b.c foo={1}>hi</a.b.c>;", JsxLang::Jsx).as_str(),
+        "export function render(_ctx, _cache) {\n  \
+         return (_openBlock(), _createBlock(_resolveDynamicComponent(a.b.c), { foo: 1 }, {\n    \
+         default: _withCtx(() => [\n      \
+         _createTextVNode(\"hi\")\n    \
+         ]),\n    \
+         _: 1 /* STABLE */\n  \
+         }))\n}"
+    );
 }
 
 #[test]
@@ -85,14 +131,22 @@ fn deeply_nested_tree_preserves_structure() {
     assert!(span.is_self_closing);
 }
 
+/// `svg:` and `math:` are the qualified spellings of the two foreign-content
+/// namespaces, and stay verbatim. Every other prefix is diagnosed instead — see
+/// `diagnostics.rs::unsupported_tag_namespace_is_reported` (#3421).
 #[test]
-fn namespaced_element_name_is_preserved() {
-    let bump = Bump::new();
-    let root = lower_one(&bump, "const a = <svg:circle/>;");
-    let element = root_element(&root);
-    assert_eq!(element.tag.as_str(), "svg:circle");
-    // `circle` starts lowercase -> intrinsic.
-    assert_eq!(element.tag_type, ElementType::Element);
+fn known_namespaced_element_names_are_preserved() {
+    for (source, tag) in [
+        ("const a = <svg:circle/>;", "svg:circle"),
+        ("const a = <math:mi/>;", "math:mi"),
+    ] {
+        let bump = Bump::new();
+        let root = lower_one(&bump, source);
+        let element = root_element(&root);
+        assert_eq!(element.tag.as_str(), tag);
+        // The local name starts lowercase -> intrinsic.
+        assert_eq!(element.tag_type, ElementType::Element);
+    }
 }
 
 #[test]

--- a/crates/vize_atelier_jsx/tests/fragments.rs
+++ b/crates/vize_atelier_jsx/tests/fragments.rs
@@ -2,9 +2,9 @@
 
 mod common;
 
-use common::{as_element, as_text, lower_all, lower_one, root_element};
+use common::{as_element, as_text, lower_all, lower_one, root_element, vapor_code, vdom_code};
+use vize_atelier_jsx::JsxLang;
 use vize_carton::Bump;
-use vize_relief::ElementType;
 
 #[test]
 fn top_level_fragment_lifts_children_to_root() {
@@ -24,28 +24,94 @@ fn fragment_with_text_and_elements() {
     assert_eq!(as_element(&root.children[1]).tag.as_str(), "b");
 }
 
+/// A nested fragment used to become an element tagged `Fragment`, which the DOM
+/// backend emitted as `resolveComponent("Fragment")` — a component nobody
+/// registers, so the subtree rendered as nothing. A fragment in child position
+/// carries no props and cannot be keyed, so its children are spliced into the
+/// parent instead (#3421).
 #[test]
-fn nested_fragment_becomes_fragment_component_and_is_reported() {
+fn nested_fragment_children_are_spliced_into_the_parent() {
     let bump = Bump::new();
-    let out = lower_all(&bump, "const a = <div><><p/></></div>;");
+    let out = lower_all(&bump, "const a = <div>{lead}<><p/><i/></>{tail}</div>;");
     let div = root_element(&out.roots[0].root);
-    let fragment = as_element(&div.children[0]);
-    assert_eq!(fragment.tag.as_str(), "Fragment");
-    assert_eq!(fragment.tag_type, ElementType::Component);
-    assert_eq!(as_element(&fragment.children[0]).tag.as_str(), "p");
-    // The shape above is what the lowering produces, and it is wrong: the DOM
-    // backend turns a component tag into `resolveComponent("Fragment")`, which
-    // resolves to nothing. Until the IR can carry the `Fragment` symbol the
-    // shape stays, but it no longer degrades silently (#3421).
+    assert_eq!(div.children.len(), 4);
+    assert_eq!(as_element(&div.children[1]).tag.as_str(), "p");
+    assert_eq!(as_element(&div.children[2]).tag.as_str(), "i");
     assert_eq!(
         out.diagnostics
             .iter()
             .map(|diagnostic| (diagnostic.is_error(), diagnostic.message.as_str()))
             .collect::<std::vec::Vec<_>>(),
-        vec![(
-            true,
-            "a JSX fragment nested inside an element is not supported; it lowers to an unresolvable `Fragment` component"
-        )]
+        vec![]
+    );
+}
+
+/// Deep nesting collapses all the way: no chain of unresolvable wrappers is
+/// left behind.
+#[test]
+fn doubly_nested_fragments_collapse() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div><><><i/></></></div>;");
+    let div = root_element(&root);
+    assert_eq!(div.children.len(), 1);
+    assert_eq!(as_element(&div.children[0]).tag.as_str(), "i");
+}
+
+/// The whole emitted module. `@vue/babel-plugin-jsx` renders this as
+/// `_createVNode("div", null, [_createVNode(_Fragment, null, […])])` — the same
+/// DOM, one vnode level deeper.
+#[test]
+fn nested_fragment_emits_the_children_inline() {
+    assert_eq!(
+        vdom_code("const A = () => <div><><i/><b/></></div>;", JsxLang::Jsx).as_str(),
+        "export function render(_ctx, _cache) {\n  \
+         return (_openBlock(), _createElementBlock(\"div\", null, [\n    \
+         _createElementVNode(\"i\"),\n    \
+         _createElementVNode(\"b\")\n  \
+         ]))\n}"
+    );
+}
+
+/// Vapor took the same `resolveComponent("Fragment")` route, so the whole
+/// generated module is pinned there too.
+#[test]
+fn nested_fragment_emits_the_children_inline_under_vapor() {
+    assert_eq!(
+        vapor_code(
+            "const A = () => <div><><i/><b/></></div>;",
+            JsxLang::Jsx,
+            false
+        )
+        .as_str(),
+        "import { template as _template } from 'vue';\n\
+         const t0 = _template(\"<div><i></i><b></b></div>\", true)\n\n\
+         export function render(_ctx) {\n  \
+         const n0 = t0()\n  \
+         return n0\n\
+         }\n"
+    );
+}
+
+/// A fragment that has to stay one node — a `v-if` branch — keeps a real
+/// `Fragment` block instead of being spliced, because the branch's children
+/// have no parent child list to splice into.
+#[test]
+fn fragment_in_a_conditional_branch_becomes_a_fragment_block() {
+    assert_eq!(
+        vdom_code(
+            "const A = () => <div>{cond ? <><i/><b/></> : <c/>}</div>;",
+            JsxLang::Jsx
+        )
+        .as_str(),
+        "export function render(_ctx, _cache) {\n  \
+         return (_openBlock(), _createElementBlock(\"div\", null, [\n    \
+         (cond)\n      \
+         ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [\n        \
+         _createElementVNode(\"i\"),\n        \
+         _createElementVNode(\"b\")\n      \
+         ], 64 /* STABLE_FRAGMENT */))\n      \
+         : (_openBlock(), _createElementBlock(\"c\", { key: 1 }))\n  \
+         ]))\n}"
     );
 }
 

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__elements.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__elements.snap
@@ -108,7 +108,7 @@ export function render(_ctx, _cache) {
 
 ## elements/member_tag
 ### verdict
-divergent: member tag resolved as a name string
+equivalent
 ### source (jsx)
 const A = () => <a.b.c foo={1}/>;
 ### babel options
@@ -119,16 +119,14 @@ const A = () => _createVNode(a.b.c, {
   "foo": 1
 }, null);
 ### vize (vdom, default config)
-import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
-  const _component_a46b46c = _resolveComponent("a.b.c")
-  
-  return (_openBlock(), _createBlock(_component_a46b46c, { foo: 1 }))
+  return (_openBlock(), _createBlock(_resolveDynamicComponent(a.b.c), { foo: 1 }))
 }
 
 ## elements/namespaced_tag
 ### verdict
-divergent: namespaced tag accepted, babel rejects
+equivalent
 ### source (jsx)
 const A = () => <a:b foo={1}/>;
 ### babel options
@@ -136,6 +134,7 @@ const A = () => <a:b foo={1}/>;
 ### babel
 <error> getTag: JSXNamespacedName is not supported
 ### vize (vdom, default config)
+<Error> unsupported JSX tag namespace `a:`; only `svg:` and `math:` name a real element namespace, so `a:b` would be emitted verbatim as a tag name nothing resolves (`@vue/babel-plugin-jsx` rejects every namespaced tag)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("a:b", { foo: 1 }))
@@ -162,7 +161,7 @@ export function render(_ctx, _cache) {
 
 ## elements/nested_fragment_child
 ### verdict
-divergent: nested fragment resolved by name, now reported
+equivalent
 ### source (jsx)
 const A = () => <div><><i/></></div>;
 ### babel options
@@ -171,17 +170,9 @@ const A = () => <div><><i/></></div>;
 import { Fragment as _Fragment, createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [_createVNode(_Fragment, null, [_createVNode("i", null, null)])]);
 ### vize (vdom, default config)
-<Error> a JSX fragment nested inside an element is not supported; it lowers to an unresolvable `Fragment` component
-import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, createVNode as _createVNode, openBlock as _openBlock, createElementBlock as _createElementBlock, withCtx as _withCtx } from "vue"
+import { createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
-  const _component_Fragment = _resolveComponent("Fragment")
-  
   return (_openBlock(), _createElementBlock("div", null, [
-    _createVNode(_component_Fragment, null, {
-      default: _withCtx(() => [
-        _createElementVNode("i")
-      ]),
-      _: 1 /* STABLE */
-    })
+    _createElementVNode("i")
   ]))
 }


### PR DESCRIPTION
## Surface

`crates/vize_atelier_jsx` — the shared JSX/TSX lowering layer, on the default
(non-compat) path. The bad output reached all three backends (VDOM, SSR, Vapor)
because they all consume the same lowered `RootNode`.

## Reproduction

```jsx
const A = () => <a.b.c foo={1}/>;
const B = () => <div><><i/></></div>;
const C = () => <a:b foo={1}/>;
```

**Expected** — `@vue/babel-plugin-jsx`, recorded in
`tests/babel_compat/fixtures/babel-output.json`:

```js
_createVNode(a.b.c, { "foo": 1 }, null);
_createVNode("div", null, [_createVNode(_Fragment, null, [_createVNode("i", null, null)])]);
// <a:b foo={1}/>  ->  rejected: "getTag: JSXNamespacedName is not supported"
```

**Actual, before this change:**

```js
const _component_a46b46c = _resolveComponent("a.b.c")     // a component nobody registers
const _component_Fragment = _resolveComponent("Fragment") // ditto
_createElementBlock("a:b", { foo: 1 })                    // no diagnostic at all
```

The first two render nothing. Only the nested fragment said anything, and only
in element-child position — the error #3501 added described the wrong output
rather than replacing it, and the same `resolveComponent("Fragment")` came out
of a slot body (`{() => <><i/><b/></>}`) and a `v-if` branch
(`{cond ? <><i/></> : <b/>}`) with no diagnostic at all.

## Root cause

The lowering layer turned a JSX tag into a **tag string** unconditionally.
`<a.b.c/>` names a component *value* and `<>…</>` names no component at all, so
stringifying them produced `resolveComponent(<name>)` lookups that can never
resolve. A namespaced tag was stringified verbatim and never questioned.

## What the fix does

- **Member-expression / `this` tags** lower to `<component :is="a.b.c">`, so
  every backend emits `resolveDynamicComponent(a.b.c)`
  (`createDynamicComponent` under Vapor, `ssrRenderVNode(createVNode(resolveDynamicComponent(…)))`
  under SSR). `resolveDynamicComponent` passes a non-string straight through,
  which is exactly what babel's `createVNode(a.b.c, …)` does.
- **Fragments in a child list or a slot body** are spliced into that list. A JSX
  fragment carries no props and cannot be keyed, so its children *are* the
  parent's children at that position — same DOM and same patch order as babel's
  nested `Fragment` vnode, one vnode level fewer. A fragment that has to be a
  single node (a `v-if` branch, a `v-for` body) becomes an
  `ElementType::Template` node — the `<template v-if>` shape every backend
  already handles, which codegens as a real `Fragment` block.
- **Namespaced tags** are rejected with the namespace named, except `svg:` and
  `math:`, the two prefixes that name a real element namespace.
  `elements.rs::known_namespaced_element_names_are_preserved` pins that
  `<svg:circle/>` keeps working; babel rejects that too, and this is the one
  place Vize stays deliberately more permissive.

## Scope decision, row by row

The issue asks for diagnostics; where lowering the shape correctly was small and
clearly right, that was done instead, because correct output beats a diagnostic.

| Issue row | Decision | Landed |
| --- | --- | --- |
| `<a.b.c/>` | **(b) lower it** — `resolveDynamicComponent` | this PR |
| `<div><><i/></></div>` | **(b) lower it** — splice into the parent | this PR |
| `<a:b foo={1}/>` | **(a) diagnose**, narrowed to non-`svg:`/`math:` prefixes | this PR |
| `<B v-models={foo}/>` (non-array) | (a) diagnose | already closed by #3418 / #3465 |
| `<B>{() => 'foo'}</B>` | (b) lower it | already closed by #3501 |
| `<a v-custom={[val, 'arg', ['a','b']]}/>` | (b) lower it | already closed by #3522 |
| `<div>{...items}</div>` | (a) diagnose | already closed by #3501 |
| `<B>{slots}</B>` | **neither — deliberately left divergent** | see below |

`<div>{...items}</div>` stays a diagnostic: the IR has no spread-child node, so
lowering it correctly is a feature, not a fix, and the diagnostic already names
the construct.

`<B>{slots}</B>` gets **no** diagnostic on purpose. Statically it is the same
shape as `<B>{count}</B>`, so any diagnostic here would fire on ordinary
interpolation children. Babel decides it *at runtime* with
`_isSlot(slots) ? slots : {default: () => [slots]}`; emitting that check for
every lone expression child of a component is the `enableObjectSlots` semantics
choice that belongs to the compat mode (`options/object_slots_default` /
`options/object_slots_false`, #3391 / #3441), not to this issue. The row stays
`divergent` in the inventory with that reasoning recorded.

## Inventory

`BABEL_COMPAT_INVENTORY.md` and `babel_compat/verdicts.rs` move
`elements/member_tag`, `elements/namespaced_tag` and
`elements/nested_fragment_child` from ❌ to ✅. #3593 moved three `slots` rows in
the same direction just before this landed, so the totals pinned by
`babel_compat_verdict_totals` go **75/21/2 → 78/18/2** on top of it — git merges
the two verdict-table edits cleanly but leaves the totals line at #3593's value,
so it is reconciled here by hand. A new subsection records what the three
element ✅ are equivalent *up to*, so they are not read as byte equality.

## Tests

All full-equality; no substring matching.

- `tests/elements.rs` — `member_expression_tag_lowers_to_a_dynamic_component`,
  `this_member_tag_lowers_to_a_dynamic_component`,
  `member_expression_tag_emits_resolve_dynamic_component` (whole module),
  `member_expression_tag_with_children_keeps_props_and_slots` (whole module,
  proves the `is` binding does not leak into the props object),
  `known_namespaced_element_names_are_preserved`.
- `tests/fragments.rs` — `nested_fragment_children_are_spliced_into_the_parent`
  (children + empty diagnostic list), `doubly_nested_fragments_collapse`,
  `nested_fragment_emits_the_children_inline` (whole VDOM module),
  `nested_fragment_emits_the_children_inline_under_vapor` (whole Vapor module),
  `fragment_in_a_conditional_branch_becomes_a_fragment_block` (whole module).
- `tests/diagnostics.rs` — `unsupported_tag_namespace_is_reported` (complete
  diagnostic list + the exact source span), `svg_and_math_namespaced_tags_are_not_reported`,
  `fragments_are_not_reported_at_any_depth`.
- `tests/babel_compat_oracle.rs` — the differential oracle from #3408 is
  unchanged and re-run; only the three `elements` rows move, visible in the
  committed snapshot diff.

Closes #3421
