### PR TITLE
perf(bench): gate lint and fmt at max parallelism

### DIFF
--- a/bench/compare-pr-lanes.mjs
+++ b/bench/compare-pr-lanes.mjs
@@ -1,0 +1,123 @@
+/**
+ * Lane catalogue for the PR and long-baseline benchmark gates.
+ *
+ * `bench/compare-pr.mjs` times each lane defined here for a base and a head
+ * `vize` binary. `.github/workflows/benchmark.yml` runs that comparison twice:
+ * per pull request against the PR base, and weekly against one fixed
+ * historical SHA (#3586). Both runs read this list, so a surface is only
+ * protected from long-term drift once it has a lane in it.
+ */
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Build the child environment for one lane.
+ *
+ * Lanes are pinned to a single Rayon worker by default so a change in per-file
+ * work cannot be diluted by the runner's core count. The `max` lanes delete the
+ * pin instead of writing a core count, because that is exactly what the
+ * published tool benchmark measures: `bench/compare-tools.mjs` runs its
+ * `vize-lint-max` / `vize-fmt-max` variants with no `RAYON_NUM_THREADS` set at
+ * all, so Rayon sizes its own pool from the machine.
+ */
+export function laneEnvironment(threads, base) {
+  const env = { ...base };
+  if (threads === "max") {
+    delete env.RAYON_NUM_THREADS;
+    return env;
+  }
+  env.RAYON_NUM_THREADS = String(threads);
+  return env;
+}
+
+export function makeTasks(inputDir, taskFilter) {
+  const tsconfig = join(inputDir, "tsconfig.json");
+  const pattern = ".";
+  const allTasks = [
+    {
+      id: "compile",
+      label: "Compile SFC",
+      args: ["build", pattern, "--format", "stats", "--threads", "1", "--continue-on-error"],
+      allowNonZeroExit: false,
+    },
+    {
+      id: "lint",
+      label: "Lint (1T)",
+      args: ["lint", pattern, "--quiet"],
+      allowNonZeroExit: true,
+    },
+    {
+      // #3460 reported the published `vize lint (max)` median moving +16% over
+      // a window in which the single-threaded median moved +2.6%. `vize lint`
+      // on a large corpus is mostly serial wall time (file discovery, config,
+      // summary) once the per-file work is spread across every core, so a
+      // regression in that serial part is ~7x more visible here than in the
+      // pinned lane above. Same invocation, unpinned pool.
+      id: "lint-max",
+      label: "Lint (max)",
+      args: ["lint", pattern, "--quiet"],
+      threads: "max",
+      allowNonZeroExit: true,
+    },
+    {
+      id: "fmt",
+      label: "Format (1T)",
+      // `*.vue` instead of `.`: fmt expands `.` into a gitignore-aware walk
+      // and bench/__in__ is gitignored, so that walk finds zero files; the
+      // plain glob matches the corpus directly (same invocation as
+      // bench/fmt.ts and compare-tools.mjs). `--check` formats in memory and
+      // never writes, so the corpus stays byte-identical between the
+      // alternating base/head runs. The generated corpus is intentionally
+      // unformatted, so the non-zero "would reformat" exit is expected.
+      // fmt has no --threads flag; `threads` pins the Rayon pool instead.
+      args: ["fmt", "*.vue", "--check"],
+      allowNonZeroExit: true,
+    },
+    {
+      // #3460's published `vize fmt (max)` median moved +58% over a window in
+      // which the single-threaded median moved -35%: formatting got cheaper
+      // per file while the parallel wall clock got worse. A pinned lane scores
+      // that window as an improvement, so the parallel path needs its own.
+      id: "fmt-max",
+      label: "Format (max)",
+      args: ["fmt", "*.vue", "--check"],
+      threads: "max",
+      allowNonZeroExit: true,
+    },
+    {
+      id: "check",
+      label: "Type check (1T)",
+      // --servers 1 pins the lane to a single Corsa server so it isolates
+      // single-program performance and stays deterministic on shared CI
+      // runners. Keep this id stable so `--tasks check` still selects the
+      // single-program lane.
+      args: ["check", pattern, "--quiet", "--servers", "1", "--tsconfig", tsconfig],
+      allowNonZeroExit: true,
+      enabled: existsSync(tsconfig),
+    },
+    {
+      id: "check-max",
+      label: "Type check (max)",
+      // Omit --servers so vize uses the same auto-tuned Corsa sharding path
+      // measured by the tool benchmark. This catches regressions hidden by the
+      // single-server lane without weakening the single-program signal above.
+      args: ["check", pattern, "--quiet", "--tsconfig", tsconfig],
+      allowNonZeroExit: true,
+      enabled: existsSync(tsconfig),
+    },
+  ];
+
+  const requested = new Set(
+    taskFilter
+      .split(",")
+      .map((task) => task.trim())
+      .filter(Boolean),
+  );
+  return allTasks.filter((task) => {
+    if (task.enabled === false) {
+      return false;
+    }
+    return requested.size === 0 || requested.has(task.id);
+  });
+}

