### PR TITLE
feat(maestro): re-indent the typed line via textDocument/onTypeFormatting

### DIFF
--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -3,11 +3,12 @@
 
 use tower_lsp::lsp_types::{
     CodeActionKind, CodeActionOptions, CodeActionProviderCapability, CodeLensOptions,
-    ColorProviderCapability, CompletionOptions, DocumentLinkOptions, FileOperationFilter,
-    FileOperationPattern, FileOperationPatternKind, FileOperationRegistrationOptions,
-    FoldingRangeProviderCapability, HoverProviderCapability, LinkedEditingRangeServerCapabilities,
-    OneOf, RenameOptions, SaveOptions, SelectionRangeProviderCapability, SemanticTokenModifier,
-    SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
+    ColorProviderCapability, CompletionOptions, DocumentLinkOptions,
+    DocumentOnTypeFormattingOptions, FileOperationFilter, FileOperationPattern,
+    FileOperationPatternKind, FileOperationRegistrationOptions, FoldingRangeProviderCapability,
+    HoverProviderCapability, LinkedEditingRangeServerCapabilities, OneOf, RenameOptions,
+    SaveOptions, SelectionRangeProviderCapability, SemanticTokenModifier, SemanticTokenType,
+    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
     SemanticTokensServerCapabilities, ServerCapabilities, TextDocumentSyncCapability,
     TextDocumentSyncKind, TextDocumentSyncOptions, TextDocumentSyncSaveOptions,
     WorkDoneProgressOptions, WorkspaceFileOperationsServerCapabilities,
@@ -95,6 +96,18 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
         // whole-document format back onto the SFC blocks the selection
         // intersects, so the two commands can never disagree.
         document_range_formatting_provider: features.formatting.then_some(OneOf::Left(true)),
+
+        // On-type formatting re-indents the line as a `;`, `}` or newline is
+        // typed. Same trigger set as `@vue/language-server` so an editor
+        // configured for one server behaves identically under the other. Rides
+        // the `formatting` flag with its two siblings above: it is the same
+        // formatter again, narrowed to the line under the caret.
+        document_on_type_formatting_provider: features.formatting.then(|| {
+            DocumentOnTypeFormattingOptions {
+                first_trigger_character: ";".to_string(),
+                more_trigger_character: Some(vec!["}".to_string(), "\n".to_string()]),
+            }
+        }),
 
         // Signature help is not implemented yet.
         signature_help_provider: None,
@@ -197,7 +210,6 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
         type_definition_provider: None,
         implementation_provider: None,
         declaration_provider: None,
-        document_on_type_formatting_provider: None,
         execute_command_provider: None,
         call_hierarchy_provider: None,
         moniker_provider: None,

--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -109,11 +109,12 @@ fn individual_feature_flags_gate_matching_providers() {
         (
             "formatting",
             |features| features.formatting = false,
-            // Range formatting rides the same flag: "Format Selection" is the
-            // same formatter scoped to the blocks a selection touches.
+            // All three formatting commands ride the same flag: they are one
+            // formatter scoped to the document, to a selection, and to a line.
             |capabilities| {
                 capabilities.document_formatting_provider.is_some()
                     && capabilities.document_range_formatting_provider.is_some()
+                    && capabilities.document_on_type_formatting_provider.is_some()
             },
         ),
         (
@@ -251,6 +252,22 @@ fn default_features_advertise_non_opinionated_providers() {
     assert!(capabilities.document_link_provider.is_some());
     assert!(capabilities.document_formatting_provider.is_none());
     assert!(capabilities.document_range_formatting_provider.is_none());
+    assert!(capabilities.document_on_type_formatting_provider.is_none());
+}
+
+/// The trigger set is `@vue/language-server`'s, character for character, so an
+/// editor configured for one server behaves the same under the other (#3456).
+#[test]
+fn on_type_formatting_advertises_the_vue_language_server_trigger_set() {
+    let options = server_capabilities(all_features())
+        .document_on_type_formatting_provider
+        .expect("on-type formatting rides the formatting flag");
+
+    assert_eq!(options.first_trigger_character, ";");
+    assert_eq!(
+        options.more_trigger_character,
+        Some(vec!["}".to_string(), "\n".to_string()])
+    );
 }
 
 #[test]

--- a/crates/vize_maestro/src/server/format.rs
+++ b/crates/vize_maestro/src/server/format.rs
@@ -3,8 +3,14 @@
 //! Provides SFC document formatting via the vize_glyph formatter.
 
 #[cfg(feature = "glyph")]
+mod blocks;
+#[cfg(feature = "glyph")]
+mod on_type;
+#[cfg(feature = "glyph")]
 mod range;
 
+#[cfg(feature = "glyph")]
+pub(crate) use on_type::format_on_type;
 #[cfg(feature = "glyph")]
 pub(crate) use range::format_range;
 

--- a/crates/vize_maestro/src/server/format/blocks.rs
+++ b/crates/vize_maestro/src/server/format/blocks.rs
@@ -1,0 +1,46 @@
+//! Pairing an authored SFC's blocks with the formatted document's blocks.
+//!
+//! Both `rangeFormatting` and `onTypeFormatting` answer by formatting the whole
+//! document once and then projecting the result back onto the part of the file
+//! the request is about. That projection needs the same blocks on both sides,
+//! which is what this module provides: content spans in one fixed discovery
+//! order, so `authored[i]` and `formatted[i]` are the same block.
+
+/// Byte span of one block's content — from just after the open tag to just
+/// before the close tag — in discovery order.
+pub(super) type BlockSpan = (usize, usize);
+
+pub(super) fn block_spans(source: &str, filename: &str) -> Option<Vec<BlockSpan>> {
+    let options = vize_atelier_sfc::SfcParseOptions {
+        filename: filename.into(),
+        ..Default::default()
+    };
+    let descriptor = vize_atelier_sfc::parse_sfc(source, options).ok()?;
+
+    Some(
+        descriptor
+            .template
+            .as_ref()
+            .map(|block| (block.loc.start, block.loc.end))
+            .into_iter()
+            .chain(
+                descriptor
+                    .script_setup
+                    .as_ref()
+                    .map(|block| (block.loc.start, block.loc.end)),
+            )
+            .chain(
+                descriptor
+                    .script
+                    .as_ref()
+                    .map(|block| (block.loc.start, block.loc.end)),
+            )
+            .chain(
+                descriptor
+                    .styles
+                    .iter()
+                    .map(|block| (block.loc.start, block.loc.end)),
+            )
+            .collect(),
+    )
+}

--- a/crates/vize_maestro/src/server/format/on_type.rs
+++ b/crates/vize_maestro/src/server/format/on_type.rs
@@ -1,0 +1,139 @@
+//! `textDocument/onTypeFormatting`: re-indent the line being typed on.
+//!
+//! # What this does, and deliberately does not, do
+//!
+//! On-type formatting fires under the caret — on every `;`, `}` and newline the
+//! user types (#3456). Anything that rewrites *content* there fights the
+//! typist: it moves the caret, undoes a half-finished edit, and turns one
+//! keystroke into an unbounded diff. So this handler only ever changes a line's
+//! **leading whitespace**, and only on the line the request names.
+//!
+//! # Why the indent comes from the whole-document format
+//!
+//! The indent is not guessed from brace depth — it is read off the same
+//! `vize fmt` run that backs Format Document, then applied to one line. Format
+//! Document, Format Selection and Format On Type therefore agree by
+//! construction rather than by three implementations happening to match.
+//!
+//! # Why the pairing is per block
+//!
+//! Reading an indent off "formatted line N" requires authored line N and
+//! formatted line N to be the same line. Across a whole `.vue` that almost
+//! never holds: the formatter breaks `<p>hello</p>` onto three lines, so one
+//! unformatted element in the template shifts every line below it and the
+//! script's indentation could never be answered.
+//!
+//! The pairing is therefore scoped to the SFC block the caret is in — the same
+//! authored/formatted block pairing `format_range` projects through. A template
+//! that is mid-edit no longer stops the script from being indented, and vice
+//! versa.
+//!
+//! Within that block the handler still declines — returns no edits — whenever
+//! the formatter would
+//!
+//! - add or remove lines, which would slide every later line out of its pair;
+//!   or
+//! - rewrite the line's own content, which is the formatter asking for an edit
+//!   this request must not make.
+//!
+//! Declining is cheap and correct: the keystroke produces no edit, and Format
+//! Document still does the full job on demand.
+
+use tower_lsp::lsp_types::{Position, Range, TextEdit};
+
+use super::blocks::block_spans;
+use crate::ide::position_to_offset;
+
+/// Re-indent `position.line` to the indent whole-document formatting gives it.
+///
+/// `None` means the request is not answerable at all: the document has no such
+/// line, or the formatter could not parse the file — routine while typing.
+/// `Some(vec![])` means "nothing to change here".
+pub(crate) fn format_on_type(
+    content: &str,
+    filename: &str,
+    position: Position,
+    options: &vize_glyph::FormatOptions,
+) -> Option<Vec<TextEdit>> {
+    let line_start = position_to_offset(content, position.line, 0)?;
+
+    let allocator = vize_glyph::Allocator::with_capacity(content.len());
+    let formatted = vize_glyph::format_sfc_with_allocator(content, options, &allocator).ok()?;
+    if !formatted.changed {
+        return Some(Vec::new());
+    }
+
+    let authored = block_spans(content, filename)?;
+    let target = block_spans(&formatted.code, filename)?;
+    // A formatter must not add, drop or reorder blocks. If it did, the two
+    // lists cannot be paired and there is no indent to read.
+    if authored.len() != target.len() {
+        return Some(Vec::new());
+    }
+
+    let Some(index) = authored
+        .iter()
+        .position(|&(start, end)| (start..=end).contains(&line_start))
+    else {
+        // Between blocks, or on a block's own tag line. Neither is content the
+        // formatter indents.
+        return Some(Vec::new());
+    };
+
+    let (authored_start, authored_end) = authored[index];
+    let (target_start, target_end) = target[index];
+    let authored_lines: Vec<&str> = content[authored_start..authored_end].split('\n').collect();
+    let target_lines: Vec<&str> = formatted.code[target_start..target_end]
+        .split('\n')
+        .collect();
+    // Line N of this block must still be line N after formatting.
+    if authored_lines.len() != target_lines.len() {
+        return Some(Vec::new());
+    }
+
+    // Block content opens partway through the tag's own line, so relative line
+    // 0 is the tail of `<script …>` rather than a line of its own.
+    let relative = content[authored_start..line_start].matches('\n').count();
+    if relative == 0 {
+        return Some(Vec::new());
+    }
+    let (Some(&authored_line), Some(&target_line)) =
+        (authored_lines.get(relative), target_lines.get(relative))
+    else {
+        return Some(Vec::new());
+    };
+
+    let authored_indent = indent_of(authored_line);
+    let target_indent = indent_of(target_line);
+    // Everything after the indent must already match: this request re-indents,
+    // it never rewrites what the user is in the middle of typing.
+    if authored_line[authored_indent.len()..] != target_line[target_indent.len()..]
+        || authored_indent == target_indent
+    {
+        return Some(Vec::new());
+    }
+
+    Some(vec![TextEdit {
+        range: Range {
+            start: Position::new(position.line, 0),
+            // Indentation is spaces and tabs, one UTF-16 unit each, so the byte
+            // length is also the character offset the client expects.
+            end: Position::new(position.line, authored_indent.len() as u32),
+        },
+        #[allow(clippy::disallowed_methods)]
+        new_text: target_indent.to_string(),
+    }])
+}
+
+/// The leading run of spaces and tabs. Deliberately not `trim_start`, which
+/// also eats non-breaking spaces and other Unicode whitespace that is authored
+/// content rather than indentation.
+fn indent_of(line: &str) -> &str {
+    let end = line
+        .find(|ch: char| ch != ' ' && ch != '\t')
+        .unwrap_or(line.len());
+    &line[..end]
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_maestro/src/server/format/on_type/tests.rs
+++ b/crates/vize_maestro/src/server/format/on_type/tests.rs
@@ -1,0 +1,134 @@
+use tower_lsp::lsp_types::{Position, Range, TextEdit};
+
+use super::format_on_type;
+
+/// A whole SFC that is `vize fmt`-clean apart from two closing braces left one
+/// level too deep — one in TypeScript, one in CSS. That is the state a file is
+/// in while `editor.formatOnType` keeps up with the typist.
+///
+/// ```text
+///  0  <script setup lang="ts">
+///  1  function greet() {
+///  2    const name = "vize";
+///  3    return name;
+///  4    }
+///  5  </script>
+///  6
+///  7  <template>
+///  8    <p>
+///  9      hello
+/// 10    </p>
+/// 11  </template>
+/// 12
+/// 13  <style scoped>
+/// 14  .box {
+/// 15    color: red;
+/// 16    }
+/// 17  </style>
+/// ```
+const SOURCE: &str = "<script setup lang=\"ts\">\nfunction greet() {\n  const name = \"vize\";\n  return name;\n  }\n</script>\n\n<template>\n  <p>\n    hello\n  </p>\n</template>\n\n<style scoped>\n.box {\n  color: red;\n  }\n</style>\n";
+
+/// SOURCE with both braces where `vize fmt` puts them.
+const FORMATTED: &str = "<script setup lang=\"ts\">\nfunction greet() {\n  const name = \"vize\";\n  return name;\n}\n</script>\n\n<template>\n  <p>\n    hello\n  </p>\n</template>\n\n<style scoped>\n.box {\n  color: red;\n}\n</style>\n";
+
+fn edits_at(source: &str, line: u32) -> Option<Vec<TextEdit>> {
+    format_on_type(
+        source,
+        "/App.vue",
+        Position::new(line, 0),
+        &vize_glyph::FormatOptions::default(),
+    )
+}
+
+/// The one edit that drops `width` leading columns from `line`.
+fn dedent(line: u32, width: u32) -> Option<Vec<TextEdit>> {
+    Some(vec![TextEdit {
+        range: Range {
+            start: Position { line, character: 0 },
+            end: Position {
+                line,
+                character: width,
+            },
+        },
+        new_text: String::new(),
+    }])
+}
+
+#[test]
+fn a_closing_brace_loses_its_stray_indent() {
+    assert_eq!(edits_at(SOURCE, 4), dedent(4, 2));
+}
+
+#[test]
+fn the_same_holds_for_a_closing_brace_in_css() {
+    // Proof the answer is the SFC formatter's and not a TypeScript-only path:
+    // the CSS rule's brace is fixed on its own, without the script's coming
+    // along for the ride.
+    assert_eq!(edits_at(SOURCE, 16), dedent(16, 2));
+}
+
+#[test]
+fn an_already_correct_line_yields_no_edit() {
+    // Line 2 is `vize fmt`-clean even though the document is not.
+    assert_eq!(edits_at(SOURCE, 2), Some(Vec::new()));
+}
+
+#[test]
+fn lines_outside_block_content_yield_no_edit() {
+    for line in [
+        0,  // the `<script setup>` tag itself
+        6,  // the blank line between two blocks
+        7,  // the `<template>` tag itself
+        12, // the blank line before `<style>`
+    ] {
+        assert_eq!(
+            edits_at(SOURCE, line),
+            Some(Vec::new()),
+            "line {line} is not block content"
+        );
+    }
+}
+
+#[test]
+fn a_line_whose_content_the_formatter_would_rewrite_is_left_alone() {
+    // `const   name="vize"` needs more than an indent change. Rewriting it
+    // under the caret would undo what the user is halfway through typing.
+    let source = SOURCE.replace("  const name = \"vize\";", "  const   name=\"vize\"");
+    assert_eq!(edits_at(&source, 2), Some(Vec::new()));
+}
+
+#[test]
+fn a_block_the_formatter_reflows_declines_without_silencing_its_neighbours() {
+    // `<p>hello</p>` on one line becomes three, so template line N is no longer
+    // formatted line N and the template can answer nothing...
+    let source = SOURCE.replace("  <p>\n    hello\n  </p>", "  <p>hello</p>");
+    assert_eq!(edits_at(&source, 8), Some(Vec::new()));
+    // ...while the script block, paired independently, still re-indents. This
+    // is the whole reason the pairing is per block.
+    assert_eq!(edits_at(&source, 4), dedent(4, 2));
+}
+
+#[test]
+fn a_line_the_document_does_not_have_is_not_answerable() {
+    assert_eq!(edits_at(SOURCE, 900), None);
+}
+
+#[test]
+fn an_already_formatted_document_needs_no_edit() {
+    for line in 0..18 {
+        assert_eq!(
+            edits_at(FORMATTED, line),
+            Some(Vec::new()),
+            "formatted line {line}"
+        );
+    }
+}
+
+#[test]
+fn a_whitespace_only_line_loses_the_indent_the_editor_guessed() {
+    // Pressing Enter leaves the caret on a line the editor pre-indented by its
+    // own rules; `\n` is a trigger character precisely so that guess can be
+    // corrected against the formatter's.
+    let source = FORMATTED.replace("  return name;", "    \n  return name;");
+    assert_eq!(edits_at(&source, 3), dedent(3, 4));
+}

--- a/crates/vize_maestro/src/server/format/range.rs
+++ b/crates/vize_maestro/src/server/format/range.rs
@@ -24,10 +24,8 @@
 
 use tower_lsp::lsp_types::{Position, Range, TextEdit};
 
+use super::blocks::block_spans;
 use crate::ide::position_to_offset;
-
-/// Byte span of one block's content, in discovery order.
-type BlockSpan = (usize, usize);
 
 pub(crate) fn format_range(
     content: &str,
@@ -83,43 +81,6 @@ pub(crate) fn format_range(
     // the list non-overlapping and ascending, which is what clients apply.
     edits.sort_by_key(|edit| (edit.range.start.line, edit.range.start.character));
     Some(edits)
-}
-
-/// Content spans of every SFC block, in a fixed discovery order so the authored
-/// and formatted documents pair up positionally.
-fn block_spans(source: &str, filename: &str) -> Option<Vec<BlockSpan>> {
-    let options = vize_atelier_sfc::SfcParseOptions {
-        filename: filename.into(),
-        ..Default::default()
-    };
-    let descriptor = vize_atelier_sfc::parse_sfc(source, options).ok()?;
-
-    Some(
-        descriptor
-            .template
-            .as_ref()
-            .map(|block| (block.loc.start, block.loc.end))
-            .into_iter()
-            .chain(
-                descriptor
-                    .script_setup
-                    .as_ref()
-                    .map(|block| (block.loc.start, block.loc.end)),
-            )
-            .chain(
-                descriptor
-                    .script
-                    .as_ref()
-                    .map(|block| (block.loc.start, block.loc.end)),
-            )
-            .chain(
-                descriptor
-                    .styles
-                    .iter()
-                    .map(|block| (block.loc.start, block.loc.end)),
-            )
-            .collect(),
-    )
 }
 
 fn offset_position(content: &str, offset: usize) -> Position {

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -14,15 +14,15 @@ use tower_lsp::{
         DidChangeTextDocumentParams, DidChangeWatchedFilesParams, DidChangeWorkspaceFoldersParams,
         DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
         DocumentColorParams, DocumentFormattingParams, DocumentHighlight, DocumentHighlightParams,
-        DocumentLink, DocumentLinkParams, DocumentRangeFormattingParams, DocumentSymbolParams,
-        DocumentSymbolResponse, FoldingRange, FoldingRangeParams, GotoDefinitionParams,
-        GotoDefinitionResponse, Hover, HoverParams, InitializeParams, InitializeResult,
-        InitializedParams, InlayHint, InlayHintParams, LinkedEditingRangeParams,
-        LinkedEditingRanges, Location, PrepareRenameResponse, ReferenceParams, RenameFilesParams,
-        RenameParams, SelectionRange, SelectionRangeParams, SemanticTokensParams,
-        SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, ServerInfo,
-        SymbolInformation, TextDocumentPositionParams, TextEdit, WorkspaceEdit,
-        WorkspaceSymbolParams,
+        DocumentLink, DocumentLinkParams, DocumentOnTypeFormattingParams,
+        DocumentRangeFormattingParams, DocumentSymbolParams, DocumentSymbolResponse, FoldingRange,
+        FoldingRangeParams, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams,
+        InitializeParams, InitializeResult, InitializedParams, InlayHint, InlayHintParams,
+        LinkedEditingRangeParams, LinkedEditingRanges, Location, PrepareRenameResponse,
+        ReferenceParams, RenameFilesParams, RenameParams, SelectionRange, SelectionRangeParams,
+        SemanticTokensParams, SemanticTokensRangeParams, SemanticTokensRangeResult,
+        SemanticTokensResult, ServerInfo, SymbolInformation, TextDocumentPositionParams, TextEdit,
+        WorkspaceEdit, WorkspaceSymbolParams,
     },
 };
 
@@ -777,6 +777,39 @@ impl LanguageServer for MaestroServer {
         #[cfg(not(feature = "glyph"))]
         Ok(None)
     }
+
+    /// Re-indent the line being typed on — see `server::format::on_type` for
+    /// why this never rewrites content.
+    async fn on_type_formatting(
+        &self,
+        params: DocumentOnTypeFormattingParams,
+    ) -> Result<Option<Vec<TextEdit>>> {
+        if !self.state.lsp_features().formatting {
+            return Ok(None);
+        }
+
+        let uri = &params.text_document_position.text_document.uri;
+
+        // See `formatting`: standalone HTML must not go through the SFC formatter.
+        if crate::utils::is_standalone_html_path(uri.path()) {
+            return Ok(None);
+        }
+
+        let Some(_content) = self.state.documents.text(uri) else {
+            return Ok(None);
+        };
+        #[cfg(feature = "glyph")]
+        {
+            let options = self.state.get_format_options();
+            let position = params.text_document_position.position;
+            let path = uri.path();
+            return Ok(super::format::format_on_type(
+                &_content, path, position, &options,
+            ));
+        }
+        #[cfg(not(feature = "glyph"))]
+        Ok(None)
+    }
 }
 
 #[cfg(test)]
@@ -787,67 +820,11 @@ mod tests {
         lsp_types::{FormattingOptions, TextDocumentIdentifier, Url, WorkDoneProgressParams},
     };
 
-    fn formatting_params(uri: Url) -> DocumentFormattingParams {
-        DocumentFormattingParams {
-            text_document: TextDocumentIdentifier { uri },
-            options: FormattingOptions::default(),
-            work_done_progress_params: WorkDoneProgressParams::default(),
-        }
-    }
-
-    #[test]
-    fn formatting_returns_no_edits_for_standalone_html() {
-        let (service, _socket) = LspService::new(MaestroServer::new);
-        let server = service.inner();
-        server
-            .state
-            .apply_lsp_initialization_options(Some(&serde_json::json!({ "formatting": true })));
-
-        let uri = Url::parse("file:///index.html").unwrap();
-        let source = "<!DOCTYPE html>\n<html><body>\n<div   v-scope=\"{ count: 0 }\" >{{ count }}</div>\n</body></html>\n";
-        server
-            .state
-            .documents
-            .open(uri.clone(), source.to_string(), 1, "html".to_string());
-
-        let edits =
-            futures::executor::block_on(server.formatting(formatting_params(uri.clone()))).unwrap();
-        assert!(
-            edits.is_none(),
-            "the SFC formatter must not touch standalone HTML documents"
-        );
-
-        let range_params = DocumentRangeFormattingParams {
-            text_document: TextDocumentIdentifier { uri },
-            range: Range::new(Position::new(0, 0), Position::new(0, 1)),
-            options: FormattingOptions::default(),
-            work_done_progress_params: WorkDoneProgressParams::default(),
-        };
-        let edits = futures::executor::block_on(server.range_formatting(range_params)).unwrap();
-        assert!(
-            edits.is_none(),
-            "range formatting must not touch standalone HTML documents"
-        );
-
-        // Guard against the gate over-matching: SFC formatting must still work.
-        #[cfg(feature = "glyph")]
-        {
-            let vue_uri = Url::parse("file:///App.vue").unwrap();
-            let vue_source = "<template>\n<div>hello</div>\n</template>\n";
-            server.state.documents.open(
-                vue_uri.clone(),
-                vue_source.to_string(),
-                1,
-                "vue".to_string(),
-            );
-            let edits =
-                futures::executor::block_on(server.formatting(formatting_params(vue_uri))).unwrap();
-            assert!(edits.is_some(), "Vue SFC formatting must keep working");
-        }
-    }
-
+    mod formatting;
     mod lifecycle;
     mod requests;
+
+    use formatting::formatting_params;
 
     use tower_lsp::lsp_types::{
         CodeActionContext, CodeActionParams, DocumentSymbolParams, PartialResultParams,

--- a/crates/vize_maestro/src/server/handlers/tests/formatting.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/formatting.rs
@@ -1,0 +1,125 @@
+//! Gate tests for the three formatting handlers.
+//!
+//! `formatting`, `range_formatting` and `on_type_formatting` all reach the same
+//! SFC formatter, so they share the same two gates: the `formatting` feature
+//! flag, and the standalone-HTML exclusion. The formatting *behaviour* is
+//! covered where it lives — `server::format::range` and
+//! `server::format::on_type` — so these tests only prove the routing.
+
+use super::*;
+use tower_lsp::lsp_types::DocumentOnTypeFormattingParams;
+
+const STANDALONE_HTML: &str = "<!DOCTYPE html>\n<html><body>\n<div   v-scope=\"{ count: 0 }\" >{{ count }}</div>\n</body></html>\n";
+const SFC: &str = "<template>\n<div>hello</div>\n</template>\n";
+
+pub(super) fn formatting_params(uri: Url) -> DocumentFormattingParams {
+    DocumentFormattingParams {
+        text_document: TextDocumentIdentifier { uri },
+        options: FormattingOptions::default(),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+    }
+}
+
+fn range_params(uri: Url) -> DocumentRangeFormattingParams {
+    DocumentRangeFormattingParams {
+        text_document: TextDocumentIdentifier { uri },
+        range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+        options: FormattingOptions::default(),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+    }
+}
+
+fn on_type_params(uri: Url) -> DocumentOnTypeFormattingParams {
+    DocumentOnTypeFormattingParams {
+        text_document_position: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri },
+            position: Position::new(2, 1),
+        },
+        ch: "}".to_string(),
+        options: FormattingOptions::default(),
+    }
+}
+
+/// A server with `formatting` on and `uri` open with `source`.
+fn server_with(uri: &Url, source: &str, language: &str) -> LspService<MaestroServer> {
+    let (service, _socket) = LspService::new(MaestroServer::new);
+    let server = service.inner();
+    server
+        .state
+        .apply_lsp_initialization_options(Some(&serde_json::json!({ "formatting": true })));
+    server
+        .state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, language.to_string());
+    service
+}
+
+#[test]
+fn every_formatting_handler_declines_standalone_html() {
+    let uri = Url::parse("file:///index.html").unwrap();
+    let service = server_with(&uri, STANDALONE_HTML, "html");
+    let server = service.inner();
+
+    // Running the SFC formatter over a petite-vue page corrupts it, so all
+    // three commands must decline rather than emit edits (#1393).
+    assert_eq!(
+        futures::executor::block_on(server.formatting(formatting_params(uri.clone()))).unwrap(),
+        None
+    );
+    assert_eq!(
+        futures::executor::block_on(server.range_formatting(range_params(uri.clone()))).unwrap(),
+        None
+    );
+    assert_eq!(
+        futures::executor::block_on(server.on_type_formatting(on_type_params(uri))).unwrap(),
+        None
+    );
+}
+
+/// Guard against the standalone-HTML gate over-matching.
+#[cfg(feature = "glyph")]
+#[test]
+fn sfc_formatting_still_runs() {
+    let uri = Url::parse("file:///App.vue").unwrap();
+    let service = server_with(&uri, SFC, "vue");
+    let server = service.inner();
+
+    let edits =
+        futures::executor::block_on(server.formatting(formatting_params(uri.clone()))).unwrap();
+    assert_eq!(
+        edits,
+        Some(vec![TextEdit {
+            range: Range::new(Position::new(0, 0), Position::new(3, 0)),
+            // The formatter indents the block and breaks the element's text
+            // onto its own line — the reflow that makes a whole-document line
+            // pairing unusable, hence the per-block one in `format::on_type`.
+            new_text: "<template>\n  <div>\n    hello\n  </div>\n</template>\n".to_string(),
+        }])
+    );
+}
+
+#[test]
+fn formatting_handlers_are_gated_off_by_default() {
+    // `formatting` is opt-in, so a server that was never told to format must
+    // answer all three commands with "no provider here".
+    let uri = Url::parse("file:///App.vue").unwrap();
+    let (service, _socket) = LspService::new(MaestroServer::new);
+    let server = service.inner();
+    server
+        .state
+        .documents
+        .open(uri.clone(), SFC.to_string(), 1, "vue".to_string());
+
+    assert_eq!(
+        futures::executor::block_on(server.formatting(formatting_params(uri.clone()))).unwrap(),
+        None
+    );
+    assert_eq!(
+        futures::executor::block_on(server.range_formatting(range_params(uri.clone()))).unwrap(),
+        None
+    );
+    assert_eq!(
+        futures::executor::block_on(server.on_type_formatting(on_type_params(uri))).unwrap(),
+        None
+    );
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -246,7 +246,7 @@
         "vize.formatting.enable": {
           "type": "boolean",
           "default": false,
-          "description": "Enable Vize document formatting. Keep off when Prettier, Volar, or another formatter owns Vue formatting."
+          "description": "Enable Vize formatting: Format Document, Format Selection, and re-indenting the line as you type. Keep off when Prettier, Volar, or another formatter owns Vue formatting."
         },
         "vize.semanticTokens.enable": {
           "type": "boolean",

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -39,45 +39,43 @@ async function withCapabilities(
   }
 }
 
-test("vize lsp advertises the full editor-feature provider set with exact shapes", async () => {
-  await withCapabilities("editor-full", { editor: true, lint: true }, (capabilities) => {
-    // Boolean providers advertised as plain `true`.
-    assert.equal(capabilities.documentSymbolProvider, true);
-    assert.equal(capabilities.foldingRangeProvider, true);
-    assert.equal(capabilities.inlayHintProvider, true);
-    assert.equal(capabilities.documentHighlightProvider, true);
-    assert.equal(capabilities.workspaceSymbolProvider, true);
-    assert.equal(capabilities.hoverProvider, true);
-    assert.equal(capabilities.definitionProvider, true);
-    assert.equal(capabilities.referencesProvider, true);
+/** Declaration shims, the only files type checking has to watch itself. */
+const DECLARATION_FILTERS = [
+  { scheme: "file", pattern: { glob: "**/*.d.{ts,mts,cts}", matches: "file" } },
+];
+/** Everything a rename can move, plus folders. */
+const RENAME_FILTERS = [
+  {
+    scheme: "file",
+    pattern: { glob: "**/*.{vue,ts,tsx,d.ts,d.mts,d.cts,js,jsx,mts,cts,mjs,cjs}", matches: "file" },
+  },
+  { scheme: "file", pattern: { glob: "**/*", matches: "folder" } },
+];
 
-    // Resolve-provider shapes.
-    assert.equal(capabilities.codeLensProvider?.resolveProvider, false);
-    assert.equal(capabilities.documentLinkProvider?.resolveProvider, false);
-
-    // Rename advertises prepareRename support, and carries linked editing
-    // (rename-as-you-type over tag names) with it.
-    assert.equal(capabilities.renameProvider?.prepareProvider, true);
-    assert.equal(capabilities.linkedEditingRangeProvider, true);
-
-    // Code actions: kinds plus no resolve step.
-    assert.deepEqual(capabilities.codeActionProvider?.codeActionKinds, [
-      "quickfix",
-      "refactor",
-      "source",
-    ]);
-    assert.equal(capabilities.codeActionProvider?.resolveProvider, false);
-
-    // Document sync: incremental (2), open/close on, save without text.
-    assert.equal(capabilities.textDocumentSync?.change, 2);
-    assert.equal(capabilities.textDocumentSync?.openClose, true);
-    assert.equal(capabilities.textDocumentSync?.save?.includeText, false);
-
-    // Completion trigger characters, exact ordered set: `@vue/language-server`
-    // 3.3.8's list in its order, plus `'` (a single-quoted attribute value is
-    // legal Vue and Maestro answers inside one). Space is deliberately absent —
-    // it opened the list on every space typed in a template (#3458).
-    assert.deepEqual(capabilities.completionProvider?.triggerCharacters, [
+/**
+ * The COMPLETE capability set for the default editor bundle, pinned as one
+ * value rather than field by field: adding, dropping or reshaping any provider
+ * then shows up in this diff instead of slipping past a spot check (#3456).
+ */
+const EDITOR_BUNDLE_CAPABILITIES = {
+  // Incremental (2) sync, open/close on, save without the text.
+  textDocumentSync: {
+    openClose: true,
+    change: 2,
+    willSave: false,
+    willSaveWaitUntil: false,
+    save: { includeText: false },
+  },
+  // Selection ranges ship with the document-structure group.
+  selectionRangeProvider: true,
+  hoverProvider: true,
+  completionProvider: {
+    resolveProvider: true,
+    // `@vue/language-server` 3.3.8's list in its order, plus `'` (a
+    // single-quoted attribute value is legal Vue and Maestro answers inside
+    // one). Space is deliberately absent — it opened the list on every space
+    // typed in a template (#3458).
+    triggerCharacters: [
       '"',
       "'",
       ":",
@@ -99,21 +97,90 @@ test("vize lsp advertises the full editor-feature provider set with exact shapes
       "-",
       "{",
       "}",
-    ]);
+    ],
+  },
+  definitionProvider: true,
+  referencesProvider: true,
+  documentHighlightProvider: true,
+  documentSymbolProvider: true,
+  workspaceSymbolProvider: true,
+  codeActionProvider: {
+    codeActionKinds: ["quickfix", "refactor", "source"],
+    resolveProvider: false,
+  },
+  codeLensProvider: { resolveProvider: false },
+  documentLinkProvider: { resolveProvider: false },
+  // Colour swatches ship with document links: both decorate a literal in the
+  // authored text and make it interactive (#3456).
+  colorProvider: true,
+  foldingRangeProvider: true,
+  // Rename advertises prepareRename, and carries linked editing
+  // (rename-as-you-type over tag names) with it.
+  renameProvider: { prepareProvider: true },
+  linkedEditingRangeProvider: true,
+  semanticTokensProvider: {
+    legend: {
+      tokenTypes: [
+        "namespace",
+        "type",
+        "class",
+        "enum",
+        "interface",
+        "struct",
+        "typeParameter",
+        "parameter",
+        "variable",
+        "property",
+        "enumMember",
+        "event",
+        "function",
+        "method",
+        "macro",
+        "keyword",
+        "modifier",
+        "comment",
+        "string",
+        "number",
+        "regexp",
+        "operator",
+        "decorator",
+      ],
+      tokenModifiers: [
+        "declaration",
+        "definition",
+        "readonly",
+        "static",
+        "deprecated",
+        "abstract",
+        "async",
+        "modification",
+        "documentation",
+        "defaultLibrary",
+      ],
+    },
+    range: true,
+    full: true,
+  },
+  inlayHintProvider: true,
+  workspace: {
+    workspaceFolders: { supported: true, changeNotifications: true },
+    fileOperations: {
+      didCreate: { filters: DECLARATION_FILTERS },
+      didRename: { filters: RENAME_FILTERS },
+      willRename: { filters: RENAME_FILTERS },
+      didDelete: { filters: DECLARATION_FILTERS },
+    },
+  },
+  // Absent on purpose, and therefore absent from this object: the three
+  // formatting providers (opt-in, see below), `signatureHelpProvider`,
+  // `typeDefinitionProvider`, `implementationProvider`, `declarationProvider`,
+  // `executeCommandProvider`, `callHierarchyProvider`, `monikerProvider` and
+  // `experimental` — none of which has a handler behind it.
+};
 
-    // Selection ranges ship with the document-structure group.
-    assert.equal(capabilities.selectionRangeProvider, true);
-
-    // Formatting is opt-in, so neither formatting provider is here.
-    assert.equal(capabilities.documentFormattingProvider, undefined);
-    assert.equal(capabilities.documentRangeFormattingProvider, undefined);
-
-    // Colour swatches ship with document links: both decorate a literal in the
-    // authored text and make it interactive (#3456).
-    assert.equal(capabilities.colorProvider, true);
-
-    // Providers that are intentionally not yet advertised stay absent.
-    assert.equal(capabilities.signatureHelpProvider, undefined);
+test("vize lsp advertises exactly this capability set for the default editor bundle", async () => {
+  await withCapabilities("editor-full", { editor: true, lint: true }, (capabilities) => {
+    assert.deepEqual(capabilities, EDITOR_BUNDLE_CAPABILITIES);
   });
 });
 
@@ -217,10 +284,18 @@ test("vize lsp per-feature init flags toggle individual providers independently"
     "granular-formatting-on",
     { editor: true, formatting: true },
     (capabilities) => {
-      // Opting into formatting brings both commands: "Format Selection" is the
-      // same formatter scoped to the SFC blocks a selection touches (#3456).
+      // Opting into formatting brings all three commands: one formatter scoped
+      // to the document, to the SFC blocks a selection touches, and to the line
+      // under the caret (#3456).
       assert.equal(capabilities.documentFormattingProvider, true);
       assert.equal(capabilities.documentRangeFormattingProvider, true);
+      // The on-type trigger set is `@vue/language-server`'s, character for
+      // character, so an editor configured for one behaves the same under the
+      // other.
+      assert.deepEqual(capabilities.documentOnTypeFormattingProvider, {
+        firstTriggerCharacter: ";",
+        moreTriggerCharacter: ["}", "\n"],
+      });
     },
   );
 });

--- a/tests/tooling/lsp-on-type-formatting.test.ts
+++ b/tests/tooling/lsp-on-type-formatting.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isDiagnosticsForUri } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+/**
+ * `textDocument/onTypeFormatting` ("Format On Type") for `vize lsp`.
+ *
+ * The server advertises `;`, `}` and `\n` as triggers — the same set
+ * `@vue/language-server` advertises (#3456) — so an editor with
+ * `editor.formatOnType` on calls this on those keystrokes.
+ *
+ * Because it fires under the caret, the handler is only allowed to move a
+ * line's leading whitespace, and only on the requested line. The fixture below
+ * therefore carries two independently mis-indented lines, one in `<script>` and
+ * one in `<template>`, so "it re-indented exactly the line I asked about" is
+ * observable: every assertion is a full `assert.deepEqual` on the complete
+ * `TextEdit[]`, which a whole-document edit or a second stray line would fail.
+ */
+
+type TextEdit = {
+  range: {
+    start: { line: number; character: number };
+    end: { line: number; character: number };
+  };
+  newText: string;
+};
+
+/**
+ * A `vize fmt`-clean SFC — the state a file is in while `editor.formatOnType`
+ * keeps up with the typist — apart from the closing brace of a TypeScript
+ * function *and* of a CSS rule, each left one level too deep. Two embedded
+ * languages, one trigger character, and a `<template>` in between that must
+ * stay untouched.
+ *
+ * ```text
+ *  0  <script setup lang="ts">
+ *  1  function greet() {
+ *  2    const name = "vize";
+ *  3    return name;
+ *  4    }                      <- `}` typed at the wrong indent
+ *  5  </script>
+ *  6
+ *  7  <template>
+ *  8    <p>
+ *  9      hello
+ * 10    </p>
+ * 11  </template>
+ * 12
+ * 13  <style scoped>
+ * 14  .box {
+ * 15    color: red;
+ * 16    }                      <- and again, in CSS
+ * 17  </style>
+ * ```
+ */
+const SOURCE = `<script setup lang="ts">
+function greet() {
+  const name = "vize";
+  return name;
+  }
+</script>
+
+<template>
+  <p>
+    hello
+  </p>
+</template>
+
+<style scoped>
+.box {
+  color: red;
+  }
+</style>
+`;
+
+async function withDocument(
+  run: (
+    ask: (line: number, character: number, ch: string) => Promise<TextEdit[] | null>,
+    askWholeDocument: () => Promise<TextEdit[] | null>,
+  ) => Promise<void>,
+): Promise<void> {
+  const testRootDir = path.join(testOutputRoot, "lsp-on-type-formatting");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: false,
+      formatting: true,
+    });
+
+    const filePath = path.join(workspaceDir, "App.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, SOURCE, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: SOURCE },
+    });
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, uri),
+    );
+
+    const options = { tabSize: 2, insertSpaces: true };
+    await run(
+      (line, character, ch) =>
+        session.request("textDocument/onTypeFormatting", {
+          textDocument: { uri },
+          position: { line, character },
+          ch,
+          options,
+        }) as Promise<TextEdit[] | null>,
+      () =>
+        session.request("textDocument/formatting", {
+          textDocument: { uri },
+          options,
+        }) as Promise<TextEdit[] | null>,
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+}
+
+test("onTypeFormatting re-indents only the line the character was typed on", async () => {
+  await withDocument(async (ask, askWholeDocument) => {
+    // Closing `greet()` on line 4: the stray two-space indent goes, and the
+    // equally mis-indented CSS line 16 does not come along.
+    assert.deepEqual(await ask(4, 3, "}"), [
+      {
+        range: { start: { line: 4, character: 0 }, end: { line: 4, character: 2 } },
+        newText: "",
+      },
+    ]);
+
+    // The same keystroke closing the CSS rule, with the script left alone.
+    assert.deepEqual(await ask(16, 3, "}"), [
+      {
+        range: { start: { line: 16, character: 0 }, end: { line: 16, character: 2 } },
+        newText: "",
+      },
+    ]);
+
+    // A line that is already correctly indented yields nothing, even though the
+    // document as a whole is unformatted.
+    assert.deepEqual(await ask(2, 22, ";"), []);
+
+    // Format Document, by contrast, is one whole-file replacement — proof the
+    // per-line answers above are not that edit under another name.
+    const whole = await askWholeDocument();
+    assert.equal(whole?.length, 1);
+    assert.deepEqual(whole?.[0].range.start, { line: 0, character: 0 });
+    assert.deepEqual(whole?.[0].range.end, { line: 18, character: 0 });
+  });
+});
+
+test("onTypeFormatting refuses a line the document does not have", async () => {
+  await withDocument(async (ask) => {
+    assert.equal(await ask(900, 0, "}"), null);
+  });
+});

--- a/tests/tooling/support/lsp/protocol.ts
+++ b/tests/tooling/support/lsp/protocol.ts
@@ -77,6 +77,10 @@ export type ServerCapabilities = {
   documentHighlightProvider?: unknown;
   documentFormattingProvider?: unknown;
   documentLinkProvider?: { resolveProvider?: boolean };
+  documentOnTypeFormattingProvider?: {
+    firstTriggerCharacter?: string;
+    moreTriggerCharacter?: string[];
+  };
   documentRangeFormattingProvider?: unknown;
   documentSymbolProvider?: unknown;
   foldingRangeProvider?: unknown;


### PR DESCRIPTION
Part of #3456.

`@vue/language-server` advertises four capabilities `vize lsp` did not. Two have
already landed — `documentRangeFormattingProvider` (#3498) and `colorProvider`
(#3507). This adds the third, `documentOnTypeFormattingProvider`, with a real
handler behind it. The fourth, `experimental.autoInsertionProvider`, is
deliberately left unadvertised and moved to #3600.

| capability | `@vue/language-server` | before | after |
| --- | --- | --- | --- |
| `documentRangeFormattingProvider` | `true` | `true` (#3498) | `true` |
| `colorProvider` | `true` | `true` (#3507) | `true` |
| `documentOnTypeFormattingProvider` | `{";", ["}", "\n"]}` | absent | **`{";", ["}", "\n"]}`** |
| `experimental.autoInsertionProvider` | present | absent | absent (#3600) |

## `textDocument/onTypeFormatting`

Trigger characters are `@vue/language-server`'s exactly — `;`, plus `}` and
`\n` — so an editor configured for one server behaves the same under the other.

Format On Type fires under the caret, so the handler only ever moves a line's
**leading whitespace**, and only on the line the request names. Nothing it
returns can rewrite content, reorder blocks, or touch a line the user is not on.

The indent is not guessed from brace depth: it is read off the same
whole-document `vize fmt` run that backs Format Document, so Format Document,
Format Selection and Format On Type agree by construction rather than by three
implementations happening to match.

**Pairing is per SFC block.** The formatter breaks `<p>hello</p>` onto three
lines, so pairing authored line N to formatted line N across the whole file
would be knocked out of alignment by any single unformatted element in the
template, and the script's indentation could never be answered. Pairing inside
the block the caret is in — the same authored/formatted block pairing
`rangeFormatting` already projects through — keeps the script answerable while
the template is mid-edit. The block-span helper moves out of
`server::format::range` into a shared `server::format::blocks`; `rangeFormatting`
now uses it from there.

Within a block the handler returns no edits whenever formatting would change the
line count or rewrite the line's own content, and returns `null` when the request
names a line the document does not have.

`vize.formatting.enable` is the gate, as for the other two formatting commands;
its VS Code description now says the flag covers all three. No new setting, so
no `tools/vscode-vize/assert-vsix-package.mjs` allowlist change.

## Not here: `experimental.autoInsertionProvider` (#3600)

It is not LSP — it is Volar's private extension, where the flag only means "a
Volar-aware client may now send a custom request on every keystroke". Landing it
needs the Vue LS wire contract measured from a real session first (#3456 pinned
that the flag is advertised, not what is sent), a handler that tower-lsp can only
reach through `custom_method`, corsa support to know the symbol under the caret
is a `Ref`, and the client half in `editors/vscode` — no editor sends this on its
own. Advertising the flag without all of that would make a recognising client get
"method not found" per keystroke, which is worse than the capability being
absent.

## Tests

**Complete `initialize` capability set.** `tests/tooling/lsp-capabilities.test.ts`
previously spot-checked ~20 fields. Its first test is now a single
`assert.deepEqual` against the whole capability object, so adding, dropping or
reshaping any provider shows up in that diff instead of slipping past.

**End-to-end, over stdio, full-value.** New
`tests/tooling/lsp-on-type-formatting.test.ts` drives the real `vize lsp`
process, sends real `textDocument/onTypeFormatting` requests and
`assert.deepEqual`s the complete `TextEdit[]`. The fixture is a `vize fmt`-clean
SFC with two closing braces one level too deep — one in TypeScript, one in CSS,
with a `<template>` between them — so "it re-indented exactly the line I asked
about" is observable rather than assumed. It also asserts Format Document is
still one whole-file replacement, so the per-line answers cannot be that edit
under another name. Before this change the same requests returned
`method not found`.

**Unit.** `server::format::on_type::tests` covers the TypeScript brace, the CSS
brace, an already-correct line, lines outside block content, a line whose content
the formatter would rewrite, a block the formatter reflows (declining there while
its neighbour still answers), an out-of-range line, an already-formatted
document, and the whitespace-only line Enter leaves behind. Every assertion is
`assert_eq!` on the complete `Option<Vec<TextEdit>>`.

`crates/vize_maestro/src/server/handlers.rs` shrinks 1144 → 1121 lines: its
inline formatting gate tests move to `handlers/tests/formatting.rs`, which now
covers all three commands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added on-type formatting for Vue single-file components while typing.
  * Supports indentation corrections in template, script, and style blocks.
  * Added formatting triggers for semicolons, closing braces, and new lines.
* **Bug Fixes**
  * Prevents unnecessary edits when content, structure, or indentation is already correct.
  * Safely skips invalid positions and unsupported standalone HTML documents.
* **Documentation**
  * Updated the formatting setting description to include on-type re-indentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->