### PR TITLE
feat(maestro): add automatic insertion provider

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
 pub mod auto_import;
+pub mod auto_insert;
 pub mod code_action;
 pub mod code_lens;
 pub mod completion;
@@ -35,6 +36,7 @@ mod template_expression;
 pub mod type_service;
 pub mod workspace_symbols;
 
+pub use auto_insert::AutoInsertService;
 pub use code_action::CodeActionService;
 pub use code_lens::CodeLensService;
 pub use completion::{CompletionService, TRIGGER_CHARACTERS, trigger_characters};

--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -6,7 +6,6 @@
 //! - Structure: document/workspace symbols, selection ranges, semantic tokens, inlay hints
 //! - Ecosystem: router/i18n awareness, file rename, auto-import, code lens, document links
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
-
 pub mod auto_import;
 pub mod auto_insert;
 pub mod code_action;
@@ -35,7 +34,6 @@ pub(crate) mod tag_pair;
 mod template_expression;
 pub mod type_service;
 pub mod workspace_symbols;
-
 pub use auto_insert::AutoInsertService;
 pub use code_action::CodeActionService;
 pub use code_lens::CodeLensService;

--- a/crates/vize_maestro/src/ide/auto_insert.rs
+++ b/crates/vize_maestro/src/ide/auto_insert.rs
@@ -1,0 +1,296 @@
+//! Volar-compatible automatic insertion snippets.
+//!
+//! The wire method is private Volar protocol, but the snippets deliberately
+//! match `@vue/language-server` 3.3.8 so one VS Code client can drive either
+//! server. Markup insertions are syntax-only. `.value` is different: it is
+//! returned only when Corsa's TypeScript quick info identifies the symbol as a
+//! Vue ref; authored source is never scanned to guess its type.
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros
+)]
+
+#[cfg(feature = "native")]
+mod corsa;
+
+use super::IdeContext;
+use crate::virtual_code::BlockType;
+
+pub struct AutoInsertService;
+
+impl AutoInsertService {
+    pub async fn snippet(
+        ctx: &IdeContext<'_>,
+        selection_offset: usize,
+        range_offset: usize,
+        change_text: &str,
+    ) -> Option<String> {
+        match change_text {
+            "{}" => bracket_spacing(&ctx.content, selection_offset, range_offset),
+            "=" => auto_quote(ctx, selection_offset),
+            ">" => auto_close_tag(ctx, selection_offset),
+            "/" => auto_complete_close_tag(ctx, selection_offset),
+            _ if dot_value_candidate(ctx, selection_offset, range_offset, change_text) => {
+                #[cfg(feature = "native")]
+                {
+                    let bridge = ctx.state.get_corsa_bridge().await;
+                    corsa::dot_value(ctx, selection_offset, bridge).await
+                }
+                #[cfg(not(feature = "native"))]
+                {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+fn bracket_spacing(content: &str, selection: usize, change_start: usize) -> Option<String> {
+    (selection == change_start.checked_add(1)?
+        && change_start > 0
+        && content.get(change_start - 1..change_start.checked_add(3)?)? == "{{}}")
+        .then(|| " $0 ".to_string())
+}
+
+fn auto_quote(ctx: &IdeContext<'_>, selection: usize) -> Option<String> {
+    let region = markup_region(ctx, selection)?;
+    if selection == 0
+        || ctx.content.as_bytes().get(selection - 1) != Some(&b'=')
+        || matches!(ctx.content.as_bytes().get(selection), Some(b'\'' | b'"'))
+        || !inside_open_start_tag(&ctx.content, region, selection - 1)
+    {
+        return None;
+    }
+    Some("\"$1\"".to_string())
+}
+
+fn auto_close_tag(ctx: &IdeContext<'_>, selection: usize) -> Option<String> {
+    let region = markup_region(ctx, selection)?;
+    let end = selection.checked_sub(1)?;
+    if ctx.content.as_bytes().get(end) != Some(&b'>') {
+        return None;
+    }
+    let (name, tag_start) = start_tag_before(&ctx.content, region, end)?;
+    if ctx.content[tag_start..end].trim_end().ends_with('/')
+        || vize_carton::is_void_tag(name)
+        || already_has_close_tag(&ctx.content, selection, name)
+    {
+        return None;
+    }
+    Some(format!("$0</{name}>"))
+}
+
+fn auto_complete_close_tag(ctx: &IdeContext<'_>, selection: usize) -> Option<String> {
+    let region = markup_region(ctx, selection)?;
+    let slash = selection.checked_sub(1)?;
+    if slash == 0 || ctx.content.as_bytes().get(slash - 1..selection) != Some(&b"</"[..]) {
+        return None;
+    }
+    nearest_unclosed_tag(&ctx.content, region, slash - 1).map(|name| format!("{name}>"))
+}
+
+fn markup_region(ctx: &IdeContext<'_>, offset: usize) -> Option<(usize, usize)> {
+    super::sfc_region::resolve(&ctx.content, ctx.uri.path(), offset).markup
+}
+
+fn inside_open_start_tag(content: &str, region: (usize, usize), offset: usize) -> bool {
+    let bytes = content.as_bytes();
+    let mut cursor = region.0;
+    let mut tag_start = None;
+    let mut quote = None;
+    while cursor <= offset && cursor < region.1 {
+        let byte = bytes[cursor];
+        match quote {
+            Some(open) if byte == open => quote = None,
+            Some(_) => {}
+            None if byte == b'\'' || byte == b'"' => quote = Some(byte),
+            None if byte == b'<' => tag_start = Some(cursor),
+            None if byte == b'>' => tag_start = None,
+            None => {}
+        }
+        cursor += 1;
+    }
+    tag_start.is_some_and(|start| !content[start..].starts_with("</")) && quote.is_none()
+}
+
+fn start_tag_before(content: &str, region: (usize, usize), end: usize) -> Option<(&str, usize)> {
+    let bytes = content.as_bytes();
+    let mut cursor = region.0;
+    let mut start = None;
+    let mut quote = None;
+    while cursor < end && cursor < region.1 {
+        let byte = bytes[cursor];
+        match quote {
+            Some(open) if byte == open => quote = None,
+            Some(_) => {}
+            None if byte == b'\'' || byte == b'"' => quote = Some(byte),
+            None if byte == b'<' => start = Some(cursor),
+            None if byte == b'>' => start = None,
+            None => {}
+        }
+        cursor += 1;
+    }
+    let start = start?;
+    let tail = content.get(start + 1..end)?;
+    if tail.starts_with(['/', '!', '?']) {
+        return None;
+    }
+    let name_end = tail
+        .bytes()
+        .position(|byte| !is_tag_name_byte(byte))
+        .unwrap_or(tail.len());
+    (name_end > 0).then(|| (&tail[..name_end], start))
+}
+
+fn already_has_close_tag(content: &str, selection: usize, name: &str) -> bool {
+    let Some(after) = content.get(selection..) else {
+        return false;
+    };
+    let after = after.trim_start();
+    after.starts_with("</")
+        && after.get(2..).is_some_and(|tail| {
+            tail.starts_with(name) && tail.as_bytes().get(name.len()) == Some(&b'>')
+        })
+}
+
+fn nearest_unclosed_tag(content: &str, region: (usize, usize), before: usize) -> Option<&str> {
+    let bytes = content.as_bytes();
+    let mut stack = Vec::new();
+    let mut cursor = region.0;
+    let limit = before.min(region.1);
+    while cursor < limit {
+        if bytes[cursor] != b'<' {
+            cursor += 1;
+            continue;
+        }
+        if content[cursor..limit].starts_with("<!--") {
+            cursor = content[cursor..limit]
+                .find("-->")
+                .map_or(limit, |relative| cursor + relative + 3);
+            continue;
+        }
+        let closing = bytes.get(cursor + 1) == Some(&b'/');
+        let name_start = cursor + if closing { 2 } else { 1 };
+        let mut name_end = name_start;
+        while name_end < limit && is_tag_name_byte(bytes[name_end]) {
+            name_end += 1;
+        }
+        let name = content.get(name_start..name_end)?;
+        let tag_end = find_tag_end(content, name_end, limit)?;
+        if closing {
+            if let Some(index) = stack.iter().rposition(|open| *open == name) {
+                stack.truncate(index);
+            }
+        } else if !name.is_empty()
+            && !vize_carton::is_void_tag(name)
+            && !content[cursor..tag_end]
+                .trim_end_matches('>')
+                .trim_end()
+                .ends_with('/')
+        {
+            stack.push(name);
+        }
+        cursor = tag_end;
+    }
+    stack.pop()
+}
+
+fn find_tag_end(content: &str, start: usize, limit: usize) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut quote = None;
+    for (relative, byte) in bytes[start..limit].iter().copied().enumerate() {
+        match quote {
+            Some(open) if byte == open => quote = None,
+            Some(_) => {}
+            None if byte == b'\'' || byte == b'"' => quote = Some(byte),
+            None if byte == b'>' => return Some(start + relative + 1),
+            None => {}
+        }
+    }
+    None
+}
+
+fn dot_value_candidate(
+    ctx: &IdeContext<'_>,
+    selection: usize,
+    range_offset: usize,
+    change_text: &str,
+) -> bool {
+    if !matches!(
+        ctx.block_type,
+        Some(BlockType::Script | BlockType::ScriptSetup)
+    ) || change_text.contains('\n')
+        || change_text.is_empty()
+        || !change_text
+            .as_bytes()
+            .last()
+            .is_some_and(u8::is_ascii_alphanumeric)
+        || selection <= range_offset
+        || ctx
+            .content
+            .as_bytes()
+            .get(selection)
+            .is_some_and(|byte| is_identifier_byte(*byte))
+    {
+        return false;
+    }
+    let Some((start, end)) =
+        super::token_span_at_offset(&ctx.content, selection, is_identifier_byte)
+    else {
+        return false;
+    };
+    if end != selection
+        || ctx.content.as_bytes().get(start.wrapping_sub(1)) == Some(&b'.')
+        || ctx
+            .content
+            .get(selection..)
+            .is_some_and(|tail| tail.starts_with(".value"))
+    {
+        return false;
+    }
+    let line_start = ctx.content[..start].rfind('\n').map_or(0, |at| at + 1);
+    let before = ctx.content[line_start..start].trim_start();
+    !is_declaration_or_pass_through(before, ctx.content.get(end..).unwrap_or_default())
+}
+
+fn is_declaration_or_pass_through(before: &str, after: &str) -> bool {
+    const PREFIXES: &[&str] = &[
+        "const ",
+        "let ",
+        "var ",
+        "function ",
+        "class ",
+        "interface ",
+        "type ",
+        "import ",
+    ];
+    if PREFIXES.iter().any(|prefix| before.starts_with(prefix))
+        || after.trim_start().starts_with(':')
+    {
+        return true;
+    }
+    let compact = before.trim_end();
+    ["watch(", "unref(", "triggerRef(", "isRef("]
+        .iter()
+        .any(|prefix| compact.ends_with(prefix))
+        || compact.rsplit_once('(').is_some_and(|(head, _)| {
+            head.split_whitespace()
+                .last()
+                .is_some_and(|name| name.starts_with("use"))
+        })
+}
+
+#[inline]
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')
+}
+
+#[inline]
+fn is_tag_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':')
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_maestro/src/ide/auto_insert/corsa.rs
+++ b/crates/vize_maestro/src/ide/auto_insert/corsa.rs
@@ -1,0 +1,103 @@
+//! Corsa-backed Vue ref classification for automatic `.value` insertion.
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros
+)]
+
+use std::sync::Arc;
+
+use vize_canon::{CorsaBridge, LspHoverContents, LspMarkedString};
+
+use super::IdeContext;
+
+pub(super) async fn dot_value(
+    ctx: &IdeContext<'_>,
+    selection: usize,
+    bridge: Option<Arc<CorsaBridge>>,
+) -> Option<String> {
+    let bridge = bridge?;
+    if !bridge.is_initialized() {
+        return None;
+    }
+    let document =
+        super::super::corsa_support::open_canonical_virtual_document(ctx, &bridge).await?;
+    let (line, character) =
+        super::super::corsa_support::canonical_source_offset_to_position(&document, selection)?;
+    let hover = bridge
+        .hover(&document.request_uri, line, character)
+        .await
+        .ok()??;
+    hover_is_ref(hover.contents).then(|| "${1:.value}".to_string())
+}
+
+pub(super) fn hover_is_ref(contents: LspHoverContents) -> bool {
+    match contents {
+        LspHoverContents::Markup(markup) => {
+            let quick_info = if markup.kind == "markdown" {
+                markdown_quick_info(&markup.value)
+            } else {
+                first_nonempty_line(&markup.value)
+            };
+            quick_info.is_some_and(quick_info_has_ref_type)
+        }
+        LspHoverContents::String(value) => {
+            first_nonempty_line(&value).is_some_and(quick_info_has_ref_type)
+        }
+        LspHoverContents::Array(items) => {
+            let mut legacy_string = None;
+            let mut saw_language_string = false;
+            for item in items {
+                match item {
+                    LspMarkedString::LanguageString { value, .. } => {
+                        saw_language_string = true;
+                        if quick_info_has_ref_type(&value) {
+                            return true;
+                        }
+                    }
+                    LspMarkedString::String(value) if legacy_string.is_none() => {
+                        legacy_string = Some(value);
+                    }
+                    _ => {}
+                }
+            }
+            if saw_language_string {
+                return false;
+            }
+            legacy_string
+                .as_deref()
+                .and_then(first_nonempty_line)
+                .is_some_and(quick_info_has_ref_type)
+        }
+    }
+}
+
+fn markdown_quick_info(markdown: &str) -> Option<&str> {
+    let fence = markdown.find("```")?;
+    let after_fence = markdown.get(fence + 3..)?;
+    let code_start = after_fence.find('\n')? + 1;
+    let code = after_fence.get(code_start..)?;
+    let code_end = code.find("```")?;
+    code.get(..code_end)
+}
+
+fn first_nonempty_line(value: &str) -> Option<&str> {
+    value.lines().find(|line| !line.trim().is_empty())
+}
+
+fn quick_info_has_ref_type(value: &str) -> bool {
+    [
+        "Ref<",
+        "ShallowRef<",
+        "ComputedRef<",
+        "WritableComputedRef<",
+    ]
+    .iter()
+    .any(|needle| {
+        value.match_indices(needle).any(|(offset, _)| {
+            offset == 0
+                || !value.as_bytes()[offset - 1].is_ascii_alphanumeric()
+                    && value.as_bytes()[offset - 1] != b'_'
+        })
+    })
+}

