### PR TITLE
fix(nuxt): tolerate eager lint inspector start failures

### DIFF
--- a/npm/framework/nuxt/src/lint/inspector-devtools.test.ts
+++ b/npm/framework/nuxt/src/lint/inspector-devtools.test.ts
@@ -57,15 +57,20 @@ async function rawRequest(
 
 async function availablePort(): Promise<number> {
   const server = createNetServer();
+  const port = await listen(server);
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return port;
+}
+
+async function listen(server: ReturnType<typeof createNetServer>): Promise<number> {
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
     server.listen({ host: "127.0.0.1", port: 0 }, resolve);
   });
   const address = server.address();
   assert.ok(address && typeof address === "object");
-  await new Promise<void>((resolve, reject) => {
-    server.close((error) => (error ? reject(error) : resolve()));
-  });
   return address.port;
 }
 
@@ -164,6 +169,26 @@ void test("eager lint inspector starts immediately and closes with Nuxt", async 
   assert.equal((tabs[0] as { view: { type: string } }).view.type, "iframe");
   await hooks.get("close")?.();
   assert.equal(controller?.url(), undefined);
+});
+
+void test("eager lint inspector degrades to lazy launch when its port is occupied", async (t) => {
+  const occupied = createNetServer();
+  const port = await listen(occupied);
+  const warning = t.mock.method(console, "warn", () => {});
+  const { nuxt } = createNuxt();
+  const controller = await setupNuxtLintDevtools({ enabled: true, port }, nuxt, () => ({}));
+  assert.ok(controller);
+  t.after(() => controller.close());
+
+  assert.equal(controller.url(), undefined);
+  assert.equal(warning.mock.callCount(), 1);
+  assert.match(String(warning.mock.calls[0]?.arguments[0]), /failed to start.*EADDRINUSE/iu);
+
+  await new Promise<void>((resolve, reject) => {
+    occupied.close((error) => (error ? reject(error) : resolve()));
+  });
+  await controller.start();
+  assert.equal(new URL(controller.url() ?? "").port, String(port));
 });
 
 void test("lint inspector close waits for an in-flight lazy start", async () => {

--- a/npm/framework/nuxt/src/lint/inspector-devtools.test.ts
+++ b/npm/framework/nuxt/src/lint/inspector-devtools.test.ts
@@ -140,6 +140,10 @@ void test("lazy lint inspector launches a hardened UI and forwards API requests"
   assert.equal((await rawRequest(api, { method: "POST" })).status, 405);
   assert.equal((await rawRequest(api, { host: "example.com" })).status, 421);
   assert.equal((await rawRequest(new URL("api?file=../secret", viewer))).status, 400);
+  assert.equal((await rawRequest(new URL("/wrong-token/", viewer))).status, 404);
+  assert.equal((await rawRequest(new URL("/wrong-token/api", viewer))).status, 404);
+  assert.equal((await rawRequest(new URL("api?unknown=1", viewer))).status, 400);
+  assert.equal((await rawRequest(new URL("api?fresh=0", viewer))).status, 400);
   const head = await rawRequest(viewer, { method: "HEAD" });
   assert.equal(head.status, 200);
   assert.equal(head.body, "");

--- a/npm/framework/nuxt/src/lint/inspector-devtools.ts
+++ b/npm/framework/nuxt/src/lint/inspector-devtools.ts
@@ -72,7 +72,15 @@ export async function setupNuxtLintDevtools(
     tabs.push(controller.tab());
   });
   nuxt.hook("close", () => controller.close());
-  if (resolved.enabled === true) await controller.start();
+  if (resolved.enabled === true) {
+    try {
+      await controller.start();
+    } catch (error) {
+      console.warn(
+        `[vize] Nuxt lint inspector failed to start: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
   return controller;
 }
 

--- a/npm/framework/nuxt/src/lint/inspector-view.ts
+++ b/npm/framework/nuxt/src/lint/inspector-view.ts
@@ -120,7 +120,7 @@ export function renderNuxtLintInspectorHtml(nonce: string): string {
         const payload = await response.json();
         if (!response.ok) throw new Error(payload.error || "Inspector request failed");
         renderEffective(payload); renderItems(payload);
-        status.textContent = "Resolved " + payload.items.length + " config items";
+        status.textContent = "Resolved " + (payload.items || []).length + " config items";
       } catch (error) {
         status.className = "error";
         status.textContent = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
Follow-up to #3652, which merged before its review comments were addressed.

An eager (`enabled: true`) lint inspector previously let a failed `listen` reject out of `setupNuxtLintDevtools` and abort the whole Nuxt module setup, so an occupied port took the dev server down with it. The eager start now degrades to a warning and the controller stays usable via its lazy launch action:

```ts
if (resolved.enabled === true) {
  try {
    await controller.start();
  } catch (error) {
    console.warn(
      `[vize] Nuxt lint inspector failed to start: ${error instanceof Error ? error.message : String(error)}`,
    );
  }
}
```

The viewer's success path also read `payload.items.length` unguarded, so a payload without `items` threw a `TypeError` after a successful render and surfaced as an error in the UI; it now uses the same `payload.items || []` fallback as `renderItems`.

Tests gain negative coverage for the URL token (wrong token on both the root and `api` paths returns 404) and for the `invalid_query` / `invalid_fresh` rejections, which were previously untested despite the token being the server's only authentication control.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->