### PR TITLE
feat(nuxt): wire resolved lint plan inspector provider

### DIFF
--- a/npm/framework/nuxt/package.json
+++ b/npm/framework/nuxt/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "catalog:nuxt-module",
+    "@vizejs/native": "workspace:*",
     "@vizejs/nuxt-lint-config": "workspace:*",
     "@vizejs/vite-plugin": "workspace:*",
     "@vizejs/vite-plugin-musea": "workspace:*",

--- a/npm/framework/nuxt/src/compiler-options.ts
+++ b/npm/framework/nuxt/src/compiler-options.ts
@@ -10,6 +10,15 @@ export interface VizeNuxtCompilerCompatibilityOptions {
   webpackVersion?: 4 | 5;
 }
 
+export interface VizeNuxtInspectorLintPlanRequest {
+  files: string[];
+  fresh: boolean;
+}
+
+export interface VizeNuxtInspectorOptions {
+  lintPlan?: (request: VizeNuxtInspectorLintPlanRequest) => unknown;
+}
+
 /**
  * Nuxt-facing mirror of the public `@vizejs/vite-plugin` options.
  *
@@ -36,6 +45,8 @@ export interface VizeNuxtCompilerOptions {
   runtimeModuleName?: string;
   /** Global variable name for standalone/function mode. */
   runtimeGlobalName?: string;
+  /** Development inspector integrations forwarded to the Vite plugin. */
+  inspector?: VizeNuxtInspectorOptions;
   /** Override the public base used for dev-time asset URLs. */
   devUrlBase?: string;
   /** Files to include in compilation. */

--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -1,7 +1,7 @@
 import { createNuxtComponentResolver, injectNuxtComponentImports } from "./components";
 import { injectNuxtI18nHelpers } from "./i18n";
 import { setupNuxtLintChecker } from "./lint/checker/setup";
-import { setupNuxtLintConfigGeneration } from "./lint/generation";
+import { setupNuxtLintConfigGeneration, setupNuxtLintInspector } from "./lint/generation";
 import { appendMuseaArtComponentIgnore } from "./musea-components";
 import { registerNuxtMuseaStaticPublicAsset } from "./musea-static";
 import "./schema";
@@ -347,7 +347,6 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
 
   if (museaOptions !== false) nuxt.hook("components:dirs", appendMuseaArtComponentIgnore);
 
-  // Compiler
   const compilerOptions = resolveNuxtCompilerOptions(
     nuxt.options.rootDir,
     appBaseURL,
@@ -358,6 +357,7 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
       vueVersion,
     },
   );
+  setupNuxtLintInspector(compilerOptions, lintGeneration, nuxt.options.dev !== false);
   const usesVizeCompiler = shouldUseVizeCompiler(compilerOptions);
   if (compilerOptions !== false && compilerOptions.compatibility?.hostCompiler !== true) {
     const { default: vize } = await import("@vizejs/vite-plugin");

--- a/npm/framework/nuxt/src/lint/generation.test.ts
+++ b/npm/framework/nuxt/src/lint/generation.test.ts
@@ -128,6 +128,27 @@ void test("regeneration resolves addons afresh and rewrites same-length changes"
   assert.equal(await absent(path.join(root, "oxlint.config.mts")), true);
 });
 
