### PR TITLE
fix(vapor): lower transparent template children

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,6 +3678,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "vize_atelier_core",
+ "vize_atelier_dom",
  "vize_carton",
  "vize_croquis",
 ]

--- a/crates/vize_atelier_vapor/Cargo.toml
+++ b/crates/vize_atelier_vapor/Cargo.toml
@@ -24,4 +24,8 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+# The DOM backend is compiled alongside Vapor in the cross-backend agreement
+# tests (`<template>` children must lower the same way in both backends).
+vize_atelier_dom = { workspace = true }
+
 insta = { workspace = true }

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -28,6 +28,8 @@ mod tests_sibling_navigation;
 #[cfg(test)]
 mod tests_slot_outlets;
 #[cfg(test)]
+mod tests_template_children;
+#[cfg(test)]
 mod tests_valueless_attr;
 
 pub use compile::{

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__adjacent_control_flow_and_keyed_pattern_dom_output.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__adjacent_control_flow_and_keyed_pattern_dom_output.snap
@@ -1,0 +1,26 @@
+---
+source: crates/vize_atelier_vapor/src/tests_template_children.rs
+expression: dom_output(CONTROL_FLOW)
+---
+errors=[]
+components=[]
+preamble=
+const { toDisplayString: _toDisplayString, createElementVNode: _createElementVNode, normalizeClass: _normalizeClass, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, createCommentVNode: _createCommentVNode, renderList: _renderList } = Vue
+
+code=
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, [
+    (aside)
+      ? (_openBlock(), _createElementBlock("aside", { key: 0 }, "Aside"))
+      : _createCommentVNode("v-if", true),
+    ((status) === ('ready'))
+      ? (_openBlock(true), _createElementBlock(_Fragment, { key: 1 }, _renderList(items, (item) => {
+        return (_openBlock(), _createElementBlock("li", {
+          key: item.id,
+          class: _normalizeClass(item.kind)
+        }, _toDisplayString(item.label), 3 /* TEXT, CLASS */))
+      }), 128 /* KEYED_FRAGMENT */))
+      : (_openBlock(), _createElementBlock("li", { key: 2 }, "Empty")),
+    _createElementVNode("p", null, "Last")
+  ]))
+}

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__adjacent_control_flow_and_keyed_pattern_vapor_output.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__adjacent_control_flow_and_keyed_pattern_vapor_output.snap
@@ -1,0 +1,39 @@
+---
+source: crates/vize_atelier_vapor/src/tests_template_children.rs
+expression: vapor_output(CONTROL_FLOW)
+---
+errors=[]
+templates=["<aside>Aside</aside>", "<li> </li>", "<li>Empty</li>", "<div><p>Last</p></div>"]
+code=
+import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, setClass as _setClass, setInsertionState as _setInsertionState, renderEffect as _renderEffect, createIf as _createIf, createFor as _createFor, template as _template } from 'vue';
+const t0 = _template("<aside>Aside</aside>", true)
+const t1 = _template("<li> </li>")
+const t2 = _template("<li>Empty</li>", true)
+const t3 = _template("<div><p>Last</p></div>", true)
+
+export function render(_ctx) {
+  const n10 = t3()
+  _setInsertionState(n10, null, true)
+  const n0 = _createIf(() => (_ctx.aside), () => {
+    const n2 = t0()
+    return n2
+  })
+  _setInsertionState(n10, null, true)
+  const n3 = _createIf(() => ((_ctx.status) === ('ready')), () => {
+    _setInsertionState(n10, null, true)
+    const n5 = _createFor(() => (_ctx.items), (_for_item0) => {
+      const n7 = t1()
+      const x7 = _txt(n7)
+      _renderEffect(() => {
+        _setClass(n7, _for_item0.value.kind)
+        _setText(x7, _toDisplayString(_for_item0.value.label))
+      })
+      return n7
+    }, (item) => (item.id), 1)
+    return n5
+  }, () => {
+    const n9 = t2()
+    return n9
+  })
+  return n10
+}

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__dynamic_sibling_inside_patterned_template_dom_output.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__dynamic_sibling_inside_patterned_template_dom_output.snap
@@ -1,0 +1,22 @@
+---
+source: crates/vize_atelier_vapor/src/tests_template_children.rs
+expression: dom_output(DYNAMIC_SIBLING)
+---
+errors=[]
+components=[]
+preamble=
+const { toDisplayString: _toDisplayString, createElementVNode: _createElementVNode, normalizeClass: _normalizeClass, openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode } = Vue
+
+code=
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, [
+    [((status) === ('ready'))
+      ? (_openBlock(), _createElementBlock("li", { key: 0 }, "Ready"))
+      : _createCommentVNode("v-if", true), _createElementVNode("li", { id: plainId }, [
+      _createElementVNode("span", null, _toDisplayString(label), 1 /* TEXT */)
+    ], 8 /* PROPS */, ["id"])],
+    _createElementVNode("footer", {
+      class: _normalizeClass(cls)
+    }, "Tail", 2 /* CLASS */)
+  ]))
+}

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__dynamic_sibling_inside_patterned_template_vapor_output.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__dynamic_sibling_inside_patterned_template_vapor_output.snap
@@ -1,0 +1,29 @@
+---
+source: crates/vize_atelier_vapor/src/tests_template_children.rs
+expression: vapor_output(DYNAMIC_SIBLING)
+---
+errors=[]
+templates=["<li>Ready</li>", "<div><li><span> </span></li><footer>Tail</footer></div>"]
+code=
+import { child as _child, next as _next, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, setClass as _setClass, setProp as _setProp, setInsertionState as _setInsertionState, renderEffect as _renderEffect, createIf as _createIf, template as _template } from 'vue';
+const t0 = _template("<li>Ready</li>", true)
+const t1 = _template("<div><li><span> </span></li><footer>Tail</footer></div>", true)
+
+export function render(_ctx) {
+  const n2 = t1()
+  const n0 = _child(n2)
+  const n3 = _child(n0)
+  const n1 = _next(n0, 1)
+  const x3 = _txt(n3)
+  _setInsertionState(n2, null, true)
+  const n4 = _createIf(() => ((_ctx.status) === ('ready')), () => {
+    const n6 = t0()
+    return n6
+  })
+  _renderEffect(() => {
+    _setProp(n0, "id", _ctx.plainId)
+    _setText(x3, _toDisplayString(_ctx.label))
+    _setClass(n1, _ctx.cls)
+  })
+  return n2
+}

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__nested_patterned_template_child_dom_output.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__nested_patterned_template_child_dom_output.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_atelier_vapor/src/tests_template_children.rs
+expression: dom_output(NESTED)
+---
+errors=[]
+components=[]
+preamble=
+const { createElementVNode: _createElementVNode, normalizeClass: _normalizeClass, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, createCommentVNode: _createCommentVNode } = Vue
+
+code=
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, [
+    ((outer) === ('open'))
+      ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [
+        ((inner) === ('x'))
+          ? (_openBlock(), _createElementBlock("li", { key: 0 }, "X"))
+          : (_openBlock(), _createElementBlock("li", { key: 1 }, "Inner fallback"))
+      ], 64 /* STABLE_FRAGMENT */))
+      : (_openBlock(), _createElementBlock("p", { key: 1 }, "Outer fallback")),
+    _createElementVNode("footer", {
+      class: _normalizeClass(cls)
+    }, "tail", 2 /* CLASS */)
+  ]))
+}

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__nested_patterned_template_child_vapor_output.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__nested_patterned_template_child_vapor_output.snap
@@ -1,0 +1,34 @@
+---
+source: crates/vize_atelier_vapor/src/tests_template_children.rs
+expression: vapor_output(NESTED)
+---
+errors=[]
+templates=["<li>X</li>", "<li>Inner fallback</li>", "<p>Outer fallback</p>", "<div><footer>tail</footer></div>"]
+code=
+import { child as _child, setClass as _setClass, setInsertionState as _setInsertionState, renderEffect as _renderEffect, createIf as _createIf, template as _template } from 'vue';
+const t0 = _template("<li>X</li>")
+const t1 = _template("<li>Inner fallback</li>")
+const t2 = _template("<p>Outer fallback</p>", true)
+const t3 = _template("<div><footer>tail</footer></div>", true)
+
+export function render(_ctx) {
+  const n1 = t3()
+  const n0 = _child(n1)
+  _setInsertionState(n1, null, true)
+  const n2 = _createIf(() => ((_ctx.outer) === ('open')), () => {
+    _setInsertionState(n1, null, true)
+    const n4 = _createIf(() => ((_ctx.inner) === ('x')), () => {
+      const n6 = t0()
+      return n6
+    }, () => {
+      const n8 = t1()
+      return n8
+    })
+    return n4
+  }, () => {
+    const n10 = t2()
+    return n10
+  })
+  _renderEffect(() => _setClass(n0, _ctx.cls))
+  return n1
+}

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__nested_text_run_inside_patterned_template_dom_output.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__nested_text_run_inside_patterned_template_dom_output.snap
@@ -1,0 +1,20 @@
+---
+source: crates/vize_atelier_vapor/src/tests_template_children.rs
+expression: dom_output(TEXT_RUN)
+---
+errors=[]
+components=[]
+preamble=
+const { toDisplayString: _toDisplayString, createElementVNode: _createElementVNode, normalizeClass: _normalizeClass, openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode, createTextVNode: _createTextVNode } = Vue
+
+code=
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, [
+    [((status) === ('ready'))
+      ? (_openBlock(), _createElementBlock("li", { key: 0 }, "Ready"))
+      : _createCommentVNode("v-if", true), _createTextVNode("Before "), _toDisplayString(label), _createTextVNode(" after")],
+    _createElementVNode("footer", {
+      class: _normalizeClass(cls)
+    }, "Tail", 2 /* CLASS */)
+  ]))
+}

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__nested_text_run_inside_patterned_template_vapor_output.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__nested_text_run_inside_patterned_template_vapor_output.snap
@@ -1,0 +1,26 @@
+---
+source: crates/vize_atelier_vapor/src/tests_template_children.rs
+expression: vapor_output(TEXT_RUN)
+---
+errors=[]
+templates=["<li>Ready</li>", "<div>Before   after<footer>Tail</footer></div>"]
+code=
+import { child as _child, next as _next, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, setClass as _setClass, setInsertionState as _setInsertionState, renderEffect as _renderEffect, createIf as _createIf, template as _template } from 'vue';
+const t0 = _template("<li>Ready</li>", true)
+const t1 = _template("<div>Before   after<footer>Tail</footer></div>", true)
+
+export function render(_ctx) {
+  const n1 = t1()
+  const n0 = _next(_child(n1), 1)
+  const x1 = _txt(n1)
+  _setInsertionState(n1, null, true)
+  const n2 = _createIf(() => ((_ctx.status) === ('ready')), () => {
+    const n4 = t0()
+    return n4
+  })
+  _renderEffect(() => {
+    _setText(x1, "Before " + _toDisplayString(_ctx.label) + " after")
+    _setClass(n0, _ctx.cls)
+  })
+  return n1
+}

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__patterned_template_child_dom_output.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__patterned_template_child_dom_output.snap
@@ -1,0 +1,20 @@
+---
+source: crates/vize_atelier_vapor/src/tests_template_children.rs
+expression: dom_output(V_MATCH)
+---
+errors=[]
+components=[]
+preamble=
+const { toDisplayString: _toDisplayString, createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode } = Vue
+
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode("li", null, "Plain")
+
+code=
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, [
+    [((status) === ('ready'))
+      ? (_openBlock(), _createElementBlock("li", { key: 0 }, "Ready"))
+      : _createCommentVNode("v-if", true), _hoisted_1],
+    _createElementVNode("span", null, _toDisplayString(x), 1 /* TEXT */)
+  ]))
+}

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__patterned_template_child_vapor_output.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__patterned_template_child_vapor_output.snap
@@ -1,0 +1,23 @@
+---
+source: crates/vize_atelier_vapor/src/tests_template_children.rs
+expression: vapor_output(V_MATCH)
+---
+errors=[]
+templates=["<li>Ready</li>", "<div><li>Plain</li><span> </span></div>"]
+code=
+import { child as _child, next as _next, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, setInsertionState as _setInsertionState, renderEffect as _renderEffect, createIf as _createIf, template as _template } from 'vue';
+const t0 = _template("<li>Ready</li>", true)
+const t1 = _template("<div><li>Plain</li><span> </span></div>", true)
+
+export function render(_ctx) {
+  const n1 = t1()
+  const n0 = _next(_child(n1), 1)
+  const x0 = _txt(n0)
+  _setInsertionState(n1, null, true)
+  const n2 = _createIf(() => ((_ctx.status) === ('ready')), () => {
+    const n4 = t0()
+    return n4
+  })
+  _renderEffect(() => _setText(x0, _toDisplayString(_ctx.x)))
+  return n1
+}

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__separated_text_runs_inside_patterned_template_dom_output.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__separated_text_runs_inside_patterned_template_dom_output.snap
@@ -1,0 +1,19 @@
+---
+source: crates/vize_atelier_vapor/src/tests_template_children.rs
+expression: dom_output(SEPARATED_TEXT_RUNS)
+---
+errors=[]
+components=[]
+preamble=
+const { toDisplayString: _toDisplayString, createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode, createTextVNode: _createTextVNode } = Vue
+
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode("em", null, "mid")
+
+code=
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, [
+    [((status) === ('ready'))
+      ? (_openBlock(), _createElementBlock("li", { key: 0 }, "Ready"))
+      : _createCommentVNode("v-if", true), _createTextVNode("Before "), _toDisplayString(a), _hoisted_1, _createTextVNode("After "), _toDisplayString(b)]
+  ]))
+}

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__separated_text_runs_inside_patterned_template_vapor_output.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests_template_children__separated_text_runs_inside_patterned_template_vapor_output.snap
@@ -1,0 +1,26 @@
+---
+source: crates/vize_atelier_vapor/src/tests_template_children.rs
+expression: vapor_output(SEPARATED_TEXT_RUNS)
+---
+errors=[]
+templates=["<li>Ready</li>", "<div>Before  <em>mid</em>After  </div>"]
+code=
+import { child as _child, txt as _txt, toDisplayString as _toDisplayString, setText as _setText, nthChild as _nthChild, setInsertionState as _setInsertionState, renderEffect as _renderEffect, createIf as _createIf, template as _template } from 'vue';
+const t0 = _template("<li>Ready</li>", true)
+const t1 = _template("<div>Before  <em>mid</em>After  </div>", true)
+
+export function render(_ctx) {
+  const n0 = t1()
+  const n1 = _nthChild(n0, 2)
+  const x0 = _txt(n0)
+  _setInsertionState(n0, null, true)
+  const n2 = _createIf(() => ((_ctx.status) === ('ready')), () => {
+    const n4 = t0()
+    return n4
+  })
+  _renderEffect(() => {
+    _setText(x0, "Before " + _toDisplayString(_ctx.a))
+    _setText(n1, "After " + _toDisplayString(_ctx.b))
+  })
+  return n0
+}

