### PR TITLE
feat(nuxt): generate lint globals from auto imports

### DIFF
--- a/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/INVENTORY.md
+++ b/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/INVENTORY.md
@@ -44,6 +44,7 @@ overrides an earlier one — so it is part of the contract.
 | `nuxt/nuxt-config`     | `nuxt.config`                                             | `nuxt/no-nuxt-config-test-key`       | not ported yet |
 | `nuxt/sort-config`     | `nuxt.config`                                             | `nuxt/nuxt-config-keys-order`        | not ported yet |
 | `nuxt/disables/routes` | app/error, layouts, pages, nested and prefixed components | `vue/multi-word-component-names` off | supported      |
+| `nuxt/import-globals`  | whole project                                             | — (Nuxt/Nitro auto-import globals)   | supported      |
 
 Items outside this table belong to `@nuxt/eslint-config`'s generic
 JavaScript/TypeScript/Vue/import/stylistic/tooling presets. They are a separate
@@ -53,11 +54,12 @@ the oracle.
 
 ## Intentional divergences
 
-| Difference                                                           | Why                                                                                                                                                                                                    |
-| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| The ignore block is named `nuxt/ignores`; upstream leaves it unnamed | Every block needs a stable identity for the emitter to address and for users to override. Applied in exactly one place in `oracle.test.ts`.                                                            |
-| `features` carries only feature keys                                 | Upstream serialises the whole module option object into `features`, so `configFile`, `autoInit`, `rootDir` and `devtools` leak into it. Vize keeps module options and feature flags separate.          |
-| Auto-init creates an `oxlint.config.mts` loader                      | Oxlint 1.64 does not inherit `globals` from a JSON config in `extends`. The loader returns the current generated object directly and rebases its JS plugin URL, preserving `$fetch` and addon globals. |
+| Difference                                                                              | Why                                                                                                                                                                                                                                                                                    |
+| --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The ignore block is named `nuxt/ignores`; upstream leaves it unnamed                    | Every block needs a stable identity for the emitter to address and for users to override. Applied in exactly one place in `oracle.test.ts`.                                                                                                                                            |
+| `features` carries only feature keys                                                    | Upstream serialises the whole module option object into `features`, so `configFile`, `autoInit`, `rootDir` and `devtools` leak into it. Vize keeps module options and feature flags separate.                                                                                          |
+| Auto-init creates an `oxlint.config.mts` loader                                         | Oxlint 1.64 does not inherit `globals` from a JSON config in `extends`. The loader returns the current generated object directly and rebases its JS plugin URL, preserving `$fetch` and addon globals.                                                                                 |
+| The addon hook is `vize:lint:config:addons` and contributes engine-neutral config items | Upstream's `eslint:config:addons` contributes raw JavaScript and import statements. Those are ESLint implementation details and cannot be represented safely in an oxlint config; the Vize hook preserves ordered, async addon composition without accepting executable config source. |
 
 ## Directory defaults
 
@@ -65,13 +67,13 @@ Defaults for a hand-written config, where directory lists may be absent.
 A generated config always supplies every list, so these only apply to the
 standalone entry point.
 
-| Case                    | Behaviour                                                                            |
-| ----------------------- | ------------------------------------------------------------------------------------ | --- | ------------------------------------------------------------------------------------ |
-| `defaults/empty`        | No dirs at all: `root` becomes `[".", "./app"]` and everything else derives from it. |
-| `defaults/src-only`     | Declaring `src` derives every per-feature directory from it.                         |
-| `defaults/root-only`    | Declaring `root` makes `src` follow `root` rather than the built-in pair.            |
-| `defaults/empty-arrays` | Present-but-empty lists stay empty: an empty array is truthy, so the `               |     | =`defaults never fire. This is why a generated config keeps`servers`and`root` empty. |
-| `defaults/partial`      | Only missing lists are defaulted; declared ones pass through untouched.              |
+| Case                    | Behaviour                                                                                         |
+| ----------------------- | ------------------------------------------------------------------------------------------------- |
+| `defaults/empty`        | No dirs at all: `root` becomes `[".", "./app"]` and everything else derives from it.              |
+| `defaults/src-only`     | Declaring `src` derives every per-feature directory from it.                                      |
+| `defaults/root-only`    | Declaring `root` makes `src` follow `root` rather than the built-in pair.                         |
+| `defaults/empty-arrays` | Present-but-empty lists stay empty: an empty array is truthy, so the `\|\|=` defaults never fire. |
+| `defaults/partial`      | Only missing lists are defaulted; declared ones pass through untouched.                           |
 
 Derived paths are built by interpolation (`` `${src}/pages` ``), not by joining,
 so a `.` or `./app` source directory keeps its leading segment.
@@ -103,6 +105,12 @@ How Nuxt project state reduces to the directory lists every glob is built from.
 | `features/typescript-false`       | Drops the TypeScript blocks from the baseline.                                                       |
 | `features/typescript-true`        | Adds them regardless of package detection.                                                           |
 | `features/tooling`                | Adds the module-author rule blocks (jsdoc, unicorn, regexp).                                         |
+
+## Addons
+
+| Case                    | Behaviour                                                                                                                                                        |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `addons/import-globals` | Nuxt and Nitro registries are combined, sorted by `from` then imported `name`, and emitted in full order as readonly globals using each import's alias when set. |
 
 `features.typescript` defaults to whether the `typescript` package resolves from
 `@nuxt/eslint-config`. The recording stores that probe's answer as

--- a/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/fixtures/corpus.json
+++ b/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/fixtures/corpus.json
@@ -6,6 +6,23 @@
     "configVersion": "1.16.0"
   },
   "description": "Nuxt project states whose generated lint config @vizejs/nuxt-lint-config must reproduce. Each case is materialised under a scratch root by oracle.mjs; every path is expressed relative to that root so the recording stays machine-independent.",
