### PR TITLE
fix(atelier): preserve raw v-text in JSX compatibility mode

### DIFF
--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -263,6 +263,16 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             }
         }
 
+        // Babel lowers `v-text` to a raw `textContent` prop. Keep Vize's
+        // established `_toDisplayString` behavior outside the explicit
+        // compatibility mode.
+        if raw_name == "text"
+            && arg.is_none()
+            && let Some(prop) = self.compat_v_text_prop(attr, loc.clone())
+        {
+            return DirectiveAttributeLowering::Lowered(prop);
+        }
+
         // `v-custom={[value, 'arg', ['a','b']]}` — babel-plugin-jsx's array
         // encoding for a custom directive's value, argument and modifiers.
         // Restricted to custom directives with no JSX-namespace argument: the

--- a/crates/vize_atelier_jsx/src/lower/attr/compat.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr/compat.rs
@@ -8,6 +8,24 @@ use vize_relief::{DirectiveNode, PropNode, SourceLocation};
 use crate::lower::Lowerer;
 
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// Babel's `v-text` transform passes the authored value directly to the
+    /// DOM `textContent` prop. Native Vize keeps its established template-style
+    /// `_toDisplayString` normalization, so this rewrite is compatibility-only.
+    pub(super) fn compat_v_text_prop(
+        &self,
+        attr: &JSXAttribute<'_>,
+        loc: SourceLocation,
+    ) -> Option<PropNode<'a>> {
+        if !self.uses_babel_compat() {
+            return None;
+        }
+
+        let mut directive = DirectiveNode::new(self.bump(), "bind", loc);
+        directive.arg = Some(self.static_expr("textContent", attr.name.span()));
+        directive.exp = self.directive_value_expr(attr.value.as_ref());
+        Some(PropNode::Directive(Box::new_in(directive, self.bump())))
+    }
+
     /// Apply Babel's `transformOn: true` option to the two exact prop names the
     /// real plugin recognizes. The generated no-argument `v-bind` keeps this
     /// listener object in authored merge order while the helper performs the

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   83 |
-| divergent  |   13 |
+| equivalent |   84 |
+| divergent  |   12 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -192,7 +192,7 @@ Recorded so the verdicts are not read as byte equality (#3421,
 | `directives/v_show_component`              | `[[vShow, vis]]` on the component vnode                        | same                                                            | no change               | ✅      |
 | `directives/v_html`                        | `{innerHTML: h}`                                               | same                                                            | no change               | ✅      |
 | `directives/v_html_with_children`          | keeps the children too                                         | same                                                            | no change               | ✅      |
-| `directives/v_text`                        | `{textContent: t}` raw                                         | `textContent: toDisplayString(t)`                               | assign raw              | ❌      |
+| `directives/v_text`                        | `{textContent: t}` raw                                         | `textContent: toDisplayString(t)`                               | raw in compat mode      | ✅      |
 | `directives/v_custom_arg`                  | `[[resolveDirective("custom"), val, "arg"]]`                   | same                                                            | no change               | ✅      |
 | `directives/v_custom_array`                | unpacks `[val, 'arg', ['a','b']]` into value / arg / modifiers | same (#3421)                                                    | no change               | ✅      |
 | `directives/v_dashed_custom`               | `resolveDirective("unknown-thing")`                            | same                                                            | no change               | ✅      |

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -102,10 +102,7 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("directives/v_show_component", Same),
     ("directives/v_html", Same),
     ("directives/v_html_with_children", Same),
-    (
-        "directives/v_text",
-        Diff("v-text wrapped in toDisplayString"),
-    ),
+    ("directives/v_text", Same),
     ("directives/v_custom_arg", Same),
     ("directives/v_custom_array", Same),
     ("directives/v_dashed_custom", Same),

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (83, 13, 2));
+    assert_eq!((equivalent, divergent, deferred), (84, 12, 2));
     assert_eq!(VERDICTS.len(), 98);
 }
 

--- a/crates/vize_atelier_jsx/tests/compat_mode.rs
+++ b/crates/vize_atelier_jsx/tests/compat_mode.rs
@@ -125,6 +125,25 @@ fn babel_compat_emits_true_for_a_valueless_attribute_only_when_opted_in() {
 }
 
 #[test]
+fn babel_compat_assigns_v_text_raw_only_when_opted_in() {
+    let source = "const A = () => <div v-text={value}/>;";
+    let native = compile_module(source, JsxCompatMode::Native, JsxOutputMode::Vdom);
+    let babel = compile_module(source, JsxCompatMode::Babel, JsxOutputMode::Vdom);
+
+    assert!(
+        native.contains("textContent: _toDisplayString(value)"),
+        "{native}"
+    );
+    assert!(
+        native.contains("toDisplayString as _toDisplayString"),
+        "{native}"
+    );
+    assert!(babel.contains("textContent: value"), "{babel}");
+    assert!(!babel.contains("toDisplayString"), "{babel}");
+    assert_ne!(native, babel);
+}
+
+#[test]
 fn babel_compat_rewrites_xlink_href_across_prop_shapes_only_when_opted_in() {
     let source = concat!(
         "const A = () => <svg>",

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
@@ -336,7 +336,7 @@ export function render(_ctx, _cache) {
 
 ## directives/v_text
 ### verdict
-divergent: v-text wrapped in toDisplayString
+equivalent
 ### source (jsx)
 const A = () => <div v-text={t}/>;
 ### babel options
@@ -347,11 +347,9 @@ const A = () => _createVNode("div", {
   "textContent": t
 }, null);
 ### vize (vdom, babel compat)
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", {
-    textContent: _toDisplayString(t)
-  }, null, 8 /* PROPS */, ["textContent"]))
+  return (_openBlock(), _createElementBlock("div", { textContent: t }, null, 8 /* PROPS */, ["textContent"]))
 }
 
 ## directives/v_custom_arg


### PR DESCRIPTION
## Summary

- lower JSX `v-text` to a raw `textContent` binding in the opt-in Babel compatibility mode
- preserve native Vize `_toDisplayString` output when compatibility is not enabled
- move the differential oracle row from divergent to equivalent and ratchet the totals to 84 / 12 / 2

## Root cause

The shared DOM directive codegen always applies template-style `_toDisplayString` normalization for `v-text`. Babel JSX instead passes the authored value directly to `textContent`, so compatibility mode needs an earlier JSX-only rewrite to `v-bind:textContent`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vize_atelier_jsx`
- `cargo clippy -p vize_atelier_jsx --lib -- -D warnings`
- `node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check`
- `node --test tests/tooling/babel-jsx-oracle.test.ts`

Closes one differential row in #3391.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->