### PR TITLE
fix(vitrine): write Nuxt lint fixes atomically

### DIFF
--- a/crates/vize/src/commands.rs
+++ b/crates/vize/src/commands.rs
@@ -1,4 +1,4 @@
-mod atomic_write;
+pub(crate) mod atomic_write;
 pub mod build;
 pub mod check;
 #[cfg(unix)]

--- a/crates/vize/src/commands/atomic_write.rs
+++ b/crates/vize/src/commands/atomic_write.rs
@@ -13,7 +13,7 @@ use tempfile::NamedTempFile;
 /// existing file or symlink can never redirect writes. Its persist operation
 /// uses an overwriting rename on Unix and `MoveFileExW(REPLACE_EXISTING)` on
 /// Windows, without deleting the destination first.
-pub(super) fn atomic_write(path: &Path, contents: &[u8]) -> io::Result<()> {
+pub fn atomic_write(path: &Path, contents: &[u8]) -> io::Result<()> {
     atomic_write_with(path, contents, &mut OsOperations)
 }
 

--- a/crates/vize/src/lib.rs
+++ b/crates/vize/src/lib.rs
@@ -29,6 +29,11 @@ pub mod lint_plan;
 /// Shared native CLI entrypoint.
 pub mod cli;
 
+/// Failure-safe source replacement shared with the native bindings.
+pub mod source_write {
+    pub use crate::commands::atomic_write::atomic_write;
+}
+
 /// Shared allocator, string, hash, and utility types.
 pub use vize_carton as carton;
 

--- a/crates/vize_patina/src/rules/script/nuxt_config_keys_order_tests.rs
+++ b/crates/vize_patina/src/rules/script/nuxt_config_keys_order_tests.rs
@@ -11,10 +11,14 @@ const RECORDING: &str = include_str!(
     "../../../../../npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/fixtures/nuxt-eslint-output.json"
 );
 
-fn lint(source: &str) -> ScriptLintResult {
+fn lint_at(source: &str, offset: usize) -> ScriptLintResult {
     let mut linter = ScriptLinter::new();
     linter.add_rule(Box::new(NuxtConfigKeysOrder));
-    linter.lint(source, 0)
+    linter.lint(source, offset)
+}
+
+fn lint(source: &str) -> ScriptLintResult {
+    lint_at(source, 0)
 }
 
 fn apply_non_overlapping_fixes(source: &str, result: &ScriptLintResult) -> String {
@@ -55,10 +59,13 @@ fn fix_until_stable(source: &str) -> String {
 fn line_column(source: &str, offset: usize) -> (u64, u64) {
     let prefix = &source[..offset];
     let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u64 + 1;
+    // ESLint columns count UTF-16 code units, not bytes.
     let column = prefix
         .rsplit_once('\n')
         .map_or(prefix, |(_, tail)| tail)
-        .len() as u64
+        .chars()
+        .map(char::len_utf16)
+        .sum::<usize>() as u64
         + 1;
     (line, column)
 }
@@ -247,8 +254,7 @@ fn only_direct_default_export_shapes_are_inspected() {
 #[test]
 fn diagnostic_and_fix_offsets_include_the_sfc_block_offset() {
     let source = "export default { ssr: true, modules: [] }";
-    let mut result = ScriptLintResult::default();
-    NuxtConfigKeysOrder.check(source, 41, &mut result);
+    let result = lint_at(source, 41);
     let diagnostic = &result.diagnostics[0];
     assert_eq!((diagnostic.start, diagnostic.end), (56, 82));
     let edit = &diagnostic.fix.as_ref().unwrap().edits[0];

--- a/crates/vize_vitrine/Cargo.toml
+++ b/crates/vize_vitrine/Cargo.toml
@@ -85,3 +85,6 @@ napi-build.workspace = true
 [dev-dependencies]
 insta.workspace = true
 tempfile.workspace = true
+# The lint/fix path is covered without the `napi` feature (see `lib.rs`), so the
+# atomic writer it shares with the CLI has to be linkable in test builds too.
+vize = { path = "../vize" }

--- a/crates/vize_vitrine/src/napi/lint_fix.rs
+++ b/crates/vize_vitrine/src/napi/lint_fix.rs
@@ -26,7 +26,11 @@ pub(super) fn lint_file_with_optional_fix(
             source = fixed_source;
             result = lint_source(linter, &source, &filename);
         }
-        if source != original && fs::write(path, source.as_bytes()).is_err() {
+        // Replace the file only once its successor is fully written, so a
+        // failed write leaves the original config on disk instead of a
+        // truncated one.
+        if source != original && vize::source_write::atomic_write(path, source.as_bytes()).is_err()
+        {
             source = original;
             result = lint_source(linter, &source, &filename);
         }


### PR DESCRIPTION
Follow-up to review feedback on #3651, which merged before the comments could be addressed there.

The native lint-fix path replaced files with `fs::write`, which truncates the target before writing, so a failed write could leave a Nuxt config empty or partial even though the in-memory fallback restored the original text. The CLI already solves this with `commands::atomic_write`, so the napi path now reuses it (the helper is exposed as `vize::source_write::atomic_write`):

```rust
// Replace the file only once its successor is fully written, so a
// failed write leaves the original config on disk instead of a
// truncated one.
if source != original && vize::source_write::atomic_write(path, source.as_bytes()).is_err()
{
    source = original;
    result = lint_source(linter, &source, &filename);
}
```

Two test-only fixes in `nuxt_config_keys_order_tests.rs`: the SFC-offset test now lints through `ScriptLinter`, so it exercises the `check_program_with_sfc` dispatch the production path uses instead of the parse-owning `ScriptRule::check` wrapper, and `line_column` counts UTF-16 code units rather than bytes to match ESLint's column semantics if the corpus ever gains non-ASCII sources.

A third review suggestion (unwrapping `TSAsExpression` / `TSSatisfiesExpression` around the exported config object) was deliberately skipped: `@nuxt/eslint-plugin@1.16.0` only inspects a direct `ObjectExpression` or `arguments[0]` of a `CallExpression`, so handling TS wrappers would diverge from the recorded upstream oracle.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->