### PR TITLE
feat(atelier): support Babel transformOn option

### DIFF
--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -21,6 +21,19 @@ use crate::{JsxLang, JsxOutputMode, lower_source_with_compat};
 
 pub use component::JsxComponent;
 
+/// Options matching the opt-in switches exposed by `@vue/babel-plugin-jsx`.
+///
+/// These are intentionally separate from [`JsxCompileConfig`] so adding Babel
+/// compatibility options remains additive for callers that construct that
+/// configuration with a struct literal. They only take effect when
+/// [`JsxCompileConfig::compat`] is [`JsxCompatMode::Babel`].
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BabelJsxOptions {
+    /// Transform `on={{ click: handler }}` and `nativeOn={listeners}` objects
+    /// into Vue listener props, matching Babel's `transformOn: true` option.
+    pub transform_on: bool,
+}
+
 /// Configuration for mode-aware JSX compilation.
 #[derive(Debug, Clone, Default)]
 pub struct JsxCompileConfig {
@@ -209,7 +222,33 @@ pub fn compile_jsx(
     lang: JsxLang,
     config: &JsxCompileConfig,
 ) -> JsxCompileOutput {
-    let lowered = lower_source_with_compat(bump, source, lang, config.compat);
+    compile_jsx_with_babel_options(bump, source, lang, config, &BabelJsxOptions::default())
+}
+
+/// Compile JSX/TSX with explicit `@vue/babel-plugin-jsx` option compatibility.
+///
+/// The Babel-specific options are inert unless [`JsxCompileConfig::compat`] is
+/// [`JsxCompatMode::Babel`]. Existing [`compile_jsx`] callers therefore retain
+/// byte-for-byte output while Babel-compatible consumers can opt in one option
+/// at a time.
+pub fn compile_jsx_with_babel_options(
+    bump: &Bump,
+    source: &str,
+    lang: JsxLang,
+    config: &JsxCompileConfig,
+    babel_options: &BabelJsxOptions,
+) -> JsxCompileOutput {
+    let transform_on_helper =
+        (config.compat.is_babel() && babel_options.transform_on && !config.ssr)
+            .then(|| collision_free_transform_on_helper(source));
+    let lowered = lower_source_with_compat(
+        bump,
+        source,
+        lang,
+        config.compat,
+        config.default_mode,
+        transform_on_helper.as_deref(),
+    );
     let mut diagnostics = lowered.diagnostics;
     let is_ts = lang.is_typescript();
 
@@ -256,6 +295,7 @@ pub fn compile_jsx(
                     analysis,
                     is_ts,
                     &config.vdom,
+                    transform_on_helper.as_deref(),
                     &mut diagnostics,
                 )),
                 JsxOutputMode::Vapor => JsxComponent::Vapor(compile_root_to_vapor(
@@ -274,4 +314,16 @@ pub fn compile_jsx(
         source: String::from(source),
         diagnostics,
     }
+}
+
+/// Babel allocates a fresh helper binding when the source already declares
+/// `_transformOn`. A conservative source-text check gives the generated module
+/// the same collision safety without coupling this option to a second semantic
+/// analysis pass.
+fn collision_free_transform_on_helper(source: &str) -> String {
+    let mut helper = String::from("_transformOn");
+    while source.contains(helper.as_str()) {
+        helper.push('_');
+    }
+    helper
 }

--- a/crates/vize_atelier_jsx/src/finder.rs
+++ b/crates/vize_atelier_jsx/src/finder.rs
@@ -30,6 +30,7 @@ use crate::{ComponentSetupSpan, LoweredRoot, StyleExprSpan};
 pub(crate) fn lower_program_roots<'a>(
     program: &Program<'_>,
     lowerer: &mut Lowerer<'a, '_, '_>,
+    default_mode: JsxOutputMode,
 ) -> std::vec::Vec<LoweredRoot<'a>> {
     let mut collector = RootLowerer {
         lowerer,
@@ -37,6 +38,7 @@ pub(crate) fn lower_program_roots<'a>(
         scopes: std::vec::Vec::new(),
         pending_name: None,
         pending_declaration_span: None,
+        default_mode,
     };
     collector.visit_program(program);
     collector.roots
@@ -57,6 +59,7 @@ struct RootLowerer<'l, 'a, 'm, 's> {
     /// function/arrow we enter.
     pending_name: Option<String>,
     pending_declaration_span: Option<Span>,
+    default_mode: JsxOutputMode,
 }
 
 impl RootLowerer<'_, '_, '_, '_> {
@@ -243,11 +246,14 @@ impl<'ast> Visit<'ast> for RootLowerer<'_, '_, '_, '_> {
     fn visit_jsx_element(&mut self, element: &JSXElement<'ast>) {
         // Lower this root and intentionally do NOT descend: nested JSX is
         // lowered as part of this root's children, not as separate roots.
+        let mode = self.current_mode();
+        self.lowerer
+            .set_current_output_mode(mode.unwrap_or(self.default_mode));
         let root = self.lowerer.lower_element_root(element);
         let (scoped_css, scoped_style_exprs) = self.take_scoped_style();
         self.roots.push(LoweredRoot {
             root,
-            mode: self.current_mode(),
+            mode,
             component_name: self.current_name(),
             component_setup: self.current_setup_for_span(element.span),
             scoped_css,
@@ -256,11 +262,14 @@ impl<'ast> Visit<'ast> for RootLowerer<'_, '_, '_, '_> {
     }
 
     fn visit_jsx_fragment(&mut self, fragment: &JSXFragment<'ast>) {
+        let mode = self.current_mode();
+        self.lowerer
+            .set_current_output_mode(mode.unwrap_or(self.default_mode));
         let root = self.lowerer.lower_fragment_root(fragment);
         let (scoped_css, scoped_style_exprs) = self.take_scoped_style();
         self.roots.push(LoweredRoot {
             root,
-            mode: self.current_mode(),
+            mode,
             component_name: self.current_name(),
             component_setup: self.current_setup_for_span(fragment.span),
             scoped_css,

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -53,7 +53,10 @@ use vize_croquis::croquis::BindingMetadata;
 use vize_relief::RootNode;
 
 pub use compat::JsxCompatMode;
-pub use compile::{JsxCompileConfig, JsxCompileOutput, JsxComponent, compile_jsx, resolve_mode};
+pub use compile::{
+    BabelJsxOptions, JsxCompileConfig, JsxCompileOutput, JsxComponent, compile_jsx,
+    compile_jsx_with_babel_options, resolve_mode,
+};
 pub use diagnostics::{JsxDiagnostic, Severity};
 pub use lang::JsxLang;
 pub use lower::Lowerer;
@@ -163,7 +166,14 @@ impl<'a> LowerOutput<'a> {
 /// allocator used for parsing is dropped before returning, so the result only
 /// borrows `bump`.
 pub fn lower_source<'a>(bump: &'a Bump, source: &str, lang: JsxLang) -> LowerOutput<'a> {
-    lower_source_with_compat(bump, source, lang, JsxCompatMode::Native)
+    lower_source_with_compat(
+        bump,
+        source,
+        lang,
+        JsxCompatMode::Native,
+        JsxOutputMode::Vdom,
+        None,
+    )
 }
 
 /// Lower a module with project-level compatibility semantics.
@@ -176,16 +186,18 @@ fn lower_source_with_compat<'a>(
     source: &str,
     lang: JsxLang,
     compat: JsxCompatMode,
+    default_mode: JsxOutputMode,
+    transform_on_helper: Option<&str>,
 ) -> LowerOutput<'a> {
     let allocator = oxc_allocator::Allocator::default();
     let parse_source = parse::prepare_source_for_parse(source, lang);
     let parsed = parse::parse_module(&allocator, parse_source.as_ref(), lang);
     let mapper = SpanMapper::new(source);
-    let mut lowerer = Lowerer::with_compat(bump, &mapper, compat);
+    let mut lowerer = Lowerer::with_compat(bump, &mapper, compat, transform_on_helper);
     for diagnostic in parsed.diagnostics {
         lowerer.report(diagnostic);
     }
-    let roots = finder::lower_program_roots(&parsed.program, &mut lowerer);
+    let roots = finder::lower_program_roots(&parsed.program, &mut lowerer, default_mode);
     let analysis = analyze::analyze_program(&parsed.program, source);
     LowerOutput {
         roots,

--- a/crates/vize_atelier_jsx/src/lower.rs
+++ b/crates/vize_atelier_jsx/src/lower.rs
@@ -36,6 +36,8 @@ pub struct Lowerer<'a, 'm, 's> {
     bump: &'a Bump,
     mapper: &'m SpanMapper<'s>,
     compat: JsxCompatMode,
+    transform_on_helper: Option<String>,
+    transform_on_active: bool,
     diagnostics: std::vec::Vec<JsxDiagnostic>,
     /// `<style scoped>` blocks extracted from the render root currently being
     /// lowered, in source order. Drained by [`Self::take_scoped_styles`] once
@@ -46,7 +48,7 @@ pub struct Lowerer<'a, 'm, 's> {
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Build a lowerer that allocates IR in `bump` and maps spans via `mapper`.
     pub fn new(bump: &'a Bump, mapper: &'m SpanMapper<'s>) -> Self {
-        Self::with_compat(bump, mapper, JsxCompatMode::Native)
+        Self::with_compat(bump, mapper, JsxCompatMode::Native, None)
     }
 
     /// Build a lowerer using the requested project-level JSX semantics.
@@ -54,11 +56,14 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         bump: &'a Bump,
         mapper: &'m SpanMapper<'s>,
         compat: JsxCompatMode,
+        transform_on_helper: Option<&str>,
     ) -> Self {
         Self {
             bump,
             mapper,
             compat,
+            transform_on_helper: transform_on_helper.map(String::from),
+            transform_on_active: false,
             diagnostics: std::vec::Vec::new(),
             pending_styles: std::vec::Vec::new(),
         }
@@ -160,5 +165,19 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Whether the project opted into `@vue/babel-plugin-jsx` semantics.
     pub(crate) fn uses_babel_compat(&self) -> bool {
         self.compat.is_babel()
+    }
+
+    /// Select whether the current render root may use VDOM-only Babel options.
+    pub(crate) fn set_current_output_mode(&mut self, mode: crate::JsxOutputMode) {
+        self.transform_on_active = mode == crate::JsxOutputMode::Vdom;
+    }
+
+    /// Collision-free helper binding for Babel's opt-in `transformOn` lowering.
+    pub(crate) fn transform_on_helper(&self) -> Option<&str> {
+        if self.transform_on_active {
+            self.transform_on_helper.as_deref()
+        } else {
+            None
+        }
     }
 }

--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -96,6 +96,10 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             DirectiveAttributeLowering::NotDirective => {}
         }
 
+        if let Some(prop) = self.transform_on_attribute(attr, loc.clone()) {
+            return Some(prop);
+        }
+
         let name = self.compat_attribute_name(attr.name.span());
         let name_loc = self.mapper().location(attr.name.span());
         let prop = match attr.value.as_ref() {

--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -9,6 +9,8 @@
 
 mod compat;
 
+use compat::split_on_event_modifiers;
+
 use oxc_ast::ast::{
     JSXAttribute, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXSpreadAttribute,
 };
@@ -303,52 +305,4 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             JSXAttributeValue::Fragment(fragment) => Some(self.dyn_expr(fragment.span())),
         }
     }
-}
-
-/// Split a babel-plugin-jsx event attribute name into its event name and
-/// trailing option modifiers, e.g. `onClickCapture` -> `("click", ["capture"])`
-/// and `onInputPassiveCapture` -> `("input", ["passive", "capture"])`.
-///
-/// Returns `None` for names without an `on<Event>` shape, without any
-/// recognized trailing modifier, or whose only content is modifiers (so bare
-/// `onCapture` / `onOnce` keep their plain-bind behavior).
-fn split_on_event_modifiers(name: &str) -> Option<(String, std::vec::Vec<&str>)> {
-    // Require an `on` prefix immediately followed by an uppercase event char.
-    let rest = name.strip_prefix("on")?;
-    if !rest.chars().next()?.is_ascii_uppercase() {
-        return None;
-    }
-
-    // Peel recognized option modifiers off the END, preserving source order.
-    let mut event = rest;
-    let mut mods = std::vec::Vec::new();
-    loop {
-        let modifier = if let Some(head) = event.strip_suffix("Capture") {
-            event = head;
-            "capture"
-        } else if let Some(head) = event.strip_suffix("Once") {
-            event = head;
-            "once"
-        } else if let Some(head) = event.strip_suffix("Passive") {
-            event = head;
-            "passive"
-        } else {
-            break;
-        };
-        mods.push(modifier);
-    }
-    mods.reverse();
-
-    // Require at least one modifier and a non-empty event tail.
-    if mods.is_empty() || event.is_empty() {
-        return None;
-    }
-
-    // Lowercase the first char of the remaining event name.
-    let mut chars = event.chars();
-    let first = chars.next()?;
-    let mut lowered = String::new("");
-    lowered.push(first.to_ascii_lowercase());
-    lowered.push_str(chars.as_str());
-    Some((lowered, mods))
 }

--- a/crates/vize_atelier_jsx/src/lower/attr/compat.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr/compat.rs
@@ -1,12 +1,52 @@
 //! Attribute lowering specific to Babel JSX compatibility mode.
 
-use oxc_span::Span;
+use oxc_ast::ast::{JSXAttribute, JSXAttributeName, JSXAttributeValue};
+use oxc_span::{GetSpan, Span};
 use vize_carton::{Box, String};
 use vize_relief::{DirectiveNode, PropNode, SourceLocation};
 
 use crate::lower::Lowerer;
 
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// Apply Babel's `transformOn: true` option to the two exact prop names the
+    /// real plugin recognizes. The generated no-argument `v-bind` keeps this
+    /// listener object in authored merge order while the helper performs the
+    /// runtime key rewrite (`click` -> `onClick`).
+    pub(super) fn transform_on_attribute(
+        &self,
+        attr: &JSXAttribute<'_>,
+        loc: SourceLocation,
+    ) -> Option<PropNode<'a>> {
+        let helper = self.transform_on_helper()?;
+        let JSXAttributeName::Identifier(name) = &attr.name else {
+            return None;
+        };
+        if name.name != "on" && name.name != "nativeOn" {
+            return None;
+        }
+
+        let value = match attr.value.as_ref() {
+            None => "true",
+            Some(JSXAttributeValue::StringLiteral(string)) => self.mapper().slice(string.span),
+            Some(JSXAttributeValue::ExpressionContainer(container)) => {
+                super::container_expr_span(container)
+                    .map(|span| self.mapper().slice(span))
+                    .unwrap_or("true")
+            }
+            Some(JSXAttributeValue::Element(element)) => self.mapper().slice(element.span()),
+            Some(JSXAttributeValue::Fragment(fragment)) => self.mapper().slice(fragment.span()),
+        };
+
+        let mut expression = String::from(helper);
+        expression.push('(');
+        expression.push_str(value);
+        expression.push(')');
+
+        let mut directive = DirectiveNode::new(self.bump(), "bind", loc);
+        directive.exp = Some(self.constant_expr(&expression, attr.span));
+        Some(PropNode::Directive(Box::new_in(directive, self.bump())))
+    }
+
     /// Normalize the camel-cased SVG prop exactly as Babel does (#3391).
     pub(super) fn compat_attribute_name(&self, name_span: Span) -> String {
         let authored = self.mapper().slice(name_span);

--- a/crates/vize_atelier_jsx/src/lower/attr/compat.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr/compat.rs
@@ -77,3 +77,51 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         PropNode::Directive(Box::new_in(directive, self.bump()))
     }
 }
+
+/// Split a babel-plugin-jsx event attribute name into its event name and
+/// trailing option modifiers, e.g. `onClickCapture` -> `("click", ["capture"])`
+/// and `onInputPassiveCapture` -> `("input", ["passive", "capture"])`.
+///
+/// Returns `None` for names without an `on<Event>` shape, without any
+/// recognized trailing modifier, or whose only content is modifiers (so bare
+/// `onCapture` / `onOnce` keep their plain-bind behavior).
+pub(super) fn split_on_event_modifiers(name: &str) -> Option<(String, std::vec::Vec<&str>)> {
+    // Require an `on` prefix immediately followed by an uppercase event char.
+    let rest = name.strip_prefix("on")?;
+    if !rest.chars().next()?.is_ascii_uppercase() {
+        return None;
+    }
+
+    // Peel recognized option modifiers off the END, preserving source order.
+    let mut event = rest;
+    let mut mods = std::vec::Vec::new();
+    loop {
+        let modifier = if let Some(head) = event.strip_suffix("Capture") {
+            event = head;
+            "capture"
+        } else if let Some(head) = event.strip_suffix("Once") {
+            event = head;
+            "once"
+        } else if let Some(head) = event.strip_suffix("Passive") {
+            event = head;
+            "passive"
+        } else {
+            break;
+        };
+        mods.push(modifier);
+    }
+    mods.reverse();
+
+    // Require at least one modifier and a non-empty event tail.
+    if mods.is_empty() || event.is_empty() {
+        return None;
+    }
+
+    // Lowercase the first char of the remaining event name.
+    let mut chars = event.chars();
+    let first = chars.next()?;
+    let mut lowered = String::new("");
+    lowered.push(first.to_ascii_lowercase());
+    lowered.push_str(chars.as_str());
+    Some((lowered, mods))
+}

--- a/crates/vize_atelier_jsx/src/vdom.rs
+++ b/crates/vize_atelier_jsx/src/vdom.rs
@@ -104,6 +104,7 @@ pub fn compile_to_vdom(
             analysis,
             is_ts,
             &options,
+            None,
             &mut diagnostics,
         ));
     }