--- a/crates/vize_maestro/src/ide/auto_insert/tests.rs
+++ b/crates/vize_maestro/src/ide/auto_insert/tests.rs
@@ -1,0 +1,135 @@
+use tower_lsp::lsp_types::Url;
+
+use super::*;
+use crate::server::ServerState;
+
+fn context<'a>(
+    state: &'a ServerState,
+    uri: &'a Url,
+    source: String,
+    offset: usize,
+) -> IdeContext<'a> {
+    IdeContext::with_content(state, uri, offset, source)
+}
+
+#[test]
+fn markup_snippets_match_the_vue_language_server_oracle() {
+    crate::runtime::block_on(async {
+        let state = ServerState::new();
+        let uri = Url::parse("file:///fixture.vue").unwrap();
+
+        let source = "<template>{{}}</template>".to_string();
+        let start = source.find("{{}}").unwrap() + 1;
+        let ctx = context(&state, &uri, source, start + 1);
+        assert_eq!(
+            AutoInsertService::snippet(&ctx, start + 1, start, "{}").await,
+            Some(" $0 ".to_string())
+        );
+
+        let source = "<template><div class=></div></template>".to_string();
+        let start = source.find('=').unwrap();
+        let ctx = context(&state, &uri, source, start + 1);
+        assert_eq!(
+            AutoInsertService::snippet(&ctx, start + 1, start, "=").await,
+            Some("\"$1\"".to_string())
+        );
+
+        let source = "<template><section></template>".to_string();
+        let start = source[10..].find('>').unwrap() + 10;
+        let ctx = context(&state, &uri, source, start + 1);
+        assert_eq!(
+            AutoInsertService::snippet(&ctx, start + 1, start, ">").await,
+            Some("$0</section>".to_string())
+        );
+
+        let source = "<template><section title=\"<x>\"></template>".to_string();
+        let start = source.find("\"></template>").unwrap() + 1;
+        let ctx = context(&state, &uri, source, start + 1);
+        assert_eq!(
+            AutoInsertService::snippet(&ctx, start + 1, start, ">").await,
+            Some("$0</section>".to_string())
+        );
+
+        let source = "<template><section></</template>".to_string();
+        let start = source.find("</").unwrap() + 1;
+        let ctx = context(&state, &uri, source, start + 1);
+        assert_eq!(
+            AutoInsertService::snippet(&ctx, start + 1, start, "/").await,
+            Some("section>".to_string())
+        );
+    });
+}
+
+#[test]
+fn markup_snippets_reject_script_text_duplicates_void_tags_and_bad_carets() {
+    crate::runtime::block_on(async {
+        let state = ServerState::new();
+        let uri = Url::parse("file:///fixture.vue").unwrap();
+        for (source, needle, needle_shift, change) in [
+            ("<script>const value=1</script>", "=", 0, "="),
+            ("<template><input></template>", "<input>", 6, ">"),
+            ("<template><div></div></template>", "<div>", 4, ">"),
+            ("<template>{{}}</template>", "{{}}", 3, "{"),
+        ] {
+            let start = source.find(needle).unwrap() + needle_shift;
+            let ctx = context(&state, &uri, source.to_string(), start + 1);
+            assert_eq!(
+                AutoInsertService::snippet(&ctx, start + 1, start, change).await,
+                None,
+                "{source}"
+            );
+        }
+    });
+}
+
+#[test]
+fn dot_value_candidate_is_conservative_before_corsa_type_queries() {
+    let state = ServerState::new();
+    let uri = Url::parse("file:///fixture.vue").unwrap();
+    for (line, expected) in [
+        ("count", true),
+        ("const count", false),
+        ("state.count", false),
+        ("count.value", false),
+        ("watch(count", false),
+        ("const item = { count: 1 }", false),
+    ] {
+        let source = format!("<script setup lang=\"ts\">\n{line}\n</script>");
+        let selection = source.find("count").unwrap() + "count".len();
+        let ctx = context(&state, &uri, source, selection);
+        assert_eq!(
+            dot_value_candidate(&ctx, selection, selection - 1, "t"),
+            expected,
+            "{line}"
+        );
+    }
+}
+
+#[cfg(feature = "native")]
+#[test]
+fn corsa_ref_classification_uses_only_quick_info_code() {
+    use vize_canon::{LspHoverContents, LspMarkedString, LspMarkupContent};
+
+    assert!(corsa::hover_is_ref(LspHoverContents::Markup(
+        LspMarkupContent {
+            kind: "markdown".to_string(),
+            value: "```typescript\nconst count: Ref<number>\n```\nA counter.".to_string(),
+        }
+    )));
+    assert!(!corsa::hover_is_ref(LspHoverContents::Markup(
+        LspMarkupContent {
+            kind: "markdown".to_string(),
+            value: "```typescript\nconst count: number\n```\nReturns a Ref<number>.".to_string(),
+        }
+    )));
+    assert!(!corsa::hover_is_ref(LspHoverContents::String(
+        "const count: MyRef<number>".to_string(),
+    )));
+    assert!(!corsa::hover_is_ref(LspHoverContents::Array(vec![
+        LspMarkedString::String("Returns a Ref<number>.".to_string()),
+        LspMarkedString::LanguageString {
+            language: "typescript".to_string(),
+            value: "const count: number".to_string(),
+        },
+    ])));
+}

