### PR TITLE
fix(atelier): stop aborting past the element nesting limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +1731,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2495,6 +2513,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2988,6 +3016,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys",
+]
 
 [[package]]
 name = "static-self"
@@ -3691,6 +3732,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "stacker",
  "tempfile",
  "which",
  "xxhash-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,10 @@ xxhash-rust = { version = "=0.8.15", features = ["xxh3"] }
 sha2 = "=0.11.0"
 htmlize = { version = "=1.1.0", features = ["unescape"] }
 libc = "=0.2.186"
+# Moves a recursive AST pass onto a heap-allocated stack when the thread stack
+# runs low, so template nesting depth costs heap instead of stack. See
+# `vize_carton::recursion` for why the compiler needs it.
+stacker = "=0.1.24"
 
 # Allocator
 mimalloc = "=0.1.52"

--- a/crates/vize_armature/src/parser/element/nesting.rs
+++ b/crates/vize_armature/src/parser/element/nesting.rs
@@ -3,7 +3,8 @@
 //! Elements nested deeper than [`MAX_ELEMENT_NESTING_DEPTH`] are attached to the
 //! tree as leaves instead of being pushed onto the open-element stack, so the
 //! AST the recursive later passes (transform, codegen, semantic analysis) walk
-//! stays within a predictable amount of stack space regardless of the input.
+//! stays bounded regardless of the input, and the limit is reported as an
+//! ordinary diagnostic instead of aborting the process.
 //!
 //! That recovery used to leak into the diagnostics. Because the over-limit
 //! elements never reached the stack, their end tags found nothing to close and
@@ -22,10 +23,24 @@ use super::super::Parser;
 
 /// Maximum element nesting depth retained by the parser.
 ///
-/// The limit is far beyond any realistic template while still cheap to enforce.
-pub(super) const MAX_ELEMENT_NESTING_DEPTH: usize = 256;
+/// This used to be 256, chosen for the stack the recursive later passes needed:
+/// 256 was exactly the depth a debug build survived on Rust's default 2 MiB
+/// thread stack, and one level past whatever the constant said, the failure mode
+/// was `fatal runtime error: stack overflow` — `SIGABRT`, not a diagnostic
+/// (#3480). Those passes now grow onto the heap when the stack runs low
+/// (`vize_carton::recursion`), so nesting depth no longer costs stack and the
+/// limit is free to be chosen for what it actually bounds: output size.
+///
+/// 4096 is that choice. It is ~3.7x the representative element-only nesting
+/// depth `@vue/compiler-dom` reaches before its own recursion raises
+/// `RangeError: Maximum call stack size exceeded` (measured at 1092 levels of
+/// `<div>` on a default Node stack, 3.6.0-beta.10), leaving ample headroom over
+/// upstream's practical depth. Past it, generated code grows quadratically in
+/// depth — indentation adds two bytes per level per line, so depth 4096 is
+/// already tens of megabytes of output — which is the real reason to stop.
+pub(super) const MAX_ELEMENT_NESTING_DEPTH: usize = 4096;
 
