### PR TITLE
perf(glyph): recover formatter throughput

### DIFF
--- a/crates/vize_glyph/src/formatter.rs
+++ b/crates/vize_glyph/src/formatter.rs
@@ -5,13 +5,13 @@
 mod block_indent;
 mod custom_block;
 mod raw_mask;
+mod template_indent;
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
 use crate::script;
 use crate::style;
 use crate::template;
-use raw_mask::compute_raw_line_mask;
 use std::borrow::Cow;
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
 use vize_carton::{Allocator, FxHashMap, String, ToCompactString};
@@ -257,15 +257,12 @@ impl<'a> GlyphFormatter<'a> {
         let trimmed = formatted_content
             .trim_end_matches('\n')
             .trim_end_matches('\r');
-        let lines: Vec<&[u8]> = trimmed.as_bytes().split(|&b| b == b'\n').collect();
-        let raw_mask = compute_raw_line_mask(&lines);
-        for (i, line) in lines.iter().enumerate() {
-            if !line.is_empty() && line != b"\r" && !raw_mask[i] {
-                output.extend_from_slice(indent);
-            }
-            output.extend_from_slice(line);
-            output.extend_from_slice(self.options.newline_bytes());
-        }
+        template_indent::write_indented_template(
+            output,
+            trimmed,
+            indent,
+            self.options.newline_bytes(),
+        );
 
         output.extend_from_slice(b"</template>");
 

--- a/crates/vize_glyph/src/formatter/raw_mask.rs
+++ b/crates/vize_glyph/src/formatter/raw_mask.rs
@@ -6,6 +6,8 @@ mod tests;
 use interpolation::InterpolationScan;
 use tags::{RawRegion, starts_v_pre_attribute, tag_name_at};
 
+pub(super) use tags::starts_v_pre_attribute as starts_v_pre_attribute_at;
+
 /// Per-line "this line is inside a whitespace-significant block" mask.
 ///
 /// Lines inside `<pre>`, `<textarea>`, `v-pre`, multi-line comments,

--- a/crates/vize_glyph/src/formatter/raw_mask/tags.rs
+++ b/crates/vize_glyph/src/formatter/raw_mask/tags.rs
@@ -52,7 +52,7 @@ fn is_tag_name_byte(byte: u8) -> bool {
 /// The byte before the name must be a separator, so `data-v-pre` and
 /// `:title="v-pre"` never match. A cursor at column 0 is a separator too: the
 /// attribute then opens a continuation line of the tag.
-pub(super) fn starts_v_pre_attribute(bytes: &[u8], cursor: usize) -> bool {
+pub(in crate::formatter) fn starts_v_pre_attribute(bytes: &[u8], cursor: usize) -> bool {
     const NAME: &[u8] = b"v-pre";
     if !bytes[cursor..]
         .get(..NAME.len())
@@ -63,7 +63,7 @@ pub(super) fn starts_v_pre_attribute(bytes: &[u8], cursor: usize) -> bool {
     let terminated = bytes
         .get(cursor + NAME.len())
         .is_none_or(|byte| matches!(byte, b' ' | b'\t' | b'\r' | b'=' | b'/' | b'>'));
-    let separated = cursor == 0 || matches!(bytes[cursor - 1], b' ' | b'\t');
+    let separated = cursor == 0 || matches!(bytes[cursor - 1], b' ' | b'\t' | b'\n');
     terminated && separated
 }
 

--- a/crates/vize_glyph/src/formatter/raw_mask/tests.rs
+++ b/crates/vize_glyph/src/formatter/raw_mask/tests.rs
@@ -85,6 +85,12 @@ fn a_v_pre_directive_on_a_later_line_of_the_opening_tag_still_opens_the_region()
 }
 
 #[test]
+fn a_flush_left_v_pre_continuation_still_opens_the_region() {
+    let source = "<code\nv-pre\n>\n  {{ variable }}\n</code>\n<span>y</span>";
+    assert_eq!(mask(source), [false, false, false, true, true, false]);
+}
+
+#[test]
 fn a_same_name_element_nested_in_a_v_pre_region_does_not_end_it() {
     let source = "<div v-pre>\n  <div>x</div>\n  y\n</div>\n<span>z</span>";
     assert_eq!(mask(source), [false, true, true, true, false]);

--- a/crates/vize_glyph/src/formatter/template_indent.rs
+++ b/crates/vize_glyph/src/formatter/template_indent.rs
@@ -1,0 +1,186 @@
+//! Template-block indentation without paying for raw-region lexing when the
+//! formatted template cannot contain a raw continuation line.
+
+use super::raw_mask::{compute_raw_line_mask, starts_v_pre_attribute_at};
+use memchr::{memchr, memchr2, memchr3};
+
+/// Whether the full raw-region lexer can mark any continuation line.
+///
+/// The common formatter corpus has only single-line tags and attribute values.
+/// This preflight skips text and complete attribute values with SIMD searches;
+/// it deliberately falls back for every whitespace-significant tag, comment,
+/// `v-pre` region, backtick, or quoted value crossing a line boundary.
+fn needs_raw_line_mask(source: &[u8]) -> bool {
+    // A backtick is uncommon in templates and may open a multi-line literal in
+    // either an interpolation or directive value. Keep that hostile path on
+    // the real lexer instead of trying to duplicate its JS state machine here.
+    if memchr(b'`', source).is_some() {
+        return true;
+    }
+
+    let mut cursor = 0;
+    let mut in_tag = false;
+    while cursor < source.len() {
+        if !in_tag {
+            let Some(offset) = memchr(b'<', &source[cursor..]) else {
+                break;
+            };
+            cursor += offset;
+            let tail = &source[cursor..];
+            if tail.starts_with(b"<!--") || starts_raw_tag(tail) {
+                return true;
+            }
+            in_tag = source
+                .get(cursor + 1)
+                .is_some_and(|byte| byte.is_ascii_alphabetic() || *byte == b'/');
+            cursor += 1;
+            continue;
+        }
+
+        let structural = memchr3(b'\'', b'"', b'>', &source[cursor..]);
+        let maybe_v_pre = memchr2(b'v', b'V', &source[cursor..]);
+        let Some(offset) = earliest(structural, maybe_v_pre) else {
+            break;
+        };
+        cursor += offset;
+
+        if matches!(source[cursor], b'v' | b'V') {
+            if starts_v_pre_attribute_at(source, cursor) {
+                return true;
+            }
+            cursor += 1;
+            continue;
+        }
+        if source[cursor] == b'>' {
+            in_tag = false;
+            cursor += 1;
+            continue;
+        }
+
+        let quote = source[cursor];
+        let tail = &source[cursor + 1..];
+        let close = memchr(quote, tail);
+        let newline = memchr(b'\n', tail);
+        if newline.is_some_and(|line| close.is_none_or(|end| line < end)) {
+            return true;
+        }
+        cursor += close.map_or(tail.len() + 1, |end| end + 2);
+    }
+
+    false
+}
+
+fn earliest(left: Option<usize>, right: Option<usize>) -> Option<usize> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(offset), None) | (None, Some(offset)) => Some(offset),
+        (None, None) => None,
+    }
+}
+
+fn starts_raw_tag(tail: &[u8]) -> bool {
+    for name in [b"pre".as_slice(), b"textarea".as_slice()] {
+        let Some(head) = tail.get(1..1 + name.len()) else {
+            continue;
+        };
+        if head.eq_ignore_ascii_case(name)
+            && tail
+                .get(1 + name.len())
+                .is_none_or(|byte| matches!(byte, b'>' | b' ' | b'\t' | b'\r' | b'\n' | b'/'))
+        {
+            return true;
+        }
+    }
+    false
+}
+
+pub(super) fn write_indented_template(
+    output: &mut Vec<u8>,
+    source: &str,
+    indent: &[u8],
+    newline: &[u8],
+) {
+    if !needs_raw_line_mask(source.as_bytes()) {
+        for line in source.as_bytes().split(|byte| *byte == b'\n') {
+            write_line(output, line, indent, newline, false);
+        }
+        return;
+    }
+
+    let lines: Vec<_> = source.as_bytes().split(|byte| *byte == b'\n').collect();
+    let raw_mask = compute_raw_line_mask(&lines);
+    for (line, raw) in lines.into_iter().zip(raw_mask) {
+        write_line(output, line, indent, newline, raw);
+    }
+}
+
+fn write_line(output: &mut Vec<u8>, line: &[u8], indent: &[u8], newline: &[u8], raw: bool) {
+    if !line.is_empty() && line != b"\r" && !raw {
+        output.extend_from_slice(indent);
+    }
+    output.extend_from_slice(line);
+    output.extend_from_slice(newline);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compute_raw_line_mask, needs_raw_line_mask, write_indented_template, write_line};
+
+    fn full_lexer_output(source: &str) -> Vec<u8> {
+        let lines: Vec<_> = source.as_bytes().split(|byte| *byte == b'\n').collect();
+        let mask = compute_raw_line_mask(&lines);
+        let mut output = Vec::new();
+        for (line, raw) in lines.into_iter().zip(mask) {
+            write_line(&mut output, line, b"  ", b"\n", raw);
+        }
+        output
+    }
+
+    fn selected_output(source: &str) -> Vec<u8> {
+        let mut output = Vec::new();
+        write_indented_template(&mut output, source, b"  ", b"\n");
+        output
+    }
+
+    #[test]
+    fn ordinary_templates_bypass_the_raw_line_mask() {
+        let ordinary = [
+            "<div>{{ message }}</div>",
+            "<main>\n  <button :disabled=\"loading\" @click=\"save\">Save</button>\n</main>",
+            "<ul>\n  <li v-for=\"item in items\" :key=\"item.id\">{{ item.name }}</li>\n</ul>",
+            "<div :title=\"'quoted'\" data-note=\"v-prepare\">{{ oneLine }}</div>",
+        ];
+
+        for source in ordinary {
+            assert!(
+                !needs_raw_line_mask(source.as_bytes()),
+                "ordinary template must stay on the allocation-free path: {source}"
+            );
+            assert_eq!(
+                selected_output(source),
+                full_lexer_output(source),
+                "the fast path must stay byte-identical to the full lexer"
+            );
+        }
+    }
+
+    #[test]
+    fn every_raw_continuation_shape_keeps_the_full_lexer() {
+        let raw = [
+            "<pre>\nraw\n</pre>",
+            "<TEXTAREA>\nraw\n</TEXTAREA>",
+            "<code V-PRE>\n  {{ raw }}\n</code>",
+            "<!--\nraw\n-->",
+            "<div title=\"first\nsecond\">x</div>",
+            "<div>{{ `first\nsecond` }}</div>",
+        ];
+
+        for source in raw {
+            assert!(
+                needs_raw_line_mask(source.as_bytes()),
+                "raw template must keep the full lexer: {source}"
+            );
+            assert_eq!(selected_output(source), full_lexer_output(source));
+        }
+    }
+}

