### PR TITLE
test(glyph): verify formatter check-write agreement

### DIFF
--- a/tests/tooling/glyph-corpus-idempotence.test.ts
+++ b/tests/tooling/glyph-corpus-idempotence.test.ts
@@ -1,19 +1,25 @@
 // Corpus-wide glyph formatter idempotence: for every Vue SFC in the hydrated
-// ecosystem fixtures, `fmt(fmt(x)) == fmt(x)` byte-for-byte. Fixtures are
-// hydrated per-lane, so absent projects are reported as skipped, never failed;
-// the weekly Real Project Matrix shards hydrate the full registry. Set
-// VIZE_GLYPH_CORPUS_MAX_FILES_PER_PROJECT to cap files for local iteration.
+// ecosystem fixtures, `fmt(fmt(x)) == fmt(x)` byte-for-byte. In the Real
+// Project Matrix, the preceding `--check` prediction must also equal the first
+// `--write` mutation set. Fixtures are hydrated per-lane, so absent projects
+// are reported as skipped, never failed; the weekly matrix shards hydrate the
+// full registry. Set VIZE_GLYPH_CORPUS_MAX_FILES_PER_PROJECT to cap files for
+// local iteration.
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
+import { createFormatterChangeEvidence } from "../../tools/fixtures/tool-matrix-formatter.mjs";
 import {
+  assertFormatterCheckWriteAgreement,
+  collectFormatterWriteEvidence,
   collectProjectVueFiles,
   diffExcerpt,
   isKnownViolation,
   loadGlyphCorpusProjects,
+  loadFormatterCheckEvidence,
   loadKnownViolations,
   renderViolations,
   resolveGlyphLaunch,
@@ -39,6 +45,7 @@ function sweepProject(
   launch: { command: string; prefix: string[] },
   violations: Violation[],
   counters: { files: number; skipped: number },
+  checkEvidence: FormatterEvidence | null = null,
 ): void {
   const files = collectProjectVueFiles(project) as string[];
   if (files.length === 0) return;
@@ -47,6 +54,13 @@ function sweepProject(
     files,
     launch,
     (workspace: { workspaceDir: string; reformat: () => void }) => {
+      if (checkEvidence != null) {
+        assertFormatterCheckWriteAgreement(
+          project.id,
+          checkEvidence,
+          collectFormatterWriteEvidence(project, files, workspace.workspaceDir),
+        );
+      }
       const firstPass = snapshotWorkspaceFiles(workspace.workspaceDir, files) as Map<
         string,
         Buffer
@@ -88,7 +102,7 @@ test("glyph corpus idempotence holds for every hydrated fixture", () => {
   const violations: Violation[] = [];
   const counters = { files: 0, skipped: 0 };
   for (const project of hydrated) {
-    sweepProject(project, launch, violations, counters);
+    sweepProject(project, launch, violations, counters, loadFormatterCheckEvidence(project));
   }
   process.stderr.write(
     `glyph ${property}: ${counters.files} file(s) across ${hydrated.length} project(s), ` +
@@ -148,6 +162,148 @@ test("glyph corpus idempotence machinery flags a drifting formatter", () => {
     fs.rmSync(fakeDir, { recursive: true, force: true });
   }
 });
+
+for (const fixtureCase of [
+  {
+    name: "glyph corpus accepts an exact formatter check/write prediction",
+    write: "change",
+    checkPaths: ["src/App.vue"],
+    agrees: true,
+  },
+  {
+    name: "glyph corpus rejects a formatter check false positive",
+    write: "clean",
+    checkPaths: ["src/App.vue"],
+    agrees: false,
+  },
+  {
+    name: "glyph corpus rejects a formatter check false negative",
+    write: "change",
+    checkPaths: [],
+    agrees: false,
+  },
+] as const) {
+  test(fixtureCase.name, () => {
+    const fixture = makeAgreementFixture(fixtureCase.write);
+    const violations: Violation[] = [];
+    const counters = { files: 0, skipped: 0 };
+    const sweep = () =>
+      sweepProject(
+        fixture.project,
+        fixture.launch,
+        violations,
+        counters,
+        formatterEvidence(1, [...fixtureCase.checkPaths]),
+      );
+    try {
+      if (fixtureCase.agrees) {
+        assert.doesNotThrow(sweep);
+        assert.deepEqual(violations, []);
+        assert.deepEqual(counters, { files: 1, skipped: 0 });
+      } else {
+        assert.throws(sweep, /--check prediction disagrees with actual --write mutation/);
+      }
+    } finally {
+      fixture.cleanup();
+    }
+  });
+}
+
+test("glyph corpus rejects different changed paths even when counts agree", () => {
+  assert.throws(
+    () =>
+      assertFormatterCheckWriteAgreement(
+        "synthetic-path-mismatch",
+        formatterEvidence(2, ["src/App.vue"]),
+        formatterEvidence(2, ["src/Card.vue"]),
+      ),
+    /changedPathsSha256/,
+  );
+});
+
+test("glyph corpus loads only the matching validated matrix check evidence", () => {
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-glyph-check-report-"));
+  const project = { id: "synthetic-report" };
+  const evidence = formatterEvidence(2, ["src/App.vue"]);
+  const reportPath = path.join(reportDir, `${project.id}-formatter.json`);
+  try {
+    assert.throws(
+      () => loadFormatterCheckEvidence(project, reportDir),
+      /missing formatter check report/,
+    );
+    fs.writeFileSync(
+      reportPath,
+      `${JSON.stringify({
+        schema: "vize.fixtureToolRun",
+        version: 1,
+        project: project.id,
+        tool: "formatter",
+        formatterCheck: evidence,
+      })}\n`,
+    );
+    assert.deepEqual(loadFormatterCheckEvidence(project, reportDir), evidence);
+
+    fs.writeFileSync(
+      reportPath,
+      `${JSON.stringify({
+        schema: "vize.fixtureToolRun",
+        version: 1,
+        project: "wrong-project",
+        tool: "formatter",
+        formatterCheck: evidence,
+      })}\n`,
+    );
+    assert.throws(
+      () => loadFormatterCheckEvidence(project, reportDir),
+      /invalid formatter check report identity/,
+    );
+  } finally {
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
+});
+
+type FormatterEvidence = {
+  checkedFileCount: number;
+  changedFileCount: number;
+  unchangedFileCount: number;
+  changedPathsSha256: string;
+};
+
+function formatterEvidence(checkedFileCount: number, changedPaths: string[]): FormatterEvidence {
+  return createFormatterChangeEvidence(checkedFileCount, changedPaths) as FormatterEvidence;
+}
+
+function makeAgreementFixture(mode: "change" | "clean") {
+  const project = makeSyntheticProject([["src/App.vue", "<template><p>x</p></template>\n"]]);
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-glyph-check-write-"));
+  const executable = path.join(fakeDir, "fake-vize.mjs");
+  fs.writeFileSync(
+    executable,
+    [
+      "#!/usr/bin/env node",
+      'import fs from "node:fs";',
+      ...(mode === "change"
+        ? [
+            'const file = "src/App.vue";',
+            'const source = fs.readFileSync(file, "utf8");',
+            'if (source === "<template><p>x</p></template>\\n") {',
+            '  fs.writeFileSync(file, "<template>\\n  <p>x</p>\\n</template>\\n");',
+            "}",
+          ]
+        : []),
+      "",
+    ].join("\n"),
+  );
+  fs.chmodSync(executable, 0o755);
+  return {
+    project,
+    launch: { command: executable, prefix: [] },
+    cleanup: () => {
+      fs.rmSync(project.fixtureDir, { recursive: true, force: true });
+      fs.rmSync(fakeDir, { recursive: true, force: true });
+    },
+  };
+}
 
 function makeSyntheticProject(files: Array<[string, string]>): CorpusProject {
   const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-glyph-corpus-"));

--- a/tools/fixtures/glyph-corpus.mjs
+++ b/tools/fixtures/glyph-corpus.mjs
@@ -12,6 +12,10 @@ import {
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  createFormatterChangeEvidence,
+  validateFormatterChangeEvidence,
+} from "./tool-matrix-formatter.mjs";
 import { collectVueInputPaths } from "./tool-matrix-inputs.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
@@ -119,6 +123,59 @@ export function withFormattedWorkspace(project, files, launch, run) {
   } finally {
     rmSync(workspaceDir, { recursive: true, force: true });
   }
+}
+
+/** Load the preceding real-project matrix's validated formatter check evidence. */
+export function loadFormatterCheckEvidence(project, reportDir = process.env.FIXTURE_REPORT_DIR) {
+  if (reportDir == null || reportDir === "") return null;
+
+  const reportPath = resolve(repoRoot, reportDir, `${project.id}-formatter.json`);
+  if (!existsSync(reportPath)) {
+    throw new Error(`missing formatter check report for ${project.id}: ${reportPath}`);
+  }
+  const report = JSON.parse(readFileSync(reportPath, "utf8"));
+  if (
+    report.schema !== "vize.fixtureToolRun" ||
+    report.version !== 1 ||
+    report.project !== project.id ||
+    report.tool !== "formatter"
+  ) {
+    throw new Error(`invalid formatter check report identity for ${project.id}: ${reportPath}`);
+  }
+  validateFormatterChangeEvidence(
+    report.formatterCheck,
+    `${project.id} formatter --check evidence`,
+  );
+  return report.formatterCheck;
+}
+
+/** Measure which copied fixture inputs the first formatter write actually changed. */
+export function collectFormatterWriteEvidence(project, files, workspaceDir) {
+  const changedPaths = files.filter(
+    (file) =>
+      !readFileSync(join(project.fixtureDir, file)).equals(readFileSync(join(workspaceDir, file))),
+  );
+  return createFormatterChangeEvidence(files.length, changedPaths);
+}
+
+/** Require formatter --check's prediction to equal the first --write mutation set. */
+export function assertFormatterCheckWriteAgreement(projectId, checkEvidence, writeEvidence) {
+  validateFormatterChangeEvidence(checkEvidence, `${projectId} formatter --check evidence`);
+  validateFormatterChangeEvidence(writeEvidence, `${projectId} formatter --write evidence`);
+  const fields = [
+    "checkedFileCount",
+    "changedFileCount",
+    "unchangedFileCount",
+    "changedPathsSha256",
+  ];
+  const mismatches = fields.filter((field) => checkEvidence[field] !== writeEvidence[field]);
+  if (mismatches.length === 0) return;
+  throw new Error(
+    `${projectId}: formatter --check prediction disagrees with actual --write mutation ` +
+      `(${mismatches.join(", ")})\n` +
+      `  --check: ${JSON.stringify(checkEvidence)}\n` +
+      `  --write: ${JSON.stringify(writeEvidence)}`,
+  );
 }
 
 function formatWorkspace(project, workspaceDir, launch) {

--- a/tools/fixtures/tool-matrix-formatter.mjs
+++ b/tools/fixtures/tool-matrix-formatter.mjs
@@ -59,7 +59,7 @@ export function validateFormatterOutput(
       invalid("zero-file fixture emitted an unexpected report");
     }
     if (exitCode !== 1) invalid(`zero-file exit code ${exitCode} does not match expected 1`);
-    return formatterSummary(0, [], 0);
+    return createFormatterChangeEvidence(0, []);
   }
 
   const lines = normalizedStderr.slice(0, -1).split("\n");
@@ -115,21 +115,46 @@ export function validateFormatterOutput(
   if (exitCode !== expectedExitCode) {
     invalid(`exit code ${exitCode} does not match expected ${expectedExitCode}`);
   }
-  return formatterSummary(checked, changedPaths, unchanged);
+  return createFormatterChangeEvidence(checked, changedPaths);
 }
 
-function formatterSummary(checkedFileCount, changedPaths, unchangedFileCount) {
+/** Build the canonical evidence shared by formatter check and write validation. */
+export function createFormatterChangeEvidence(checkedFileCount, changedPaths) {
   const digest = createHash("sha256");
   for (const inputPath of [...changedPaths].sort((left, right) => left.localeCompare(right))) {
     digest.update(inputPath);
     digest.update("\0");
   }
-  return {
+  const evidence = {
     checkedFileCount,
     changedFileCount: changedPaths.length,
-    unchangedFileCount,
+    unchangedFileCount: checkedFileCount - changedPaths.length,
     changedPathsSha256: digest.digest("hex"),
   };
+  validateFormatterChangeEvidence(evidence);
+  return evidence;
+}
+
+/** Validate persisted formatter evidence before comparing separate CLI runs. */
+export function validateFormatterChangeEvidence(evidence, label = "formatter change evidence") {
+  if (evidence == null || typeof evidence !== "object" || Array.isArray(evidence)) {
+    throw new Error(`invalid ${label}`);
+  }
+  const keys = ["changedFileCount", "changedPathsSha256", "checkedFileCount", "unchangedFileCount"];
+  if (JSON.stringify(Object.keys(evidence).sort()) !== JSON.stringify(keys)) {
+    throw new Error(`invalid ${label} keys`);
+  }
+  for (const field of ["checkedFileCount", "changedFileCount", "unchangedFileCount"]) {
+    if (!Number.isSafeInteger(evidence[field]) || evidence[field] < 0) {
+      throw new Error(`invalid ${label} ${field}`);
+    }
+  }
+  if (evidence.checkedFileCount !== evidence.changedFileCount + evidence.unchangedFileCount) {
+    throw new Error(`${label} counts do not reconcile`);
+  }
+  if (!/^[0-9a-f]{64}$/.test(evidence.changedPathsSha256)) {
+    throw new Error(`invalid ${label} changedPathsSha256`);
+  }
 }
 
 function parseCount(line, pattern, label) {


### PR DESCRIPTION
## Summary

- persist canonical formatter `--check` evidence in each real-project matrix artifact
- compare that evidence with the existing first isolated `fmt --write` pass
- fail on false positives, false negatives, or equal-count/different-path disagreements
- validate report identity, exact schema, reconciled counts, and stable path digests

## Why

The matrix exercised all 132 registered projects, but formatter exit status and reported changed files were never compared with the bytes actually changed by `--write`. A formatter could therefore report the wrong files while the corpus stayed green.

This adds no formatter invocation: it reuses the matrix `--check` run and the glyph idempotence suite's existing first write.

## Verification

- formatter/glyph/workflow tests: 22/22
- matrix report and Vue parity structure tests: 13/13
- create-vue real fixture: 42 SFC check/write agreement plus idempotence, parse preservation, and lint agreement
- formatting, lint, and `git diff --check`

Refs #3674

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->