### PR TITLE
fix(patina): scope Nuxt config ordering by filename

### DIFF
--- a/crates/vize_patina/src/linter/script_rules.rs
+++ b/crates/vize_patina/src/linter/script_rules.rs
@@ -13,7 +13,7 @@ mod template_ast;
 use html_scripts::extract_inline_scripts;
 use prefilter::{
     descriptor_scripts_may_match_ecosystem_rule, has_only_active_ecosystem_script_rules,
-    script_rule_may_match,
+    script_rule_applies_to_filename, script_rule_may_match,
 };
 pub use registry::BuiltinScriptRuleMeta;
 use registry::{ALL_BUILTIN_SCRIPT_RULE_NAMES, BUILTIN_SCRIPT_RULES, BuiltinScriptRuleEntry};
@@ -112,10 +112,10 @@ pub(crate) fn append_builtin_script_diagnostics<'a>(
         .script
         .as_ref()
         .map(|block| (block.content.as_ref(), block.loc.start))
-        .filter(|(source, _)| block_has_active_rule(linter, source));
+        .filter(|(source, _)| block_has_active_rule(linter, source, result.filename.as_str()));
     let script_alloc = Allocator::default();
     let script_parsed = script
-        .filter(|(source, _)| block_has_active_ast_rule(linter, source))
+        .filter(|(source, _)| block_has_active_ast_rule(linter, source, result.filename.as_str()))
         .map(|(source, _)| {
             let parsed = profile!(
                 "patina.script_rule.parse",
@@ -128,10 +128,10 @@ pub(crate) fn append_builtin_script_diagnostics<'a>(
         .script_setup
         .as_ref()
         .map(|block| (block.content.as_ref(), block.loc.start))
-        .filter(|(source, _)| block_has_active_rule(linter, source));
+        .filter(|(source, _)| block_has_active_rule(linter, source, result.filename.as_str()));
     let setup_alloc = Allocator::default();
     let script_setup_parsed = script_setup
-        .filter(|(source, _)| block_has_active_ast_rule(linter, source))
+        .filter(|(source, _)| block_has_active_ast_rule(linter, source, result.filename.as_str()))
         .map(|(source, _)| {
             let parsed = profile!(
                 "patina.script_rule.parse",
@@ -211,23 +211,30 @@ fn resolved_rule<'a>(
 /// byte prefilter (its deny list may reference identifiers the default prefilter
 /// does not know about), so the block is always parsed for overridden rules.
 #[inline]
-fn entry_may_match(linter: &Linter, entry: &BuiltinScriptRuleEntry, source: &str) -> bool {
-    linter.script_rule_overrides.contains_key(entry.rule_name)
-        || script_rule_may_match(entry.rule_name, source)
+fn entry_may_match(
+    linter: &Linter,
+    entry: &BuiltinScriptRuleEntry,
+    source: &str,
+    filename: &str,
+) -> bool {
+    script_rule_applies_to_filename(entry.rule_name, filename)
+        && (linter.script_rule_overrides.contains_key(entry.rule_name)
+            || script_rule_may_match(entry.rule_name, source))
 }
 
 /// Whether any enabled built-in script rule could match `source`.
 ///
 /// Mirrors the per-rule `is_rule_enabled` + `script_rules.contains` +
 /// `script_rule_may_match` gate so a block matching no rule is never parsed.
-fn block_has_active_rule(linter: &Linter, source: &str) -> bool {
-    active_builtin_script_rule_entries(linter).any(|entry| entry_may_match(linter, entry, source))
+fn block_has_active_rule(linter: &Linter, source: &str, filename: &str) -> bool {
+    active_builtin_script_rule_entries(linter)
+        .any(|entry| entry_may_match(linter, entry, source, filename))
 }
 
 /// Whether any enabled AST-based built-in script rule could match `source`.
-fn block_has_active_ast_rule(linter: &Linter, source: &str) -> bool {
+fn block_has_active_ast_rule(linter: &Linter, source: &str, filename: &str) -> bool {
     active_builtin_script_rule_entries(linter).any(|entry| {
-        resolved_rule(linter, entry).uses_ast() && entry_may_match(linter, entry, source)
+        resolved_rule(linter, entry).uses_ast() && entry_may_match(linter, entry, source, filename)
     })
 }
 
@@ -247,7 +254,7 @@ fn run_builtin_script_rule(
     sfc: SfcScriptContext<'_>,
     result: &mut LintResult,
 ) {
-    if !entry_may_match(linter, entry, source) {
+    if !entry_may_match(linter, entry, source, result.filename.as_str()) {
         return;
     }
     let mut lint = ScriptLintResult::default();
@@ -301,12 +308,12 @@ pub(crate) fn append_builtin_script_rules_for_source(
     result: &mut LintResult,
 ) {
     // Skip work entirely when no enabled rule could match this block.
-    if !block_has_active_rule(linter, source) {
+    if !block_has_active_rule(linter, source, result.filename.as_str()) {
         return;
     }
 
     let allocator = Allocator::default();
-    let parsed = block_has_active_ast_rule(linter, source).then(|| {
+    let parsed = block_has_active_ast_rule(linter, source, result.filename.as_str()).then(|| {
         profile!(
             "patina.script_rule.parse",
             Parser::new(&allocator, source, script_source_type()).parse()

--- a/crates/vize_patina/src/linter/script_rules/prefilter.rs
+++ b/crates/vize_patina/src/linter/script_rules/prefilter.rs
@@ -48,6 +48,47 @@ pub(super) fn script_rule_may_match(rule_name: &str, source: &str) -> bool {
     }
 }
 
+/// Whether a built-in script rule applies to the current file.
+///
+/// The Nuxt config ordering rule mirrors an upstream rule that is activated by
+/// config overrides. Native presets do not have an override layer, so preserve
+/// that boundary here instead of treating every default export as Nuxt config.
+pub(super) fn script_rule_applies_to_filename(rule_name: &str, filename: &str) -> bool {
+    rule_name != RULE_NUXT_CONFIG_KEYS_ORDER || is_nuxt_config_filename(filename)
+}
+
+fn is_nuxt_config_filename(filename: &str) -> bool {
+    let mut components = filename
+        .rsplit(['/', '\\'])
+        .filter(|component| !component.is_empty());
+    let Some(basename) = components.next() else {
+        return false;
+    };
+
+    has_script_extension(basename, "nuxt.config")
+        || (components.next() == Some(".config") && has_script_extension(basename, "nuxt"))
+}
+
+fn has_script_extension(filename: &str, stem: &str) -> bool {
+    matches!(
+        filename.strip_prefix(stem),
+        Some(
+            ".js"
+                | ".jsx"
+                | ".ts"
+                | ".tsx"
+                | ".cjs"
+                | ".cjsx"
+                | ".cts"
+                | ".ctsx"
+                | ".mjs"
+                | ".mjsx"
+                | ".mts"
+                | ".mtsx"
+        )
+    )
+}
+
 pub(super) fn descriptor_scripts_may_match_ecosystem_rule(descriptor: &SfcDescriptor<'_>) -> bool {
     descriptor
         .script
@@ -81,4 +122,40 @@ fn source_may_match_ecosystem_rule(source: &str) -> bool {
     ]
     .into_iter()
     .any(|rule_name| script_rule_may_match(rule_name, source))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_nuxt_config_filename;
+
+    #[test]
+    fn recognizes_supported_nuxt_config_paths() {
+        for extension in [
+            "js", "jsx", "ts", "tsx", "cjs", "cjsx", "cts", "ctsx", "mjs", "mjsx", "mts", "mtsx",
+        ] {
+            let root = format!("apps/web/nuxt.config.{extension}");
+            let hidden = format!("apps/web/.config/nuxt.{extension}");
+            assert!(is_nuxt_config_filename(&root), "{root}");
+            assert!(is_nuxt_config_filename(&hidden), "{hidden}");
+        }
+
+        assert!(is_nuxt_config_filename(r"apps\web\nuxt.config.js"));
+        assert!(is_nuxt_config_filename(r"apps\web\.config\nuxt.mts"));
+    }
+
+    #[test]
+    fn rejects_unrelated_or_lookalike_paths() {
+        for filename in [
+            "vitest.config.ts",
+            "vize.config.ts",
+            "components/DataTable.vue",
+            "nuxt.config.d.ts",
+            "nuxt.config.json",
+            "config/nuxt.ts",
+            ".config/not-nuxt.ts",
+            "my-nuxt.config.ts",
+        ] {
+            assert!(!is_nuxt_config_filename(filename), "{filename}");
+        }
+    }
 }

--- a/crates/vize_patina/src/linter/tests/nuxt_config_order.rs
+++ b/crates/vize_patina/src/linter/tests/nuxt_config_order.rs
@@ -33,6 +33,72 @@ fn nuxt_preset_reports_fixable_config_order() {
 }
 
 #[test]
+fn nuxt_preset_ignores_unrelated_default_export_configs() {
+    let linter = Linter::with_preset(LintPreset::Nuxt);
+    for (filename, source) in [
+        (
+            "vitest.config.ts",
+            "export default defineConfig({ resolve: {}, test: {} })",
+        ),
+        (
+            "vize.config.ts",
+            "export default defineConfig({ compiler: {}, vite: {} })",
+        ),
+    ] {
+        let result = linter.lint_script(source, filename);
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.rule_name != "nuxt/nuxt-config-keys-order"),
+            "{filename}: {:#?}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
+fn nuxt_preset_ignores_component_option_objects() {
+    let source = r#"<script lang="ts">
+export default defineComponent({ name: "DataTable", model: {} })
+</script>
+"#;
+    let result = Linter::with_preset(LintPreset::Nuxt).lint_sfc(source, "components/DataTable.vue");
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.rule_name != "nuxt/nuxt-config-keys-order"),
+        "{:#?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn nuxt_preset_checks_supported_nuxt_config_path_forms() {
+    let linter = Linter::with_preset(LintPreset::Nuxt);
+    let source = "export default defineNuxtConfig({ ssr: true, modules: [] })";
+    for filename in [
+        "nuxt.config.ts",
+        "apps/web/nuxt.config.mjs",
+        ".config/nuxt.ts",
+        "apps/web/.config/nuxt.cts",
+        r"apps\web\nuxt.config.js",
+        r"apps\web\.config\nuxt.mts",
+    ] {
+        let result = linter.lint_script(source, filename);
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.rule_name == "nuxt/nuxt-config-keys-order"),
+            "{filename}: {:#?}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
 fn config_order_rule_is_nuxt_only_but_can_be_selected_explicitly() {
     let source = "export default { ssr: true, modules: [] }";
     for preset in [LintPreset::Ecosystem, LintPreset::Opinionated] {


### PR DESCRIPTION
## Summary

- gate `nuxt/nuxt-config-keys-order` to `nuxt.config.*` and `.config/nuxt.*` files in the native script-rule dispatcher
- avoid parsing unrelated default exports when this is the only matching AST rule
- cover Vitest, Vize config, Vue component-option, supported path, extension, and Windows-path cases

## Root cause

The upstream rule is normally activated through filename-scoped config overrides. The native Nuxt preset enabled the rule globally, so every directly default-exported object (including unrelated `defineConfig` and `defineComponent` calls) was treated as Nuxt configuration.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- positive and negative Rust regression tests added; full execution delegated to GitHub Actions because the local volume exhausted its remaining build space before tests started

Closes #3685

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->