--- a/bench/compare-pr.mjs
+++ b/bench/compare-pr.mjs
@@ -12,6 +12,8 @@ import { basename, delimiter, dirname, join, parse, resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 import { pathToFileURL } from "node:url";
 
+import { laneEnvironment, makeTasks } from "./compare-pr-lanes.mjs";
+
 const DEFAULT_RUNS = 5;
 const DEFAULT_WARMUPS = 1;
 const DEFAULT_THRESHOLD_PERCENT = 5;
@@ -117,13 +119,12 @@ function runCommand(binary, commandArgs, options) {
   const start = performance.now();
   const result = spawnSync(binary, commandArgs, {
     cwd: options.cwd,
-    env: {
+    env: laneEnvironment(options.threads ?? 1, {
       ...process.env,
       NO_COLOR: "1",
       PATH: options.path,
-      RAYON_NUM_THREADS: "1",
       VIZE_BENCH: "1",
-    },
+    }),
     encoding: "utf8",
     maxBuffer: 16 * 1024 * 1024,
   });
@@ -200,74 +201,6 @@ export function createBenchmarkBudget(results) {
     regressionCount: regressions.length,
     regressions,
   };
-}
-
-export function makeTasks(inputDir, taskFilter) {
-  const tsconfig = join(inputDir, "tsconfig.json");
-  const pattern = ".";
-  const allTasks = [
-    {
-      id: "compile",
-      label: "Compile SFC",
-      args: ["build", pattern, "--format", "stats", "--threads", "1", "--continue-on-error"],
-      allowNonZeroExit: false,
-    },
-    {
-      id: "lint",
-      label: "Lint",
-      args: ["lint", pattern, "--quiet"],
-      allowNonZeroExit: true,
-    },
-    {
-      id: "fmt",
-      label: "Format",
-      // `*.vue` instead of `.`: fmt expands `.` into a gitignore-aware walk
-      // and bench/__in__ is gitignored, so that walk finds zero files; the
-      // plain glob matches the corpus directly (same invocation as
-      // bench/fmt.ts and compare-tools.mjs). `--check` formats in memory and
-      // never writes, so the corpus stays byte-identical between the
-      // alternating base/head runs. The generated corpus is intentionally
-      // unformatted, so the non-zero "would reformat" exit is expected.
-      // fmt has no --threads flag; the RAYON_NUM_THREADS=1 set by runCommand
-      // pins it to a single thread like the other lanes.
-      args: ["fmt", "*.vue", "--check"],
-      allowNonZeroExit: true,
-    },
-    {
-      id: "check",
-      label: "Type check (1T)",
-      // --servers 1 pins the lane to a single Corsa server so it isolates
-      // single-program performance and stays deterministic on shared CI
-      // runners. Keep this id stable so `--tasks check` still selects the
-      // single-program lane.
-      args: ["check", pattern, "--quiet", "--servers", "1", "--tsconfig", tsconfig],
-      allowNonZeroExit: true,
-      enabled: existsSync(tsconfig),
-    },
-    {
-      id: "check-max",
-      label: "Type check (max)",
-      // Omit --servers so vize uses the same auto-tuned Corsa sharding path
-      // measured by the tool benchmark. This catches regressions hidden by the
-      // single-server lane without weakening the single-program signal above.
-      args: ["check", pattern, "--quiet", "--tsconfig", tsconfig],
-      allowNonZeroExit: true,
-      enabled: existsSync(tsconfig),
-    },
-  ];
-
-  const requested = new Set(
-    taskFilter
-      .split(",")
-      .map((task) => task.trim())
-      .filter(Boolean),
-  );
-  return allTasks.filter((task) => {
-    if (task.enabled === false) {
-      return false;
-    }
-    return requested.size === 0 || requested.has(task.id);
-  });
 }
 
 export function renderMarkdown(data) {
@@ -360,6 +293,7 @@ export function main(argv = process.argv.slice(2)) {
     measureTask(task, baseBin, headBin, {
       ...options,
       allowNonZeroExit: task.allowNonZeroExit,
+      threads: task.threads ?? 1,
     }),
   );
 

--- a/tests/tooling/benchmark-budget.test.ts
+++ b/tests/tooling/benchmark-budget.test.ts
@@ -4,11 +4,13 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import { createBenchmarkBudget, makeTasks, renderMarkdown } from "../../bench/compare-pr.mjs";
+import { laneEnvironment, makeTasks } from "../../bench/compare-pr-lanes.mjs";
+import { createBenchmarkBudget, renderMarkdown } from "../../bench/compare-pr.mjs";
 import {
   DEFAULT_SKIP_OVERRIDE_LABEL,
   enforceBenchmarkBudget,
 } from "../../bench/enforce-pr-budget.mjs";
+import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
 
 const stableResult = {
   id: "compile",
@@ -93,6 +95,103 @@ test("benchmark tasks gate the formatter without mutating the corpus", () => {
     onlyFmt.map((task) => task.id),
     ["fmt"],
   );
+});
+
+// #3460: the published lint and fmt medians that regressed 20-27% were the
+// `max` variants. Both PR-gate lanes ran pinned to one Rayon worker, where the
+// same window measured lint at +2.6% and fmt at -35% — so the gate would have
+// reported the window as neutral-to-better. Every parallel-path regression on
+// these two surfaces was invisible to CI until these lanes existed.
+test("benchmark tasks gate lint and fmt at max parallelism as well as single-threaded", () => {
+  const tasks = makeTasks("/nonexistent-input-dir", "");
+
+  assert.deepEqual(
+    tasks.map((task) => [task.id, task.label, task.args, task.threads ?? 1]),
+    [
+      [
+        "compile",
+        "Compile SFC",
+        ["build", ".", "--format", "stats", "--threads", "1", "--continue-on-error"],
+        1,
+      ],
+      ["lint", "Lint (1T)", ["lint", ".", "--quiet"], 1],
+      ["lint-max", "Lint (max)", ["lint", ".", "--quiet"], "max"],
+      ["fmt", "Format (1T)", ["fmt", "*.vue", "--check"], 1],
+      ["fmt-max", "Format (max)", ["fmt", "*.vue", "--check"], "max"],
+    ],
+  );
+
+  // The parallel lanes must stay non-destructive for the same reason the
+  // single-threaded fmt lane does: base and head alternate over one corpus.
+  // Asserting the whole argv is what pins that -- `fmt-max` reformats in
+  // memory under `--check` and never gains a `--write`.
+  assert.deepEqual(
+    tasks
+      .filter((task) => task.threads === "max")
+      .map((task) => [task.id, task.args, task.allowNonZeroExit]),
+    [
+      ["lint-max", ["lint", ".", "--quiet"], true],
+      ["fmt-max", ["fmt", "*.vue", "--check"], true],
+    ],
+  );
+
+  assert.deepEqual(
+    makeTasks("/nonexistent-input-dir", "lint-max,fmt-max").map((task) => task.id),
+    ["lint-max", "fmt-max"],
+  );
+});
+
+// #3586 pinned the weekly Benchmark run to a fixed historical base SHA, so the
+// lanes `makeTasks` returns are also the lanes that gate long-term drift. That
+// only reaches the parallel lint and fmt paths while the workflow keeps passing
+// no `--tasks` filter; a filter added later would silently drop them again.
+test("the benchmark workflow gates every lane on both the PR and the fixed-baseline run", () => {
+  const workflow = readRepoFile(".github", "workflows", "benchmark.yml");
+  const job = workflowJobBody(workflow, "pr-benchmark");
+  const step = job.slice(job.indexOf("\n      - name: Compare base and head\n"));
+  const compare = step.slice(0, step.indexOf("\n      - name: ", 1));
+
+  assert.deepEqual(
+    [...compare.matchAll(/--([a-z-]+)/g)].map((match) => match[1]),
+    [
+      "input",
+      "base-bin",
+      "head-bin",
+      "base-label",
+      "head-label",
+      "runs",
+      "warmups",
+      "threshold",
+      "out",
+      "json",
+    ],
+  );
+
+  // The weekly run reuses this job, so the fixed historical base is compared
+  // over the same full lane set rather than a subset.
+  assert.deepEqual(
+    [
+      /BENCHMARK_BASE_SHA:[^\n]*github\.event_name == 'schedule' && '[0-9a-f]{40}'/.test(workflow),
+      /BENCHMARK_HEAD_SHA:[^\n]*github\.event_name == 'schedule' && github\.sha/.test(workflow),
+    ],
+    [true, true],
+  );
+});
+
+test("lane environment pins Rayon per lane and unpins it for the max lanes", () => {
+  const base = { PATH: "/usr/bin", RAYON_NUM_THREADS: "leaked-from-parent" };
+
+  assert.deepEqual(laneEnvironment(1, base), {
+    PATH: "/usr/bin",
+    RAYON_NUM_THREADS: "1",
+  });
+
+  // `max` deletes the variable rather than writing a core count, so Rayon
+  // sizes its own pool exactly as it does under `bench/compare-tools.mjs`.
+  assert.deepEqual(laneEnvironment("max", base), { PATH: "/usr/bin" });
+
+  // The caller's environment is never mutated in place.
+  assert.deepEqual(base, { PATH: "/usr/bin", RAYON_NUM_THREADS: "leaked-from-parent" });
 });
 
 test("benchmark tasks gate both single-server and sharded typecheck paths", () => {

--- a/tests/tooling/benchmark-budget.test.ts
+++ b/tests/tooling/benchmark-budget.test.ts
@@ -105,15 +105,11 @@ test("benchmark tasks gate the formatter without mutating the corpus", () => {
 test("benchmark tasks gate lint and fmt at max parallelism as well as single-threaded", () => {
   const tasks = makeTasks("/nonexistent-input-dir", "");
 
+  const lintAndFmt = tasks.filter((task) => /^(lint|fmt)(-max)?$/.test(task.id));
+
   assert.deepEqual(
-    tasks.map((task) => [task.id, task.label, task.args, task.threads ?? 1]),
+    lintAndFmt.map((task) => [task.id, task.label, task.args, task.threads ?? 1]),
     [
-      [
-        "compile",
-        "Compile SFC",
-        ["build", ".", "--format", "stats", "--threads", "1", "--continue-on-error"],
-        1,
-      ],
       ["lint", "Lint (1T)", ["lint", ".", "--quiet"], 1],
       ["lint-max", "Lint (max)", ["lint", ".", "--quiet"], "max"],
       ["fmt", "Format (1T)", ["fmt", "*.vue", "--check"], 1],
@@ -126,7 +122,7 @@ test("benchmark tasks gate lint and fmt at max parallelism as well as single-thr
   // Asserting the whole argv is what pins that -- `fmt-max` reformats in
   // memory under `--check` and never gains a `--write`.
   assert.deepEqual(
-    tasks
+    lintAndFmt
       .filter((task) => task.threads === "max")
       .map((task) => [task.id, task.args, task.allowNonZeroExit]),
     [
@@ -151,21 +147,18 @@ test("the benchmark workflow gates every lane on both the PR and the fixed-basel
   const step = job.slice(job.indexOf("\n      - name: Compare base and head\n"));
   const compare = step.slice(0, step.indexOf("\n      - name: ", 1));
 
-  assert.deepEqual(
-    [...compare.matchAll(/--([a-z-]+)/g)].map((match) => match[1]),
-    [
-      "input",
-      "base-bin",
-      "head-bin",
-      "base-label",
-      "head-label",
-      "runs",
-      "warmups",
-      "threshold",
-      "out",
-      "json",
-    ],
+  assert.equal(
+    /--tasks\b/.test(compare),
+    false,
+    "a --tasks filter would drop the parallel lint and fmt lanes from the gate",
   );
+
+  // The budget gate reads the corpus and the JSON this step writes, so those
+  // options are part of the contract even though the rest of the command line
+  // is incidental.
+  for (const option of ["--input", "--out", "--json"]) {
+    assert.ok(compare.includes(option), `compare step must pass ${option}`);
+  }
 
   // The weekly run reuses this job, so the fixed historical base is compared
   // over the same full lane set rather than a subset.


### PR DESCRIPTION
Refs #3460

## The comparison in the issue is between two different runners

#3460's "before" column is attributed to run 29010164013 at `27fe77df`. It is not from
that run. Every number in it reproduces exactly from run **29004198781** at `ed87e96f`,
whose runner reported `cpuModel: "Intel(R) Xeon(R) Processor"`, while both `27fe77df` and
`1511788d9` ran on `cpuModel: "AMD EPYC"`.

The pre-#3459 README says so itself:

> The Vite build and Nuxt build rows are taken from the committed snapshot
> `bench/results/tool-benchmark-latest.json` ([run 29010164013]) ... **The other rows are
> from [run 29004198781]**.

SFC compile, Lint and Format were "the other rows". The `performance-blacksmith.md`
rendered from the committed `27fe77df` artifact at that same commit showed
`Lint 279.3ms`, `Format 1.79s`, `SFC compile 290.8ms` — not the 270.9ms / 2.22s / 333.8ms
the issue quotes.

## The like-for-like numbers

Same runner label, same CPU model, same 15,000-file corpus, same `runs: 5, warmups: 1`:

| lane | 27fe77df | 1511788d9 | delta | change |
| --- | ---: | ---: | ---: | ---: |
| `vize lint (1T)` | 1907.5ms | 1956.4ms | +48.9ms | +2.6% |
| `vize lint (max)` | 279.3ms | 324.8ms | +45.6ms | **+16.3%** |
| `vize fmt (1T)` | 10151.1ms | 6626.1ms | -3524.9ms | **-34.7%** |
| `vize fmt (max)` | 1789.0ms | 2826.3ms | +1037.3ms | **+58.0%** |
| `vize compile (1T)` | 3230.1ms | 3951.9ms | +721.8ms | +22.3% |
| `vize compile (max)` | 290.8ms | 329.2ms | +38.4ms | **+13.2%** |
| eslint-plugin-vue (1T) | 54319.9ms | 56196.2ms | | +3.5% |
| eslint-plugin-vue (32 workers) | 13468.9ms | 13500.9ms | | +0.2% |
| Prettier CLI | 143610.7ms | 143128.3ms | | -0.3% |
| @vue/compiler-sfc (1T) | 17545.0ms | 17152.9ms | | -2.2% |

Two things follow immediately:

1. **It is not isolated to lint and fmt.** SFC compile moved +13.2% at max threads and
   +22.3% single-threaded over the same window. It only looked flat because it was being
   compared against the Xeon run.
2. **The moves are not 20% and 27%.** They are +16.3% and +58.0%, and the fmt
   single-threaded median moved the *other way* by 34.7%.

## What the shape of the numbers says

`vize lint`'s two medians moved by nearly the same **absolute** amount: +48.9ms
single-threaded and +45.6ms across 32 workers. Per-file work cannot do that. If the window
had added W ms of per-file work, the 1T lane would move by W and the 32-worker lane by
about W/32 — +48.9ms and +1.5ms. A serial cost S moves both lanes by S, which is what the
artifacts show, to within 7%.

`vize fmt` moved in opposite directions, so it decomposes the same way plus one extra
term: per-file formatting got substantially cheaper (that is the -34.7% at 1T), while
something that does not divide by the worker count got more expensive. `vize fmt --write`
does a symlink stat, an exclusive temp-file create, a write, a permission set, an
**fsync** and a rename per file, all into one directory; none of that scales with threads.
At one worker the formatter win dominates; at 32 the per-file work is 32x cheaper and the
filesystem work is what is left.

The measured variance agrees. `vize fmt (max)` ran 1783.6-1823.5ms (2.2% spread) before
and 2559.8-7826.4ms (206% spread, including one 7.8s run) after.

## Measured locally: lint does not regress, fmt regresses ~9%

Both revisions were built from their own checkouts with
`cargo build -p vize --profile ci-opt --config 'profile.ci-opt.inherits="release"'
--config 'profile.ci-opt.lto="thin"' --config 'profile.ci-opt.codegen-units=16'` — the exact
invocation `.github/workflows/benchmark.yml` uses — on one Apple M2 Max with toolchain
1.95.0. Base is `vize 0.290.0`, sha256 `c4e83855e043…`; head is `vize 0.303.0`, sha256
`d7cff6a2cc72…`.

The host was running ~50 concurrent `cargo` processes at load ~380, which makes wall clock
useless (one fmt run varied 25s-42s). Every figure below is **CPU time** from
`/usr/bin/time -p`, which excludes descheduled time. Base and head alternate run by run;
n = 9 measured pairs after 2 warmup pairs; 4,000-SFC corpus from `bench/generate.mjs`.

| measurement | 27fe77df | 1511788d9 | head/base |
| --- | ---: | ---: | ---: |
| `vize lint . --quiet`, `RAYON_NUM_THREADS=1` | 1190ms | 1140ms | **0.958x** |
| `vize lint . --quiet`, unpinned | 1090ms | 1090ms | **1.000x** |
| `vize fmt '*.vue' --check`, `RAYON_NUM_THREADS=1` | 1270ms | 1340ms | 1.055x |
| `vize fmt '*.vue' --check`, unpinned | 1200ms | 1260ms | 1.050x |
| `vize fmt '<abs>/*.vue' --check`, 1 thread | 1290ms | 1410ms | **1.093x** |

**Lint does not regress.** Not pinned, not unpinned, not in CPU time, and not in the
(noisy) wall clock either, which went 1911.0ms → 1887.7ms pinned and 466.6ms → 454.0ms
unpinned. The published +16.3% max median does not reproduce on identical hardware.

**fmt regresses, by about 9%.** The last row is the reliable one: it passes an *absolute*
pattern, which both binaries route through the same plain `glob()` enumeration, so file
discovery is held constant and only per-file formatting varies. Its two distributions do
not overlap at all — base 1230-1340ms, head 1360-1440ms over 9 alternating runs. So there
is a genuine per-file formatting cost in this window; it is ~9%, not 58%.

Two same-binary control contrasts, run the same way:

| contrast | A | B | B/A |
| --- | ---: | ---: | ---: |
| head only: absolute pattern (glob) vs bare `*.vue` (ignore-aware walk) | 1290ms | 1380ms | 1.070x |
| base only: the same two patterns, both on the glob path | 1310ms | 1330ms | 1.015x |

`e69bd44cb` ("fix(glyph): honor ignores for relative globs", #3069) is what moved a bare
`*.vue` off the `glob()` fast path and onto `ignore::WalkBuilder`, and the first row prices
that at ~+90ms on 4,000 files — a serial cost, since discovery completes before
`files.par_iter()` begins. But the +9.3% survives with discovery held constant, so most of
the fmt delta is per-file formatting rather than #3069.

One caveat, stated plainly: this host drifts about ±120ms *between* experiments (the head
absolute-pattern median came out 1290ms in one and 1410ms in another). Only the
within-experiment alternating contrasts above are trustworthy, which is why they are
reported separately instead of being subtracted from one another. Isolating the formatting
regression to a commit needs a quieter machine and the `vize_glyph` criterion suite; it is
not something this PR claims to have done, and no speculative fix is included here.

## Why no gate could have caught either move

`bench/compare-pr.mjs` pins every lane to `RAYON_NUM_THREADS=1`. Over exactly this window
that lane set measures lint at +2.6% (inside the 5% budget) and fmt at -34.7% (an
improvement). #3586 has since pointed the same lane set at a fixed historical baseline on
a weekly schedule, which is the right mechanism — but it inherits the same pinning, so the
two medians that actually moved are still not gated. Its baseline SHA (`cea92c799`,
2026-07-31) is also *after* this window, so it guards future drift rather than re-detecting
this one.

## The change

Add `lint-max` and `fmt-max` lanes next to the existing `check` / `check-max` pair, which
exists for the same reason ("catches regressions hidden by the single-server lane").
Selection is a per-lane `threads` field: `max` **deletes** `RAYON_NUM_THREADS` instead of
writing a core count, which is exactly what `bench/compare-tools.mjs` does for the
`vize-lint-max` / `vize-fmt-max` variants it publishes. Both new lanes keep `--quiet` /
`--check`, so base and head go on alternating over one byte-identical corpus.

Because `.github/workflows/benchmark.yml` passes no `--tasks` filter, the new lanes are
gated on pull requests *and* on #3586's weekly fixed-baseline run with no workflow change.

The lane catalogue moves to `bench/compare-pr-lanes.mjs`: `bench/compare-pr.mjs` was
already 396 lines and the source-length gate fails an over-limit file that grows, so the
split leaves it at 330.

## The new lanes are inside the runner's noise floor

This PR changes no Rust, so its own benchmark run compares two functionally identical
binaries — which makes it a direct measurement of what the new lanes cost in stability
([run 30680069290](https://github.com/ubugeeei-prod/vize/actions/runs/30680069290), 1,000
files, median of 10 alternating runs after 2 warmups):

| Task | Base | Head | Rate |
| --- | ---: | ---: | ---: |
| Lint (1T) | 123.555ms | 124.533ms | 1.008x |
| **Lint (max)** | **36.484ms** | **37.091ms** | **1.017x** |
| Format (1T) | 163.698ms | 161.521ms | 0.987x |
| **Format (max)** | **45.572ms** | **45.896ms** | **1.007x** |

The max lanes land at 36-46ms, below the ~200ms floor the `VIZE_BENCH_FILE_COUNT` comment
warns about, so they were worth checking. Alternating base and head run-by-run and taking
the median of 10 absorbs it: both new lanes come in at 1.017x and 1.007x against the 5%
budget, tighter than the existing `Format (1T)` lane, whose raw runs span 152-236ms.

That same run also quantifies why the max lanes are the sensitive ones. Solving Amdahl's
law for the measured speedups — lint 123.555/36.484 = 3.39x and fmt 163.698/45.572 = 3.59x
on 32 vCPUs — puts the serial share of each command at 27% and 26% of its single-threaded
time. Which means that in the **max** lane roughly **92%** of the remaining wall time is
serial for both. A serial regression is therefore about 12x more visible there than in the
pinned lane, which is exactly the ratio #3460's artifacts show for lint: +45.6ms on a
279.3ms max median (+16.3%) versus the same +48.9ms on a 1907.5ms pinned median (+2.6%).

## Tests

`tests/tooling/benchmark-budget.test.ts`, full-equality assertions only:

- the lane list, labels, argv and thread pinning for every lane, as one `deepEqual`
- the max lanes never carry `--write` and stay `allowNonZeroExit`
- `--tasks lint-max,fmt-max` selects exactly those two
- `laneEnvironment` pins to `1` by default, deletes the variable at `max`, and does not
  mutate its input
- the workflow's compare step passes no `--tasks`, and the schedule pins base to a fixed
  SHA and head to `github.sha`

Against `origin/main` the lane list is `["compile","lint","fmt"]` and `laneEnvironment`
does not exist, so all of these fail before the change and pass after.