### PR TITLE
fix(atelier): preserve raw JSX expression children in Babel mode

### DIFF
--- a/crates/vize_atelier_core/src/codegen/expression.rs
+++ b/crates/vize_atelier_core/src/codegen/expression.rs
@@ -8,7 +8,9 @@ mod generate;
 pub(crate) mod helpers;
 pub(crate) mod scope_prefix;
 
-use crate::{CompoundExpressionChild, ExpressionNode, SimpleExpressionNode};
+use crate::{
+    CompoundExpressionChild, CompoundExpressionNode, ExpressionNode, SimpleExpressionNode,
+};
 
 use super::{context::CodegenContext, helpers::escape_js_string};
 
@@ -30,20 +32,30 @@ pub fn generate_expression(ctx: &mut CodegenContext, expr: &ExpressionNode<'_>) 
             generate_simple_expression(ctx, exp);
         }
         ExpressionNode::Compound(comp) => {
-            for child in comp.children.iter() {
-                match child {
-                    CompoundExpressionChild::Simple(exp) => {
-                        generate_simple_expression(ctx, exp);
-                    }
-                    CompoundExpressionChild::String(s) => {
-                        ctx.push(s);
-                    }
-                    CompoundExpressionChild::Symbol(helper) => {
-                        ctx.push(ctx.helper(*helper));
-                    }
-                    _ => {}
-                }
+            generate_compound_expression(ctx, comp);
+        }
+    }
+}
+
+/// Generate a compound expression used directly in child position.
+pub fn generate_compound_expression(
+    ctx: &mut CodegenContext,
+    compound: &CompoundExpressionNode<'_>,
+) {
+    for child in compound.children.iter() {
+        match child {
+            CompoundExpressionChild::Simple(exp) => {
+                generate_simple_expression(ctx, exp);
             }
+            CompoundExpressionChild::String(s) => {
+                ctx.push(s);
+            }
+            CompoundExpressionChild::Symbol(helper) => {
+                ctx.push(ctx.helper(*helper));
+            }
+            CompoundExpressionChild::Compound(_)
+            | CompoundExpressionChild::Interpolation(_)
+            | CompoundExpressionChild::Text(_) => {}
         }
     }
 }

--- a/crates/vize_atelier_core/src/codegen/node.rs
+++ b/crates/vize_atelier_core/src/codegen/node.rs
@@ -5,6 +5,7 @@ use crate::TemplateChildNode;
 use super::children::{generate_comment, generate_interpolation, generate_text};
 use super::context::CodegenContext;
 use super::element::generate_element;
+use super::expression::generate_compound_expression;
 use super::v_for::generate_for;
 use super::v_if::generate_if;
 use vize_carton::{ToCompactString, ensure_sufficient_stack};
@@ -22,6 +23,9 @@ pub fn generate_node(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>) {
         TemplateChildNode::Text(text) => generate_text(ctx, text),
         TemplateChildNode::Comment(comment) => generate_comment(ctx, comment),
         TemplateChildNode::Interpolation(interp) => generate_interpolation(ctx, interp),
+        TemplateChildNode::CompoundExpression(compound) => {
+            generate_compound_expression(ctx, compound)
+        }
         TemplateChildNode::If(if_node) => generate_if(ctx, if_node),
         TemplateChildNode::For(for_node) => generate_for(ctx, for_node),
         TemplateChildNode::Hoisted(index) => {

--- a/crates/vize_atelier_jsx/src/lower.rs
+++ b/crates/vize_atelier_jsx/src/lower.rs
@@ -37,7 +37,7 @@ pub struct Lowerer<'a, 'm, 's> {
     mapper: &'m SpanMapper<'s>,
     compat: JsxCompatMode,
     transform_on_helper: Option<String>,
-    transform_on_active: bool,
+    babel_vdom_compat_active: bool,
     diagnostics: std::vec::Vec<JsxDiagnostic>,
     /// `<style scoped>` blocks extracted from the render root currently being
     /// lowered, in source order. Drained by [`Self::take_scoped_styles`] once
@@ -63,7 +63,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             mapper,
             compat,
             transform_on_helper: transform_on_helper.map(String::from),
-            transform_on_active: false,
+            babel_vdom_compat_active: false,
             diagnostics: std::vec::Vec::new(),
             pending_styles: std::vec::Vec::new(),
         }
@@ -167,14 +167,19 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         self.compat.is_babel()
     }
 
