### PR TITLE
feat(vite): expose guarded lint plan inspector endpoint

### DIFF
--- a/npm/builder/vite/src/index.ts
+++ b/npm/builder/vite/src/index.ts
@@ -21,6 +21,9 @@ export type {
   LoadConfigOptions,
   VizeVueVersion,
   VizeCompatibilityOptions,
+  VizeInspectorLintPlanProvider,
+  VizeInspectorLintPlanRequest,
+  VizeInspectorOptions,
 } from "./types.ts";
 
 // Test-only export for snapshot coverage (re-exported for backward compat).

--- a/npm/builder/vite/src/inspector-types.ts
+++ b/npm/builder/vite/src/inspector-types.ts
@@ -1,0 +1,13 @@
+export interface VizeInspectorLintPlanRequest {
+  /** Project-relative files whose effective lint rules should be explained. */
+  files: string[];
+  /** Ask the integration to rebuild its plan before resolving the files. */
+  fresh: boolean;
+}
+
+export type VizeInspectorLintPlanProvider = (request: VizeInspectorLintPlanRequest) => unknown;
+
+export interface VizeInspectorOptions {
+  /** Optional development-only lint-plan payload provider. */
+  lintPlan?: VizeInspectorLintPlanProvider;
+}

--- a/npm/builder/vite/src/plugin/dev-middleware.ts
+++ b/npm/builder/vite/src/plugin/dev-middleware.ts
@@ -6,6 +6,7 @@ import { buildInspectorGraph, normalizeViteDevMiddlewareUrl } from "@vizejs/nati
 import { glob } from "tinyglobby";
 
 import type { VizePluginState } from "./state.ts";
+import { installInspectorLintPlanMiddleware } from "./inspector-lint-plan.ts";
 
 export const VIZE_INSPECTOR_GRAPH_ENDPOINT = "/__vize/inspector/graph";
 
