### PR TITLE
fix(maestro): ignore CRLF carriage returns when pairing on-type lines

### DIFF
--- a/crates/vize_maestro/src/server/format/on_type.rs
+++ b/crates/vize_maestro/src/server/format/on_type.rs
@@ -82,9 +82,17 @@ pub(crate) fn format_on_type(
 
     let (authored_start, authored_end) = authored[index];
     let (target_start, target_end) = target[index];
-    let authored_lines: Vec<&str> = content[authored_start..authored_end].split('\n').collect();
+    // Splitting on '\n' leaves the '\r' of a CRLF pair on the line. The
+    // formatter writes the configured newline, which need not be the authored
+    // one, so a surviving '\r' would make every CRLF line look rewritten and
+    // silence the handler on CRLF documents.
+    let authored_lines: Vec<&str> = content[authored_start..authored_end]
+        .split('\n')
+        .map(strip_cr)
+        .collect();
     let target_lines: Vec<&str> = formatted.code[target_start..target_end]
         .split('\n')
+        .map(strip_cr)
         .collect();
     // Line N of this block must still be line N after formatting.
     if authored_lines.len() != target_lines.len() {
@@ -123,6 +131,12 @@ pub(crate) fn format_on_type(
         #[allow(clippy::disallowed_methods)]
         new_text: target_indent.to_string(),
     }])
+}
+
+/// The line without the `'\r'` a CRLF pair leaves behind when splitting on
+/// `'\n'`. Only the trailing one: a lone `'\r'` mid-line is authored content.
+fn strip_cr(line: &str) -> &str {
+    line.strip_suffix('\r').unwrap_or(line)
 }
 
 /// The leading run of spaces and tabs. Deliberately not `trim_start`, which

--- a/crates/vize_maestro/src/server/format/on_type/tests.rs
+++ b/crates/vize_maestro/src/server/format/on_type/tests.rs
@@ -109,6 +109,15 @@ fn a_block_the_formatter_reflows_declines_without_silencing_its_neighbours() {
 }
 
 #[test]
+fn a_crlf_document_is_re_indented_like_an_lf_one() {
+    // The formatter writes LF by default, so the authored line keeps a '\r'
+    // the formatted line does not have. That difference is the line ending,
+    // not content the formatter wants rewritten.
+    let source = SOURCE.replace('\n', "\r\n");
+    assert_eq!(edits_at(&source, 4), dedent(4, 2));
+}
+
+#[test]
 fn a_line_the_document_does_not_have_is_not_answerable() {
     assert_eq!(edits_at(SOURCE, 900), None);
 }


### PR DESCRIPTION
Follow-up to #3601, from review feedback that arrived after it merged.

`format_on_type` pairs authored line N with formatted line N by splitting both on `'
'`, which leaves the `'\r'` of a CRLF pair attached to the authored line. The formatter writes the configured newline (`EndOfLine::Lf` by default), so on a CRLF-authored document every authored line ends in `'\r'` and its formatted counterpart does not. The "content after the indent must already match" guard then fails on every line, and Format On Type silently does nothing for the whole file.

Both sides now drop that trailing `'\r'` before the comparison:

```rust
fn strip_cr(line: &str) -> &str {
    line.strip_suffix('\r').unwrap_or(line)
}
```

Only the comparison is normalized. Slicing, the relative-line count and `authored_indent.len()` (the edit's end character) are unchanged, so the emitted edit still replaces just the line's leading whitespace and leaves the document's own line endings alone. A CRLF copy of the existing fixture is asserted to produce the same dedent as the LF one.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->