### PR TITLE
fix(atelier): spread JSX children in Babel mode

### DIFF
--- a/crates/vize_atelier_jsx/src/lower/child.rs
+++ b/crates/vize_atelier_jsx/src/lower/child.rs
@@ -2,7 +2,7 @@
 
 use oxc_ast::ast::{JSXChild, JSXExpression, JSXExpressionContainer, JSXSpreadChild};
 use oxc_span::GetSpan;
-use vize_carton::{Box, Vec};
+use vize_carton::{Box, String, Vec};
 use vize_relief::{
     CompoundExpressionChild, CompoundExpressionNode, ExpressionNode, InterpolationNode,
     TemplateChildNode, TextNode,
@@ -132,6 +132,21 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// `{...children}` keeps the spread argument as an interpolation expression,
     /// which is not what a spread means; report before doing so.
     fn lower_spread_child(&mut self, spread: &JSXSpreadChild<'_>) -> TemplateChildNode<'a> {
+        if self.uses_babel_vdom_compat() {
+            let ExpressionNode::Simple(expression) = self.dyn_expr(spread.expression.span()) else {
+                unreachable!("span-backed JSX expressions are always simple expressions")
+            };
+            let mut compound =
+                CompoundExpressionNode::new(self.bump(), self.mapper().location(spread.span));
+            compound
+                .children
+                .push(CompoundExpressionChild::String(String::from("...")));
+            compound
+                .children
+                .push(CompoundExpressionChild::Simple(expression));
+            return TemplateChildNode::CompoundExpression(Box::new_in(compound, self.bump()));
+        }
+
         self.reject(spread.span, SPREAD_CHILD_UNSUPPORTED);
         let content = self.dyn_expr(spread.expression.span());
         self.interpolation(content, spread.span)

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   88 |
-| divergent  |    8 |
+| equivalent |   89 |
+| divergent  |    7 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -298,7 +298,7 @@ here so the choice is not implicit (#3418, #3467, `src/lower/v_slots.rs`):
 | `children/text_interp_mix` | three children                | one concatenated `TEXT` child      | no change                      | ✅      |
 | `children/comment_only`    | children `null`               | no children                        | no change                      | ✅      |
 | `children/empty_expr`      | children `null`               | no children                        | no change                      | ✅      |
-| `children/spread_child`    | `[...items]`                  | `toDisplayString(items)`, reported | spread into the children array | ❌      |
+| `children/spread_child`    | `[...items]`                  | `toDisplayString(items)`, reported | spread into the children array | ✅      |
 | `children/logical_and`     | `[c && vnode]`                | `v-if` with a comment placeholder  | no change                      | ✅      |
 | `children/ternary`         | `[c ? a : b]`                 | two-branch `v-if` with keys        | no change                      | ✅      |
 | `children/map_list`        | raw `list.map(…)` array child | `renderList` + `KEYED_FRAGMENT`    | no change                      | ✅      |

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -124,10 +124,7 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("children/text_interp_mix", Same),
     ("children/comment_only", Same),
     ("children/empty_expr", Same),
-    (
-        "children/spread_child",
-        Diff("spread child stringified, now reported"),
-    ),
+    ("children/spread_child", Same),
     ("children/logical_and", Same),
     ("children/ternary", Same),
     ("children/map_list", Same),

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (88, 8, 2));
+    assert_eq!((equivalent, divergent, deferred), (89, 7, 2));
     assert_eq!(VERDICTS.len(), 98);
 }
 

--- a/crates/vize_atelier_jsx/tests/babel_spread_child.rs
+++ b/crates/vize_atelier_jsx/tests/babel_spread_child.rs
@@ -1,0 +1,71 @@
+//! JSX spread-child behavior in opt-in Babel compatibility mode (#3391).
+
+use oxc_allocator::Allocator;
+use vize_atelier_jsx::{JsxCompatMode, JsxCompileConfig, JsxLang, compile_jsx, parse_module};
+use vize_carton::{Bump, String};
+
+fn compile(source: &str, compat: JsxCompatMode) -> (vize_carton::String, Vec<String>) {
+    let bump = Bump::new();
+    let output = compile_jsx(
+        &bump,
+        source,
+        JsxLang::Jsx,
+        &JsxCompileConfig {
+            compat,
+            ..Default::default()
+        },
+    );
+    (
+        output.module_code(),
+        output
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message.clone())
+            .collect(),
+    )
+}
+
+#[test]
+fn spread_children_expand_only_in_babel_vdom_compatibility_mode() {
+    let source = "const A = () => <div>{...items}</div>;";
+    let (native, native_diagnostics) = compile(source, JsxCompatMode::Native);
+    let (babel, babel_diagnostics) = compile(source, JsxCompatMode::Babel);
+
+    assert_eq!(native_diagnostics.len(), 1, "{native_diagnostics:?}");
+    assert!(native.contains("_toDisplayString(items)"), "{native}");
+
+    assert!(babel_diagnostics.is_empty(), "{babel_diagnostics:?}");
+    assert!(babel.contains("[\n    ...items\n  ]"), "{babel}");
+    assert!(!babel.contains("toDisplayString"), "{babel}");
+
+    let allocator = Allocator::default();
+    let parsed = parse_module(&allocator, babel.as_str(), JsxLang::Jsx);
+    assert!(
+        parsed.diagnostics.is_empty(),
+        "{:?}\n{babel}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
+fn spread_children_keep_order_between_neighboring_vnodes() {
+    let source = "const A = () => <div><i/>{...items}<b/></div>;";
+    let (babel, diagnostics) = compile(source, JsxCompatMode::Babel);
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    let before = babel.find("_createElementVNode(\"i\")").expect("i vnode");
+    let spread = babel.find("...items").expect("spread child");
+    let after = babel.find("_createElementVNode(\"b\")").expect("b vnode");
+    assert!(before < spread && spread < after, "{babel}");
+}
+
+#[test]
+fn component_spread_children_expand_inside_the_default_slot() {
+    let source = "const A = () => <B>{...items}</B>;";
+    let (babel, diagnostics) = compile(source, JsxCompatMode::Babel);
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert!(babel.contains("default: _withCtx(() => ["), "{babel}");
+    assert!(babel.contains("...items"), "{babel}");
+    assert!(!babel.contains("toDisplayString"), "{babel}");
+}

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__children.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__children.snap
@@ -68,7 +68,7 @@ export function render(_ctx, _cache) {
 
 ## children/spread_child
 ### verdict
-divergent: spread child stringified, now reported
+equivalent
 ### source (jsx)
 const A = () => <div>{...items}</div>;
 ### babel options
@@ -77,10 +77,11 @@ const A = () => <div>{...items}</div>;
 import { createVNode as _createVNode } from "vue";
 const A = () => _createVNode("div", null, [...items]);
 ### vize (vdom, babel compat)
-<Error> spread children (`{...items}`) are not supported; the value would be stringified instead of spread
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(items), 1 /* TEXT */))
+  return (_openBlock(), _createElementBlock("div", null, [
+    ...items
+  ]))
 }
 
 ## children/logical_and


### PR DESCRIPTION
## Summary

- emit JSX spread children as spread array entries in opt-in Babel VDOM compatibility mode
- keep native mode diagnostic and stringifying fallback unchanged
- cover intrinsic ordering, component default slots, generated-module parsing, and the real Babel oracle row

Compatibility inventory: **89 equivalent / 7 divergent / 2 deferred**.

## Validation

- full `vize_atelier_jsx` crate tests
- focused spread-child, diagnostics, and differential-oracle tests
- real Babel oracle check
- library and focused-test clippy with warnings denied
- rustfmt and diff checks

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->