### PR TITLE
feat(nuxt): add lint plan DevTools inspector

### DIFF
--- a/npm/framework/nuxt/src/index.ts
+++ b/npm/framework/nuxt/src/index.ts
@@ -1,7 +1,7 @@
 import { createNuxtComponentResolver, injectNuxtComponentImports } from "./components";
 import { injectNuxtI18nHelpers } from "./i18n";
 import { setupNuxtLintChecker } from "./lint/checker/setup";
-import { setupNuxtLintConfigGeneration, setupNuxtLintInspector } from "./lint/generation";
+import { setupLintInspector, setupNuxtLintConfigGeneration } from "./lint/generation";
 import { appendMuseaArtComponentIgnore } from "./musea-components";
 import { registerNuxtMuseaStaticPublicAsset } from "./musea-static";
 import "./schema";
@@ -357,7 +357,7 @@ async function setupVizeNuxtModule(options: VizeNuxtOptions, nuxt: NuxtWithBuild
       vueVersion,
     },
   );
-  setupNuxtLintInspector(compilerOptions, lintGeneration, nuxt.options.dev !== false);
+  await setupLintInspector(options.lint, nuxt, compilerOptions, lintGeneration, nuxt.options.dev);
   const usesVizeCompiler = shouldUseVizeCompiler(compilerOptions);
   if (compilerOptions !== false && compilerOptions.compatibility?.hostCompiler !== true) {
     const { default: vize } = await import("@vizejs/vite-plugin");

--- a/npm/framework/nuxt/src/lint/generation.ts
+++ b/npm/framework/nuxt/src/lint/generation.ts
@@ -48,7 +48,7 @@ export interface NuxtLintConfigGeneration {
   resolvePlan(fresh?: boolean): Promise<readonly NuxtLintConfigItem[]>;
 }
 
-export { setupNuxtLintInspector } from "./inspector.ts";
+export { setupLintInspector } from "./inspector.ts";
 
 function isNotFound(error: unknown): boolean {
   return (error as NodeJS.ErrnoException).code === "ENOENT";

--- a/npm/framework/nuxt/src/lint/inspector-devtools.test.ts
+++ b/npm/framework/nuxt/src/lint/inspector-devtools.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import { request } from "node:http";
+import { createServer as createNetServer } from "node:net";
+import test from "node:test";
+
+import {
+  resolveNuxtLintDevtoolsOptions,
+  setupNuxtLintDevtools,
+  type NuxtLintDevtoolsNuxt,
+} from "./inspector-devtools.ts";
+import { renderNuxtLintInspectorHtml } from "./inspector-view.ts";
+
+type Hook = (...args: unknown[]) => unknown;
+
+function createNuxt() {
+  const hooks = new Map<string, Hook>();
+  const refreshes: string[] = [];
+  const nuxt: NuxtLintDevtoolsNuxt = {
+    hook(name, callback) {
+      hooks.set(name, callback);
+    },
+    callHook(name) {
+      refreshes.push(name);
+    },
+  };
+  return { hooks, nuxt, refreshes };
+}
+
+async function rawRequest(
+  url: URL,
+  options: { host?: string; method?: string } = {},
+): Promise<{
+  body: string;
+  headers: Record<string, string | string[] | undefined>;
+  status: number;
+}> {
+  return new Promise((resolve, reject) => {
+    const current = request(
+      url,
+      { headers: options.host ? { host: options.host } : undefined, method: options.method },
+      (response) => {
+        const chunks: Buffer[] = [];
+        response.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        response.on("end", () => {
+          resolve({
+            body: Buffer.concat(chunks).toString(),
+            headers: response.headers,
+            status: response.statusCode ?? 0,
+          });
+        });
+      },
+    );
+    current.once("error", reject);
+    current.end();
+  });
+}
+
+async function availablePort(): Promise<number> {
+  const server = createNetServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen({ host: "127.0.0.1", port: 0 }, resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return address.port;
+}
+
+void test("lint inspector DevTools options default to lazy and validate ports", () => {
+  assert.deepEqual(resolveNuxtLintDevtoolsOptions(undefined), {
+    enabled: "lazy",
+    port: undefined,
+  });
+  assert.deepEqual(resolveNuxtLintDevtoolsOptions({ enabled: true, port: 4187 }), {
+    enabled: true,
+    port: 4187,
+  });
+  for (const port of [0, 65_536, 1.5]) {
+    assert.throws(() => resolveNuxtLintDevtoolsOptions({ port }), RangeError);
+  }
+});
+
+void test("disabled lint inspector does not register hooks", async () => {
+  const { hooks, nuxt } = createNuxt();
+  assert.equal(await setupNuxtLintDevtools({ enabled: false }, nuxt, () => ({})), undefined);
+  assert.equal(hooks.size, 0);
+});
+
+void test("lazy lint inspector launches a hardened UI and forwards API requests", async (t) => {
+  const { hooks, nuxt, refreshes } = createNuxt();
+  const requests: unknown[] = [];
+  const controller = await setupNuxtLintDevtools({ enabled: "lazy" }, nuxt, (input) => {
+    requests.push(input);
+    return {
+      schema: "vize.inspector.lint-plan",
+      version: 1,
+      root: "/project",
+      items: [],
+      files: [],
+    };
+  });
+  assert.ok(controller);
+  t.after(() => controller.close());
+
+  const tabs: unknown[] = [];
+  hooks.get("devtools:customTabs")?.(tabs);
+  const lazyTab = tabs[0] as {
+    requireAuth: boolean;
+    view: { actions: Array<{ handle(): Promise<void> }>; type: string };
+  };
+  assert.equal(lazyTab.requireAuth, true);
+  assert.equal(lazyTab.view.type, "launch");
+  await lazyTab.view.actions[0]?.handle();
+  assert.deepEqual(refreshes, ["devtools:customTabs:refresh"]);
+
+  const viewer = new URL(controller.url() ?? "");
+  const html = await rawRequest(viewer);
+  assert.equal(html.status, 200);
+  assert.match(html.body, /Project-relative file/u);
+  assert.equal(html.headers["cache-control"], "no-store");
+  assert.equal(html.headers["cross-origin-resource-policy"], "cross-origin");
+  assert.equal(html.headers["x-content-type-options"], "nosniff");
+  assert.match(String(html.headers["content-security-policy"]), /default-src 'none'/u);
+
+  const api = new URL("api?file=app.vue&fresh=1", viewer);
+  const response = await rawRequest(api);
+  assert.equal(response.status, 200);
+  assert.deepEqual(JSON.parse(response.body), {
+    schema: "vize.inspector.lint-plan",
+    version: 1,
+    root: "/project",
+    items: [],
+    files: [],
+  });
+  assert.deepEqual(requests, [{ files: ["app.vue"], fresh: true }]);
+
+  assert.equal((await rawRequest(api, { method: "POST" })).status, 405);
+  assert.equal((await rawRequest(api, { host: "example.com" })).status, 421);
+  assert.equal((await rawRequest(new URL("api?file=../secret", viewer))).status, 400);
+  const head = await rawRequest(viewer, { method: "HEAD" });
+  assert.equal(head.status, 200);
+  assert.equal(head.body, "");
+  assert.ok(Number(head.headers["content-length"]) > 0);
+});
+
+void test("eager lint inspector starts immediately and closes with Nuxt", async () => {
+  const { hooks, nuxt } = createNuxt();
+  const port = await availablePort();
+  const controller = await setupNuxtLintDevtools({ enabled: true, port }, nuxt, () => ({
+    ok: true,
+  }));
+  assert.ok(controller?.url());
+  assert.equal(new URL(controller.url() ?? "").port, String(port));
+
+  const tabs: unknown[] = [];
+  hooks.get("devtools:customTabs")?.(tabs);
+  assert.equal((tabs[0] as { view: { type: string } }).view.type, "iframe");
+  await hooks.get("close")?.();
+  assert.equal(controller?.url(), undefined);
+});
+
+void test("lint inspector close waits for an in-flight lazy start", async () => {
+  const { nuxt } = createNuxt();
+  const controller = await setupNuxtLintDevtools({ enabled: "lazy" }, nuxt, () => ({}));
+  assert.ok(controller);
+  const starting = controller.start();
+  await controller.close();
+  await starting;
+  assert.equal(controller.url(), undefined);
+  await assert.rejects(controller.start(), /closed/u);
+});
+
+void test("lint inspector UI avoids HTML injection sinks", () => {
+  const html = renderNuxtLintInspectorHtml("nonce");
+  assert.doesNotMatch(html, /innerHTML|outerHTML|insertAdjacentHTML/u);
+  assert.match(html, /textContent/u);
+});
+
+void test("lint inspector hides provider failures and caps responses", async (t) => {
+  const first = createNuxt();
+  const failed = await setupNuxtLintDevtools({ enabled: true }, first.nuxt, () => {
+    throw new Error("private path");
+  });
+  assert.ok(failed);
+  t.after(() => failed.close());
+  const error = await rawRequest(new URL("api", failed.url()));
+  assert.equal(error.status, 500);
+  assert.equal(error.body, '{"error":"inspector_lint_plan_failed"}');
+  assert.doesNotMatch(error.body, /private path/u);
+
+  const second = createNuxt();
+  const oversized = await setupNuxtLintDevtools({ enabled: true }, second.nuxt, () => ({
+    value: "x".repeat(4 * 1024 * 1024),
+  }));
+  assert.ok(oversized);
+  t.after(() => oversized.close());
+  assert.equal((await rawRequest(new URL("api", oversized.url()))).status, 413);
+});

--- a/npm/framework/nuxt/src/lint/inspector-devtools.ts
+++ b/npm/framework/nuxt/src/lint/inspector-devtools.ts
@@ -1,0 +1,284 @@
+import { randomBytes } from "node:crypto";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { VizeNuxtInspectorLintPlanRequest } from "../compiler-options.ts";
+import type { VizeNuxtLintDevtoolsOptions } from "./options.ts";
+import { renderNuxtLintInspectorHtml } from "./inspector-view.ts";
+
+const MAX_URL_BYTES = 8 * 1024;
+const MAX_FILES = 128;
+const MAX_FILE_BYTES = 4 * 1024;
+const MAX_RESPONSE_BYTES = 4 * 1024 * 1024;
+
+type Awaitable<T> = T | Promise<T>;
+export type NuxtLintPlanProvider = (
+  request: VizeNuxtInspectorLintPlanRequest,
+) => Awaitable<unknown>;
+
+interface NuxtDevtoolsTab {
+  name: string;
+  title: string;
+  icon: string;
+  requireAuth: boolean;
+  view:
+    | { type: "iframe"; src: string; persistent: boolean }
+    | {
+        type: "launch";
+        description: string;
+        actions: Array<{ label: string; pending: boolean; handle: () => Promise<void> }>;
+      };
+}
+
+export interface NuxtLintDevtoolsNuxt {
+  hook(name: string, callback: (...args: unknown[]) => unknown): void;
+  callHook?(name: string, ...args: unknown[]): Awaitable<unknown>;
+}
+
+export interface ResolvedNuxtLintDevtoolsOptions {
+  enabled: boolean | "lazy";
+  port: number | undefined;
+}
+
+export interface NuxtLintDevtoolsController {
+  close(): Promise<void>;
+  start(): Promise<void>;
+  tab(): NuxtDevtoolsTab;
+  url(): string | undefined;
+}
+
+export function resolveNuxtLintDevtoolsOptions(
+  options: VizeNuxtLintDevtoolsOptions | undefined,
+): ResolvedNuxtLintDevtoolsOptions {
+  const enabled = options?.enabled ?? "lazy";
+  const port = options?.port;
+  if (port !== undefined && (!Number.isInteger(port) || port < 1 || port > 65_535)) {
+    throw new RangeError("Nuxt lint inspector port must be an integer from 1 to 65535");
+  }
+  return { enabled, port };
+}
+
+export async function setupNuxtLintDevtools(
+  options: VizeNuxtLintDevtoolsOptions | undefined,
+  nuxt: NuxtLintDevtoolsNuxt,
+  provider: NuxtLintPlanProvider,
+): Promise<NuxtLintDevtoolsController | undefined> {
+  const resolved = resolveNuxtLintDevtoolsOptions(options);
+  if (resolved.enabled === false) return undefined;
+
+  const controller = createController(resolved.port, provider, nuxt);
+  nuxt.hook("devtools:customTabs", (...args) => {
+    const tabs = args[0] as NuxtDevtoolsTab[];
+    tabs.push(controller.tab());
+  });
+  nuxt.hook("close", () => controller.close());
+  if (resolved.enabled === true) await controller.start();
+  return controller;
+}
+
+function createController(
+  requestedPort: number | undefined,
+  provider: NuxtLintPlanProvider,
+  nuxt: NuxtLintDevtoolsNuxt,
+): NuxtLintDevtoolsController {
+  const token = randomBytes(18).toString("base64url");
+  const nonce = randomBytes(18).toString("base64url");
+  const server = createServer((request, response) => {
+    void handleRequest(request, response, provider, token, nonce, server);
+  });
+  let closed = false;
+  let startPromise: Promise<void> | undefined;
+  let viewerUrl: string | undefined;
+
+  const start = async (): Promise<void> => {
+    if (closed) throw new Error("Nuxt lint inspector is closed");
+    if (viewerUrl) return;
+    startPromise ||= listen(server, requestedPort).then(async (port) => {
+      viewerUrl = `http://127.0.0.1:${port}/${token}/`;
+      await nuxt.callHook?.("devtools:customTabs:refresh");
+    });
+    try {
+      await startPromise;
+    } catch (error) {
+      startPromise = undefined;
+      throw error;
+    }
+  };
+
+  return {
+    async close() {
+      closed = true;
+      try {
+        await startPromise;
+      } catch {
+        // A failed listener has nothing left to close.
+      }
+      if (!server.listening) return;
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
+      });
+      viewerUrl = undefined;
+      startPromise = undefined;
+    },
+    start,
+    tab() {
+      return {
+        name: "vize-nuxt-lint-plan",
+        title: "Vize Nuxt Lint Plan",
+        icon: "carbon:rule",
+        requireAuth: true,
+        view: viewerUrl
+          ? { type: "iframe", src: viewerUrl, persistent: true }
+          : {
+              type: "launch",
+              description: "Inspect the effective Vize lint rules for any Nuxt source file.",
+              actions: [{ label: "Launch", pending: startPromise !== undefined, handle: start }],
+            },
+      };
+    },
+    url: () => viewerUrl,
+  };
+}
+
+function listen(server: Server, port: number | undefined): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off("listening", onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off("error", onError);
+      resolve((server.address() as AddressInfo).port);
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen({ host: "127.0.0.1", port: port ?? 0, exclusive: true });
+  });
+}
+
+async function handleRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  provider: NuxtLintPlanProvider,
+  token: string,
+  nonce: string,
+  server: Server,
+): Promise<void> {
+  if (Buffer.byteLength(request.url ?? "") > MAX_URL_BYTES) {
+    sendJson(response, 414, { error: "request_uri_too_long" });
+    return;
+  }
+  const port = (server.address() as AddressInfo | null)?.port;
+  if (!port || ![`127.0.0.1:${port}`, `localhost:${port}`].includes(request.headers.host ?? "")) {
+    sendJson(response, 421, { error: "misdirected_request" });
+    return;
+  }
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    response.setHeader("allow", "GET, HEAD");
+    sendJson(response, 405, { error: "method_not_allowed" });
+    return;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(request.url ?? "", "http://localhost");
+  } catch {
+    sendJson(response, 400, { error: "invalid_url" }, request.method === "HEAD");
+    return;
+  }
+  const rootPath = `/${token}/`;
+  if (url.pathname === rootPath && url.search === "") {
+    sendHtml(response, renderNuxtLintInspectorHtml(nonce), nonce, request.method === "HEAD");
+    return;
+  }
+  if (url.pathname !== `${rootPath}api`) {
+    sendJson(response, 404, { error: "not_found" }, request.method === "HEAD");
+    return;
+  }
+
+  const parsed = parseApiRequest(url);
+  if ("error" in parsed) {
+    sendJson(response, parsed.status, { error: parsed.error }, request.method === "HEAD");
+    return;
+  }
+  try {
+    sendJson(response, 200, await provider(parsed.request), request.method === "HEAD");
+  } catch {
+    sendJson(response, 500, { error: "inspector_lint_plan_failed" }, request.method === "HEAD");
+  }
+}
+
+function parseApiRequest(
+  url: URL,
+): { request: VizeNuxtInspectorLintPlanRequest } | { status: number; error: string } {
+  for (const key of url.searchParams.keys()) {
+    if (key !== "file" && key !== "fresh") return { status: 400, error: "invalid_query" };
+  }
+  const fresh = url.searchParams.getAll("fresh");
+  if (fresh.length > 1 || (fresh[0] !== undefined && fresh[0] !== "1")) {
+    return { status: 400, error: "invalid_fresh" };
+  }
+  const requested = url.searchParams.getAll("file");
+  if (requested.length > MAX_FILES) return { status: 413, error: "too_many_files" };
+  const files = [...new Set(requested)];
+  if (files.some((file) => !isSafeFile(file))) return { status: 400, error: "invalid_file" };
+  return { request: { files, fresh: fresh[0] === "1" } };
+}
+
+function isSafeFile(file: string): boolean {
+  return (
+    file.length > 0 &&
+    Buffer.byteLength(file) <= MAX_FILE_BYTES &&
+    !file.includes("\0") &&
+    !file.includes("\\") &&
+    !file.startsWith("/") &&
+    !/^[A-Za-z]:/u.test(file) &&
+    !file.split("/").some((part) => part.length === 0 || part === "..")
+  );
+}
+
+function setCommonHeaders(
+  response: ServerResponse,
+  resourcePolicy: "cross-origin" | "same-origin",
+): void {
+  response.setHeader("cache-control", "no-store");
+  response.setHeader("cross-origin-resource-policy", resourcePolicy);
+  response.setHeader("referrer-policy", "no-referrer");
+  response.setHeader("x-content-type-options", "nosniff");
+}
+
+function sendHtml(response: ServerResponse, body: string, nonce: string, headOnly: boolean): void {
+  response.statusCode = 200;
+  setCommonHeaders(response, "cross-origin");
+  response.setHeader(
+    "content-security-policy",
+    `default-src 'none'; script-src 'nonce-${nonce}'; style-src 'nonce-${nonce}'; connect-src 'self'; frame-ancestors http://localhost:* http://127.0.0.1:*`,
+  );
+  response.setHeader("content-type", "text/html; charset=utf-8");
+  response.setHeader("content-length", Buffer.byteLength(body));
+  response.end(headOnly ? undefined : body);
+}
+
+function sendJson(
+  response: ServerResponse,
+  status: number,
+  payload: unknown,
+  headOnly = false,
+): void {
+  let body = JSON.stringify(payload);
+  if (body === undefined) {
+    status = 500;
+    body = JSON.stringify({ error: "inspector_lint_plan_failed" });
+  }
+  if (Buffer.byteLength(body) > MAX_RESPONSE_BYTES) {
+    status = 413;
+    body = JSON.stringify({ error: "inspector_response_too_large" });
+  }
+  response.statusCode = status;
+  setCommonHeaders(response, "same-origin");
+  response.setHeader("content-security-policy", "default-src 'none'");
+  response.setHeader("content-type", "application/json; charset=utf-8");
+  response.setHeader("content-length", Buffer.byteLength(body));
+  response.end(headOnly ? undefined : body);
+}

