### PR TITLE
fix(vapor): drop patterned IR without recursion

### DIFF
--- a/crates/vize_atelier_jsx/src/vapor.rs
+++ b/crates/vize_atelier_jsx/src/vapor.rs
@@ -14,7 +14,9 @@
 
 use vize_atelier_core::lane::transform;
 use vize_atelier_core::options::TransformOptions;
-use vize_atelier_vapor::{VaporGenerateOptions, generate_vapor_with_options, transform_to_ir};
+use vize_atelier_vapor::{
+    VaporGenerateOptions, drop_ir_stack_safe, generate_vapor_with_options, transform_to_ir,
+};
 use vize_carton::{Bump, String};
 use vize_croquis::Croquis;
 
@@ -160,6 +162,7 @@ pub(crate) fn compile_root_to_vapor(
     let ir = transform_to_ir(bump, &root);
     let generated =
         generate_vapor_with_options(&ir, None, VaporGenerateOptions { jsx_closure: true });
+    drop_ir_stack_safe(ir);
 
     let (code, templates) = if let Some(style) = scoped_style.as_ref() {
         inject_scope_id(&generated.code, &generated.templates, &style.scope_id)

--- a/crates/vize_atelier_vapor/src/compile.rs
+++ b/crates/vize_atelier_vapor/src/compile.rs
@@ -4,6 +4,7 @@
 //! code generation behind the public `compile_vapor*` functions.
 
 use crate::generate::generate_vapor;
+use crate::ir_drop::drop_ir_stack_safe;
 use crate::lower as vapor_lower;
 use vize_atelier_core::{
     CompilerError, Namespace,
@@ -111,6 +112,17 @@ fn compile_vapor_inner<'a>(
     options: VaporCompilerOptions,
     template_syntax: TemplateSyntaxMode,
 ) -> (VaporCompileResult, std::vec::Vec<CompilerError>) {
+    vize_carton::ensure_sufficient_stack(|| {
+        compile_vapor_inner_with_stack(allocator, source, options, template_syntax)
+    })
+}
+
+fn compile_vapor_inner_with_stack<'a>(
+    allocator: &'a Bump,
+    source: &'a str,
+    options: VaporCompilerOptions,
+    template_syntax: TemplateSyntaxMode,
+) -> (VaporCompileResult, std::vec::Vec<CompilerError>) {
     // Parse
     let parser_opts = ParserOptions {
         is_void_tag: vize_carton::is_void_tag,
@@ -161,6 +173,8 @@ fn compile_vapor_inner<'a>(
 
     // Generate Vapor code
     let result = generate_vapor(&ir, binding_metadata.as_ref());
+    drop_ir_stack_safe(ir);
+    drop(root);
 
     (
         VaporCompileResult {

--- a/crates/vize_atelier_vapor/src/ir_drop.rs
+++ b/crates/vize_atelier_vapor/src/ir_drop.rs
@@ -1,0 +1,69 @@
+//! Stack-safe teardown for the recursive Vapor IR graph.
+
+use crate::ir::{BlockIRNode, IRDynamicInfo, NegativeBranch, OperationNode, RootIRNode};
+use vize_carton::Box;
+
+/// Drop a completed Vapor IR without following nested blocks on the machine stack.
+///
+/// Patterned templates lower to nested `If` operations. Ordinary derived drop
+/// follows that graph recursively, so sufficiently deep valid input can abort a
+/// small-stack compiler worker after code generation has already completed.
+/// This consumes every recursive edge into an explicit heap worklist first;
+/// the remaining values are shallow when their normal destructors run.
+pub fn drop_ir_stack_safe(mut ir: RootIRNode<'_>) {
+    let mut operations = std::vec::Vec::new();
+    let mut dynamics = std::vec::Vec::new();
+    drain_block(&mut ir.block, &mut operations, &mut dynamics);
+
+    while let Some(operation) = operations.pop() {
+        match operation {
+            OperationNode::If(node) => {
+                let mut node = Box::into_inner(node);
+                drain_block(&mut node.positive, &mut operations, &mut dynamics);
+                if let Some(negative) = node.negative.take() {
+                    match negative {
+                        NegativeBranch::Block(mut block) => {
+                            drain_block(&mut block, &mut operations, &mut dynamics);
+                        }
+                        NegativeBranch::If(node) => operations.push(OperationNode::If(node)),
+                    }
+                }
+            }
+            OperationNode::For(node) => {
+                let mut node = Box::into_inner(node);
+                drain_block(&mut node.render, &mut operations, &mut dynamics);
+            }
+            OperationNode::CreateComponent(mut node) => {
+                while let Some(mut slot) = node.slots.pop() {
+                    drain_block(&mut slot.block, &mut operations, &mut dynamics);
+                }
+            }
+            OperationNode::SlotOutlet(mut node) => {
+                if let Some(mut fallback) = node.fallback.take() {
+                    drain_block(&mut fallback, &mut operations, &mut dynamics);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    while let Some(mut dynamic) = dynamics.pop() {
+        dynamics.append(&mut dynamic.children);
+    }
+}
+
+fn drain_block<'a>(
+    block: &mut BlockIRNode<'a>,
+    operations: &mut std::vec::Vec<OperationNode<'a>>,
+    dynamics: &mut std::vec::Vec<IRDynamicInfo>,
+) {
+    while let Some(operation) = block.operation.pop() {
+        operations.push(operation);
+    }
+    while let Some(mut effect) = block.effect.pop() {
+        while let Some(operation) = effect.operations.pop() {
+            operations.push(operation);
+        }
+    }
+    dynamics.push(std::mem::take(&mut block.dynamic));
+}

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -14,6 +14,7 @@ pub mod compile;
 pub mod generate;
 pub mod generators;
 pub mod ir;
+mod ir_drop;
 pub mod lower;
 pub mod steps;
 
@@ -64,6 +65,7 @@ pub use ir::{
     PrependNodeIRNode, RootIRNode, SetDynamicPropsIRNode, SetEventIRNode, SetHtmlIRNode,
     SetPropIRNode, SetTemplateRefIRNode, SetTextIRNode, SlotOutletIRNode,
 };
+pub use ir_drop::drop_ir_stack_safe;
 pub use lower::transform_to_ir;
 pub use steps::{
     collect_component_slots, generate_element_template, generate_event_handler,

--- a/crates/vize_atelier_vapor/src/tests_template_children.rs
+++ b/crates/vize_atelier_vapor/src/tests_template_children.rs
@@ -106,6 +106,7 @@ fn separated_text_runs_inside_patterned_template_dom_output() {
 
 const DEEP_TEMPLATE_DEPTH: usize = 1100;
 const SMALL_STACK: usize = 256 * 1024;
+const DEEP_PATTERN_CHILD: &str = "VIZE_VAPOR_DEEP_PATTERN_DROP_CHILD";
 
 fn vapor_output_on_small_stack(source: std::string::String) -> std::string::String {
     std::thread::Builder::new()
@@ -133,6 +134,61 @@ fn deeply_nested_template_source(wrapped: bool) -> std::string::String {
         source.push_str("</div>");
     }
     source
+}
+
+fn deeply_nested_pattern_source(with_diagnostic: bool) -> std::string::String {
+    let mut source = if with_diagnostic {
+        std::string::String::from(r#"<div v-memo="[label]">"#)
+    } else {
+        std::string::String::from("<div>")
+    };
+    for _ in 0..DEEP_TEMPLATE_DEPTH {
+        source.push_str(r#"<ul v-match="status"><li v-case="'ready'">"#);
+    }
+    source.push_str("{{ label }}");
+    for _ in 0..DEEP_TEMPLATE_DEPTH {
+        source.push_str("</li></ul>");
+    }
+    source.push_str("</div>");
+    source
+}
+
+#[test]
+fn deeply_nested_patterned_ir_teardown_is_stack_safe() {
+    if std::env::var_os(DEEP_PATTERN_CHILD).is_some() {
+        for with_diagnostic in [false, true] {
+            let source = deeply_nested_pattern_source(with_diagnostic);
+            let expected = vapor_output(&source);
+            let actual = vapor_output_on_small_stack(source);
+            assert_eq!(actual, expected);
+            if with_diagnostic {
+                assert!(
+                    actual.contains(
+                        "v-memo with dependencies is not supported in Vapor yet. Use v-once or v-memo=\\\"[]\\\" until memo guards are implemented."
+                    )
+                );
+            } else {
+                assert!(actual.starts_with("errors=[]"));
+            }
+        }
+        return;
+    }
+
+    let output = std::process::Command::new(std::env::current_exe().expect("current test binary"))
+        .arg("tests_template_children::deeply_nested_patterned_ir_teardown_is_stack_safe")
+        .arg("--exact")
+        .arg("--nocapture")
+        .env(DEEP_PATTERN_CHILD, "1")
+        .output()
+        .expect("spawn isolated deep-pattern teardown regression");
+
+    assert!(
+        output.status.success(),
+        "child failed with {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        std::string::String::from_utf8_lossy(&output.stdout),
+        std::string::String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- drain recursive Vapor IR edges through an explicit worklist
- keep compile-local teardown on a sufficient stack
- cover normal and diagnostic output at depth 1100 on a 256 KiB worker stack

## Tests
- cargo test -p vize_atelier_vapor -p vize_atelier_jsx
- cargo clippy -p vize_atelier_vapor -p vize_atelier_jsx --lib -- -D warnings
- cargo fmt --all -- --check

Closes #3623

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->