### PR TITLE
fix(release): prepare CLI first-publish handoff

### DIFF
--- a/.github/workflows/release-npm-bootstrap.yml
+++ b/.github/workflows/release-npm-bootstrap.yml
@@ -1,10 +1,10 @@
-name: Bootstrap npm package
+name: Prepare npm first-publish CLI handoff
 
 on:
   repository_dispatch:
     types: [npm-bootstrap]
 
-run-name: Bootstrap ${{ github.event.client_payload.package_path }} from ${{ github.event.client_payload.tag_name }} run ${{ github.event.client_payload.release_run_id }}
+run-name: Prepare CLI handoff for ${{ github.event.client_payload.package_path }} from ${{ github.event.client_payload.tag_name }} run ${{ github.event.client_payload.release_run_id }}
 
 concurrency:
   group: npm-bootstrap-${{ github.event.client_payload.package_path }}
@@ -14,19 +14,14 @@ permissions: { contents: read }
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  PUBLISH_RETRY_LIMIT: 3
-  PUBLISH_RETRY_DELAY: 10
-  PUBLISH_RESOLUTION_RETRY_LIMIT: 24
-  PUBLISH_RESOLUTION_RETRY_DELAY: 10
 
 jobs:
-  bootstrap:
-    name: First publish to npm
+  handoff:
+    name: Prepare first-publish CLI handoff
     runs-on: ubuntu-24.04
     timeout-minutes: 20
-    environment: npm
-    # actions: read downloads the Release run artifact; id-token: write signs npm provenance.
-    permissions: { actions: read, contents: read, id-token: write }
+    # actions: read downloads the exact Release run artifact. This job never publishes.
+    permissions: { actions: read, contents: read }
     steps:
       - name: Checkout bootstrap controls from main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -75,12 +70,23 @@ jobs:
           RELEASE_RUN_ID: ${{ steps.preflight.outputs.release_run_id }}
           RELEASE_TAG_NAME: ${{ github.event.client_payload.tag_name }}
         run: node tools/github/npm-bootstrap-preflight.mjs registry-recheck
-      - name: Publish the package once with provenance
+      - name: Pack deterministic npm CLI first-publish handoff
+        id: handoff
         env:
-          BOOTSTRAP_PACKAGE_PATH: bootstrap-package
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/npm-bootstrap.npmrc
-        run: |
-          trap 'rm -f "$NPM_CONFIG_USERCONFIG"' EXIT
-          printf '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}\n' > "$NPM_CONFIG_USERCONFIG"
-          moon run --target native tools/moon/cmd/publish_npm_package -- "$BOOTSTRAP_PACKAGE_PATH" --provenance
+          BOOTSTRAP_ARTIFACT_PATH: bootstrap-package
+          BOOTSTRAP_HANDOFF_PATH: npm-cli-first-publish
+          EXPECTED_PACKAGE_NAME: ${{ steps.preflight.outputs.package_name }}
+          EXPECTED_PACKAGE_VERSION: ${{ steps.preflight.outputs.version }}
+          RELEASE_ARTIFACT_NAME: ${{ steps.preflight.outputs.artifact_name }}
+          RELEASE_RUN_ID: ${{ steps.preflight.outputs.release_run_id }}
+          RELEASE_TAG_NAME: ${{ github.event.client_payload.tag_name }}
+          RELEASE_TAG_SHA: ${{ steps.preflight.outputs.tag_sha }}
+        run: node tools/github/npm-bootstrap-handoff.mjs
+      - name: Upload npm CLI first-publish handoff
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.handoff.outputs.artifact_name }}
+          path: npm-cli-first-publish
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 7

--- a/docs/release/supply-chain.md
+++ b/docs/release/supply-chain.md
@@ -109,14 +109,32 @@ available. The run must be the completed failed `.github/workflows/release.yml`
 tag run for the same SHA. Its package build, release preflight, and tarball smoke
 jobs must be successful, while only the target package publish job is required
 to have failed. The exact package artifact from that run is downloaded,
-identity-checked, smoke-installed again, and published with provenance. The
-workflow refuses to run unless the package remains absent from npm.
+identity-checked, manifest-normalized, and smoke-installed again. The workflow
+refuses to run unless the package remains absent from npm. It then runs
+`npm pack` twice and requires both tarballs to be byte-for-byte identical before
+uploading this credential-free handoff artifact:
 
