### PR TITLE
fix(canon): isolate resolver test overrides

### DIFF
--- a/crates/vize_canon/src/batch/runtime_deps.rs
+++ b/crates/vize_canon/src/batch/runtime_deps.rs
@@ -9,6 +9,9 @@ mod stubs;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+pub(crate) use resolver::{test_env_var_os, with_test_env_overrides};
+
 use resolver::{
     VueRuntimePackages, resolve_package, resolve_vue_package, resolve_vue_runtime_packages,
 };

--- a/crates/vize_canon/src/batch/runtime_deps/resolver.rs
+++ b/crates/vize_canon/src/batch/runtime_deps/resolver.rs
@@ -1,7 +1,11 @@
 use std::{
     env,
+    ffi::OsString,
     path::{Path, PathBuf},
 };
+
+#[cfg(test)]
+use std::cell::RefCell;
 
 const VIZE_VITE_PACKAGE_ENV: &str = "VIZE_VITE_PACKAGE";
 const VIZE_VUE_PACKAGE_ENV: &str = "VIZE_VUE_PACKAGE";
@@ -10,6 +14,69 @@ const VIZE_VUE_RUNTIME_DOM_PACKAGE_ENV: &str = "VIZE_VUE_RUNTIME_DOM_PACKAGE";
 const VIZE_RUNTIME_NODE_MODULES_ENV: &str = "VIZE_RUNTIME_NODE_MODULES";
 #[cfg(test)]
 const VIZE_TEST_WORKSPACE_NODE_MODULES_ENV: &str = "VIZE_TEST_WORKSPACE_NODE_MODULES";