+void test("resolved plans stay cached until an inspector requests a fresh plan", async (t) => {
+  const root = await temporaryRoot(t, "vize-nuxt-lint-inspector-");
+  const { nuxt } = createNuxt(root);
+  let addonName = "nuxt/initial-addon";
+  let resolutions = 0;
+  const generation = await setupNuxtLintConfigGeneration({ autoInit: false }, nuxt, {
+    resolvePluginSpecifier: () => "../plugin.mjs",
+    resolveAddons() {
+      resolutions += 1;
+      return [{ name: addonName }];
+    },
+  });
+  assert.ok(generation);
+
+  addonName = "nuxt/fresh-addon";
+  assert.equal((await generation.resolvePlan()).at(-1)?.name, "nuxt/initial-addon");
+  assert.equal(resolutions, 1);
+  assert.equal((await generation.resolvePlan(true)).at(-1)?.name, "nuxt/fresh-addon");
+  assert.equal(resolutions, 2);
+});
+
 void test("auto-init preserves every supported existing root or ancestor config", async (t) => {
   for (const name of ROOT_OXLINT_CONFIG_NAMES) {
     const parent = await temporaryRoot(t, "vize-nuxt-lint-existing-");

--- a/npm/framework/nuxt/src/lint/generation.ts
+++ b/npm/framework/nuxt/src/lint/generation.ts
@@ -43,8 +43,12 @@ export interface NuxtLintGenerationDependencies {
 
 export interface NuxtLintConfigGeneration {
   configFile: string;
+  root: string;
   regenerate(): Promise<boolean>;
+  resolvePlan(fresh?: boolean): Promise<readonly NuxtLintConfigItem[]>;
 }
+
+export { setupNuxtLintInspector } from "./inspector.ts";
 
 function isNotFound(error: unknown): boolean {
   return (error as NodeJS.ErrnoException).code === "ENOENT";
@@ -197,6 +201,8 @@ export async function setupNuxtLintConfigGeneration(
       ? setupNuxtLintConfigAddons(nuxt as NuxtLintGenerationNuxt & NuxtLintConfigAddonNuxt)
       : undefined);
 
+  let currentPlan: readonly NuxtLintConfigItem[] = [];
+
   const regenerate = async (): Promise<boolean> => {
     const features = resolveNuxtLintFeatures(featureOptions, () => hasTypeScriptProbe(planRoot));
     const project = toNuxtLintProjectState(nuxt.options as NuxtLintSourceOptions, {
@@ -204,16 +210,24 @@ export async function setupNuxtLintConfigGeneration(
     });
     const plan = buildNuxtLintPlan(features, collectNuxtLintDirs(project));
     const addons = (await resolveAddons?.()) ?? [];
+    const nextPlan = [...plan, ...addons];
     const artifact = renderNuxtOxlintConfig(
-      [...plan, ...addons],
+      nextPlan,
       resolvePluginSpecifier(path.dirname(configFile)),
     );
-    return writeFileIfChanged(configFile, artifact);
+    const changed = await writeFileIfChanged(configFile, artifact);
+    currentPlan = nextPlan;
+    return changed;
+  };
+
+  const resolvePlan = async (fresh = false): Promise<readonly NuxtLintConfigItem[]> => {
+    if (fresh) await regenerate();
+    return currentPlan;
   };
 
   await regenerate();
   nuxt.hook("builder:generateApp", regenerate);
   if (autoInit) await initRootOxlintConfig(nuxtRoot, configFile);
 
-  return { configFile, regenerate };
+  return { configFile, root: planRoot, regenerate, resolvePlan };
 }

--- a/npm/framework/nuxt/src/lint/inspector.test.ts
+++ b/npm/framework/nuxt/src/lint/inspector.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { VizeNuxtCompilerOptions } from "../compiler-options.ts";
+import { createNuxtLintInspectorProvider, setupNuxtLintInspector } from "./inspector.ts";
+
+const payload = {
+  schema: "vize.inspector.lint-plan",
+  version: 1,
+  root: "/project",
+  items: [],
+  files: [],
+};
+
+void test("Nuxt lint inspector forwards the cached plan, root, files, and freshness", async () => {
+  const freshness: boolean[] = [];
+  let received: unknown;
+  const provider = createNuxtLintInspectorProvider(
+    {
+      root: "/project",
+      async resolvePlan(fresh) {
+        freshness.push(fresh ?? false);
+        return [{ name: "nuxt/rules", rules: { "nuxt/prefer-import-meta": "error" } }];
+      },
+    },
+    {
+      inspectLintPlan(plan, root, files) {
+        received = { plan: JSON.parse(plan), root, files };
+        return JSON.stringify(payload);
+      },
+    },
+  );
+
+  assert.deepEqual(await provider({ files: ["app.vue"], fresh: true }), payload);
+  assert.deepEqual(freshness, [true]);
+  assert.deepEqual(received, {
+    plan: {
+      items: [{ name: "nuxt/rules", rules: { "nuxt/prefer-import-meta": "error" } }],
+    },
+    root: "/project",
+    files: ["app.vue"],
+  });
+});
+
+void test("Nuxt lint inspector rejects malformed native payloads", async () => {
+  const generation = {
+    root: "/project",
+    async resolvePlan() {
+      return [];
+    },
+  };
+  const malformed = createNuxtLintInspectorProvider(generation, {
+    inspectLintPlan: () => "not json",
+  });
+  await assert.rejects(malformed({ files: [], fresh: false }), SyntaxError);
+
+  const wrongSchema = createNuxtLintInspectorProvider(generation, {
+    inspectLintPlan: () => JSON.stringify({ ...payload, schema: "wrong" }),
+  });
+  await assert.rejects(wrongSchema({ files: [], fresh: false }), /returned an invalid payload/u);
+});
+
+void test("Nuxt lint inspector wiring is development-only and preserves explicit providers", () => {
+  const generation = {
+    configFile: "/project/.nuxt/oxlint.config.json",
+    root: "/project",
+    async regenerate() {
+      return false;
+    },
+    async resolvePlan() {
+      return [];
+    },
+  };
+  const disabled: VizeNuxtCompilerOptions = {};
+  setupNuxtLintInspector(disabled, generation, false);
+  assert.equal(disabled.inspector, undefined);
+
+  const explicit = () => ({ explicit: true });
+  const configured: VizeNuxtCompilerOptions = { inspector: { lintPlan: explicit } };
+  setupNuxtLintInspector(configured, generation, true);
+  assert.equal(configured.inspector?.lintPlan, explicit);
+
+  const automatic: VizeNuxtCompilerOptions = {};
+  setupNuxtLintInspector(automatic, generation, true);
+  assert.equal(typeof automatic.inspector?.lintPlan, "function");
+});

--- a/npm/framework/nuxt/src/lint/inspector.ts
+++ b/npm/framework/nuxt/src/lint/inspector.ts
@@ -1,0 +1,57 @@
+import type {
+  VizeNuxtCompilerOptions,
+  VizeNuxtInspectorLintPlanRequest,
+} from "../compiler-options.ts";
+import type { NuxtLintConfigGeneration } from "./generation.ts";
+
+type Awaitable<T> = T | Promise<T>;
+type InspectLintPlan = (plan: string, root: string, files: string[]) => Awaitable<string>;
+
+export interface NuxtLintInspectorDependencies {
+  inspectLintPlan?: InspectLintPlan;
+}
+
+export function createNuxtLintInspectorProvider(
+  generation: Pick<NuxtLintConfigGeneration, "resolvePlan" | "root">,
+  dependencies: NuxtLintInspectorDependencies = {},
+): (request: VizeNuxtInspectorLintPlanRequest) => Promise<Record<string, unknown>> {
+  const inspect = dependencies.inspectLintPlan ?? inspectWithNative;
+
+  return async (request) => {
+    const items = await generation.resolvePlan(request.fresh);
+    const serialized = await inspect(JSON.stringify({ items }), generation.root, request.files);
+    const payload = JSON.parse(serialized) as unknown;
+    if (!isLintPlanPayload(payload)) {
+      throw new Error("Native lint-plan inspector returned an invalid payload");
+    }
+    return payload;
+  };
+}
+
+export function setupNuxtLintInspector(
+  compiler: false | VizeNuxtCompilerOptions,
+  generation: NuxtLintConfigGeneration | undefined,
+  enabled: boolean,
+): void {
+  if (!enabled || compiler === false || !generation) return;
+  compiler.inspector ||= {};
+  compiler.inspector.lintPlan ||= createNuxtLintInspectorProvider(generation);
+}
+
+async function inspectWithNative(plan: string, root: string, files: string[]): Promise<string> {
+  const { inspectLintPlan } = await import("@vizejs/native");
+  return inspectLintPlan(plan, root, files);
+}
+
+function isLintPlanPayload(value: unknown): value is Record<string, unknown> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (value as Record<string, unknown>).schema === "vize.inspector.lint-plan" &&
+    (value as Record<string, unknown>).version === 1 &&
+    typeof (value as Record<string, unknown>).root === "string" &&
+    Array.isArray((value as Record<string, unknown>).items) &&
+    Array.isArray((value as Record<string, unknown>).files)
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -711,6 +711,9 @@ importers:
       '@nuxt/kit':
         specifier: catalog:nuxt-module
         version: 3.11.2(magicast@0.5.2)(rollup@4.60.3)
+      '@vizejs/native':
+        specifier: workspace:*
+        version: link:../../native
       '@vizejs/nuxt-lint-config':
         specifier: workspace:*
         version: link:../nuxt-lint-config


### PR DESCRIPTION
Refs #3617

- retain the exact generated Nuxt lint plan and refresh addons only when requested
- resolve per-file rule provenance through the shared native matcher
- install the provider only for development and preserve explicit integrations

Tests:
- node --experimental-strip-types npm/framework/nuxt/src/lint/inspector.test.ts
- node --experimental-strip-types npm/framework/nuxt/src/lint/generation.test.ts
- vp check npm/framework/nuxt/src npm/framework/nuxt/vite.config.ts npm/framework/nuxt/package.json
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->