--- a/npm/framework/nuxt/src/lint/inspector-view.ts
+++ b/npm/framework/nuxt/src/lint/inspector-view.ts
@@ -1,0 +1,138 @@
+/** Render the dependency-free UI served by the in-process lint-plan inspector. */
+export function renderNuxtLintInspectorHtml(nonce: string): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Vize Nuxt Lint Plan</title>
+  <style nonce="${nonce}">
+    :root { color-scheme: light dark; font: 14px/1.5 ui-sans-serif, system-ui, sans-serif; }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: #0d1117; color: #e6edf3; }
+    header { position: sticky; top: 0; z-index: 1; padding: 16px 20px; background: #161b22; border-bottom: 1px solid #30363d; }
+    h1 { margin: 0 0 12px; font-size: 18px; }
+    h2 { margin: 24px 0 10px; font-size: 16px; }
+    form { display: flex; gap: 8px; flex-wrap: wrap; }
+    input { flex: 1 1 320px; min-width: 180px; padding: 8px 10px; color: inherit; background: #0d1117; border: 1px solid #484f58; border-radius: 6px; }
+    button { padding: 8px 12px; color: #fff; background: #238636; border: 0; border-radius: 6px; cursor: pointer; }
+    button.secondary { background: #30363d; }
+    button:disabled { opacity: .6; cursor: wait; }
+    main { max-width: 1100px; margin: 0 auto; padding: 0 20px 32px; }
+    #status { min-height: 22px; margin-top: 8px; color: #8c959f; }
+    #status.error { color: #ff7b72; }
+    .card { margin: 8px 0; padding: 12px; background: #161b22; border: 1px solid #30363d; border-radius: 8px; }
+    .meta { color: #8c959f; overflow-wrap: anywhere; }
+    .badge { display: inline-block; margin: 2px 4px 2px 0; padding: 1px 6px; border-radius: 10px; background: #30363d; }
+    .severity-error { color: #ff7b72; } .severity-warn { color: #d29922; } .severity-off { color: #8c959f; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 7px 8px; text-align: left; border-bottom: 1px solid #30363d; overflow-wrap: anywhere; }
+    th { color: #8c959f; font-weight: 600; }
+    code { font-family: ui-monospace, SFMono-Regular, Consolas, monospace; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Vize Nuxt Lint Plan</h1>
+    <form id="inspect-form">
+      <input id="file" name="file" autocomplete="off" placeholder="app/pages/index.vue" aria-label="Project-relative file">
+      <button type="submit">Inspect file</button>
+      <button id="refresh" class="secondary" type="button">Refresh plan</button>
+    </form>
+    <div id="status" role="status" aria-live="polite"></div>
+  </header>
+  <main>
+    <section><h2>Effective rules</h2><div id="effective"></div></section>
+    <section><h2>Ordered config items</h2><div id="items"></div></section>
+  </main>
+  <script nonce="${nonce}">
+    const fileInput = document.getElementById("file");
+    const form = document.getElementById("inspect-form");
+    const refresh = document.getElementById("refresh");
+    const status = document.getElementById("status");
+    const effective = document.getElementById("effective");
+    const items = document.getElementById("items");
+    const buttons = Array.from(document.querySelectorAll("button"));
+
+    function node(tag, text, className) {
+      const value = document.createElement(tag);
+      if (text !== undefined) value.textContent = String(text);
+      if (className) value.className = className;
+      return value;
+    }
+
+    function badges(values) {
+      const wrapper = node("div");
+      for (const value of values || []) wrapper.append(node("span", value, "badge"));
+      return wrapper;
+    }
+
+    function renderItems(payload) {
+      items.replaceChildren();
+      for (const item of payload.items || []) {
+        const card = node("article", undefined, "card");
+        card.append(node("strong", item.name || "unnamed"));
+        if (item.globalIgnore) card.append(node("span", " global ignore", "meta"));
+        if (item.basePath) card.append(node("div", "base: " + item.basePath, "meta"));
+        if (item.files) card.append(node("div", "files", "meta"), badges(item.files));
+        if (item.ignores && item.ignores.length) card.append(node("div", "ignores", "meta"), badges(item.ignores));
+        const rules = Object.entries(item.rules || {});
+        if (rules.length) card.append(badges(rules.map(([name, severity]) => name + ": " + severity)));
+        items.append(card);
+      }
+    }
+
+    function renderEffective(payload) {
+      effective.replaceChildren();
+      const file = payload.files && payload.files[0];
+      if (!file) {
+        effective.append(node("p", "Enter a project-relative file to explain its effective rules.", "meta"));
+        return;
+      }
+      const summary = node("div", undefined, "card");
+      summary.append(node("strong", file.path));
+      if (file.ignored) summary.append(node("div", "Ignored by: " + (file.ignoredBy || []).join(", "), "severity-warn"));
+      else summary.append(node("div", "Matched: " + (file.matchedItems || []).join(" → "), "meta"));
+      effective.append(summary);
+      if (!file.rules || !file.rules.length) return;
+      const table = node("table");
+      const head = node("tr");
+      for (const label of ["Rule", "Severity", "Set by"]) head.append(node("th", label));
+      const thead = node("thead"); thead.append(head); table.append(thead);
+      const tbody = node("tbody");
+      for (const rule of file.rules) {
+        const row = node("tr");
+        row.append(node("td", rule.name), node("td", rule.severity, "severity-" + rule.severity), node("td", rule.setBy));
+        tbody.append(row);
+      }
+      table.append(tbody); effective.append(table);
+    }
+
+    async function load(fresh) {
+      const url = new URL("api", location.href);
+      const file = fileInput.value.trim();
+      if (file) url.searchParams.set("file", file);
+      if (fresh) url.searchParams.set("fresh", "1");
+      buttons.forEach(button => { button.disabled = true; });
+      status.className = ""; status.textContent = fresh ? "Refreshing…" : "Loading…";
+      try {
+        const response = await fetch(url, { headers: { accept: "application/json" } });
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload.error || "Inspector request failed");
+        renderEffective(payload); renderItems(payload);
+        status.textContent = "Resolved " + payload.items.length + " config items";
+      } catch (error) {
+        status.className = "error";
+        status.textContent = error instanceof Error ? error.message : String(error);
+      } finally {
+        buttons.forEach(button => { button.disabled = false; });
+      }
+    }
+
+    form.addEventListener("submit", event => { event.preventDefault(); void load(false); });
+    refresh.addEventListener("click", () => { void load(true); });
+    void load(false);
+  </script>
+</body>
+</html>`;
+}

--- a/npm/framework/nuxt/src/lint/inspector.test.ts
+++ b/npm/framework/nuxt/src/lint/inspector.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import type { VizeNuxtCompilerOptions } from "../compiler-options.ts";
-import { createNuxtLintInspectorProvider, setupNuxtLintInspector } from "./inspector.ts";
+import { createNuxtLintInspectorProvider, setupLintInspector } from "./inspector.ts";
 
 const payload = {
   schema: "vize.inspector.lint-plan",
@@ -60,7 +60,7 @@ void test("Nuxt lint inspector rejects malformed native payloads", async () => {
   await assert.rejects(wrongSchema({ files: [], fresh: false }), /returned an invalid payload/u);
 });
 
-void test("Nuxt lint inspector wiring is development-only and preserves explicit providers", () => {
+void test("Nuxt lint inspector wiring is development-only and preserves explicit providers", async () => {
   const generation = {
     configFile: "/project/.nuxt/oxlint.config.json",
     root: "/project",
@@ -71,16 +71,25 @@ void test("Nuxt lint inspector wiring is development-only and preserves explicit
       return [];
     },
   };
+  const hooks: string[] = [];
+  const nuxt = {
+    hook(name: string) {
+      hooks.push(name);
+    },
+  };
   const disabled: VizeNuxtCompilerOptions = {};
-  setupNuxtLintInspector(disabled, generation, false);
+  await setupLintInspector({ devtools: { enabled: false } }, nuxt, disabled, generation, false);
   assert.equal(disabled.inspector, undefined);
 
   const explicit = () => ({ explicit: true });
   const configured: VizeNuxtCompilerOptions = { inspector: { lintPlan: explicit } };
-  setupNuxtLintInspector(configured, generation, true);
+  await setupLintInspector({ devtools: { enabled: false } }, nuxt, configured, generation, true);
   assert.equal(configured.inspector?.lintPlan, explicit);
 
   const automatic: VizeNuxtCompilerOptions = {};
-  setupNuxtLintInspector(automatic, generation, true);
+  await setupLintInspector({ devtools: { enabled: false } }, nuxt, automatic, generation, true);
   assert.equal(typeof automatic.inspector?.lintPlan, "function");
+
+  await setupLintInspector({}, nuxt, false, generation, true);
+  assert.deepEqual(hooks, ["devtools:customTabs", "close"]);
 });

--- a/npm/framework/nuxt/src/lint/inspector.ts
+++ b/npm/framework/nuxt/src/lint/inspector.ts
@@ -3,6 +3,8 @@ import type {
   VizeNuxtInspectorLintPlanRequest,
 } from "../compiler-options.ts";
 import type { NuxtLintConfigGeneration } from "./generation.ts";
+import { setupNuxtLintDevtools, type NuxtLintDevtoolsNuxt } from "./inspector-devtools.ts";
+import type { VizeNuxtLintOptions } from "./options.ts";
 
 type Awaitable<T> = T | Promise<T>;
 type InspectLintPlan = (plan: string, root: string, files: string[]) => Awaitable<string>;
@@ -28,14 +30,25 @@ export function createNuxtLintInspectorProvider(
   };
 }
 
-export function setupNuxtLintInspector(
+export async function setupLintInspector(
+  lint: boolean | VizeNuxtLintOptions | undefined,
+  nuxt: NuxtLintDevtoolsNuxt,
   compiler: false | VizeNuxtCompilerOptions,
   generation: NuxtLintConfigGeneration | undefined,
-  enabled: boolean,
-): void {
-  if (!enabled || compiler === false || !generation) return;
-  compiler.inspector ||= {};
-  compiler.inspector.lintPlan ||= createNuxtLintInspectorProvider(generation);
+  enabled: boolean | undefined,
+): Promise<void> {
+  if (enabled === false || !generation) return;
+  const provider = createNuxtLintInspectorProvider(generation);
+  if (compiler !== false) {
+    compiler.inspector ||= {};
+    compiler.inspector.lintPlan ||= provider;
+  }
+  const devtools = typeof lint === "object" && lint !== null ? lint.devtools : undefined;
+  await setupNuxtLintDevtools(
+    devtools,
+    nuxt,
+    compiler === false ? provider : compiler.inspector.lintPlan,
+  );
 }
 
 async function inspectWithNative(plan: string, root: string, files: string[]): Promise<string> {

--- a/npm/framework/nuxt/src/lint/options.ts
+++ b/npm/framework/nuxt/src/lint/options.ts
@@ -1,6 +1,13 @@
 import type { NuxtLintFeatures } from "@vizejs/nuxt-lint-config";
 export type { VizeNuxtLintCheckerOptions } from "./checker/options.ts";
 
+export interface VizeNuxtLintDevtoolsOptions {
+  /** Enable the inspector eagerly, lazily from its tab, or not at all. @default "lazy" */
+  enabled?: boolean | "lazy";
+  /** Localhost port for the in-process inspector UI. An available port is chosen by default. */
+  port?: number;
+}
+
 /** Options for the generated Nuxt-aware oxlint configuration. */
 export interface VizeNuxtLintOptions extends NuxtLintFeatures {
   /**
@@ -23,4 +30,7 @@ export interface VizeNuxtLintOptions extends NuxtLintFeatures {
    * @default nuxt.options.rootDir
    */
   rootDir?: string;
+
+  /** Expose the resolved plan in a Nuxt DevTools tab. @default { enabled: "lazy" } */
+  devtools?: VizeNuxtLintDevtoolsOptions;
 }


### PR DESCRIPTION
Closes #3617

- render ordered config items and effective per-file rule provenance in a dependency-free Nuxt DevTools view
- match false, lazy, and eager lifecycle semantics while honoring the configured localhost port
- protect the in-process endpoint with a random URL token, host and path validation, bounded requests and responses, CSP, and clean shutdown
- preserve the existing Vite inspector provider and support lint inspection when the Vize compiler is disabled

Tests:
- @vizejs/nuxt check (62 files)
- @vizejs/nuxt build
- @vizejs/nuxt tests (199; the environment-only worker fixture rerun passed after its local plugin dependency was built)
- focused lint generation and inspector tests (17)
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Nuxt DevTools lint inspector for viewing lint plans, files, rules, and configuration details.
  * Added configurable inspector startup modes and port settings.
  * Added secure local API access with request validation, security headers, and clear error handling.

* **Bug Fixes**
  * Improved lint inspector setup across Nuxt development workflows.

* **Tests**
  * Added comprehensive coverage for inspector startup, requests, security, rendering, and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->