-npm Granular Access Tokens expire after at most 90 days. Before dispatch, rotate
-an expired or long-lived `NPM_TOKEN` repository secret to a short-lived Granular
-Access Token scoped to write packages in `@vizejs` and permitted to bypass 2FA.
-The secret is exposed only to the final publish step. Never place the token in a
-workflow-level or job-level environment.
+```text
+npm-cli-first-publish-vizejs-nuxt-lint-config-X.Y.Z/
+├── SHA512SUMS
+├── npm-publish-handoff.json
+└── vizejs-nuxt-lint-config-X.Y.Z.tgz
+```
+
+The handoff workflow does not request an OIDC token, read an npm secret, or
+publish anything. Download the named artifact shown in its job summary, verify
+`SHA512SUMS`, authenticate locally as an npm owner with settings 2FA, and make
+the one-time first publish from the exact tarball:
+
+```bash
+shasum -a 512 --check SHA512SUMS
+npm whoami
+npm publish ./vizejs-nuxt-lint-config-X.Y.Z.tgz --access public
+```
+
+This local CLI first publish does not have GitHub Actions OIDC provenance. That
+is expected only for the package-creation bootstrap; do not pass
+`--provenance`, and do not describe this run as Trusted Publishing.
 
 Immediately after the first publish of `@vizejs/nuxt-lint-config`, configure the
 normal release workflow as its trusted publisher. Use npm CLI 11.17.0 or newer
