### PR TITLE
fix(vize): correct entry linter glob scoping

### DIFF
--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -16,7 +16,7 @@ pub use args::LintArgs;
 
 use crate::profile_support;
 use aggregate::{LintRunAccumulator, should_retain_file_results};
-use collect::{collect_lint_files, load_lint_ignore_set, resolve_lint_config_path};
+use collect::{LintIgnoreSet, collect_lint_files, resolve_lint_config_path};
 use cross_file::apply_sfc_cross_file_lint;
 use entry_rules::LinterRuleResolver;
 use fix::lint_source_with_optional_fix;
@@ -79,7 +79,7 @@ pub fn run(args: LintArgs) {
         .type_checker
         .runtime_path()
         .map(|path| resolve_lint_config_path(config_dir, path));
-    let ignore_set = load_lint_ignore_set(&linter_plan.global_ignores, config_dir);
+    let ignore_set = LintIgnoreSet::new(&linter_plan.global_ignores, config_dir);
     let collect_start = Instant::now();
     let files = collect_lint_files(&args.patterns, ignore_set.as_ref());
     let collect_time = collect_start.elapsed();

--- a/crates/vize/src/commands/lint/collect.rs
+++ b/crates/vize/src/commands/lint/collect.rs
@@ -13,7 +13,7 @@ pub(super) struct LintIgnoreSet {
 }
 
 impl LintIgnoreSet {
-    fn new(ignores: &[config::ConfigEntryIgnore], config_dir: &Path) -> Option<Self> {
+    pub(super) fn new(ignores: &[config::ConfigEntryIgnore], config_dir: &Path) -> Option<Self> {
         let patterns = ignores
             .iter()
             .flat_map(|ignore| expand_entry_ignore_patterns(ignore, config_dir))
@@ -25,13 +25,6 @@ impl LintIgnoreSet {
     fn is_ignored(&self, path: &Path) -> bool {
         self.patterns.iter().any(|pattern| pattern.matches(path))
     }
-}
-
-pub(super) fn load_lint_ignore_set(
-    ignores: &[config::ConfigEntryIgnore],
-    config_dir: &Path,
-) -> Option<LintIgnoreSet> {
-    LintIgnoreSet::new(ignores, config_dir)
 }
 
 pub(super) fn collect_lint_files(

--- a/crates/vize/src/commands/lint/entry_rules.rs
+++ b/crates/vize/src/commands/lint/entry_rules.rs
@@ -123,11 +123,15 @@ impl LinterRuleResolver {
         let mut file_config_indices = Vec::with_capacity(files.len());
         for file in files {
             let signature = self.matching_entries(file, cwd);
-            let index = *signatures.entry(signature.clone()).or_insert_with(|| {
-                let index = configs.len();
-                configs.push(self.plan.resolve_matching_entries(&signature));
-                index
-            });
+            let index = match signatures.get(&signature) {
+                Some(index) => *index,
+                None => {
+                    let index = configs.len();
+                    configs.push(self.plan.resolve_matching_entries(&signature));
+                    signatures.insert(signature, index);
+                    index
+                }
+            };
             file_config_indices.push(index);
         }
         ResolvedLinterRuleGroups {
@@ -163,26 +167,32 @@ impl GlobSequence {
     fn new(patterns: &[String]) -> Self {
         let steps = patterns
             .iter()
-            .filter_map(|pattern| {
-                let normalized = normalize_pattern(pattern);
-                if normalized.is_empty() {
-                    return None;
-                }
-                let (negated, pattern) = normalized
+            .filter_map(|source| {
+                // Split the negation marker before stripping `./`, otherwise
+                // `!./src/generated/**` keeps the `./` and silently stops
+                // matching the relative paths it is meant to exclude.
+                let slashed = source.replace('\\', "/");
+                let (negated, rest) = slashed
                     .strip_prefix('!')
-                    .map_or((false, normalized.as_str()), |pattern| (true, pattern));
+                    .map_or((false, slashed.as_str()), |rest| (true, rest));
+                let pattern = strip_leading_current_dir(rest);
                 if pattern.is_empty() {
                     return None;
                 }
-                GlobBuilder::new(pattern)
+                match GlobBuilder::new(pattern)
                     .literal_separator(true)
                     .backslash_escape(false)
                     .build()
-                    .ok()
-                    .map(|glob| GlobStep {
+                {
+                    Ok(glob) => Some(GlobStep {
                         negated,
                         matcher: glob.compile_matcher(),
-                    })
+                    }),
+                    Err(error) => {
+                        eprintln!("[vize] Ignoring invalid entry glob '{source}': {error}");
+                        None
+                    }
+                }
             })
             .collect::<Vec<_>>();
         let has_positive_source = steps.iter().any(|step| !step.negated);
@@ -199,7 +209,7 @@ impl GlobSequence {
         }
         let mut matched = !self.has_positive_source;
         for step in &self.steps {
-            if step.matcher.is_match(file) {
+            if matches_file_or_parent(&step.matcher, file) {
                 matched = !step.negated;
             }
         }
@@ -217,16 +227,22 @@ impl GlobSequence {
     }
 }
 
+/// Match `file` or any of its parent directories, so a directory-form pattern
+/// such as `src` or `src/pages` covers the whole subtree. `file` is already
+/// `/`-normalized, so ancestors are plain string slices.
 fn matches_file_or_parent(matcher: &GlobMatcher, file: &str) -> bool {
     if matcher.is_match(file) {
         return true;
     }
-    let mut parent = Path::new(file).parent();
-    while let Some(path) = parent.filter(|path| !path.as_os_str().is_empty()) {
-        if matcher.is_match(normalize_path(path).as_str()) {
+    let mut parent = file;
+    while let Some((head, _)) = parent.rsplit_once('/') {
+        if head.is_empty() {
+            break;
+        }
+        if matcher.is_match(head) {
             return true;
         }
-        parent = path.parent();
+        parent = head;
     }
     false
 }
@@ -266,12 +282,12 @@ fn normalize_lexically(path: &Path) -> PathBuf {
     normalized
 }
 
-fn normalize_pattern(pattern: &str) -> String {
-    let mut normalized: String = pattern.replace('\\', "/").into();
-    while let Some(stripped) = normalized.strip_prefix("./") {
-        normalized = stripped.into();
+fn strip_leading_current_dir(pattern: &str) -> &str {
+    let mut stripped = pattern;
+    while let Some(rest) = stripped.strip_prefix("./") {
+        stripped = rest;
     }
-    normalized
+    stripped
 }
 
 fn normalize_path(path: &Path) -> String {

--- a/crates/vize/src/commands/lint/entry_rules_tests.rs
+++ b/crates/vize/src/commands/lint/entry_rules_tests.rs
@@ -52,6 +52,26 @@ fn file_globs_preserve_ordered_repeats_and_fail_closed_when_all_are_invalid() {
 }
 
 #[test]
+fn directory_form_file_globs_select_their_whole_subtree() {
+    let directory = GlobSequence::new(&["src/pages".into()]);
+    assert!(directory.matches_files("src/pages/index.vue"));
+    assert!(directory.matches_files("src/pages/nested/index.vue"));
+    assert!(!directory.matches_files("src/components/Card.vue"));
+}
+
+#[test]
+fn negated_globs_keep_their_marker_when_relative_prefixes_are_stripped() {
+    for pattern in ["!./src/generated/**", "!.\\src\\generated\\**"] {
+        let sequence = GlobSequence::new(&["src/**/*.vue".into(), pattern.into()]);
+        assert!(sequence.matches_files("src/App.vue"), "{pattern}");
+        assert!(
+            !sequence.matches_files("src/generated/drop.vue"),
+            "{pattern}"
+        );
+    }
+}
+
+#[test]
 fn resolves_whole_rule_maps_for_each_distinct_glob_set_once() {
     let project = tempfile::tempdir().unwrap();
     for file in [

--- a/crates/vize/tests/lint_rule_severity_cli.rs
+++ b/crates/vize/tests/lint_rule_severity_cli.rs
@@ -160,6 +160,7 @@ emit("update:current-step-index", 1)
         .output()
         .unwrap();
 
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
     let actual = serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
     assert_eq!(
         actual,


### PR DESCRIPTION
Follow-up to #3635, which merged before its review feedback landed. Two of the findings are real correctness bugs in `entries[].linter` glob scoping.

A directory-form pattern such as `"files": ["src/pages"]` selected nothing, because `matches_files` only tested the exact relative file path while `matches_ignore` already walked parents. Both now share `matches_file_or_parent`, so a plain directory covers its subtree in `files` the same way it does in `ignores`:

```rust
fn matches_file_or_parent(matcher: &GlobMatcher, file: &str) -> bool {
    if matcher.is_match(file) {
        return true;
    }
    let mut parent = file;
    while let Some((head, _)) = parent.rsplit_once('/') {
        if head.is_empty() {
            break;
        }
        if matcher.is_match(head) {
            return true;
        }
        parent = head;
    }
    false
}
```

That helper also drops the per-ancestor `Path::parent` + `normalize_path` allocation, since the input string is already `/`-normalized.

Separately, `!./src/generated/**` silently lost its negation: the old `normalize_pattern` stripped `./` from the front of the whole pattern, but `GlobSequence::new` split the `!` marker afterwards, leaving `./src/generated/**` to compile against relative paths that never carry a `./` prefix. The marker is now split first and the remainder normalized after, so `!./…` and `!.\…` both behave like `!…`.

The rest is review cleanup: invalid entry globs report the compile error on stderr instead of vanishing via `.ok()`, the signature-to-config cache skips its per-file `Vec` clone on hits, the pass-through `load_lint_ignore_set` wrapper is gone in favor of `LintIgnoreSet::new`, and the JSON severity oracle asserts the exit status before parsing stdout so an early exit surfaces stderr instead of a JSON parse panic.

Validation: `cargo clippy -p vize --lib -- -D warnings` and `cargo fmt --all -- --check`. The sandbox disk could not fit the `vize` test binary, so the new `entry_rules` unit tests run in CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->