### PR TITLE
test(editor): drive five real-server steps in VS Code and Neovim

### DIFF
--- a/.github/actions/vscode-host-smoke/action.yml
+++ b/.github/actions/vscode-host-smoke/action.yml
@@ -1,5 +1,5 @@
-name: VS Code host smoke
-description: Run the VS Code extension-host smoke against a real vize language server
+name: Editor real-server end-to-end
+description: Run the VS Code and Neovim editor scenarios against a real vize language server
 
 runs:
   using: composite
@@ -38,9 +38,36 @@ runs:
       shell: bash
       run: command -v xvfb-run || (sudo apt-get update && sudo apt-get install -y xvfb)
 
+    - name: Install Neovim
+      shell: bash
+      env:
+        NVIM_SHA256: a74740047e73b2b380d63a474282814063d10650cd6cc95efa16d1713c7e616c
+        NVIM_VERSION: v0.11.4
+      run: |
+        set -euo pipefail
+        curl -fsSL -o /tmp/nvim.tar.gz \
+          "https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/nvim-linux-x86_64.tar.gz"
+        echo "${NVIM_SHA256}  /tmp/nvim.tar.gz" | sha256sum --check --strict
+        sudo tar -C /opt -xzf /tmp/nvim.tar.gz
+        sudo ln -sf /opt/nvim-linux-x86_64/bin/nvim /usr/local/bin/nvim
+        nvim --version | head -1
+
     - name: Run VS Code host smoke against the real server
       shell: bash
       env:
         NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
         VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize
       run: xvfb-run -a vp run --workspace-root test:vscode-extension:host-real
+
+    - name: Run the packaged Neovim unit spec
+      shell: bash
+      env:
+        NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+      run: vp run --workspace-root test:nvim-extension:headless
+
+    - name: Run the Neovim scenario against the real server
+      shell: bash
+      env:
+        NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+        VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize
+      run: vp run --workspace-root test:nvim-extension:real-server

