### PR TITLE
test(maestro): prove the overlay cache does not track open buffer size

### DIFF
--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -18,6 +18,8 @@ mod global_components;
 #[cfg(test)]
 mod config_tests;
 #[cfg(all(test, feature = "native"))]
+mod corsa_overlays_perf_tests;
+#[cfg(all(test, feature = "native"))]
 mod corsa_overlays_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/vize_maestro/src/server/state/corsa_overlays_perf_tests.rs
+++ b/crates/vize_maestro/src/server/state/corsa_overlays_perf_tests.rs
@@ -1,0 +1,137 @@
+//! Scaling tests for the incremental Corsa overlay cache.
+//!
+//! Split from [`super::corsa_overlays_tests`] to stay inside the
+//! per-file line budget; the fixtures are shared from there.
+
+use super::ServerState;
+use super::corsa_overlays_tests::{open, rewrite, uri};
+
+/// The point of the cache: a pass costs the documents that changed, not the
+/// documents that are open. Counting materializations rather than timing keeps
+/// the assertion exact and independent of the machine running it.
+#[test]
+fn a_pass_materializes_only_the_documents_that_changed() {
+    let state = ServerState::new();
+    let document = "<template>{{ value }}</template>\n".repeat(512);
+    for index in 0..40 {
+        open(&state, &format!("C{index}.vue"), &document);
+    }
+
+    // Cold pass reads every open document exactly once.
+    let _ = state.corsa_overlays();
+    assert_eq!(state.corsa_overlay_materializations(), 40);
+
+    // A pass with nothing changed reads none of them.
+    let _ = state.corsa_overlays();
+    assert_eq!(state.corsa_overlay_materializations(), 40);
+
+    // Ten keystrokes on one file read one document each, regardless of the 40
+    // that are open.
+    for keystroke in 0..10 {
+        rewrite(
+            &state,
+            "C7.vue",
+            &format!("{document}<!-- {keystroke} -->"),
+            keystroke + 2,
+        );
+        let _ = state.corsa_overlays();
+    }
+    assert_eq!(state.corsa_overlay_materializations(), 50);
+
+    // Opening one more document reads only that one.
+    open(&state, "C40.vue", &document);
+    let _ = state.corsa_overlays();
+    assert_eq!(state.corsa_overlay_materializations(), 51);
+
+    // Closing one reads nothing.
+    state.close_document(&uri("C40.vue"));
+    let _ = state.corsa_overlays();
+    assert_eq!(state.corsa_overlay_materializations(), 51);
+}
+
+/// Average cost of one overlay pass over `documents` open buffers of
+/// `bytes` each: `(cold, warm)`, where cold rebuilds the whole set the way the
+/// pre-#3442 code did and warm follows a single edit.
+///
+/// Samples alternate so host load lands on both populations equally, and the
+/// edits and invalidation that set each sample up stay outside the timers.
+fn overlay_pass_cost(
+    documents: usize,
+    bytes: usize,
+    passes: u32,
+) -> (std::time::Duration, std::time::Duration) {
+    let state = ServerState::new();
+    let document = "<template>{{ value }}</template>\n".repeat(bytes / 33);
+    for index in 0..documents {
+        open(&state, &format!("D{index}.vue"), &document);
+    }
+
+    let _ = state.corsa_overlays();
+    let mut warm = std::time::Duration::ZERO;
+    let mut cold = std::time::Duration::ZERO;
+    for keystroke in 0..passes {
+        rewrite(
+            &state,
+            "D3.vue",
+            &format!("{document}<!-- {keystroke} -->"),
+            keystroke as i32 + 2,
+        );
+
+        let started = std::time::Instant::now();
+        let _ = state.corsa_overlays();
+        warm += started.elapsed();
+
+        state.invalidate_corsa_overlays();
+        let started = std::time::Instant::now();
+        let _ = state.corsa_overlays();
+        cold += started.elapsed();
+    }
+    (cold / passes, warm / passes)
+}
+
+/// The wall-clock companion to the deterministic counter test above, and the
+/// source of the numbers in the PR body. Run manually on an idle host: scheduler
+/// contention makes elapsed-time assertions unsuitable as a CI correctness
+/// gate, while `a_pass_materializes_only_the_documents_that_changed` catches
+/// the same full-rebuild regression exactly.
+///
+/// Sweeping the buffer size at a fixed document count is what isolates the
+/// claim. A cold pass copies every open buffer, so its cost tracks
+/// `documents x bytes`; a warm pass copies only the edited one, so growing the
+/// buffers must leave it flat. Any residual growth in the warm column is the
+/// per-document bookkeeping (path clone, hash lookup) that survives caching.
+#[test]
+#[ignore = "wall-clock benchmark; run manually on an idle host"]
+fn a_warm_pass_does_not_scale_with_open_buffer_size() {
+    const DOCUMENTS: usize = 60;
+    const PASSES: u32 = 64;
+
+    let mut measurements = Vec::new();
+    for bytes in [8 * 1024, 32 * 1024, 128 * 1024] {
+        let (cold, warm) = overlay_pass_cost(DOCUMENTS, bytes, PASSES);
+        println!(
+            "{DOCUMENTS} open buffers of {}KiB: cold {cold:?}, warm (1 edited) {warm:?}",
+            bytes / 1024
+        );
+        measurements.push((bytes, cold, warm));
+    }
+
+    let (_, smallest_cold, smallest_warm) = measurements[0];
+    let (_, largest_cold, largest_warm) = measurements[measurements.len() - 1];
+
+    // 16x the bytes per buffer. The cold pass has to copy all of them.
+    assert!(
+        largest_cold > smallest_cold * 4,
+        "a cold pass must track total open bytes, got {smallest_cold:?} -> {largest_cold:?}"
+    );
+    // The warm pass copies one buffer regardless, so it must not follow.
+    assert!(
+        largest_warm < smallest_warm * 4,
+        "a warm pass must not track total open bytes, got {smallest_warm:?} -> {largest_warm:?}"
+    );
+    assert!(
+        largest_warm * 4 < largest_cold,
+        "a warm pass should cost a fraction of a full rebuild, \
+         got warm {largest_warm:?} vs cold {largest_cold:?}"
+    );
+}