--- a/crates/vize_maestro/src/lib.rs
+++ b/crates/vize_maestro/src/lib.rs
@@ -79,7 +79,7 @@ pub use ide::{
 pub use server::MaestroServer;
 pub use virtual_code::{VirtualCodeGenerator, VirtualDocuments};
 
-use tower_lsp::{LspService, Server};
+use tower_lsp::Server;
 
 /// Initialize file-based logging to node_modules/.vize/lsp.log
 fn init_file_logging() {
@@ -127,7 +127,7 @@ pub async fn serve() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let stdin = runtime::threaded_reader("vize-lsp-stdin", std::io::stdin())?;
     let stdout = runtime::threaded_writer("vize-lsp-stdout", std::io::stdout())?;
 
-    let (service, socket) = LspService::new(MaestroServer::new);
+    let (service, socket) = server::build_lsp_service();
 
     Server::new(stdin, stdout, socket).serve(service).await;
 
@@ -163,7 +163,7 @@ pub async fn serve_tcp(port: u16) -> Result<(), Box<dyn std::error::Error + Send
     let read = runtime::threaded_reader("vize-lsp-tcp-read", stream.try_clone()?)?;
     let write = runtime::threaded_writer("vize-lsp-tcp-write", stream)?;
 
-    let (service, socket) = LspService::new(MaestroServer::new);
+    let (service, socket) = server::build_lsp_service();
 
     Server::new(read, write, socket).serve(service).await;
 

--- a/crates/vize_maestro/src/server.rs
+++ b/crates/vize_maestro/src/server.rs
@@ -3,6 +3,7 @@
 //! This module contains the core LSP server using tower-lsp.
 
 mod annotations;
+mod auto_insert;
 mod capabilities;
 mod document_structure;
 mod format;
@@ -17,7 +18,7 @@ pub use capabilities::server_capabilities;
 pub use state::BatchTypeCheckCache;
 pub use state::{LspFeatureConfig, ServerState};
 
-use tower_lsp::Client;
+use tower_lsp::{Client, ClientSocket, LspService};
 
 use crate::document::DocumentStore;
 
@@ -42,4 +43,13 @@ impl MaestroServer {
     pub fn documents(&self) -> &DocumentStore {
         &self.state.documents
     }
+}
+
+/// Build the language service, including Volar's private automatic-insertion
+/// request. `LanguageServer` cannot declare custom methods, so every transport
+/// must use this builder rather than `LspService::new`.
+pub(crate) fn build_lsp_service() -> (LspService<MaestroServer>, ClientSocket) {
+    LspService::build(MaestroServer::new)
+        .custom_method(auto_insert::AUTO_INSERT_METHOD, MaestroServer::auto_insert)
+        .finish()
 }

--- a/crates/vize_maestro/src/server/auto_insert.rs
+++ b/crates/vize_maestro/src/server/auto_insert.rs
@@ -1,0 +1,106 @@
+//! `volar/client/autoInsert` custom JSON-RPC request.
+#![allow(clippy::disallowed_types)]
+
+use serde::Deserialize;
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::{Position, TextDocumentIdentifier};
+
+use super::MaestroServer;
+use crate::ide::{AutoInsertService, IdeContext, position_to_offset};
+
+pub(super) const AUTO_INSERT_METHOD: &str = "volar/client/autoInsert";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct AutoInsertParams {
+    text_document: TextDocumentIdentifier,
+    selection: Position,
+    change: AutoInsertChange,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AutoInsertChange {
+    range_offset: usize,
+    range_length: usize,
+    text: String,
+}
+
+impl MaestroServer {
+    pub(super) async fn auto_insert(&self, params: AutoInsertParams) -> Result<Option<String>> {
+        if !self.state.lsp_features().auto_insert || params.change.range_length != 0 {
+            return Ok(None);
+        }
+
+        let uri = &params.text_document.uri;
+        let Some(content) = self.state.documents.text(uri) else {
+            return Ok(None);
+        };
+        let Some(selection_offset) =
+            position_to_offset(&content, params.selection.line, params.selection.character)
+        else {
+            return Ok(None);
+        };
+        let Some(range_offset) = utf16_offset_to_byte(&content, params.change.range_offset) else {
+            return Ok(None);
+        };
+        let change_matches_document = if params.change.text == "{}" {
+            let (Some(caret), Some(change_end)) =
+                (range_offset.checked_add(1), range_offset.checked_add(2))
+            else {
+                return Ok(None);
+            };
+            selection_offset == caret && content.get(range_offset..change_end) == Some("{}")
+        } else {
+            let Some(change_end) = range_offset.checked_add(params.change.text.len()) else {
+                return Ok(None);
+            };
+            selection_offset == change_end
+                && content
+                    .get(range_offset..selection_offset)
+                    .is_some_and(|inserted| inserted == params.change.text)
+        };
+        if !change_matches_document {
+            return Ok(None);
+        }
+
+        let ctx = IdeContext::with_content(&self.state, uri, selection_offset, content);
+        Ok(
+            AutoInsertService::snippet(&ctx, selection_offset, range_offset, &params.change.text)
+                .await,
+        )
+    }
+}
+
+/// Volar's `rangeOffset` is a JavaScript string offset (UTF-16 code units),
+/// while Rust strings and Maestro internals use UTF-8 byte offsets.
+fn utf16_offset_to_byte(content: &str, target: usize) -> Option<usize> {
+    let mut utf16 = 0usize;
+    for (byte, ch) in content.char_indices() {
+        if utf16 == target {
+            return Some(byte);
+        }
+        utf16 = utf16.checked_add(ch.len_utf16())?;
+        if utf16 > target {
+            return None;
+        }
+    }
+    (utf16 == target).then_some(content.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::utf16_offset_to_byte;
+
+    #[test]
+    fn utf16_offsets_reject_surrogate_splits_and_map_boundaries() {
+        let source = "a😀éz";
+        assert_eq!(utf16_offset_to_byte(source, 0), Some(0));
+        assert_eq!(utf16_offset_to_byte(source, 1), Some(1));
+        assert_eq!(utf16_offset_to_byte(source, 2), None);
+        assert_eq!(utf16_offset_to_byte(source, 3), Some(5));
+        assert_eq!(utf16_offset_to_byte(source, 4), Some(7));
+        assert_eq!(utf16_offset_to_byte(source, 5), Some(8));
+        assert_eq!(utf16_offset_to_byte(source, usize::MAX), None);
+    }
+}

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -213,7 +213,20 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
         execute_command_provider: None,
         call_hierarchy_provider: None,
         moniker_provider: None,
-        experimental: None,
+        experimental: features.auto_insert.then(|| {
+            serde_json::json!({
+                "autoInsertionProvider": {
+                    "triggerCharacters": ["}", "=", ">", "/", "\\w"],
+                    "configurationSections": [
+                        ["vize.autoInsert.bracketSpacing"],
+                        ["vize.autoInsert.autoCreateQuotes"],
+                        ["vize.autoInsert.autoClosingTags"],
+                        ["vize.autoInsert.autoClosingTags"],
+                        ["vize.autoInsert.dotValue"]
+                    ]
+                }
+            })
+        }),
 
         // Default for other fields
         ..Default::default()

--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -23,6 +23,7 @@ fn all_features() -> LspFeatureConfig {
         folding_ranges: true,
         inlay_hints: true,
         file_rename: true,
+        auto_insert: true,
         cross_file: true,
     }
 }

--- a/crates/vize_maestro/src/server/state/features.rs
+++ b/crates/vize_maestro/src/server/state/features.rs
@@ -30,6 +30,7 @@ pub(super) struct LspConfigSection {
     folding_ranges: Option<bool>,
     inlay_hints: Option<bool>,
     file_rename: Option<bool>,
+    auto_insert: Option<bool>,
     corsa: Option<bool>,
     tsgo: Option<bool>,
     cross_file: Option<bool>,
@@ -121,6 +122,9 @@ impl LspConfigSection {
         if let Some(enabled) = self.file_rename {
             features.file_rename = enabled;
         }
+        if let Some(enabled) = self.auto_insert {
+            features.auto_insert = enabled;
+        }
         if let Some(enabled) = self.cross_file {
             features.cross_file = enabled;
         }
@@ -153,6 +157,7 @@ impl From<LanguageServerConfig> for LspConfigSection {
             folding_ranges: config.folding_ranges,
             inlay_hints: config.inlay_hints,
             file_rename: config.file_rename,
+            auto_insert: None,
             corsa: config.corsa,
             tsgo: config.tsgo,
             cross_file: config.cross_file,
@@ -186,6 +191,7 @@ pub struct LspFeatureConfig {
     pub(crate) folding_ranges: bool,
     pub(crate) inlay_hints: bool,
     pub(crate) file_rename: bool,
+    pub(crate) auto_insert: bool,
     pub(crate) cross_file: bool,
 }
 
@@ -212,6 +218,7 @@ impl LspFeatureConfig {
             folding_ranges: false,
             inlay_hints: false,
             file_rename: false,
+            auto_insert: false,
             cross_file: false,
         }
     }
@@ -241,6 +248,9 @@ impl LspFeatureConfig {
         self.folding_ranges = enabled;
         self.inlay_hints = enabled;
         self.file_rename = enabled;
+        if !enabled {
+            self.auto_insert = false;
+        }
     }
 }
 
@@ -267,6 +277,10 @@ impl Default for LspFeatureConfig {
             folding_ranges: true,
             inlay_hints: true,
             file_rename: true,
+            // Volar's custom request is private protocol and only VS Code has
+            // a client for it. Keep it opt-in until the client explicitly
+            // requests the extension.
+            auto_insert: false,
             // Cross-file diagnostic groups are off by default — they scan
             // every Vue file in the workspace, which is too slow for the
             // default editor experience. Opt in via

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -272,6 +272,31 @@
           "type": "boolean",
           "default": true,
           "description": "Enable Vize edits for file rename operations."
+        },
+        "vize.autoInsert.enable": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable experimental automatic insertion for Vue refs, interpolation spacing, tags, and attribute quotes."
+        },
+        "vize.autoInsert.dotValue": {
+          "type": "boolean",
+          "default": true,
+          "description": "Insert .value after an identifier when Vize resolves its TypeScript type as a Vue Ref. Requires vize.autoInsert.enable and type checking."
+        },
+        "vize.autoInsert.bracketSpacing": {
+          "type": "boolean",
+          "default": true,
+          "description": "Insert spaces inside an empty Vue interpolation. Requires vize.autoInsert.enable."
+        },
+        "vize.autoInsert.autoCreateQuotes": {
+          "type": "boolean",
+          "default": true,
+          "description": "Insert quotes after an attribute equals sign. Requires vize.autoInsert.enable."
+        },
+        "vize.autoInsert.autoClosingTags": {
+          "type": "boolean",
+          "default": true,
+          "description": "Insert matching closing tags in Vue templates. Requires vize.autoInsert.enable."
         }
       }
     },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -8,16 +8,6 @@
     "Linters",
     "Programming Languages"
   ],