@@ -123,6 +124,7 @@ pub(crate) fn compile_root_to_vdom(
     analysis: &Croquis,
     is_ts: bool,
     options: &VdomCompileOptions,
+    transform_on_helper: Option<&str>,
     diagnostics: &mut Vec<JsxDiagnostic>,
 ) -> VdomComponent {
     let LoweredRoot {
@@ -170,13 +172,24 @@ pub(crate) fn compile_root_to_vdom(
         ..Default::default()
     };
     let result = generate(&root, codegen_opts);
+    let mut preamble = result.preamble;
+    if let Some(helper) = transform_on_helper
+        && result.code.contains(helper)
+    {
+        if !preamble.is_empty() && !preamble.ends_with('\n') {
+            preamble.push('\n');
+        }
+        preamble.push_str("import ");
+        preamble.push_str(helper);
+        preamble.push_str(" from \"@vue/babel-helper-vue-transform-on\"\n");
+    }
 
     VdomComponent {
         component_name,
         component_setup,
         mode: mode.unwrap_or(JsxOutputMode::Vdom),
         code: result.code,
-        preamble: result.preamble,
+        preamble,
         map: result.map,
         scoped_style,
     }

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -94,7 +94,7 @@ deliberate answer, recorded here so it is not relitigated.
 | Case                                | Babel                                               | Vize today                                   | Compat mode                                          | Verdict |
 | ----------------------------------- | --------------------------------------------------- | -------------------------------------------- | ---------------------------------------------------- | ------- |
 | `options/transform_on_off`          | `on` object passed through as a prop                | same                                         | no change                                            | ✅      |
-| `options/transform_on_on`           | wraps props in `_transformOn(...)`                  | `on` stays a prop by default                  | `BabelJsxOptions::transform_on` wraps via the helper | ✅      |
+| `options/transform_on_on`           | wraps props in `_transformOn(...)`                  | `on` stays a prop by default                 | `BabelJsxOptions::transform_on` wraps via the helper | ✅      |
 | `options/pragma`                    | emits `h("div", …)`, no `vue` import                | always emits Vue runtime helpers             | add `pragma`                                         | ❌      |
 | `options/merge_props_default`       | `mergeProps({class:"a"}, p, {class:c})`             | same                                         | no change                                            | ✅      |
 | `options/merge_props_false`         | one object literal with a duplicate key             | always merges via `mergeProps`               | add `mergeProps: false`                              | ❌      |

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   80 |
-| divergent  |   16 |
+| equivalent |   81 |
+| divergent  |   15 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -94,7 +94,7 @@ deliberate answer, recorded here so it is not relitigated.
 | Case                                | Babel                                               | Vize today                                   | Compat mode                                          | Verdict |
 | ----------------------------------- | --------------------------------------------------- | -------------------------------------------- | ---------------------------------------------------- | ------- |
 | `options/transform_on_off`          | `on` object passed through as a prop                | same                                         | no change                                            | ✅      |
-| `options/transform_on_on`           | wraps props in `_transformOn(...)`                  | no such option; `on` stays a prop            | add `transformOn`                                    | ❌      |
+| `options/transform_on_on`           | wraps props in `_transformOn(...)`                  | `on` stays a prop by default                  | `BabelJsxOptions::transform_on` wraps via the helper | ✅      |
 | `options/pragma`                    | emits `h("div", …)`, no `vue` import                | always emits Vue runtime helpers             | add `pragma`                                         | ❌      |
 | `options/merge_props_default`       | `mergeProps({class:"a"}, p, {class:c})`             | same                                         | no change                                            | ✅      |
 | `options/merge_props_false`         | one object literal with a duplicate key             | always merges via `mergeProps`               | add `mergeProps: false`                              | ❌      |

--- a/crates/vize_atelier_jsx/tests/babel_compat/mod.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/mod.rs
@@ -12,7 +12,9 @@ use std::fmt;
 use std::path::PathBuf;
 
 use serde::Deserialize;
-use vize_atelier_jsx::{JsxCompatMode, JsxCompileConfig, JsxLang, compile_jsx};
+use vize_atelier_jsx::{
+    BabelJsxOptions, JsxCompatMode, JsxCompileConfig, JsxLang, compile_jsx_with_babel_options,
+};
 use vize_carton::Bump;
 
 /// The relationship between Vize's default output and babel's for one case.
@@ -171,13 +173,20 @@ pub fn load_recording() -> Recording {
 /// diagnosing case is a legitimate, recordable outcome.
 pub fn vize_vdom_output(case: &Case) -> std::string::String {
     let bump = Bump::new();
-    let out = compile_jsx(
+    let out = compile_jsx_with_babel_options(
         &bump,
         &case.source,
         case.jsx_lang(),
         &JsxCompileConfig {
             compat: JsxCompatMode::Babel,
             ..Default::default()
+        },
+        &BabelJsxOptions {
+            transform_on: case
+                .babel_options
+                .get("transformOn")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or_default(),
         },
     );
 

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -13,7 +13,7 @@ use super::Verdict::{Deferred as Todo, Divergent as Diff, Equivalent as Same};
 pub const VERDICTS: &[(&str, Verdict)] = &[
     // -- options ---------------------------------------------------------
     ("options/transform_on_off", Same),
-    ("options/transform_on_on", Diff("no transformOn option")),
+    ("options/transform_on_on", Same),
     ("options/pragma", Diff("no pragma option")),
     ("options/merge_props_default", Same),
     ("options/merge_props_false", Diff("no mergeProps option")),

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (80, 16, 2));
+    assert_eq!((equivalent, divergent, deferred), (81, 15, 2));
     assert_eq!(VERDICTS.len(), 98);
 }
 

--- a/crates/vize_atelier_jsx/tests/compat_mode.rs
+++ b/crates/vize_atelier_jsx/tests/compat_mode.rs
@@ -7,7 +7,11 @@
 //! The "default output is unchanged" test is the important one — flipping the
 //! default would be a silent compatibility break for every existing Vize user.
 
-use vize_atelier_jsx::{JsxCompatMode, JsxCompileConfig, JsxLang, JsxOutputMode, compile_jsx};
+use oxc_allocator::Allocator;
+use vize_atelier_jsx::{
+    BabelJsxOptions, JsxCompatMode, JsxCompileConfig, JsxLang, JsxOutputMode, compile_jsx,
+    compile_jsx_with_babel_options, parse_module,
+};
 use vize_carton::Bump;
 
 /// A representative module touching elements, props, interpolation, control
@@ -47,6 +51,23 @@ fn diagnostics(compat: JsxCompatMode, mode: JsxOutputMode) -> Vec<String> {
         .iter()
         .map(|diagnostic| format!("{:?}: {}", diagnostic.severity, diagnostic.message))
         .collect()
+}
+
+fn compile_with_transform_on(source: &str, compat: JsxCompatMode, mode: JsxOutputMode) -> String {
+    let bump = Bump::new();
+    compile_jsx_with_babel_options(
+        &bump,
+        source,
+        JsxLang::Jsx,
+        &JsxCompileConfig {
+            default_mode: mode,
+            compat,
+            ..Default::default()
+        },
+        &BabelJsxOptions { transform_on: true },
+    )
+    .module_code()
+    .to_string()
 }
 
 #[test]
@@ -129,6 +150,102 @@ fn babel_compat_rewrites_xlink_href_across_prop_shapes_only_when_opted_in() {
     assert!(babel.contains("\"xlink:href\": \"#d\""), "{babel}");
     assert!(babel.contains("\"xlink:href\": id"), "{babel}");
     assert_ne!(native, babel);
+}
+
+#[test]
+fn transform_on_is_off_by_default_and_inert_in_native_mode() {
+    let source = "const A = () => <button on={{ click: h }}/>;";
+    let native = compile_module(source, JsxCompatMode::Native, JsxOutputMode::Vdom);
+    let native_with_option =
+        compile_with_transform_on(source, JsxCompatMode::Native, JsxOutputMode::Vdom);
+    let babel_without_option = compile_module(source, JsxCompatMode::Babel, JsxOutputMode::Vdom);
+
+    assert!(!BabelJsxOptions::default().transform_on);
+    assert_eq!(native_with_option, native);
+    assert!(
+        !native.contains("@vue/babel-helper-vue-transform-on"),
+        "{native}"
+    );
+    assert!(
+        babel_without_option.contains("on: { click: h }"),
+        "{babel_without_option}"
+    );
+    assert!(
+        !babel_without_option.contains("@vue/babel-helper-vue-transform-on"),
+        "{babel_without_option}"
+    );
+}
+
+#[test]
+fn babel_transform_on_wraps_exact_on_props_in_authored_merge_order() {
+    let source = concat!(
+        "const A = () => <button id=\"first\" ",
+        "on={{ click: h }} {...attrs} nativeOn={native} ",
+        "only={other} nativeon={lower} onClick={direct} on-call={dashed}/>;",
+    );
+    let output = compile_with_transform_on(source, JsxCompatMode::Babel, JsxOutputMode::Vdom);
+
+    assert_eq!(
+        output.matches("@vue/babel-helper-vue-transform-on").count(),
+        1
+    );
+    assert_eq!(output.matches("_transformOn(").count(), 2, "{output}");
+    assert!(output.contains("_transformOn({ click: h })"), "{output}");
+    assert!(output.contains("_transformOn(native)"), "{output}");
+    assert!(output.contains("only: other"), "{output}");
+    assert!(output.contains("nativeon: lower"), "{output}");
+    assert!(output.contains("onClick: direct"), "{output}");
+    assert!(output.contains("\"on-call\": dashed"), "{output}");
+
+    let first = output.find("id: \"first\"").unwrap();
+    let on = output.find("_transformOn({ click: h })").unwrap();
+    let spread = output.find("attrs").unwrap();
+    let native_on = output.find("_transformOn(native)").unwrap();
+    let near_misses = output.find("only: other").unwrap();
+    assert!(first < on && on < spread && spread < native_on && native_on < near_misses);
+}
+
+#[test]
+fn babel_transform_on_keeps_generated_modules_parseable_and_helper_bindings_unique() {
+    let source = concat!(
+        "const _transformOn = existing; ",
+        "const A = () => <button on/>; ",
+        "const B = () => <button nativeOn={{}}/>; ",
+        "const C = () => <button on=\"tap\"/>; ",
+        "const D = () => <button on={}/>;",
+    );
+    let output = compile_with_transform_on(source, JsxCompatMode::Babel, JsxOutputMode::Vdom);
+
+    assert!(
+        output.contains("import _transformOn_ from \"@vue/babel-helper-vue-transform-on\""),
+        "{output}"
+    );
+    assert!(output.contains("_transformOn_(true)"), "{output}");
+    assert!(output.contains("_transformOn_({})"), "{output}");
+    assert!(output.contains("_transformOn_(\"tap\")"), "{output}");
+    assert_eq!(
+        output.matches("@vue/babel-helper-vue-transform-on").count(),
+        1
+    );
+
+    let allocator = Allocator::default();
+    let parsed = parse_module(&allocator, &output, JsxLang::Jsx);
+    assert!(
+        parsed.diagnostics.is_empty(),
+        "{:?}\n{output}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
+fn babel_transform_on_does_not_leak_into_vapor_output() {
+    let source = "const A = () => { 'use vue:vapor'; return <button on={{ click: h }}/>; };";
+    let output = compile_with_transform_on(source, JsxCompatMode::Babel, JsxOutputMode::Vdom);
+    assert!(!output.contains("_transformOn"), "{output}");
+    assert!(
+        !output.contains("@vue/babel-helper-vue-transform-on"),
+        "{output}"
+    );
 }
 
 #[test]

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__options.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__options.snap
@@ -24,7 +24,7 @@ export function render(_ctx, _cache) {
 
 ## options/transform_on_on
 ### verdict
-divergent: no transformOn option
+equivalent
 ### source (jsx)
 const A = () => <button on={{click: h}}/>;
 ### babel options
@@ -36,9 +36,10 @@ const A = () => _createVNode("button", _transformOn({
   click: h
 }), null);
 ### vize (vdom, babel compat)
-import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+import { normalizeProps as _normalizeProps, guardReactiveProps as _guardReactiveProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+import _transformOn from "@vue/babel-helper-vue-transform-on"
 export function render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("button", { on: {click: h} }, null, 8 /* PROPS */, ["on"]))
+  return (_openBlock(), _createElementBlock("button", _normalizeProps(_guardReactiveProps(_transformOn({click: h}))), null, 16 /* FULL_PROPS */))
 }
 
 ## options/pragma


### PR DESCRIPTION
## Summary

- add an additive `BabelJsxOptions` compile entrypoint without changing constructible compile configs
- lower exact `on` and `nativeOn` props through Babel's transform helper only in Babel-compatible VDOM output
- preserve Native, SSR, and Vapor behavior while keeping helper bindings collision-free and deduplicated
- mark the `options/transform_on_on` differential-oracle row equivalent

## Why

The compatibility inventory recorded Babel's `transformOn: true` behavior, but Vize had no production Rust compile path that could opt into it. This left one documented #3391 divergence unresolved.

## Validation

- `cargo test -p vize_atelier_jsx`
- `cargo clippy -p vize_atelier_jsx --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check`
- `node --test tests/tooling/babel-jsx-oracle.test.ts`

Refs #3391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->