--- a/crates/vize_maestro/src/server/state/corsa_overlays_tests.rs
+++ b/crates/vize_maestro/src/server/state/corsa_overlays_tests.rs
@@ -1,4 +1,7 @@
-//! Correctness and scaling tests for the incremental Corsa overlay cache.
+//! Correctness tests for the incremental Corsa overlay cache.
+//!
+//! The scaling half lives in [`super::corsa_overlays_perf_tests`], which
+//! reuses the fixtures below.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -7,22 +10,22 @@ use tower_lsp::lsp_types::{Position, Range, TextDocumentContentChangeEvent, Url}
 
 use super::ServerState;
 
-fn uri(name: &str) -> Url {
+pub(super) fn uri(name: &str) -> Url {
     Url::parse(&format!("file:///project/{name}")).expect("uri")
 }
 
-fn path(name: &str) -> PathBuf {
+pub(super) fn path(name: &str) -> PathBuf {
     uri(name).to_file_path().expect("file path")
 }
 
-fn open(state: &ServerState, name: &str, text: &str) {
+pub(super) fn open(state: &ServerState, name: &str, text: &str) {
     state
         .documents
         .open(uri(name), text.to_string(), 1, "vue".to_string());
 }
 
 /// Replace the whole buffer, the way an editor reports a non-incremental edit.
-fn rewrite(state: &ServerState, name: &str, text: &str, version: i32) {
+pub(super) fn rewrite(state: &ServerState, name: &str, text: &str, version: i32) {
     state.documents.apply_changes(
         &uri(name),
         vec![TextDocumentContentChangeEvent {
@@ -36,7 +39,7 @@ fn rewrite(state: &ServerState, name: &str, text: &str, version: i32) {
 
 /// The overlay set as compared by tests: order is an artifact of `DashMap`
 /// iteration, so sort before asserting full equality.
-fn overlays(state: &ServerState) -> Vec<(PathBuf, String)> {
+pub(super) fn overlays(state: &ServerState) -> Vec<(PathBuf, String)> {
     let mut overlays = state
         .corsa_overlays()
         .into_iter()
@@ -219,100 +222,5 @@ fn concurrent_edits_and_snapshots_finish_with_the_latest_text() {
     assert_eq!(
         overlays(&state),
         vec![(path("A.vue"), "version 128".into())]
-    );
-}
-
-/// The point of the cache: a pass costs the documents that changed, not the
-/// documents that are open. Counting materializations rather than timing keeps
-/// the assertion exact and independent of the machine running it.
-#[test]
-fn a_pass_materializes_only_the_documents_that_changed() {
-    let state = ServerState::new();
-    let document = "<template>{{ value }}</template>\n".repeat(512);
-    for index in 0..40 {
-        open(&state, &format!("C{index}.vue"), &document);
-    }
-
-    // Cold pass reads every open document exactly once.
-    let _ = state.corsa_overlays();
-    assert_eq!(state.corsa_overlay_materializations(), 40);
-
-    // A pass with nothing changed reads none of them.
-    let _ = state.corsa_overlays();
-    assert_eq!(state.corsa_overlay_materializations(), 40);
-
-    // Ten keystrokes on one file read one document each, regardless of the 40
-    // that are open.
-    for keystroke in 0..10 {
-        rewrite(
-            &state,
-            "C7.vue",
-            &format!("{document}<!-- {keystroke} -->"),
-            keystroke + 2,
-        );
-        let _ = state.corsa_overlays();
-    }
-    assert_eq!(state.corsa_overlay_materializations(), 50);
-
-    // Opening one more document reads only that one.
-    open(&state, "C40.vue", &document);
-    let _ = state.corsa_overlays();
-    assert_eq!(state.corsa_overlay_materializations(), 51);
-
-    // Closing one reads nothing.
-    state.close_document(&uri("C40.vue"));
-    let _ = state.corsa_overlays();
-    assert_eq!(state.corsa_overlay_materializations(), 51);
-}
-
-/// The wall-clock companion to the deterministic counter test above, and the
-/// source of the numbers in the PR body. Run manually on an idle host: scheduler
-/// contention makes elapsed-time assertions unsuitable as a CI correctness
-/// gate, while `a_pass_materializes_only_the_documents_that_changed` catches
-/// the same full-rebuild regression exactly.
-#[test]
-#[ignore = "wall-clock benchmark; run manually on an idle host"]
-fn a_warm_pass_is_far_cheaper_than_a_cold_one() {
-    const DOCUMENTS: usize = 60;
-    const PASSES: u32 = 64;
-
-    let state = ServerState::new();
-    let document = "<template>{{ value }}</template>\n".repeat(512);
-    for index in 0..DOCUMENTS {
-        open(&state, &format!("D{index}.vue"), &document);
-    }
-
-    // Prime the cache, then interleave warm/cold samples so host load affects
-    // both populations equally. Edits and invalidation are setup, not overlay
-    // snapshot work, and therefore deliberately stay outside the timers.
-    let _ = state.corsa_overlays();
-    let mut warm = std::time::Duration::ZERO;
-    let mut cold = std::time::Duration::ZERO;
-    for keystroke in 0..PASSES {
-        rewrite(
-            &state,
-            "D3.vue",
-            &format!("{document}<!-- {keystroke} -->"),
-            keystroke as i32 + 2,
-        );
-
-        let started = std::time::Instant::now();
-        let _ = state.corsa_overlays();
-        warm += started.elapsed();
-
-        state.invalidate_corsa_overlays();
-        let started = std::time::Instant::now();
-        let _ = state.corsa_overlays();
-        cold += started.elapsed();
-    }
-    let warm = warm / PASSES;
-    let cold = cold / PASSES;
-
-    println!(
-        "corsa overlay pass over {DOCUMENTS} documents: cold {cold:?}, warm (1 edited) {warm:?}"
-    );
-    assert!(
-        warm * 4 < cold,
-        "a warm pass should cost a fraction of a full rebuild, got warm {warm:?} vs cold {cold:?}"
     );
 }


### PR DESCRIPTION
Follow-up to #3597 (which closed #3442).

## Why

The benchmark #3597 shipped timed one document count at one buffer size and asserted `warm * 4 < cold`. That is a ratio at a single point, not the property the cache exists for — and the margin was thin: on this host it measured 4.7x, so ordinary scheduler noise could flip it.

The claim #3442 asked to be proven is that a diagnostics pass no longer costs `O(open documents x document size)` when only one document changed. Sweeping the buffer size at a fixed document count is what isolates that:

- a **cold** pass copies every open buffer, so its cost must track `documents x bytes`;
- a **warm** pass copies only the edited buffer, so growing the buffers must leave it flat.

Asserting both directions separates the two failure modes. A cache that silently stopped caching shows up as a warm column that started tracking bytes — which the old single-point ratio could not distinguish from a slow machine.

## Numbers

60 open buffers, one edited per pass, 64 passes, debug build (`cargo test -p vize_maestro --lib -- --ignored --nocapture a_warm_pass`):

| buffer size | cold pass | warm pass (1 edited) |
| --- | --- | --- |
| 8 KiB | 617 us | 234 us |
| 32 KiB | 1.56 ms | 190 us |
| 128 KiB | 3.64 ms | 245 us |

16x the bytes per buffer moves the cold pass 5.9x and leaves the warm pass flat. At 128 KiB x 60 buffers the warm pass is 14.9x cheaper than the full rebuild.

## Why these tests bite

Reintroducing each way the cache can be wrong, against this branch:

- **drop the revision comparison** (reuse cached text unconditionally — the stale-overlay bug): 4 correctness tests fail — `overlay_set_tracks_opens_edits_and_closes`, `reopening_a_document_at_the_same_version_is_not_served_from_cache`, `incremental_edits_are_reflected_in_the_overlay_set`, `concurrent_edits_and_snapshots_finish_with_the_latest_text`.
- **never reuse cached text** (the pre-#3442 full rebuild): `a_pass_materializes_only_the_documents_that_changed` fails, while every correctness test still passes — rebuilding is slow, not wrong. That is the discrimination the perf test is there to provide.

## Notes

- The sweep stays `#[ignore]`d. Elapsed-time assertions are not a sound CI gate; `a_pass_materializes_only_the_documents_that_changed` catches the same full-rebuild regression deterministically by counting materializations.
- The perf tests move to their own module because the sweep pushed `corsa_overlays_tests.rs` to 353 lines, past the 350-line budget. Fixtures are shared from the correctness module.

## Validation

- `cargo test -p vize_maestro -p vize_canon` — all green (maestro lib 685 passed / 0 failed / 2 ignored)
- `cargo clippy -p vize_maestro -p vize_canon -- -D warnings -D clippy::wildcard_imports` — clean
- `rustfmt --edition 2024 --config style_edition=2024 --check` — clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->