### PR TITLE
feat(nuxt): run lint checker during development

### DIFF
--- a/npm/framework/nuxt-lint-config/src/oracle.test.ts
+++ b/npm/framework/nuxt-lint-config/src/oracle.test.ts
@@ -161,7 +161,7 @@ void test("corpus pins the package versions the recording was produced with", ()
 });
 
 void test("recording covers exactly the corpus cases", () => {
-  assert.equal(recording.schemaVersion, 4);
+  assert.equal(recording.schemaVersion, 5);
   assert.deepEqual(
     Object.keys(recording.cases).sort(),
     corpus.cases.map((entry) => entry.id).sort(),

--- a/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/INVENTORY.md
+++ b/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/INVENTORY.md
@@ -84,6 +84,14 @@ the oracle.
 | `no-page-meta-runtime-values/function-parameters-are-lazy` | Function default parameters are lazy together with their bodies; an adjacent eager API still reports. |
 | `no-page-meta-runtime-values/optional-macro-call`          | Optional direct macro calls form a boundary; empty and identifier-only arguments stay valid.          |
 
+## Dev-server checker
+
+| Case                   | Behaviour                                                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `checker/default`      | An empty object resolves every portable upstream default, including `fix: false`, and always runs outside the main thread.      |
+| `checker/true`         | Boolean opt-in resolves identically to the empty object.                                                                        |
+| `checker/all-explicit` | `cache`, globs, formatter, startup, warning/error emission and fixing all pass through exactly; worker execution stays enabled. |
+
 ## Intentional divergences
 
 | Difference                                                                              | Why                                                                                                                                                                                                                                                                                    |
@@ -92,6 +100,9 @@ the oracle.
 | `features` carries only feature keys                                                    | Upstream serialises the whole module option object into `features`, so `configFile`, `autoInit`, `rootDir` and `devtools` leak into it. Vize keeps module options and feature flags separate.                                                                                          |
 | Auto-init creates an `oxlint.config.mts` loader                                         | Oxlint 1.64 does not inherit `globals` from a JSON config in `extends`. The loader returns the current generated object directly and rebases its JS plugin URL, preserving `$fetch` and addon globals.                                                                                 |
 | The addon hook is `vize:lint:config:addons` and contributes engine-neutral config items | Upstream's `eslint:config:addons` contributes raw JavaScript and import statements. Those are ESLint implementation details and cannot be represented safely in an oxlint config; the Vize hook preserves ordered, async addon composition without accepting executable config source. |
+| `configType` and `eslintPath` are absent from checker options                           | They choose an ESLint implementation. Vize always runs oxlint + Patina, so neither setting has a meaningful equivalent.                                                                                                                                                                |
+| Checker `cache` means incremental target selection                                      | Oxlint needs no ESLint cache file. `true` lints only watched changes after startup; `false` reruns the full include set.                                                                                                                                                               |
+| Checker `formatter` output is engine-native                                             | Vize renders filtered oxlint diagnostics (`json`, `unix`, or a concise readable form) instead of loading ESLint formatter modules.                                                                                                                                                     |
 
 ## Directory defaults
 
@@ -148,3 +159,11 @@ How Nuxt project state reduces to the directory lists every glob is built from.
 `@nuxt/eslint-config`. The recording stores that probe's answer as
 `typeScriptDetected` so the offline test stays on the same branch as the
 recording rather than guessing.
+
+## Dev-server checker
+
+| Case                   | Behaviour                                                                                                                       |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `checker/default`      | An empty object resolves every portable upstream default, including `fix: false`, and always runs outside the main thread.      |
+| `checker/true`         | Boolean opt-in resolves identically to the empty object.                                                                        |
+| `checker/all-explicit` | `cache`, globs, formatter, startup, warning/error emission and fixing all pass through exactly; worker execution stays enabled. |

--- a/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/checker-oracle.mjs
+++ b/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/checker-oracle.mjs
@@ -1,0 +1,101 @@
+/** Record the portable checker contract from the pinned `@nuxt/eslint`. */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function replaceExactlyOnce(source, needle, replacement) {
+  const first = source.indexOf(needle);
+  if (first < 0 || source.indexOf(needle, first + needle.length) >= 0) {
+    throw new Error(`Unable to instrument the pinned checker at: ${needle}`);
+  }
+  return `${source.slice(0, first)}${replacement}${source.slice(first + needle.length)}`;
+}
+
+/** Execute the pinned checker while intercepting only its builder adapters. */
+async function loadCheckerSetup(moduleEntry) {
+  const checkerFile = fileURLToPath(new URL("./chunks/checker.mjs", moduleEntry));
+  const temporary = mkdtempSync(join(dirname(checkerFile), ".vize-checker-oracle-"));
+  const key = `__vizeNuxtCheckerOracle${process.pid}${Date.now()}`;
+  let source = readFileSync(checkerFile, "utf8");
+  source = replaceExactlyOnce(
+    source,
+    "import { addVitePlugin, addWebpackPlugin, useLogger } from '@nuxt/kit';",
+    [
+      `const __oracle = () => globalThis[${JSON.stringify(key)}];`,
+      "const addVitePlugin = (...args) => __oracle().addVitePlugin(...args);",
+      "const addWebpackPlugin = (...args) => __oracle().addWebpackPlugin(...args);",
+      "const useLogger = (...args) => __oracle().useLogger(...args);",
+    ].join("\n"),
+  );
+  source = replaceExactlyOnce(
+    source,
+    "await import('vite-plugin-eslint2')",
+    `await Promise.resolve({ default: globalThis[${JSON.stringify(key)}].vitePlugin })`,
+  );
+  writeFileSync(join(temporary, "checker.mjs"), source);
+  globalThis[key] = {
+    addVitePlugin() {},
+    addWebpackPlugin() {},
+    useLogger: () => ({ info() {}, warn() {} }),
+    vitePlugin: () => ({ name: "checker-oracle" }),
+  };
+  try {
+    const setup = (await import(join(temporary, "checker.mjs"))).setupESLintChecker;
+    return { key, setup };
+  } catch (error) {
+    delete globalThis[key];
+    throw error;
+  } finally {
+    rmSync(temporary, { force: true, recursive: true });
+  }
+}
+
+/** Record the complete portable checker option object produced upstream. */
+export async function recordCheckerOptions(moduleEntry, cases) {
+  const { key, setup } = await loadCheckerSetup(moduleEntry);
+  const results = {};
+  try {
+    for (const entry of cases) {
+      let captured;
+      globalThis[key] = {
+        addVitePlugin(factory) {
+          factory();
+        },
+        addWebpackPlugin() {
+          throw new Error("checker oracle unexpectedly selected webpack");
+        },
+        useLogger: () => ({ info() {}, warn() {} }),
+        vitePlugin(options) {
+          captured = structuredClone(options);
+          return { name: "checker-oracle" };
+        },
+      };
+      const nuxt = {
+        options: {
+          buildDir: "/project/.nuxt",
+          builder: "@nuxt/vite-builder",
+          rootDir: "/project",
+          srcDir: "/project/app",
+          watch: [],
+        },
+        hook() {},
+      };
+      await setup({ checker: structuredClone(entry.checker) }, nuxt);
+      if (!captured) throw new Error(`upstream checker did not register for ${entry.id}`);
+      results[entry.id] = {
+        cache: captured.cache,
+        include: captured.include,
+        exclude: captured.exclude,
+        formatter: captured.formatter,
+        lintOnStart: captured.lintOnStart,
+        emitWarning: captured.emitWarning,
+        emitError: captured.emitError,
+        fix: captured.fix ?? false,
+        worker: captured.lintInWorker,
+      };
+    }
+  } finally {
+    delete globalThis[key];
+  }
+  return results;
+}

--- a/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/fixtures/corpus.json
+++ b/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/fixtures/corpus.json
@@ -8,6 +8,32 @@
     "pluginVersion": "1.16.0"
   },
   "description": "Nuxt project states and rule cases whose @nuxt/eslint behaviour @vizejs/nuxt-lint-config, the Nuxt runtime emitter, and Vize Patina must reproduce. Project cases are materialised under a scratch root by oracle.mjs; every path is expressed relative to that root so the recording stays machine-independent.",
+  "checkerCases": [
+    {
+      "id": "checker/default",
+      "description": "An empty checker object takes every portable upstream default.",
+      "checker": {}
+    },
+    {
+      "id": "checker/true",
+      "description": "checker: true is identical to an empty checker object.",
+      "checker": true
+    },
+    {
+      "id": "checker/all-explicit",
+      "description": "Every portable checker option passes through without being widened or dropped.",
+      "checker": {
+        "cache": false,
+        "include": ["src/**/*.vue", "server/**/*.ts"],
+        "exclude": ["vendor/**", "generated/**"],
+        "formatter": "json",
+        "lintOnStart": false,
+        "emitWarning": false,
+        "emitError": false,
+        "fix": true
+      }
+    }
+  ],
   "noPageMetaRuntimeValuesCases": [
     {
       "id": "no-page-meta-runtime-values/eager-context-apis",

--- a/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/fixtures/nuxt-eslint-output.json
+++ b/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/fixtures/nuxt-eslint-output.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 4,
+  "schemaVersion": 5,
   "description": "Recorded @nuxt/eslint output for every case in corpus.json. Generated — do not hand-edit; re-record with oracle.mjs --write.",
   "moduleVersion": "1.16.0",
   "configVersion": "1.16.0",
@@ -945,6 +945,41 @@
       "secondPassMessagesMatch": true,
       "secondPassOutput": "definePageMeta(); definePageMeta(runtimeMeta); definePageMeta?.({ title: ref() })",
       "secondPassFixed": false
+    }
+  },
+  "checkerOptions": {
+    "checker/default": {
+      "cache": true,
+      "include": ["/project/app/**/*.{js,jsx,ts,tsx,vue}"],
+      "exclude": ["**/node_modules/**", "/project/.nuxt"],
+      "formatter": "stylish",
+      "lintOnStart": true,
+      "emitWarning": true,
+      "emitError": true,
+      "fix": false,
+      "worker": true
+    },
+    "checker/true": {
+      "cache": true,
+      "include": ["/project/app/**/*.{js,jsx,ts,tsx,vue}"],
+      "exclude": ["**/node_modules/**", "/project/.nuxt"],
+      "formatter": "stylish",
+      "lintOnStart": true,
+      "emitWarning": true,
+      "emitError": true,
+      "fix": false,
+      "worker": true
+    },
+    "checker/all-explicit": {
+      "cache": false,
+      "include": ["src/**/*.vue", "server/**/*.ts"],
+      "exclude": ["vendor/**", "generated/**"],
+      "formatter": "json",
+      "lintOnStart": false,
+      "emitWarning": false,
+      "emitError": false,
+      "fix": true,
+      "worker": true
     }
   },
   "dirDefaults": {

--- a/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/oracle.mjs
+++ b/npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/oracle.mjs
@@ -20,6 +20,8 @@
  *      in what order, over which globs. Produced by `@nuxt/eslint-config`.
  *   3. `importGlobals` — the complete ordered globals list emitted after both
  *      Nuxt and Nitro publish their auto-import registries.
+ *   4. `checkerOptions` — every engine-neutral checker option after upstream
+ *      defaults, plus its mandatory worker invariant.
  *
  * Rule cases separately record the real plugin's exact diagnostics and output,
  * plus a second application proving fix convergence or non-fixable stability.
@@ -34,6 +36,7 @@ import { fileURLToPath } from "node:url";
 
 import { renderNuxtOxlintConfig } from "../../../nuxt/src/lint/emitter.ts";
 import { buildNuxtLintPlan } from "../../src/plan.ts";
+import { recordCheckerOptions } from "./checker-oracle.mjs";
 import { recordNoPageMetaRuntimeValuesCases } from "./no-page-meta-runtime-values-oracle.mjs";
 import { recordPreferImportMetaCases } from "./prefer-import-meta-oracle.mjs";
 
@@ -215,9 +218,10 @@ export async function runOracle() {
   ]);
 
   const corpus = readCorpus();
-  const [preferImportMeta, noPageMetaRuntimeValues] = await Promise.all([
+  const [preferImportMeta, noPageMetaRuntimeValues, checkerOptions] = await Promise.all([
     recordPreferImportMetaCases(moduleEntry, corpus, packageVersionFrom),
     recordNoPageMetaRuntimeValuesCases(moduleEntry, corpus, packageVersionFrom),
+    recordCheckerOptions(moduleEntry, corpus.checkerCases),
   ]);
   if (preferImportMeta.pluginVersion !== noPageMetaRuntimeValues.pluginVersion) {
     throw new Error("Nuxt rule oracles resolved different @nuxt/eslint-plugin versions");
@@ -279,7 +283,7 @@ export async function runOracle() {
   );
 
   return {
-    schemaVersion: 4,
+    schemaVersion: 5,
     description:
       "Recorded @nuxt/eslint output for every case in corpus.json. Generated — do not hand-edit; re-record with oracle.mjs --write.",
     moduleVersion: packageVersionFrom(moduleEntry),
@@ -298,6 +302,7 @@ export async function runOracle() {
     },
     preferImportMetaCases: preferImportMeta.cases,
     noPageMetaRuntimeValuesCases: noPageMetaRuntimeValues.cases,
+    checkerOptions,
     dirDefaults,
     cases,
   };

--- a/npm/framework/nuxt/package.json
+++ b/npm/framework/nuxt/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "build": "vp pack",
     "dev": "vp pack --watch",
-    "test": "pnpm --filter @vizejs/nuxt-lint-config build && pnpm build && node --test src/*.test.ts src/**/*.test.ts",
+    "test": "pnpm --filter @vizejs/nuxt-lint-config build && pnpm build && node --test src/*.test.ts src/**/*.test.ts src/lint/checker/*.test.ts",
     "check": "vp check src vite.config.ts",
     "check:fix": "vp check --fix src vite.config.ts",
     "fmt": "vp fmt --write src vite.config.ts"
@@ -70,7 +70,13 @@
   },
   "peerDependencies": {
     "nuxt": "^2.16.0 || ^3.0.0 || ^4.0.0",
+    "oxlint": "^1.64.0",
     "vite": "^7.3.0 || ^8.0.0"
+  },
+  "peerDependenciesMeta": {
+    "oxlint": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=22"

--- a/npm/framework/nuxt/src/index.test.ts
+++ b/npm/framework/nuxt/src/index.test.ts
@@ -78,6 +78,7 @@ void test("Nuxt module entry runs in a Nuxt 2 webpack-style context", async () =
     name: "@vizejs/nuxt",
     configKey: "vize",
   });
+  assert.equal(nuxtModule.defaults.checker, false);
   assert.deepEqual(
     {
       hookNames,

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -1,5 +1,6 @@
 import { createNuxtComponentResolver, injectNuxtComponentImports } from "./components";
 import { injectNuxtI18nHelpers } from "./i18n";
+import { setupNuxtLintChecker } from "./lint/checker/setup";
 import { setupNuxtLintConfigGeneration } from "./lint/generation";
 import { appendMuseaArtComponentIgnore } from "./musea-components";
 import { registerNuxtMuseaStaticPublicAsset } from "./musea-static";
@@ -68,13 +69,12 @@ type NuxtWithBuilderOptions = {
     [key: string]: unknown;
   };
 };
-type VizeNuxtModuleContext = {
-  nuxt?: NuxtWithBuilderOptions;
-};
+type VizeNuxtModuleContext = { nuxt?: NuxtWithBuilderOptions };
 
 const moduleMeta = { name: "@vizejs/nuxt", configKey: "vize" } as const;
 
 const moduleDefaults = {
+  checker: false,
   lint: true,
   musea: false,
   nuxtMusea: { route: { path: "/" } },
@@ -88,13 +88,11 @@ function loadNuxtKit(): Promise<NuxtKit> {
 }
 
 async function addNuxtServerPlugin(plugin: string): Promise<void> {
-  const { addServerPlugin } = await loadNuxtKit();
-  addServerPlugin(plugin);
+  (await loadNuxtKit()).addServerPlugin(plugin);
 }
 
 async function addNuxtVitePlugin(plugin: unknown): Promise<void> {
-  const { addVitePlugin } = await loadNuxtKit();
-  addVitePlugin(plugin as never);
+  (await loadNuxtKit()).addVitePlugin(plugin as never);
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -333,7 +331,8 @@ function patchNuxtAutoImportTransformPlugin(
 }
 
 async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuilderOptions) {
-  await setupNuxtLintConfigGeneration(options.lint, nuxt);
+  const lintGeneration = await setupNuxtLintConfigGeneration(options.lint, nuxt);
+  await setupNuxtLintChecker(options.checker, nuxt, lintGeneration);
   const resolver = createNuxtModuleResolver();
   const detectedNuxtMajor = options.compatibility?.nuxtVersion ?? getDetectedNuxtMajor(nuxt) ?? 3;
   const vueVersion = options.compatibility?.vueVersion ?? (detectedNuxtMajor === 2 ? 2 : 3);
@@ -672,6 +671,7 @@ export type {
   VizeNuxtCompatibilityOptions,
   VizeNuxtCompilerOptions,
   VizeNuxtDevOptions,
+  VizeNuxtLintCheckerOptions,
   VizeNuxtLintOptions,
   VizeNuxtMajorVersion,
   VizeNuxtOptions,

--- a/npm/framework/nuxt/src/lint/checker/filter.test.ts
+++ b/npm/framework/nuxt/src/lint/checker/filter.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { matchesNuxtLintCheckerFile } from "./filter.ts";
+import type { ResolvedVizeNuxtLintCheckerOptions } from "./options.ts";
+
+const options: ResolvedVizeNuxtLintCheckerOptions = {
+  cache: true,
+  emitError: true,
+  emitWarning: true,
+  exclude: ["**/node_modules/**", "/project/.nuxt", "generated/**"],
+  fix: false,
+  formatter: "stylish",
+  include: ["/project/app/**/*.{js,jsx,ts,tsx,vue}", "server/**/*.ts"],
+  lintOnStart: true,
+};
+
+void test("checker filtering accepts every included extension and relative glob", () => {
+  for (const extension of ["js", "jsx", "ts", "tsx", "vue"]) {
+    assert.equal(
+      matchesNuxtLintCheckerFile(`/project/app/pages/index.${extension}`, "/project", options),
+      true,
+    );
+  }
+  assert.equal(matchesNuxtLintCheckerFile("/project/server/api.ts", "/project", options), true);
+});
+
+void test("checker filtering gives excludes precedence, including directory paths", () => {
+  assert.equal(
+    matchesNuxtLintCheckerFile("/project/app/node_modules/pkg/index.ts", "/project", options),
+    false,
+  );
+  assert.equal(
+    matchesNuxtLintCheckerFile("/project/.nuxt/generated/client.ts", "/project", options),
+    false,
+  );
+  assert.equal(
+    matchesNuxtLintCheckerFile("/project/generated/types.ts", "/project", options),
+    false,
+  );
+  assert.equal(matchesNuxtLintCheckerFile("/project/docs/index.ts", "/project", options), false);
+});
+
+void test("checker filtering normalizes Windows separators deterministically", () => {
+  assert.equal(
+    matchesNuxtLintCheckerFile(String.raw`C:\project\app\pages\index.vue`, String.raw`C:\project`, {
+      ...options,
+      exclude: [String.raw`C:\project\.nuxt`],
+      include: [String.raw`C:\project\app\**\*.{js,jsx,ts,tsx,vue}`],
+    }),
+    true,
+  );
+});
+
+void test("relative include globs never escape the project root", () => {
+  const config = { ...options, include: ["**/*.vue"] };
+  assert.equal(matchesNuxtLintCheckerFile("/project/App.vue", "/project", config), true);
+  assert.equal(matchesNuxtLintCheckerFile("/outside/App.vue", "/project", config), false);
+});

--- a/npm/framework/nuxt/src/lint/checker/filter.ts
+++ b/npm/framework/nuxt/src/lint/checker/filter.ts
@@ -1,0 +1,53 @@
+import path from "node:path";
+
+import type { ResolvedVizeNuxtLintCheckerOptions } from "./options.ts";
+
+const GLOB_TOKEN = /[*?[\]{}()]/u;
+
+function normalize(value: string): string {
+  const normalized = value.replaceAll("\\", "/").replace(/\/{2,}/gu, "/");
+  if (normalized === "/" || /^[A-Za-z]:\/$/u.test(normalized)) return normalized;
+  return normalized.replace(/\/$/u, "");
+}
+
+function relativeToRoot(file: string, rootDir: string): string | undefined {
+  const root = normalize(rootDir);
+  const absolute = normalize(file);
+  const prefix = `${root}/`;
+  if (absolute.startsWith(prefix)) return absolute.slice(prefix.length);
+
+  const relative = path.relative(rootDir, file);
+  const normalized = normalize(relative);
+  return normalized === ".." || normalized.startsWith("../") ? undefined : normalized;
+}
+
+function matchesDirectory(candidate: string, pattern: string): boolean {
+  if (GLOB_TOKEN.test(pattern)) return false;
+  return candidate === pattern || candidate.startsWith(`${pattern}/`);
+}
+
+function matchesPattern(
+  absolute: string,
+  relative: string | undefined,
+  rawPattern: string,
+): boolean {
+  const pattern = normalize(rawPattern);
+  const absolutePattern = path.isAbsolute(pattern) || /^[A-Za-z]:\//u.test(pattern);
+  const candidates = absolutePattern ? [absolute] : relative === undefined ? [] : [relative];
+  for (const candidate of candidates) {
+    if (matchesDirectory(candidate, pattern) || path.matchesGlob(candidate, pattern)) return true;
+  }
+  return false;
+}
+
+/** Whether one watcher path belongs to the checker include/exclude contract. */
+export function matchesNuxtLintCheckerFile(
+  file: string,
+  rootDir: string,
+  options: Pick<ResolvedVizeNuxtLintCheckerOptions, "exclude" | "include">,
+): boolean {
+  const absolute = normalize(file);
+  const relative = relativeToRoot(file, rootDir);
+  if (options.exclude.some((pattern) => matchesPattern(absolute, relative, pattern))) return false;
+  return options.include.some((pattern) => matchesPattern(absolute, relative, pattern));
+}

--- a/npm/framework/nuxt/src/lint/checker/fixtures/fake-oxlint.mjs
+++ b/npm/framework/nuxt/src/lint/checker/fixtures/fake-oxlint.mjs
@@ -1,0 +1,25 @@
+const argv = process.argv.slice(2);
+const message = argv.join(" ");
+
+process.stdout.write(
+  `${JSON.stringify({
+    diagnostics: [
+      {
+        code: "vize(nuxt/error)",
+        filename: argv.at(-1),
+        labels: [{ span: { column: 2, line: 1 } }],
+        message,
+        severity: "error",
+      },
+      {
+        code: "vize(nuxt/warning)",
+        filename: argv.at(-1),
+        labels: [{ span: { column: 4, line: 3 } }],
+        message: "warning from fake oxlint",
+        severity: "warning",
+      },
+    ],
+    number_of_files: 1,
+  })}\n`,
+);
+process.exitCode = 1;

--- a/npm/framework/nuxt/src/lint/checker/options.test.ts
+++ b/npm/framework/nuxt/src/lint/checker/options.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveNuxtLintCheckerOptions } from "./options.ts";
+
+const project = {
+  buildDir: "/project/.nuxt",
+  srcDir: "/project/app",
+};
+
+const defaults = {
+  cache: true,
+  emitError: true,
+  emitWarning: true,
+  exclude: ["**/node_modules/**", "/project/.nuxt"],
+  fix: false,
+  formatter: "stylish",
+  include: ["/project/app/**/*.{js,jsx,ts,tsx,vue}"],
+  lintOnStart: true,
+};
+
+void test("checker is opt-in and true resolves the full upstream defaults", () => {
+  assert.equal(resolveNuxtLintCheckerOptions(undefined, project), false);
+  assert.equal(resolveNuxtLintCheckerOptions(false, project), false);
+  assert.deepEqual(resolveNuxtLintCheckerOptions(true, project), defaults);
+  assert.deepEqual(resolveNuxtLintCheckerOptions({}, project), defaults);
+});
+
+void test("checker preserves every explicit portable option", () => {
+  assert.deepEqual(
+    resolveNuxtLintCheckerOptions(
+      {
+        cache: false,
+        emitError: false,
+        emitWarning: false,
+        exclude: ["generated/**", "vendor/**"],
+        fix: true,
+        formatter: "json",
+        include: ["src/**/*.vue", "server/**/*.ts"],
+        lintOnStart: false,
+      },
+      project,
+    ),
+    {
+      cache: false,
+      emitError: false,
+      emitWarning: false,
+      exclude: ["generated/**", "vendor/**"],
+      fix: true,
+      formatter: "json",
+      include: ["src/**/*.vue", "server/**/*.ts"],
+      lintOnStart: false,
+    },
+  );
+});
+
+void test("resolved arrays never alias caller input", () => {
+  const include = ["src/**/*.vue"];
+  const exclude = ["build/**"];
+  const resolved = resolveNuxtLintCheckerOptions({ include, exclude }, project);
+  assert.notEqual(resolved, false);
+  include.push("late/**/*.ts");
+  exclude.push("late/**");
+  assert.deepEqual(resolved.include, ["src/**/*.vue"]);
+  assert.deepEqual(resolved.exclude, ["build/**"]);
+});

--- a/npm/framework/nuxt/src/lint/checker/options.ts
+++ b/npm/framework/nuxt/src/lint/checker/options.ts
@@ -48,7 +48,7 @@ export function resolveNuxtLintCheckerOptions(
 ): ResolvedVizeNuxtLintCheckerOptions | false {
   if (checker !== true && (checker === false || checker == null)) return false;
 
-  const overrides = typeof checker === "object" && checker !== null ? checker : {};
+  const overrides = typeof checker === "object" ? checker : {};
   return {
     cache: overrides.cache ?? true,
     include: [...(overrides.include ?? [`${project.srcDir}/**/*.{js,jsx,ts,tsx,vue}`])],

--- a/npm/framework/nuxt/src/lint/checker/options.ts
+++ b/npm/framework/nuxt/src/lint/checker/options.ts
@@ -1,0 +1,62 @@
+/** Portable checker options mirrored from `@nuxt/eslint`. */
+export interface VizeNuxtLintCheckerOptions {
+  /** Reuse the long-lived checker and lint only changed files after startup. */
+  cache?: boolean;
+  /** Files considered by the checker. */
+  include?: string[];
+  /** Files and directories excluded from checker runs. */
+  exclude?: string[];
+  /** Oxlint output formatter. */
+  formatter?: string;
+  /** Run a complete lint pass when the dev server starts. */
+  lintOnStart?: boolean;
+  /** Print warning diagnostics and surface them in the browser overlay. */
+  emitWarning?: boolean;
+  /** Print error diagnostics and surface them in the browser overlay. */
+  emitError?: boolean;
+  /** Apply safe fixes before reporting diagnostics. */
+  fix?: boolean;
+}
+
+/** Project paths used by upstream's checker defaults. */
+export interface NuxtLintCheckerProject {
+  buildDir: string;
+  srcDir: string;
+}
+
+/** Fully defaulted checker options consumed by the worker integration. */
+export interface ResolvedVizeNuxtLintCheckerOptions {
+  cache: boolean;
+  include: string[];
+  exclude: string[];
+  formatter: string;
+  lintOnStart: boolean;
+  emitWarning: boolean;
+  emitError: boolean;
+  fix: boolean;
+}
+
+/**
+ * Resolve the engine-neutral part of `@nuxt/eslint`'s checker contract.
+ *
+ * `configType` and `eslintPath` intentionally do not exist: they choose an
+ * ESLint implementation, while this checker always executes oxlint + Patina.
+ */
+export function resolveNuxtLintCheckerOptions(
+  checker: boolean | VizeNuxtLintCheckerOptions | undefined,
+  project: NuxtLintCheckerProject,
+): ResolvedVizeNuxtLintCheckerOptions | false {
+  if (checker !== true && (checker === false || checker == null)) return false;
+
+  const overrides = typeof checker === "object" && checker !== null ? checker : {};
+  return {
+    cache: overrides.cache ?? true,
+    include: [...(overrides.include ?? [`${project.srcDir}/**/*.{js,jsx,ts,tsx,vue}`])],
+    exclude: [...(overrides.exclude ?? ["**/node_modules/**", project.buildDir])],
+    formatter: overrides.formatter ?? "stylish",
+    lintOnStart: overrides.lintOnStart ?? true,
+    emitWarning: overrides.emitWarning ?? true,
+    emitError: overrides.emitError ?? true,
+    fix: overrides.fix ?? false,
+  };
+}

--- a/npm/framework/nuxt/src/lint/checker/setup.test.ts
+++ b/npm/framework/nuxt/src/lint/checker/setup.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { setupNuxtLintChecker } from "./setup.ts";
+import type { NuxtLintConfigGeneration } from "../generation.ts";
+
+const generation: NuxtLintConfigGeneration = {
+  configFile: "/project/.nuxt/oxlint.config.json",
+  regenerate: async () => false,
+};
+
+function nuxt(
+  overrides: Partial<{
+    buildDir: string;
+    builder: string;
+    dev: boolean;
+    rootDir: string;
+    srcDir: string;
+  }> = {},
+) {
+  return {
+    options: {
+      buildDir: "/project/.nuxt",
+      builder: "@nuxt/vite-builder",
+      dev: true,
+      rootDir: "/project",
+      srcDir: "/project/app",
+      ...overrides,
+    },
+  };
+}
+
+void test("setup is checker-opt-in and strictly dev-server-only", async () => {
+  let registrations = 0;
+  const dependencies = {
+    addVitePlugin: async () => {
+      registrations += 1;
+    },
+  };
+  assert.equal(await setupNuxtLintChecker(false, nuxt(), generation, dependencies), undefined);
+  assert.equal(
+    await setupNuxtLintChecker(true, nuxt({ dev: false }), generation, dependencies),
+    undefined,
+  );
+  assert.equal(registrations, 0);
+});
+
+void test("setup connects the generated config seam to the Vite addon", async () => {
+  let registered: unknown;
+  const result = await setupNuxtLintChecker(true, nuxt(), generation, {
+    addVitePlugin: async (plugin) => {
+      registered = plugin;
+    },
+  });
+
+  assert.equal(result?.builder, "vite");
+  assert.equal((registered as { apply: string }).apply, "serve");
+  assert.equal(result?.configFile, generation.configFile);
+  assert.deepEqual(result?.options, {
+    cache: true,
+    emitError: true,
+    emitWarning: true,
+    exclude: ["**/node_modules/**", "/project/.nuxt"],
+    fix: false,
+    formatter: "stylish",
+    include: ["/project/app/**/*.{js,jsx,ts,tsx,vue}"],
+    lintOnStart: true,
+  });
+});
+
+void test("setup connects every explicit option to the webpack addon", async () => {
+  let registered: unknown;
+  const result = await setupNuxtLintChecker(
+    {
+      cache: false,
+      emitError: false,
+      emitWarning: true,
+      exclude: ["vendor/**"],
+      fix: true,
+      formatter: "unix",
+      include: ["src/**/*.vue"],
+      lintOnStart: false,
+    },
+    nuxt({ builder: "@nuxt/webpack-builder" }),
+    generation,
+    {
+      addWebpackPlugin: async (plugin) => {
+        registered = plugin;
+      },
+    },
+  );
+
+  assert.equal(result?.builder, "webpack");
+  assert.equal(typeof (registered as { apply: unknown }).apply, "function");
+  assert.deepEqual(result?.options, {
+    cache: false,
+    emitError: false,
+    emitWarning: true,
+    exclude: ["vendor/**"],
+    fix: true,
+    formatter: "unix",
+    include: ["src/**/*.vue"],
+    lintOnStart: false,
+  });
+});
+
+void test("setup rejects a checker without the generated artifact", async () => {
+  await assert.rejects(
+    setupNuxtLintChecker(true, nuxt(), undefined),
+    /requires lint config generation/u,
+  );
+});
+
+void test("setup reports an unsupported dev builder without partial registration", async () => {
+  const warnings: string[] = [];
+  const result = await setupNuxtLintChecker(true, nuxt({ builder: "custom-builder" }), generation, {
+    warn: (message) => warnings.push(message),
+  });
+  assert.equal(result?.builder, "unsupported");
+  assert.deepEqual(warnings, [
+    "Unsupported Nuxt builder custom-builder; Vize lint checker is disabled.",
+  ]);
+});

--- a/npm/framework/nuxt/src/lint/checker/setup.ts
+++ b/npm/framework/nuxt/src/lint/checker/setup.ts
@@ -1,0 +1,97 @@
+import path from "node:path";
+
+import type { NuxtLintConfigGeneration } from "../generation.ts";
+import {
+  resolveNuxtLintCheckerOptions,
+  type ResolvedVizeNuxtLintCheckerOptions,
+  type VizeNuxtLintCheckerOptions,
+} from "./options.ts";
+import { createNuxtLintCheckerVitePlugin, type NuxtLintCheckerVitePlugin } from "./vite.ts";
+import {
+  createNuxtLintCheckerWebpackPlugin,
+  type NuxtLintCheckerWebpackPlugin,
+} from "./webpack.ts";
+
+interface NuxtLintCheckerNuxt {
+  options: {
+    buildDir: string;
+    builder?: unknown;
+    dev?: boolean;
+    rootDir: string;
+    srcDir?: string;
+  };
+}
+
+type Awaitable<T> = T | Promise<T>;
+
+export interface NuxtLintCheckerSetupDependencies {
+  addVitePlugin?: (plugin: NuxtLintCheckerVitePlugin) => Awaitable<void>;
+  addWebpackPlugin?: (plugin: NuxtLintCheckerWebpackPlugin) => Awaitable<void>;
+  warn?: (message: string) => void;
+}
+
+export interface NuxtLintCheckerSetup {
+  builder: "unsupported" | "vite" | "webpack";
+  configFile: string;
+  options: ResolvedVizeNuxtLintCheckerOptions;
+}
+
+interface NuxtKitPluginRegistration {
+  addVitePlugin(plugin: unknown, options?: { server?: boolean }): void;
+  addWebpackPlugin(plugin: unknown, options?: { server?: boolean }): void;
+}
+
+async function addVitePlugin(plugin: NuxtLintCheckerVitePlugin): Promise<void> {
+  const kit = (await import("@nuxt/kit")) as unknown as NuxtKitPluginRegistration;
+  kit.addVitePlugin(plugin, { server: false });
+}
+
+async function addWebpackPlugin(plugin: NuxtLintCheckerWebpackPlugin): Promise<void> {
+  const kit = (await import("@nuxt/kit")) as unknown as NuxtKitPluginRegistration;
+  kit.addWebpackPlugin(plugin, { server: false });
+}
+
+function builderKind(builder: unknown): "unsupported" | "vite" | "webpack" {
+  if (typeof builder !== "string") return "unsupported";
+  if (builder === "vite" || builder.includes("vite-builder")) return "vite";
+  if (builder === "webpack" || builder.includes("webpack-builder")) return "webpack";
+  return "unsupported";
+}
+
+/** Register the dev-only adapter over Phase 3's generated config artifact. */
+export async function setupNuxtLintChecker(
+  checker: boolean | VizeNuxtLintCheckerOptions | undefined,
+  nuxt: NuxtLintCheckerNuxt,
+  generation: NuxtLintConfigGeneration | undefined,
+  dependencies: NuxtLintCheckerSetupDependencies = {},
+): Promise<NuxtLintCheckerSetup | undefined> {
+  if (checker !== true && (checker === false || checker == null)) return undefined;
+  if (nuxt.options.dev !== true) return undefined;
+  if (!generation) {
+    throw new Error("The Nuxt lint checker requires lint config generation; enable `vize.lint`.");
+  }
+
+  const options = resolveNuxtLintCheckerOptions(checker, {
+    buildDir: nuxt.options.buildDir,
+    srcDir: nuxt.options.srcDir ?? nuxt.options.rootDir,
+  });
+  if (options === false) return undefined;
+  const rootDir = path.resolve(nuxt.options.rootDir);
+  const config = { configFile: generation.configFile, options, rootDir };
+  const builder = builderKind(nuxt.options.builder);
+
+  if (builder === "vite") {
+    const register = dependencies.addVitePlugin ?? addVitePlugin;
+    await register(createNuxtLintCheckerVitePlugin(config));
+  } else if (builder === "webpack") {
+    const register = dependencies.addWebpackPlugin ?? addWebpackPlugin;
+    await register(createNuxtLintCheckerWebpackPlugin(config));
+  } else {
+    const label = typeof nuxt.options.builder === "string" ? nuxt.options.builder : "unknown";
+    (dependencies.warn ?? console.warn)(
+      `Unsupported Nuxt builder ${label}; Vize lint checker is disabled.`,
+    );
+  }
+
+  return { builder, configFile: generation.configFile, options };
+}

--- a/npm/framework/nuxt/src/lint/checker/vite.test.ts
+++ b/npm/framework/nuxt/src/lint/checker/vite.test.ts
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+
+import { createNuxtLintCheckerVitePlugin } from "./vite.ts";
+import type { ResolvedVizeNuxtLintCheckerOptions } from "./options.ts";
+import type { NuxtLintCheckerResult, NuxtLintCheckerTask } from "./worker.ts";
+
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+function result(overrides: Partial<NuxtLintCheckerResult> = {}): NuxtLintCheckerResult {
+  return {
+    diagnosticCount: 0,
+    hasErrors: false,
+    hasWarnings: false,
+    output: "",
+    ...overrides,
+  };
+}
+
+function options(
+  overrides: Partial<ResolvedVizeNuxtLintCheckerOptions> = {},
+): ResolvedVizeNuxtLintCheckerOptions {
+  return {
+    cache: true,
+    emitError: true,
+    emitWarning: true,
+    exclude: ["**/node_modules/**", "/project/.nuxt"],
+    fix: false,
+    formatter: "stylish",
+    include: ["/project/app/**/*.{js,jsx,ts,tsx,vue}"],
+    lintOnStart: true,
+    ...overrides,
+  };
+}
+
+function harness(responses: NuxtLintCheckerResult[] = [result()]) {
+  const watcher = new EventEmitter() as EventEmitter & { add(path: string): void; added: string[] };
+  watcher.added = [];
+  watcher.add = (file) => watcher.added.push(file);
+  const httpServer = new EventEmitter();
+  const messages: unknown[] = [];
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const tasks: NuxtLintCheckerTask[] = [];
+  let closed = 0;
+  const runner = {
+    close: async () => {
+      closed += 1;
+    },
+    run: async (task: NuxtLintCheckerTask) => {
+      tasks.push(task);
+      return responses.shift() ?? result();
+    },
+  };
+  const server = {
+    config: {
+      logger: {
+        error: (message: string) => errors.push(message),
+        warn: (message: string) => warnings.push(message),
+      },
+    },
+    httpServer,
+    watcher,
+    ws: { send: (message: unknown) => messages.push(message) },
+  };
+  return {
+    errors,
+    get closed() {
+      return closed;
+    },
+    httpServer,
+    messages,
+    runner,
+    server,
+    tasks,
+    warnings,
+    watcher,
+  };
+}
+
+void test("Vite addon lints on start in a worker and watches the generated config", async () => {
+  const state = harness();
+  const plugin = createNuxtLintCheckerVitePlugin(
+    {
+      configFile: "/project/.nuxt/oxlint.config.json",
+      options: options(),
+      rootDir: "/project",
+    },
+    { createRunner: () => state.runner },
+  );
+
+  assert.equal(plugin.apply, "serve");
+  plugin.configureServer?.(state.server as never);
+  await flush();
+  assert.deepEqual(state.watcher.added, ["/project/.nuxt/oxlint.config.json"]);
+  assert.deepEqual(
+    state.tasks.map((task) => task.targets),
+    [["/project/app/**/*.{js,jsx,ts,tsx,vue}"]],
+  );
+
+  state.httpServer.emit("close");
+  await flush();
+  assert.equal(state.closed, 1);
+});
+
+void test("Vite addon lints changed files with cache and full includes without it", async () => {
+  for (const cache of [true, false]) {
+    const state = harness([result(), result()]);
+    const plugin = createNuxtLintCheckerVitePlugin(
+      {
+        configFile: "/project/.nuxt/oxlint.config.json",
+        options: options({ cache, lintOnStart: false }),
+        rootDir: "/project",
+      },
+      { createRunner: () => state.runner },
+    );
+    plugin.configureServer?.(state.server as never);
+    state.watcher.emit("change", "/project/app/pages/index.vue");
+    state.watcher.emit("change", "/project/app/node_modules/ignored.ts");
+    await flush();
+    assert.deepEqual(
+      state.tasks.map((task) => task.targets),
+      [cache ? ["/project/app/pages/index.vue"] : ["/project/app/**/*.{js,jsx,ts,tsx,vue}"]],
+    );
+
+    state.watcher.emit("change", "/project/.nuxt/oxlint.config.json");
+    await flush();
+    assert.deepEqual(state.tasks[1].targets, ["/project/app/**/*.{js,jsx,ts,tsx,vue}"]);
+  }
+});
+
+void test("Vite addon reports terminal diagnostics, opens and clears the overlay", async () => {
+  const state = harness([
+    result({ diagnosticCount: 1, hasErrors: true, output: "error output\n" }),
+    result(),
+    result({ diagnosticCount: 1, hasWarnings: true, output: "warning output\n" }),
+  ]);
+  const plugin = createNuxtLintCheckerVitePlugin(
+    {
+      configFile: "/project/.nuxt/oxlint.config.json",
+      options: options({ lintOnStart: false }),
+      rootDir: "/project",
+    },
+    { createRunner: () => state.runner },
+  );
+  plugin.configureServer?.(state.server as never);
+
+  state.watcher.emit("change", "/project/app/error.vue");
+  await flush();
+  state.watcher.emit("change", "/project/app/clean.vue");
+  await flush();
+  state.watcher.emit("change", "/project/app/warning.vue");
+  await flush();
+
+  assert.deepEqual(state.errors, ["error output\n"]);
+  assert.deepEqual(state.warnings, ["warning output\n"]);
+  assert.deepEqual(
+    state.messages.map((message) => (message as { type: string }).type),
+    ["error", "update", "error"],
+  );
+  assert.match(JSON.stringify(state.messages[0]), /error output/u);
+  assert.match(JSON.stringify(state.messages[2]), /warning output/u);
+});
+
+void test("Vite addon turns worker failures into actionable terminal and overlay errors", async () => {
+  const state = harness();
+  state.runner.run = async () => {
+    throw new Error("oxlint disappeared");
+  };
+  const plugin = createNuxtLintCheckerVitePlugin(
+    {
+      configFile: "/project/.nuxt/oxlint.config.json",
+      options: options(),
+      rootDir: "/project",
+    },
+    { createRunner: () => state.runner },
+  );
+  plugin.configureServer?.(state.server as never);
+  await flush();
+
+  assert.match(state.errors[0], /Nuxt lint checker failed: oxlint disappeared/u);
+  assert.equal((state.messages[0] as { type: string }).type, "error");
+});
+
+void test("Vite addon stays silent when shutdown cancels an active pass", async () => {
+  const state = harness();
+  let rejectRun = (_error: Error): void => {};
+  state.runner.run = () =>
+    new Promise((_resolve, reject) => {
+      rejectRun = reject;
+    });
+  const plugin = createNuxtLintCheckerVitePlugin(
+    {
+      configFile: "/project/.nuxt/oxlint.config.json",
+      options: options(),
+      rootDir: "/project",
+    },
+    { createRunner: () => state.runner },
+  );
+  plugin.configureServer?.(state.server as never);
+  await flush();
+  state.httpServer.emit("close");
+  rejectRun(new Error("worker closed"));
+  await flush();
+
+  assert.deepEqual(state.errors, []);
+  assert.deepEqual(state.messages, []);
+});

--- a/npm/framework/nuxt/src/lint/checker/vite.ts
+++ b/npm/framework/nuxt/src/lint/checker/vite.ts
@@ -1,0 +1,200 @@
+import path from "node:path";
+
+import { matchesNuxtLintCheckerFile } from "./filter.ts";
+import type { ResolvedVizeNuxtLintCheckerOptions } from "./options.ts";
+import {
+  NuxtLintCheckerWorker,
+  type NuxtLintCheckerResult,
+  type NuxtLintCheckerTask,
+} from "./worker.ts";
+
+const PLUGIN_NAME = "vize:nuxt-lint-checker";
+
+interface CheckerWatcher {
+  add(file: string): void;
+  on(event: "add" | "change" | "unlink", listener: (file: string) => void): unknown;
+}
+
+interface CheckerServer {
+  config: { logger: { error(message: string): void; warn(message: string): void } };
+  httpServer?: { once(event: "close", listener: () => void): unknown } | null;
+  watcher: CheckerWatcher;
+  ws: { send(message: unknown): void };
+}
+
+export interface NuxtLintCheckerVitePlugin {
+  apply: "serve";
+  enforce: "post";
+  name: typeof PLUGIN_NAME;
+  configureServer(server: CheckerServer): void;
+}
+
+export interface NuxtLintCheckerViteOptions {
+  configFile: string;
+  options: ResolvedVizeNuxtLintCheckerOptions;
+  rootDir: string;
+}
+
+export interface NuxtLintCheckerRunner {
+  close(): void | Promise<void>;
+  run(task: NuxtLintCheckerTask): Promise<NuxtLintCheckerResult>;
+}
+
+export interface NuxtLintCheckerViteDependencies {
+  createRunner?: () => NuxtLintCheckerRunner;
+  oxlintEntrypoint?: string;
+}
+
+function overlayError(output: string): unknown {
+  return {
+    type: "error",
+    err: {
+      message: "Vize lint checker found diagnostics",
+      stack: output,
+      plugin: PLUGIN_NAME,
+    },
+  };
+}
+
+class NuxtLintChangeCollector {
+  private readonly pendingFiles = new Set<string>();
+  private pendingFull = false;
+  private draining = false;
+  private closed = false;
+  private overlayVisible = false;
+  private readonly config: NuxtLintCheckerViteOptions;
+  private readonly runner: NuxtLintCheckerRunner;
+  private readonly server: CheckerServer;
+  private readonly oxlintEntrypoint: string | undefined;
+
+  constructor(
+    config: NuxtLintCheckerViteOptions,
+    runner: NuxtLintCheckerRunner,
+    server: CheckerServer,
+    oxlintEntrypoint: string | undefined,
+  ) {
+    this.config = config;
+    this.runner = runner;
+    this.server = server;
+    this.oxlintEntrypoint = oxlintEntrypoint;
+  }
+
+  full(): void {
+    if (this.closed) return;
+    this.pendingFull = true;
+    this.pendingFiles.clear();
+    this.schedule();
+  }
+
+  file(file: string): void {
+    if (this.closed) return;
+    if (path.resolve(file) === path.resolve(this.config.configFile)) {
+      this.full();
+      return;
+    }
+    if (!matchesNuxtLintCheckerFile(file, this.config.rootDir, this.config.options)) return;
+    if (!this.config.options.cache) {
+      this.full();
+      return;
+    }
+    if (!this.pendingFull) this.pendingFiles.add(path.resolve(file));
+    this.schedule();
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.pendingFiles.clear();
+    await this.runner.close();
+  }
+
+  private schedule(): void {
+    if (this.draining) return;
+    this.draining = true;
+    queueMicrotask(() => void this.drain());
+  }
+
+  private async drain(): Promise<void> {
+    while (!this.closed && (this.pendingFull || this.pendingFiles.size > 0)) {
+      const targets = this.pendingFull
+        ? [...this.config.options.include]
+        : [...this.pendingFiles].sort();
+      this.pendingFull = false;
+      this.pendingFiles.clear();
+      try {
+        const result = await this.runner.run(this.task(targets));
+        if (!this.closed) this.report(result);
+      } catch (error) {
+        if (!this.closed) this.reportFailure(error);
+      }
+    }
+    this.draining = false;
+    // A request can land after the loop condition but before the flag reset.
+    if (!this.closed && (this.pendingFull || this.pendingFiles.size > 0)) this.schedule();
+  }
+
+  private task(targets: string[]): NuxtLintCheckerTask {
+    const options = this.config.options;
+    return {
+      configFile: this.config.configFile,
+      cwd: this.config.rootDir,
+      emitError: options.emitError,
+      emitWarning: options.emitWarning,
+      exclude: [...options.exclude],
+      fix: options.fix,
+      formatter: options.formatter,
+      oxlintEntrypoint: this.oxlintEntrypoint,
+      targets,
+    };
+  }
+
+  private report(result: NuxtLintCheckerResult): void {
+    if (result.output) {
+      if (result.hasErrors) this.server.config.logger.error(result.output);
+      else if (result.hasWarnings) this.server.config.logger.warn(result.output);
+    }
+    if (result.diagnosticCount > 0) {
+      this.server.ws.send(overlayError(result.output));
+      this.overlayVisible = true;
+    } else if (this.overlayVisible) {
+      // Vite clears its error overlay whenever an update payload arrives.
+      this.server.ws.send({ type: "update", updates: [] });
+      this.overlayVisible = false;
+    }
+  }
+
+  private reportFailure(error: unknown): void {
+    const message = `Nuxt lint checker failed: ${error instanceof Error ? error.message : String(error)}`;
+    this.server.config.logger.error(message);
+    this.server.ws.send(overlayError(message));
+    this.overlayVisible = true;
+  }
+}
+
+/** Create the client-side Vite dev plugin; it has no transform/render hooks. */
+export function createNuxtLintCheckerVitePlugin(
+  config: NuxtLintCheckerViteOptions,
+  dependencies: NuxtLintCheckerViteDependencies = {},
+): NuxtLintCheckerVitePlugin {
+  return {
+    name: PLUGIN_NAME,
+    apply: "serve",
+    enforce: "post",
+    configureServer(server) {
+      const runner = dependencies.createRunner?.() ?? new NuxtLintCheckerWorker();
+      const collector = new NuxtLintChangeCollector(
+        config,
+        runner,
+        server,
+        dependencies.oxlintEntrypoint,
+      );
+      server.watcher.add(config.configFile);
+      const changed = (file: string) => collector.file(file);
+      server.watcher.on("add", changed);
+      server.watcher.on("change", changed);
+      server.watcher.on("unlink", changed);
+      server.httpServer?.once("close", () => void collector.close());
+      if (config.options.lintOnStart) collector.full();
+    },
+  };
+}

--- a/npm/framework/nuxt/src/lint/checker/webpack.test.ts
+++ b/npm/framework/nuxt/src/lint/checker/webpack.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createNuxtLintCheckerWebpackPlugin } from "./webpack.ts";
+import type { ResolvedVizeNuxtLintCheckerOptions } from "./options.ts";
+import type { NuxtLintCheckerResult, NuxtLintCheckerTask } from "./worker.ts";
+
+type SyncHook = (compiler: FakeCompiler) => void;
+type AsyncHook = (compilation: FakeCompilation) => Promise<void>;
+
+interface FakeCompilation {
+  errors: Error[];
+  fileDependencies: Set<string>;
+  warnings: Error[];
+}
+
+function resolved(
+  overrides: Partial<ResolvedVizeNuxtLintCheckerOptions> = {},
+): ResolvedVizeNuxtLintCheckerOptions {
+  return {
+    cache: true,
+    emitError: true,
+    emitWarning: true,
+    exclude: ["**/node_modules/**", "/project/.nuxt"],
+    fix: false,
+    formatter: "stylish",
+    include: ["/project/app/**/*.{js,jsx,ts,tsx,vue}"],
+    lintOnStart: true,
+    ...overrides,
+  };
+}
+
+function ok(overrides: Partial<NuxtLintCheckerResult> = {}): NuxtLintCheckerResult {
+  return {
+    diagnosticCount: 0,
+    hasErrors: false,
+    hasWarnings: false,
+    output: "",
+    ...overrides,
+  };
+}
+
+class FakeCompiler {
+  modifiedFiles: Set<string> | undefined;
+  watchRunHook: SyncHook | undefined;
+  afterCompileHook: AsyncHook | undefined;
+  watchCloseHook: (() => void) | undefined;
+  hooks = {
+    watchRun: { tap: (_name: string, hook: SyncHook) => (this.watchRunHook = hook) },
+    afterCompile: {
+      tapPromise: (_name: string, hook: AsyncHook) => (this.afterCompileHook = hook),
+    },
+    watchClose: { tap: (_name: string, hook: () => void) => (this.watchCloseHook = hook) },
+  };
+}
+
+function harness(options: ResolvedVizeNuxtLintCheckerOptions) {
+  const compiler = new FakeCompiler();
+  const tasks: NuxtLintCheckerTask[] = [];
+  const responses: NuxtLintCheckerResult[] = [];
+  let closed = 0;
+  const runner = {
+    close: async () => {
+      closed += 1;
+    },
+    run: async (task: NuxtLintCheckerTask) => {
+      tasks.push(task);
+      return responses.shift() ?? ok();
+    },
+  };
+  createNuxtLintCheckerWebpackPlugin(
+    { configFile: "/project/.nuxt/oxlint.config.json", options, rootDir: "/project" },
+    { createRunner: () => runner },
+  ).apply(compiler as never);
+  return {
+    compiler,
+    get closed() {
+      return closed;
+    },
+    responses,
+    tasks,
+  };
+}
+
+function compilation(): FakeCompilation {
+  return { errors: [], fileDependencies: new Set(), warnings: [] };
+}
+
+void test("webpack addon starts worker lint before compilation completes and feeds its overlay", async () => {
+  const state = harness(resolved());
+  state.responses.push(ok({ diagnosticCount: 2, hasErrors: true, output: "lint failed\n" }));
+  state.compiler.watchRunHook?.(state.compiler);
+  assert.equal(state.tasks.length, 1, "worker starts at watchRun rather than afterCompile");
+
+  const built = compilation();
+  await state.compiler.afterCompileHook?.(built);
+  assert.deepEqual(state.tasks[0].targets, ["/project/app/**/*.{js,jsx,ts,tsx,vue}"]);
+  assert.equal(built.errors.length, 1);
+  assert.match(built.errors[0].message, /lint failed/u);
+  assert.deepEqual([...built.fileDependencies], ["/project/.nuxt/oxlint.config.json"]);
+});
+
+void test("webpack addon uses modified files with cache and reruns all on config changes", async () => {
+  const state = harness(resolved({ lintOnStart: false }));
+  state.compiler.modifiedFiles = new Set([
+    "/project/app/pages/index.vue",
+    "/project/app/node_modules/ignored.ts",
+  ]);
+  state.compiler.watchRunHook?.(state.compiler);
+  await state.compiler.afterCompileHook?.(compilation());
+  assert.deepEqual(
+    state.tasks.map((task) => task.targets),
+    [["/project/app/pages/index.vue"]],
+  );
+
+  state.compiler.modifiedFiles = new Set(["/project/.nuxt/oxlint.config.json"]);
+  state.compiler.watchRunHook?.(state.compiler);
+  await state.compiler.afterCompileHook?.(compilation());
+  assert.deepEqual(state.tasks[1].targets, ["/project/app/**/*.{js,jsx,ts,tsx,vue}"]);
+});
+
+void test("webpack addon honours lintOnStart false, warning output, and closes its worker", async () => {
+  const state = harness(resolved({ lintOnStart: false }));
+  state.compiler.modifiedFiles = undefined;
+  state.compiler.watchRunHook?.(state.compiler);
+  const first = compilation();
+  await state.compiler.afterCompileHook?.(first);
+  assert.equal(state.tasks.length, 0);
+
+  state.responses.push(ok({ diagnosticCount: 1, hasWarnings: true, output: "lint warning\n" }));
+  state.compiler.modifiedFiles = new Set(["/project/app/page.vue"]);
+  state.compiler.watchRunHook?.(state.compiler);
+  const second = compilation();
+  await state.compiler.afterCompileHook?.(second);
+  assert.equal(second.warnings.length, 1);
+  assert.match(second.warnings[0].message, /lint warning/u);
+
+  state.compiler.watchCloseHook?.();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(state.closed, 1);
+});

--- a/npm/framework/nuxt/src/lint/checker/webpack.ts
+++ b/npm/framework/nuxt/src/lint/checker/webpack.ts
@@ -1,0 +1,145 @@
+import path from "node:path";
+
+import { matchesNuxtLintCheckerFile } from "./filter.ts";
+import type { ResolvedVizeNuxtLintCheckerOptions } from "./options.ts";
+import {
+  NuxtLintCheckerWorker,
+  type NuxtLintCheckerResult,
+  type NuxtLintCheckerTask,
+} from "./worker.ts";
+
+const PLUGIN_NAME = "VizeNuxtLintChecker";
+
+interface WebpackCompilation {
+  errors: Error[];
+  fileDependencies: Set<string>;
+  warnings: Error[];
+}
+
+interface WebpackCompiler {
+  modifiedFiles?: Set<string>;
+  hooks: {
+    watchRun: { tap(name: string, callback: (compiler: WebpackCompiler) => void): void };
+    afterCompile: {
+      tapPromise(name: string, callback: (compilation: WebpackCompilation) => Promise<void>): void;
+    };
+    watchClose: { tap(name: string, callback: () => void): void };
+  };
+}
+
+export interface NuxtLintCheckerWebpackPlugin {
+  apply(compiler: WebpackCompiler): void;
+}
+
+export interface NuxtLintCheckerWebpackOptions {
+  configFile: string;
+  options: ResolvedVizeNuxtLintCheckerOptions;
+  rootDir: string;
+}
+
+export interface NuxtLintCheckerWebpackRunner {
+  close(): void | Promise<void>;
+  run(task: NuxtLintCheckerTask): Promise<NuxtLintCheckerResult>;
+}
+
+export interface NuxtLintCheckerWebpackDependencies {
+  createRunner?: () => NuxtLintCheckerWebpackRunner;
+  oxlintEntrypoint?: string;
+}
+
+function checkerError(message: string): Error {
+  const error = new Error(message);
+  error.name = PLUGIN_NAME;
+  return error;
+}
+
+function reportResult(compilation: WebpackCompilation, result: NuxtLintCheckerResult): void {
+  if (result.hasErrors) compilation.errors.push(checkerError(result.output));
+  else if (result.hasWarnings) compilation.warnings.push(checkerError(result.output));
+}
+
+function task(
+  config: NuxtLintCheckerWebpackOptions,
+  targets: string[],
+  oxlintEntrypoint: string | undefined,
+): NuxtLintCheckerTask {
+  const options = config.options;
+  return {
+    configFile: config.configFile,
+    cwd: config.rootDir,
+    emitError: options.emitError,
+    emitWarning: options.emitWarning,
+    exclude: [...options.exclude],
+    fix: options.fix,
+    formatter: options.formatter,
+    oxlintEntrypoint,
+    targets,
+  };
+}
+
+function changedTargets(
+  compiler: WebpackCompiler,
+  config: NuxtLintCheckerWebpackOptions,
+  initial: boolean,
+): string[] | undefined {
+  const modified = compiler.modifiedFiles;
+  if (initial && config.options.lintOnStart) return [...config.options.include];
+  if (!modified || modified.size === 0) return undefined;
+  if (!config.options.cache) return [...config.options.include];
+
+  const configFile = path.resolve(config.configFile);
+  if ([...modified].some((file) => path.resolve(file) === configFile)) {
+    return [...config.options.include];
+  }
+  const files = [...modified]
+    .filter((file) => matchesNuxtLintCheckerFile(file, config.rootDir, config.options))
+    .map((file) => path.resolve(file))
+    .sort();
+  return files.length > 0 ? files : undefined;
+}
+
+/**
+ * Create Nuxt 2's webpack adapter.
+ *
+ * The worker starts at `watchRun`, concurrently with compilation; only the
+ * final diagnostic handoff happens at `afterCompile`, where webpack can feed
+ * the result to its existing terminal and browser overlays.
+ */
+export function createNuxtLintCheckerWebpackPlugin(
+  config: NuxtLintCheckerWebpackOptions,
+  dependencies: NuxtLintCheckerWebpackDependencies = {},
+): NuxtLintCheckerWebpackPlugin {
+  return {
+    apply(compiler) {
+      const runner = dependencies.createRunner?.() ?? new NuxtLintCheckerWorker();
+      let initial = true;
+      let pending: Promise<NuxtLintCheckerResult> | undefined;
+
+      compiler.hooks.watchRun.tap(PLUGIN_NAME, (nextCompiler) => {
+        const targets = changedTargets(nextCompiler, config, initial);
+        initial = false;
+        pending = targets
+          ? runner.run(task(config, targets, dependencies.oxlintEntrypoint))
+          : undefined;
+      });
+
+      compiler.hooks.afterCompile.tapPromise(PLUGIN_NAME, async (compilation) => {
+        compilation.fileDependencies.add(config.configFile);
+        if (!pending) return;
+        const current = pending;
+        pending = undefined;
+        try {
+          reportResult(compilation, await current);
+        } catch (error) {
+          compilation.errors.push(
+            checkerError(
+              `Nuxt lint checker failed: ${error instanceof Error ? error.message : String(error)}`,
+            ),
+          );
+        }
+      });
+
+      compiler.hooks.watchClose.tap(PLUGIN_NAME, () => void runner.close());
+    },
+  };
+}

--- a/npm/framework/nuxt/src/lint/checker/worker.integration.test.ts
+++ b/npm/framework/nuxt/src/lint/checker/worker.integration.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { createRequire } from "node:module";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { NuxtLintCheckerWorker, type NuxtLintCheckerTask } from "./worker.ts";
+import type { createNuxtLintCheckerVitePlugin as CreateVitePlugin } from "./vite.ts";
+
+const require = createRequire(import.meta.url);
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+void test("real worker re-reads its oxlint + Patina config on every pass", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "vize-nuxt-real-checker-"));
+  const worker = new NuxtLintCheckerWorker();
+  t.after(async () => {
+    await worker.close();
+    await rm(root, { force: true, recursive: true });
+  });
+
+  const configFile = path.join(root, "oxlint.config.json");
+  const source = path.join(root, "App.vue");
+  const pluginEntry = fileURLToPath(import.meta.resolve("oxlint-plugin-vize"));
+  const pluginSpecifier = path.relative(root, pluginEntry).replaceAll(path.sep, "/");
+  const oxlintManifest = require.resolve("oxlint/package.json");
+  const oxlintEntrypoint = path.join(path.dirname(oxlintManifest), "bin", "oxlint");
+  await writeFile(
+    source,
+    `<script setup>\nconst items = [1]\n</script>\n<template>\n  <div v-for="item in items">{{ item }}</div>\n</template>\n`,
+  );
+
+  const task: NuxtLintCheckerTask = {
+    configFile,
+    cwd: root,
+    emitError: true,
+    emitWarning: true,
+    exclude: [],
+    fix: false,
+    formatter: "json",
+    oxlintEntrypoint,
+    targets: [path.join(root, "**/*.{js,jsx,ts,tsx,vue}")],
+  };
+
+  await writeConfig("error");
+  const failing = await worker.run(task);
+  assert.equal(failing.hasErrors, true);
+  assert.equal(failing.diagnosticCount, 1);
+  assert.deepEqual(
+    (JSON.parse(failing.output) as { diagnostics: Array<{ code: string }> }).diagnostics.map(
+      ({ code }) => code,
+    ),
+    ["vize(vue/require-v-for-key)"],
+  );
+
+  await writeConfig("off");
+  assert.deepEqual(await worker.run(task), {
+    diagnosticCount: 0,
+    hasErrors: false,
+    hasWarnings: false,
+    output: "",
+  });
+  assert.match(await readFile(configFile, "utf8"), /"off"/u);
+
+  async function writeConfig(severity: "error" | "off"): Promise<void> {
+    await writeFile(
+      configFile,
+      `${JSON.stringify(
+        {
+          jsPlugins: [{ name: "vize", specifier: pluginSpecifier }],
+          plugins: ["vue"],
+          rules: { "vize/vue/require-v-for-key": severity },
+          settings: { vize: { preset: "incremental" } },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  }
+});
+
+void test("packed checker starts its self-hosted worker chunk", { timeout: 5_000 }, async () => {
+  const packed = (await import(new URL("../../../dist/lint/index.mjs", import.meta.url).href)) as {
+    createNuxtLintCheckerVitePlugin: typeof CreateVitePlugin;
+  };
+  const watcher = new EventEmitter() as EventEmitter & {
+    add(file: string): void;
+  };
+  watcher.add = () => {};
+  const httpServer = new EventEmitter();
+  let resolveOutput = (_output: string): void => {};
+  const output = new Promise<string>((resolve) => {
+    resolveOutput = resolve;
+  });
+  const plugin = packed.createNuxtLintCheckerVitePlugin(
+    {
+      configFile: path.join(here, "fixtures", "unused.config.json"),
+      options: {
+        cache: true,
+        emitError: true,
+        emitWarning: true,
+        exclude: [],
+        fix: false,
+        formatter: "json",
+        include: [path.join(here, "**/*.vue")],
+        lintOnStart: true,
+      },
+      rootDir: here,
+    },
+    {
+      oxlintEntrypoint: path.join(here, "fixtures", "fake-oxlint.mjs"),
+    },
+  );
+  plugin.configureServer({
+    config: { logger: { error: resolveOutput, warn: resolveOutput } },
+    httpServer,
+    watcher,
+    ws: { send() {} },
+  } as never);
+
+  try {
+    assert.match(await output, /vize\(nuxt\/error\)/u);
+  } finally {
+    httpServer.emit("close");
+  }
+});

--- a/npm/framework/nuxt/src/lint/checker/worker.test.ts
+++ b/npm/framework/nuxt/src/lint/checker/worker.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  NuxtLintCheckerWorker,
+  runNuxtLintCheckerTask,
+  type NuxtLintCheckerTask,
+} from "./worker.ts";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fakeOxlint = path.join(here, "fixtures", "fake-oxlint.mjs");
+
+function task(overrides: Partial<NuxtLintCheckerTask> = {}): NuxtLintCheckerTask {
+  return {
+    cwd: here,
+    configFile: "/project/.nuxt/oxlint.config.json",
+    exclude: ["generated/**", "**/node_modules/**"],
+    fix: true,
+    formatter: "json",
+    oxlintEntrypoint: fakeOxlint,
+    targets: ["/project/app/pages/error.vue"],
+    emitError: true,
+    emitWarning: true,
+    ...overrides,
+  };
+}
+
+void test("worker execution reports the complete filtered diagnostic payload", async () => {
+  const result = await runNuxtLintCheckerTask(task());
+  assert.equal(result.hasErrors, true);
+  assert.equal(result.hasWarnings, true);
+  assert.equal(result.diagnosticCount, 2);
+  const payload = JSON.parse(result.output) as {
+    diagnostics: Array<{ message: string; severity: string }>;
+  };
+  assert.deepEqual(
+    payload.diagnostics.map(({ severity }) => severity),
+    ["error", "warning"],
+  );
+  assert.match(payload.diagnostics[0].message, /--config/u);
+  assert.match(payload.diagnostics[0].message, /--fix/u);
+  assert.match(payload.diagnostics[0].message, /--ignore-pattern generated\/\*\*/u);
+});
+
+void test("worker rebases project-absolute globs for oxlint", async () => {
+  const result = await runNuxtLintCheckerTask(
+    task({
+      exclude: [path.join(here, "generated/**")],
+      targets: [path.join(here, "app/**/*.{ts,vue}")],
+    }),
+  );
+  const message = (JSON.parse(result.output) as { diagnostics: Array<{ message: string }> })
+    .diagnostics[0].message;
+  assert.match(message, /--ignore-pattern generated\/\*\*/u);
+  assert.match(message, /app\/\*\*\/\*\.ts/u);
+  assert.match(message, /app\/\*\*\/\*\.vue/u);
+  assert.match(message, /app\/\*\.ts/u);
+  assert.match(message, /app\/\*\.vue/u);
+});
+
+void test("worker execution honours emitError and emitWarning independently", async () => {
+  const warnings = await runNuxtLintCheckerTask(task({ emitError: false }));
+  assert.equal(warnings.hasErrors, false);
+  assert.equal(warnings.hasWarnings, true);
+  assert.equal(warnings.diagnosticCount, 1);
+  assert.deepEqual(
+    (JSON.parse(warnings.output) as { diagnostics: Array<{ severity: string }> }).diagnostics.map(
+      ({ severity }) => severity,
+    ),
+    ["warning"],
+  );
+
+  const errors = await runNuxtLintCheckerTask(task({ emitWarning: false }));
+  assert.equal(errors.hasErrors, true);
+  assert.equal(errors.hasWarnings, false);
+  assert.equal(errors.diagnosticCount, 1);
+
+  assert.deepEqual(await runNuxtLintCheckerTask(task({ emitError: false, emitWarning: false })), {
+    diagnosticCount: 0,
+    hasErrors: false,
+    hasWarnings: false,
+    output: "",
+  });
+  await assert.rejects(
+    runNuxtLintCheckerTask(
+      task({
+        emitError: false,
+        emitWarning: false,
+        fix: true,
+        oxlintEntrypoint: "/missing/oxlint",
+      }),
+    ),
+    /Failed to start oxlint/u,
+  );
+});
+
+void test("long-lived worker runs outside the main thread and closes cleanly", async (t) => {
+  const worker = new NuxtLintCheckerWorker();
+  t.after(() => worker.close());
+
+  const result = await worker.run(task({ fix: false, targets: ["/project/app/pages/warn.vue"] }));
+  assert.equal(result.hasErrors, true);
+  assert.equal(result.hasWarnings, true);
+  assert.equal(result.diagnosticCount, 2);
+});
+
+void test("worker failures carry actionable subprocess context", async () => {
+  await assert.rejects(
+    runNuxtLintCheckerTask(task({ oxlintEntrypoint: "/missing/oxlint" })),
+    /Failed to start oxlint/u,
+  );
+});

--- a/npm/framework/nuxt/src/lint/checker/worker.ts
+++ b/npm/framework/nuxt/src/lint/checker/worker.ts
@@ -1,0 +1,303 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { glob } from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { isMainThread, parentPort, Worker } from "node:worker_threads";
+
+export interface NuxtLintCheckerTask {
+  cwd: string;
+  configFile: string;
+  targets: string[];
+  exclude: string[];
+  formatter: string;
+  emitWarning: boolean;
+  emitError: boolean;
+  fix: boolean;
+  /** Test/integration override. Normal callers resolve the project's oxlint. */
+  oxlintEntrypoint?: string;
+}
+
+export interface NuxtLintCheckerResult {
+  diagnosticCount: number;
+  hasErrors: boolean;
+  hasWarnings: boolean;
+  output: string;
+}
+
+interface OxlintDiagnostic {
+  code?: string;
+  filePath?: string;
+  filename?: string;
+  labels?: Array<{ span?: { column?: number; line?: number } }>;
+  message?: string;
+  severity?: string | number;
+}
+
+interface OxlintPayload {
+  diagnostics: OxlintDiagnostic[];
+  [key: string]: unknown;
+}
+
+interface WorkerRequest {
+  id: number;
+  task: NuxtLintCheckerTask;
+}
+
+type WorkerResponse =
+  | { id: number; result: NuxtLintCheckerResult }
+  | { error: { message: string; stack?: string }; id: number };
+
+function resolveOxlintEntrypoint(cwd: string): string {
+  try {
+    const manifest = createRequire(path.join(cwd, "package.json")).resolve("oxlint/package.json");
+    return path.join(path.dirname(manifest), "bin", "oxlint");
+  } catch (error) {
+    throw new Error(
+      `Unable to resolve oxlint from ${cwd}. Install oxlint before enabling the Nuxt lint checker.`,
+      { cause: error },
+    );
+  }
+}
+
+function projectPattern(pattern: string, cwd: string): string {
+  if (!path.isAbsolute(pattern)) return pattern;
+  const relative = path.relative(cwd, pattern);
+  if (path.isAbsolute(relative) || relative === ".." || relative.startsWith(`..${path.sep}`)) {
+    return pattern;
+  }
+  return relative.split(path.sep).join("/") || ".";
+}
+
+function expandBraces(pattern: string): string[] {
+  const match = /\{([^{}]+)\}/u.exec(pattern);
+  if (!match || match.index === undefined) return [pattern];
+  const before = pattern.slice(0, match.index);
+  const after = pattern.slice(match.index + match[0].length);
+  return match[1].split(",").flatMap((part) => expandBraces(`${before}${part}${after}`));
+}
+
+function oxlintPatterns(pattern: string, cwd: string): string[] {
+  const rebased = projectPattern(pattern, cwd);
+  const patterns = expandBraces(rebased).flatMap((expanded) => {
+    const shallow = expanded.replace(/(^|\/)\*\*\//gu, "$1");
+    return shallow === expanded ? [expanded] : [expanded, shallow];
+  });
+  return [...new Set(patterns)];
+}
+
+async function oxlintTargets(pattern: string, cwd: string): Promise<string[]> {
+  const rebased = projectPattern(pattern, cwd);
+  const defaultSuffix = "/**/*.{js,jsx,ts,tsx,vue}";
+  if (rebased.endsWith(defaultSuffix)) return [rebased.slice(0, -defaultSuffix.length) || "."];
+  if (!/[*?[\]{}()]/u.test(rebased)) return [rebased];
+  const matches = await Array.fromAsync(glob(rebased, { cwd }));
+  return matches.length > 0 ? matches : oxlintPatterns(pattern, cwd);
+}
+
+async function checkerArgs(task: NuxtLintCheckerTask): Promise<string[]> {
+  const args = ["--config", task.configFile, "--format", "json", "--no-error-on-unmatched-pattern"];
+  if (task.fix) args.push("--fix");
+  for (const pattern of task.exclude) {
+    for (const exclude of oxlintPatterns(pattern, task.cwd)) {
+      args.push("--ignore-pattern", exclude);
+    }
+  }
+  for (const target of task.targets) args.push(...(await oxlintTargets(target, task.cwd)));
+  return args;
+}
+
+function spawnOxlint(
+  node: string,
+  entrypoint: string,
+  args: string[],
+  cwd: string,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(node, [entrypoint, ...args], {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer | string) => stdout.push(Buffer.from(chunk)));
+    child.stderr.on("data", (chunk: Buffer | string) => stderr.push(Buffer.from(chunk)));
+    child.on("error", (error) => {
+      reject(
+        new Error(`Failed to start oxlint at ${entrypoint}: ${error.message}`, { cause: error }),
+      );
+    });
+    child.on("close", (status) => {
+      const output = Buffer.concat(stdout).toString("utf8");
+      if (output.trim()) {
+        resolve(output);
+        return;
+      }
+      const details = Buffer.concat(stderr).toString("utf8").trim();
+      if (status === 0) {
+        resolve('{"diagnostics":[]}\n');
+        return;
+      }
+      reject(
+        new Error(
+          `oxlint exited with ${String(status)} without JSON output${details ? `: ${details}` : ""}`,
+        ),
+      );
+    });
+  });
+}
+
+async function executeOxlint(entrypoint: string, args: string[], cwd: string): Promise<string> {
+  if (!existsSync(entrypoint)) {
+    throw new Error(`Failed to start oxlint: entrypoint does not exist: ${entrypoint}`);
+  }
+  // Vite+ can launch Node through a short-lived bundled runtime path. Its
+  // executable can disappear between the existence check and spawn, so retry
+  // the ENOENT race through the stable PATH shim.
+  const node = existsSync(process.execPath) ? process.execPath : "node";
+  try {
+    return await spawnOxlint(node, entrypoint, args, cwd);
+  } catch (error) {
+    const cause = (error as Error & { cause?: NodeJS.ErrnoException }).cause;
+    if (node !== "node" && cause?.code === "ENOENT") {
+      return spawnOxlint("node", entrypoint, args, cwd);
+    }
+    throw error;
+  }
+}
+
+function diagnosticKind(diagnostic: OxlintDiagnostic): "error" | "warning" | undefined {
+  if (diagnostic.severity === 2 || diagnostic.severity === "error") return "error";
+  if (
+    diagnostic.severity === 1 ||
+    diagnostic.severity === "warn" ||
+    diagnostic.severity === "warning"
+  ) {
+    return "warning";
+  }
+  return undefined;
+}
+
+function readableDiagnostics(diagnostics: OxlintDiagnostic[], formatter: string): string {
+  const unix = formatter === "unix";
+  const lines = diagnostics.map((diagnostic) => {
+    const span = diagnostic.labels?.find((label) => label.span)?.span;
+    const file = diagnostic.filename ?? diagnostic.filePath ?? "<unknown>";
+    const line = span?.line ?? 1;
+    const column = span?.column ?? 1;
+    const severity = diagnosticKind(diagnostic) ?? "warning";
+    const message = diagnostic.message ?? "lint diagnostic";
+    const code = diagnostic.code ? ` (${diagnostic.code})` : "";
+    return unix
+      ? `${file}:${line}:${column}: ${message} [${severity}${code}]`
+      : `${file}:${line}:${column}  ${severity}  ${message}${code}`;
+  });
+  return lines.length > 0 ? `${lines.join("\n")}\n` : "";
+}
+
+function resultFromPayload(
+  payload: OxlintPayload,
+  task: NuxtLintCheckerTask,
+): NuxtLintCheckerResult {
+  const diagnostics = payload.diagnostics.filter((diagnostic) => {
+    const kind = diagnosticKind(diagnostic);
+    return (kind === "error" && task.emitError) || (kind === "warning" && task.emitWarning);
+  });
+  const hasErrors = diagnostics.some((diagnostic) => diagnosticKind(diagnostic) === "error");
+  const hasWarnings = diagnostics.some((diagnostic) => diagnosticKind(diagnostic) === "warning");
+  const output =
+    task.formatter === "json"
+      ? diagnostics.length > 0
+        ? `${JSON.stringify({ ...payload, diagnostics })}\n`
+        : ""
+      : readableDiagnostics(diagnostics, task.formatter);
+  return { diagnosticCount: diagnostics.length, hasErrors, hasWarnings, output };
+}
+
+/** Run one checker pass. This function executes inside the long-lived worker. */
+export async function runNuxtLintCheckerTask(
+  task: NuxtLintCheckerTask,
+): Promise<NuxtLintCheckerResult> {
+  if (!task.emitError && !task.emitWarning && !task.fix) {
+    return { diagnosticCount: 0, hasErrors: false, hasWarnings: false, output: "" };
+  }
+  const entrypoint = task.oxlintEntrypoint ?? resolveOxlintEntrypoint(task.cwd);
+  const stdout = await executeOxlint(entrypoint, await checkerArgs(task), task.cwd);
+  let payload: OxlintPayload;
+  try {
+    payload = JSON.parse(stdout) as OxlintPayload;
+  } catch (error) {
+    throw new Error(`oxlint returned invalid JSON: ${stdout.slice(0, 240)}`, { cause: error });
+  }
+  if (!Array.isArray(payload.diagnostics)) throw new Error("oxlint JSON has no diagnostics array");
+  return resultFromPayload(payload, task);
+}
+
+function serializeError(error: unknown): { message: string; stack?: string } {
+  if (error instanceof Error) return { message: error.message, stack: error.stack };
+  return { message: String(error) };
+}
+
+if (!isMainThread && parentPort) {
+  parentPort.on("message", async ({ id, task }: WorkerRequest) => {
+    try {
+      parentPort?.postMessage({
+        id,
+        result: await runNuxtLintCheckerTask(task),
+      } satisfies WorkerResponse);
+    } catch (error) {
+      parentPort?.postMessage({ error: serializeError(error), id } satisfies WorkerResponse);
+    }
+  });
+}
+
+/** Persistent worker-thread client used by the Vite dev plugin. */
+export class NuxtLintCheckerWorker {
+  private readonly worker = new Worker(new URL(import.meta.url));
+  private readonly pending = new Map<
+    number,
+    { reject(error: Error): void; resolve(result: NuxtLintCheckerResult): void }
+  >();
+  private nextId = 0;
+  private closed = false;
+
+  constructor() {
+    this.worker.on("message", (response: WorkerResponse) => {
+      const pending = this.pending.get(response.id);
+      if (!pending) return;
+      this.pending.delete(response.id);
+      if ("error" in response) {
+        const error = new Error(response.error.message);
+        error.stack = response.error.stack ?? error.stack;
+        pending.reject(error);
+      } else {
+        pending.resolve(response.result);
+      }
+    });
+    this.worker.on("error", (error) => this.rejectAll(error));
+    this.worker.on("exit", (code) => {
+      if (!this.closed) this.rejectAll(new Error(`Nuxt lint worker exited with ${code}`));
+    });
+  }
+
+  run(task: NuxtLintCheckerTask): Promise<NuxtLintCheckerResult> {
+    if (this.closed) return Promise.reject(new Error("Nuxt lint worker is closed"));
+    const id = ++this.nextId;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { reject, resolve });
+      this.worker.postMessage({ id, task } satisfies WorkerRequest);
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    this.rejectAll(new Error("Nuxt lint worker closed"));
+    await this.worker.terminate();
+  }
+
+  private rejectAll(error: Error): void {
+    for (const pending of this.pending.values()) pending.reject(error);
+    this.pending.clear();
+  }
+}

--- a/npm/framework/nuxt/src/lint/index.ts
+++ b/npm/framework/nuxt/src/lint/index.ts
@@ -10,6 +10,18 @@ export {
   type ResolveNuxtLintConfigAddons,
 } from "./addons.ts";
 export {
+  setupNuxtLintChecker,
+  type NuxtLintCheckerSetup,
+  type NuxtLintCheckerSetupDependencies,
+} from "./checker/setup.ts";
+export {
+  resolveNuxtLintCheckerOptions,
+  type ResolvedVizeNuxtLintCheckerOptions,
+  type VizeNuxtLintCheckerOptions,
+} from "./checker/options.ts";
+export { createNuxtLintCheckerVitePlugin } from "./checker/vite.ts";
+export { createNuxtLintCheckerWebpackPlugin } from "./checker/webpack.ts";
+export {
   toNuxtLintProjectState,
   type NuxtLintSourceOptions,
   type NuxtLintStateOverrides,

--- a/npm/framework/nuxt/src/lint/options.ts
+++ b/npm/framework/nuxt/src/lint/options.ts
@@ -1,4 +1,5 @@
 import type { NuxtLintFeatures } from "@vizejs/nuxt-lint-config";
+export type { VizeNuxtLintCheckerOptions } from "./checker/options.ts";
 
 /** Options for the generated Nuxt-aware oxlint configuration. */
 export interface VizeNuxtLintOptions extends NuxtLintFeatures {

--- a/npm/framework/nuxt/src/lint/oracle.test.ts
+++ b/npm/framework/nuxt/src/lint/oracle.test.ts
@@ -17,6 +17,10 @@ import {
   type NuxtLintConfigAddonNuxt,
   type NuxtLintImport,
 } from "./addons.ts";
+import {
+  resolveNuxtLintCheckerOptions,
+  type VizeNuxtLintCheckerOptions,
+} from "./checker/options.ts";
 import { renderNuxtOxlintConfig } from "./emitter.ts";
 
 const compatDir = join(
@@ -45,6 +49,12 @@ function readJson<T>(...segments: string[]): T {
   return JSON.parse(readFileSync(join(compatDir, ...segments), "utf8")) as T;
 }
 
+interface CheckerCase {
+  id: string;
+  description: string;
+  checker: true | VizeNuxtLintCheckerOptions;
+}
+
 const corpus = readJson<{
   importGlobals: {
     id: string;
@@ -52,6 +62,7 @@ const corpus = readJson<{
     nuxt: NuxtLintImport[];
     nitro: NuxtLintImport[];
   };
+  checkerCases: CheckerCase[];
   cases: CorpusCase[];
 }>("fixtures", "corpus.json");
 const recording = readJson<{
@@ -60,6 +71,7 @@ const recording = readJson<{
     globals: string[];
     artifacts: { initial: string; regenerated: string };
   };
+  checkerOptions: Record<string, Record<string, unknown>>;
   cases: Record<string, RecordedCase>;
 }>("fixtures", "nuxt-eslint-output.json");
 
@@ -87,6 +99,17 @@ function projectState(entry: CorpusCase): NuxtLintProjectState {
       srcDir: join(ROOT_DIR, layer.srcDir),
     })),
   };
+}
+
+for (const entry of corpus.checkerCases) {
+  void test(`${entry.id}: resolved checker options match @nuxt/eslint in full`, () => {
+    const resolved = resolveNuxtLintCheckerOptions(entry.checker, {
+      buildDir: "/project/.nuxt",
+      srcDir: "/project/app",
+    });
+    assert.notEqual(resolved, false);
+    assert.deepEqual({ ...resolved, worker: true }, recording.checkerOptions[entry.id]);
+  });
 }
 
 void test(`${corpus.importGlobals.id}: globals and artifacts match @nuxt/eslint byte for byte`, async () => {

--- a/npm/framework/nuxt/src/options.ts
+++ b/npm/framework/nuxt/src/options.ts
@@ -4,7 +4,7 @@ import type {
   VizeNuxtCompilerOptions,
   VizeNuxtVueVersion,
 } from "./compiler-options.ts";
-import type { VizeNuxtLintOptions } from "./lint/options.ts";
+import type { VizeNuxtLintCheckerOptions, VizeNuxtLintOptions } from "./lint/options.ts";
 import { NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE, buildNuxtCompilerOptions } from "./utils.ts";
 
 export type {
@@ -12,7 +12,7 @@ export type {
   VizeNuxtCompilerOptions,
   VizeNuxtVueVersion,
 } from "./compiler-options.ts";
-export type { VizeNuxtLintOptions } from "./lint/options.ts";
+export type { VizeNuxtLintCheckerOptions, VizeNuxtLintOptions } from "./lint/options.ts";
 export { NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE };
 
 export type VizeNuxtMajorVersion = 2 | 3 | 4;
@@ -184,6 +184,9 @@ export interface VizeNuxtOptions {
    * @default true
    */
   lint?: boolean | VizeNuxtLintOptions;
+
+  /** Run oxlint + Patina beside the dev server. @default false */
+  checker?: boolean | VizeNuxtLintCheckerOptions;
 
   /**
    * Musea gallery options.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -723,6 +723,9 @@ importers:
       nuxt:
         specifier: 4.4.8
         version: 4.4.8(@azure/identity@4.13.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.2)(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(@vue/compiler-sfc@3.5.35)(cac@6.7.14)(commander@13.1.0)(db0@0.3.4)(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.64.0(oxlint-tsgolint@0.22.1))(rolldown@1.0.1)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.1)(rollup@4.60.3))(rollup@4.60.3)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(vue-tsc@3.3.4(typescript@6.0.3))(yaml@2.9.0)
+      oxlint:
+        specifier: ^1.64.0
+        version: 1.64.0(oxlint-tsgolint@0.22.1)
       oxlint-plugin-vize:
         specifier: workspace:*
         version: link:../../oxint

--- a/tests/tooling/nuxt-eslint-oracle.test.ts
+++ b/tests/tooling/nuxt-eslint-oracle.test.ts
@@ -35,13 +35,14 @@ test("recorded output matches the installed @nuxt/eslint packages", async () => 
   const recomputed = await oracle.runOracle();
   const recorded = oracle.readRecorded();
 
-  assert.equal(recomputed.schemaVersion, 4);
-  assert.equal(recorded.schemaVersion, 4);
+  assert.equal(recomputed.schemaVersion, 5);
+  assert.equal(recorded.schemaVersion, 5);
   assert.equal(recomputed.moduleVersion, recorded.moduleVersion);
   assert.equal(recomputed.configVersion, recorded.configVersion);
   assert.equal(recomputed.pluginVersion, recorded.pluginVersion);
   assert.equal(recomputed.typeScriptDetected, recorded.typeScriptDetected);
   assert.deepEqual(recomputed.importGlobals, recorded.importGlobals);
+  assert.deepEqual(recomputed.checkerOptions, recorded.checkerOptions);
   assert.deepEqual(Object.keys(recomputed.cases).sort(), Object.keys(recorded.cases).sort());
   assert.deepEqual(recomputed.dirDefaults, recorded.dirDefaults);
   assert.deepEqual(recomputed.preferImportMetaCases, recorded.preferImportMetaCases);
@@ -71,6 +72,7 @@ test("inventory markdown documents exactly the corpus cases", () => {
   // exist — so a missing *or* an extra case row still fails.
   const ids = [
     corpus.importGlobals.id,
+    ...corpus.checkerCases.map((entry: { id: string }) => entry.id),
     ...corpus.preferImportMetaCases.map((entry: { id: string }) => entry.id),
     ...corpus.noPageMetaRuntimeValuesCases.map((entry: { id: string }) => entry.id),
     ...corpus.dirDefaultCases.map((entry: { id: string }) => entry.id),


### PR DESCRIPTION
Closes #3615

- add an opt-in dev-only oxlint + Patina checker for Vite and webpack
- run lint work off the main thread with changed-file caching and overlays
- record portable checker defaults against the pinned upstream implementation

Tests:
- pnpm --dir npm/framework/nuxt test
- node --test npm/framework/nuxt/src/lint/checker/*.test.ts
- node --test tests/tooling/nuxt-eslint-oracle.test.ts
- node npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/oracle.mjs --check
- pnpm exec vp check npm/framework/nuxt/package.json npm/framework/nuxt/src npm/framework/nuxt-lint-config/src npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/checker-oracle.mjs tests/tooling/nuxt-eslint-oracle.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nuxt lint checker for real-time linting during development, supporting both Vite and Webpack builders
  * Runs automatically on startup and file changes with live feedback in the development overlay
  * Configurable with file patterns, exclusions, caching behavior, and diagnostic formatting options
  * Checker is disabled by default; enable via the new checker configuration option

* **Dependencies**
  * Added oxlint as an optional peer dependency for linting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->