--- a/crates/vize_atelier_vapor/src/tests_template_children.rs
+++ b/crates/vize_atelier_vapor/src/tests_template_children.rs
@@ -1,0 +1,162 @@
+//! Complete-output regressions for transparent `<template>` children (#3595).
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
+use super::{VaporCompilerOptions, compile_vapor};
+use vize_atelier_dom::{DomCompilerOptions, compile_template_with_options};
+use vize_carton::Bump;
+
+const V_MATCH: &str = r#"<div><ul v-match="status"><li v-case="'ready'">Ready</li><li>Plain</li></ul><span>{{ x }}</span></div>"#;
+const DYNAMIC_SIBLING: &str = r#"<div><ul v-match="status"><li v-case="'ready'">Ready</li><li :id="plainId"><span>{{ label }}</span></li></ul><footer :class="cls">Tail</footer></div>"#;
+const NESTED: &str = r#"<div><section v-match="outer"><ul v-case="'open'" v-match="inner"><li v-case="'x'">X</li><li v-case.default>Inner fallback</li></ul><p v-case.default>Outer fallback</p></section><footer :class="cls">tail</footer></div>"#;
+const CONTROL_FLOW: &str = r#"<div><aside v-if="aside">Aside</aside><ul v-match="status"><li v-case="'ready'" v-for="item in items" :key="item.id" :class="item.kind">{{ item.label }}</li><li v-case.default>Empty</li></ul><p>Last</p></div>"#;
+const TEXT_RUN: &str = r#"<div><ul v-match="status"><li v-case="'ready'">Ready</li>Before {{ label }} after</ul><footer :class="cls">Tail</footer></div>"#;
+const SEPARATED_TEXT_RUNS: &str = r#"<div><ul v-match="status"><li v-case="'ready'">Ready</li>Before {{ a }}<em>mid</em>After {{ b }}</ul></div>"#;
+
+fn vapor_output(source: &str) -> std::string::String {
+    let allocator = Bump::new();
+    let result = compile_vapor(
+        &allocator,
+        source,
+        VaporCompilerOptions {
+            experimental_patterned_template: true,
+            ..Default::default()
+        },
+    );
+    format!(
+        "errors={:?}\ntemplates={:?}\ncode=\n{}",
+        result.error_messages, result.templates, result.code
+    )
+}
+
+fn dom_output(source: &str) -> std::string::String {
+    let allocator = Bump::new();
+    let (root, errors, result) = compile_template_with_options(
+        &allocator,
+        source,
+        DomCompilerOptions {
+            experimental_patterned_template: true,
+            ..Default::default()
+        },
+    );
+    format!(
+        "errors={:?}\ncomponents={:?}\npreamble=\n{}\ncode=\n{}",
+        errors, root.components, result.preamble, result.code
+    )
+}
+
+#[test]
+fn patterned_template_child_vapor_output() {
+    insta::assert_snapshot!(vapor_output(V_MATCH));
+}
+
+#[test]
+fn patterned_template_child_dom_output() {
+    insta::assert_snapshot!(dom_output(V_MATCH));
+}
+
+#[test]
+fn dynamic_sibling_inside_patterned_template_vapor_output() {
+    insta::assert_snapshot!(vapor_output(DYNAMIC_SIBLING));
+}
+
+#[test]
+fn dynamic_sibling_inside_patterned_template_dom_output() {
+    insta::assert_snapshot!(dom_output(DYNAMIC_SIBLING));
+}
+
+#[test]
+fn nested_patterned_template_child_vapor_output() {
+    insta::assert_snapshot!(vapor_output(NESTED));
+}
+
+#[test]
+fn nested_patterned_template_child_dom_output() {
+    insta::assert_snapshot!(dom_output(NESTED));
+}
+
+#[test]
+fn adjacent_control_flow_and_keyed_pattern_vapor_output() {
+    insta::assert_snapshot!(vapor_output(CONTROL_FLOW));
+}
+
+#[test]
+fn adjacent_control_flow_and_keyed_pattern_dom_output() {
+    insta::assert_snapshot!(dom_output(CONTROL_FLOW));
+}
+
+#[test]
+fn nested_text_run_inside_patterned_template_vapor_output() {
+    insta::assert_snapshot!(vapor_output(TEXT_RUN));
+}
+
+#[test]
+fn nested_text_run_inside_patterned_template_dom_output() {
+    insta::assert_snapshot!(dom_output(TEXT_RUN));
+}
+
+#[test]
+fn separated_text_runs_inside_patterned_template_vapor_output() {
+    insta::assert_snapshot!(vapor_output(SEPARATED_TEXT_RUNS));
+}
+
+#[test]
+fn separated_text_runs_inside_patterned_template_dom_output() {
+    insta::assert_snapshot!(dom_output(SEPARATED_TEXT_RUNS));
+}
+
+const DEEP_TEMPLATE_DEPTH: usize = 1100;
+const SMALL_STACK: usize = 256 * 1024;
+
+fn vapor_output_on_small_stack(source: std::string::String) -> std::string::String {
+    std::thread::Builder::new()
+        .stack_size(SMALL_STACK)
+        .spawn(move || vapor_output(&source))
+        .expect("spawn small-stack compiler thread")
+        .join()
+        .expect("small-stack compiler thread finished")
+}
+
+fn deeply_nested_template_source(wrapped: bool) -> std::string::String {
+    let mut source = if wrapped {
+        std::string::String::from("<div>")
+    } else {
+        std::string::String::new()
+    };
+    for _ in 0..DEEP_TEMPLATE_DEPTH {
+        source.push_str("<template>");
+    }
+    source.push_str(r#"<ul v-match="status"><li v-case="'ready'">Ready</li>{{ label }}</ul>"#);
+    for _ in 0..DEEP_TEMPLATE_DEPTH {
+        source.push_str("</template>");
+    }
+    if wrapped {
+        source.push_str("</div>");
+    }
+    source
+}
+
+#[test]
+fn deeply_nested_transparent_templates_compile_on_a_small_stack() {
+    // Match the depth/stack ratio used by the whole-pipeline regression in
+    // vize_atelier_dom: an ordinary recursive walk exhausts this stack well
+    // before reaching the innermost patterned child.
+    let output = vapor_output_on_small_stack(deeply_nested_template_source(false));
+
+    assert!(output.starts_with("errors=[]"), "{output}");
+    assert!(
+        !output.contains("resolveComponent(\"template\")"),
+        "{output}"
+    );
+    assert!(output.contains("_toDisplayString(_ctx.label)"), "{output}");
+}
+
+#[test]
+fn deeply_nested_deferred_template_chain_compiles_on_a_small_stack() {
+    let output = vapor_output_on_small_stack(deeply_nested_template_source(true));
+    assert!(output.starts_with("errors=[]"), "{output}");
+    assert!(
+        !output.contains("resolveComponent(\"template\")"),
+        "{output}"
+    );
+    assert!(output.contains("_toDisplayString(_ctx.label)"), "{output}");
+}

--- a/crates/vize_atelier_vapor/src/transform/element.rs
+++ b/crates/vize_atelier_vapor/src/transform/element.rs
@@ -7,7 +7,7 @@ mod deferred;
 #[path = "element/template.rs"]
 mod template;
 
-use vize_carton::{Box, String, Vec, append, cstr};
+use vize_carton::{Box, String, Vec, append, cstr, ensure_sufficient_stack};
 
 use crate::ir::{
     BlockIRNode, ChildRefIRNode, ComponentKind, CreateComponentIRNode, IRProp, IRSlot,
@@ -57,7 +57,7 @@ pub(crate) fn transform_element<'a>(
         for child in el.children.iter() {
             match child {
                 TemplateChildNode::Element(child_el) => {
-                    transform_element(ctx, child_el, block);
+                    ensure_sufficient_stack(|| transform_element(ctx, child_el, block));
                 }
                 TemplateChildNode::Text(text) => {
                     transform_text(ctx, text, block);
@@ -143,22 +143,7 @@ pub(crate) fn transform_element<'a>(
 
             transform_template_ref(ctx, el, element_id, block);
 
-            // Check if we have mixed text and interpolation children
-            let has_text_or_interpolation = el.children.iter().any(|c| {
-                matches!(
-                    c,
-                    TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_)
-                )
-            });
-            let has_interpolation = el
-                .children
-                .iter()
-                .any(|c| matches!(c, TemplateChildNode::Interpolation(_)));
-
-            if has_interpolation && has_text_or_interpolation {
-                // Collect all text parts and interpolations together
-                transform_text_children(ctx, &el.children, element_id, block);
-            }
+            transform_text_children(ctx, &el.children, element_id, block);
 
             // Register template (no deferred children to process)
             ctx.add_template(element_id, template);

--- a/crates/vize_atelier_vapor/src/transform/element/deferred.rs
+++ b/crates/vize_atelier_vapor/src/transform/element/deferred.rs
@@ -1,6 +1,7 @@
 //! Deferred child ID allocation for dynamic and control-flow descendants.
 
 use crate::ir::{ForIRNode, IfIRNode, InsertNodeIRNode, NegativeBranch};
+use vize_carton::ensure_sufficient_stack;
 
 use super::component::transform_component;
 use super::template::{
@@ -26,13 +27,10 @@ pub(super) fn transform_element_with_control_flow_children<'a>(
     block: &mut BlockIRNode<'a>,
 ) {
     let template = generate_element_template(el);
-    let dynamic_child_indices = collect_dynamic_child_indices(el);
-    let child_ids: std::vec::Vec<usize> = dynamic_child_indices
-        .iter()
-        .map(|_| ctx.next_id())
-        .collect();
+    let dynamic_child_count = count_dynamic_element_children(&el.children);
+    let child_ids: std::vec::Vec<usize> = (0..dynamic_child_count).map(|_| ctx.next_id()).collect();
 
-    if dynamic_child_indices.is_empty() {
+    if child_ids.is_empty() {
         transform_element_with_deferred_control_flow_parent(ctx, el, block, template);
         return;
     }
@@ -53,31 +51,10 @@ pub(super) fn transform_element_with_control_flow_children<'a>(
 
     transform_template_ref(ctx, el, element_id, block);
 
-    // Handle text content if needed
-    let has_text_or_interpolation = el.children.iter().any(|c| {
-        matches!(
-            c,
-            TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_)
-        )
-    });
-    let has_interpolation = el
-        .children
-        .iter()
-        .any(|c| matches!(c, TemplateChildNode::Interpolation(_)));
+    transform_text_children(ctx, &el.children, element_id, block);
 
-    if has_interpolation && has_text_or_interpolation {
-        transform_text_children(ctx, &el.children, element_id, block);
-    }
-
-    if !dynamic_child_indices.is_empty() {
-        transform_dynamic_children_with_ids(
-            ctx,
-            el,
-            element_id,
-            block,
-            &dynamic_child_indices,
-            &child_ids,
-        );
+    if !child_ids.is_empty() {
+        transform_dynamic_children_with_ids(ctx, el, element_id, block, &child_ids);
     }
 
     transform_existing_element_control_flow_children(ctx, el, element_id, block);
@@ -110,20 +87,7 @@ fn transform_element_with_deferred_control_flow_parent<'a>(
 
     transform_template_ref(ctx, el, element_id, block);
 
-    let has_text_or_interpolation = el.children.iter().any(|c| {
-        matches!(
-            c,
-            TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_)
-        )
-    });
-    let has_interpolation = el
-        .children
-        .iter()
-        .any(|c| matches!(c, TemplateChildNode::Interpolation(_)));
-
-    if has_interpolation && has_text_or_interpolation {
-        transform_text_children(ctx, &el.children, element_id, block);
-    }
+    transform_text_children(ctx, &el.children, element_id, block);
 
     append_deferred_control_flow_children(block, deferred_children, element_id);
 
@@ -140,11 +104,8 @@ pub(super) fn transform_element_with_dynamic_children<'a>(
     el: &ElementNode<'a>,
     block: &mut BlockIRNode<'a>,
 ) {
-    let dynamic_child_indices = collect_dynamic_child_indices(el);
-    let child_ids: std::vec::Vec<usize> = dynamic_child_indices
-        .iter()
-        .map(|_| ctx.next_id())
-        .collect();
+    let dynamic_child_count = count_dynamic_element_children(&el.children);
+    let child_ids: std::vec::Vec<usize> = (0..dynamic_child_count).map(|_| ctx.next_id()).collect();
 
     // Now allocate parent ID (will be higher than all child IDs)
     let parent_id = ctx.next_id();
@@ -163,15 +124,10 @@ pub(super) fn transform_element_with_dynamic_children<'a>(
     }
 
     transform_template_ref(ctx, el, parent_id, block);
+    transform_text_children(ctx, &el.children, parent_id, block);
 
-    transform_dynamic_children_with_ids(
-        ctx,
-        el,
-        parent_id,
-        block,
-        &dynamic_child_indices,
-        &child_ids,
-    );
+    transform_dynamic_children_with_ids(ctx, el, parent_id, block, &child_ids);
+    transform_existing_element_control_flow_children(ctx, el, parent_id, block);
 
     // Register template for parent
     ctx.add_template(parent_id, template);
@@ -179,16 +135,17 @@ pub(super) fn transform_element_with_dynamic_children<'a>(
     block.returns.push(parent_id);
 }
 
-fn collect_dynamic_child_indices(el: &ElementNode<'_>) -> std::vec::Vec<usize> {
-    let mut dynamic_child_indices = std::vec::Vec::new();
-    for (i, child) in el.children.iter().enumerate() {
-        if let TemplateChildNode::Element(child_el) = child
-            && !is_static_element(child_el)
-        {
-            dynamic_child_indices.push(i);
-        }
-    }
-    dynamic_child_indices
+fn count_dynamic_element_children(children: &[TemplateChildNode<'_>]) -> usize {
+    children
+        .iter()
+        .map(|child| match child {
+            TemplateChildNode::Element(child_el) if child_el.tag_type == ElementType::Template => {
+                ensure_sufficient_stack(|| count_dynamic_element_children(&child_el.children))
+            }
+            TemplateChildNode::Element(child_el) if !is_static_element(child_el) => 1,
+            _ => 0,
+        })
+        .sum()
 }
 
 fn transform_dynamic_children_with_ids<'a>(
@@ -196,50 +153,113 @@ fn transform_dynamic_children_with_ids<'a>(
     el: &ElementNode<'a>,
     parent_id: usize,
     block: &mut BlockIRNode<'a>,
-    dynamic_child_indices: &[usize],
     child_ids: &[usize],
 ) {
     // (child id, absolute rendered index within the parent)
     let mut prev_template_backed_child: Option<(usize, usize)> = None;
+    let mut child_id_index = 0usize;
+    let mut rendered_index = 0usize;
+    let mut in_text_run = false;
+    transform_dynamic_children_in_slice(
+        ctx,
+        &el.children,
+        parent_id,
+        block,
+        child_ids,
+        &mut child_id_index,
+        &mut rendered_index,
+        &mut in_text_run,
+        &mut prev_template_backed_child,
+    );
+    debug_assert_eq!(child_id_index, child_ids.len());
+}
 
-    for (idx, &child_index) in dynamic_child_indices.iter().enumerate() {
-        let child_id = child_ids[idx];
-        let TemplateChildNode::Element(child_el) = &el.children[child_index] else {
+#[allow(clippy::too_many_arguments)]
+fn transform_dynamic_children_in_slice<'a>(
+    ctx: &mut TransformContext<'a>,
+    children: &[TemplateChildNode<'a>],
+    parent_id: usize,
+    block: &mut BlockIRNode<'a>,
+    child_ids: &[usize],
+    child_id_index: &mut usize,
+    rendered_index: &mut usize,
+    in_text_run: &mut bool,
+    prev_template_backed_child: &mut Option<(usize, usize)>,
+) {
+    for child in children {
+        let TemplateChildNode::Element(child_el) = child else {
+            if matches!(
+                child,
+                TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_)
+            ) && !*in_text_run
+            {
+                *rendered_index += 1;
+                *in_text_run = true;
+            }
             continue;
         };
 
-        if is_template_backed_element(child_el) {
-            let index = count_rendered_child_nodes(&el.children, 0, child_index).saturating_sub(1);
-            if let Some((prev_child_id, prev_index)) = prev_template_backed_child {
-                block.operation.push(OperationNode::NextRef(NextRefIRNode {
-                    child_id,
-                    prev_id: prev_child_id,
-                    offset: index.saturating_sub(prev_index),
-                }));
-            } else {
-                block
-                    .operation
-                    .push(OperationNode::ChildRef(ChildRefIRNode {
-                        child_id,
-                        parent_id,
-                        offset: index,
-                    }));
-            }
+        if child_el.tag_type == ElementType::Template {
+            ensure_sufficient_stack(|| {
+                transform_dynamic_children_in_slice(
+                    ctx,
+                    &child_el.children,
+                    parent_id,
+                    block,
+                    child_ids,
+                    child_id_index,
+                    rendered_index,
+                    in_text_run,
+                    prev_template_backed_child,
+                );
+            });
+            continue;
+        }
 
-            prev_template_backed_child = Some((child_id, index));
-            transform_existing_element(ctx, child_el, child_id, block);
-        } else if child_el.tag_type == ElementType::Slot {
-            transform_slot_outlet_child(ctx, child_el, child_id, parent_id, block);
-        } else {
-            transform_component(
-                ctx,
-                child_el,
-                block,
-                Some(child_id),
-                Some(parent_id),
-                None,
-                false,
-            );
+        if !is_static_element(child_el) {
+            let child_id = child_ids[*child_id_index];
+            *child_id_index += 1;
+
+            if is_template_backed_element(child_el) {
+                let index = *rendered_index;
+                if let Some((prev_child_id, prev_index)) = *prev_template_backed_child {
+                    block.operation.push(OperationNode::NextRef(NextRefIRNode {
+                        child_id,
+                        prev_id: prev_child_id,
+                        offset: index.saturating_sub(prev_index),
+                    }));
+                } else {
+                    block
+                        .operation
+                        .push(OperationNode::ChildRef(ChildRefIRNode {
+                            child_id,
+                            parent_id,
+                            offset: index,
+                        }));
+                }
+
+                *prev_template_backed_child = Some((child_id, index));
+                ensure_sufficient_stack(|| {
+                    transform_existing_element(ctx, child_el, child_id, block);
+                });
+            } else if child_el.tag_type == ElementType::Slot {
+                transform_slot_outlet_child(ctx, child_el, child_id, parent_id, block);
+            } else {
+                transform_component(
+                    ctx,
+                    child_el,
+                    block,
+                    Some(child_id),
+                    Some(parent_id),
+                    None,
+                    false,
+                );
+            }
+        }
+
+        if is_template_backed_element(child_el) {
+            *rendered_index += 1;
+            *in_text_run = false;
         }
     }
 }
@@ -277,14 +297,7 @@ fn transform_existing_element<'a>(
     element_id: usize,
     block: &mut BlockIRNode<'a>,
 ) {
-    let has_control_flow_children = el
-        .children
-        .iter()
-        .any(|c| matches!(c, TemplateChildNode::If(_) | TemplateChildNode::For(_)));
-    let has_dynamic_element_children = el
-        .children
-        .iter()
-        .any(|c| matches!(c, TemplateChildNode::Element(child_el) if !is_static_element(child_el)));
+    let dynamic_child_count = count_dynamic_element_children(&el.children);
 
     for prop in el.props.iter() {
         if let PropNode::Directive(dir) = prop {
@@ -294,39 +307,43 @@ fn transform_existing_element<'a>(
 
     transform_template_ref(ctx, el, element_id, block);
 
-    let has_text_or_interpolation = el.children.iter().any(|c| {
-        matches!(
-            c,
-            TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_)
-        )
-    });
-    let has_interpolation = el
-        .children
-        .iter()
-        .any(|c| matches!(c, TemplateChildNode::Interpolation(_)));
+    transform_text_children(ctx, &el.children, element_id, block);
 
-    if has_interpolation && has_text_or_interpolation {
-        transform_text_children(ctx, &el.children, element_id, block);
+    if dynamic_child_count != 0 {
+        let child_ids: std::vec::Vec<usize> =
+            (0..dynamic_child_count).map(|_| ctx.next_id()).collect();
+        transform_dynamic_children_with_ids(ctx, el, element_id, block, &child_ids);
     }
 
-    if has_dynamic_element_children {
-        let dynamic_child_indices = collect_dynamic_child_indices(el);
-        let child_ids: std::vec::Vec<usize> = dynamic_child_indices
-            .iter()
-            .map(|_| ctx.next_id())
-            .collect();
-        transform_dynamic_children_with_ids(
-            ctx,
-            el,
-            element_id,
-            block,
-            &dynamic_child_indices,
-            &child_ids,
-        );
-    }
+    transform_existing_element_control_flow_children(ctx, el, element_id, block);
+}
 
-    if has_control_flow_children {
-        transform_existing_element_control_flow_children(ctx, el, element_id, block);
+fn transform_control_flow_children_into_parent<'a>(
+    ctx: &mut TransformContext<'a>,
+    children: &[TemplateChildNode<'a>],
+    parent_id: usize,
+    block: &mut BlockIRNode<'a>,
+) {
+    for child in children {
+        match child {
+            TemplateChildNode::If(if_node) => {
+                transform_if_node_into_parent(ctx, if_node, block, parent_id);
+            }
+            TemplateChildNode::For(for_node) => {
+                transform_for_node_into_parent(ctx, for_node, block, parent_id);
+            }
+            TemplateChildNode::Element(template) if template.tag_type == ElementType::Template => {
+                ensure_sufficient_stack(|| {
+                    transform_control_flow_children_into_parent(
+                        ctx,
+                        &template.children,
+                        parent_id,
+                        block,
+                    );
+                });
+            }
+            _ => {}
+        }
     }
 }
 
@@ -336,17 +353,7 @@ fn transform_existing_element_control_flow_children<'a>(
     element_id: usize,
     block: &mut BlockIRNode<'a>,
 ) {
-    for child in el.children.iter() {
-        match child {
-            TemplateChildNode::If(if_node) => {
-                transform_if_node_into_parent(ctx, if_node, block, element_id);
-            }
-            TemplateChildNode::For(for_node) => {
-                transform_for_node_into_parent(ctx, for_node, block, element_id);
-            }
-            _ => {}
-        }
-    }
+    transform_control_flow_children_into_parent(ctx, &el.children, element_id, block);
 }
 
 fn transform_deferred_parent_control_flow_children<'a>(
@@ -361,6 +368,11 @@ fn transform_deferred_parent_control_flow_children<'a>(
             }
             TemplateChildNode::For(for_node) => {
                 transform_for_node_deferred_parent(ctx, for_node, block);
+            }
+            TemplateChildNode::Element(template) if template.tag_type == ElementType::Template => {
+                ensure_sufficient_stack(|| {
+                    transform_deferred_parent_control_flow_children(ctx, template, block);
+                });
             }
             _ => {}
         }
@@ -398,45 +410,4 @@ fn set_if_parent(if_node: &mut IfIRNode<'_>, parent_id: usize) {
 
 fn set_for_parent(for_node: &mut ForIRNode<'_>, parent_id: usize) {
     for_node.parent = Some(parent_id);
-}
-
-fn count_rendered_child_nodes(
-    children: &[TemplateChildNode<'_>],
-    start: usize,
-    end: usize,
-) -> usize {
-    let mut count = 0usize;
-    let mut in_text_run = false;
-    for child in &children[start..=end] {
-        count += count_rendered_nodes_for_child(child, &mut in_text_run);
-    }
-    count
-}
-
-fn count_rendered_nodes_for_child(child: &TemplateChildNode<'_>, in_text_run: &mut bool) -> usize {
-    match child {
-        TemplateChildNode::Element(child_el) => {
-            if child_el.tag_type == ElementType::Template {
-                child_el
-                    .children
-                    .iter()
-                    .map(|child| count_rendered_nodes_for_child(child, in_text_run))
-                    .sum()
-            } else if is_template_backed_element(child_el) {
-                *in_text_run = false;
-                1
-            } else {
-                0
-            }
-        }
-        TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_) => {
-            if *in_text_run {
-                0
-            } else {
-                *in_text_run = true;
-                1
-            }
-        }
-        _ => 0,
-    }
 }

--- a/crates/vize_atelier_vapor/src/transform/element/template.rs
+++ b/crates/vize_atelier_vapor/src/transform/element/template.rs
@@ -5,6 +5,7 @@ use super::{
     SetTemplateRefIRNode, SimpleExpressionNode, String, TemplateChildNode, TransformContext,
     append, cstr,
 };
+use vize_carton::ensure_sufficient_stack;
 
 /// Generate element template string (recursively includes static children)
 pub(crate) fn generate_element_template(el: &ElementNode<'_>) -> String {
@@ -50,29 +51,38 @@ pub(crate) fn generate_element_template(el: &ElementNode<'_>) -> String {
     } else {
         template.push('>');
 
-        // Recursively add template-backed children. Interpolations contribute a
-        // text placeholder while control-flow nodes are inserted at runtime.
-        for child in el.children.iter() {
-            match child {
-                TemplateChildNode::Text(text) => {
-                    template.push_str(&escape_html_text(&text.content));
-                }
-                TemplateChildNode::Interpolation(_) => {
-                    template.push(' ');
-                }
-                TemplateChildNode::Element(child_el) => {
-                    if is_template_backed_element(child_el) {
-                        template.push_str(&generate_element_template(child_el));
-                    }
-                }
-                _ => {}
-            }
-        }
+        // Recursively add template-backed children. `<template>` is a
+        // transparent wrapper in Vapor just as it is in the main element
+        // dispatcher, so its children contribute directly to the enclosing
+        // element's static template instead of producing a component lookup.
+        append_child_templates(&mut template, &el.children);
 
         append!(template, "</{}>", el.tag);
     }
 
     template
+}
+
+fn append_child_templates(template: &mut String, children: &[TemplateChildNode<'_>]) {
+    for child in children {
+        match child {
+            TemplateChildNode::Text(text) => {
+                template.push_str(&escape_html_text(&text.content));
+            }
+            TemplateChildNode::Interpolation(_) => {
+                template.push(' ');
+            }
+            TemplateChildNode::Element(child_el) if child_el.tag_type == ElementType::Template => {
+                ensure_sufficient_stack(|| append_child_templates(template, &child_el.children));
+            }
+            TemplateChildNode::Element(child_el) if is_template_backed_element(child_el) => {
+                let child_template =
+                    ensure_sufficient_stack(|| generate_element_template(child_el));
+                template.push_str(&child_template);
+            }
+            _ => {}
+        }
+    }
 }
 
 /// Escape HTML special characters in text content (vuejs/core #14310)
@@ -112,7 +122,7 @@ pub(crate) fn is_static_element(el: &ElementNode<'_>) -> bool {
         match child {
             TemplateChildNode::Interpolation(_) => return false,
             TemplateChildNode::Element(child_el) => {
-                if !is_static_element(child_el) {
+                if !ensure_sufficient_stack(|| is_static_element(child_el)) {
                     return false;
                 }
             }

--- a/crates/vize_atelier_vapor/src/transform/text.rs
+++ b/crates/vize_atelier_vapor/src/transform/text.rs
@@ -2,12 +2,12 @@
 //!
 //! Handles `TextNode`, `InterpolationNode`, and mixed text/interpolation children.
 
-use vize_carton::{Box, Vec};
+use vize_carton::{Box, Vec, ensure_sufficient_stack};
 
-use crate::ir::{BlockIRNode, OperationNode, SetTextIRNode};
+use crate::ir::{BlockIRNode, ChildRefIRNode, OperationNode, SetTextIRNode};
 use vize_atelier_core::{
-    ExpressionNode, InterpolationNode, SimpleExpressionNode, SourceLocation, TemplateChildNode,
-    TextNode,
+    ElementType, ExpressionNode, InterpolationNode, SimpleExpressionNode, SourceLocation,
+    TemplateChildNode, TextNode,
 };
 
 use super::context::TransformContext;
@@ -70,20 +70,50 @@ pub(crate) fn transform_text_children<'a>(
     block: &mut BlockIRNode<'a>,
 ) {
     let mut values = Vec::new_in(ctx.allocator);
+    let mut has_interpolation = false;
+    let mut run_index = None;
+    let mut rendered_index = 0usize;
+    collect_text_runs(
+        ctx,
+        children,
+        parent_element_id,
+        block,
+        &mut values,
+        &mut has_interpolation,
+        &mut run_index,
+        &mut rendered_index,
+    );
+    flush_text_run(
+        ctx,
+        parent_element_id,
+        block,
+        &mut values,
+        &mut has_interpolation,
+        &mut run_index,
+    );
+}
 
-    // Collect all text parts and interpolations
-    for child in children.iter() {
+#[allow(clippy::too_many_arguments)]
+fn collect_text_runs<'a>(
+    ctx: &mut TransformContext<'a>,
+    children: &[TemplateChildNode<'a>],
+    parent_element_id: usize,
+    block: &mut BlockIRNode<'a>,
+    values: &mut Vec<'a, Box<'a, SimpleExpressionNode<'a>>>,
+    has_interpolation: &mut bool,
+    run_index: &mut Option<usize>,
+    rendered_index: &mut usize,
+) {
+    for child in children {
         match child {
             TemplateChildNode::Text(text) => {
-                // Static text part
-                let exp = SimpleExpressionNode::new(
-                    text.content.clone(),
-                    true, // is_static = true
-                    SourceLocation::STUB,
-                );
+                begin_text_run(run_index, rendered_index);
+                let exp =
+                    SimpleExpressionNode::new(text.content.clone(), true, SourceLocation::STUB);
                 values.push(Box::new_in(exp, ctx.allocator));
             }
             TemplateChildNode::Interpolation(interp) => {
+                begin_text_run(run_index, rendered_index);
                 // Dynamic interpolation
                 if let ExpressionNode::Simple(simple) = &interp.content {
                     let exp = SimpleExpressionNode::new(
@@ -92,18 +122,82 @@ pub(crate) fn transform_text_children<'a>(
                         simple.loc.clone(),
                     );
                     values.push(Box::new_in(exp, ctx.allocator));
+                    *has_interpolation = true;
                 }
+            }
+            TemplateChildNode::Element(template) if template.tag_type == ElementType::Template => {
+                ensure_sufficient_stack(|| {
+                    collect_text_runs(
+                        ctx,
+                        &template.children,
+                        parent_element_id,
+                        block,
+                        values,
+                        has_interpolation,
+                        run_index,
+                        rendered_index,
+                    );
+                });
+            }
+            TemplateChildNode::Element(element) if element.tag_type == ElementType::Element => {
+                flush_text_run(
+                    ctx,
+                    parent_element_id,
+                    block,
+                    values,
+                    has_interpolation,
+                    run_index,
+                );
+                *rendered_index += 1;
             }
             _ => {}
         }
     }
+}
 
-    if !values.is_empty() {
-        let set_text = SetTextIRNode {
-            element: parent_element_id,
-            values,
-        };
-
-        ctx.push_dynamic_operation(block, OperationNode::SetText(set_text));
+fn begin_text_run(run_index: &mut Option<usize>, rendered_index: &mut usize) {
+    if run_index.is_none() {
+        *run_index = Some(*rendered_index);
+        *rendered_index += 1;
     }
+}
+
+fn flush_text_run<'a>(
+    ctx: &mut TransformContext<'a>,
+    parent_element_id: usize,
+    block: &mut BlockIRNode<'a>,
+    values: &mut Vec<'a, Box<'a, SimpleExpressionNode<'a>>>,
+    has_interpolation: &mut bool,
+    run_index: &mut Option<usize>,
+) {
+    let Some(offset) = run_index.take() else {
+        return;
+    };
+    if *has_interpolation {
+        let text_id = if offset == 0 {
+            parent_element_id
+        } else {
+            let text_id = ctx.next_id();
+            block
+                .operation
+                .push(OperationNode::ChildRef(ChildRefIRNode {
+                    child_id: text_id,
+                    parent_id: parent_element_id,
+                    offset,
+                }));
+            ctx.standalone_text_elements.insert(text_id);
+            text_id
+        };
+        let run_values = std::mem::replace(values, Vec::new_in(ctx.allocator));
+        ctx.push_dynamic_operation(
+            block,
+            OperationNode::SetText(SetTextIRNode {
+                element: text_id,
+                values: run_values,
+            }),
+        );
+    } else {
+        values.clear();
+    }
+    *has_interpolation = false;
 }


### PR DESCRIPTION
## Summary

- splice transparent `<template>` descendants into Vapor deferred-element templates instead of resolving `template` as a component
- lower nested dynamic elements, control flow, and distinct text runs in rendered order
- grow deep transparent traversals onto a safe stack while preserving existing common-path output

## Regression coverage

- complete DOM and Vapor output for patterned, nested, dynamic-sibling, keyed control-flow, adjacent text, and element-separated text-run cases
- two 1,100-level regressions on a 256 KiB worker stack, covering top-level and deferred transparent-template traversal
- no `resolveComponent("template")` output

## Validation

- `cargo test -p vize_atelier_vapor` (123 passed)
- `cargo clippy -p vize_atelier_vapor --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #3595

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of transparent templates containing dynamic content, nested structures, control flow, keyed elements, and mixed text.
  * Preserved correct child ordering, text updates, and dynamic content references across nested templates.
  * Added safeguards to prevent failures when compiling deeply nested templates.

* **Tests**
  * Added cross-renderer regression coverage for template children, text runs, and deeply nested structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->