### PR TITLE
fix(fixtures): resolve compiler binary from invocation cwd

### DIFF
--- a/tests/tooling/compiler-fixture-diff-report.test.ts
+++ b/tests/tooling/compiler-fixture-diff-report.test.ts
@@ -9,6 +9,70 @@ import { fileURLToPath } from "node:url";
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const toolPath = path.join(root, "tools", "fixtures", "compiler-diff-report.mjs");
 
+function writeFakeVizePreload(directory: string): string {
+  const preloadPath = path.join(directory, "fake-vize.cjs");
+  const report = JSON.stringify({
+    files: [],
+    summary: {
+      fileCount: 0,
+      changedFiles: 0,
+      additions: 0,
+      removals: 0,
+      officialErrors: 0,
+      vizeErrors: 0,
+    },
+  });
+  fs.writeFileSync(
+    preloadPath,
+    `const path = require("node:path");
+if (path.basename(process.argv[1] ?? "") === "inspector") {
+  process.stdout.write(${JSON.stringify(report)});
+  process.exit(0);
+}
+`,
+  );
+  return preloadPath;
+}
+
+function fakeVizeEnv(preloadPath: string): NodeJS.ProcessEnv {
+  const preloadOption = `--require=${JSON.stringify(preloadPath)}`;
+  return {
+    ...process.env,
+    NODE_OPTIONS: [process.env.NODE_OPTIONS, preloadOption].filter(Boolean).join(" "),
+  };
+}
+
+function runCompilerFixtureDiff(vizeBin: string, invocationDirectory = root) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-compiler-diff-bin-"));
+  const outputDir = path.join(tempDir, "report");
+  const preloadPath = writeFakeVizePreload(tempDir);
+
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [
+        toolPath,
+        "--project",
+        "element-plus",
+        "--target",
+        "dom",
+        "--max-files",
+        "1",
+        "--output-dir",
+        outputDir,
+        "--vize-bin",
+        vizeBin,
+      ],
+      { cwd: invocationDirectory, encoding: "utf8", env: fakeVizeEnv(preloadPath) },
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    return JSON.parse(fs.readFileSync(path.join(outputDir, "summary.json"), "utf8"));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 test("compiler fixture diff reporter documents the shared artifact directory", () => {
   const result = spawnSync(process.execPath, [toolPath, "--help"], {
     cwd: root,
@@ -79,4 +143,22 @@ test("compiler fixture diff reporter rejects unknown fixture ids", () => {
   } finally {
     fs.rmSync(outputDir, { recursive: true, force: true });
   }
+});
+
+test("compiler fixture diff reporter resolves --vize-bin from the invocation directory", () => {
+  const binPath = process.execPath;
+  const invocationDirectory = path.dirname(binPath);
+  const relativeBinPath = `.${path.sep}${path.basename(binPath)}`;
+  const summary = runCompilerFixtureDiff(relativeBinPath, invocationDirectory);
+
+  assert.equal(summary.command.vize, binPath);
+  assert.equal(summary.projects[0].targets[0].status, "ok");
+});
+
+test("compiler fixture diff reporter preserves an absolute --vize-bin path", () => {
+  const binPath = process.execPath;
+  const summary = runCompilerFixtureDiff(binPath);
+
+  assert.equal(summary.command.vize, binPath);
+  assert.equal(summary.projects[0].targets[0].status, "ok");
 });

--- a/tools/fixtures/compiler-diff-report.mjs
+++ b/tools/fixtures/compiler-diff-report.mjs
@@ -390,7 +390,9 @@ function resolveVizeLaunch(vizeBin) {
     join(repoRoot, "target", "ci", executableName("vize")),
     join(repoRoot, "target", "debug", executableName("vize")),
     join(repoRoot, "target", "release", executableName("vize")),
-  ].filter(Boolean);
+  ]
+    .filter(Boolean)
+    .map((candidate) => resolve(candidate));
 
   for (const candidate of candidates) {
     if (!existsSync(candidate)) {


### PR DESCRIPTION
## Summary

- resolve compiler binary candidates to absolute paths from the invocation directory
- preserve explicit absolute binary paths
- cover both path forms with focused regression tests

## Root cause

An explicit relative `--vize-bin` was checked from the process invocation directory, then probed and executed under repository or fixture working directories. The same relative string could therefore point to a different location after the working directory changed.

## Validation

- `node --test --test-concurrency=1 tests/tooling/compiler-fixture-diff-report.test.ts` (5/5)
- `vp check` (format 1962 files; lint 1363 files)

Relates #3674

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage to verify compiler diff reports resolve relative tool paths from the invocation directory.
  - Confirmed absolute tool paths remain unchanged and reports are generated successfully.

- **Style**
  - Reformatted internal candidate chaining without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->