-/// Message attached to the recoverable error raised when the nesting limit is hit.
+/// Message attached to the diagnostic raised when the nesting limit is hit.
 const NESTING_TOO_DEEP_MESSAGE: &str = "Element nesting is too deep.";
 
 impl<'a> Parser<'a> {

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -733,25 +733,25 @@ fn test_parse_extreme_nesting_is_bounded() {
 
     let (root, errors) = parse(&allocator, &source);
 
-    // The nesting limit was reported.
-    assert!(
+    // The nesting limit was reported, once, and nothing else was.
+    assert_eq!(
         errors
             .iter()
-            .any(|e| e.message.contains("nesting is too deep")),
-        "expected a nesting-depth error for deeply nested input"
+            .map(|e| (e.code, e.message.as_str()))
+            .collect::<std::vec::Vec<_>>(),
+        vec![(ErrorCode::ExtendPoint, "Element nesting is too deep.")]
     );
 
-    // The retained tree depth is bounded by the cap, not by the input depth.
+    // The retained tree depth is bounded by the cap, not by the input depth:
+    // the first over-limit element is kept as a leaf on the deepest retained
+    // parent, so the tree is exactly one level deeper than the cap.
     let mut node = root.children.first();
     let mut measured = 0usize;
     while let Some(TemplateChildNode::Element(el)) = node {
         measured += 1;
         node = el.children.first();
     }
-    assert!(
-        measured <= 257,
-        "tree depth should stay bounded near the cap, got {measured}"
-    );
+    assert_eq!(measured, 4097);
 }
 
 #[test]

--- a/crates/vize_armature/src/parser/whitespace.rs
+++ b/crates/vize_armature/src/parser/whitespace.rs
@@ -6,7 +6,7 @@
 //! whitespace alphabet is the ASCII set `[ \t\n\f\r]`, so this module uses
 //! `is_vue_whitespace` rather than the full-Unicode `char::is_whitespace`.
 
-use vize_carton::{String, Vec};
+use vize_carton::{String, Vec, ensure_sufficient_stack};
 use vize_relief::TemplateChildNode;
 
 /// Per Vue: only `[ \t\n\f\r]` is whitespace for the condense strategy.
@@ -58,6 +58,11 @@ fn condense_internal_whitespace(text: &str) -> Option<String> {
 }
 
 /// Condense whitespace in children
+///
+/// Tokenizing is iterative — the parser keeps its own open-element stack — but
+/// this post-pass walks the finished tree with the call stack, so it is the one
+/// place where parsing costs a frame per nesting level. Its descent is therefore
+/// guarded (`vize_carton::recursion`).
 pub(super) fn condense_whitespace<'a>(
     children: &mut Vec<'a, TemplateChildNode<'a>>,
     is_pre_tag: fn(&str) -> bool,
@@ -146,7 +151,7 @@ pub(super) fn condense_whitespace<'a>(
         if let TemplateChildNode::Element(ref mut el) = children[i]
             && !is_pre_tag(el.tag.as_str())
         {
-            condense_whitespace(&mut el.children, is_pre_tag);
+            ensure_sufficient_stack(|| condense_whitespace(&mut el.children, is_pre_tag));
         }
 
         i += 1;

--- a/crates/vize_armature/tests/element_nesting_limit.rs
+++ b/crates/vize_armature/tests/element_nesting_limit.rs
@@ -20,7 +20,7 @@ use vize_relief::{
 };
 
 /// Mirrors `MAX_ELEMENT_NESTING_DEPTH` in `parser::element::nesting`.
-const NESTING_LIMIT: usize = 256;
+const NESTING_LIMIT: usize = 4096;
 
 const TOO_DEEP: &str = "Element nesting is too deep.";
 
@@ -65,7 +65,7 @@ fn nesting_at_the_limit_parses_without_diagnostics() {
 
 #[test]
 fn nesting_past_the_limit_reports_the_limit_once_without_inventing_end_tag_errors() {
-    for depth in [NESTING_LIMIT + 1, NESTING_LIMIT + 2, 300, 1000] {
+    for depth in [NESTING_LIMIT + 1, NESTING_LIMIT + 2, 5_000, 10_000] {
         let allocator = Bump::new();
         let source = nested_divs(depth);
         let (_, errors) = parse(&allocator, &source);
@@ -100,7 +100,7 @@ fn each_over_limit_region_is_reported_at_its_own_location() {
 #[test]
 fn retained_tree_depth_stays_bounded_past_the_limit() {
     let allocator = Bump::new();
-    let source = nested_divs(5000);
+    let source = nested_divs(5_000);
     let (root, errors) = parse(&allocator, &source);
 
     assert_eq!(

--- a/crates/vize_atelier_core/src/codegen/element/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/element/helpers.rs
@@ -6,7 +6,7 @@
 use crate::{
     DirectiveNode, ElementNode, ElementType, ExpressionNode, Namespace, PropNode, TemplateChildNode,
 };
-use vize_carton::is_builtin_directive;
+use vize_carton::{ensure_sufficient_stack, is_builtin_directive};
 
 use super::super::{
     context::CodegenContext, node::generate_node, props::is_supported_directive,
@@ -194,15 +194,16 @@ fn child_crosses_namespace_boundary(ns: Namespace, child: &TemplateChildNode<'_>
     match child {
         TemplateChildNode::Element(el) => match el.tag_type {
             ElementType::Element => el.ns != ns,
-            ElementType::Template => children_cross_namespace_boundary(ns, &el.children),
+            ElementType::Template => {
+                ensure_sufficient_stack(|| children_cross_namespace_boundary(ns, &el.children))
+            }
             _ => false,
         },
-        TemplateChildNode::If(if_node) => if_node
-            .branches
-            .iter()
-            .any(|branch| children_cross_namespace_boundary(ns, &branch.children)),
+        TemplateChildNode::If(if_node) => if_node.branches.iter().any(|branch| {
+            ensure_sufficient_stack(|| children_cross_namespace_boundary(ns, &branch.children))
+        }),
         TemplateChildNode::For(for_node) => {
-            children_cross_namespace_boundary(ns, &for_node.children)
+            ensure_sufficient_stack(|| children_cross_namespace_boundary(ns, &for_node.children))
         }
         _ => false,
     }

--- a/crates/vize_atelier_core/src/codegen/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/generate.rs
@@ -3,14 +3,23 @@
 //! Generates hoisted variable declarations and serializes JS child nodes,
 //! VNode calls, props expressions, and children to byte output.
 
+#[path = "generate/collect_helpers.rs"]
+mod collect_helpers;
+#[path = "generate/static_vnode.rs"]
+mod static_vnode;
+
 use crate::{
     DynamicProps, ExpressionNode, JsChildNode, PropsExpression, RootNode, RuntimeHelper,
     TemplateChildNode, TemplateTextChildNode, VNodeCall, VNodeChildren, VNodeTag,
 };
 
+pub(super) use collect_helpers::collect_hoist_helpers;
+use static_vnode::generate_static_element_to_bytes;
+
 use super::{context::CodegenContext, helpers::escape_js_string};
 use vize_carton::String;
 use vize_carton::ToCompactString;
+use vize_carton::ensure_sufficient_stack;
 
 /// Generate hoisted variable declarations.
 pub(super) fn generate_hoists(ctx: &CodegenContext, root: &RootNode<'_>) -> String {
@@ -33,97 +42,19 @@ pub(super) fn generate_hoists(ctx: &CodegenContext, root: &RootNode<'_>) -> Stri
     hoists_code
 }
 
-/// Collect runtime helpers needed by hoisted nodes.
-///
-/// Since `generate_hoists()` takes `&CodegenContext` (immutable), helpers used in hoisted
-/// VNodes are not tracked via `use_helper()`. This function pre-scans hoists to collect them.
-pub(super) fn collect_hoist_helpers(root: &RootNode<'_>, helpers: &mut Vec<RuntimeHelper>) {
-    for node in root.hoists.iter().flatten() {
-        collect_helpers_from_js_child_node(node, helpers);
-    }
-}
-
-fn collect_helpers_from_js_child_node(node: &JsChildNode<'_>, helpers: &mut Vec<RuntimeHelper>) {
-    match node {
-        JsChildNode::VNodeCall(vnode) => collect_helpers_from_vnode_call(vnode, helpers),
-        JsChildNode::Object(obj) => {
-            for prop in &obj.properties {
-                collect_helpers_from_js_child_node(&prop.value, helpers);
-            }
-        }
-        _ => {}
-    }
-}
-
-fn collect_helpers_from_vnode_call(vnode: &VNodeCall<'_>, helpers: &mut Vec<RuntimeHelper>) {
-    // Match the logic in generate_vnode_call_to_bytes
-    if vnode.is_block {
-        helpers.push(RuntimeHelper::OpenBlock);
-        if vnode.is_component {
-            helpers.push(RuntimeHelper::CreateBlock);
-        } else {
-            helpers.push(RuntimeHelper::CreateElementBlock);
-        }
-    } else if vnode.is_component {
-        helpers.push(RuntimeHelper::CreateVNode);
-    } else {
-        helpers.push(RuntimeHelper::CreateElementVNode);
-    }
-
-    // Tag symbol (e.g., Fragment)
-    if let VNodeTag::Symbol(helper) = &vnode.tag {
-        helpers.push(*helper);
-    }
-
-    // Recurse into props (may contain nested VNodeCalls)
-    if let Some(props) = &vnode.props {
-        collect_helpers_from_props(props, helpers);
-    }
-
-    // Recurse into a hoisted nested-static subtree's children so the helpers
-    // used by descendant `createElementVNode` / `createTextVNode` calls are
-    // declared in the import preamble.
-    if let Some(VNodeChildren::Multiple(children)) = &vnode.children {
-        collect_helpers_from_static_children(children, helpers);
-    }
-}
-
-/// Collect helpers for a hoisted static children list, matching exactly what
-/// [`generate_static_element_to_bytes`] / the `Multiple` codegen branch emit:
-/// element children always need `createElementVNode`; a text child only needs
-/// `createTextVNode` when it is emitted in array form (i.e. siblings include an
-/// element), since a single/all-text run collapses to a string literal.
-fn collect_helpers_from_static_children(
-    children: &[TemplateChildNode<'_>],
-    helpers: &mut Vec<RuntimeHelper>,
-) {
-    let has_element = children
-        .iter()
-        .any(|c| matches!(c, TemplateChildNode::Element(_)));
-    for child in children.iter() {
-        match child {
-            TemplateChildNode::Element(el) => {
-                helpers.push(RuntimeHelper::CreateElementVNode);
-                collect_helpers_from_static_children(&el.children, helpers);
-            }
-            TemplateChildNode::Text(_) if has_element => {
-                helpers.push(RuntimeHelper::CreateText);
-            }
-            _ => {}
-        }
-    }
-}
-
-fn collect_helpers_from_props(props: &PropsExpression<'_>, helpers: &mut Vec<RuntimeHelper>) {
-    if let PropsExpression::Object(obj) = props {
-        for prop in &obj.properties {
-            collect_helpers_from_js_child_node(&prop.value, helpers);
-        }
-    }
-}
-
 /// Generate `JsChildNode` to bytes.
+///
+/// Guarded: serializing a hoisted VNode descends one frame per level of the
+/// subtree it was hoisted from (`vize_carton::recursion`).
 fn generate_js_child_node_to_bytes(ctx: &CodegenContext, node: &JsChildNode<'_>, out: &mut String) {
+    ensure_sufficient_stack(|| generate_js_child_node_to_bytes_guarded(ctx, node, out));
+}
+
+fn generate_js_child_node_to_bytes_guarded(
+    ctx: &CodegenContext,
+    node: &JsChildNode<'_>,
+    out: &mut String,
+) {
     match node {
         JsChildNode::VNodeCall(vnode) => generate_vnode_call_to_bytes(ctx, vnode, out),
         JsChildNode::SimpleExpression(exp) => {
@@ -372,125 +303,4 @@ fn generate_vnode_children_to_bytes(
         }
         _ => out.push_str("null"),
     }
-}
-
-/// Serialize a fully-static element as a nested `createElementVNode(...)` for a
-/// hoisted subtree. Children recurse the same way; text children collapse to a
-/// string literal, matching @vue/compiler-core's hoisted static output.
-fn generate_static_element_to_bytes(
-    ctx: &CodegenContext,
-    el: &crate::ElementNode<'_>,
-    out: &mut String,
-) {
-    out.push_str(ctx.helper(RuntimeHelper::CreateElementVNode));
-    out.push_str("(\"");
-    out.push_str(el.tag.as_str());
-    out.push('"');
-
-    // Props: static attributes and constant v-bind only (the subtree is static).
-    let props = build_static_props(el);
-    if let Some(props) = &props {
-        out.push_str(", ");
-        out.push_str(props.as_str());
-    } else if !el.children.is_empty() {
-        out.push_str(", null");
-    }
-
-    if !el.children.is_empty() {
-        out.push_str(", ");
-        // Single text child collapses to a string literal.
-        if el.children.len() == 1
-            && let TemplateChildNode::Text(text) = &el.children[0]
-        {
-            out.push('"');
-            out.push_str(escape_js_string(&text.content).as_str());
-            out.push('"');
-        } else if el
-            .children
-            .iter()
-            .all(|c| matches!(c, TemplateChildNode::Text(_)))
-        {
-            let mut combined = String::default();
-            for c in el.children.iter() {
-                if let TemplateChildNode::Text(t) = c {
-                    combined.push_str(t.content.as_str());
-                }
-            }
-            out.push('"');
-            out.push_str(escape_js_string(&combined).as_str());
-            out.push('"');
-        } else {
-            out.push('[');
-            let mut emitted = 0usize;
-            for c in el.children.iter() {
-                match c {
-                    TemplateChildNode::Element(child_el) => {
-                        if emitted > 0 {
-                            out.push_str(", ");
-                        }
-                        emitted += 1;
-                        generate_static_element_to_bytes(ctx, child_el, out);
-                    }
-                    TemplateChildNode::Text(text) => {
-                        if emitted > 0 {
-                            out.push_str(", ");
-                        }
-                        emitted += 1;
-                        out.push_str(ctx.helper(RuntimeHelper::CreateText));
-                        out.push_str("(\"");
-                        out.push_str(escape_js_string(&text.content).as_str());
-                        out.push_str("\")");
-                    }
-                    _ => {}
-                }
-            }
-            out.push(']');
-        }
-    }
-
-    out.push(')');
-}
-
-/// Build the props-object literal for a static element, or `None` when it has
-/// no renderable static props. Mirrors the dedupe and quoting rules used by the
-/// main props codegen.
-fn build_static_props(el: &crate::ElementNode<'_>) -> Option<String> {
-    use crate::PropNode;
-
-    let mut buf = String::default();
-    buf.push_str("{ ");
-    let mut seen: vize_carton::FxHashSet<vize_carton::String> = vize_carton::FxHashSet::default();
-    let mut emitted = 0usize;
-
-    for prop in el.props.iter() {
-        if let PropNode::Attribute(attr) = prop {
-            if attr.name == "ref" || seen.contains(attr.name.as_str()) {
-                continue;
-            }
-            seen.insert(attr.name.clone());
-            if emitted > 0 {
-                buf.push_str(", ");
-            }
-            emitted += 1;
-            let needs_quote = !crate::codegen::helpers::is_valid_js_identifier(&attr.name);
-            if needs_quote {
-                buf.push('"');
-                buf.push_str(attr.name.as_str());
-                buf.push('"');
-            } else {
-                buf.push_str(attr.name.as_str());
-            }
-            buf.push_str(": \"");
-            if let Some(v) = &attr.value {
-                buf.push_str(escape_js_string(&v.content).as_str());
-            }
-            buf.push('"');
-        }
-    }
-
-    if emitted == 0 {
-        return None;
-    }
-    buf.push_str(" }");
-    Some(buf)
 }

--- a/crates/vize_atelier_core/src/codegen/generate/collect_helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/generate/collect_helpers.rs
@@ -1,0 +1,108 @@
+//! Runtime-helper pre-scan for hoisted nodes.
+//!
+//! [`generate_hoists`](super::generate_hoists) takes `&CodegenContext`, so the
+//! helpers a hoisted VNode uses are never recorded through `use_helper()` while
+//! it is serialized. This walk collects them up front, and it must stay in exact
+//! agreement with what the serializers in the parent module emit — a helper
+//! collected here but not emitted leaves an unused import in the preamble, and
+//! one emitted but not collected leaves an undefined identifier in the output.
+
+use crate::{
+    JsChildNode, PropsExpression, RootNode, RuntimeHelper, TemplateChildNode, VNodeCall,
+    VNodeChildren, VNodeTag,
+};
+use vize_carton::ensure_sufficient_stack;
+
+/// Collect runtime helpers needed by hoisted nodes.
+pub(in crate::codegen) fn collect_hoist_helpers(
+    root: &RootNode<'_>,
+    helpers: &mut Vec<RuntimeHelper>,
+) {
+    for node in root.hoists.iter().flatten() {
+        collect_helpers_from_js_child_node(node, helpers);
+    }
+}
+
+/// Guarded: a hoisted subtree is as deep as the template subtree it came from,
+/// and this walk descends one frame per level (`vize_carton::recursion`).
+fn collect_helpers_from_js_child_node(node: &JsChildNode<'_>, helpers: &mut Vec<RuntimeHelper>) {
+    ensure_sufficient_stack(|| match node {
+        JsChildNode::VNodeCall(vnode) => collect_helpers_from_vnode_call(vnode, helpers),
+        JsChildNode::Object(obj) => {
+            for prop in &obj.properties {
+                collect_helpers_from_js_child_node(&prop.value, helpers);
+            }
+        }
+        _ => {}
+    });
+}
+
+fn collect_helpers_from_vnode_call(vnode: &VNodeCall<'_>, helpers: &mut Vec<RuntimeHelper>) {
+    // Match the logic in generate_vnode_call_to_bytes
+    if vnode.is_block {
+        helpers.push(RuntimeHelper::OpenBlock);
+        if vnode.is_component {
+            helpers.push(RuntimeHelper::CreateBlock);
+        } else {
+            helpers.push(RuntimeHelper::CreateElementBlock);
+        }
+    } else if vnode.is_component {
+        helpers.push(RuntimeHelper::CreateVNode);
+    } else {
+        helpers.push(RuntimeHelper::CreateElementVNode);
+    }
+
+    // Tag symbol (e.g., Fragment)
+    if let VNodeTag::Symbol(helper) = &vnode.tag {
+        helpers.push(*helper);
+    }
+
+    // Recurse into props (may contain nested VNodeCalls)
+    if let Some(props) = &vnode.props {
+        collect_helpers_from_props(props, helpers);
+    }
+
+    // Recurse into a hoisted nested-static subtree's children so the helpers
+    // used by descendant `createElementVNode` / `createTextVNode` calls are
+    // declared in the import preamble.
+    if let Some(VNodeChildren::Multiple(children)) = &vnode.children {
+        collect_helpers_from_static_children(children, helpers);
+    }
+}
+
+/// Collect helpers for a hoisted static children list, matching exactly what
+/// `generate_static_element_to_bytes` / the `Multiple` codegen branch emit:
+/// element children always need `createElementVNode`; a text child only needs
+/// `createTextVNode` when it is emitted in array form (i.e. siblings include an
+/// element), since a single/all-text run collapses to a string literal.
+fn collect_helpers_from_static_children(
+    children: &[TemplateChildNode<'_>],
+    helpers: &mut Vec<RuntimeHelper>,
+) {
+    let has_element = children
+        .iter()
+        .any(|c| matches!(c, TemplateChildNode::Element(_)));
+    for child in children.iter() {
+        match child {
+            TemplateChildNode::Element(el) => {
+                helpers.push(RuntimeHelper::CreateElementVNode);
+                // Guarded: one frame per nesting level of the hoisted subtree.
+                ensure_sufficient_stack(|| {
+                    collect_helpers_from_static_children(&el.children, helpers);
+                });
+            }
+            TemplateChildNode::Text(_) if has_element => {
+                helpers.push(RuntimeHelper::CreateText);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn collect_helpers_from_props(props: &PropsExpression<'_>, helpers: &mut Vec<RuntimeHelper>) {
+    if let PropsExpression::Object(obj) = props {
+        for prop in &obj.properties {
+            collect_helpers_from_js_child_node(&prop.value, helpers);
+        }
+    }
+}

--- a/crates/vize_atelier_core/src/codegen/generate/static_vnode.rs
+++ b/crates/vize_atelier_core/src/codegen/generate/static_vnode.rs
@@ -1,0 +1,138 @@
+//! Serialization for fully-static nested VNodes.
+
+use vize_carton::{String, ensure_sufficient_stack};
+
+use crate::{ElementNode, PropNode, RuntimeHelper, TemplateChildNode};
+
+use super::super::{context::CodegenContext, helpers::escape_js_string};
+
+/// Serialize a fully-static element as a nested `createElementVNode(...)` for a
+/// hoisted subtree. Children recurse the same way; text children collapse to a
+/// string literal, matching @vue/compiler-core's hoisted static output.
+pub(super) fn generate_static_element_to_bytes(
+    ctx: &CodegenContext,
+    el: &ElementNode<'_>,
+    out: &mut String,
+) {
+    out.push_str(ctx.helper(RuntimeHelper::CreateElementVNode));
+    out.push_str("(\"");
+    out.push_str(el.tag.as_str());
+    out.push('"');
+
+    let props = build_static_props(el);
+    if let Some(props) = &props {
+        out.push_str(", ");
+        out.push_str(props.as_str());
+    } else if !el.children.is_empty() {
+        out.push_str(", null");
+    }
+
+    if !el.children.is_empty() {
+        out.push_str(", ");
+        generate_static_children_to_bytes(ctx, el, out);
+    }
+
+    out.push(')');
+}
+
+fn generate_static_children_to_bytes(ctx: &CodegenContext, el: &ElementNode<'_>, out: &mut String) {
+    if el.children.len() == 1
+        && let TemplateChildNode::Text(text) = &el.children[0]
+    {
+        out.push('"');
+        out.push_str(escape_js_string(&text.content).as_str());
+        out.push('"');
+    } else if el
+        .children
+        .iter()
+        .all(|child| matches!(child, TemplateChildNode::Text(_)))
+    {
+        let mut combined = String::default();
+        for child in el.children.iter() {
+            if let TemplateChildNode::Text(text) = child {
+                combined.push_str(text.content.as_str());
+            }
+        }
+        out.push('"');
+        out.push_str(escape_js_string(&combined).as_str());
+        out.push('"');
+    } else {
+        generate_static_child_array_to_bytes(ctx, &el.children, out);
+    }
+}
+
+fn generate_static_child_array_to_bytes(
+    ctx: &CodegenContext,
+    children: &[TemplateChildNode<'_>],
+    out: &mut String,
+) {
+    out.push('[');
+    let mut emitted = 0usize;
+    for child in children {
+        match child {
+            TemplateChildNode::Element(child_el) => {
+                if emitted > 0 {
+                    out.push_str(", ");
+                }
+                emitted += 1;
+                ensure_sufficient_stack(|| {
+                    generate_static_element_to_bytes(ctx, child_el, out);
+                });
+            }
+            TemplateChildNode::Text(text) => {
+                if emitted > 0 {
+                    out.push_str(", ");
+                }
+                emitted += 1;
+                out.push_str(ctx.helper(RuntimeHelper::CreateText));
+                out.push_str("(\"");
+                out.push_str(escape_js_string(&text.content).as_str());
+                out.push_str("\")");
+            }
+            _ => {}
+        }
+    }
+    out.push(']');
+}
+
+/// Build the props-object literal for a static element, or `None` when it has
+/// no renderable static props. Mirrors the dedupe and quoting rules used by the
+/// main props codegen.
+fn build_static_props(el: &ElementNode<'_>) -> Option<String> {
+    let mut buf = String::default();
+    buf.push_str("{ ");
+    let mut seen: vize_carton::FxHashSet<vize_carton::String> = vize_carton::FxHashSet::default();
+    let mut emitted = 0usize;
+
+    for prop in el.props.iter() {
+        if let PropNode::Attribute(attr) = prop {
+            if attr.name == "ref" || seen.contains(attr.name.as_str()) {
+                continue;
+            }
+            seen.insert(attr.name.clone());
+            if emitted > 0 {
+                buf.push_str(", ");
+            }
+            emitted += 1;
+            let needs_quote = !crate::codegen::helpers::is_valid_js_identifier(&attr.name);
+            if needs_quote {
+                buf.push('"');
+                buf.push_str(attr.name.as_str());
+                buf.push('"');
+            } else {
+                buf.push_str(attr.name.as_str());
+            }
+            buf.push_str(": \"");
+            if let Some(value) = &attr.value {
+                buf.push_str(escape_js_string(&value.content).as_str());
+            }
+            buf.push('"');
+        }
+    }
+
+    if emitted == 0 {
+        return None;
+    }
+    buf.push_str(" }");
+    Some(buf)
+}

--- a/crates/vize_atelier_core/src/codegen/node.rs
+++ b/crates/vize_atelier_core/src/codegen/node.rs
@@ -7,11 +7,17 @@ use super::context::CodegenContext;
 use super::element::generate_element;
 use super::v_for::generate_for;
 use super::v_if::generate_if;
-use vize_carton::ToCompactString;
+use vize_carton::{ToCompactString, ensure_sufficient_stack};
 
 /// Generate node code
+///
+/// Every codegen path that emits a child funnels back through here, so this is
+/// the one point whose call depth tracks template nesting depth. The guard moves
+/// the descent onto a fresh stack before the thread stack runs out, because a
+/// stack overflow aborts the process instead of producing a diagnostic
+/// (`vize_carton::recursion`).
 pub fn generate_node(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>) {
-    match node {
+    ensure_sufficient_stack(|| match node {
         TemplateChildNode::Element(el) => generate_element(ctx, el),
         TemplateChildNode::Text(text) => generate_text(ctx, text),
         TemplateChildNode::Comment(comment) => generate_comment(ctx, comment),
@@ -26,5 +32,5 @@ pub fn generate_node(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>) {
         _ => {
             ctx.push("null /* unsupported node */");
         }
-    }
+    });
 }

--- a/crates/vize_atelier_core/src/codegen/slots/detect.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/detect.rs
@@ -2,6 +2,7 @@
 
 use crate::steps::v_slot::{collect_slots, has_v_slot};
 use crate::{ElementNode, ElementType, ExpressionNode, PropNode, TemplateChildNode};
+use vize_carton::ensure_sufficient_stack;
 
 /// The expression a component spreads into its slots object, if it carries a
 /// `v-slots` directive (#3467).
@@ -130,16 +131,17 @@ fn child_contains_slot_outlet(child: &TemplateChildNode<'_>) -> bool {
             if el.tag_type == ElementType::Slot || el.tag.as_str() == "slot" {
                 return true;
             }
-            el.children.iter().any(child_contains_slot_outlet)
+            ensure_sufficient_stack(|| el.children.iter().any(child_contains_slot_outlet))
         }
         TemplateChildNode::If(if_node) => if_node
             .branches
             .iter()
             .flat_map(|branch| branch.children.iter())
-            .any(child_contains_slot_outlet),
-        TemplateChildNode::For(for_node) => {
-            for_node.children.iter().any(child_contains_slot_outlet)
-        }
+            .any(|child| ensure_sufficient_stack(|| child_contains_slot_outlet(child))),
+        TemplateChildNode::For(for_node) => for_node
+            .children
+            .iter()
+            .any(|child| ensure_sufficient_stack(|| child_contains_slot_outlet(child))),
         _ => false,
     }
 }

--- a/crates/vize_atelier_core/src/transform/patterned_template.rs
+++ b/crates/vize_atelier_core/src/transform/patterned_template.rs
@@ -1,6 +1,6 @@
 //! Experimental patterned template desugaring (`v-match` / `v-case`).
 
-use vize_carton::{Box, Bump, String, Vec, cstr};
+use vize_carton::{Box, Bump, String, Vec, cstr, ensure_sufficient_stack};
 
 use crate::{
     DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode, RootNode,
@@ -19,7 +19,7 @@ fn rewrite_children<'a>(allocator: &'a Bump, children: &mut Vec<'a, TemplateChil
             continue;
         };
 
-        rewrite_children(allocator, &mut el.children);
+        ensure_sufficient_stack(|| rewrite_children(allocator, &mut el.children));
         rewrite_match_element(allocator, el);
     }
 }

--- a/crates/vize_atelier_core/src/transform/traverse.rs
+++ b/crates/vize_atelier_core/src/transform/traverse.rs
@@ -5,7 +5,7 @@ use crate::{
     ElementNode, ElementType, ExpressionNode, ForNode, IfBranchNode, PropNode, RuntimeHelper,
     TemplateChildNode,
 };
-use vize_carton::profile;
+use vize_carton::{ensure_sufficient_stack, profile};
 
 use super::element::{transform_element, transform_interpolation};
 use super::structural::{
@@ -78,7 +78,18 @@ pub fn traverse_children<'a>(ctx: &mut TransformContext<'a>, parent: ParentNode<
 }
 
 /// Traverse a single node
+///
+/// This is the transform lane's recursion step: `traverse_children` calls it per
+/// child and it calls `traverse_children` back for that child's subtree, so the
+/// call depth here follows template nesting depth. The guard moves the descent
+/// onto a fresh stack before the thread stack runs out, because a stack overflow
+/// aborts the process instead of producing a diagnostic
+/// (`vize_carton::recursion`).
 pub fn traverse_node<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChildNode<'a>) {
+    ensure_sufficient_stack(|| traverse_node_guarded(ctx, node));
+}
+
+fn traverse_node_guarded<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChildNode<'a>) {
     // Collect exit functions from transforms
     let mut exit_fns = ExitFns::new();
 

--- a/crates/vize_atelier_core/src/transforms/hoist_static.rs
+++ b/crates/vize_atelier_core/src/transforms/hoist_static.rs
@@ -2,146 +2,28 @@
 //!
 //! Hoists static nodes to reduce runtime overhead.
 
-use vize_carton::{Box, Bump, String, ToCompactString, Vec, camelize};
+#[path = "hoist_static/props.rs"]
+mod props;
+#[path = "hoist_static/static_type.rs"]
+mod static_type;
+#[cfg(test)]
+#[path = "hoist_static/tests.rs"]
+mod tests;
 
-use crate::codegen::is_constant_simple_expression;
+use props::{
+    create_props_expression, has_static_props, hoist_element_props, is_hoistable_static_prop,
+};
+pub use static_type::{StaticType, get_static_type, is_static_node};
+use static_type::{has_only_native_element_descendants, has_only_static_nested_children};
+
+use vize_carton::{Box, Bump, String, Vec, ensure_sufficient_stack};
+
 use crate::lane::TransformContext;
 use crate::{
-    AttributeNode, DirectiveNode, ElementNode, ElementType, ExpressionNode, JsChildNode, Namespace,
-    ObjectExpression, PropNode, Property, PropsExpression, RuntimeHelper, SimpleExpressionNode,
+    AttributeNode, ElementNode, ElementType, JsChildNode, Namespace, PropNode, RuntimeHelper,
     SourceLocation, TemplateChildNode, TemplateTextChildNode, TextNode, VNodeCall, VNodeChildren,
     VNodeTag,
 };
-
-/// Check if a node is fully static (can be hoisted)
-pub fn is_static_node(node: &TemplateChildNode<'_>) -> bool {
-    match node {
-        TemplateChildNode::Text(_) => true,
-        TemplateChildNode::Comment(_) => true,
-        TemplateChildNode::Element(el) => is_static_element(el),
-        TemplateChildNode::Interpolation(_) => false,
-        TemplateChildNode::If(_) => false,
-        TemplateChildNode::For(_) => false,
-        _ => false,
-    }
-}
-
-/// Check if an element is fully static
-fn is_static_element(el: &ElementNode<'_>) -> bool {
-    // Components are not static
-    if el.tag_type != ElementType::Element {
-        return false;
-    }
-
-    // Check for dynamic props or ref
-    for prop in el.props.iter() {
-        match prop {
-            PropNode::Directive(_) if el.tag == "svg" => return false,
-            PropNode::Directive(_) if !is_hoistable_static_prop(prop) => return false,
-            PropNode::Directive(_) => {}
-            PropNode::Attribute(attr) => {
-                // ref attribute prevents hoisting - refs need runtime owner context
-                if attr.name == "ref" {
-                    return false;
-                }
-            }
-        }
-    }
-
-    // Check children recursively. Nested fully-static element subtrees are
-    // hoistable: `create_children_expression` builds them into a single
-    // recursive VNodeCall, matching @vue/compiler-core's static caching of a
-    // top-most static element with its whole subtree as one cached vnode.
-    for child in el.children.iter() {
-        // Comments prevent hoisting since they can't be serialized to VNodeCall children
-        if matches!(child, TemplateChildNode::Comment(_)) {
-            return false;
-        }
-        if !is_static_node(child) {
-            return false;
-        }
-    }
-
-    true
-}
-
-/// Get the static type of a node
-pub fn get_static_type(node: &TemplateChildNode<'_>) -> StaticType {
-    match node {
-        TemplateChildNode::Text(_) => StaticType::FullyStatic,
-        TemplateChildNode::Comment(_) => StaticType::FullyStatic,
-        TemplateChildNode::Element(el) => get_element_static_type(el),
-        TemplateChildNode::Interpolation(_) => StaticType::NotStatic,
-        _ => StaticType::NotStatic,
-    }
-}
-
-fn get_element_static_type(el: &ElementNode<'_>) -> StaticType {
-    if el.tag_type != ElementType::Element {
-        return StaticType::NotStatic;
-    }
-
-    // Check for any dynamic content
-    let mut has_dynamic_text = false;
-
-    for prop in el.props.iter() {
-        match prop {
-            PropNode::Directive(_) if el.tag == "svg" => {
-                return StaticType::NotStatic;
-            }
-            PropNode::Directive(_) if !is_hoistable_static_prop(prop) => {
-                // Non-constant directives make the element dynamic.
-                return StaticType::NotStatic;
-            }
-            PropNode::Directive(_) => {}
-            PropNode::Attribute(attr) => {
-                // ref attribute prevents hoisting - refs need runtime owner context
-                if attr.name == "ref" {
-                    return StaticType::NotStatic;
-                }
-            }
-        }
-    }
-
-    // Check children
-    for child in el.children.iter() {
-        match child {
-            TemplateChildNode::Interpolation(_) => {
-                has_dynamic_text = true;
-            }
-            // A nested element keeps the parent fully static only when the
-            // child subtree is itself fully static (no dynamic text either):
-            // such a subtree is serialized into one recursive VNodeCall by
-            // `create_children_expression`. Any dynamic content disqualifies it.
-            TemplateChildNode::Element(child_el) => match get_element_static_type(child_el) {
-                StaticType::FullyStatic => {}
-                _ => return StaticType::NotStatic,
-            },
-            TemplateChildNode::If(_) | TemplateChildNode::For(_) => {
-                return StaticType::NotStatic;
-            }
-            // Comments prevent hoisting since they can't be serialized to VNodeCall children
-            TemplateChildNode::Comment(_) => {
-                return StaticType::NotStatic;
-            }
-            _ => {}
-        }
-    }
-
-    if has_dynamic_text {
-        StaticType::HasDynamicText
-    } else {
-        StaticType::FullyStatic
-    }
-}
-
-/// Static type enumeration
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StaticType {
-    NotStatic = 0,
-    FullyStatic = 1,
-    HasDynamicText = 2,
-}
 
 /// Hoist static nodes in the tree
 pub fn hoist_static<'a>(
@@ -218,7 +100,15 @@ fn hoist_static_inner<'a>(
                         let child_hoist_static_vnodes = hoist_static_vnodes
                             || has_directives(el)
                             || el.tag_type != ElementType::Element;
-                        hoist_static_inner(ctx, &mut el.children, false, child_hoist_static_vnodes);
+                        // Guarded: one frame per nesting level.
+                        ensure_sufficient_stack(|| {
+                            hoist_static_inner(
+                                ctx,
+                                &mut el.children,
+                                false,
+                                child_hoist_static_vnodes,
+                            );
+                        });
                     }
                     TemplateChildNode::If(if_node) => {
                         // For v-if branches, only hoist nested children, not the branch root
@@ -227,13 +117,17 @@ fn hoist_static_inner<'a>(
                             for child in branch.children.iter_mut() {
                                 if let TemplateChildNode::Element(el) = child {
                                     // Only hoist inside the branch root's children
-                                    hoist_static_inner(ctx, &mut el.children, false, true);
+                                    ensure_sufficient_stack(|| {
+                                        hoist_static_inner(ctx, &mut el.children, false, true);
+                                    });
                                 }
                             }
                         }
                     }
                     TemplateChildNode::For(for_node) => {
-                        hoist_static_inner(ctx, &mut for_node.children, false, true);
+                        ensure_sufficient_stack(|| {
+                            hoist_static_inner(ctx, &mut for_node.children, false, true);
+                        });
                     }
                     _ => {}
                 }
@@ -272,108 +166,6 @@ fn create_vnode_call_from_element<'a>(
     };
 
     JsChildNode::VNodeCall(Box::new_in(vnode_call, allocator))
-}
-
-/// Create props expression from element props
-fn create_props_expression<'a>(
-    allocator: &'a Bump,
-    props: &[PropNode<'a>],
-    scope_id: Option<&vize_carton::String>,
-) -> Option<PropsExpression<'a>> {
-    // Build object properties from attributes. Vue keeps the first
-    // occurrence on duplicate attributes (parser records both but
-    // codegen dedupes), so skip names we've already emitted. (#958)
-    let mut obj_props = Vec::new_in(allocator);
-    let mut seen: vize_carton::FxHashSet<vize_carton::String> = vize_carton::FxHashSet::default();
-
-    for prop in props {
-        match prop {
-            PropNode::Attribute(attr) => {
-                if seen.contains(attr.name.as_str()) {
-                    continue;
-                }
-                seen.insert(attr.name.clone());
-
-                let key = ExpressionNode::Simple(Box::new_in(
-                    SimpleExpressionNode::new(attr.name.clone(), true, attr.loc.clone()),
-                    allocator,
-                ));
-                let value_exp = if let Some(v) = &attr.value {
-                    SimpleExpressionNode::new(v.content.clone(), true, v.loc.clone())
-                } else {
-                    SimpleExpressionNode::new("", true, attr.loc.clone())
-                };
-                let value = JsChildNode::SimpleExpression(Box::new_in(value_exp, allocator));
-
-                obj_props.push(Property {
-                    key,
-                    value,
-                    loc: attr.loc.clone(),
-                });
-            }
-            PropNode::Directive(dir) => {
-                let Some((name, exp)) = hoistable_static_bind_parts(dir) else {
-                    continue;
-                };
-                if seen.contains(name.as_str()) {
-                    continue;
-                }
-                seen.insert(name.clone());
-
-                let key = ExpressionNode::Simple(Box::new_in(
-                    SimpleExpressionNode::new(name, true, dir.loc.clone()),
-                    allocator,
-                ));
-                let value_exp = SimpleExpressionNode {
-                    content: exp.content.clone(),
-                    is_static: false,
-                    const_type: exp.const_type,
-                    loc: exp.loc.clone(),
-                    js_ast: None,
-                    hoisted: None,
-                    identifiers: None,
-                    is_handler_key: false,
-                    is_ref_transformed: false,
-                };
-                let value = JsChildNode::SimpleExpression(Box::new_in(value_exp, allocator));
-
-                obj_props.push(Property {
-                    key,
-                    value,
-                    loc: dir.loc.clone(),
-                });
-            }
-        }
-    }
-
-    // Add scope_id attribute for scoped CSS if present
-    if let Some(scope_id) = scope_id {
-        let key = ExpressionNode::Simple(Box::new_in(
-            SimpleExpressionNode::new(scope_id.clone(), true, SourceLocation::STUB),
-            allocator,
-        ));
-        let value = JsChildNode::SimpleExpression(Box::new_in(
-            SimpleExpressionNode::new("", true, SourceLocation::STUB),
-            allocator,
-        ));
-        obj_props.push(Property {
-            key,
-            value,
-            loc: SourceLocation::STUB,
-        });
-    }
-
-    if obj_props.is_empty() {
-        return None;
-    }
-
-    Some(PropsExpression::Object(Box::new_in(
-        ObjectExpression {
-            properties: obj_props,
-            loc: SourceLocation::STUB,
-        },
-        allocator,
-    )))
 }
 
 /// Create children expression from template children.
@@ -462,238 +254,19 @@ fn inject_scope_id<'a>(
                 allocator,
             )));
         }
-        for child in el.children.iter_mut() {
-            inject_scope_id(allocator, child, scope_id);
-        }
+        // Guarded: one frame per nesting level of the hoisted subtree.
+        ensure_sufficient_stack(|| {
+            for child in el.children.iter_mut() {
+                inject_scope_id(allocator, child, scope_id);
+            }
+        });
     }
-}
-
-/// Check if an element has static props that can be hoisted as an object.
-fn has_static_props(el: &ElementNode<'_>) -> bool {
-    if el.tag_type == ElementType::Slot || el.props.is_empty() {
-        return false;
-    }
-
-    el.props.iter().all(is_hoistable_static_prop)
-}
-
-fn is_hoistable_static_prop(prop: &PropNode<'_>) -> bool {
-    match prop {
-        PropNode::Attribute(attr) => attr.name != "ref",
-        PropNode::Directive(dir) => hoistable_static_bind_parts(dir).is_some(),
-    }
-}
-
-fn hoistable_static_bind_parts<'a>(
-    dir: &'a DirectiveNode<'a>,
-) -> Option<(String, &'a SimpleExpressionNode<'a>)> {
-    if dir.name != "bind" {
-        return None;
-    }
-
-    let Some(ExpressionNode::Simple(arg)) = &dir.arg else {
-        return None;
-    };
-    if !arg.is_static {
-        return None;
-    }
-
-    let has_camel = dir.modifiers.iter().any(|m| m.content == "camel");
-    let has_prop = dir.modifiers.iter().any(|m| m.content == "prop");
-    let has_attr = dir.modifiers.iter().any(|m| m.content == "attr");
-    if dir
-        .modifiers
-        .iter()
-        .any(|m| !matches!(m.content.as_str(), "camel" | "prop" | "attr"))
-    {
-        return None;
-    }
-
-    let key = if has_camel {
-        camelize(&arg.content)
-    } else if has_prop {
-        let mut name = String::with_capacity(1 + arg.content.len());
-        name.push('.');
-        name.push_str(&arg.content);
-        name
-    } else if has_attr {
-        let mut name = String::with_capacity(1 + arg.content.len());
-        name.push('^');
-        name.push_str(&arg.content);
-        name
-    } else {
-        arg.content.to_compact_string()
-    };
-
-    // Refs require runtime owner context. Class bindings need normalizeClass,
-    // which this hoisted object path does not serialize yet.
-    if matches!(key.as_str(), "ref" | "class") {
-        return None;
-    }
-
-    let Some(ExpressionNode::Simple(exp)) = &dir.exp else {
-        return None;
-    };
-    if !is_constant_simple_expression(exp, None) {
-        return None;
-    }
-
-    Some((key, exp))
 }
 
 fn has_directives(el: &ElementNode<'_>) -> bool {
     el.props
         .iter()
         .any(|prop| matches!(prop, PropNode::Directive(_)))
-}
-
-fn has_only_static_nested_children(el: &ElementNode<'_>) -> bool {
-    if el.children.is_empty() {
-        return false;
-    }
-
-    el.children.iter().all(is_static_nested_child)
-}
-
-fn is_static_nested_child(child: &TemplateChildNode<'_>) -> bool {
-    match child {
-        TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_) => true,
-        TemplateChildNode::Element(el) => is_plain_static_nested_element(el),
-        _ => false,
-    }
-}
-
-fn has_only_native_element_descendants(el: &ElementNode<'_>) -> bool {
-    el.children.iter().all(|child| match child {
-        TemplateChildNode::Text(_)
-        | TemplateChildNode::Interpolation(_)
-        | TemplateChildNode::Comment(_) => true,
-        TemplateChildNode::Element(child_el) if child_el.tag_type == ElementType::Element => {
-            has_only_native_element_descendants(child_el)
-        }
-        _ => false,
-    })
-}
-
-fn is_plain_static_nested_element(el: &ElementNode<'_>) -> bool {
-    match el.tag_type {
-        ElementType::Element => {
-            props_are_static_attrs(el) && el.children.iter().all(is_static_nested_child)
-        }
-        ElementType::Slot => props_are_static_attrs(el),
-        _ => false,
-    }
-}
-
-fn props_are_static_attrs(el: &ElementNode<'_>) -> bool {
-    el.props.iter().all(is_hoistable_static_prop)
-}
-
-/// Hoist the props of an element with static props
-fn hoist_element_props<'a>(
-    ctx: &mut TransformContext<'a>,
-    el: &mut ElementNode<'a>,
-    allocator: &'a Bump,
-) {
-    // Build props object from static attributes and constant v-bind props.
-    // Vue keeps the first occurrence on duplicate attributes (parser records
-    // both for linters); dedupe here so a hoisted `_hoisted_N` literal doesn't
-    // emit `{ id: "a", id: "b" }`. (#958)
-    let mut obj_props = Vec::new_in(allocator);
-    let mut seen: vize_carton::FxHashSet<vize_carton::String> = vize_carton::FxHashSet::default();
-
-    for prop in el.props.iter() {
-        match prop {
-            PropNode::Attribute(attr) => {
-                if seen.contains(attr.name.as_str()) {
-                    continue;
-                }
-                seen.insert(attr.name.clone());
-
-                let key = ExpressionNode::Simple(Box::new_in(
-                    SimpleExpressionNode::new(attr.name.clone(), true, attr.loc.clone()),
-                    allocator,
-                ));
-                let value_exp = if let Some(v) = &attr.value {
-                    SimpleExpressionNode::new(v.content.clone(), true, v.loc.clone())
-                } else {
-                    SimpleExpressionNode::new("", true, attr.loc.clone())
-                };
-                let value = JsChildNode::SimpleExpression(Box::new_in(value_exp, allocator));
-
-                obj_props.push(Property {
-                    key,
-                    value,
-                    loc: attr.loc.clone(),
-                });
-            }
-            PropNode::Directive(dir) => {
-                let Some((name, exp)) = hoistable_static_bind_parts(dir) else {
-                    continue;
-                };
-                if seen.contains(name.as_str()) {
-                    continue;
-                }
-                seen.insert(name.clone());
-
-                let key = ExpressionNode::Simple(Box::new_in(
-                    SimpleExpressionNode::new(name, true, dir.loc.clone()),
-                    allocator,
-                ));
-                let value_exp = SimpleExpressionNode {
-                    content: exp.content.clone(),
-                    is_static: false,
-                    const_type: exp.const_type,
-                    loc: exp.loc.clone(),
-                    js_ast: None,
-                    hoisted: None,
-                    identifiers: None,
-                    is_handler_key: false,
-                    is_ref_transformed: false,
-                };
-                let value = JsChildNode::SimpleExpression(Box::new_in(value_exp, allocator));
-
-                obj_props.push(Property {
-                    key,
-                    value,
-                    loc: dir.loc.clone(),
-                });
-            }
-        }
-    }
-
-    // Add scope_id attribute for scoped CSS if present
-    if let Some(ref scope_id) = ctx.options.scope_id {
-        let key = ExpressionNode::Simple(Box::new_in(
-            SimpleExpressionNode::new(scope_id.clone(), true, SourceLocation::STUB),
-            allocator,
-        ));
-        let value = JsChildNode::SimpleExpression(Box::new_in(
-            SimpleExpressionNode::new("", true, SourceLocation::STUB),
-            allocator,
-        ));
-        obj_props.push(Property {
-            key,
-            value,
-            loc: SourceLocation::STUB,
-        });
-    }
-
-    if obj_props.is_empty() {
-        return;
-    }
-
-    // Create the object expression to hoist
-    let obj_expr = ObjectExpression {
-        properties: obj_props,
-        loc: SourceLocation::STUB,
-    };
-
-    let js_node = JsChildNode::Object(Box::new_in(obj_expr, allocator));
-    let hoist_index = ctx.hoist(js_node);
-
-    // Mark the element as having hoisted props (1-based index for _hoisted_N)
-    el.hoisted_props_index = Some(hoist_index + 1);
 }
 
 /// Check if children should use a block
@@ -732,176 +305,4 @@ pub fn count_dynamic_children(children: &[TemplateChildNode<'_>]) -> usize {
     }
 
     count
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{get_static_type, is_static_node};
-    use crate::parser::parse;
-    use crate::{PropNode, TemplateChildNode};
-    use bumpalo::Bump;
-
-    #[test]
-    fn test_static_text() {
-        let allocator = Bump::new();
-        let (root, _) = parse(&allocator, "hello");
-
-        assert!(is_static_node(&root.children[0]));
-    }
-
-    #[test]
-    fn test_static_element() {
-        let allocator = Bump::new();
-        let (root, _) = parse(&allocator, "<div>static</div>");
-
-        assert!(is_static_node(&root.children[0]));
-    }
-
-    #[test]
-    fn test_dynamic_element() {
-        let allocator = Bump::new();
-        let (root, _) = parse(&allocator, "<div :class=\"cls\">dynamic</div>");
-
-        assert!(!is_static_node(&root.children[0]));
-    }
-
-    #[test]
-    fn test_interpolation_not_static() {
-        let allocator = Bump::new();
-        let (root, _) = parse(&allocator, "{{ msg }}");
-
-        assert!(!is_static_node(&root.children[0]));
-    }
-
-    #[test]
-    fn test_nested_dynamic_class_not_static() {
-        let allocator = Bump::new();
-        let (root, _) = parse(
-            &allocator,
-            r#"<div class="checkbox"><span class="icon" :class="{ active: checked }" /></div>"#,
-        );
-
-        // The outer div should NOT be static because it contains a child with dynamic :class
-        assert!(!is_static_node(&root.children[0]));
-    }
-
-    #[test]
-    fn test_sibling_with_v_if() {
-        let allocator = Bump::new();
-        let (root, _) = parse(
-            &allocator,
-            r#"<div class="wrapper"><div class="checkbox"><span :class="{ active: checked }" /></div><label v-if="label">{{ label }}</label></div>"#,
-        );
-
-        // The outer div is not static because it has dynamic content
-        if let TemplateChildNode::Element(el) = &root.children[0] {
-            eprintln!(
-                "Outer div static type: {:?}",
-                get_static_type(&root.children[0])
-            );
-
-            // Check first child (div.checkbox)
-            if let TemplateChildNode::Element(checkbox_div) = &el.children[0] {
-                eprintln!("checkbox div props: {:?}", checkbox_div.props.len());
-                eprintln!("checkbox div children: {:?}", checkbox_div.children.len());
-
-                // Check nested span
-                if let TemplateChildNode::Element(span) = &checkbox_div.children[0] {
-                    eprintln!("span props count: {:?}", span.props.len());
-                    for prop in span.props.iter() {
-                        match prop {
-                            PropNode::Attribute(attr) => eprintln!("  attr: {}", attr.name),
-                            PropNode::Directive(dir) => {
-                                eprintln!("  directive: {} arg: {:?}", dir.name, dir.arg)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        assert!(!is_static_node(&root.children[0]));
-    }
-
-    #[test]
-    fn test_nested_static_element_is_static() {
-        // A fully-static nested element subtree is hoistable as one recursive
-        // VNodeCall, matching @vue/compiler-core.
-        let allocator = Bump::new();
-        let (root, _) = parse(
-            &allocator,
-            r#"<div class="outer"><span class="a">x</span></div>"#,
-        );
-        assert!(is_static_node(&root.children[0]));
-        assert_eq!(
-            get_static_type(&root.children[0]),
-            super::StaticType::FullyStatic
-        );
-    }
-
-    #[test]
-    fn test_deeply_nested_static_element_is_static() {
-        let allocator = Bump::new();
-        let (root, _) = parse(
-            &allocator,
-            r#"<div class="outer"><div class="inner"><span>deep</span></div></div>"#,
-        );
-        assert!(is_static_node(&root.children[0]));
-    }
-
-    #[test]
-    fn test_nested_with_dynamic_text_not_fully_static() {
-        // Interpolation in a nested child means the subtree is not fully static
-        // (has dynamic text), so it must not be hoisted as a static vnode.
-        let allocator = Bump::new();
-        let (root, _) = parse(
-            &allocator,
-            r#"<div class="outer"><span>{{ msg }}</span></div>"#,
-        );
-        assert_eq!(
-            get_static_type(&root.children[0]),
-            super::StaticType::NotStatic
-        );
-    }
-
-    fn compile_hoisted(src: &str) -> (String, String) {
-        let allocator = Bump::new();
-        let (mut root, _errors) = parse(&allocator, src);
-        let mut opts = crate::options::TransformOptions::default();
-        opts.hoist_static = true;
-        crate::lane::transform(&allocator, &mut root, opts, None);
-        let r = crate::codegen::generate(&root, crate::options::CodegenOptions::default());
-        (r.preamble.to_string(), r.code.to_string())
-    }
-
-    #[test]
-    fn test_codegen_nested_static_subtree_caches_recursively() {
-        // Matches @vue/compiler-core: the inner subtree is cached as ONE vnode
-        // with its descendant rendered as a plain recursive createElementVNode
-        // (no nested _cache, no per-descendant CACHED flag).
-        let (_pre, code) = compile_hoisted(
-            r#"<div class="outer"><div class="inner"><span>deep</span></div></div>"#,
-        );
-        assert!(
-            code.contains(
-                "_createElementVNode(\"div\", { class: \"inner\" }, [\n      _createElementVNode(\"span\", null, \"deep\")\n    ], -1 /* CACHED */)"
-            ),
-            "unexpected codegen:\n{code}"
-        );
-    }
-
-    #[test]
-    fn test_codegen_hoisted_nested_vnode_keeps_descendant() {
-        // Inside a v-if branch the subtree hoists to a `_hoisted_N` const built
-        // as a recursive createElementVNode; the nested <b> must be preserved
-        // (previously dropped by the unimplemented create_children_expression).
-        let (preamble, _code) =
-            compile_hoisted(r#"<div><p v-if="ok"><span class="a"><b>x</b></span></p></div>"#);
-        assert!(
-            preamble.contains(
-                "_createElementVNode(\"span\", { class: \"a\" }, [_createElementVNode(\"b\", null, \"x\")])"
-            ),
-            "nested <b> was dropped from hoisted subtree:\n{preamble}"
-        );
-    }
 }

--- a/crates/vize_atelier_core/src/transforms/hoist_static/props.rs
+++ b/crates/vize_atelier_core/src/transforms/hoist_static/props.rs
@@ -1,0 +1,200 @@
+//! Static property detection and hoisting.
+
+use vize_carton::{Box, Bump, String, ToCompactString, Vec, camelize};
+
+use crate::codegen::is_constant_simple_expression;
+use crate::lane::TransformContext;
+use crate::{
+    DirectiveNode, ElementNode, ElementType, ExpressionNode, JsChildNode, ObjectExpression,
+    PropNode, Property, PropsExpression, SimpleExpressionNode, SourceLocation,
+};
+
+pub(super) fn create_props_expression<'a>(
+    allocator: &'a Bump,
+    props: &[PropNode<'a>],
+    scope_id: Option<&String>,
+) -> Option<PropsExpression<'a>> {
+    let mut obj_props = Vec::new_in(allocator);
+    let mut seen: vize_carton::FxHashSet<String> = vize_carton::FxHashSet::default();
+
+    for prop in props {
+        match prop {
+            PropNode::Attribute(attr) => {
+                if seen.contains(attr.name.as_str()) {
+                    continue;
+                }
+                seen.insert(attr.name.clone());
+
+                let key = ExpressionNode::Simple(Box::new_in(
+                    SimpleExpressionNode::new(attr.name.clone(), true, attr.loc.clone()),
+                    allocator,
+                ));
+                let value_exp = if let Some(value) = &attr.value {
+                    SimpleExpressionNode::new(value.content.clone(), true, value.loc.clone())
+                } else {
+                    SimpleExpressionNode::new("", true, attr.loc.clone())
+                };
+                let value = JsChildNode::SimpleExpression(Box::new_in(value_exp, allocator));
+                obj_props.push(Property {
+                    key,
+                    value,
+                    loc: attr.loc.clone(),
+                });
+            }
+            PropNode::Directive(dir) => {
+                let Some((name, exp)) = hoistable_static_bind_parts(dir) else {
+                    continue;
+                };
+                if seen.contains(name.as_str()) {
+                    continue;
+                }
+                seen.insert(name.clone());
+
+                let key = ExpressionNode::Simple(Box::new_in(
+                    SimpleExpressionNode::new(name, true, dir.loc.clone()),
+                    allocator,
+                ));
+                let value = JsChildNode::SimpleExpression(Box::new_in(
+                    clone_expression_for_hoist(exp),
+                    allocator,
+                ));
+                obj_props.push(Property {
+                    key,
+                    value,
+                    loc: dir.loc.clone(),
+                });
+            }
+        }
+    }
+
+    if let Some(scope_id) = scope_id {
+        let key = ExpressionNode::Simple(Box::new_in(
+            SimpleExpressionNode::new(scope_id.clone(), true, SourceLocation::STUB),
+            allocator,
+        ));
+        let value = JsChildNode::SimpleExpression(Box::new_in(
+            SimpleExpressionNode::new("", true, SourceLocation::STUB),
+            allocator,
+        ));
+        obj_props.push(Property {
+            key,
+            value,
+            loc: SourceLocation::STUB,
+        });
+    }
+
+    if obj_props.is_empty() {
+        return None;
+    }
+
+    Some(PropsExpression::Object(Box::new_in(
+        ObjectExpression {
+            properties: obj_props,
+            loc: SourceLocation::STUB,
+        },
+        allocator,
+    )))
+}
+
+pub(super) fn has_static_props(el: &ElementNode<'_>) -> bool {
+    if el.tag_type == ElementType::Slot || el.props.is_empty() {
+        return false;
+    }
+    el.props.iter().all(is_hoistable_static_prop)
+}
+
+pub(super) fn is_hoistable_static_prop(prop: &PropNode<'_>) -> bool {
+    match prop {
+        PropNode::Attribute(attr) => attr.name != "ref",
+        PropNode::Directive(dir) => hoistable_static_bind_parts(dir).is_some(),
+    }
+}
+
+fn hoistable_static_bind_parts<'a, 'b>(
+    dir: &'b DirectiveNode<'a>,
+) -> Option<(String, &'b SimpleExpressionNode<'a>)> {
+    if dir.name != "bind" {
+        return None;
+    }
+    let Some(ExpressionNode::Simple(arg)) = &dir.arg else {
+        return None;
+    };
+    if !arg.is_static {
+        return None;
+    }
+
+    let has_camel = dir
+        .modifiers
+        .iter()
+        .any(|modifier| modifier.content == "camel");
+    let has_prop = dir
+        .modifiers
+        .iter()
+        .any(|modifier| modifier.content == "prop");
+    let has_attr = dir
+        .modifiers
+        .iter()
+        .any(|modifier| modifier.content == "attr");
+    if dir
+        .modifiers
+        .iter()
+        .any(|modifier| !matches!(modifier.content.as_str(), "camel" | "prop" | "attr"))
+    {
+        return None;
+    }
+
+    let key = if has_camel {
+        camelize(&arg.content)
+    } else if has_prop {
+        prefixed_name('.', &arg.content)
+    } else if has_attr {
+        prefixed_name('^', &arg.content)
+    } else {
+        arg.content.to_compact_string()
+    };
+    if matches!(key.as_str(), "ref" | "class") {
+        return None;
+    }
+
+    let Some(ExpressionNode::Simple(exp)) = &dir.exp else {
+        return None;
+    };
+    is_constant_simple_expression(exp, None).then_some((key, exp))
+}
+
+fn prefixed_name(prefix: char, name: &str) -> String {
+    let mut result = String::with_capacity(1 + name.len());
+    result.push(prefix);
+    result.push_str(name);
+    result
+}
+
+pub(super) fn hoist_element_props<'a>(
+    ctx: &mut TransformContext<'a>,
+    el: &mut ElementNode<'a>,
+    allocator: &'a Bump,
+) {
+    let Some(PropsExpression::Object(obj_expr)) =
+        create_props_expression(allocator, &el.props, ctx.options.scope_id.as_ref())
+    else {
+        return;
+    };
+
+    let js_node = JsChildNode::Object(obj_expr);
+    let hoist_index = ctx.hoist(js_node);
+    el.hoisted_props_index = Some(hoist_index + 1);
+}
+
+fn clone_expression_for_hoist<'a>(exp: &SimpleExpressionNode<'a>) -> SimpleExpressionNode<'a> {
+    SimpleExpressionNode {
+        content: exp.content.clone(),
+        is_static: false,
+        const_type: exp.const_type,
+        loc: exp.loc.clone(),
+        js_ast: None,
+        hoisted: None,
+        identifiers: None,
+        is_handler_key: false,
+        is_ref_transformed: false,
+    }
+}

--- a/crates/vize_atelier_core/src/transforms/hoist_static/static_type.rs
+++ b/crates/vize_atelier_core/src/transforms/hoist_static/static_type.rs
@@ -1,0 +1,189 @@
+//! Whole-subtree staticness classification for the hoisting transform.
+//!
+//! Every predicate here answers a question about an element *and everything
+//! under it*, so each one descends the tree once per nesting level. That makes
+//! them recursion steps in the sense of `vize_carton::recursion`: their call
+//! depth is bounded by the input, not by the code, so each descent is wrapped in
+//! `ensure_sufficient_stack` — otherwise a deeply nested template aborts the
+//! process instead of compiling.
+
+use vize_carton::ensure_sufficient_stack;
+
+use super::is_hoistable_static_prop;
+use crate::{ElementNode, ElementType, PropNode, TemplateChildNode};
+
+/// Static type enumeration
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StaticType {
+    NotStatic = 0,
+    FullyStatic = 1,
+    HasDynamicText = 2,
+}
+
+/// Check if a node is fully static (can be hoisted)
+pub fn is_static_node(node: &TemplateChildNode<'_>) -> bool {
+    match node {
+        TemplateChildNode::Text(_) => true,
+        TemplateChildNode::Comment(_) => true,
+        TemplateChildNode::Element(el) => ensure_sufficient_stack(|| is_static_element(el)),
+        TemplateChildNode::Interpolation(_) => false,
+        TemplateChildNode::If(_) => false,
+        TemplateChildNode::For(_) => false,
+        _ => false,
+    }
+}
+
+/// Check if an element is fully static
+fn is_static_element(el: &ElementNode<'_>) -> bool {
+    // Components are not static
+    if el.tag_type != ElementType::Element {
+        return false;
+    }
+
+    // Check for dynamic props or ref
+    for prop in el.props.iter() {
+        match prop {
+            PropNode::Directive(_) if el.tag == "svg" => return false,
+            PropNode::Directive(_) if !is_hoistable_static_prop(prop) => return false,
+            PropNode::Directive(_) => {}
+            PropNode::Attribute(attr) => {
+                // ref attribute prevents hoisting - refs need runtime owner context
+                if attr.name == "ref" {
+                    return false;
+                }
+            }
+        }
+    }
+
+    // Check children recursively. Nested fully-static element subtrees are
+    // hoistable: `create_children_expression` builds them into a single
+    // recursive VNodeCall, matching @vue/compiler-core's static caching of a
+    // top-most static element with its whole subtree as one cached vnode.
+    for child in el.children.iter() {
+        // Comments prevent hoisting since they can't be serialized to VNodeCall children
+        if matches!(child, TemplateChildNode::Comment(_)) {
+            return false;
+        }
+        if !is_static_node(child) {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Get the static type of a node
+pub fn get_static_type(node: &TemplateChildNode<'_>) -> StaticType {
+    match node {
+        TemplateChildNode::Text(_) => StaticType::FullyStatic,
+        TemplateChildNode::Comment(_) => StaticType::FullyStatic,
+        TemplateChildNode::Element(el) => ensure_sufficient_stack(|| get_element_static_type(el)),
+        TemplateChildNode::Interpolation(_) => StaticType::NotStatic,
+        _ => StaticType::NotStatic,
+    }
+}
+
+fn get_element_static_type(el: &ElementNode<'_>) -> StaticType {
+    if el.tag_type != ElementType::Element {
+        return StaticType::NotStatic;
+    }
+
+    // Check for any dynamic content
+    let mut has_dynamic_text = false;
+
+    for prop in el.props.iter() {
+        match prop {
+            PropNode::Directive(_) if el.tag == "svg" => {
+                return StaticType::NotStatic;
+            }
+            PropNode::Directive(_) if !is_hoistable_static_prop(prop) => {
+                // Non-constant directives make the element dynamic.
+                return StaticType::NotStatic;
+            }
+            PropNode::Directive(_) => {}
+            PropNode::Attribute(attr) => {
+                // ref attribute prevents hoisting - refs need runtime owner context
+                if attr.name == "ref" {
+                    return StaticType::NotStatic;
+                }
+            }
+        }
+    }
+
+    // Check children
+    for child in el.children.iter() {
+        match child {
+            TemplateChildNode::Interpolation(_) => {
+                has_dynamic_text = true;
+            }
+            // A nested element keeps the parent fully static only when the
+            // child subtree is itself fully static (no dynamic text either):
+            // such a subtree is serialized into one recursive VNodeCall by
+            // `create_children_expression`. Any dynamic content disqualifies it.
+            TemplateChildNode::Element(child_el) => {
+                match ensure_sufficient_stack(|| get_element_static_type(child_el)) {
+                    StaticType::FullyStatic => {}
+                    _ => return StaticType::NotStatic,
+                }
+            }
+            TemplateChildNode::If(_) | TemplateChildNode::For(_) => {
+                return StaticType::NotStatic;
+            }
+            // Comments prevent hoisting since they can't be serialized to VNodeCall children
+            TemplateChildNode::Comment(_) => {
+                return StaticType::NotStatic;
+            }
+            _ => {}
+        }
+    }
+
+    if has_dynamic_text {
+        StaticType::HasDynamicText
+    } else {
+        StaticType::FullyStatic
+    }
+}
+
+pub(super) fn has_only_static_nested_children(el: &ElementNode<'_>) -> bool {
+    if el.children.is_empty() {
+        return false;
+    }
+
+    el.children.iter().all(is_static_nested_child)
+}
+
+fn is_static_nested_child(child: &TemplateChildNode<'_>) -> bool {
+    match child {
+        TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_) => true,
+        TemplateChildNode::Element(el) => {
+            ensure_sufficient_stack(|| is_plain_static_nested_element(el))
+        }
+        _ => false,
+    }
+}
+
+pub(super) fn has_only_native_element_descendants(el: &ElementNode<'_>) -> bool {
+    el.children.iter().all(|child| match child {
+        TemplateChildNode::Text(_)
+        | TemplateChildNode::Interpolation(_)
+        | TemplateChildNode::Comment(_) => true,
+        TemplateChildNode::Element(child_el) if child_el.tag_type == ElementType::Element => {
+            ensure_sufficient_stack(|| has_only_native_element_descendants(child_el))
+        }
+        _ => false,
+    })
+}
+
+fn is_plain_static_nested_element(el: &ElementNode<'_>) -> bool {
+    match el.tag_type {
+        ElementType::Element => {
+            props_are_static_attrs(el) && el.children.iter().all(is_static_nested_child)
+        }
+        ElementType::Slot => props_are_static_attrs(el),
+        _ => false,
+    }
+}
+
+fn props_are_static_attrs(el: &ElementNode<'_>) -> bool {
+    el.props.iter().all(is_hoistable_static_prop)
+}

--- a/crates/vize_atelier_core/src/transforms/hoist_static/tests.rs
+++ b/crates/vize_atelier_core/src/transforms/hoist_static/tests.rs
@@ -1,0 +1,119 @@
+use super::{StaticType, get_static_type, is_static_node};
+use crate::parser::parse;
+use bumpalo::Bump;
+
+#[test]
+fn test_static_text() {
+    let allocator = Bump::new();
+    let (root, _) = parse(&allocator, "hello");
+    assert!(is_static_node(&root.children[0]));
+}
+
+#[test]
+fn test_static_element() {
+    let allocator = Bump::new();
+    let (root, _) = parse(&allocator, "<div>static</div>");
+    assert!(is_static_node(&root.children[0]));
+}
+
+#[test]
+fn test_dynamic_element() {
+    let allocator = Bump::new();
+    let (root, _) = parse(&allocator, "<div :class=\"cls\">dynamic</div>");
+    assert!(!is_static_node(&root.children[0]));
+}
+
+#[test]
+fn test_interpolation_not_static() {
+    let allocator = Bump::new();
+    let (root, _) = parse(&allocator, "{{ msg }}");
+    assert!(!is_static_node(&root.children[0]));
+}
+
+#[test]
+fn test_nested_dynamic_class_not_static() {
+    let allocator = Bump::new();
+    let (root, _) = parse(
+        &allocator,
+        r#"<div class="checkbox"><span class="icon" :class="{ active: checked }" /></div>"#,
+    );
+    assert!(!is_static_node(&root.children[0]));
+}
+
+#[test]
+fn test_sibling_with_v_if() {
+    let allocator = Bump::new();
+    let (root, _) = parse(
+        &allocator,
+        r#"<div class="wrapper"><div class="checkbox"><span :class="{ active: checked }" /></div><label v-if="label">{{ label }}</label></div>"#,
+    );
+
+    assert!(!is_static_node(&root.children[0]));
+}
+
+#[test]
+fn test_nested_static_element_is_static() {
+    let allocator = Bump::new();
+    let (root, _) = parse(
+        &allocator,
+        r#"<div class="outer"><span class="a">x</span></div>"#,
+    );
+    assert!(is_static_node(&root.children[0]));
+    assert_eq!(get_static_type(&root.children[0]), StaticType::FullyStatic);
+}
+
+#[test]
+fn test_deeply_nested_static_element_is_static() {
+    let allocator = Bump::new();
+    let (root, _) = parse(
+        &allocator,
+        r#"<div class="outer"><div class="inner"><span>deep</span></div></div>"#,
+    );
+    assert!(is_static_node(&root.children[0]));
+}
+
+#[test]
+fn test_nested_with_dynamic_text_not_fully_static() {
+    let allocator = Bump::new();
+    let (root, _) = parse(
+        &allocator,
+        r#"<div class="outer"><span>{{ msg }}</span></div>"#,
+    );
+    assert_eq!(get_static_type(&root.children[0]), StaticType::NotStatic);
+}
+
+fn compile_hoisted(src: &str) -> (vize_carton::String, vize_carton::String) {
+    let allocator = Bump::new();
+    let (mut root, _errors) = parse(&allocator, src);
+    let opts = crate::options::TransformOptions {
+        hoist_static: true,
+        ..crate::options::TransformOptions::default()
+    };
+    crate::lane::transform(&allocator, &mut root, opts, None);
+    let result = crate::codegen::generate(&root, crate::options::CodegenOptions::default());
+    (result.preamble, result.code)
+}
+
+#[test]
+fn test_codegen_nested_static_subtree_caches_recursively() {
+    let (_preamble, code) =
+        compile_hoisted(r#"<div class="outer"><div class="inner"><span>deep</span></div></div>"#);
+    assert!(
+        code.contains(
+            "_createElementVNode(\"div\", { class: \"inner\" }, [\n      _createElementVNode(\"span\", null, \"deep\")\n    ], -1 /* CACHED */)"
+        ),
+        "unexpected codegen:\n{code}"
+    );
+}
+
+#[test]
+fn test_codegen_hoisted_nested_vnode_keeps_descendant() {
+    let (preamble, _code) =
+        compile_hoisted(r#"<div><p v-if="ok"><span class="a"><b>x</b></span></p></div>"#);
+    assert!(
+        preamble.contains(
+            "_createElementVNode(\"span\", { class: \"a\" }, [_createElementVNode(\"b\", null, \"x\")])"
+        ),
+        "nested <b> was dropped from hoisted subtree:\n{preamble}"
+    );
+}

--- a/crates/vize_atelier_core/src/transforms/legacy.rs
+++ b/crates/vize_atelier_core/src/transforms/legacy.rs
@@ -43,7 +43,7 @@
 //! dialect (its call site is guarded by `supports_v2_event_sugar`).
 
 use vize_armature::legacy::LegacyDialectCapabilities;
-use vize_carton::{Box, Bump, String, Vec};
+use vize_carton::{Box, Bump, String, Vec, ensure_sufficient_stack};
 
 use crate::{
     DirectiveNode, ElementNode, ExpressionNode, PropNode, RootNode, SimpleExpressionNode,
@@ -73,7 +73,7 @@ fn desugar_children<'a>(allocator: &'a Bump, children: &mut Vec<'a, TemplateChil
     for child in children.iter_mut() {
         if let TemplateChildNode::Element(el) = child {
             desugar_element(allocator, el);
-            desugar_children(allocator, &mut el.children);
+            ensure_sufficient_stack(|| desugar_children(allocator, &mut el.children));
         }
     }
 }

--- a/crates/vize_atelier_core/src/transforms/v_slot.rs
+++ b/crates/vize_atelier_core/src/transforms/v_slot.rs
@@ -2,19 +2,23 @@
 //!
 //! Transforms v-slot (# shorthand) directives for slot content.
 
-use vize_carton::{String, is_builtin_directive};
+use vize_carton::{String, ensure_sufficient_stack};
 
-use crate::errors::ErrorCode;
 use crate::lane::TransformContext;
 use crate::{
-    DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper,
-    SourceLocation, TemplateChildNode,
+    DirectiveNode, ElementNode, ExpressionNode, PropNode, RuntimeHelper, TemplateChildNode,
 };
 
 #[path = "v_slot/params.rs"]
 mod params;
+#[cfg(test)]
+#[path = "v_slot/tests.rs"]
+mod tests;
+#[path = "v_slot/validate.rs"]
+mod validate;
 
 pub use params::extract_slot_prop_names;
+pub(crate) use validate::validate_v_slot_usage;
 
 /// Check if element has v-slot directive
 pub fn has_v_slot(el: &ElementNode<'_>) -> bool {
@@ -97,10 +101,16 @@ fn has_implicit_child(child: &TemplateChildNode<'_>) -> bool {
         TemplateChildNode::If(if_node) => if_node
             .branches
             .iter()
-            .any(|branch| branch.children.iter().any(has_implicit_child)),
-        TemplateChildNode::For(for_node) => for_node.children.iter().any(has_implicit_child),
+            .any(|branch| any_implicit_child(&branch.children)),
+        TemplateChildNode::For(for_node) => any_implicit_child(&for_node.children),
         _ => true,
     }
+}
+
+/// Guarded: `v-if`/`v-for` nodes nest, so this descends once per nesting level
+/// and its depth is bounded by the input (`vize_carton::recursion`).
+fn any_implicit_child(children: &[TemplateChildNode<'_>]) -> bool {
+    ensure_sufficient_stack(|| children.iter().any(has_implicit_child))
 }
 
 fn slot_name_is_static(dir: &DirectiveNode<'_>) -> bool {
@@ -108,93 +118,6 @@ fn slot_name_is_static(dir: &DirectiveNode<'_>) -> bool {
         ExpressionNode::Simple(exp) => exp.is_static,
         ExpressionNode::Compound(_) => false,
     })
-}
-
-/// Validate v-slot placement and slot-template structure.
-pub(crate) fn validate_v_slot_usage(ctx: &mut TransformContext<'_>, el: &ElementNode<'_>) {
-    let own_slot = find_v_slot(el);
-
-    if let Some(dir) = own_slot
-        && el.tag_type != ElementType::Component
-        && el.tag.as_str() != "template"
-    {
-        ctx.on_error(ErrorCode::VSlotMisplaced, Some(dir.loc.clone()));
-    }
-
-    if el.tag_type == ElementType::Slot || el.tag.as_str() == "slot" {
-        for prop in el.props.iter() {
-            if let PropNode::Directive(dir) = prop
-                && !is_builtin_directive(dir.name.as_str())
-            {
-                ctx.on_error(
-                    ErrorCode::VSlotUnexpectedDirectiveOnSlotOutlet,
-                    Some(dir.loc.clone()),
-                );
-            }
-        }
-    }
-
-    if el.tag_type != ElementType::Component || el.children.is_empty() {
-        return;
-    }
-
-    let mut seen_static_slots: std::vec::Vec<String> = std::vec::Vec::new();
-    let mut has_template_slots = false;
-    let mut has_named_default_slot = false;
-    let mut first_implicit_default_loc: Option<SourceLocation> = None;
-
-    for child in el.children.iter() {
-        let TemplateChildNode::Element(child_el) = child else {
-            if first_implicit_default_loc.is_none() && has_implicit_child(child) {
-                first_implicit_default_loc = Some(child.loc().clone());
-            }
-            continue;
-        };
-
-        let Some(slot_dir) = find_v_slot(child_el) else {
-            if first_implicit_default_loc.is_none() && has_implicit_child(child) {
-                first_implicit_default_loc = Some(child.loc().clone());
-            }
-            continue;
-        };
-
-        if child_el.tag.as_str() != "template" {
-            continue;
-        }
-
-        if own_slot.is_some() {
-            ctx.on_error(ErrorCode::VSlotMixedSlotUsage, Some(slot_dir.loc.clone()));
-            break;
-        }
-
-        has_template_slots = true;
-
-        if !has_structural_slot_directive(child_el) && slot_name_is_static(slot_dir) {
-            let slot_name = get_slot_name(slot_dir);
-            if seen_static_slots
-                .iter()
-                .any(|seen| seen.as_str() == slot_name.as_str())
-            {
-                ctx.on_error(
-                    ErrorCode::VSlotDuplicateSlotNames,
-                    Some(slot_dir.loc.clone()),
-                );
-                continue;
-            }
-            if slot_name.as_str() == "default" {
-                has_named_default_slot = true;
-            }
-            seen_static_slots.push(slot_name);
-        }
-    }
-
-    if own_slot.is_none()
-        && has_template_slots
-        && has_named_default_slot
-        && let Some(loc) = first_implicit_default_loc
-    {
-        ctx.on_error(ErrorCode::VSlotExtraneousDefaultSlotChildren, Some(loc));
-    }
 }
 
 /// Slot outlet info for codegen
@@ -313,168 +236,4 @@ pub fn has_dynamic_slots<'a>(el: &ElementNode<'a>) -> bool {
         }
     }
     false
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::errors::{CompilerError, ErrorCode};
-    use crate::lane::traverse::traverse_children;
-    use crate::lane::{ParentNode, TransformContext};
-    use crate::options::TransformOptions;
-    use crate::parser::parse;
-    use bumpalo::Bump;
-
-    fn transform_errors(source: &str) -> std::vec::Vec<CompilerError> {
-        let allocator = Bump::new();
-        let (mut root, errors) = parse(&allocator, source);
-        assert!(errors.is_empty(), "Parse errors: {:?}", errors);
-
-        let mut ctx =
-            TransformContext::new(&allocator, root.source.clone(), TransformOptions::default());
-        traverse_children(&mut ctx, ParentNode::Root(&mut root as *mut _));
-        ctx.errors
-    }
-
-    #[test]
-    fn test_has_v_slot() {
-        let allocator = Bump::new();
-        let (root, _) = parse(&allocator, r#"<template v-slot:header>content</template>"#);
-
-        if let TemplateChildNode::Element(el) = &root.children[0] {
-            assert!(has_v_slot(el));
-        }
-    }
-
-    #[test]
-    fn test_default_slot_name() {
-        let allocator = Bump::new();
-        let dir = DirectiveNode::new(&allocator, "slot", SourceLocation::STUB);
-        assert_eq!(get_slot_name(&dir).as_str(), "default");
-    }
-
-    #[test]
-    fn test_collect_slots() {
-        let allocator = Bump::new();
-        let (root, _) = parse(
-            &allocator,
-            r#"<Comp><template #header>H</template><template #footer>F</template></Comp>"#,
-        );
-
-        if let TemplateChildNode::Element(el) = &root.children[0] {
-            let slots = collect_slots(el);
-            assert_eq!(slots.len(), 2);
-            assert!(slots.iter().any(|s| s.name == "header"));
-            assert!(slots.iter().any(|s| s.name == "footer"));
-        }
-    }
-
-    #[test]
-    fn test_collect_slots_dedupes_static_duplicate_slot_names() {
-        let allocator = Bump::new();
-        let (root, _) = parse(
-            &allocator,
-            r#"<Comp><template #header>H1</template><template #header>H2</template></Comp>"#,
-        );
-
-        if let TemplateChildNode::Element(el) = &root.children[0] {
-            let slots = collect_slots(el);
-            assert_eq!(slots.len(), 1);
-            assert_eq!(slots[0].name, "header");
-        }
-    }
-
-    #[test]
-    fn test_v_slot_on_plain_element_reports_misplaced() {
-        let errors = transform_errors(r#"<div v-slot="{ item }">Text</div>"#);
-
-        assert_eq!(errors.len(), 1);
-        assert_eq!(errors[0].code, ErrorCode::VSlotMisplaced);
-    }
-
-    #[test]
-    fn test_v_slot_on_empty_plain_element_reports_misplaced() {
-        let errors = transform_errors(r#"<div v-slot></div>"#);
-
-        assert_eq!(errors.len(), 1);
-        assert_eq!(errors[0].code, ErrorCode::VSlotMisplaced);
-    }
-
-    #[test]
-    fn test_duplicate_slot_names_report_error() {
-        let errors = transform_errors(
-            r#"<Comp><template #header>H1</template><template #header>H2</template></Comp>"#,
-        );
-
-        assert_eq!(errors.len(), 1);
-        assert_eq!(errors[0].code, ErrorCode::VSlotDuplicateSlotNames);
-    }
-
-    #[test]
-    fn test_mixed_component_and_template_slot_usage_reports_error() {
-        let errors = transform_errors(r#"<Comp v-slot><template #header>Header</template></Comp>"#);
-
-        assert_eq!(errors.len(), 1);
-        assert_eq!(errors[0].code, ErrorCode::VSlotMixedSlotUsage);
-    }
-
-    #[test]
-    fn test_explicit_default_slot_with_children_reports_error() {
-        let errors = transform_errors(
-            r#"<Comp><template #default>Default</template><span>Extra</span></Comp>"#,
-        );
-
-        assert_eq!(errors.len(), 1);
-        assert_eq!(
-            errors[0].code,
-            ErrorCode::VSlotExtraneousDefaultSlotChildren
-        );
-    }
-
-    #[test]
-    fn test_explicit_default_slot_allows_whitespace_children() {
-        let errors = transform_errors("<Comp><template #default>Default</template>\n  \t\n</Comp>");
-
-        assert!(errors.is_empty(), "Unexpected errors: {:?}", errors);
-    }
-
-    #[test]
-    fn test_custom_directive_on_slot_outlet_reports_error() {
-        let errors = transform_errors(r#"<slot v-custom />"#);
-
-        assert_eq!(errors.len(), 1);
-        assert_eq!(
-            errors[0].code,
-            ErrorCode::VSlotUnexpectedDirectiveOnSlotOutlet
-        );
-    }
-
-    #[test]
-    fn test_get_slot_prop_names_from_directive() {
-        let allocator = Bump::new();
-        let (root, _) = parse(
-            &allocator,
-            r#"<Comp><template #default="{ item, active }">{{ item.id }}{{ active }}</template></Comp>"#,
-        );
-
-        if let TemplateChildNode::Element(el) = &root.children[0] {
-            if let TemplateChildNode::Element(slot_template) = &el.children[0] {
-                let dir = slot_template
-                    .props
-                    .iter()
-                    .find_map(|prop| match prop {
-                        crate::PropNode::Directive(dir) if dir.name == "slot" => Some(dir),
-                        _ => None,
-                    })
-                    .expect("expected v-slot directive");
-                let names = get_slot_prop_names(dir);
-                let names: Vec<_> = names.iter().map(|name| name.as_str()).collect();
-                assert_eq!(names, vec!["item", "active"]);
-            } else {
-                panic!("expected slot template element");
-            }
-        } else {
-            panic!("expected component root element");
-        }
-    }
 }

--- a/crates/vize_atelier_core/src/transforms/v_slot/tests.rs
+++ b/crates/vize_atelier_core/src/transforms/v_slot/tests.rs
@@ -1,0 +1,160 @@
+use super::*;
+use crate::SourceLocation;
+use crate::errors::{CompilerError, ErrorCode};
+use crate::lane::traverse::traverse_children;
+use crate::lane::{ParentNode, TransformContext};
+use crate::options::TransformOptions;
+use crate::parser::parse;
+use bumpalo::Bump;
+
+fn transform_errors(source: &str) -> std::vec::Vec<CompilerError> {
+    let allocator = Bump::new();
+    let (mut root, errors) = parse(&allocator, source);
+    assert!(errors.is_empty(), "Parse errors: {:?}", errors);
+
+    let mut ctx =
+        TransformContext::new(&allocator, root.source.clone(), TransformOptions::default());
+    traverse_children(&mut ctx, ParentNode::Root(&mut root as *mut _));
+    ctx.errors
+}
+
+#[test]
+fn test_has_v_slot() {
+    let allocator = Bump::new();
+    let (root, _) = parse(&allocator, r#"<template v-slot:header>content</template>"#);
+
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        assert!(has_v_slot(el));
+    }
+}
+
+#[test]
+fn test_default_slot_name() {
+    let allocator = Bump::new();
+    let dir = DirectiveNode::new(&allocator, "slot", SourceLocation::STUB);
+    assert_eq!(get_slot_name(&dir).as_str(), "default");
+}
+
+#[test]
+fn test_collect_slots() {
+    let allocator = Bump::new();
+    let (root, _) = parse(
+        &allocator,
+        r#"<Comp><template #header>H</template><template #footer>F</template></Comp>"#,
+    );
+
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        let slots = collect_slots(el);
+        assert_eq!(slots.len(), 2);
+        assert!(slots.iter().any(|s| s.name == "header"));
+        assert!(slots.iter().any(|s| s.name == "footer"));
+    }
+}
+
+#[test]
+fn test_collect_slots_dedupes_static_duplicate_slot_names() {
+    let allocator = Bump::new();
+    let (root, _) = parse(
+        &allocator,
+        r#"<Comp><template #header>H1</template><template #header>H2</template></Comp>"#,
+    );
+
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        let slots = collect_slots(el);
+        assert_eq!(slots.len(), 1);
+        assert_eq!(slots[0].name, "header");
+    }
+}
+
+#[test]
+fn test_v_slot_on_plain_element_reports_misplaced() {
+    let errors = transform_errors(r#"<div v-slot="{ item }">Text</div>"#);
+
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].code, ErrorCode::VSlotMisplaced);
+}
+
+#[test]
+fn test_v_slot_on_empty_plain_element_reports_misplaced() {
+    let errors = transform_errors(r#"<div v-slot></div>"#);
+
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].code, ErrorCode::VSlotMisplaced);
+}
+
+#[test]
+fn test_duplicate_slot_names_report_error() {
+    let errors = transform_errors(
+        r#"<Comp><template #header>H1</template><template #header>H2</template></Comp>"#,
+    );
+
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].code, ErrorCode::VSlotDuplicateSlotNames);
+}
+
+#[test]
+fn test_mixed_component_and_template_slot_usage_reports_error() {
+    let errors = transform_errors(r#"<Comp v-slot><template #header>Header</template></Comp>"#);
+
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].code, ErrorCode::VSlotMixedSlotUsage);
+}
+
+#[test]
+fn test_explicit_default_slot_with_children_reports_error() {
+    let errors =
+        transform_errors(r#"<Comp><template #default>Default</template><span>Extra</span></Comp>"#);
+
+    assert_eq!(errors.len(), 1);
+    assert_eq!(
+        errors[0].code,
+        ErrorCode::VSlotExtraneousDefaultSlotChildren
+    );
+}
+
+#[test]
+fn test_explicit_default_slot_allows_whitespace_children() {
+    let errors = transform_errors("<Comp><template #default>Default</template>\n  \t\n</Comp>");
+
+    assert!(errors.is_empty(), "Unexpected errors: {:?}", errors);
+}
+
+#[test]
+fn test_custom_directive_on_slot_outlet_reports_error() {
+    let errors = transform_errors(r#"<slot v-custom />"#);
+
+    assert_eq!(errors.len(), 1);
+    assert_eq!(
+        errors[0].code,
+        ErrorCode::VSlotUnexpectedDirectiveOnSlotOutlet
+    );
+}
+
+#[test]
+fn test_get_slot_prop_names_from_directive() {
+    let allocator = Bump::new();
+    let (root, _) = parse(
+        &allocator,
+        r#"<Comp><template #default="{ item, active }">{{ item.id }}{{ active }}</template></Comp>"#,
+    );
+
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        if let TemplateChildNode::Element(slot_template) = &el.children[0] {
+            let dir = slot_template
+                .props
+                .iter()
+                .find_map(|prop| match prop {
+                    crate::PropNode::Directive(dir) if dir.name == "slot" => Some(dir),
+                    _ => None,
+                })
+                .expect("expected v-slot directive");
+            let names = get_slot_prop_names(dir);
+            let names: Vec<_> = names.iter().map(|name| name.as_str()).collect();
+            assert_eq!(names, vec!["item", "active"]);
+        } else {
+            panic!("expected slot template element");
+        }
+    } else {
+        panic!("expected component root element");
+    }
+}

--- a/crates/vize_atelier_core/src/transforms/v_slot/validate.rs
+++ b/crates/vize_atelier_core/src/transforms/v_slot/validate.rs
@@ -1,0 +1,98 @@
+//! `v-slot` placement and slot-template structure validation.
+
+use vize_carton::{String, is_builtin_directive};
+
+use super::{
+    find_v_slot, get_slot_name, has_implicit_child, has_structural_slot_directive,
+    slot_name_is_static,
+};
+use crate::errors::ErrorCode;
+use crate::lane::TransformContext;
+use crate::{ElementNode, ElementType, PropNode, SourceLocation, TemplateChildNode};
+
+/// Validate v-slot placement and slot-template structure.
+pub(crate) fn validate_v_slot_usage(ctx: &mut TransformContext<'_>, el: &ElementNode<'_>) {
+    let own_slot = find_v_slot(el);
+
+    if let Some(dir) = own_slot
+        && el.tag_type != ElementType::Component
+        && el.tag.as_str() != "template"
+    {
+        ctx.on_error(ErrorCode::VSlotMisplaced, Some(dir.loc.clone()));
+    }
+
+    if el.tag_type == ElementType::Slot || el.tag.as_str() == "slot" {
+        for prop in el.props.iter() {
+            if let PropNode::Directive(dir) = prop
+                && !is_builtin_directive(dir.name.as_str())
+            {
+                ctx.on_error(
+                    ErrorCode::VSlotUnexpectedDirectiveOnSlotOutlet,
+                    Some(dir.loc.clone()),
+                );
+            }
+        }
+    }
+
+    if el.tag_type != ElementType::Component || el.children.is_empty() {
+        return;
+    }
+
+    let mut seen_static_slots: std::vec::Vec<String> = std::vec::Vec::new();
+    let mut has_template_slots = false;
+    let mut has_named_default_slot = false;
+    let mut first_implicit_default_loc: Option<SourceLocation> = None;
+
+    for child in el.children.iter() {
+        let TemplateChildNode::Element(child_el) = child else {
+            if first_implicit_default_loc.is_none() && has_implicit_child(child) {
+                first_implicit_default_loc = Some(child.loc().clone());
+            }
+            continue;
+        };
+
+        let Some(slot_dir) = find_v_slot(child_el) else {
+            if first_implicit_default_loc.is_none() && has_implicit_child(child) {
+                first_implicit_default_loc = Some(child.loc().clone());
+            }
+            continue;
+        };
+
+        if child_el.tag.as_str() != "template" {
+            continue;
+        }
+
+        if own_slot.is_some() {
+            ctx.on_error(ErrorCode::VSlotMixedSlotUsage, Some(slot_dir.loc.clone()));
+            break;
+        }
+
+        has_template_slots = true;
+
+        if !has_structural_slot_directive(child_el) && slot_name_is_static(slot_dir) {
+            let slot_name = get_slot_name(slot_dir);
+            if seen_static_slots
+                .iter()
+                .any(|seen| seen.as_str() == slot_name.as_str())
+            {
+                ctx.on_error(
+                    ErrorCode::VSlotDuplicateSlotNames,
+                    Some(slot_dir.loc.clone()),
+                );
+                continue;
+            }
+            if slot_name.as_str() == "default" {
+                has_named_default_slot = true;
+            }
+            seen_static_slots.push(slot_name);
+        }
+    }
+
+    if own_slot.is_none()
+        && has_template_slots
+        && has_named_default_slot
+        && let Some(loc) = first_implicit_default_loc
+    {
+        ctx.on_error(ErrorCode::VSlotExtraneousDefaultSlotChildren, Some(loc));
+    }
+}

--- a/crates/vize_atelier_dom/tests/element_nesting_depth.rs
+++ b/crates/vize_atelier_dom/tests/element_nesting_depth.rs
@@ -8,10 +8,9 @@
 //! down and cannot be turned into a diagnostic. 256 was simply the depth a debug
 //! build survived on Rust's default 2 MiB thread stack, which put Vize below
 //! `@vue/compiler-dom`, whose own recursion reaches ~1092 levels of `<div>` on a
-//! default Node stack and then raises a *catchable* `RangeError`.
-//!
-//! Those descents now grow onto the heap when the stack runs low
-//! (`vize_carton::recursion`), so the limit is chosen for output size instead.
+//! default Node stack and then raises a *catchable* `RangeError`. Those descents
+//! now grow onto the heap when the stack runs low (`vize_carton::recursion`), so
+//! the limit is chosen for output size instead.
 //!
 //! Every case here runs on a thread with a deliberately small fixed stack. That
 //! is the whole point: on a stack this size the pre-fix compiler could not reach
@@ -19,8 +18,7 @@
 //! It also keeps the test honest in a release build, where frames are ~8x
 //! smaller and a default-sized stack would hide the bug.
 //!
-//! Test-only: `std::string::String` builds the deeply nested sources and the
-//! expected output.
+//! Test-only: `std::string::String` builds the sources and expected output.
 #![allow(clippy::disallowed_macros, clippy::disallowed_types)]
 
 use vize_atelier_core::{ErrorCode, errors::CompilerError};
@@ -48,6 +46,8 @@ const SMALL_STACK: usize = 256 * 1024;
 const EXPECTED_PREAMBLE: &str = "const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue\n";
 
 const EXPECTED_STRUCTURAL_PREAMBLE: &str = "const { resolveComponent: _resolveComponent, renderSlot: _renderSlot, openBlock: _openBlock, createBlock: _createBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, createCommentVNode: _createCommentVNode, withCtx: _withCtx } = Vue\n";
+
+const EXPECTED_V_FOR_PREAMBLE: &str = "const { resolveComponent: _resolveComponent, renderSlot: _renderSlot, openBlock: _openBlock, createBlock: _createBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, renderList: _renderList, withCtx: _withCtx } = Vue\n";
 
 /// `(code, message, start, end, source)` where the positions are
 /// `(offset, line, column)`.
@@ -279,14 +279,47 @@ fn structural_recursion_paths_compile_on_a_small_stack() {
     assert_eq!(compiled.code, expected_structural_code(STRUCTURAL_DEPTH));
 }
 
+/// The render function Vize emits for [`nested_v_for_templates`] at `depth`.
+///
+/// Each level is a `renderList` fragment whose callback opens another fragment
+/// around the next level; the innermost one renders the slot.
+fn expected_v_for_code(depth: usize) -> String {
+    const LIST_OPEN: &str =
+        "(_openBlock(true), _createElementBlock(_Fragment, null, _renderList(items, (item) => {\n";
+    const BLOCK_OPEN: &str = "return (_openBlock(), _createElementBlock(_Fragment, null, [\n";
+
+    let mut out = String::new();
+    out.push_str("function render(_ctx, _cache, $props, $setup, $data, $options) {\n");
+    out.push_str("  const _component_Comp = _resolveComponent(\"Comp\")\n");
+    out.push_str("  \n");
+    out.push_str("  return (_openBlock(), _createBlock(_component_Comp, null, {\n");
+    out.push_str("    default: _withCtx(() => [\n");
+    for level in 1..=depth {
+        indent(&mut out, 2 * level + 1);
+        out.push_str(LIST_OPEN);
+        indent(&mut out, 2 * level + 2);
+        out.push_str(BLOCK_OPEN);
+    }
+    indent(&mut out, 2 * depth + 3);
+    out.push_str("_renderSlot(_ctx.$slots, \"default\")\n");
+    for level in (1..=depth).rev() {
+        indent(&mut out, 2 * level + 2);
+        out.push_str("], 64 /* STABLE_FRAGMENT */))\n");
+        indent(&mut out, 2 * level + 1);
+        out.push_str("}), 256 /* UNKEYED_FRAGMENT */))\n");
+    }
+    out.push_str("    ]),\n    _: 3 /* FORWARDED */\n  }))\n}");
+    out
+}
+
 #[test]
 fn nested_for_nodes_compile_and_drop_on_a_small_stack() {
     let compiled = compile_source_on_small_stack(nested_v_for_templates(PAST_OLD_LIMIT), true);
 
     assert_eq!(compiled.diagnostics, Vec::new());
     assert!(!compiled.has_source_map);
-    assert!(compiled.preamble.contains("renderList: _renderList"));
-    assert!(compiled.code.contains("_renderSlot"));
+    assert_eq!(compiled.preamble, EXPECTED_V_FOR_PREAMBLE);
+    assert_eq!(compiled.code, expected_v_for_code(PAST_OLD_LIMIT));
 }
 
 #[test]

--- a/crates/vize_atelier_dom/tests/element_nesting_depth.rs
+++ b/crates/vize_atelier_dom/tests/element_nesting_depth.rs
@@ -1,0 +1,315 @@
+//! Element nesting depth through the whole DOM pipeline (#3480).
+//!
+//! Vize used to refuse element nesting past 256 levels, and the constant was not
+//! free to raise: transform, static hoisting, codegen, the parser's whitespace
+//! pass and even the AST's own teardown each descended one machine-stack frame
+//! per nesting level, so one level past the constant the failure mode was
+//! `fatal runtime error: stack overflow` — `SIGABRT`, which takes the process
+//! down and cannot be turned into a diagnostic. 256 was simply the depth a debug
+//! build survived on Rust's default 2 MiB thread stack, which put Vize below
+//! `@vue/compiler-dom`, whose own recursion reaches ~1092 levels of `<div>` on a
+//! default Node stack and then raises a *catchable* `RangeError`.
+//!
+//! Those descents now grow onto the heap when the stack runs low
+//! (`vize_carton::recursion`), so the limit is chosen for output size instead.
+//!
+//! Every case here runs on a thread with a deliberately small fixed stack. That
+//! is the whole point: on a stack this size the pre-fix compiler could not reach
+//! even the old limit, so "it compiled" is only possible if depth costs heap.
+//! It also keeps the test honest in a release build, where frames are ~8x
+//! smaller and a default-sized stack would hide the bug.
+//!
+//! Test-only: `std::string::String` builds the deeply nested sources and the
+//! expected output.
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
+use vize_atelier_core::{ErrorCode, errors::CompilerError};
+use vize_atelier_dom::{DomCompilerOptions, compile_template, compile_template_with_options};
+use vize_carton::Bump;
+
+/// Mirrors `MAX_ELEMENT_NESTING_DEPTH` in `vize_armature::parser::element::nesting`.
+const NESTING_LIMIT: usize = 4096;
+
+/// Slightly above the current upstream compiler's practical default-stack
+/// boundary (~1092), while keeping the strict full-output assertion fast.
+const UPSTREAM_PRACTICAL_DEPTH: usize = 1100;
+
+/// Deeper than the old 256-level limit, shallow enough to keep the full-output
+/// assertion readable when it fails.
+const PAST_OLD_LIMIT: usize = 512;
+
+/// Exercises structural-node recursion beyond the previous parser limit.
+const STRUCTURAL_DEPTH: usize = 1100;
+
+/// Smaller than a debug build needed for even 128 levels before this fix
+/// (measured: 1 MiB survived 128 and aborted at 256).
+const SMALL_STACK: usize = 256 * 1024;
+
+const EXPECTED_PREAMBLE: &str = "const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue\n";
+
+const EXPECTED_STRUCTURAL_PREAMBLE: &str = "const { resolveComponent: _resolveComponent, renderSlot: _renderSlot, openBlock: _openBlock, createBlock: _createBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, createCommentVNode: _createCommentVNode, withCtx: _withCtx } = Vue\n";
+
+/// `(code, message, start, end, source)` where the positions are
+/// `(offset, line, column)`.
+type Diagnostic = (
+    ErrorCode,
+    String,
+    (u32, u32, u32),
+    (u32, u32, u32),
+    Option<String>,
+);
+
+/// Everything a compile produced, in a form that survives the worker thread.
+struct Compiled {
+    diagnostics: Vec<Diagnostic>,
+    code: String,
+    preamble: String,
+    has_source_map: bool,
+}
+
+fn nested_divs(depth: usize) -> String {
+    let mut source = String::with_capacity(depth * 11 + 1);
+    for _ in 0..depth {
+        source.push_str("<div>");
+    }
+    source.push('x');
+    for _ in 0..depth {
+        source.push_str("</div>");
+    }
+    source
+}
+
+/// `<Comp>` wrapping `depth` levels of `<template v-if>` around a `<slot />`.
+///
+/// Structural directives take a different route through the compiler than plain
+/// elements — `v-if` branches, slot detection, the patterned-template pre-pass —
+/// and every one of those walks is depth-proportional too.
+fn nested_v_if_templates(depth: usize) -> String {
+    let mut source = String::from("<Comp>");
+    for _ in 0..depth {
+        source.push_str("<template v-if=\"ok\">");
+    }
+    source.push_str("<slot />");
+    for _ in 0..depth {
+        source.push_str("</template>");
+    }
+    source.push_str("</Comp>");
+    source
+}
+
+/// `<Comp>` wrapping `depth` levels of `<template v-for>` around a `<slot />`.
+fn nested_v_for_templates(depth: usize) -> String {
+    let mut source = String::from("<Comp>");
+    for _ in 0..depth {
+        source.push_str("<template v-for=\"item in items\">");
+    }
+    source.push_str("<slot />");
+    for _ in 0..depth {
+        source.push_str("</template>");
+    }
+    source.push_str("</Comp>");
+    source
+}
+
+/// The render function Vize emits for [`nested_divs`] at `depth`.
+///
+/// The outermost element opens the block; every level below it is a
+/// `createElementVNode`; the innermost one carries the text child. Indentation
+/// is two spaces per level.
+fn expected_render_code(depth: usize) -> String {
+    assert!(depth >= 2, "shape below assumes at least two levels");
+    let mut out = String::new();
+    out.push_str("function render(_ctx, _cache, $props, $setup, $data, $options) {\n");
+    out.push_str("  return (_openBlock(), _createElementBlock(\"div\", null, [\n");
+    for level in 2..depth {
+        indent(&mut out, level);
+        out.push_str("_createElementVNode(\"div\", null, [\n");
+    }
+    indent(&mut out, depth);
+    out.push_str("_createElementVNode(\"div\", null, \"x\")\n");
+    for level in (2..depth).rev() {
+        indent(&mut out, level);
+        out.push_str("])\n");
+    }
+    out.push_str("  ]))\n}");
+    out
+}
+
+fn indent(out: &mut String, level: usize) {
+    for _ in 0..level {
+        out.push_str("  ");
+    }
+}
+
+fn diagnostics(errors: &[CompilerError]) -> Vec<Diagnostic> {
+    errors
+        .iter()
+        .map(|error| {
+            let (start, end, source) = match &error.loc {
+                Some(loc) => (
+                    (loc.start.offset, loc.start.line, loc.start.column),
+                    (loc.end.offset, loc.end.line, loc.end.column),
+                    Some(String::from(loc.source.as_str())),
+                ),
+                None => ((0, 0, 0), (0, 0, 0), None),
+            };
+            (
+                error.code,
+                String::from(error.message.as_str()),
+                start,
+                end,
+                source,
+            )
+        })
+        .collect()
+}
+
+/// Compile `depth`-deep nesting on a thread with [`SMALL_STACK`] bytes of stack.
+///
+/// A stack overflow here aborts the whole test binary rather than failing the
+/// assertion, so reaching the assertions at all is part of what is under test.
+fn compile_nested_on_small_stack(depth: usize) -> Compiled {
+    compile_source_on_small_stack(nested_divs(depth), false)
+}
+
+fn compile_source_on_small_stack(
+    source: String,
+    experimental_patterned_template: bool,
+) -> Compiled {
+    std::thread::Builder::new()
+        .stack_size(SMALL_STACK)
+        .spawn(move || {
+            let allocator = Bump::new();
+            let (root, errors, result) = if experimental_patterned_template {
+                compile_template_with_options(
+                    &allocator,
+                    &source,
+                    DomCompilerOptions {
+                        experimental_patterned_template: true,
+                        ..DomCompilerOptions::default()
+                    },
+                )
+            } else {
+                compile_template(&allocator, &source)
+            };
+            let compiled = Compiled {
+                diagnostics: diagnostics(&errors),
+                code: String::from(result.code.as_str()),
+                preamble: String::from(result.preamble.as_str()),
+                has_source_map: result.map.is_some(),
+            };
+            // Dropping the tree is a recursive walk of its own; do it here, on
+            // the small stack, so the teardown is under test too.
+            drop(root);
+            compiled
+        })
+        .expect("spawn worker thread")
+        .join()
+        .expect("worker thread finished")
+}
+
+#[test]
+fn nesting_past_the_old_limit_compiles_on_a_small_stack() {
+    let compiled = compile_nested_on_small_stack(PAST_OLD_LIMIT);
+
+    assert_eq!(compiled.diagnostics, Vec::new());
+    assert_eq!(compiled.preamble, EXPECTED_PREAMBLE);
+    assert!(!compiled.has_source_map);
+    assert_eq!(compiled.code, expected_render_code(PAST_OLD_LIMIT));
+}
+
+#[test]
+fn nesting_at_upstream_practical_depth_compiles_on_a_small_stack() {
+    let compiled = compile_nested_on_small_stack(UPSTREAM_PRACTICAL_DEPTH);
+
+    assert_eq!(compiled.diagnostics, Vec::new());
+    assert_eq!(compiled.preamble, EXPECTED_PREAMBLE);
+    assert!(!compiled.has_source_map);
+    assert_eq!(
+        compiled.code,
+        expected_render_code(UPSTREAM_PRACTICAL_DEPTH)
+    );
+}
+
+/// The render function Vize emits for [`nested_v_if_templates`] at `depth`.
+///
+/// Each level is a `v-if` fragment wrapping the next; the innermost one renders
+/// the slot. Indentation grows by two levels per nesting level: the condition
+/// sits one level in from its fragment, and the branch one further.
+fn expected_structural_code(depth: usize) -> String {
+    const FRAGMENT_OPEN: &str = "? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [\n";
+    const FRAGMENT_CLOSE: &str = "], 64 /* STABLE_FRAGMENT */))\n";
+    const ELSE_COMMENT: &str = ": _createCommentVNode(\"v-if\", true)\n";
+
+    let mut out = String::new();
+    out.push_str("function render(_ctx, _cache, $props, $setup, $data, $options) {\n");
+    out.push_str("  const _component_Comp = _resolveComponent(\"Comp\")\n");
+    out.push_str("  \n");
+    out.push_str("  return (_openBlock(), _createBlock(_component_Comp, null, {\n");
+    out.push_str("    default: _withCtx(() => [\n");
+    for level in 1..=depth {
+        indent(&mut out, 2 * level + 1);
+        out.push_str("(ok)\n");
+        indent(&mut out, 2 * level + 2);
+        if level == depth {
+            out.push_str("? _renderSlot(_ctx.$slots, \"default\", { key: 0 })\n");
+            indent(&mut out, 2 * level + 2);
+            out.push_str(ELSE_COMMENT);
+        } else {
+            out.push_str(FRAGMENT_OPEN);
+        }
+    }
+    for level in (1..depth).rev() {
+        indent(&mut out, 2 * level + 2);
+        out.push_str(FRAGMENT_CLOSE);
+        indent(&mut out, 2 * level + 2);
+        out.push_str(ELSE_COMMENT);
+    }
+    out.push_str("    ]),\n    _: 3 /* FORWARDED */\n  }))\n}");
+    out
+}
+
+#[test]
+fn structural_recursion_paths_compile_on_a_small_stack() {
+    let compiled = compile_source_on_small_stack(nested_v_if_templates(STRUCTURAL_DEPTH), true);
+
+    assert_eq!(compiled.diagnostics, Vec::new());
+    assert_eq!(compiled.preamble, EXPECTED_STRUCTURAL_PREAMBLE);
+    assert!(!compiled.has_source_map);
+    assert_eq!(compiled.code, expected_structural_code(STRUCTURAL_DEPTH));
+}
+
+#[test]
+fn nested_for_nodes_compile_and_drop_on_a_small_stack() {
+    let compiled = compile_source_on_small_stack(nested_v_for_templates(PAST_OLD_LIMIT), true);
+
+    assert_eq!(compiled.diagnostics, Vec::new());
+    assert!(!compiled.has_source_map);
+    assert!(compiled.preamble.contains("renderList: _renderList"));
+    assert!(compiled.code.contains("_renderSlot"));
+}
+
+#[test]
+fn nesting_past_the_limit_is_a_diagnostic_and_not_an_abort() {
+    let compiled = compile_nested_on_small_stack(NESTING_LIMIT + 1);
+
+    // One diagnostic, pointing at the first element the parser refused to
+    // descend into: the `<div>` that would have been level 4097, five bytes per
+    // preceding start tag into the source.
+    let refused_at = (NESTING_LIMIT * 5) as u32;
+    assert_eq!(
+        compiled.diagnostics,
+        vec![(
+            ErrorCode::ExtendPoint,
+            "Element nesting is too deep.".to_owned(),
+            (refused_at, 1, refused_at + 1),
+            (refused_at + 5, 1, refused_at + 6),
+            Some("<div>".to_owned()),
+        )]
+    );
+    // Like upstream's `RangeError`, the limit stops emission rather than
+    // producing code for a tree the parser deliberately did not build.
+    assert_eq!(compiled.code, "");
+    assert_eq!(compiled.preamble, "");
+    assert!(!compiled.has_source_map);
+}

--- a/crates/vize_carton/Cargo.toml
+++ b/crates/vize_carton/Cargo.toml
@@ -21,6 +21,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 once_cell = { workspace = true }
 smallvec = { workspace = true }
+stacker = { workspace = true }
 xxhash-rust = { workspace = true }
 pklrust = { workspace = true }
 

--- a/crates/vize_carton/src/lib.rs
+++ b/crates/vize_carton/src/lib.rs
@@ -56,6 +56,7 @@ pub mod line_index;
 pub mod lsp;
 pub mod path;
 pub mod profiler;
+pub mod recursion;
 pub mod source_range;
 pub mod string_builder;
 pub mod telegraph;
@@ -65,6 +66,9 @@ pub use allocator::Allocator;
 pub use boxed::Box;
 pub use clone_in::CloneIn;
 pub use vec::Vec;
+
+// Re-export the recursion guard the recursive compiler passes wrap themselves in
+pub use recursion::ensure_sufficient_stack;
 
 // Re-export bumpalo types for convenience
 pub use bumpalo::Bump;

--- a/crates/vize_carton/src/recursion.rs
+++ b/crates/vize_carton/src/recursion.rs
@@ -1,0 +1,103 @@
+//! Stack headroom for the compiler's recursive AST passes.
+//!
+//! Vize's middle end walks the template AST with the machine stack: the
+//! transform lane recurses through `traverse_node`, static hoisting recurses
+//! through its subtree predicates and `hoist_static_inner`, and codegen recurses
+//! through `generate_node`. Nesting depth in the template is therefore depth on
+//! the call stack.
+//!
+//! That matters because a Rust stack overflow is not a recoverable error. The
+//! guard page faults, the runtime prints `fatal runtime error: stack overflow`,
+//! and the process is aborted with `SIGABRT` — taking down a `vize` CLI run, an
+//! LSP session, or a test binary with it. There is no `catch_unwind` for it and
+//! no way to turn it into a diagnostic after the fact. A depth limit chosen to
+//! stay under the stack is not a fix either: it only moves the abort to a
+//! different input, and it caps the templates Vize accepts far below what
+//! `@vue/compiler-dom` accepts (measured: ~1092 levels of `<div>` on a default
+//! Node stack, after which Vue raises a *catchable* `RangeError`).
+//!
+//! [`ensure_sufficient_stack`] closes that gap. Called at the point where a
+//! recursive pass steps from a node to its children, it checks the remaining
+//! stack and, when the headroom drops below [`RED_ZONE`], moves the rest of the
+//! recursion onto a freshly allocated [`SEGMENT_SIZE`] stack. Depth then costs
+//! heap, which is recoverable and bounded by the parser's nesting limit, instead
+//! of stack, which is not.
+//!
+//! # Why not an explicit work stack
+//!
+//! An iterative traversal with a heap-allocated worklist is the cleaner shape
+//! and remains the long-term direction for the transform lane, whose recursion
+//! is confined to one function pair. It is not viable for the whole middle end
+//! today: codegen interleaves emission with recursion at ~20 call sites across
+//! ten modules (`generate_element` emits an opening call, recurses into
+//! children, then emits the closing arguments), so making it iterative means a
+//! continuation-passing rewrite of every one of those sites. Static hoisting
+//! adds four more mutually recursive walks. Guarding the recursion covers all
+//! three passes with one mechanism and no behavioural risk, and it is the same
+//! answer `rustc` reached for the same problem
+//! (`rustc_data_structures::stack::ensure_sufficient_stack`).
+//!
+//! # Cost
+//!
+//! On the shallow templates that dominate real projects the guard never grows
+//! anything: it is one thread-local read plus a pointer comparison per guarded
+//! call, and no segment is ever allocated. Growth only happens once per
+//! [`SEGMENT_SIZE`] of consumed stack, so a pathologically deep template pays a
+//! handful of stack-segment allocations in total.
+
+/// Stack headroom that must remain before a guarded call proceeds in place.
+///
+/// This has to exceed the stack a single guarded step can consume before it
+/// reaches the next guard. The deepest such step is one template nesting level
+/// of the full pipeline, measured at ~8 KiB in a debug build (the profile with
+/// the largest frames, since it keeps every temporary live); 512 KiB leaves two
+/// orders of magnitude of slack for the unguarded helper frames in between.
+const RED_ZONE: usize = 512 * 1024;
+
+/// Size of the stack allocated when [`RED_ZONE`] is breached.
+///
+/// Large enough that growth is rare (~64 debug-build nesting levels per
+/// allocation at the measured 8 KiB/level, ~500 in release), small enough that
+/// the allocation is never a meaningful cost next to the compile it enables.
+const SEGMENT_SIZE: usize = 4 * 1024 * 1024;
+
+/// Run `f`, first moving to a fresh stack segment if the current stack is close
+/// to exhausted.
+///
+/// Call this where a recursive pass descends one level — the point whose
+/// repetition is bounded by input nesting depth rather than by the code. Adding
+/// it to a leaf helper only costs a check; omitting it from a recursion step is
+/// what reintroduces the abort.
+#[inline]
+pub fn ensure_sufficient_stack<R>(f: impl FnOnce() -> R) -> R {
+    stacker::maybe_grow(RED_ZONE, SEGMENT_SIZE, f)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ensure_sufficient_stack;
+
+    /// A frame big enough that unguarded recursion overflows a small stack long
+    /// before the recursion count below is reached.
+    fn deep(n: usize) -> usize {
+        ensure_sufficient_stack(|| {
+            let padding = [0u64; 512];
+            if n == 0 {
+                return std::hint::black_box(&padding).len();
+            }
+            std::hint::black_box(&padding);
+            deep(n - 1)
+        })
+    }
+
+    #[test]
+    fn recursion_far_past_the_thread_stack_completes() {
+        // 20_000 frames of >=4 KiB each need >=80 MiB; the thread below has
+        // 256 KiB, so this can only pass by growing onto the heap.
+        let handle = std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| deep(20_000))
+            .expect("spawn");
+        assert_eq!(handle.join().expect("join"), 512);
+    }
+}

--- a/crates/vize_relief/src/relief/control_flow.rs
+++ b/crates/vize_relief/src/relief/control_flow.rs
@@ -3,7 +3,7 @@
 //! Contains if (v-if/v-else-if/v-else), for (v-for),
 //! and text call node definitions.
 
-use vize_carton::{Box, Bump, Vec};
+use vize_carton::{Box, Bump, Vec, ensure_sufficient_stack};
 
 use super::{
     core::{NodeType, SourceLocation},
@@ -62,6 +62,16 @@ impl<'a> IfBranchNode<'a> {
     }
 }
 
+/// Keep teardown of nested structural nodes under the same stack guard as the
+/// compiler passes that traverse them.
+impl Drop for IfBranchNode<'_> {
+    fn drop(&mut self) {
+        if !self.children.is_empty() {
+            ensure_sufficient_stack(|| self.children.clear());
+        }
+    }
+}
+
 /// For node (v-for)
 #[derive(Debug)]
 pub struct ForNode<'a> {
@@ -77,6 +87,16 @@ pub struct ForNode<'a> {
 impl<'a> ForNode<'a> {
     pub fn node_type(&self) -> NodeType {
         NodeType::For
+    }
+}
+
+/// A transformed `v-for` can directly contain another control-flow node, so
+/// its compiler-generated field drop would otherwise recurse without a guard.
+impl Drop for ForNode<'_> {
+    fn drop(&mut self) {
+        if !self.children.is_empty() {
+            ensure_sufficient_stack(|| self.children.clear());
+        }
     }
 }
 

--- a/crates/vize_relief/src/relief/elements.rs
+++ b/crates/vize_relief/src/relief/elements.rs
@@ -3,7 +3,7 @@
 //! Contains element, attribute, directive, text, comment,
 //! and interpolation node definitions.
 
-use vize_carton::{Box, Bump, String, Vec, directive::DirectiveKind};
+use vize_carton::{Box, Bump, String, Vec, directive::DirectiveKind, ensure_sufficient_stack};
 
 use super::{
     control_flow::ForParseResult,
@@ -43,6 +43,29 @@ impl<'a> ElementNode<'a> {
 
     pub fn node_type(&self) -> NodeType {
         NodeType::Element
+    }
+}
+
+/// Tearing an element down is itself a recursive walk of its subtree.
+///
+/// Without this, the compiler-generated drop glue chains
+/// `Vec<TemplateChildNode>` -> `Box<ElementNode>` -> `Vec<TemplateChildNode>`
+/// once per nesting level, on the machine stack, with no guard — so a template
+/// deep enough would abort the process on the way *out* of a compile that had
+/// just succeeded. Dropping the children here, inside a checked frame, puts the
+/// teardown under the same stack-growth guarantee as the passes that built the
+/// tree (`vize_carton::recursion`).
+///
+/// Leaf elements — the overwhelming majority — pay one branch and nothing else.
+impl Drop for ElementNode<'_> {
+    fn drop(&mut self) {
+        if self.children.is_empty() {
+            return;
+        }
+        // `clear` runs the children's destructors here; the implicit field drop
+        // that follows this function then sees an empty vector and recurses no
+        // further.
+        ensure_sufficient_stack(|| self.children.clear());
     }
 }
 


### PR DESCRIPTION
Closes #3480.

## The problem

A template `@vue/compiler-dom` compiles could fail in Vize because the parser refused to descend past
256 open elements — and that constant was not free to raise. Every pass after the parser walks the
AST with the machine stack, so nesting depth in the template is depth on the call stack, and one
level past the constant the failure mode is `fatal runtime error: stack overflow`: `SIGABRT`, which
takes the whole process down and cannot be turned into a diagnostic.

256 was simply the depth a **debug** build survives on Rust's default 2 MiB thread stack.

### Baseline (before), measured

`compile_template` on `"<div>".repeat(d) + "x" + "</div>".repeat(d)` inside a thread with a fixed
stack size, with `MAX_ELEMENT_NESTING_DEPTH` temporarily lifted to `1_000_000` so the abort is
reachable. Each cell is the deepest measured `d` that completed; the next power of two aborted with
`thread '<unknown>' has overflowed its stack` (debug build, macOS aarch64):

| thread stack | parse | AST drop | transform | codegen | full compile |
| --- | --- | --- | --- | --- | --- |
| 256 KiB | 256 | 256 | <128 | <128 | <128 |
| 1 MiB | 1024 | 1024 | 128 | 128 | 128 |
| 2 MiB | 2048 | 2048 | 256 | 256 | 256 |
| 8 MiB | ≥8192 | ≥8192 | 1024 | 1024 | 1024 |

This reproduces the issue's table exactly (2 MiB debug → 256 ok, 512 overflows), and adds two
findings the issue did not have: **parsing is not exempt** (its whitespace-condense post-pass walks
the tree recursively), and **dropping the AST is not exempt either** — the compiler-generated drop
glue chains `Vec<TemplateChildNode>` → `Box<ElementNode>` → `Vec<TemplateChildNode>` once per level,
so a deep enough template aborts on the way *out* of a compile that had just succeeded.

### Upstream, measured

`@vue/compiler-dom@3.6.0-beta.10`, `compile(src, { mode: 'function' })`, binary search on a default
Node 25 stack: **1092** levels of `<div>` compile; past that it raises a *catchable*
`RangeError: Maximum call stack size exceeded`. (The issue cites ~5000; that is not reproducible on
this version with a default stack. 1092 is what Vize has to beat, and the number the new limit is
justified against.)

## The fix

### 1. Depth costs heap, not stack

New `vize_carton::recursion::ensure_sufficient_stack` — a thin `stacker::maybe_grow` wrapper that
moves the rest of a recursion onto a freshly allocated 4 MiB stack when the remaining headroom drops
below 512 KiB. Every descent whose depth is bounded by the *input* rather than by the code is wrapped
in it:

- transform lane: `traverse_node`
- static hoisting: `is_static_node`, `get_static_type`, `hoist_static_inner`,
  `has_only_native_element_descendants`, `is_static_nested_child`, `inject_scope_id`
- codegen: `generate_node`, plus the hoisted-VNode serializers and helper pre-scan
- slot / namespace detection: `child_contains_slot_outlet`, `children_cross_namespace_boundary`,
  `has_implicit_child`
- pre-passes: patterned-template `rewrite_children`, legacy `desugar_children`
- parser: `condense_whitespace`
- teardown: `Drop` for `ElementNode`, `IfBranchNode`, `ForNode`

**Why not an explicit work stack.** It is the cleaner shape and stays the direction for the transform
lane, whose recursion is confined to one function pair. It is not viable for the whole middle end in
one change: codegen interleaves emission with recursion at ~20 call sites across ten modules
(`generate_element` emits the opening call, recurses into children, then emits the closing
arguments), so making it iterative is a continuation-passing rewrite of every one of those sites,
with snapshot-visible risk at each. Static hoisting adds four more mutually recursive walks, and drop
glue cannot be made iterative at all without hand-written `Drop` impls. Guarding the recursion covers
all of it with one mechanism and no behavioural change, and it is the same answer `rustc` reached for
the same problem (`rustc_data_structures::stack::ensure_sufficient_stack`).

### 2. The limit moves, and stays recoverable

`MAX_ELEMENT_NESTING_DEPTH`: 256 → **4096**, ~3.7x upstream's measured ceiling. With the stack no
longer binding, the limit is chosen for what it now actually bounds — output size. Generated code is
quadratic in nesting depth (indentation adds two bytes per level per line): 141 KB at depth 256,
2.1 MB at 1024, **33.7 MB at 4096**. Upstream has the same shape (142 KB at 256, 2.0 MB at 1000).

Exceeding it stays what it already was: a recoverable diagnostic, raised once per over-limit region,
never an abort. Like upstream's `RangeError`, it stops emission rather than producing code for a tree
the parser deliberately did not build.

### After, same methodology

Every phase — parse, transform, codegen, full compile, AST drop — completes at every measured depth
up to 8192 on a **256 KiB** stack, in both debug and release. Depth 8192 crosses the new limit and
returns the single recoverable diagnostic.

## Throughput

Wall-clock A/B on this machine was unusable (parallel CI-style load, load average ~250; the *same*
binary varied by 4x-25x run to run, and `cargo bench`'s own comparison reported "regressed" for
`vize_atelier_sfc/sfc_compile` purely from load). Measured **user CPU time** on a fixed workload
instead — it only accrues while the process is on a core — with the base and head binaries
interleaved round by round so scheduling noise hits both equally.

Workload: 100,000 × `parse_sfc` + `compile_sfc` of a representative SFC (template + `<script setup
lang="ts">` + scoped style, ~40 template nodes), 15 interleaved rounds, `bench` profile
(opt-level 3, thin LTO, 16 CGUs on both sides).

| | user CPU per compile (min) | user CPU per compile (median) |
| --- | --- | --- |
| base (`f594fab1`) | 84.10 µs | 86.90 µs |
| head | 83.70 µs | 86.40 µs |
| delta | **−0.48%** | **−0.58%** |

No measurable regression; the two sides are within run-to-run noise of each other. That matches the
mechanism: on a shallow template the guard never grows anything, and costs one thread-local read plus
a pointer compare per guarded call — a few hundred nanoseconds against ~85 µs of work. Growth only
happens once per 4 MiB of consumed stack, so even a pathological template pays a handful of `mmap`s.

## Tests

`crates/vize_atelier_dom/tests/element_nesting_depth.rs` — all five cases run on a thread with a
**256 KiB** stack, which is smaller than what a debug build needed for even 128 levels before this
change, so "it compiled" is only possible if depth costs heap. Each asserts the **complete**
`CodegenResult` (code, preamble, source-map presence) against a generated expectation, and the
complete diagnostic list:

- `nesting_past_the_old_limit_compiles_on_a_small_stack` — depth 512
- `nesting_at_upstream_practical_depth_compiles_on_a_small_stack` — depth 1100, past upstream's ceiling
- `structural_recursion_paths_compile_on_a_small_stack` — 384 nested `<template v-if>` around a `<slot />`
- `nested_for_nodes_compile_and_drop_on_a_small_stack` — 512 nested `<template v-for>`
- `nesting_past_the_limit_is_a_diagnostic_and_not_an_abort` — depth 4097; asserts the exact code,
  message and span `(20480,1,20481)..(20485,1,20486)` of the single diagnostic, and that the result
  is empty rather than the process being gone

All five fail on `f594fab1` (verified by checking the file out onto the base commit). The armature
limit tests move to 4096 and two of them also fail on base. `vize_carton::recursion` has a unit test
that recurses 20,000 frames of ≥4 KiB on a 256 KiB stack.

## Also

- `hoist_static.rs` (907), `codegen/generate.rs` (496) and `transforms/v_slot.rs` (480) are split
  into submodules so no over-limit source file grows.
- `stacker` is new (with `psm`, and `cc`'s `object`/`ar_archive_writer` at build time). It supports
  every target Vize builds for, including `wasm32-unknown-unknown` — `cargo build -p vize_vitrine
  --target wasm32-unknown-unknown --no-default-features --features wasm` verified green.
- Codegen's quadratic indentation is upstream's behaviour too (#3402's note that upstream emits
  ~11 bytes/level does not reproduce), so it is left alone here.
