### PR TITLE
test(maestro): cover untitled document lifecycle

### DIFF
--- a/tests/tooling/lsp-untitled-lifecycle.test.ts
+++ b/tests/tooling/lsp-untitled-lifecycle.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { isDiagnosticsForUri } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+test("vize lsp keeps an untitled Vue document live through open, change, and close", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-untitled-lifecycle");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+  const uri = "untitled:Untitled-1";
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: false,
+    });
+
+    const malformedSource = "<template><div></div>";
+    session.notify("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        languageId: "vue",
+        version: 1,
+        text: malformedSource,
+      },
+    });
+
+    const openPublish = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri),
+    )) as PublishDiagnosticsParams;
+    assert.equal(openPublish.version, 1);
+    assert.deepEqual(openPublish.diagnostics, [
+      {
+        message: "Malformed <template> block: the closing tag is missing.",
+        range: {
+          start: { line: 0, character: 0 },
+          end: { line: 0, character: malformedSource.length },
+        },
+        severity: 1,
+        source: "vize/sfc",
+      },
+    ]);
+
+    session.notify("textDocument/didChange", {
+      textDocument: { uri, version: 2 },
+      contentChanges: [
+        {
+          range: {
+            start: { line: 0, character: malformedSource.length },
+            end: { line: 0, character: malformedSource.length },
+          },
+          text: "</template>",
+        },
+      ],
+    });
+
+    const changePublish = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri) && params.version === 2,
+    )) as PublishDiagnosticsParams;
+    assert.equal(changePublish.version, 2);
+    assert.deepEqual(changePublish.diagnostics, []);
+
+    session.notify("textDocument/didClose", {
+      textDocument: { uri },
+    });
+
+    const closePublish = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri) && params.version === undefined,
+    )) as PublishDiagnosticsParams;
+    assert.equal(closePublish.version, undefined);
+    assert.deepEqual(closePublish.diagnostics, []);
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- add a real stdio LSP lifecycle test for an in-memory `untitled:` Vue document
- pin the exact versioned parse diagnostic published on `didOpen`
- repair the source with a range `didChange`, then assert the versioned and close-time diagnostic clears

## Why

The #2971 audit found that editor selectors advertise `untitled:` support, but no real Vize LSP session exercised that URI scheme. This test covers the production server rather than the extension fake-server fixture.

## Validation

- `cargo build -p vize`
- `vp check tests/tooling/lsp-untitled-lifecycle.test.ts`
- `node --test tests/tooling/lsp-untitled-lifecycle.test.ts tests/tooling/lsp-diagnostics-lifecycle.test.ts tests/tooling/lsp-protocol-resilience.test.ts` (10 passed)
- `node --test --test-concurrency=4 tests/tooling/lsp-*.test.ts` (2,208 passed)

Refs #2971

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->