@@ -126,17 +144,16 @@ and authenticate as an npm owner with settings 2FA:
 npm trust github @vizejs/nuxt-lint-config --file release.yml --repo ubugeeei-prod/vize --env npm --allow-publish --yes
 ```
 
-Confirm the package's npm settings name `release.yml` and the `npm` environment.
-Revoke the short-lived Granular Access Token immediately and remove or rotate
-the `NPM_TOKEN` secret, then rerun only the failed jobs in the same Release run.
-The standard OIDC-only publish job will see the exact version and finish its
-registry verification, allowing the remaining release jobs to complete. Use
+Confirm the package's npm settings name `release.yml` and the `npm` environment,
+then rerun only the failed jobs in the same Release run. The standard OIDC-only
+publish job will see the exact version and finish its registry verification,
+allowing the remaining release jobs to complete. Use
 `.github/workflows/release.yml` for every later version. Do not use the bootstrap
 workflow after the package exists; its registry guard will reject the request.
 
 After every package is configured and one release has verified OIDC publishing,
 set the npm package publishing access to require two-factor authentication and
-disallow tokens, then revoke the old automation token.
+disallow tokens, then delete any obsolete npm publishing secret from GitHub.
 
 ## What is not signed
 

--- a/tests/tooling/github-workflows-npm-bootstrap.test.ts
+++ b/tests/tooling/github-workflows-npm-bootstrap.test.ts
@@ -38,7 +38,7 @@ test("npm bootstrap workflow uses one default-branch repository dispatch event",
   assert.doesNotMatch(source, /workflow_dispatch|\$\{\{\s*inputs\./);
   assert.deepEqual(workflow.permissions, { contents: "read" });
 
-  const controlsCheckout = workflow.jobs?.bootstrap?.steps?.find(
+  const controlsCheckout = workflow.jobs?.handoff?.steps?.find(
     (step) => step.name === "Checkout bootstrap controls from main",
   );
   assert.ok(controlsCheckout);
@@ -54,14 +54,13 @@ test("npm bootstrap workflow uses one default-branch repository dispatch event",
 test("npm bootstrap validates an exact tag before building with existing release helpers", () => {
   const source = readRepoFile(".github", "workflows", "release-npm-bootstrap.yml");
   const workflow = parse(source) as BootstrapWorkflow;
-  const job = workflow.jobs?.bootstrap;
+  const job = workflow.jobs?.handoff;
   assert.ok(job);
   assert.equal(job["runs-on"], "ubuntu-24.04");
-  assert.equal(job.environment, "npm");
+  assert.equal(job.environment, undefined);
   assert.deepEqual(job.permissions, {
     actions: "read",
     contents: "read",
-    "id-token": "write",
   });
 
   const steps = job.steps ?? [];
@@ -106,29 +105,46 @@ test("npm bootstrap validates an exact tag before building with existing release
   assert.deepEqual(
     requiredIndices,
     [...requiredIndices].sort((left, right) => left - right),
-    "every credential-free validation must run before publish",
+    "every release-artifact validation must run before the CLI handoff is packed",
   );
 });
 
-test("npm bootstrap exposes NPM_TOKEN only to the provenance publish step", () => {
+test("npm bootstrap creates a credential-free deterministic CLI handoff", () => {
   const source = readRepoFile(".github", "workflows", "release-npm-bootstrap.yml");
   const workflow = parse(source) as BootstrapWorkflow;
-  const steps = workflow.jobs?.bootstrap?.steps ?? [];
-  const publish = steps.find((step) => step.name === "Publish the package once with provenance");
-  assert.ok(publish);
-  assert.equal(publish["working-directory"], undefined);
-  assert.equal(publish.env?.BOOTSTRAP_PACKAGE_PATH, "bootstrap-package");
-  assert.equal(publish.env?.NODE_AUTH_TOKEN, "${{ secrets.NPM_TOKEN }}");
-  assert.equal(publish.env?.NPM_CONFIG_USERCONFIG, "${{ runner.temp }}/npm-bootstrap.npmrc");
-  assert.match(publish.run ?? "", /_authToken=\$\{NODE_AUTH_TOKEN\}/);
-  assert.match(publish.run ?? "", /publish_npm_package -- .* --provenance/);
-  assert.equal(steps.at(-1), publish);
+  const steps = workflow.jobs?.handoff?.steps ?? [];
+  const pack = steps.find(
+    (step) => step.name === "Pack deterministic npm CLI first-publish handoff",
+  );
+  assert.ok(pack);
+  assert.equal(pack.id, "handoff");
+  assert.equal(pack.run, "node tools/github/npm-bootstrap-handoff.mjs");
+  assert.equal(pack.env?.BOOTSTRAP_ARTIFACT_PATH, "bootstrap-package");
+  assert.equal(pack.env?.BOOTSTRAP_HANDOFF_PATH, "npm-cli-first-publish");
+  assert.equal(pack.env?.EXPECTED_PACKAGE_NAME, "${{ steps.preflight.outputs.package_name }}");
+  assert.equal(pack.env?.EXPECTED_PACKAGE_VERSION, "${{ steps.preflight.outputs.version }}");
+  assert.equal(pack.env?.RELEASE_TAG_SHA, "${{ steps.preflight.outputs.tag_sha }}");
 
-  for (const step of steps) {
-    if (step === publish) continue;
-    assert.doesNotMatch(JSON.stringify(step), /NPM_TOKEN|NODE_AUTH_TOKEN|_authToken/);
-  }
-  assert.equal([...source.matchAll(/secrets\.NPM_TOKEN/g)].length, 1);
+  const upload = steps.find((step) => step.name === "Upload npm CLI first-publish handoff");
+  assert.ok(upload);
+  assert.match(upload.uses ?? "", /^actions\/upload-artifact@[0-9a-f]{40}$/);
+  assert.equal(upload.with?.name, "${{ steps.handoff.outputs.artifact_name }}");
+  assert.equal(upload.with?.path, "npm-cli-first-publish");
+  assert.equal(upload.with?.["if-no-files-found"], "error");
+  assert.equal(upload.with?.["compression-level"], 0);
+  assert.equal(upload.with?.["retention-days"], 7);
+  assert.equal(steps.at(-1), upload);
+  const registryRecheck = steps.find(
+    (step) => step.name === "Confirm package is still unpublished",
+  );
+  assert.ok(registryRecheck);
+  assert.ok(steps.indexOf(registryRecheck) < steps.indexOf(pack));
+  assert.ok(steps.indexOf(pack) < steps.indexOf(upload));
+
+  assert.doesNotMatch(
+    source,
+    /NPM_TOKEN|NODE_AUTH_TOKEN|_authToken|secrets\.|id-token|--provenance|npm publish|publish_npm_package/,
+  );
 });
 
 test("npm bootstrap handoff documents the exact trusted publisher command", () => {
@@ -155,9 +171,11 @@ test("npm bootstrap handoff documents the exact trusted publisher command", () =
   const bootstrapSectionStart = docs.indexOf("### First-publish bootstrap");
   assert.notEqual(bootstrapSectionStart, -1, "docs must keep the First-publish bootstrap section");
   assert.doesNotMatch(docs.slice(bootstrapSectionStart), /v0\.314\.0/);
-  assert.match(docs, /90 days/);
-  assert.match(docs, /short-lived Granular Access Token/);
-  assert.match(docs, /revoke/i);
+  assert.match(docs, /npm-cli-first-publish-vizejs-nuxt-lint-config-X\.Y\.Z/);
+  assert.match(docs, /npm publish \.\/vizejs-nuxt-lint-config-X\.Y\.Z\.tgz --access public/);
+  assert.match(docs, /does not request an OIDC token/i);
+  assert.match(docs, /does not have GitHub Actions OIDC provenance/i);
+  assert.doesNotMatch(docs.slice(bootstrapSectionStart), /Granular Access Token|NPM_TOKEN/);
   assert.match(docs, /Freeze `main`/);
   assert.match(docs, /Disable PR auto-merge/);
   assert.match(docs, /neither direct pushes nor other merges/);

--- a/tests/tooling/npm-bootstrap-handoff.test.ts
+++ b/tests/tooling/npm-bootstrap-handoff.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  cliHandoffNames,
+  createCliPublishHandoff,
+  formatCliHandoffSummary,
+} from "../../tools/github/npm-bootstrap-handoff.mjs";
+
+const packageName = "@vizejs/nuxt-lint-config";
+const version = "1.2.3";
+const source = {
+  sourceArtifactName: "release-package-nuxt-lint-config",
+  releaseRunId: "123456789",
+  releaseTagName: `v${version}`,
+  releaseTagSha: "a".repeat(40),
+};
+
+function writePackage(root: string): string {
+  const packagePath = path.join(root, "package");
+  fs.mkdirSync(path.join(packagePath, "dist"), { recursive: true });
+  fs.writeFileSync(path.join(packagePath, "dist", "index.mjs"), "export const ok = true;\n");
+  fs.writeFileSync(
+    path.join(packagePath, "dist", "index.d.mts"),
+    "export declare const ok: true;\n",
+  );
+  fs.writeFileSync(
+    path.join(packagePath, "package.json"),
+    `${JSON.stringify(
+      {
+        name: packageName,
+        version,
+        files: ["dist"],
+        type: "module",
+        main: "./dist/index.mjs",
+        types: "./dist/index.d.mts",
+        publishConfig: { access: "public" },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return packagePath;
+}
+
+test("npm CLI handoff names bind the package identity and version", () => {
+  assert.deepEqual(cliHandoffNames(packageName, version), {
+    artifactName: "npm-cli-first-publish-vizejs-nuxt-lint-config-1.2.3",
+    tarballName: "vizejs-nuxt-lint-config-1.2.3.tgz",
+  });
+  assert.throws(() => cliHandoffNames("nuxt-lint-config", version), /scoped npm package/);
+  assert.throws(() => cliHandoffNames(packageName, "1.2.x"), /Invalid package version/);
+});
+
+test("npm CLI handoff reproduces one exact tarball with a verified SHA-512", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-npm-handoff-test-"));
+  try {
+    const packagePath = writePackage(tempRoot);
+    const firstOutput = path.join(tempRoot, "first-output");
+    const secondOutput = path.join(tempRoot, "second-output");
+    const first = createCliPublishHandoff({
+      packagePath,
+      outputPath: firstOutput,
+      expectedName: packageName,
+      expectedVersion: version,
+      ...source,
+    });
+    const second = createCliPublishHandoff({
+      packagePath,
+      outputPath: secondOutput,
+      expectedName: packageName,
+      expectedVersion: version,
+      ...source,
+    });
+
+    const tarballName = "vizejs-nuxt-lint-config-1.2.3.tgz";
+    const firstTarball = fs.readFileSync(path.join(firstOutput, tarballName));
+    const secondTarball = fs.readFileSync(path.join(secondOutput, tarballName));
+    const expectedSha512 = createHash("sha512").update(firstTarball).digest("hex");
+    assert.ok(firstTarball.equals(secondTarball));
+    assert.equal(first.tarball.sha512, expectedSha512);
+    assert.deepEqual(first, second);
+    assert.equal(
+      fs.readFileSync(path.join(firstOutput, "SHA512SUMS"), "utf8"),
+      `${expectedSha512}  ${tarballName}\n`,
+    );
+    assert.deepEqual(
+      JSON.parse(fs.readFileSync(path.join(firstOutput, "npm-publish-handoff.json"), "utf8")),
+      first,
+    );
+    assert.equal(first.publish.command, `npm publish ./${tarballName} --access public`);
+    assert.equal(
+      first.publish.trustCommand,
+      "npm trust github @vizejs/nuxt-lint-config --file release.yml --repo ubugeeei-prod/vize --env npm --allow-publish --yes",
+    );
+
+    const summary = formatCliHandoffSummary(first);
+    assert.match(summary, /did not request an OIDC token and did not publish/);
+    assert.match(summary, /does not carry GitHub Actions OIDC provenance/);
+    assert.match(summary, /npm trust github @vizejs\/nuxt-lint-config/);
+    assert.doesNotMatch(summary, /--provenance|NPM_TOKEN/);
+  } finally {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+});
+
+test("npm CLI handoff rejects artifact identity and public-access drift", () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-npm-handoff-test-"));
+  try {
+    const packagePath = writePackage(tempRoot);
+    assert.throws(
+      () =>
+        createCliPublishHandoff({
+          packagePath,
+          outputPath: path.join(tempRoot, "wrong-version"),
+          expectedName: packageName,
+          expectedVersion: "1.2.4",
+          ...source,
+        }),
+      /Release tag .* must match package version/,
+    );
+
+    const manifestPath = path.join(packagePath, "package.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    delete manifest.publishConfig;
+    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    assert.throws(
+      () =>
+        createCliPublishHandoff({
+          packagePath,
+          outputPath: path.join(tempRoot, "private-package"),
+          expectedName: packageName,
+          expectedVersion: version,
+          ...source,
+        }),
+      /publishConfig\.access as public/,
+    );
+  } finally {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+});

--- a/tools/github/npm-bootstrap-handoff.mjs
+++ b/tools/github/npm-bootstrap-handoff.mjs
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { validateDownloadedArtifact } from "./npm-bootstrap-contract.mjs";
+
+const strictVersionPattern =
+  /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*)|(?:\d*[A-Za-z-][0-9A-Za-z-]*))(?:\.(?:(?:0|[1-9]\d*)|(?:\d*[A-Za-z-][0-9A-Za-z-]*)))*)?$/;
+
+function sha512(buffer) {
+  return createHash("sha512").update(buffer).digest();
+}
+
+function requireSingleLine(label, value, pattern) {
+  if (!pattern.test(value)) {
+    throw new Error(`Invalid ${label}: ${value || "(empty)"}`);
+  }
+  return value;
+}
+
+export function cliHandoffNames(packageName, version) {
+  const match = /^@([a-z0-9][a-z0-9._-]*)\/([a-z0-9][a-z0-9._-]*)$/.exec(packageName);
+  if (match == null) {
+    throw new Error(`CLI handoff requires a lowercase scoped npm package, got ${packageName}`);
+  }
+  requireSingleLine("package version", version, strictVersionPattern);
+  const slug = `${match[1]}-${match[2]}`;
+  return {
+    artifactName: `npm-cli-first-publish-${slug}-${version}`,
+    tarballName: `${slug}-${version}.tgz`,
+  };
+}
+
+function runNpmPack({ npmBin, packagePath, destination }) {
+  const result = spawnSync(
+    npmBin,
+    ["pack", "--ignore-scripts", "--json", "--pack-destination", destination],
+    {
+      cwd: packagePath,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 120_000,
+    },
+  );
+  if (result.error?.code === "ETIMEDOUT") {
+    throw new Error("npm pack timed out after 120000ms");
+  }
+  if (result.error != null) throw result.error;
+  if (result.signal != null) throw new Error(`npm pack was terminated by ${result.signal}`);
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+    throw new Error(
+      [`npm pack failed with exit ${result.status}`, detail].filter(Boolean).join("\n"),
+    );
+  }
+
+  let entries;
+  try {
+    entries = JSON.parse(result.stdout);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`npm pack did not return JSON metadata: ${detail}`, { cause: error });
+  }
+  if (!Array.isArray(entries) || entries.length !== 1) {
+    throw new Error(`npm pack must describe exactly one tarball, got ${JSON.stringify(entries)}`);
+  }
+  return entries[0];
+}
+
+function packOnce({
+  npmBin,
+  packagePath,
+  destination,
+  expectedName,
+  expectedVersion,
+  tarballName,
+}) {
+  const metadata = runNpmPack({ npmBin, packagePath, destination });
+  if (
+    metadata?.name !== expectedName ||
+    metadata?.version !== expectedVersion ||
+    metadata?.filename !== tarballName
+  ) {
+    throw new Error(
+      `npm pack produced ${String(metadata?.name)}@${String(metadata?.version)} in ${String(metadata?.filename)}, expected ${expectedName}@${expectedVersion} in ${tarballName}`,
+    );
+  }
+
+  const tarballPath = path.join(destination, tarballName);
+  const stat = fs.lstatSync(tarballPath);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    throw new Error(`npm pack output must be a regular file: ${tarballPath}`);
+  }
+  const contents = fs.readFileSync(tarballPath);
+  const digest = sha512(contents);
+  const integrity = `sha512-${digest.toString("base64")}`;
+  if (metadata.integrity !== integrity) {
+    throw new Error(`npm pack integrity mismatch for ${tarballName}`);
+  }
+  return { contents, integrity, sha512: digest.toString("hex") };
+}
+
+export function formatCliHandoffSummary(handoff) {
+  return [
+    "## npm CLI first-publish handoff",
+    "",
+    `- Package: \`${handoff.package.name}@${handoff.package.version}\``,
+    `- Handoff artifact: \`${handoff.handoffArtifact}\``,
+    `- Tarball: \`${handoff.tarball.file}\``,
+    `- SHA-512: \`${handoff.tarball.sha512}\``,
+    `- Source: \`${handoff.source.tagName}\` / Release run \`${handoff.source.releaseRunId}\` / \`${handoff.source.artifactName}\``,
+    "",
+    "Download the handoff artifact, verify `SHA512SUMS`, authenticate with the npm CLI as an owner with 2FA, then run:",
+    "",
+    "```bash",
+    handoff.publish.command,
+    "```",
+    "",
+    "This workflow did not request an OIDC token and did not publish. The one-time local CLI publish does not carry GitHub Actions OIDC provenance. Immediately configure `release.yml` as the trusted publisher with:",
+    "",
+    "```bash",
+    handoff.publish.trustCommand,
+    "```",
+    "",
+  ].join("\n");
+}
+
+export function createCliPublishHandoff({
+  packagePath,
+  outputPath,
+  expectedName,
+  expectedVersion,
+  sourceArtifactName,
+  releaseRunId,
+  releaseTagName,
+  releaseTagSha,
+  npmBin = process.env.NPM_BIN || "npm",
+}) {
+  requireSingleLine("Release run ID", releaseRunId, /^[1-9]\d*$/);
+  requireSingleLine("Release tag SHA", releaseTagSha, /^[0-9a-f]{40}$/);
+  requireSingleLine("Release artifact name", sourceArtifactName, /^release-package-[a-z0-9-]+$/);
+  if (releaseTagName !== `v${expectedVersion}`) {
+    throw new Error(
+      `Release tag ${releaseTagName || "(empty)"} must match package version ${expectedVersion}`,
+    );
+  }
+
+  const packageManifest = fs.readFileSync(path.join(packagePath, "package.json"), "utf8");
+  validateDownloadedArtifact({ packageManifest, expectedName, expectedVersion });
+  const packageJson = JSON.parse(packageManifest);
+  if (packageJson.publishConfig?.access !== "public") {
+    throw new Error(`${expectedName} must declare publishConfig.access as public`);
+  }
+
+  const { artifactName, tarballName } = cliHandoffNames(expectedName, expectedVersion);
+  fs.mkdirSync(outputPath);
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-npm-cli-handoff-"));
+  try {
+    const firstDestination = path.join(tempRoot, "first");
+    const secondDestination = path.join(tempRoot, "second");
+    fs.mkdirSync(firstDestination);
+    fs.mkdirSync(secondDestination);
+    const first = packOnce({
+      npmBin,
+      packagePath,
+      destination: firstDestination,
+      expectedName,
+      expectedVersion,
+      tarballName,
+    });
+    const second = packOnce({
+      npmBin,
+      packagePath,
+      destination: secondDestination,
+      expectedName,
+      expectedVersion,
+      tarballName,
+    });
+    if (!first.contents.equals(second.contents) || first.integrity !== second.integrity) {
+      throw new Error(`npm pack did not reproduce ${tarballName} byte-for-byte`);
+    }
+
+    fs.writeFileSync(path.join(outputPath, tarballName), first.contents, { flag: "wx" });
+    fs.writeFileSync(path.join(outputPath, "SHA512SUMS"), `${first.sha512}  ${tarballName}\n`, {
+      flag: "wx",
+    });
+
+    const handoff = {
+      schemaVersion: 1,
+      package: { name: expectedName, version: expectedVersion },
+      source: {
+        artifactName: sourceArtifactName,
+        releaseRunId,
+        tagName: releaseTagName,
+        tagSha: releaseTagSha,
+      },
+      handoffArtifact: artifactName,
+      tarball: { file: tarballName, integrity: first.integrity, sha512: first.sha512 },
+      publish: {
+        authentication: "interactive npm CLI owner session with 2FA",
+        command: `npm publish ./${tarballName} --access public`,
+        provenance: "none: local CLI first publish is outside GitHub Actions OIDC",
+        trustCommand: `npm trust github ${expectedName} --file release.yml --repo ubugeeei-prod/vize --env npm --allow-publish --yes`,
+      },
+    };
+    fs.writeFileSync(
+      path.join(outputPath, "npm-publish-handoff.json"),
+      `${JSON.stringify(handoff, null, 2)}\n`,
+      { flag: "wx" },
+    );
+    return handoff;
+  } finally {
+    fs.rmSync(tempRoot, { force: true, recursive: true });
+  }
+}
+
+function appendFileFromEnvironment(name, contents) {
+  const filePath = process.env[name];
+  if (!filePath) throw new Error(`${name} is required for npm CLI handoff`);
+  fs.appendFileSync(filePath, contents);
+}
+
+function main(env = process.env) {
+  if (env.BOOTSTRAP_ARTIFACT_PATH !== "bootstrap-package") {
+    throw new Error("BOOTSTRAP_ARTIFACT_PATH must be bootstrap-package");
+  }
+  if (env.BOOTSTRAP_HANDOFF_PATH !== "npm-cli-first-publish") {
+    throw new Error("BOOTSTRAP_HANDOFF_PATH must be npm-cli-first-publish");
+  }
+  const handoff = createCliPublishHandoff({
+    packagePath: env.BOOTSTRAP_ARTIFACT_PATH,
+    outputPath: env.BOOTSTRAP_HANDOFF_PATH,
+    expectedName: env.EXPECTED_PACKAGE_NAME ?? "",
+    expectedVersion: env.EXPECTED_PACKAGE_VERSION ?? "",
+    sourceArtifactName: env.RELEASE_ARTIFACT_NAME ?? "",
+    releaseRunId: env.RELEASE_RUN_ID ?? "",
+    releaseTagName: env.RELEASE_TAG_NAME ?? "",
+    releaseTagSha: env.RELEASE_TAG_SHA ?? "",
+  });
+  appendFileFromEnvironment(
+    "GITHUB_OUTPUT",
+    `artifact_name=${handoff.handoffArtifact}\ntarball_name=${handoff.tarball.file}\nsha512=${handoff.tarball.sha512}\n`,
+  );
+  appendFileFromEnvironment("GITHUB_STEP_SUMMARY", formatCliHandoffSummary(handoff));
+  console.log(
+    `Prepared deterministic npm CLI handoff ${handoff.handoffArtifact}/${handoff.tarball.file}.`,
+  );
+}
+
+const entrypoint = process.argv[1]
+  ? fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  : false;
+if (entrypoint) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary

- preserve exact-tag Release evidence, manifest normalization, registry absence, and install smoke checks
- replace token-backed Actions publishing with a byte-reproducible npm CLI handoff artifact and SHA-512 record
- document the one-time non-provenance CLI publish and immediate transition to the `release.yml` trusted publisher

## Validation

- `node --test tests/tooling/npm-bootstrap-handoff.test.ts tests/tooling/github-workflows-npm-bootstrap.test.ts tests/tooling/npm-bootstrap-preflight.test.ts tests/tooling/npm-bootstrap-release-evidence.test.ts` (19/19)
- `node --test tests/tooling/github-workflows.test.ts tests/tooling/github-workflows-release-publish.test.ts tests/tooling/repo-governance.test.ts` (24/24)
- `vp check .github/workflows/release-npm-bootstrap.yml docs/release/supply-chain.md tests/tooling/github-workflows-npm-bootstrap.test.ts tests/tooling/npm-bootstrap-handoff.test.ts tools/github/npm-bootstrap-handoff.mjs`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->