+  "importGlobals": {
+    "id": "addons/import-globals",
+    "description": "Nuxt and Nitro auto-import registries are merged, sorted by source then imported name, and aliases become readonly globals.",
+    "nuxt": [
+      { "from": "vue", "name": "watch", "as": "observe" },
+      { "from": "#app", "name": "useRoute" },
+      { "from": "vue", "name": "computed" },
+      { "from": "#app", "name": "useFetch", "as": "fetchData" },
+      { "from": "#app", "name": "alpha", "as": "constructor" },
+      { "from": "vue", "name": "ref", "as": "__proto__" }
+    ],
+    "nitro": [
+      { "from": "nitropack/runtime", "name": "defineNitroPlugin" },
+      { "from": "#app", "name": "useAsyncData" },
+      { "from": "#app", "name": "beta", "as": "toString" }
+    ]
+  },
   "dirDefaultCases": [
     {
       "id": "defaults/empty",

--- a/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/fixtures/nuxt-eslint-output.json
+++ b/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/fixtures/nuxt-eslint-output.json
@@ -1,9 +1,26 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "description": "Recorded @nuxt/eslint output for every case in corpus.json. Generated — do not hand-edit; re-record with oracle.mjs --write.",
   "moduleVersion": "1.16.0",
   "configVersion": "1.16.0",
   "typeScriptDetected": false,
+  "importGlobals": {
+    "globals": [
+      "constructor",
+      "toString",
+      "useAsyncData",
+      "fetchData",
+      "useRoute",
+      "defineNitroPlugin",
+      "computed",
+      "__proto__",
+      "observe"
+    ],
+    "artifacts": {
+      "initial": "{\n  \"plugins\": [\n    \"vue\"\n  ],\n  \"jsPlugins\": [\n    {\n      \"name\": \"vize\",\n      \"specifier\": \"../node_modules/oxlint-plugin-vize/dist/index.mjs\"\n    }\n  ],\n  \"settings\": {\n    \"vize\": {\n      \"preset\": \"incremental\"\n    }\n  },\n  \"ignorePatterns\": [\n    \"**/dist\",\n    \"**/node_modules\",\n    \"**/.nuxt\",\n    \"**/.output\",\n    \"**/.vercel\",\n    \"**/.netlify\",\n    \"**/public\"\n  ],\n  \"globals\": {\n    \"$fetch\": \"readonly\"\n  },\n  \"rules\": {\n    \"vize/nuxt/prefer-import-meta\": \"error\"\n  },\n  \"overrides\": [\n    {\n      \"files\": [\n        \"app/components/**/*.server.{js,ts,jsx,tsx,vue}\",\n        \"app/layouts/**/*.{js,ts,jsx,tsx,vue}\",\n        \"app/pages/**/*.{js,ts,jsx,tsx,vue}\"\n      ],\n      \"rules\": {\n        \"vize/vue/no-multiple-template-root\": \"error\"\n      }\n    },\n    {\n      \"files\": [\n        \"app/pages/**/*.{js,ts,jsx,tsx,vue}\"\n      ],\n      \"rules\": {\n        \"vize/nuxt/no-page-meta-runtime-values\": \"error\"\n      }\n    },\n    {\n      \"files\": [\n        \"**/.config/nuxt.?([cm])[jt]s?(x)\",\n        \"**/nuxt.config.?([cm])[jt]s?(x)\"\n      ],\n      \"rules\": {\n        \"vize/nuxt/no-nuxt-config-test-key\": \"error\"\n      }\n    },\n    {\n      \"files\": [\n        \"app/app.{js,ts,jsx,tsx,vue}\",\n        \"app/components/*/**/*.{js,ts,jsx,tsx,vue}\",\n        \"app/error.{js,ts,jsx,tsx,vue}\",\n        \"app/layouts/**/*.{js,ts,jsx,tsx,vue}\",\n        \"app/pages/**/*.{js,ts,jsx,tsx,vue}\"\n      ],\n      \"rules\": {\n        \"vize/vue/multi-word-component-names\": \"off\"\n      }\n    }\n  ]\n}\n",
+      "regenerated": "{\n  \"plugins\": [\n    \"vue\"\n  ],\n  \"jsPlugins\": [\n    {\n      \"name\": \"vize\",\n      \"specifier\": \"../node_modules/oxlint-plugin-vize/dist/index.mjs\"\n    }\n  ],\n  \"settings\": {\n    \"vize\": {\n      \"preset\": \"incremental\"\n    }\n  },\n  \"ignorePatterns\": [\n    \"**/dist\",\n    \"**/node_modules\",\n    \"**/.nuxt\",\n    \"**/.output\",\n    \"**/.vercel\",\n    \"**/.netlify\",\n    \"**/public\"\n  ],\n  \"globals\": {\n    \"$fetch\": \"readonly\",\n    \"constructor\": \"readonly\",\n    \"toString\": \"readonly\",\n    \"useAsyncData\": \"readonly\",\n    \"fetchData\": \"readonly\",\n    \"useRoute\": \"readonly\",\n    \"defineNitroPlugin\": \"readonly\",\n    \"computed\": \"readonly\",\n    \"__proto__\": \"readonly\",\n    \"observe\": \"readonly\"\n  },\n  \"rules\": {\n    \"vize/nuxt/prefer-import-meta\": \"error\"\n  },\n  \"overrides\": [\n    {\n      \"files\": [\n        \"app/components/**/*.server.{js,ts,jsx,tsx,vue}\",\n        \"app/layouts/**/*.{js,ts,jsx,tsx,vue}\",\n        \"app/pages/**/*.{js,ts,jsx,tsx,vue}\"\n      ],\n      \"rules\": {\n        \"vize/vue/no-multiple-template-root\": \"error\"\n      }\n    },\n    {\n      \"files\": [\n        \"app/pages/**/*.{js,ts,jsx,tsx,vue}\"\n      ],\n      \"rules\": {\n        \"vize/nuxt/no-page-meta-runtime-values\": \"error\"\n      }\n    },\n    {\n      \"files\": [\n        \"**/.config/nuxt.?([cm])[jt]s?(x)\",\n        \"**/nuxt.config.?([cm])[jt]s?(x)\"\n      ],\n      \"rules\": {\n        \"vize/nuxt/no-nuxt-config-test-key\": \"error\"\n      }\n    },\n    {\n      \"files\": [\n        \"app/app.{js,ts,jsx,tsx,vue}\",\n        \"app/components/*/**/*.{js,ts,jsx,tsx,vue}\",\n        \"app/error.{js,ts,jsx,tsx,vue}\",\n        \"app/layouts/**/*.{js,ts,jsx,tsx,vue}\",\n        \"app/pages/**/*.{js,ts,jsx,tsx,vue}\"\n      ],\n      \"rules\": {\n        \"vize/vue/multi-word-component-names\": \"off\"\n      }\n    }\n  ]\n}\n"
+    }
+  },
   "dirDefaults": {
     "defaults/empty": {
       "root": [".", "./app"],

--- a/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/oracle.mjs
+++ b/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/oracle.mjs
@@ -9,7 +9,7 @@
  * `tests/tooling/nuxt-eslint-oracle.test.ts` re-runs this script in CI and
  * fails if the recording has drifted from the installed packages.
  *
- * Two upstream contracts are recorded per case, because the port splits along
+ * Three upstream contracts are recorded, because the port splits along
  * the same seam:
  *
  *   1. `dirs` — the Nuxt project state (layers, `srcDir`, `dir` overrides,
@@ -17,6 +17,8 @@
  *      built from. Produced by `@nuxt/eslint`'s module.
  *   2. `features` + the resolved config items — which named rule blocks exist,
  *      in what order, over which globs. Produced by `@nuxt/eslint-config`.
+ *   3. `importGlobals` — the complete ordered globals list emitted after both
+ *      Nuxt and Nitro publish their auto-import registries.
  *
  * Usage:
  *   node npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/oracle.mjs --check
@@ -72,6 +74,7 @@ export const NUXT_OWNED_CONFIG_NAMES = [
   "nuxt/nuxt-config",
   "nuxt/sort-config",
   "nuxt/disables/routes",
+  "nuxt/import-globals",
 ];
 
 export function readCorpus() {
@@ -131,6 +134,33 @@ async function recordDirs(setupConfigGen, entry) {
     await setupConfigGen({ config: { autoInit: false } }, nuxt);
     const generated = await import(join(rootDir, ".nuxt", "eslint.config.mjs"));
     return generated.options.dirs;
+  } finally {
+    rmSync(rootDir, { force: true, recursive: true });
+  }
+}
+
+/** Record the full globals object emitted from Nuxt and Nitro's registries. */
+async function recordImportGlobals(setupConfigGen, entry, importGlobals) {
+  mkdirSync(scratchRoot, { recursive: true });
+  const rootDir = mkdtempSync(join(scratchRoot, "globals-"));
+  try {
+    mkdirSync(join(rootDir, ".nuxt"), { recursive: true });
+    const nuxt = createNuxtStub(rootDir, entry);
+    await setupConfigGen({ config: { autoInit: false } }, nuxt);
+    await nuxt.callHook("imports:context", {
+      getImports: async () => structuredClone(importGlobals.nuxt),
+    });
+    await nuxt.callHook("nitro:init", {
+      unimport: { getImports: async () => structuredClone(importGlobals.nitro) },
+    });
+    await nuxt.callHook("builder:generateApp");
+
+    const generated = await import(join(rootDir, ".nuxt", "eslint.config.mjs"));
+    const configs = await generated.configs;
+    const globals = configs.find((item) => item.name === "nuxt/import-globals")?.languageOptions
+      ?.globals;
+    if (!globals) throw new Error("@nuxt/eslint did not emit nuxt/import-globals");
+    return globals;
   } finally {
     rmSync(rootDir, { force: true, recursive: true });
   }
@@ -210,8 +240,33 @@ export async function runOracle() {
     };
   }
 
+  const importGlobalsEntry = corpus.cases[0];
+  if (!importGlobalsEntry) throw new Error("the import-globals oracle requires a project case");
+  const recordedImportGlobals = await recordImportGlobals(
+    setupConfigGen,
+    importGlobalsEntry,
+    corpus.importGlobals,
+  );
+  const importGlobalsCase = cases[importGlobalsEntry.id];
+  if (!importGlobalsCase) throw new Error("the import-globals oracle case was not recorded");
+  const importGlobalsPlan = buildNuxtLintPlan(importGlobalsCase.features, importGlobalsCase.dirs);
+  const initialOxlintConfig = renderNuxtOxlintConfig(
+    importGlobalsPlan,
+    RECORDED_VIZE_PLUGIN_SPECIFIER,
+  );
+  const regeneratedOxlintConfig = renderNuxtOxlintConfig(
+    [
+      ...importGlobalsPlan,
+      {
+        name: "nuxt/import-globals",
+        globals: recordedImportGlobals,
+      },
+    ],
+    RECORDED_VIZE_PLUGIN_SPECIFIER,
+  );
+
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     description:
       "Recorded @nuxt/eslint output for every case in corpus.json. Generated — do not hand-edit; re-record with oracle.mjs --write.",
     moduleVersion: packageVersionFrom(moduleEntry),
@@ -220,6 +275,13 @@ export async function runOracle() {
     // `typescript` package resolves. Recording the probe's answer keeps the
     // offline test honest about which branch the rest of the recording is on.
     typeScriptDetected: resolveOptions({ features: {}, dirs: {} }).features.typescript,
+    importGlobals: {
+      globals: Object.keys(recordedImportGlobals),
+      artifacts: {
+        initial: initialOxlintConfig,
+        regenerated: regeneratedOxlintConfig,
+      },
+    },
     dirDefaults,
     cases,
   };

--- a/npm/framework/nuxt/src/lint/addons.test.ts
+++ b/npm/framework/nuxt/src/lint/addons.test.ts
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  setupNuxtLintConfigAddons,
+  VIZE_NUXT_LINT_CONFIG_ADDONS_HOOK,
+  type NuxtLintConfigAddon,
+  type NuxtLintConfigAddonNuxt,
+  type NuxtLintImport,
+} from "./addons.ts";
+import { setupNuxtLintConfigGeneration } from "./generation.ts";
+
+type Hook = (...args: unknown[]) => unknown;
+
+function createNuxtStub(
+  extendAddons?: (addons: NuxtLintConfigAddon[]) => void | Promise<void>,
+): NuxtLintConfigAddonNuxt & {
+  callRegisteredHook(name: string, ...args: unknown[]): Promise<void>;
+} {
+  const hooks = new Map<string, Hook[]>();
+
+  return {
+    hook(name, handler) {
+      const registered = hooks.get(name) ?? [];
+      registered.push(handler as Hook);
+      hooks.set(name, registered);
+    },
+    async callHook(name, addons) {
+      assert.equal(name, VIZE_NUXT_LINT_CONFIG_ADDONS_HOOK);
+      await extendAddons?.(addons);
+    },
+    async callRegisteredHook(name, ...args) {
+      for (const handler of hooks.get(name) ?? []) {
+        await handler(...args);
+      }
+    },
+  };
+}
+
+function importContext(imports: NuxtLintImport[]) {
+  return { getImports: async () => imports };
+}
+
+void test("auto-import addon emits the complete deterministically ordered globals list", async () => {
+  const nuxt = createNuxtStub();
+  const resolveAddons = setupNuxtLintConfigAddons(nuxt);
+
+  await nuxt.callRegisteredHook(
+    "imports:context",
+    importContext([
+      { from: "vue", name: "watch", as: "observe" },
+      { from: "#app", name: "useRoute" },
+      { from: "vue", name: "computed" },
+      { from: "#app", name: "useFetch", as: "fetchData" },
+    ]),
+  );
+  await nuxt.callRegisteredHook("nitro:init", {
+    unimport: importContext([
+      { from: "nitropack/runtime", name: "defineNitroPlugin" },
+      { from: "#app", name: "useAsyncData" },
+    ]),
+  });
+
+  const configs = await resolveAddons();
+  assert.equal(configs.length, 1);
+  assert.equal(configs[0].name, "nuxt/import-globals");
+  assert.deepEqual(Object.entries(configs[0].globals ?? {}), [
+    ["useAsyncData", "readonly"],
+    ["fetchData", "readonly"],
+    ["useRoute", "readonly"],
+    ["defineNitroPlugin", "readonly"],
+    ["computed", "readonly"],
+    ["observe", "readonly"],
+  ]);
+});
+
+void test("auto-import addon remains valid before Nuxt publishes either registry", async () => {
+  const configs = await setupNuxtLintConfigAddons(createNuxtStub())();
+
+  assert.deepEqual(configs, [{ name: "nuxt/import-globals", globals: {} }]);
+});
+
+void test("aliases use nullish fallback without losing object-prototype names", async () => {
+  const nuxt = createNuxtStub();
+  const resolveAddons = setupNuxtLintConfigAddons(nuxt);
+  await nuxt.callRegisteredHook(
+    "imports:context",
+    importContext([
+      { from: "source", name: "aProto", as: "__proto__" },
+      { from: "source", name: "bConstructor", as: "constructor" },
+      { from: "source", name: "cToString", as: "toString" },
+      { from: "source", name: "dEmpty", as: "" },
+    ]),
+  );
+
+  const globals = (await resolveAddons())[0].globals ?? {};
+  assert.deepEqual(Object.keys(globals), ["__proto__", "constructor", "toString", ""]);
+  for (const hostileName of ["__proto__", "constructor", "toString"]) {
+    assert.equal(Object.hasOwn(globals, hostileName), true);
+    assert.equal(globals[hostileName], "readonly");
+  }
+  assert.equal(globals[""], "readonly");
+});
+
+void test("addon hook contributes config items in registration order", async () => {
+  const seenArrays: NuxtLintConfigAddon[][] = [];
+  const nuxt = createNuxtStub(async (addons) => {
+    seenArrays.push(addons);
+    addons.push(
+      {
+        name: "first",
+        async getConfigs() {
+          return [{ name: "first", rules: { "vue/first": "warn" } }];
+        },
+      },
+      {
+        name: "empty",
+        getConfigs() {
+          return undefined;
+        },
+      },
+      {
+        name: "second",
+        getConfigs() {
+          return [
+            { name: "second-a", globals: { contributed: "readonly" } },
+            { name: "second-b", ignores: ["generated/**"] },
+          ];
+        },
+      },
+    );
+  });
+  const resolveAddons = setupNuxtLintConfigAddons(nuxt);
+
+  const first = await resolveAddons();
+  const second = await resolveAddons();
+
+  assert.deepEqual(first.slice(1), [
+    { name: "first", rules: { "vue/first": "warn" } },
+    { name: "second-a", globals: { contributed: "readonly" } },
+    { name: "second-b", ignores: ["generated/**"] },
+  ]);
+  assert.deepEqual(second, first);
+  assert.equal(seenArrays.length, 2);
+  assert.notEqual(seenArrays[0], seenArrays[1], "each generation must use a fresh addon array");
+  assert.equal(seenArrays[0].length, 4);
+  assert.equal(seenArrays[1].length, 4);
+});
+
+void test("the most recently published unimport contexts drive regeneration", async () => {
+  const nuxt = createNuxtStub();
+  const resolveAddons = setupNuxtLintConfigAddons(nuxt);
+
+  await nuxt.callRegisteredHook(
+    "imports:context",
+    importContext([{ from: "old", name: "oldImport" }]),
+  );
+  assert.deepEqual((await resolveAddons())[0].globals, { oldImport: "readonly" });
+
+  await nuxt.callRegisteredHook(
+    "imports:context",
+    importContext([{ from: "new", name: "newImport" }]),
+  );
+  await nuxt.callRegisteredHook("nitro:init", {
+    unimport: importContext([{ from: "nitro", name: "serverImport" }]),
+  });
+  assert.deepEqual((await resolveAddons())[0].globals, {
+    newImport: "readonly",
+    serverImport: "readonly",
+  });
+});
+
+void test("generation writes the recorded initial and regenerated artifacts byte for byte", async (t) => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "vize-nuxt-lint-imports-"));
+  t.after(() => rm(rootDir, { force: true, recursive: true }));
+  const hooks = new Map<string, Hook[]>();
+  const nuxt = {
+    options: {
+      rootDir,
+      buildDir: path.join(rootDir, ".nuxt"),
+      srcDir: path.join(rootDir, "app"),
+      dir: {},
+      _layers: [{ config: { srcDir: path.join(rootDir, "app") } }],
+    },
+    hook(name: string, handler: Hook) {
+      hooks.set(name, [...(hooks.get(name) ?? []), handler]);
+    },
+    async callHook(name: string, ...args: unknown[]) {
+      for (const handler of hooks.get(name) ?? []) await handler(...args);
+    },
+  };
+  const corpus = JSON.parse(
+    await readFile(
+      new URL(
+        "../../../nuxt-lint-config/test/nuxt-eslint-compat/fixtures/corpus.json",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  ) as {
+    importGlobals: { nuxt: NuxtLintImport[]; nitro: NuxtLintImport[] };
+  };
+  const recording = JSON.parse(
+    await readFile(
+      new URL(
+        "../../../nuxt-lint-config/test/nuxt-eslint-compat/fixtures/nuxt-eslint-output.json",
+        import.meta.url,
+      ),
+      "utf8",
+    ),
+  ) as {
+    typeScriptDetected: boolean;
+    importGlobals: { artifacts: { initial: string; regenerated: string } };
+  };
+
+  const resolveAddons = setupNuxtLintConfigAddons(nuxt);
+  const generation = await setupNuxtLintConfigGeneration({ autoInit: false }, nuxt, {
+    resolveAddons,
+    hasTypeScript: () => recording.typeScriptDetected,
+    resolvePluginSpecifier: () => "../node_modules/oxlint-plugin-vize/dist/index.mjs",
+  });
+  assert.equal(
+    await readFile(generation?.configFile ?? "", "utf8"),
+    recording.importGlobals.artifacts.initial,
+  );
+
+  await nuxt.callHook("imports:context", importContext(corpus.importGlobals.nuxt));
+  await nuxt.callHook("nitro:init", {
+    unimport: importContext(corpus.importGlobals.nitro),
+  });
+  await nuxt.callHook("builder:generateApp");
+  assert.equal(
+    await readFile(generation?.configFile ?? "", "utf8"),
+    recording.importGlobals.artifacts.regenerated,
+  );
+});
+
+void test("registry and third-party addon failures remain visible", async () => {
+  const registryNuxt = createNuxtStub();
+  const resolveRegistry = setupNuxtLintConfigAddons(registryNuxt);
+  await registryNuxt.callRegisteredHook("imports:context", {
+    async getImports() {
+      throw new Error("registry failed");
+    },
+  });
+  await assert.rejects(resolveRegistry, /registry failed/);
+
+  const addonNuxt = createNuxtStub((addons) => {
+    addons.push({
+      name: "broken",
+      getConfigs() {
+        throw new Error("addon failed");
+      },
+    });
+  });
+  await assert.rejects(setupNuxtLintConfigAddons(addonNuxt), /addon failed/);
+});

--- a/npm/framework/nuxt/src/lint/addons.ts
+++ b/npm/framework/nuxt/src/lint/addons.ts
@@ -1,0 +1,115 @@
+import type { NuxtLintConfigItem } from "@vizejs/nuxt-lint-config";
+
+/** Hook other Nuxt modules use to extend Vize's generated lint config. */
+export const VIZE_NUXT_LINT_CONFIG_ADDONS_HOOK = "vize:lint:config:addons" as const;
+
+/** A synchronous or asynchronous addon result, matching Nuxt hook conventions. */
+export type NuxtLintAwaitable<T> = T | Promise<T>;
+
+/** The import identity exposed by Nuxt and Nitro's unimport registries. */
+export interface NuxtLintImport {
+  from: string;
+  name: string;
+  as?: string;
+}
+
+interface NuxtLintImportContext {
+  getImports(): NuxtLintAwaitable<readonly NuxtLintImport[]>;
+}
+
+/** One extension of the generated, engine-neutral lint config plan. */
+export interface NuxtLintConfigAddon {
+  name: string;
+  getConfigs(): NuxtLintAwaitable<readonly NuxtLintConfigItem[] | undefined>;
+}
+
+/** The Nuxt hook surface used by lint config addons. */
+export interface NuxtLintConfigAddonNuxt {
+  hook(name: "imports:context" | "nitro:init", callback: (value: unknown) => unknown): void;
+  callHook(
+    name: typeof VIZE_NUXT_LINT_CONFIG_ADDONS_HOOK,
+    addons: NuxtLintConfigAddon[],
+  ): NuxtLintAwaitable<void>;
+}
+
+/** Resolve the config items contributed by the current addon registry. */
+export type ResolveNuxtLintConfigAddons = () => Promise<readonly NuxtLintConfigItem[]>;
+
+function asImportContext(value: unknown): NuxtLintImportContext | undefined {
+  if (value == null || typeof value !== "object" || !("getImports" in value)) {
+    return undefined;
+  }
+  return typeof value.getImports === "function" ? (value as NuxtLintImportContext) : undefined;
+}
+
+function nitroImportContext(value: unknown): NuxtLintImportContext | undefined {
+  if (value == null || typeof value !== "object" || !("unimport" in value)) {
+    return undefined;
+  }
+  return asImportContext(value.unimport);
+}
+
+/**
+ * Capture Nuxt's client and server auto-import registries as readonly globals.
+ *
+ * Nuxt publishes both contexts after modules have begun setting up. Keeping
+ * their latest values in the addon means every config regeneration observes
+ * the current registry rather than a module-setup-time snapshot.
+ */
+function createNuxtImportGlobalsAddon(nuxt: NuxtLintConfigAddonNuxt): NuxtLintConfigAddon {
+  let unimport: NuxtLintImportContext | undefined;
+  let nitroUnimport: NuxtLintImportContext | undefined;
+
+  nuxt.hook("imports:context", (context) => {
+    unimport = asImportContext(context);
+  });
+  nuxt.hook("nitro:init", (nitro) => {
+    nitroUnimport = nitroImportContext(nitro);
+  });
+
+  return {
+    name: "vize:lint:import-globals",
+    async getConfigs() {
+      const imports = [
+        ...((await unimport?.getImports()) ?? []),
+        ...((await nitroUnimport?.getImports()) ?? []),
+      ].sort(
+        (left, right) => left.from.localeCompare(right.from) || left.name.localeCompare(right.name),
+      );
+      const globals = Object.fromEntries(
+        imports.map((imported) => [imported.as ?? imported.name, "readonly"] as const),
+      ) as Record<string, "readonly">;
+
+      return [{ name: "nuxt/import-globals", globals }];
+    },
+  };
+}
+
+/**
+ * Register the built-in auto-import addon and return the generation-time
+ * resolver consumed by the Nuxt lint config writer.
+ *
+ * The addon array is rebuilt for every generation. This mirrors Nuxt's addon
+ * hook without retaining contributions across `builder:generateApp` runs.
+ * The Vize-namespaced hook carries engine-neutral config items instead of raw
+ * ESLint source, so contributors remain compatible with the oxlint emitter.
+ */
+export function setupNuxtLintConfigAddons(
+  nuxt: NuxtLintConfigAddonNuxt,
+): ResolveNuxtLintConfigAddons {
+  const defaults = [createNuxtImportGlobalsAddon(nuxt)] satisfies NuxtLintConfigAddon[];
+
+  return async () => {
+    const addons = [...defaults];
+    await nuxt.callHook(VIZE_NUXT_LINT_CONFIG_ADDONS_HOOK, addons);
+
+    const configs: NuxtLintConfigItem[] = [];
+    for (const addon of addons) {
+      const contributed = await addon.getConfigs();
+      if (contributed) {
+        configs.push(...contributed);
+      }
+    }
+    return configs;
+  };
+}

--- a/npm/framework/nuxt/src/lint/generation.ts
+++ b/npm/framework/nuxt/src/lint/generation.ts
@@ -13,6 +13,7 @@ import {
 } from "@vizejs/nuxt-lint-config";
 
 import type { VizeNuxtLintOptions } from "../options.ts";
+import { setupNuxtLintConfigAddons, type NuxtLintConfigAddonNuxt } from "./addons.ts";
 import { renderNuxtOxlintConfig } from "./emitter.ts";
 import { toNuxtLintProjectState, type NuxtLintSourceOptions } from "./nuxt-state.ts";
 
@@ -190,6 +191,11 @@ export async function setupNuxtLintConfigGeneration(
   );
   const hasTypeScriptProbe = dependencies.hasTypeScript ?? hasTypeScript;
   const resolvePluginSpecifier = dependencies.resolvePluginSpecifier ?? resolveVizePluginSpecifier;
+  const resolveAddons =
+    dependencies.resolveAddons ??
+    ("callHook" in nuxt
+      ? setupNuxtLintConfigAddons(nuxt as NuxtLintGenerationNuxt & NuxtLintConfigAddonNuxt)
+      : undefined);
 
   const regenerate = async (): Promise<boolean> => {
     const features = resolveNuxtLintFeatures(featureOptions, () => hasTypeScriptProbe(planRoot));
@@ -197,7 +203,7 @@ export async function setupNuxtLintConfigGeneration(
       rootDir: planRoot,
     });
     const plan = buildNuxtLintPlan(features, collectNuxtLintDirs(project));
-    const addons = (await dependencies.resolveAddons?.()) ?? [];
+    const addons = (await resolveAddons?.()) ?? [];
     const artifact = renderNuxtOxlintConfig(
       [...plan, ...addons],
       resolvePluginSpecifier(path.dirname(configFile)),

--- a/npm/framework/nuxt/src/lint/index.ts
+++ b/npm/framework/nuxt/src/lint/index.ts
@@ -1,6 +1,15 @@
 /** Nuxt runtime integration plus the shared `@vizejs/nuxt-lint-config` API. */
 export * from "@vizejs/nuxt-lint-config";
 export {
+  setupNuxtLintConfigAddons,
+  VIZE_NUXT_LINT_CONFIG_ADDONS_HOOK,
+  type NuxtLintAwaitable,
+  type NuxtLintConfigAddon,
+  type NuxtLintConfigAddonNuxt,
+  type NuxtLintImport,
+  type ResolveNuxtLintConfigAddons,
+} from "./addons.ts";
+export {
   toNuxtLintProjectState,
   type NuxtLintSourceOptions,
   type NuxtLintStateOverrides,

--- a/npm/framework/nuxt/src/lint/module-addons.test.ts
+++ b/npm/framework/nuxt/src/lint/module-addons.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+type Hook = (...args: unknown[]) => unknown;
+
+void test("Nuxt module regenerates lint globals from live registries before later addons", async (t) => {
+  const { default: nuxtModule } = await import(
+    new URL("../../dist/index.mjs", import.meta.url).href
+  );
+  const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-nuxt-module-lint-"));
+  t.after(() => fs.rmSync(rootDir, { recursive: true, force: true }));
+  const hooks = new Map<string, Hook[]>();
+  const nuxt = {
+    _version: "4.0.0",
+    options: {
+      rootDir,
+      srcDir: path.join(rootDir, "app"),
+      buildDir: path.join(rootDir, ".nuxt"),
+      builder: "vite",
+      modules: [],
+      dir: {},
+      _layers: [{ config: { srcDir: path.join(rootDir, "app") } }],
+      dev: false,
+    },
+    hook(name: string, callback: Hook) {
+      hooks.set(name, [...(hooks.get(name) ?? []), callback]);
+    },
+    async callHook(name: string, ...args: unknown[]) {
+      for (const callback of hooks.get(name) ?? []) await callback(...args);
+    },
+  };
+  nuxt.hook("vize:lint:config:addons", (value) => {
+    const addons = value as Array<{
+      name: string;
+      getConfigs(): Array<{ name: string; globals: Record<string, "readonly"> }>;
+    }>;
+    addons.push({
+      name: "later-module",
+      getConfigs: () => [{ name: "nuxt/later-module", globals: { afterImports: "readonly" } }],
+    });
+  });
+
+  await nuxtModule({ compiler: false, lint: { autoInit: false }, musea: false }, nuxt);
+  const generated = path.join(rootDir, ".nuxt", "oxlint.config.json");
+  const initial = JSON.parse(fs.readFileSync(generated, "utf8")) as {
+    globals: Record<string, string>;
+  };
+  assert.deepEqual(Object.keys(initial.globals), ["$fetch", "afterImports"]);
+
+  await nuxt.callHook("imports:context", {
+    getImports: async () => [
+      { from: "vue", name: "watch", as: "observe" },
+      { from: "#app", name: "useRoute" },
+      { from: "#app", name: "alpha", as: "constructor" },
+    ],
+  });
+  await nuxt.callHook("nitro:init", {
+    unimport: {
+      getImports: async () => [{ from: "#app", name: "beta", as: "__proto__" }],
+    },
+  });
+  await nuxt.callHook("builder:generateApp");
+
+  const regenerated = JSON.parse(fs.readFileSync(generated, "utf8")) as {
+    globals: Record<string, string>;
+  };
+  assert.deepEqual(Object.keys(regenerated.globals), [
+    "$fetch",
+    "constructor",
+    "__proto__",
+    "useRoute",
+    "observe",
+    "afterImports",
+  ]);
+  assert.deepEqual(new Set(Object.values(regenerated.globals)), new Set(["readonly"]));
+});

--- a/npm/framework/nuxt/src/lint/oracle.test.ts
+++ b/npm/framework/nuxt/src/lint/oracle.test.ts
@@ -12,6 +12,11 @@ import {
   type NuxtLintProjectState,
 } from "@vizejs/nuxt-lint-config";
 
+import {
+  setupNuxtLintConfigAddons,
+  type NuxtLintConfigAddonNuxt,
+  type NuxtLintImport,
+} from "./addons.ts";
 import { renderNuxtOxlintConfig } from "./emitter.ts";
 
 const compatDir = join(
@@ -40,11 +45,38 @@ function readJson<T>(...segments: string[]): T {
   return JSON.parse(readFileSync(join(compatDir, ...segments), "utf8")) as T;
 }
 
-const corpus = readJson<{ cases: CorpusCase[] }>("fixtures", "corpus.json");
+const corpus = readJson<{
+  importGlobals: {
+    id: string;
+    description: string;
+    nuxt: NuxtLintImport[];
+    nitro: NuxtLintImport[];
+  };
+  cases: CorpusCase[];
+}>("fixtures", "corpus.json");
 const recording = readJson<{
   typeScriptDetected: boolean;
+  importGlobals: {
+    globals: string[];
+    artifacts: { initial: string; regenerated: string };
+  };
   cases: Record<string, RecordedCase>;
 }>("fixtures", "nuxt-eslint-output.json");
+
+function createAddonNuxtStub(): NuxtLintConfigAddonNuxt & {
+  callRegisteredHook(name: string, value: unknown): Promise<void>;
+} {
+  const hooks = new Map<string, Array<(value: unknown) => unknown>>();
+  return {
+    hook(name, callback) {
+      hooks.set(name, [...(hooks.get(name) ?? []), callback]);
+    },
+    callHook() {},
+    async callRegisteredHook(name, value) {
+      for (const callback of hooks.get(name) ?? []) await callback(value);
+    },
+  };
+}
 
 function projectState(entry: CorpusCase): NuxtLintProjectState {
   return {
@@ -56,6 +88,38 @@ function projectState(entry: CorpusCase): NuxtLintProjectState {
     })),
   };
 }
+
+void test(`${corpus.importGlobals.id}: globals and artifacts match @nuxt/eslint byte for byte`, async () => {
+  const nuxt = createAddonNuxtStub();
+  const resolveAddons = setupNuxtLintConfigAddons(nuxt);
+  await nuxt.callRegisteredHook("imports:context", {
+    getImports: async () => corpus.importGlobals.nuxt,
+  });
+  await nuxt.callRegisteredHook("nitro:init", {
+    unimport: { getImports: async () => corpus.importGlobals.nitro },
+  });
+
+  const addons = await resolveAddons();
+  const globals = addons[0]?.globals ?? {};
+  assert.deepEqual(Object.keys(globals), recording.importGlobals.globals);
+  assert.deepEqual(new Set(Object.values(globals)), new Set(["readonly"]));
+  for (const hostileName of ["__proto__", "constructor", "toString"]) {
+    assert.equal(Object.hasOwn(globals, hostileName), true);
+  }
+
+  const entry = corpus.cases[0];
+  assert.ok(entry, "the import-globals oracle requires a base project case");
+  const features = resolveNuxtLintFeatures(entry.config, () => recording.typeScriptDetected);
+  const plan = buildNuxtLintPlan(features, collectNuxtLintDirs(projectState(entry)));
+  assert.equal(
+    renderNuxtOxlintConfig(plan, RECORDED_VIZE_PLUGIN_SPECIFIER),
+    recording.importGlobals.artifacts.initial,
+  );
+  assert.equal(
+    renderNuxtOxlintConfig([...plan, ...addons], RECORDED_VIZE_PLUGIN_SPECIFIER),
+    recording.importGlobals.artifacts.regenerated,
+  );
+});
 
 for (const entry of corpus.cases) {
   void test(`${entry.id}: whole generated oxlint artifact matches upstream`, () => {

--- a/npm/framework/nuxt/src/schema.ts
+++ b/npm/framework/nuxt/src/schema.ts
@@ -1,4 +1,5 @@
 import type { VizeNuxtOptions } from "./options";
+import type { NuxtLintConfigAddon } from "./lint/addons";
 
 declare module "nuxt/schema" {
   interface NuxtConfig {
@@ -7,6 +8,10 @@ declare module "nuxt/schema" {
 
   interface NuxtOptions {
     vize?: Partial<VizeNuxtOptions>;
+  }
+
+  interface NuxtHooks {
+    "vize:lint:config:addons": (addons: NuxtLintConfigAddon[]) => void;
   }
 }
 
@@ -17,5 +22,9 @@ declare module "@nuxt/schema" {
 
   interface NuxtOptions {
     vize?: Partial<VizeNuxtOptions>;
+  }
+
+  interface NuxtHooks {
+    "vize:lint:config:addons": (addons: NuxtLintConfigAddon[]) => void;
   }
 }

--- a/tests/tooling/nuxt-eslint-oracle.test.ts
+++ b/tests/tooling/nuxt-eslint-oracle.test.ts
@@ -35,9 +35,12 @@ test("recorded output matches the installed @nuxt/eslint packages", async () => 
   const recomputed = await oracle.runOracle();
   const recorded = oracle.readRecorded();
 
+  assert.equal(recomputed.schemaVersion, 3);
+  assert.equal(recorded.schemaVersion, 3);
   assert.equal(recomputed.moduleVersion, recorded.moduleVersion);
   assert.equal(recomputed.configVersion, recorded.configVersion);
   assert.equal(recomputed.typeScriptDetected, recorded.typeScriptDetected);
+  assert.deepEqual(recomputed.importGlobals, recorded.importGlobals);
   assert.deepEqual(Object.keys(recomputed.cases).sort(), Object.keys(recorded.cases).sort());
   assert.deepEqual(recomputed.dirDefaults, recorded.dirDefaults);
   assert.deepEqual(recomputed.cases, recorded.cases);
@@ -62,6 +65,7 @@ test("inventory markdown documents exactly the corpus cases", () => {
   // backticked cell, e.g. config item names) without pre-supposing which ids
   // exist — so a missing *or* an extra case row still fails.
   const ids = [
+    corpus.importGlobals.id,
     ...corpus.dirDefaultCases.map((entry: { id: string }) => entry.id),
     ...corpus.cases.map((entry: { id: string }) => entry.id),
   ];


### PR DESCRIPTION
Closes #3614

## Summary
- collect Nuxt and Nitro auto-import registries as readonly lint globals
- expose an ordered addon hook and regenerate from the latest registries
- pin initial and regenerated artifacts against the upstream Nuxt ESLint oracle

## Validation
- `pnpm --filter @vizejs/nuxt test` (158 tests)
- `pnpm --filter @vizejs/nuxt-lint-config test` (55 tests)
- `node --test tests/tooling/nuxt-eslint-oracle.test.ts` (3 tests)
- `pnpm --filter @vizejs/nuxt check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Nuxt lint configuration addons, allowing integrations to contribute lint settings through a public hook.
  * Automatically detects Nuxt and Nitro auto-imports and exposes them as sorted, readonly lint globals.
  * Preserves contributed settings when lint configurations are regenerated.
  * Added support for special global names and aliases without corrupting generated configurations.

* **Bug Fixes**
  * Improved consistency between generated lint configurations and live Nuxt/Nitro import registries.

* **Tests**
  * Added comprehensive coverage for addon ordering, regeneration, registry updates, and generated output compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->