### PR TITLE
fix(bench): pair alternating benchmark samples

### DIFF
--- a/bench/compare-pr-results.mjs
+++ b/bench/compare-pr-results.mjs
@@ -1,0 +1,68 @@
+/**
+ * Pure result classification and confirmation for the PR benchmark gate.
+ */
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[mid];
+  }
+  return (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+export function summarizeBenchmarkRuns({ id, label, baseRuns, headRuns, thresholdPercent }) {
+  if (baseRuns.length !== headRuns.length || baseRuns.length === 0) {
+    throw new Error("Benchmark samples must contain equally sized, non-empty base/head pairs");
+  }
+  const baseMs = median(baseRuns);
+  const headMs = median(headRuns);
+  const pairRates = baseRuns.map((baseMs, index) =>
+    baseMs === 0 ? Number.NaN : headRuns[index] / baseMs,
+  );
+  const rate = pairRates.every(Number.isFinite) ? median(pairRates) : Number.NaN;
+  const changePercent = Number.isFinite(rate) ? (rate - 1) * 100 : Number.NaN;
+  const status =
+    changePercent >= thresholdPercent
+      ? "regression"
+      : changePercent <= -thresholdPercent
+        ? "faster"
+        : "stable";
+
+  return {
+    id,
+    label,
+    baseMs,
+    headMs,
+    rate,
+    changePercent,
+    status,
+    baseRuns,
+    headRuns,
+    pairRates,
+  };
+}
+
+// #3621: no-code comparisons have crossed the 5% budget by both 5.37% and
+// 15.11%, then passed when the measurements (not only the budget job) were
+// rerun. A real regression must reproduce in a fresh sample; one runner-noise
+// excursion must not cancel a release after every other exact-SHA gate passes.
+export function confirmRegressions(measurements, remeasure, thresholdPercent) {
+  return measurements.map(({ task, result }) => {
+    if (result.status !== "regression") {
+      return result;
+    }
+    const confirmation = remeasure(task);
+    const combined = summarizeBenchmarkRuns({
+      id: result.id,
+      label: result.label,
+      baseRuns: [...result.baseRuns, ...confirmation.baseRuns],
+      headRuns: [...result.headRuns, ...confirmation.headRuns],
+      thresholdPercent,
+    });
+    return {
+      ...combined,
+      attempts: [result, confirmation],
+    };
+  });
+}

--- a/bench/compare-pr.mjs
+++ b/bench/compare-pr.mjs
@@ -13,6 +13,7 @@ import { performance } from "node:perf_hooks";
 import { pathToFileURL } from "node:url";
 
 import { laneEnvironment, makeTasks } from "./compare-pr-lanes.mjs";
+import { confirmRegressions, summarizeBenchmarkRuns } from "./compare-pr-results.mjs";
 
 const DEFAULT_RUNS = 5;
 const DEFAULT_WARMUPS = 1;
@@ -58,15 +59,6 @@ function parseNonNegativeInt(value, fallback) {
 function parsePositiveFloat(value, fallback) {
   const parsed = Number.parseFloat(value ?? "");
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-function median(values) {
-  const sorted = [...values].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  if (sorted.length % 2 === 1) {
-    return sorted[mid];
-  }
-  return (sorted[mid - 1] + sorted[mid]) / 2;
 }
 
 function formatMs(ms) {
@@ -162,28 +154,13 @@ function measureTask(task, baseBin, headBin, options) {
     }
   }
 
-  const baseMs = median(baseRuns);
-  const headMs = median(headRuns);
-  const rate = baseMs === 0 ? Number.NaN : headMs / baseMs;
-  const changePercent = Number.isFinite(rate) ? (rate - 1) * 100 : Number.NaN;
-  const status =
-    changePercent >= options.thresholdPercent
-      ? "regression"
-      : changePercent <= -options.thresholdPercent
-        ? "faster"
-        : "stable";
-
-  return {
+  return summarizeBenchmarkRuns({
     id: task.id,
     label: task.label,
-    baseMs,
-    headMs,
-    rate,
-    changePercent,
-    status,
     baseRuns,
     headRuns,
-  };
+    thresholdPercent: options.thresholdPercent,
+  });
 }
 
 export function createBenchmarkBudget(results) {
@@ -212,13 +189,13 @@ export function renderMarkdown(data) {
     `Base: \`${data.baseLabel}\`  Head: \`${data.headLabel}\`  Input: ${data.fileCount.toLocaleString()} generated SFC files`,
   );
   lines.push(
-    `Median of ${data.runs} measured run(s) after ${data.warmups} warmup run(s). Times are shown in milliseconds to 0.001ms. Rate is head/base, so below 1.000x is faster. Regression threshold: ${data.thresholdPercent}%.`,
+    `Median of ${data.runs} adjacent head/base pairs after ${data.warmups} warmup pair(s). Any threshold breach receives ${data.runs} fresh confirmation pairs, and the final rate is the paired median over all samples. Times are shown in milliseconds to 0.001ms. Rate below 1.000x is faster. Regression threshold: ${data.thresholdPercent}%.`,
   );
   lines.push(
     `Budget: ${budget.status}${budget.regressionCount > 0 ? ` (${budget.regressionCount} regression${budget.regressionCount === 1 ? "" : "s"})` : ""}.`,
   );
   lines.push("");
-  lines.push("| Task | Base | Head | Rate | Result |");
+  lines.push("| Task | Base median | Head median | Paired rate | Result |");
   lines.push("| --- | ---: | ---: | ---: | --- |");
   for (const result of data.results) {
     lines.push(
@@ -241,8 +218,15 @@ export function renderMarkdown(data) {
   for (const result of data.results) {
     lines.push(`### ${result.label}`);
     lines.push("");
-    lines.push(`- Base: ${formatRunList(result.baseRuns)}`);
-    lines.push(`- Head: ${formatRunList(result.headRuns)}`);
+    const attempts = result.attempts ?? [result];
+    for (const [index, attempt] of attempts.entries()) {
+      const prefix = attempts.length === 1 ? "" : index === 0 ? "Initial " : "Confirmation ";
+      lines.push(
+        `- ${prefix}Result: ${formatRate(attempt.rate)} (${formatPercent(attempt.changePercent)}), ${attempt.status}`,
+      );
+      lines.push(`- ${prefix}Base: ${formatRunList(attempt.baseRuns)}`);
+      lines.push(`- ${prefix}Head: ${formatRunList(attempt.headRuns)}`);
+    }
     lines.push("");
   }
   lines.push("</details>");
@@ -289,12 +273,16 @@ export function main(argv = process.argv.slice(2)) {
     allowNonZeroExit: false,
   };
 
-  const results = tasks.map((task) =>
+  const measure = (task) =>
     measureTask(task, baseBin, headBin, {
       ...options,
       allowNonZeroExit: task.allowNonZeroExit,
       threads: task.threads ?? 1,
-    }),
+    });
+  const results = confirmRegressions(
+    tasks.map((task) => ({ task, result: measure(task) })),
+    measure,
+    thresholdPercent,
   );
 
   const data = {

--- a/bench/enforce-pr-budget.mjs
+++ b/bench/enforce-pr-budget.mjs
@@ -84,9 +84,13 @@ export function enforceBenchmarkBudget(data, options = {}) {
 
   const budget = data.budget ?? createBenchmarkBudget(data.results ?? []);
   if (budget.status !== "failed") {
+    const confirmed = (data.results ?? []).filter((result) => result.attempts?.length === 2);
     return {
       ok: true,
-      message: "Benchmark budget passed.",
+      message:
+        confirmed.length === 0
+          ? "Benchmark budget passed."
+          : `Benchmark budget passed after extending ${confirmed.length} initial breach(es) with paired confirmation samples: ${confirmed.map((result) => result.label).join(", ")}.`,
     };
   }
 
@@ -99,7 +103,7 @@ export function enforceBenchmarkBudget(data, options = {}) {
 
   return {
     ok: false,
-    message: `Benchmark regression budget failed for ${budget.regressionCount} task(s):\n${failures}`,
+    message: `Benchmark regression budget failed for ${budget.regressionCount} task(s) after paired confirmation:\n${failures}`,
   };
 }
 

--- a/tests/tooling/benchmark-budget.test.ts
+++ b/tests/tooling/benchmark-budget.test.ts
@@ -69,6 +69,8 @@ test("benchmark markdown reports the active regression budget", () => {
   });
 
   assert.match(markdown, /Budget: failed \(1 regression\)\./);
+  assert.match(markdown, /Any threshold breach receives 5 fresh confirmation pairs/);
+  assert.match(markdown, /\| Task \| Base median \| Head median \| Paired rate \| Result \|/);
   assert.match(markdown, /Regression budget failures:/);
   assert.match(markdown, /Type check: 1\.150x \(\+15\.00%\)/);
 });

--- a/tests/tooling/benchmark-confirmation.test.ts
+++ b/tests/tooling/benchmark-confirmation.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createBenchmarkBudget, renderMarkdown } from "../../bench/compare-pr.mjs";
+import { confirmRegressions, summarizeBenchmarkRuns } from "../../bench/compare-pr-results.mjs";
+import { enforceBenchmarkBudget } from "../../bench/enforce-pr-budget.mjs";
+
+test("a transient breach is judged over the initial and confirmation pairs together", () => {
+  const initial = summarizeBenchmarkRuns({
+    id: "lint-max",
+    label: "Lint (max)",
+    baseRuns: Array(10).fill(100),
+    headRuns: Array(10).fill(106),
+    thresholdPercent: 5,
+  });
+  const confirmation = summarizeBenchmarkRuns({
+    id: "lint-max",
+    label: "Lint (max)",
+    baseRuns: Array(10).fill(100),
+    headRuns: Array(10).fill(100),
+    thresholdPercent: 5,
+  });
+  const [result] = confirmRegressions(
+    [{ task: "lint-max", result: initial }],
+    () => confirmation,
+    5,
+  );
+
+  assert.equal(result.status, "stable");
+  assert.deepEqual(result.attempts, [initial, confirmation]);
+  assert.equal(result.baseRuns.length, 20);
+  assert.equal(result.headRuns.length, 20);
+  assert.equal(result.changePercent, 3.0000000000000027);
+  assert.equal(createBenchmarkBudget([result]).status, "passed");
+  const enforcement = enforceBenchmarkBudget({ results: [result] });
+  assert.equal(enforcement.ok, true);
+  assert.match(enforcement.message, /paired confirmation samples: Lint \(max\)/);
+
+  const markdown = renderMarkdown({
+    baseLabel: "base",
+    headLabel: "head",
+    fileCount: 300,
+    runs: 10,
+    warmups: 1,
+    thresholdPercent: 5,
+    results: [result],
+  });
+  assert.match(markdown, /Initial Result: 1\.060x \(\+6\.00%\), regression/);
+  assert.match(markdown, /Confirmation Result: 1\.000x \(0\.00%\), stable/);
+});
+
+test("a persistent regression still fails over the combined paired sample", () => {
+  const initial = summarizeBenchmarkRuns({
+    id: "check",
+    label: "Type check",
+    baseRuns: Array(10).fill(100),
+    headRuns: Array(10).fill(106),
+    thresholdPercent: 5,
+  });
+  const [result] = confirmRegressions([{ task: "check", result: initial }], () => initial, 5);
+
+  assert.equal(result.status, "regression");
+  assert.equal(result.changePercent, 6.000000000000005);
+  assert.equal(createBenchmarkBudget([result]).status, "failed");
+  const enforcement = enforceBenchmarkBudget({ results: [result] });
+  assert.equal(enforcement.ok, false);
+  assert.match(enforcement.message, /after paired confirmation/);
+});
+
+test("paired rates reject the real no-code sample whose independent medians read +15.11%", () => {
+  const result = summarizeBenchmarkRuns({
+    id: "check",
+    label: "Type check (1T)",
+    baseRuns: [
+      854.049178, 851.61708, 839.336498, 1236.117059, 1132.082518, 1207.947092, 1124.93331,
+      805.315192, 837.220344, 821.461661,
+    ],
+    headRuns: [
+      847.309434, 840.243178, 1251.908881, 1241.231136, 1071.22636, 1205.936823, 1191.733354,
+      892.158345, 830.561208, 838.986677,
+    ],
+    thresholdPercent: 5,
+  });
+
+  assert.equal(result.status, "stable");
+  assert.equal(result.changePercent, 0.12365040342325884);
+  assert.equal(createBenchmarkBudget([result]).status, "passed");
+});
+
+test("stable lanes are never measured a second time", () => {
+  const stable = summarizeBenchmarkRuns({
+    id: "compile",
+    label: "Compile SFC",
+    baseRuns: Array(10).fill(100),
+    headRuns: Array(10).fill(102),
+    thresholdPercent: 5,
+  });
+  let confirmations = 0;
+  const [result] = confirmRegressions(
+    [{ task: "compile", result: stable }],
+    () => {
+      confirmations += 1;
+      return stable;
+    },
+    5,
+  );
+
+  assert.equal(result, stable);
+  assert.equal(confirmations, 0);
+});
+
+test("an exact-threshold regression remains a failure after confirmation", () => {
+  const initial = summarizeBenchmarkRuns({
+    id: "compile",
+    label: "Compile SFC",
+    baseRuns: Array(10).fill(100),
+    headRuns: Array(10).fill(105),
+    thresholdPercent: 5,
+  });
+  const [result] = confirmRegressions([{ task: "compile", result: initial }], () => initial, 5);
+
+  assert.equal(result.status, "regression");
+  assert.equal(result.changePercent, 5.000000000000004);
+});


### PR DESCRIPTION
Closes #3621

## Failure reproduced

The v0.312.0 release stopped after a version-only range reported `Lint (max) +5.37%`; a fresh measurement passed. PR #3619 then supplied the stronger reproduction: no Rust production change, independent medians reported `Type check (1T) +15.11%`, while the median of its ten adjacent `head/base` pairs is only `+0.12%`. Multimodal runner load put a different number of slow observations on each side.

## Change

- classify each alternating iteration as one adjacent `head/base` pair and use the median paired rate;
- when that paired rate first breaches 5%, measure the lane once more and apply the same estimator to all 20 pairs;
- retain both attempt rates, statuses, and raw timings in JSON and Markdown;
- keep stable lanes at the original cost and leave release preflight's latest-red contract untouched.

The 5% budget is unchanged. A persistent 5% regression still fails.

## Verification

- exact #3619 raw vector regression fixture;
- transient, persistent, exact-threshold, and stable-lane confirmation cases;
- benchmark budget/workflow and release-preflight contract tests: 34 passed;
- formatting, syntax checks, diff check, and 350-line source budget passed;
- two independent reviews approved the final paired estimator.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Benchmark comparisons now confirm detected performance regressions with additional paired measurements.
  * Results distinguish temporary regressions from persistent changes and apply threshold checks more consistently.
  * Benchmark reports now include confirmation details, paired-run information, and raw results for each attempt.
  * Budget enforcement messages now clarify when regressions were evaluated through confirmation runs.

* **Tests**
  * Added coverage for transient and persistent regressions, stable benchmarks, threshold boundaries, budget enforcement, and report formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->