### PR TITLE
test(maestro): enforce real-file LSP churn

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -401,6 +401,7 @@
           "initialize": 1000,
           "coldOpen": 8000,
           "cycle": 9000,
+          "fileLifecycle": 9000,
           "phaseFence": 1500,
           "cancellationConverge": 6000,
           "closeClear": 3000

--- a/tests/performance/lsp-churn-stress.test.ts
+++ b/tests/performance/lsp-churn-stress.test.ts
@@ -16,6 +16,7 @@ import {
   assertStreamOrdering,
   recordPublishes,
 } from "./support/churn-oracle.ts";
+import { runFileLifecycleChurn } from "./support/file-lifecycle-churn.ts";
 import { countFiles } from "./support/incremental-metrics.ts";
 import {
   assertSingleInjectedMismatch,
@@ -236,6 +237,13 @@ test(
             expectedByVersion,
             leafVersion,
           );
+          await runFileLifecycleChurn({
+            session,
+            metrics,
+            workspaceDir,
+            cycles,
+            publishes,
+          });
         } catch (error) {
           failure = error;
           // A hang or divergence is only diagnosable from the publish stream

--- a/tests/performance/support/file-lifecycle-churn.ts
+++ b/tests/performance/support/file-lifecycle-churn.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { isDiagnosticsForUri } from "../../tooling/support/lsp/assertions.ts";
+import type { LspSession } from "../../tooling/support/lsp/session.ts";
+import type { ChurnMetrics } from "./churn-metrics.ts";
+import type { PublishRecord } from "./churn-oracle.ts";
+import {
+  assertSingleInjectedMismatch,
+  diagnosticsTimeoutMs,
+  normalizeDiagnostics,
+  waitForDiagnostics,
+} from "./lsp-oracle.ts";
+
+type WorkspaceSymbol = { name: string; location: { uri: string } };
+
+const fileName = "__vize_ephemeral_lifecycle.vue";
+const symbol = "createdLifecycleProbe";
+const source = `<script setup lang="ts">
+const ${symbol}: number = 'broken';
+void ${symbol};
+</script>
+`;
+
+/**
+ * Repeatedly creates and deletes one real SFC while the same server stays
+ * alive. Exact diagnostic/clear publishes are the lifecycle fences; workspace
+ * symbols prove the open-document index neither misses nor retains an epoch.
+ */
+export async function runFileLifecycleChurn(options: {
+  session: LspSession;
+  metrics: ChurnMetrics;
+  workspaceDir: string;
+  cycles: number;
+  publishes: PublishRecord[];
+}): Promise<void> {
+  const { session, metrics, workspaceDir, cycles, publishes } = options;
+  const filePath = path.join(workspaceDir, "src", fileName);
+  const uri = pathToFileURL(filePath).href;
+  const streamStart = publishes.length;
+  let referencePayload: string[] | null = null;
+
+  assert.equal(fs.existsSync(filePath), false, `${filePath} must start absent`);
+  try {
+    for (let cycle = 0; cycle < cycles; cycle += 1) {
+      const version = cycle + 1;
+      await metrics.measure("fileLifecycle", async () => {
+        assert.equal(fs.existsSync(filePath), false, `cycle ${cycle}: stale file remained`);
+        fs.writeFileSync(filePath, source, { encoding: "utf8", flag: "wx" });
+        assert.equal(fs.readFileSync(filePath, "utf8"), source, `cycle ${cycle}: bytes changed`);
+
+        session.notify("textDocument/didOpen", {
+          textDocument: { uri, languageId: "vue", version, text: source },
+        });
+        const opened = await waitForDiagnostics(session, uri, version, true);
+        assertSingleInjectedMismatch(opened.diagnostics, [], source, symbol);
+        const payload = normalizeDiagnostics(opened.diagnostics);
+        if (referencePayload == null) referencePayload = payload;
+        else assert.deepEqual(payload, referencePayload, `cycle ${cycle}: diagnostics changed`);
+        await assertIndexedExactlyOnce(session, uri);
+
+        session.notify("textDocument/didClose", { textDocument: { uri } });
+        await session.waitForNotification(
+          "textDocument/publishDiagnostics",
+          (params) =>
+            isDiagnosticsForUri(params, uri) &&
+            params.version == null &&
+            params.diagnostics.length === 0,
+          diagnosticsTimeoutMs,
+        );
+        fs.unlinkSync(filePath);
+        assert.equal(fs.existsSync(filePath), false, `cycle ${cycle}: delete failed`);
+        assert.equal(await session.request("workspace/symbol", { query: symbol }), null);
+        assert.equal(
+          await session.request("textDocument/documentSymbol", { textDocument: { uri } }),
+          null,
+        );
+      });
+      metrics.sampleRss(`file-lifecycle-${cycle}`);
+    }
+
+    assert.ok(referencePayload, "file lifecycle must run at least once");
+    assertLifecycleStream(publishes.slice(streamStart), uri, cycles, referencePayload);
+  } finally {
+    if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+  }
+}
+
+async function assertIndexedExactlyOnce(session: LspSession, uri: string): Promise<void> {
+  const symbols = (await session.request("workspace/symbol", { query: symbol })) as
+    | WorkspaceSymbol[]
+    | null;
+  assert.ok(Array.isArray(symbols), JSON.stringify(symbols));
+  assert.deepEqual(
+    symbols.map((entry) => ({ name: entry.name, uri: entry.location.uri })),
+    [{ name: symbol, uri }],
+  );
+}
+
+function assertLifecycleStream(
+  records: PublishRecord[],
+  uri: string,
+  cycles: number,
+  payload: string[],
+): void {
+  assert.equal(records.length, cycles * 2, "each file epoch must publish diagnostics then clear");
+  for (let cycle = 0; cycle < cycles; cycle += 1) {
+    assert.deepEqual(records[cycle * 2], {
+      uri,
+      version: cycle + 1,
+      payload,
+      mismatch: true,
+    });
+    assert.deepEqual(records[cycle * 2 + 1], {
+      uri,
+      version: null,
+      payload: [],
+      mismatch: false,
+    });
+  }
+}

--- a/tests/tooling/lsp-incremental-budgets.test.ts
+++ b/tests/tooling/lsp-incremental-budgets.test.ts
@@ -164,6 +164,7 @@ test("the churn budget resolves from the registry and unknown suites are rejecte
     "closeClear",
     "coldOpen",
     "cycle",
+    "fileLifecycle",
     "initialize",
     "phaseFence",
   ]);


### PR DESCRIPTION
## Summary

- extend the Misskey LSP churn oracle with 20 real `.vue` create/open/close/delete lifecycles
- require exact diagnostics, diagnostic clears, workspace index convergence, and byte-stable publish streams
- enforce the existing timeout, RSS, and process-tree ceilings through a dedicated checked-in budget lane

## Validation

- `cargo build --profile ci -p vize --features legacy`
- `VIZE_LSP_BIN=target/ci/vize vp run --filter ./tests test:performance:lsp-churn`
- `node --test tests/tooling/lsp-incremental-budgets.test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `vp check tests/performance/lsp-churn-stress.test.ts tests/performance/support/file-lifecycle-churn.ts tests/tooling/lsp-incremental-budgets.test.ts`
- `git diff --check`

Refs #3222

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->