### PR TITLE
fix(release): require supported npm trust permissions

### DIFF
--- a/docs/release/supply-chain.md
+++ b/docs/release/supply-chain.md
@@ -119,7 +119,7 @@ The secret is exposed only to the final publish step. Never place the token in a
 workflow-level or job-level environment.
 
 Immediately after the first publish of `@vizejs/nuxt-lint-config`, configure the
-normal release workflow as its trusted publisher. Use npm CLI 11.10.0 or newer
+normal release workflow as its trusted publisher. Use npm CLI 11.17.0 or newer
 and authenticate as an npm owner with settings 2FA:
 
 ```bash

--- a/tests/tooling/github-workflows-npm-bootstrap.test.ts
+++ b/tests/tooling/github-workflows-npm-bootstrap.test.ts
@@ -151,6 +151,7 @@ test("npm bootstrap handoff documents the exact trusted publisher command", () =
     docs,
     /npm trust github @vizejs\/nuxt-lint-config --file release\.yml --repo ubugeeei-prod\/vize --env npm --allow-publish --yes/,
   );
+  assert.match(docs, /Use npm CLI 11\.17\.0 or newer/);
   const bootstrapSectionStart = docs.indexOf("### First-publish bootstrap");
   assert.notEqual(bootstrapSectionStart, -1, "docs must keep the First-publish bootstrap section");
   assert.doesNotMatch(docs.slice(bootstrapSectionStart), /v0\.314\.0/);


### PR DESCRIPTION
## Summary

- keep the first-publish handoff on npm CLI 11.17.0+, which supports the documented `--allow-publish` permission
- assert the supported CLI floor alongside the exact trusted publisher command

## Verification

- npm 11.10.0 exact dry-run: rejects `--allow-publish` with `EUSAGE`
- npm 11.17.0 exact dry-run: accepts the permission and environment options
- bootstrap contract tests: 16/16
- independent full-diff review: no remaining findings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Trusted Publishing setup guidance to require npm CLI version 11.17.0 or newer.

* **Tests**
  * Added coverage to verify the documented npm CLI version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->