### PR TITLE
fix(atelier): parenthesize non-identifier JSX pragma callee

### DIFF
--- a/crates/vize_atelier_core/src/codegen/context/vnode_factory.rs
+++ b/crates/vize_atelier_core/src/codegen/context/vnode_factory.rs
@@ -96,9 +96,11 @@ fn normalize_vnode_factory(factory: &str) -> String {
     if is_member_expression_chain(factory) {
         return String::from(factory);
     }
-    let mut wrapped = String::with_capacity(factory.len() + 2);
+    let mut wrapped = String::with_capacity(factory.len() + 3);
     wrapped.push('(');
     wrapped.push_str(factory);
+    // Keep the closing parenthesis outside a trailing line comment.
+    wrapped.push('\n');
     wrapped.push(')');
     wrapped
 }

--- a/crates/vize_atelier_core/src/codegen/context/vnode_factory.rs
+++ b/crates/vize_atelier_core/src/codegen/context/vnode_factory.rs
@@ -25,7 +25,7 @@ impl CodegenContext {
             indent_level: 0,
             ssr: options.ssr,
             helper_alias: default_helper_alias,
-            vnode_factory: vnode_factory.map(String::from),
+            vnode_factory: vnode_factory.map(normalize_vnode_factory),
             runtime_global_name: options.runtime_global_name.to_compact_string(),
             runtime_module_name: options.runtime_module_name.to_compact_string(),
             options,
@@ -85,6 +85,29 @@ impl CodegenContext {
     pub(in crate::codegen) fn needs_open_block_shim(&self) -> bool {
         self.vnode_factory.is_some() && self.used_helpers.contains(RuntimeHelper::OpenBlock)
     }
+}
+
+/// Store a JSX factory pragma so it can be emitted directly as a call callee.
+///
+/// The pragma may be any valid JavaScript expression, so anything that is not a
+/// plain identifier or dotted member chain is parenthesized once here to keep
+/// callee precedence: `a || b` must emit `(a || b)("div")`.
+fn normalize_vnode_factory(factory: &str) -> String {
+    if is_member_expression_chain(factory) {
+        return String::from(factory);
+    }
+    let mut wrapped = String::with_capacity(factory.len() + 2);
+    wrapped.push('(');
+    wrapped.push_str(factory);
+    wrapped.push(')');
+    wrapped
+}
+
+fn is_member_expression_chain(factory: &str) -> bool {
+    !factory.is_empty()
+        && factory
+            .split('.')
+            .all(crate::codegen::helpers::is_valid_js_identifier)
 }
 
 fn is_vnode_factory_helper(helper: RuntimeHelper) -> bool {

--- a/crates/vize_atelier_jsx/src/compile/babel.rs
+++ b/crates/vize_atelier_jsx/src/compile/babel.rs
@@ -92,7 +92,7 @@ pub(super) fn resolve_vnode_factory<'a>(
 fn valid_pragma_expression(pragma: &str) -> bool {
     let mut probe = String::from("const __vize_pragma = (");
     probe.push_str(pragma);
-    probe.push_str(");");
+    probe.push_str("\n);");
     let allocator = Allocator::default();
     !crate::parse_module(&allocator, probe.as_str(), JsxLang::Jsx).has_errors()
 }

--- a/crates/vize_atelier_jsx/tests/pragma.rs
+++ b/crates/vize_atelier_jsx/tests/pragma.rs
@@ -114,9 +114,13 @@ fn babel_pragma_keeps_callee_precedence_for_non_identifier_expressions() {
     // not a plain identifier or dotted member chain has to stay parenthesized
     // to remain the callee of the vnode call.
     for (pragma, callee) in [
-        ("left || right", "(left || right)("),
-        ("cond ? a : b", "(cond ? a : b)("),
-        ("(setup(), h)", "((setup(), h))("),
+        ("left || right", "(left || right\n)("),
+        ("cond ? a : b", "(cond ? a : b\n)("),
+        ("(setup(), h)", "((setup(), h)\n)("),
+        (
+            "left || right // fallback",
+            "(left || right // fallback\n)(",
+        ),
     ] {
         let bump = Bump::new();
         let output = compile(

--- a/crates/vize_atelier_jsx/tests/pragma.rs
+++ b/crates/vize_atelier_jsx/tests/pragma.rs
@@ -109,6 +109,40 @@ fn babel_pragma_routes_every_vnode_shape_through_the_custom_factory() {
 }
 
 #[test]
+fn babel_pragma_keeps_callee_precedence_for_non_identifier_expressions() {
+    // The pragma accepts any valid JavaScript expression, so anything that is
+    // not a plain identifier or dotted member chain has to stay parenthesized
+    // to remain the callee of the vnode call.
+    for (pragma, callee) in [
+        ("left || right", "(left || right)("),
+        ("cond ? a : b", "(cond ? a : b)("),
+        ("(setup(), h)", "((setup(), h))("),
+    ] {
+        let bump = Bump::new();
+        let output = compile(
+            &bump,
+            "const A = () => <div>{ok ? <i/> : <b/>}</div>;",
+            &JsxCompileConfig {
+                compat: JsxCompatMode::Babel,
+                ..Default::default()
+            },
+            Some(pragma),
+        );
+        let module = output.module_code();
+
+        assert!(output.diagnostics.is_empty(), "{:?}", output.diagnostics);
+        assert!(module.contains(callee), "{pragma}: {module}");
+        let allocator = Allocator::default();
+        let parsed = parse_module(&allocator, module.as_str(), JsxLang::Jsx);
+        assert!(
+            parsed.diagnostics.is_empty(),
+            "{pragma}: {:?}\n{module}",
+            parsed.diagnostics
+        );
+    }
+}
+
+#[test]
 fn babel_pragma_removes_the_vue_import_when_no_other_helper_is_needed() {
     let bump = Bump::new();
     let output = compile(


### PR DESCRIPTION
Follow-up to the CodeRabbit review on #3653 (comment 3695411671), which merged before the fix landed.

`compile_jsx_with_babel_pragma` accepts any valid JavaScript expression as the pragma, but the factory string was stored verbatim and emitted directly as the call callee. For a pragma like `left || right` that produced `left || right("div", ...)`, silently binding the call to `right` instead of the whole expression. The pragma is now normalized once at context construction, wrapping anything that is not a plain identifier or dotted member chain:

```rust
fn normalize_vnode_factory(factory: &str) -> String {
    if is_member_expression_chain(factory) {
        return String::from(factory);
    }
    let mut wrapped = String::with_capacity(factory.len() + 2);
    wrapped.push('(');
    wrapped.push_str(factory);
    wrapped.push(')');
    wrapped
}
```

Identifier and member-chain pragmas (`h`, `Vue.h`) are untouched, so existing output — including the Babel oracle's `options/pragma` case — is byte-identical. `crates/vize_atelier_jsx/tests/pragma.rs` gains coverage for `left || right`, `cond ? a : b`, and `(setup(), h)`, asserting the parenthesized callee and that the emitted module reparses without diagnostics.

## Testing
- `cargo test -p vize_atelier_jsx --test pragma`
- `cargo test -p vize_atelier_core --lib`
- `cargo clippy -p vize_atelier_core -p vize_atelier_jsx --lib -- -D warnings`
- `cargo clippy -p vize_atelier_jsx --test pragma -- -D warnings`

The Node oracle checks (`oracle.mjs --check`, `tests/tooling/*`) could not run in this sandbox: `@babel/core` and the moon toolchain are not installed there.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custom JSX pragma expressions to preserve correct JavaScript operator precedence.
  * Complex pragma expressions, including logical, conditional, and sequence expressions, now generate valid factory calls without syntax errors.
  * Existing identifier and member-chain pragmas continue to work as expected.

* **Tests**
  * Added coverage to verify generated output is valid, parseable, and free of diagnostics across supported pragma expression types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->