### PR TITLE
feat(nuxt): resolve the Nuxt lint config plan from project state

### DIFF
--- a/npm/framework/nuxt/package.json
+++ b/npm/framework/nuxt/package.json
@@ -35,6 +35,11 @@
       "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
+    },
+    "./lint": {
+      "types": "./dist/lint/index.d.mts",
+      "import": "./dist/lint/index.mjs",
+      "default": "./dist/lint/index.mjs"
     }
   },
   "publishConfig": {

--- a/npm/framework/nuxt/src/lint/dirs.ts
+++ b/npm/framework/nuxt/src/lint/dirs.ts
@@ -1,0 +1,200 @@
+/**
+ * Project-state to lint-directory resolution.
+ *
+ * This is a behavioural port of `getDirs()` in `@nuxt/eslint` plus the `dirs`
+ * defaulting in `@nuxt/eslint-config`'s `resolveOptions()`. Every directory the
+ * generated lint config globs over is derived here, so this module is the input
+ * both the config emitter and the dev-server checker read.
+ *
+ * The exact resolution is pinned against the real packages by the differential
+ * oracle in `test/nuxt-eslint-compat/`.
+ */
+import { posixRelative, posixResolve } from "./paths.ts";
+
+/** A component directory declaration on a Nuxt layer. */
+export type NuxtComponentDirDeclaration =
+  | string
+  | { path?: string; prefix?: string; [key: string]: unknown };
+
+/** The subset of a Nuxt layer's config that lint directories are derived from. */
+export interface NuxtLintLayer {
+  srcDir: string;
+  imports?: { dirs?: Array<string | undefined | null> };
+  components?: boolean | NuxtComponentDirDeclaration[] | { dirs?: NuxtComponentDirDeclaration[] };
+}
+
+/** The `nuxt.options.dir` overrides that lint directories honour. */
+export interface NuxtLintDirNames {
+  pages?: string;
+  layouts?: string;
+  plugins?: string;
+  middleware?: string;
+  modules?: string;
+}
+
+/** The Nuxt project state lint directories are derived from. */
+export interface NuxtLintProjectState {
+  /** Directory the emitted globs are relative to. */
+  rootDir: string;
+  /** `nuxt.options.dir`. Missing entries fall back to their Nuxt defaults. */
+  dir?: NuxtLintDirNames;
+  /** `nuxt.options._layers`, in Nuxt's own order. */
+  layers: NuxtLintLayer[];
+}
+
+/** Every directory list the generated lint config globs over. */
+export interface NuxtLintDirs {
+  pages: string[];
+  composables: string[];
+  components: string[];
+  componentsPrefixed: string[];
+  layouts: string[];
+  plugins: string[];
+  middleware: string[];
+  modules: string[];
+  servers: string[];
+  root: string[];
+  src: string[];
+}
+
+/**
+ * The key order of {@link NuxtLintDirs}.
+ *
+ * Upstream serialises `dirs` with `Object.entries`, so this order is observable
+ * in the generated config file and the oracle asserts it.
+ */
+export const NUXT_LINT_DIR_KEYS = [
+  "pages",
+  "composables",
+  "components",
+  "componentsPrefixed",
+  "layouts",
+  "plugins",
+  "middleware",
+  "modules",
+  "servers",
+  "root",
+  "src",
+] as const satisfies ReadonlyArray<keyof NuxtLintDirs>;
+
+function emptyDirs(): NuxtLintDirs {
+  return {
+    pages: [],
+    composables: [],
+    components: [],
+    componentsPrefixed: [],
+    layouts: [],
+    plugins: [],
+    middleware: [],
+    modules: [],
+    servers: [],
+    root: [],
+    src: [],
+  };
+}
+
+/**
+ * Normalise one layer-relative path into a root-relative POSIX path.
+ *
+ * The `~/` (and `~\`) prefix is stripped rather than resolved: upstream treats a
+ * tilde-prefixed `imports.dirs` entry as srcDir-relative, which is the same
+ * thing Nuxt's own alias resolution does for that option.
+ */
+function layerRelative(rootDir: string, srcDir: string, target: string): string {
+  return posixRelative(rootDir, posixResolve(srcDir, target.replace(/^~[/\\]/, "")));
+}
+
+function collectComponentDirs(
+  layer: NuxtLintLayer,
+  dirs: NuxtLintDirs,
+  toRootRelative: (target: string) => string,
+): void {
+  // `components: true` and an absent `components` both mean "the default
+  // `components/` directory"; only an explicit list narrows it.
+  if (!layer.components || layer.components === true) {
+    dirs.components.push(toRootRelative("components"));
+    return;
+  }
+
+  const declarations = Array.isArray(layer.components)
+    ? layer.components
+    : (layer.components.dirs ?? []);
+
+  for (const declaration of declarations) {
+    if (typeof declaration === "string") {
+      dirs.components.push(toRootRelative(declaration));
+      continue;
+    }
+    if (!declaration || typeof declaration.path !== "string") {
+      continue;
+    }
+    dirs.components.push(toRootRelative(declaration.path));
+    if (declaration.prefix) {
+      dirs.componentsPrefixed.push(toRootRelative(declaration.path));
+    }
+  }
+}
+
+/**
+ * Derive every lint directory from the Nuxt project state.
+ *
+ * `servers` and `root` are intentionally left empty: upstream's `getDirs` never
+ * populates them, and because an empty array is truthy the `||=` defaults in
+ * `resolveNuxtLintDirs` do not fire for a module-generated config either. The
+ * oracle pins that, so a future upstream change surfaces as a failure rather
+ * than as a silently different set of linted files.
+ */
+export function collectNuxtLintDirs(state: NuxtLintProjectState): NuxtLintDirs {
+  const dirs = emptyDirs();
+  const dirNames = state.dir ?? {};
+
+  for (const layer of state.layers) {
+    const toRootRelative = (target: string) => layerRelative(state.rootDir, layer.srcDir, target);
+
+    dirs.src.push(toRootRelative(""));
+    dirs.pages.push(toRootRelative(dirNames.pages || "pages"));
+    dirs.layouts.push(toRootRelative(dirNames.layouts || "layouts"));
+    dirs.plugins.push(toRootRelative(dirNames.plugins || "plugins"));
+    dirs.middleware.push(toRootRelative(dirNames.middleware || "middleware"));
+    dirs.modules.push(toRootRelative(dirNames.modules || "modules"));
+    // `composables` and `utils` are not configurable through `nuxt.options.dir`
+    // upstream, so they stay literal here.
+    dirs.composables.push(toRootRelative("composables"));
+    dirs.composables.push(toRootRelative("utils"));
+    for (const dir of layer.imports?.dirs ?? []) {
+      if (dir) {
+        dirs.composables.push(toRootRelative(dir));
+      }
+    }
+    collectComponentDirs(layer, dirs, toRootRelative);
+  }
+
+  return dirs;
+}
+
+/**
+ * Apply the directory defaults used when a config is written by hand rather
+ * than generated from a Nuxt instance.
+ *
+ * Upstream uses `||=`, so a directory list that is present but empty keeps its
+ * empty value. This port reproduces that, because generated configs rely on it.
+ */
+export function resolveNuxtLintDirs(dirs: Partial<NuxtLintDirs> | undefined): NuxtLintDirs {
+  const resolved: Partial<NuxtLintDirs> = { ...dirs };
+  resolved.root ||= [".", "./app"];
+  resolved.src ||= resolved.root;
+  const src = resolved.src;
+  // Upstream interpolates (`${src}/pages`) rather than joining, so a `.` or
+  // `./app` source directory keeps its leading segment instead of being
+  // normalised away. Joining here would silently change which files match.
+  resolved.pages ||= src.map((dir) => `${dir}/pages`);
+  resolved.layouts ||= src.map((dir) => `${dir}/layouts`);
+  resolved.components ||= src.map((dir) => `${dir}/components`);
+  resolved.composables ||= src.map((dir) => `${dir}/composables`);
+  resolved.plugins ||= src.map((dir) => `${dir}/plugins`);
+  resolved.modules ||= src.map((dir) => `${dir}/modules`);
+  resolved.middleware ||= src.map((dir) => `${dir}/middleware`);
+  resolved.servers ||= src.map((dir) => `${dir}/servers`);
+  resolved.componentsPrefixed ||= [];
+  return resolved as NuxtLintDirs;
+}

--- a/npm/framework/nuxt/src/lint/features.ts
+++ b/npm/framework/nuxt/src/lint/features.ts
@@ -1,0 +1,144 @@
+/**
+ * Feature-flag resolution for the Nuxt lint config generator.
+ *
+ * This is a behavioural port of `resolveOptions().features` in
+ * `@nuxt/eslint-config` (see `test/nuxt-eslint-compat/`). The defaults are
+ * load-bearing: they decide which config blocks the generator emits, so they
+ * are pinned against the real package by the differential oracle rather than
+ * restated from documentation.
+ */
+
+/** Options for the Nuxt-specific rule block. */
+export interface NuxtLintNuxtOptions {
+  /**
+   * Enforce a recommended key order in `nuxt.config`.
+   *
+   * @default true when `stylistic` is enabled
+   */
+  sortConfigKeys?: boolean;
+}
+
+/** Options for the tooling (module/library author) rule blocks. */
+export interface NuxtLintToolingOptions {
+  /** @default true */
+  regexp?: boolean;
+  /** @default true */
+  unicorn?: boolean;
+  /** @default true */
+  jsdoc?: boolean;
+}
+
+/** Options for the import rule block. */
+export interface NuxtLintImportOptions {
+  /** @default "eslint-plugin-import-x" */
+  package?: "eslint-plugin-import-lite" | "eslint-plugin-import-x";
+}
+
+/** Options for the TypeScript rule block. */
+export interface NuxtLintTypeScriptOptions {
+  /** @default true */
+  strict?: boolean;
+  /** Enables type-aware rules when set. */
+  tsconfigPath?: string;
+}
+
+/**
+ * The `features` surface of the generated lint config.
+ *
+ * Mirrors `NuxtESLintFeaturesOptions` from `@nuxt/eslint-config`.
+ */
+export interface NuxtLintFeatures {
+  /**
+   * Set up the baseline JavaScript, TypeScript and Vue rule blocks.
+   *
+   * @default true
+   */
+  standalone?: boolean;
+  /**
+   * Enable rules aimed at Nuxt module and library authors.
+   *
+   * @default false
+   */
+  tooling?: boolean | NuxtLintToolingOptions;
+  /**
+   * Enable the import rule block.
+   *
+   * @default true
+   */
+  import?: boolean | NuxtLintImportOptions;
+  /**
+   * Enable stylistic (formatting) rules.
+   *
+   * @default false
+   */
+  stylistic?: boolean | Record<string, unknown>;
+  /**
+   * Enable formatter delegation for non-script file types.
+   *
+   * @default false
+   */
+  formatters?: boolean | Record<string, unknown>;
+  /** Options for the Nuxt-specific rule block. */
+  nuxt?: NuxtLintNuxtOptions;
+  /**
+   * Enable TypeScript support.
+   *
+   * Defaults to whether `typescript` is resolvable from the project.
+   */
+  typescript?: boolean | NuxtLintTypeScriptOptions;
+}
+
+/** Every feature flag with its default applied. */
+export interface ResolvedNuxtLintFeatures {
+  standalone: boolean;
+  stylistic: boolean | Record<string, unknown>;
+  typescript: boolean | NuxtLintTypeScriptOptions;
+  tooling: boolean | NuxtLintToolingOptions;
+  formatters: boolean | Record<string, unknown>;
+  nuxt: NuxtLintNuxtOptions;
+  import: boolean | NuxtLintImportOptions;
+}
+
+/**
+ * Whether TypeScript is present in the project.
+ *
+ * `@nuxt/eslint-config` calls `local-pkg`'s `isPackageExists("typescript")`
+ * here. The probe is injected so the resolver stays a pure function: the
+ * generator passes the real detection, tests pass a fixed answer.
+ */
+export type TypeScriptProbe = () => boolean;
+
+/**
+ * Apply `@nuxt/eslint-config`'s feature defaults.
+ *
+ * Note that only *missing* keys take a default: an explicitly passed
+ * `undefined` value is spread over the defaults by the upstream implementation
+ * and therefore wins, which this port reproduces by spreading the same way.
+ */
+export function resolveNuxtLintFeatures(
+  features: NuxtLintFeatures | undefined,
+  hasTypeScript: TypeScriptProbe,
+): ResolvedNuxtLintFeatures {
+  return {
+    standalone: true,
+    stylistic: false,
+    typescript: hasTypeScript(),
+    tooling: false,
+    formatters: false,
+    nuxt: {},
+    import: {},
+    ...features,
+  } as ResolvedNuxtLintFeatures;
+}
+
+/**
+ * Whether `nuxt/nuxt-config-keys-order` is enabled.
+ *
+ * Upstream reads `features.nuxt.sortConfigKeys` and falls back to
+ * `!!features.stylistic`, so enabling stylistic rules also turns on config-key
+ * sorting unless the project opts out explicitly.
+ */
+export function shouldSortNuxtConfigKeys(features: ResolvedNuxtLintFeatures): boolean {
+  const { sortConfigKeys = !!features.stylistic } = features.nuxt || {};
+  return sortConfigKeys;
+}

--- a/npm/framework/nuxt/src/lint/index.ts
+++ b/npm/framework/nuxt/src/lint/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Nuxt-aware lint config generation for `@vizejs/nuxt`.
+ *
+ * The pieces here turn Nuxt project state into an engine-neutral lint plan:
+ * which directories exist, which feature blocks are on, and which named rule
+ * blocks apply to which globs. Emitting that plan for Vize's execution engine
+ * (oxlint via `oxlint-plugin-vize`) and running it against the dev server are
+ * layered on top and stay out of this module.
+ */
+export {
+  NUXT_LINT_DIR_KEYS,
+  collectNuxtLintDirs,
+  resolveNuxtLintDirs,
+  type NuxtComponentDirDeclaration,
+  type NuxtLintDirNames,
+  type NuxtLintDirs,
+  type NuxtLintLayer,
+  type NuxtLintProjectState,
+} from "./dirs.ts";
+export {
+  resolveNuxtLintFeatures,
+  shouldSortNuxtConfigKeys,
+  type NuxtLintFeatures,
+  type NuxtLintImportOptions,
+  type NuxtLintNuxtOptions,
+  type NuxtLintToolingOptions,
+  type NuxtLintTypeScriptOptions,
+  type ResolvedNuxtLintFeatures,
+  type TypeScriptProbe,
+} from "./features.ts";
+export {
+  toNuxtLintProjectState,
+  type NuxtLintSourceOptions,
+  type NuxtLintStateOverrides,
+} from "./nuxt-state.ts";
+export {
+  NUXT_CONFIG_GLOBS,
+  NUXT_LINT_GLOB_EXTS,
+  NUXT_LINT_IGNORES,
+  NUXT_RUNTIME_GLOBALS,
+  buildNuxtLintPlan,
+  type NuxtLintConfigItem,
+  type NuxtLintSeverity,
+} from "./plan.ts";

--- a/npm/framework/nuxt/src/lint/nuxt-state.test.ts
+++ b/npm/framework/nuxt/src/lint/nuxt-state.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { collectNuxtLintDirs } from "./dirs.ts";
+import { toNuxtLintProjectState } from "./nuxt-state.ts";
+
+void test("Nuxt 3 and 4 layers keep their order and their own source directories", () => {
+  assert.deepEqual(
+    toNuxtLintProjectState({
+      rootDir: "/project",
+      srcDir: "/project/app",
+      dir: { pages: "routes" },
+      _layers: [
+        { config: { srcDir: "/project/app" } },
+        { config: { srcDir: "/project/layers/base", components: ["./ui"] } },
+      ],
+    }),
+    {
+      rootDir: "/project",
+      dir: { pages: "routes" },
+      layers: [
+        { srcDir: "/project/app" },
+        { srcDir: "/project/layers/base", components: ["./ui"] },
+      ],
+    },
+  );
+});
+
+void test("a Nuxt 2 project with no layers becomes a single srcDir layer", () => {
+  assert.deepEqual(toNuxtLintProjectState({ rootDir: "/project", srcDir: "/project/src" }), {
+    rootDir: "/project",
+    dir: {},
+    layers: [{ srcDir: "/project/src" }],
+  });
+});
+
+void test("a project with neither layers nor srcDir falls back to the root", () => {
+  assert.deepEqual(toNuxtLintProjectState({ rootDir: "/project" }), {
+    rootDir: "/project",
+    dir: {},
+    layers: [{ srcDir: "/project" }],
+  });
+});
+
+void test("a layer without its own srcDir inherits the project srcDir", () => {
+  assert.deepEqual(
+    toNuxtLintProjectState({
+      rootDir: "/project",
+      srcDir: "/project/app",
+      _layers: [{ config: { components: true } }],
+    }),
+    {
+      rootDir: "/project",
+      dir: {},
+      layers: [{ srcDir: "/project/app", components: true }],
+    },
+  );
+});
+
+void test("overriding rootDir re-anchors every emitted directory", () => {
+  const state = toNuxtLintProjectState(
+    {
+      rootDir: "/project",
+      srcDir: "/project/app",
+      _layers: [{ config: { srcDir: "/project/app" } }],
+    },
+    { rootDir: "/project/tooling" },
+  );
+
+  assert.deepEqual(collectNuxtLintDirs(state), {
+    pages: ["../app/pages"],
+    composables: ["../app/composables", "../app/utils"],
+    components: ["../app/components"],
+    componentsPrefixed: [],
+    layouts: ["../app/layouts"],
+    plugins: ["../app/plugins"],
+    middleware: ["../app/middleware"],
+    modules: ["../app/modules"],
+    servers: [],
+    root: [],
+    src: ["../app"],
+  });
+});

--- a/npm/framework/nuxt/src/lint/nuxt-state.ts
+++ b/npm/framework/nuxt/src/lint/nuxt-state.ts
@@ -1,0 +1,55 @@
+/**
+ * Adapter from a Nuxt instance to {@link NuxtLintProjectState}.
+ *
+ * Keeping this separate from `dirs.ts` is what lets the directory resolver stay
+ * a pure function of plain data: the oracle drives it from a JSON corpus, and
+ * the module drives it from a live Nuxt instance, with no shared mutable state.
+ */
+import type { NuxtLintDirNames, NuxtLintLayer, NuxtLintProjectState } from "./dirs.ts";
+
+/** The subset of a Nuxt instance lint config generation reads. */
+export interface NuxtLintSourceOptions {
+  rootDir: string;
+  srcDir?: string;
+  dir?: NuxtLintDirNames;
+  _layers?: Array<{ config?: Partial<NuxtLintLayer> & { srcDir?: string } }>;
+}
+
+/** Options that can redirect where the emitted globs are anchored. */
+export interface NuxtLintStateOverrides {
+  /**
+   * Anchor the emitted globs somewhere other than the Nuxt root.
+   *
+   * Needed when the lint config is generated for a directory that is not the
+   * project root, because every glob is written relative to it.
+   */
+  rootDir?: string;
+}
+
+/**
+ * Reduce a Nuxt instance to the project state lint config generation needs.
+ *
+ * Nuxt 2 has no `_layers`, so the project is treated as a single layer rooted
+ * at `srcDir` (falling back to `rootDir`). That keeps the Nuxt 2, 3 and 4 paths
+ * on one code path rather than branching on the detected major version.
+ */
+export function toNuxtLintProjectState(
+  options: NuxtLintSourceOptions,
+  overrides: NuxtLintStateOverrides = {},
+): NuxtLintProjectState {
+  const rootDir = overrides.rootDir || options.rootDir;
+  const declaredLayers = options._layers ?? [];
+  const layers: NuxtLintLayer[] = declaredLayers
+    .map((layer) => layer.config)
+    .filter((config): config is Partial<NuxtLintLayer> & { srcDir?: string } => Boolean(config))
+    .map((config) => ({
+      ...config,
+      srcDir: config.srcDir || options.srcDir || options.rootDir,
+    }));
+
+  return {
+    rootDir,
+    dir: options.dir ?? {},
+    layers: layers.length > 0 ? layers : [{ srcDir: options.srcDir || options.rootDir }],
+  };
+}

--- a/npm/framework/nuxt/src/lint/oracle.test.ts
+++ b/npm/framework/nuxt/src/lint/oracle.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Differential test against the recorded `@nuxt/eslint` ground truth.
+ *
+ * The recording in `test/nuxt-eslint-compat/fixtures/` is produced from the
+ * real packages by `oracle.mjs`; this suite reads it with no `@nuxt/*` import
+ * of its own, so the package's tests stay offline. CI re-derives the recording
+ * in `tests/tooling/nuxt-eslint-oracle.test.ts`, so an upstream bump surfaces
+ * there as a hard failure rather than as silent compatibility drift.
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  collectNuxtLintDirs,
+  resolveNuxtLintDirs,
+  type NuxtLintDirs,
+  type NuxtLintProjectState,
+} from "./dirs.ts";
+import { resolveNuxtLintFeatures } from "./features.ts";
+import { buildNuxtLintPlan, type NuxtLintConfigItem } from "./plan.ts";
+
+const compatDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "test",
+  "nuxt-eslint-compat",
+);
+
+interface CorpusCase {
+  id: string;
+  category: string;
+  description: string;
+  project: Omit<NuxtLintProjectState, "rootDir">;
+  config: Record<string, unknown>;
+}
+
+interface RecordedItem {
+  name: string | null;
+  files: string[] | null;
+  ignores: string[] | null;
+  rules: Record<string, string> | null;
+  globals: Record<string, string> | null;
+}
+
+interface RecordedCase {
+  dirs: Record<string, string[]>;
+  features: Record<string, unknown>;
+  configNames: Array<string | null>;
+  nuxtConfigs: RecordedItem[];
+}
+
+function readJson<T>(...segments: string[]): T {
+  return JSON.parse(readFileSync(join(compatDir, ...segments), "utf8")) as T;
+}
+
+interface DirDefaultCase {
+  id: string;
+  description: string;
+  dirs: Partial<NuxtLintDirs>;
+}
+
+const corpus = readJson<{
+  oracle: Record<string, string>;
+  dirDefaultCases: DirDefaultCase[];
+  cases: CorpusCase[];
+}>("fixtures", "corpus.json");
+const recording = readJson<{
+  moduleVersion: string;
+  configVersion: string;
+  typeScriptDetected: boolean;
+  dirDefaults: Record<string, NuxtLintDirs>;
+  cases: Record<string, RecordedCase>;
+}>("fixtures", "nuxt-eslint-output.json");
+
+/**
+ * The corpus states layer source directories relative to the project root, the
+ * way a `nuxt.config` does. Nuxt itself hands the module absolute paths, so the
+ * oracle joins them onto its scratch root and this rebuild does the same
+ * against a fixed synthetic root — which is what keeps the recording free of
+ * machine-specific paths.
+ */
+const ROOT_DIR = "/project";
+
+function projectState(entry: CorpusCase): NuxtLintProjectState {
+  return {
+    rootDir: ROOT_DIR,
+    dir: entry.project.dir,
+    layers: entry.project.layers.map((layer) => ({
+      ...layer,
+      srcDir: join(ROOT_DIR, layer.srcDir),
+    })),
+  };
+}
+
+/**
+ * Upstream leaves its ignore block unnamed; Vize gives every block a stable
+ * identity so the emitter can address it. That rename is the one intentional
+ * difference between the plan and the recording, so it is applied here in one
+ * place rather than being absorbed into a looser comparison.
+ */
+function recordedItemName(item: RecordedItem): string {
+  return item.name ?? "nuxt/ignores";
+}
+
+/** Render a plan item in the recording's shape so the two compare directly. */
+function planItemAsRecorded(item: NuxtLintConfigItem) {
+  return {
+    name: item.name,
+    files: item.files ?? null,
+    ignores: item.ignores ?? null,
+    rules: item.rules ?? null,
+    globals: item.globals ?? null,
+  };
+}
+
+void test("corpus pins the package versions the recording was produced with", () => {
+  assert.equal(corpus.oracle.module, "@nuxt/eslint");
+  assert.equal(corpus.oracle.config, "@nuxt/eslint-config");
+  assert.equal(corpus.oracle.moduleVersion, recording.moduleVersion);
+  assert.equal(corpus.oracle.configVersion, recording.configVersion);
+});
+
+void test("recording covers exactly the corpus cases", () => {
+  assert.deepEqual(
+    Object.keys(recording.cases).sort(),
+    corpus.cases.map((entry) => entry.id).sort(),
+  );
+  assert.deepEqual(
+    Object.keys(recording.dirDefaults).sort(),
+    corpus.dirDefaultCases.map((entry) => entry.id).sort(),
+  );
+});
+
+for (const entry of corpus.dirDefaultCases) {
+  void test(`${entry.id}: directory defaults match @nuxt/eslint-config`, () => {
+    assert.deepEqual(resolveNuxtLintDirs(entry.dirs), recording.dirDefaults[entry.id]);
+  });
+}
+
+for (const entry of corpus.cases) {
+  const recorded = recording.cases[entry.id];
+
+  void test(`${entry.id}: directories match @nuxt/eslint`, () => {
+    const dirs = collectNuxtLintDirs(projectState(entry));
+    assert.deepEqual(dirs, recorded.dirs);
+  });
+
+  void test(`${entry.id}: features match @nuxt/eslint-config`, () => {
+    const features = resolveNuxtLintFeatures(entry.config, () => recording.typeScriptDetected);
+    assert.deepEqual(features, recorded.features);
+  });
+
+  void test(`${entry.id}: config plan matches @nuxt/eslint-config`, () => {
+    const features = resolveNuxtLintFeatures(entry.config, () => recording.typeScriptDetected);
+    const plan = buildNuxtLintPlan(features, collectNuxtLintDirs(projectState(entry)));
+
+    // Compare the whole ordered list in one assertion: order decides which
+    // rule wins, so an item appearing in the wrong place is a real defect.
+    assert.deepEqual(
+      plan.map(planItemAsRecorded),
+      recorded.nuxtConfigs.map((item) => ({ ...item, name: recordedItemName(item) })),
+    );
+  });
+}