@@ -28,10 +29,14 @@ export interface VizeInspectorGraphPayload {
 
 export function installDevMiddleware(
   devServer: ViteDevServer,
-  state: Pick<VizePluginState, "ignorePatterns" | "logger" | "root" | "scanPatterns">,
+  state: Pick<
+    VizePluginState,
+    "clientViteBase" | "ignorePatterns" | "logger" | "mergedOptions" | "root" | "scanPatterns"
+  >,
 ): void {
   installVirtualAssetMiddleware(devServer, state);
   installInspectorGraphMiddleware(devServer, state);
+  installInspectorLintPlanMiddleware(devServer, state);
 }
 
 export function installVirtualAssetMiddleware(

--- a/npm/builder/vite/src/plugin/inspector-lint-plan.test.ts
+++ b/npm/builder/vite/src/plugin/inspector-lint-plan.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  handleInspectorLintPlanRequest,
+  installInspectorLintPlanMiddleware,
+  isInspectorLintPlanRequest,
+  parseInspectorLintPlanRequest,
+  VIZE_INSPECTOR_LINT_PLAN_ENDPOINT,
+} from "./inspector-lint-plan.ts";
+
+class MemoryResponse {
+  statusCode = 0;
+  readonly headers = new Map<string, number | string>();
+  body: string | undefined;
+
+  setHeader(name: string, value: number | string): void {
+    this.headers.set(name.toLowerCase(), value);
+  }
+
+  end(chunk?: string): void {
+    this.body = chunk;
+  }
+}
+
+const silentLogger = { error() {} };
+
+void test("lint-plan middleware is installed only when a provider exists", () => {
+  let installed = 0;
+  const devServer = {
+    middlewares: {
+      use() {
+        installed += 1;
+      },
+    },
+  } as Parameters<typeof installInspectorLintPlanMiddleware>[0];
+  const state = (inspector?: { lintPlan: () => unknown }) =>
+    ({
+      clientViteBase: "/",
+      logger: silentLogger,
+      mergedOptions: { inspector },
+    }) as Parameters<typeof installInspectorLintPlanMiddleware>[1];
+
+  installInspectorLintPlanMiddleware(devServer, state());
+  assert.equal(installed, 0);
+  installInspectorLintPlanMiddleware(devServer, state({ lintPlan: () => ({}) }));
+  assert.equal(installed, 1);
+});
+
+void test("lint-plan request parser accepts bounded relative files and fresh mode", () => {
+  assert.equal(isInspectorLintPlanRequest(VIZE_INSPECTOR_LINT_PLAN_ENDPOINT), true);
+  assert.equal(isInspectorLintPlanRequest("/__vize/other"), false);
+  assert.deepEqual(
+    parseInspectorLintPlanRequest(
+      `${VIZE_INSPECTOR_LINT_PLAN_ENDPOINT}?file=pages%2Findex.vue&file=pages%2Findex.vue&fresh=1`,
+    ),
+    { request: { files: ["pages/index.vue"], fresh: true } },
+  );
+});
+
+void test("lint-plan request parser honors the configured Vite base", () => {
+  const endpoint = `/docs/_nuxt${VIZE_INSPECTOR_LINT_PLAN_ENDPOINT}`;
+  assert.equal(isInspectorLintPlanRequest(endpoint, "/docs/_nuxt/"), true);
+  assert.equal(
+    isInspectorLintPlanRequest(VIZE_INSPECTOR_LINT_PLAN_ENDPOINT, "/docs/_nuxt/"),
+    false,
+  );
+  assert.deepEqual(parseInspectorLintPlanRequest(`${endpoint}?file=app.vue`, "/docs/_nuxt/"), {
+    request: { files: ["app.vue"], fresh: false },
+  });
+});
+
+void test("lint-plan request parser rejects ambiguous and unsafe input", () => {
+  assert.deepEqual(
+    parseInspectorLintPlanRequest(`${VIZE_INSPECTOR_LINT_PLAN_ENDPOINT}?unknown=1`),
+    { statusCode: 400, error: "invalid_query" },
+  );
+  assert.deepEqual(parseInspectorLintPlanRequest(`${VIZE_INSPECTOR_LINT_PLAN_ENDPOINT}?fresh=0`), {
+    statusCode: 400,
+    error: "invalid_fresh",
+  });
+  for (const file of ["../secret", "/absolute.vue", "nested//file.vue", "C:%5Cfile.vue"]) {
+    assert.deepEqual(
+      parseInspectorLintPlanRequest(`${VIZE_INSPECTOR_LINT_PLAN_ENDPOINT}?file=${file}`),
+      { statusCode: 400, error: "invalid_file" },
+    );
+  }
+});
+
+void test("lint-plan request parser enforces URL and file-count limits", () => {
+  const files = Array.from({ length: 129 }, (_, index) => `file=f${index}.vue`).join("&");
+  assert.deepEqual(parseInspectorLintPlanRequest(`${VIZE_INSPECTOR_LINT_PLAN_ENDPOINT}?${files}`), {
+    statusCode: 413,
+    error: "too_many_files",
+  });
+  assert.deepEqual(
+    parseInspectorLintPlanRequest(`${VIZE_INSPECTOR_LINT_PLAN_ENDPOINT}?file=${"a".repeat(9000)}`),
+    { statusCode: 414, error: "request_uri_too_long" },
+  );
+});
+
+void test("lint-plan handler emits guarded JSON and forwards a normalized request", async () => {
+  const response = new MemoryResponse();
+  let received: unknown;
+  await handleInspectorLintPlanRequest(
+    { method: "GET", url: `${VIZE_INSPECTOR_LINT_PLAN_ENDPOINT}?file=app.vue` },
+    response,
+    (request) => {
+      received = request;
+      return { schema: "vize.inspector.lint-plan", version: 1 };
+    },
+    silentLogger,
+  );
+
+  assert.deepEqual(received, { files: ["app.vue"], fresh: false });
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers.get("cache-control"), "no-store");
+  assert.equal(response.headers.get("x-content-type-options"), "nosniff");
+  assert.deepEqual(JSON.parse(response.body ?? ""), {
+    schema: "vize.inspector.lint-plan",
+    version: 1,
+  });
+});
+
+void test("lint-plan handler supports HEAD and rejects other methods", async () => {
+  const head = new MemoryResponse();
+  await handleInspectorLintPlanRequest(
+    { method: "HEAD", url: VIZE_INSPECTOR_LINT_PLAN_ENDPOINT },
+    head,
+    () => ({ ok: true }),
+    silentLogger,
+  );
+  assert.equal(head.statusCode, 200);
+  assert.equal(head.body, undefined);
+  assert.ok(Number(head.headers.get("content-length")) > 0);
+
+  const post = new MemoryResponse();
+  await handleInspectorLintPlanRequest(
+    { method: "POST", url: VIZE_INSPECTOR_LINT_PLAN_ENDPOINT },
+    post,
+    () => ({ ok: true }),
+    silentLogger,
+  );
+  assert.equal(post.statusCode, 405);
+  assert.equal(post.headers.get("allow"), "GET, HEAD");
+});
+
+void test("lint-plan handler hides provider failures", async () => {
+  const response = new MemoryResponse();
+  await handleInspectorLintPlanRequest(
+    { method: "GET", url: VIZE_INSPECTOR_LINT_PLAN_ENDPOINT },
+    response,
+    () => {
+      throw new Error("do not expose this path");
+    },
+    silentLogger,
+  );
+  assert.equal(response.statusCode, 500);
+  assert.deepEqual(JSON.parse(response.body ?? ""), { error: "inspector_lint_plan_failed" });
+  assert.doesNotMatch(response.body ?? "", /expose|path/);
+});
+
+void test("lint-plan handler bounds provider responses", async () => {
+  const response = new MemoryResponse();
+  await handleInspectorLintPlanRequest(
+    { method: "GET", url: VIZE_INSPECTOR_LINT_PLAN_ENDPOINT },
+    response,
+    () => ({ value: "x".repeat(4 * 1024 * 1024) }),
+    silentLogger,
+  );
+  assert.equal(response.statusCode, 413);
+  assert.deepEqual(JSON.parse(response.body ?? ""), { error: "inspector_response_too_large" });
+});

