### PR TITLE
fix(release): gate GitHub release on every publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -683,7 +683,6 @@ jobs:
       - name: Publish oxlint-plugin-vize
         run: moon run --target native tools/moon/cmd/publish_npm_package -- npm/oxint --provenance
 
-  # Publish @vizejs/marquette (using Trusted Publishing / OIDC)
   release-npm-marquette:
     name: Release @vizejs/marquette to npm
     runs-on: ubuntu-24.04
@@ -704,7 +703,6 @@ jobs:
       - name: Publish @vizejs/marquette
         run: moon run --target native tools/moon/cmd/publish_npm_package -- npm/marquette --provenance
 
-  # Publish @vizejs/composable (using Trusted Publishing / OIDC)
   release-npm-composable:
     name: Release @vizejs/composable to npm
     runs-on: ubuntu-24.04
@@ -725,7 +723,6 @@ jobs:
       - name: Publish @vizejs/composable
         run: moon run --target native tools/moon/cmd/publish_npm_package -- npm/compose/core --provenance
 
-  # Publish @vizejs/ui (using Trusted Publishing / OIDC)
   release-npm-ui:
     name: Release @vizejs/ui to npm
     runs-on: ubuntu-24.04
@@ -965,6 +962,9 @@ jobs:
       - release-npm-cli
       - release-npm-vite-plugin
       - release-npm-oxlint-plugin
+      - release-npm-marquette
+      - release-npm-composable
+      - release-npm-ui
       - release-npm-unplugin
       - release-npm-fresco
       - release-npm-musea-mcp-server

--- a/tests/tooling/github-workflows-release-publish.test.ts
+++ b/tests/tooling/github-workflows-release-publish.test.ts
@@ -25,11 +25,8 @@ function jobNeeds(job: ReleaseJob): string[] {
   return Array.isArray(job.needs) ? job.needs : [job.needs];
 }
 
-test("every publication edge waits for credential-free release preflight", () => {
-  const source = readRepoFile(".github", "workflows", "release.yml");
-  const workflow = parse(source) as { jobs?: Record<string, ReleaseJob> };
-  const jobs = workflow.jobs ?? {};
-  const publishJobs = Object.entries(jobs)
+function publicationJobNames(jobs: Record<string, ReleaseJob>): string[] {
+  return Object.entries(jobs)
     .filter(([, job]) => {
       const serialized = JSON.stringify(job);
       return (
@@ -41,6 +38,13 @@ test("every publication edge waits for credential-free release preflight", () =>
     })
     .map(([name]) => name)
     .sort();
+}
+
+test("every publication edge waits for credential-free release preflight", () => {
+  const source = readRepoFile(".github", "workflows", "release.yml");
+  const workflow = parse(source) as { jobs?: Record<string, ReleaseJob> };
+  const jobs = workflow.jobs ?? {};
+  const publishJobs = publicationJobNames(jobs);
 
   assert.deepEqual(publishJobs, [
     "create-github-release",
@@ -229,34 +233,27 @@ test("release workflow smokes the wasm package wrapper before publishing", () =>
 });
 
 test("release workflow creates GitHub Releases only after registry publishing succeeds", () => {
-  const workflow = readRepoFile(".github", "workflows", "release.yml");
-  const releaseJob = workflowJobBody(workflow, "create-github-release");
+  const source = readRepoFile(".github", "workflows", "release.yml");
+  const workflow = parse(source) as { jobs?: Record<string, ReleaseJob> };
+  const jobs = workflow.jobs ?? {};
+  const releaseJob = jobs["create-github-release"];
+  assert.ok(releaseJob);
+  const releaseNeeds = jobNeeds(releaseJob);
 
-  for (const requiredNeed of [
-    "build-cli",
-    "release-vscode-extension",
-    "release-npm-native",
-    "release-npm-fresco-native",
-    "release-npm-wasm",
-    "smoke-release-packages",
-    "release-npm-cli",
-    "release-npm-vite-plugin",
-    "release-npm-oxlint-plugin",
-    "release-npm-unplugin",
-    "release-npm-fresco",
-    "release-npm-musea-mcp-server",
-    "release-npm-vite-plugin-musea",
-    "release-npm-rspack-plugin",
-    "release-npm-musea-nuxt",
-    "release-npm-nuxt-lint-config",
-    "release-npm-nuxt",
-    "release-crates",
-  ]) {
-    assert.match(releaseJob, new RegExp(`- ${requiredNeed}\\b`));
+  for (const requiredNeed of ["build-cli", "smoke-release-packages", "release-preflight"]) {
+    assert.ok(releaseNeeds.includes(requiredNeed), requiredNeed);
   }
 
-  const createRelease = releaseJob.indexOf("name: Create Release");
-  assert.notEqual(createRelease, -1);
+  const registryPublishJobs = publicationJobNames(jobs).filter(
+    (jobName) => jobName !== "create-github-release",
+  );
+  assert.deepEqual(
+    registryPublishJobs.filter((jobName) => !releaseNeeds.includes(jobName)),
+    [],
+    "GitHub Release must wait for every registry publish job",
+  );
+
+  assert.match(JSON.stringify(releaseJob), /softprops\/action-gh-release@/);
 });
 
 test("release workflow requires VS Code Marketplace publication", () => {


### PR DESCRIPTION
## Summary

- make `create-github-release` wait for the Marquette, composable, and UI npm publish jobs
- derive the release gate assertion from every detected publication job so future publish jobs cannot be omitted silently

## Root cause

The three npm publish jobs ran independently, but were absent from `create-github-release.needs`. A GitHub Release could therefore be created while one of those registry publishes was still pending or had failed.

## Validation

- demonstrated the updated focused test fails against the previous dependency set and reports all three missing jobs
- `node --test tests/tooling/github-workflows-release-publish.test.ts` (9 passed)
- all release-related tooling tests (83 passed)
- source-length regression test with the current workflow held at its base line count
- `pnpm exec oxfmt --check .github/workflows/release.yml tests/tooling/github-workflows-release-publish.test.ts`
- `vp check tests/tooling/github-workflows-release-publish.test.ts`