-  "keywords": [
-    "language-server",
-    "lsp",
-    "sfc",
-    "vue"
-  ],
-  "homepage": "https://github.com/ubugeeei-prod/vize",
-  "bugs": {
-    "url": "https://github.com/ubugeeei-prod/vize/issues"
-  },
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -399,6 +389,19 @@
       }
     ]
   },
+  "activationEvents": [
+    "onCommand:vize.disable",
+    "onCommand:vize.enableLintOnlyProfile",
+    "onCommand:vize.enableRecommendedProfile",
+    "onCommand:vize.findReferences",
+    "onCommand:vize.restartServer",
+    "onCommand:vize.selectServerPath",
+    "onCommand:vize.showOutput",
+    "onCommand:vize.showStatus",
+    "onLanguage:art-vue",
+    "onLanguage:html",
+    "onLanguage:vue"
+  ],
   "icon": "icons/logo.png",
   "engines": {
     "vscode": "^1.75.0"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -345,21 +345,6 @@
     "menus": {
       "commandPalette": [
         {
-          "command": "vize.showStatus"
-        },
-        {
-          "command": "vize.enableRecommendedProfile"
-        },
-        {
-          "command": "vize.enableLintOnlyProfile"
-        },
-        {
-          "command": "vize.selectServerPath"
-        },
-        {
-          "command": "vize.disable"
-        },
-        {
           "command": "vize.restartServer",
           "when": "editorLangId == vue || editorLangId == art-vue || editorLangId == html"
         },
@@ -414,19 +399,6 @@
       }
     ]
   },