+    /// Whether Babel-only VDOM child semantics apply to the current render root.
+    pub(crate) fn uses_babel_vdom_compat(&self) -> bool {
+        self.uses_babel_compat() && self.babel_vdom_compat_active
+    }
+
     /// Select whether the current render root may use VDOM-only Babel options.
     pub(crate) fn set_current_output_mode(&mut self, mode: crate::JsxOutputMode) {
-        self.transform_on_active = mode == crate::JsxOutputMode::Vdom;
+        self.babel_vdom_compat_active = mode == crate::JsxOutputMode::Vdom;
     }
 
     /// Collision-free helper binding for Babel's opt-in `transformOn` lowering.
     pub(crate) fn transform_on_helper(&self) -> Option<&str> {
-        if self.transform_on_active {
+        if self.babel_vdom_compat_active {
             self.transform_on_helper.as_deref()
         } else {
             None

--- a/crates/vize_atelier_jsx/src/lower/child.rs
+++ b/crates/vize_atelier_jsx/src/lower/child.rs
@@ -3,7 +3,10 @@
 use oxc_ast::ast::{JSXChild, JSXExpression, JSXExpressionContainer, JSXSpreadChild};
 use oxc_span::GetSpan;
 use vize_carton::{Box, Vec};
-use vize_relief::{InterpolationNode, TemplateChildNode, TextNode};
+use vize_relief::{
+    CompoundExpressionChild, CompoundExpressionNode, ExpressionNode, InterpolationNode,
+    TemplateChildNode, TextNode,
+};
 
 use super::Lowerer;
 
@@ -13,6 +16,42 @@ use super::Lowerer;
 const SPREAD_CHILD_UNSUPPORTED: &str = "spread children (`{...items}`) are not supported; the value would be stringified instead of spread";
 
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// Lower children of an intrinsic element, preserving Babel's raw value
+    /// semantics for a lone expression child in opt-in VDOM compatibility mode.
+    ///
+    /// Vize's native template-shaped output stringifies `{value}` and marks the
+    /// vnode with `TEXT`. Babel passes the value as a child array entry instead,
+    /// so it contributes no text patch flag. Component children deliberately do
+    /// not use this path because they are lowered through slot synthesis.
+    pub(crate) fn lower_element_children(
+        &mut self,
+        children: &[JSXChild<'_>],
+    ) -> Vec<'a, TemplateChildNode<'a>> {
+        if !self.uses_babel_vdom_compat() {
+            return self.lower_children(children);
+        }
+
+        let [JSXChild::ExpressionContainer(container)] = children else {
+            return self.lower_children(children);
+        };
+        match &container.expression {
+            JSXExpression::EmptyExpression(_) | JSXExpression::StringLiteral(_) => {
+                self.lower_children(children)
+            }
+            expression => {
+                let mut out = Vec::new_in(self.bump());
+                if let Some(control_flow) =
+                    self.lower_control_flow_child(expression, container.span)
+                {
+                    out.push(control_flow);
+                } else {
+                    out.push(self.raw_expression_child(expression.span(), container.span));
+                }
+                out
+            }
+        }
+    }
+
     /// Lower a list of JSX children, dropping whitespace-only text.
     pub(crate) fn lower_children(
         &mut self,
@@ -112,5 +151,26 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             raw: false,
         };
         TemplateChildNode::Interpolation(Box::new_in(node, self.bump()))
+    }
+
+    /// Represent a JSX child value as an unescaped expression rather than a
+    /// template interpolation. The core code generator already models mixed
+    /// JavaScript expressions as compound expressions; a single dynamic part
+    /// is the narrowest existing IR shape that keeps this JSX-only distinction
+    /// out of the public relief node surface.
+    fn raw_expression_child(
+        &self,
+        expression_span: oxc_span::Span,
+        container_span: oxc_span::Span,
+    ) -> TemplateChildNode<'a> {
+        let ExpressionNode::Simple(expression) = self.dyn_expr(expression_span) else {
+            unreachable!("span-backed JSX expressions are always simple expressions")
+        };
+        let mut compound =
+            CompoundExpressionNode::new(self.bump(), self.mapper().location(container_span));
+        compound
+            .children
+            .push(CompoundExpressionChild::Simple(expression));
+        TemplateChildNode::CompoundExpression(Box::new_in(compound, self.bump()))
     }
 }

--- a/crates/vize_atelier_jsx/src/lower/element.rs
+++ b/crates/vize_atelier_jsx/src/lower/element.rs
@@ -52,7 +52,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         node.children = if node.tag_type == ElementType::Component {
             self.lower_component_children(&element.children)
         } else {
-            self.lower_children(&element.children)
+            self.lower_element_children(&element.children)
         };
         // `v-slots` contributes slot templates, appended after the element's own
         // children so those still become the `default` slot when the slots object

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -307,24 +307,24 @@ here so the choice is not implicit (#3418, #3467, `src/lower/v_slots.rs`):
 
 Compared against Vize's default, which is already fully optimized.
 
-| Case                             | Babel                                 | Vize today                            | Compat mode         | Verdict |
-| -------------------------------- | ------------------------------------- | ------------------------------------- | ------------------- | ------- |
-| `optimize/static`                | no flag                               | no flag                               | no change           | ✅      |
-| `optimize/class_only`            | `2`                                   | `2 /* CLASS */`                       | no change           | ✅      |
-| `optimize/style_only`            | `4`                                   | `4 /* STYLE */`                       | no change           | ✅      |
-| `optimize/text_only`             | raw child, no flag                    | `toDisplayString(t)` + `1 /* TEXT */` | raw child, no flag  | ✅      |
-| `optimize/class_and_props`       | `10, ["id"]`                          | `11 /* TEXT, CLASS, PROPS */, ["id"]` | drops `TEXT`        | ✅      |
-| `optimize/spread`                | `16`                                  | `16 /* FULL_PROPS */`                 | no change           | ✅      |
-| `optimize/ref`                   | `512`                                 | `512 /* NEED_PATCH */`                | no change           | ✅      |
-| `optimize/key`                   | no flag                               | no flag                               | no change           | ✅      |
-| `optimize/event`                 | `8, ["onClick"]`                      | same                                  | no change           | ✅      |
-| `optimize/component_props`       | `8, ["foo"]`                          | same                                  | no change           | ✅      |
-| `optimize/v_model_input`         | `8, ["onUpdate:modelValue"]`          | same                                  | no change           | ✅      |
-| `optimize/slots_stability`       | `_: 1`                                | `_: 1 /* STABLE */`                   | no change           | ✅      |
-| `optimize/scoped_slot_stability` | `_: 1`                                | `_: 1 /* STABLE */`                   | no change           | ✅      |
-| `optimize/v_slots_stability`     | slots object as children, no `_` flag | same, no `_` flag (#3467)             | no change           | ✅      |
-| `optimize/fragment`              | no flag                               | `64 /* STABLE_FRAGMENT */`            | no change           | ✅      |
-| `optimize/map_list`              | raw array child                       | `renderList` + `KEYED_FRAGMENT`       | no change           | ✅      |
+| Case                             | Babel                                 | Vize today                            | Compat mode        | Verdict |
+| -------------------------------- | ------------------------------------- | ------------------------------------- | ------------------ | ------- |
+| `optimize/static`                | no flag                               | no flag                               | no change          | ✅      |
+| `optimize/class_only`            | `2`                                   | `2 /* CLASS */`                       | no change          | ✅      |
+| `optimize/style_only`            | `4`                                   | `4 /* STYLE */`                       | no change          | ✅      |
+| `optimize/text_only`             | raw child, no flag                    | `toDisplayString(t)` + `1 /* TEXT */` | raw child, no flag | ✅      |
+| `optimize/class_and_props`       | `10, ["id"]`                          | `11 /* TEXT, CLASS, PROPS */, ["id"]` | drops `TEXT`       | ✅      |
+| `optimize/spread`                | `16`                                  | `16 /* FULL_PROPS */`                 | no change          | ✅      |
+| `optimize/ref`                   | `512`                                 | `512 /* NEED_PATCH */`                | no change          | ✅      |
+| `optimize/key`                   | no flag                               | no flag                               | no change          | ✅      |
+| `optimize/event`                 | `8, ["onClick"]`                      | same                                  | no change          | ✅      |
+| `optimize/component_props`       | `8, ["foo"]`                          | same                                  | no change          | ✅      |
+| `optimize/v_model_input`         | `8, ["onUpdate:modelValue"]`          | same                                  | no change          | ✅      |
+| `optimize/slots_stability`       | `_: 1`                                | `_: 1 /* STABLE */`                   | no change          | ✅      |
+| `optimize/scoped_slot_stability` | `_: 1`                                | `_: 1 /* STABLE */`                   | no change          | ✅      |
+| `optimize/v_slots_stability`     | slots object as children, no `_` flag | same, no `_` flag (#3467)             | no change          | ✅      |
+| `optimize/fragment`              | no flag                               | `64 /* STABLE_FRAGMENT */`            | no change          | ✅      |
+| `optimize/map_list`              | raw array child                       | `renderList` + `KEYED_FRAGMENT`       | no change          | ✅      |
 
 ## Inputs babel rejects
 

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   86 |
-| divergent  |   10 |
+| equivalent |   88 |
+| divergent  |    8 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -312,8 +312,8 @@ Compared against Vize's default, which is already fully optimized.
 | `optimize/static`                | no flag                               | no flag                               | no change           | ✅      |
 | `optimize/class_only`            | `2`                                   | `2 /* CLASS */`                       | no change           | ✅      |
 | `optimize/style_only`            | `4`                                   | `4 /* STYLE */`                       | no change           | ✅      |
-| `optimize/text_only`             | raw child, no flag                    | `toDisplayString(t)` + `1 /* TEXT */` | emit the raw child  | ❌      |
-| `optimize/class_and_props`       | `10, ["id"]`                          | `11 /* TEXT, CLASS, PROPS */, ["id"]` | drop the TEXT child | ❌      |
+| `optimize/text_only`             | raw child, no flag                    | `toDisplayString(t)` + `1 /* TEXT */` | raw child, no flag  | ✅      |
+| `optimize/class_and_props`       | `10, ["id"]`                          | `11 /* TEXT, CLASS, PROPS */, ["id"]` | drops `TEXT`        | ✅      |
 | `optimize/spread`                | `16`                                  | `16 /* FULL_PROPS */`                 | no change           | ✅      |
 | `optimize/ref`                   | `512`                                 | `512 /* NEED_PATCH */`                | no change           | ✅      |
 | `optimize/key`                   | no flag                               | no flag                               | no change           | ✅      |

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -135,14 +135,8 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("optimize/static", Same),
     ("optimize/class_only", Same),
     ("optimize/style_only", Same),
-    (
-        "optimize/text_only",
-        Diff("interpolated child becomes a TEXT child"),
-    ),
-    (
-        "optimize/class_and_props",
-        Diff("interpolated child becomes a TEXT child"),
-    ),
+    ("optimize/text_only", Same),
+    ("optimize/class_and_props", Same),
     ("optimize/spread", Same),
     ("optimize/ref", Same),
     ("optimize/key", Same),

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (86, 10, 2));
+    assert_eq!((equivalent, divergent, deferred), (88, 8, 2));
     assert_eq!(VERDICTS.len(), 98);
 }
 

--- a/crates/vize_atelier_jsx/tests/compat_mode.rs
+++ b/crates/vize_atelier_jsx/tests/compat_mode.rs
@@ -172,6 +172,44 @@ fn babel_compat_rewrites_xlink_href_across_prop_shapes_only_when_opted_in() {
 }
 
 #[test]
+fn babel_compat_keeps_lone_element_expressions_raw_without_a_text_flag() {
+    let source = concat!(
+        "const A = () => <div>{t}</div>;\n",
+        "const B = () => <div class={c} id={i}>{t}</div>;",
+    );
+    let bump = Bump::new();
+    let implicit_native = compile_jsx(&bump, source, JsxLang::Jsx, &JsxCompileConfig::default())
+        .module_code()
+        .to_string();
+    let explicit_native = compile_module(source, JsxCompatMode::Native, JsxOutputMode::Vdom);
+    let babel = compile_module(source, JsxCompatMode::Babel, JsxOutputMode::Vdom);
+
+    assert_eq!(implicit_native, explicit_native);
+    assert_eq!(explicit_native.matches("_toDisplayString(t)").count(), 2);
+    assert!(
+        explicit_native.contains("1 /* TEXT */"),
+        "{explicit_native}"
+    );
+    assert!(
+        explicit_native.contains("11 /* TEXT, CLASS, PROPS */, [\"id\"]"),
+        "{explicit_native}"
+    );
+
+    assert_eq!(babel.matches("[\n    t\n  ]").count(), 2, "{babel}");
+    assert!(!babel.contains("toDisplayString"), "{babel}");
+    assert!(!babel.contains("1 /* TEXT */"), "{babel}");
+    assert!(babel.contains("10 /* CLASS, PROPS */, [\"id\"]"), "{babel}");
+
+    let allocator = Allocator::default();
+    let parsed = parse_module(&allocator, &babel, JsxLang::Jsx);
+    assert!(
+        parsed.diagnostics.is_empty(),
+        "{:?}\n{babel}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
 fn transform_on_is_off_by_default_and_inert_in_native_mode() {
     let source = "const A = () => <button on={{ click: h }}/>;";
     let native = compile_module(source, JsxCompatMode::Native, JsxOutputMode::Vdom);

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__children.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__children.snap
@@ -136,11 +136,13 @@ const A = () => _createVNode("div", null, [list.map(i => _createVNode("span", {
   "key": i
 }, [i]))]);
 ### vize (vdom, babel compat)
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
+import { openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, [
     (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(list, (i) => {
-      return (_openBlock(), _createElementBlock("span", { key: i }, _toDisplayString(i), 1 /* TEXT */))
+      return (_openBlock(), _createElementBlock("span", { key: i }, [
+        i
+      ]))
     }), 128 /* KEYED_FRAGMENT */))
   ]))
 }

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__optimize.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__optimize.snap
@@ -62,7 +62,7 @@ export function render(_ctx, _cache) {
 
 ## optimize/text_only
 ### verdict
-divergent: interpolated child becomes a TEXT child
+equivalent
 ### source (jsx)
 const A = () => <div>{t}</div>;
 ### babel options
@@ -71,14 +71,16 @@ const A = () => <div>{t}</div>;
 import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [t]);
 ### vize (vdom, babel compat)
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(t), 1 /* TEXT */))
+  return (_openBlock(), _createElementBlock("div", null, [
+    t
+  ]))
 }
 
 ## optimize/class_and_props
 ### verdict
