### PR TITLE
feat(atelier): emit true for Babel boolean JSX attrs

### DIFF
--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -17,7 +17,7 @@ use crate::forwarded_slots::{SlotsForwardingBackend, reject_forwarded_slots};
 use crate::ssr::compile_lowered_root_to_ssr;
 use crate::vapor::{VaporCompileOptions, compile_root_to_vapor};
 use crate::vdom::{VdomCompileOptions, compile_root_to_vdom};
-use crate::{JsxLang, JsxOutputMode, lower_source};
+use crate::{JsxLang, JsxOutputMode, lower_source_with_compat};
 
 pub use component::JsxComponent;
 
@@ -209,7 +209,7 @@ pub fn compile_jsx(
     lang: JsxLang,
     config: &JsxCompileConfig,
 ) -> JsxCompileOutput {
-    let lowered = lower_source(bump, source, lang);
+    let lowered = lower_source_with_compat(bump, source, lang, config.compat);
     let mut diagnostics = lowered.diagnostics;
     let is_ts = lang.is_typescript();
 

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -163,11 +163,25 @@ impl<'a> LowerOutput<'a> {
 /// allocator used for parsing is dropped before returning, so the result only
 /// borrows `bump`.
 pub fn lower_source<'a>(bump: &'a Bump, source: &str, lang: JsxLang) -> LowerOutput<'a> {
+    lower_source_with_compat(bump, source, lang, JsxCompatMode::Native)
+}
+
+/// Lower a module with project-level compatibility semantics.
+///
+/// This stays crate-private so analysis, LSP, and direct backend entry points
+/// retain native semantics; the configured compatibility switch is consumed by
+/// the mode-aware compiler.
+fn lower_source_with_compat<'a>(
+    bump: &'a Bump,
+    source: &str,
+    lang: JsxLang,
+    compat: JsxCompatMode,
+) -> LowerOutput<'a> {
     let allocator = oxc_allocator::Allocator::default();
     let parse_source = parse::prepare_source_for_parse(source, lang);
     let parsed = parse::parse_module(&allocator, parse_source.as_ref(), lang);
     let mapper = SpanMapper::new(source);
-    let mut lowerer = Lowerer::new(bump, &mapper);
+    let mut lowerer = Lowerer::with_compat(bump, &mapper, compat);
     for diagnostic in parsed.diagnostics {
         lowerer.report(diagnostic);
     }

--- a/crates/vize_atelier_jsx/src/lower.rs
+++ b/crates/vize_atelier_jsx/src/lower.rs
@@ -27,6 +27,7 @@ use oxc_span::Span;
 use vize_carton::{Box, Bump, String, ToCompactString};
 use vize_relief::{RootNode, TemplateChildNode};
 
+use crate::compat::JsxCompatMode;
 use crate::diagnostics::JsxDiagnostic;
 use crate::span::SpanMapper;
 
@@ -34,6 +35,7 @@ use crate::span::SpanMapper;
 pub struct Lowerer<'a, 'm, 's> {
     bump: &'a Bump,
     mapper: &'m SpanMapper<'s>,
+    compat: JsxCompatMode,
     diagnostics: std::vec::Vec<JsxDiagnostic>,
     /// `<style scoped>` blocks extracted from the render root currently being
     /// lowered, in source order. Drained by [`Self::take_scoped_styles`] once
@@ -44,9 +46,19 @@ pub struct Lowerer<'a, 'm, 's> {
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Build a lowerer that allocates IR in `bump` and maps spans via `mapper`.
     pub fn new(bump: &'a Bump, mapper: &'m SpanMapper<'s>) -> Self {
+        Self::with_compat(bump, mapper, JsxCompatMode::Native)
+    }
+
+    /// Build a lowerer using the requested project-level JSX semantics.
+    pub(crate) fn with_compat(
+        bump: &'a Bump,
+        mapper: &'m SpanMapper<'s>,
+        compat: JsxCompatMode,
+    ) -> Self {
         Self {
             bump,
             mapper,
+            compat,
             diagnostics: std::vec::Vec::new(),
             pending_styles: std::vec::Vec::new(),
         }
@@ -143,5 +155,10 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Shared accessor used by sibling lowering modules.
     pub(crate) fn mapper(&self) -> &'m SpanMapper<'s> {
         self.mapper
+    }
+
+    /// Whether the project opted into `@vue/babel-plugin-jsx` semantics.
+    pub(crate) fn uses_babel_compat(&self) -> bool {
+        self.compat.is_babel()
     }
 }

