### PR TITLE
fix(vite): map compiled SFCs back to the authored .vue file

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -15,7 +15,7 @@ mod patch_flag;
 mod props;
 mod root;
 mod slots;
-mod source_map;
+pub mod source_map;
 mod v_for;
 mod v_if;
 

--- a/crates/vize_atelier_core/src/codegen/source_map.rs
+++ b/crates/vize_atelier_core/src/codegen/source_map.rs
@@ -59,7 +59,7 @@ struct Segment {
 /// Lives in the codegen context as an `Option`; it is `Some` only when the
 /// `source_map` codegen flag is enabled, so the no-map path pays nothing.
 #[derive(Debug, Default)]
-pub(crate) struct SourceMapBuilder {
+pub struct SourceMapBuilder {
     segments: Vec<Segment>,
     /// The v3 `names` array, in insertion order. A segment's `name` is an index
     /// into this vector.
@@ -71,7 +71,7 @@ pub(crate) struct SourceMapBuilder {
 
 impl SourceMapBuilder {
     /// Create an empty builder.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             segments: Vec::new(),
             names: Vec::new(),
@@ -85,7 +85,7 @@ impl SourceMapBuilder {
     /// Call this *immediately before* writing the mapped token to the code
     /// buffer, passing the buffer's current length as `generated_offset` and the
     /// originating AST node's `loc.start.offset` as `source_offset`.
-    pub(crate) fn add_raw(&mut self, generated_offset: usize, source_offset: u32) {
+    pub fn add_raw(&mut self, generated_offset: usize, source_offset: u32) {
         self.segments.push(Segment {
             generated_offset: generated_offset as u32,
             source_offset,
@@ -100,7 +100,7 @@ impl SourceMapBuilder {
     /// the generated token back to the original identifier. Otherwise identical
     /// to [`add_raw`](Self::add_raw): call it immediately before writing the
     /// mapped token.
-    pub(crate) fn add_named(&mut self, generated_offset: usize, source_offset: u32, name: &str) {
+    pub fn add_named(&mut self, generated_offset: usize, source_offset: u32, name: &str) {
         let index = self.intern_name(name);
         self.segments.push(Segment {
             generated_offset: generated_offset as u32,
@@ -135,12 +135,7 @@ impl SourceMapBuilder {
     /// document and generated column reset per line). Segments that carry a
     /// source symbol add a 5th field: the name-index delta (relative to the
     /// previous named segment across the whole document).
-    pub(crate) fn finish(
-        mut self,
-        generated_code: &str,
-        filename: &str,
-        source_content: &str,
-    ) -> String {
+    pub fn finish(mut self, generated_code: &str, filename: &str, source_content: &str) -> String {
         // Resolve byte offsets to (line, col). Sort by generated offset first so
         // the generated-side scan cursor advances monotonically; the source side
         // is resolved with an independent binary search over precomputed line

--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -471,9 +471,9 @@ fn compile_sfc_inner(
         trim_trailing_newlines(&mut code);
 
         return Ok(SfcCompileResult {
+            map: crate::source_map::sfc_source_map(&code, descriptor, filename, &codegen_options),
             code,
             css,
-            map: None,
             errors,
             warnings,
             bindings: None,
@@ -843,9 +843,9 @@ fn compile_sfc_inner(
     trim_trailing_newlines(&mut code);
 
     Ok(SfcCompileResult {
+        map: crate::source_map::sfc_source_map(&code, descriptor, filename, &codegen_options),
         code,
         css,
-        map: None,
         errors,
         warnings,
         bindings: script_result.bindings,

--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -47,6 +47,7 @@ pub mod module_shape;
 pub mod parse;
 pub mod rewrite_default;
 pub mod script;
+pub mod source_map;
 pub mod style;
 pub mod types;
 pub mod vite_plugin;
@@ -72,6 +73,7 @@ pub use css::{
 };
 pub use parse::parse_sfc;
 pub use script::{TypeResolutionBatchGuard, begin_type_resolution_batch};
+pub use source_map::build_sfc_source_map;
 pub use types::{
     BindingMetadata, BindingType, BlockLocation, PadOption, PropsDestructure, ScriptCompileOptions,
     SfcCompileOptions, SfcCompileResult, SfcCustomBlock, SfcDescriptor, SfcError, SfcMacroArtifact,

--- a/crates/vize_atelier_sfc/src/source_map.rs
+++ b/crates/vize_atelier_sfc/src/source_map.rs
@@ -1,0 +1,321 @@
+//! Source-map emission for the assembled SFC module (#3399).
+//!
+//! # Why the map is recovered rather than recorded
+//!
+//! [`compile_sfc`](crate::compile_sfc) does not edit the `.vue` source into its
+//! output the way a MagicString-based compiler does. It *concatenates*
+//! independently produced chunks: hoisted template imports, the rewritten
+//! `<script>`/`<script setup>` body, a synthesized render function, an
+//! `export default`. Several of those chunks come from passes that only ever see
+//! strings (the script sections are split into lines, filtered and re-joined),
+//! and a `lang="ts"` SFC is re-printed wholesale by oxc before it crosses the
+//! napi boundary. There is no edit script to turn into mappings, and no offset
+//! that survives the pipeline end to end.
+//!
+//! What does survive is the *content* of what the author wrote. This module
+//! recovers the mapping from that, by indexing the authored
+//! `<script>`/`<script setup>` lines and matching emitted lines back to them.
+//!
+//! # The anchor rules
+//!
+//! A generated line is mapped only when it matches **exactly one** authored
+//! script line under the first of these keys that resolves. Every key is
+//! uniqueness-gated on its own: a key shared by two authored lines anchors
+//! nothing, because there would be no single origin to name.
+//!
+//! 1. **Exact text** — the trimmed line is byte-identical. This is the common
+//!    case for plain JavaScript SFCs, whose script statements are copied out
+//!    verbatim and only re-indented.
+//! 2. **Printer-normalised text** — whitespace runs collapsed, `'` folded to
+//!    `"`, a trailing `;` dropped. This survives oxc re-printing a TypeScript
+//!    module, which changes exactly those things and nothing else about a
+//!    statement it did not otherwise transform.
+//! 3. **Declared binding** — the `(kind, name)` a declaration introduces, e.g.
+//!    `const msg`. This is what survives when the printer *did* change the line:
+//!    `const msg: string = 'x'` is emitted as `const msg = "x"`, and
+//!    `const props = defineProps(...)` as `const props = __props`. Mapping the
+//!    generated declaration of a binding to the authored declaration of that
+//!    same binding is right by construction, not by coincidence.
+//!
+//! Anything that matches no key — synthesized render code, `_sfc_main`
+//! plumbing — is left unmapped rather than guessed at. Unmapped lines degrade to
+//! the nearest preceding mapping, which is still inside the authored `.vue`
+//! file: the behaviour the issue asks for, instead of the virtual `.vue.ts`
+//! module.
+//!
+//! Fidelity is line-level: a mapping anchors the first non-whitespace column of
+//! the generated line to the first non-whitespace column of the authored line.
+//! Widening it to expression level requires the emitter to record offsets and is
+//! tracked separately; see the crate-level codegen docs and #1533.
+
+use vize_atelier_core::codegen::source_map::SourceMapBuilder;
+use vize_carton::{FxHashMap, String};
+
+use crate::types::SfcDescriptor;
+
+#[cfg(test)]
+mod anchor_tests;
+#[cfg(test)]
+mod test_support;
+#[cfg(test)]
+mod tests;
+
+/// Shortest trimmed line worth anchoring.
+///
+/// Below this every candidate is structural punctuation (`}`, `})`, `};`) that
+/// the emitter also produces on its own, so an anchor would be noise even when
+/// the text happens to be unique.
+const MIN_ANCHOR_LEN: usize = 3;
+
+/// Keywords that introduce a binding, for anchor rule 3.
+const DECLARATION_KEYWORDS: [&str; 5] = ["const", "let", "var", "function", "class"];
+
+/// Modifiers that may precede a declaration without changing what it declares.
+const DECLARATION_MODIFIERS: [&str; 3] = ["export", "default", "async"];
+
+/// Where a key was found in the authored script blocks.
+#[derive(Debug, Clone, Copy)]
+enum Anchor {
+    /// The key occurs exactly once; the payload is the byte offset of the first
+    /// non-whitespace character of that line in the SFC source.
+    Unique(u32),
+    /// The key occurs more than once, so no single origin can be chosen.
+    Ambiguous,
+}
+
+/// The authored script lines, indexed under each anchor key.
+#[derive(Default)]
+struct AnchorIndex<'a> {
+    exact: FxHashMap<&'a str, Anchor>,
+    normalized: FxHashMap<String, Anchor>,
+    declared: FxHashMap<String, Anchor>,
+}
+
+impl<'a> AnchorIndex<'a> {
+    fn is_empty(&self) -> bool {
+        self.exact.is_empty()
+    }
+
+    fn insert(&mut self, trimmed: &'a str, offset: u32) {
+        record(&mut self.exact, trimmed, offset);
+        record(&mut self.normalized, normalized_key(trimmed), offset);
+        if let Some(key) = declaration_index_key(trimmed) {
+            record(&mut self.declared, key, offset);
+        }
+    }
+
+    /// The authored offset `trimmed` unambiguously came from, by rule order.
+    fn lookup(&self, trimmed: &str) -> Option<u32> {
+        unique(self.exact.get(trimmed))
+            .or_else(|| unique(self.normalized.get(&normalized_key(trimmed))))
+            .or_else(|| {
+                declaration_index_key(trimmed).and_then(|key| unique(self.declared.get(&key)))
+            })
+    }
+}
+
+fn record<K: std::hash::Hash + Eq>(index: &mut FxHashMap<K, Anchor>, key: K, offset: u32) {
+    index
+        .entry(key)
+        .and_modify(|anchor| *anchor = Anchor::Ambiguous)
+        .or_insert(Anchor::Unique(offset));
+}
+
+fn unique(anchor: Option<&Anchor>) -> Option<u32> {
+    match anchor {
+        Some(Anchor::Unique(offset)) => Some(*offset),
+        _ => None,
+    }
+}
+
+/// Whether a trimmed line carries enough signal to be an anchor.
+///
+/// Requires real identifier content, which rules out brace/paren-only lines
+/// without needing a list of them.
+fn is_anchorable(trimmed: &str) -> bool {
+    trimmed.len() >= MIN_ANCHOR_LEN
+        && trimmed
+            .chars()
+            .any(|ch| ch.is_alphanumeric() || ch == '_' || ch == '$')
+}
+
+/// Reduce a line to what a JavaScript printer cannot change about it.
+fn normalized_key(trimmed: &str) -> String {
+    let mut out = String::with_capacity(trimmed.len());
+    let mut pending_space = false;
+    for ch in trimmed.chars() {
+        if ch.is_whitespace() {
+            pending_space = true;
+            continue;
+        }
+        if pending_space && !out.is_empty() {
+            out.push(' ');
+        }
+        pending_space = false;
+        out.push(if ch == '\'' { '"' } else { ch });
+    }
+    // The space before a dropped `;` has to go with it, or `const a = 'x' ;`
+    // and `const a = "x";` would normalise differently.
+    while out.ends_with(';') || out.ends_with(' ') {
+        out.pop();
+    }
+    out
+}
+
+/// Strip a leading keyword and the separator after it.
+fn strip_keyword<'a>(text: &'a str, keyword: &str) -> Option<&'a str> {
+    let rest = text.strip_prefix(keyword)?;
+    rest.starts_with(|ch: char| ch.is_whitespace() || ch == '*')
+        .then(|| rest.trim_start())
+}
+
+/// The declaration a line introduces, rendered as the index key `"kind name"`.
+fn declaration_index_key(trimmed: &str) -> Option<String> {
+    let (kind, name) = declaration_key(trimmed)?;
+    let mut key = String::with_capacity(kind.len() + name.len() + 1);
+    key.push_str(kind);
+    key.push(' ');
+    key.push_str(name);
+    Some(key)
+}
+
+/// The `(kind, name)` a declaration line introduces, or `None` when the line is
+/// not a declaration.
+fn declaration_key(trimmed: &str) -> Option<(&str, &str)> {
+    let mut rest = trimmed;
+    while let Some(stripped) = DECLARATION_MODIFIERS
+        .iter()
+        .find_map(|modifier| strip_keyword(rest, modifier))
+    {
+        rest = stripped;
+    }
+
+    let (kind, after) = DECLARATION_KEYWORDS
+        .into_iter()
+        .find_map(|kind| strip_keyword(rest, kind).map(|after| (kind, after)))?;
+    // `function* gen()` declares `gen`, same as `function gen()`.
+    let after = after.strip_prefix('*').map_or(after, str::trim_start);
+    let end = after
+        .find(|ch: char| !(ch.is_alphanumeric() || ch == '_' || ch == '$'))
+        .unwrap_or(after.len());
+    (end > 0).then(|| (kind, &after[..end]))
+}
+
+/// Iterate `(byte offset of the line, line without its terminator)`.
+///
+/// `split_inclusive` keeps the terminator so the running offset stays exact for
+/// both `\n` and `\r\n` inputs; the terminator is then trimmed off the yielded
+/// text so callers compare line bodies.
+fn lines_with_offsets(text: &str) -> impl Iterator<Item = (usize, &str)> {
+    let mut offset = 0usize;
+    text.split_inclusive('\n').map(move |raw| {
+        let start = offset;
+        offset += raw.len();
+        let body = raw
+            .strip_suffix('\n')
+            .map_or(raw, |line| line.strip_suffix('\r').unwrap_or(line));
+        (start, body)
+    })
+}
+
+/// Split a line into `(leading whitespace length, trimmed body)`.
+fn split_indent(line: &str) -> (usize, &str) {
+    let without_indent = line.trim_start();
+    (line.len() - without_indent.len(), without_indent.trim_end())
+}
+
+/// Byte ranges of the authored `<script>` and `<script setup>` block contents.
+fn script_ranges(descriptor: &SfcDescriptor<'_>) -> Vec<(usize, usize)> {
+    [descriptor.script.as_ref(), descriptor.script_setup.as_ref()]
+        .into_iter()
+        .flatten()
+        .map(|block| (block.loc.start, block.loc.end))
+        .filter(|(start, end)| end > start)
+        .collect()
+}
+
+/// Index the authored script lines under every anchor key.
+///
+/// A line participates when it overlaps a script block's content range, so the
+/// `<script>`/`</script>` tag lines and everything in `<template>`/`<style>` are
+/// excluded: only text the emitter could have derived from is a candidate.
+fn index_script_lines<'a>(source: &'a str, ranges: &[(usize, usize)]) -> AnchorIndex<'a> {
+    let mut index = AnchorIndex::default();
+
+    for (start, line) in lines_with_offsets(source) {
+        let end = start + line.len();
+        if !ranges.iter().any(|&(lo, hi)| start < hi && end > lo) {
+            continue;
+        }
+        let (indent, trimmed) = split_indent(line);
+        if !is_anchorable(trimmed) {
+            continue;
+        }
+        index.insert(trimmed, (start + indent) as u32);
+    }
+
+    index
+}
+
+/// Build a Source Map v3 document for `generated`, the exact emitted module.
+///
+/// `filename` becomes the map's single `sources` entry and the SFC source is
+/// embedded as `sourcesContent`, so a consumer resolves a frame to the authored
+/// `.vue` file without a second fetch.
+///
+/// Returns `None` when the SFC has no script block, or when no generated line
+/// could be anchored — an empty map is worse than none, because it claims to
+/// describe the module while resolving every position to nothing.
+///
+/// `generated` must be the bytes the caller actually hands on. The emitted
+/// module is re-printed when TypeScript is stripped at the napi boundary, so a
+/// map built before that pass does not describe the module after it.
+pub fn build_sfc_source_map(
+    generated: &str,
+    descriptor: &SfcDescriptor<'_>,
+    filename: &str,
+) -> Option<String> {
+    let source = descriptor.source.as_ref();
+    let ranges = script_ranges(descriptor);
+    if ranges.is_empty() {
+        return None;
+    }
+
+    let index = index_script_lines(source, &ranges);
+    if index.is_empty() {
+        return None;
+    }
+
+    let mut builder = SourceMapBuilder::new();
+    let mut mapped = 0usize;
+    for (start, line) in lines_with_offsets(generated) {
+        let (indent, trimmed) = split_indent(line);
+        if !is_anchorable(trimmed) {
+            continue;
+        }
+        if let Some(source_offset) = index.lookup(trimmed) {
+            builder.add_raw(start + indent, source_offset);
+            mapped += 1;
+        }
+    }
+
+    if mapped == 0 {
+        return None;
+    }
+    Some(builder.finish(generated, filename, source))
+}
+
+/// [`build_sfc_source_map`] gated on the codegen `source_map` flag, as the
+/// `SfcCompileResult.map` field wants it.
+pub(crate) fn sfc_source_map(
+    generated: &str,
+    descriptor: &SfcDescriptor<'_>,
+    filename: &str,
+    codegen_options: &vize_atelier_core::CodegenOptions,
+) -> Option<serde_json::Value> {
+    if !codegen_options.source_map {
+        return None;
+    }
+    let json = build_sfc_source_map(generated, descriptor, filename)?;
+    serde_json::from_str(&json).ok()
+}

--- a/crates/vize_atelier_sfc/src/source_map/anchor_tests.rs
+++ b/crates/vize_atelier_sfc/src/source_map/anchor_tests.rs
@@ -1,0 +1,105 @@
+//! Tests for the anchor rules that survive an oxc re-print (#3399).
+
+use super::test_support::{Segment, decode_mappings, descriptor_of};
+use super::*;
+
+/// A `lang="ts"` SFC: oxc re-prints the whole module before it leaves the napi
+/// boundary, so no emitted line is byte-identical to the authored one. The
+/// printer-normalised and declared-binding rules have to carry it.
+const TS_VUE: &str = "<template><p>{{ msg }}</p></template>\n<script setup lang=\"ts\">\nconst msg: string = 'hello'\nfunction shout(): string {\n  return msg.toUpperCase()\n}\n</script>\n";
+
+#[test]
+fn oxc_reprinted_typescript_still_anchors_on_the_authored_lines() {
+    let descriptor = descriptor_of(TS_VUE);
+    // Verbatim oxc output shape: double quotes, semicolons, re-indentation,
+    // type annotations gone.
+    let generated = "import { toDisplayString as _toDisplayString } from \"vue\";\nconst msg = \"hello\";\nexport default {\n  __name: \"ts\",\n  setup(__props) {\n    function shout() {\n      return msg.toUpperCase();\n    }\n    return (_ctx, _cache) => {};\n  }\n};\n";
+
+    let json = build_sfc_source_map(generated, &descriptor, "/a.vue")
+        .expect("a re-printed TypeScript module still anchors");
+    let map: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    // Authored lines: 2 `const msg: string = 'hello'`, 3 `function shout(): string {`,
+    // 4 `  return msg.toUpperCase()`.
+    assert_eq!(
+        decode_mappings(map["mappings"].as_str().unwrap()),
+        vec![
+            Segment {
+                generated_line: 1,
+                generated_column: 0,
+                source_index: 0,
+                source_line: 2,
+                source_column: 0,
+            },
+            Segment {
+                generated_line: 5,
+                generated_column: 4,
+                source_index: 0,
+                source_line: 3,
+                source_column: 0,
+            },
+            Segment {
+                generated_line: 6,
+                generated_column: 6,
+                source_index: 0,
+                source_line: 4,
+                source_column: 2,
+            },
+        ],
+    );
+}
+
+#[test]
+fn normalized_key_folds_only_what_a_printer_changes() {
+    assert_eq!(
+        normalized_key("return msg.toUpperCase();"),
+        "return msg.toUpperCase()"
+    );
+    assert_eq!(normalized_key("const a  =   'x' ;"), "const a = \"x\"");
+    assert_eq!(normalized_key("if (a) {"), "if (a) {");
+}
+
+#[test]
+fn declaration_key_names_the_binding_a_line_introduces() {
+    assert_eq!(
+        declaration_key("const msg: string = 'x'"),
+        Some(("const", "msg"))
+    );
+    assert_eq!(
+        declaration_key("export const msg = 1"),
+        Some(("const", "msg"))
+    );
+    assert_eq!(
+        declaration_key("export default async function run() {"),
+        Some(("function", "run"))
+    );
+    assert_eq!(
+        declaration_key("function* gen() {"),
+        Some(("function", "gen"))
+    );
+    assert_eq!(declaration_key("class Widget {"), Some(("class", "Widget")));
+    assert_eq!(declaration_key("constant = 5"), None);
+    assert_eq!(declaration_key("return msg"), None);
+}
+
+#[test]
+fn a_generated_declaration_maps_to_the_authored_declaration_of_the_same_binding() {
+    // `const props = defineProps(...)` is emitted as `const props = __props`;
+    // both declare `props`, so the binding rule anchors them together.
+    let source = "<script setup>\nconst props = defineProps({ id: String })\n</script>\n";
+    let descriptor = descriptor_of(source);
+
+    let json = build_sfc_source_map("const props = __props\n", &descriptor, "/a.vue").unwrap();
+    let map: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(
+        decode_mappings(map["mappings"].as_str().unwrap()),
+        vec![Segment {
+            generated_line: 0,
+            generated_column: 0,
+            source_index: 0,
+            source_line: 1,
+            source_column: 0,
+        }],
+    );
+}

--- a/crates/vize_atelier_sfc/src/source_map/test_support.rs
+++ b/crates/vize_atelier_sfc/src/source_map/test_support.rs
@@ -1,0 +1,78 @@
+//! Shared helpers for the source-map test modules (#3399).
+//!
+//! The decoder is a deliberate mirror of the v3 `mappings` encoding rather than
+//! a dependency: a map that exists but decodes to the wrong position is the
+//! exact failure mode this feature has to rule out, so the assertions decode
+//! every segment and compare full values.
+
+use crate::parse_sfc;
+use crate::types::SfcParseOptions;
+
+const BASE64: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/// One decoded Source Map v3 segment, with every field absolute.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct Segment {
+    pub(super) generated_line: usize,
+    pub(super) generated_column: i64,
+    pub(super) source_index: i64,
+    pub(super) source_line: i64,
+    pub(super) source_column: i64,
+}
+
+fn decode_vlq(bytes: &[u8], cursor: &mut usize) -> i64 {
+    let mut result: u64 = 0;
+    let mut shift = 0u32;
+    loop {
+        let digit = BASE64.iter().position(|&c| c == bytes[*cursor]).unwrap() as u64;
+        *cursor += 1;
+        result |= (digit & 0b1_1111) << shift;
+        shift += 5;
+        if digit & 0b10_0000 == 0 {
+            break;
+        }
+    }
+    let magnitude = (result >> 1) as i64;
+    if result & 1 != 0 {
+        -magnitude
+    } else {
+        magnitude
+    }
+}
+
+pub(super) fn decode_mappings(mappings: &str) -> Vec<Segment> {
+    let mut decoded = Vec::new();
+    let (mut source_index, mut source_line, mut source_column) = (0i64, 0i64, 0i64);
+
+    for (generated_line, group) in mappings.split(';').enumerate() {
+        let mut generated_column = 0i64;
+        for field in group.split(',').filter(|field| !field.is_empty()) {
+            let bytes = field.as_bytes();
+            let mut cursor = 0usize;
+            generated_column += decode_vlq(bytes, &mut cursor);
+            source_index += decode_vlq(bytes, &mut cursor);
+            source_line += decode_vlq(bytes, &mut cursor);
+            source_column += decode_vlq(bytes, &mut cursor);
+            decoded.push(Segment {
+                generated_line,
+                generated_column,
+                source_index,
+                source_line,
+                source_column,
+            });
+        }
+    }
+
+    decoded
+}
+
+pub(super) fn descriptor_of(source: &str) -> crate::types::SfcDescriptor<'_> {
+    parse_sfc(
+        source,
+        SfcParseOptions {
+            filename: "/app/src/Counter.vue".into(),
+            ..Default::default()
+        },
+    )
+    .expect("fixture parses")
+}

--- a/crates/vize_atelier_sfc/src/source_map/tests.rs
+++ b/crates/vize_atelier_sfc/src/source_map/tests.rs
@@ -1,0 +1,224 @@
+//! Tests for the SFC module source map (#3399).
+
+use super::test_support::{Segment, decode_mappings, descriptor_of};
+use super::*;
+use crate::compile_sfc_with_template_syntax_and_codegen_options;
+use crate::types::{ScriptCompileOptions, SfcCompileOptions, SfcParseOptions};
+use vize_atelier_core::{CodegenOptions, TemplateSyntaxMode};
+
+/// A `.vue` whose script lines are all distinct, so every one of them is an
+/// unambiguous anchor.
+const COUNTER_VUE: &str = "<template>\n  <button @click=\"bump\">{{ count }}</button>\n</template>\n\n<script setup>\nimport { ref } from 'vue'\n\nconst count = ref(0)\nfunction bump() {\n  count.value += 1\n}\n</script>\n";
+
+#[test]
+fn map_document_and_every_segment_land_on_the_authored_lines() {
+    let descriptor = descriptor_of(COUNTER_VUE);
+    // Stand-in for the emitted module: the shape the SFC emitter produces —
+    // hoisted template import, relocated user import, the setup body copied
+    // verbatim, then synthesized render code that the source never contained.
+    let generated = "import { toDisplayString as _toDisplayString } from \"vue\"\nimport { ref } from 'vue'\n\nexport default {\n  setup(__props) {\n\nconst count = ref(0)\nfunction bump() {\n  count.value += 1\n}\n\nreturn (_ctx, _cache) => {}\n}\n\n}\n";
+
+    let json = build_sfc_source_map(generated, &descriptor, "/app/src/Counter.vue")
+        .expect("a script-bearing SFC produces a map");
+    let map: serde_json::Value = serde_json::from_str(&json).expect("map is valid JSON");
+
+    assert_eq!(map["version"], serde_json::json!(3));
+    assert_eq!(map["file"], serde_json::json!("/app/src/Counter.vue"));
+    assert_eq!(map["sources"], serde_json::json!(["/app/src/Counter.vue"]));
+    assert_eq!(map["sourcesContent"], serde_json::json!([COUNTER_VUE]));
+    assert_eq!(map["names"], serde_json::json!([]));
+
+    // Authored lines are 0-indexed: 0 `<template>`, 4 `<script setup>`,
+    // 5 `import { ref } from 'vue'`, 7 `const count = ref(0)`,
+    // 8 `function bump() {`, 9 `  count.value += 1`.
+    assert_eq!(
+        decode_mappings(map["mappings"].as_str().expect("mappings is a string")),
+        vec![
+            Segment {
+                generated_line: 1,
+                generated_column: 0,
+                source_index: 0,
+                source_line: 5,
+                source_column: 0,
+            },
+            Segment {
+                generated_line: 6,
+                generated_column: 0,
+                source_index: 0,
+                source_line: 7,
+                source_column: 0,
+            },
+            Segment {
+                generated_line: 7,
+                generated_column: 0,
+                source_index: 0,
+                source_line: 8,
+                source_column: 0,
+            },
+            Segment {
+                generated_line: 8,
+                generated_column: 2,
+                source_index: 0,
+                source_line: 9,
+                source_column: 2,
+            },
+        ],
+    );
+}
+
+#[test]
+fn re_indented_lines_keep_the_authored_column() {
+    let source = "<script setup>\n    const deep = 1\n</script>\n";
+    let descriptor = descriptor_of(source);
+    // The emitter re-indents the statement to column 0; the anchor must still
+    // report the authored column 4, not the generated one.
+    let json = build_sfc_source_map("const deep = 1\n", &descriptor, "/a.vue")
+        .expect("a re-indented copy still anchors");
+    let map: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(
+        decode_mappings(map["mappings"].as_str().unwrap()),
+        vec![Segment {
+            generated_line: 0,
+            generated_column: 0,
+            source_index: 0,
+            source_line: 1,
+            source_column: 4,
+        }],
+    );
+}
+
+#[test]
+fn duplicated_and_synthesized_lines_are_left_unmapped() {
+    // `count.value += 1` occurs twice, so it has no single origin; `_sfc_main`
+    // plumbing occurs nowhere in the source. Only the unique line anchors.
+    let source = "<script setup>\nconst only = 1\nfunction a() {\n  count.value += 1\n}\nfunction b() {\n  count.value += 1\n}\n</script>\n";
+    let descriptor = descriptor_of(source);
+    let generated = "const only = 1\n  count.value += 1\nconst _sfc_main = {}\n";
+
+    let json = build_sfc_source_map(generated, &descriptor, "/a.vue").unwrap();
+    let map: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(
+        decode_mappings(map["mappings"].as_str().unwrap()),
+        vec![Segment {
+            generated_line: 0,
+            generated_column: 0,
+            source_index: 0,
+            source_line: 1,
+            source_column: 0,
+        }],
+    );
+}
+
+#[test]
+fn template_and_style_text_is_never_an_anchor() {
+    // The generated line is byte-identical to a `<template>` line, but the
+    // index only covers script blocks, so nothing anchors and no map is made.
+    let source =
+        "<template>\n  const fake = 1\n</template>\n<script setup>\nconst real = 2\n</script>\n";
+    let descriptor = descriptor_of(source);
+
+    assert_eq!(
+        build_sfc_source_map("const fake = 1\n", &descriptor, "/a.vue"),
+        None,
+    );
+}
+
+#[test]
+fn script_less_sfc_produces_no_map() {
+    let descriptor = descriptor_of("<template>\n  <p>hi</p>\n</template>\n");
+
+    assert_eq!(
+        build_sfc_source_map("export default {}\n", &descriptor, "/a.vue"),
+        None,
+    );
+}
+
+#[test]
+fn structural_punctuation_is_not_anchorable() {
+    assert!(!is_anchorable("}"));
+    assert!(!is_anchorable("})"));
+    assert!(!is_anchorable("});"));
+    assert!(!is_anchorable("[]"));
+    assert!(is_anchorable("a++"));
+    assert!(is_anchorable("const only = 1"));
+}
+
+#[test]
+fn crlf_sources_resolve_to_the_same_positions() {
+    let source = "<script setup>\r\nconst crlf = 1\r\n</script>\r\n";
+    let descriptor = descriptor_of(source);
+
+    let json = build_sfc_source_map("const crlf = 1\r\n", &descriptor, "/a.vue").unwrap();
+    let map: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(
+        decode_mappings(map["mappings"].as_str().unwrap()),
+        vec![Segment {
+            generated_line: 0,
+            generated_column: 0,
+            source_index: 0,
+            source_line: 1,
+            source_column: 0,
+        }],
+    );
+}
+
+fn compile_with_source_map(source: &str, source_map: bool) -> crate::types::SfcCompileResult {
+    let descriptor = descriptor_of(source);
+    let options = SfcCompileOptions {
+        parse: SfcParseOptions {
+            filename: "/app/src/Counter.vue".into(),
+            ..Default::default()
+        },
+        script: ScriptCompileOptions {
+            id: Some("/app/src/Counter.vue".into()),
+            inline_template: false,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    compile_sfc_with_template_syntax_and_codegen_options(
+        &descriptor,
+        options,
+        TemplateSyntaxMode::Standard,
+        CodegenOptions {
+            source_map,
+            ..Default::default()
+        },
+    )
+    .expect("fixture compiles")
+}
+
+#[test]
+fn compile_sfc_attaches_a_map_only_when_the_flag_is_on() {
+    assert_eq!(compile_with_source_map(COUNTER_VUE, false).map, None);
+
+    let result = compile_with_source_map(COUNTER_VUE, true);
+    let map = result.map.clone().expect("source_map: true attaches a map");
+
+    assert_eq!(map["sources"], serde_json::json!(["/app/src/Counter.vue"]));
+    assert_eq!(map["sourcesContent"], serde_json::json!([COUNTER_VUE]));
+
+    // The emitted module really does carry the authored statement, and its
+    // segment resolves back to authored line 7, column 0.
+    let generated_line = result
+        .code
+        .lines()
+        .position(|line| line == "const count = ref(0)")
+        .expect("the emitter copies the authored statement verbatim");
+    let segments = decode_mappings(map["mappings"].as_str().unwrap());
+    assert_eq!(
+        segments
+            .iter()
+            .find(|segment| segment.generated_line == generated_line),
+        Some(&Segment {
+            generated_line,
+            generated_column: 0,
+            source_index: 0,
+            source_line: 7,
+            source_column: 0,
+        }),
+    );
+}

--- a/crates/vize_vitrine/src/napi/sfc/batch_results.rs
+++ b/crates/vize_vitrine/src/napi/sfc/batch_results.rs
@@ -5,6 +5,7 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
     time::Instant,
 };
+use vize_atelier_sfc::build_sfc_source_map;
 use vize_atelier_sfc::compile_script::typescript::ensure_javascript_output;
 use vize_carton::cstr;
 
@@ -58,6 +59,7 @@ fn compile_sfc_batch_with_results_inner(
     let include_custom_blocks = opts.include_custom_blocks.unwrap_or(false);
     let include_macro_artifacts = opts.include_macro_artifacts.unwrap_or(false);
     let include_hashes = opts.include_hashes.unwrap_or(false);
+    let include_source_map = opts.include_source_map.unwrap_or(false);
     let start = Instant::now();
     // Snapshot the filesystem for this batch: imported-type resolution treats
     // every file it stats as stable for the batch's duration, so the second and
@@ -86,6 +88,7 @@ fn compile_sfc_batch_with_results_inner(
                     return BatchFileResultNapi {
                         path: file.path,
                         code: String::new(),
+                        map: None,
                         css: None,
                         scope_id: scope_id.into(),
                         has_scoped: false,
@@ -200,10 +203,17 @@ fn compile_sfc_batch_with_results_inner(
                     // after every rewriting pass, so the offsets cannot be
                     // stale (#3425).
                     let module_shape = ModuleShapeNapi::of(&code);
+                    // Same reason as `module_shape`: the map has to describe
+                    // the post-strip bytes the bundler receives (#3399).
+                    let map = include_source_map
+                        .then(|| build_sfc_source_map(&code, &descriptor, &file.path))
+                        .flatten()
+                        .map(Into::into);
                     BatchFileResultNapi {
                         path: file.path,
                         module_shape,
                         code,
+                        map,
                         css: result.css.map(Into::into),
                         scope_id: scope_id.into(),
                         has_scoped,
@@ -220,6 +230,7 @@ fn compile_sfc_batch_with_results_inner(
                 Err(error) => BatchFileResultNapi {
                     path: file.path,
                     code: String::new(),
+                    map: None,
                     css: None,
                     scope_id: scope_id.into(),
                     has_scoped,

--- a/crates/vize_vitrine/src/napi/sfc/compile.rs
+++ b/crates/vize_vitrine/src/napi/sfc/compile.rs
@@ -1,5 +1,6 @@
 use napi::{Result, Status};
 use napi_derive::napi;
+use vize_atelier_sfc::build_sfc_source_map;
 use vize_atelier_sfc::compile_script::typescript::ensure_javascript_output;
 use vize_carton::cstr;
 
@@ -38,6 +39,7 @@ pub fn compile_sfc(
         Err(e) => {
             return Ok(SfcCompileResultNapi {
                 code: String::new(),
+                map: None,
                 css: None,
                 errors: vec![e.message.into()],
                 warnings: vec![],
@@ -61,6 +63,7 @@ pub fn compile_sfc(
     let has_scoped = descriptor.styles.iter().any(|s| s.scoped);
     let vapor = opts.vapor.unwrap_or(false);
     let is_ts = opts.is_ts.unwrap_or(false);
+    let source_map = opts.source_map.unwrap_or(false);
     let experimentals = ExperimentalTemplateOptions::from_compile(&opts);
     let template_syntax = resolve_template_syntax(opts.template_syntax.as_deref())
         .map_err(|message| napi::Error::new(Status::InvalidArg, message))?;
@@ -129,8 +132,19 @@ pub fn compile_sfc(
             // Analyzed from the very bytes that cross the boundary, after every
             // rewriting pass, so the offsets cannot be stale (#3425).
             let module_shape = ModuleShapeNapi::of(&code);
+            // Built from those same bytes for the same reason: stripping
+            // TypeScript above re-prints the module, so a map produced before
+            // that pass would describe code nobody receives (#3399).
+            let map = source_map
+                .then(|| {
+                    let path = opts.filename.as_deref().unwrap_or("anonymous.vue");
+                    build_sfc_source_map(&code, &descriptor, path)
+                })
+                .flatten()
+                .map(Into::into);
             Ok(SfcCompileResultNapi {
                 code,
+                map,
                 css: result.css.map(Into::into),
                 errors: result
                     .errors
@@ -154,6 +168,7 @@ pub fn compile_sfc(
         }
         Err(e) => Ok(SfcCompileResultNapi {
             code: String::new(),
+            map: None,
             css: None,
             errors: vec![e.message.into()],
             warnings: vec![],

--- a/crates/vize_vitrine/src/napi/sfc/types.rs
+++ b/crates/vize_vitrine/src/napi/sfc/types.rs
@@ -119,6 +119,10 @@ impl ModuleShapeNapi {
 #[napi(object)]
 pub struct SfcCompileResultNapi {
     pub code: String,
+    /// Source Map v3 document (JSON) describing `code`, present only when
+    /// `sourceMap` was requested and at least one authored line could be
+    /// anchored (#3399). Its single `sources` entry is the authored `.vue` path.
+    pub map: Option<String>,
     pub css: Option<String>,
     pub errors: Vec<String>,
     pub warnings: Vec<String>,
@@ -165,6 +169,13 @@ pub struct BatchCompileOptionsNapi {
     pub include_macro_artifacts: Option<bool>,
     /// Include template/style/script content hashes (for HMR). Default OFF.
     pub include_hashes: Option<bool>,
+    /// Emit a Source Map v3 document per file (`map`). Default OFF.
+    ///
+    /// The pre-compile batch is the path every build takes, so a production
+    /// build with `build.sourcemap` on has to be able to ask for maps here or
+    /// the bundle's maps point at the virtual module instead of the `.vue`
+    /// file (#3399).
+    pub include_source_map: Option<bool>,
 }
 
 #[napi(object)]
@@ -186,6 +197,9 @@ pub struct BatchFileInputNapi {
 pub struct BatchFileResultNapi {
     pub path: String,
     pub code: String,
+    /// Source Map v3 document (JSON) describing `code`, present only when
+    /// `includeSourceMap` was requested and a line could be anchored (#3399).
+    pub map: Option<String>,
     pub css: Option<String>,
     pub scope_id: String,
     pub has_scoped: bool,

--- a/docs/content/guide/vite-plugin.md
+++ b/docs/content/guide/vite-plugin.md
@@ -198,24 +198,24 @@ vize({
 });
 ```
 
-| Option                 | Where to set it                                         | Description                                                                                                                              |
-| ---------------------- | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `vueVersion`           | `vize({ vueVersion })`                                  | Set `0.11`, `1`, `2`, or `"legacy"` to run in non-invasive legacy Vue compatibility mode and leave SFC compilation to the host compiler. |
-| `sourceMap`            | `compiler.sourceMap` or `vize({ sourceMap })`           | Generate source maps. Defaults to development on, production off.                                                                        |
-| `ssr`                  | `compiler.ssr` or `vize({ ssr })`                       | Force SSR compilation when Vite's SSR build flag is not enough.                                                                          |
-| `vapor`                | `compiler.vapor` or `vize({ vapor })`                   | Compile templates through the Vapor backend.                                                                                             |
-| `jsxMode`              | `compiler.jsxMode` or `vize({ jsxMode })`               | Default output backend (`"vdom"` / `"vapor"`) for `.jsx`/`.tsx` components. Per-component `"use vue:*"` directives override it.          |
-| `customRenderer`       | `compiler.customRenderer` or `vize({ customRenderer })` | Treat lowercase non-HTML tags as custom renderer elements. Useful for renderer ecosystems such as TresJS.                                |
-| `templateSyntax`       | `compiler.templateSyntax` or `vize({ templateSyntax })` | Choose `"standard"`, `"strict"`, or `"quirks"` template syntax handling.                                                                 |
-| `include`              | `vite.include` or `vize({ include })`                   | Files that the plugin should compile.                                                                                                    |
-| `exclude`              | `vite.exclude` or `vize({ exclude })`                   | Files that the plugin should ignore.                                                                                                     |
-| `scanPatterns`         | `vite.scanPatterns` or `vize({ scanPatterns })`         | Glob patterns used for startup pre-compilation.                                                                                          |
-| `ignorePatterns`       | `vite.ignorePatterns` or `vize({ ignorePatterns })`     | Glob patterns skipped during startup pre-compilation.                                                                                    |
-| `configMode`           | `vize({ configMode })`                                  | Use `"root"`, `"auto"`, or `false` for shared config loading.                                                                            |
-| `configFile`           | `vize({ configFile })`                                  | Load a specific config file.                                                                                                             |
-| `config`               | `vize({ config })`                                      | Inline shared config for Vite Plus runtime settings.                                                                                     |
-| `handleNodeModulesVue` | `vize({ handleNodeModulesVue })`                        | Compile `.vue` files imported from `node_modules` on demand.                                                                             |
-| `debug`                | `vize({ debug })`                                       | Print plugin debug logs.                                                                                                                 |
+| Option                 | Where to set it                                         | Description                                                                                                                                     |
+| ---------------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `vueVersion`           | `vize({ vueVersion })`                                  | Set `0.11`, `1`, `2`, or `"legacy"` to run in non-invasive legacy Vue compatibility mode and leave SFC compilation to the host compiler.        |
+| `sourceMap`            | `compiler.sourceMap` or `vize({ sourceMap })`           | Generate source maps whose `sources` name the authored `.vue` file. Defaults to development on, production off unless `build.sourcemap` is set. |
+| `ssr`                  | `compiler.ssr` or `vize({ ssr })`                       | Force SSR compilation when Vite's SSR build flag is not enough.                                                                                 |
+| `vapor`                | `compiler.vapor` or `vize({ vapor })`                   | Compile templates through the Vapor backend.                                                                                                    |
+| `jsxMode`              | `compiler.jsxMode` or `vize({ jsxMode })`               | Default output backend (`"vdom"` / `"vapor"`) for `.jsx`/`.tsx` components. Per-component `"use vue:*"` directives override it.                 |
+| `customRenderer`       | `compiler.customRenderer` or `vize({ customRenderer })` | Treat lowercase non-HTML tags as custom renderer elements. Useful for renderer ecosystems such as TresJS.                                       |
+| `templateSyntax`       | `compiler.templateSyntax` or `vize({ templateSyntax })` | Choose `"standard"`, `"strict"`, or `"quirks"` template syntax handling.                                                                        |
+| `include`              | `vite.include` or `vize({ include })`                   | Files that the plugin should compile.                                                                                                           |
+| `exclude`              | `vite.exclude` or `vize({ exclude })`                   | Files that the plugin should ignore.                                                                                                            |
+| `scanPatterns`         | `vite.scanPatterns` or `vize({ scanPatterns })`         | Glob patterns used for startup pre-compilation.                                                                                                 |
+| `ignorePatterns`       | `vite.ignorePatterns` or `vize({ ignorePatterns })`     | Glob patterns skipped during startup pre-compilation.                                                                                           |
+| `configMode`           | `vize({ configMode })`                                  | Use `"root"`, `"auto"`, or `false` for shared config loading.                                                                                   |
+| `configFile`           | `vize({ configFile })`                                  | Load a specific config file.                                                                                                                    |
+| `config`               | `vize({ config })`                                      | Inline shared config for Vite Plus runtime settings.                                                                                            |
+| `handleNodeModulesVue` | `vize({ handleNodeModulesVue })`                        | Compile `.vue` files imported from `node_modules` on demand.                                                                                    |
+| `debug`                | `vize({ debug })`                                       | Print plugin debug logs.                                                                                                                        |
 
 Common recipes:
 

--- a/npm/builder/vite/README.md
+++ b/npm/builder/vite/README.md
@@ -181,8 +181,9 @@ interface VizeNativeOptions {
   ssr?: boolean;
 
   /**
-   * Enable source map generation
-   * @default true in development, false in production
+   * Enable source map generation. The emitted map's `sources` names the
+   * authored `.vue` file, not the virtual `.vue.ts` module.
+   * @default true in development, false in production unless `build.sourcemap` is set
    */
   sourceMap?: boolean;
 

--- a/npm/builder/vite/src/batch-types.ts
+++ b/npm/builder/vite/src/batch-types.ts
@@ -15,6 +15,11 @@ export interface BatchFileInput {
 export interface BatchFileResult {
   path: string;
   code: string;
+  /**
+   * Source Map v3 document (JSON) describing `code`, present only when
+   * `includeSourceMap` was requested and a line could be anchored (#3399).
+   */
+  map?: string;
   css?: string;
   scopeId: string;
   hasScoped: boolean;
@@ -56,6 +61,13 @@ export interface BatchCompileOptionsNapi extends ExperimentalCompileFlags {
   includeMacroArtifacts?: boolean;
   /** Include template/style/script content hashes (for HMR). Default OFF. */
   includeHashes?: boolean;
+  /**
+   * Emit a Source Map v3 document per file (`map`). Default OFF.
+   *
+   * The pre-compile batch is the path every build takes, so a production build
+   * with source maps on has to be able to ask for them here (#3399).
+   */
+  includeSourceMap?: boolean;
 }
 
 export interface BatchCompileResultWithFiles {

--- a/npm/builder/vite/src/compile-options.test.ts
+++ b/npm/builder/vite/src/compile-options.test.ts
@@ -15,16 +15,23 @@ assert.equal(fileOptions.experimentalInTagComments, true);
 assert.equal(fileOptions.experimentalPatternedTemplate, true);
 assert.equal(fileOptions.experimentalServerScript, true);
 
-const batchOptions = buildCompileBatchOptions({
+const batchInput = {
+  sourceMap: false,
   ssr: false,
   vapor: false,
   experimentalInTagComments: true,
   experimentalPatternedTemplate: true,
   experimentalServerScript: true,
-});
+};
+const batchOptions = buildCompileBatchOptions(batchInput);
 
 assert.equal(batchOptions.experimentalInTagComments, true);
 assert.equal(batchOptions.experimentalPatternedTemplate, true);
 assert.equal(batchOptions.experimentalServerScript, true);
+assert.equal(batchOptions.includeSourceMap, false);
+
+// The batch options object is also the pre-compile cache key material, so the
+// source-map decision has to be visible in it (#3399).
+assert.equal(buildCompileBatchOptions({ ...batchInput, sourceMap: true }).includeSourceMap, true);
 
 console.log("vite-plugin-vize compile option tests passed!");

--- a/npm/builder/vite/src/compile-options.ts
+++ b/npm/builder/vite/src/compile-options.ts
@@ -17,6 +17,7 @@ export interface CompileFileOptions {
 }
 
 export interface CompileBatchOptions {
+  sourceMap: boolean;
   ssr: boolean;
   vapor: boolean;
   mode?: "module" | "function";
@@ -70,6 +71,9 @@ export function buildCompileBatchOptions(options: CompileBatchOptions): BatchCom
     includeStyles: true,
     includeMacroArtifacts: true,
     includeHashes: true,
+    // Also part of the pre-compile cache key, so a run that wants maps cannot
+    // be served entries compiled without them (#3399).
+    includeSourceMap: options.sourceMap,
     ...(options.mode === undefined ? {} : { mode: options.mode }),
     ...(options.templateSyntax === undefined ? {} : { templateSyntax: options.templateSyntax }),
     ...(options.runtimeModuleName === undefined

--- a/npm/builder/vite/src/compiler.test.ts
+++ b/npm/builder/vite/src/compiler.test.ts
@@ -163,7 +163,7 @@ assert.match(
 const hoistedScopedBatch = compileBatch(
   [{ path: "/src/HoistedScoped.vue", source: hoistedScopedSource }],
   new Map(),
-  { ssr: false, vapor: false },
+  { sourceMap: false, ssr: false, vapor: false },
 );
 
 assert.match(
@@ -291,7 +291,7 @@ const batchResult = compileBatch(
     },
   ],
   new Map(),
-  { ssr: true, vapor: true },
+  { sourceMap: false, ssr: true, vapor: true },
 );
 
 assert.equal(
@@ -354,7 +354,7 @@ const styleBatchCache = new Map();
 const styleBatchResult = compileBatch(
   [{ path: "/src/Styled.vue", source: styleMetadataSource }],
   styleBatchCache,
-  { ssr: false, vapor: false },
+  { sourceMap: false, ssr: false, vapor: false },
 );
 
 assert.equal(styleBatchResult.failedCount, 0, "Batch style metadata compilation should succeed");
@@ -430,7 +430,7 @@ const srcImportBatchCache = new Map();
 const srcImportBatchResult = compileBatch(
   [{ path: srcImportFile, source: srcImportSource }],
   srcImportBatchCache,
-  { ssr: false, vapor: false },
+  { sourceMap: false, ssr: false, vapor: false },
 );
 
 assert.equal(srcImportBatchResult.failedCount, 0, "Batch src import compilation should succeed");

--- a/npm/builder/vite/src/compiler.ts
+++ b/npm/builder/vite/src/compiler.ts
@@ -193,6 +193,10 @@ export function compileFile(
 
   const compiled: CompiledModule = {
     code: result.code,
+    // Set only when present: the persistent cache round-trips through JSON, so
+    // an explicit `map: undefined` would not survive and a restored entry would
+    // stop being byte-identical to the compiled one.
+    ...(result.map ? { map: result.map } : {}),
     css: result.css,
     scopeId,
     hasScoped: result.hasScoped,
@@ -304,6 +308,7 @@ export function compileBatch(
     if (fileResult.errors.length === 0) {
       cache.set(fileResult.path, {
         code: fileResult.code,
+        ...(fileResult.map ? { map: fileResult.map } : {}),
         css: fileResult.css,
         scopeId: fileResult.scopeId,
         hasScoped: fileResult.hasScoped,

--- a/npm/builder/vite/src/jsx-types.ts
+++ b/npm/builder/vite/src/jsx-types.ts
@@ -1,0 +1,62 @@
+/**
+ * The native `compileJsx` binding surface.
+ *
+ * Split out of `types.ts` (which is over the repo's per-file line budget) so the
+ * `.jsx`/`.tsx` boundary types live next to each other; `types.ts` re-exports
+ * them, so every existing import site is unchanged.
+ */
+
+/** Options for the native `compileJsx` binding. */
+export interface JsxCompileOptionsNapi {
+  filename?: string;
+  lang?: string;
+  /**
+   * Default JSX output mode (`"vdom"` | `"vapor"`). Mirrors `compiler.jsxMode`
+   * and takes precedence over `vapor`. Per-component `"use vue:*"` directives
+   * still override it.
+   */
+  jsxMode?: "vdom" | "vapor";
+  vapor?: boolean;
+  /**
+   * Emit a v3 source map for the generated render code (#1533). When `true`,
+   * the result's `map` carries the map JSON; `null` otherwise.
+   */
+  sourceMap?: boolean;
+}
+
+/** A JSX component's extracted `<style scoped>` block (#1495, #1533). */
+export interface JsxScopedStyleNapi {
+  /** Generated scope id, e.g. `data-v-1a2b3c4d`, already applied to the CSS. */
+  scopeId: string;
+  /** Scope-rewritten CSS, with the `data-v-<hash>` attribute applied. */
+  css: string;
+}
+
+/** Result of the native `compileJsx` binding. */
+export interface JsxCompileResultNapi {
+  /**
+   * Self-contained module: the deduplicated runtime-helper preamble followed by
+   * every component's render code, in source order (the helper imports are no
+   * longer dropped, #1533).
+   */
+  code: string;
+  /**
+   * v3 source map (JSON) for `code`, present only when `sourceMap` was
+   * requested and the module is a single component. `null` otherwise (#1533).
+   */
+  map?: string;
+  errors: string[];
+  warnings: string[];
+  /**
+   * Extracted `<style scoped>` blocks across the module's components, in source
+   * order (#1495). Empty when no component had a `<style scoped>`. Each entry's
+   * CSS is already scope-rewritten; the plugin emits it through the same path
+   * SFC `<style>` blocks use (#1533).
+   */
+  scopedStyles: JsxScopedStyleNapi[];
+}
+
+export type CompileJsxFn = (
+  source: string,
+  options?: JsxCompileOptionsNapi,
+) => JsxCompileResultNapi;

--- a/npm/builder/vite/src/plugin/index.ts
+++ b/npm/builder/vite/src/plugin/index.ts
@@ -98,6 +98,7 @@ export function vize(options: VizeOptions = {}): Plugin[] {
     pendingHmrUpdateTypes: new Map(),
     viteResolveCache: new Map(),
     isProduction: false,
+    viteBuildSourcemap: false,
     root: "",
     clientViteBase: "/",
     serverViteBase: "/",
@@ -141,6 +142,7 @@ export function vize(options: VizeOptions = {}): Plugin[] {
     async configResolved(resolvedConfig: ResolvedConfig) {
       state.root = options.root ?? resolvedConfig.root;
       state.isProduction = options.isProduction ?? resolvedConfig.isProduction;
+      state.viteBuildSourcemap = !!resolvedConfig.build?.sourcemap;
 
       const isSsrBuild = !!resolvedConfig.build?.ssr;
       const currentBase =

--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -12,7 +12,8 @@ import {
 } from "./state.ts";
 import { getLoadableVueSfcPath, shouldLoadCompiledVueSfcPath } from "./load-sfc.ts";
 import { compileFile, compileJsxModule } from "../compiler.ts";
-import { embedsInlineCss, generateOutput, hasDelegatedStyles } from "../utils/index.ts";
+import { embedsInlineCss, generateOutputWithMap, hasDelegatedStyles } from "../utils/index.ts";
+import { MappedModule, type SourceMapV3 } from "../utils/source-map.ts";
 import {
   resolveCssImports,
   scopeCssForPipeline,
@@ -30,6 +31,9 @@ import {
   rewriteStaticAssetUrls,
 } from "../transform.ts";
 import { transformVizeVirtualModule } from "./vite-transform.ts";
+
+/** What `load` hands Vite: emitted code plus its map, when one was produced. */
+type LoadResult = { code: string; map: SourceMapV3 | null };
 
 const SERVER_PLACEHOLDER_CODE = `import { createElementBlock, defineComponent } from "vue";
 export default defineComponent({
@@ -90,14 +94,11 @@ function loadCompiledSfcModule(
   isSsr: boolean,
   currentBase: string,
   loadOptions?: { ssr?: boolean; addWatchFile?: (id: string) => void },
-): { code: string; map: null } | string | null {
+): LoadResult | string | null {
   const placeholderCode = getBoundaryPlaceholderCode(realPath, !!loadOptions?.ssr);
   if (placeholderCode) {
     state.logger.log(`load: using boundary placeholder for ${realPath}`);
-    return {
-      code: placeholderCode,
-      map: null,
-    };
+    return { code: placeholderCode, map: null };
   }
 
   const cache = getEnvironmentCache(state, isSsr);
@@ -142,22 +143,20 @@ function loadCompiledSfcModule(
       ),
     };
   }
-  const generatedOutput = generateOutput(compiled, outputOptions);
-  const output = rewriteStaticAssetUrls(
-    rewriteDynamicTemplateImports(
-      isSsr ? normalizeVueServerRendererImport(generatedOutput) : generatedOutput,
-      state.dynamicImportAliasRules,
-    ),
-    state.dynamicImportAliasRules,
+  const emitted = generateOutputWithMap(compiled, outputOptions);
+  // Each rewrite below substitutes inside a single line, but they go through
+  // `MappedModule` anyway so the map cannot silently drift if one ever does not.
+  const rewritten = new MappedModule(
+    isSsr ? normalizeVueServerRendererImport(emitted.code) : emitted.code,
+    emitted.map,
   );
-  const normalizedOutput = rewriteImportMetaGlobBase(output, realPath, state.root);
+  rewritten.edit(rewriteDynamicTemplateImports(rewritten.code, state.dynamicImportAliasRules));
+  rewritten.edit(rewriteStaticAssetUrls(rewritten.code, state.dynamicImportAliasRules));
+  rewritten.edit(rewriteImportMetaGlobBase(rewritten.code, realPath, state.root));
   if (!loadOptions?.ssr) {
     state.pendingHmrUpdateTypes.delete(realPath);
   }
-  return {
-    code: normalizedOutput,
-    map: null,
-  };
+  return { code: rewritten.code, map: rewritten.map };
 }
 
 function loadDefinePageArtifact(
@@ -185,7 +184,7 @@ export function loadHook(
   state: VizePluginState,
   id: string,
   loadOptions?: { ssr?: boolean; addWatchFile?: (id: string) => void },
-): string | { code: string; map: null } | null {
+): string | LoadResult | null {
   if (id !== RESOLVED_CSS_MODULE && !id.startsWith("\0") && !id.includes(".vue")) return null;
 
   const request = classifyVitePluginRequest(id);

--- a/npm/builder/vite/src/plugin/precompile-cache-key.ts
+++ b/npm/builder/vite/src/plugin/precompile-cache-key.ts
@@ -25,8 +25,16 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 
-/** Bump when the persisted entry shape changes; abandons every old manifest. */
-export const PRECOMPILE_CACHE_FORMAT = 2;
+/**
+ * Bump when the persisted entry shape changes; abandons every old manifest.
+ *
+ * 3: entries carry the compiled module's source map (#3399). The container
+ * persists it automatically (it stores "everything but `code`/`css`" by rest
+ * destructuring), but a format-2 manifest holds mapless entries, and serving
+ * those to a build that asked for maps is exactly the silent regression this
+ * gate exists to prevent.
+ */
+export const PRECOMPILE_CACHE_FORMAT = 3;
 
 /**
  * SHA-256 of the exact source text handed to the compiler.

--- a/npm/builder/vite/src/plugin/precompile-run.ts
+++ b/npm/builder/vite/src/plugin/precompile-run.ts
@@ -24,7 +24,11 @@ import {
   openPrecompileCache,
   type PrecompileCache,
 } from "./precompile-cache.ts";
-import { syncCollectedCssForFile, type VizePluginState } from "./state.ts";
+import {
+  getCompileOptionsForRequest,
+  syncCollectedCssForFile,
+  type VizePluginState,
+} from "./state.ts";
 
 /**
  * The options the pre-compile batch actually compiles with.
@@ -34,6 +38,9 @@ import { syncCollectedCssForFile, type VizePluginState } from "./state.ts";
  */
 function resolvePrecompileBatchOptions(state: VizePluginState): CompileBatchOptions {
   return {
+    // The batch fills the same caches `load` serves from, so it has to make the
+    // same source-map decision the on-demand path makes (#3399).
+    sourceMap: getCompileOptionsForRequest(state, false).sourceMap,
     ssr: false,
     vapor: state.mergedOptions.vapor ?? false,
     mode: state.mergedOptions.mode,

--- a/npm/builder/vite/src/plugin/source-map.test.ts
+++ b/npm/builder/vite/src/plugin/source-map.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Source maps for compiled `.vue` SFCs (#3399).
+ *
+ * Before this, `compileSfc` ignored `sourceMap` and the plugin returned
+ * `map: null` for every SFC module, so a production build with
+ * `build.sourcemap` on resolved stack frames to the virtual `<file>.vue.ts`
+ * module — a path that does not exist on disk — instead of the authored `.vue`.
+ *
+ * These tests decode the emitted mappings rather than merely asserting a map
+ * exists: a map that resolves to the wrong place is the failure mode that
+ * matters here.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { compileFile } from "../compiler.ts";
+import { generateOutputWithMap } from "../utils/index.ts";
+import { MappedModule, parseSourceMap, shiftMappedLines } from "../utils/source-map.ts";
+import type { SourceMapV3 } from "../utils/source-map.ts";
+import { toVirtualId } from "../virtual.ts";
+import { loadHook } from "./load.ts";
+import { getCompileOptionsForRequest, type VizePluginState } from "./state.ts";
+import type { CompiledModule } from "../types.ts";
+
+const BASE64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+interface DecodedSegment {
+  generatedLine: number;
+  generatedColumn: number;
+  sourceIndex: number;
+  sourceLine: number;
+  sourceColumn: number;
+}
+
+/** Decode a v3 `mappings` string into absolute segments. */
+function decodeMappings(mappings: string): DecodedSegment[] {
+  const decoded: DecodedSegment[] = [];
+  let sourceIndex = 0;
+  let sourceLine = 0;
+  let sourceColumn = 0;
+
+  mappings.split(";").forEach((group, generatedLine) => {
+    let generatedColumn = 0;
+    for (const field of group.split(",")) {
+      if (field === "") continue;
+      let cursor = 0;
+      const next = (): number => {
+        let result = 0;
+        let shift = 0;
+        for (;;) {
+          const digit = BASE64.indexOf(field[cursor++]);
+          result |= (digit & 0b11111) << shift;
+          shift += 5;
+          if ((digit & 0b100000) === 0) break;
+        }
+        const magnitude = result >>> 1;
+        return result & 1 ? -magnitude : magnitude;
+      };
+      generatedColumn += next();
+      sourceIndex += next();
+      sourceLine += next();
+      sourceColumn += next();
+      decoded.push({ generatedLine, generatedColumn, sourceIndex, sourceLine, sourceColumn });
+    }
+  });
+
+  return decoded;
+}
+
+/** The 0-based generated line whose body is exactly `text` once trimmed. */
+function generatedLineOf(code: string, text: string): number {
+  const line = code.split("\n").findIndex((candidate) => candidate.trim() === text);
+  assert.notEqual(line, -1, `emitted module should contain the line ${JSON.stringify(text)}`);
+  return line;
+}
+
+function segmentForLine(map: SourceMapV3, code: string, text: string): DecodedSegment | undefined {
+  const generatedLine = generatedLineOf(code, text);
+  return decodeMappings(map.mappings).find((segment) => segment.generatedLine === generatedLine);
+}
+
+// ---------------------------------------------------------------------------
+// shiftMappedLines / MappedModule
+// ---------------------------------------------------------------------------
+
+const threeMappedLines: SourceMapV3 = {
+  version: 3,
+  sources: ["/a.vue"],
+  names: [],
+  mappings: "AACA;AAEA;AAGA",
+};
+
+assert.equal(
+  shiftMappedLines(threeMappedLines, 0, 2).mappings,
+  ";;AACA;AAEA;AAGA",
+  "prepending two lines pushes every mapped line down by two",
+);
+assert.equal(
+  shiftMappedLines(threeMappedLines, 1, 1).mappings,
+  "AACA;;AAEA;AAGA",
+  "inserting a line mid-module moves only the lines after it",
+);
+assert.equal(
+  shiftMappedLines(threeMappedLines, 3, 5).mappings,
+  "AACA;AAEA;AAGA",
+  "an insertion past the last mapped line changes nothing",
+);
+assert.equal(
+  shiftMappedLines(threeMappedLines, 0, 0).mappings,
+  "AACA;AAEA;AAGA",
+  "a zero-line insertion is a no-op",
+);
+
+const appended = new MappedModule("a\nb\nc", { ...threeMappedLines });
+appended.edit("a\nb\nc\ntail");
+assert.equal(appended.map?.mappings, "AACA;AAEA;AAGA", "appending never moves existing mappings");
+
+const prepended = new MappedModule("a\nb\nc", { ...threeMappedLines });
+prepended.edit("x\ny\na\nb\nc");
+assert.equal(prepended.map?.mappings, ";;AACA;AAEA;AAGA", "a prepend shifts by the lines it adds");
+
+const sameLine = new MappedModule("export default {}\nb\nc", { ...threeMappedLines });
+sameLine.edit("const _sfc_main = {}\nb\nc");
+assert.equal(
+  sameLine.map?.mappings,
+  "AACA;AAEA;AAGA",
+  "a same-line substitution leaves the line layout, and the mappings, alone",
+);
+
+const removedLines = new MappedModule("a\nb\nc", { ...threeMappedLines });
+removedLines.edit("a\nc");
+assert.equal(removedLines.map, null, "an edit that removes lines drops the map instead of lying");
+
+assert.equal(parseSourceMap(undefined), null, "a missing map parses to null");
+assert.equal(parseSourceMap("{"), null, "malformed JSON parses to null");
+assert.equal(parseSourceMap('{"version":2}'), null, "a non-v3 document parses to null");
+
+// ---------------------------------------------------------------------------
+// compileFile: the napi boundary now carries the map
+// ---------------------------------------------------------------------------
+
+const SFC_SOURCE = `<template>
+  <p @click="bump">{{ message }}</p>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+const message = ref('from the sfc')
+function bump() {
+  message.value = 'bumped'
+}
+</script>
+`;
+
+const workspaceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../../..");
+const testRoot = path.join(
+  workspaceRoot,
+  "target",
+  "vize-tests",
+  "tests",
+  "vite-plugin-vize",
+  "map",
+);
+fs.mkdirSync(testRoot, { recursive: true });
+const projectRoot = fs.mkdtempSync(path.join(testRoot, "sfc-"));
+const sfcPath = path.join(projectRoot, "Counter.vue");
+fs.writeFileSync(sfcPath, SFC_SOURCE);
+
+const withoutMap = compileFile(sfcPath, new Map(), { sourceMap: false, ssr: false, vapor: false });
+assert.equal(withoutMap.map ?? null, null, "sourceMap: false must not produce a map");
+
+const compiled = compileFile(sfcPath, new Map(), { sourceMap: true, ssr: false, vapor: false });
+const compiledMap = parseSourceMap(compiled.map);
+assert.ok(compiledMap, "sourceMap: true must produce a parseable v3 map");
+assert.equal(compiledMap.version, 3);
+assert.equal(compiledMap.file, sfcPath);
+assert.deepEqual(compiledMap.sources, [sfcPath], "sources must name the authored .vue file");
+assert.deepEqual(compiledMap.sourcesContent, [SFC_SOURCE]);
+assert.deepEqual(compiledMap.names, []);
+
+// `const message = ref('from the sfc')` is authored line 7 (0-based), column 0.
+assert.deepEqual(
+  segmentForLine(compiledMap, compiled.code, "const message = ref('from the sfc')"),
+  {
+    generatedLine: generatedLineOf(compiled.code, "const message = ref('from the sfc')"),
+    generatedColumn: 0,
+    sourceIndex: 0,
+    sourceLine: 7,
+    sourceColumn: 0,
+  },
+  "the copied statement resolves to its authored line and column",
+);
+
+// ---------------------------------------------------------------------------
+// generateOutputWithMap: the map survives the module rewrites
+// ---------------------------------------------------------------------------
+
+const styled: CompiledModule = { ...compiled, css: ".a{color:red}", hasScoped: true };
+const generated = generateOutputWithMap(styled, {
+  isProduction: false,
+  isDev: false,
+  filePath: sfcPath,
+});
+assert.ok(generated.map, "generateOutput must carry the map through its rewrites");
+assert.deepEqual(generated.map.sources, [sfcPath]);
+assert.deepEqual(
+  segmentForLine(generated.map, generated.code, "const message = ref('from the sfc')"),
+  {
+    generatedLine: generatedLineOf(generated.code, "const message = ref('from the sfc')"),
+    generatedColumn: 0,
+    sourceIndex: 0,
+    sourceLine: 7,
+    sourceColumn: 0,
+  },
+  "prepending the inline <style> injection moves the mapping with the code",
+);
+
+// ---------------------------------------------------------------------------
+// loadHook: a production build with build.sourcemap resolves to the .vue file
+// ---------------------------------------------------------------------------
+
+const productionState: VizePluginState = {
+  cache: new Map(),
+  ssrCache: new Map(),
+  collectedCss: new Map(),
+  precompileMetadata: new Map(),
+  pendingHmrUpdateTypes: new Map(),
+  isProduction: true,
+  viteBuildSourcemap: true,
+  root: projectRoot,
+  clientViteBase: "/",
+  serverViteBase: "/",
+  server: null,
+  filter: () => true,
+  scanPatterns: ["**/*.vue"],
+  precompileBatchSize: 128,
+  ignorePatterns: [],
+  mergedOptions: {},
+  initialized: true,
+  dynamicImportAliasRules: [],
+  cssAliasRules: [],
+  extractCss: false,
+  componentsCssFileName: "assets/vize-components.css",
+  clientViteDefine: {},
+  serverViteDefine: {},
+  logger: { log() {}, info() {}, warn() {}, error() {} } as never,
+};
+
+assert.equal(
+  getCompileOptionsForRequest(productionState, false).sourceMap,
+  true,
+  "build.sourcemap must override the production-off default",
+);
+assert.equal(
+  getCompileOptionsForRequest({ ...productionState, viteBuildSourcemap: false }, false).sourceMap,
+  false,
+  "a production build without build.sourcemap keeps maps off",
+);
+assert.equal(
+  getCompileOptionsForRequest({ ...productionState, isProduction: false }, false).sourceMap,
+  true,
+  "development keeps maps on",
+);
+assert.equal(
+  getCompileOptionsForRequest({ ...productionState, mergedOptions: { sourceMap: false } }, false)
+    .sourceMap,
+  false,
+  "an explicit compiler option still wins over build.sourcemap",
+);
+
+const loaded = loadHook(productionState, toVirtualId(sfcPath), { ssr: false });
+assert.ok(loaded && typeof loaded === "object", "the virtual SFC module should load");
+const loadedMap = loaded.map;
+assert.ok(loadedMap, "the plugin must stop returning map: null for SFC modules");
+assert.deepEqual(
+  loadedMap.sources,
+  [sfcPath],
+  "the loaded module's map must name the authored .vue file, not the virtual .vue.ts id",
+);
+assert.deepEqual(
+  segmentForLine(loadedMap, loaded.code, "const message = ref('from the sfc')"),
+  {
+    generatedLine: generatedLineOf(loaded.code, "const message = ref('from the sfc')"),
+    generatedColumn: 0,
+    sourceIndex: 0,
+    sourceLine: 7,
+    sourceColumn: 0,
+  },
+  "a frame in the loaded module resolves to the authored .vue line",
+);
+
+fs.rmSync(projectRoot, { recursive: true, force: true });
+
+console.log("vite-plugin-vize source map tests passed!");

--- a/npm/builder/vite/src/plugin/state.ts
+++ b/npm/builder/vite/src/plugin/state.ts
@@ -36,6 +36,17 @@ export interface VizePluginState {
   pendingHmrUpdateTypes: Map<string, HmrUpdateType>;
   viteResolveCache?: Map<string, Promise<{ id: string; external?: boolean } | null>>;
   isProduction: boolean;
+  /**
+   * Whether Vite's own `build.sourcemap` asks for source maps (#3399).
+   *
+   * The documented compiler default is "development on, production off", but a
+   * production build that turns `build.sourcemap` on is asking for exactly the
+   * maps that default would suppress, so it overrides the production half.
+   *
+   * Optional so a caller that builds a state literal without it keeps the
+   * previous behaviour (dev on, production off) rather than failing to compile.
+   */
+  viteBuildSourcemap?: boolean;
   root: string;
   clientViteBase: string;
   serverViteBase: string;
@@ -80,11 +91,12 @@ export type CompileOptionsForRequest = {
 >;
 
 export function getCompileOptionsForRequest(
-  state: Pick<VizePluginState, "isProduction" | "mergedOptions">,
+  state: Pick<VizePluginState, "isProduction" | "mergedOptions" | "viteBuildSourcemap">,
   ssr: boolean,
 ): CompileOptionsForRequest {
   const options: CompileOptionsForRequest = {
-    sourceMap: state.mergedOptions?.sourceMap ?? !state.isProduction,
+    sourceMap:
+      state.mergedOptions?.sourceMap ?? (!state.isProduction || !!state.viteBuildSourcemap),
     ssr,
     // Vapor runtime is client-oriented today; use VDOM for SSR and Vapor on the client.
     vapor: !ssr && (state.mergedOptions?.vapor ?? false),

--- a/npm/builder/vite/src/plugin/vite-transform.ts
+++ b/npm/builder/vite/src/plugin/vite-transform.ts
@@ -109,6 +109,12 @@ export async function transformVizeVirtualModule(
     if (transformed.includes("import.meta.")) {
       transformed = applyDefineReplacements(transformed, getVirtualModuleDefines(state, ssr));
     }
+    // `map: null` is Rollup's "this transform did not move code, keep the map
+    // the load hook produced" signal, which is what both branches above do:
+    // `applyDefineReplacements` substitutes within a line, and the TypeScript
+    // strip only runs for modules the emitter did not produce (`?macro=true`
+    // artifacts and hand-written virtual modules), which never carried a map to
+    // begin with (#3399).
     return transformed === code ? null : { code: transformed, map: null };
   } catch (e: unknown) {
     state.logger.error(`transformWithOxc failed for ${realPath}:`, e);

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -30,6 +30,7 @@ import "./plugin/resolve-vue-runtime.test.ts";
 import "./plugin/resolve-dependency-style.test.ts";
 import "./plugin/resolve-relative-vue.test.ts";
 import "./plugin/resolve.test.ts";
+import "./plugin/source-map.test.ts";
 import "./plugin/precompile.test.ts";
 import "./plugin/precompile-cache.test.ts";
 import "./plugin/precompile-cache-corrupt.test.ts";

--- a/npm/builder/vite/src/types.ts
+++ b/npm/builder/vite/src/types.ts
@@ -39,6 +39,12 @@ export interface MacroArtifact {
 
 export interface SfcCompileResultNapi {
   code: string;
+  /**
+   * Source Map v3 document (JSON) describing `code`, present only when
+   * `sourceMap` was requested and a line could be anchored (#3399). Its single
+   * `sources` entry is the authored `.vue` path.
+   */
+  map?: string;
   css?: string;
   errors: string[];
   warnings: string[];
@@ -56,60 +62,12 @@ export type CompileSfcFn = (
   options?: SfcCompileOptionsNapi,
 ) => SfcCompileResultNapi;
 
-/** Options for the native `compileJsx` binding. */
-export interface JsxCompileOptionsNapi {
-  filename?: string;
-  lang?: string;
-  /**
-   * Default JSX output mode (`"vdom"` | `"vapor"`). Mirrors `compiler.jsxMode`
-   * and takes precedence over `vapor`. Per-component `"use vue:*"` directives
-   * still override it.
-   */
-  jsxMode?: "vdom" | "vapor";
-  vapor?: boolean;
-  /**
-   * Emit a v3 source map for the generated render code (#1533). When `true`,
-   * the result's `map` carries the map JSON; `null` otherwise.
-   */
-  sourceMap?: boolean;
-}
-
-/** A JSX component's extracted `<style scoped>` block (#1495, #1533). */
-export interface JsxScopedStyleNapi {
-  /** Generated scope id, e.g. `data-v-1a2b3c4d`, already applied to the CSS. */
-  scopeId: string;
-  /** Scope-rewritten CSS, with the `data-v-<hash>` attribute applied. */
-  css: string;
-}
-
-/** Result of the native `compileJsx` binding. */
-export interface JsxCompileResultNapi {
-  /**
-   * Self-contained module: the deduplicated runtime-helper preamble followed by
-   * every component's render code, in source order (the helper imports are no
-   * longer dropped, #1533).
-   */
-  code: string;
-  /**
-   * v3 source map (JSON) for `code`, present only when `sourceMap` was
-   * requested and the module is a single component. `null` otherwise (#1533).
-   */
-  map?: string;
-  errors: string[];
-  warnings: string[];
-  /**
-   * Extracted `<style scoped>` blocks across the module's components, in source
-   * order (#1495). Empty when no component had a `<style scoped>`. Each entry's
-   * CSS is already scope-rewritten; the plugin emits it through the same path
-   * SFC `<style>` blocks use (#1533).
-   */
-  scopedStyles: JsxScopedStyleNapi[];
-}
-
-export type CompileJsxFn = (
-  source: string,
-  options?: JsxCompileOptionsNapi,
-) => JsxCompileResultNapi;
+export type {
+  CompileJsxFn,
+  JsxCompileOptionsNapi,
+  JsxCompileResultNapi,
+  JsxScopedStyleNapi,
+} from "./jsx-types.ts";
 
 export type VizeVueVersion = 0.11 | 1 | 2 | "2.7" | 3 | "legacy";
 
@@ -209,7 +167,10 @@ export interface VizeOptions extends ExperimentalPluginOptions {
 
   ssr?: boolean;
 
-  /** Enable source map generation */
+  /**
+   * Enable source map generation.
+   * @default development on; production off unless Vite's `build.sourcemap` is set
+   */
   sourceMap?: boolean;
 
   /**
@@ -330,6 +291,13 @@ export interface NativeStyleBlockInfo {
 
 export interface CompiledModule {
   code: string;
+  /**
+   * Source Map v3 document (JSON) describing `code`, when the compiler was
+   * asked for one (#3399). Absent when source maps are off, when the SFC has no
+   * script block, and for the rspack and unplugin builders, which do not request
+   * maps. Persisted with the rest of the module in the pre-compile cache.
+   */
+  map?: string;
   css?: string;
   scopeId: string;
   hasScoped: boolean;

--- a/npm/builder/vite/src/utils/index.ts
+++ b/npm/builder/vite/src/utils/index.ts
@@ -6,6 +6,7 @@ import {
   insertBeforeSfcMainDefaultExport,
   rewriteDefaultExportToSfcMain,
 } from "./module-output.ts";
+import { MappedModule, parseSourceMap, type SourceMapV3 } from "./source-map.ts";
 
 // Re-export CSS utilities for backward compatibility
 export { resolveCssImports, type CssAliasRule } from "./css.ts";
@@ -145,56 +146,73 @@ export function embedsInlineCss(compiled: CompiledModule, options: GenerateOutpu
 }
 
 export function generateOutput(compiled: CompiledModule, options: GenerateOutputOptions): string {
+  return generateOutputWithMap(compiled, options).code;
+}
+
+/**
+ * `generateOutput` plus the source map that describes the module it returns.
+ *
+ * The compiler's map (`compiled.map`) describes `compiled.code`; every rewrite
+ * below goes through {@link MappedModule}, which realigns the map to the lines
+ * it inserts, so the returned map describes the returned code (#3399). `map` is
+ * `null` when the compiler produced none.
+ */
+export function generateOutputWithMap(
+  compiled: CompiledModule,
+  options: GenerateOutputOptions,
+): { code: string; map: SourceMapV3 | null } {
   const { isProduction, isDev, ssr, hmrUpdateType, extractCss, filePath } = options;
 
-  let output = compiled.code;
+  const emitted = new MappedModule(compiled.code, parseSourceMap(compiled.map));
 
   // The native compiler already parsed this module and reports its shape, so
   // the oxc parse here is redundant (#3425). `??` rather than a required field:
   // a `.vpc` cache entry written before this existed reads back without it and
   // simply pays the parse it always paid, so no cache-format bump is needed and
   // the fallback stays exercised.
-  const moduleInfo = compiled.moduleShape ?? analyzeModuleOutput(output);
+  const moduleInfo = compiled.moduleShape ?? analyzeModuleOutput(emitted.code);
   const hasExportDefault = moduleInfo.hasDefaultExport;
   const hasNamedRenderExport = moduleInfo.hasNamedRenderExport;
   const hasNamedSsrRenderExport = moduleInfo.hasNamedSsrRenderExport;
   const hasSfcMainDefined = moduleInfo.hasSfcMainDefined;
 
   if (hasExportDefault && !hasSfcMainDefined) {
-    output = rewriteDefaultExportToSfcMain(output, moduleInfo);
+    emitted.edit(rewriteDefaultExportToSfcMain(emitted.code, moduleInfo));
     // Add __scopeId for scoped CSS support
     if (compiled.hasScoped && compiled.scopeId) {
-      output += `\n_sfc_main.__scopeId = "data-v-${compiled.scopeId}";`;
+      emitted.edit(`${emitted.code}\n_sfc_main.__scopeId = "data-v-${compiled.scopeId}";`);
     }
-    output += "\nexport default _sfc_main;";
+    emitted.edit(`${emitted.code}\nexport default _sfc_main;`);
   } else if (hasExportDefault && hasSfcMainDefined) {
     // _sfc_main already defined, just add scopeId if needed
     if (compiled.hasScoped && compiled.scopeId) {
-      // `output` is still `compiled.code` on this branch -- nothing above it
-      // rewrote the module -- so `moduleInfo`'s offsets describe it exactly and
+      // `emitted.code` is still `compiled.code` on this branch -- nothing above
+      // it rewrote the module -- so `moduleInfo`'s offsets describe it exactly and
       // the insertion can reuse them instead of parsing the module again
       // (#3425). The later CSS-modules insertion below cannot: by then the
       // module has been rewritten and the offsets are stale.
-      output = insertBeforeSfcMainDefaultExport(
-        output,
-        `_sfc_main.__scopeId = "data-v-${compiled.scopeId}";`,
-        { moduleInfo },
+      emitted.edit(
+        insertBeforeSfcMainDefaultExport(
+          emitted.code,
+          `_sfc_main.__scopeId = "data-v-${compiled.scopeId}";`,
+          { moduleInfo },
+        ),
       );
     }
   } else if (!hasExportDefault && !hasSfcMainDefined && hasNamedRenderExport) {
-    output += "\nconst _sfc_main = {};";
+    emitted.edit(`${emitted.code}\nconst _sfc_main = {};`);
     if (compiled.hasScoped && compiled.scopeId) {
-      output += `\n_sfc_main.__scopeId = "data-v-${compiled.scopeId}";`;
+      emitted.edit(`${emitted.code}\n_sfc_main.__scopeId = "data-v-${compiled.scopeId}";`);
     }
-    output += "\n_sfc_main.render = render;";
-    output += "\nexport default _sfc_main;";
+    emitted.edit(`${emitted.code}\n_sfc_main.render = render;`);
+    emitted.edit(`${emitted.code}\nexport default _sfc_main;`);
   } else if (!hasExportDefault && !hasSfcMainDefined && hasNamedSsrRenderExport) {
-    output += "\nconst _sfc_main = {};";
+    emitted.edit(`${emitted.code}\nconst _sfc_main = {};`);
     if (compiled.hasScoped && compiled.scopeId) {
-      output += `\n_sfc_main.__scopeId = "data-v-${compiled.scopeId}";`;
+      emitted.edit(`${emitted.code}\n_sfc_main.__scopeId = "data-v-${compiled.scopeId}";`);
     }
-    output += "\n_sfc_main.ssrRender = ssrRender;";
-    output += "\nexport default _sfc_main;";
+    emitted.edit(`${emitted.code}\n_sfc_main.ssrRender = ssrRender;`);
+    emitted.edit(`${emitted.code}\nexport default _sfc_main;`);
   }
 
   // Determine whether to use style imports or inline CSS injection.
@@ -236,7 +254,7 @@ export function generateOutput(compiled: CompiledModule, options: GenerateOutput
     // override child component defaults.
     const allImports = [...styleImports, ...cssModuleImports].join("\n");
     if (allImports) {
-      output = insertAfterStaticImports(output, allImports);
+      emitted.edit(insertAfterStaticImports(emitted.code, allImports));
     }
 
     // Inject CSS module bindings into the component
@@ -258,25 +276,27 @@ export function generateOutput(compiled: CompiledModule, options: GenerateOutput
             `_sfc_main.__cssModules = _sfc_main.__cssModules || {};\n_sfc_main.__cssModules[${JSON.stringify(m.name)}] = ${m.bindingName};`,
         )
         .join("\n");
-      output = insertBeforeSfcMainDefaultExport(output, cssModuleSetup, {
-        normalizeSemicolon: true,
-      });
+      emitted.edit(
+        insertBeforeSfcMainDefaultExport(emitted.code, cssModuleSetup, {
+          normalizeSemicolon: true,
+        }),
+      );
     }
   } else if (!ssr && compiled.css && !(isProduction && extractCss)) {
     // --- Inline CSS injection (original behavior for plain CSS) ---
-    output = prependInlineStyleInjection(output, compiled.css, compiled.scopeId);
+    emitted.edit(prependInlineStyleInjection(emitted.code, compiled.css, compiled.scopeId));
   }
 
   // Add HMR support in development (skip in production)
   if (!isProduction && isDev && hasExportDefault) {
     const effectiveHmrUpdateType =
-      hmrUpdateType === "template-only" && !supportsTemplateOnlyHmr(output)
+      hmrUpdateType === "template-only" && !supportsTemplateOnlyHmr(emitted.code)
         ? "full-reload"
         : (hmrUpdateType ?? "full-reload");
-    output += generateHmrCode(compiled.scopeId, effectiveHmrUpdateType);
+    emitted.edit(`${emitted.code}${generateHmrCode(compiled.scopeId, effectiveHmrUpdateType)}`);
   }
 
-  return output;
+  return { code: emitted.code, map: emitted.map };
 }
 
 /**

--- a/npm/builder/vite/src/utils/source-map.ts
+++ b/npm/builder/vite/src/utils/source-map.ts
@@ -1,0 +1,158 @@
+/**
+ * Keeping the compiler's Source Map v3 document valid through the edits
+ * `generateOutput` makes to the emitted module (#3399).
+ *
+ * The native compiler returns a map for the module it emitted. `generateOutput`
+ * then rewrites that module: it prepends a `<style>` injection, splices style
+ * imports in after the last static import, inserts CSS-module wiring before the
+ * default export, rewrites `export default` to `const _sfc_main =`, and appends
+ * `__scopeId`/HMR code. All of those are whole-line insertions or same-line
+ * substitutions, which is exactly the class of edit a v3 `mappings` string can
+ * absorb without being decoded:
+ *
+ * - Lines are separated by `;` and each line's segments by `,`.
+ * - A segment's generated column is relative to the previous segment **on the
+ *   same line** and resets at every line, so an inserted line never disturbs the
+ *   columns after it.
+ * - The source index/line/column fields are relative to the previous *segment*,
+ *   not the previous line, so inserting empty lines between segments leaves
+ *   every delta untouched.
+ *
+ * Shifting generated lines is therefore literally inserting `;` characters, with
+ * no VLQ decoding and no chance of a rounding error.
+ *
+ * Rather than have every call site declare where its edit landed — which would
+ * silently rot the first time an edit moves — {@link MappedModule.edit} derives
+ * it from the two strings: the common prefix and suffix bound the changed span
+ * exactly, and the change in newline count inside that span is the line shift.
+ * A same-line substitution comes out as a zero shift (columns within a line are
+ * not tracked; a frame still resolves to the right authored line), and an edit
+ * that *removes* lines drops the map rather than emit one that is wrong.
+ */
+
+/** A parsed Source Map v3 document, as Rollup/Vite want it on a hook result. */
+export interface SourceMapV3 {
+  version: number;
+  file?: string;
+  sources: string[];
+  sourcesContent?: (string | null)[];
+  names: string[];
+  mappings: string;
+}
+
+function isSourceMapV3(value: unknown): value is SourceMapV3 {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  const map = value as Partial<SourceMapV3>;
+  return (
+    map.version === 3 &&
+    Array.isArray(map.sources) &&
+    Array.isArray(map.names) &&
+    typeof map.mappings === "string"
+  );
+}
+
+/**
+ * Parse a compiler-produced map, or `null` when there is nothing usable.
+ *
+ * A malformed map is worse than no map — Vite would chain garbage into the
+ * bundle's map — so anything that is not a v3 document is dropped.
+ */
+export function parseSourceMap(json: string | undefined | null): SourceMapV3 | null {
+  if (!json) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  return isSourceMapV3(parsed) ? parsed : null;
+}
+
+function countNewlines(text: string): number {
+  let total = 0;
+  for (let index = text.indexOf("\n"); index !== -1; index = text.indexOf("\n", index + 1)) {
+    total++;
+  }
+  return total;
+}
+
+/**
+ * Insert `count` unmapped generated lines at generated line `atLine`.
+ *
+ * Returns the map unchanged when the insertion lands past the last mapped line,
+ * because nothing after it needs moving.
+ */
+export function shiftMappedLines(map: SourceMapV3, atLine: number, count: number): SourceMapV3 {
+  if (count <= 0) {
+    return map;
+  }
+  const groups = map.mappings.split(";");
+  if (atLine >= groups.length) {
+    return map;
+  }
+  const shifted = [...groups.slice(0, atLine), ...Array(count).fill(""), ...groups.slice(atLine)];
+  return { ...map, mappings: shifted.join(";") };
+}
+
+/**
+ * A module's code and the map that describes it, edited together.
+ *
+ * Every write goes through {@link edit}, so the map is corrected in the same
+ * step that changes the code and the two cannot drift.
+ */
+export class MappedModule {
+  code: string;
+  map: SourceMapV3 | null;
+
+  constructor(code: string, map: SourceMapV3 | null) {
+    this.code = code;
+    this.map = map;
+  }
+
+  /** Replace the module with `next`, realigning the map to the new line layout. */
+  edit(next: string): void {
+    const previous = this.code;
+    this.code = next;
+    if (this.map === null || next === previous) {
+      return;
+    }
+
+    const limit = Math.min(previous.length, next.length);
+    let prefix = 0;
+    while (prefix < limit && previous.charCodeAt(prefix) === next.charCodeAt(prefix)) {
+      prefix++;
+    }
+    let suffix = 0;
+    while (
+      suffix < limit - prefix &&
+      previous.charCodeAt(previous.length - 1 - suffix) ===
+        next.charCodeAt(next.length - 1 - suffix)
+    ) {
+      suffix++;
+    }
+
+    const removed = previous.slice(prefix, previous.length - suffix);
+    const inserted = next.slice(prefix, next.length - suffix);
+    const addedLines = countNewlines(inserted) - countNewlines(removed);
+    if (addedLines === 0) {
+      return;
+    }
+    if (addedLines < 0) {
+      // No edit in `generateOutput` removes lines. If one ever does, dropping
+      // the map is the only honest answer: the shift cannot express it.
+      this.map = null;
+      return;
+    }
+
+    // Lines strictly after the edit point move down. When the edit starts at a
+    // line start, that line moves too; otherwise its head stayed put, so the
+    // shift begins on the following line.
+    const editLine = countNewlines(previous.slice(0, prefix));
+    const startsAtLineStart = prefix === 0 || previous.charCodeAt(prefix - 1) === 10;
+    this.map = shiftMappedLines(this.map, startsAtLineStart ? editLine : editLine + 1, addedLines);
+  }
+}

--- a/npm/native/index.d.ts
+++ b/npm/native/index.d.ts
@@ -93,6 +93,15 @@ export interface BatchCompileOptionsNapi {
   includeMacroArtifacts?: boolean;
   /** Include template/style/script content hashes (for HMR). Default OFF. */
   includeHashes?: boolean;
+  /**
+   * Emit a Source Map v3 document per file (`map`). Default OFF.
+   *
+   * The pre-compile batch is the path every build takes, so a production
+   * build with `build.sourcemap` on has to be able to ask for maps here or
+   * the bundle's maps point at the virtual module instead of the `.vue`
+   * file (#3399).
+   */
+  includeSourceMap?: boolean;
 }
 
 export interface BatchCompileResultNapi {
@@ -118,6 +127,9 @@ export interface BatchFileInputNapi {
 export interface BatchFileResultNapi {
   path: string;
   code: string;
+  /** Source Map v3 document (JSON) describing `code`, present only when
+   * `includeSourceMap` was requested and a line could be anchored (#3399). */
+  map?: string;
   css?: string;
   scopeId: string;
   hasScoped: boolean;
@@ -919,6 +931,10 @@ export interface SfcCompileOptionsNapi {
 
 export interface SfcCompileResultNapi {
   code: string;
+  /** Source Map v3 document (JSON) describing `code`, present only when
+   * `sourceMap` was requested and at least one authored line could be
+   * anchored (#3399). Its single `sources` entry is the authored `.vue` path. */
+  map?: string;
   css?: string;
   errors: Array<string>;
   warnings: Array<string>;


### PR DESCRIPTION
## Surface

`@vizejs/vite-plugin` (`npm/builder/vite`), backed by `compileSfc` /
`compileSfcBatchWithResults` in `crates/vize_vitrine` and `vize_atelier_sfc`.

## Reproduction

At the napi layer, straight from the issue:

```js
import { compileSfc } from "@vizejs/native";

const source = `<template><p>{{ msg }}</p></template>
<script setup>
const msg = 'hello'
</script>
`;
const result = compileSfc(source, { filename: "/x/App.vue", sourceMap: true });
console.log(Object.keys(result));
console.log(result.map);
```

**Before:** `code,errors,warnings,hasScoped,styles,customBlocks,macroArtifacts,templateHash,scriptHash,moduleShape`
and `result.map === undefined`. End to end, a production build with
`build.sourcemap: true` resolved a frame to `<file>.vue.ts?vue&vize` — a virtual
module that does not exist on disk and holds *compiled* output — and no `.vue`
file appeared in `map.sources` at all.

**After:** the result carries `map`, and `JSON.parse(result.map)` is a Source Map
v3 document with `sources: ["/x/App.vue"]`, `sourcesContent` holding the SFC
text, and mappings that decode to the authored lines.

## Root cause

Mapping information was **not** being produced and dropped at the napi boundary —
none existed for the SFC path at all. `vize_atelier_core`'s `SourceMapBuilder`
only ever served the standalone DOM/JSX compilers; the SFC path never enabled it
and never read `CodegenResult.map`. Even if it had, the template map is anchored
to the template-block substring and to the template-only code buffer, so it
cannot describe the assembled module, and the script half — where user code and
therefore stack frames actually live — had no mapping of any kind.

There is also no offset that survives the SFC pipeline: the emitter concatenates
independently generated chunks, the script sections are split into lines and
re-joined by passes that only see strings, and a `lang="ts"` module is re-printed
wholesale by oxc before it crosses the boundary.

## What the fix does

**`vize_atelier_sfc::source_map`** (new) recovers the mapping from what does
survive — the content of the authored `<script>`/`<script setup>` lines. It
indexes them and maps a generated line only when that line matches **exactly one**
authored line, under the first key that resolves:

1. **exact trimmed text** — plain-JS SFCs copy script statements out verbatim;
2. **printer-normalised text** (whitespace collapsed, `'` folded to `"`, trailing
   `;` dropped) — survives oxc re-printing a TypeScript module;
3. **the binding a line declares** (`const msg`) — survives when the printer *did*
   change the line: `const msg: string = 'x'` is emitted as `const msg = "x"`, and
   `const props = defineProps(...)` as `const props = __props`. Mapping the
   generated declaration of a binding to the authored declaration of that same
   binding is right by construction.

Every key is uniqueness-gated on its own, so an ambiguous or synthesized line is
left unmapped rather than guessed at. Serialisation reuses the existing
`SourceMapBuilder` (made `pub`) rather than a second VLQ encoder.

**napi**: `SfcCompileResultNapi.map` and `BatchFileResultNapi.map`, built from the
exact bytes each path hands on (after the TypeScript strip, for the same reason
`moduleShape` is). The batch path is gated behind `includeSourceMap`, which is
part of the object that seeds the pre-compile cache key, so a run that wants maps
can never be served entries compiled without them (cache format bumped to 3).

**Plugin**: `CompiledModule.map` is carried and persisted, and
`generateOutputWithMap` keeps the map valid through the module rewrites. Those
rewrites are whole-line insertions, which a v3 `mappings` string absorbs by
inserting `;` separators, so `MappedModule.edit` derives the shift from the two
strings instead of trusting each call site to declare it; an edit that removes
lines drops the map rather than emit a wrong one. `load` returns that map instead
of `map: null`.

`build.sourcemap` now overrides the production half of the documented
"development on, production off" default.

## Tests

- `crates/vize_atelier_sfc/src/source_map/{tests,anchor_tests}.rs` — 12 tests.
  The full v3 document is asserted field by field (`version`, `file`, `sources`,
  `sourcesContent`, `names`) and every segment is VLQ-decoded and compared as a
  complete vector against the exact authored line/column, including the
  oxc-re-printed TypeScript case.
- `npm/builder/vite/src/plugin/source-map.test.ts` — the napi boundary, the
  `generateOutput` rewrites, the `build.sourcemap` policy, and `loadHook`
  end to end, each decoding the emitted mapping and asserting the exact authored
  line and column it resolves to.
- `npm/builder/vite/src/compile-options.test.ts` — `includeSourceMap` reaches the
  batch options that seed the cache key.

## Known limitation

Fidelity is line-level: a mapping anchors the first non-whitespace column of the
generated line to the first non-whitespace column of the authored line. Generated
render code has no authored counterpart and stays unmapped, so a frame inside it
resolves to the nearest preceding mapping — still inside the `.vue` file rather
than the virtual module. Expression-level fidelity needs the emitter to record
offsets and is tracked with #1533.

Closes #3399

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->