### PR TITLE
feat(atelier): support Babel mergeProps false option

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -30,6 +30,9 @@ pub use context::{CodegenContext, CodegenResult, CodegenResultWithSections, Code
 pub(crate) use helpers::is_constant_simple_expression;
 // Shared with the dialect-gated Vue 2 filter transform, which builds the same
 // `_filter_<name>` asset id the codegen preamble declares.
-pub use emit::{generate, generate_with_sections, generate_with_vnode_factory};
+pub use emit::{
+    generate, generate_with_merge_props, generate_with_sections, generate_with_vnode_factory,
+    generate_with_vnode_factory_and_merge_props,
+};
 #[cfg(feature = "legacy")]
 pub(crate) use helpers::to_valid_asset_identifier;

--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -30,6 +30,11 @@ pub struct CodegenContext {
     pub(super) runtime_module_name: String,
     /// Options
     pub(super) options: CodegenOptions,
+    /// Whether object-valued props are combined through Vue's `mergeProps`
+    /// helper. JSX Babel compatibility can disable this internally to emit
+    /// JavaScript object spreads instead; the public core codegen entry points
+    /// keep the existing `true` behavior.
+    pub(super) merge_props: bool,
     /// Pure annotation for tree-shaking
     pub(super) pure: bool,
     /// Helpers used during codegen

--- a/crates/vize_atelier_core/src/codegen/context/vnode_factory.rs
+++ b/crates/vize_atelier_core/src/codegen/context/vnode_factory.rs
@@ -11,13 +11,13 @@ use super::CodegenContext;
 impl CodegenContext {
     /// Create a new codegen context.
     pub fn new(options: CodegenOptions) -> Self {
-        Self::new_with_vnode_factory(options, None)
+        Self::new_with_vnode_factory_and_merge_props(options, None, true)
     }
 
-    /// Create a context that emits vnode creation through a custom factory.
-    pub(in crate::codegen) fn new_with_vnode_factory(
+    pub(in crate::codegen) fn new_with_vnode_factory_and_merge_props(
         options: CodegenOptions,
         vnode_factory: Option<&str>,
+        merge_props: bool,
     ) -> Self {
         let map_builder = options.source_map.then(SourceMapBuilder::new);
         Self {
@@ -29,6 +29,7 @@ impl CodegenContext {
             runtime_global_name: options.runtime_global_name.to_compact_string(),
             runtime_module_name: options.runtime_module_name.to_compact_string(),
             options,
+            merge_props,
             pure: false,
             used_helpers: RuntimeHelpers::default(),
             cache_index: 0,

--- a/crates/vize_atelier_core/src/codegen/emit.rs
+++ b/crates/vize_atelier_core/src/codegen/emit.rs
@@ -18,7 +18,21 @@ use super::root::{
 
 /// Generate code from root AST.
 pub fn generate(root: &RootNode<'_>, options: CodegenOptions) -> CodegenResult {
-    generate_with_sections(root, options).into_result()
+    generate_with_vnode_factory_and_merge_props(root, options, None, true)
+}
+
+/// Generate code with an explicit `mergeProps` policy.
+///
+/// This is an additive internal integration point for JSX Babel compatibility.
+/// Template compilation and existing callers continue through [`generate`],
+/// which always preserves Vue template compiler `mergeProps` behavior.
+#[doc(hidden)]
+pub fn generate_with_merge_props(
+    root: &RootNode<'_>,
+    options: CodegenOptions,
+    merge_props: bool,
+) -> CodegenResult {
+    generate_with_vnode_factory_and_merge_props(root, options, None, merge_props)
 }
 
 /// Generate code while routing vnode creation through a caller-provided JSX
@@ -28,7 +42,18 @@ pub fn generate_with_vnode_factory(
     options: CodegenOptions,
     vnode_factory: &str,
 ) -> CodegenResult {
-    generate_with_sections_and_vnode_factory(root, options, Some(vnode_factory)).into_result()
+    generate_with_vnode_factory_and_merge_props(root, options, Some(vnode_factory), true)
+}
+
+/// Generate code with optional custom vnode creation and `mergeProps` policy.
+#[doc(hidden)]
+pub fn generate_with_vnode_factory_and_merge_props(
+    root: &RootNode<'_>,
+    options: CodegenOptions,
+    vnode_factory: Option<&str>,
+    merge_props: bool,
+) -> CodegenResult {
+    generate_with_sections_and_options(root, options, vnode_factory, merge_props).into_result()
 }
 
 /// Generate code from root AST and return emission-recorded section boundaries.
@@ -36,15 +61,17 @@ pub fn generate_with_sections(
     root: &RootNode<'_>,
     options: CodegenOptions,
 ) -> CodegenResultWithSections {
-    generate_with_sections_and_vnode_factory(root, options, None)
+    generate_with_sections_and_options(root, options, None, true)
 }
 
-fn generate_with_sections_and_vnode_factory(
+fn generate_with_sections_and_options(
     root: &RootNode<'_>,
     options: CodegenOptions,
     vnode_factory: Option<&str>,
+    merge_props: bool,
 ) -> CodegenResultWithSections {
-    let mut ctx = CodegenContext::new_with_vnode_factory(options, vnode_factory);
+    let mut ctx =
+        CodegenContext::new_with_vnode_factory_and_merge_props(options, vnode_factory, merge_props);
     ctx.static_cache = ctx.options.inline || !root.hoists.is_empty();
     let root_children: std::vec::Vec<&TemplateChildNode<'_>> = root
         .children

--- a/crates/vize_atelier_core/src/codegen/props.rs
+++ b/crates/vize_atelier_core/src/codegen/props.rs
@@ -3,18 +3,21 @@
 mod directives;
 mod events;
 mod generate;
+mod object_spread;
 mod scan;
+mod static_merge;
 
 use crate::{PropNode, RuntimeHelper};
 
 use super::{context::CodegenContext, expression::generate_expression};
 
 pub use directives::{
-    StaticMerge, generate_directive_prop_with_static,
-    generate_slot_outlet_directive_prop_with_static, is_supported_directive,
+    generate_directive_prop_with_static, generate_slot_outlet_directive_prop_with_static,
+    is_supported_directive,
 };
 pub use events::von_event_key_for;
 pub use generate::generate_props;
+pub use static_merge::StaticMerge;
 
 /// Check if there's a v-bind without argument (object spread)
 pub(crate) fn has_vbind_object(props: &[PropNode<'_>]) -> bool {

--- a/crates/vize_atelier_core/src/codegen/props/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/props/directives.rs
@@ -10,6 +10,8 @@ use super::super::{
 use vize_carton::String;
 use vize_carton::ToCompactString;
 
+use super::StaticMerge;
+
 /// Check if an expression is a static literal (no runtime identifiers).
 /// Returns true for: object literals, array literals, string literals, numbers
 /// that don't reference any runtime variables (no `_ctx.` after processing).
@@ -33,53 +35,6 @@ pub fn is_supported_directive(dir: &DirectiveNode<'_>) -> bool {
         });
     }
     matches!(dir.name.as_str(), "bind" | "on" | "html" | "text")
-}
-
-/// A static class/style attribute that will be merged with a dynamic
-/// `:class`/`:style` binding, plus whether the static value appears before
-/// the dynamic one in source order (Vue preserves source order in the merged
-/// array).
-#[derive(Clone, Copy, Default)]
-pub struct StaticMerge<'a> {
-    pub class: Option<&'a str>,
-    pub class_before: bool,
-    pub style: Option<&'a str>,
-    pub style_before: bool,
-}
-
-impl<'a> StaticMerge<'a> {
-    /// Build the merge metadata from an element's props in source order.
-    pub fn from_props(props: &'a [crate::PropNode<'a>]) -> Self {
-        let mut merge = StaticMerge::default();
-        let mut class_index = None;
-        let mut style_index = None;
-        for (index, prop) in props.iter().enumerate() {
-            match prop {
-                crate::PropNode::Attribute(attr) => {
-                    if attr.name == "class" && merge.class.is_none() {
-                        merge.class = attr.value.as_ref().map(|v| v.content.as_str());
-                        class_index = Some(index);
-                    } else if attr.name == "style" && merge.style.is_none() {
-                        merge.style = attr.value.as_ref().map(|v| v.content.as_str());
-                        style_index = Some(index);
-                    }
-                }
-                crate::PropNode::Directive(dir) => {
-                    if dir.name == "bind"
-                        && let Some(ExpressionNode::Simple(exp)) = &dir.arg
-                        && exp.is_static
-                    {
-                        if exp.content == "class" && class_index.is_some_and(|i| i < index) {
-                            merge.class_before = true;
-                        } else if exp.content == "style" && style_index.is_some_and(|i| i < index) {
-                            merge.style_before = true;
-                        }
-                    }
-                }
-            }
-        }
-        merge
-    }
 }
 
 /// Generate directive as prop with optional static class/style merging
@@ -170,6 +125,16 @@ fn generate_vbind_prop(
     static_merge: StaticMerge<'_>,
     static_key_casing: StaticBindKeyCasing,
 ) {
+    if dir.arg.is_none() && !ctx.merge_props {
+        ctx.push("...");
+        if let Some(exp) = &dir.exp {
+            generate_expression(ctx, exp);
+        } else {
+            ctx.push("undefined");
+        }
+        return;
+    }
+
     let static_class = static_merge.class;
     let static_style = static_merge.style;
     let mut is_class = false;
@@ -407,6 +372,20 @@ fn split_style_declarations(value: &str) -> Vec<&str> {
 
 /// Generate v-on directive as a prop
 fn generate_von_prop(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
+    if dir.arg.is_none() && !ctx.merge_props {
+        ctx.use_helper(RuntimeHelper::ToHandlers);
+        ctx.push("...");
+        ctx.push(ctx.helper(RuntimeHelper::ToHandlers));
+        ctx.push("(");
+        if let Some(exp) = &dir.exp {
+            generate_expression(ctx, exp);
+        } else {
+            ctx.push("undefined");
+        }
+        ctx.push(", true)");
+        return;
+    }
+
     let is_dynamic_event = if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
         !exp.is_static
     } else {

--- a/crates/vize_atelier_core/src/codegen/props/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/props/generate.rs
@@ -12,6 +12,7 @@ use super::{
     directives::{generate_directive_prop_with_static, is_supported_directive},
     events::{generate_merged_event_handlers, get_von_event_key},
     generate_vbind_object_exp, generate_von_object_exp,
+    object_spread::try_generate_without_merge_props,
     scan::PropsScan,
 };
 use vize_carton::{FxHashSet, String};
@@ -46,6 +47,10 @@ pub fn generate_props(ctx: &mut CodegenContext, props: &[PropNode<'_>]) {
 
     // Handle cases with object spreads (v-bind="obj" or v-on="obj")
     if scan.has_vbind_obj || scan.has_von_obj {
+        if try_generate_without_merge_props(ctx, props, scope_id.as_deref(), &scan) {
+            return;
+        }
+
         if scan.has_other || (scan.has_vbind_obj && scan.has_von_obj) {
             // Multiple spreads or spread with other props: _mergeProps(...).
             // Vue walks props in source order, accumulating non-spread props into
@@ -219,7 +224,7 @@ fn try_generate_static_attrs(
     props: &[PropNode<'_>],
     scope_id: Option<&str>,
 ) -> bool {
-    if ctx.skip_is_prop || ctx.options.inline {
+    if !ctx.merge_props || ctx.skip_is_prop || ctx.options.inline {
         return false;
     }
     if ctx.in_v_for
@@ -332,7 +337,7 @@ fn try_generate_static_attrs(
 }
 
 /// Generate props as a regular object { key: value, ... }
-fn generate_props_object(
+pub(super) fn generate_props_object(
     ctx: &mut CodegenContext,
     props: &[PropNode<'_>],
     skip_object_spreads: bool,
@@ -353,7 +358,7 @@ fn generate_props_object_inner(
 ) {
     // When inside mergeProps, skip normalizeClass/normalizeStyle wrappers
     let prev_skip = ctx.skip_normalize;
-    if inside_merge_props {
+    if inside_merge_props || !ctx.merge_props {
         ctx.skip_normalize = true;
     }
 
@@ -504,7 +509,8 @@ fn generate_props_object_inner(
                 // Only add comma if directive produces valid output
                 if is_supported_directive(dir) {
                     // Check for duplicate v-on events that should be merged into arrays
-                    if dir.name == "on"
+                    if ctx.merge_props
+                        && dir.name == "on"
                         && let Some(event_key) = get_von_event_key(dir, ctx.props_is_plain_element)
                     {
                         let count = scan.event_counts.count(&event_key);
@@ -546,16 +552,7 @@ fn generate_props_object_inner(
                         ctx.push(" ");
                     }
                     first = false;
-                    generate_directive_prop_with_static(
-                        ctx,
-                        dir,
-                        super::directives::StaticMerge {
-                            class: scan.static_class,
-                            class_before: scan.static_class_before_dynamic,
-                            style: scan.static_style,
-                            style_before: scan.static_style_before_dynamic,
-                        },
-                    );
+                    generate_directive_prop_with_static(ctx, dir, scan.static_merge());
                 }
             }
         }

--- a/crates/vize_atelier_core/src/codegen/props/object_spread.rs
+++ b/crates/vize_atelier_core/src/codegen/props/object_spread.rs
@@ -1,0 +1,35 @@
+//! Object-spread generation for Babel JSX compatibility.
+
+use crate::PropNode;
+
+use super::super::context::CodegenContext;
+use super::generate::generate_props_object;
+use super::generate_vbind_object_exp;
+use super::scan::PropsScan;
+
+/// Emit the `mergeProps: false` path, preserving JavaScript spread semantics.
+pub(super) fn try_generate_without_merge_props(
+    ctx: &mut CodegenContext,
+    props: &[PropNode<'_>],
+    scope_id: Option<&str>,
+    scan: &PropsScan<'_>,
+) -> bool {
+    if ctx.merge_props {
+        return false;
+    }
+
+    // Babel leaves a lone JSX spread as the props expression itself. Once
+    // another visible prop participates, it emits one object literal with
+    // spread members in authored order instead of calling `mergeProps`.
+    if scope_id.is_none()
+        && scan.has_vbind_obj
+        && !scan.has_von_obj
+        && !scan.has_other
+        && scan.visible_count(false) == 1
+    {
+        generate_vbind_object_exp(ctx, props);
+    } else {
+        generate_props_object(ctx, props, false, scan);
+    }
+    true
+}

--- a/crates/vize_atelier_core/src/codegen/props/scan.rs
+++ b/crates/vize_atelier_core/src/codegen/props/scan.rs
@@ -60,6 +60,7 @@ impl EventNameCounts {
 }
 
 pub(super) struct PropsScan<'props> {
+    pub(super) merge_props: bool,
     pub(super) static_class: Option<&'props str>,
     pub(super) static_style: Option<&'props str>,
     pub(super) has_vbind_obj: bool,
@@ -96,6 +97,7 @@ impl<'props> PropsScan<'props> {
         skip_is: bool,
     ) -> Self {
         let mut scan = Self {
+            merge_props: ctx.merge_props,
             static_class: None,
             static_style: None,
             has_vbind_obj: false,
@@ -186,12 +188,12 @@ impl<'props> PropsScan<'props> {
 
     #[inline]
     pub(super) fn skip_static_class(&self) -> bool {
-        self.static_class.is_some() && self.has_dynamic_class
+        self.merge_props && self.static_class.is_some() && self.has_dynamic_class
     }
 
     #[inline]
     pub(super) fn skip_static_style(&self) -> bool {
-        self.static_style.is_some() && self.has_dynamic_style
+        self.merge_props && self.static_style.is_some() && self.has_dynamic_style
     }
 
     #[inline]

--- a/crates/vize_atelier_core/src/codegen/props/static_merge.rs
+++ b/crates/vize_atelier_core/src/codegen/props/static_merge.rs
@@ -1,0 +1,66 @@
+//! Static class/style metadata for dynamic prop bindings.
+
+use crate::{ExpressionNode, PropNode};
+
+use super::scan::PropsScan;
+
+/// A static class/style attribute that will be merged with a dynamic
+/// `:class`/`:style` binding, plus whether the static value appears before
+/// the dynamic one in source order (Vue preserves source order in the merged
+/// array).
+#[derive(Clone, Copy, Default)]
+pub struct StaticMerge<'a> {
+    pub class: Option<&'a str>,
+    pub class_before: bool,
+    pub style: Option<&'a str>,
+    pub style_before: bool,
+}
+
+impl<'a> StaticMerge<'a> {
+    /// Build the merge metadata from an element's props in source order.
+    pub fn from_props(props: &'a [PropNode<'a>]) -> Self {
+        let mut merge = Self::default();
+        let mut class_index = None;
+        let mut style_index = None;
+        for (index, prop) in props.iter().enumerate() {
+            match prop {
+                PropNode::Attribute(attr) => {
+                    if attr.name == "class" && merge.class.is_none() {
+                        merge.class = attr.value.as_ref().map(|v| v.content.as_str());
+                        class_index = Some(index);
+                    } else if attr.name == "style" && merge.style.is_none() {
+                        merge.style = attr.value.as_ref().map(|v| v.content.as_str());
+                        style_index = Some(index);
+                    }
+                }
+                PropNode::Directive(dir) => {
+                    if dir.name == "bind"
+                        && let Some(ExpressionNode::Simple(exp)) = &dir.arg
+                        && exp.is_static
+                    {
+                        if exp.content == "class" && class_index.is_some_and(|i| i < index) {
+                            merge.class_before = true;
+                        } else if exp.content == "style" && style_index.is_some_and(|i| i < index) {
+                            merge.style_before = true;
+                        }
+                    }
+                }
+            }
+        }
+        merge
+    }
+}
+
+impl<'props> PropsScan<'props> {
+    pub(super) fn static_merge(&self) -> StaticMerge<'props> {
+        if !self.merge_props {
+            return StaticMerge::default();
+        }
+        StaticMerge {
+            class: self.static_class,
+            class_before: self.static_class_before_dynamic,
+            style: self.static_style,
+            style_before: self.static_style_before_dynamic,
+        }
+    }
+}

--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -22,6 +22,10 @@ use crate::{JsxLang, JsxOutputMode, lower_source_with_compat};
 
 use self::babel::{collision_free_transform_on_helper, resolve_vnode_factory};
 
+pub use self::babel::{
+    compile_jsx_with_babel_merge_props, compile_jsx_with_babel_options,
+    compile_jsx_with_babel_pragma,
+};
 pub use component::JsxComponent;
 
 /// Options matching the opt-in switches exposed by `@vue/babel-plugin-jsx`.
@@ -228,39 +232,21 @@ pub fn compile_jsx(
     compile_jsx_with_babel_options(bump, source, lang, config, &BabelJsxOptions::default())
 }
 
-/// Compile JSX/TSX with explicit `@vue/babel-plugin-jsx` option compatibility.
-///
-/// The Babel-specific options are inert unless [`JsxCompileConfig::compat`] is
-/// [`JsxCompatMode::Babel`]. Existing [`compile_jsx`] callers therefore retain
-/// byte-for-byte output while Babel-compatible consumers can opt in one option
-/// at a time.
-pub fn compile_jsx_with_babel_options(
-    bump: &Bump,
-    source: &str,
-    lang: JsxLang,
-    config: &JsxCompileConfig,
-    babel_options: &BabelJsxOptions,
-) -> JsxCompileOutput {
-    compile_jsx_with_babel_pragma(bump, source, lang, config, babel_options, None)
-}
-
-/// Compile JSX/TSX with an optional Babel-compatible vnode factory pragma.
-///
-/// This additive entry point keeps [`BabelJsxOptions`] constructible for
-/// existing callers while exposing Babel's string-valued `pragma` option. An
-/// empty pragma has the same meaning as Babel's default. The option is inert in
-/// native compatibility mode, SSR, and Vapor output.
-pub fn compile_jsx_with_babel_pragma(
+/// Compile with the two additive Babel options combined.
+#[doc(hidden)]
+pub fn compile_jsx_with_babel_pragma_and_merge_props(
     bump: &Bump,
     source: &str,
     lang: JsxLang,
     config: &JsxCompileConfig,
     babel_options: &BabelJsxOptions,
     pragma: Option<&str>,
+    merge_props: bool,
 ) -> JsxCompileOutput {
     let transform_on_helper =
         (config.compat.is_babel() && babel_options.transform_on && !config.ssr)
             .then(|| collision_free_transform_on_helper(source));
+    let merge_props = !config.compat.is_babel() || config.ssr || merge_props;
     let lowered = lower_source_with_compat(
         bump,
         source,
@@ -328,6 +314,7 @@ pub fn compile_jsx_with_babel_pragma(
                     VdomCompatOptions {
                         transform_on_helper: transform_on_helper.as_deref(),
                         vnode_factory,
+                        merge_props,
                     },
                     &mut diagnostics,
                 )),

--- a/crates/vize_atelier_jsx/src/compile/babel.rs
+++ b/crates/vize_atelier_jsx/src/compile/babel.rs
@@ -1,7 +1,70 @@
 use oxc_allocator::Allocator;
-use vize_carton::String;
+use vize_carton::{Bump, String};
 
+use super::{
+    BabelJsxOptions, JsxCompileConfig, JsxCompileOutput,
+    compile_jsx_with_babel_pragma_and_merge_props,
+};
 use crate::{JsxDiagnostic, JsxLang};
+
+/// Compile JSX/TSX with explicit `@vue/babel-plugin-jsx` option compatibility.
+pub fn compile_jsx_with_babel_options(
+    bump: &Bump,
+    source: &str,
+    lang: JsxLang,
+    config: &JsxCompileConfig,
+    babel_options: &BabelJsxOptions,
+) -> JsxCompileOutput {
+    compile_jsx_with_babel_pragma_and_merge_props(
+        bump,
+        source,
+        lang,
+        config,
+        babel_options,
+        None,
+        true,
+    )
+}
+
+/// Compile JSX/TSX with an optional Babel-compatible vnode factory pragma.
+pub fn compile_jsx_with_babel_pragma(
+    bump: &Bump,
+    source: &str,
+    lang: JsxLang,
+    config: &JsxCompileConfig,
+    babel_options: &BabelJsxOptions,
+    pragma: Option<&str>,
+) -> JsxCompileOutput {
+    compile_jsx_with_babel_pragma_and_merge_props(
+        bump,
+        source,
+        lang,
+        config,
+        babel_options,
+        pragma,
+        true,
+    )
+}
+
+/// Compile JSX/TSX with an explicit Babel-compatible `mergeProps` value.
+pub fn compile_jsx_with_babel_merge_props(
+    bump: &Bump,
+    source: &str,
+    lang: JsxLang,
+    config: &JsxCompileConfig,
+    babel_options: &BabelJsxOptions,
+    merge_props: bool,
+) -> JsxCompileOutput {
+    compile_jsx_with_babel_pragma_and_merge_props(
+        bump,
+        source,
+        lang,
+        config,
+        babel_options,
+        None,
+        merge_props,
+    )
+}
 
 pub(super) fn resolve_vnode_factory<'a>(
     pragma: Option<&'a str>,

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -55,7 +55,8 @@ use vize_relief::RootNode;
 pub use compat::JsxCompatMode;
 pub use compile::{
     BabelJsxOptions, JsxCompileConfig, JsxCompileOutput, JsxComponent, compile_jsx,
-    compile_jsx_with_babel_options, compile_jsx_with_babel_pragma, resolve_mode,
+    compile_jsx_with_babel_merge_props, compile_jsx_with_babel_options,
+    compile_jsx_with_babel_pragma, compile_jsx_with_babel_pragma_and_merge_props, resolve_mode,
 };
 pub use diagnostics::{JsxDiagnostic, Severity};
 pub use lang::JsxLang;

--- a/crates/vize_atelier_jsx/src/vdom.rs
+++ b/crates/vize_atelier_jsx/src/vdom.rs
@@ -11,7 +11,7 @@
 //! `_ctx.`. Static hoisting and handler caching default off for predictable,
 //! `@vue/babel-plugin-jsx`-shaped output; callers can opt in.
 
-use vize_atelier_core::codegen::{generate, generate_with_vnode_factory};
+use vize_atelier_core::codegen::generate_with_vnode_factory_and_merge_props;
 use vize_atelier_core::lane::transform;
 use vize_atelier_core::options::{CodegenMode, CodegenOptions, TransformOptions};
 // `CodegenMode::Module` is the only supported JSX target: JSX/TSX is authored
@@ -75,10 +75,21 @@ pub struct VdomOutput {
     pub diagnostics: Vec<JsxDiagnostic>,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct VdomCompatOptions<'a> {
     pub transform_on_helper: Option<&'a str>,
     pub vnode_factory: Option<&'a str>,
+    pub merge_props: bool,
+}
+
+impl Default for VdomCompatOptions<'_> {
+    fn default() -> Self {
+        Self {
+            transform_on_helper: None,
+            vnode_factory: None,
+            merge_props: true,
+        }
+    }
 }
 
 impl VdomOutput {
@@ -177,10 +188,12 @@ pub(crate) fn compile_root_to_vdom(
         scope_id: scoped_style.as_ref().map(|style| style.scope_id.clone()),
         ..Default::default()
     };
-    let result = match compat.vnode_factory {
-        Some(factory) => generate_with_vnode_factory(&root, codegen_opts, factory),
-        None => generate(&root, codegen_opts),
-    };
+    let result = generate_with_vnode_factory_and_merge_props(
+        &root,
+        codegen_opts,
+        compat.vnode_factory,
+        compat.merge_props,
+    );
     let mut preamble = result.preamble;
     if let Some(helper) = compat.transform_on_helper
         && result.code.contains(helper)

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   82 |
-| divergent  |   14 |
+| equivalent |   83 |
+| divergent  |   13 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -97,7 +97,7 @@ deliberate answer, recorded here so it is not relitigated.
 | `options/transform_on_on`           | wraps props in `_transformOn(...)`                  | `on` stays a prop by default                 | `BabelJsxOptions::transform_on` wraps via the helper | ✅      |
 | `options/pragma`                    | emits `h("div", …)`, no `vue` import                | always emits Vue runtime helpers             | custom factory via additive pragma API               | ✅      |
 | `options/merge_props_default`       | `mergeProps({class:"a"}, p, {class:c})`             | same                                         | no change                                            | ✅      |
-| `options/merge_props_false`         | one object literal with a duplicate key             | always merges via `mergeProps`               | add `mergeProps: false`                              | ❌      |
+| `options/merge_props_false`         | one object literal with a duplicate key             | always merges via `mergeProps`               | object spread + duplicate-key semantics (#3391)      | ✅      |
 | `options/is_custom_element_default` | `<my-el/>` → `resolveComponent("my-el")`            | same                                         | no change                                            | ✅      |
 | `options/is_custom_element_fn`      | matching tag becomes a string tag                   | always resolved as a component               | add `isCustomElement`                                | ❌      |
 | `options/object_slots_default`      | `_isSlot(slots) ? slots : {default: () => [slots]}` | `toDisplayString(slots)` in the default slot | treat a lone expression child as a slot object       | ❌      |

--- a/crates/vize_atelier_jsx/tests/babel_compat/mod.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/mod.rs
@@ -13,7 +13,8 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 use vize_atelier_jsx::{
-    BabelJsxOptions, JsxCompatMode, JsxCompileConfig, JsxLang, compile_jsx_with_babel_pragma,
+    BabelJsxOptions, JsxCompatMode, JsxCompileConfig, JsxLang,
+    compile_jsx_with_babel_pragma_and_merge_props,
 };
 use vize_carton::Bump;
 
@@ -173,7 +174,7 @@ pub fn load_recording() -> Recording {
 /// diagnosing case is a legitimate, recordable outcome.
 pub fn vize_vdom_output(case: &Case) -> std::string::String {
     let bump = Bump::new();
-    let out = compile_jsx_with_babel_pragma(
+    let out = compile_jsx_with_babel_pragma_and_merge_props(
         &bump,
         &case.source,
         case.jsx_lang(),
@@ -191,6 +192,10 @@ pub fn vize_vdom_output(case: &Case) -> std::string::String {
         case.babel_options
             .get("pragma")
             .and_then(serde_json::Value::as_str),
+        case.babel_options
+            .get("mergeProps")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(true),
     );
 
     let mut rendered = std::string::String::new();

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -16,7 +16,7 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("options/transform_on_on", Same),
     ("options/pragma", Same),
     ("options/merge_props_default", Same),
-    ("options/merge_props_false", Diff("no mergeProps option")),
+    ("options/merge_props_false", Same),
     ("options/is_custom_element_default", Same),
     (
         "options/is_custom_element_fn",

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (82, 14, 2));
+    assert_eq!((equivalent, divergent, deferred), (83, 13, 2));
     assert_eq!(VERDICTS.len(), 98);
 }
 

--- a/crates/vize_atelier_jsx/tests/babel_merge_props.rs
+++ b/crates/vize_atelier_jsx/tests/babel_merge_props.rs
@@ -1,0 +1,215 @@
+//! Babel JSX `mergeProps` option compatibility.
+
+use oxc_allocator::Allocator;
+use vize_atelier_jsx::{
+    BabelJsxOptions, JsxCompatMode, JsxCompileConfig, JsxLang, JsxOutputMode, compile_jsx,
+    compile_jsx_with_babel_merge_props, compile_jsx_with_babel_pragma_and_merge_props,
+    parse_module,
+};
+use vize_carton::Bump;
+
+fn compile_module(source: &str, compat: JsxCompatMode, mode: JsxOutputMode) -> String {
+    let bump = Bump::new();
+    let config = JsxCompileConfig {
+        default_mode: mode,
+        compat,
+        ..Default::default()
+    };
+    compile_jsx(&bump, source, JsxLang::Jsx, &config)
+        .module_code()
+        .to_string()
+}
+
+fn compile_with_merge_props(
+    source: &str,
+    compat: JsxCompatMode,
+    mode: JsxOutputMode,
+    merge_props: bool,
+) -> (String, Vec<String>) {
+    let bump = Bump::new();
+    let out = compile_jsx_with_babel_merge_props(
+        &bump,
+        source,
+        JsxLang::Jsx,
+        &JsxCompileConfig {
+            default_mode: mode,
+            compat,
+            ..Default::default()
+        },
+        &BabelJsxOptions::default(),
+        merge_props,
+    );
+    let diagnostics = out
+        .diagnostics
+        .iter()
+        .map(|diagnostic| format!("{:?}: {}", diagnostic.severity, diagnostic.message))
+        .collect();
+    (out.module_code().to_string(), diagnostics)
+}
+
+#[test]
+fn false_uses_object_spread_and_javascript_overwrite_order() {
+    let target = "const A = () => <div class=\"a\" {...p} class={c}/>;";
+    let (first, diagnostics) =
+        compile_with_merge_props(target, JsxCompatMode::Babel, JsxOutputMode::Vdom, false);
+    let (second, second_diagnostics) =
+        compile_with_merge_props(target, JsxCompatMode::Babel, JsxOutputMode::Vdom, false);
+
+    assert_eq!(first, second, "the option must be deterministic");
+    assert_eq!(diagnostics, second_diagnostics);
+    assert!(diagnostics.is_empty(), "{diagnostics:?}\n{first}");
+    assert!(!first.contains("_mergeProps"), "{first}");
+    assert!(!first.contains("_normalizeClass"), "{first}");
+    let static_class = first.find("class: \"a\"").unwrap();
+    let spread = first.find("...p").unwrap();
+    let dynamic_class = first.find("class: c").unwrap();
+    assert!(static_class < spread && spread < dynamic_class, "{first}");
+
+    let (spread_only, diagnostics) = compile_with_merge_props(
+        "const A = () => <div {...p}/>;",
+        JsxCompatMode::Babel,
+        JsxOutputMode::Vdom,
+        false,
+    );
+    assert!(diagnostics.is_empty(), "{diagnostics:?}\n{spread_only}");
+    assert!(
+        spread_only.contains("createElementBlock(\"div\", p, null"),
+        "{spread_only}"
+    );
+    assert!(!spread_only.contains("...p"), "{spread_only}");
+
+    let (multiple, diagnostics) = compile_with_merge_props(
+        "const A = () => <Comp {...a} id={x} {...b}/>;",
+        JsxCompatMode::Babel,
+        JsxOutputMode::Vdom,
+        false,
+    );
+    assert!(diagnostics.is_empty(), "{diagnostics:?}\n{multiple}");
+    let first_spread = multiple.find("...a").unwrap();
+    let middle = multiple.find("id: x").unwrap();
+    let second_spread = multiple.find("...b").unwrap();
+    assert!(
+        first_spread < middle && middle < second_spread,
+        "{multiple}"
+    );
+
+    let (parenthesized, diagnostics) = compile_with_merge_props(
+        "const A = () => <button {...(ok ? a : b)} id=\"x\"/>;",
+        JsxCompatMode::Babel,
+        JsxOutputMode::Vdom,
+        false,
+    );
+    assert!(diagnostics.is_empty(), "{diagnostics:?}\n{parenthesized}");
+    assert!(parenthesized.contains("...(ok ? a : b)"), "{parenthesized}");
+    assert_parseable(&parenthesized);
+
+    let (duplicates, diagnostics) = compile_with_merge_props(
+        concat!(
+            "const A = () => <button class=\"a\" class={c}/>;\n",
+            "const B = () => <button id=\"a\" id=\"b\"/>;\n",
+            "const C = () => <button onClick={a} onClick={b}/>;",
+        ),
+        JsxCompatMode::Babel,
+        JsxOutputMode::Vdom,
+        false,
+    );
+    assert!(diagnostics.is_empty(), "{diagnostics:?}\n{duplicates}");
+    assert_eq!(
+        duplicates.matches("class: \"a\"").count(),
+        1,
+        "{duplicates}"
+    );
+    assert_eq!(duplicates.matches("class: c").count(), 1, "{duplicates}");
+    assert!(duplicates.contains("id: \"a\""), "{duplicates}");
+    assert!(duplicates.contains("id: \"b\""), "{duplicates}");
+    assert_eq!(duplicates.matches("onClick:").count(), 2, "{duplicates}");
+    assert!(!duplicates.contains("onClick: ["), "{duplicates}");
+    assert_parseable(&duplicates);
+}
+
+#[test]
+fn option_is_inert_by_default_in_native_vapor_and_ssr() {
+    let source = "const A = () => <div class=\"a\" {...p} class={c}/>;";
+
+    let babel_default = compile_module(source, JsxCompatMode::Babel, JsxOutputMode::Vdom);
+    let (babel_true, diagnostics) =
+        compile_with_merge_props(source, JsxCompatMode::Babel, JsxOutputMode::Vdom, true);
+    assert!(diagnostics.is_empty());
+    assert_eq!(babel_true, babel_default);
+    assert!(babel_default.contains("_mergeProps"), "{babel_default}");
+
+    let native = compile_module(source, JsxCompatMode::Native, JsxOutputMode::Vdom);
+    let (native_false, diagnostics) =
+        compile_with_merge_props(source, JsxCompatMode::Native, JsxOutputMode::Vdom, false);
+    assert!(diagnostics.is_empty());
+    assert_eq!(native_false, native);
+
+    let (vapor_true, vapor_true_diagnostics) =
+        compile_with_merge_props(source, JsxCompatMode::Babel, JsxOutputMode::Vapor, true);
+    let (vapor_false, vapor_false_diagnostics) =
+        compile_with_merge_props(source, JsxCompatMode::Babel, JsxOutputMode::Vapor, false);
+    assert_eq!(vapor_false, vapor_true);
+    assert_eq!(vapor_false_diagnostics, vapor_true_diagnostics);
+    assert_eq!(vapor_false_diagnostics.len(), 1);
+
+    let compile_ssr = |merge_props| {
+        let bump = Bump::new();
+        let out = compile_jsx_with_babel_merge_props(
+            &bump,
+            source,
+            JsxLang::Jsx,
+            &JsxCompileConfig {
+                compat: JsxCompatMode::Babel,
+                ssr: true,
+                ..Default::default()
+            },
+            &BabelJsxOptions::default(),
+            merge_props,
+        );
+        (
+            out.module_code().to_string(),
+            out.diagnostics
+                .iter()
+                .map(|diagnostic| diagnostic.message.to_string())
+                .collect::<Vec<_>>(),
+        )
+    };
+    assert_eq!(compile_ssr(false), compile_ssr(true));
+}
+
+#[test]
+fn false_composes_with_a_custom_pragma() {
+    let bump = Bump::new();
+    let out = compile_jsx_with_babel_pragma_and_merge_props(
+        &bump,
+        "const A = () => <div class=\"a\" {...p} class={c}/>;",
+        JsxLang::Jsx,
+        &JsxCompileConfig {
+            compat: JsxCompatMode::Babel,
+            ..Default::default()
+        },
+        &BabelJsxOptions::default(),
+        Some("h"),
+        false,
+    );
+    let output = out.module_code();
+    assert!(
+        out.diagnostics.is_empty(),
+        "{:?}\n{output}",
+        out.diagnostics
+    );
+    assert!(!output.contains("from \"vue\""), "{output}");
+    assert!(!output.contains("_mergeProps"), "{output}");
+    assert!(output.contains("h(\"div\", {"), "{output}");
+    assert!(output.contains("...p"), "{output}");
+}
+
+fn assert_parseable(output: &str) {
+    let allocator = Allocator::default();
+    let parsed = parse_module(&allocator, output, JsxLang::Jsx);
+    assert!(
+        parsed.diagnostics.is_empty(),
+        "{:?}\n{output}",
+        parsed.diagnostics
+    );
+}

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__options.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__options.snap
@@ -81,7 +81,7 @@ export function render(_ctx, _cache) {
 
 ## options/merge_props_false
 ### verdict
-divergent: no mergeProps option
+equivalent
 ### source (jsx)
 const A = () => <div class="a" {...p} class={c}/>;
 ### babel options
@@ -94,11 +94,13 @@ const A = () => _createVNode("div", {
   "class": c
 }, null);
 ### vize (vdom, babel compat)
-import { mergeProps as _mergeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", _mergeProps({ class: "a" }, p, {
+  return (_openBlock(), _createElementBlock("div", {
+    class: "a",
+    ...p,
     class: c
-  }), null, 16 /* FULL_PROPS */))
+  }, null, 16 /* FULL_PROPS */))
 }
 
 ## options/is_custom_element_default


### PR DESCRIPTION
## Summary

- emit authored-order object spreads when Babel compatibility uses `mergeProps: false`
- preserve JavaScript overwrite behavior for duplicate class, style, event, and static keys
- keep the default, Native, Vapor, and SSR paths unchanged
- mark `options/merge_props_false` equivalent in the pinned Babel 2.0.1 inventory

## Why

Vize always routed JSX prop spreads through Vue's `mergeProps` helper. Babel's disabled option instead emits a single object literal, so duplicate keys follow normal JavaScript overwrite order. The new additive compile entry point carries that option without adding a field to an existing constructible public struct.

## Validation

- `cargo test -p vize_atelier_core -p vize_atelier_jsx`
- `cargo test -p vize_atelier_jsx --test compat_mode`
- `cargo clippy -p vize_atelier_core -p vize_atelier_jsx --lib -- -D warnings`
- `cargo semver-checks check-release --package vize_atelier_core --baseline-rev origin/main`
- `node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check`
- `node --test tests/tooling/babel-jsx-oracle.test.ts`

Refs #3391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable prop-merging behavior for JSX compilation.
  * Added support for disabling prop merging while preserving correct spread ordering, duplicate-property handling, event listeners, and bindings.
  * Added a public compilation option for Babel-compatible JSX workflows.
* **Bug Fixes**
  * Improved compatibility with Babel’s disabled prop-merging behavior.
* **Tests**
  * Expanded coverage for spreads, duplicate props, deterministic output, diagnostics, and mode-specific behavior.
  * Babel compatibility results improved from 81 to 82 equivalent cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->