+
+#[cfg(test)]
+thread_local! {
+    static TEST_ENV_OVERRIDE_STACK: RefCell<Vec<Vec<(&'static str, Option<OsString>)>>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+#[cfg(test)]
+struct TestEnvOverrideGuard;
+
+#[cfg(test)]
+impl Drop for TestEnvOverrideGuard {
+    fn drop(&mut self) {
+        TEST_ENV_OVERRIDE_STACK.with(|stack| {
+            debug_assert!(stack.borrow_mut().pop().is_some());
+        });
+    }
+}
+
+/// Scope test-only resolver overrides to the calling test thread.
+///
+/// Rust unit tests share a process and run concurrently. Mutating the real
+/// environment here would let unrelated resolver calls observe partial fixture
+/// state, so overrides live in a thread-local stack instead.
+#[cfg(test)]
+pub(crate) fn with_test_env_overrides<T>(
+    vars: &[(&'static str, Option<&Path>)],
+    run: impl FnOnce() -> T,
+) -> T {
+    let frame = vars
+        .iter()
+        .map(|(name, value)| (*name, value.map(Path::as_os_str).map(OsString::from)))
+        .collect();
+    TEST_ENV_OVERRIDE_STACK.with(|stack| stack.borrow_mut().push(frame));
+    let _guard = TestEnvOverrideGuard;
+    run()
+}
+
+#[cfg(test)]
+pub(crate) fn test_env_var_os(name: &str) -> Option<OsString> {
+    env_var_os(name)
+}
+
+fn env_var_os(name: &str) -> Option<OsString> {
+    #[cfg(test)]
+    {
+        let overridden = TEST_ENV_OVERRIDE_STACK.with(|stack| {
+            for frame in stack.borrow().iter().rev() {
+                if let Some((_, value)) =
+                    frame.iter().rev().find(|(candidate, _)| *candidate == name)
+                {
+                    return Some(value.clone());
+                }
+            }
+            None
+        });
+        if let Some(value) = overridden {
+            return value;
+        }
+    }
+
+    env::var_os(name)
+}
 
 #[derive(Debug, Eq, PartialEq)]
 pub(super) enum VueRuntimePackages {
@@ -109,13 +176,13 @@ fn explicit_package_env(package: &str) -> Option<&'static str> {
 }
 
 fn resolve_explicit_package_env(name: &str) -> Option<PathBuf> {
-    env::var_os(name)
+    env_var_os(name)
         .map(PathBuf::from)
         .filter(|path| path.exists())
 }
 
 fn resolve_package_from_runtime_node_modules(package: &str) -> Option<PathBuf> {
-    env::var_os(VIZE_RUNTIME_NODE_MODULES_ENV)
+    env_var_os(VIZE_RUNTIME_NODE_MODULES_ENV)
         .into_iter()
         .flat_map(|paths| env::split_paths(&paths).collect::<Vec<_>>())
         .map(|node_modules| node_modules.join(package_path(package)))
@@ -128,7 +195,7 @@ fn package_path(package: &str) -> PathBuf {
 
 #[cfg(test)]
 fn resolve_test_workspace_package(package: &str) -> Option<PathBuf> {
-    if let Some(override_path) = env::var_os(VIZE_TEST_WORKSPACE_NODE_MODULES_ENV) {
+    if let Some(override_path) = env_var_os(VIZE_TEST_WORKSPACE_NODE_MODULES_ENV) {
         if override_path.as_os_str() == "__none__" {
             return None;
         }
@@ -162,4 +229,83 @@ fn resolve_ancestor_package(project_root: &Path, package: &str) -> Option<PathBu
     }
 
     None
+}
+
+#[cfg(test)]
+mod test_override_tests {
+    use std::sync::{Arc, Barrier};
+
+    use super::*;
+
+    #[test]
+    fn resolver_overrides_are_isolated_to_the_calling_thread() {
+        let actual = env::var_os(VIZE_VUE_PACKAGE_ENV);
+        let override_path = PathBuf::from("thread-local-vue-package");
+        let barrier = Arc::new(Barrier::new(2));
+
+        std::thread::scope(|scope| {
+            let worker_barrier = Arc::clone(&barrier);
+            let worker_actual = actual.clone();
+            let worker_override = override_path.clone();
+            let worker = scope.spawn(move || {
+                let observed_inside = with_test_env_overrides(
+                    &[(VIZE_VUE_PACKAGE_ENV, Some(worker_override.as_path()))],
+                    || {
+                        worker_barrier.wait();
+                        worker_barrier.wait();
+                        test_env_var_os(VIZE_VUE_PACKAGE_ENV)
+                    },
+                );
+                let observed_after = test_env_var_os(VIZE_VUE_PACKAGE_ENV);
+                (observed_inside, observed_after, worker_actual)
+            });
+
+            barrier.wait();
+            let observed_concurrently = test_env_var_os(VIZE_VUE_PACKAGE_ENV);
+            barrier.wait();
+
+            let (observed_inside, observed_after, worker_actual) = worker.join().unwrap();
+            assert_eq!(observed_concurrently, actual);
+            assert_eq!(observed_inside, Some(override_path.into_os_string()));
+            assert_eq!(observed_after, worker_actual);
+        });
+    }
+
+    #[test]
+    fn nested_absent_override_restores_after_return_and_panic() {
+        let actual = env::var_os(VIZE_VUE_PACKAGE_ENV);
+        let outer_path = PathBuf::from("outer-vue-package");
+
+        with_test_env_overrides(
+            &[(VIZE_VUE_PACKAGE_ENV, Some(outer_path.as_path()))],
+            || {
+                assert_eq!(
+                    test_env_var_os(VIZE_VUE_PACKAGE_ENV),
+                    Some(outer_path.clone().into_os_string())
+                );
+
+                with_test_env_overrides(&[(VIZE_VUE_PACKAGE_ENV, None)], || {
+                    assert_eq!(test_env_var_os(VIZE_VUE_PACKAGE_ENV), None);
+                });
+                assert_eq!(
+                    test_env_var_os(VIZE_VUE_PACKAGE_ENV),
+                    Some(outer_path.clone().into_os_string())
+                );
+
+                let panic = std::panic::catch_unwind(|| {
+                    with_test_env_overrides(&[(VIZE_VUE_PACKAGE_ENV, None)], || {
+                        assert_eq!(test_env_var_os(VIZE_VUE_PACKAGE_ENV), None);
+                        panic!("test override cleanup");
+                    });
+                });
+                assert!(panic.is_err());
+                assert_eq!(
+                    test_env_var_os(VIZE_VUE_PACKAGE_ENV),
+                    Some(outer_path.clone().into_os_string())
+                );
+            },
+        );
+
+        assert_eq!(test_env_var_os(VIZE_VUE_PACKAGE_ENV), actual);
+    }
 }

--- a/crates/vize_canon/src/batch/runtime_deps/tests.rs
+++ b/crates/vize_canon/src/batch/runtime_deps/tests.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 
 use super::resolver::{
     VueRuntimePackages, resolve_package, resolve_vue_package, resolve_vue_runtime_packages,
+    with_test_env_overrides,
 };
 
 #[test]
@@ -16,7 +17,7 @@ fn explicit_runtime_packages_override_project_packages() {
     let explicit_runtime_dom = create_package(&explicit, "@vue/runtime-dom");
     let explicit_vite = create_package(&explicit, "vite");
 
-    with_env_overrides(
+    with_test_env_overrides(
         &[
             ("VIZE_VUE_PACKAGE", Some(explicit_vue.as_path())),
             ("VIZE_VUE_NAMESPACE_PACKAGE", None),
@@ -54,7 +55,7 @@ fn explicit_vue_namespace_overrides_explicit_runtime_dom() {
     create_package(&namespace, "runtime-dom");
     let runtime_dom = create_package(&temp.path().join("explicit"), "@vue-runtime-dom");
 
-    with_env_overrides(
+    with_test_env_overrides(
         &[
             ("VIZE_VUE_PACKAGE", None),
             ("VIZE_VUE_NAMESPACE_PACKAGE", Some(namespace.as_path())),
@@ -84,7 +85,7 @@ fn runtime_node_modules_supply_vue_and_vite_fallbacks() {
     let runtime_dom = create_package(&runtime_node_modules, "@vue/runtime-dom");
     let runtime_vite = create_package(&runtime_node_modules, "vite");
 
-    with_env_overrides(
+    with_test_env_overrides(
         &[
             ("VIZE_VUE_PACKAGE", None),
             ("VIZE_VUE_NAMESPACE_PACKAGE", None),
@@ -118,37 +119,4 @@ fn create_package(root: &Path, relative: &str) -> PathBuf {
     std::fs::create_dir_all(&dir).unwrap();
     std::fs::write(dir.join("package.json"), "{}").unwrap();
     dir
-}
-
-fn with_env_overrides<T>(vars: &[(&str, Option<&Path>)], run: impl FnOnce() -> T) -> T {
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    struct EnvGuard {
-        previous: Vec<(String, Option<std::ffi::OsString>)>,
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            for (name, value) in self.previous.drain(..).rev() {
-                match value {
-                    Some(value) => unsafe { std::env::set_var(name, value) },
-                    None => unsafe { std::env::remove_var(name) },
-                }
-            }
-        }
-    }
-
-    let _lock = ENV_LOCK.lock().unwrap();
-    let previous = vars
-        .iter()
-        .map(|(name, _)| ((*name).to_owned(), std::env::var_os(name)))
-        .collect();
-    for (name, value) in vars {
-        match value {
-            Some(value) => unsafe { std::env::set_var(name, value) },
-            None => unsafe { std::env::remove_var(name) },
-        }
-    }
-    let _guard = EnvGuard { previous };
-    run()
 }

--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -1,6 +1,8 @@
 use super::{BatchTypeChecker, DeclarationEmitOptions};
 use crate::batch::TypeChecker;
-use crate::batch::runtime_deps::VUE_RUNTIME_DOM_STUB_TYPES;
+use crate::batch::runtime_deps::{
+    VUE_RUNTIME_DOM_STUB_TYPES, test_env_var_os, with_test_env_overrides,
+};
 use crate::sfc_typecheck::{SfcTypeCheckOptions, type_check_sfc};
 use corsa::{
     api::{ApiMode, ApiSpawnConfig, ProjectSession},
@@ -2252,7 +2254,7 @@ fn package_link_source(source: &Path, package: &str) -> PathBuf {
 }
 
 fn resolve_workspace_node_modules(workspace_root: &Path) -> Option<PathBuf> {
-    let override_path = std::env::var_os("VIZE_TEST_WORKSPACE_NODE_MODULES");
+    let override_path = test_env_var_os("VIZE_TEST_WORKSPACE_NODE_MODULES");
     if let Some(override_path) = override_path {
         let override_path = PathBuf::from(override_path);
         if override_path.as_os_str() == "__none__" {
@@ -2268,30 +2270,8 @@ fn resolve_workspace_node_modules(workspace_root: &Path) -> Option<PathBuf> {
 }
 
 fn with_workspace_node_modules_override<T>(value: Option<&str>, run: impl FnOnce() -> T) -> T {
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    struct EnvOverrideGuard {
-        previous: Option<std::ffi::OsString>,
-    }
-
-    impl Drop for EnvOverrideGuard {
-        fn drop(&mut self) {
-            if let Some(previous) = self.previous.take() {
-                unsafe { std::env::set_var("VIZE_TEST_WORKSPACE_NODE_MODULES", previous) };
-            } else {
-                unsafe { std::env::remove_var("VIZE_TEST_WORKSPACE_NODE_MODULES") };
-            }
-        }
-    }
-
-    let _lock = ENV_LOCK.lock().unwrap();
-    let previous = std::env::var_os("VIZE_TEST_WORKSPACE_NODE_MODULES");
-    match value {
-        Some(value) => unsafe { std::env::set_var("VIZE_TEST_WORKSPACE_NODE_MODULES", value) },
-        None => unsafe { std::env::remove_var("VIZE_TEST_WORKSPACE_NODE_MODULES") },
-    }
-    let _guard = EnvOverrideGuard { previous };
-    run()
+    let value = value.map(Path::new);
+    with_test_env_overrides(&[("VIZE_TEST_WORKSPACE_NODE_MODULES", value)], run)
 }
 
 fn write_test_vue_stub(target: &Path) -> std::io::Result<()> {


### PR DESCRIPTION
## Summary

- isolate resolver fixture overrides per test thread
- share the override path between runtime dependency and type-checker tests
- cover concurrent visibility, nested absence, normal restoration, and panic restoration

## Root cause

The runtime dependency tests and type-checker fallback tests each guarded process-global environment mutations with different mutexes. Parallel unit tests could therefore observe another test's temporary Vue fixture. The fixture only contained an empty package manifest, so the affected type-checker test intermittently reported that `vue` did not export `ref`.

This is test-only infrastructure; production resolver behavior is unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports`
- `VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --lib -- --test-threads=16` (770 passed)
- original failing test: 10 consecutive passes
- focused resolver, runtime dependency, and fallback tests
- 32-thread full-suite stress: 6 consecutive passes before an unrelated Corsa session test flaked

Failure evidence: [workflow run 30699345893, attempt 1](https://github.com/ubugeeei-prod/vize/actions/runs/30699345893/attempts/1)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->