### PR TITLE
fix(canon): reject unmapped SFC diagnostic positions

### DIFF
--- a/crates/vize_canon/src/batch/source_map.rs
+++ b/crates/vize_canon/src/batch/source_map.rs
@@ -130,16 +130,16 @@ impl CompositeSourceMap {
     ///
     /// The mapping order is:
     /// 1. Import rewrite mapping (materialized TS -> original TS with `.vue` specifiers)
-    /// 2. SFC mapping (virtual TS -> SFC source)
+    /// 2. SFC mapping (virtual TS -> SFC source); unmapped SFC positions are rejected
     pub fn get_original_position(
         &self,
         virtual_offset: u32,
     ) -> Option<(u32, u32, Option<SfcBlockType>)> {
         let after_import = self.import_map.get_original_offset(virtual_offset);
-        if let Some(ref sfc_map) = self.sfc_map
-            && let Some((offset, column, block)) = sfc_map.get_original_position(after_import)
-        {
-            return Some((offset, column, Some(block)));
+        if let Some(ref sfc_map) = self.sfc_map {
+            return sfc_map
+                .get_original_position(after_import)
+                .map(|(offset, column, block)| (offset, column, Some(block)));
         }
         Some((after_import, 0, None))
     }
@@ -333,13 +333,16 @@ mod tests {
     }
 
     #[test]
-    fn test_composite_source_map() {
-        let sfc_map = SfcSourceMap::empty();
+    fn composite_source_map_only_uses_identity_fallback_for_plain_scripts() {
         let import_map = ImportSourceMap::empty();
-        let composite = CompositeSourceMap::new_vue(sfc_map, import_map);
-
-        // Should return position even without mappings
-        let result = composite.get_original_position(50);
-        assert!(result.is_some());
+        assert_eq!(
+            CompositeSourceMap::new_script(import_map).get_original_position(50),
+            Some((50, 0, None))
+        );
+        assert_eq!(
+            CompositeSourceMap::new_vue(SfcSourceMap::empty(), ImportSourceMap::empty())
+                .get_original_position(50),
+            None
+        );
     }
 }

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
@@ -11,6 +11,7 @@ mod sequence_prop_expressions;
 mod spread_props;
 mod spread_scope_bindings;
 mod ts_extension_substitution;
+mod unmapped_template_fallback;
 #[test]
 fn issue_2645_infers_generic_sfc_props_in_tsx() {
     if resolve_test_tsgo_binary().is_none() {

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/unmapped_template_fallback.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/unmapped_template_fallback.rs
@@ -1,0 +1,71 @@
+//! Synthetic template diagnostics must never use virtual offsets as SFC positions.
+
+use super::super::{
+    BatchTypeChecker, create_project_case, relative_path, resolve_test_tsgo_binary,
+};
+use crate::batch::{SfcBlockType, TypeChecker};
+use vize_carton::{String, cstr};
+
+#[test]
+fn unmapped_v_if_guard_does_not_duplicate_into_a_long_style_block() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let mut source = String::from(
+        r#"<template>
+  <section v-for="foods in menuList">
+    <ul v-if="foods.attributes.length">
+      <li v-if="attribute" v-for="(attribute, index) in foods.attributes" :key="index">
+        {{ attribute }}
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup lang="ts">
+const menuList = [{ attributes: ["size"] }];
+</script>
+
+<style>
+"#,
+    );
+    source.push_str(&".row { color: red; }\n".repeat(2_000));
+    source.push_str("</style>\n");
+    let project_root = create_project_case(
+        "unmapped-template-fallback",
+        &[("src/App.vue", source.as_str())],
+    );
+    let mut checker =
+        BatchTypeChecker::new(&project_root).expect("batch type checker construction");
+    checker.scan_project().expect("project scan");
+    let result = checker.check_project().expect("project check");
+
+    let diagnostics: Vec<_> = result
+        .diagnostics
+        .into_iter()
+        .map(|diagnostic| {
+            (
+                relative_path(&project_root, &diagnostic.file),
+                diagnostic.code,
+                diagnostic.message,
+                diagnostic.line + 1,
+                diagnostic.column + 1,
+                diagnostic.block_type,
+            )
+        })
+        .collect();
+    let _ = std::fs::remove_dir_all(&project_root);
+
+    assert_eq!(
+        diagnostics,
+        vec![(
+            cstr!("src/App.vue"),
+            Some(2304),
+            cstr!("Cannot find name 'attribute'."),
+            4,
+            17,
+            Some(SfcBlockType::Template),
+        )]
+    );
+}

--- a/tests/snapshots/check/__snapshots__/npmx.dev-check.snap
+++ b/tests/snapshots/check/__snapshots__/npmx.dev-check.snap
@@ -354,9 +354,7 @@
     },
     {
       "file": "app/components/Package/SkillsModal.vue",
-      "diagnostics": [
-        "error:217:18 [TS2367] This comparison appears to be unintentional because the types '\"skills-cli\"' and '\"skills-npm\"' have no overlap."
-      ]
+      "diagnostics": []
     },
     {
       "file": "app/components/Package/Table.vue",
@@ -749,7 +747,7 @@
       ]
     }
   ],