--- a/npm/builder/vite/src/plugin/inspector-lint-plan.ts
+++ b/npm/builder/vite/src/plugin/inspector-lint-plan.ts
@@ -1,0 +1,175 @@
+import type { IncomingMessage } from "node:http";
+import path from "node:path";
+import type { ViteDevServer } from "vite";
+
+import type {
+  VizeInspectorLintPlanProvider,
+  VizeInspectorLintPlanRequest,
+} from "../inspector-types.ts";
+import type { VizePluginState } from "./state.ts";
+
+export const VIZE_INSPECTOR_LINT_PLAN_ENDPOINT = "/__vize/inspector/lint-plan";
+
+const MAX_REQUEST_URL_BYTES = 8 * 1024;
+const MAX_FILE_COUNT = 128;
+const MAX_FILE_BYTES = 4 * 1024;
+const MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+const ALLOWED_QUERY_KEYS = new Set(["file", "fresh"]);
+
+interface InspectorResponse {
+  statusCode: number;
+  setHeader(name: string, value: number | string): void;
+  end(chunk?: string): void;
+}
+
+export type InspectorLintPlanParseResult =
+  | { request: VizeInspectorLintPlanRequest }
+  | { statusCode: number; error: string }
+  | null;
+
+export function installInspectorLintPlanMiddleware(
+  devServer: ViteDevServer,
+  state: Pick<VizePluginState, "clientViteBase" | "logger" | "mergedOptions">,
+): void {
+  const provider = state.mergedOptions.inspector?.lintPlan;
+  if (!provider) {
+    return;
+  }
+
+  devServer.middlewares.use((req, res, next) => {
+    if (!isInspectorLintPlanRequest(req.url, state.clientViteBase)) {
+      next();
+      return;
+    }
+
+    void handleInspectorLintPlanRequest(req, res, provider, state.logger, state.clientViteBase);
+  });
+}
+
+export function isInspectorLintPlanRequest(reqUrl: string | undefined, base = "/"): boolean {
+  if (!reqUrl) {
+    return false;
+  }
+
+  try {
+    return new URL(reqUrl, "http://localhost").pathname === resolveInspectorEndpoint(base);
+  } catch {
+    return false;
+  }
+}
+
+export function parseInspectorLintPlanRequest(
+  reqUrl: string | undefined,
+  base = "/",
+): InspectorLintPlanParseResult {
+  if (!reqUrl || !isInspectorLintPlanRequest(reqUrl, base)) {
+    return null;
+  }
+  if (Buffer.byteLength(reqUrl) > MAX_REQUEST_URL_BYTES) {
+    return { statusCode: 414, error: "request_uri_too_long" };
+  }
+
+  const url = new URL(reqUrl, "http://localhost");
+  for (const key of url.searchParams.keys()) {
+    if (!ALLOWED_QUERY_KEYS.has(key)) {
+      return { statusCode: 400, error: "invalid_query" };
+    }
+  }
+
+  const freshValues = url.searchParams.getAll("fresh");
+  if (freshValues.length > 1 || (freshValues[0] !== undefined && freshValues[0] !== "1")) {
+    return { statusCode: 400, error: "invalid_fresh" };
+  }
+
+  const rawFiles = url.searchParams.getAll("file");
+  if (rawFiles.length > MAX_FILE_COUNT) {
+    return { statusCode: 413, error: "too_many_files" };
+  }
+
+  const files: string[] = [];
+  const seen = new Set<string>();
+  for (const file of rawFiles) {
+    if (!isSafeInspectorFile(file)) {
+      return { statusCode: 400, error: "invalid_file" };
+    }
+    if (!seen.has(file)) {
+      seen.add(file);
+      files.push(file);
+    }
+  }
+
+  return { request: { files, fresh: freshValues[0] === "1" } };
+}
+
+export async function handleInspectorLintPlanRequest(
+  req: Pick<IncomingMessage, "method" | "url">,
+  res: InspectorResponse,
+  provider: VizeInspectorLintPlanProvider,
+  logger: Pick<Console, "error">,
+  base = "/",
+): Promise<void> {
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    res.setHeader("allow", "GET, HEAD");
+    sendJson(res, 405, { error: "method_not_allowed" });
+    return;
+  }
+
+  const parsed = parseInspectorLintPlanRequest(req.url, base);
+  if (!parsed) {
+    sendJson(res, 404, { error: "not_found" });
+    return;
+  }
+  if ("error" in parsed) {
+    sendJson(res, parsed.statusCode, { error: parsed.error }, req.method === "HEAD");
+    return;
+  }
+
+  try {
+    const payload = await provider(parsed.request);
+    sendJson(res, 200, payload, req.method === "HEAD");
+  } catch (error) {
+    logger.error("Failed to build inspector lint plan:", error);
+    sendJson(res, 500, { error: "inspector_lint_plan_failed" }, req.method === "HEAD");
+  }
+}
+
+function resolveInspectorEndpoint(base: string): string {
+  const pathname = new URL(base, "http://localhost").pathname.replace(/\/+$/, "");
+  return `${pathname}${VIZE_INSPECTOR_LINT_PLAN_ENDPOINT}`;
+}
+
+function isSafeInspectorFile(file: string): boolean {
+  if (
+    file.length === 0 ||
+    Buffer.byteLength(file) > MAX_FILE_BYTES ||
+    file.includes("\0") ||
+    file.includes("\\") ||
+    path.posix.isAbsolute(file)
+  ) {
+    return false;
+  }
+  return !file.split("/").some((segment) => segment === ".." || segment.length === 0);
+}
+
+function sendJson(
+  res: InspectorResponse,
+  statusCode: number,
+  payload: unknown,
+  headOnly = false,
+): void {
+  let body = JSON.stringify(payload);
+  if (body === undefined) {
+    throw new TypeError("Inspector payload is not JSON serializable");
+  }
+  if (Buffer.byteLength(body) > MAX_RESPONSE_BYTES) {
+    statusCode = 413;
+    body = JSON.stringify({ error: "inspector_response_too_large" });
+  }
+
+  res.statusCode = statusCode;
+  res.setHeader("cache-control", "no-store");
+  res.setHeader("content-type", "application/json; charset=utf-8");
+  res.setHeader("content-length", Buffer.byteLength(body));
+  res.setHeader("x-content-type-options", "nosniff");
+  res.end(headOnly ? undefined : body);
+}

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -16,6 +16,7 @@ import "./plugin/compiled-module-cache.test.ts";
 import "./plugin/config-bridge.test.ts";
 import "./plugin/css-modules.test.ts";
 import "./plugin/dev-middleware.test.ts";
