### PR TITLE
fix(editor): restore Art Vue syntax fallback

### DIFF
--- a/.github/actions/vscode-host-smoke/action.yml
+++ b/.github/actions/vscode-host-smoke/action.yml
@@ -1,5 +1,5 @@
 name: Editor real-server end-to-end
-description: Run the VS Code and Neovim editor scenarios against a real vize language server
+description: Run VS Code and Neovim real-server scenarios plus Neovim and Vim headless specs
 
 runs:
   using: composite
@@ -52,6 +52,10 @@ runs:
         sudo ln -sf /opt/nvim-linux-x86_64/bin/nvim /usr/local/bin/nvim
         nvim --version | head -1
 
+    - name: Ensure Vim is available
+      shell: bash
+      run: command -v vim || (sudo apt-get update && sudo apt-get install -y vim)
+
     - name: Run VS Code host smoke against the real server
       shell: bash
       env:
@@ -64,6 +68,12 @@ runs:
       env:
         NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
       run: vp run --workspace-root test:nvim-extension:headless
+
+    - name: Run the packaged Vim unit spec
+      shell: bash
+      env:
+        NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+      run: vp run --workspace-root test:vim-extension:headless
 
     - name: Run the Neovim scenario against the real server
       shell: bash

--- a/editors/nvim/ftdetect/vize.lua
+++ b/editors/nvim/ftdetect/vize.lua
@@ -6,10 +6,34 @@ vim.api.nvim_create_autocmd({ "BufNewFile", "BufRead" }, {
   end,
 })
 
+local function has_explicit_art_vue_language()
+  local language = vim.treesitter.language.get_lang("art-vue")
+  if language ~= "art-vue" then
+    return true
+  end
+
+  -- get_filetypes() starts with the language itself; a second match records
+  -- an explicit identity registration for the Art Vue filetype.
+  local registrations = 0
+  for _, filetype in ipairs(vim.treesitter.language.get_filetypes(language)) do
+    if filetype == "art-vue" then
+      registrations = registrations + 1
+    end
+  end
+  return registrations > 1
+end
+
+if not has_explicit_art_vue_language() and not vim.treesitter.language.add("art-vue") then
+  vim.treesitter.language.register("vue", "art-vue")
+end
+
 vim.api.nvim_create_autocmd({ "BufNewFile", "BufRead" }, {
   group = vim.api.nvim_create_augroup("vize_art_vue_filetypes", { clear = true }),
   pattern = "*.art.vue",
   callback = function()
     vim.bo.filetype = "art-vue"
+    if vim.bo.syntax == "" then
+      vim.bo.syntax = "vue"
+    end
   end,
 })

--- a/editors/nvim/test/vize_spec.lua
+++ b/editors/nvim/test/vize_spec.lua
@@ -1,6 +1,24 @@
 local plugin_root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h")
 vim.opt.runtimepath:prepend(plugin_root)
 
+if vim.env.VIZE_TEST_ART_VUE_NATIVE_PARSER == "1" then
+  -- Reuse a bundled parser binary to exercise Neovim's real loaded-parser path
+  -- under the otherwise unavailable Art Vue language name.
+  local parser_path = vim.api.nvim_get_runtime_file("parser/vim.*", false)[1]
+  assert(parser_path, "finds Neovim's bundled Vim parser")
+  local loaded, err = vim.treesitter.language.add("art-vue", {
+    path = parser_path,
+    symbol_name = "vim",
+  })
+  assert(loaded, err)
+  vim.cmd("runtime! ftdetect/vize.lua")
+  assert(
+    vim.treesitter.language.get_lang("art-vue") == "art-vue",
+    "preserves a loaded parser under the Art Vue language name"
+  )
+  return
+end
+
 local config = require("vize.config")
 
 local function assert_eq(actual, expected, label)
@@ -165,3 +183,42 @@ vim.cmd("edit " .. vim.fn.fnameescape(vim.fn.tempname() .. ".vue"))
 assert(vim.bo.filetype == "vue", "detects .vue")
 vim.cmd("edit " .. vim.fn.fnameescape(vim.fn.tempname() .. ".art.vue"))
 assert(vim.bo.filetype == "art-vue", "detects .art.vue")
