### PR TITLE
fix(test): keep LSP sessions on workspace binaries

### DIFF
--- a/tests/tooling/lsp-launch.test.ts
+++ b/tests/tooling/lsp-launch.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolveVizeLaunchCommand } from "./support/lsp/launch.ts";
+
+test("LSP tests ignore a globally installed vize binary", () => {
+  const probed: string[] = [];
+  const command = resolveVizeLaunchCommand((candidate) => {
+    probed.push(candidate);
+    return candidate === "vize";
+  }, "");
+
+  assert.ok(!probed.includes("vize"));
+  assert.deepEqual(command, ["cargo", "run", "-q", "-p", "vize", "--", "lsp"]);
+});

--- a/tests/tooling/support/lsp/launch.ts
+++ b/tests/tooling/support/lsp/launch.ts
@@ -6,26 +6,27 @@ import { root } from "./paths.ts";
  * Resolves the fastest available way to launch `vize lsp` for smoke tests.
  *
  * A caller-provided binary wins first, then the checkout's debug binary, then
- * CI/release artifacts, then a globally installed CLI. Preferring the debug
- * binary keeps local and workflow tests tied to the code that was just built
- * instead of a stale `target/ci/vize` left by a previous job.
+ * CI/release artifacts. If none exist, build and run the current workspace;
+ * a globally installed CLI may exercise unrelated code and invalidate the
+ * regression that the test is meant to cover.
  */
-export function resolveVizeLaunchCommand(): string[] {
-  const envBinary = process.env.VIZE_LSP_BIN;
+export function resolveVizeLaunchCommand(
+  canLaunch: (command: string) => boolean = (command) =>
+    spawnSync(command, ["--version"], {
+      cwd: root,
+      encoding: "utf8",
+    }).status === 0,
+  envBinary = process.env.VIZE_LSP_BIN,
+): string[] {
   const candidates = [
     ...(envBinary ? [[envBinary, "lsp"]] : []),
     [path.join(root, "target/debug/vize"), "lsp"],
     [path.join(root, "target/ci/vize"), "lsp"],
     [path.join(root, "target/release/vize"), "lsp"],
-    ["vize", "lsp"],
   ];
 
   for (const candidate of candidates) {
-    const probe = spawnSync(candidate[0], ["--version"], {
-      cwd: root,
-      encoding: "utf8",
-    });
-    if (probe.status === 0) {
+    if (canLaunch(candidate[0])) {
       return candidate;
     }
   }


### PR DESCRIPTION
## Summary

- remove the bare `vize` fallback from LSP test launch resolution
- keep explicit `VIZE_LSP_BIN` and checkout-local debug, CI, and release artifacts
- fall back to `cargo run -q -p vize -- lsp` when no checkout binary exists
- add a focused regression test proving an available global binary is ignored

## Root cause

A direct tooling test run in a fresh worktree could select an unrelated `vize` from `PATH`. On this machine that was version 0.24.0, which produced a versionless workspace diagnostic before the current didOpen publish and made the supersession assertion fail. Building the current checkout made the test pass consistently, so this was a launcher integrity issue rather than a publish-order product regression.

## Validation

- explicit old global binary: reproduced the versionless diagnostic failure
- current checkout binary: supersession test passed 20/20 repeated runs
- focused launcher and supersession tests: 2 passed
- LSP tooling suite: 2,209 passed
- formatting and diff checks passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->