--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -1,13 +1,13 @@
-//! Lowering JSX attributes into Vize props (attributes, binds, directives).
-//!
-//! The mapping is backend-neutral; richer `v-on`/`v-model` semantics belong to
-//! the VDOM/Vapor backends (#1493/#1494). Here we faithfully classify:
+//! Lowering JSX attributes into backend-neutral Vize props leaves richer `v-on`/`v-model` semantics to the
+//! VDOM/Vapor backends (#1493/#1494):
 //!
 //! - `name="str"`      -> static [`AttributeNode`]
 //! - `name` (no value) -> boolean [`AttributeNode`]
 //! - `name={expr}`     -> `v-bind:name` [`DirectiveNode`]
 //! - `{...obj}`        -> `v-bind="obj"` [`DirectiveNode`]
 //! - `v-x` / `v-x:arg` -> [`DirectiveNode`] named `x`
+
+mod compat;
 
 use oxc_ast::ast::{
     JSXAttribute, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXSpreadAttribute,
@@ -99,7 +99,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         let name = String::from(self.mapper().slice(attr.name.span()));
         let name_loc = self.mapper().location(attr.name.span());
         let prop = match attr.value.as_ref() {
-            None => self.boolean_attr(name, name_loc, loc),
+            None => self.valueless_attr(name, attr.name.span(), name_loc, loc),
             Some(JSXAttributeValue::StringLiteral(string)) => {
                 let value =
                     TextNode::new(string.value.as_str(), self.mapper().location(string.span));

--- a/crates/vize_atelier_jsx/src/lower/attr/compat.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr/compat.rs
@@ -1,0 +1,29 @@
+//! Attribute lowering specific to Babel JSX compatibility mode.
+
+use oxc_span::Span;
+use vize_carton::{Box, String};
+use vize_relief::{DirectiveNode, PropNode, SourceLocation};
+
+use crate::lower::Lowerer;
+
+impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// A valueless JSX attribute is a boolean `true` in Babel's JSX
+    /// semantics. Native Vize lowering deliberately keeps its established
+    /// template-style empty-string value.
+    pub(super) fn valueless_attr(
+        &self,
+        name: String,
+        name_span: Span,
+        name_loc: SourceLocation,
+        loc: SourceLocation,
+    ) -> PropNode<'a> {
+        if !self.uses_babel_compat() {
+            return self.boolean_attr(name, name_loc, loc);
+        }
+
+        let mut directive = DirectiveNode::new(self.bump(), "bind", loc);
+        directive.arg = Some(self.static_expr(&name, name_span));
+        directive.exp = Some(self.constant_expr("true", name_span));
+        PropNode::Directive(Box::new_in(directive, self.bump()))
+    }
+}

--- a/crates/vize_atelier_jsx/src/lower/expr.rs
+++ b/crates/vize_atelier_jsx/src/lower/expr.rs
@@ -29,6 +29,15 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             self.bump(),
         ))
     }
