### PR TITLE
test(patina): cover multi-byte and unclosed roots in single-root rule

### DIFF
--- a/crates/vize_patina/src/rules/vue/no_multiple_template_root_tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_multiple_template_root_tests.rs
@@ -2,8 +2,9 @@
 //!
 //! Each fragment was wrapped in an SFC `<template>`, linted through ESLint's
 //! flat `Linter` API with `vue-eslint-parser@10.4.1`, then translated back to
-//! template-local byte offsets. The ASCII fixtures make that translation
-//! exact and keep the expected upstream messages and spans reviewable offline.
+//! template-local byte offsets. Mostly ASCII fixtures make that translation
+//! exact and keep the expected upstream messages and spans reviewable offline;
+//! a multi-byte fixture pins the byte offsets real templates produce.
 
 use super::NoMultipleTemplateRoot;
 use crate::linter::{LintResult, Linter};
@@ -12,6 +13,7 @@ use crate::rule::RuleRegistry;
 use vize_carton::String;
 
 const RULE: &str = "vue/no-multiple-template-root";
+const PARSER: &str = "parser/template";
 const MULTIPLE_ROOT: &str = "The template root requires exactly one element.";
 const TEXT_ROOT: &str = "The template root requires an element rather than texts.";
 const V_FOR_ROOT: &str = "The template root disallows 'v-for' directives.";
@@ -80,6 +82,19 @@ fn eslint_vue_10_9_2_differential_roots() {
         (
             r#"<div></div><div v-else-if="a"></div>"#,
             &[(RULE, MULTIPLE_ROOT, 11, 36)],
+        ),
+        // Multi-byte attribute and text content must not shift the span.
+        (
+            r#"<div title="日本語">あ</div><section>x</section>"#,
+            &[(RULE, MULTIPLE_ROOT, 32, 52)],
+        ),
+        // An unclosed extra root falls back to its start-tag span.
+        (
+            "<div></div><section>",
+            &[
+                (PARSER, "Element is missing end tag.", 11, 20),
+                (RULE, MULTIPLE_ROOT, 11, 20),
+            ],
         ),
     ];
 


### PR DESCRIPTION
Follow-up to #3626, which merged before its review feedback landed. Every `vue/no-multiple-template-root` fixture was ASCII, so nothing pinned the byte offsets `full_element_loc` / `start_tag_loc` compute on real templates, where non-ASCII attribute and text content is common, or the start-tag fallback taken when the closing tag is missing.

Two fixtures added to the differential table, with spans verified against the rule rather than assumed:

```rust
// Multi-byte attribute and text content must not shift the span.
(
    r#"<div title="日本語">あ</div><section>x</section>"#,
    &[(RULE, MULTIPLE_ROOT, 32, 52)],
),
// An unclosed extra root falls back to its start-tag span.
(
    "<div></div><section>",
    &[
        (PARSER, "Element is missing end tag.", 11, 20),
        (RULE, MULTIPLE_ROOT, 11, 20),
    ],
),
```

The unclosed fixture also captures the parser's own `Element is missing end tag.` diagnostic, since `lint_template` surfaces it alongside the rule report. Tests only; the rule itself is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->