### PR TITLE
fix(test): prepare Nuxt runtime workspace dependencies

### DIFF
--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -3,6 +3,11 @@ import { execFileSync, execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  createVizeSymlinks,
+  ensureLocalVizePackagesBuilt,
+  ensureSymlink,
+} from "./vize-local-packages.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -12,8 +17,6 @@ const GIT_DIR = path.join(TESTS_DIR, "_fixtures", "_git");
 const PROJECTS_DIR = path.join(TESTS_DIR, "_fixtures", "_projects");
 const MUTABLE_GIT_PROJECTS_DIR = path.join(PROJECTS_DIR, "_git-worktrees");
 const MUTABLE_GIT_WORKTREE_INSTANCE = process.env.VIZE_TEST_WORKTREE_ID ?? `pid-${process.pid}`;
-const NPM_DIR = path.resolve(__dirname, "../../npm");
-const REPO_ROOT = path.resolve(__dirname, "../..");
 
 export interface AppConfig {
   name: string;
@@ -51,46 +54,6 @@ export interface AppConfig {
 }
 
 // --- Setup helpers ---
-
-const VIZE_SYMLINK_TARGETS: Record<string, string> = {
-  native: path.join(NPM_DIR, "native"),
-  "vite-plugin": path.join(NPM_DIR, "builder/vite"),
-  nuxt: path.join(NPM_DIR, "framework/nuxt"),
-  "vite-plugin-musea": path.join(NPM_DIR, "builder/vite-musea"),
-  "musea-nuxt": path.join(NPM_DIR, "framework/musea-nuxt"),
-};
-const VIZE_LOCAL_BUILD_TARGETS = [
-  {
-    name: "vize",
-    filter: "vize",
-    dir: path.join(NPM_DIR, "cli"),
-    outputs: ["dist/index.mjs", "dist/config.mjs"],
-  },
-  {
-    name: "@vizejs/vite-plugin",
-    filter: "@vizejs/vite-plugin",
-    dir: path.join(NPM_DIR, "builder/vite"),
-    outputs: ["dist/index.mjs"],
-  },
-  {
-    name: "@vizejs/nuxt",
-    filter: "@vizejs/nuxt",
-    dir: path.join(NPM_DIR, "framework/nuxt"),
-    outputs: ["dist/index.mjs"],
-  },
-  {
-    name: "@vizejs/vite-plugin-musea",
-    filter: "@vizejs/vite-plugin-musea",
-    dir: path.join(NPM_DIR, "builder/vite-musea"),
-    outputs: ["dist/index.mjs", "dist/cli/index.mjs"],
-  },
-  {
-    name: "@vizejs/musea-nuxt",
-    filter: "@vizejs/musea-nuxt",
-    dir: path.join(NPM_DIR, "framework/musea-nuxt"),
-    outputs: ["dist/index.mjs"],
-  },
-] as const;
 const MISSKEY_FLUENT_EMOJI_RE = /\/fluent-emoji(?:s)?\/([0-9a-z-]+\.png)\b/g;
 const NPMX_E2E_ENV = {
   NUXT_SESSION_PASSWORD: "e2e-test-dummy-session-password-32chars!",
@@ -120,31 +83,6 @@ const TRANSPARENT_PNG = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P8z/C/HwAFgwJ/lE6nWQAAAABJRU5ErkJggg==",
   "base64",
 );
-const BUILT_VIZE_PACKAGES = new Set<string>();
-
-function hasBuildOutputs(dir: string, outputs: readonly string[]): boolean {
-  return outputs.every((output) => fs.existsSync(path.join(dir, output)));
-}
-
-function ensureLocalVizePackagesBuilt(): void {
-  for (const target of VIZE_LOCAL_BUILD_TARGETS) {
-    if (BUILT_VIZE_PACKAGES.has(target.name) && hasBuildOutputs(target.dir, target.outputs)) {
-      continue;
-    }
-
-    if (!hasBuildOutputs(target.dir, target.outputs)) {
-      console.log(`[vize:setup] building ${target.name}...`);
-      execFileSync("npx", ["-y", "pnpm@10", "--filter", target.filter, "build"], {
-        cwd: REPO_ROOT,
-        stdio: "inherit",
-        timeout: 300_000,
-      });
-    }
-
-    BUILT_VIZE_PACKAGES.add(target.name);
-  }
-}
-
 interface PnpmInstallOptions {
   env?: NodeJS.ProcessEnv;
   ignoreScripts?: boolean;
@@ -170,33 +108,6 @@ export function installPnpmDependencies(cwd: string, options: PnpmInstallOptions
     stdio: "inherit",
     timeout: options.timeout ?? 600_000,
   });
-}
-
-function ensureSymlink(link: string, target: string): void {
-  try {
-    const stat = fs.lstatSync(link);
-    if (stat.isSymbolicLink()) {
-      try {
-        fs.statSync(link);
-        return; // valid symlink
-      } catch {
-        fs.unlinkSync(link); // broken symlink — recreate
-      }
-    } else {
-      return; // real dir/file
-    }
-  } catch {
-    // does not exist
-  }
-  fs.symlinkSync(target, link, "dir");
-}
-
-function createVizeSymlinks(nodeModulesDir: string): void {
-  const vizejsDir = path.join(nodeModulesDir, "@vizejs");
-  fs.mkdirSync(vizejsDir, { recursive: true });
-  for (const [name, target] of Object.entries(VIZE_SYMLINK_TARGETS)) {
-    ensureSymlink(path.join(vizejsDir, name), target);
-  }
 }
 
 function patchNuxtConfig(

--- a/tests/_helpers/vize-local-packages.ts
+++ b/tests/_helpers/vize-local-packages.ts
@@ -123,11 +123,13 @@ export function ensureSymlink(link: string, target: string): void {
     const stat = fs.lstatSync(link);
     if (stat.isSymbolicLink()) {
       try {
-        fs.statSync(link);
-        return;
+        if (fs.realpathSync(link) === fs.realpathSync(target)) {
+          return;
+        }
       } catch {
-        fs.unlinkSync(link);
+        // Replace a broken link.
       }
+      fs.unlinkSync(link);
     } else {
       return;
     }

--- a/tests/_helpers/vize-local-packages.ts
+++ b/tests/_helpers/vize-local-packages.ts
@@ -1,0 +1,147 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HELPERS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const NPM_DIR = path.resolve(HELPERS_DIR, "../../npm");
+const REPO_ROOT = path.resolve(HELPERS_DIR, "../..");
+
+interface VizeLocalPackage {
+  packageName: string;
+  filter: string;
+  dir: string;
+  outputs: readonly string[];
+  buildInFixtureSetup: boolean;
+  linkIntoFixture: boolean;
+}
+
+/**
+ * Local packages exposed to copied app fixtures, in dependency-first build order.
+ *
+ * Exported so the tooling regression can verify that this list remains closed
+ * over runtime workspace dependencies as package manifests evolve.
+ */
+export const VIZE_LOCAL_PACKAGES = [
+  {
+    packageName: "@vizejs/native",
+    filter: "@vizejs/native",
+    dir: path.join(NPM_DIR, "native"),
+    outputs: ["index.js"],
+    buildInFixtureSetup: false,
+    linkIntoFixture: true,
+  },
+  {
+    packageName: "vize",
+    filter: "vize",
+    dir: path.join(NPM_DIR, "cli"),
+    outputs: ["dist/index.mjs", "dist/config.mjs"],
+    buildInFixtureSetup: true,
+    linkIntoFixture: true,
+  },
+  {
+    packageName: "@vizejs/vite-plugin",
+    filter: "@vizejs/vite-plugin",
+    dir: path.join(NPM_DIR, "builder/vite"),
+    outputs: ["dist/index.mjs"],
+    buildInFixtureSetup: true,
+    linkIntoFixture: true,
+  },
+  {
+    packageName: "@vizejs/nuxt-lint-config",
+    filter: "@vizejs/nuxt-lint-config",
+    dir: path.join(NPM_DIR, "framework/nuxt-lint-config"),
+    outputs: ["dist/index.mjs"],
+    buildInFixtureSetup: true,
+    linkIntoFixture: true,
+  },
+  {
+    packageName: "oxlint-plugin-vize",
+    filter: "oxlint-plugin-vize",
+    dir: path.join(NPM_DIR, "oxint"),
+    outputs: ["dist/index.mjs"],
+    buildInFixtureSetup: true,
+    linkIntoFixture: true,
+  },
+  {
+    packageName: "@vizejs/vite-plugin-musea",
+    filter: "@vizejs/vite-plugin-musea",
+    dir: path.join(NPM_DIR, "builder/vite-musea"),
+    outputs: ["dist/index.mjs", "dist/cli/index.mjs"],
+    buildInFixtureSetup: true,
+    linkIntoFixture: true,
+  },
+  {
+    packageName: "@vizejs/nuxt",
+    filter: "@vizejs/nuxt",
+    dir: path.join(NPM_DIR, "framework/nuxt"),
+    outputs: ["dist/index.mjs"],
+    buildInFixtureSetup: true,
+    linkIntoFixture: true,
+  },
+  {
+    packageName: "@vizejs/musea-nuxt",
+    filter: "@vizejs/musea-nuxt",
+    dir: path.join(NPM_DIR, "framework/musea-nuxt"),
+    outputs: ["dist/index.mjs"],
+    buildInFixtureSetup: true,
+    linkIntoFixture: true,
+  },
+] as const satisfies readonly VizeLocalPackage[];
+
+const BUILT_VIZE_PACKAGES = new Set<string>();
+
+function hasBuildOutputs(dir: string, outputs: readonly string[]): boolean {
+  return outputs.every((output) => fs.existsSync(path.join(dir, output)));
+}
+
+export function ensureLocalVizePackagesBuilt(): void {
+  for (const target of VIZE_LOCAL_PACKAGES) {
+    if (!target.buildInFixtureSetup) continue;
+    if (
+      BUILT_VIZE_PACKAGES.has(target.packageName) &&
+      hasBuildOutputs(target.dir, target.outputs)
+    ) {
+      continue;
+    }
+
+    if (!hasBuildOutputs(target.dir, target.outputs)) {
+      console.log(`[vize:setup] building ${target.packageName}...`);
+      execFileSync("npx", ["-y", "pnpm@10", "--filter", target.filter, "build"], {
+        cwd: REPO_ROOT,
+        stdio: "inherit",
+        timeout: 300_000,
+      });
+    }
+
+    BUILT_VIZE_PACKAGES.add(target.packageName);
+  }
+}
+
+export function ensureSymlink(link: string, target: string): void {
+  try {
+    const stat = fs.lstatSync(link);
+    if (stat.isSymbolicLink()) {
+      try {
+        fs.statSync(link);
+        return;
+      } catch {
+        fs.unlinkSync(link);
+      }
+    } else {
+      return;
+    }
+  } catch {
+    // The link does not exist yet.
+  }
+  fs.symlinkSync(target, link, "dir");
+}
+
+export function createVizeSymlinks(nodeModulesDir: string): void {
+  for (const target of VIZE_LOCAL_PACKAGES) {
+    if (!target.linkIntoFixture) continue;
+    const link = path.join(nodeModulesDir, ...target.packageName.split("/"));
+    fs.mkdirSync(path.dirname(link), { recursive: true });
+    ensureSymlink(link, target.dir);
+  }
+}

--- a/tests/tooling/app-local-packages.test.ts
+++ b/tests/tooling/app-local-packages.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { createVizeSymlinks, VIZE_LOCAL_PACKAGES } from "../_helpers/vize-local-packages.ts";
+
+interface PackageManifest {
+  dependencies?: Record<string, string>;
+  name?: string;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+}
+
+function readManifest(packageDir: string): PackageManifest {
+  return JSON.parse(
+    fs.readFileSync(path.join(packageDir, "package.json"), "utf8"),
+  ) as PackageManifest;
+}
+
+test("app fixture links cover local packages' runtime workspace dependency graph", () => {
+  const packagesByName = new Map(VIZE_LOCAL_PACKAGES.map((pkg) => [pkg.packageName, pkg]));
+  const packageOrder = new Map(VIZE_LOCAL_PACKAGES.map((pkg, index) => [pkg.packageName, index]));
+  const omissions: string[] = [];
+
+  for (const [index, pkg] of VIZE_LOCAL_PACKAGES.entries()) {
+    if (!pkg.linkIntoFixture) continue;
+    const manifest = readManifest(pkg.dir);
+    assert.equal(manifest.name, pkg.packageName, `${pkg.packageName} package directory`);
+
+    const runtimeDependencies = {
+      ...manifest.dependencies,
+      ...manifest.optionalDependencies,
+      ...manifest.peerDependencies,
+    };
+    for (const [dependency, version] of Object.entries(runtimeDependencies)) {
+      if (!version.startsWith("workspace:")) continue;
+      const target = packagesByName.get(dependency);
+      if (!target) {
+        omissions.push(`${pkg.packageName} -> ${dependency}: missing local package target`);
+      } else if (!target.linkIntoFixture) {
+        omissions.push(`${pkg.packageName} -> ${dependency}: not linked into fixtures`);
+      } else if ((packageOrder.get(dependency) ?? Number.POSITIVE_INFINITY) >= index) {
+        omissions.push(`${pkg.packageName} -> ${dependency}: dependency must be prepared first`);
+      }
+    }
+  }
+
+  assert.deepEqual(omissions, []);
+});
+
+test("app fixture links include scoped and unscoped package names", () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-app-local-packages-"));
+  const nodeModules = path.join(fixtureRoot, "node_modules");
+
+  try {
+    createVizeSymlinks(nodeModules);
+    for (const pkg of VIZE_LOCAL_PACKAGES.filter((candidate) => candidate.linkIntoFixture)) {
+      const link = path.join(nodeModules, ...pkg.packageName.split("/"));
+      assert.equal(fs.realpathSync(link), fs.realpathSync(pkg.dir), pkg.packageName);
+    }
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/app-local-packages.test.ts
+++ b/tests/tooling/app-local-packages.test.ts
@@ -55,10 +55,40 @@ test("app fixture links include scoped and unscoped package names", () => {
 
   try {
     createVizeSymlinks(nodeModules);
-    for (const pkg of VIZE_LOCAL_PACKAGES.filter((candidate) => candidate.linkIntoFixture)) {
+    const linkedPackages = VIZE_LOCAL_PACKAGES.filter((candidate) => candidate.linkIntoFixture);
+    assert.ok(
+      linkedPackages.some((pkg) => pkg.packageName.startsWith("@")),
+      "expected at least one scoped linked package",
+    );
+    assert.ok(
+      linkedPackages.some((pkg) => !pkg.packageName.startsWith("@")),
+      "expected at least one unscoped linked package",
+    );
+
+    for (const pkg of linkedPackages) {
       const link = path.join(nodeModules, ...pkg.packageName.split("/"));
       assert.equal(fs.realpathSync(link), fs.realpathSync(pkg.dir), pkg.packageName);
     }
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("app fixture links replace valid symlinks pointing elsewhere", () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-app-local-packages-"));
+  const nodeModules = path.join(fixtureRoot, "node_modules");
+  const decoy = path.join(fixtureRoot, "decoy");
+
+  try {
+    fs.mkdirSync(decoy, { recursive: true });
+    const [pkg] = VIZE_LOCAL_PACKAGES.filter((candidate) => candidate.linkIntoFixture);
+    const link = path.join(nodeModules, ...pkg.packageName.split("/"));
+    fs.mkdirSync(path.dirname(link), { recursive: true });
+    fs.symlinkSync(decoy, link, "dir");
+
+    createVizeSymlinks(nodeModules);
+
+    assert.equal(fs.realpathSync(link), fs.realpathSync(pkg.dir), pkg.packageName);
   } finally {
     fs.rmSync(fixtureRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- centralize app-fixture local package builds and links in dependency order
- prepare the Nuxt module runtime workspace dependency closure
- add a regression for dependency closure, order, and scoped/unscoped links

## Root cause
The app E2E harness built and linked `@vizejs/nuxt` but did not prepare its newer runtime workspace dependencies. Importing the local module therefore failed before Nuxt startup.

## Verification
- exact Elk preview E2E: 1/1 passed with Nuxt client/server and Nitro build
- `node --test tests/tooling/app-local-packages.test.ts tests/tooling/source-file-lengths.test.ts` (9/9)
- formatting and changed-file checks
- CLI tooling contracts: 47 passed, 1 fixture skip, 0 failed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3669"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for building and linking local packages used by test fixtures.
  * Validated dependency ordering and resolution for scoped and unscoped packages.
  * Verified incorrect fixture symlinks are replaced and temporary test directories are cleaned up.

* **Chores**
  * Centralized local package build, verification, and symlink management for more consistent test setup.
  * Added safeguards to reuse completed builds while confirming required outputs remain available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->