+
+    /// A generated JavaScript constant anchored to an authored token.
+    pub(crate) fn constant_expr(&self, content: &str, span: Span) -> ExpressionNode<'a> {
+        let loc = self.mapper().location(span);
+        ExpressionNode::Simple(Box::new_in(
+            SimpleExpressionNode::new(content, false, loc),
+            self.bump(),
+        ))
+    }
 }
 
 /// The span of the expression inside a container, or `None` for an empty

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -148,7 +148,7 @@ Recorded so the verdicts are not read as byte equality (#3421,
 | Case                             | Babel                                       | Vize today                              | Compat mode            | Verdict |
 | -------------------------------- | ------------------------------------------- | --------------------------------------- | ---------------------- | ------- |
 | `props/static_attr`              | `{type: "email"}`                           | same                                    | no change              | ✅      |
-| `props/boolean_attr`             | `<input disabled/>` → `disabled: true`      | `disabled: ""`                          | emits `true` (#3391)    | ✅      |
+| `props/boolean_attr`             | `<input disabled/>` → `disabled: true`      | `disabled: ""`                          | emits `true` (#3391)   | ✅      |
 | `props/dynamic_attr`             | `{placeholder: p}`                          | same + `PROPS` flag                     | no change              | ✅      |
 | `props/dashed_attrs`             | `data-foo` / `aria-label` kept verbatim     | same                                    | no change              | ✅      |
 | `props/xlink_camel`              | `xlinkHref` → `"xlink:href"`                | keeps `xlinkHref`                       | rewrite the camel form | ❌      |

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   78 |
-| divergent  |   18 |
+| equivalent |   79 |
+| divergent  |   17 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -148,7 +148,7 @@ Recorded so the verdicts are not read as byte equality (#3421,
 | Case                             | Babel                                       | Vize today                              | Compat mode            | Verdict |
 | -------------------------------- | ------------------------------------------- | --------------------------------------- | ---------------------- | ------- |
 | `props/static_attr`              | `{type: "email"}`                           | same                                    | no change              | ✅      |
-| `props/boolean_attr`             | `<input disabled/>` → `disabled: true`      | `disabled: ""`                          | emit `true`            | ❌      |
+| `props/boolean_attr`             | `<input disabled/>` → `disabled: true`      | `disabled: ""`                          | emits `true` (#3391)    | ✅      |
 | `props/dynamic_attr`             | `{placeholder: p}`                          | same + `PROPS` flag                     | no change              | ✅      |
 | `props/dashed_attrs`             | `data-foo` / `aria-label` kept verbatim     | same                                    | no change              | ✅      |
 | `props/xlink_camel`              | `xlinkHref` → `"xlink:href"`                | keeps `xlinkHref`                       | rewrite the camel form | ❌      |

--- a/crates/vize_atelier_jsx/tests/babel_compat/mod.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/mod.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use std::path::PathBuf;
 
 use serde::Deserialize;
-use vize_atelier_jsx::{JsxCompileConfig, JsxLang, compile_jsx};
+use vize_atelier_jsx::{JsxCompatMode, JsxCompileConfig, JsxLang, compile_jsx};
 use vize_carton::Bump;
 
 /// The relationship between Vize's default output and babel's for one case.
@@ -22,13 +22,12 @@ use vize_carton::Bump;
 /// emits bare `createVNode` calls, so identical bytes are never the goal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Verdict {
-    /// Vize's default output is semantically equivalent to babel's: it mounts to
-    /// the same DOM and patches the same way, even where the emitted call shape
+    /// Vize's Babel-compat output is semantically equivalent to babel's: it mounts
+    /// to the same DOM and patches the same way, even where the emitted call shape
     /// differs.
     Equivalent,
-    /// Vize's default output differs observably from babel's. The payload names
-    /// the difference; the matching `BABEL_COMPAT_INVENTORY.md` row records what
-    /// compat mode is expected to do about it.
+    /// Vize's Babel-compat output still differs observably from babel's. The
+    /// payload names the remaining difference.
     Divergent(&'static str),
     /// Vize does not implement this case at all yet. The payload names the
     /// reason and the tracking issue.
@@ -159,8 +158,8 @@ pub fn load_recording() -> Recording {
     serde_json::from_str(&text).unwrap_or_else(|error| panic!("parse {}: {error}", path.display()))
 }
 
-/// Compile one corpus case with Vize's **default** configuration and render the
-/// result for the snapshot.
+/// Compile one corpus case with Vize's opt-in Babel compatibility mode and
+/// render the result for the snapshot.
 ///
 /// This uses [`compile_jsx`] + `module_code()` rather than the lower-level
 /// per-component render code, because that is the module Vize's bundler
@@ -176,7 +175,10 @@ pub fn vize_vdom_output(case: &Case) -> std::string::String {
         &bump,
         &case.source,
         case.jsx_lang(),
-        &JsxCompileConfig::default(),
+        &JsxCompileConfig {
+            compat: JsxCompatMode::Babel,
+            ..Default::default()
+        },
     );
 
     let mut rendered = std::string::String::new();

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -56,10 +56,7 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("elements/nested_fragment_child", Same),
     // -- props -----------------------------------------------------------
     ("props/static_attr", Same),
-    (
-        "props/boolean_attr",
-        Diff("valueless attribute lowers to \"\" not true"),
-    ),
+    ("props/boolean_attr", Same),
     ("props/dynamic_attr", Same),
     ("props/dashed_attrs", Same),
     (

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (78, 18, 2));
+    assert_eq!((equivalent, divergent, deferred), (79, 17, 2));
     assert_eq!(VERDICTS.len(), 98);
 }
 
@@ -113,7 +113,7 @@ fn babel_compat_matrix_snapshot() {
             writeln!(body, "{}", case.babel_options_display()).unwrap();
             writeln!(body, "### babel").unwrap();
             writeln!(body, "{}", babel.display()).unwrap();
-            writeln!(body, "### vize (vdom, default config)").unwrap();
+            writeln!(body, "### vize (vdom, babel compat)").unwrap();
             writeln!(body, "{}", vize_vdom_output(case)).unwrap();
             body.push('\n');
         }

--- a/crates/vize_atelier_jsx/tests/compat_mode.rs
+++ b/crates/vize_atelier_jsx/tests/compat_mode.rs
@@ -1,9 +1,8 @@
 //! The opt-in `@vue/babel-plugin-jsx` compatibility switch (#3391).
 //!
-//! These tests pin the switch's *contract* rather than any particular compat
-//! behavior: the mode is off by default, turning it on never changes VDOM
-//! output yet (behaviors land one PR per inventory row), and asking for it under
-//! Vapor output is rejected with a diagnostic rather than silently ignored.
+//! These tests pin the switch's contract and each compatibility behavior: the
+//! mode is off by default, behaviors land one inventory row at a time, and
+//! asking for it under Vapor output is rejected rather than silently ignored.
 //!
 //! The "default output is unchanged" test is the important one — flipping the
 //! default would be a silent compatibility break for every existing Vize user.
@@ -69,19 +68,35 @@ fn default_config_output_equals_explicit_native() {
 }
 
 #[test]
-fn babel_compat_vdom_output_is_unchanged_for_now() {
-    // No inventory row has been closed yet, so compat mode is still a no-op on
-    // VDOM output. This test is what the first behavioral PR flips: when a
-    // divergence is closed, these two stop being equal and the assertion here
-    // becomes the pin for the new compat-only output.
-    assert_eq!(
-        module_code(JsxCompatMode::Babel, JsxOutputMode::Vdom),
-        module_code(JsxCompatMode::Native, JsxOutputMode::Vdom)
-    );
+fn babel_compat_vdom_remains_error_free() {
     assert_eq!(
         diagnostics(JsxCompatMode::Babel, JsxOutputMode::Vdom),
         Vec::<String>::new()
     );
+}
+
+#[test]
+fn babel_compat_emits_true_for_a_valueless_attribute_only_when_opted_in() {
+    let compile = |compat| {
+        let bump = Bump::new();
+        compile_jsx(
+            &bump,
+            "const A = () => <input disabled/>;",
+            JsxLang::Jsx,
+            &JsxCompileConfig {
+                compat,
+                ..Default::default()
+            },
+        )
+        .module_code()
+        .to_string()
+    };
+
+    let native = compile(JsxCompatMode::Native);
+    let babel = compile(JsxCompatMode::Babel);
+    assert!(native.contains("{ disabled: \"\" }"), "{native}");
+    assert!(babel.contains("{ disabled: true }"), "{babel}");
+    assert_ne!(native, babel);
 }
 
 #[test]

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__children.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__children.snap
@@ -12,7 +12,7 @@ const A = () => <div>x</div>;
 ### babel
 import { createTextVNode as _createTextVNode, createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [_createTextVNode("x")]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, "x"))
@@ -28,7 +28,7 @@ const A = () => <div>hi {name}!</div>;
 ### babel
 import { createTextVNode as _createTextVNode, createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [_createTextVNode("hi "), name, _createTextVNode("!")]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, "hi " + _toDisplayString(name) + "!", 1 /* TEXT */))
@@ -44,7 +44,7 @@ const A = () => <div>{/* c */}</div>;
 ### babel
 import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div"))
@@ -60,7 +60,7 @@ const A = () => <div>{}</div>;
 ### babel
 import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div"))
@@ -76,7 +76,7 @@ const A = () => <div>{...items}</div>;
 ### babel
 import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [...items]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 <Error> spread children (`{...items}`) are not supported; the value would be stringified instead of spread
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
@@ -93,7 +93,7 @@ const A = () => <div>{c && <span/>}</div>;
 ### babel
 import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [c && _createVNode("span", null, null)]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, [
@@ -113,7 +113,7 @@ const A = () => <div>{c ? <a/> : <b/>}</div>;
 ### babel
 import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [c ? _createVNode("a", null, null) : _createVNode("b", null, null)]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, [
@@ -135,7 +135,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [list.map(i => _createVNode("span", {
   "key": i
 }, [i]))]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, [

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
@@ -14,7 +14,7 @@ import { vModelText as _vModelText, createVNode as _createVNode, withDirectives 
 const A = () => _withDirectives(_createVNode("input", {
   "onUpdate:modelValue": $event => val = $event
 }, null), [[_vModelText, val]]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return _withDirectives((_openBlock(), _createElementBlock("input", {
@@ -36,7 +36,7 @@ import { vModelText as _vModelText, createVNode as _createVNode, withDirectives 
 const A = () => _withDirectives(_createVNode("input", {
   "onUpdate:foo": $event => val = $event
 }, null), [[_vModelText, val, "foo"]]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 <Error> v-model argument is not supported on plain elements.
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
@@ -57,7 +57,7 @@ const A = () => _withDirectives(_createVNode("input", {
 }, null), [[_vModelText, val, void 0, {
   trim: true
 }]]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return _withDirectives((_openBlock(), _createElementBlock("input", {
@@ -86,7 +86,7 @@ const A = () => _withDirectives(_createVNode("input", {
 }, null), [[_vModelText, val, void 0, {
   lazy: true
 }]]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return _withDirectives((_openBlock(), _createElementBlock("input", {
@@ -115,7 +115,7 @@ const A = () => _withDirectives(_createVNode("input", {
 }, null), [[_vModelText, val, "foo", {
   trim: true
 }]]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 <Error> v-model argument is not supported on plain elements.
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
@@ -135,7 +135,7 @@ const A = () => _createVNode(_resolveComponent("B"), {
   "modelValue": val,
   "onUpdate:modelValue": $event => val = $event
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -162,7 +162,7 @@ const A = () => _createVNode(_resolveComponent("B"), {
   },
   "onUpdate:argument": $event => val = $event
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -187,7 +187,7 @@ const A = () => _createVNode(_resolveComponent("B"), {
   [bar]: foo,
   ["onUpdate:" + bar]: $event => foo = $event
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 <Error> v-model argument `bar` must be a string literal; dynamic arguments are not supported.
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
@@ -211,7 +211,7 @@ const A = () => _createVNode(_resolveComponent("B"), {
   'bar': bar,
   "onUpdate:bar": $event => bar = $event
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -245,7 +245,7 @@ const A = () => _createVNode(_resolveComponent("B"), {
   },
   "onUpdate:bar": $event => bar = $event
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -270,7 +270,7 @@ const A = () => <div v-show={vis}/>;
 ### babel
 import { vShow as _vShow, createVNode as _createVNode, withDirectives as _withDirectives } from "vue";
 const A = () => _withDirectives(_createVNode("div", null, null), [[_vShow, vis]]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock, vShow as _vShow } from "vue"
 export function render(_ctx, _cache) {
   return _withDirectives((_openBlock(), _createElementBlock("div", null, null, 512 /* NEED_PATCH */)), [
@@ -288,7 +288,7 @@ const A = () => <B v-show={vis}/>;
 ### babel
 import { resolveComponent as _resolveComponent, vShow as _vShow, createVNode as _createVNode, withDirectives as _withDirectives } from "vue";
 const A = () => _withDirectives(_createVNode(_resolveComponent("B"), null, null), [[_vShow, vis]]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, withDirectives as _withDirectives, openBlock as _openBlock, createBlock as _createBlock, vShow as _vShow } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -310,7 +310,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "innerHTML": h
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { innerHTML: h }, null, 8 /* PROPS */, ["innerHTML"]))
@@ -328,7 +328,7 @@ import { createTextVNode as _createTextVNode, createVNode as _createVNode } from
 const A = () => _createVNode("div", {
   "innerHTML": h
 }, [_createTextVNode("ignored")]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { innerHTML: h }, "ignored", 8 /* PROPS */, ["innerHTML"]))
@@ -346,7 +346,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "textContent": t
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", {
@@ -364,7 +364,7 @@ const A = () => <a v-custom:arg={val}/>;
 ### babel
 import { resolveDirective as _resolveDirective, createVNode as _createVNode, withDirectives as _withDirectives } from "vue";
 const A = () => _withDirectives(_createVNode("a", null, null), [[_resolveDirective("custom"), val, "arg"]]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   const _directive_custom = _resolveDirective("custom")
@@ -387,7 +387,7 @@ const A = () => _withDirectives(_createVNode("a", null, null), [[_resolveDirecti
   a: true,
   b: true
 }]]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   const _directive_custom = _resolveDirective("custom")
@@ -407,7 +407,7 @@ const A = () => <div v-unknown-thing={x}/>;
 ### babel
 import { resolveDirective as _resolveDirective, createVNode as _createVNode, withDirectives as _withDirectives } from "vue";
 const A = () => _withDirectives(_createVNode("div", null, null), [[_resolveDirective("unknown-thing"), x]]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   const _directive_unknown_thing = _resolveDirective("unknown-thing")

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__elements.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__elements.snap
@@ -12,7 +12,7 @@ const A = () => <div/>;
 ### babel
 import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div"))
@@ -28,7 +28,7 @@ const A = () => <B/>;
 ### babel
 import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_resolveComponent("B"), null, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -46,7 +46,7 @@ const A = () => <foo/>;
 ### babel
 import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_resolveComponent("foo"), null, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("foo"))
@@ -62,7 +62,7 @@ const A = () => <my-el/>;
 ### babel
 import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_resolveComponent("my-el"), null, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_my_el = _resolveComponent("my-el")
@@ -82,7 +82,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("circle", {
   "cx": 1
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("circle", { cx: 1 }))
@@ -100,7 +100,7 @@ import { createTextVNode as _createTextVNode, resolveComponent as _resolveCompon
 const A = () => _createVNode(_resolveComponent("mi"), null, {
   default: () => [_createTextVNode("x")]
 });
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("mi", null, "x"))
@@ -118,7 +118,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode(a.b.c, {
   "foo": 1
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createBlock(_resolveDynamicComponent(a.b.c), { foo: 1 }))
@@ -133,7 +133,7 @@ const A = () => <a:b foo={1}/>;
 (defaults)
 ### babel
 <error> getTag: JSXNamespacedName is not supported
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 <Error> unsupported JSX tag namespace `a:`; only `svg:` and `math:` name a real element namespace, so `a:b` would be emitted verbatim as a tag name nothing resolves (`@vue/babel-plugin-jsx` rejects every namespaced tag)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
@@ -150,7 +150,7 @@ const A = () => <><span>I</span><span>F</span></>;
 ### babel
 import { Fragment as _Fragment, createTextVNode as _createTextVNode, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_Fragment, null, [_createVNode("span", null, [_createTextVNode("I")]), _createVNode("span", null, [_createTextVNode("F")])]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock(_Fragment, null, [
@@ -169,7 +169,7 @@ const A = () => <div><><i/></></div>;
 ### babel
 import { Fragment as _Fragment, createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [_createVNode(_Fragment, null, [_createVNode("i", null, null)])]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, [

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
@@ -11,7 +11,7 @@ const A = () => <input v-model={{a:1}}/>;
 (defaults)
 ### babel
 <error> Property left of AssignmentExpression expected node to be of a type ["LVal","OptionalMemberExpression"] but instead got "ObjectExpression"
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 <Error> v-model target `{a:1}` cannot be assigned to; v-model needs a variable or property reference.
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
@@ -27,7 +27,7 @@ const A = () => <input v-model/>;
 (defaults)
 ### babel
 <error> You have to use JSX Expression inside your v-model
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 <Error> v-model is missing expression.
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
@@ -43,7 +43,7 @@ const A = () => <B v-models={foo}/>;
 (defaults)
 ### babel
 <error> Property key of ObjectProperty expected node to be of a type ["Identifier","StringLiteral","NumericLiteral","BigIntLiteral","DecimalLiteral","PrivateName"] but instead got undefined
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 <Error> v-models expects a two-dimensional array of `[value, arg?, modifiers?]` entries, e.g. v-models={[[foo], [bar, "bar"]]}.
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
@@ -61,7 +61,7 @@ const A = () => <B v-models={[foo]}/>;
 (defaults)
 ### babel
 <error> You should pass a Two-dimensional Arrays to v-models
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 <Error> v-models entry `foo` is not an array; each entry must be `[value, arg?, modifiers?]`.
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
@@ -80,7 +80,7 @@ const A = () => <B v-slots={1}/>;
 ### babel
 import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_resolveComponent("B"), null, 1);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 <Error> v-slots value `1` is not a slots object: babel forwards it as the component's children, which leaves the component with no slots. Write the slots inline, e.g. v-slots={{ default: () => <div/> }}, or forward a slots object, e.g. v-slots={slots}.
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__events.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__events.snap
@@ -14,7 +14,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "onClick": h
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { onClick: h }, null, 8 /* PROPS */, ["onClick"]))
@@ -32,7 +32,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "onClickCapture": h
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { onClickCapture: h }, null, 40 /* PROPS, NEED_HYDRATION */, ["onClickCapture"]))
@@ -50,7 +50,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "onClickOnce": h
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { onClickOnce: h }, null, 40 /* PROPS, NEED_HYDRATION */, ["onClickOnce"]))
@@ -68,7 +68,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "onClickCapturePassive": h
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { onClickCapturePassive: h }, null, 40 /* PROPS, NEED_HYDRATION */, ["onClickCapturePassive"]))

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__optimize.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__optimize.snap
@@ -14,7 +14,7 @@ import { createTextVNode as _createTextVNode, createVNode as _createVNode } from
 const A = () => _createVNode("div", {
   "class": "a"
 }, [_createTextVNode("x")]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { class: "a" }, "x"))
@@ -32,7 +32,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "class": c
 }, null, 2);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", {
@@ -52,7 +52,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "style": s
 }, null, 4);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { normalizeStyle as _normalizeStyle, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", {
@@ -70,7 +70,7 @@ const A = () => <div>{t}</div>;
 ### babel
 import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [t]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, _toDisplayString(t), 1 /* TEXT */))
@@ -89,7 +89,7 @@ const A = () => _createVNode("div", {
   "class": c,
   "id": i
 }, [t], 10, ["id"]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { toDisplayString as _toDisplayString, normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", {
@@ -108,7 +108,7 @@ const A = () => <div {...p}/>;
 ### babel
 import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", p, null, 16);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { normalizeProps as _normalizeProps, guardReactiveProps as _guardReactiveProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _normalizeProps(_guardReactiveProps(p)), null, 16 /* FULL_PROPS */))
@@ -126,7 +126,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "ref": r
 }, null, 512);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { ref: r }, null, 512 /* NEED_PATCH */))
@@ -144,7 +144,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "key": k
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { key: k }))
@@ -162,7 +162,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "onClick": h
 }, null, 8, ["onClick"]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { onClick: h }, null, 8 /* PROPS */, ["onClick"]))
@@ -180,7 +180,7 @@ import { resolveComponent as _resolveComponent, createVNode as _createVNode } fr
 const A = () => _createVNode(_resolveComponent("B"), {
   "foo": f
 }, null, 8, ["foo"]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -200,7 +200,7 @@ import { vModelText as _vModelText, createVNode as _createVNode, withDirectives 
 const A = () => _withDirectives(_createVNode("input", {
   "onUpdate:modelValue": $event => val = $event
 }, null, 8, ["onUpdate:modelValue"]), [[_vModelText, val]]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return _withDirectives((_openBlock(), _createElementBlock("input", {
@@ -224,7 +224,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
   bar: () => _createVNode("b", null, null),
   _: 1
 });
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -253,7 +253,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
   default: s => _createVNode("i", null, [s.x]),
   _: 1
 });
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -276,7 +276,7 @@ const A = () => <B v-slots={slots}/>;
 ### babel
 import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_resolveComponent("B"), null, slots);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -294,7 +294,7 @@ const A = () => <><i/><b/></>;
 ### babel
 import { Fragment as _Fragment, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_Fragment, null, [_createVNode("i", null, null), _createVNode("b", null, null)]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock(_Fragment, null, [
@@ -315,7 +315,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [list.map(i => _createVNode("span", {
   "key": i
 }, [i]))]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, [

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__options.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__options.snap
@@ -16,7 +16,7 @@ const A = () => _createVNode("button", {
     click: h
   }
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("button", { on: {click: h} }, null, 8 /* PROPS */, ["on"]))
@@ -35,7 +35,7 @@ import _transformOn from "@vue/babel-helper-vue-transform-on";
 const A = () => _createVNode("button", _transformOn({
   click: h
 }), null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("button", { on: {click: h} }, null, 8 /* PROPS */, ["on"]))
@@ -50,7 +50,7 @@ const A = () => <div/>;
 {"pragma":"h"}
 ### babel
 const A = () => h("div", null, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div"))
@@ -70,7 +70,7 @@ const A = () => _createVNode("div", _mergeProps({
 }, p, {
   "class": c
 }), null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { mergeProps as _mergeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _mergeProps({ class: "a" }, p, {
@@ -92,7 +92,7 @@ const A = () => _createVNode("div", {
   ...p,
   "class": c
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { mergeProps as _mergeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _mergeProps({ class: "a" }, p, {
@@ -112,7 +112,7 @@ import { resolveComponent as _resolveComponent, createVNode as _createVNode } fr
 const A = () => _createVNode(_resolveComponent("my-el"), {
   "foo": 1
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_my_el = _resolveComponent("my-el")
@@ -132,7 +132,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("MyEl", {
   "foo": 1
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_MyEl = _resolveComponent("MyEl")
@@ -155,7 +155,7 @@ function _isSlot(s) {
 const A = () => _createVNode(_resolveComponent("B"), null, _isSlot(slots) ? slots : {
   default: () => [slots]
 });
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock, createTextVNode as _createTextVNode, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -180,7 +180,7 @@ import { resolveComponent as _resolveComponent, createVNode as _createVNode } fr
 const A = () => _createVNode(_resolveComponent("B"), null, {
   default: () => [slots]
 });
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock, createTextVNode as _createTextVNode, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -206,7 +206,7 @@ import { defineComponent, createVNode as _createVNode } from 'vue';
 const A = defineComponent((props: {
   foo: string;
 }) => () => _createVNode("div", null, [props.foo]));
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, _toDisplayString(props.foo), 1 /* TEXT */))
@@ -233,7 +233,7 @@ const A = defineComponent((props: {
   },
   name: "A"
 });
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, _toDisplayString(props.foo), 1 /* TEXT */))

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__props.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__props.snap
@@ -14,7 +14,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("input", {
   "type": "email"
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("input", { type: "email" }))
@@ -22,7 +22,7 @@ export function render(_ctx, _cache) {
 
 ## props/boolean_attr
 ### verdict
-divergent: valueless attribute lowers to "" not true
+equivalent
 ### source (jsx)
 const A = () => <input disabled/>;
 ### babel options
@@ -32,10 +32,10 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("input", {
   "disabled": true
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("input", { disabled: "" }))
+  return (_openBlock(), _createElementBlock("input", { disabled: true }))
 }
 
 ## props/dynamic_attr
@@ -50,7 +50,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("input", {
   "placeholder": p
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("input", { placeholder: p }, null, 8 /* PROPS */, ["placeholder"]))
@@ -69,7 +69,7 @@ const A = () => _createVNode("div", {
   "data-foo": "1",
   "aria-label": l
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", {
@@ -90,7 +90,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("svg", null, [_createVNode("use", {
   "xlink:href": "#a"
 }, null)]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("svg", null, [
@@ -110,7 +110,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("svg", null, [_createVNode("use", {
   "xlink:href": "#a"
 }, null)]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("svg", null, [
@@ -130,7 +130,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "class": c
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", {
@@ -150,7 +150,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "class": ["a", c]
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", {
@@ -170,7 +170,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "style": s
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { normalizeStyle as _normalizeStyle, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", {
@@ -192,7 +192,7 @@ const A = () => _createVNode("div", _mergeProps({
 }, p, {
   "style": s
 }), null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { mergeProps as _mergeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _mergeProps({ style: "color:red" }, p, {
@@ -210,7 +210,7 @@ const A = () => <div {...p}/>;
 ### babel
 import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", p, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { normalizeProps as _normalizeProps, guardReactiveProps as _guardReactiveProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _normalizeProps(_guardReactiveProps(p)), null, 16 /* FULL_PROPS */))
@@ -228,7 +228,7 @@ import { mergeProps as _mergeProps, createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", _mergeProps(p, {
   "id": "x"
 }), null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { mergeProps as _mergeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _mergeProps(p, { id: "x" }), null, 16 /* FULL_PROPS */))
@@ -248,7 +248,7 @@ const A = () => _createVNode("div", _mergeProps({
 }, p, {
   "onClick": b
 }), null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { mergeProps as _mergeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _mergeProps({ onClick: a }, p, { onClick: b }), null, 16 /* FULL_PROPS */, ["onClick"]))
@@ -266,7 +266,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "key": k
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { key: k }))
@@ -284,7 +284,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "ref": r
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { ref: r }, null, 512 /* NEED_PATCH */))
@@ -302,7 +302,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [list.map(i => _createVNode("span", {
   "ref": r
 }, null))]);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, [
@@ -324,7 +324,7 @@ import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", {
   "$foo": 1
 }, null);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { $foo: 1 }))

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__slots.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__slots.snap
@@ -15,7 +15,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
   default: () => _createVNode("i", null, null),
   bar: () => _createVNode("b", null, null)
 });
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -43,7 +43,7 @@ import { resolveComponent as _resolveComponent, createVNode as _createVNode } fr
 const A = () => _createVNode(_resolveComponent("B"), null, {
   default: () => 'foo'
 });
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock, createTextVNode as _createTextVNode, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -68,7 +68,7 @@ import { createVNode as _createVNode, resolveComponent as _resolveComponent } fr
 const A = () => _createVNode(_resolveComponent("B"), null, {
   default: s => _createVNode("i", null, [s.x])
 });
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -94,7 +94,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
   default: () => [_createVNode("div", null, [_createTextVNode("A")])],
   ...slots
 });
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -117,7 +117,7 @@ const A = () => <B v-slots={slots}/>;
 ### babel
 import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_resolveComponent("B"), null, slots);
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -138,7 +138,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
   default: () => _createVNode("i", null, null),
   bar: () => _createVNode("b", null, null)
 });
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -167,7 +167,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
   default: () => [_createVNode("div", null, [_createTextVNode("A")])],
   bar: () => _createVNode("b", null, null)
 });
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -195,7 +195,7 @@ import { createVNode as _createVNode, resolveComponent as _resolveComponent } fr
 const A = () => _createVNode(_resolveComponent("B"), null, {
   default: () => [_createVNode("i", null, null)]
 });
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
@@ -220,7 +220,7 @@ import { createVNode as _createVNode, resolveComponent as _resolveComponent } fr
 const A = () => _createVNode(_resolveComponent("B"), null, {
   [n]: () => _createVNode("i", null, null)
 });
-### vize (vdom, default config)
+### vize (vdom, babel compat)
 <Warning> computed JSX slot names are not supported and were ignored
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {


### PR DESCRIPTION
Refs #3391.

Implements only the props/boolean_attr compatibility row:

- keeps Native JSX output byte-for-byte unchanged
- lowers a valueless JSX attribute to boolean true only in Babel compatibility mode
- switches the differential matrix to exercise the opt-in compatibility mode
- moves the oracle total from 78/18/2 to 79/17/2

Validation:
- full vize_atelier_jsx test suite
- real @vue/babel-plugin-jsx 2.0.1 recording check (98 cases)
- compatibility oracle and tooling inventory checks
- strict crate clippy, fmt, and source-length ratchet

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->