### PR TITLE
feat(inspector): expose lint plan provenance core

### DIFF
--- a/crates/vize/src/commands/lint/entry_rules.rs
+++ b/crates/vize/src/commands/lint/entry_rules.rs
@@ -1,7 +1,6 @@
 //! Batch resolution of declaration-ordered `entries[].linter.rules`.
 
-use globset::{GlobBuilder, GlobMatcher};
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use vize_carton::{
     FxHashMap, String,
     config::{LintRuleOptions, LintRuleSeverity, LinterConfigPlan, LinterFeatureFlags},
@@ -9,6 +8,9 @@ use vize_carton::{
 use vize_patina::{HelpLevel, LintPreset, Linter, Severity};
 
 use super::LintArgs;
+#[cfg(test)]
+use crate::lint_plan::matcher::GlobSequence;
+use crate::lint_plan::matcher::{LintPlanScope, absolute_path};
 
 pub(super) struct ResolvedLinterRuleGroups {
     pub(super) configs: Vec<crate::config::LinterConfig>,
@@ -75,24 +77,7 @@ fn severity_overrides(entries: Vec<(String, LintRuleSeverity)>) -> Vec<(String, 
 
 pub(super) struct LinterRuleResolver {
     plan: LinterConfigPlan,
-    scopes: Vec<EntryRuleScope>,
-}
-
-struct EntryRuleScope {
-    base_dir: PathBuf,
-    files: Option<GlobSequence>,
-    ignores: GlobSequence,
-}
-
-struct GlobSequence {
-    steps: Vec<GlobStep>,
-    has_steps: bool,
-    has_positive_source: bool,
-}
-
-struct GlobStep {
-    negated: bool,
-    matcher: GlobMatcher,
+    scopes: Vec<LintPlanScope>,
 }
 
 impl LinterRuleResolver {
@@ -101,10 +86,14 @@ impl LinterRuleResolver {
         let scopes = plan
             .entries
             .iter()
-            .map(|entry| EntryRuleScope {
-                base_dir: resolve_base_dir(entry.base_path.as_deref(), &config_dir),
-                files: entry.files.as_deref().map(GlobSequence::new),
-                ignores: GlobSequence::new(&entry.ignores),
+            .map(|entry| {
+                LintPlanScope::new(
+                    entry.base_path.as_deref(),
+                    entry.files.as_deref(),
+                    &entry.ignores,
+                    &config_dir,
+                    cwd,
+                )
             })
             .collect();
         Self { plan, scopes }
@@ -148,150 +137,6 @@ impl LinterRuleResolver {
             .filter_map(|(index, scope)| scope.matches(&file).then_some(index))
             .collect()
     }
-}
-
-impl EntryRuleScope {
-    fn matches(&self, file: &Path) -> bool {
-        let Ok(relative) = file.strip_prefix(&self.base_dir) else {
-            return false;
-        };
-        let relative = normalize_path(relative);
-        self.files
-            .as_ref()
-            .is_none_or(|patterns| patterns.matches_files(relative.as_str()))
-            && !self.ignores.matches_ignore(relative.as_str())
-    }
-}
-
-impl GlobSequence {
-    fn new(patterns: &[String]) -> Self {
-        let steps = patterns
-            .iter()
-            .filter_map(|source| {
-                // Split the negation marker before stripping `./`, otherwise
-                // `!./src/generated/**` keeps the `./` and silently stops
-                // matching the relative paths it is meant to exclude.
-                let slashed = source.replace('\\', "/");
-                let (negated, rest) = slashed
-                    .strip_prefix('!')
-                    .map_or((false, slashed.as_str()), |rest| (true, rest));
-                let pattern = strip_leading_current_dir(rest);
-                if pattern.is_empty() {
-                    return None;
-                }
-                match GlobBuilder::new(pattern)
-                    .literal_separator(true)
-                    .backslash_escape(false)
-                    .build()
-                {
-                    Ok(glob) => Some(GlobStep {
-                        negated,
-                        matcher: glob.compile_matcher(),
-                    }),
-                    Err(error) => {
-                        eprintln!("[vize] Ignoring invalid entry glob '{source}': {error}");
-                        None
-                    }
-                }
-            })
-            .collect::<Vec<_>>();
-        let has_positive_source = steps.iter().any(|step| !step.negated);
-        Self {
-            has_steps: !steps.is_empty(),
-            steps,
-            has_positive_source,
-        }
-    }
-
-    fn matches_files(&self, file: &str) -> bool {
-        if !self.has_steps {
-            return false;
-        }
-        let mut matched = !self.has_positive_source;
-        for step in &self.steps {
-            if matches_file_or_parent(&step.matcher, file) {
-                matched = !step.negated;
-            }
-        }
-        matched
-    }
-
-    fn matches_ignore(&self, file: &str) -> bool {
-        let mut ignored = false;
-        for step in &self.steps {
-            if matches_file_or_parent(&step.matcher, file) {
-                ignored = !step.negated;
-            }
-        }
-        ignored
-    }
-}
-
-/// Match `file` or any of its parent directories, so a directory-form pattern
-/// such as `src` or `src/pages` covers the whole subtree. `file` is already
-/// `/`-normalized, so ancestors are plain string slices.
-fn matches_file_or_parent(matcher: &GlobMatcher, file: &str) -> bool {
-    if matcher.is_match(file) {
-        return true;
-    }
-    let mut parent = file;
-    while let Some((head, _)) = parent.rsplit_once('/') {
-        if head.is_empty() {
-            break;
-        }
-        if matcher.is_match(head) {
-            return true;
-        }
-        parent = head;
-    }
-    false
-}
-
-fn resolve_base_dir(base_path: Option<&str>, config_dir: &Path) -> PathBuf {
-    let Some(base_path) = base_path.filter(|path| !path.is_empty()) else {
-        return config_dir.to_path_buf();
-    };
-    absolute_path(Path::new(&base_path.replace('\\', "/")), config_dir)
-}
-
-fn absolute_path(path: &Path, cwd: &Path) -> PathBuf {
-    let normalized = PathBuf::from(path.to_string_lossy().replace('\\', "/"));
-    let absolute = if normalized.is_absolute() {
-        normalized
-    } else {
-        cwd.join(normalized)
-    };
-    normalize_lexically(&absolute)
-}
-
-fn normalize_lexically(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                if !normalized.pop() && !path.is_absolute() {
-                    normalized.push(component.as_os_str());
-                }
-            }
-            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
-                normalized.push(component.as_os_str());
-            }
-        }
-    }
-    normalized
-}
-
-fn strip_leading_current_dir(pattern: &str) -> &str {
-    let mut stripped = pattern;
-    while let Some(rest) = stripped.strip_prefix("./") {
-        stripped = rest;
-    }
-    stripped
-}
-
-fn normalize_path(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/").into()
 }
 
 #[cfg(test)]

--- a/crates/vize/src/lib.rs
+++ b/crates/vize/src/lib.rs
@@ -23,6 +23,9 @@ mod commands;
 mod config;
 mod profile_support;
 
+/// Ordered lint-plan resolution and provenance for inspector consumers.
+pub mod lint_plan;
+
 /// Shared native CLI entrypoint.
 pub mod cli;
 

--- a/crates/vize/src/lint_plan.rs
+++ b/crates/vize/src/lint_plan.rs
@@ -1,0 +1,169 @@
+//! Resolved lint-plan inspection shared by CLI and development integrations.
+
+pub(crate) mod matcher;
+
+use matcher::{LintPlanScope, absolute_path, normalize_path};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, path::Path};
+use vize_carton::{String, config::LintRuleSeverity};
+
+/// Serializable ordered plan accepted by the inspector surface.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct InspectorLintPlan {
+    pub items: Vec<InspectorLintPlanItem>,
+}
+
+/// One named rule block and its file scope.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct InspectorLintPlanItem {
+    pub name: String,
+    pub base_path: Option<String>,
+    pub files: Option<Vec<String>>,
+    pub ignores: Vec<String>,
+    pub rules: BTreeMap<String, LintRuleSeverity>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InspectorLintPlanPayload {
+    pub schema: &'static str,
+    pub version: u8,
+    pub root: String,
+    pub items: Vec<InspectorLintPlanItemSummary>,
+    pub files: Vec<InspectorLintPlanFile>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InspectorLintPlanItemSummary {
+    pub name: String,
+    pub base_path: Option<String>,
+    pub files: Option<Vec<String>>,
+    pub ignores: Vec<String>,
+    pub rules: BTreeMap<String, LintRuleSeverity>,
+    pub global_ignore: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InspectorLintPlanFile {
+    pub path: String,
+    pub ignored: bool,
+    pub ignored_by: Vec<String>,
+    pub matched_items: Vec<String>,
+    pub rules: Vec<InspectorLintPlanRule>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InspectorLintPlanRule {
+    pub name: String,
+    pub severity: LintRuleSeverity,
+    pub set_by: String,
+}
+
+struct CompiledItem<'a> {
+    item: &'a InspectorLintPlanItem,
+    scope: LintPlanScope,
+    global_ignore: bool,
+}
+
+/// Resolve ordered rule provenance for every requested file.
+pub fn inspect_lint_plan(
+    plan: &InspectorLintPlan,
+    root: &Path,
+    files: &[String],
+) -> InspectorLintPlanPayload {
+    let root = absolute_path(root, Path::new("."));
+    let compiled = plan
+        .items
+        .iter()
+        .map(|item| CompiledItem {
+            global_ignore: item.files.is_none()
+                && item.rules.is_empty()
+                && !item.ignores.is_empty(),
+            scope: LintPlanScope::new(
+                item.base_path.as_deref(),
+                item.files.as_deref(),
+                &item.ignores,
+                &root,
+                Path::new("."),
+            ),
+            item,
+        })
+        .collect::<Vec<_>>();
+    let files = files
+        .iter()
+        .map(|file| inspect_file(&compiled, &root, file.as_str()))
+        .collect();
+    let items = compiled
+        .iter()
+        .map(|entry| InspectorLintPlanItemSummary {
+            name: entry.item.name.clone(),
+            base_path: entry.item.base_path.clone(),
+            files: entry.item.files.clone(),
+            ignores: entry.item.ignores.clone(),
+            rules: entry.item.rules.clone(),
+            global_ignore: entry.global_ignore,
+        })
+        .collect();
+    InspectorLintPlanPayload {
+        schema: "vize.inspector.lint-plan",
+        version: 1,
+        root: normalize_path(&root),
+        items,
+        files,
+    }
+}
+
+fn inspect_file(compiled: &[CompiledItem<'_>], root: &Path, file: &str) -> InspectorLintPlanFile {
+    let absolute = absolute_path(Path::new(file), root);
+    let path = absolute
+        .strip_prefix(root)
+        .map_or_else(|_| normalize_path(&absolute), normalize_path);
+    let ignored_by = compiled
+        .iter()
+        .filter(|entry| entry.global_ignore && entry.scope.ignores(&absolute))
+        .map(|entry| entry.item.name.clone())
+        .collect::<Vec<_>>();
+    if !ignored_by.is_empty() {
+        return InspectorLintPlanFile {
+            path,
+            ignored: true,
+            ignored_by,
+            matched_items: Vec::new(),
+            rules: Vec::new(),
+        };
+    }
+
+    let mut matched_items = Vec::new();
+    let mut rules = BTreeMap::new();
+    for entry in compiled {
+        if entry.global_ignore || !entry.scope.matches(&absolute) {
+            continue;
+        }
+        matched_items.push(entry.item.name.clone());
+        for (name, severity) in &entry.item.rules {
+            rules.insert(name.clone(), (*severity, entry.item.name.clone()));
+        }
+    }
+    InspectorLintPlanFile {
+        path,
+        ignored: false,
+        ignored_by,
+        matched_items,
+        rules: rules
+            .into_iter()
+            .map(|(name, (severity, set_by))| InspectorLintPlanRule {
+                name,
+                severity,
+                set_by,
+            })
+            .collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize/src/lint_plan/matcher.rs
+++ b/crates/vize/src/lint_plan/matcher.rs
@@ -1,0 +1,182 @@
+//! Shared ordered glob semantics for lint execution and inspection.
+
+use globset::{GlobBuilder, GlobMatcher};
+use std::path::{Component, Path, PathBuf};
+use vize_carton::String;
+
+pub(crate) struct LintPlanScope {
+    base_dir: PathBuf,
+    files: Option<GlobSequence>,
+    ignores: GlobSequence,
+}
+
+pub(crate) struct GlobSequence {
+    steps: Vec<GlobStep>,
+    has_steps: bool,
+    has_positive_source: bool,
+}
+
+struct GlobStep {
+    negated: bool,
+    matcher: GlobMatcher,
+}
+
+impl LintPlanScope {
+    pub(crate) fn new(
+        base_path: Option<&str>,
+        files: Option<&[String]>,
+        ignores: &[String],
+        config_dir: &Path,
+        cwd: &Path,
+    ) -> Self {
+        Self {
+            base_dir: resolve_base_dir(base_path, &absolute_path(config_dir, cwd)),
+            files: files.map(GlobSequence::new),
+            ignores: GlobSequence::new(ignores),
+        }
+    }
+
+    pub(crate) fn matches(&self, file: &Path) -> bool {
+        let Some(relative) = self.relative(file) else {
+            return false;
+        };
+        self.files
+            .as_ref()
+            .is_none_or(|patterns| patterns.matches_files(relative.as_str()))
+            && !self.ignores.matches_ignore(relative.as_str())
+    }
+
+    pub(crate) fn ignores(&self, file: &Path) -> bool {
+        self.relative(file)
+            .is_some_and(|relative| self.ignores.matches_ignore(relative.as_str()))
+    }
+
+    fn relative(&self, file: &Path) -> Option<String> {
+        file.strip_prefix(&self.base_dir).ok().map(normalize_path)
+    }
+}
+
+impl GlobSequence {
+    pub(crate) fn new(patterns: &[String]) -> Self {
+        let steps = patterns
+            .iter()
+            .filter_map(|source| {
+                let slashed = source.replace('\\', "/");
+                let (negated, rest) = slashed
+                    .strip_prefix('!')
+                    .map_or((false, slashed.as_str()), |pattern| (true, pattern));
+                let pattern = strip_leading_current_dir(rest);
+                if pattern.is_empty() {
+                    return None;
+                }
+                match GlobBuilder::new(pattern)
+                    .literal_separator(true)
+                    .backslash_escape(false)
+                    .build()
+                {
+                    Ok(glob) => Some(GlobStep {
+                        negated,
+                        matcher: glob.compile_matcher(),
+                    }),
+                    Err(error) => {
+                        eprintln!("[vize] Ignoring invalid entry glob '{source}': {error}");
+                        None
+                    }
+                }
+            })
+            .collect::<Vec<_>>();
+        let has_positive_source = steps.iter().any(|step| !step.negated);
+        Self {
+            has_steps: !steps.is_empty(),
+            steps,
+            has_positive_source,
+        }
+    }
+
+    pub(crate) fn matches_files(&self, file: &str) -> bool {
+        if !self.has_steps {
+            return false;
+        }
+        let mut matched = !self.has_positive_source;
+        for step in &self.steps {
+            if matches_file_or_parent(&step.matcher, file) {
+                matched = !step.negated;
+            }
+        }
+        matched
+    }
+
+    fn matches_ignore(&self, file: &str) -> bool {
+        let mut ignored = false;
+        for step in &self.steps {
+            if matches_file_or_parent(&step.matcher, file) {
+                ignored = !step.negated;
+            }
+        }
+        ignored
+    }
+}
+
+fn matches_file_or_parent(matcher: &GlobMatcher, file: &str) -> bool {
+    if matcher.is_match(file) {
+        return true;
+    }
+    let mut parent = file;
+    while let Some((head, _)) = parent.rsplit_once('/') {
+        if head.is_empty() {
+            break;
+        }
+        if matcher.is_match(head) {
+            return true;
+        }
+        parent = head;
+    }
+    false
+}
+
+fn resolve_base_dir(base_path: Option<&str>, config_dir: &Path) -> PathBuf {
+    let Some(base_path) = base_path.filter(|path| !path.is_empty()) else {
+        return config_dir.to_path_buf();
+    };
+    absolute_path(Path::new(&base_path.replace('\\', "/")), config_dir)
+}
+
+pub(crate) fn absolute_path(path: &Path, cwd: &Path) -> PathBuf {
+    let normalized = PathBuf::from(path.to_string_lossy().replace('\\', "/"));
+    let absolute = if normalized.is_absolute() {
+        normalized
+    } else {
+        cwd.join(normalized)
+    };
+    normalize_lexically(&absolute)
+}
+
+fn normalize_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() && !path.is_absolute() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+    normalized
+}
+
+fn strip_leading_current_dir(pattern: &str) -> &str {
+    let mut stripped = pattern;
+    while let Some(rest) = stripped.strip_prefix("./") {
+        stripped = rest;
+    }
+    stripped
+}
+
+pub(crate) fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/").into()
+}

--- a/crates/vize/src/lint_plan/tests.rs
+++ b/crates/vize/src/lint_plan/tests.rs
@@ -1,0 +1,140 @@
+use super::{InspectorLintPlan, InspectorLintPlanItem, inspect_lint_plan};
+use std::{collections::BTreeMap, path::Path};
+use vize_carton::config::LintRuleSeverity as Severity;
+
+fn item(
+    name: &str,
+    files: Option<Vec<&str>>,
+    ignores: Vec<&str>,
+    rules: &[(&str, Severity)],
+) -> InspectorLintPlanItem {
+    InspectorLintPlanItem {
+        name: name.into(),
+        base_path: None,
+        files: files.map(|patterns| patterns.into_iter().map(Into::into).collect()),
+        ignores: ignores.into_iter().map(Into::into).collect(),
+        rules: rules
+            .iter()
+            .map(|(name, severity)| ((*name).into(), *severity))
+            .collect::<BTreeMap<_, _>>(),
+    }
+}
+
+#[test]
+fn reports_ordered_winners_and_matches_execution_glob_semantics() {
+    let plan = InspectorLintPlan {
+        items: vec![
+            item(
+                "base",
+                None,
+                vec![],
+                &[("base", Severity::Error), ("shared", Severity::Warn)],
+            ),
+            item(
+                "first",
+                Some(vec!["src/**/*.{vue,tsx}"]),
+                vec![],
+                &[("first", Severity::Warn), ("shared", Severity::Error)],
+            ),
+            item(
+                "second",
+                Some(vec![
+                    "src/**/*.vue",
+                    "src/**/*.vue",
+                    "!src/**/*.test.vue",
+                    "[unterminated",
+                    "\0**/*.vue",
+                ]),
+                vec!["src/generated/**", "!src/generated/keep.vue"],
+                &[("second", Severity::Error), ("shared", Severity::Off)],
+            ),
+        ],
+    };
+    let payload = inspect_lint_plan(
+        &plan,
+        Path::new("/project"),
+        &[
+            "src/App.vue".into(),
+            "src/App.test.vue".into(),
+            "src/generated/keep.vue".into(),
+        ],
+    );
+
+    assert_eq!(payload.schema, "vize.inspector.lint-plan");
+    assert_eq!(payload.files[0].matched_items, ["base", "first", "second"]);
+    let shared = payload.files[0]
+        .rules
+        .iter()
+        .find(|rule| rule.name == "shared")
+        .unwrap();
+    assert_eq!(shared.severity, Severity::Off);
+    assert_eq!(shared.set_by, "second");
+    assert_eq!(payload.files[1].matched_items, ["base", "first"]);
+    assert_eq!(payload.files[2].matched_items, ["base", "first", "second"]);
+}
+
+#[test]
+fn distinguishes_global_ignores_from_scoped_ignores_with_rules() {
+    let plan = InspectorLintPlan {
+        items: vec![
+            item("global", None, vec!["generated/**"], &[]),
+            item(
+                "scoped",
+                None,
+                vec!["private/**"],
+                &[("visible", Severity::Error)],
+            ),
+        ],
+    };
+    let payload = inspect_lint_plan(
+        &plan,
+        Path::new("/project"),
+        &[
+            "generated/File.vue".into(),
+            "private/File.vue".into(),
+            "App.vue".into(),
+        ],
+    );
+
+    assert!(payload.items[0].global_ignore);
+    assert!(!payload.items[1].global_ignore);
+    assert!(payload.files[0].ignored);
+    assert_eq!(payload.files[0].ignored_by, ["global"]);
+    assert!(!payload.files[1].ignored);
+    assert!(payload.files[1].matched_items.is_empty());
+    assert_eq!(payload.files[2].matched_items, ["scoped"]);
+}
+
+#[test]
+fn invalid_and_empty_file_patterns_fail_closed() {
+    let plan = InspectorLintPlan {
+        items: vec![
+            item("empty", Some(vec![]), vec![], &[("empty", Severity::Error)]),
+            item(
+                "invalid",
+                Some(vec!["[unterminated", "\0**/*.vue"]),
+                vec![],
+                &[("invalid", Severity::Error)],
+            ),
+        ],
+    };
+    let payload = inspect_lint_plan(&plan, Path::new("/project"), &["src/App.vue".into()]);
+    assert!(payload.files[0].matched_items.is_empty());
+    assert!(payload.files[0].rules.is_empty());
+}
+
+#[test]
+fn relative_roots_anchor_files_once() {
+    let plan = InspectorLintPlan {
+        items: vec![item(
+            "source",
+            Some(vec!["src/**/*.vue"]),
+            vec![],
+            &[("matched", Severity::Error)],
+        )],
+    };
+    let payload = inspect_lint_plan(&plan, Path::new("project"), &["src/App.vue".into()]);
+    assert_eq!(payload.root, "project");
+    assert_eq!(payload.files[0].path, "src/App.vue");
+    assert_eq!(payload.files[0].matched_items, ["source"]);
+}

--- a/crates/vize_vitrine/src/napi/inspector.rs
+++ b/crates/vize_vitrine/src/napi/inspector.rs
@@ -2,7 +2,9 @@
 
 #![allow(clippy::disallowed_types)]
 
+use napi::{Error, Result, Status};
 use napi_derive::napi;
+use std::path::Path;
 use vize_curator::inspector::{InspectorSourceFile, build_graph};
 
 #[napi(object)]
@@ -45,6 +47,19 @@ pub fn build_inspector_graph(files: Vec<InspectorSourceFileNapi>) -> InspectorGr
         .collect::<Vec<_>>();
 
     build_graph(&files).into()
+}
+
+/// Resolve lint severities and their winning config items with CLI-identical glob semantics.
+#[napi(js_name = "inspectLintPlan")]
+pub fn inspect_lint_plan(plan: String, root: String, files: Vec<String>) -> Result<String> {
+    let plan = serde_json::from_str::<vize::lint_plan::InspectorLintPlan>(&plan)
+        .map_err(|error| Error::new(Status::InvalidArg, format!("Invalid lint plan: {error}")))?;
+    serde_json::to_string(&vize::lint_plan::inspect_lint_plan(
+        &plan,
+        Path::new(&root),
+        &files.into_iter().map(Into::into).collect::<Vec<_>>(),
+    ))
+    .map_err(|error| Error::new(Status::GenericFailure, error.to_string()))
 }
 
 impl From<vize_curator::inspector::InspectorGraph> for InspectorGraphNapi {

--- a/npm/native/index.d.ts
+++ b/npm/native/index.d.ts
@@ -158,6 +158,13 @@ export declare function buildInspectorGraph(
   files: Array<InspectorSourceFileNapi>,
 ): InspectorGraphNapi;
 
+/** Resolve effective lint rules and provenance using Vize's execution matcher. */
+export declare function inspectLintPlan(
+  plan: string,
+  root: string,
+  files: Array<string>,
+): string;
+
 /** Catalog entry for NAPI */
 export interface CatalogEntryNapi {
   title: string;

--- a/npm/native/index.d.ts
+++ b/npm/native/index.d.ts
@@ -159,11 +159,7 @@ export declare function buildInspectorGraph(
 ): InspectorGraphNapi;
 
 /** Resolve effective lint rules and provenance using Vize's execution matcher. */
-export declare function inspectLintPlan(
-  plan: string,
-  root: string,
-  files: Array<string>,
-): string;
+export declare function inspectLintPlan(plan: string, root: string, files: Array<string>): string;
 
 /** Catalog entry for NAPI */
 export interface CatalogEntryNapi {

--- a/npm/native/index.js
+++ b/npm/native/index.js
@@ -46,6 +46,7 @@ module.exports.hasSfcScopedStyle = nativeBinding.hasSfcScopedStyle;
 module.exports.hasViteHmrChanges = nativeBinding.hasViteHmrChanges;
 module.exports.hasVitePrecompileFileMetadataChanged =
   nativeBinding.hasVitePrecompileFileMetadataChanged;
+module.exports.inspectLintPlan = nativeBinding.inspectLintPlan;
 module.exports.isBuiltinViteDefine = nativeBinding.isBuiltinViteDefine;
 module.exports.isSfcImportableAssetUrl = nativeBinding.isSfcImportableAssetUrl;
 module.exports.isViteBareSpecifier = nativeBinding.isViteBareSpecifier;


### PR DESCRIPTION
Refs #3617

- share one ordered glob matcher between lint execution and inspector provenance
- report per-file effective severities and winning config items
- expose a deterministic JSON resolver through the native binding

Tests:
- cargo test -p vize lint_plan --lib
- cargo test -p vize entry_rules --lib
- cargo clippy -p vize --lib --all-features -- -D warnings
- cargo check -p vize_vitrine --features napi,legacy
- node npm/native/scripts/sync-entrypoint.mjs --check
- cargo fmt --all -- --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->