--- a/crates/vize_glyph/src/style.rs
+++ b/crates/vize_glyph/src/style.rs
@@ -3,15 +3,12 @@
 //! This module provides formatting for CSS/SCSS/Less content
 //! in Vue SFC `<style>` blocks using lightningcss for parsing and printing.
 
+mod stabilization;
+
 use crate::error::FormatError;
 use crate::options::FormatOptions;
 use lightningcss::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
 use vize_carton::{String, ToCompactString};
-
-/// Upper bound on lightningcss re-format passes when reaching a fixed point.
-/// A single extra pass fixes the known shorthand-normalization cases; the
-/// bound guards against a pathological non-converging value. (#3248)
-const MAX_STYLE_STABILIZATION_PASSES: usize = 4;
 
 /// Format CSS content using lightningcss.
 ///
@@ -72,20 +69,7 @@ fn format_with_preserved_top_level_comments(
 }
 
 fn format_chunk(trimmed: &str, options: &FormatOptions) -> Result<String, FormatError> {
-    let mut current = format_chunk_once(trimmed, options)?;
-    // lightningcss normalization is not always a fixed point: parsing its own
-    // output can normalize a value further (e.g. collapsing the CSS shorthand
-    // `background-position: 1em 50%` to `1em`, since a missing y-position
-    // defaults to center). Re-run to a fixed point so one `vize fmt` pass
-    // already emits the normal form and the formatter stays idempotent. (#3248)
-    for _ in 1..MAX_STYLE_STABILIZATION_PASSES {
-        let next = format_chunk_once(current.as_str(), options)?;
-        if next.as_str() == current.as_str() {
-            return Ok(next);
-        }
-        current = next;
-    }
-    Ok(current)
+    stabilization::format_to_fixed_point(trimmed, |source| format_chunk_once(source, options))
 }
 
 fn format_chunk_once(trimmed: &str, options: &FormatOptions) -> Result<String, FormatError> {

--- a/crates/vize_glyph/src/style/stabilization.rs
+++ b/crates/vize_glyph/src/style/stabilization.rs
@@ -1,0 +1,77 @@
+//! Selective lightningcss fixed-point passes.
+//!
+//! The real-project idempotence corpus found one construct whose first printed
+//! form is not stable: `background-position` shorthand (#3248). Re-parsing all
+//! other style blocks doubled their parse/print work to guard one property.
+
+use crate::error::FormatError;
+use memchr::memmem;
+use vize_carton::String;
+
+/// Upper bound for a pathological non-converging lightningcss value.
+const MAX_PASSES: usize = 4;
+
+pub(super) fn format_to_fixed_point(
+    source: &str,
+    mut format_once: impl FnMut(&str) -> Result<String, FormatError>,
+) -> Result<String, FormatError> {
+    let mut current = format_once(source)?;
+    if !may_need_another_pass(current.as_bytes()) {
+        return Ok(current);
+    }
+
+    for _ in 1..MAX_PASSES {
+        let next = format_once(current.as_str())?;
+        if next == current {
+            return Ok(next);
+        }
+        current = next;
+    }
+    Ok(current)
+}
+
+fn may_need_another_pass(printed: &[u8]) -> bool {
+    memmem::find(printed, b"background-position").is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_to_fixed_point;
+    use std::cell::Cell;
+    use vize_carton::ToCompactString;
+
+    #[test]
+    fn ordinary_css_is_parsed_and_printed_once() {
+        let calls = Cell::new(0);
+        let result = format_to_fixed_point(".a{color:red}", |source| {
+            calls.set(calls.get() + 1);
+            Ok(source.to_compact_string())
+        })
+        .unwrap();
+
+        assert_eq!(result.as_str(), ".a{color:red}");
+        assert_eq!(calls.get(), 1, "ordinary CSS must not pay a stability pass");
+    }
+
+    #[test]
+    fn background_position_runs_until_the_printed_form_is_stable() {
+        let calls = Cell::new(0);
+        let result = format_to_fixed_point("input", |_| {
+            let pass = calls.get();
+            calls.set(pass + 1);
+            Ok(match pass {
+                0 => ".a { background-position: 1em 50%; }",
+                _ => ".a { background-position: 1em; }",
+            }
+            .to_compact_string())
+        })
+        .unwrap();
+
+        assert_eq!(result.as_str(), ".a { background-position: 1em; }");
+        assert_eq!(
+            calls.get(),
+            3,
+            "the stable result must be observed, not assumed"
+        );
+    }
+}


### PR DESCRIPTION
Closes #3460.

- bypasses raw-region allocation for ordinary formatted templates
- limits repeated lightningcss stabilization to the known background-position case
- preserves raw template and CSS idempotence fallbacks

Validation:
- full vize_glyph test suite
- Vux 312-SFC idempotence, parser-preservation, and lint-agreement corpus
- exact-base Criterion: format_sfc -14.30%, allocator reuse -12.52%
- cargo fmt and strict changed-surface clippy

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->