+import "./plugin/inspector-lint-plan.test.ts";
 import "./plugin/external-sfc-hmr.test.ts";
 import "./plugin/hmr.test.ts";
 import "./plugin/index.test.ts";

--- a/npm/builder/vite/src/types.ts
+++ b/npm/builder/vite/src/types.ts
@@ -3,6 +3,13 @@ import type {
   ExperimentalCompileFlags,
   ExperimentalPluginOptions,
 } from "./experimental-options.ts";
+import type { VizeInspectorOptions } from "./inspector-types.ts";
+
+export type {
+  VizeInspectorLintPlanProvider,
+  VizeInspectorLintPlanRequest,
+  VizeInspectorOptions,
+} from "./inspector-types.ts";
 
 export type {
   VizeConfig,
@@ -105,6 +112,9 @@ export interface VizeOptions extends ExperimentalPluginOptions {
    * Direct plugin options still take precedence over these values.
    */
   config?: UserConfigExport;
+
+  /** Development inspector integrations exposed through Vite's dev server. */
+  inspector?: VizeInspectorOptions;
 
   /**
    * Vue major version for the host project.


### PR DESCRIPTION
Refs #3617

- register an opt-in lint-plan provider on the existing Vite inspector surface
- honor configured dev bases and normalize bounded project-relative file requests
- guard methods, request size, file count, response size, caching, MIME sniffing, and internal errors

Tests:
- node --experimental-strip-types npm/builder/vite/src/plugin/inspector-lint-plan.test.ts
- vp check npm/builder/vite/src npm/builder/vite/vite.config.ts
- git diff --check