### PR TITLE
feat(patina): implement vue/no-multiple-template-root

### DIFF
--- a/crates/vize_carton/src/i18n_supplemental_extra2.rs
+++ b/crates/vize_carton/src/i18n_supplemental_extra2.rs
@@ -15,6 +15,37 @@ pub(crate) fn register(messages: &mut [MessageMap; 3]) {
 
 /// Extra supplemental translation entries: `(key, en, ja, zh)`.
 static ENTRIES: &[(&str, &str, &str, &str)] = &[
+    // vue/no-multiple-template-root
+    (
+        "vue/no-multiple-template-root.multiple_root",
+        "The template root requires exactly one element.",
+        "テンプレートのルートには要素が1つだけ必要です。",
+        "模板根节点必须恰好包含一个元素。",
+    ),
+    (
+        "vue/no-multiple-template-root.text_root",
+        "The template root requires an element rather than texts.",
+        "テンプレートのルートにはテキストではなく要素が必要です。",
+        "模板根节点需要元素而不是文本。",
+    ),
+    (
+        "vue/no-multiple-template-root.disallowed_element",
+        "The template root disallows '<{tag}>' elements.",
+        "テンプレートのルートでは '<{tag}>' 要素を使用できません。",
+        "模板根节点不允许 '<{tag}>' 元素。",
+    ),
+    (
+        "vue/no-multiple-template-root.disallowed_directive",
+        "The template root disallows 'v-for' directives.",
+        "テンプレートのルートでは 'v-for' ディレクティブを使用できません。",
+        "模板根节点不允许 'v-for' 指令。",
+    ),
+    (
+        "vue/no-multiple-template-root.help",
+        "Wrap the template in one rendered element; keep conditional branches in one v-if chain.",
+        "テンプレートを1つの描画要素で囲み、条件分岐は1つのv-ifチェーンにまとめてください。",
+        "请用一个渲染元素包裹模板，并将条件分支保留在同一个v-if链中。",
+    ),
     // vue/no-invalid-html-attribute
     (
         "vue/no-invalid-html-attribute.description",

--- a/crates/vize_patina/src/rules/vue.rs
+++ b/crates/vize_patina/src/rules/vue.rs
@@ -62,6 +62,7 @@ mod html_quotes;
 mod mustache_interpolation_spacing;
 mod no_lone_template;
 mod no_multi_spaces;
+mod no_multiple_template_root;
 mod sfc_element_order;
 mod v_on_style;
 mod v_slot_style;
@@ -145,6 +146,7 @@ pub use component_definition_name_casing::ComponentDefinitionNameCasing;
 pub use html_quotes::{HtmlQuotes, HtmlQuotesOption};
 pub use mustache_interpolation_spacing::MustacheInterpolationSpacing;
 pub use no_multi_spaces::NoMultiSpaces;
+pub use no_multiple_template_root::NoMultipleTemplateRoot;
 pub use prop_name_casing::PropNameCasing;
 pub use v_on_style::{VOnStyle, VOnStyleOption};
 pub use v_slot_style::VSlotStyle;
@@ -225,13 +227,15 @@ pub(crate) fn register_security(registry: &mut crate::rule::RuleRegistry) {
     registry.register(Box::new(NoInvalidHtmlAttribute));
 }
 
-/// Register Vue migration rules as explicit opt-in rules.
+/// Register Vue rules that require explicit opt-in.
 ///
-/// These flag deprecated Vue 2 template syntax that Vue 3 removed. They are
-/// opt-in (not part of any preset) so they only run when a project adopting the
-/// migration pack asks for them, and each rule gates itself on the default Vue 3
-/// dialect.
+/// This includes contextual contracts such as Nuxt's single-root pages and
+/// migration checks for deprecated Vue 2 syntax. Keeping them outside every
+/// preset avoids imposing those narrower contracts on general Vue 3 projects.
 pub(crate) fn register_opt_in(registry: &mut crate::rule::RuleRegistry) {
+    if !registry.has_rule("vue/no-multiple-template-root") {
+        registry.register(Box::new(NoMultipleTemplateRoot));
+    }
     if !registry.has_rule("vue/no-deprecated-v-on-native-modifier") {
         registry.register(Box::new(NoDeprecatedVOnNativeModifier));
     }

--- a/crates/vize_patina/src/rules/vue/no_multiple_template_root.rs
+++ b/crates/vize_patina/src/rules/vue/no_multiple_template_root.rs
@@ -1,0 +1,234 @@
+//! vue/no-multiple-template-root
+//!
+//! Require exactly one rendered root in templates that opt into a single-root
+//! contract, including Nuxt layouts, pages, and server components.
+//!
+//! Vue 3 normally permits fragments, so this rule is deliberately opt-in. Once
+//! enabled it mirrors `eslint-plugin-vue@10.9.2`: comments and blank text are
+//! ignored, a `v-if`/`v-else-if`/`v-else` chain is one logical root, and any
+//! other element or meaningful text is an additional root. A lone `<slot>`,
+//! `<template>`, or `v-for` root is also rejected because it may render a shape
+//! other than one element.
+//!
+//! The upstream `disallowComments` option is outside Patina's current
+//! severity-only rule configuration. Nuxt uses the default (`false`), so root
+//! comments remain accepted here.
+
+#[cfg(test)]
+#[path = "no_multiple_template_root_tests.rs"]
+mod tests;
+
+use crate::context::LintContext;
+use crate::diagnostic::Severity;
+use crate::rule::{Rule, RuleCategory, RuleMeta};
+use vize_carton::ensure_sufficient_stack;
+use vize_relief::{ElementNode, PropNode, RootNode, SourceLocation, TemplateChildNode};
+
+static META: RuleMeta = RuleMeta {
+    name: "vue/no-multiple-template-root",
+    description: "Disallow multiple root nodes in a template",
+    category: RuleCategory::Essential,
+    fixable: false,
+    default_severity: Severity::Error,
+};
+
+/// Disallow template shapes that do not render exactly one element root.
+pub struct NoMultipleTemplateRoot;
+
+#[inline]
+fn has_directive(element: &ElementNode<'_>, name: &str) -> bool {
+    element.props.iter().any(
+        |prop| matches!(prop, PropNode::Directive(directive) if directive.name.as_str() == name),
+    )
+}
+
+/// Recover the start-tag range, matching vue-eslint-parser's reported span.
+/// Quoted `>` bytes do not terminate the tag.
+fn start_tag_loc(source: &str, element: &ElementNode<'_>) -> SourceLocation {
+    let start = element.loc.start.offset as usize;
+    let end = element.loc.end.offset as usize;
+    let Some(element_source) = source.get(start..end) else {
+        return element.loc.clone();
+    };
+
+    let mut quote = None;
+    for (relative, &byte) in element_source.as_bytes().iter().enumerate() {
+        match (quote, byte) {
+            (Some(open), close) if open == close => quote = None,
+            (Some(_), _) => {}
+            (None, b'\'' | b'"') => quote = Some(byte),
+            (None, b'>') => {
+                let mut loc = element.loc.clone();
+                loc.end.offset = (start + relative + 1) as u32;
+                return loc;
+            }
+            (None, _) => {}
+        }
+    }
+
+    element.loc.clone()
+}
+
+/// Recover the whole element range. Relief intentionally keeps the start tag
+/// in `ElementNode::loc`, so the closing tag is found after the complete AST
+/// subtree. Starting after every child also handles nested elements with the
+/// same tag without a lexical nesting counter.
+fn full_element_loc(source: &str, element: &ElementNode<'_>) -> SourceLocation {
+    let mut loc = element.loc.clone();
+    if element.is_self_closing {
+        return loc;
+    }
+
+    let search_from = element
+        .children
+        .iter()
+        .fold(loc.end.offset as usize, |end, child| {
+            let child_end = match child {
+                TemplateChildNode::Element(child) => {
+                    ensure_sufficient_stack(|| full_element_loc(source, child).end.offset as usize)
+                }
+                other => other.loc().end.offset as usize,
+            };
+            end.max(child_end)
+        });
+    let bytes = source.as_bytes();
+    let tag = element.tag.as_bytes();
+    let mut cursor = search_from;
+
+    while cursor + tag.len() + 3 <= bytes.len() {
+        let Some(relative) = bytes[cursor..].iter().position(|&byte| byte == b'<') else {
+            break;
+        };
+        let start = cursor + relative;
+        let name_start = start + 2;
+        let name_end = name_start + tag.len();
+        if bytes.get(start + 1) == Some(&b'/')
+            && bytes
+                .get(name_start..name_end)
+                .is_some_and(|name| name.eq_ignore_ascii_case(tag))
+            && bytes
+                .get(name_end)
+                .is_some_and(|byte| byte.is_ascii_whitespace() || *byte == b'>')
+            && let Some(end_relative) = bytes[name_end..].iter().position(|&byte| byte == b'>')
+        {
+            loc.end.offset = (name_end + end_relative + 1) as u32;
+            return loc;
+        }
+        cursor = start + 1;
+    }
+
+    loc
+}
+
+#[inline]
+fn is_non_blank(source: &str, loc: &SourceLocation) -> bool {
+    source
+        .get(loc.start.offset as usize..loc.end.offset as usize)
+        .is_some_and(|text| !text.trim().is_empty())
+}
+
+/// Results from the first, allocation-free pass over the template root.
+struct RootShape<'ast, 'root> {
+    has_element: bool,
+    extra_element: Option<&'root ElementNode<'ast>>,
+    extra_text: Option<&'root SourceLocation>,
+}
+
+impl<'ast, 'root> RootShape<'ast, 'root> {
+    fn classify(source: &str, root: &'root RootNode<'ast>) -> Self {
+        let mut shape = Self {
+            has_element: false,
+            extra_element: None,
+            extra_text: None,
+        };
+        let mut chain_open = false;
+
+        for child in &root.children {
+            match child {
+                TemplateChildNode::Element(element) if !shape.has_element => {
+                    shape.has_element = true;
+                    chain_open = has_directive(element, "if");
+                }
+                TemplateChildNode::Element(element)
+                    if chain_open && has_directive(element, "else-if") => {}
+                TemplateChildNode::Element(element)
+                    if chain_open && has_directive(element, "else") =>
+                {
+                    chain_open = false;
+                }
+                TemplateChildNode::Element(element) => shape.extra_element = Some(element),
+                TemplateChildNode::Comment(_) => {}
+                other if is_non_blank(source, other.loc()) => {
+                    shape.extra_text = Some(other.loc());
+                }
+                _ => {}
+            }
+        }
+
+        shape
+    }
+}
+
+impl Rule for NoMultipleTemplateRoot {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn run_on_template<'a>(&self, ctx: &mut LintContext<'a>, root: &RootNode<'a>) {
+        let shape = RootShape::classify(ctx.source, root);
+
+        // Upstream gives meaningful text precedence over every element report.
+        if let Some(loc) = shape.extra_text {
+            ctx.error_with_help(
+                ctx.t("vue/no-multiple-template-root.text_root"),
+                loc,
+                ctx.t("vue/no-multiple-template-root.help"),
+            );
+            return;
+        }
+
+        // Only the last additional element is reported.
+        if let Some(element) = shape.extra_element {
+            let loc = full_element_loc(ctx.source, element);
+            ctx.error_with_help(
+                ctx.t("vue/no-multiple-template-root.multiple_root"),
+                &loc,
+                ctx.t("vue/no-multiple-template-root.help"),
+            );
+            return;
+        }
+
+        if !shape.has_element {
+            return;
+        }
+
+        // With no additional root, every element is either the first root or a
+        // branch in its conditional chain. Each branch receives the root-kind
+        // and root-v-for checks, exactly as upstream does.
+        for child in &root.children {
+            let TemplateChildNode::Element(element) = child else {
+                continue;
+            };
+            let loc = start_tag_loc(ctx.source, element);
+            let tag = element.tag.as_str();
+
+            if matches!(tag, "template" | "slot") {
+                ctx.error_with_help(
+                    ctx.t_fmt(
+                        "vue/no-multiple-template-root.disallowed_element",
+                        &[("tag", tag)],
+                    ),
+                    &loc,
+                    ctx.t("vue/no-multiple-template-root.help"),
+                );
+            }
+            if has_directive(element, "for") {
+                ctx.error_with_help(
+                    ctx.t("vue/no-multiple-template-root.disallowed_directive"),
+                    &loc,
+                    ctx.t("vue/no-multiple-template-root.help"),
+                );
+            }
+        }
+    }
+}

--- a/crates/vize_patina/src/rules/vue/no_multiple_template_root_tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_multiple_template_root_tests.rs
@@ -1,0 +1,176 @@
+//! Differential cases captured from `eslint-plugin-vue@10.9.2`.
+//!
+//! Each fragment was wrapped in an SFC `<template>`, linted through ESLint's
+//! flat `Linter` API with `vue-eslint-parser@10.4.1`, then translated back to
+//! template-local byte offsets. The ASCII fixtures make that translation
+//! exact and keep the expected upstream messages and spans reviewable offline.
+
+use super::NoMultipleTemplateRoot;
+use crate::linter::{LintResult, Linter};
+use crate::preset::LintPreset;
+use crate::rule::RuleRegistry;
+use vize_carton::String;
+
+const RULE: &str = "vue/no-multiple-template-root";
+const MULTIPLE_ROOT: &str = "The template root requires exactly one element.";
+const TEXT_ROOT: &str = "The template root requires an element rather than texts.";
+const V_FOR_ROOT: &str = "The template root disallows 'v-for' directives.";
+type ExpectedFinding = (&'static str, &'static str, u32, u32);
+type DifferentialCase<'a> = (&'a str, &'a [ExpectedFinding]);
+
+fn linter() -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(Box::new(NoMultipleTemplateRoot));
+    Linter::with_registry(registry)
+}
+
+fn reported(result: &LintResult) -> Vec<(&'static str, String, u32, u32)> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            (
+                diagnostic.rule_name,
+                diagnostic.message.clone(),
+                diagnostic.start,
+                diagnostic.end,
+            )
+        })
+        .collect()
+}
+
+fn lint(source: &str) -> Vec<(&'static str, String, u32, u32)> {
+    reported(&linter().lint_template(source, "test.vue"))
+}
+
+fn expected(items: &[ExpectedFinding]) -> Vec<(&'static str, String, u32, u32)> {
+    items
+        .iter()
+        .map(|&(rule, message, start, end)| (rule, String::from(message), start, end))
+        .collect()
+}
+
+#[test]
+fn eslint_vue_10_9_2_differential_roots() {
+    let cases: &[DifferentialCase<'_>] = &[
+        ("<div></div>", &[]),
+        ("\n <!-- comment --> <div></div> \n", &[]),
+        ("", &[]),
+        ("<div></div><div></div>", &[(RULE, MULTIPLE_ROOT, 11, 22)]),
+        (
+            "<div></div><div></div><div></div>",
+            &[(RULE, MULTIPLE_ROOT, 22, 33)],
+        ),
+        (
+            "<div></div><section><div></div></section>",
+            &[(RULE, MULTIPLE_ROOT, 11, 41)],
+        ),
+        (
+            "<div></div><section><!-- </section> --><p>x</p></section>",
+            &[(RULE, MULTIPLE_ROOT, 11, 57)],
+        ),
+        ("<slot></slot><div></div>", &[(RULE, MULTIPLE_ROOT, 13, 24)]),
+        (r#"<div v-if="a"></div><div v-else></div>"#, &[]),
+        (r#"<div v-if="a"></div><!-- gap --><div v-else></div>"#, &[]),
+        (r#"<c1 v-if="a"/><c2 v-else-if="b"/><c3 v-else/>"#, &[]),
+        (
+            r#"<div v-if="a"></div><div v-else></div><p></p>"#,
+            &[(RULE, MULTIPLE_ROOT, 38, 45)],
+        ),
+        (
+            r#"<div></div><div v-else-if="a"></div>"#,
+            &[(RULE, MULTIPLE_ROOT, 11, 36)],
+        ),
+    ];
+
+    for &(source, expected_reports) in cases {
+        assert_eq!(lint(source), expected(expected_reports), "source: {source}");
+    }
+}
+
+#[test]
+fn eslint_vue_10_9_2_differential_text_roots() {
+    let cases: &[DifferentialCase<'_>] = &[
+        ("{{ a }}", &[(RULE, TEXT_ROOT, 0, 7)]),
+        ("hello", &[(RULE, TEXT_ROOT, 0, 5)]),
+        ("<div></div>text<div></div>", &[(RULE, TEXT_ROOT, 11, 15)]),
+        ("<slot></slot>text", &[(RULE, TEXT_ROOT, 13, 17)]),
+    ];
+
+    for &(source, expected_reports) in cases {
+        assert_eq!(lint(source), expected(expected_reports), "source: {source}");
+    }
+}
+
+#[test]
+fn eslint_vue_10_9_2_differential_disallowed_roots() {
+    let cases: &[DifferentialCase<'_>] = &[
+        (
+            "<slot></slot>",
+            &[(RULE, "The template root disallows '<slot>' elements.", 0, 6)],
+        ),
+        (
+            "<template></template>",
+            &[(
+                RULE,
+                "The template root disallows '<template>' elements.",
+                0,
+                10,
+            )],
+        ),
+        (
+            r#"<div v-for="x in xs"></div>"#,
+            &[(RULE, V_FOR_ROOT, 0, 21)],
+        ),
+        (
+            r#"<template v-for="x in xs"><li/></template>"#,
+            &[
+                (
+                    RULE,
+                    "The template root disallows '<template>' elements.",
+                    0,
+                    26,
+                ),
+                (RULE, V_FOR_ROOT, 0, 26),
+            ],
+        ),
+        (
+            r#"<div v-if="a" v-for="x in xs"></div><div v-else v-for="y in ys"></div>"#,
+            &[(RULE, V_FOR_ROOT, 0, 30), (RULE, V_FOR_ROOT, 36, 64)],
+        ),
+        (
+            r#"<div v-for="a in b" :title="a > b"></div>"#,
+            &[(RULE, V_FOR_ROOT, 0, 35)],
+        ),
+    ];
+
+    for &(source, expected_reports) in cases {
+        assert_eq!(lint(source), expected(expected_reports), "source: {source}");
+    }
+}
+
+#[test]
+fn sfc_diagnostics_use_absolute_offsets() {
+    let source = "<template>\n  <div>a</div>\n  <div>b</div>\n</template>\n";
+    let result = linter().lint_sfc(source, "test.vue");
+    assert_eq!(
+        reported(&result),
+        expected(&[(RULE, MULTIPLE_ROOT, 28, 40)])
+    );
+    assert_eq!(&source[28..40], "<div>b</div>");
+}
+
+#[test]
+fn stays_opt_in_for_general_vue_but_can_be_enabled_by_name() {
+    assert!(!RuleRegistry::default().has_rule(RULE));
+    assert!(!RuleRegistry::with_essential().has_rule(RULE));
+    assert!(RuleRegistry::with_opt_in_rules().has_rule(RULE));
+
+    let result = Linter::with_preset(LintPreset::Incremental)
+        .with_enabled_rules(Some(vec![String::from(RULE)]))
+        .lint_template("<div></div><div></div>", "page.vue");
+    assert_eq!(
+        reported(&result),
+        expected(&[(RULE, MULTIPLE_ROOT, 11, 22)])
+    );
+}

--- a/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -534,6 +534,7 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "petite-vue/no-unsupported-directive",
     "petite-vue/valid-v-effect",
     "petite-vue/valid-v-scope",
+    "vue/no-multiple-template-root",
     "vue/no-deprecated-v-on-native-modifier",
     "vue/no-deprecated-v-on-number-modifiers",
     "vue/no-deprecated-v-bind-sync",

--- a/npm/cli/src/types/rules.ts
+++ b/npm/cli/src/types/rules.ts
@@ -169,6 +169,7 @@ export const LINT_RULE_NAMES = [
   "vue/no-lone-template",
   "vue/no-multi-spaces",
   "vue/no-multiple-objects-in-class",
+  "vue/no-multiple-template-root",
   "vue/no-mutating-props",
   "vue/no-negated-v-if-condition",
   "vue/no-preprocessor-lang",

--- a/npm/framework/nuxt/test/nuxt-eslint-compat/INVENTORY.md
+++ b/npm/framework/nuxt/test/nuxt-eslint-compat/INVENTORY.md
@@ -29,16 +29,16 @@ prefix) is a later phase.
 The blocks the port owns, in emission order. Order is observable — a later item
 overrides an earlier one — so it is part of the contract.
 
-| Config item            | Applies to                                                | Rule                                 | Patina status                                  |
-| ---------------------- | --------------------------------------------------------- | ------------------------------------ | ---------------------------------------------- |
-| `nuxt/ignores`         | whole project                                             | — (7 ignore globs)                   | supported                                      |
-| `nuxt/setup`           | every linted file                                         | — (declares the `$fetch` global)     | supported                                      |
-| `nuxt/vue/single-root` | layouts, pages, server components                         | `vue/no-multiple-template-root`      | supported                                      |
-| `nuxt/rules`           | every linted file                                         | `nuxt/prefer-import-meta`            | not ported yet                                 |
-| `nuxt/pages`           | pages                                                     | `nuxt/no-page-meta-runtime-values`   | not ported yet                                 |
-| `nuxt/nuxt-config`     | `nuxt.config`                                             | `nuxt/no-nuxt-config-test-key`       | not ported yet                                 |
-| `nuxt/sort-config`     | `nuxt.config`                                             | `nuxt/nuxt-config-keys-order`        | not ported yet                                 |
-| `nuxt/disables/routes` | app/error, layouts, pages, nested and prefixed components | `vue/multi-word-component-names` off | supported                                      |
+| Config item            | Applies to                                                | Rule                                 | Patina status  |
+| ---------------------- | --------------------------------------------------------- | ------------------------------------ | -------------- |
+| `nuxt/ignores`         | whole project                                             | — (7 ignore globs)                   | supported      |
+| `nuxt/setup`           | every linted file                                         | — (declares the `$fetch` global)     | supported      |
+| `nuxt/vue/single-root` | layouts, pages, server components                         | `vue/no-multiple-template-root`      | supported      |
+| `nuxt/rules`           | every linted file                                         | `nuxt/prefer-import-meta`            | not ported yet |
+| `nuxt/pages`           | pages                                                     | `nuxt/no-page-meta-runtime-values`   | not ported yet |
+| `nuxt/nuxt-config`     | `nuxt.config`                                             | `nuxt/no-nuxt-config-test-key`       | not ported yet |
+| `nuxt/sort-config`     | `nuxt.config`                                             | `nuxt/nuxt-config-keys-order`        | not ported yet |
+| `nuxt/disables/routes` | app/error, layouts, pages, nested and prefixed components | `vue/multi-word-component-names` off | supported      |
 
 Items outside this table belong to `@nuxt/eslint-config`'s generic
 JavaScript/TypeScript/Vue/import/stylistic/tooling presets. They are a separate

--- a/npm/framework/nuxt/test/nuxt-eslint-compat/INVENTORY.md
+++ b/npm/framework/nuxt/test/nuxt-eslint-compat/INVENTORY.md
@@ -33,7 +33,7 @@ overrides an earlier one — so it is part of the contract.
 | ---------------------- | --------------------------------------------------------- | ------------------------------------ | ---------------------------------------------- |
 | `nuxt/ignores`         | whole project                                             | — (7 ignore globs)                   | supported                                      |
 | `nuxt/setup`           | every linted file                                         | — (declares the `$fetch` global)     | supported                                      |
-| `nuxt/vue/single-root` | layouts, pages, server components                         | `vue/no-multiple-template-root`      | **unimplemented in Patina** (tracked by #3223) |
+| `nuxt/vue/single-root` | layouts, pages, server components                         | `vue/no-multiple-template-root`      | supported                                      |
 | `nuxt/rules`           | every linted file                                         | `nuxt/prefer-import-meta`            | not ported yet                                 |
 | `nuxt/pages`           | pages                                                     | `nuxt/no-page-meta-runtime-values`   | not ported yet                                 |
 | `nuxt/nuxt-config`     | `nuxt.config`                                             | `nuxt/no-nuxt-config-test-key`       | not ported yet                                 |

--- a/tests/_fixtures/patina-eslint-vue-rule-map.json
+++ b/tests/_fixtures/patina-eslint-vue-rule-map.json
@@ -6,8 +6,8 @@
     "ruleCount": 252
   },
   "summary": {
-    "mapped": 120,
-    "unimplemented": 132
+    "mapped": 121,
+    "unimplemented": 131
   },
   "entries": {
     "vue/array-bracket-newline": {
@@ -439,8 +439,8 @@
       "patinaRule": "script/no-multiple-slot-args"
     },
     "vue/no-multiple-template-root": {
-      "status": "unimplemented",
-      "issue": 3223
+      "status": "mapped",
+      "patinaRule": "vue/no-multiple-template-root"
     },
     "vue/no-mutating-props": {
       "status": "mapped",


### PR DESCRIPTION
## Summary
- implement vue/no-multiple-template-root with eslint-plugin-vue 10.9.2-compatible diagnostics
- keep the rule opt-in so general Vue 3 fragment templates remain valid
- expose the rule through Patina configuration, generated CLI types, and the compatibility scorecard
- mark Nuxt single-root lint coverage as supported

## Tests
- cargo test -p vize_patina
- cargo clippy -p vize_patina --lib -- -D warnings
- cargo test -p vize_carton i18n
- node --test npm/framework/nuxt/src/lint/oracle.test.ts tests/tooling/patina-eslint-vue-rule-map.test.ts
- cargo fmt --all -- --check
- oxfmt --check npm/cli/src/types/rules.ts tests/_fixtures/patina-eslint-vue-rule-map.json
- oxlint npm/cli/src/types/rules.ts --deny-warnings
- git diff --check

Closes #3613

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Vue `no-multiple-template-root` lint rule.
  * Detects multiple template roots, text roots, disallowed elements, and invalid `v-for` roots.
  * Added English, Japanese, and Chinese diagnostic messages.
  * Registered the rule for CLI use and Nuxt ESLint compatibility.

* **Tests**
  * Added coverage for root detection, conditional roots, diagnostics, source locations, and opt-in registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->