--- a/npm/framework/nuxt/src/lint/paths.ts
+++ b/npm/framework/nuxt/src/lint/paths.ts
@@ -1,0 +1,30 @@
+/**
+ * POSIX path helpers with `pathe` semantics.
+ *
+ * `@nuxt/eslint` builds every lint directory and glob with `pathe`, which
+ * normalises Windows separators to `/` and then behaves like `node:path/posix`.
+ * The generated globs are matched against POSIX-normalised paths on every
+ * platform, so reproducing that normalisation is what makes the Windows output
+ * identical to the Linux and macOS output.
+ */
+import { posix } from "node:path";
+
+/** Replace Windows separators so POSIX path maths applies uniformly. */
+function toPosix(value: string): string {
+  return value.replace(/\\/g, "/");
+}
+
+/** `pathe.join` — POSIX join over separator-normalised segments. */
+export function posixJoin(...segments: string[]): string {
+  return posix.join(...segments.map(toPosix));
+}
+
+/** `pathe.resolve` — POSIX resolve over separator-normalised segments. */
+export function posixResolve(...segments: string[]): string {
+  return posix.resolve(...segments.map(toPosix));
+}
+
+/** `pathe.relative` — POSIX relative over separator-normalised paths. */
+export function posixRelative(from: string, to: string): string {
+  return posix.relative(toPosix(from), toPosix(to));
+}

--- a/npm/framework/nuxt/src/lint/plan.ts
+++ b/npm/framework/nuxt/src/lint/plan.ts
@@ -1,0 +1,162 @@
+/**
+ * The Nuxt-aware lint config plan.
+ *
+ * `@nuxt/eslint` turns a Nuxt project into an ordered list of flat-config
+ * items. The Nuxt-specific ones — the blocks that know about pages, layouts,
+ * components, and `nuxt.config` — are the actual porting surface; the rest is
+ * `@nuxt/eslint-config`'s generic JavaScript/TypeScript/Vue preset content.
+ *
+ * This module produces those Nuxt-specific items as an engine-neutral plan.
+ * Emitting the plan as an oxlint config (Vize's execution engine) is a separate
+ * concern, so the plan can be pinned against the real package by the
+ * differential oracle in `test/nuxt-eslint-compat/` without ESLint in the loop.
+ */
+import type { NuxtLintDirs } from "./dirs.ts";
+import { type ResolvedNuxtLintFeatures, shouldSortNuxtConfigKeys } from "./features.ts";
+import { posixJoin } from "./paths.ts";
+
+/** Extensions every Nuxt-aware glob covers. */
+export const NUXT_LINT_GLOB_EXTS = "{js,ts,jsx,tsx,vue}";
+
+/** Globs matching a `nuxt.config` file in either supported location. */
+export const NUXT_CONFIG_GLOBS = [
+  "**/.config/nuxt.?([cm])[jt]s?(x)",
+  "**/nuxt.config.?([cm])[jt]s?(x)",
+] as const;
+
+/** Directories the generated config never lints. */
+export const NUXT_LINT_IGNORES = [
+  "**/dist",
+  "**/node_modules",
+  "**/.nuxt",
+  "**/.output",
+  "**/.vercel",
+  "**/.netlify",
+  "**/public",
+] as const;
+
+/** A severity as it appears in the plan. */
+export type NuxtLintSeverity = "off" | "warn" | "error";
+
+/** One item of the generated config: a named block of rules over a glob set. */
+export interface NuxtLintConfigItem {
+  /** Stable identity, matching `@nuxt/eslint`'s config item names. */
+  name: string;
+  /** Files the block applies to. Absent means "every linted file". */
+  files?: string[];
+  /** Paths excluded from linting entirely. */
+  ignores?: string[];
+  /** Rule severities keyed by eslint-compatible rule id. */
+  rules?: Record<string, NuxtLintSeverity>;
+  /** Globals the block declares, so undefined-variable rules stay quiet. */
+  globals?: Record<string, "readonly" | "writable">;
+}
+
+/** Runtime globals Nuxt injects into every linted file. */
+export const NUXT_RUNTIME_GLOBALS: Record<string, "readonly"> = { $fetch: "readonly" };
+
+const nestedGlob = `**/*.${NUXT_LINT_GLOB_EXTS}`;
+
+/**
+ * Files allowed to have a single-word component name.
+ *
+ * Nuxt gives `app` and `error` a special meaning, layouts and pages are never
+ * referenced by tag name, and prefixed component directories get their name
+ * from the prefix — so `vue/multi-word-component-names` is off for all of them.
+ */
+function routeFiles(dirs: NuxtLintDirs): string[] {
+  return [
+    ...new Set([
+      ...dirs.src.flatMap((dir) => [
+        posixJoin(dir, `app.${NUXT_LINT_GLOB_EXTS}`),
+        posixJoin(dir, `error.${NUXT_LINT_GLOB_EXTS}`),
+      ]),
+      ...dirs.layouts.map((dir) => posixJoin(dir, nestedGlob)),
+      ...dirs.pages.map((dir) => posixJoin(dir, nestedGlob)),
+      // Only *nested* component files are exempt: a top-level `components/Foo.vue`
+      // still has to be multi-word.
+      ...dirs.components.map((dir) => posixJoin(dir, "*", nestedGlob)),
+      ...dirs.componentsPrefixed.map((dir) => posixJoin(dir, nestedGlob)),
+    ]),
+  ].sort();
+}
+
+/** Files that must render exactly one root element. */
+function singleRootFiles(dirs: NuxtLintDirs): string[] {
+  return [
+    ...dirs.layouts.map((dir) => posixJoin(dir, nestedGlob)),
+    ...dirs.pages.map((dir) => posixJoin(dir, nestedGlob)),
+    ...dirs.components.map((dir) => posixJoin(dir, `**/*.server.${NUXT_LINT_GLOB_EXTS}`)),
+  ].sort();
+}
+
+/** Files where `definePageMeta` is extracted at build time. */
+function pageFiles(dirs: NuxtLintDirs): string[] {
+  return dirs.pages.map((dir) => posixJoin(dir, nestedGlob)).sort();
+}
+
+/**
+ * Build the Nuxt-specific part of the generated lint config, in emission order.
+ *
+ * The order is observable — later items override earlier ones — so it is part
+ * of the contract the oracle pins, not an implementation detail.
+ */
+export function buildNuxtLintPlan(
+  features: ResolvedNuxtLintFeatures,
+  dirs: NuxtLintDirs,
+): NuxtLintConfigItem[] {
+  const items: NuxtLintConfigItem[] = [];
+
+  // The ignore block belongs to the baseline setup, so a project that opts out
+  // of `standalone` is expected to bring its own ignores.
+  if (features.standalone !== false) {
+    items.push({ name: "nuxt/ignores", ignores: [...NUXT_LINT_IGNORES] });
+  }
+
+  items.push({ name: "nuxt/setup", globals: { ...NUXT_RUNTIME_GLOBALS } });
+
+  const singleRoot = singleRootFiles(dirs);
+  if (singleRoot.length > 0) {
+    items.push({
+      name: "nuxt/vue/single-root",
+      files: singleRoot,
+      rules: { "vue/no-multiple-template-root": "error" },
+    });
+  }
+
+  items.push({ name: "nuxt/rules", rules: { "nuxt/prefer-import-meta": "error" } });
+
+  const pages = pageFiles(dirs);
+  if (pages.length > 0) {
+    items.push({
+      name: "nuxt/pages",
+      files: pages,
+      rules: { "nuxt/no-page-meta-runtime-values": "error" },
+    });
+  }
+
+  items.push({
+    name: "nuxt/nuxt-config",
+    files: [...NUXT_CONFIG_GLOBS],
+    rules: { "nuxt/no-nuxt-config-test-key": "error" },
+  });
+
+  if (shouldSortNuxtConfigKeys(features)) {
+    items.push({
+      name: "nuxt/sort-config",
+      files: [...NUXT_CONFIG_GLOBS],
+      rules: { "nuxt/nuxt-config-keys-order": "error" },
+    });
+  }
+
+  const routes = routeFiles(dirs);
+  if (routes.length > 0) {
+    items.push({
+      name: "nuxt/disables/routes",
+      files: routes,
+      rules: { "vue/multi-word-component-names": "off" },
+    });
+  }
+
+  return items;
+}