-  "errorCount": 161,
+  "errorCount": 160,
   "warningCount": 0,
   "fileCount": 134
 }

--- a/tests/snapshots/check/__snapshots__/vue2-elm-check.snap
+++ b/tests/snapshots/check/__snapshots__/vue2-elm-check.snap
@@ -605,8 +605,7 @@
         "error:629:35 [TS2339] Property 'timer' does not exist on type '__VizeThis'.",
         "error:630:22 [TS2339] Property 'timer' does not exist on type '__VizeThis'.",
         "error:631:39 [TS2339] Property 'timer' does not exist on type '__VizeThis'.",
-        "error:661:22 [TS2339] Property '$router' does not exist on type '__VizeThis'.",
-        "error:1365:28 [TS2304] Cannot find name 'attribute'."
+        "error:661:22 [TS2339] Property '$router' does not exist on type '__VizeThis'."
       ]
     },
     {
@@ -643,7 +642,7 @@
       ]
     }
   ],
-  "errorCount": 374,
+  "errorCount": 373,
   "warningCount": 0,
   "fileCount": 55
 }

--- a/tests/snapshots/check/vue2-elm.ts
+++ b/tests/snapshots/check/vue2-elm.ts
@@ -66,6 +66,7 @@ async function verifyVue2ElmSnapshot(): Promise<void> {
       assert.equal(first.report.fileCount, 55, "every pinned vue2-elm SFC must be checked");
       assert.equal(first.report.warningCount, 0);
       assert.ok(first.report.errorCount > 0, "the legacy surface is intentionally not clean");
+      assertDiagnosticsStayInAuthoredBlocks(fixture.workspaceDir, first.report.files);
 
       assertSnapshot(SNAPSHOT_DIR, "vue2-elm-check", `${JSON.stringify(first.report, null, 2)}\n`);
     },
@@ -80,4 +81,30 @@ test(
 
 function json(value: unknown): string {
   return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function assertDiagnosticsStayInAuthoredBlocks(
+  workspaceDir: string,
+  files: Array<{ diagnostics: string[]; file: string }>,
+): void {
+  for (const file of files) {
+    const source = fs.readFileSync(path.join(workspaceDir, file.file), "utf8");
+    const ranges = [...source.matchAll(/<(template|script)\b[^>]*>[\s\S]*?<\/\1>/g)].map(
+      (match) => {
+        const start = source.slice(0, match.index ?? 0).split("\n").length;
+        const end = start + match[0].split("\n").length - 1;
+        return { end, start };
+      },
+    );
+
+    for (const diagnostic of file.diagnostics) {
+      const match = /^(?:error|warning|info|hint):(\d+):(\d+) /.exec(diagnostic);
+      assert.ok(match, `diagnostic must include an authored location: ${file.file}: ${diagnostic}`);
+      const line = Number(match[1]);
+      assert.ok(
+        ranges.some((range) => line >= range.start && line <= range.end),
+        `diagnostic escaped template/script blocks: ${file.file}: ${diagnostic}`,
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- treat the SFC source map as authoritative for Vue and JSX virtual files
- retain identity fallback only for plain scripts
- remove duplicate diagnostics projected into long style blocks

## Tests
- cargo test -p vize_canon --lib
- cargo test -p vize_canon --features legacy unmapped_v_if_guard_does_not_duplicate_into_a_long_style_block
- cargo test -p vize_canon --features legacy composite_source_map_only_uses_identity_fallback_for_plain_scripts
- cargo clippy -p vize_canon --lib --features legacy -- -D warnings
- cargo fmt --all -- --check
- Vue 2 elm fixture snapshot

Closes #3608

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected source locations for diagnostics in Vue templates without matching source-map entries.
  * Prevented duplicate or incorrectly positioned template diagnostics, including files with large style sections.
  * Preserved expected location behavior for plain scripts.

* **Tests**
  * Added regression coverage for unmapped template diagnostics and source-map fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->