### PR TITLE
fix(atelier): normalize Babel xlink attributes

### DIFF
--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -96,7 +96,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             DirectiveAttributeLowering::NotDirective => {}
         }
 
-        let name = String::from(self.mapper().slice(attr.name.span()));
+        let name = self.compat_attribute_name(attr.name.span());
         let name_loc = self.mapper().location(attr.name.span());
         let prop = match attr.value.as_ref() {
             None => self.valueless_attr(name, attr.name.span(), name_loc, loc),

--- a/crates/vize_atelier_jsx/src/lower/attr/compat.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr/compat.rs
@@ -7,6 +7,16 @@ use vize_relief::{DirectiveNode, PropNode, SourceLocation};
 use crate::lower::Lowerer;
 
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// Normalize the camel-cased SVG prop exactly as Babel does (#3391).
+    pub(super) fn compat_attribute_name(&self, name_span: Span) -> String {
+        let authored = self.mapper().slice(name_span);
+        String::from(if self.uses_babel_compat() && authored == "xlinkHref" {
+            "xlink:href"
+        } else {
+            authored
+        })
+    }
+
     /// A valueless JSX attribute is a boolean `true` in Babel's JSX
     /// semantics. Native Vize lowering deliberately keeps its established
     /// template-style empty-string value.

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   79 |
-| divergent  |   17 |
+| equivalent |   80 |
+| divergent  |   16 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -151,7 +151,7 @@ Recorded so the verdicts are not read as byte equality (#3421,
 | `props/boolean_attr`             | `<input disabled/>` → `disabled: true`      | `disabled: ""`                          | emits `true` (#3391)   | ✅      |
 | `props/dynamic_attr`             | `{placeholder: p}`                          | same + `PROPS` flag                     | no change              | ✅      |
 | `props/dashed_attrs`             | `data-foo` / `aria-label` kept verbatim     | same                                    | no change              | ✅      |
-| `props/xlink_camel`              | `xlinkHref` → `"xlink:href"`                | keeps `xlinkHref`                       | rewrite the camel form | ❌      |
+| `props/xlink_camel`              | `xlinkHref` → `"xlink:href"`                | keeps `xlinkHref`                       | rewrites it (#3391)    | ✅      |
 | `props/xlink_colon`              | `"xlink:href"`                              | same                                    | no change              | ✅      |
 | `props/class_dynamic`            | `{class: c}` (runtime normalizes)           | `normalizeClass(c)` + `CLASS`           | no change              | ✅      |
 | `props/class_static_and_dynamic` | `{class: ["a", c]}`                         | `normalizeClass(["a", c])`              | no change              | ✅      |

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -145,25 +145,25 @@ Recorded so the verdicts are not read as byte equality (#3421,
 
 ## Props and attributes
 
-| Case                             | Babel                                       | Vize today                              | Compat mode            | Verdict |
-| -------------------------------- | ------------------------------------------- | --------------------------------------- | ---------------------- | ------- |
-| `props/static_attr`              | `{type: "email"}`                           | same                                    | no change              | ✅      |
-| `props/boolean_attr`             | `<input disabled/>` → `disabled: true`      | `disabled: ""`                          | emits `true` (#3391)   | ✅      |
-| `props/dynamic_attr`             | `{placeholder: p}`                          | same + `PROPS` flag                     | no change              | ✅      |
-| `props/dashed_attrs`             | `data-foo` / `aria-label` kept verbatim     | same                                    | no change              | ✅      |
-| `props/xlink_camel`              | `xlinkHref` → `"xlink:href"`                | keeps `xlinkHref`                       | rewrites it (#3391)    | ✅      |
-| `props/xlink_colon`              | `"xlink:href"`                              | same                                    | no change              | ✅      |
-| `props/class_dynamic`            | `{class: c}` (runtime normalizes)           | `normalizeClass(c)` + `CLASS`           | no change              | ✅      |
-| `props/class_static_and_dynamic` | `{class: ["a", c]}`                         | `normalizeClass(["a", c])`              | no change              | ✅      |
-| `props/style_dynamic`            | `{style: s}`                                | `normalizeStyle(s)` + `STYLE`           | no change              | ✅      |
-| `props/style_merge_with_spread`  | `mergeProps` in source order                | same                                    | no change              | ✅      |
-| `props/spread_only`              | props are the spread expression itself      | `normalizeProps(guardReactiveProps(p))` | no change              | ✅      |
-| `props/spread_then_static`       | `mergeProps(p, {id: "x"})`                  | same                                    | no change              | ✅      |
-| `props/on_merge_with_spread`     | `mergeProps({onClick: a}, p, {onClick: b})` | same                                    | no change              | ✅      |
-| `props/key`                      | `{key: k}`, no flag                         | same                                    | no change              | ✅      |
-| `props/ref`                      | `{ref: r}`                                  | same + `NEED_PATCH`                     | no change              | ✅      |
-| `props/ref_in_for`               | no `ref_for` emitted                        | no `ref_for` emitted                    | no change              | ✅      |
-| `props/dollar_prefixed`          | `{$foo: 1}`                                 | same                                    | no change              | ✅      |
+| Case                             | Babel                                       | Vize today                              | Compat mode          | Verdict |
+| -------------------------------- | ------------------------------------------- | --------------------------------------- | -------------------- | ------- |
+| `props/static_attr`              | `{type: "email"}`                           | same                                    | no change            | ✅      |
+| `props/boolean_attr`             | `<input disabled/>` → `disabled: true`      | `disabled: ""`                          | emits `true` (#3391) | ✅      |
+| `props/dynamic_attr`             | `{placeholder: p}`                          | same + `PROPS` flag                     | no change            | ✅      |
+| `props/dashed_attrs`             | `data-foo` / `aria-label` kept verbatim     | same                                    | no change            | ✅      |
+| `props/xlink_camel`              | `xlinkHref` → `"xlink:href"`                | keeps `xlinkHref`                       | rewrites it (#3391)  | ✅      |
+| `props/xlink_colon`              | `"xlink:href"`                              | same                                    | no change            | ✅      |
+| `props/class_dynamic`            | `{class: c}` (runtime normalizes)           | `normalizeClass(c)` + `CLASS`           | no change            | ✅      |
+| `props/class_static_and_dynamic` | `{class: ["a", c]}`                         | `normalizeClass(["a", c])`              | no change            | ✅      |
+| `props/style_dynamic`            | `{style: s}`                                | `normalizeStyle(s)` + `STYLE`           | no change            | ✅      |
+| `props/style_merge_with_spread`  | `mergeProps` in source order                | same                                    | no change            | ✅      |
+| `props/spread_only`              | props are the spread expression itself      | `normalizeProps(guardReactiveProps(p))` | no change            | ✅      |
+| `props/spread_then_static`       | `mergeProps(p, {id: "x"})`                  | same                                    | no change            | ✅      |
+| `props/on_merge_with_spread`     | `mergeProps({onClick: a}, p, {onClick: b})` | same                                    | no change            | ✅      |
+| `props/key`                      | `{key: k}`, no flag                         | same                                    | no change            | ✅      |
+| `props/ref`                      | `{ref: r}`                                  | same + `NEED_PATCH`                     | no change            | ✅      |
+| `props/ref_in_for`               | no `ref_for` emitted                        | no `ref_for` emitted                    | no change            | ✅      |
+| `props/dollar_prefixed`          | `{$foo: 1}`                                 | same                                    | no change            | ✅      |
 
 ## Events
 

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -59,10 +59,7 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("props/boolean_attr", Same),
     ("props/dynamic_attr", Same),
     ("props/dashed_attrs", Same),
-    (
-        "props/xlink_camel",
-        Diff("xlinkHref not rewritten to xlink:href"),
-    ),
+    ("props/xlink_camel", Same),
     ("props/xlink_colon", Same),
     ("props/class_dynamic", Same),
     ("props/class_static_and_dynamic", Same),

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (79, 17, 2));
+    assert_eq!((equivalent, divergent, deferred), (80, 16, 2));
     assert_eq!(VERDICTS.len(), 98);
 }
 

--- a/crates/vize_atelier_jsx/tests/compat_mode.rs
+++ b/crates/vize_atelier_jsx/tests/compat_mode.rs
@@ -21,13 +21,17 @@ const SOURCE: &str = concat!(
 );
 
 fn module_code(compat: JsxCompatMode, mode: JsxOutputMode) -> String {
+    compile_module(SOURCE, compat, mode)
+}
+
+fn compile_module(source: &str, compat: JsxCompatMode, mode: JsxOutputMode) -> String {
     let bump = Bump::new();
     let config = JsxCompileConfig {
         default_mode: mode,
         compat,
         ..Default::default()
     };
-    let out = compile_jsx(&bump, SOURCE, JsxLang::Jsx, &config);
+    let out = compile_jsx(&bump, source, JsxLang::Jsx, &config);
     out.module_code().to_string()
 }
 
@@ -96,6 +100,32 @@ fn babel_compat_emits_true_for_a_valueless_attribute_only_when_opted_in() {
     let babel = compile(JsxCompatMode::Babel);
     assert!(native.contains("{ disabled: \"\" }"), "{native}");
     assert!(babel.contains("{ disabled: true }"), "{babel}");
+    assert_ne!(native, babel);
+}
+
+#[test]
+fn babel_compat_rewrites_xlink_href_across_prop_shapes_only_when_opted_in() {
+    let source = concat!(
+        "const A = () => <svg>",
+        "<use xlinkHref=\"#a\"/>",
+        "<use xlinkHref={href}/>",
+        "<use xlink:href=\"#b\"/>",
+        "</svg>;\n",
+        "const C = () => <Comp xlinkHref=\"#c\"/>;\n",
+        "const B = () => <svg>{ok ? <use xlinkHref=\"#d\"/> : ",
+        "items.map(id => <use xlinkHref={id}/>)}</svg>;",
+    );
+    let native = compile_module(source, JsxCompatMode::Native, JsxOutputMode::Vdom);
+    let babel = compile_module(source, JsxCompatMode::Babel, JsxOutputMode::Vdom);
+
+    assert!(native.contains("{ xlinkHref: \"#a\" }"), "{native}");
+    assert!(native.contains("{ xlinkHref: href }"), "{native}");
+    assert!(babel.contains("{ \"xlink:href\": \"#a\" }"), "{babel}");
+    assert!(babel.contains("{ \"xlink:href\": href }"), "{babel}");
+    assert!(babel.contains("{ \"xlink:href\": \"#b\" }"), "{babel}");
+    assert!(babel.contains("{ \"xlink:href\": \"#c\" }"), "{babel}");
+    assert!(babel.contains("\"xlink:href\": \"#d\""), "{babel}");
+    assert!(babel.contains("\"xlink:href\": id"), "{babel}");
     assert_ne!(native, babel);
 }
 

--- a/crates/vize_atelier_jsx/tests/compat_mode.rs
+++ b/crates/vize_atelier_jsx/tests/compat_mode.rs
@@ -120,6 +120,8 @@ fn babel_compat_rewrites_xlink_href_across_prop_shapes_only_when_opted_in() {
 
     assert!(native.contains("{ xlinkHref: \"#a\" }"), "{native}");
     assert!(native.contains("{ xlinkHref: href }"), "{native}");
+    assert!(native.contains("{ \"xlink:href\": \"#b\" }"), "{native}");
+    assert!(!babel.contains("xlinkHref"), "{babel}");
     assert!(babel.contains("{ \"xlink:href\": \"#a\" }"), "{babel}");
     assert!(babel.contains("{ \"xlink:href\": href }"), "{babel}");
     assert!(babel.contains("{ \"xlink:href\": \"#b\" }"), "{babel}");

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__props.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__props.snap
@@ -80,7 +80,7 @@ export function render(_ctx, _cache) {
 
 ## props/xlink_camel
 ### verdict
-divergent: xlinkHref not rewritten to xlink:href
+equivalent
 ### source (jsx)
 const A = () => <svg><use xlinkHref="#a"/></svg>;
 ### babel options
@@ -94,7 +94,7 @@ const A = () => _createVNode("svg", null, [_createVNode("use", {
 import { createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("svg", null, [
-    _createElementVNode("use", { xlinkHref: "#a" })
+    _createElementVNode("use", { "xlink:href": "#a" })
   ]))
 }
 


### PR DESCRIPTION
Refs #3391

## Summary
- rewrite authored `xlinkHref` to `xlink:href` only in Babel compatibility mode
- preserve native output and already-colonized attributes
- cover static/dynamic props, intrinsic/component nodes, and nested expressions

## Validation
- full `vize_atelier_jsx` test/doc-test suite
- real `@vue/babel-plugin-jsx` 2.0.1 oracle: 98/98
- focused Native/Babel shape test
- strict Clippy, formatting, diff check, and source-length checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Babel compatibility mode now correctly converts JSX `xlinkHref` attributes to `xlink:href`.
  * The conversion works consistently across static, dynamic, namespaced, component, conditional, and mapped JSX usage.
  * Native mode continues to preserve `xlinkHref`.

* **Tests**
  * Expanded compatibility coverage and updated compatibility results to reflect the corrected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->