+assert(vim.bo.syntax == "vue", "reuses Vue syntax for .art.vue")
+assert(
+  vim.treesitter.language.get_lang(vim.bo.filetype) == "vue",
+  "reuses the Vue tree-sitter parser for .art.vue"
+)
+
+vim.treesitter.language.register("art-vue", "art-vue")
+vim.cmd("runtime! ftdetect/vize.lua")
+assert(
+  vim.treesitter.language.get_lang("art-vue") == "art-vue",
+  "preserves an explicit identity Art Vue parser mapping"
+)
+
+vim.treesitter.language.register("custom-art", "art-vue")
+vim.cmd("runtime! ftdetect/vize.lua")
+assert(
+  vim.treesitter.language.get_lang("art-vue") == "custom-art",
+  "preserves an explicit Art Vue tree-sitter parser mapping"
+)
+
+local syntax_root = vim.fn.tempname()
+vim.fn.mkdir(syntax_root .. "/syntax", "p")
+vim.fn.writefile({ 'let b:current_syntax = "art-vue"' }, syntax_root .. "/syntax/art-vue.vim")
+vim.opt.runtimepath:prepend(syntax_root)
+vim.cmd("syntax on")
+vim.cmd("edit " .. vim.fn.fnameescape(vim.fn.tempname() .. ".art.vue"))
+assert(vim.bo.syntax == "art-vue", "preserves a standard Art Vue syntax file")
+assert(vim.b.current_syntax == "art-vue", "loads the standard Art Vue syntax file")
+vim.opt.runtimepath:remove(syntax_root)
+vim.fn.delete(syntax_root, "rf")
+
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "art-vue",
+  callback = function()
+    vim.bo.syntax = "custom-art"
+  end,
+})
+vim.cmd("edit " .. vim.fn.fnameescape(vim.fn.tempname() .. ".art.vue"))
+assert(vim.bo.syntax == "custom-art", "preserves an explicit Art Vue syntax override")

--- a/editors/vim/ftdetect/vize.vim
+++ b/editors/vim/ftdetect/vize.vim
@@ -1,5 +1,12 @@
+function! s:detect_art_vue() abort
+  setlocal filetype=art-vue
+  if empty(&l:syntax)
+    setlocal syntax=vue
+  endif
+endfunction
+
 augroup vize_filetypes
   autocmd!
   autocmd BufNewFile,BufRead *.vue setlocal filetype=vue
-  autocmd BufNewFile,BufRead *.art.vue setlocal filetype=art-vue
+  autocmd BufNewFile,BufRead *.art.vue call <SID>detect_art_vue()
 augroup END

--- a/editors/vim/test/vize_spec.vim
+++ b/editors/vim/test/vize_spec.vim
@@ -139,6 +139,25 @@ execute 'edit ' . fnameescape(tempname() . '.vue')
 call assert_equal('vue', &filetype)
 execute 'edit ' . fnameescape(tempname() . '.art.vue')
 call assert_equal('art-vue', &filetype)
+call assert_equal('vue', &syntax)
+
+let s:syntax_root = tempname()
+call mkdir(s:syntax_root . '/syntax', 'p')
+call writefile(["let b:current_syntax = 'art-vue'"], s:syntax_root . '/syntax/art-vue.vim')
+execute 'set runtimepath^=' . fnameescape(s:syntax_root)
+syntax on
+execute 'edit ' . fnameescape(tempname() . '.art.vue')
+call assert_equal('art-vue', &syntax)
+call assert_equal('art-vue', b:current_syntax)
+execute 'set runtimepath-=' . fnameescape(s:syntax_root)
+call delete(s:syntax_root, 'rf')
+
+augroup vize_test_custom_art_syntax
+  autocmd!
+  autocmd FileType art-vue setlocal syntax=custom-art
+augroup END
+execute 'edit ' . fnameescape(tempname() . '.art.vue')
+call assert_equal('custom-art', &syntax)
 
 if !empty(v:errors)
   cquit

