### PR TITLE
perf(maestro): cache Corsa overlays incrementally

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -85,6 +85,32 @@ impl CorsaBridge {
         overlays: &[(PathBuf, String)],
         virtual_ts_options: &VirtualTsOptions,
     ) -> Result<CorsaVueVirtualDocument, CorsaBridgeError> {
+        let overlays = overlays
+            .iter()
+            .map(|(path, content)| (path.clone(), content.as_str()))
+            .collect::<Vec<_>>();
+        self.open_vue_virtual_document_with_borrowed_overlays_and_options(
+            source_path,
+            content,
+            options,
+            &overlays,
+            virtual_ts_options,
+        )
+        .await
+    }
+
+    /// Generate and sync a Vue document without copying unchanged overlay text.
+    ///
+    /// Only dependency entries reachable from the host's imports are read, so
+    /// callers with shared buffer snapshots can lend their text for this call.
+    pub async fn open_vue_virtual_document_with_borrowed_overlays_and_options(
+        &self,
+        source_path: &Path,
+        content: &str,
+        options: CorsaVueVirtualDocumentOptions,
+        overlays: &[(PathBuf, &str)],
+        virtual_ts_options: &VirtualTsOptions,
+    ) -> Result<CorsaVueVirtualDocument, CorsaBridgeError> {
         let project = build_vue_virtual_project_with_overlays_and_options(
             source_path,
             content,
@@ -133,7 +159,7 @@ pub(crate) fn build_vue_virtual_project_with_overlays(
     source_path: &Path,
     content: &str,
     options: CorsaVueVirtualDocumentOptions,
-    overlays: &[(PathBuf, String)],
+    overlays: &[(PathBuf, &str)],
 ) -> Result<CorsaVueVirtualProject, CorsaBridgeError> {
     build_vue_virtual_project_with_overlays_and_options(
         source_path,
@@ -148,7 +174,7 @@ fn build_vue_virtual_project_with_overlays_and_options(
     source_path: &Path,
     content: &str,
     options: CorsaVueVirtualDocumentOptions,
-    overlays: &[(PathBuf, String)],
+    overlays: &[(PathBuf, &str)],
     virtual_ts_options: &VirtualTsOptions,
 ) -> Result<CorsaVueVirtualProject, CorsaBridgeError> {
     let rewriter = ImportRewriter::new();
@@ -167,7 +193,7 @@ fn build_vue_virtual_project_with_overlays_and_options(
         .iter()
         .map(|(path, content)| {
             let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
-            (key, content.as_str())
+            (key, *content)
         })
         .collect::<FxHashMap<_, _>>();
     collect_dependency_documents(&mut documents, &host, options, &rewriter, &overlays);

--- a/crates/vize_canon/src/corsa_bridge/vue_document_tests.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document_tests.rs
@@ -2,6 +2,7 @@ use super::vue_document::{
     CorsaVueVirtualDocumentOptions, build_vue_virtual_project,
     build_vue_virtual_project_with_overlays,
 };
+use crate::CorsaBridge;
 use crate::file_uri::path_to_file_uri;
 
 #[test]
@@ -133,7 +134,7 @@ fn vue_virtual_project_prefers_open_dependency_overlays() {
     .expect("child");
     let overlays = vec![(
         child_path.clone(),
-        "<script setup lang=\"ts\">defineProps<{ count: number }>()</script>".into(),
+        "<script setup lang=\"ts\">defineProps<{ count: number }>()</script>",
     )];
 
     let virtual_project = build_vue_virtual_project_with_overlays(
@@ -151,6 +152,19 @@ fn vue_virtual_project_prefers_open_dependency_overlays() {
         .expect("child virtual document");
     assert!(child.contains("count: number"), "{child}");
     assert!(!child.contains("count: string"), "{child}");
+}
+
+#[test]
+fn owned_overlay_bridge_api_remains_source_compatible() {
+    let bridge = CorsaBridge::new();
+    let overlays: Vec<(std::path::PathBuf, vize_carton::String)> =
+        vec![(std::path::PathBuf::from("Child.vue"), "".into())];
+    let _future = bridge.open_vue_virtual_document_with_overlays(
+        std::path::Path::new("Host.vue"),
+        "",
+        CorsaVueVirtualDocumentOptions::default(),
+        &overlays,
+    );
 }
 
 #[test]

--- a/crates/vize_maestro/src/document/store.rs
+++ b/crates/vize_maestro/src/document/store.rs
@@ -2,12 +2,26 @@
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
 use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use dashmap::DashMap;
 use ropey::Rope;
 use tower_lsp::lsp_types::{TextDocumentContentChangeEvent, Url};
 
 use crate::utils::position_to_offset;
+
+/// Source of [`Document::revision`] stamps.
+///
+/// Process-global and monotonic, so a stamp identifies one exact content
+/// snapshot across the whole server for the lifetime of the process. The
+/// client-supplied `version` cannot do this job: it is chosen by the editor,
+/// resets on reopen, and is reused across documents, so equal versions do not
+/// imply equal text.
+static NEXT_DOCUMENT_REVISION: AtomicU64 = AtomicU64::new(1);
+
+fn next_revision() -> u64 {
+    NEXT_DOCUMENT_REVISION.fetch_add(1, Ordering::Relaxed)
+}
 
 /// A document managed by the LSP server.
 #[derive(Debug)]
@@ -20,6 +34,13 @@ pub struct Document {
     pub content: Rope,
     /// Language ID (e.g., "vue", "typescript")
     pub language_id: String,
+    /// Monotonic stamp for the exact content this document currently holds.
+    ///
+    /// Bumped by every mutation. Caches that key derived data on a document
+    /// compare this instead of `version`: an unchanged stamp is proof the
+    /// content is byte-identical, which is what makes reusing a cached
+    /// snapshot safe rather than merely likely.
+    revision: u64,
     /// Lazily computed structural petite-vue detection result, memoized per
     /// document version so per-request consumers (completion, definition, ...)
     /// never re-scan the content. Reset on every edit.
@@ -34,8 +55,18 @@ impl Document {
             version,
             content: Rope::from_str(&content),
             language_id,
+            revision: next_revision(),
             petite_vue_detected: OnceLock::new(),
         }
+    }
+
+    /// Monotonic stamp for the content this document currently holds.
+    ///
+    /// Two reads that return the same value observed the same text; a bumped
+    /// value means the text may differ. Never reused across documents.
+    #[inline]
+    pub fn revision(&self) -> u64 {
+        self.revision
     }
 
     /// Whether the document structurally uses petite-vue (see
@@ -69,6 +100,7 @@ impl Document {
     /// Apply an incremental change to the document.
     pub fn apply_change(&mut self, change: &TextDocumentContentChangeEvent, new_version: i32) {
         self.version = new_version;
+        self.revision = next_revision();
         self.petite_vue_detected = OnceLock::new();
 
         if let Some(range) = change.range {
@@ -142,6 +174,10 @@ impl DocumentStore {
         };
 
         document.uri = new_uri.clone();
+        // A rename moves the same text to a new path. Overlay consumers key on
+        // the path, so the entry they cached under the old URI must not be
+        // mistaken for this one; a fresh stamp keeps the two unrelatable.
+        document.revision = next_revision();
         self.documents.insert(new_uri, document);
         true
     }

--- a/crates/vize_maestro/src/document/store/tests.rs
+++ b/crates/vize_maestro/src/document/store/tests.rs
@@ -305,3 +305,38 @@ fn test_document_store_text_snapshot_holds_no_shard_lock() {
     assert_eq!(store.text(&uri).as_deref(), Some("after"));
     assert_eq!(store.text(&Url::parse("file:///absent.vue").unwrap()), None);
 }
+
+// `revision` is what content caches key on, so an unchanged stamp has to be
+// proof the text is unchanged. The client-supplied `version` cannot carry that
+// promise: editors restart it at 1 on reopen and hand the same numbers to
+// every document (#3442).
+#[test]
+fn test_document_revision_is_unique_per_content_snapshot() {
+    let store = DocumentStore::new();
+    let uri = test_uri();
+    let other = Url::parse("file:///other.vue").unwrap();
+
+    store.open(uri.clone(), "first".to_string(), 1, "vue".to_string());
+    let opened = store.get(&uri).unwrap().revision();
+
+    store.open(other.clone(), "first".to_string(), 1, "vue".to_string());
+    assert_ne!(
+        store.get(&other).unwrap().revision(),
+        opened,
+        "documents opened at the same version must not share a revision"
+    );
+
+    store.apply_changes(&uri, vec![full_change("second")], 2);
+    let edited = store.get(&uri).unwrap().revision();
+    assert_ne!(edited, opened, "an edit must move the revision");
+
+    // Reopening resets the client version to 1; the revision must still move.
+    store.close(&uri);
+    store.open(uri.clone(), "third".to_string(), 1, "vue".to_string());
+    let reopened = store.get(&uri).unwrap().revision();
+    assert_ne!(reopened, opened);
+    assert_ne!(reopened, edited);
+
+    // A read that changes nothing must report the same stamp.
+    assert_eq!(store.get(&uri).unwrap().revision(), reopened);
+}

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
@@ -148,18 +148,18 @@ impl DiagnosticService {
                 tracing::warn!("cannot derive source path for {}", uri);
                 return Ok(vec![]);
             };
-            let overlays = state
-                .documents
+            // Incrementally refreshed: documents unchanged since the last pass
+            // keep their cached text instead of being copied out of their ropes
+            // again, so a keystroke costs one document rather than every open
+            // one (#3442). The snapshot is owned and lock-free, so holding it
+            // across the bridge `.await` below is safe (#3315).
+            let cached_overlays = state.corsa_overlays();
+            let overlays = cached_overlays
                 .iter()
-                .filter_map(|document| {
-                    Some((
-                        document.key().to_file_path().ok()?,
-                        document.value().text().into(),
-                    ))
-                })
-                .collect::<Vec<(std::path::PathBuf, vize_carton::String)>>();
+                .map(|(path, text)| (path.clone(), &**text))
+                .collect::<Vec<(std::path::PathBuf, &str)>>();
             let opened = bridge
-                .open_vue_virtual_document_with_overlays_and_options(
+                .open_vue_virtual_document_with_borrowed_overlays_and_options(
                     &source_path,
                     &content,
                     CorsaVueVirtualDocumentOptions {

--- a/crates/vize_maestro/src/ide/file_rename/manual.rs
+++ b/crates/vize_maestro/src/ide/file_rename/manual.rs
@@ -256,7 +256,7 @@ pub(super) fn rename_open_documents(
             continue;
         }
 
-        if state.documents.rename(&old_uri, new_uri.clone()) {
+        if state.rename_document(&old_uri, new_uri.clone()) {
             state.remove_virtual_docs(&old_uri);
 
             if let Some(document) = state.documents.get(&new_uri) {

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -128,7 +128,7 @@ impl LanguageServer for MaestroServer {
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         let uri = params.text_document.uri;
-        self.state.documents.close(&uri);
+        self.state.close_document(&uri);
 
         // Clean up virtual documents cache
         self.state.remove_virtual_docs(&uri);

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -11,10 +11,14 @@ mod batch_cache;
 #[cfg(feature = "native")]
 mod corsa;
 #[cfg(feature = "native")]
+mod corsa_overlays;
+#[cfg(feature = "native")]
 mod global_components;
 
 #[cfg(test)]
 mod config_tests;
+#[cfg(all(test, feature = "native"))]
+mod corsa_overlays_tests;
 #[cfg(test)]
 mod tests;
 
@@ -130,6 +134,13 @@ pub struct ServerState {
     /// Batch type check result cache
     #[cfg(feature = "native")]
     batch_cache: BatchTypeCheckCache,
+    /// Unsaved-buffer overlays handed to Corsa, rebuilt incrementally.
+    ///
+    /// Rebuilding the whole set per pass costs one full copy of every open
+    /// document per keystroke; this keeps the unchanged ones and re-reads only
+    /// the document whose revision moved (#3442).
+    #[cfg(feature = "native")]
+    corsa_overlays: corsa_overlays::CorsaOverlayCache,
 }
 
 impl Default for ServerState {
@@ -183,6 +194,8 @@ impl ServerState {
             batch_checker: OnceLock::new(),
             #[cfg(feature = "native")]
             batch_cache: BatchTypeCheckCache::new(),
+            #[cfg(feature = "native")]
+            corsa_overlays: corsa_overlays::CorsaOverlayCache::default(),
         }
     }
 
@@ -193,6 +206,26 @@ impl ServerState {
         self.global_component_references.invalidate();
         // Invalidate batch cache when workspace changes
         self.batch_cache.invalidate();
+        // Overlays shadow files resolved relative to the workspace root, so a
+        // new root retargets them even though no document changed.
+        self.corsa_overlays.invalidate();
+    }
+
+    /// Close a document and release any cached Corsa overlay immediately.
+    pub(crate) fn close_document(&self, uri: &Url) {
+        self.documents.close(uri);
+        #[cfg(feature = "native")]
+        self.corsa_overlays.remove(uri);
+    }
+
+    /// Rename a document while dropping the overlay cached under its old URI.
+    pub(crate) fn rename_document(&self, old_uri: &Url, new_uri: Url) -> bool {
+        let renamed = self.documents.rename(old_uri, new_uri);
+        #[cfg(feature = "native")]
+        if renamed {
+            self.corsa_overlays.remove(old_uri);
+        }
+        renamed
     }
 
     /// Check whether LSP type checking is enabled.

--- a/crates/vize_maestro/src/server/state/config.rs
+++ b/crates/vize_maestro/src/server/state/config.rs
@@ -77,6 +77,11 @@ impl ServerState {
 
     fn apply_type_checker_config(&self, config: TypeCheckerConfig, source: &str) {
         *self.type_checker_config.write() = config;
+        // The tsconfig and runtime this selects decide which project the
+        // overlays are layered onto, so a reload retargets them even though no
+        // document changed (#3442).
+        #[cfg(feature = "native")]
+        self.invalidate_corsa_overlays();
         tracing::info!("Loaded type checker config from {}", source);
     }
 

--- a/crates/vize_maestro/src/server/state/corsa_overlays.rs
+++ b/crates/vize_maestro/src/server/state/corsa_overlays.rs
@@ -1,0 +1,169 @@
+//! Incremental cache of the unsaved-buffer overlays handed to Corsa.
+//!
+//! Corsa resolves a component's imports against the filesystem, so every
+//! diagnostics pass must also tell it about buffers the user has edited but not
+//! saved. The straightforward way to do that — materialize the text of every
+//! open document on every pass — makes one keystroke cost
+//! `O(open documents x document size)` in copying before any type checking
+//! starts, which is what #3442 is about.
+//!
+//! Between two consecutive passes at most one document can have changed, so the
+//! overlays for the rest are already known. This cache keeps them as `Arc<str>`
+//! and rebuilds only the entries whose [`Document::revision`] moved, turning the
+//! steady-state pass into pointer work.
+//!
+//! [`Document::revision`]: crate::document::Document::revision
+#![cfg(feature = "native")]
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use parking_lot::RwLock;
+use tower_lsp::lsp_types::Url;
+use vize_carton::FxHashMap;
+
+use super::ServerState;
+use crate::document::DocumentStore;
+
+/// One open document's contribution to the overlay set.
+struct OverlayEntry {
+    /// Stamp of the document content `text` was materialized from. The cached
+    /// text is reusable exactly while this still matches the live document.
+    revision: u64,
+    /// Pass that last observed this document open, used to evict entries for
+    /// documents closed since.
+    seen: u64,
+    /// Shared so a pass can hand out the text without copying it.
+    text: Arc<str>,
+}
+
+#[derive(Default)]
+struct OverlayCacheState {
+    /// Monotonic pass counter; see [`OverlayEntry::seen`].
+    pass: u64,
+    entries: FxHashMap<Url, OverlayEntry>,
+}
+
+/// Cached overlay set, refreshed incrementally per diagnostics pass.
+#[derive(Default)]
+pub(crate) struct CorsaOverlayCache {
+    state: RwLock<OverlayCacheState>,
+    /// Count of documents whose text this cache has materialized. Rises by one
+    /// per changed document per pass once warm, which is the property the
+    /// perf tests assert (a wall-clock bound could not).
+    materializations: AtomicU64,
+}
+
+impl CorsaOverlayCache {
+    /// The complete overlay set for the currently open documents.
+    ///
+    /// Reuses the cached text of every document whose revision is unchanged and
+    /// materializes only the rest, so a pass following a single edit copies one
+    /// document rather than all of them. Documents opened since the last pass
+    /// are added, documents closed since are dropped.
+    ///
+    /// The returned snapshot is owned: it borrows nothing from the document
+    /// store and holds no lock, so callers may keep it across the `.await` of a
+    /// bridge call without parking the executor thread the next `didOpen` /
+    /// `didChange` / `didClose` needs (#3315, #3377).
+    pub(crate) fn snapshot(&self, documents: &DocumentStore) -> Vec<(PathBuf, Arc<str>)> {
+        let mut state = self.state.write();
+        let pass = state.pass.wrapping_add(1);
+        state.pass = pass;
+
+        let mut overlays = Vec::with_capacity(documents.len());
+        for document in documents.iter() {
+            // A document with no filesystem path cannot shadow a file Corsa
+            // would otherwise read, so it is not an overlay.
+            let Ok(path) = document.key().to_file_path() else {
+                continue;
+            };
+            let revision = document.value().revision();
+
+            let mut cached = None;
+            if let Some(entry) = state.entries.get_mut(document.key())
+                && entry.revision == revision
+            {
+                entry.seen = pass;
+                cached = Some(Arc::clone(&entry.text));
+            }
+
+            let text = match cached {
+                Some(text) => text,
+                None => {
+                    // Read the text from the same guard that produced
+                    // `revision`, so the stamp always describes the bytes
+                    // actually cached. Re-reading under a fresh guard could
+                    // pair a stamp with text from a later edit and pin a stale
+                    // overlay until the next change.
+                    let text: Arc<str> = Arc::from(document.value().text());
+                    self.materializations.fetch_add(1, Ordering::Relaxed);
+                    state.entries.insert(
+                        document.key().clone(),
+                        OverlayEntry {
+                            revision,
+                            seen: pass,
+                            text: Arc::clone(&text),
+                        },
+                    );
+                    text
+                }
+            };
+            overlays.push((path, text));
+        }
+
+        state.entries.retain(|_, entry| entry.seen == pass);
+        overlays
+    }
+
+    /// Drop every cached overlay.
+    ///
+    /// Only ever costs a rebuild: entries are keyed by revision, so a stale
+    /// entry cannot survive invalidation being missed. Called where the
+    /// resolution the overlays feed can change out from under them.
+    pub(crate) fn invalidate(&self) {
+        let mut state = self.state.write();
+        state.entries.clear();
+    }
+
+    /// Stop retaining the buffer for a document removed from the store.
+    pub(super) fn remove(&self, uri: &Url) {
+        self.state.write().entries.remove(uri);
+    }
+
+    /// How many documents this cache has materialized text for since creation.
+    #[cfg(test)]
+    pub(crate) fn materializations(&self) -> u64 {
+        self.materializations.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn entry_count(&self) -> usize {
+        self.state.read().entries.len()
+    }
+}
+
+impl ServerState {
+    /// The complete Corsa overlay set for the currently open documents.
+    ///
+    /// See [`CorsaOverlayCache::snapshot`].
+    pub(crate) fn corsa_overlays(&self) -> Vec<(PathBuf, Arc<str>)> {
+        self.corsa_overlays.snapshot(&self.documents)
+    }
+
+    /// Drop the cached Corsa overlays.
+    pub(crate) fn invalidate_corsa_overlays(&self) {
+        self.corsa_overlays.invalidate();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn corsa_overlay_materializations(&self) -> u64 {
+        self.corsa_overlays.materializations()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn corsa_overlay_entries(&self) -> usize {
+        self.corsa_overlays.entry_count()
+    }
+}

--- a/crates/vize_maestro/src/server/state/corsa_overlays_tests.rs
+++ b/crates/vize_maestro/src/server/state/corsa_overlays_tests.rs
@@ -1,0 +1,318 @@
+//! Correctness and scaling tests for the incremental Corsa overlay cache.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::{Position, Range, TextDocumentContentChangeEvent, Url};
+
+use super::ServerState;
+
+fn uri(name: &str) -> Url {
+    Url::parse(&format!("file:///project/{name}")).expect("uri")
+}
+
+fn path(name: &str) -> PathBuf {
+    uri(name).to_file_path().expect("file path")
+}
+
+fn open(state: &ServerState, name: &str, text: &str) {
+    state
+        .documents
+        .open(uri(name), text.to_string(), 1, "vue".to_string());
+}
+
+/// Replace the whole buffer, the way an editor reports a non-incremental edit.
+fn rewrite(state: &ServerState, name: &str, text: &str, version: i32) {
+    state.documents.apply_changes(
+        &uri(name),
+        vec![TextDocumentContentChangeEvent {
+            range: None,
+            range_length: None,
+            text: text.to_string(),
+        }],
+        version,
+    );
+}
+
+/// The overlay set as compared by tests: order is an artifact of `DashMap`
+/// iteration, so sort before asserting full equality.
+fn overlays(state: &ServerState) -> Vec<(PathBuf, String)> {
+    let mut overlays = state
+        .corsa_overlays()
+        .into_iter()
+        .map(|(path, text)| (path, text.to_string()))
+        .collect::<Vec<_>>();
+    overlays.sort();
+    overlays
+}
+
+/// The stale-overlay guard: a wrong overlay makes Corsa type-check text the
+/// user never wrote, so the whole set is asserted after each step of a
+/// realistic editing session rather than spot-checked.
+#[test]
+fn overlay_set_tracks_opens_edits_and_closes() {
+    let state = ServerState::new();
+
+    open(&state, "A.vue", "<template>A1</template>");
+    assert_eq!(
+        overlays(&state),
+        vec![(path("A.vue"), "<template>A1</template>".to_string())]
+    );
+
+    open(&state, "B.vue", "<template>B1</template>");
+    assert_eq!(
+        overlays(&state),
+        vec![
+            (path("A.vue"), "<template>A1</template>".to_string()),
+            (path("B.vue"), "<template>B1</template>".to_string()),
+        ]
+    );
+
+    rewrite(&state, "A.vue", "<template>A2</template>", 2);
+    assert_eq!(
+        overlays(&state),
+        vec![
+            (path("A.vue"), "<template>A2</template>".to_string()),
+            (path("B.vue"), "<template>B1</template>".to_string()),
+        ]
+    );
+
+    state.documents.close(&uri("B.vue"));
+    assert_eq!(
+        overlays(&state),
+        vec![(path("A.vue"), "<template>A2</template>".to_string())]
+    );
+
+    rewrite(&state, "A.vue", "<template>A3</template>", 3);
+    assert_eq!(
+        overlays(&state),
+        vec![(path("A.vue"), "<template>A3</template>".to_string())]
+    );
+}
+
+/// A reopen restarts the client's `version` at 1, so a version-keyed cache
+/// would serve the closed document's text. Revisions are monotonic and never
+/// reused, so this reads the new content.
+#[test]
+fn reopening_a_document_at_the_same_version_is_not_served_from_cache() {
+    let state = ServerState::new();
+
+    open(&state, "A.vue", "<template>first</template>");
+    assert_eq!(
+        overlays(&state),
+        vec![(path("A.vue"), "<template>first</template>".to_string())]
+    );
+
+    state.documents.close(&uri("A.vue"));
+    open(&state, "A.vue", "<template>second</template>");
+    assert_eq!(
+        overlays(&state),
+        vec![(path("A.vue"), "<template>second</template>".to_string())]
+    );
+}
+
+/// An in-place edit keeps the same `Document`, so the cache has to notice the
+/// rope changed underneath an entry it already holds.
+#[test]
+fn incremental_edits_are_reflected_in_the_overlay_set() {
+    let state = ServerState::new();
+    open(&state, "A.vue", "<template>ab</template>");
+    assert_eq!(
+        overlays(&state),
+        vec![(path("A.vue"), "<template>ab</template>".to_string())]
+    );
+
+    state.documents.apply_changes(
+        &uri("A.vue"),
+        vec![TextDocumentContentChangeEvent {
+            range: Some(Range {
+                start: Position {
+                    line: 0,
+                    character: 11,
+                },
+                end: Position {
+                    line: 0,
+                    character: 12,
+                },
+            }),
+            range_length: None,
+            text: "X".to_string(),
+        }],
+        2,
+    );
+    assert_eq!(
+        overlays(&state),
+        vec![(path("A.vue"), "<template>aX</template>".to_string())]
+    );
+}
+
+/// A rename moves text to a new path; the overlay must follow and the old path
+/// must not linger.
+#[test]
+fn renaming_a_document_moves_its_overlay() {
+    let state = ServerState::new();
+    open(&state, "Old.vue", "<template>same</template>");
+    assert_eq!(
+        overlays(&state),
+        vec![(path("Old.vue"), "<template>same</template>".to_string())]
+    );
+
+    assert!(state.rename_document(&uri("Old.vue"), uri("New.vue")));
+    assert_eq!(state.corsa_overlay_entries(), 0);
+    assert_eq!(
+        overlays(&state),
+        vec![(path("New.vue"), "<template>same</template>".to_string())]
+    );
+}
+
+/// Invalidation may only cost work, never correctness: the set it rebuilds is
+/// the same one it dropped.
+#[test]
+fn invalidation_rebuilds_an_identical_overlay_set() {
+    let state = ServerState::new();
+    open(&state, "A.vue", "<template>A</template>");
+    open(&state, "B.vue", "<template>B</template>");
+    let before = overlays(&state);
+
+    state.invalidate_corsa_overlays();
+    let after = overlays(&state);
+
+    assert_eq!(before, after);
+    assert_eq!(
+        after,
+        vec![
+            (path("A.vue"), "<template>A</template>".to_string()),
+            (path("B.vue"), "<template>B</template>".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn closing_a_document_releases_its_cached_overlay_without_another_pass() {
+    let state = ServerState::new();
+    open(&state, "A.vue", &"large buffer".repeat(4_096));
+    let _ = state.corsa_overlays();
+    assert_eq!(state.corsa_overlay_entries(), 1);
+
+    state.close_document(&uri("A.vue"));
+
+    assert_eq!(state.corsa_overlay_entries(), 0);
+    assert!(state.documents.is_empty());
+}
+
+#[test]
+fn concurrent_edits_and_snapshots_finish_with_the_latest_text() {
+    let state = Arc::new(ServerState::new());
+    open(&state, "A.vue", "version 1");
+    let reader = Arc::clone(&state);
+    let snapshots = std::thread::spawn(move || {
+        for _ in 0..128 {
+            let _ = reader.corsa_overlays();
+        }
+    });
+
+    for version in 2..=128 {
+        rewrite(&state, "A.vue", &format!("version {version}"), version);
+    }
+    snapshots.join().expect("snapshot thread");
+
+    assert_eq!(
+        overlays(&state),
+        vec![(path("A.vue"), "version 128".into())]
+    );
+}
+
+/// The point of the cache: a pass costs the documents that changed, not the
+/// documents that are open. Counting materializations rather than timing keeps
+/// the assertion exact and independent of the machine running it.
+#[test]
+fn a_pass_materializes_only_the_documents_that_changed() {
+    let state = ServerState::new();
+    let document = "<template>{{ value }}</template>\n".repeat(512);
+    for index in 0..40 {
+        open(&state, &format!("C{index}.vue"), &document);
+    }
+
+    // Cold pass reads every open document exactly once.
+    let _ = state.corsa_overlays();
+    assert_eq!(state.corsa_overlay_materializations(), 40);
+
+    // A pass with nothing changed reads none of them.
+    let _ = state.corsa_overlays();
+    assert_eq!(state.corsa_overlay_materializations(), 40);
+
+    // Ten keystrokes on one file read one document each, regardless of the 40
+    // that are open.
+    for keystroke in 0..10 {
+        rewrite(
+            &state,
+            "C7.vue",
+            &format!("{document}<!-- {keystroke} -->"),
+            keystroke + 2,
+        );
+        let _ = state.corsa_overlays();
+    }
+    assert_eq!(state.corsa_overlay_materializations(), 50);
+
+    // Opening one more document reads only that one.
+    open(&state, "C40.vue", &document);
+    let _ = state.corsa_overlays();
+    assert_eq!(state.corsa_overlay_materializations(), 51);
+
+    // Closing one reads nothing.
+    state.close_document(&uri("C40.vue"));
+    let _ = state.corsa_overlays();
+    assert_eq!(state.corsa_overlay_materializations(), 51);
+}
+
+/// The wall-clock companion to the deterministic counter test above, and the
+/// source of the numbers in the PR body. Run manually on an idle host: scheduler
+/// contention makes elapsed-time assertions unsuitable as a CI correctness
+/// gate, while `a_pass_materializes_only_the_documents_that_changed` catches
+/// the same full-rebuild regression exactly.
+#[test]
+#[ignore = "wall-clock benchmark; run manually on an idle host"]
+fn a_warm_pass_is_far_cheaper_than_a_cold_one() {
+    const DOCUMENTS: usize = 60;
+    const PASSES: u32 = 64;
+
+    let state = ServerState::new();
+    let document = "<template>{{ value }}</template>\n".repeat(512);
+    for index in 0..DOCUMENTS {
+        open(&state, &format!("D{index}.vue"), &document);
+    }
+
+    // Prime the cache, then interleave warm/cold samples so host load affects
+    // both populations equally. Edits and invalidation are setup, not overlay
+    // snapshot work, and therefore deliberately stay outside the timers.
+    let _ = state.corsa_overlays();
+    let mut warm = std::time::Duration::ZERO;
+    let mut cold = std::time::Duration::ZERO;
+    for keystroke in 0..PASSES {
+        rewrite(
+            &state,
+            "D3.vue",
+            &format!("{document}<!-- {keystroke} -->"),
+            keystroke as i32 + 2,
+        );
+
+        let started = std::time::Instant::now();
+        let _ = state.corsa_overlays();
+        warm += started.elapsed();
+
+        state.invalidate_corsa_overlays();
+        let started = std::time::Instant::now();
+        let _ = state.corsa_overlays();
+        cold += started.elapsed();
+    }
+    let warm = warm / PASSES;
+    let cold = cold / PASSES;
+
+    println!(
+        "corsa overlay pass over {DOCUMENTS} documents: cold {cold:?}, warm (1 edited) {warm:?}"
+    );
+    assert!(
+        warm * 4 < cold,
+        "a warm pass should cost a fraction of a full rebuild, got warm {warm:?} vs cold {cold:?}"
+    );
+}


### PR DESCRIPTION
## Summary
- cache open-document Corsa overlays incrementally instead of rebuilding every request
- evict cached overlays immediately on close and rename while preserving the public owned bridge API
- cover edits, close/rename, concurrency, stale snapshots, and deterministic materialization counts

## Validation
- cargo test -p vize_maestro -p vize_canon --lib
- cargo clippy -p vize_maestro -p vize_canon --lib -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check

Closes #3442

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved Vue virtual-document processing by reusing cached document overlays and avoiding unnecessary text copying.
  * Incremental updates now process only documents whose content has changed.

* **Reliability**
  * Document snapshots receive stable revisions across edits, reopenings, and repeated reads.
  * Overlay caches are correctly refreshed after configuration changes, renames, closes, and workspace updates.

* **Compatibility**
  * Existing overlay-opening behavior remains supported while enabling more efficient borrowed overlay content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->