### PR TITLE
fix(patina): classify built-in script rules for category severities

### DIFF
--- a/crates/vize/tests/lint_rule_severity_cli.rs
+++ b/crates/vize/tests/lint_rule_severity_cli.rs
@@ -76,6 +76,63 @@ const handleStepClick = (stepIndex: number) => {
 }
 
 #[test]
+fn lint_config_category_severity_applies_to_builtin_script_rules() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_file(
+        project_root.path(),
+        "vize.config.json",
+        r#"{
+  "linter": {
+    "preset": "nuxt",
+    "categories": {
+      "correctness": "warn",
+      "suspicious": "warn",
+      "style": "warn",
+      "perf": "warn",
+      "a11y": "warn",
+      "security": "warn"
+    }
+  }
+}"#,
+    );
+    write_file(
+        project_root.path(),
+        "nuxt.config.ts",
+        "export default { ssr: true, modules: [] }\n",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--format",
+            "json",
+            "nuxt.config.ts",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_details(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let file = json.as_array().unwrap().first().unwrap();
+    assert_eq!(file["errorCount"], serde_json::json!(0), "{stdout}");
+    assert_eq!(file["warningCount"], serde_json::json!(1), "{stdout}");
+    assert_eq!(
+        file["messages"][0]["ruleId"],
+        serde_json::json!("nuxt/nuxt-config-keys-order"),
+        "{stdout}"
+    );
+    assert_eq!(
+        file["messages"][0]["severity"],
+        serde_json::json!(1),
+        "{stdout}"
+    );
+}
+
+#[test]
 fn quiet_lint_reduces_warning_totals_and_preserves_max_warnings_exit() {
     let project_root = tempfile::tempdir().unwrap();
     write_file(

--- a/crates/vize_patina/src/linter.rs
+++ b/crates/vize_patina/src/linter.rs
@@ -5,6 +5,7 @@
 //! - [`config`]: `Linter` struct, builder methods, and `LintResult`
 //! - [`engine`]: Core linting methods and template extraction
 
+mod category_config;
 mod category_rules;
 mod compatibility;
 mod config;

--- a/crates/vize_patina/src/linter/category_config.rs
+++ b/crates/vize_patina/src/linter/category_config.rs
@@ -1,0 +1,60 @@
+//! Host category configuration across Patina's separate rule registries.
+
+use super::{
+    category_rules::{rule_matches_config_category, rule_name_matches_config_category},
+    config::Linter,
+};
+use crate::Severity;
+use vize_carton::String;
+
+impl Linter {
+    /// Disable every registered rule that belongs to one of the configured categories.
+    #[inline]
+    pub fn with_disabled_categories(mut self, categories: Vec<String>) -> Self {
+        for category in categories {
+            let template_rules = self
+                .registry
+                .rules()
+                .iter()
+                .filter(|rule| {
+                    rule_matches_config_category(rule.meta().name, rule.meta().category, &category)
+                })
+                .map(|rule| String::from(rule.meta().name));
+            self.disabled_rules.extend(template_rules);
+
+            let script_rules = self
+                .script_rules
+                .iter()
+                .copied()
+                .filter(|rule_name| rule_name_matches_config_category(rule_name, &category))
+                .map(String::from);
+            self.disabled_rules.extend(script_rules);
+        }
+        self
+    }
+
+    /// Apply category-level severity overrides to every registered matching rule.
+    #[inline]
+    pub fn with_category_severity_overrides(mut self, categories: Vec<(String, Severity)>) -> Self {
+        for (category, severity) in categories {
+            let template_rules = self
+                .registry
+                .rules()
+                .iter()
+                .filter(|rule| {
+                    rule_matches_config_category(rule.meta().name, rule.meta().category, &category)
+                })
+                .map(|rule| (String::from(rule.meta().name), severity));
+            self.severity_overrides.extend(template_rules);
+
+            let script_rules = self
+                .script_rules
+                .iter()
+                .copied()
+                .filter(|rule_name| rule_name_matches_config_category(rule_name, &category))
+                .map(|rule_name| (String::from(rule_name), severity));
+            self.severity_overrides.extend(script_rules);
+        }
+        self
+    }
+}

--- a/crates/vize_patina/src/linter/category_rules.rs
+++ b/crates/vize_patina/src/linter/category_rules.rs
@@ -7,6 +7,19 @@
 
 use crate::rule::RuleCategory;
 
+/// Match categories that are defined by an explicit rule-name classification.
+///
+/// Built-in script and CSS rules do not use [`RuleCategory`], so callers that
+/// own those registries use this name-only half of the category mapping.
+pub(super) fn rule_name_matches_config_category(rule_name: &str, config_category: &str) -> bool {
+    match config_category {
+        "style" => is_style_rule_name(rule_name),
+        "security" => is_security_rule_name(rule_name),
+        "perf" => is_perf_rule_name(rule_name),
+        _ => false,
+    }
+}
+
 pub(super) fn rule_matches_config_category(
     rule_name: &str,
     rule_category: RuleCategory,
@@ -15,12 +28,11 @@ pub(super) fn rule_matches_config_category(
     match config_category {
         "correctness" => matches!(rule_category, RuleCategory::Essential),
         "style" => {
-            is_style_rule_name(rule_name)
+            rule_name_matches_config_category(rule_name, config_category)
                 || matches!(rule_category, RuleCategory::StronglyRecommended)
         }
         "a11y" => matches!(rule_category, RuleCategory::Accessibility),
-        "security" => is_security_rule_name(rule_name),
-        "perf" => is_perf_rule_name(rule_name),
+        "security" | "perf" => rule_name_matches_config_category(rule_name, config_category),
         "suspicious" => {
             matches!(
                 rule_category,
@@ -61,6 +73,7 @@ fn is_style_rule_name(rule_name: &str) -> bool {
             | "css/prefer-logical-properties"
             | "css/prefer-nested-selectors"
             | "css/prefer-slotted"
+            | "nuxt/nuxt-config-keys-order"
     )
 }
 

--- a/crates/vize_patina/src/linter/config.rs
+++ b/crates/vize_patina/src/linter/config.rs
@@ -3,7 +3,6 @@
 //! Defines the `LintResult` output type and the `Linter` struct with its
 //! builder-pattern configuration methods.
 
-use super::category_rules::rule_matches_config_category;
 #[cfg(not(target_arch = "wasm32"))]
 use super::corsa_session::CorsaTypeAwareSession;
 use crate::{
@@ -261,52 +260,10 @@ impl Linter {
         self
     }
 
-    /// Disable every registered rule that belongs to one of the configured categories.
-    #[inline]
-    pub fn with_disabled_categories(mut self, categories: Vec<String>) -> Self {
-        if categories.is_empty() {
-            return self;
-        }
-
-        for category in categories {
-            let disabled = self
-                .registry
-                .rules()
-                .iter()
-                .filter(|rule| {
-                    rule_matches_config_category(rule.meta().name, rule.meta().category, &category)
-                })
-                .map(|rule| String::from(rule.meta().name));
-            self.disabled_rules.extend(disabled);
-        }
-        self
-    }
-
     /// Apply rule-level severity overrides from host configuration.
     #[inline]
     pub fn with_rule_severity_overrides(mut self, rules: Vec<(String, Severity)>) -> Self {
         self.severity_overrides.extend(rules);
-        self
-    }
-
-    /// Apply category-level severity overrides to every registered matching rule.
-    #[inline]
-    pub fn with_category_severity_overrides(mut self, categories: Vec<(String, Severity)>) -> Self {
-        if categories.is_empty() {
-            return self;
-        }
-
-        for (category, severity) in categories {
-            let overrides = self
-                .registry
-                .rules()
-                .iter()
-                .filter(|rule| {
-                    rule_matches_config_category(rule.meta().name, rule.meta().category, &category)
-                })
-                .map(|rule| (String::from(rule.meta().name), severity));
-            self.severity_overrides.extend(overrides);
-        }
         self
     }
 

--- a/crates/vize_patina/src/linter/tests/severity_overrides.rs
+++ b/crates/vize_patina/src/linter/tests/severity_overrides.rs
@@ -36,3 +36,54 @@ fn css_rule_severity_override_recounts_sfc_result() {
     assert_eq!(result.warning_count, 0, "{:?}", result.diagnostics);
     assert_eq!(result.diagnostics[0].severity, Severity::Error);
 }
+
+const NUXT_CONFIG_ORDER_SOURCE: &str = "export default { ssr: true, modules: [] }";
+
+#[test]
+fn script_rule_category_severity_override_recounts_sfc_result() {
+    let result = Linter::with_preset(LintPreset::Nuxt)
+        .with_category_severity_overrides(vec![("style".into(), Severity::Warning)])
+        .lint_script(NUXT_CONFIG_ORDER_SOURCE, "nuxt.config.ts");
+
+    assert_eq!(result.error_count, 0, "{:?}", result.diagnostics);
+    assert_eq!(result.warning_count, 1, "{:?}", result.diagnostics);
+    assert_eq!(result.diagnostics[0].severity, Severity::Warning);
+    assert_eq!(
+        result.diagnostics[0].rule_name,
+        "nuxt/nuxt-config-keys-order"
+    );
+}
+
+#[test]
+fn existing_perf_category_classification_applies_to_script_rule() {
+    let result = Linter::with_preset(LintPreset::Incremental)
+        .with_enabled_rules(Some(vec!["script/no-async-in-computed".into()]))
+        .with_category_severity_overrides(vec![("perf".into(), Severity::Warning)])
+        .lint_script("const value = computed(async () => 1)", "component.ts");
+
+    assert_eq!(result.error_count, 0, "{:?}", result.diagnostics);
+    assert_eq!(result.warning_count, 1, "{:?}", result.diagnostics);
+    assert_eq!(result.diagnostics[0].severity, Severity::Warning);
+}
+
+#[test]
+fn unrelated_category_does_not_override_script_rule_severity() {
+    let result = Linter::with_preset(LintPreset::Nuxt)
+        .with_category_severity_overrides(vec![("correctness".into(), Severity::Warning)])
+        .lint_script(NUXT_CONFIG_ORDER_SOURCE, "nuxt.config.ts");
+
+    assert_eq!(result.error_count, 1, "{:?}", result.diagnostics);
+    assert_eq!(result.warning_count, 0, "{:?}", result.diagnostics);
+    assert_eq!(result.diagnostics[0].severity, Severity::Error);
+}
+
+#[test]
+fn disabled_category_disables_classified_script_rule() {
+    let result = Linter::with_preset(LintPreset::Nuxt)
+        .with_disabled_categories(vec!["style".into()])
+        .lint_script(NUXT_CONFIG_ORDER_SOURCE, "nuxt.config.ts");
+
+    assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(result.warning_count, 0);
+}


### PR DESCRIPTION
## Summary

- apply host category severity and disable settings to built-in script rules
- classify `nuxt/nuxt-config-keys-order` as a `style` rule
- keep category handling for template and script registries in one focused module

## Root cause

Category configuration only traversed the template rule registry. Built-in script rules live in a separate registry, so their diagnostics retained their default severity even when the matching public category was configured.

## Tests

- add Patina coverage for warning counts and severity, an unrelated-category negative case, category disable behavior, and an existing performance-classified script rule
- add an end-to-end CLI JSON regression against a real `nuxt.config.ts` target; #3695 now correctly excludes component option exports from this rule
- `cargo fmt --all -- --check`

Closes #3690
