### PR TITLE
test(atelier): normalize Babel oracle whitespace

### DIFF
--- a/crates/vize_atelier_jsx/tests/babel_compat/mod.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/mod.rs
@@ -145,6 +145,30 @@ fn fixture_dir() -> PathBuf {
         .join("fixtures")
 }
 
+/// Canonicalize generated text before it becomes snapshot input.
+///
+/// The compiler output is semantically unchanged; this only keeps platform
+/// line endings and indentation on otherwise blank lines out of snapshots.
+fn normalize_snapshot_text(input: &str) -> std::string::String {
+    let input = input.trim_end();
+    let mut normalized = std::string::String::with_capacity(input.len());
+    for (index, line) in input.lines().enumerate() {
+        if index > 0 {
+            normalized.push('\n');
+        }
+        normalized.push_str(line.trim_end());
+    }
+    normalized
+}
+
+#[test]
+fn snapshot_text_normalizes_line_endings_and_trailing_whitespace() {
+    assert_eq!(
+        normalize_snapshot_text("first  \r\n \t\r\nlast\t\r\n"),
+        "first\n\nlast"
+    );
+}
+
 /// Load `fixtures/corpus.json`.
 pub fn load_corpus() -> Corpus {
     let path = fixture_dir().join("corpus.json");
@@ -212,5 +236,5 @@ pub fn vize_vdom_output(case: &Case) -> std::string::String {
     } else {
         rendered.push_str(module);
     }
-    rendered
+    normalize_snapshot_text(&rendered)
 }

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
@@ -139,7 +139,7 @@ const A = () => _createVNode(_resolveComponent("B"), {
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, {
     modelValue: val,
     "onUpdate:modelValue": $event => ((val) = $event)
@@ -166,7 +166,7 @@ const A = () => _createVNode(_resolveComponent("B"), {
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, {
     argument: val,
     "onUpdate:argument": $event => ((val) = $event),
@@ -192,7 +192,7 @@ const A = () => _createVNode(_resolveComponent("B"), {
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B))
 }
 
@@ -215,7 +215,7 @@ const A = () => _createVNode(_resolveComponent("B"), {
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, {
     modelValue: foo,
     "onUpdate:modelValue": $event => ((foo) = $event),
@@ -249,7 +249,7 @@ const A = () => _createVNode(_resolveComponent("B"), {
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, {
     modelValue: foo,
     "onUpdate:modelValue": $event => ((foo) = $event),
@@ -292,7 +292,7 @@ const A = () => _withDirectives(_createVNode(_resolveComponent("B"), null, null)
 import { resolveComponent as _resolveComponent, withDirectives as _withDirectives, openBlock as _openBlock, createBlock as _createBlock, vShow as _vShow } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return _withDirectives((_openBlock(), _createBlock(_component_B, null, null, 512 /* NEED_PATCH */)), [
     [_vShow, vis]
   ])
@@ -366,7 +366,7 @@ const A = () => _withDirectives(_createVNode("a", null, null), [[_resolveDirecti
 import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   const _directive_custom = _resolveDirective("custom")
-  
+
   return _withDirectives((_openBlock(), _createElementBlock("a", null, null, 512 /* NEED_PATCH */)), [
     [_directive_custom, val, "arg"]
   ])
@@ -389,7 +389,7 @@ const A = () => _withDirectives(_createVNode("a", null, null), [[_resolveDirecti
 import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   const _directive_custom = _resolveDirective("custom")
-  
+
   return _withDirectives((_openBlock(), _createElementBlock("a", null, null, 512 /* NEED_PATCH */)), [
     [_directive_custom, val, "arg", { a: true, b: true }]
   ])
@@ -409,7 +409,7 @@ const A = () => _withDirectives(_createVNode("div", null, null), [[_resolveDirec
 import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   const _directive_unknown_thing = _resolveDirective("unknown-thing")
-  
+
   return _withDirectives((_openBlock(), _createElementBlock("div", null, null, 512 /* NEED_PATCH */)), [
     [_directive_unknown_thing, x]
   ])

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__elements.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__elements.snap
@@ -32,7 +32,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, null);
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B))
 }
 
@@ -66,7 +66,7 @@ const A = () => _createVNode(_resolveComponent("my-el"), null, null);
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_my_el = _resolveComponent("my-el")
-  
+
   return (_openBlock(), _createBlock(_component_my_el))
 }
 

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
@@ -48,7 +48,7 @@ const A = () => <B v-models={foo}/>;
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B))
 }
 
@@ -66,7 +66,7 @@ const A = () => <B v-models={[foo]}/>;
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B))
 }
 
@@ -85,6 +85,6 @@ const A = () => _createVNode(_resolveComponent("B"), null, 1);
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B))
 }

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__optimize.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__optimize.snap
@@ -184,7 +184,7 @@ const A = () => _createVNode(_resolveComponent("B"), {
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, { foo: f }, null, 8 /* PROPS */, ["foo"]))
 }
 
@@ -228,7 +228,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
 import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, null, {
     default: _withCtx(() => [
       _createElementVNode("i")
@@ -257,7 +257,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
 import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, null, {
     default: _withCtx((s) => [
       _createElementVNode("i", null, _toDisplayString(s.x), 1 /* TEXT */)
@@ -280,7 +280,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, slots);
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, null, slots, 1024 /* DYNAMIC_SLOTS */))
 }
 

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__options.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__options.snap
@@ -119,7 +119,7 @@ const A = () => _createVNode(_resolveComponent("my-el"), {
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_my_el = _resolveComponent("my-el")
-  
+
   return (_openBlock(), _createBlock(_component_my_el, { foo: 1 }))
 }
 
@@ -139,7 +139,7 @@ const A = () => _createVNode("MyEl", {
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_MyEl = _resolveComponent("MyEl")
-  
+
   return (_openBlock(), _createBlock(_component_MyEl, { foo: 1 }))
 }
 
@@ -162,7 +162,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, _isSlot(slots) ? slot
 import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock, createTextVNode as _createTextVNode, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, null, {
     default: _withCtx(() => [
       _createTextVNode(_toDisplayString(slots), 1 /* TEXT */)
@@ -187,7 +187,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
 import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock, createTextVNode as _createTextVNode, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, null, {
     default: _withCtx(() => [
       _createTextVNode(_toDisplayString(slots), 1 /* TEXT */)

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__slots.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__slots.snap
@@ -19,7 +19,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
 import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, null, {
     default: _withCtx(() => [
       _createElementVNode("i")
@@ -47,7 +47,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock, createTextVNode as _createTextVNode, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, null, {
     default: _withCtx(() => [
       _createTextVNode("foo")
@@ -72,7 +72,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
 import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, null, {
     default: _withCtx((s) => [
       _createElementVNode("i", null, _toDisplayString(s.x), 1 /* TEXT */)
@@ -98,7 +98,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
 import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, null, {
     default: _withCtx(() => [
       _createElementVNode("div", null, "A")
@@ -121,7 +121,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, slots);
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, null, slots, 1024 /* DYNAMIC_SLOTS */))
 }
 
@@ -142,7 +142,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
 import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, null, {
     default: _withCtx(() => [
       _createElementVNode("i")
@@ -171,7 +171,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
 import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, null, {
     bar: _withCtx(() => [
       _createElementVNode("b")
@@ -199,7 +199,7 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
 import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B, null, {
     default: _withCtx(() => [
       _createElementVNode("i")
@@ -225,6 +225,6 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
-  
+
   return (_openBlock(), _createBlock(_component_B))
 }


### PR DESCRIPTION
## Summary

- canonicalize Vize-side Babel oracle snapshot text to LF line endings without trailing whitespace
- add a direct regression test for CRLF, trailing spaces, and whitespace-only lines
- mechanically refresh only the six affected oracle snapshots

## Root cause

Some generated modules indent an otherwise blank separator line before the render return. The differential oracle copied that presentation detail into snapshots, so an otherwise valid compatibility change could fail repository diff checks on a spaces-only line.

The normalization stays entirely in the test harness; production compiler output and compatibility behavior are unchanged. This is the test-only prerequisite for #3662.

## Validation

- `INSTA_UPDATE=always cargo test -p vize_atelier_jsx --test babel_compat_oracle`
- `cargo test -p vize_atelier_jsx`
- `node --test tests/tooling/babel-jsx-oracle.test.ts`
- `cargo clippy -p vize_atelier_jsx --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- snapshot diff is empty under `--ignore-space-at-eol`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendered output consistency by normalizing line endings and removing unnecessary trailing whitespace.
  * Prevented formatting differences caused by trailing input whitespace.

* **Tests**
  * Added coverage for whitespace and line-ending normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->