### PR TITLE
fix(ci): restore branch coverage gate

### DIFF
--- a/crates/vize_atelier_core/src/transforms/hoist_static/tests.rs
+++ b/crates/vize_atelier_core/src/transforms/hoist_static/tests.rs
@@ -1,4 +1,6 @@
+use super::static_type::{has_only_native_element_descendants, has_only_static_nested_children};
 use super::{StaticType, get_static_type, is_static_node};
+use crate::TemplateChildNode;
 use crate::parser::parse;
 use bumpalo::Bump;
 
@@ -115,5 +117,52 @@ fn test_codegen_hoisted_nested_vnode_keeps_descendant() {
             "_createElementVNode(\"span\", { class: \"a\" }, [_createElementVNode(\"b\", null, \"x\")])"
         ),
         "nested <b> was dropped from hoisted subtree:\n{preamble}"
+    );
+}
+
+#[test]
+fn static_nested_predicates_accept_native_dynamic_text_subtrees() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(
+        &allocator,
+        r#"<div><span title="label">text</span>{{ value }}</div>"#,
+    );
+    assert!(errors.is_empty(), "unexpected parse errors: {errors:?}");
+    let TemplateChildNode::Element(root_element) = &root.children[0] else {
+        panic!("expected root element");
+    };
+
+    assert!(has_only_static_nested_children(root_element));
+    assert!(has_only_native_element_descendants(root_element));
+
+    let (empty_root, errors) = parse(&allocator, "<div></div>");
+    assert!(errors.is_empty(), "unexpected parse errors: {errors:?}");
+    let TemplateChildNode::Element(empty_element) = &empty_root.children[0] else {
+        panic!("expected empty root element");
+    };
+    assert!(!has_only_static_nested_children(empty_element));
+}
+
+#[test]
+fn constant_bind_modifiers_are_preserved_in_hoisted_props() {
+    let (preamble, code) = compile_hoisted(
+        r#"<div :data-id.camel="'x'" :value.prop="'y'" :role.attr="'z'">{{ message }}</div>"#,
+    );
+
+    assert!(
+        preamble.contains(r#"dataId: 'x'"#),
+        "camel modifier was not hoisted:\n{preamble}\n{code}"
+    );
+    assert!(
+        preamble.contains(r#"".value": 'y'"#),
+        "prop modifier was not hoisted:\n{preamble}\n{code}"
+    );
+    assert!(
+        preamble.contains(r#""^role": 'z'"#),
+        "attr modifier was not hoisted:\n{preamble}\n{code}"
+    );
+    assert!(
+        code.contains("_hoisted_1"),
+        "hoisted props were not used:\n{code}"
     );
 }

--- a/tests/tooling/local-default-tasks.test.ts
+++ b/tests/tooling/local-default-tasks.test.ts
@@ -82,16 +82,18 @@ test("workspace build, test, and lint default to their local task graphs", () =>
 
 test("branch coverage reports every metric before enforcing thresholds", () => {
   const command = taskShape(testAndBenchmarkTasks["coverage:source:branch"]).command;
-  const [reportCommand, enforcementCommand] = command.split(" && ").slice(1);
 
-  assert.match(reportCommand, /cargo \+nightly llvm-cov/);
-  assert.match(reportCommand, /--branch(?:\s|$)/);
-  assert.doesNotMatch(reportCommand, /--fail-under-/);
-  assert.match(enforcementCommand, /enforce_rust_source_coverage/);
-  assert.match(enforcementCommand, /--min-lines 55/);
-  assert.match(enforcementCommand, /--min-functions 70/);
-  assert.match(enforcementCommand, /--min-regions 55/);
-  assert.match(enforcementCommand, /--min-branches 40/);
+  assert.match(command, /cargo \+nightly llvm-cov/);
+  assert.match(command, /--branch(?:\s|$)/);
+  assert.doesNotMatch(command, /--fail-under-/);
+  assert.match(command, /enforce_rust_source_coverage/);
+  assert.match(command, /--min-lines 55/);
+  assert.match(command, /--min-functions 70/);
+  assert.match(command, /--min-regions 55/);
+  assert.match(command, /--min-branches 40/);
+  assert.ok(
+    command.indexOf("cargo +nightly llvm-cov") < command.indexOf("enforce_rust_source_coverage"),
+  );
 });
 
 test("Testbox commands fail with an actionable lifecycle when the box id is absent", () => {

--- a/tests/tooling/local-default-tasks.test.ts
+++ b/tests/tooling/local-default-tasks.test.ts
@@ -85,6 +85,7 @@ test("branch coverage reports every metric before enforcing thresholds", () => {
   const [reportCommand, enforcementCommand] = command.split(" && ").slice(1);
 
   assert.match(reportCommand, /cargo \+nightly llvm-cov/);
+  assert.match(reportCommand, /--branch(?:\s|$)/);
   assert.doesNotMatch(reportCommand, /--fail-under-/);
   assert.match(enforcementCommand, /enforce_rust_source_coverage/);
   assert.match(enforcementCommand, /--min-lines 55/);

--- a/tests/tooling/local-default-tasks.test.ts
+++ b/tests/tooling/local-default-tasks.test.ts
@@ -80,6 +80,19 @@ test("workspace build, test, and lint default to their local task graphs", () =>
   assert.doesNotMatch(ci.command, /blacksmith|test:testbox/);
 });
 
+test("branch coverage reports every metric before enforcing thresholds", () => {
+  const command = taskShape(testAndBenchmarkTasks["coverage:source:branch"]).command;
+  const [reportCommand, enforcementCommand] = command.split(" && ").slice(1);
+
+  assert.match(reportCommand, /cargo \+nightly llvm-cov/);
+  assert.doesNotMatch(reportCommand, /--fail-under-/);
+  assert.match(enforcementCommand, /enforce_rust_source_coverage/);
+  assert.match(enforcementCommand, /--min-lines 55/);
+  assert.match(enforcementCommand, /--min-functions 70/);
+  assert.match(enforcementCommand, /--min-regions 55/);
+  assert.match(enforcementCommand, /--min-branches 40/);
+});
+
 test("Testbox commands fail with an actionable lifecycle when the box id is absent", () => {
   const result = spawnSync(
     "/bin/sh",

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -70,8 +70,9 @@ const rustBranchCoverageCommand = [
     "cargo +nightly llvm-cov -p vize_carton -p vize_armature -p vize_atelier_core",
     "--branch --json --summary-only",
     `--output-path ${rustBranchCoverageJson}`,
-    "--fail-under-lines 55 --fail-under-functions 70 --fail-under-regions 55",
   ].join(" "),
+  // Keep threshold enforcement in one place so failures still render the
+  // complete metric table instead of stopping at cargo-llvm-cov's exit code.
   moonScript(
     "enforce_rust_source_coverage",
     "--json",


### PR DESCRIPTION
## Summary

- cover static nested subtree predicates extracted by the hoist refactor
- cover constant `v-bind` modifier handling in hoisted props
- keep branch coverage thresholds in the Moon enforcer so failed gates always print the complete metric table
- restore function coverage without lowering any threshold

## Root cause

The main-only branch coverage job began failing after the static-hoist module split added uncovered helper functions. Linux function coverage had only a 0.03 percentage-point margin before that split, so the additional uncovered functions pushed the gate below 70%. The duplicated cargo-level threshold stopped the task before the repository enforcer could render its diagnostic table.

Generic `ensure_sufficient_stack` records were also checked: LLVM reports those separately as instantiations, not as the source-function total used by this gate, so no coverage exclusions are added.

## Validation

- `cargo test -p vize_atelier_core`
- `cargo test -p vize_atelier_core --lib hoist_static::tests`
- exact branch report plus Moon enforcement: lines 72.72%, functions 77.94%, regions 71.64%, branches 58.58%
- `node --test tests/tooling/local-default-tasks.test.ts`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `vp fmt --check tools/vite-plus/tasks/test-benchmark.ts tests/tooling/local-default-tasks.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of statically nested dynamic text and empty elements during template compilation.
  * Preserved constant binding modifiers when properties are hoisted.

* **Tests**
  * Expanded coverage for static nesting, native descendants, and hoisted bindings.
  * Enhanced branch coverage reporting to generate complete metrics before enforcing thresholds.
  * Added validation for all LLVM coverage metrics and configured coverage thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->