-divergent: interpolated child becomes a TEXT child
+equivalent
 ### source (jsx)
 const A = () => <div class={c} id={i}>{t}</div>;
 ### babel options
@@ -90,12 +92,14 @@ const A = () => _createVNode("div", {
   "id": i
 }, [t], 10, ["id"]);
 ### vize (vdom, babel compat)
-import { toDisplayString as _toDisplayString, normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+import { normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", {
     class: _normalizeClass(c),
     id: i
-  }, _toDisplayString(t), 11 /* TEXT, CLASS, PROPS */, ["id"]))
+  }, [
+    t
+  ], 10 /* CLASS, PROPS */, ["id"]))
 }
 
 ## optimize/spread
@@ -254,13 +258,15 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
   _: 1
 });
 ### vize (vdom, babel compat)
-import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
+import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
 
   return (_openBlock(), _createBlock(_component_B, null, {
     default: _withCtx((s) => [
-      _createElementVNode("i", null, _toDisplayString(s.x), 1 /* TEXT */)
+      _createElementVNode("i", null, [
+        s.x
+      ])
     ]),
     _: 1 /* STABLE */
   }))
@@ -316,11 +322,13 @@ const A = () => _createVNode("div", null, [list.map(i => _createVNode("span", {
   "key": i
 }, [i]))]);
 ### vize (vdom, babel compat)
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
+import { openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, [
     (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(list, (i) => {
-      return (_openBlock(), _createElementBlock("span", { key: i }, _toDisplayString(i), 1 /* TEXT */))
+      return (_openBlock(), _createElementBlock("span", { key: i }, [
+        i
+      ]))
     }), 128 /* KEYED_FRAGMENT */))
   ]))
 }

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__options.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__options.snap
@@ -210,9 +210,11 @@ const A = defineComponent((props: {
   foo: string;
 }) => () => _createVNode("div", null, [props.foo]));
 ### vize (vdom, babel compat)
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(props.foo), 1 /* TEXT */))
+  return (_openBlock(), _createElementBlock("div", null, [
+    props.foo
+  ]))
 }
 
 ## options/resolve_type_on