-  "activationEvents": [
-    "onCommand:vize.disable",
-    "onCommand:vize.enableLintOnlyProfile",
-    "onCommand:vize.enableRecommendedProfile",
-    "onCommand:vize.findReferences",
-    "onCommand:vize.restartServer",
-    "onCommand:vize.selectServerPath",
-    "onCommand:vize.showOutput",
-    "onCommand:vize.showStatus",
-    "onLanguage:art-vue",
-    "onLanguage:html",
-    "onLanguage:vue"
-  ],
   "icon": "icons/logo.png",
   "engines": {
     "vscode": "^1.75.0"

--- a/editors/vscode/src/auto-insert.ts
+++ b/editors/vscode/src/auto-insert.ts
@@ -1,0 +1,111 @@
+import { SnippetString, window, type TextDocumentChangeEvent, type TextEditor } from "vscode";
+import type { LanguageClient, Middleware } from "vscode-languageclient/node";
+import type { VizeConfigurationLike } from "./extension-core";
+
+export const AUTO_INSERT_METHOD = "volar/client/autoInsert";
+
+type AutoInsertionProvider = {
+  triggerCharacters?: string[];
+  configurationSections?: Array<string[] | null>;
+};
+
+export function createAutoInsertMiddleware(
+  getClient: () => LanguageClient | undefined,
+  config: VizeConfigurationLike,
+): Middleware {
+  let applyingSnippet = false;
+
+  return {
+    async didChange(event, next): Promise<void> {
+      await next(event);
+      if (applyingSnippet || !config.get<boolean>("autoInsert.enable", false)) {
+        return;
+      }
+
+      // VS Code updates the active selection immediately after emitting the
+      // document change. Yield once so paired-character changes such as "{}"
+      // report the caret between the braces, matching Volar's wire contract.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+      const client = getClient();
+      const editor = window.activeTextEditor;
+      if (
+        !client ||
+        !editor ||
+        !supportsAutoInsert(client) ||
+        !shouldRequest(event, editor, config)
+      ) {
+        return;
+      }
+
+      const [change] = event.contentChanges;
+      const selection = editor.selection.active;
+      const documentVersion = event.document.version;
+      const snippet = await client
+        .sendRequest<string | null>(AUTO_INSERT_METHOD, {
+          textDocument: { uri: event.document.uri.toString() },
+          selection: { line: selection.line, character: selection.character },
+          change: {
+            rangeOffset: change.rangeOffset,
+            rangeLength: change.rangeLength,
+            text: change.text,
+          },
+        })
+        .catch(() => null);
+      if (
+        !snippet ||
+        editor.document.version !== documentVersion ||
+        !editor.selection.active.isEqual(selection)
+      ) {
+        return;
+      }
+
+      applyingSnippet = true;
+      try {
+        await editor.insertSnippet(new SnippetString(snippet), selection, {
+          undoStopBefore: false,
+          undoStopAfter: false,
+        });
+      } finally {
+        applyingSnippet = false;
+      }
+    },
+  };
+}
+
+function supportsAutoInsert(client: LanguageClient): boolean {
+  const experimental = client.initializeResult?.capabilities.experimental as
+    | { autoInsertionProvider?: AutoInsertionProvider }
+    | undefined;
+  return experimental?.autoInsertionProvider != null;
+}
+
+export function shouldRequest(
+  event: TextDocumentChangeEvent,
+  editor: TextEditor,
+  config: VizeConfigurationLike,
+): boolean {
+  if (
+    event.contentChanges.length !== 1 ||
+    editor.document !== event.document ||
+    editor.selections.length !== 1
+  ) {
+    return false;
+  }
+  const text = event.contentChanges[0].text;
+  if (text === "{}") {
+    return config.get<boolean>("autoInsert.bracketSpacing", true);
+  }
+  if (text === "=") {
+    return config.get<boolean>("autoInsert.autoCreateQuotes", true);
+  }
+  if (text === ">" || text === "/") {
+    return config.get<boolean>("autoInsert.autoClosingTags", true);
+  }
+  return (
+    text.length > 0 &&
+    !text.includes("\n") &&
+    /\w/u.test(text.at(-1) ?? "") &&
+    config.get<boolean>("autoInsert.dotValue", true)
+  );
+}

--- a/editors/vscode/src/extension-core.ts
+++ b/editors/vscode/src/extension-core.ts
@@ -42,6 +42,7 @@ export const FEATURE_SETTING_KEYS = [
   "foldingRanges.enable",
   "inlayHints.enable",
   "fileRename.enable",
+  "autoInsert.enable",
 ] as const;
 
 export const LINT_ONLY_CONFIGURATION_UPDATES: Array<[string, boolean]> = [
@@ -68,6 +69,7 @@ export const LINT_ONLY_CONFIGURATION_UPDATES: Array<[string, boolean]> = [
   ["foldingRanges.enable", false],
   ["inlayHints.enable", false],
   ["fileRename.enable", false],
+  ["autoInsert.enable", false],
 ];
 
 export const CAPABILITY_LABELS: Record<string, string> = {
@@ -91,6 +93,7 @@ export const CAPABILITY_LABELS: Record<string, string> = {
   foldingRanges: "folding",
   inlayHints: "inlay hints",
   fileRename: "file rename",
+  autoInsert: "automatic insertion",
 };
 
 export function createDocumentSelector(): Array<{ language: string; scheme: string }> {
@@ -163,6 +166,7 @@ export function getInitializationOptions(
   setFeatureOption(options, config, "foldingRanges.enable", "foldingRanges", true);
   setFeatureOption(options, config, "inlayHints.enable", "inlayHints", true);
   setFeatureOption(options, config, "fileRename.enable", "fileRename", true);
+  setFeatureOption(options, config, "autoInsert.enable", "autoInsert", false);
 
   if (
     Object.keys(options).length === 0 &&

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -37,6 +37,7 @@ import {
   type LspInitializationOptions,
 } from "./extension-core";
 import { registerTypeScriptContentMapperDiscovery } from "./content-mapper-discovery";
+import { createAutoInsertMiddleware } from "./auto-insert";
 
 const execFileAsync = promisify(execFile);
 let client: LanguageClient | undefined;
@@ -534,11 +535,12 @@ async function startClient(
   outputChannel.appendLine(`Using server: ${serverPath}`);
 
   const serverOptions: ServerOptions = createServerOptions(serverPath);
-  const nextClient = new LanguageClient(
+  let nextClient: LanguageClient | undefined;
+  nextClient = new LanguageClient(
     "vize",
     "Vize Language Server",
     serverOptions,
-    createClientOptions(initializationOptions),
+    createClientOptions(initializationOptions, () => nextClient, config),
   );
 
   applyTraceSetting(nextClient, config);
@@ -567,6 +569,8 @@ async function stopClient(): Promise<void> {
 
 function createClientOptions(
   initializationOptions: LspInitializationOptions,
+  getClient: () => LanguageClient | undefined,
+  config: ReturnType<typeof workspace.getConfiguration>,
 ): LanguageClientOptions {
   return {
     documentSelector: createDocumentSelector(),
@@ -580,6 +584,7 @@ function createClientOptions(
     outputChannel,
     traceOutputChannel: outputChannel,
     initializationOptions,
+    middleware: createAutoInsertMiddleware(getClient, config),
   };
 }
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -517,23 +517,19 @@ async function startClient(
   });
   activeInitializationOptions = initializationOptions;
   updateStatusBar("starting", `Starting with ${describeCapabilities(initializationOptions)}`);
-
   if (Object.keys(initializationOptions).length === 0) {
     outputChannel.appendLine(
       "Vize server is enabled with no opt-in features. Enable lint, typecheck, editor assistance, and ecosystem helpers to activate diagnostics and navigation.",
     );
     void maybeOfferCapabilitySetup(context, config);
   }
-
   const serverPath = await findServerPath(context, config);
   if (!serverPath) {
     updateStatusBar("missing-server", "Language server executable was not found");
     await showServerNotFoundMessage(context);
     return;
   }
-
   outputChannel.appendLine(`Using server: ${serverPath}`);
-
   const serverOptions: ServerOptions = createServerOptions(serverPath);
   let nextClient: LanguageClient | undefined;
   nextClient = new LanguageClient(
@@ -542,7 +538,6 @@ async function startClient(
     serverOptions,
     createClientOptions(initializationOptions, () => nextClient, config),
   );
-
   applyTraceSetting(nextClient, config);
 
   try {

--- a/editors/vscode/test/fixtures/fake-vize-server.cjs
+++ b/editors/vscode/test/fixtures/fake-vize-server.cjs
@@ -135,10 +135,12 @@ function summarizeParams(params) {
 
   return {
     changes: summarizeWatchedFileChanges(params.changes),
+    change: params.change,
     context: summarizeContext(params.context),
     initializationOptions: params.initializationOptions,
     newName: params.newName,
     position: params.position,
+    selection: params.selection,
     processId: params.processId,
     query: params.query,
     range: params.range,
@@ -150,7 +152,7 @@ function summarizeParams(params) {
 }
 
 function createCapabilities() {
-  return {
+  const capabilities = {
     codeActionProvider: true,
     codeLensProvider: {
       resolveProvider: false,
@@ -184,12 +186,24 @@ function createCapabilities() {
     textDocumentSync: 1,
     workspaceSymbolProvider: true,
   };
+  if (activeInitializationOptions.autoInsert === true) {
+    capabilities.experimental = {
+      autoInsertionProvider: {
+        triggerCharacters: ["}", "=", ">", "/", "\\w"],
+        configurationSections: [["vize.autoInsert.bracketSpacing"]],
+      },
+    };
+  }
+  return capabilities;
 }
 
 function createResponse(message) {
   const uri = message.params?.textDocument?.uri ?? workspaceRootUri;
 
   switch (message.method) {
+    case "volar/client/autoInsert":
+      return message.params?.change?.text === "{}" ? " $0 " : null;
+
     case "textDocument/codeAction":
       return [
         {

--- a/editors/vscode/test/suite/auto-insert-smoke.cjs
+++ b/editors/vscode/test/suite/auto-insert-smoke.cjs
@@ -1,0 +1,137 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const vscode = require("vscode");
+
+exports.runAutoInsertSmoke = async function runAutoInsertSmoke() {
+  const { logPath, serverPath } = getFakeServer();
+
+  await prepareConfiguredFakeServer({ logPath, serverPath });
+  const document = await openWorkspaceDocument("src", "App.vue");
+  const editor = await vscode.window.showTextDocument(document);
+  const line = document.lineAt(5);
+  const insertion = line.text.indexOf("</main>");
+  assert.ok(insertion > 0, "expected the fixture main close tag");
+  assert.ok(
+    await editor.edit((edit) => edit.insert(new vscode.Position(5, insertion), "{}")),
+    "expected interpolation seed edit to apply",
+  );
+  editor.selection = new vscode.Selection(5, insertion + 1, 5, insertion + 1);
+
+  await updateVizeConfiguration("autoInsert.enable", true);
+  await updateVizeConfiguration("enable", true);
+  let entries = await waitForReadyServer(logPath, "automatic insertion profile");
+  assertInitializationOptions(entries, { autoInsert: true });
+
+  await vscode.commands.executeCommand("type", { text: "{" });
+
+  entries = await waitForLogEntries(
+    logPath,
+    (nextEntries) => methodMessages(nextEntries, "volar/client/autoInsert").length >= 1,
+    "automatic insertion request",
+  );
+  const request = methodMessages(entries, "volar/client/autoInsert").at(-1);
+  assert.deepEqual(request.params.change, {
+    rangeLength: 0,
+    rangeOffset: document.offsetAt(new vscode.Position(5, insertion + 1)),
+    text: "{}",
+  });
+  assert.deepEqual(request.params.selection, { character: insertion + 2, line: 5 });
+  const insertedLine = await waitForDocumentText(
+    document,
+    (text) => text.includes("{{  }}</main>"),
+    "automatic insertion snippet",
+  );
+  assert.ok(insertedLine.includes("{{  }}</main>"), insertedLine);
+
+  await disableVizeAndWaitForShutdown(logPath);
+};
+
+function getFakeServer() {
+  const serverPath = process.env.VIZE_TEST_SERVER_PATH;
+  const logPath = process.env.VIZE_TEST_SERVER_LOG;
+  assert.ok(serverPath, "VIZE_TEST_SERVER_PATH must be set");
+  assert.ok(logPath, "VIZE_TEST_SERVER_LOG must be set");
+  assert.ok(fs.existsSync(serverPath), `missing fake server: ${serverPath}`);
+  return { logPath, serverPath };
+}
+
+async function prepareConfiguredFakeServer({ logPath, serverPath }) {
+  fs.writeFileSync(logPath, "");
+  const config = vscode.workspace.getConfiguration("vize");
+  await config.update("enable", false, vscode.ConfigurationTarget.Workspace);
+  await config.update("serverPath", serverPath, vscode.ConfigurationTarget.Workspace);
+  await sleep(300);
+  assert.equal(initializeMessages(readLogEntries(logPath)).length, 0);
+}
+
+async function updateVizeConfiguration(key, value) {
+  await vscode.workspace
+    .getConfiguration("vize")
+    .update(key, value, vscode.ConfigurationTarget.Workspace);
+}
+
+async function disableVizeAndWaitForShutdown(logPath) {
+  const exitCount = methodMessages(readLogEntries(logPath), "exit").length;
+  await vscode.commands.executeCommand("vize.disable");
+  await waitForLogEntries(
+    logPath,
+    (entries) => methodMessages(entries, "exit").length > exitCount,
+    "language server shutdown",
+  );
+}
+
+function waitForReadyServer(logPath, label) {
+  return waitForLogEntries(
+    logPath,
+    (entries) =>
+      initializeMessages(entries).length >= 1 && methodMessages(entries, "initialized").length >= 1,
+    label,
+  );
+}
+
+function openWorkspaceDocument(...segments) {
+  const folder = vscode.workspace.workspaceFolders?.[0];
+  assert.ok(folder, "expected a workspace folder");
+  return vscode.workspace.openTextDocument(
+    vscode.Uri.file(path.join(folder.uri.fsPath, ...segments)),
+  );
+}
+
+function assertInitializationOptions(entries, expected) {
+  assert.deepEqual(initializeMessages(entries).at(-1).params.initializationOptions ?? {}, expected);
+}
+
+const initializeMessages = (entries) => entries.filter((entry) => entry.method === "initialize");
+const methodMessages = (entries, method) => entries.filter((entry) => entry.method === method);
+
+async function waitForLogEntries(logPath, predicate, label) {
+  const timeoutAt = Date.now() + 20_000;
+  let entries = [];
+  while (Date.now() < timeoutAt) {
+    entries = readLogEntries(logPath);
+    if (predicate(entries)) return entries;
+    await sleep(100);
+  }
+  assert.fail(`${label} did not happen. Last log entries: ${JSON.stringify(entries.slice(-10))}`);
+}
+
+function readLogEntries(logPath) {
+  const text = fs.readFileSync(logPath, "utf-8").trim();
+  return text ? text.split("\n").map((line) => JSON.parse(line)) : [];
+}
+
+async function waitForDocumentText(document, predicate, label) {
+  const timeoutAt = Date.now() + 20_000;
+  let text = document.getText();
+  while (Date.now() < timeoutAt) {
+    text = document.getText();
+    if (predicate(text)) return text;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  assert.fail(`${label} did not happen. Last document: ${text}`);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/editors/vscode/test/suite/auto-insert-smoke.cjs
+++ b/editors/vscode/test/suite/auto-insert-smoke.cjs
@@ -3,6 +3,32 @@ const fs = require("node:fs");
 const path = require("node:path");
 const vscode = require("vscode");
 
+const featureSettingKeys = [
+  "lint.enable",
+  "diagnostics.enable",
+  "typecheck.enable",
+  "editor.enable",
+  "ecosystem.enable",
+  "optionsApi.enable",
+  "legacyVue2.enable",
+  "completion.enable",
+  "hover.enable",
+  "definition.enable",
+  "references.enable",
+  "documentSymbols.enable",
+  "workspaceSymbols.enable",
+  "codeActions.enable",
+  "rename.enable",
+  "codeLens.enable",
+  "formatting.enable",
+  "semanticTokens.enable",
+  "documentLinks.enable",
+  "foldingRanges.enable",
+  "inlayHints.enable",
+  "fileRename.enable",
+  "autoInsert.enable",
+];
+
 exports.runAutoInsertSmoke = async function runAutoInsertSmoke() {
   const { logPath, serverPath } = getFakeServer();
 
@@ -60,6 +86,11 @@ async function prepareConfiguredFakeServer({ logPath, serverPath }) {
   fs.writeFileSync(logPath, "");
   const config = vscode.workspace.getConfiguration("vize");
   await config.update("enable", false, vscode.ConfigurationTarget.Workspace);
+  await config.update("serverPath", undefined, vscode.ConfigurationTarget.Workspace);
+  await config.update("trace.server", undefined, vscode.ConfigurationTarget.Workspace);
+  for (const key of featureSettingKeys) {
+    await config.update(key, undefined, vscode.ConfigurationTarget.Workspace);
+  }
   await config.update("serverPath", serverPath, vscode.ConfigurationTarget.Workspace);
   await sleep(300);
   assert.equal(initializeMessages(readLogEntries(logPath)).length, 0);

--- a/editors/vscode/test/suite/extension-host.cjs
+++ b/editors/vscode/test/suite/extension-host.cjs
@@ -2,8 +2,8 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const vscode = require("vscode");
+const { runAutoInsertSmoke } = require("./auto-insert-smoke.cjs");
 const { runEditorCapabilityProviderSmoke } = require("./editor-capability-smoke.cjs");
-
 const extensionId = "ubugeeei.vize";
 const recommendedInitializationOptions = {
   editor: true,
@@ -91,7 +91,6 @@ const commandIds = [
   "vize.showOutput",
   "vize.showStatus",
 ];
-
 exports.run = async function run() {
   await runDisabledContributionSmoke();
   await runSyntaxHighlightContributionSmoke();
@@ -114,7 +113,6 @@ exports.run = async function run() {
   });
   await runDocumentSelectorAndWatcherSmoke();
 };
-
 async function runDisabledContributionSmoke() {
   const extension = vscode.extensions.getExtension(extensionId);
   assert.ok(extension, `missing extension: ${extensionId}`);
@@ -128,7 +126,6 @@ async function runDisabledContributionSmoke() {
   for (const commandId of commandIds) {
     assert.ok(allCommands.includes(commandId), `missing command: ${commandId}`);
   }
-
   const config = vscode.workspace.getConfiguration("vize");
   assert.equal(config.get("enable"), false);
   assert.equal(config.get("serverPath"), "");
@@ -410,50 +407,6 @@ async function runConfigurationEdgeCaseSmoke() {
     entries,
     Object.fromEntries(granularEditorCapabilitySettings.map(([, option]) => [option, true])),
   );
-  await disableVizeAndWaitForShutdown(logPath);
-}
-
-async function runAutoInsertSmoke() {
-  const { logPath, serverPath } = getFakeServer();
-
-  await prepareConfiguredFakeServer({ logPath, serverPath });
-  const document = await openWorkspaceDocument("src", "App.vue");
-  const editor = await vscode.window.showTextDocument(document);
-  const line = document.lineAt(5);
-  const insertion = line.text.indexOf("</main>");
-  assert.ok(insertion > 0, "expected the fixture main close tag");
-  assert.ok(
-    await editor.edit((edit) => edit.insert(new vscode.Position(5, insertion), "{}")),
-    "expected interpolation seed edit to apply",
-  );
-  editor.selection = new vscode.Selection(5, insertion + 1, 5, insertion + 1);
-
-  await updateVizeConfiguration("autoInsert.enable", true);
-  await updateVizeConfiguration("enable", true);
-  let entries = await waitForReadyServer(logPath, "automatic insertion profile");
-  assertInitializationOptions(entries, { autoInsert: true });
-
-  await vscode.commands.executeCommand("type", { text: "{" });
-
-  entries = await waitForLogEntries(
-    logPath,
-    (nextEntries) => methodMessages(nextEntries, "volar/client/autoInsert").length >= 1,
-    "automatic insertion request",
-  );
-  const request = methodMessages(entries, "volar/client/autoInsert").at(-1);
-  assert.deepEqual(request.params.change, {
-    rangeLength: 0,
-    rangeOffset: document.offsetAt(new vscode.Position(5, insertion + 1)),
-    text: "{}",
-  });
-  assert.deepEqual(request.params.selection, { character: insertion + 2, line: 5 });
-  const insertedLine = await waitForDocumentText(
-    document,
-    (text) => text.includes("{{  }}</main>"),
-    "automatic insertion snippet",
-  );
-  assert.ok(insertedLine.includes("{{  }}</main>"), insertedLine);
-
   await disableVizeAndWaitForShutdown(logPath);
 }
 
@@ -744,22 +697,6 @@ async function waitForDiagnostics(uri, predicate, label) {
   }
 
   assert.fail(`${label} did not happen. Last diagnostics: ${JSON.stringify(diagnostics)}`);
-}
-
-async function waitForDocumentText(document, predicate, label) {
-  const timeoutAt = Date.now() + 20_000;
-  let text = document.getText();
-
-  while (Date.now() < timeoutAt) {
-    text = document.getText();
-    if (predicate(text)) {
-      return text;
-    }
-
-    await sleep(100);
-  }
-
-  assert.fail(`${label} did not happen. Last document: ${text}`);
 }
 
 function readGrammar(extension, grammarPath) {

--- a/editors/vscode/test/suite/extension-host.cjs
+++ b/editors/vscode/test/suite/extension-host.cjs
@@ -21,6 +21,7 @@ const explicitlyDisabledInitializationOptions = {
   ecosystem: false,
   editor: false,
   fileRename: false,
+  autoInsert: false,
   foldingRanges: false,
   formatting: false,
   hover: false,
@@ -61,6 +62,7 @@ const featureSettingKeys = [
   "foldingRanges.enable",
   "inlayHints.enable",
   "fileRename.enable",
+  "autoInsert.enable",
 ];
 const granularEditorCapabilitySettings = [
   ["completion.enable", "completion"],
@@ -95,6 +97,7 @@ exports.run = async function run() {
   await runSyntaxHighlightContributionSmoke();
   await runFakeServerLifecycleSmoke();
   await runConfigurationEdgeCaseSmoke();
+  await runAutoInsertSmoke();
   await runDiagnosticSmoke();
   await runEditorCapabilityProviderSmoke({
     assertLocation,
@@ -410,6 +413,50 @@ async function runConfigurationEdgeCaseSmoke() {
   await disableVizeAndWaitForShutdown(logPath);
 }
 
+async function runAutoInsertSmoke() {
+  const { logPath, serverPath } = getFakeServer();
+
+  await prepareConfiguredFakeServer({ logPath, serverPath });
+  const document = await openWorkspaceDocument("src", "App.vue");
+  const editor = await vscode.window.showTextDocument(document);
+  const line = document.lineAt(5);
+  const insertion = line.text.indexOf("</main>");
+  assert.ok(insertion > 0, "expected the fixture main close tag");
+  assert.ok(
+    await editor.edit((edit) => edit.insert(new vscode.Position(5, insertion), "{}")),
+    "expected interpolation seed edit to apply",
+  );
+  editor.selection = new vscode.Selection(5, insertion + 1, 5, insertion + 1);
+
+  await updateVizeConfiguration("autoInsert.enable", true);
+  await updateVizeConfiguration("enable", true);
+  let entries = await waitForReadyServer(logPath, "automatic insertion profile");
+  assertInitializationOptions(entries, { autoInsert: true });
+
+  await vscode.commands.executeCommand("type", { text: "{" });
+
+  entries = await waitForLogEntries(
+    logPath,
+    (nextEntries) => methodMessages(nextEntries, "volar/client/autoInsert").length >= 1,
+    "automatic insertion request",
+  );
+  const request = methodMessages(entries, "volar/client/autoInsert").at(-1);
+  assert.deepEqual(request.params.change, {
+    rangeLength: 0,
+    rangeOffset: document.offsetAt(new vscode.Position(5, insertion + 1)),
+    text: "{}",
+  });
+  assert.deepEqual(request.params.selection, { character: insertion + 2, line: 5 });
+  const insertedLine = await waitForDocumentText(
+    document,
+    (text) => text.includes("{{  }}</main>"),
+    "automatic insertion snippet",
+  );
+  assert.ok(insertedLine.includes("{{  }}</main>"), insertedLine);
+
+  await disableVizeAndWaitForShutdown(logPath);
+}
+
 async function runDiagnosticSmoke() {
   const { logPath, serverPath } = getFakeServer();
 
@@ -697,6 +744,22 @@ async function waitForDiagnostics(uri, predicate, label) {
   }
 
   assert.fail(`${label} did not happen. Last diagnostics: ${JSON.stringify(diagnostics)}`);
+}
+
+async function waitForDocumentText(document, predicate, label) {
+  const timeoutAt = Date.now() + 20_000;
+  let text = document.getText();
+
+  while (Date.now() < timeoutAt) {
+    text = document.getText();
+    if (predicate(text)) {
+      return text;
+    }
+
+    await sleep(100);
+  }
+
+  assert.fail(`${label} did not happen. Last document: ${text}`);
 }
 
 function readGrammar(extension, grammarPath) {

--- a/tests/_fixtures/vue-language-server-auto-insertion.json
+++ b/tests/_fixtures/vue-language-server-auto-insertion.json
@@ -1,0 +1,61 @@
+{
+  "oracle": {
+    "package": "@vue/language-server",
+    "version": "3.3.8",
+    "method": "volar/client/autoInsert",
+    "measuredAt": "2026-08-01"
+  },
+  "capability": {
+    "triggerCharacters": ["}", "=", ">", "/", "\\w"],
+    "configurationSections": [
+      ["vue.autoInsert.bracketSpacing"],
+      ["html.autoCreateQuotes"],
+      ["html.autoClosingTags", "javascript.autoClosingTags", "typescript.autoClosingTags"],
+      ["html.autoClosingTags"],
+      ["vue.autoInsert.dotValue"]
+    ]
+  },
+  "cases": [
+    {
+      "name": "interpolation spacing",
+      "source": "<template>{{}}</template>",
+      "selection": { "line": 0, "character": 12 },
+      "change": { "rangeOffset": 11, "rangeLength": 0, "text": "{}" },
+      "response": " $0 "
+    },
+    {
+      "name": "attribute quotes",
+      "source": "<template><div class=></div></template>",
+      "selection": { "line": 0, "character": 21 },
+      "change": { "rangeOffset": 20, "rangeLength": 0, "text": "=" },
+      "response": "\"$1\""
+    },
+    {
+      "name": "closing tag",
+      "source": "<template><section></template>",
+      "selection": { "line": 0, "character": 19 },
+      "change": { "rangeOffset": 18, "rangeLength": 0, "text": ">" },
+      "response": "$0</section>"
+    },
+    {
+      "name": "slash closing tag",
+      "source": "<template><section></</template>",
+      "selection": { "line": 0, "character": 21 },
+      "change": { "rangeOffset": 20, "rangeLength": 0, "text": "/" },
+      "response": "section>"
+    },
+    {
+      "name": "void tag",
+      "source": "<template><input></template>",
+      "selection": { "line": 0, "character": 17 },
+      "change": { "rangeOffset": 16, "rangeLength": 0, "text": ">" },
+      "response": null
+    }
+  ],
+  "dotValue": {
+    "source": "<script setup lang=\"ts\">\nimport { ref } from \"vue\"\nconst count = ref(0)\ncount\n</script>",
+    "selection": { "line": 3, "character": 5 },
+    "change": { "rangeOffset": 76, "rangeLength": 0, "text": "t" },
+    "response": "${1:.value}"
+  }
+}

--- a/tests/tooling/lsp-auto-insertion.test.ts
+++ b/tests/tooling/lsp-auto-insertion.test.ts
@@ -17,7 +17,10 @@ type OracleCase = {
 };
 
 const oracle = JSON.parse(
-  fs.readFileSync(path.join(root, "tests/_fixtures/vue-language-server-auto-insertion.json"), "utf8"),
+  fs.readFileSync(
+    path.join(root, "tests/_fixtures/vue-language-server-auto-insertion.json"),
+    "utf8",
+  ),
 ) as {
   oracle: { package: string; version: string; method: string; measuredAt: string };
   capability: {
@@ -36,11 +39,7 @@ function resolveCorsaBinary(): string | undefined {
   ].find((candidate) => fs.existsSync(candidate));
 }
 
-async function request(
-  session: LspSession,
-  uri: string,
-  fixture: OracleCase,
-): Promise<unknown> {
+async function request(session: LspSession, uri: string, fixture: OracleCase): Promise<unknown> {
   session.notify("textDocument/didOpen", {
     textDocument: { uri, languageId: "vue", version: 1, text: fixture.source },
   });

--- a/tests/tooling/lsp-auto-insertion.test.ts
+++ b/tests/tooling/lsp-auto-insertion.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
+import type { AutoInsertParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+type OracleCase = {
+  name: string;
+  source: string;
+  selection: { line: number; character: number };
+  change: { rangeOffset: number; rangeLength: number; text: string };
+  response: string | null;
+};
+
+const oracle = JSON.parse(
+  fs.readFileSync(path.join(root, "tests/_fixtures/vue-language-server-auto-insertion.json"), "utf8"),
+) as {
+  oracle: { package: string; version: string; method: string; measuredAt: string };
+  capability: {
+    triggerCharacters: string[];
+    configurationSections: Array<string[] | null>;
+  };
+  cases: OracleCase[];
+  dotValue: OracleCase;
+};
+
+function resolveCorsaBinary(): string | undefined {
+  return [
+    path.join(root, "../corsa-bind/.cache/tsgo"),
+    path.join(root, "node_modules/.bin/tsgo"),
+    path.join(root, "tests/node_modules/.bin/tsgo"),
+  ].find((candidate) => fs.existsSync(candidate));
+}
+
+async function request(
+  session: LspSession,
+  uri: string,
+  fixture: OracleCase,
+): Promise<unknown> {
+  session.notify("textDocument/didOpen", {
+    textDocument: { uri, languageId: "vue", version: 1, text: fixture.source },
+  });
+  const params: AutoInsertParams = {
+    textDocument: { uri },
+    selection: fixture.selection,
+    change: fixture.change,
+  };
+  const response = await session.request(oracle.oracle.method, params);
+  session.notify("textDocument/didClose", { textDocument: { uri } });
+  return response;
+}
+
+test("real stdio server matches the pinned Vue LS auto-insertion responses", async () => {
+  assert.deepEqual(oracle.oracle, {
+    package: "@vue/language-server",
+    version: "3.3.8",
+    method: "volar/client/autoInsert",
+    measuredAt: "2026-08-01",
+  });
+
+  const testRootDir = path.join(testOutputRoot, "lsp-auto-insertion-markup");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      typecheck: false,
+      lint: false,
+      autoInsert: true,
+    });
+    for (const [index, fixture] of oracle.cases.entries()) {
+      const uri = pathToFileURL(path.join(workspaceDir, `Case${index}.vue`)).href;
+      assert.deepEqual(await request(session, uri, fixture), fixture.response, fixture.name);
+    }
+
+    const hostile = oracle.cases[0];
+    const uri = pathToFileURL(path.join(workspaceDir, "Hostile.vue")).href;
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: hostile.source },
+    });
+    assert.deepEqual(
+      await session.request(oracle.oracle.method, {
+        textDocument: { uri },
+        selection: hostile.selection,
+        change: { ...hostile.change, rangeOffset: Number.MAX_SAFE_INTEGER },
+      }),
+      null,
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+test("real stdio server asks Corsa type information before inserting .value", async (t) => {
+  const corsaPath = resolveCorsaBinary();
+  if (!corsaPath) {
+    t.skip("Corsa runtime is unavailable");
+    return;
+  }
+
+  const testRootDir = path.join(testOutputRoot, "lsp-auto-insertion-dot-value");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+  try {
+    fs.mkdirSync(path.join(workspaceDir, "node_modules"), { recursive: true });
+    fs.symlinkSync(
+      path.join(root, "tests/node_modules/vue"),
+      path.join(workspaceDir, "node_modules/vue"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "tsconfig.json"),
+      JSON.stringify({ include: ["*.vue"], compilerOptions: { strict: true } }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "vize.config.json"),
+      JSON.stringify({ typeChecker: { corsaPath } }),
+      "utf8",
+    );
+
+    await session.initialize(workspaceDir, {
+      editor: true,
+      typecheck: true,
+      lint: false,
+      autoInsert: true,
+    });
+    const uri = pathToFileURL(path.join(workspaceDir, "Ref.vue")).href;
+    assert.deepEqual(await request(session, uri, oracle.dotValue), oracle.dotValue.response);
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -175,12 +175,33 @@ const EDITOR_BUNDLE_CAPABILITIES = {
   // formatting providers (opt-in, see below), `signatureHelpProvider`,
   // `typeDefinitionProvider`, `implementationProvider`, `declarationProvider`,
   // `executeCommandProvider`, `callHierarchyProvider`, `monikerProvider` and
-  // `experimental` — none of which has a handler behind it.
+  // `experimental` is absent unless the private client explicitly opts in.
 };
 
 test("vize lsp advertises exactly this capability set for the default editor bundle", async () => {
   await withCapabilities("editor-full", { editor: true, lint: true }, (capabilities) => {
     assert.deepEqual(capabilities, EDITOR_BUNDLE_CAPABILITIES);
+  });
+});
+
+test("vize lsp advertises the exact measured auto-insertion extension only when opted in", async () => {
+  await withCapabilities("auto-insert", { editor: true, autoInsert: true }, (capabilities) => {
+    assert.deepEqual(capabilities.experimental, {
+      autoInsertionProvider: {
+        triggerCharacters: ["}", "=", ">", "/", "\\w"],
+        configurationSections: [
+          ["vize.autoInsert.bracketSpacing"],
+          ["vize.autoInsert.autoCreateQuotes"],
+          ["vize.autoInsert.autoClosingTags"],
+          ["vize.autoInsert.autoClosingTags"],
+          ["vize.autoInsert.dotValue"],
+        ],
+      },
+    });
+  });
+
+  await withCapabilities("auto-insert-off", { editor: true, autoInsert: false }, (capabilities) => {
+    assert.equal(capabilities.experimental, undefined);
   });
 });
 

--- a/tests/tooling/lsp-editor-feature-matrix.test.ts
+++ b/tests/tooling/lsp-editor-feature-matrix.test.ts
@@ -126,6 +126,7 @@ test("lint-only profile explicitly disables every non-lint capability", () => {
     ecosystem: false,
     editor: false,
     fileRename: false,
+    autoInsert: false,
     foldingRanges: false,
     formatting: false,
     hover: false,

--- a/tests/tooling/lsp-editor-feature-routing.test.ts
+++ b/tests/tooling/lsp-editor-feature-routing.test.ts
@@ -16,6 +16,7 @@ const ALL_EDITOR_FEATURES_OFF: LspInitializationOptions = {
   documentSymbols: false,
   editor: true,
   fileRename: false,
+  autoInsert: false,
   foldingRanges: false,
   formatting: false,
   hover: false,

--- a/tests/tooling/support/lsp/protocol.ts
+++ b/tests/tooling/support/lsp/protocol.ts
@@ -31,6 +31,7 @@ export type LspInitializationOptions = {
   semanticTokens?: boolean;
   typecheck?: boolean;
   workspaceSymbols?: boolean;
+  autoInsert?: boolean;
 };
 
 export type LspPosition = {
@@ -99,6 +100,22 @@ export type ServerCapabilities = {
   };
   workspace?: unknown;
   workspaceSymbolProvider?: unknown;
+  experimental?: {
+    autoInsertionProvider?: {
+      triggerCharacters: string[];
+      configurationSections: Array<string[] | null>;
+    };
+  };
+};
+
+export type AutoInsertParams = {
+  textDocument: TextDocumentIdentifier;
+  selection: LspPosition;
+  change: {
+    rangeOffset: number;
+    rangeLength: number;
+    text: string;
+  };
 };
 
 export type LspDiagnostic = {

--- a/tests/tooling/vscode-extension-core-behavior.test.ts
+++ b/tests/tooling/vscode-extension-core-behavior.test.ts
@@ -41,6 +41,7 @@ const FEATURE_TO_OPTION = {
   "foldingRanges.enable": "foldingRanges",
   "inlayHints.enable": "inlayHints",
   "fileRename.enable": "fileRename",
+  "autoInsert.enable": "autoInsert",
 } as const satisfies Record<(typeof FEATURE_SETTING_KEYS)[number], string>;
 
 const FEATURE_MANIFEST_DEFAULTS = {
@@ -66,6 +67,7 @@ const FEATURE_MANIFEST_DEFAULTS = {
   "foldingRanges.enable": true,
   "inlayHints.enable": true,
   "fileRename.enable": true,
+  "autoInsert.enable": false,
 } as const satisfies Record<(typeof FEATURE_SETTING_KEYS)[number], boolean>;
 
 type Scope = "global" | "workspace" | "workspaceFolder";
@@ -232,6 +234,7 @@ test("vscode lint-only profile updates every feature switch exactly once", () =>
     "foldingRanges.enable": false,
     "inlayHints.enable": false,
     "fileRename.enable": false,
+    "autoInsert.enable": false,
   });
 });
 
@@ -268,6 +271,20 @@ test("vscode file rename can be enabled without the editor bundle", () => {
   });
   assert.equal(hasAnyEnabledCapability(config), true);
   assert.equal(hasAnyExplicitCapabilityValue(config), true);
+});
+
+test("vscode automatic insertion is an explicit opt-in independent of the editor bundle", () => {
+  const config = new FakeConfig({
+    enable: true,
+    "editor.enable": false,
+    "autoInsert.enable": true,
+  });
+
+  assert.deepEqual(getInitializationOptions(config), {
+    editor: false,
+    autoInsert: true,
+  });
+  assert.equal(hasAnyEnabledCapability(config), true);
 });
 
 test("vscode explicit capability detection ignores unrelated settings", () => {

--- a/tools/vscode-vize/assert-vsix-package.mjs
+++ b/tools/vscode-vize/assert-vsix-package.mjs
@@ -110,8 +110,7 @@ assert.equal(packageJson.main, "./dist/extension.cjs");
 assert.equal(packageJson.engines?.vscode, "^1.75.0");
 assert.equal(packageJson.dependencies?.["vscode-languageclient"], "9.0.1");
 
-// VS Code 1.74+ derives activation events from contributed commands and languages.
-assert.equal(packageJson.activationEvents, undefined);
+assertUniqueStrings(packageJson.activationEvents, "activationEvents");
 assertUniqueStrings(
   packageJson.contributes?.commands?.map((command) => command.command),
   "contributes.commands",
@@ -120,7 +119,11 @@ assertUniqueStrings(
 for (const command of packageJson.contributes.commands) {
   assert.equal(command.category, "Vize", `${command.command} must stay in the Vize category`);
   assert.ok(command.title, `${command.command} must have a title`);
+  assert.ok(packageJson.activationEvents.includes(`onCommand:${command.command}`));
 }
+
+assert.ok(packageJson.activationEvents.includes("onLanguage:vue"));
+assert.ok(packageJson.activationEvents.includes("onLanguage:art-vue"));
 tsVueVsix.assertTypeScriptVuePluginPackage({
   packageJson,
   readJsonEntry: (name) => readJsonEntry(archive, name),

--- a/tools/vscode-vize/assert-vsix-package.mjs
+++ b/tools/vscode-vize/assert-vsix-package.mjs
@@ -151,14 +151,19 @@ assert.equal(configurationProperties["vize.serverPath"].default, "");
 assert.equal(configurationProperties["vize.trace.server"].default, "off");
 
 for (const [key, property] of Object.entries(configurationProperties)) {
-  if (key === "vize.serverPath" || key === "vize.trace.server") {
+  if (
+    key === "vize.serverPath" ||
+    key === "vize.trace.server" ||
+    (key.startsWith("vize.autoInsert.") && key !== "vize.autoInsert.enable")
+  ) {
     continue;
   }
   const expectedDefault =
     key === "vize.diagnostics.enable" ||
     key === "vize.formatting.enable" ||
     key === "vize.optionsApi.enable" ||
-    key === "vize.legacyVue2.enable"
+    key === "vize.legacyVue2.enable" ||
+    key === "vize.autoInsert.enable"
       ? false
       : true;
   assert.equal(property.default, expectedDefault, `${key} has an unexpected default`);

--- a/tools/vscode-vize/assert-vsix-package.mjs
+++ b/tools/vscode-vize/assert-vsix-package.mjs
@@ -110,7 +110,8 @@ assert.equal(packageJson.main, "./dist/extension.cjs");
 assert.equal(packageJson.engines?.vscode, "^1.75.0");
 assert.equal(packageJson.dependencies?.["vscode-languageclient"], "9.0.1");
 
-assertUniqueStrings(packageJson.activationEvents, "activationEvents");
+// VS Code 1.74+ derives activation events from contributed commands and languages.
+assert.equal(packageJson.activationEvents, undefined);
 assertUniqueStrings(
   packageJson.contributes?.commands?.map((command) => command.command),
   "contributes.commands",
@@ -119,14 +120,7 @@ assertUniqueStrings(
 for (const command of packageJson.contributes.commands) {
   assert.equal(command.category, "Vize", `${command.command} must stay in the Vize category`);
   assert.ok(command.title, `${command.command} must have a title`);
-  assert.ok(
-    packageJson.activationEvents.includes(`onCommand:${command.command}`),
-    `${command.command} must activate the extension when invoked directly`,
-  );
 }
-
-assert.ok(packageJson.activationEvents.includes("onLanguage:vue"));
-assert.ok(packageJson.activationEvents.includes("onLanguage:art-vue"));
 tsVueVsix.assertTypeScriptVuePluginPackage({
   packageJson,
   readJsonEntry: (name) => readJsonEntry(archive, name),
@@ -149,7 +143,6 @@ const configurationProperties = packageJson.contributes.configuration.properties
 assert.equal(configurationProperties["vize.enable"].default, true);
 assert.equal(configurationProperties["vize.serverPath"].default, "");
 assert.equal(configurationProperties["vize.trace.server"].default, "off");
-
 for (const [key, property] of Object.entries(configurationProperties)) {
   if (
     key === "vize.serverPath" ||
@@ -168,7 +161,6 @@ for (const [key, property] of Object.entries(configurationProperties)) {
       : true;
   assert.equal(property.default, expectedDefault, `${key} has an unexpected default`);
 }
-
 const extensionBundle = readTextEntry(archive, "extension/dist/extension.cjs");
 assert.match(extensionBundle, /exports\.activate=/);
 assert.match(extensionBundle, /exports\.deactivate=/);


### PR DESCRIPTION
Closes #3600

## Summary
- implement the measured `volar/client/autoInsert` request and opt-in capability
- classify `.value` insertion through Corsa quick info and guard hostile UTF-16/change inputs
- add the opt-in VS Code middleware, configuration, host smoke, and VSIX checks

## Measured Vue LS 3.3.8 contract
- method: `volar/client/autoInsert`
- params: `{ textDocument, selection, change: { rangeOffset, rangeLength, text } }`
- responses: ` $0 `, `"$1"`, `$0</section>`, `section>`, `${1:.value}`, or `null`
- pinned in `tests/_fixtures/vue-language-server-auto-insertion.json`

## Validation
- `cargo test -p vize_maestro auto_insert --all-features`
- `cargo clippy -p vize_maestro --lib --all-features -- -D warnings`
- 225 focused tooling tests, including real stdio and Corsa
- full Maestro, tooling, VS Code host, and VSIX suites in the implementation lane

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental automatic insertion for Vue editing, including interpolation spacing, attribute quotes, closing tags, and Vue ref `.value` completion.
  * Added configurable controls to enable automatic insertion and individual behaviors.
  * Added support for advertising and handling the feature through the language server and VS Code extension.

* **Tests**
  * Added comprehensive LSP, VS Code smoke, capability, and configuration coverage.
  * Added fixtures covering supported insertion scenarios and invalid contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->