--- a/editors/nvim/test/vize_e2e_expected.lua
+++ b/editors/nvim/test/vize_e2e_expected.lua
@@ -1,0 +1,152 @@
+-- Expected real-server responses for `vize_e2e_spec.lua` (#3457).
+--
+-- Every table here is a COMPLETE response captured from a raw LSP probe of the
+-- real `vize lsp` binary against the `real-vue` fixture's `src/Scenario.vue`.
+-- They are compared with `vim.deep_equal`, so a capability that starts
+-- answering with more, fewer, or differently anchored results fails the
+-- scenario instead of quietly losing coverage.
+
+local authored_source = table.concat({
+  '<script setup lang="ts">',
+  'import Child from "./Child.vue";',
+  "",
+  'const total = "3";',
+  "</script>",
+  "",
+  "<template>",
+  '<Child  :count="total" />',
+  "</template>",
+  "",
+}, "\n")
+
+local quick_fixed_source = authored_source:gsub("<Child  :count", "<Child :count", 1)
+local formatted_source = quick_fixed_source:gsub(
+  '<Child :count="total" />',
+  '  <Child :count="total" />',
+  1
+)
+local renamed_source = formatted_source
+  :gsub("const total =", "const quantity =", 1)
+  :gsub(':count="total"', ':count="quantity"', 1)
+
+return {
+  authored_source = authored_source,
+  quick_fixed_source = quick_fixed_source,
+  formatted_source = formatted_source,
+  renamed_source = renamed_source,
+
+  -- The authored `<Child  :count="total" />` carries two independent authored
+  -- bugs on one line: two spaces after the tag name (a fixable lint warning)
+  -- and a string bound to a `number` prop (the type bug the #3224 scorecard
+  -- asks for). Both anchor on the authored span, never on virtual TS.
+  diagnostics = {
+    {
+      code = "vue/no-multi-spaces",
+      codeDescription = { href = "https://eslint.vuejs.org/rules/no-multi-spaces.html" },
+      message = "Multiple consecutive spaces",
+      range = {
+        ["end"] = { character = 8, line = 7 },
+        start = { character = 6, line = 7 },
+      },
+      severity = 2,
+      source = "vize/lint",
+    },
+    {
+      code = 2322,
+      message = "Type 'string' is not assignable to type 'number'.",
+      range = {
+        ["end"] = { character = 14, line = 7 },
+        start = { character = 9, line = 7 },
+      },
+      severity = 1,
+      source = "vize/types",
+    },
+  },
+
+  quick_fix_range = {
+    ["end"] = { character = 8, line = 7 },
+    start = { character = 6, line = 7 },
+  },
+
+  code_actions = function(uri)
+    return {
+      {
+        edit = {
+          changes = {
+            [uri] = {
+              {
+                newText = " ",
+                range = {
+                  ["end"] = { character = 8, line = 7 },
+                  start = { character = 6, line = 7 },
+                },
+              },
+            },
+          },
+        },
+        isPreferred = true,
+        kind = "quickfix",
+        title = "Fix: Replace multiple spaces with single space",
+      },
+      {
+        edit = {
+          changes = {
+            [uri] = {
+              {
+                newText = "<!-- @vize:forget vue/no-multi-spaces -->\n",
+                range = {
+                  ["end"] = { character = 0, line = 7 },
+                  start = { character = 0, line = 7 },
+                },
+              },
+            },
+          },
+        },
+        isPreferred = false,
+        kind = "quickfix",
+        title = "Suppress with @vize:forget (vue/no-multi-spaces)",
+      },
+    }
+  end,
+
+  -- The SFC formatter answers with one whole-document replacement.
+  formatting_edits = {
+    {
+      newText = formatted_source,
+      range = {
+        ["end"] = { character = 0, line = 9 },
+        start = { character = 0, line = 0 },
+      },
+    },
+  },
+
+  -- `{deltaLine, deltaStart, length, tokenType, tokenModifiers} * 2` against
+  -- the server legend: `:count` is a `property` (type 9) and `total` a
+  -- `variable` (type 8), both on the formatted template line.
+  semantic_tokens = { data = { 7, 9, 6, 9, 0, 0, 8, 5, 8, 0 } },
+
+  rename_new_name = "quantity",
+  rename_position = { character = 8, line = 3 },
+  rename_edit = function(uri)
+    return {
+      changes = {
+        [uri] = {
+          {
+            newText = "quantity",
+            range = {
+              ["end"] = { character = 11, line = 3 },
+              start = { character = 6, line = 3 },
+            },
+          },
+          {
+            newText = "quantity",
+            range = {
+              ["end"] = { character = 22, line = 7 },
+              start = { character = 17, line = 7 },
+            },
+          },
+        },
+      },
+    }
+  end,
+}

--- a/editors/nvim/test/vize_e2e_expected.lua
+++ b/editors/nvim/test/vize_e2e_expected.lua
@@ -19,15 +19,21 @@ local authored_source = table.concat({
   "",
 }, "\n")
 
-local quick_fixed_source = authored_source:gsub("<Child  :count", "<Child :count", 1)
-local formatted_source = quick_fixed_source:gsub(
-  '<Child :count="total" />',
-  '  <Child :count="total" />',
-  1
-)
-local renamed_source = formatted_source
-  :gsub("const total =", "const quantity =", 1)
-  :gsub(':count="total"', ':count="quantity"', 1)
+-- Each derived source is one authored edit away from the previous stage. A
+-- silent zero-replacement `gsub` would leave the expectation equal to the
+-- previous stage and fail later under a misleading label, so every step
+-- asserts it actually matched the fixture text.
+local function replace_once(source, pattern, replacement)
+  local result, count = source:gsub(pattern, replacement, 1)
+  assert(count == 1, "expected fixture text not found: " .. pattern)
+  return result
+end
+
+local quick_fixed_source = replace_once(authored_source, "<Child  :count", "<Child :count")
+local formatted_source =
+  replace_once(quick_fixed_source, '<Child :count="total" />', '  <Child :count="total" />')
+local renamed_source = replace_once(formatted_source, "const total =", "const quantity =")
+renamed_source = replace_once(renamed_source, ':count="total"', ':count="quantity"')
 
 return {
   authored_source = authored_source,

--- a/editors/nvim/test/vize_e2e_spec.lua
+++ b/editors/nvim/test/vize_e2e_spec.lua
@@ -75,12 +75,15 @@ local function step_diagnostics(uri, published)
     fail("real server did not publish the scenario diagnostics", published)
   end
 
-  assert_eq(vim.tbl_keys(published), { uri }, "diagnostics were published for exactly one file")
+  -- `vim.tbl_keys` has no defined order, so sort before the deep compare.
+  local published_uris = vim.tbl_keys(published)
+  table.sort(published_uris)
+  assert_eq(published_uris, { uri }, "diagnostics were published for exactly one file")
   assert_eq(sorted_by_start(published[uri]), expected.diagnostics, "published diagnostics")
 end
 
 --- Step 2: the quick fix the server offers on the lint warning's own span.
-local function step_quick_fix(bufnr, uri)
+local function step_quick_fix(bufnr, uri, offset_encoding)
   local actions = request(bufnr, "textDocument/codeAction", {
     context = { diagnostics = {} },
     range = expected.quick_fix_range,
@@ -88,7 +91,7 @@ local function step_quick_fix(bufnr, uri)
   })
   assert_eq(actions, expected.code_actions(uri), "code actions on the lint warning span")
 
-  vim.lsp.util.apply_workspace_edit(actions[1].edit, "utf-16")
+  vim.lsp.util.apply_workspace_edit(actions[1].edit, offset_encoding)
   assert_eq(buffer_text(bufnr), expected.quick_fixed_source, "buffer after applying the quick fix")
 end
 
@@ -123,7 +126,7 @@ local function step_semantic_tokens(bufnr, uri)
 end
 
 --- Step 5: rename the script binding the template consumes.
-local function step_rename(bufnr, uri)
+local function step_rename(bufnr, uri, offset_encoding)
   local edit = request(bufnr, "textDocument/rename", {
     newName = expected.rename_new_name,
     position = expected.rename_position,
@@ -131,7 +134,7 @@ local function step_rename(bufnr, uri)
   })
   assert_eq(edit, expected.rename_edit(uri), "rename workspace edit")
 
-  vim.lsp.util.apply_workspace_edit(edit, "utf-16")
+  vim.lsp.util.apply_workspace_edit(edit, offset_encoding)
   assert_eq(buffer_text(bufnr), expected.renamed_source, "buffer after applying the rename")
 end
 
@@ -193,11 +196,19 @@ local function main()
   local client_id = start_client(bufnr, published)
   local uri = vim.uri_from_bufnr(bufnr)
 
+  -- Apply edits with the position encoding the client actually negotiated
+  -- rather than assuming UTF-16, so a future encoding change is not silently
+  -- mis-applied here.
+  local client = vim.lsp.get_client_by_id(client_id)
+  assert(client ~= nil, "the vize client disappeared after initialization")
+  local offset_encoding = client.offset_encoding
+  assert(offset_encoding ~= nil, "the vize client negotiated no position encoding")
+
   step_diagnostics(uri, published)
-  step_quick_fix(bufnr, uri)
+  step_quick_fix(bufnr, uri, offset_encoding)
   step_format_on_save(bufnr, uri, scenario_path)
   step_semantic_tokens(bufnr, uri)
-  step_rename(bufnr, uri)
+  step_rename(bufnr, uri, offset_encoding)
 
   vim.lsp.stop_client(client_id, true)
 end

--- a/editors/nvim/test/vize_e2e_spec.lua
+++ b/editors/nvim/test/vize_e2e_spec.lua
@@ -1,0 +1,211 @@
+-- Headless Neovim end-to-end scenario against a real `vize lsp` process.
+--
+-- Covers the #3224 parity scorecard row for Neovim: type bug -> diagnostic at
+-- the authored span -> quick fix -> format-on-save -> semantic tokens ->
+-- rename. Every step asserts the COMPLETE server response with
+-- `vim.deep_equal`; there is no substring or "contains" check anywhere here.
+--
+-- `tools/nvim-vize/run-real-server.mjs` prepares the workspace and launches
+-- this file; run it with `vp run --workspace-root test:nvim-extension:real-server`.
+--
+-- The session starts through `vim.lsp.start` rather than `require("vize").setup()`
+-- so the scenario runs on every Neovim that ships a Lua LSP client, not only
+-- the 0.11+ releases that provide `vim.lsp.config`/`vim.lsp.enable`. The config
+-- it starts from is still the plugin's own `vize.config.normalize` output, so a
+-- regression in the packaged defaults still fails here.
+
+local plugin_root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h")
+vim.opt.runtimepath:prepend(plugin_root)
+
+local expected = dofile(plugin_root .. "/test/vize_e2e_expected.lua")
+local config = require("vize.config")
+
+local server_path = os.getenv("VIZE_E2E_SERVER")
+local workspace_path = os.getenv("VIZE_E2E_WORKSPACE")
+
+local function fail(label, actual)
+  error(label .. "\nactual: " .. vim.inspect(actual), 0)
+end
+
+local function assert_eq(actual, want, label)
+  if not vim.deep_equal(actual, want) then
+    fail(label .. "\nexpected: " .. vim.inspect(want), actual)
+  end
+end
+
+local function request(bufnr, method, params)
+  local responses, request_error = vim.lsp.buf_request_sync(bufnr, method, params, 120000)
+  assert(request_error == nil, method .. " failed: " .. tostring(request_error))
+  assert(responses ~= nil, method .. " timed out")
+  local _, response = next(responses)
+  assert(response ~= nil, method .. " produced no response")
+  assert(response.error == nil, method .. " returned an error: " .. vim.inspect(response.error))
+  return response.result
+end
+
+local function buffer_text(bufnr)
+  return table.concat(vim.api.nvim_buf_get_lines(bufnr, 0, -1, true), "\n") .. "\n"
+end
+
+local function read_file(path)
+  local handle = assert(io.open(path, "r"))
+  local contents = handle:read("*a")
+  handle:close()
+  return contents
+end
+
+local function sorted_by_start(diagnostics)
+  local sorted = vim.deepcopy(diagnostics)
+  table.sort(sorted, function(left, right)
+    if left.range.start.line ~= right.range.start.line then
+      return left.range.start.line < right.range.start.line
+    end
+    return left.range.start.character < right.range.start.character
+  end)
+  return sorted
+end
+
+--- Step 1: the real server publishes both authored bugs, on authored spans.
+local function step_diagnostics(uri, published)
+  local settled = vim.wait(240000, function()
+    local diagnostics = published[uri]
+    return diagnostics ~= nil and #diagnostics >= #expected.diagnostics
+  end, 200)
+  if not settled then
+    fail("real server did not publish the scenario diagnostics", published)
+  end
+
+  assert_eq(vim.tbl_keys(published), { uri }, "diagnostics were published for exactly one file")
+  assert_eq(sorted_by_start(published[uri]), expected.diagnostics, "published diagnostics")
+end
+
+--- Step 2: the quick fix the server offers on the lint warning's own span.
+local function step_quick_fix(bufnr, uri)
+  local actions = request(bufnr, "textDocument/codeAction", {
+    context = { diagnostics = {} },
+    range = expected.quick_fix_range,
+    textDocument = { uri = uri },
+  })
+  assert_eq(actions, expected.code_actions(uri), "code actions on the lint warning span")
+
+  vim.lsp.util.apply_workspace_edit(actions[1].edit, "utf-16")
+  assert_eq(buffer_text(bufnr), expected.quick_fixed_source, "buffer after applying the quick fix")
+end
+
+--- Step 3: format-on-save, wired the way a Neovim user wires it.
+local function step_format_on_save(bufnr, uri, scenario_path)
+  vim.api.nvim_create_autocmd("BufWritePre", {
+    buffer = bufnr,
+    callback = function()
+      vim.lsp.buf.format({ async = false, bufnr = bufnr, timeout_ms = 120000 })
+    end,
+  })
+
+  local edits = request(bufnr, "textDocument/formatting", {
+    options = { insertSpaces = true, tabSize = 2 },
+    textDocument = { uri = uri },
+  })
+  assert_eq(edits, expected.formatting_edits, "formatting edits")
+  assert_eq(buffer_text(bufnr), expected.quick_fixed_source, "formatting must not edit on its own")
+
+  vim.cmd("write")
+  assert_eq(buffer_text(bufnr), expected.formatted_source, "buffer after format-on-save")
+  assert_eq(read_file(scenario_path), expected.formatted_source, "file on disk after format-on-save")
+  assert_eq(vim.bo[bufnr].modified, false, "format-on-save leaves the buffer saved")
+end
+
+--- Step 4: semantic tokens for the formatted document.
+local function step_semantic_tokens(bufnr, uri)
+  local tokens = request(bufnr, "textDocument/semanticTokens/full", {
+    textDocument = { uri = uri },
+  })
+  assert_eq(tokens, expected.semantic_tokens, "semantic tokens")
+end
+
+--- Step 5: rename the script binding the template consumes.
+local function step_rename(bufnr, uri)
+  local edit = request(bufnr, "textDocument/rename", {
+    newName = expected.rename_new_name,
+    position = expected.rename_position,
+    textDocument = { uri = uri },
+  })
+  assert_eq(edit, expected.rename_edit(uri), "rename workspace edit")
+
+  vim.lsp.util.apply_workspace_edit(edit, "utf-16")
+  assert_eq(buffer_text(bufnr), expected.renamed_source, "buffer after applying the rename")
+end
+
+local function start_client(bufnr, published)
+  -- The packaged `recommended` profile leaves formatting off, matching the
+  -- server default. Format-on-save is an explicit opt-in, so the scenario
+  -- turns it on the same way a user would: through `init_options`.
+  local init_options = config.profile("recommended")
+  init_options.formatting = true
+
+  local resolved = config.normalize({
+    cmd = { server_path, "lsp" },
+    init_options = init_options,
+  })
+  assert_eq(resolved.filetypes, { "vue", "art-vue" }, "packaged filetypes")
+  assert_eq(
+    resolved.root_markers,
+    { "vize.config.pkl", "vize.config.json", "package.json", ".git" },
+    "packaged root markers"
+  )
+
+  local client_id = vim.lsp.start({
+    cmd = resolved.cmd,
+    handlers = {
+      ["textDocument/publishDiagnostics"] = function(_, result)
+        if result ~= nil then
+          published[result.uri] = result.diagnostics
+        end
+      end,
+    },
+    init_options = resolved.init_options,
+    name = "vize",
+    root_dir = workspace_path,
+  }, { bufnr = bufnr })
+  assert(client_id ~= nil, "vim.lsp.start did not return a client id")
+
+  local ready = vim.wait(120000, function()
+    local client = vim.lsp.get_client_by_id(client_id)
+    return client ~= nil and client.initialized == true and vim.lsp.buf_is_attached(bufnr, client_id)
+  end, 100)
+  assert(ready, "the vize language server did not initialize")
+
+  return client_id
+end
+
+local function main()
+  assert(server_path ~= nil and server_path ~= "", "VIZE_E2E_SERVER must be set")
+  assert(workspace_path ~= nil and workspace_path ~= "", "VIZE_E2E_WORKSPACE must be set")
+
+  local scenario_path = workspace_path .. "/src/Scenario.vue"
+  vim.cmd("runtime! ftdetect/vize.lua")
+  vim.cmd("edit " .. vim.fn.fnameescape(scenario_path))
+
+  local bufnr = vim.api.nvim_get_current_buf()
+  assert_eq(vim.bo[bufnr].filetype, "vue", "ftdetect maps the fixture to the vue filetype")
+  assert_eq(buffer_text(bufnr), expected.authored_source, "authored fixture source")
+
+  local published = {}
+  local client_id = start_client(bufnr, published)
+  local uri = vim.uri_from_bufnr(bufnr)
+
+  step_diagnostics(uri, published)
+  step_quick_fix(bufnr, uri)
+  step_format_on_save(bufnr, uri, scenario_path)
+  step_semantic_tokens(bufnr, uri)
+  step_rename(bufnr, uri)
+
+  vim.lsp.stop_client(client_id, true)
+end
+
+local ok, err = pcall(main)
+if not ok then
+  io.stderr:write("neovim real-server scenario failed:\n" .. tostring(err) .. "\n")
+  vim.cmd("cquit 1")
+end
+
+io.stdout:write("neovim real-server scenario passed\n")

--- a/editors/vscode/test-fixtures/extension-host/real-vue/.vscode/settings.json
+++ b/editors/vscode/test-fixtures/extension-host/real-vue/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
+  "chat.disableAIFeatures": true,
   "vize.enable": false
 }

--- a/editors/vscode/test-fixtures/extension-host/real-vue/src/Scenario.vue
+++ b/editors/vscode/test-fixtures/extension-host/real-vue/src/Scenario.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import Child from "./Child.vue";
+
+const total = "3";
+</script>
+
+<template>
+<Child  :count="total" />
+</template>

--- a/editors/vscode/test/run-extension-host-real.mjs
+++ b/editors/vscode/test/run-extension-host-real.mjs
@@ -1,21 +1,17 @@
 #!/usr/bin/env node
 import fs from "node:fs";
-import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { runVSCodeCommand } from "@vscode/test-electron";
 
+import {
+  prepareRealVueWorkspace,
+  resolveRealServerPath,
+} from "../../../tools/editor-e2e/real-vue-workspace.mjs";
 import { runPackagedExtensionHost } from "./packaged-host-contract.mjs";
 
 const sourceExtensionPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const repositoryRoot = path.resolve(sourceExtensionPath, "..", "..");
-const fixtureWorkspacePath = path.join(
-  sourceExtensionPath,
-  "test-fixtures",
-  "extension-host",
-  "real-vue",
-);
 const testDataPath = path.join(sourceExtensionPath, ".vscode-test", "host-smoke-real");
 const workspacePath = path.join(testDataPath, "workspaces", "real-vue");
 const extensionTestsPath = path.join(
@@ -27,17 +23,9 @@ const extensionTestsPath = path.join(
 const vsixPath = path.join(sourceExtensionPath, "dist", "vize.vsix");
 
 const serverPath = resolveRealServerPath();
-const corsaPath = resolveCorsaPath();
-const vuePackagePath = resolveVuePackagePath();
 
 fs.rmSync(testDataPath, { force: true, recursive: true });
-fs.cpSync(fixtureWorkspacePath, workspacePath, { recursive: true });
-fs.mkdirSync(path.join(workspacePath, "node_modules"), { recursive: true });
-fs.symlinkSync(vuePackagePath, path.join(workspacePath, "node_modules", "vue"), "junction");
-fs.writeFileSync(
-  path.join(workspacePath, "vize.config.json"),
-  `${JSON.stringify({ typeChecker: { corsaPath } }, null, 2)}\n`,
-);
+prepareRealVueWorkspace(workspacePath);
 
 // macOS caps AF_UNIX socket paths at 104 bytes, and VS Code creates its
 // singleton socket inside the user-data directory. Deep checkouts overflow the
@@ -73,77 +61,4 @@ try {
 function writeCommandOutput({ stderr, stdout }) {
   if (stdout) process.stdout.write(stdout);
   if (stderr) process.stderr.write(stderr);
-}
-
-/**
- * The real `vize` binary under test. CI builds it with `--profile ci` and
- * points `VIZE_SERVER_PATH` at the produced artifact; local runs fall back to
- * the conventional cargo target directories.
- */
-function resolveRealServerPath() {
-  const exeName = process.platform === "win32" ? "vize.exe" : "vize";
-  const configured = process.env.VIZE_SERVER_PATH?.trim();
-  const candidates = configured
-    ? [configured]
-    : ["ci", "release", "debug"].map((profile) =>
-        path.join(repositoryRoot, "target", profile, exeName),
-      );
-
-  for (const candidate of candidates) {
-    if (fs.existsSync(candidate)) {
-      return candidate;
-    }
-  }
-
-  throw new Error(
-    `missing real vize server binary (checked ${candidates.join(", ")}). ` +
-      "Build one with `cargo build --profile ci -p vize` or set VIZE_SERVER_PATH.",
-  );
-}
-
-/**
- * Pin the Corsa/tsgo executable that ships with the extension's own
- * `@typescript/native-preview` install so `vize.config.json` never depends on
- * ambient discovery. Resolution mirrors Node: read the meta package, then
- * resolve the platform package from the meta package's real location.
- */
-function resolveCorsaPath() {
-  const extensionRequire = createRequire(path.join(sourceExtensionPath, "package.json"));
-  const metaManifestPath = fs.realpathSync(
-    extensionRequire.resolve("@typescript/native-preview/package.json"),
-  );
-  const platformPackage = `@typescript/native-preview-${process.platform}-${process.arch}`;
-  const platformManifestPath = createRequire(metaManifestPath).resolve(
-    `${platformPackage}/package.json`,
-  );
-  const tsgoPath = path.join(
-    path.dirname(platformManifestPath),
-    "lib",
-    process.platform === "win32" ? "tsgo.exe" : "tsgo",
-  );
-
-  if (!fs.existsSync(tsgoPath)) {
-    throw new Error(`missing tsgo binary for ${platformPackage}: ${tsgoPath}`);
-  }
-
-  return tsgoPath;
-}
-
-/**
- * The fixture workspace symlinks `node_modules/vue` to the repository's
- * installed Vue package, so the real type checker sees the same Vue type
- * surface as the app fixtures. pnpm keeps the package's dependencies next to
- * its real path, which keeps `@vue/*` resolution working through the symlink.
- */
-function resolveVuePackagePath() {
-  const testsRequire = createRequire(path.join(repositoryRoot, "tests", "package.json"));
-
-  try {
-    return path.dirname(fs.realpathSync(testsRequire.resolve("vue/package.json")));
-  } catch (error) {
-    throw new Error(
-      "could not resolve the repository vue install for the fixture workspace. " +
-        `Run \`vp install\` at the repository root first. (${error})`,
-    );
-  }
 }

--- a/editors/vscode/test/suite/extension-host-real.cjs
+++ b/editors/vscode/test/suite/extension-host-real.cjs
@@ -1,33 +1,18 @@
 const assert = require("node:assert/strict");
-const fs = require("node:fs");
-const path = require("node:path");
 const vscode = require("vscode");
 
+const { runRealServerScenario } = require("./real-scenario.cjs");
+const {
+  assertPackagedExtension,
+  assertStaysDiagnosticFree,
+  getRealServer,
+  openWorkspaceDocument,
+  positionAfter,
+  prepareConfiguredRealServer,
+  waitForDiagnostics,
+} = require("./real-server-support.cjs");
+
 const extensionId = "ubugeeei.vize";
-const featureSettingKeys = [
-  "lint.enable",
-  "diagnostics.enable",
-  "typecheck.enable",
-  "editor.enable",
-  "ecosystem.enable",
-  "optionsApi.enable",
-  "legacyVue2.enable",
-  "completion.enable",
-  "hover.enable",
-  "definition.enable",
-  "references.enable",
-  "documentSymbols.enable",
-  "workspaceSymbols.enable",
-  "codeActions.enable",
-  "rename.enable",
-  "codeLens.enable",
-  "formatting.enable",
-  "semanticTokens.enable",
-  "documentLinks.enable",
-  "foldingRanges.enable",
-  "inlayHints.enable",
-  "fileRename.enable",
-];
 // Derived from a raw LSP probe of `vize lsp` against this fixture: the prop
 // mismatch in `<Child :count="label" />` publishes exactly one TS 2322 error
 // anchored on the authored `count` attribute name.
@@ -65,7 +50,12 @@ exports.run = async function run() {
   await extension.activate();
   assert.equal(extension.isActive, true);
 
-  await prepareConfiguredRealServer(serverPath);
+  // `vize.formatting.enable` defaults to false on both the extension and the
+  // server, and `enableRecommendedProfile` does not turn it on. Opt in before
+  // the client starts so the whole suite runs against one server session: the
+  // real server is busy type checking, and a mid-suite restart races its
+  // shutdown.
+  await prepareConfiguredRealServer(serverPath, { "formatting.enable": true });
   await vscode.commands.executeCommand("vize.enableRecommendedProfile");
 
   const cleanDocument = await openWorkspaceDocument("src", "Clean.vue");
@@ -78,42 +68,11 @@ exports.run = async function run() {
   await runRealHoverSmoke(mismatchDocument);
   await runRealDidChangeRepairSmoke(mismatchDocument, extension);
 
+  await runRealServerScenario();
+
   await vscode.commands.executeCommand("vize.disable");
   assert.equal(vscode.workspace.getConfiguration("vize").get("enable"), false);
 };
-
-function assertPackagedExtension(extension) {
-  const extensionsPath = getRequiredPath(
-    "VIZE_TEST_PACKAGED_EXTENSIONS_DIR",
-    "packaged extension directory",
-  );
-  const sourceExtensionPath = getRequiredPath(
-    "VIZE_TEST_SOURCE_EXTENSION_PATH",
-    "source extension directory",
-  );
-  const installedPath = fs.realpathSync(extension.extensionPath);
-  const relativeToInstallRoot = path.relative(extensionsPath, installedPath);
-
-  assert.ok(
-    relativeToInstallRoot &&
-      !relativeToInstallRoot.startsWith(`..${path.sep}`) &&
-      !path.isAbsolute(relativeToInstallRoot),
-    `extension must load from the isolated install directory: ${installedPath}`,
-  );
-  assert.notEqual(installedPath, sourceExtensionPath, "extension must not load from repo source");
-  assert.equal(extension.packageJSON.main, "./dist/extension.cjs");
-  assert.ok(
-    fs.existsSync(path.resolve(installedPath, extension.packageJSON.main)),
-    "installed extension must contain its packaged entrypoint",
-  );
-}
-
-function getRequiredPath(environmentName, label) {
-  const value = process.env[environmentName];
-  assert.ok(value, `${environmentName} must be set`);
-  assert.ok(fs.existsSync(value), `missing ${label}: ${value}`);
-  return fs.realpathSync(value);
-}
 
 async function runRealDiagnosticSmoke(mismatchDocument, cleanDocument) {
   const diagnostics = await waitForDiagnostics(
@@ -216,71 +175,4 @@ async function runRealDidChangeRepairSmoke(mismatchDocument, extension) {
   // still dirty (never saved) and the same extension host instance is active.
   assert.equal(mismatchDocument.isDirty, true);
   assert.equal(extension.isActive, true);
-}
-
-async function prepareConfiguredRealServer(serverPath) {
-  await updateVizeConfiguration("enable", false);
-  await updateVizeConfiguration("trace.server", undefined);
-  for (const key of featureSettingKeys) {
-    await updateVizeConfiguration(key, undefined);
-  }
-  await updateVizeConfiguration("serverPath", serverPath);
-  await sleep(300);
-}
-
-async function updateVizeConfiguration(key, value) {
-  await vscode.workspace
-    .getConfiguration("vize")
-    .update(key, value, vscode.ConfigurationTarget.Workspace);
-}
-
-async function assertStaysDiagnosticFree(uri, label) {
-  const settleUntil = Date.now() + 2_000;
-
-  while (Date.now() < settleUntil) {
-    const diagnostics = vscode.languages.getDiagnostics(uri);
-    assert.deepEqual(diagnostics, [], `${label} must stay diagnostic-free`);
-    await sleep(100);
-  }
-}
-
-function positionAfter(document, needle, prefix) {
-  const offset = document.getText().indexOf(needle);
-  assert.notEqual(offset, -1, `fixture must contain ${JSON.stringify(needle)}`);
-  return document.positionAt(offset + prefix.length);
-}
-
-async function openWorkspaceDocument(...segments) {
-  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-  assert.ok(workspaceFolder, "expected a workspace folder");
-  return vscode.workspace.openTextDocument(
-    vscode.Uri.file(path.join(workspaceFolder.uri.fsPath, ...segments)),
-  );
-}
-
-function getRealServer() {
-  const serverPath = process.env.VIZE_TEST_SERVER_PATH;
-  assert.ok(serverPath, "VIZE_TEST_SERVER_PATH must be set");
-  assert.ok(fs.existsSync(serverPath), `missing real server: ${serverPath}`);
-  return serverPath;
-}
-
-async function waitForDiagnostics(uri, predicate, label, timeoutMs) {
-  const timeoutAt = Date.now() + timeoutMs;
-  let diagnostics = [];
-
-  while (Date.now() < timeoutAt) {
-    diagnostics = vscode.languages.getDiagnostics(uri);
-    if (predicate(diagnostics)) {
-      return diagnostics;
-    }
-
-    await sleep(100);
-  }
-
-  assert.fail(`${label} did not happen. Last diagnostics: ${JSON.stringify(diagnostics)}`);
-}
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/editors/vscode/test/suite/real-scenario-expected.cjs
+++ b/editors/vscode/test/suite/real-scenario-expected.cjs
@@ -1,0 +1,143 @@
+const vscode = require("vscode");
+
+// Every value below was captured from a raw LSP probe of the real `vize lsp`
+// binary against `test-fixtures/extension-host/real-vue/src/Scenario.vue`
+// (#3457). They are complete responses, not samples: if the server starts
+// answering with more, fewer, or differently anchored results, the scenario
+// fails instead of quietly losing coverage.
+
+const authoredSource = [
+  '<script setup lang="ts">',
+  'import Child from "./Child.vue";',
+  "",
+  'const total = "3";',
+  "</script>",
+  "",
+  "<template>",
+  '<Child  :count="total" />',
+  "</template>",
+  "",
+].join("\n");
+
+const quickFixedSource = authoredSource.replace("<Child  :count", "<Child :count");
+const formattedSource = quickFixedSource.replace(
+  '<Child :count="total" />',
+  '  <Child :count="total" />',
+);
+const renamedSource = formattedSource
+  .replace("const total =", "const quantity =")
+  .replace(':count="total"', ':count="quantity"');
+
+// The authored `<Child  :count="total" />` carries two independent authored
+// bugs on one line: two spaces after the tag name (a fixable lint warning) and
+// a string bound to a `number` prop (the type bug the scorecard asks for).
+const diagnostics = [
+  {
+    code: {
+      target: "https://eslint.vuejs.org/rules/no-multi-spaces.html",
+      value: "vue/no-multi-spaces",
+    },
+    message: "Multiple consecutive spaces",
+    range: [7, 6, 7, 8],
+    relatedInformation: undefined,
+    severity: vscode.DiagnosticSeverity.Warning,
+    source: "vize/lint",
+    tags: undefined,
+  },
+  {
+    code: 2322,
+    message: "Type 'string' is not assignable to type 'number'.",
+    range: [7, 9, 7, 14],
+    relatedInformation: undefined,
+    severity: vscode.DiagnosticSeverity.Error,
+    source: "vize/types",
+    tags: undefined,
+  },
+];
+
+const quickFixRange = new vscode.Range(7, 6, 7, 8);
+
+function codeActions(uri) {
+  return [
+    {
+      command: undefined,
+      diagnostics: undefined,
+      disabled: undefined,
+      edit: {
+        entries: [[uri, [{ newEol: undefined, newText: " ", range: [7, 6, 7, 8] }]]],
+        size: 1,
+      },
+      isPreferred: true,
+      kind: "quickfix",
+      title: "Fix: Replace multiple spaces with single space",
+    },
+    {
+      command: undefined,
+      diagnostics: undefined,
+      disabled: undefined,
+      edit: {
+        entries: [
+          [
+            uri,
+            [
+              {
+                newEol: undefined,
+                newText: "<!-- @vize:forget vue/no-multi-spaces -->\n",
+                range: [7, 0, 7, 0],
+              },
+            ],
+          ],
+        ],
+        size: 1,
+      },
+      isPreferred: false,
+      kind: "quickfix",
+      title: "Suppress with @vize:forget (vue/no-multi-spaces)",
+    },
+  ];
+}
+
+// The SFC formatter answers with one whole-document replacement; VS Code
+// minimizes it before handing it to a client, so the only surviving edit is the
+// two-space indent the template line was missing. (The headless Neovim
+// scenario asserts the unminimized whole-document edit the server actually
+// sends — see `editors/nvim/test/vize_e2e_expected.lua`.)
+const formattingEdits = [{ newEol: undefined, newText: "  ", range: [7, 0, 7, 0] }];
+
+// `[deltaLine, deltaStart, length, tokenType, tokenModifiers] * 2` against the
+// server legend: `:count` is a `property` (type 9) and `total` a `variable`
+// (type 8), both on the formatted template line.
+const semanticTokens = { data: [7, 9, 6, 9, 0, 0, 8, 5, 8, 0], resultId: undefined };
+
+const renameNewName = "quantity";
+const renamePosition = new vscode.Position(3, 8);
+
+function renameEdit(uri) {
+  return {
+    entries: [
+      [
+        uri,
+        [
+          { newEol: undefined, newText: renameNewName, range: [3, 6, 3, 11] },
+          { newEol: undefined, newText: renameNewName, range: [7, 17, 7, 22] },
+        ],
+      ],
+    ],
+    size: 1,
+  };
+}
+
+module.exports = {
+  authoredSource,
+  codeActions,
+  diagnostics,
+  formattedSource,
+  formattingEdits,
+  quickFixRange,
+  quickFixedSource,
+  renameEdit,
+  renameNewName,
+  renamePosition,
+  renamedSource,
+  semanticTokens,
+};

--- a/editors/vscode/test/suite/real-scenario.cjs
+++ b/editors/vscode/test/suite/real-scenario.cjs
@@ -1,0 +1,146 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vscode = require("vscode");
+
+const expected = require("./real-scenario-expected.cjs");
+const {
+  describeCodeAction,
+  describeDiagnostic,
+  describeSemanticTokens,
+  describeTextEdit,
+  describeWorkspaceEdit,
+  getWorkspaceFolderPath,
+  openWorkspaceDocument,
+  waitFor,
+  waitForDiagnostics,
+} = require("./real-server-support.cjs");
+
+const scenarioSegments = ["src", "Scenario.vue"];
+
+/**
+ * The #3224 parity scorecard scenario, end to end against the real `vize`
+ * binary: type bug -> diagnostic at the authored span -> quick fix ->
+ * format-on-save -> semantic tokens -> rename.
+ *
+ * Every step asserts the complete provider result, so a capability that
+ * regresses to "returns nothing" fails here instead of silently passing.
+ */
+exports.runRealServerScenario = async function runRealServerScenario() {
+  // The suite opted `vize.formatting.enable` in before the client started; the
+  // formatting step below is what proves the setting reached the server.
+  assert.equal(vscode.workspace.getConfiguration("vize").get("formatting.enable"), true);
+  await enableFormatOnSave();
+
+  const document = await openWorkspaceDocument(...scenarioSegments);
+  const editor = await vscode.window.showTextDocument(document);
+  assert.equal(document.getText(), expected.authoredSource, "scenario fixture as authored");
+
+  await stepDiagnosticAtAuthoredSpan(document);
+  await stepQuickFix(document, editor);
+  await stepFormatOnSave(document);
+  await stepSemanticTokens(document);
+  await stepRename(document);
+};
+
+async function enableFormatOnSave() {
+  const editorConfiguration = vscode.workspace.getConfiguration("editor", {
+    languageId: "vue",
+    uri: vscode.Uri.file(path.join(getWorkspaceFolderPath(), ...scenarioSegments)),
+  });
+  await editorConfiguration.update(
+    "formatOnSave",
+    true,
+    vscode.ConfigurationTarget.Workspace,
+    true,
+  );
+  await editorConfiguration.update(
+    "defaultFormatter",
+    "ubugeeei.vize",
+    vscode.ConfigurationTarget.Workspace,
+    true,
+  );
+}
+
+/** Step 1: the authored type bug and the fixable lint warning are published. */
+async function stepDiagnosticAtAuthoredSpan(document) {
+  const diagnostics = await waitForDiagnostics(
+    document.uri,
+    (next) => next.length >= expected.diagnostics.length,
+    "real server scenario diagnostics",
+    180_000,
+  );
+
+  assert.deepEqual(sortDiagnostics(diagnostics).map(describeDiagnostic), expected.diagnostics);
+}
+
+/** Step 2: the quick fix the server offers on the lint warning's own span. */
+async function stepQuickFix(document, editor) {
+  const actions = await vscode.commands.executeCommand(
+    "vscode.executeCodeActionProvider",
+    document.uri,
+    expected.quickFixRange,
+  );
+
+  assert.deepEqual(actions.map(describeCodeAction), expected.codeActions(document.uri.toString()));
+
+  const applied = await vscode.workspace.applyEdit(actions[0].edit);
+  assert.equal(applied, true, "expected the quick fix edit to apply");
+  assert.equal(document.getText(), expected.quickFixedSource, "document after the quick fix");
+  assert.equal(editor.document.uri.toString(), document.uri.toString());
+}
+
+/** Step 3: format-on-save rewrites the buffer and the file on disk. */
+async function stepFormatOnSave(document) {
+  const edits = await vscode.commands.executeCommand(
+    "vscode.executeFormatDocumentProvider",
+    document.uri,
+    { insertSpaces: true, tabSize: 2 },
+  );
+  assert.deepEqual(edits.map(describeTextEdit), expected.formattingEdits);
+
+  const saved = await document.save();
+  assert.equal(saved, true, "expected the scenario document to save");
+  assert.equal(document.getText(), expected.formattedSource, "document after format-on-save");
+  assert.equal(document.isDirty, false, "format-on-save must leave the document saved");
+
+  const diskPath = path.join(getWorkspaceFolderPath(), ...scenarioSegments);
+  assert.equal(fs.readFileSync(diskPath, "utf8"), expected.formattedSource, "file after save");
+}
+
+/** Step 4: semantic tokens for the formatted document. */
+async function stepSemanticTokens(document) {
+  const tokens = await waitFor(
+    () => vscode.commands.executeCommand("vscode.provideDocumentSemanticTokens", document.uri),
+    (value) => value !== undefined && value !== null,
+    "real server semantic tokens",
+    60_000,
+  );
+
+  assert.deepEqual(describeSemanticTokens(tokens), expected.semanticTokens);
+}
+
+/** Step 5: rename the script binding the template consumes. */
+async function stepRename(document) {
+  const edit = await vscode.commands.executeCommand(
+    "vscode.executeDocumentRenameProvider",
+    document.uri,
+    expected.renamePosition,
+    expected.renameNewName,
+  );
+
+  assert.deepEqual(describeWorkspaceEdit(edit), expected.renameEdit(document.uri.toString()));
+
+  const applied = await vscode.workspace.applyEdit(edit);
+  assert.equal(applied, true, "expected the rename edit to apply");
+  assert.equal(document.getText(), expected.renamedSource, "document after the rename");
+}
+
+function sortDiagnostics(diagnostics) {
+  return [...diagnostics].sort((left, right) => {
+    if (left.range.start.line !== right.range.start.line) {
+      return left.range.start.line - right.range.start.line;
+    }
+    return left.range.start.character - right.range.start.character;
+  });
+}

--- a/editors/vscode/test/suite/real-scenario.cjs
+++ b/editors/vscode/test/suite/real-scenario.cjs
@@ -99,6 +99,11 @@ async function stepFormatOnSave(document) {
   );
   assert.deepEqual(edits.map(describeTextEdit), expected.formattingEdits);
 
+  // `vscode.executeFormatDocumentProvider` only computes the edits, it never
+  // applies them, so the document is still unformatted here. `save()` is what
+  // exercises format-on-save: it runs the `editor.formatOnSave` save
+  // participant configured in `enableFormatOnSave`, which applies the very
+  // edits asserted above before the file hits disk.
   const saved = await document.save();
   assert.equal(saved, true, "expected the scenario document to save");
   assert.equal(document.getText(), expected.formattedSource, "document after format-on-save");

--- a/editors/vscode/test/suite/real-server-support.cjs
+++ b/editors/vscode/test/suite/real-server-support.cjs
@@ -81,6 +81,12 @@ async function prepareConfiguredRealServer(serverPath, overrides = {}) {
     await updateVizeConfiguration(key, value);
   }
   await updateVizeConfiguration("serverPath", serverPath);
+  // This short settle only lets the extension coalesce the configuration
+  // writes above into a single client restart; it is deliberately not a
+  // readiness wait. Callers must not fire one-shot provider requests straight
+  // after this: every suite first blocks on `waitForDiagnostics` for a document
+  // it opens after the restart, which is the deterministic gate that proves the
+  // new session is serving.
   await sleep(300);
 }
 

--- a/editors/vscode/test/suite/real-server-support.cjs
+++ b/editors/vscode/test/suite/real-server-support.cjs
@@ -1,0 +1,239 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vscode = require("vscode");
+
+// Every `vize.<key>.enable` switch the extension maps onto an LSP
+// initialization option. The real-server suites reset all of them so a run
+// never inherits a previous run's workspace settings.
+const featureSettingKeys = [
+  "lint.enable",
+  "diagnostics.enable",
+  "typecheck.enable",
+  "editor.enable",
+  "ecosystem.enable",
+  "optionsApi.enable",
+  "legacyVue2.enable",
+  "completion.enable",
+  "hover.enable",
+  "definition.enable",
+  "references.enable",
+  "documentSymbols.enable",
+  "workspaceSymbols.enable",
+  "codeActions.enable",
+  "rename.enable",
+  "codeLens.enable",
+  "formatting.enable",
+  "semanticTokens.enable",
+  "documentLinks.enable",
+  "foldingRanges.enable",
+  "inlayHints.enable",
+  "fileRename.enable",
+];
+
+function assertPackagedExtension(extension) {
+  const extensionsPath = getRequiredPath(
+    "VIZE_TEST_PACKAGED_EXTENSIONS_DIR",
+    "packaged extension directory",
+  );
+  const sourceExtensionPath = getRequiredPath(
+    "VIZE_TEST_SOURCE_EXTENSION_PATH",
+    "source extension directory",
+  );
+  const installedPath = fs.realpathSync(extension.extensionPath);
+  const relativeToInstallRoot = path.relative(extensionsPath, installedPath);
+
+  assert.ok(
+    relativeToInstallRoot &&
+      !relativeToInstallRoot.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relativeToInstallRoot),
+    `extension must load from the isolated install directory: ${installedPath}`,
+  );
+  assert.notEqual(installedPath, sourceExtensionPath, "extension must not load from repo source");
+  assert.equal(extension.packageJSON.main, "./dist/extension.cjs");
+  assert.ok(
+    fs.existsSync(path.resolve(installedPath, extension.packageJSON.main)),
+    "installed extension must contain its packaged entrypoint",
+  );
+}
+
+function getRequiredPath(environmentName, label) {
+  const value = process.env[environmentName];
+  assert.ok(value, `${environmentName} must be set`);
+  assert.ok(fs.existsSync(value), `missing ${label}: ${value}`);
+  return fs.realpathSync(value);
+}
+
+function getRealServer() {
+  const serverPath = process.env.VIZE_TEST_SERVER_PATH;
+  assert.ok(serverPath, "VIZE_TEST_SERVER_PATH must be set");
+  assert.ok(fs.existsSync(serverPath), `missing real server: ${serverPath}`);
+  return serverPath;
+}
+
+async function prepareConfiguredRealServer(serverPath, overrides = {}) {
+  await updateVizeConfiguration("enable", false);
+  await updateVizeConfiguration("trace.server", undefined);
+  for (const key of featureSettingKeys) {
+    await updateVizeConfiguration(key, undefined);
+  }
+  for (const [key, value] of Object.entries(overrides)) {
+    await updateVizeConfiguration(key, value);
+  }
+  await updateVizeConfiguration("serverPath", serverPath);
+  await sleep(300);
+}
+
+async function updateVizeConfiguration(key, value) {
+  await vscode.workspace
+    .getConfiguration("vize")
+    .update(key, value, vscode.ConfigurationTarget.Workspace);
+}
+
+async function assertStaysDiagnosticFree(uri, label) {
+  const settleUntil = Date.now() + 2_000;
+
+  while (Date.now() < settleUntil) {
+    const diagnostics = vscode.languages.getDiagnostics(uri);
+    assert.deepEqual(diagnostics, [], `${label} must stay diagnostic-free`);
+    await sleep(100);
+  }
+}
+
+function positionAfter(document, needle, prefix) {
+  const offset = document.getText().indexOf(needle);
+  assert.notEqual(offset, -1, `fixture must contain ${JSON.stringify(needle)}`);
+  return document.positionAt(offset + prefix.length);
+}
+
+function getWorkspaceFolderPath() {
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  assert.ok(workspaceFolder, "expected a workspace folder");
+  return workspaceFolder.uri.fsPath;
+}
+
+async function openWorkspaceDocument(...segments) {
+  return vscode.workspace.openTextDocument(
+    vscode.Uri.file(path.join(getWorkspaceFolderPath(), ...segments)),
+  );
+}
+
+async function waitForDiagnostics(uri, predicate, label, timeoutMs) {
+  const timeoutAt = Date.now() + timeoutMs;
+  let diagnostics = [];
+
+  while (Date.now() < timeoutAt) {
+    diagnostics = vscode.languages.getDiagnostics(uri);
+    if (predicate(diagnostics)) {
+      return diagnostics;
+    }
+
+    await sleep(100);
+  }
+
+  assert.fail(`${label} did not happen. Last diagnostics: ${JSON.stringify(diagnostics)}`);
+}
+
+async function waitFor(produce, predicate, label, timeoutMs) {
+  const timeoutAt = Date.now() + timeoutMs;
+  let value;
+
+  while (Date.now() < timeoutAt) {
+    value = await produce();
+    if (predicate(value)) {
+      return value;
+    }
+
+    await sleep(100);
+  }
+
+  assert.fail(`${label} did not happen. Last value: ${JSON.stringify(value)}`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// The `describe*` helpers below enumerate every field of the corresponding
+// `vscode` API type, so a `deepEqual` against their output is a complete
+// assertion on the provider result rather than a spot check. They exist only
+// because `vscode.WorkspaceEdit` and `vscode.SemanticTokens` carry private
+// state that cannot be reconstructed for a direct instance comparison.
+
+function describeRange(range) {
+  return [range.start.line, range.start.character, range.end.line, range.end.character];
+}
+
+function describeDiagnostic(diagnostic) {
+  const code = diagnostic.code;
+  return {
+    code:
+      code !== null && typeof code === "object"
+        ? { target: code.target.toString(), value: code.value }
+        : code,
+    message: diagnostic.message,
+    range: describeRange(diagnostic.range),
+    relatedInformation: diagnostic.relatedInformation,
+    severity: diagnostic.severity,
+    source: diagnostic.source,
+    tags: diagnostic.tags,
+  };
+}
+
+function describeTextEdit(edit) {
+  return { newEol: edit.newEol, newText: edit.newText, range: describeRange(edit.range) };
+}
+
+function describeWorkspaceEdit(edit) {
+  if (edit === undefined || edit === null) {
+    return edit;
+  }
+
+  return {
+    entries: edit
+      .entries()
+      .map(([uri, edits]) => [uri.toString(), edits.map((textEdit) => describeTextEdit(textEdit))]),
+    size: edit.size,
+  };
+}
+
+function describeCodeAction(action) {
+  return {
+    command: action.command,
+    diagnostics: action.diagnostics,
+    disabled: action.disabled,
+    edit: describeWorkspaceEdit(action.edit),
+    isPreferred: action.isPreferred,
+    kind: action.kind?.value,
+    title: action.title,
+  };
+}
+
+function describeSemanticTokens(tokens) {
+  if (tokens === undefined || tokens === null) {
+    return tokens;
+  }
+
+  return { data: Array.from(tokens.data), resultId: tokens.resultId };
+}
+
+module.exports = {
+  assertPackagedExtension,
+  assertStaysDiagnosticFree,
+  describeCodeAction,
+  describeDiagnostic,
+  describeRange,
+  describeSemanticTokens,
+  describeTextEdit,
+  describeWorkspaceEdit,
+  featureSettingKeys,
+  getRealServer,
+  getWorkspaceFolderPath,
+  openWorkspaceDocument,
+  positionAfter,
+  prepareConfiguredRealServer,
+  sleep,
+  updateVizeConfiguration,
+  waitFor,
+  waitForDiagnostics,
+};

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { testAndBenchmarkTasks } from "../../tools/vite-plus/tasks/test-benchmark.ts";
+import { readRepoFile } from "./support/github-workflows.ts";
+
+// Guardrails for the #3457 real-server editor scenarios. A scenario nobody
+// executes is not coverage, so these assert the wiring that makes CI run them,
+// not the scenario contents themselves.
+
+function taskCommand(name: string): string {
+  return (testAndBenchmarkTasks[name] as { command: string }).command;
+}
+
+test("the Neovim real-server scenario has a task that runs its Node launcher", () => {
+  assert.equal(
+    taskCommand("test:nvim-extension:real-server"),
+    "node tools/nvim-vize/run-real-server.mjs",
+  );
+});
+
+test("CI runs both real-server editor scenarios from one built server binary", () => {
+  const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
+
+  // One `cargo build` feeds both scenarios; both must consume that binary.
+  assert.match(action, /run: cargo build --profile ci -p vize/);
+  assert.deepEqual(
+    action.match(/VIZE_SERVER_PATH: \$\{\{ github\.workspace \}\}\/target\/ci\/vize/g),
+    [
+      "VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize",
+      "VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize",
+    ],
+  );
+  assert.match(action, /vp run --workspace-root test:vscode-extension:host-real/);
+  assert.match(action, /vp run --workspace-root test:nvim-extension:headless/);
+  assert.match(action, /vp run --workspace-root test:nvim-extension:real-server/);
+
+  // The scenario needs a Neovim with a Lua LSP client, pinned and checksummed.
+  assert.match(action, /NVIM_VERSION: v\d+\.\d+\.\d+/);
+  assert.match(action, /NVIM_SHA256: [0-9a-f]{64}/);
+  assert.match(action, /sha256sum --check --strict/);
+});
+
+test("check.yml keeps the editor real-server job in the required set", () => {
+  const workflow = readRepoFile(".github", "workflows", "check.yml");
+
+  assert.match(
+    workflow,
+    /\n  editor-host-smoke:\n[\s\S]*?uses: \.\/\.github\/actions\/vscode-host-smoke\n/,
+  );
+  assert.match(workflow, /\n      - editor-host-smoke\n/);
+});
+
+test("the packaged Neovim archive ships the real-server scenario", () => {
+  const assertion = readRepoFile("tools", "nvim-vize", "assert-nvim-package.mjs");
+
+  assert.match(assertion, /"nvim\/test\/vize_e2e_expected\.lua"/);
+  assert.match(assertion, /"nvim\/test\/vize_e2e_spec\.lua"/);
+  assert.match(assertion, /\^nvim\\\/test\\\/vize_e2e_\(\?:expected\|spec\)\\\.lua\$/);
+});
+
+test("the VS Code real-server suite drives all five scorecard steps", () => {
+  const scenario = readRepoFile("editors", "vscode", "test", "suite", "real-scenario.cjs");
+
+  assert.match(scenario, /vscode\.executeCodeActionProvider/);
+  assert.match(scenario, /vscode\.executeFormatDocumentProvider/);
+  assert.match(scenario, /vscode\.provideDocumentSemanticTokens/);
+  assert.match(scenario, /vscode\.executeDocumentRenameProvider/);
+  assert.match(scenario, /document\.save\(\)/);
+
+  // Rule for this suite: complete-response assertions only.
+  assert.doesNotMatch(scenario, /\.includes\(|\.contains\(/);
+});

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -68,6 +68,19 @@ test("the VS Code real-server suite drives all five scorecard steps", () => {
   assert.match(scenario, /vscode\.executeDocumentRenameProvider/);
   assert.match(scenario, /document\.save\(\)/);
 
+  // Step 1 and step 3 are the two steps whose value lives in what is asserted
+  // rather than in the call itself: diagnostics must be compared against the
+  // authored-span expectation, and the save must be followed by a check that
+  // the document really came back formatted.
+  assert.match(
+    scenario,
+    /assert\.deepEqual\(sortDiagnostics\(diagnostics\)\.map\(describeDiagnostic\), expected\.diagnostics\)/,
+  );
+  assert.match(
+    scenario,
+    /const saved = await document\.save\(\);[\s\S]*?assert\.equal\(document\.getText\(\), expected\.formattedSource,/,
+  );
+
   // Rule for this suite: complete-response assertions only.
   assert.doesNotMatch(scenario, /\.includes\(|\.contains\(/);
 });

--- a/tests/tooling/vscode-packaged-host-smoke.test.ts
+++ b/tests/tooling/vscode-packaged-host-smoke.test.ts
@@ -12,7 +12,7 @@ import {
   runVSCodeCommandWithTimeout,
 } from "../../editors/vscode/test/packaged-host-contract.mjs";
 import { testAndBenchmarkTasks } from "../../tools/vite-plus/tasks/test-benchmark.ts";
-import { root } from "./support/github-workflows.ts";
+import { readRepoFile, root } from "./support/github-workflows.ts";
 
 test("packaged VS Code host smoke installs the VSIX before launching its tests", () => {
   const installArgs = createPackagedHostInstallArgs({
@@ -50,6 +50,26 @@ test("packaged VS Code host smoke installs the VSIX before launching its tests",
   ]);
   assert.equal(launchArgs.includes("--extensionDevelopmentPath=/repo/editors/vscode"), false);
   assert.equal(launchArgs.includes("--disable-extensions"), false);
+});
+
+test("the real-server fixture workspace turns off the built-in AI code actions", () => {
+  // VS Code contributes "Fix"/"Explain" quick fixes of its own to every
+  // diagnostic span. The real-server scenario asserts the COMPLETE code-action
+  // list the language server answers with (#3457), so the fixture workspace has
+  // to keep the workbench's own AI actions out of that list.
+  const settings = JSON.parse(
+    readRepoFile(
+      "editors",
+      "vscode",
+      "test-fixtures",
+      "extension-host",
+      "real-vue",
+      ".vscode",
+      "settings.json",
+    ),
+  );
+
+  assert.deepEqual(settings, { "chat.disableAIFeatures": true, "vize.enable": false });
 });
 
 test("packaged host resolves exactly one installed Vize extension", () => {

--- a/tests/tooling/vscode-packaged-host-smoke.test.ts
+++ b/tests/tooling/vscode-packaged-host-smoke.test.ts
@@ -57,6 +57,11 @@ test("the real-server fixture workspace turns off the built-in AI code actions",
   // diagnostic span. The real-server scenario asserts the COMPLETE code-action
   // list the language server answers with (#3457), so the fixture workspace has
   // to keep the workbench's own AI actions out of that list.
+  //
+  // `chat.disableAIFeatures` only exists from VS Code 1.104, which is below the
+  // stable build `@vscode/test-electron` downloads for this harness. It does not
+  // constrain the extension's own `engines.vscode` range: this file is a test
+  // fixture workspace, never shipped, and older builds ignore unknown keys.
   const settings = JSON.parse(
     readRepoFile(
       "editors",

--- a/tools/editor-e2e/real-vue-workspace.mjs
+++ b/tools/editor-e2e/real-vue-workspace.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+// Shared setup for the editor end-to-end scenarios that drive a real
+// `vize lsp` process (#3457). The VS Code extension host and the headless
+// Neovim scenario both need the exact same workspace: the `real-vue` fixture,
+// a `node_modules/vue` symlink so the type checker sees real Vue types, and a
+// `vize.config.json` that pins the Corsa/tsgo executable instead of relying on
+// ambient discovery.
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const repositoryRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+);
+export const vscodeExtensionPath = path.join(repositoryRoot, "editors", "vscode");
+export const realVueFixturePath = path.join(
+  vscodeExtensionPath,
+  "test-fixtures",
+  "extension-host",
+  "real-vue",
+);
+
+/**
+ * Materialize the `real-vue` fixture at `workspacePath` and wire it up for the
+ * real server. Returns the workspace path so callers can chain.
+ */
+export function prepareRealVueWorkspace(workspacePath) {
+  fs.rmSync(workspacePath, { force: true, recursive: true });
+  fs.mkdirSync(path.dirname(workspacePath), { recursive: true });
+  fs.cpSync(realVueFixturePath, workspacePath, { recursive: true });
+  fs.mkdirSync(path.join(workspacePath, "node_modules"), { recursive: true });
+  fs.symlinkSync(
+    resolveVuePackagePath(),
+    path.join(workspacePath, "node_modules", "vue"),
+    "junction",
+  );
+  fs.writeFileSync(
+    path.join(workspacePath, "vize.config.json"),
+    `${JSON.stringify({ typeChecker: { corsaPath: resolveCorsaPath() } }, null, 2)}\n`,
+  );
+
+  return workspacePath;
+}
+
+/**
+ * The real `vize` binary under test. CI builds it with `--profile ci` and
+ * points `VIZE_SERVER_PATH` at the produced artifact; local runs fall back to
+ * the conventional cargo target directories.
+ */
+export function resolveRealServerPath() {
+  const exeName = process.platform === "win32" ? "vize.exe" : "vize";
+  const configured = process.env.VIZE_SERVER_PATH?.trim();
+  const candidates = configured
+    ? [configured]
+    : ["ci", "release", "debug"].map((profile) =>
+        path.join(repositoryRoot, "target", profile, exeName),
+      );
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `missing real vize server binary (checked ${candidates.join(", ")}). ` +
+      "Build one with `cargo build --profile ci -p vize` or set VIZE_SERVER_PATH.",
+  );
+}
+
+/**
+ * Pin the Corsa/tsgo executable that ships with the VS Code extension's own
+ * `@typescript/native-preview` install so `vize.config.json` never depends on
+ * ambient discovery. Resolution mirrors Node: read the meta package, then
+ * resolve the platform package from the meta package's real location.
+ */
+export function resolveCorsaPath() {
+  const extensionRequire = createRequire(path.join(vscodeExtensionPath, "package.json"));
+  const metaManifestPath = fs.realpathSync(
+    extensionRequire.resolve("@typescript/native-preview/package.json"),
+  );
+  const platformPackage = `@typescript/native-preview-${process.platform}-${process.arch}`;
+  const platformManifestPath = createRequire(metaManifestPath).resolve(
+    `${platformPackage}/package.json`,
+  );
+  const tsgoPath = path.join(
+    path.dirname(platformManifestPath),
+    "lib",
+    process.platform === "win32" ? "tsgo.exe" : "tsgo",
+  );
+
+  if (!fs.existsSync(tsgoPath)) {
+    throw new Error(`missing tsgo binary for ${platformPackage}: ${tsgoPath}`);
+  }
+
+  return tsgoPath;
+}
+
+/**
+ * The fixture workspace symlinks `node_modules/vue` to the repository's
+ * installed Vue package, so the real type checker sees the same Vue type
+ * surface as the app fixtures. pnpm keeps the package's dependencies next to
+ * its real path, which keeps `@vue/*` resolution working through the symlink.
+ */
+export function resolveVuePackagePath() {
+  const testsRequire = createRequire(path.join(repositoryRoot, "tests", "package.json"));
+
+  try {
+    return path.dirname(fs.realpathSync(testsRequire.resolve("vue/package.json")));
+  } catch (error) {
+    throw new Error(
+      "could not resolve the repository vue install for the fixture workspace. " +
+        `Run \`vp install\` at the repository root first. (${error})`,
+    );
+  }
+}

--- a/tools/editor-e2e/real-vue-workspace.mjs
+++ b/tools/editor-e2e/real-vue-workspace.mjs
@@ -59,9 +59,12 @@ export function resolveRealServerPath() {
         path.join(repositoryRoot, "target", profile, exeName),
       );
 
+  // Always hand back an absolute path: callers spawn the binary with the
+  // fixture workspace as the working directory, so a relative
+  // `VIZE_SERVER_PATH` would otherwise resolve differently per caller.
   for (const candidate of candidates) {
     if (fs.existsSync(candidate)) {
-      return candidate;
+      return path.resolve(candidate);
     }
   }
 
@@ -82,21 +85,43 @@ export function resolveCorsaPath() {
   const metaManifestPath = fs.realpathSync(
     extensionRequire.resolve("@typescript/native-preview/package.json"),
   );
-  const platformPackage = `@typescript/native-preview-${process.platform}-${process.arch}`;
-  const platformManifestPath = createRequire(metaManifestPath).resolve(
-    `${platformPackage}/package.json`,
-  );
-  const tsgoPath = path.join(
-    path.dirname(platformManifestPath),
-    "lib",
-    process.platform === "win32" ? "tsgo.exe" : "tsgo",
-  );
+  const metaRequire = createRequire(metaManifestPath);
+  const basePackage = `@typescript/native-preview-${process.platform}-${process.arch}`;
+  // The platform packages are optional dependencies gated on os/cpu/libc, so a
+  // host only ever has one of them installed. On Linux that is either the
+  // glibc or the musl build; probe both instead of assuming glibc.
+  const platformPackages =
+    process.platform === "linux" ? [basePackage, `${basePackage}-musl`] : [basePackage];
+  const attempted = [];
 
-  if (!fs.existsSync(tsgoPath)) {
-    throw new Error(`missing tsgo binary for ${platformPackage}: ${tsgoPath}`);
+  for (const platformPackage of platformPackages) {
+    const platformManifestPath = resolveOptional(metaRequire, `${platformPackage}/package.json`);
+    if (platformManifestPath === undefined) {
+      attempted.push(`${platformPackage} (not installed)`);
+      continue;
+    }
+
+    const tsgoPath = path.join(
+      path.dirname(platformManifestPath),
+      "lib",
+      process.platform === "win32" ? "tsgo.exe" : "tsgo",
+    );
+    if (fs.existsSync(tsgoPath)) {
+      return tsgoPath;
+    }
+    attempted.push(tsgoPath);
   }
 
-  return tsgoPath;
+  throw new Error(`missing tsgo binary (checked ${attempted.join(", ")})`);
+}
+
+/** `require.resolve` that reports a missing package as `undefined`. */
+function resolveOptional(resolver, specifier) {
+  try {
+    return resolver.resolve(specifier);
+  } catch {
+    return undefined;
+  }
 }
 
 /**

--- a/tools/editor-e2e/real-vue-workspace.mjs
+++ b/tools/editor-e2e/real-vue-workspace.mjs
@@ -113,7 +113,7 @@ export function resolveVuePackagePath() {
   } catch (error) {
     throw new Error(
       "could not resolve the repository vue install for the fixture workspace. " +
-        `Run \`vp install\` at the repository root first. (${error})`,
+        `Run \`vp install\` at the repository root first. (${String(error)})`,
     );
   }
 }

--- a/tools/nvim-vize/assert-nvim-package.mjs
+++ b/tools/nvim-vize/assert-nvim-package.mjs
@@ -38,6 +38,8 @@ const requiredFiles = [
   "nvim/lua/vize/config.lua",
   "nvim/lua/vize/init.lua",
   "nvim/plugin/vize.lua",
+  "nvim/test/vize_e2e_expected.lua",
+  "nvim/test/vize_e2e_spec.lua",
   "nvim/test/vize_spec.lua",
 ];
 
@@ -58,6 +60,7 @@ const allowedEntries = [
   /^nvim\/plugin\/$/,
   /^nvim\/plugin\/vize\.lua$/,
   /^nvim\/test\/$/,
+  /^nvim\/test\/vize_e2e_(?:expected|spec)\.lua$/,
   /^nvim\/test\/vize_spec\.lua$/,
 ];
 
@@ -88,6 +91,7 @@ const configLua = readTextEntry(entryMap, "nvim/lua/vize/config.lua");
 const initLua = readTextEntry(entryMap, "nvim/lua/vize/init.lua");
 const ftdetectLua = readTextEntry(entryMap, "nvim/ftdetect/vize.lua");
 const specLua = readTextEntry(entryMap, "nvim/test/vize_spec.lua");
+const e2eSpecLua = readTextEntry(entryMap, "nvim/test/vize_e2e_spec.lua");
 
 assert.match(configLua, /cmd = \{ "vize", "lsp" \}/);
 assert.match(configLua, /filetypes = \{ "vue", "art-vue" \}/);
@@ -106,6 +110,13 @@ assert.match(ftdetectLua, /pattern = "\*\.art\.vue"/);
 assert.match(ftdetectLua, /filetype = "art-vue"/);
 assert.match(specLua, /config\.normalize/);
 assert.match(specLua, /vim\.lsp\.config\.vize/);
+// The packaged archive must be able to run the real-server scenario, not only
+// the in-process config unit spec (#3457).
+assert.match(e2eSpecLua, /vim\.lsp\.start/);
+assert.match(e2eSpecLua, /textDocument\/codeAction/);
+assert.match(e2eSpecLua, /textDocument\/formatting/);
+assert.match(e2eSpecLua, /textDocument\/semanticTokens\/full/);
+assert.match(e2eSpecLua, /textDocument\/rename/);
 
 console.log(
   `Neovim package smoke passed: ${path.relative(root, archivePath)} (${entryNames.length} entries)`,

--- a/tools/nvim-vize/run-real-server.mjs
+++ b/tools/nvim-vize/run-real-server.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Drive the packaged Neovim integration against a real `vize lsp` process
+// (#3457). Neovim is the only non-VS Code editor in the packaged set with a
+// scriptable headless LSP client, so it carries the second end-to-end scenario
+// for the #3224 parity scorecard.
+//
+// This runner only prepares the workspace and launches headless Neovim; every
+// assertion lives in `editors/nvim/test/vize_e2e_spec.lua`, which ships inside
+// the Neovim tarball so a packaged checkout can run the same scenario.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  prepareRealVueWorkspace,
+  repositoryRoot,
+  resolveRealServerPath,
+} from "../editor-e2e/real-vue-workspace.mjs";
+
+const nvimPath = process.env.VIZE_TEST_NVIM_PATH?.trim() || "nvim";
+const pluginRoot = path.join(repositoryRoot, "editors", "nvim");
+const specPath = path.join(pluginRoot, "test", "vize_e2e_spec.lua");
+const serverPath = path.resolve(resolveRealServerPath());
+const sessionPath = fs.mkdtempSync(path.join(os.tmpdir(), "vize-nvim-e2e-"));
+const workspacePath = path.join(sessionPath, "real-vue");
+
+prepareRealVueWorkspace(workspacePath);
+
+try {
+  const result = spawnSync(
+    nvimPath,
+    [
+      "--headless",
+      "-u",
+      "NONE",
+      "--noplugin",
+      "-n",
+      "-i",
+      "NONE",
+      "-c",
+      `set runtimepath^=${pluginRoot}`,
+      "-c",
+      `luafile ${specPath}`,
+      "-c",
+      "qall!",
+    ],
+    {
+      cwd: workspacePath,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        VIZE_E2E_SERVER: serverPath,
+        VIZE_E2E_WORKSPACE: workspacePath,
+      },
+      timeout: 300_000,
+    },
+  );
+
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`headless Neovim scenario failed with exit code ${result.status}`);
+  }
+} finally {
+  fs.rmSync(sessionPath, { force: true, recursive: true });
+}

--- a/tools/nvim-vize/run-real-server.mjs
+++ b/tools/nvim-vize/run-real-server.mjs
@@ -21,7 +21,7 @@ import {
 const nvimPath = process.env.VIZE_TEST_NVIM_PATH?.trim() || "nvim";
 const pluginRoot = path.join(repositoryRoot, "editors", "nvim");
 const specPath = path.join(pluginRoot, "test", "vize_e2e_spec.lua");
-const serverPath = path.resolve(resolveRealServerPath());
+const serverPath = resolveRealServerPath();
 const sessionPath = fs.mkdtempSync(path.join(os.tmpdir(), "vize-nvim-e2e-"));
 const workspacePath = path.join(sessionPath, "real-vue");
 
@@ -38,10 +38,14 @@ try {
       "-n",
       "-i",
       "NONE",
+      // Paths can contain spaces, backslashes or `|`, which ex commands would
+      // mangle, so hand them to Lua as literals instead. The spec prepends the
+      // plugin root itself, but do it here too so `require("vize.…")` works even
+      // if the spec is ever loaded differently.
       "-c",
-      `set runtimepath^=${pluginRoot}`,
+      `lua vim.opt.runtimepath:prepend(${JSON.stringify(pluginRoot)})`,
       "-c",
-      `luafile ${specPath}`,
+      `lua dofile(${JSON.stringify(specPath)})`,
       "-c",
       "qall!",
     ],
@@ -53,7 +57,11 @@ try {
         VIZE_E2E_SERVER: serverPath,
         VIZE_E2E_WORKSPACE: workspacePath,
       },
-      timeout: 300_000,
+      // The spec's own waits already add up to 960s in the worst case (120s
+      // initialize + 240s diagnostics + 120s for each of the five requests and
+      // the synchronous format), so this outer kill switch has to sit above
+      // that or it would pre-empt the assertions it is meant to bound.
+      timeout: 1_200_000,
     },
   );
 

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -125,6 +125,10 @@ export const testAndBenchmarkTasks = defineTasks({
     "nvim --headless -u NONE --noplugin '+set runtimepath^=editors/nvim' '+luafile editors/nvim/test/vize_spec.lua' '+qa'",
   ),
   "test:nvim-extension:package": noCacheTask("vp run --workspace-root package:nvim-extension"),
+  // The headless Neovim end-to-end scenario against a real `vize lsp` (#3457).
+  // It needs a built server binary, so CI runs it in the same job that builds
+  // one for the VS Code host smoke.
+  "test:nvim-extension:real-server": noCacheTask("node tools/nvim-vize/run-real-server.mjs"),
   "test:vim-extension:headless": noCacheTask(
     "vim -Nu NONE -n -es -S editors/vim/test/vize_spec.vim",
   ),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,14 @@ const localGeneratedIgnorePatterns = [
   "target/**",
 ];
 const testOutputIgnorePattern = ["**", "target", "vize-tests", "**"].join("/");
+/**
+ * The VS Code / Neovim real-server scenario file carries deliberate authored
+ * defects (a `vue/no-multi-spaces` warning next to a prop type error) that the
+ * editor tests fix and re-read at runtime. Formatting it would erase the very
+ * diagnostic the scenario asserts on.
+ */
+const editorScenarioFixtureIgnorePattern =
+  "editors/vscode/test-fixtures/extension-host/real-vue/src/Scenario.vue";
 
 /**
  * Root Vite+ configuration.
@@ -40,6 +48,7 @@ const config = {
       testOutputIgnorePattern,
       "**/__ubugeeei__/**",
       "tests/_fixtures/**",
+      editorScenarioFixtureIgnorePattern,
     ],
   },
   lint: {


### PR DESCRIPTION
Closes #3457.

## Scope I chose

The issue lists four gaps and five uncovered editors. I did the two the issue
ranks highest and left the rest measured rather than faked:

1. **VS Code: all five scorecard steps against the real binary.** The four
   "stub only" cells were the actively misleading part — they passed against
   `test/fixtures/fake-vize-server.cjs`, which proves the client decodes a
   canned answer, not that the server produces one.
2. **Neovim: a real-server scenario for the same five steps.** It has
   `--headless` plus a Lua LSP client, so it is the most tractable second
   editor. Its previously orphaned unit spec now runs in CI too.

Zed, Vim, Helix and Emacs are untouched. See "What is still uncovered".

## The scenario

`editors/vscode/test-fixtures/extension-host/real-vue/src/Scenario.vue` puts two
independent authored bugs on one line:

```vue
<Child  :count="total" />
```

- two spaces after the tag name — a **fixable** `vue/no-multi-spaces` warning,
- a `string` bound to a `number` prop — the **type bug** the scorecard asks for.

Both clients then walk the same chain: diagnostics → quick fix → format-on-save
→ semantic tokens → rename, re-reading the document after each mutation.

| step | VS Code | Neovim |
| --- | --- | --- |
| diagnostic at authored span | real — full 2-diagnostic list, TS 2322 on the authored `count` at `(7,9)-(7,14)` | real — same list from raw `publishDiagnostics` |
| quick fix | real — full 2-action list, applied, document re-asserted | real — same, applied via `apply_workspace_edit` |
| format-on-save | real — `document.save()` with `editor.formatOnSave`, buffer **and** file on disk asserted | real — `BufWritePre` + `vim.lsp.buf.format`, buffer **and** file on disk asserted |
| semantic tokens | real — full `[7,9,6,9,0, 0,8,5,8,0]` array | real — same |
| rename | real — full workspace edit, both occurrences, applied | real — same |

## Full-output assertions only

Every expected value was captured from a raw LSP probe of the built binary and
is compared with `assert.deepEqual` / `vim.deep_equal` against the complete
response — the whole diagnostic list, the whole code-action list, the whole
formatting edit, the whole token array, the whole workspace edit. No
`.includes()`, no substring, no regex on a known string. A capability that
regresses to "answers with nothing" fails here.

Where a `vscode` API type carries private state that cannot be reconstructed
for a direct instance comparison (`WorkspaceEdit`, `SemanticTokens`,
`Diagnostic` as rebuilt by `vscode-languageclient`), `real-server-support.cjs`
projects it through a `describe*` helper that **enumerates every field** of the
public shape, so the `deepEqual` stays total.

Both scenarios were verified to fail on a single wrong token id, not just to
pass.

## Format-on-save was the largest silent hole

`vize.formatting.enable` defaults to `false` on the extension **and** the
server, and `vize.enableRecommendedProfile` does not turn it on, so nothing in
the repo ever asserted the server returns formatting edits — only that it
returns `null` when disabled. The suite now opts the setting in before the
client starts (a mid-suite restart races the busy real server's shutdown) and
the formatting step is what proves the setting reaches the server.

Note the two clients legitimately see different bytes: the server sends one
whole-document replacement, and VS Code minimizes it to the two-space indent
before handing it to a provider caller. Each side asserts what its own client
actually receives.

## CI

`.github/actions/vscode-host-smoke` (job `editor-host-smoke`, already in the
required set) now runs three things off the one `cargo build --profile ci -p vize`
it already did:

- `test:vscode-extension:host-real` (extended),
- `test:nvim-extension:headless` — the existing spec that no workflow invoked,
- `test:nvim-extension:real-server` — new.

Neovim is installed from a pinned, sha256-checked release tarball.
`tests/tooling/editor-real-server-e2e.test.ts` guards that wiring, and
`tools/nvim-vize/assert-nvim-package.mjs` now requires the e2e spec to ship
inside the Neovim tarball so a packaged checkout can run it.

The fixture workspace sets `chat.disableAIFeatures`: VS Code's workbench
contributes its own "Fix"/"Explain" quick fixes to every diagnostic span, and
they are not the language server's answer.

## What is still uncovered, and why

- **Zed** — the extension is a WASM host adapter with no headless driver; Zed
  ships no `--headless` mode. Driving it would mean re-implementing the host.
- **Vim** — `editors/vim/test/vize_spec.vim` runs headless but Vim 9 has no
  built-in LSP client, so a real-server scenario would need a third-party
  plugin (`vim-lsp`/`lsp`) as a CI dependency. Its packaging/config coverage is
  unchanged here.
- **Helix** — `editors/helix/` is a `languages.toml` and has no test file at
  all; Helix has no scripting or headless mode.
- **Emacs** — `editors/emacs/test/vize-test.el` has 16 `ert-deftest`s and no
  task runs them; `emacs -batch … ert` is scriptable, so this is tractable, but
  it is a separate change from the two scenarios here.
- `test:vscode-extension:host` (the fake-server suite) is still not invoked by
  any workflow. It is no longer the scorecard coverage for steps 2/4/5, but the
  gap the issue records is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive real-server end-to-end scenarios for VS Code and Neovim.
  * Coverage includes diagnostics, quick fixes, formatting, semantic tokens, and rename operations.
  * Added automated Neovim setup, packaging checks, and a dedicated real-server test task.

* **Bug Fixes**
  * Improved consistency and reliability of editor scenario setup and assertions.
  * Disabled built-in AI features in test workspaces to prevent interference.

* **Tests**
  * Added CI validation for editor workflows, packaged assets, and complete provider responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->