### PR TITLE
fix(glyph): stabilize legacy keyframe formatting

### DIFF
--- a/crates/vize_glyph/src/style.rs
+++ b/crates/vize_glyph/src/style.rs
@@ -248,31 +248,6 @@ mod tests {
     }
 
     #[test]
-    fn test_legacy_keyframes_reach_fixed_point_in_one_pass() {
-        let options = FormatOptions::default();
-        for source in [
-            concat!(
-                "@-moz-keyframes orbit { 0% { transform: rotate(0deg); } }\n",
-                "@-ms-keyframes orbit { 0% { transform: rotate(0deg); } }\n",
-                "@keyframes orbit { 0% { transform: rotate(0deg); } }",
-            ),
-            concat!(
-                "@-moz-keyframes orbit { 0% { transform: rotate(0deg); } }\n",
-                "@-MS-keyframes orbit { 0% { transform: rotate(0deg); } }\n",
-                "@keyframes orbit { 0% { transform: rotate(0deg); } }",
-            ),
-        ] {
-            let result = format_style_content(source, &options).unwrap();
-            let again = format_style_content(&result, &options).unwrap();
-
-            assert_eq!(
-                result, again,
-                "legacy keyframe normalization must be idempotent after one format"
-            );
-        }
-    }
-
-    #[test]
     fn test_format_simple_css() {
         let source = ".container{color:red;display:flex;gap:8px}";
         let options = FormatOptions::default();

--- a/crates/vize_glyph/src/style.rs
+++ b/crates/vize_glyph/src/style.rs
@@ -248,6 +248,31 @@ mod tests {
     }
 
     #[test]
+    fn test_legacy_keyframes_reach_fixed_point_in_one_pass() {
+        let options = FormatOptions::default();
+        for source in [
+            concat!(
+                "@-moz-keyframes orbit { 0% { transform: rotate(0deg); } }\n",
+                "@-ms-keyframes orbit { 0% { transform: rotate(0deg); } }\n",
+                "@keyframes orbit { 0% { transform: rotate(0deg); } }",
+            ),
+            concat!(
+                "@-moz-keyframes orbit { 0% { transform: rotate(0deg); } }\n",
+                "@-MS-keyframes orbit { 0% { transform: rotate(0deg); } }\n",
+                "@keyframes orbit { 0% { transform: rotate(0deg); } }",
+            ),
+        ] {
+            let result = format_style_content(source, &options).unwrap();
+            let again = format_style_content(&result, &options).unwrap();
+
+            assert_eq!(
+                result, again,
+                "legacy keyframe normalization must be idempotent after one format"
+            );
+        }
+    }
+
+    #[test]
     fn test_format_simple_css() {
         let source = ".container{color:red;display:flex;gap:8px}";
         let options = FormatOptions::default();

--- a/crates/vize_glyph/src/style/stabilization.rs
+++ b/crates/vize_glyph/src/style/stabilization.rs
@@ -1,8 +1,8 @@
 //! Selective lightningcss fixed-point passes.
 //!
-//! The real-project idempotence corpus found one construct whose first printed
-//! form is not stable: `background-position` shorthand (#3248). Re-parsing all
-//! other style blocks doubled their parse/print work to guard one property.
+//! The real-project idempotence corpus found a small set of constructs whose
+//! first printed form is not stable. Re-parsing all other style blocks doubled
+//! their parse/print work to guard those properties.
 
 use crate::error::FormatError;
 use memchr::memmem;
@@ -16,7 +16,7 @@ pub(super) fn format_to_fixed_point(
     mut format_once: impl FnMut(&str) -> Result<String, FormatError>,
 ) -> Result<String, FormatError> {
     let mut current = format_once(source)?;
-    if !may_need_another_pass(current.as_bytes()) {
+    if !may_need_another_pass(source.as_bytes(), current.as_bytes()) {
         return Ok(current);
     }
 
@@ -30,8 +30,21 @@ pub(super) fn format_to_fixed_point(
     Ok(current)
 }
 
-fn may_need_another_pass(printed: &[u8]) -> bool {
+fn may_need_another_pass(source: &[u8], printed: &[u8]) -> bool {
     memmem::find(printed, b"background-position").is_some()
+        // lightningcss drops the unsupported legacy rule on its first pass but
+        // leaves its surrounding whitespace behind until the second pass.
+        || contains_legacy_ms_keyframes(source)
+}
+
+fn contains_legacy_ms_keyframes(source: &[u8]) -> bool {
+    const NAME: &[u8] = b"@-ms-keyframes";
+
+    memchr::memchr_iter(b'@', source).any(|start| {
+        source
+            .get(start..start + NAME.len())
+            .is_some_and(|candidate| candidate.eq_ignore_ascii_case(NAME))
+    })
 }
 
 #[cfg(test)]

--- a/crates/vize_glyph/src/style/stabilization.rs
+++ b/crates/vize_glyph/src/style/stabilization.rs
@@ -50,6 +50,7 @@ fn contains_legacy_ms_keyframes(source: &[u8]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::format_to_fixed_point;
+    use crate::{options::FormatOptions, style::format_style_content};
     use std::cell::Cell;
     use vize_carton::ToCompactString;
 
@@ -86,5 +87,30 @@ mod tests {
             3,
             "the stable result must be observed, not assumed"
         );
+    }
+
+    #[test]
+    fn legacy_keyframes_reach_fixed_point_in_one_pass() {
+        let options = FormatOptions::default();
+        for source in [
+            concat!(
+                "@-moz-keyframes orbit { 0% { transform: rotate(0deg); } }\n",
+                "@-ms-keyframes orbit { 0% { transform: rotate(0deg); } }\n",
+                "@keyframes orbit { 0% { transform: rotate(0deg); } }",
+            ),
+            concat!(
+                "@-moz-keyframes orbit { 0% { transform: rotate(0deg); } }\n",
+                "@-MS-keyframes orbit { 0% { transform: rotate(0deg); } }\n",
+                "@keyframes orbit { 0% { transform: rotate(0deg); } }",
+            ),
+        ] {
+            let result = format_style_content(source, &options).unwrap();
+            let again = format_style_content(&result, &options).unwrap();
+
+            assert_eq!(
+                result, again,
+                "legacy keyframe normalization must be idempotent after one format"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- run the selective CSS fixed-point pass for legacy `@-ms-keyframes`
- detect the legacy at-rule case-insensitively
- add a regression covering prefixed and standard keyframes

## Root cause
The formatter throughput optimization limited lightningcss stabilization to `background-position`. lightningcss drops unsupported `@-ms-keyframes` during the first print, while the surrounding whitespace only normalizes on the second parse.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p vize_glyph --all-targets`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- Crater glyph corpus: idempotence, parse preservation, and lint agreement (311 files, 0 violations)
- build-free Criterion A/B: no statistically significant formatter regression

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of legacy Microsoft keyframe rules, including mixed-case variants.
  * Preserved correct stabilization behavior for `background-position` declarations.

* **Tests**
  * Added coverage confirming consistent one-pass processing for lowercase and mixed-case legacy keyframes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->