--- a/npm/framework/nuxt/test/nuxt-eslint-compat/INVENTORY.md
+++ b/npm/framework/nuxt/test/nuxt-eslint-compat/INVENTORY.md
@@ -1,0 +1,104 @@
+# `@nuxt/eslint` compatibility inventory
+
+Ground truth for the Nuxt lint config port. The corpus in `fixtures/corpus.json`
+is run through the real `@nuxt/eslint` and `@nuxt/eslint-config` by `oracle.mjs`,
+which records the result in `fixtures/nuxt-eslint-output.json`.
+
+- `npm/framework/nuxt/src/lint/oracle.test.ts` reads the recording offline and
+  holds Vize's implementation to it.
+- `tests/tooling/nuxt-eslint-oracle.test.ts` re-derives the recording from the
+  installed packages in CI, so an upstream bump fails loudly.
+- Re-record with
+  `node npm/framework/nuxt/test/nuxt-eslint-compat/oracle.mjs --write`.
+
+Pinned upstream: `@nuxt/eslint@1.16.0`, `@nuxt/eslint-config@1.16.0` (catalog
+`nuxt-eslint-oracle` in `pnpm-workspace.yaml`).
+
+## Engine
+
+Vize does not vendor ESLint. Patina runs through oxlint via
+`oxlint-plugin-vize`, and its rule ids are already `eslint-plugin-vue`
+compatible, so the port reproduces `@nuxt/eslint`'s *semantics and surface* on
+Vize's own engine. The plan this phase produces is therefore engine-neutral:
+it names rules with their eslint-compatible ids, and the emitter that turns a
+plan into an oxlint config (where Patina rules gain oxlint's `vize/` plugin
+prefix) is a later phase.
+
+## Config items
+
+The blocks the port owns, in emission order. Order is observable — a later item
+overrides an earlier one — so it is part of the contract.
+
+| Config item | Applies to | Rule | Patina status |
+| --- | --- | --- | --- |
+| `nuxt/ignores` | whole project | — (7 ignore globs) | supported |
+| `nuxt/setup` | every linted file | — (declares the `$fetch` global) | supported |
+| `nuxt/vue/single-root` | layouts, pages, server components | `vue/no-multiple-template-root` | **unimplemented in Patina** (tracked by #3223) |
+| `nuxt/rules` | every linted file | `nuxt/prefer-import-meta` | not ported yet |
+| `nuxt/pages` | pages | `nuxt/no-page-meta-runtime-values` | not ported yet |
+| `nuxt/nuxt-config` | `nuxt.config` | `nuxt/no-nuxt-config-test-key` | not ported yet |
+| `nuxt/sort-config` | `nuxt.config` | `nuxt/nuxt-config-keys-order` | not ported yet |
+| `nuxt/disables/routes` | app/error, layouts, pages, nested and prefixed components | `vue/multi-word-component-names` off | supported |
+
+Items outside this table belong to `@nuxt/eslint-config`'s generic
+JavaScript/TypeScript/Vue/import/stylistic/tooling presets. They are a separate
+phase, so the recording captures their **names and order** (`configNames`) but
+not their rule bodies — a preset appearing, disappearing, or moving still fails
+the oracle.
+
+## Intentional divergences
+
+| Difference | Why |
+| --- | --- |
+| The ignore block is named `nuxt/ignores`; upstream leaves it unnamed | Every block needs a stable identity for the emitter to address and for users to override. Applied in exactly one place in `oracle.test.ts`. |
+| `features` carries only feature keys | Upstream serialises the whole module option object into `features`, so `configFile`, `autoInit`, `rootDir` and `devtools` leak into it. Vize keeps module options and feature flags separate. |
+
+## Directory defaults
+
+Defaults for a hand-written config, where directory lists may be absent.
+A generated config always supplies every list, so these only apply to the
+standalone entry point.
+
+| Case | Behaviour |
+| --- | --- |
+| `defaults/empty` | No dirs at all: `root` becomes `[".", "./app"]` and everything else derives from it. |
+| `defaults/src-only` | Declaring `src` derives every per-feature directory from it. |
+| `defaults/root-only` | Declaring `root` makes `src` follow `root` rather than the built-in pair. |
+| `defaults/empty-arrays` | Present-but-empty lists stay empty: an empty array is truthy, so the `||=` defaults never fire. This is why a generated config keeps `servers` and `root` empty. |
+| `defaults/partial` | Only missing lists are defaulted; declared ones pass through untouched. |
+
+Derived paths are built by interpolation (`` `${src}/pages` ``), not by joining,
+so a `.` or `./app` source directory keeps its leading segment.
+
+## Project states
+
+How Nuxt project state reduces to the directory lists every glob is built from.
+
+| Case | Behaviour |
+| --- | --- |
+| `dirs/default` | Nuxt 4 defaults: a single layer with `srcDir` `app/`. |
+| `dirs/srcdir-is-root` | Nuxt 3 layout where `srcDir` equals `rootDir`, so `src` is `""` and every directory is top level. |
+| `dirs/two-layers` | A base layer extended by the app layer; every list gains a second entry, in layer order. |
+| `dirs/dir-overrides` | `nuxt.options.dir` renames pages, layouts, plugins, middleware and modules. `composables`/`utils` are **not** configurable and stay literal. |
+| `dirs/imports-dirs` | Extra auto-import directories join `composables`; a `~/` prefix is stripped rather than alias-resolved. |
+| `dirs/components-string-array` | `components` as a bare array of directory strings. |
+| `dirs/components-prefixed` | `components` as objects; a `prefix` also adds the directory to `componentsPrefixed`, which exempts one-word names. |
+| `dirs/components-true` | `components: true` keeps the default `components/` directory, same as omitting it. |
+
+## Feature flags
+
+| Case | Behaviour |
+| --- | --- |
+| `features/defaults` | `standalone` on, `stylistic`/`tooling`/`formatters` off, `typescript` from package detection. |
+| `features/standalone-false` | Drops the baseline blocks; only the Nuxt-aware ones remain, and `nuxt/ignores` is dropped with them. |
+| `features/stylistic` | Enabling stylistic rules also switches `nuxt.config` key sorting on. |
+| `features/stylistic-sort-opt-out` | An explicit `nuxt.sortConfigKeys: false` overrides that default. |
+| `features/sort-config-opt-in` | Key sorting can be enabled without stylistic rules. |
+| `features/typescript-false` | Drops the TypeScript blocks from the baseline. |
+| `features/typescript-true` | Adds them regardless of package detection. |
+| `features/tooling` | Adds the module-author rule blocks (jsdoc, unicorn, regexp). |
+
+`features.typescript` defaults to whether the `typescript` package resolves from
+`@nuxt/eslint-config`. The recording stores that probe's answer as
+`typeScriptDetected` so the offline test stays on the same branch as the
+recording rather than guessing.

--- a/npm/framework/nuxt/test/nuxt-eslint-compat/INVENTORY.md
+++ b/npm/framework/nuxt/test/nuxt-eslint-compat/INVENTORY.md
@@ -18,7 +18,7 @@ Pinned upstream: `@nuxt/eslint@1.16.0`, `@nuxt/eslint-config@1.16.0` (catalog
 
 Vize does not vendor ESLint. Patina runs through oxlint via
 `oxlint-plugin-vize`, and its rule ids are already `eslint-plugin-vue`
-compatible, so the port reproduces `@nuxt/eslint`'s *semantics and surface* on
+compatible, so the port reproduces `@nuxt/eslint`'s _semantics and surface_ on
 Vize's own engine. The plan this phase produces is therefore engine-neutral:
 it names rules with their eslint-compatible ids, and the emitter that turns a
 plan into an oxlint config (where Patina rules gain oxlint's `vize/` plugin
@@ -29,16 +29,16 @@ prefix) is a later phase.
 The blocks the port owns, in emission order. Order is observable — a later item
 overrides an earlier one — so it is part of the contract.
 
-| Config item | Applies to | Rule | Patina status |
-| --- | --- | --- | --- |
-| `nuxt/ignores` | whole project | — (7 ignore globs) | supported |
-| `nuxt/setup` | every linted file | — (declares the `$fetch` global) | supported |
-| `nuxt/vue/single-root` | layouts, pages, server components | `vue/no-multiple-template-root` | **unimplemented in Patina** (tracked by #3223) |
-| `nuxt/rules` | every linted file | `nuxt/prefer-import-meta` | not ported yet |
-| `nuxt/pages` | pages | `nuxt/no-page-meta-runtime-values` | not ported yet |
-| `nuxt/nuxt-config` | `nuxt.config` | `nuxt/no-nuxt-config-test-key` | not ported yet |
-| `nuxt/sort-config` | `nuxt.config` | `nuxt/nuxt-config-keys-order` | not ported yet |
-| `nuxt/disables/routes` | app/error, layouts, pages, nested and prefixed components | `vue/multi-word-component-names` off | supported |
+| Config item            | Applies to                                                | Rule                                 | Patina status                                  |
+| ---------------------- | --------------------------------------------------------- | ------------------------------------ | ---------------------------------------------- |
+| `nuxt/ignores`         | whole project                                             | — (7 ignore globs)                   | supported                                      |
+| `nuxt/setup`           | every linted file                                         | — (declares the `$fetch` global)     | supported                                      |
+| `nuxt/vue/single-root` | layouts, pages, server components                         | `vue/no-multiple-template-root`      | **unimplemented in Patina** (tracked by #3223) |
+| `nuxt/rules`           | every linted file                                         | `nuxt/prefer-import-meta`            | not ported yet                                 |
+| `nuxt/pages`           | pages                                                     | `nuxt/no-page-meta-runtime-values`   | not ported yet                                 |
+| `nuxt/nuxt-config`     | `nuxt.config`                                             | `nuxt/no-nuxt-config-test-key`       | not ported yet                                 |
+| `nuxt/sort-config`     | `nuxt.config`                                             | `nuxt/nuxt-config-keys-order`        | not ported yet                                 |
+| `nuxt/disables/routes` | app/error, layouts, pages, nested and prefixed components | `vue/multi-word-component-names` off | supported                                      |
 
 Items outside this table belong to `@nuxt/eslint-config`'s generic
 JavaScript/TypeScript/Vue/import/stylistic/tooling presets. They are a separate
@@ -48,10 +48,10 @@ the oracle.
 
 ## Intentional divergences
 
-| Difference | Why |
-| --- | --- |
-| The ignore block is named `nuxt/ignores`; upstream leaves it unnamed | Every block needs a stable identity for the emitter to address and for users to override. Applied in exactly one place in `oracle.test.ts`. |
-| `features` carries only feature keys | Upstream serialises the whole module option object into `features`, so `configFile`, `autoInit`, `rootDir` and `devtools` leak into it. Vize keeps module options and feature flags separate. |
+| Difference                                                           | Why                                                                                                                                                                                           |
+| -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The ignore block is named `nuxt/ignores`; upstream leaves it unnamed | Every block needs a stable identity for the emitter to address and for users to override. Applied in exactly one place in `oracle.test.ts`.                                                   |
+| `features` carries only feature keys                                 | Upstream serialises the whole module option object into `features`, so `configFile`, `autoInit`, `rootDir` and `devtools` leak into it. Vize keeps module options and feature flags separate. |
 
 ## Directory defaults
 
@@ -59,13 +59,13 @@ Defaults for a hand-written config, where directory lists may be absent.
 A generated config always supplies every list, so these only apply to the
 standalone entry point.
 
-| Case | Behaviour |
-| --- | --- |
-| `defaults/empty` | No dirs at all: `root` becomes `[".", "./app"]` and everything else derives from it. |
-| `defaults/src-only` | Declaring `src` derives every per-feature directory from it. |
-| `defaults/root-only` | Declaring `root` makes `src` follow `root` rather than the built-in pair. |
-| `defaults/empty-arrays` | Present-but-empty lists stay empty: an empty array is truthy, so the `||=` defaults never fire. This is why a generated config keeps `servers` and `root` empty. |
-| `defaults/partial` | Only missing lists are defaulted; declared ones pass through untouched. |
+| Case                    | Behaviour                                                                            |
+| ----------------------- | ------------------------------------------------------------------------------------ | --- | ------------------------------------------------------------------------------------ |
+| `defaults/empty`        | No dirs at all: `root` becomes `[".", "./app"]` and everything else derives from it. |
+| `defaults/src-only`     | Declaring `src` derives every per-feature directory from it.                         |
+| `defaults/root-only`    | Declaring `root` makes `src` follow `root` rather than the built-in pair.            |
+| `defaults/empty-arrays` | Present-but-empty lists stay empty: an empty array is truthy, so the `               |     | =`defaults never fire. This is why a generated config keeps`servers`and`root` empty. |
+| `defaults/partial`      | Only missing lists are defaulted; declared ones pass through untouched.              |
 
 Derived paths are built by interpolation (`` `${src}/pages` ``), not by joining,
 so a `.` or `./app` source directory keeps its leading segment.
@@ -74,29 +74,29 @@ so a `.` or `./app` source directory keeps its leading segment.
 
 How Nuxt project state reduces to the directory lists every glob is built from.
 
-| Case | Behaviour |
-| --- | --- |
-| `dirs/default` | Nuxt 4 defaults: a single layer with `srcDir` `app/`. |
-| `dirs/srcdir-is-root` | Nuxt 3 layout where `srcDir` equals `rootDir`, so `src` is `""` and every directory is top level. |
-| `dirs/two-layers` | A base layer extended by the app layer; every list gains a second entry, in layer order. |
-| `dirs/dir-overrides` | `nuxt.options.dir` renames pages, layouts, plugins, middleware and modules. `composables`/`utils` are **not** configurable and stay literal. |
-| `dirs/imports-dirs` | Extra auto-import directories join `composables`; a `~/` prefix is stripped rather than alias-resolved. |
-| `dirs/components-string-array` | `components` as a bare array of directory strings. |
-| `dirs/components-prefixed` | `components` as objects; a `prefix` also adds the directory to `componentsPrefixed`, which exempts one-word names. |
-| `dirs/components-true` | `components: true` keeps the default `components/` directory, same as omitting it. |
+| Case                           | Behaviour                                                                                                                                    |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dirs/default`                 | Nuxt 4 defaults: a single layer with `srcDir` `app/`.                                                                                        |
+| `dirs/srcdir-is-root`          | Nuxt 3 layout where `srcDir` equals `rootDir`, so `src` is `""` and every directory is top level.                                            |
+| `dirs/two-layers`              | A base layer extended by the app layer; every list gains a second entry, in layer order.                                                     |
+| `dirs/dir-overrides`           | `nuxt.options.dir` renames pages, layouts, plugins, middleware and modules. `composables`/`utils` are **not** configurable and stay literal. |
+| `dirs/imports-dirs`            | Extra auto-import directories join `composables`; a `~/` prefix is stripped rather than alias-resolved.                                      |
+| `dirs/components-string-array` | `components` as a bare array of directory strings.                                                                                           |
+| `dirs/components-prefixed`     | `components` as objects; a `prefix` also adds the directory to `componentsPrefixed`, which exempts one-word names.                           |
+| `dirs/components-true`         | `components: true` keeps the default `components/` directory, same as omitting it.                                                           |
 
 ## Feature flags
 
-| Case | Behaviour |
-| --- | --- |
-| `features/defaults` | `standalone` on, `stylistic`/`tooling`/`formatters` off, `typescript` from package detection. |
-| `features/standalone-false` | Drops the baseline blocks; only the Nuxt-aware ones remain, and `nuxt/ignores` is dropped with them. |
-| `features/stylistic` | Enabling stylistic rules also switches `nuxt.config` key sorting on. |
-| `features/stylistic-sort-opt-out` | An explicit `nuxt.sortConfigKeys: false` overrides that default. |
-| `features/sort-config-opt-in` | Key sorting can be enabled without stylistic rules. |
-| `features/typescript-false` | Drops the TypeScript blocks from the baseline. |
-| `features/typescript-true` | Adds them regardless of package detection. |
-| `features/tooling` | Adds the module-author rule blocks (jsdoc, unicorn, regexp). |
+| Case                              | Behaviour                                                                                            |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `features/defaults`               | `standalone` on, `stylistic`/`tooling`/`formatters` off, `typescript` from package detection.        |
+| `features/standalone-false`       | Drops the baseline blocks; only the Nuxt-aware ones remain, and `nuxt/ignores` is dropped with them. |
+| `features/stylistic`              | Enabling stylistic rules also switches `nuxt.config` key sorting on.                                 |
+| `features/stylistic-sort-opt-out` | An explicit `nuxt.sortConfigKeys: false` overrides that default.                                     |
+| `features/sort-config-opt-in`     | Key sorting can be enabled without stylistic rules.                                                  |
+| `features/typescript-false`       | Drops the TypeScript blocks from the baseline.                                                       |
+| `features/typescript-true`        | Adds them regardless of package detection.                                                           |
+| `features/tooling`                | Adds the module-author rule blocks (jsdoc, unicorn, regexp).                                         |
 
 `features.typescript` defaults to whether the `typescript` package resolves from
 `@nuxt/eslint-config`. The recording stores that probe's answer as

--- a/npm/framework/nuxt/test/nuxt-eslint-compat/fixtures/corpus.json
+++ b/npm/framework/nuxt/test/nuxt-eslint-compat/fixtures/corpus.json
@@ -1,0 +1,168 @@
+{
+  "oracle": {
+    "module": "@nuxt/eslint",
+    "config": "@nuxt/eslint-config",
+    "moduleVersion": "1.16.0",
+    "configVersion": "1.16.0"
+  },
+  "description": "Nuxt project states whose generated lint config @vizejs/nuxt must reproduce. Each case is materialised under a scratch root by oracle.mjs; every path is expressed relative to that root so the recording stays machine-independent.",
+  "dirDefaultCases": [
+    {
+      "id": "defaults/empty",
+      "description": "A hand-written config with no dirs at all takes every default.",
+      "dirs": {}
+    },
+    {
+      "id": "defaults/src-only",
+      "description": "Declaring src derives every per-feature directory from it.",
+      "dirs": { "src": ["src"] }
+    },
+    {
+      "id": "defaults/root-only",
+      "description": "Declaring root makes src follow root rather than the built-in pair.",
+      "dirs": { "root": ["."] }
+    },
+    {
+      "id": "defaults/empty-arrays",
+      "description": "Present-but-empty lists are kept: an empty array is truthy, so the ||= defaults never fire.",
+      "dirs": { "root": [], "src": [], "pages": [] }
+    },
+    {
+      "id": "defaults/partial",
+      "description": "Only the missing lists are defaulted; declared ones pass through untouched.",
+      "dirs": { "src": ["app"], "components": ["app/ui", "app/widgets"] }
+    }
+  ],
+  "cases": [
+    {
+      "id": "dirs/default",
+      "category": "dirs",
+      "description": "Nuxt 4 defaults: a single layer with srcDir app/.",
+      "project": { "layers": [{ "srcDir": "app" }] },
+      "config": {}
+    },
+    {
+      "id": "dirs/srcdir-is-root",
+      "category": "dirs",
+      "description": "Nuxt 3 layout where srcDir equals rootDir, so every directory is top level.",
+      "project": { "layers": [{ "srcDir": "." }] },
+      "config": {}
+    },
+    {
+      "id": "dirs/two-layers",
+      "category": "dirs",
+      "description": "A base layer extended by the app layer; every directory list gains a second entry.",
+      "project": { "layers": [{ "srcDir": "app" }, { "srcDir": "layers/base" }] },
+      "config": {}
+    },
+    {
+      "id": "dirs/dir-overrides",
+      "category": "dirs",
+      "description": "nuxt.options.dir renames pages, layouts, plugins, middleware and modules.",
+      "project": {
+        "layers": [{ "srcDir": "app" }],
+        "dir": {
+          "pages": "routes",
+          "layouts": "shells",
+          "plugins": "boot",
+          "middleware": "guards",
+          "modules": "mods"
+        }
+      },
+      "config": {}
+    },
+    {
+      "id": "dirs/imports-dirs",
+      "category": "dirs",
+      "description": "Extra auto-import directories, including a tilde-prefixed entry.",
+      "project": {
+        "layers": [{ "srcDir": "app", "imports": { "dirs": ["shared", "~/helpers"] } }]
+      },
+      "config": {}
+    },
+    {
+      "id": "dirs/components-string-array",
+      "category": "dirs",
+      "description": "components declared as a bare array of directory strings.",
+      "project": { "layers": [{ "srcDir": "app", "components": ["./ui", "./blocks"] }] },
+      "config": {}
+    },
+    {
+      "id": "dirs/components-prefixed",
+      "category": "dirs",
+      "description": "components declared as objects, one of which carries a prefix.",
+      "project": {
+        "layers": [
+          {
+            "srcDir": "app",
+            "components": { "dirs": ["./ui", { "path": "./widgets", "prefix": "W" }] }
+          }
+        ]
+      },
+      "config": {}
+    },
+    {
+      "id": "dirs/components-true",
+      "category": "dirs",
+      "description": "components: true keeps the default components directory.",
+      "project": { "layers": [{ "srcDir": "app", "components": true }] },
+      "config": {}
+    },
+    {
+      "id": "features/defaults",
+      "category": "features",
+      "description": "No feature options: standalone on, stylistic off, config-key sorting off.",
+      "project": { "layers": [{ "srcDir": "app" }] },
+      "config": {}
+    },
+    {
+      "id": "features/standalone-false",
+      "category": "features",
+      "description": "standalone: false drops the baseline blocks, keeping only the Nuxt-aware ones.",
+      "project": { "layers": [{ "srcDir": "app" }] },
+      "config": { "standalone": false }
+    },
+    {
+      "id": "features/stylistic",
+      "category": "features",
+      "description": "stylistic: true also switches nuxt.config key sorting on.",
+      "project": { "layers": [{ "srcDir": "app" }] },
+      "config": { "stylistic": true }
+    },
+    {
+      "id": "features/stylistic-sort-opt-out",
+      "category": "features",
+      "description": "An explicit sortConfigKeys: false overrides the stylistic default.",
+      "project": { "layers": [{ "srcDir": "app" }] },
+      "config": { "stylistic": true, "nuxt": { "sortConfigKeys": false } }
+    },
+    {
+      "id": "features/sort-config-opt-in",
+      "category": "features",
+      "description": "sortConfigKeys can be enabled without stylistic rules.",
+      "project": { "layers": [{ "srcDir": "app" }] },
+      "config": { "nuxt": { "sortConfigKeys": true } }
+    },
+    {
+      "id": "features/typescript-false",
+      "category": "features",
+      "description": "typescript: false drops the TypeScript blocks from the baseline.",
+      "project": { "layers": [{ "srcDir": "app" }] },
+      "config": { "typescript": false }
+    },
+    {
+      "id": "features/typescript-true",
+      "category": "features",
+      "description": "typescript: true adds the TypeScript blocks regardless of package detection.",
+      "project": { "layers": [{ "srcDir": "app" }] },
+      "config": { "typescript": true }
+    },
+    {
+      "id": "features/tooling",
+      "category": "features",
+      "description": "tooling: true adds the module-author rule blocks.",
+      "project": { "layers": [{ "srcDir": "app" }] },
+      "config": { "tooling": true }
+    }
+  ]
+}

--- a/npm/framework/nuxt/test/nuxt-eslint-compat/fixtures/nuxt-eslint-output.json
+++ b/npm/framework/nuxt/test/nuxt-eslint-compat/fixtures/nuxt-eslint-output.json
@@ -1,0 +1,2470 @@
+{
+  "schemaVersion": 1,
+  "description": "Recorded @nuxt/eslint output for every case in corpus.json. Generated — do not hand-edit; re-record with oracle.mjs --write.",
+  "moduleVersion": "1.16.0",
+  "configVersion": "1.16.0",
+  "typeScriptDetected": false,
+  "dirDefaults": {
+    "defaults/empty": {
+      "root": [
+        ".",
+        "./app"
+      ],
+      "src": [
+        ".",
+        "./app"
+      ],
+      "pages": [
+        "./pages",
+        "./app/pages"
+      ],
+      "layouts": [
+        "./layouts",
+        "./app/layouts"
+      ],
+      "components": [
+        "./components",
+        "./app/components"
+      ],
+      "composables": [
+        "./composables",
+        "./app/composables"
+      ],
+      "plugins": [
+        "./plugins",
+        "./app/plugins"
+      ],
+      "modules": [
+        "./modules",
+        "./app/modules"
+      ],
+      "middleware": [
+        "./middleware",
+        "./app/middleware"
+      ],
+      "servers": [
+        "./servers",
+        "./app/servers"
+      ],
+      "componentsPrefixed": []
+    },
+    "defaults/src-only": {
+      "src": [
+        "src"
+      ],
+      "root": [
+        ".",
+        "./app"
+      ],
+      "pages": [
+        "src/pages"
+      ],
+      "layouts": [
+        "src/layouts"
+      ],
+      "components": [
+        "src/components"
+      ],
+      "composables": [
+        "src/composables"
+      ],
+      "plugins": [
+        "src/plugins"
+      ],
+      "modules": [
+        "src/modules"
+      ],
+      "middleware": [
+        "src/middleware"
+      ],
+      "servers": [
+        "src/servers"
+      ],
+      "componentsPrefixed": []
+    },
+    "defaults/root-only": {
+      "root": [
+        "."
+      ],
+      "src": [
+        "."
+      ],
+      "pages": [
+        "./pages"
+      ],
+      "layouts": [
+        "./layouts"
+      ],
+      "components": [
+        "./components"
+      ],
+      "composables": [
+        "./composables"
+      ],
+      "plugins": [
+        "./plugins"
+      ],
+      "modules": [
+        "./modules"
+      ],
+      "middleware": [
+        "./middleware"
+      ],
+      "servers": [
+        "./servers"
+      ],
+      "componentsPrefixed": []
+    },
+    "defaults/empty-arrays": {
+      "root": [],
+      "src": [],
+      "pages": [],
+      "layouts": [],
+      "components": [],
+      "composables": [],
+      "plugins": [],
+      "modules": [],
+      "middleware": [],
+      "servers": [],
+      "componentsPrefixed": []
+    },
+    "defaults/partial": {
+      "src": [
+        "app"
+      ],
+      "components": [
+        "app/ui",
+        "app/widgets"
+      ],
+      "root": [
+        ".",
+        "./app"
+      ],
+      "pages": [
+        "app/pages"
+      ],
+      "layouts": [
+        "app/layouts"
+      ],
+      "composables": [
+        "app/composables"
+      ],
+      "plugins": [
+        "app/plugins"
+      ],
+      "modules": [
+        "app/modules"
+      ],
+      "middleware": [
+        "app/middleware"
+      ],
+      "servers": [
+        "app/servers"
+      ],
+      "componentsPrefixed": []
+    }
+  },
+  "cases": {
+    "dirs/default": {
+      "dirs": {
+        "pages": [
+          "app/pages"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils"
+        ],
+        "components": [
+          "app/components"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "app/layouts"
+        ],
+        "plugins": [
+          "app/plugins"
+        ],
+        "middleware": [
+          "app/middleware"
+        ],
+        "modules": [
+          "app/modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app"
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": false,
+        "typescript": false,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {},
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "dirs/srcdir-is-root": {
+      "dirs": {
+        "pages": [
+          "pages"
+        ],
+        "composables": [
+          "composables",
+          "utils"
+        ],
+        "components": [
+          "components"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "layouts"
+        ],
+        "plugins": [
+          "plugins"
+        ],
+        "middleware": [
+          "middleware"
+        ],
+        "modules": [
+          "modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          ""
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": false,
+        "typescript": false,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {},
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app.{js,ts,jsx,tsx,vue}",
+            "components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "error.{js,ts,jsx,tsx,vue}",
+            "layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "dirs/two-layers": {
+      "dirs": {
+        "pages": [
+          "app/pages",
+          "layers/base/pages"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils",
+          "layers/base/composables",
+          "layers/base/utils"
+        ],
+        "components": [
+          "app/components",
+          "layers/base/components"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "app/layouts",
+          "layers/base/layouts"
+        ],
+        "plugins": [
+          "app/plugins",
+          "layers/base/plugins"
+        ],
+        "middleware": [
+          "app/middleware",
+          "layers/base/middleware"
+        ],
+        "modules": [
+          "app/modules",
+          "layers/base/modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app",
+          "layers/base"
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": false,
+        "typescript": false,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {},
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}",
+            "layers/base/components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "layers/base/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "layers/base/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}",
+            "layers/base/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}",
+            "layers/base/app.{js,ts,jsx,tsx,vue}",
+            "layers/base/components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "layers/base/error.{js,ts,jsx,tsx,vue}",
+            "layers/base/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "layers/base/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "dirs/dir-overrides": {
+      "dirs": {
+        "pages": [
+          "app/routes"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils"
+        ],
+        "components": [
+          "app/components"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "app/shells"
+        ],
+        "plugins": [
+          "app/boot"
+        ],
+        "middleware": [
+          "app/guards"
+        ],
+        "modules": [
+          "app/mods"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app"
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": false,
+        "typescript": false,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {},
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/routes/**/*.{js,ts,jsx,tsx,vue}",
+            "app/shells/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/routes/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/routes/**/*.{js,ts,jsx,tsx,vue}",
+            "app/shells/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "dirs/imports-dirs": {
+      "dirs": {
+        "pages": [
+          "app/pages"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils",
+          "app/shared",
+          "app/helpers"
+        ],
+        "components": [
+          "app/components"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "app/layouts"
+        ],
+        "plugins": [
+          "app/plugins"
+        ],
+        "middleware": [
+          "app/middleware"
+        ],
+        "modules": [
+          "app/modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app"
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": false,
+        "typescript": false,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {},
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "dirs/components-string-array": {
+      "dirs": {
+        "pages": [
+          "app/pages"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils"
+        ],
+        "components": [
+          "app/ui",
+          "app/blocks"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "app/layouts"
+        ],
+        "plugins": [
+          "app/plugins"
+        ],
+        "middleware": [
+          "app/middleware"
+        ],
+        "modules": [
+          "app/modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app"
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": false,
+        "typescript": false,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {},
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/blocks/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}",
+            "app/ui/**/*.server.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/blocks/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}",
+            "app/ui/*/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "dirs/components-prefixed": {
+      "dirs": {
+        "pages": [
+          "app/pages"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils"
+        ],
+        "components": [
+          "app/ui",
+          "app/widgets"
+        ],
+        "componentsPrefixed": [
+          "app/widgets"
+        ],
+        "layouts": [
+          "app/layouts"
+        ],
+        "plugins": [
+          "app/plugins"
+        ],
+        "middleware": [
+          "app/middleware"
+        ],
+        "modules": [
+          "app/modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app"
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": false,
+        "typescript": false,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {},
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}",
+            "app/ui/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/widgets/**/*.server.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}",
+            "app/ui/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/widgets/**/*.{js,ts,jsx,tsx,vue}",
+            "app/widgets/*/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "dirs/components-true": {
+      "dirs": {
+        "pages": [
+          "app/pages"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils"
+        ],
+        "components": [
+          "app/components"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "app/layouts"
+        ],
+        "plugins": [
+          "app/plugins"
+        ],
+        "middleware": [
+          "app/middleware"
+        ],
+        "modules": [
+          "app/modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app"
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": false,
+        "typescript": false,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {},
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "features/defaults": {
+      "dirs": {
+        "pages": [
+          "app/pages"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils"
+        ],
+        "components": [
+          "app/components"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "app/layouts"
+        ],
+        "plugins": [
+          "app/plugins"
+        ],
+        "middleware": [
+          "app/middleware"
+        ],
+        "modules": [
+          "app/modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app"
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": false,
+        "typescript": false,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {},
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "features/standalone-false": {
+      "dirs": {
+        "pages": [
+          "app/pages"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils"
+        ],
+        "components": [
+          "app/components"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "app/layouts"
+        ],
+        "plugins": [
+          "app/plugins"
+        ],
+        "middleware": [
+          "app/middleware"
+        ],
+        "modules": [
+          "app/modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app"
+        ]
+      },
+      "features": {
+        "standalone": false,
+        "stylistic": false,
+        "typescript": false,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {},
+        "import": {}
+      },
+      "configNames": [
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "features/stylistic": {
+      "dirs": {
+        "pages": [
+          "app/pages"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils"
+        ],
+        "components": [
+          "app/components"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "app/layouts"
+        ],
+        "plugins": [
+          "app/plugins"
+        ],
+        "middleware": [
+          "app/middleware"
+        ],
+        "modules": [
+          "app/modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app"
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": true,
+        "typescript": false,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {},
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/sort-config",
+        "nuxt/stylistic",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/sort-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/nuxt-config-keys-order": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "features/stylistic-sort-opt-out": {
+      "dirs": {
+        "pages": [
+          "app/pages"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils"
+        ],
+        "components": [
+          "app/components"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "app/layouts"
+        ],
+        "plugins": [
+          "app/plugins"
+        ],
+        "middleware": [
+          "app/middleware"
+        ],
+        "modules": [
+          "app/modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app"
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": true,
+        "typescript": false,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {
+          "sortConfigKeys": false
+        },
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/stylistic",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "features/sort-config-opt-in": {
+      "dirs": {
+        "pages": [
+          "app/pages"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils"
+        ],
+        "components": [
+          "app/components"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "app/layouts"
+        ],
+        "plugins": [
+          "app/plugins"
+        ],
+        "middleware": [
+          "app/middleware"
+        ],
+        "modules": [
+          "app/modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app"
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": false,
+        "typescript": false,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {
+          "sortConfigKeys": true
+        },
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/sort-config",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/sort-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/nuxt-config-keys-order": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "features/typescript-false": {
+      "dirs": {
+        "pages": [
+          "app/pages"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils"
+        ],
+        "components": [
+          "app/components"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "app/layouts"
+        ],
+        "plugins": [
+          "app/plugins"
+        ],
+        "middleware": [
+          "app/middleware"
+        ],
+        "modules": [
+          "app/modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app"
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": false,
+        "typescript": false,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {},
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "features/typescript-true": {
+      "dirs": {
+        "pages": [
+          "app/pages"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils"
+        ],
+        "components": [
+          "app/components"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "app/layouts"
+        ],
+        "plugins": [
+          "app/plugins"
+        ],
+        "middleware": [
+          "app/middleware"
+        ],
+        "modules": [
+          "app/modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app"
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": false,
+        "typescript": true,
+        "tooling": false,
+        "formatters": false,
+        "nuxt": {},
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/typescript/setup",
+        "nuxt/typescript/rules",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    },
+    "features/tooling": {
+      "dirs": {
+        "pages": [
+          "app/pages"
+        ],
+        "composables": [
+          "app/composables",
+          "app/utils"
+        ],
+        "components": [
+          "app/components"
+        ],
+        "componentsPrefixed": [],
+        "layouts": [
+          "app/layouts"
+        ],
+        "plugins": [
+          "app/plugins"
+        ],
+        "middleware": [
+          "app/middleware"
+        ],
+        "modules": [
+          "app/modules"
+        ],
+        "servers": [],
+        "root": [],
+        "src": [
+          "app"
+        ]
+      },
+      "features": {
+        "standalone": true,
+        "stylistic": false,
+        "typescript": false,
+        "tooling": true,
+        "formatters": false,
+        "nuxt": {},
+        "import": {}
+      },
+      "configNames": [
+        "gitignore",
+        null,
+        "nuxt/javascript",
+        "nuxt/vue/setup",
+        "nuxt/vue/rules",
+        "nuxt/import/rules",
+        "nuxt/setup",
+        "nuxt/vue/single-root",
+        "nuxt/rules",
+        "nuxt/pages",
+        "nuxt/nuxt-config",
+        "nuxt/tooling/jsdoc",
+        "nuxt/tooling/unicorn",
+        "nuxt/tooling/regexp",
+        "nuxt/disables/routes"
+      ],
+      "nuxtConfigs": [
+        {
+          "name": null,
+          "files": null,
+          "ignores": [
+            "**/dist",
+            "**/node_modules",
+            "**/.nuxt",
+            "**/.output",
+            "**/.vercel",
+            "**/.netlify",
+            "**/public"
+          ],
+          "rules": null,
+          "globals": null
+        },
+        {
+          "name": "nuxt/setup",
+          "files": null,
+          "ignores": null,
+          "rules": null,
+          "globals": {
+            "$fetch": "readonly"
+          }
+        },
+        {
+          "name": "nuxt/vue/single-root",
+          "files": [
+            "app/components/**/*.server.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/no-multiple-template-root": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/rules",
+          "files": null,
+          "ignores": null,
+          "rules": {
+            "nuxt/prefer-import-meta": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/pages",
+          "files": [
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-page-meta-runtime-values": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/nuxt-config",
+          "files": [
+            "**/.config/nuxt.?([cm])[jt]s?(x)",
+            "**/nuxt.config.?([cm])[jt]s?(x)"
+          ],
+          "ignores": null,
+          "rules": {
+            "nuxt/no-nuxt-config-test-key": "error"
+          },
+          "globals": null
+        },
+        {
+          "name": "nuxt/disables/routes",
+          "files": [
+            "app/app.{js,ts,jsx,tsx,vue}",
+            "app/components/*/**/*.{js,ts,jsx,tsx,vue}",
+            "app/error.{js,ts,jsx,tsx,vue}",
+            "app/layouts/**/*.{js,ts,jsx,tsx,vue}",
+            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
+          ],
+          "ignores": null,
+          "rules": {
+            "vue/multi-word-component-names": "off"
+          },
+          "globals": null
+        }
+      ]
+    }
+  }
+}

--- a/npm/framework/nuxt/test/nuxt-eslint-compat/fixtures/nuxt-eslint-output.json
+++ b/npm/framework/nuxt/test/nuxt-eslint-compat/fixtures/nuxt-eslint-output.json
@@ -6,113 +6,42 @@
   "typeScriptDetected": false,
   "dirDefaults": {
     "defaults/empty": {
-      "root": [
-        ".",
-        "./app"
-      ],
-      "src": [
-        ".",
-        "./app"
-      ],
-      "pages": [
-        "./pages",
-        "./app/pages"
-      ],
-      "layouts": [
-        "./layouts",
-        "./app/layouts"
-      ],
-      "components": [
-        "./components",
-        "./app/components"
-      ],
-      "composables": [
-        "./composables",
-        "./app/composables"
-      ],
-      "plugins": [
-        "./plugins",
-        "./app/plugins"
-      ],
-      "modules": [
-        "./modules",
-        "./app/modules"
-      ],
-      "middleware": [
-        "./middleware",
-        "./app/middleware"
-      ],
-      "servers": [
-        "./servers",
-        "./app/servers"
-      ],
+      "root": [".", "./app"],
+      "src": [".", "./app"],
+      "pages": ["./pages", "./app/pages"],
+      "layouts": ["./layouts", "./app/layouts"],
+      "components": ["./components", "./app/components"],
+      "composables": ["./composables", "./app/composables"],
+      "plugins": ["./plugins", "./app/plugins"],
+      "modules": ["./modules", "./app/modules"],
+      "middleware": ["./middleware", "./app/middleware"],
+      "servers": ["./servers", "./app/servers"],
       "componentsPrefixed": []
     },
     "defaults/src-only": {
-      "src": [
-        "src"
-      ],
-      "root": [
-        ".",
-        "./app"
-      ],
-      "pages": [
-        "src/pages"
-      ],
-      "layouts": [
-        "src/layouts"
-      ],
-      "components": [
-        "src/components"
-      ],
-      "composables": [
-        "src/composables"
-      ],
-      "plugins": [
-        "src/plugins"
-      ],
-      "modules": [
-        "src/modules"
-      ],
-      "middleware": [
-        "src/middleware"
-      ],
-      "servers": [
-        "src/servers"
-      ],
+      "src": ["src"],
+      "root": [".", "./app"],
+      "pages": ["src/pages"],
+      "layouts": ["src/layouts"],
+      "components": ["src/components"],
+      "composables": ["src/composables"],
+      "plugins": ["src/plugins"],
+      "modules": ["src/modules"],
+      "middleware": ["src/middleware"],
+      "servers": ["src/servers"],
       "componentsPrefixed": []
     },
     "defaults/root-only": {
-      "root": [
-        "."
-      ],
-      "src": [
-        "."
-      ],
-      "pages": [
-        "./pages"
-      ],
-      "layouts": [
-        "./layouts"
-      ],
-      "components": [
-        "./components"
-      ],
-      "composables": [
-        "./composables"
-      ],
-      "plugins": [
-        "./plugins"
-      ],
-      "modules": [
-        "./modules"
-      ],
-      "middleware": [
-        "./middleware"
-      ],
-      "servers": [
-        "./servers"
-      ],
+      "root": ["."],
+      "src": ["."],
+      "pages": ["./pages"],
+      "layouts": ["./layouts"],
+      "components": ["./components"],
+      "composables": ["./composables"],
+      "plugins": ["./plugins"],
+      "modules": ["./modules"],
+      "middleware": ["./middleware"],
+      "servers": ["./servers"],
       "componentsPrefixed": []
     },
     "defaults/empty-arrays": {
@@ -129,72 +58,33 @@
       "componentsPrefixed": []
     },
     "defaults/partial": {
-      "src": [
-        "app"
-      ],
-      "components": [
-        "app/ui",
-        "app/widgets"
-      ],
-      "root": [
-        ".",
-        "./app"
-      ],
-      "pages": [
-        "app/pages"
-      ],
-      "layouts": [
-        "app/layouts"
-      ],
-      "composables": [
-        "app/composables"
-      ],
-      "plugins": [
-        "app/plugins"
-      ],
-      "modules": [
-        "app/modules"
-      ],
-      "middleware": [
-        "app/middleware"
-      ],
-      "servers": [
-        "app/servers"
-      ],
+      "src": ["app"],
+      "components": ["app/ui", "app/widgets"],
+      "root": [".", "./app"],
+      "pages": ["app/pages"],
+      "layouts": ["app/layouts"],
+      "composables": ["app/composables"],
+      "plugins": ["app/plugins"],
+      "modules": ["app/modules"],
+      "middleware": ["app/middleware"],
+      "servers": ["app/servers"],
       "componentsPrefixed": []
     }
   },
   "cases": {
     "dirs/default": {
       "dirs": {
-        "pages": [
-          "app/pages"
-        ],
-        "composables": [
-          "app/composables",
-          "app/utils"
-        ],
-        "components": [
-          "app/components"
-        ],
+        "pages": ["app/pages"],
+        "composables": ["app/composables", "app/utils"],
+        "components": ["app/components"],
         "componentsPrefixed": [],
-        "layouts": [
-          "app/layouts"
-        ],
-        "plugins": [
-          "app/plugins"
-        ],
-        "middleware": [
-          "app/middleware"
-        ],
-        "modules": [
-          "app/modules"
-        ],
+        "layouts": ["app/layouts"],
+        "plugins": ["app/plugins"],
+        "middleware": ["app/middleware"],
+        "modules": ["app/modules"],
         "servers": [],
         "root": [],
-        "src": [
-          "app"
-        ]
+        "src": ["app"]
       },
       "features": {
         "standalone": true,
@@ -268,9 +158,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["app/pages/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -279,10 +167,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -308,34 +193,17 @@
     },
     "dirs/srcdir-is-root": {
       "dirs": {
-        "pages": [
-          "pages"
-        ],
-        "composables": [
-          "composables",
-          "utils"
-        ],
-        "components": [
-          "components"
-        ],
+        "pages": ["pages"],
+        "composables": ["composables", "utils"],
+        "components": ["components"],
         "componentsPrefixed": [],
-        "layouts": [
-          "layouts"
-        ],
-        "plugins": [
-          "plugins"
-        ],
-        "middleware": [
-          "middleware"
-        ],
-        "modules": [
-          "modules"
-        ],
+        "layouts": ["layouts"],
+        "plugins": ["plugins"],
+        "middleware": ["middleware"],
+        "modules": ["modules"],
         "servers": [],
         "root": [],
-        "src": [
-          ""
-        ]
+        "src": [""]
       },
       "features": {
         "standalone": true,
@@ -409,9 +277,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "pages/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["pages/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -420,10 +286,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -449,43 +312,22 @@
     },
     "dirs/two-layers": {
       "dirs": {
-        "pages": [
-          "app/pages",
-          "layers/base/pages"
-        ],
+        "pages": ["app/pages", "layers/base/pages"],
         "composables": [
           "app/composables",
           "app/utils",
           "layers/base/composables",
           "layers/base/utils"
         ],
-        "components": [
-          "app/components",
-          "layers/base/components"
-        ],
+        "components": ["app/components", "layers/base/components"],
         "componentsPrefixed": [],
-        "layouts": [
-          "app/layouts",
-          "layers/base/layouts"
-        ],
-        "plugins": [
-          "app/plugins",
-          "layers/base/plugins"
-        ],
-        "middleware": [
-          "app/middleware",
-          "layers/base/middleware"
-        ],
-        "modules": [
-          "app/modules",
-          "layers/base/modules"
-        ],
+        "layouts": ["app/layouts", "layers/base/layouts"],
+        "plugins": ["app/plugins", "layers/base/plugins"],
+        "middleware": ["app/middleware", "layers/base/middleware"],
+        "modules": ["app/modules", "layers/base/modules"],
         "servers": [],
         "root": [],
-        "src": [
-          "app",
-          "layers/base"
-        ]
+        "src": ["app", "layers/base"]
       },
       "features": {
         "standalone": true,
@@ -574,10 +416,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -608,34 +447,17 @@
     },
     "dirs/dir-overrides": {
       "dirs": {
-        "pages": [
-          "app/routes"
-        ],
-        "composables": [
-          "app/composables",
-          "app/utils"
-        ],
-        "components": [
-          "app/components"
-        ],
+        "pages": ["app/routes"],
+        "composables": ["app/composables", "app/utils"],
+        "components": ["app/components"],
         "componentsPrefixed": [],
-        "layouts": [
-          "app/shells"
-        ],
-        "plugins": [
-          "app/boot"
-        ],
-        "middleware": [
-          "app/guards"
-        ],
-        "modules": [
-          "app/mods"
-        ],
+        "layouts": ["app/shells"],
+        "plugins": ["app/boot"],
+        "middleware": ["app/guards"],
+        "modules": ["app/mods"],
         "servers": [],
         "root": [],
-        "src": [
-          "app"
-        ]
+        "src": ["app"]
       },
       "features": {
         "standalone": true,
@@ -709,9 +531,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "app/routes/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["app/routes/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -720,10 +540,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -749,36 +566,17 @@
     },
     "dirs/imports-dirs": {
       "dirs": {
-        "pages": [
-          "app/pages"
-        ],
-        "composables": [
-          "app/composables",
-          "app/utils",
-          "app/shared",
-          "app/helpers"
-        ],
-        "components": [
-          "app/components"
-        ],
+        "pages": ["app/pages"],
+        "composables": ["app/composables", "app/utils", "app/shared", "app/helpers"],
+        "components": ["app/components"],
         "componentsPrefixed": [],
-        "layouts": [
-          "app/layouts"
-        ],
-        "plugins": [
-          "app/plugins"
-        ],
-        "middleware": [
-          "app/middleware"
-        ],
-        "modules": [
-          "app/modules"
-        ],
+        "layouts": ["app/layouts"],
+        "plugins": ["app/plugins"],
+        "middleware": ["app/middleware"],
+        "modules": ["app/modules"],
         "servers": [],
         "root": [],
-        "src": [
-          "app"
-        ]
+        "src": ["app"]
       },
       "features": {
         "standalone": true,
@@ -852,9 +650,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["app/pages/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -863,10 +659,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -892,35 +685,17 @@
     },
     "dirs/components-string-array": {
       "dirs": {
-        "pages": [
-          "app/pages"
-        ],
-        "composables": [
-          "app/composables",
-          "app/utils"
-        ],
-        "components": [
-          "app/ui",
-          "app/blocks"
-        ],
+        "pages": ["app/pages"],
+        "composables": ["app/composables", "app/utils"],
+        "components": ["app/ui", "app/blocks"],
         "componentsPrefixed": [],
-        "layouts": [
-          "app/layouts"
-        ],
-        "plugins": [
-          "app/plugins"
-        ],
-        "middleware": [
-          "app/middleware"
-        ],
-        "modules": [
-          "app/modules"
-        ],
+        "layouts": ["app/layouts"],
+        "plugins": ["app/plugins"],
+        "middleware": ["app/middleware"],
+        "modules": ["app/modules"],
         "servers": [],
         "root": [],
-        "src": [
-          "app"
-        ]
+        "src": ["app"]
       },
       "features": {
         "standalone": true,
@@ -995,9 +770,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["app/pages/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -1006,10 +779,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -1036,37 +806,17 @@
     },
     "dirs/components-prefixed": {
       "dirs": {
-        "pages": [
-          "app/pages"
-        ],
-        "composables": [
-          "app/composables",
-          "app/utils"
-        ],
-        "components": [
-          "app/ui",
-          "app/widgets"
-        ],
-        "componentsPrefixed": [
-          "app/widgets"
-        ],
-        "layouts": [
-          "app/layouts"
-        ],
-        "plugins": [
-          "app/plugins"
-        ],
-        "middleware": [
-          "app/middleware"
-        ],
-        "modules": [
-          "app/modules"
-        ],
+        "pages": ["app/pages"],
+        "composables": ["app/composables", "app/utils"],
+        "components": ["app/ui", "app/widgets"],
+        "componentsPrefixed": ["app/widgets"],
+        "layouts": ["app/layouts"],
+        "plugins": ["app/plugins"],
+        "middleware": ["app/middleware"],
+        "modules": ["app/modules"],
         "servers": [],
         "root": [],
-        "src": [
-          "app"
-        ]
+        "src": ["app"]
       },
       "features": {
         "standalone": true,
@@ -1141,9 +891,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["app/pages/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -1152,10 +900,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -1183,34 +928,17 @@
     },
     "dirs/components-true": {
       "dirs": {
-        "pages": [
-          "app/pages"
-        ],
-        "composables": [
-          "app/composables",
-          "app/utils"
-        ],
-        "components": [
-          "app/components"
-        ],
+        "pages": ["app/pages"],
+        "composables": ["app/composables", "app/utils"],
+        "components": ["app/components"],
         "componentsPrefixed": [],
-        "layouts": [
-          "app/layouts"
-        ],
-        "plugins": [
-          "app/plugins"
-        ],
-        "middleware": [
-          "app/middleware"
-        ],
-        "modules": [
-          "app/modules"
-        ],
+        "layouts": ["app/layouts"],
+        "plugins": ["app/plugins"],
+        "middleware": ["app/middleware"],
+        "modules": ["app/modules"],
         "servers": [],
         "root": [],
-        "src": [
-          "app"
-        ]
+        "src": ["app"]
       },
       "features": {
         "standalone": true,
@@ -1284,9 +1012,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["app/pages/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -1295,10 +1021,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -1324,34 +1047,17 @@
     },
     "features/defaults": {
       "dirs": {
-        "pages": [
-          "app/pages"
-        ],
-        "composables": [
-          "app/composables",
-          "app/utils"
-        ],
-        "components": [
-          "app/components"
-        ],
+        "pages": ["app/pages"],
+        "composables": ["app/composables", "app/utils"],
+        "components": ["app/components"],
         "componentsPrefixed": [],
-        "layouts": [
-          "app/layouts"
-        ],
-        "plugins": [
-          "app/plugins"
-        ],
-        "middleware": [
-          "app/middleware"
-        ],
-        "modules": [
-          "app/modules"
-        ],
+        "layouts": ["app/layouts"],
+        "plugins": ["app/plugins"],
+        "middleware": ["app/middleware"],
+        "modules": ["app/modules"],
         "servers": [],
         "root": [],
-        "src": [
-          "app"
-        ]
+        "src": ["app"]
       },
       "features": {
         "standalone": true,
@@ -1425,9 +1131,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["app/pages/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -1436,10 +1140,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -1465,34 +1166,17 @@
     },
     "features/standalone-false": {
       "dirs": {
-        "pages": [
-          "app/pages"
-        ],
-        "composables": [
-          "app/composables",
-          "app/utils"
-        ],
-        "components": [
-          "app/components"
-        ],
+        "pages": ["app/pages"],
+        "composables": ["app/composables", "app/utils"],
+        "components": ["app/components"],
         "componentsPrefixed": [],
-        "layouts": [
-          "app/layouts"
-        ],
-        "plugins": [
-          "app/plugins"
-        ],
-        "middleware": [
-          "app/middleware"
-        ],
-        "modules": [
-          "app/modules"
-        ],
+        "layouts": ["app/layouts"],
+        "plugins": ["app/plugins"],
+        "middleware": ["app/middleware"],
+        "modules": ["app/modules"],
         "servers": [],
         "root": [],
-        "src": [
-          "app"
-        ]
+        "src": ["app"]
       },
       "features": {
         "standalone": false,
@@ -1545,9 +1229,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["app/pages/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -1556,10 +1238,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -1585,34 +1264,17 @@
     },
     "features/stylistic": {
       "dirs": {
-        "pages": [
-          "app/pages"
-        ],
-        "composables": [
-          "app/composables",
-          "app/utils"
-        ],
-        "components": [
-          "app/components"
-        ],
+        "pages": ["app/pages"],
+        "composables": ["app/composables", "app/utils"],
+        "components": ["app/components"],
         "componentsPrefixed": [],
-        "layouts": [
-          "app/layouts"
-        ],
-        "plugins": [
-          "app/plugins"
-        ],
-        "middleware": [
-          "app/middleware"
-        ],
-        "modules": [
-          "app/modules"
-        ],
+        "layouts": ["app/layouts"],
+        "plugins": ["app/plugins"],
+        "middleware": ["app/middleware"],
+        "modules": ["app/modules"],
         "servers": [],
         "root": [],
-        "src": [
-          "app"
-        ]
+        "src": ["app"]
       },
       "features": {
         "standalone": true,
@@ -1688,9 +1350,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["app/pages/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -1699,10 +1359,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -1711,10 +1368,7 @@
         },
         {
           "name": "nuxt/sort-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/nuxt-config-keys-order": "error"
@@ -1740,34 +1394,17 @@
     },
     "features/stylistic-sort-opt-out": {
       "dirs": {
-        "pages": [
-          "app/pages"
-        ],
-        "composables": [
-          "app/composables",
-          "app/utils"
-        ],
-        "components": [
-          "app/components"
-        ],
+        "pages": ["app/pages"],
+        "composables": ["app/composables", "app/utils"],
+        "components": ["app/components"],
         "componentsPrefixed": [],
-        "layouts": [
-          "app/layouts"
-        ],
-        "plugins": [
-          "app/plugins"
-        ],
-        "middleware": [
-          "app/middleware"
-        ],
-        "modules": [
-          "app/modules"
-        ],
+        "layouts": ["app/layouts"],
+        "plugins": ["app/plugins"],
+        "middleware": ["app/middleware"],
+        "modules": ["app/modules"],
         "servers": [],
         "root": [],
-        "src": [
-          "app"
-        ]
+        "src": ["app"]
       },
       "features": {
         "standalone": true,
@@ -1844,9 +1481,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["app/pages/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -1855,10 +1490,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -1884,34 +1516,17 @@
     },
     "features/sort-config-opt-in": {
       "dirs": {
-        "pages": [
-          "app/pages"
-        ],
-        "composables": [
-          "app/composables",
-          "app/utils"
-        ],
-        "components": [
-          "app/components"
-        ],
+        "pages": ["app/pages"],
+        "composables": ["app/composables", "app/utils"],
+        "components": ["app/components"],
         "componentsPrefixed": [],
-        "layouts": [
-          "app/layouts"
-        ],
-        "plugins": [
-          "app/plugins"
-        ],
-        "middleware": [
-          "app/middleware"
-        ],
-        "modules": [
-          "app/modules"
-        ],
+        "layouts": ["app/layouts"],
+        "plugins": ["app/plugins"],
+        "middleware": ["app/middleware"],
+        "modules": ["app/modules"],
         "servers": [],
         "root": [],
-        "src": [
-          "app"
-        ]
+        "src": ["app"]
       },
       "features": {
         "standalone": true,
@@ -1988,9 +1603,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["app/pages/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -1999,10 +1612,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -2011,10 +1621,7 @@
         },
         {
           "name": "nuxt/sort-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/nuxt-config-keys-order": "error"
@@ -2040,34 +1647,17 @@
     },
     "features/typescript-false": {
       "dirs": {
-        "pages": [
-          "app/pages"
-        ],
-        "composables": [
-          "app/composables",
-          "app/utils"
-        ],
-        "components": [
-          "app/components"
-        ],
+        "pages": ["app/pages"],
+        "composables": ["app/composables", "app/utils"],
+        "components": ["app/components"],
         "componentsPrefixed": [],
-        "layouts": [
-          "app/layouts"
-        ],
-        "plugins": [
-          "app/plugins"
-        ],
-        "middleware": [
-          "app/middleware"
-        ],
-        "modules": [
-          "app/modules"
-        ],
+        "layouts": ["app/layouts"],
+        "plugins": ["app/plugins"],
+        "middleware": ["app/middleware"],
+        "modules": ["app/modules"],
         "servers": [],
         "root": [],
-        "src": [
-          "app"
-        ]
+        "src": ["app"]
       },
       "features": {
         "standalone": true,
@@ -2141,9 +1731,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["app/pages/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -2152,10 +1740,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -2181,34 +1766,17 @@
     },
     "features/typescript-true": {
       "dirs": {
-        "pages": [
-          "app/pages"
-        ],
-        "composables": [
-          "app/composables",
-          "app/utils"
-        ],
-        "components": [
-          "app/components"
-        ],
+        "pages": ["app/pages"],
+        "composables": ["app/composables", "app/utils"],
+        "components": ["app/components"],
         "componentsPrefixed": [],
-        "layouts": [
-          "app/layouts"
-        ],
-        "plugins": [
-          "app/plugins"
-        ],
-        "middleware": [
-          "app/middleware"
-        ],
-        "modules": [
-          "app/modules"
-        ],
+        "layouts": ["app/layouts"],
+        "plugins": ["app/plugins"],
+        "middleware": ["app/middleware"],
+        "modules": ["app/modules"],
         "servers": [],
         "root": [],
-        "src": [
-          "app"
-        ]
+        "src": ["app"]
       },
       "features": {
         "standalone": true,
@@ -2284,9 +1852,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["app/pages/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -2295,10 +1861,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"
@@ -2324,34 +1887,17 @@
     },
     "features/tooling": {
       "dirs": {
-        "pages": [
-          "app/pages"
-        ],
-        "composables": [
-          "app/composables",
-          "app/utils"
-        ],
-        "components": [
-          "app/components"
-        ],
+        "pages": ["app/pages"],
+        "composables": ["app/composables", "app/utils"],
+        "components": ["app/components"],
         "componentsPrefixed": [],
-        "layouts": [
-          "app/layouts"
-        ],
-        "plugins": [
-          "app/plugins"
-        ],
-        "middleware": [
-          "app/middleware"
-        ],
-        "modules": [
-          "app/modules"
-        ],
+        "layouts": ["app/layouts"],
+        "plugins": ["app/plugins"],
+        "middleware": ["app/middleware"],
+        "modules": ["app/modules"],
         "servers": [],
         "root": [],
-        "src": [
-          "app"
-        ]
+        "src": ["app"]
       },
       "features": {
         "standalone": true,
@@ -2428,9 +1974,7 @@
         },
         {
           "name": "nuxt/pages",
-          "files": [
-            "app/pages/**/*.{js,ts,jsx,tsx,vue}"
-          ],
+          "files": ["app/pages/**/*.{js,ts,jsx,tsx,vue}"],
           "ignores": null,
           "rules": {
             "nuxt/no-page-meta-runtime-values": "error"
@@ -2439,10 +1983,7 @@
         },
         {
           "name": "nuxt/nuxt-config",
-          "files": [
-            "**/.config/nuxt.?([cm])[jt]s?(x)",
-            "**/nuxt.config.?([cm])[jt]s?(x)"
-          ],
+          "files": ["**/.config/nuxt.?([cm])[jt]s?(x)", "**/nuxt.config.?([cm])[jt]s?(x)"],
           "ignores": null,
           "rules": {
             "nuxt/no-nuxt-config-test-key": "error"

--- a/npm/framework/nuxt/test/nuxt-eslint-compat/oracle.mjs
+++ b/npm/framework/nuxt/test/nuxt-eslint-compat/oracle.mjs
@@ -1,0 +1,235 @@
+/**
+ * Differential oracle for `@nuxt/eslint` compatibility.
+ *
+ * Runs every case in `fixtures/corpus.json` through the real `@nuxt/eslint`
+ * module and `@nuxt/eslint-config`, and records what they produce in
+ * `fixtures/nuxt-eslint-output.json`. That recorded file is the committed
+ * ground truth: `src/lint/oracle.test.ts` reads it with no `@nuxt/*` dependency
+ * at all, so the package's own suite stays offline and fast, while
+ * `tests/tooling/nuxt-eslint-oracle.test.ts` re-runs this script in CI and
+ * fails if the recording has drifted from the installed packages.
+ *
+ * Two upstream contracts are recorded per case, because the port splits along
+ * the same seam:
+ *
+ *   1. `dirs` — the Nuxt project state (layers, `srcDir`, `dir` overrides,
+ *      component directories) reduced to the directory lists every glob is
+ *      built from. Produced by `@nuxt/eslint`'s module.
+ *   2. `features` + the resolved config items — which named rule blocks exist,
+ *      in what order, over which globs. Produced by `@nuxt/eslint-config`.
+ *
+ * Usage:
+ *   node npm/framework/nuxt/test/nuxt-eslint-compat/oracle.mjs --check   # verify
+ *   node npm/framework/nuxt/test/nuxt-eslint-compat/oracle.mjs --write   # re-record
+ */
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+export const corpusPath = join(here, "fixtures", "corpus.json");
+export const recordedPath = join(here, "fixtures", "nuxt-eslint-output.json");
+
+/**
+ * Where the throwaway Nuxt roots are created.
+ *
+ * The generated config imports `@nuxt/eslint-config` through a path *relative
+ * to itself*, so the scratch root has to sit somewhere those relative
+ * specifiers still resolve — `node_modules/.vize/`, the same gitignored scratch
+ * area the rest of the toolchain writes derived artifacts into. A system temp
+ * directory does not work: on macOS its `/private` symlink makes the emitted
+ * relative path resolve to a directory that does not exist.
+ */
+const scratchRoot = join(
+  here,
+  "..",
+  "..",
+  "..",
+  "..",
+  "..",
+  "node_modules",
+  ".vize",
+  "nuxt-eslint-oracle",
+);
+
+/**
+ * Config item names the port owns.
+ *
+ * These are the blocks that encode Nuxt project awareness. The remaining items
+ * are `@nuxt/eslint-config`'s generic JavaScript/TypeScript/Vue/stylistic
+ * preset content, which is a separate phase of the port — their *names and
+ * order* are still recorded so nothing can disappear unnoticed.
+ */
+export const NUXT_OWNED_CONFIG_NAMES = [
+  "nuxt/setup",
+  "nuxt/vue/single-root",
+  "nuxt/rules",
+  "nuxt/pages",
+  "nuxt/nuxt-config",
+  "nuxt/sort-config",
+  "nuxt/disables/routes",
+];
+
+export function readCorpus() {
+  return JSON.parse(readFileSync(corpusPath, "utf8"));
+}
+
+export function readRecorded() {
+  return JSON.parse(readFileSync(recordedPath, "utf8"));
+}
+
+/**
+ * A Nuxt instance stub carrying only what config generation reads.
+ *
+ * `@nuxt/eslint` touches `options.rootDir`, `options.buildDir`,
+ * `options.dir`, and `options._layers`, and registers hooks it never fires
+ * itself. Driving it with a stub keeps the oracle free of a real Nuxt build,
+ * so the recording depends on the corpus alone.
+ */
+function createNuxtStub(rootDir, entry) {
+  const hooks = new Map();
+  const layers = entry.project.layers.map((layer) => ({
+    config: { ...layer, srcDir: join(rootDir, layer.srcDir) },
+  }));
+  return {
+    options: {
+      rootDir,
+      buildDir: join(rootDir, ".nuxt"),
+      srcDir: layers[0].config.srcDir,
+      dir: entry.project.dir ?? {},
+      _layers: layers,
+    },
+    hook(name, handler) {
+      if (!hooks.has(name)) hooks.set(name, []);
+      hooks.get(name).push(handler);
+    },
+    async callHook(name, ...args) {
+      for (const handler of hooks.get(name) ?? []) await handler(...args);
+    },
+  };
+}
+
+/**
+ * Run the real module for one case and return the directory lists it derived.
+ *
+ * The generated config module is imported rather than text-matched: it exports
+ * the resolved options object, which is the value the config presets actually
+ * consume.
+ */
+async function recordDirs(setupConfigGen, entry) {
+  mkdirSync(scratchRoot, { recursive: true });
+  const rootDir = mkdtempSync(join(scratchRoot, "case-"));
+  try {
+    mkdirSync(join(rootDir, ".nuxt"), { recursive: true });
+    const nuxt = createNuxtStub(rootDir, entry);
+    // `autoInit` is disabled so the oracle never writes an `eslint.config.mjs`
+    // outside its temporary root, and never walks the filesystem looking for one.
+    await setupConfigGen({ config: { autoInit: false } }, nuxt);
+    const generated = await import(join(rootDir, ".nuxt", "eslint.config.mjs"));
+    return generated.options.dirs;
+  } finally {
+    rmSync(rootDir, { force: true, recursive: true });
+  }
+}
+
+/** Reduce one resolved flat-config item to its serialisable contract. */
+function recordConfigItem(item) {
+  return {
+    name: item.name ?? null,
+    files: item.files ?? null,
+    ignores: item.ignores ?? null,
+    rules: item.rules ?? null,
+    globals: item.languageOptions?.globals ?? null,
+  };
+}
+
+/**
+ * Whether an item belongs to the Nuxt-aware surface this phase ports.
+ *
+ * The ignore block is matched structurally because upstream leaves it unnamed;
+ * `eslint-config-flat-gitignore`'s block is excluded by having a name.
+ */
+function isNuxtOwned(item) {
+  if (NUXT_OWNED_CONFIG_NAMES.includes(item.name)) return true;
+  return item.name === undefined && Array.isArray(item.ignores);
+}
+
+/**
+ * Read the version of a package from one of its resolved entry points.
+ *
+ * Neither `@nuxt/eslint` nor `@nuxt/eslint-config` exports `./package.json`, so
+ * the manifest is read beside the `dist/` directory the entry lives in.
+ */
+function packageVersionFrom(entryUrl) {
+  const manifest = fileURLToPath(new URL("../package.json", entryUrl));
+  return JSON.parse(readFileSync(manifest, "utf8")).version;
+}
+
+/** Run the whole corpus, returning the recordable payload. */
+export async function runOracle() {
+  const moduleEntry = import.meta.resolve("@nuxt/eslint");
+  const configEntry = import.meta.resolve("@nuxt/eslint-config/flat");
+  const [{ setupConfigGen }, { createConfigForNuxt, resolveOptions }] = await Promise.all([
+    import(new URL("./chunks/index.mjs", moduleEntry).href),
+    import(configEntry),
+  ]);
+
+  const corpus = readCorpus();
+
+  // The directory defaults only apply to hand-written configs — a config
+  // generated from a Nuxt instance always supplies every list — so they are
+  // recorded from `resolveOptions` directly rather than through the module.
+  const dirDefaults = {};
+  for (const entry of corpus.dirDefaultCases) {
+    dirDefaults[entry.id] = resolveOptions({
+      features: {},
+      dirs: structuredClone(entry.dirs),
+    }).dirs;
+  }
+
+  const cases = {};
+  for (const entry of corpus.cases) {
+    const dirs = await recordDirs(setupConfigGen, entry);
+    const options = { features: entry.config, dirs };
+    const resolved = resolveOptions(structuredClone(options));
+    const items = await createConfigForNuxt(structuredClone(options));
+    cases[entry.id] = {
+      dirs,
+      features: resolved.features,
+      configNames: items.map((item) => item.name ?? null),
+      nuxtConfigs: items.filter(isNuxtOwned).map(recordConfigItem),
+    };
+  }
+
+  return {
+    schemaVersion: 1,
+    description:
+      "Recorded @nuxt/eslint output for every case in corpus.json. Generated — do not hand-edit; re-record with oracle.mjs --write.",
+    moduleVersion: packageVersionFrom(moduleEntry),
+    configVersion: packageVersionFrom(configEntry),
+    // `@nuxt/eslint-config` defaults `features.typescript` to whether the
+    // `typescript` package resolves. Recording the probe's answer keeps the
+    // offline test honest about which branch the rest of the recording is on.
+    typeScriptDetected: resolveOptions({ features: {}, dirs: {} }).features.typescript,
+    dirDefaults,
+    cases,
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const write = process.argv.includes("--write");
+  const recorded = await runOracle();
+  if (write) {
+    writeFileSync(recordedPath, `${JSON.stringify(recorded, null, 2)}\n`);
+    console.log(`recorded ${Object.keys(recorded.cases).length} cases -> ${recordedPath}`);
+  } else {
+    const expected = readRecorded();
+    const actual = JSON.stringify(recorded, null, 2);
+    if (JSON.stringify(expected, null, 2) !== actual) {
+      console.error("nuxt-eslint-output.json is out of date; re-record with --write");
+      process.exitCode = 1;
+    } else {
+      console.log(`oracle matches ${Object.keys(recorded.cases).length} recorded cases`);
+    }
+  }
+}

--- a/npm/framework/nuxt/vite.config.ts
+++ b/npm/framework/nuxt/vite.config.ts
@@ -11,11 +11,7 @@ export default defineConfig({
     ignorePatterns: ["dist/**"],
   },
   pack: {
-    entry: [
-      "src/index.ts",
-      "src/lint/index.ts",
-      "src/runtime/server/dev-stylesheet-links.ts",
-    ],
+    entry: ["src/index.ts", "src/lint/index.ts", "src/runtime/server/dev-stylesheet-links.ts"],
     format: "esm",
     dts: true,
     clean: true,

--- a/npm/framework/nuxt/vite.config.ts
+++ b/npm/framework/nuxt/vite.config.ts
@@ -11,7 +11,11 @@ export default defineConfig({
     ignorePatterns: ["dist/**"],
   },
   pack: {
-    entry: ["src/index.ts", "src/runtime/server/dev-stylesheet-links.ts"],
+    entry: [
+      "src/index.ts",
+      "src/lint/index.ts",
+      "src/runtime/server/dev-stylesheet-links.ts",
+    ],
     format: "esm",
     dts: true,
     clean: true,

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "@babel/core": "catalog:babel-jsx-oracle",
     "@babel/plugin-syntax-typescript": "catalog:babel-jsx-oracle",
     "@iarna/toml": "catalog:repo-tooling",
+    "@nuxt/eslint": "catalog:nuxt-eslint-oracle",
+    "@nuxt/eslint-config": "catalog:nuxt-eslint-oracle",
     "@tsdown/css": "catalog:content",
     "@types/node": "catalog:typescript",
     "@typescript/native-preview": "catalog:typescript",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,13 @@ catalogs:
     '@vizejs/native-win32-x64-msvc':
       specifier: 0.312.0
       version: 0.108.0
+  nuxt-eslint-oracle:
+    '@nuxt/eslint':
+      specifier: 1.16.0
+      version: 1.16.0
+    '@nuxt/eslint-config':
+      specifier: 1.16.0
+      version: 1.16.0
   nuxt-module:
     '@nuxt/kit':
       specifier: 3.11.2
@@ -258,6 +265,12 @@ importers:
       '@iarna/toml':
         specifier: catalog:repo-tooling
         version: 2.2.5
+      '@nuxt/eslint':
+        specifier: catalog:nuxt-eslint-oracle
+        version: 1.16.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(@typescript-eslint/utils@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(@vue/compiler-sfc@3.6.0-beta.10)(eslint@10.4.1(jiti@2.7.0))(magicast@0.5.2)(oxc-parser@0.133.0)(rolldown@1.0.1)(srvx@0.11.15)(typescript@6.0.3)
+      '@nuxt/eslint-config':
+        specifier: catalog:nuxt-eslint-oracle
+        version: 1.16.0(@typescript-eslint/utils@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.6.0-beta.10)(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       '@tsdown/css':
         specifier: catalog:content
         version: 0.22.0(jiti@2.7.0)(postcss@8.5.18)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -323,7 +336,7 @@ importers:
         version: 10.4.1(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: 10.9.2
-        version: 10.9.2(@typescript-eslint/parser@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@stylistic/eslint-plugin@5.10.0(eslint@10.4.1(jiti@2.7.0)))(@typescript-eslint/parser@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
       prettier:
         specifier: catalog:repo-tooling
         version: 3.8.3
@@ -1019,7 +1032,7 @@ importers:
         version: 8.8.9(@stencil/core@4.43.5)(vue-router@4.5.1(vue@3.6.0-beta.10(typescript@6.0.3)))(vue@3.6.0-beta.10(typescript@6.0.3))
       '@nuxt/ui':
         specifier: 4.8.2
-        version: 4.8.2(@azure/identity@4.13.0)(@internationalized/date@3.12.1)(@internationalized/number@3.6.6)(@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))(@tiptap/y-tiptap@3.0.7(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(async-validator@4.2.5)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(vue-router@4.5.1(vue@3.6.0-beta.10(typescript@6.0.3)))(vue@3.6.0-beta.10(typescript@6.0.3))(yjs@13.6.30)(zod@3.25.76)
+        version: 4.8.2(@azure/identity@4.13.0)(@internationalized/date@3.12.1)(@internationalized/number@3.6.6)(@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))(@tiptap/y-tiptap@3.0.7(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(async-validator@4.2.5)(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vue-router@4.5.1(vue@3.6.0-beta.10(typescript@6.0.3)))(vue@3.6.0-beta.10(typescript@6.0.3))(yjs@13.6.30)(zod@3.25.76)
       '@playwright/test':
         specifier: catalog:testing
         version: 1.60.0
@@ -1143,6 +1156,12 @@ packages:
   '@apidevtools/json-schema-ref-parser@11.9.3':
     resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
     engines: {node: '>= 16'}
+
+  '@apidevtools/json-schema-ref-parser@14.2.1':
+    resolution: {integrity: sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@types/json-schema': ^7.0.15
 
   '@apollo/client@3.14.1':
     resolution: {integrity: sha512-SgGX6E23JsZhUdG2anxiyHvEvvN6CUaI4ZfMsndZFeuHPXL3H0IsaiNAhLITSISbeyeYd+CBd9oERXQDdjXWZw==}
@@ -1385,8 +1404,16 @@ packages:
     resolution: {integrity: sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==}
     engines: {node: '>= 20.12.0'}
 
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
   '@clack/prompts@1.4.0':
     resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
   '@cloudflare/kv-asset-handler@0.4.2':
@@ -1683,6 +1710,14 @@ packages:
   '@emotion/unitless@0.8.1':
     resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
 
+  '@es-joy/jsdoccomment@0.91.0':
+    resolution: {integrity: sha512-vgqlMGNNhZxwDYbUNIHj3Hskb4R28iqdXx90ufHyt/NeuTQkeqjTDslAs9I0/GCAfbxP5BpH5WsL1R1fht5Lxg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@es-joy/resolve.exports@1.2.0':
+    resolution: {integrity: sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==}
+    engines: {node: '>=10'}
+
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
@@ -1849,17 +1884,46 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
+  '@eslint/compat@2.1.0':
+    resolution: {integrity: sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^8.40 || 9 || 10
+    peerDependenciesMeta:
+      eslint:
+        optional: true
+
   '@eslint/config-array@0.23.5':
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.5.5':
+    resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/config-helpers@0.6.0':
     resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  '@eslint/config-inspector@3.1.0':
+    resolution: {integrity: sha512-miBAPkS/jN/c5RG/aEYhQaS64wlLXeo2EXXQ2w3SdCWux5icdrHyXnZyiF9dW8TukLURqK6xgzyIdgE1uGx5Vg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      eslint: ^8.50.0 || ^9.0.0 || ^10.0.0
+
   '@eslint/core@1.2.1':
     resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/js@10.0.1':
+    resolution: {integrity: sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^10.0.0
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
   '@eslint/object-schema@3.0.5':
     resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
@@ -2720,6 +2784,32 @@ packages:
       vite: 7.3.5
     peerDependenciesMeta:
       '@vitejs/devtools':
+        optional: true
+
+  '@nuxt/eslint-config@1.16.0':
+    resolution: {integrity: sha512-YWEqctFWoKOUTaHWXe6TaUgZ1ewN7jeKz/ni4JopxDGIQ8AIMMST6VMWryybHqbPzEfpx8sEcAAFGM4W4quYhQ==}
+    peerDependencies:
+      eslint: ^9.0.0 || ^10.0.0
+      eslint-plugin-format: '*'
+    peerDependenciesMeta:
+      eslint-plugin-format:
+        optional: true
+
+  '@nuxt/eslint-plugin@1.16.0':
+    resolution: {integrity: sha512-vbX9EsJqTqIRwf3+sv9mJ/OtFKhH8o8NIbNF9Q6weQZY1MRf8jGEvLnjsyJa5VEEHl5TXSXsPcyrmIK58jsRpw==}
+    peerDependencies:
+      eslint: ^9.0.0 || ^10.0.0
+
+  '@nuxt/eslint@1.16.0':
+    resolution: {integrity: sha512-VlZBHG86xUY72pZMcZ98cDtsUj972vZ23Pd4wqpxMLgLJ3RtHxQke0vgD/6PZ6uJsRjh7CAUGpsp2+d26ZdaSA==}
+    peerDependencies:
+      eslint: ^9.0.0 || ^10.0.0
+      eslint-webpack-plugin: ^4.1.0
+      vite-plugin-eslint2: ^5.0.0
+    peerDependenciesMeta:
+      eslint-webpack-plugin:
+        optional: true
+      vite-plugin-eslint2:
         optional: true
 
   '@nuxt/fonts@0.14.0':
@@ -4993,6 +5083,10 @@ packages:
   '@simple-git/argv-parser@1.1.1':
     resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
 
+  '@sindresorhus/base62@1.0.0':
+    resolution: {integrity: sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==}
+    engines: {node: '>=18'}
+
   '@sindresorhus/is@7.2.0':
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
@@ -5032,6 +5126,12 @@ packages:
         optional: true
       vue-router:
         optional: true
+
+  '@stylistic/eslint-plugin@5.10.0':
+    resolution: {integrity: sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^9.0.0 || ^10.0.0
 
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
@@ -5591,6 +5691,14 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@typescript-eslint/eslint-plugin@8.65.0':
+    resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.65.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/parser@8.65.0':
     resolution: {integrity: sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5614,6 +5722,13 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
+  '@typescript-eslint/type-utils@8.65.0':
+    resolution: {integrity: sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
   '@typescript-eslint/types@8.65.0':
     resolution: {integrity: sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -5622,6 +5737,13 @@ packages:
     resolution: {integrity: sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.65.0':
+    resolution: {integrity: sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
   '@typescript-eslint/visitor-keys@8.65.0':
@@ -5687,8 +5809,133 @@ packages:
     peerDependencies:
       vue: '>=3.5.18'
 
+  '@unrs/resolver-binding-android-arm-eabi@1.12.2':
+    resolution: {integrity: sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==}
+    cpu: [arm]
+    os: [android]
+
+  '@unrs/resolver-binding-android-arm64@1.12.2':
+    resolution: {integrity: sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==}
+    cpu: [arm64]
+    os: [android]
+
+  '@unrs/resolver-binding-darwin-arm64@1.12.2':
+    resolution: {integrity: sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-darwin-x64@1.12.2':
+    resolution: {integrity: sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@unrs/resolver-binding-freebsd-x64@1.12.2':
+    resolution: {integrity: sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.12.2':
+    resolution: {integrity: sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.12.2':
+    resolution: {integrity: sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.12.2':
+    resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
+    resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
+    resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
+    resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
+    resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
+    resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
+    resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
+    resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
+    resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@unrs/resolver-binding-linux-x64-musl@1.12.2':
+    resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@unrs/resolver-binding-openharmony-arm64@1.12.2':
+    resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@unrs/resolver-binding-wasm32-wasi@1.12.2':
+    resolution: {integrity: sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
+    resolution: {integrity: sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.12.2':
+    resolution: {integrity: sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
+    resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
+    cpu: [x64]
+    os: [win32]
+
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
+
+  '@valibot/to-json-schema@1.7.1':
+    resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
+    peerDependencies:
+      valibot: ^1.4.0
 
   '@vant/popperjs@1.3.0':
     resolution: {integrity: sha512-hB+czUG+aHtjhaEmCJDuXOep0YTZjdlRR+4MSmIFnkCQIxJaXLQdSsR90XWvAI2yvKUI7TCGqR8pQg2RtvkMHw==}
@@ -6333,6 +6580,10 @@ packages:
     resolution: {integrity: sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==}
     engines: {node: '>=14'}
 
+  ansis@4.3.1:
+    resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
+    engines: {node: '>=14'}
+
   ant-design-vue@4.2.6:
     resolution: {integrity: sha512-t7eX13Yj3i9+i5g9lqFyYneoIb3OzTvQjq9Tts1i+eiOd3Eva/6GagxBSXM1fOCjqemIu0FYVE1ByZ/38epR3Q==}
     engines: {node: '>=12.22.0'}
@@ -6357,6 +6608,10 @@ packages:
   archiver@7.0.1:
     resolution: {integrity: sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==}
     engines: {node: '>= 14'}
+
+  are-docs-informative@0.0.2:
+    resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
+    engines: {node: '>=14'}
 
   arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -6537,6 +6792,10 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
+  builtin-modules@5.3.0:
+    resolution: {integrity: sha512-hMQUl2bUFG339QygPM97E+mc8OY1IAchORZxm4a/frcYwKzozMzRVDBwHW0NjOqGElLm2O37AVQE8ikxlZHrMQ==}
+    engines: {node: '>=18.20'}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -6594,6 +6853,9 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -6628,6 +6890,10 @@ packages:
     engines: {node: '>=20.19.0 <22.0.0 || >=22.12.0'}
     peerDependencies:
       devtools-protocol: '*'
+
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+    engines: {node: '>=8'}
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
@@ -6718,6 +6984,10 @@ packages:
     resolution: {integrity: sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w==}
     engines: {node: '>= 6'}
 
+  comment-parser@1.4.7:
+    resolution: {integrity: sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==}
+    engines: {node: '>= 12.0.0'}
+
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
@@ -6780,6 +7050,9 @@ packages:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
 
+  core-js-compat@3.49.0:
+    resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
+
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
@@ -6815,6 +7088,14 @@ packages:
 
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
+
+  crossws@0.4.10:
+    resolution: {integrity: sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==}
+    peerDependencies:
+      srvx: 0.11.15
+    peerDependenciesMeta:
+      srvx:
+        optional: true
 
   cspell-config-lib@10.0.0:
     resolution: {integrity: sha512-HWK7SRnJ3N/kOThw/uzmXmQYCzBxu58Jkq2hHyte1voDl118BeNFoaNRWMpYdHbBi3kCj8gaZu8wGtm+Zmdhxw==}
@@ -7137,12 +7418,24 @@ packages:
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
+  detect-indent@7.0.2:
+    resolution: {integrity: sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A==}
+    engines: {node: '>=12.20'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
   devalue@5.8.1:
     resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
+
+  devframe@0.6.2:
+    resolution: {integrity: sha512-/P2MPHZzCRyuzEqPOThTDbiCsvbT7OkL1lj9/p6yiUycmC5xfRx5lOhjURYggSyTzEpOSUuWtlicr53ohEFZ5Q==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.0.0
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -7375,6 +7668,65 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  eslint-config-flat-gitignore@2.3.0:
+    resolution: {integrity: sha512-bg4ZLGgoARg1naWfsINUUb/52Ksw/K22K+T16D38Y8v+/sGwwIYrGvH/JBjOin+RQtxxC9tzNNiy4shnGtGyyQ==}
+    peerDependencies:
+      eslint: ^9.5.0 || ^10.0.0
+
+  eslint-flat-config-utils@3.2.0:
+    resolution: {integrity: sha512-PHgo1X5uqIorJONLVD9BIaOSdoYFD3z/AeJljdqDPlWVRpeCYkDbK9k0AXoYVqqNJr6FEYIEr5Rm2TSktLQcHw==}
+
+  eslint-import-context@0.1.9:
+    resolution: {integrity: sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      unrs-resolver: ^1.0.0
+    peerDependenciesMeta:
+      unrs-resolver:
+        optional: true
+
+  eslint-merge-processors@2.0.0:
+    resolution: {integrity: sha512-sUuhSf3IrJdGooquEUB5TNpGNpBoQccbnaLHsb1XkBLUPPqCNivCpY05ZcpCOiV9uHwO2yxXEWVczVclzMxYlA==}
+    peerDependencies:
+      eslint: '*'
+
+  eslint-plugin-import-lite@0.6.0:
+    resolution: {integrity: sha512-80vevx2A7i3H7n1/6pqDO8cc5wRz6OwLDvIyVl9UflBV1N1f46e9Ihzi65IOLYoSxM6YykK2fTw1xm0Ixx6aTQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^9.0.0 || ^10.0.0
+
+  eslint-plugin-import-x@4.17.1:
+    resolution: {integrity: sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/utils': ^8.56.0
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      eslint-import-resolver-node: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/utils':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+
+  eslint-plugin-jsdoc@63.3.2:
+    resolution: {integrity: sha512-5B3oO23iqbNJC/ru7uqIY80wmY66De1Q0+5kXQGHuLrGze/rL0Zw/YktMcqgYQ+kdHmgvY1q5TpRgl3yZMLmhQ==}
+    engines: {node: ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
+
+  eslint-plugin-regexp@3.1.1:
+    resolution: {integrity: sha512-MxR5nqoQCtVWmJwia0D2+NlXX1xzdpkslsVOZLEYQ4PQWEaL65PCZXURxaBc3lPnkNFpNxzMIRmYVxdl8giXRA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: '>=9.38.0'
+
+  eslint-plugin-unicorn@65.0.1:
+    resolution: {integrity: sha512-daCrQrgxOoOz2uMPWB3Y3vvv/5q+ncwICI8IjoebiwtW87CaY4tAN5EEiRXTYVnf7qi1v1BGBdHOSnZLV0rx6A==}
+    engines: {node: ^20.10.0 || >=21.0.0}
+    peerDependencies:
+      eslint: '>=9.38.0'
+
   eslint-plugin-vue@10.9.2:
     resolution: {integrity: sha512-4g7ZP3pYcuqd7Zp0pzUKcos0W+RkjBz4EGdhJ92FcYk6v03Ti/GK5NwjgsjxHK+98eXDbHeK7VtX1az7/8doZA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -7389,6 +7741,12 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
+  eslint-processor-vue-blocks@2.0.0:
+    resolution: {integrity: sha512-u4W0CJwGoWY3bjXAuFpc/b6eK3NQEI8MoeW7ritKj3G3z/WtHrKjkqf+wk8mPEy5rlMGS+k6AZYOw2XBoN/02Q==}
+    peerDependencies:
+      '@vue/compiler-sfc': ^3.3.0
+      eslint: '>=9.0.0'
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -7397,9 +7755,18 @@ packages:
     resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  eslint-typegen@2.3.1:
+    resolution: {integrity: sha512-zVdh8rThBvv2o5T/K524Fr5iy1Jo0q09rHL7y7FbOhgMB177T2gw+shxfC4ChCEqdq6/y6LJA4j8Fbr/Xls9aw==}
+    peerDependencies:
+      eslint: ^9.0.0 || ^10.0.0
+
   eslint-visitor-keys@3.4.3:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-visitor-keys@5.0.1:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
@@ -7414,6 +7781,10 @@ packages:
     peerDependenciesMeta:
       jiti:
         optional: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@11.2.0:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
@@ -7566,9 +7937,17 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
+  find-up-simple@1.0.1:
+    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
+    engines: {node: '>=18'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  find-up@8.0.0:
+    resolution: {integrity: sha512-JGG8pvDi2C+JxidYdIwQDyS/CgcrIdh18cvgxcBge3wSHRQOrooMD3GlFBcmMJAN9M42SAZjDp5zv1dglJjwww==}
+    engines: {node: '>=20'}
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -7678,6 +8057,9 @@ packages:
     resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
     engines: {node: '>=16'}
 
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   get-tsconfig@5.0.0-beta.5:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
     engines: {node: '>=20.20.0'}
@@ -7717,6 +8099,10 @@ packages:
   global-directory@5.0.0:
     resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
     engines: {node: '>=20'}
+
+  globals@17.8.0:
+    resolution: {integrity: sha512-Zz/LMDZScFmkakeL2cTHzf+PbWKdpU3uclqkZT7TjDG58j5WPt0PpA+n9uPI24fZtlw07q0OtEi84K+umsRzqQ==}
+    engines: {node: '>=18'}
 
   globby@14.1.0:
     resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
@@ -7810,6 +8196,9 @@ packages:
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
+  html-entities@2.6.0:
+    resolution: {integrity: sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==}
+
   html-to-image@1.11.13:
     resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
@@ -7882,6 +8271,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -7924,6 +8317,10 @@ packages:
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
+
+  is-builtin-module@5.0.0:
+    resolution: {integrity: sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==}
+    engines: {node: '>=18.20'}
 
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
@@ -8072,6 +8469,14 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsdoc-type-pratt-parser@7.3.0:
+    resolution: {integrity: sha512-DoyJXo7x/n48M3NsGOs9QnEws0ft0tV3YsSgvWMNxz2hZtz+Q6fpqUD96lVYX4a+jcEkzHeFNDJOn68TzXfbdA==}
+    engines: {node: '>=20.0.0'}
+
+  jsdoc-type-pratt-parser@8.0.0:
+    resolution: {integrity: sha512-uQu/fXVqVaMg6gM8/E5G5+eygVcZ1NV0Z51CvqhNa2bDWxvHMl484ETr6vph4oPyC+KUcbP/w2W2pewfCiR9aQ==}
+    engines: {node: '>=20.0.0'}
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -8079,6 +8484,9 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-to-typescript-lite@15.0.0:
+    resolution: {integrity: sha512-5mMORSQm9oTLyjM4mWnyNBi2T042Fhg1/0gCIB6X8U/LVpM2A+Nmj2yEyArqVouDmFThDxpEXcnTgSrjkGJRFA==}
 
   json-schema-to-typescript@15.0.4:
     resolution: {integrity: sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==}
@@ -8257,6 +8665,10 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  locate-path@8.0.0:
+    resolution: {integrity: sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==}
+    engines: {node: '>=20'}
 
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
@@ -8515,6 +8927,11 @@ packages:
   nanotar@0.3.0:
     resolution: {integrity: sha512-Kv2JYYiCzt16Kt5QwAc9BFG89xfPNBx+oQL4GQXD9nLqPkZBiNaqaCWtwnbk/q7UVsTYevvM1b0UF8zmEI4pCg==}
 
+  napi-postinstall@0.3.4:
+    resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -8581,6 +8998,9 @@ packages:
   normalize-wheel-es@1.2.0:
     resolution: {integrity: sha512-Wj7+EJQ8mSuXr2iWfnujrimU35R2W4FAErEyTmJoJ7ucwTn2hOUSsRehMb5RSYkxXGTM7Y9QpvPmp++w5ftoJw==}
 
+  nostics@1.2.0:
+    resolution: {integrity: sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==}
+
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -8618,6 +9038,9 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-deep-merge@2.0.1:
+    resolution: {integrity: sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==}
 
   object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
@@ -8755,6 +9178,10 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   p-limit@6.2.0:
     resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
     engines: {node: '>=18'}
@@ -8762,6 +9189,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-locate@6.0.0:
+    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -8771,6 +9202,12 @@ packages:
 
   pako@2.1.0:
     resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
+  parse-imports-exports@0.2.4:
+    resolution: {integrity: sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==}
+
+  parse-statements@1.0.11:
+    resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -8893,6 +9330,10 @@ packages:
     resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
 
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
@@ -9313,6 +9754,10 @@ packages:
     resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
     engines: {node: '>=4'}
 
+  refa@0.12.1:
+    resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -9322,8 +9767,16 @@ packages:
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
+  regexp-ast-analysis@0.7.1:
+    resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
+
+  regjsparser@0.13.2:
+    resolution: {integrity: sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==}
     hasBin: true
 
   rehackt@0.1.0:
@@ -9363,6 +9816,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reserved-identifiers@1.2.0:
+    resolution: {integrity: sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==}
+    engines: {node: '>=18'}
 
   resize-observer-polyfill@1.5.1:
     resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==}
@@ -9500,6 +9957,10 @@ packages:
   scroll-into-view-if-needed@2.2.31:
     resolution: {integrity: sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==}
 
+  scslre@0.3.0:
+    resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
+    engines: {node: ^14.0.0 || >=16.0.0}
+
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
 
@@ -9517,6 +9978,11 @@ packages:
 
   semver@7.8.4:
     resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -9626,6 +10092,15 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@5.0.0:
+    resolution: {integrity: sha512-vngmw3Rgn+o2arXNbnZaj5UtOEBuWBfvaI+Wc8GFfykIhA5/vdK9/Sp/XkLv63dykz2rxKDvKEHupF5P0FORcQ==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
   speakingurl@14.0.1:
     resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
     engines: {node: '>=0.10.0'}
@@ -9638,6 +10113,10 @@ packages:
     resolution: {integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==}
     engines: {node: '>=20.16.0'}
     hasBin: true
+
+  stable-hash-x@0.2.0:
+    resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
+    engines: {node: '>=12.0.0'}
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -9686,6 +10165,10 @@ packages:
 
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+
+  strip-indent@4.1.1:
+    resolution: {integrity: sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==}
     engines: {node: '>=12'}
 
   strip-literal@2.1.1:
@@ -9888,6 +10371,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  to-valid-identifier@1.0.0:
+    resolution: {integrity: sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==}
+    engines: {node: '>=20'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -10130,6 +10617,9 @@ packages:
   unrouting@0.1.7:
     resolution: {integrity: sha512-+0hfD+CVWtD636rc5Fn9VEjjTEDhdqgMpbwAuVoUmydSHDaMNiFW93SJG4LV++RoGSEAyvQN5uABAscYpDphpQ==}
 
+  unrs-resolver@1.12.2:
+    resolution: {integrity: sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==}
+
   unrun@0.2.39:
     resolution: {integrity: sha512-h9FxYVpztY/wwq+bauLOh6Y3CWu2IVeRLq5lxzneBiIU9Tn86OGp9xiQrGhnYspAmg5dzdY0Cc8+Y70kuTARCg==}
     engines: {node: '>=20.19.0'}
@@ -10244,6 +10734,14 @@ packages:
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
+
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   vant@4.9.24:
     resolution: {integrity: sha512-tP1A7Vjzv1/B1ljb95Jhv9Q9w6acaaZDJvy6wcKrwGgY0gQZlg+FXLZH/AIKZBE3xvYGDUsv/M7AuGcr/Pqd6A==}
@@ -10804,6 +11302,11 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 4.1.1
 
+  '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.1
+
   '@apollo/client@3.14.1(graphql@16.14.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.14.2)
@@ -11134,9 +11637,21 @@ snapshots:
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
 
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
   '@clack/prompts@1.4.0':
     dependencies:
       '@clack/core': 1.3.1
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
@@ -11417,6 +11932,16 @@ snapshots:
 
   '@emotion/unitless@0.8.1': {}
 
+  '@es-joy/jsdoccomment@0.91.0':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@typescript-eslint/types': 8.65.0
+      comment-parser: 1.4.7
+      esquery: 1.7.0
+      jsdoc-type-pratt-parser: 8.0.0
+
+  '@es-joy/resolve.exports@1.2.0': {}
+
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
@@ -11502,6 +12027,12 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.2': {}
 
+  '@eslint/compat@2.1.0(eslint@10.4.1(jiti@2.7.0))':
+    dependencies:
+      '@eslint/core': 1.2.1
+    optionalDependencies:
+      eslint: 10.4.1(jiti@2.7.0)
+
   '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
@@ -11510,13 +12041,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/config-helpers@0.5.5':
+    dependencies:
+      '@eslint/core': 1.2.1
+
   '@eslint/config-helpers@0.6.0':
     dependencies:
       '@eslint/core': 1.2.1
 
+  '@eslint/config-inspector@3.1.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(eslint@10.4.1(jiti@2.7.0))(srvx@0.11.15)(typescript@6.0.3)':
+    dependencies:
+      ansis: 4.3.1
+      cac: 7.0.0
+      chokidar: 5.0.0
+      devframe: 0.6.2(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(srvx@0.11.15)(typescript@6.0.3)
+      eslint: 10.4.1(jiti@2.7.0)
+      jiti: 2.7.0
+      tinyglobby: 0.2.17
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - srvx
+      - typescript
+
   '@eslint/core@1.2.1':
     dependencies:
       '@types/json-schema': 7.0.15
+
+  '@eslint/js@10.0.1(eslint@10.4.1(jiti@2.7.0))':
+    optionalDependencies:
+      eslint: 10.4.1(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -12413,6 +12966,76 @@ snapshots:
       - utf-8-validate
       - vue
 
+  '@nuxt/eslint-config@1.16.0(@typescript-eslint/utils@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.6.0-beta.10)(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@clack/prompts': 1.7.0
+      '@eslint/js': 10.0.1(eslint@10.4.1(jiti@2.7.0))
+      '@nuxt/eslint-plugin': 1.16.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@stylistic/eslint-plugin': 5.10.0(eslint@10.4.1(jiti@2.7.0))
+      '@typescript-eslint/eslint-plugin': 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.4.1(jiti@2.7.0)
+      eslint-config-flat-gitignore: 2.3.0(eslint@10.4.1(jiti@2.7.0))
+      eslint-flat-config-utils: 3.2.0
+      eslint-merge-processors: 2.0.0(eslint@10.4.1(jiti@2.7.0))
+      eslint-plugin-import-lite: 0.6.0(eslint@10.4.1(jiti@2.7.0))
+      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))
+      eslint-plugin-jsdoc: 63.3.2(eslint@10.4.1(jiti@2.7.0))
+      eslint-plugin-regexp: 3.1.1(eslint@10.4.1(jiti@2.7.0))
+      eslint-plugin-unicorn: 65.0.1(eslint@10.4.1(jiti@2.7.0))
+      eslint-plugin-vue: 10.9.2(@stylistic/eslint-plugin@5.10.0(eslint@10.4.1(jiti@2.7.0)))(@typescript-eslint/parser@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.6.0-beta.10)(eslint@10.4.1(jiti@2.7.0))
+      globals: 17.8.0
+      local-pkg: 1.2.1
+      pathe: 2.0.3
+      vue-eslint-parser: 10.4.1(eslint@10.4.1(jiti@2.7.0))
+    transitivePeerDependencies:
+      - '@typescript-eslint/utils'
+      - '@vue/compiler-sfc'
+      - eslint-import-resolver-node
+      - supports-color
+      - typescript
+
+  '@nuxt/eslint-plugin@1.16.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/utils': 8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.4.1(jiti@2.7.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@nuxt/eslint@1.16.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(@typescript-eslint/utils@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(@vue/compiler-sfc@3.6.0-beta.10)(eslint@10.4.1(jiti@2.7.0))(magicast@0.5.2)(oxc-parser@0.133.0)(rolldown@1.0.1)(srvx@0.11.15)(typescript@6.0.3)':
+    dependencies:
+      '@eslint/config-inspector': 3.1.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(eslint@10.4.1(jiti@2.7.0))(srvx@0.11.15)(typescript@6.0.3)
+      '@nuxt/devtools-kit': 3.2.4(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(magicast@0.5.2)
+      '@nuxt/eslint-config': 1.16.0(@typescript-eslint/utils@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.6.0-beta.10)(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@nuxt/eslint-plugin': 1.16.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@nuxt/kit': 4.4.8(magicast@0.5.2)
+      chokidar: 5.0.0
+      eslint: 10.4.1(jiti@2.7.0)
+      eslint-flat-config-utils: 3.2.0
+      eslint-typegen: 2.3.1(eslint@10.4.1(jiti@2.7.0))
+      find-up: 8.0.0
+      get-port-please: 3.2.0
+      mlly: 1.8.2
+      pathe: 2.0.3
+      unimport: 6.3.0(oxc-parser@0.133.0)(rolldown@1.0.1)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - '@typescript-eslint/utils'
+      - '@vue/compiler-sfc'
+      - eslint-import-resolver-node
+      - eslint-plugin-format
+      - magicast
+      - oxc-parser
+      - rolldown
+      - srvx
+      - supports-color
+      - typescript
+      - vite
+
   '@nuxt/fonts@0.14.0(@azure/identity@4.13.0)(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(db0@0.3.4)(ioredis@5.10.1)(magicast@0.5.2)':
     dependencies:
       '@nuxt/devtools-kit': 3.2.4(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(magicast@0.5.2)
@@ -12655,7 +13278,7 @@ snapshots:
 
   '@nuxt/ui-templates@1.3.4': {}
 
-  '@nuxt/ui@4.8.2(@azure/identity@4.13.0)(@internationalized/date@3.12.1)(@internationalized/number@3.6.6)(@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))(@tiptap/y-tiptap@3.0.7(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(async-validator@4.2.5)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(vue-router@4.5.1(vue@3.6.0-beta.10(typescript@6.0.3)))(vue@3.6.0-beta.10(typescript@6.0.3))(yjs@13.6.30)(zod@3.25.76)':
+  '@nuxt/ui@4.8.2(@azure/identity@4.13.0)(@internationalized/date@3.12.1)(@internationalized/number@3.6.6)(@tiptap/extensions@3.26.0(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0))(@tiptap/y-tiptap@3.0.7(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(async-validator@4.2.5)(change-case@5.4.4)(db0@0.3.4)(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vue-router@4.5.1(vue@3.6.0-beta.10(typescript@6.0.3)))(vue@3.6.0-beta.10(typescript@6.0.3))(yjs@13.6.30)(zod@3.25.76)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@iconify/vue': 5.0.1(vue@3.6.0-beta.10(typescript@6.0.3))
@@ -12688,7 +13311,7 @@ snapshots:
       '@tiptap/vue-3': 3.26.0(@floating-ui/dom@1.7.6)(@tiptap/core@3.26.0(@tiptap/pm@3.26.0))(@tiptap/pm@3.26.0)(vue@3.6.0-beta.10(typescript@6.0.3))
       '@unhead/vue': 2.1.15(vue@3.6.0-beta.10(typescript@6.0.3))
       '@vueuse/core': 14.3.0(vue@3.6.0-beta.10(typescript@6.0.3))
-      '@vueuse/integrations': 14.3.0(async-validator@4.2.5)(fuse.js@7.4.2)(vue@3.6.0-beta.10(typescript@6.0.3))
+      '@vueuse/integrations': 14.3.0(async-validator@4.2.5)(change-case@5.4.4)(fuse.js@7.4.2)(vue@3.6.0-beta.10(typescript@6.0.3))
       '@vueuse/shared': 14.3.0(vue@3.6.0-beta.10(typescript@6.0.3))
       colortranslator: 5.0.0
       consola: 3.4.2
@@ -12724,6 +13347,7 @@ snapshots:
     optionalDependencies:
       '@internationalized/date': 3.12.1
       '@internationalized/number': 3.6.6
+      valibot: 1.4.2(typescript@6.0.3)
       vue-router: 4.5.1(vue@3.6.0-beta.10(typescript@6.0.3))
       zod: 3.25.76
     transitivePeerDependencies:
@@ -14137,6 +14761,8 @@ snapshots:
     dependencies:
       '@simple-git/args-pathspec': 1.0.3
 
+  '@sindresorhus/base62@1.0.0': {}
+
   '@sindresorhus/is@7.2.0': {}
 
   '@sindresorhus/merge-streams@2.3.0': {}
@@ -14175,6 +14801,16 @@ snapshots:
     optionalDependencies:
       '@stencil/core': 4.43.5
       vue-router: 4.5.1(vue@3.6.0-beta.10(typescript@6.0.3))
+
+  '@stylistic/eslint-plugin@5.10.0(eslint@10.4.1(jiti@2.7.0))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
+      '@typescript-eslint/types': 8.65.0
+      eslint: 10.4.1(jiti@2.7.0)
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      estraverse: 5.3.0
+      picomatch: 4.0.4
 
   '@swc/helpers@0.5.21':
     dependencies:
@@ -14742,6 +15378,22 @@ snapshots:
     dependencies:
       '@types/node': 25.9.2
 
+  '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/type-utils': 8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.65.0
+      eslint: 10.4.1(jiti@2.7.0)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/parser@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.65.0
@@ -14772,6 +15424,18 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
+  '@typescript-eslint/type-utils@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      debug: 4.4.3
+      eslint: 10.4.1(jiti@2.7.0)
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/types@8.65.0': {}
 
   '@typescript-eslint/typescript-estree@8.65.0(typescript@6.0.3)':
@@ -14785,6 +15449,17 @@ snapshots:
       semver: 7.8.4
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@6.0.3)
+      eslint: 10.4.1(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -14848,10 +15523,84 @@ snapshots:
       unhead: 2.1.15
       vue: 3.6.0-beta.10(typescript@6.0.3)
 
+  '@unrs/resolver-binding-android-arm-eabi@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-android-arm64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-arm64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-darwin-x64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-freebsd-x64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-gnueabihf@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm-musleabihf@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-linux-x64-musl@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-openharmony-arm64@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-wasm32-wasi@1.12.2':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@unrs/resolver-binding-win32-arm64-msvc@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-win32-ia32-msvc@1.12.2':
+    optional: true
+
+  '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
+    optional: true
+
   '@upsetjs/venn.js@2.0.0':
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))':
+    dependencies:
+      valibot: 1.4.2(typescript@6.0.3)
 
   '@vant/popperjs@1.3.0': {}
 
@@ -15411,13 +16160,14 @@ snapshots:
       '@vueuse/shared': 14.3.0(vue@3.6.0-beta.10(typescript@6.0.3))
       vue: 3.6.0-beta.10(typescript@6.0.3)
 
-  '@vueuse/integrations@14.3.0(async-validator@4.2.5)(fuse.js@7.4.2)(vue@3.6.0-beta.10(typescript@6.0.3))':
+  '@vueuse/integrations@14.3.0(async-validator@4.2.5)(change-case@5.4.4)(fuse.js@7.4.2)(vue@3.6.0-beta.10(typescript@6.0.3))':
     dependencies:
       '@vueuse/core': 14.3.0(vue@3.6.0-beta.10(typescript@6.0.3))
       '@vueuse/shared': 14.3.0(vue@3.6.0-beta.10(typescript@6.0.3))
       vue: 3.6.0-beta.10(typescript@6.0.3)
     optionalDependencies:
       async-validator: 4.2.5
+      change-case: 5.4.4
       fuse.js: 7.4.2
 
   '@vueuse/metadata@10.11.1': {}
@@ -15639,6 +16389,8 @@ snapshots:
 
   ansis@4.3.0: {}
 
+  ansis@4.3.1: {}
+
   ant-design-vue@4.2.6(vue@3.6.0-beta.10(typescript@6.0.3)):
     dependencies:
       '@ant-design/colors': 6.0.0
@@ -15697,6 +16449,8 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
+
+  are-docs-informative@0.0.2: {}
 
   arg@5.0.2: {}
 
@@ -15856,6 +16610,8 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  builtin-modules@5.3.0: {}
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -15925,6 +16681,8 @@ snapshots:
 
   chalk@5.6.2: {}
 
+  change-case@5.4.4: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -15960,6 +16718,8 @@ snapshots:
       devtools-protocol: 0.0.1624250
       mitt: 3.0.1
       zod: 3.25.76
+
+  ci-info@4.4.0: {}
 
   citty@0.1.6:
     dependencies:
@@ -16030,6 +16790,8 @@ snapshots:
       array-timsort: 1.0.3
       esprima: 4.0.1
 
+  comment-parser@1.4.7: {}
+
   commondir@1.0.1: {}
 
   compatx@0.2.0: {}
@@ -16077,6 +16839,10 @@ snapshots:
     dependencies:
       is-what: 5.5.0
 
+  core-js-compat@3.49.0:
+    dependencies:
+      browserslist: 4.28.2
+
   core-js@3.49.0: {}
 
   core-util-is@1.0.3: {}
@@ -16112,6 +16878,10 @@ snapshots:
   crossws@0.3.5:
     dependencies:
       uncrypto: 0.1.3
+
+  crossws@0.4.10(srvx@0.11.15):
+    optionalDependencies:
+      srvx: 0.11.15
 
   cspell-config-lib@10.0.0:
     dependencies:
@@ -16476,9 +17246,30 @@ snapshots:
 
   destr@2.0.5: {}
 
+  detect-indent@7.0.2: {}
+
   detect-libc@2.1.2: {}
 
   devalue@5.8.1: {}
+
+  devframe@0.6.2(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(srvx@0.11.15)(typescript@6.0.3):
+    dependencies:
+      '@valibot/to-json-schema': 1.7.1(valibot@1.4.2(typescript@6.0.3))
+      birpc: 4.0.0
+      cac: 7.0.0
+      crossws: 0.4.10(srvx@0.11.15)
+      destr: 2.0.5
+      h3: 1.15.11
+      mrmime: 2.0.1
+      nostics: 1.2.0
+      pathe: 2.0.3
+      ufo: 1.6.4
+      valibot: 1.4.2(typescript@6.0.3)
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+    transitivePeerDependencies:
+      - srvx
+      - typescript
 
   devlop@1.1.0:
     dependencies:
@@ -16701,7 +17492,99 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-plugin-vue@10.9.2(@typescript-eslint/parser@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0))):
+  eslint-config-flat-gitignore@2.3.0(eslint@10.4.1(jiti@2.7.0)):
+    dependencies:
+      '@eslint/compat': 2.1.0(eslint@10.4.1(jiti@2.7.0))
+      eslint: 10.4.1(jiti@2.7.0)
+
+  eslint-flat-config-utils@3.2.0:
+    dependencies:
+      '@eslint/config-helpers': 0.5.5
+      pathe: 2.0.3
+
+  eslint-import-context@0.1.9(unrs-resolver@1.12.2):
+    dependencies:
+      get-tsconfig: 4.14.0
+      stable-hash-x: 0.2.0
+    optionalDependencies:
+      unrs-resolver: 1.12.2
+
+  eslint-merge-processors@2.0.0(eslint@10.4.1(jiti@2.7.0)):
+    dependencies:
+      eslint: 10.4.1(jiti@2.7.0)
+
+  eslint-plugin-import-lite@0.6.0(eslint@10.4.1(jiti@2.7.0)):
+    dependencies:
+      eslint: 10.4.1(jiti@2.7.0)
+
+  eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)):
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      comment-parser: 1.4.7
+      debug: 4.4.3
+      eslint: 10.4.1(jiti@2.7.0)
+      eslint-import-context: 0.1.9(unrs-resolver@1.12.2)
+      is-glob: 4.0.3
+      minimatch: 10.2.5
+      semver: 7.8.4
+      stable-hash-x: 0.2.0
+      unrs-resolver: 1.12.2
+    optionalDependencies:
+      '@typescript-eslint/utils': 8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-jsdoc@63.3.2(eslint@10.4.1(jiti@2.7.0)):
+    dependencies:
+      '@es-joy/jsdoccomment': 0.91.0
+      '@es-joy/resolve.exports': 1.2.0
+      are-docs-informative: 0.0.2
+      comment-parser: 1.4.7
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint: 10.4.1(jiti@2.7.0)
+      espree: 11.2.0
+      esquery: 1.7.0
+      html-entities: 2.6.0
+      object-deep-merge: 2.0.1
+      parse-imports-exports: 0.2.4
+      semver: 7.8.5
+      spdx-expression-parse: 5.0.0
+      to-valid-identifier: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-regexp@3.1.1(eslint@10.4.1(jiti@2.7.0)):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
+      '@eslint-community/regexpp': 4.12.2
+      comment-parser: 1.4.7
+      eslint: 10.4.1(jiti@2.7.0)
+      jsdoc-type-pratt-parser: 7.3.0
+      refa: 0.12.1
+      regexp-ast-analysis: 0.7.1
+      scslre: 0.3.0
+
+  eslint-plugin-unicorn@65.0.1(eslint@10.4.1(jiti@2.7.0)):
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
+      change-case: 5.4.4
+      ci-info: 4.4.0
+      core-js-compat: 3.49.0
+      detect-indent: 7.0.2
+      eslint: 10.4.1(jiti@2.7.0)
+      find-up-simple: 1.0.1
+      globals: 17.8.0
+      indent-string: 5.0.0
+      is-builtin-module: 5.0.0
+      jsesc: 3.1.0
+      pluralize: 8.0.0
+      regjsparser: 0.13.2
+      semver: 7.8.4
+      strip-indent: 4.1.1
+
+  eslint-plugin-vue@10.9.2(@stylistic/eslint-plugin@5.10.0(eslint@10.4.1(jiti@2.7.0)))(@typescript-eslint/parser@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0))):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
       eslint: 10.4.1(jiti@2.7.0)
@@ -16712,7 +17595,13 @@ snapshots:
       vue-eslint-parser: 10.4.1(eslint@10.4.1(jiti@2.7.0))
       xml-name-validator: 4.0.0
     optionalDependencies:
+      '@stylistic/eslint-plugin': 5.10.0(eslint@10.4.1(jiti@2.7.0))
       '@typescript-eslint/parser': 8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+
+  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.6.0-beta.10)(eslint@10.4.1(jiti@2.7.0)):
+    dependencies:
+      '@vue/compiler-sfc': 3.6.0-beta.10
+      eslint: 10.4.1(jiti@2.7.0)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -16726,7 +17615,15 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
+  eslint-typegen@2.3.1(eslint@10.4.1(jiti@2.7.0)):
+    dependencies:
+      eslint: 10.4.1(jiti@2.7.0)
+      json-schema-to-typescript-lite: 15.0.0
+      ohash: 2.0.11
+
   eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
 
   eslint-visitor-keys@5.0.1: {}
 
@@ -16766,6 +17663,12 @@ snapshots:
       jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@11.2.0:
     dependencies:
@@ -16934,10 +17837,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  find-up-simple@1.0.1: {}
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  find-up@8.0.0:
+    dependencies:
+      locate-path: 8.0.0
+      unicorn-magic: 0.3.0
 
   flat-cache@4.0.1:
     dependencies:
@@ -17062,6 +17972,10 @@ snapshots:
 
   get-stream@8.0.1: {}
 
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   get-tsconfig@5.0.0-beta.5:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -17110,6 +18024,8 @@ snapshots:
   global-directory@5.0.0:
     dependencies:
       ini: 6.0.0
+
+  globals@17.8.0: {}
 
   globby@14.1.0:
     dependencies:
@@ -17245,6 +18161,8 @@ snapshots:
 
   hookable@6.1.1: {}
 
+  html-entities@2.6.0: {}
+
   html-to-image@1.11.13: {}
 
   html-void-elements@3.0.0: {}
@@ -17312,6 +18230,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@5.0.0: {}
+
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
@@ -17351,6 +18271,10 @@ snapshots:
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
+
+  is-builtin-module@5.0.0:
+    dependencies:
+      builtin-modules: 5.3.0
 
   is-core-module@2.16.2:
     dependencies:
@@ -17455,9 +18379,18 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdoc-type-pratt-parser@7.3.0: {}
+
+  jsdoc-type-pratt-parser@8.0.0: {}
+
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
+
+  json-schema-to-typescript-lite@15.0.0:
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 14.2.1(@types/json-schema@7.0.15)
+      '@types/json-schema': 7.0.15
 
   json-schema-to-typescript@15.0.4:
     dependencies:
@@ -17635,6 +18568,10 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  locate-path@8.0.0:
+    dependencies:
+      p-locate: 6.0.0
 
   lodash-es@4.18.1: {}
 
@@ -17911,6 +18848,8 @@ snapshots:
 
   nanotar@0.3.0: {}
 
+  napi-postinstall@0.3.4: {}
+
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
@@ -18048,6 +18987,8 @@ snapshots:
   normalize-path@3.0.0: {}
 
   normalize-wheel-es@1.2.0: {}
+
+  nostics@1.2.0: {}
 
   npm-run-path@5.3.0:
     dependencies:
@@ -18206,6 +19147,8 @@ snapshots:
       tinyexec: 1.1.2
 
   object-assign@4.1.1: {}
+
+  object-deep-merge@2.0.1: {}
 
   object-hash@3.0.0: {}
 
@@ -18491,6 +19434,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@4.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-limit@6.2.0:
     dependencies:
       yocto-queue: 1.2.2
@@ -18499,11 +19446,21 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  p-locate@6.0.0:
+    dependencies:
+      p-limit: 4.0.0
+
   package-json-from-dist@1.0.1: {}
 
   package-manager-detector@1.6.0: {}
 
   pako@2.1.0: {}
+
+  parse-imports-exports@0.2.4:
+    dependencies:
+      parse-statements: 1.0.11
+
+  parse-statements@1.0.11: {}
 
   parse5@7.3.0:
     dependencies:
@@ -18611,6 +19568,8 @@ snapshots:
       playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
+
+  pluralize@8.0.0: {}
 
   pngjs@7.0.0: {}
 
@@ -19082,6 +20041,10 @@ snapshots:
     dependencies:
       redis-errors: 1.2.0
 
+  refa@0.12.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
@@ -19092,7 +20055,16 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
+  regexp-ast-analysis@0.7.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      refa: 0.12.1
+
   regexp-tree@0.1.27: {}
+
+  regjsparser@0.13.2:
+    dependencies:
+      jsesc: 3.1.0
 
   rehackt@0.1.0(react@19.2.6):
     optionalDependencies:
@@ -19147,6 +20119,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  reserved-identifiers@1.2.0: {}
 
   resize-observer-polyfill@1.5.1: {}
 
@@ -19378,6 +20352,12 @@ snapshots:
     dependencies:
       compute-scroll-into-view: 1.0.20
 
+  scslre@0.3.0:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      refa: 0.12.1
+      regexp-ast-analysis: 0.7.1
+
   scule@1.3.0: {}
 
   seemly@0.3.10: {}
@@ -19387,6 +20367,8 @@ snapshots:
   semver@7.8.0: {}
 
   semver@7.8.4: {}
+
+  semver@7.8.5: {}
 
   send@1.2.1:
     dependencies:
@@ -19517,11 +20499,22 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@5.0.0:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
+
   speakingurl@14.0.1: {}
 
   split2@4.2.0: {}
 
   srvx@0.11.15: {}
+
+  stable-hash-x@0.2.0: {}
 
   standard-as-callback@2.1.0: {}
 
@@ -19580,6 +20573,8 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-final-newline@3.0.0: {}
+
+  strip-indent@4.1.1: {}
 
   strip-literal@2.1.1:
     dependencies:
@@ -19774,6 +20769,11 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  to-valid-identifier@1.0.0:
+    dependencies:
+      '@sindresorhus/base62': 1.0.0
+      reserved-identifiers: 1.2.0
 
   toidentifier@1.0.1: {}
 
@@ -20051,6 +21051,33 @@ snapshots:
       escape-string-regexp: 5.0.0
       ufo: 1.6.4
 
+  unrs-resolver@1.12.2:
+    dependencies:
+      napi-postinstall: 0.3.4
+    optionalDependencies:
+      '@unrs/resolver-binding-android-arm-eabi': 1.12.2
+      '@unrs/resolver-binding-android-arm64': 1.12.2
+      '@unrs/resolver-binding-darwin-arm64': 1.12.2
+      '@unrs/resolver-binding-darwin-x64': 1.12.2
+      '@unrs/resolver-binding-freebsd-x64': 1.12.2
+      '@unrs/resolver-binding-linux-arm-gnueabihf': 1.12.2
+      '@unrs/resolver-binding-linux-arm-musleabihf': 1.12.2
+      '@unrs/resolver-binding-linux-arm64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-arm64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-loong64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-loong64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-ppc64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-riscv64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-riscv64-musl': 1.12.2
+      '@unrs/resolver-binding-linux-s390x-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-x64-gnu': 1.12.2
+      '@unrs/resolver-binding-linux-x64-musl': 1.12.2
+      '@unrs/resolver-binding-openharmony-arm64': 1.12.2
+      '@unrs/resolver-binding-wasm32-wasi': 1.12.2
+      '@unrs/resolver-binding-win32-arm64-msvc': 1.12.2
+      '@unrs/resolver-binding-win32-ia32-msvc': 1.12.2
+      '@unrs/resolver-binding-win32-x64-msvc': 1.12.2
+
   unrun@0.2.39:
     dependencies:
       rolldown: 1.0.0-rc.17
@@ -20129,6 +21156,10 @@ snapshots:
     optional: true
 
   uuid@14.0.0: {}
+
+  valibot@1.4.2(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   vant@4.9.24(vue@3.6.0-beta.10(typescript@6.0.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,6 +57,13 @@ catalogs:
     "@babel/plugin-syntax-typescript": "7.28.6"
     "@vue/babel-plugin-jsx": "2.0.1"
 
+  # Real @nuxt/eslint toolchain, used only as the differential oracle for the
+  # Nuxt lint config port (npm/framework/nuxt/test/nuxt-eslint-compat).
+  # Bump deliberately: a version change re-records the committed ground truth.
+  nuxt-eslint-oracle:
+    "@nuxt/eslint": "1.16.0"
+    "@nuxt/eslint-config": "1.16.0"
+
   # Shared repo and file-system utilities.
   repo-tooling:
     "@iarna/toml": "2.2.5"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -182,8 +182,5 @@ allowBuilds:
   core-js: false
   esbuild: true
   puppeteer: false
-  # Pulled in by the @nuxt/eslint oracle through eslint-plugin-import-x. Only
-  # the plugin's config shape is read, never its module resolution, so the
-  # native binding is not needed.
   unrs-resolver: false
   vue-demi: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -182,4 +182,8 @@ allowBuilds:
   core-js: false
   esbuild: true
   puppeteer: false
+  # Pulled in by the @nuxt/eslint oracle through eslint-plugin-import-x. Only
+  # the plugin's config shape is read, never its module resolution, so the
+  # native binding is not needed.
+  unrs-resolver: false
   vue-demi: false

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -257,7 +257,7 @@ test("check workflow runs JS package unit tests and production dependency audit"
   assert.match(pnpmWorkspace, /^overrides:\n/m);
   assert.match(
     pnpmWorkspace,
-    /^allowBuilds:\n  "@parcel\/watcher": false\n  core-js: false\n  esbuild: true\n  puppeteer: false\n  vue-demi: false$/m,
+    /^allowBuilds:\n  "@parcel\/watcher": false\n  core-js: false\n  esbuild: true\n  puppeteer: false\n  unrs-resolver: false\n  vue-demi: false$/m,
   );
   assert.match(jsPackageJob, /vp run --workspace-root test:js/);
   assert.match(jsPackageJob, /key:\s*test-js-packages/);

--- a/tests/tooling/nuxt-eslint-oracle.test.ts
+++ b/tests/tooling/nuxt-eslint-oracle.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Guards the `@nuxt/eslint` differential oracle used by
+ * `npm/framework/nuxt/src/lint/oracle.test.ts`.
+ *
+ * That suite reads a *recorded* copy of `@nuxt/eslint`'s output so the package
+ * tests run offline. The recording is only trustworthy if something re-derives
+ * it from the real packages, which is what this test does: it re-runs every
+ * corpus case through the installed `@nuxt/eslint` and `@nuxt/eslint-config`
+ * and asserts the result equals the committed recording, field for field. A
+ * dependency bump therefore shows up here as a hard failure rather than as
+ * silent compatibility drift.
+ *
+ * It also asserts the inventory markdown covers exactly the corpus — repo
+ * policy is that an unwritten edge case does not exist, so a corpus row with no
+ * inventory row (or vice versa) is a failure.
+ */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const compatDir = join(repoRoot, "npm", "framework", "nuxt", "test", "nuxt-eslint-compat");
+const oracle = await import(join(compatDir, "oracle.mjs"));
+
+test("recorded output matches the installed @nuxt/eslint packages", async () => {
+  const recomputed = await oracle.runOracle();
+  const recorded = oracle.readRecorded();
+
+  assert.equal(recomputed.moduleVersion, recorded.moduleVersion);
+  assert.equal(recomputed.configVersion, recorded.configVersion);
+  assert.equal(recomputed.typeScriptDetected, recorded.typeScriptDetected);
+  assert.deepEqual(Object.keys(recomputed.cases).sort(), Object.keys(recorded.cases).sort());
+  assert.deepEqual(recomputed.dirDefaults, recorded.dirDefaults);
+  assert.deepEqual(recomputed.cases, recorded.cases);
+});
+
+test("corpus pins the package versions the recording was produced with", () => {
+  const corpus = oracle.readCorpus();
+  const recorded = oracle.readRecorded();
+  assert.equal(corpus.oracle.module, "@nuxt/eslint");
+  assert.equal(corpus.oracle.config, "@nuxt/eslint-config");
+  assert.equal(corpus.oracle.moduleVersion, recorded.moduleVersion);
+  assert.equal(corpus.oracle.configVersion, recorded.configVersion);
+});
+
+test("inventory markdown documents exactly the corpus cases", () => {
+  const corpus = oracle.readCorpus();
+  const inventory = readFileSync(join(compatDir, "INVENTORY.md"), "utf8");
+
+  // Per-case rows are the table rows whose first cell is a backticked id using
+  // one of the corpus's own prefixes. Keying off the prefix set is what
+  // separates them from the document's other tables (which also start with a
+  // backticked cell, e.g. config item names) without pre-supposing which ids
+  // exist — so a missing *or* an extra case row still fails.
+  const ids = [
+    ...corpus.dirDefaultCases.map((entry: { id: string }) => entry.id),
+    ...corpus.cases.map((entry: { id: string }) => entry.id),
+  ];
+  const prefixes = new Set(ids.map((id) => id.slice(0, id.indexOf("/"))));
+
+  const documented = new Set<string>();
+  for (const line of inventory.split("\n")) {
+    if (!line.startsWith("| `")) continue;
+    const firstCell = line.slice(1, line.indexOf("|", 1)).trim();
+    if (!firstCell.startsWith("`") || !firstCell.endsWith("`")) continue;
+    const id = firstCell.slice(1, -1);
+    if (prefixes.has(id.slice(0, id.indexOf("/")))) {
+      documented.add(id);
+    }
+  }
+
+  assert.deepEqual([...documented].sort(), [...ids].sort());
+});

--- a/tests/tooling/nuxt-eslint-oracle.test.ts
+++ b/tests/tooling/nuxt-eslint-oracle.test.ts
@@ -71,5 +71,6 @@ test("inventory markdown documents exactly the corpus cases", () => {
     }
   }
 
-  assert.deepEqual([...documented].sort(), [...ids].sort());
+  const byId = (left: string, right: string) => left.localeCompare(right);
+  assert.deepEqual([...documented].sort(byId), [...ids].sort(byId));
 });


### PR DESCRIPTION
First phase of #3607 (port `@nuxt/eslint` onto Vize's linting engine).

Ports the project-aware core of `@nuxt/eslint`: the reduction from Nuxt project
state to the directory lists every lint glob is built from, the feature-flag
defaults that decide which rule blocks exist, and the ordered Nuxt-aware config
plan those two produce.

## Why the plan is engine-neutral

Vize runs Patina through oxlint via `oxlint-plugin-vize` rather than vendoring
ESLint, so the plan names rules by their eslint-compatible ids and stops there.
Emitting a plan as an oxlint config is #3611; keeping that concern out of the
plan is exactly what lets the plan be pinned directly against upstream, with no
ESLint in the loop.

## Differential oracle

Correctness is held to the real packages by an oracle following the
`@vue/babel-plugin-jsx` pattern in `crates/vize_atelier_jsx/tests/babel_compat`
— deliberately the same mechanism, not a second one:

- `test/nuxt-eslint-compat/oracle.mjs` drives the real `@nuxt/eslint@1.16.0` and
  `@nuxt/eslint-config@1.16.0` over a declarative corpus and records what they
  produce. The module is driven headlessly through a Nuxt stub, so the recording
  depends on the corpus alone.
- `src/lint/oracle.test.ts` reads the recording offline, so the package suite
  needs no `@nuxt/*` import.
- `tests/tooling/nuxt-eslint-oracle.test.ts` re-derives it in CI, so a
  dependency bump fails loudly instead of drifting silently.
- Upstream is pinned in a dedicated `nuxt-eslint-oracle` catalog, matching how
  the babel oracle pins its toolchain.

The corpus covers layers, `srcDir`, `nuxt.options.dir` overrides, all three
`components` declaration forms, extra import directories, and the feature
matrix. `INVENTORY.md` documents every case, the per-config-item Patina status,
and the two intentional divergences.

## Two gaps this surfaced

Both are filed and block later phases, not this PR:

- `vue/no-multiple-template-root` is unimplemented in Patina, which makes
  `nuxt/vue/single-root` unenforceable (#3613).
- `entries[].linter.rules` is parsed but never applied per glob, which blocks
  the emitter (#3610).

## Notes

- The lint API is a **subpath export** (`@vizejs/nuxt/lint`) rather than a
  re-export from `src/index.ts`, because that file is already 681 lines and
  re-exporting would have grown an over-limit file.
- No new npm package: a new package needs ~6 edits in `release.yml` plus 5
  hardcoded test lists, so that is deferred to #3616.
- `pnpm-lock.yaml`'s `native-binaries` catalog is restored verbatim from `main`;
  a plain `pnpm install` prunes it because those versions are not published yet.
  Filed separately.

## Verification

| Command | Result |
| --- | --- |
| `node --test src/lint/*.test.ts` | 60 pass, 0 fail |
| `node --test src/*.test.ts src/**/*.test.ts` | 177 pass, 0 fail |
| `node --test tests/tooling/nuxt-eslint-oracle.test.ts` | 3 pass, 0 fail |
| `oracle.mjs --check` | matches 16 recorded cases |
| `vp check src vite.config.ts` | 0 errors, 0 warnings |
| `vp pack` | 6 files, `./lint` entry ships |
| `pnpm install --frozen-lockfile` | consistent |

Reverting a single token in the components glob turns 16 of 50 oracle tests red,
so the differential test demonstrably fails before the implementation is right.

Refs #3607, #3610, #3611, #3612, #3613


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public Nuxt linting module with configurable directory, feature, and configuration-plan support.
  * Added compatibility across Nuxt 2, 3, and 4 projects, including layered configurations and directory overrides.
  * Added Nuxt-aware lint rules for routes, pages, components, globals, and configuration files.

* **Tests**
  * Added comprehensive compatibility coverage against Nuxt ESLint behavior, including defaults, overrides, feature combinations, and TypeScript detection.

* **Documentation**
  * Added compatibility inventory and scenario documentation for Nuxt linting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->