--- a/tests/tooling/editor-integrations-neovim.test.ts
+++ b/tests/tooling/editor-integrations-neovim.test.ts
@@ -20,6 +20,15 @@ test("nvim ftdetect maps .vue -> vue and .art.vue -> art-vue", () => {
   // *.art.vue files override to the "art-vue" filetype.
   assert.match(ftdetect, /pattern\s*=\s*["']\*\.art\.vue["']/);
   assert.match(ftdetect, /vim\.bo\.filetype\s*=\s*["']art-vue["']/);
+  assert.match(ftdetect, /vim\.bo\.syntax\s*=\s*["']vue["']/);
+  assert.match(ftdetect, /if\s+vim\.bo\.syntax\s*==\s*["']["']\s+then/);
+  assert.doesNotMatch(ftdetect, /syntax\s*==\s*vim\.bo\.filetype/);
+  assert.match(
+    ftdetect,
+    /vim\.treesitter\.language\.register\(\s*["']vue["']\s*,\s*["']art-vue["']\s*\)/,
+  );
+  assert.match(ftdetect, /vim\.treesitter\.language\.get_filetypes\(language\)/);
+  assert.match(ftdetect, /vim\.treesitter\.language\.add\(\s*["']art-vue["']\s*\)/);
 
   // Detection is wired through BufNewFile/BufRead autocommands.
   assert.match(

--- a/tests/tooling/editor-integrations-neovim.test.ts
+++ b/tests/tooling/editor-integrations-neovim.test.ts
@@ -17,18 +17,12 @@ test("nvim ftdetect maps .vue -> vue and .art.vue -> art-vue", () => {
   assert.match(ftdetect, /pattern\s*=\s*["']\*\.vue["']/);
   assert.match(ftdetect, /vim\.bo\.filetype\s*=\s*["']vue["']/);
 
-  // *.art.vue files override to the "art-vue" filetype.
+  // *.art.vue files override to the "art-vue" filetype. The resulting buffer
+  // syntax and tree-sitter parser resolution are observable behavior and are
+  // asserted against a real editor in editors/nvim/test/vize_spec.lua, so they
+  // are deliberately not re-asserted here as ftdetect source text.
   assert.match(ftdetect, /pattern\s*=\s*["']\*\.art\.vue["']/);
   assert.match(ftdetect, /vim\.bo\.filetype\s*=\s*["']art-vue["']/);
-  assert.match(ftdetect, /vim\.bo\.syntax\s*=\s*["']vue["']/);
-  assert.match(ftdetect, /if\s+vim\.bo\.syntax\s*==\s*["']["']\s+then/);
-  assert.doesNotMatch(ftdetect, /syntax\s*==\s*vim\.bo\.filetype/);
-  assert.match(
-    ftdetect,
-    /vim\.treesitter\.language\.register\(\s*["']vue["']\s*,\s*["']art-vue["']\s*\)/,
-  );
-  assert.match(ftdetect, /vim\.treesitter\.language\.get_filetypes\(language\)/);
-  assert.match(ftdetect, /vim\.treesitter\.language\.add\(\s*["']art-vue["']\s*\)/);
 
   // Detection is wired through BufNewFile/BufRead autocommands.
   assert.match(

--- a/tests/tooling/editor-integrations-vim.test.ts
+++ b/tests/tooling/editor-integrations-vim.test.ts
@@ -23,13 +23,11 @@ test("vim ftdetect maps *.vue -> vue and *.art.vue -> art-vue inside an augroup"
   // `setlocal filetype=vue` (not `setf`/`set filetype`), so assert what it actually does.
   assert.match(ftdetect, /autocmd\s+BufNewFile,BufRead\s+\*\.vue\s+setlocal\s+filetype=vue/);
 
-  // *.art.vue files override to the "art-vue" filetype.
-  assert.match(
-    ftdetect,
-    /autocmd\s+BufNewFile,BufRead\s+\*\.art\.vue\s+call\s+<SID>detect_art_vue\(\)/,
-  );
-  assert.match(ftdetect, /if\s+empty\(&l:syntax\)/);
-  assert.doesNotMatch(ftdetect, /&l:syntax\s+==#\s+&l:filetype/);
+  // *.art.vue files are routed through a dedicated detector. The resulting
+  // buffer filetype and syntax are observable behavior and are asserted against
+  // a real editor in editors/vim/test/vize_spec.vim, so they are deliberately
+  // not re-asserted here as ftdetect source text.
+  assert.match(ftdetect, /autocmd\s+BufNewFile,BufRead\s+\*\.art\.vue\s+\S/);
 });
 
 test("vim ftdetect autocommands are scoped only to *.vue / *.art.vue (no clobbering)", () => {

--- a/tests/tooling/editor-integrations-vim.test.ts
+++ b/tests/tooling/editor-integrations-vim.test.ts
@@ -26,8 +26,10 @@ test("vim ftdetect maps *.vue -> vue and *.art.vue -> art-vue inside an augroup"
   // *.art.vue files override to the "art-vue" filetype.
   assert.match(
     ftdetect,
-    /autocmd\s+BufNewFile,BufRead\s+\*\.art\.vue\s+setlocal\s+filetype=art-vue/,
+    /autocmd\s+BufNewFile,BufRead\s+\*\.art\.vue\s+call\s+<SID>detect_art_vue\(\)/,
   );
+  assert.match(ftdetect, /if\s+empty\(&l:syntax\)/);
+  assert.doesNotMatch(ftdetect, /&l:syntax\s+==#\s+&l:filetype/);
 });
 
 test("vim ftdetect autocommands are scoped only to *.vue / *.art.vue (no clobbering)", () => {

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -32,13 +32,25 @@ test("CI runs both real-server editor scenarios from one built server binary", (
     ],
   );
   assert.match(action, /vp run --workspace-root test:vscode-extension:host-real/);
-  assert.match(action, /vp run --workspace-root test:nvim-extension:headless/);
   assert.match(action, /vp run --workspace-root test:nvim-extension:real-server/);
 
   // The scenario needs a Neovim with a Lua LSP client, pinned and checksummed.
   assert.match(action, /NVIM_VERSION: v\d+\.\d+\.\d+/);
   assert.match(action, /NVIM_SHA256: [0-9a-f]{64}/);
   assert.match(action, /sha256sum --check --strict/);
+});
+
+test("CI runs both headless editor specs", () => {
+  const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
+
+  assert.match(taskCommand("test:nvim-extension:headless"), /VIZE_TEST_ART_VUE_NATIVE_PARSER=1/);
+  assert.match(
+    action,
+    /^description: Run VS Code and Neovim real-server scenarios plus Neovim and Vim headless specs$/m,
+  );
+  assert.match(action, /vp run --workspace-root test:nvim-extension:headless/);
+  assert.match(action, /vp run --workspace-root test:vim-extension:headless/);
+  assert.match(action, /command -v vim/);
 });
 
 test("check.yml keeps the editor real-server job in the required set", () => {

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -44,10 +44,6 @@ test("CI runs both headless editor specs", () => {
   const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
 
   assert.match(taskCommand("test:nvim-extension:headless"), /VIZE_TEST_ART_VUE_NATIVE_PARSER=1/);
-  assert.match(
-    action,
-    /^description: Run VS Code and Neovim real-server scenarios plus Neovim and Vim headless specs$/m,
-  );
   assert.match(action, /vp run --workspace-root test:nvim-extension:headless/);
   assert.match(action, /vp run --workspace-root test:vim-extension:headless/);
   assert.match(action, /command -v vim/);

--- a/tools/nvim-vize/assert-nvim-package.mjs
+++ b/tools/nvim-vize/assert-nvim-package.mjs
@@ -108,6 +108,10 @@ assert.match(initLua, /vim\.lsp\.enable\("vize"\)/);
 assert.match(ftdetectLua, /pattern = "\*\.vue"/);
 assert.match(ftdetectLua, /pattern = "\*\.art\.vue"/);
 assert.match(ftdetectLua, /filetype = "art-vue"/);
+assert.match(ftdetectLua, /if vim\.bo\.syntax == "" then\s+vim\.bo\.syntax = "vue"\s+end/);
+assert.doesNotMatch(ftdetectLua, /syntax == vim\.bo\.filetype/);
+assert.match(ftdetectLua, /vim\.treesitter\.language\.add\("art-vue"\)/);
+assert.match(ftdetectLua, /vim\.treesitter\.language\.register\("vue", "art-vue"\)/);
 assert.match(specLua, /config\.normalize/);
 assert.match(specLua, /vim\.lsp\.config\.vize/);
 // The packaged archive must be able to run the real-server scenario, not only

--- a/tools/vim-vize/assert-vim-package.mjs
+++ b/tools/vim-vize/assert-vim-package.mjs
@@ -92,7 +92,9 @@ assert.match(autoload, /'initialization_options': s:profiles\.recommended/);
 assert.match(autoload, /function! vize#vim_lsp_config/);
 assert.match(autoload, /lsp#register_server/);
 assert.match(ftdetect, /\*\.vue setlocal filetype=vue/);
-assert.match(ftdetect, /\*\.art\.vue setlocal filetype=art-vue/);
+assert.match(ftdetect, /\*\.art\.vue call <SID>detect_art_vue\(\)/);
+assert.match(ftdetect, /setlocal filetype=art-vue/);
+assert.match(ftdetect, /if empty\(&l:syntax\)/);
 assert.match(spec, /vize#vim_lsp_config/);
 assert.match(spec, /assert_equal\(\['vize', 'lsp'\]/);
 

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -124,7 +124,7 @@ export const testAndBenchmarkTasks = defineTasks({
     input: ["editors/zed/**"],
   }),
   "test:nvim-extension:headless": noCacheTask(
-    "nvim --headless -u NONE --noplugin '+set runtimepath^=editors/nvim' '+luafile editors/nvim/test/vize_spec.lua' '+qa'",
+    "nvim --headless -u NONE --noplugin '+set runtimepath^=editors/nvim' '+luafile editors/nvim/test/vize_spec.lua' '+qa' && VIZE_TEST_ART_VUE_NATIVE_PARSER=1 nvim --headless -u NONE --noplugin '+set runtimepath^=editors/nvim' '+luafile editors/nvim/test/vize_spec.lua' '+qa'",
   ),
   "test:nvim-extension:package": noCacheTask("vp run --workspace-root package:nvim-extension"),
   // The headless Neovim end-to-end scenario against a real `vize lsp` (#3457).


### PR DESCRIPTION
## Summary

- keep `art-vue` as the LSP filetype while falling back to Vue syntax only when no Art Vue syntax exists
- reuse the Vue Tree-sitter parser only when no explicit identity/alias mapping or loadable native Art Vue parser exists
- preserve same-name syntax files, FileType overrides, identity mappings, alias mappings, and native parsers
- run both Vim and Neovim headless specs in the required editor CI job
- validate the same contract in packaged Vim and Neovim archives

## Verification

- independent review: approved
- Vim and Neovim headless runtime specs
- native Art Vue parser isolation process
- same-name and custom syntax/mapping preservation cases
- package:nvim-extension and package:vim-extension
- package fault injection for missing syntax/add/register contracts
- editor/workflow Node tests: 53/53
- formatting, lint, YAML, source-length, and diff checks

Closes #3675
Refs #3674

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `.art.vue` file detection and syntax handling in Vim and Neovim.
  * Added Tree-sitter support for `art-vue`, including reuse of the Vue parser when appropriate.
  * Preserved explicit syntax and parser settings while providing sensible Vue defaults.

* **Bug Fixes**
  * Prevented filetype detection from overriding existing syntax configurations.

* **Tests**
  * Expanded Vim and Neovim coverage for syntax detection, parser registration, overrides, and packaged editor checks.
  * Added headless validation for both native and standard parser modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->