### PR TITLE
fix(ci): clean branch coverage artifacts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -475,9 +475,8 @@ jobs:
   branch-coverage:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 45
-    # Nightly Rust branch coverage on the core compiler crates. Same trend
-    # rationale as source-coverage, so push-to-main + schedule, never per-PR.
-    if: ${{ github.event_name != 'pull_request' }}
+    # Run the strict nightly gate before merge as well as on main. A main-only
+    # gate allowed generic instrumentation growth to hide across many PRs.
     env:
       NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -476,7 +476,7 @@ jobs:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 45
     # Run the strict nightly gate before merge as well as on main. A main-only
-    # gate allowed generic instrumentation growth to hide across many PRs.
+    # gate allowed stale instrumented artifacts to distort metrics across many PRs.
     env:
       NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
     steps:

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -290,6 +290,7 @@ test("check workflow blocks on Rust source and branch coverage budgets", () => {
   assert.match(branchJob, /source-branch-summary\.json/);
   assert.match(branchJob, /rust-branch-coverage-summary/);
   assert.match(branchJob, /continue-on-error:\s*true/);
+  assert.doesNotMatch(branchJob, /github\.event_name != 'pull_request'/);
 });
 
 test("check workflow only installs Playwright browsers on cache misses", () => {

--- a/tests/tooling/local-default-tasks.test.ts
+++ b/tests/tooling/local-default-tasks.test.ts
@@ -82,7 +82,7 @@ test("workspace build, test, and lint default to their local task graphs", () =>
 
 test("branch coverage reports every metric before enforcing thresholds", () => {
   const command = taskShape(testAndBenchmarkTasks["coverage:source:branch"]).command;
-  const cleanIndex = command.indexOf("cargo +nightly llvm-cov clean --workspace");
+  const cleanIndex = command.indexOf("cargo clean --target-dir target/llvm-cov-target");
   const reportIndex = command.indexOf("cargo +nightly llvm-cov -p vize_carton");
   const enforcementIndex = command.indexOf("enforce_rust_source_coverage");
 

--- a/tests/tooling/local-default-tasks.test.ts
+++ b/tests/tooling/local-default-tasks.test.ts
@@ -82,7 +82,11 @@ test("workspace build, test, and lint default to their local task graphs", () =>
 
 test("branch coverage reports every metric before enforcing thresholds", () => {
   const command = taskShape(testAndBenchmarkTasks["coverage:source:branch"]).command;
+  const cleanIndex = command.indexOf("cargo +nightly llvm-cov clean --workspace");
+  const reportIndex = command.indexOf("cargo +nightly llvm-cov -p vize_carton");
+  const enforcementIndex = command.indexOf("enforce_rust_source_coverage");
 
+  assert.ok(cleanIndex >= 0);
   assert.match(command, /cargo \+nightly llvm-cov/);
   assert.match(command, /--branch(?:\s|$)/);
   assert.doesNotMatch(command, /--fail-under-/);
@@ -91,9 +95,8 @@ test("branch coverage reports every metric before enforcing thresholds", () => {
   assert.match(command, /--min-functions 70/);
   assert.match(command, /--min-regions 55/);
   assert.match(command, /--min-branches 40/);
-  assert.ok(
-    command.indexOf("cargo +nightly llvm-cov") < command.indexOf("enforce_rust_source_coverage"),
-  );
+  assert.ok(cleanIndex < reportIndex);
+  assert.ok(reportIndex < enforcementIndex);
 });
 
 test("Testbox commands fail with an actionable lifecycle when the box id is absent", () => {

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -66,7 +66,7 @@ const rustSourceCoverageCommand = [
 ].join(" && ");
 const rustBranchCoverageCommand = [
   "mkdir -p target/llvm-cov",
-  "cargo +nightly llvm-cov clean --workspace",
+  "cargo clean --target-dir target/llvm-cov-target",
   [
     "cargo +nightly llvm-cov -p vize_carton -p vize_armature -p vize_atelier_core",
     "--branch --json --summary-only",

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -66,6 +66,7 @@ const rustSourceCoverageCommand = [
 ].join(" && ");
 const rustBranchCoverageCommand = [
   "mkdir -p target/llvm-cov",
+  "cargo +nightly llvm-cov clean --workspace",
   [
     "cargo +nightly llvm-cov -p vize_carton -p vize_armature -p vize_atelier_core",
     "--branch --json --summary-only",


### PR DESCRIPTION
## Summary

- clear the dedicated coverage target immediately before the nightly branch report
- run the strict branch coverage job on pull requests as well as main
- lock the cleanup/report/enforcement order and PR execution policy with tooling tests
- keep all coverage thresholds unchanged

## Root cause

The branch coverage sticky target retained the last successful coverage objects. After a main run failed, cache commit was skipped, and later reports combined stale dependency and monomorphization mappings with current mappings. This inflated Linux function totals from 2062 to 2315 while the covered count remained 1473, producing a persistent false regression. Repeated local reports against a shared target reproduced even larger duplicate totals.

The package-scoped `cargo llvm-cov clean --workspace` did not clear the full sticky coverage target on Linux. Clearing `target/llvm-cov-target` through `cargo clean --target-dir` removes the complete instrumented build while preserving registry, git, and normal build caches. Running this job on PRs closes the gap that allowed main-only failures to continue across many merges.

## Validation

- `node --test tests/tooling/local-default-tasks.test.ts tests/tooling/github-workflows-check.test.ts` (22 passed)
- `vp fmt --check .github/workflows/check.yml tools/vite-plus/tasks/test-benchmark.ts tests/tooling/local-default-tasks.test.ts tests/tooling/github-workflows-check.test.ts`
- `git diff --check`

The pull request branch-coverage job is the authoritative Linux verification before auto-merge is enabled.