@@ -237,7 +239,9 @@ const A = defineComponent((props: {
   name: "A"
 });
 ### vize (vdom, babel compat)
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(props.foo), 1 /* TEXT */))
+  return (_openBlock(), _createElementBlock("div", null, [
+    props.foo
+  ]))
 }

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__slots.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__slots.snap
@@ -69,13 +69,15 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
   default: s => _createVNode("i", null, [s.x])
 });
 ### vize (vdom, babel compat)
-import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
+import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
 
   return (_openBlock(), _createBlock(_component_B, null, {
     default: _withCtx((s) => [
-      _createElementVNode("i", null, _toDisplayString(s.x), 1 /* TEXT */)
+      _createElementVNode("i", null, [
+        s.x
+      ])
     ]),
     _: 1 /* STABLE */
   }))


### PR DESCRIPTION
## Summary

- preserve lone intrinsic JSX expression children as raw values in opt-in Babel compatibility mode
- omit their TEXT patch contribution so optimize/text-only and optimize/class-and-props match Babel
- preserve native/default output byte-for-byte and ratchet oracle totals from 86/10/2 to 88/8/2

## Root cause

Vize lowered every JSX expression child through a template interpolation node. That forced `toDisplayString` and a TEXT patch flag, while the Babel JSX transform passes a lone intrinsic expression through as a raw child value.

## Validation

- `cargo test -p vize_atelier_jsx`
- `cargo test -p vize_atelier_jsx --test compat_mode --test babel_compat_oracle`
- `node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check`
- `node --test tests/tooling/babel-jsx-oracle.test.ts`
- `cargo clippy -p vize_atelier_core -p vize_atelier_jsx --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Refs #3391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in Babel VDOM compatibility for JSX output.
  * Preserved lone JSX expressions as raw children in compatible Babel mode.
  * Added compound-expression generation for supported child expressions.

* **Bug Fixes**
  * Improved compatibility results for optimized text-only and class/props cases.
  * Reduced Babel compatibility discrepancies from 10 to 8.

* **Tests**
  * Added coverage confirming Babel and native modes produce the expected, parseable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->