### PR TITLE
fix(maestro): terminate stdio server after LSP exit notification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3875,6 +3875,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "tower",
  "tower-lsp",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ pklrust = "=0.9.0"
 # CLI, async, and IDE runtime
 clap = { version = "=4.6.1", features = ["derive"] }
 futures = "=0.3.32"
+tower = { version = "=0.4.13", default-features = false }
 tower-lsp = { version = "=0.20.0", default-features = false, features = ["runtime-agnostic"] }
 async-trait = "=0.1.89"
 tracing = "=0.1.44"

--- a/crates/vize/tests/lsp_cli.rs
+++ b/crates/vize/tests/lsp_cli.rs
@@ -9,6 +9,51 @@ mod lsp_process;
 use lsp_process::{LspProcess, file_uri};
 
 #[test]
+fn lsp_exit_notification_terminates_process_while_stdin_stays_open() {
+    let project = tempfile::tempdir().unwrap();
+    let root_uri = file_uri(project.path());
+    let mut lsp = LspProcess::spawn(project.path());
+
+    lsp.send(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "processId": null,
+            "rootUri": root_uri,
+            "capabilities": {},
+            "initializationOptions": {
+                "lint": false,
+                "typecheck": false,
+                "ecosystem": false
+            }
+        }
+    }));
+    let initialize = lsp.recv_response(1);
+    assert!(initialize["result"].is_object(), "{initialize:#}");
+
+    lsp.send(json!({
+        "jsonrpc": "2.0",
+        "method": "initialized",
+        "params": {}
+    }));
+    lsp.send(json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "shutdown"
+    }));
+    let shutdown = lsp.recv_response(2);
+    assert!(shutdown["result"].is_null(), "{shutdown:#}");
+
+    lsp.send(json!({
+        "jsonrpc": "2.0",
+        "method": "exit"
+    }));
+    let status = lsp.wait_for_exit();
+    assert!(status.success(), "LSP exited with {status}");
+}
+
+#[test]
 fn lsp_corsa_smoke_publishes_diagnostics_and_hover() {
     let workspace_root = workspace_root();
     let Some(corsa_path) = discover_corsa_in_ancestors(workspace_root) else {

--- a/crates/vize/tests/support/lsp_process.rs
+++ b/crates/vize/tests/support/lsp_process.rs
@@ -15,6 +15,7 @@ use serde_json::Value;
 use vize_carton::{String as CompactString, cstr, path::canonicalize_non_verbatim};
 
 const MESSAGE_TIMEOUT: Duration = Duration::from_secs(20);
+const PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub struct LspProcess {
     child: Option<Child>,
@@ -124,6 +125,35 @@ impl LspProcess {
                     "timed out waiting for LSP message: {error}; seen: {seen:#?}"
                 )),
             }
+        }
+    }
+
+    /// Wait for the server to terminate without closing its stdin. This models
+    /// editor clients, which keep the pipe alive while waiting for the LSP
+    /// `exit` notification to end the child process.
+    pub fn wait_for_exit(&mut self) -> ExitStatus {
+        assert!(
+            self.stdin.is_some(),
+            "LSP stdin must remain open while waiting for process exit"
+        );
+        let deadline = Instant::now() + PROCESS_EXIT_TIMEOUT;
+        loop {
+            let status = self
+                .child
+                .as_mut()
+                .expect("LSP child is unavailable")
+                .try_wait()
+                .unwrap_or_else(|error| self.fail(cstr!("failed to poll LSP process: {error}")));
+            if let Some(status) = status {
+                self.status = Some(status);
+                return status;
+            }
+            if Instant::now() >= deadline {
+                self.fail(cstr!(
+                    "LSP process did not exit within {PROCESS_EXIT_TIMEOUT:?} while stdin remained open"
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(10));
         }
     }
 

--- a/crates/vize_maestro/Cargo.toml
+++ b/crates/vize_maestro/Cargo.toml
@@ -23,6 +23,7 @@ tower-lsp.workspace = true
 
 # Async Runtime
 futures.workspace = true
+tower.workspace = true
 async-trait.workspace = true
 
 # Text Processing

--- a/crates/vize_maestro/src/lib.rs
+++ b/crates/vize_maestro/src/lib.rs
@@ -79,6 +79,7 @@ pub use ide::{
 pub use server::MaestroServer;
 pub use virtual_code::{VirtualCodeGenerator, VirtualDocuments};
 
+use futures::future::{Either, select};
 use tower_lsp::Server;
 
 /// Initialize file-based logging to node_modules/.vize/lsp.log
@@ -127,9 +128,7 @@ pub async fn serve() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let stdin = runtime::threaded_reader("vize-lsp-stdin", std::io::stdin())?;
     let stdout = runtime::threaded_writer("vize-lsp-stdout", std::io::stdout())?;
 
-    let (service, socket) = server::build_lsp_service();
-
-    Server::new(stdin, stdout, socket).serve(service).await;
+    serve_transport(stdin, stdout).await;
 
     Ok(())
 }
@@ -163,9 +162,7 @@ pub async fn serve_tcp(port: u16) -> Result<(), Box<dyn std::error::Error + Send
     let read = runtime::threaded_reader("vize-lsp-tcp-read", stream.try_clone()?)?;
     let write = runtime::threaded_writer("vize-lsp-tcp-write", stream)?;
 
-    let (service, socket) = server::build_lsp_service();
-
-    Server::new(read, write, socket).serve(service).await;
+    serve_transport(read, write).await;
 
     Ok(())
 }
@@ -173,4 +170,22 @@ pub async fn serve_tcp(port: u16) -> Result<(), Box<dyn std::error::Error + Send
 /// Start the TCP LSP server on the current thread.
 pub fn serve_tcp_blocking(port: u16) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     runtime::block_on(serve_tcp(port))
+}
+
+async fn serve_transport<I, O>(read: I, write: O)
+where
+    I: futures::io::AsyncRead + Unpin,
+    O: futures::io::AsyncWrite,
+{
+    let (service, socket) = server::build_lsp_service();
+    let (service, exit_notification) = server::with_exit_signal(service);
+    let transport = Server::new(read, write, socket).serve(service);
+
+    futures::pin_mut!(transport);
+    futures::pin_mut!(exit_notification);
+
+    match select(transport, exit_notification).await {
+        Either::Left(_) => {}
+        Either::Right(_) => tracing::info!("LSP exit notification handled; stopping transport"),
+    }
 }

--- a/crates/vize_maestro/src/server.rs
+++ b/crates/vize_maestro/src/server.rs
@@ -2,6 +2,16 @@
 //!
 //! This module contains the core LSP server using tower-lsp.
 
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use futures::{FutureExt, channel::oneshot, future::BoxFuture};
+use parking_lot::Mutex;
+use tower::Service;
+use tower_lsp::jsonrpc::{Request, Response};
+
 mod annotations;
 mod auto_insert;
 mod capabilities;
@@ -52,4 +62,55 @@ pub(crate) fn build_lsp_service() -> (LspService<MaestroServer>, ClientSocket) {
     LspService::build(MaestroServer::new)
         .custom_method(auto_insert::AUTO_INSERT_METHOD, MaestroServer::auto_insert)
         .finish()
+}
+
+/// Transport adapter that reports when the LSP `exit` notification has been
+/// fully handled. `tower-lsp` stops accepting requests after `exit`, but its
+/// transport continues waiting for stdin EOF. Editors keep that pipe open
+/// while waiting for the child to terminate, so the process would otherwise
+/// deadlock with its client.
+pub(crate) struct ExitAwareService<S> {
+    inner: S,
+    exit_sender: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+}
+
+pub(crate) fn with_exit_signal<S>(inner: S) -> (ExitAwareService<S>, oneshot::Receiver<()>) {
+    let (exit_sender, exit_receiver) = oneshot::channel();
+    (
+        ExitAwareService {
+            inner,
+            exit_sender: Arc::new(Mutex::new(Some(exit_sender))),
+        },
+        exit_receiver,
+    )
+}
+
+impl<S> Service<Request> for ExitAwareService<S>
+where
+    S: Service<Request, Response = Option<Response>> + Send + 'static,
+    S::Error: Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, context: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(context)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let is_exit = request.method() == "exit";
+        let response = self.inner.call(request);
+        let exit_sender = Arc::clone(&self.exit_sender);
+
+        async move {
+            let result = response.await;
+            if is_exit && let Some(sender) = exit_sender.lock().take() {
+                let _ = sender.send(());
+            }
+            result
+        }
+        .boxed()
+    }
 }

--- a/crates/vize_maestro/src/server.rs
+++ b/crates/vize_maestro/src/server.rs
@@ -3,12 +3,11 @@
 //! This module contains the core LSP server using tower-lsp.
 
 use std::{
-    sync::Arc,
+    future::Future,
     task::{Context, Poll},
 };
 
-use futures::{FutureExt, channel::oneshot, future::BoxFuture};
-use parking_lot::Mutex;
+use futures::{FutureExt, StreamExt, channel::mpsc, future::BoxFuture};
 use tower::Service;
 use tower_lsp::jsonrpc::{Request, Response};
 
@@ -71,18 +70,16 @@ pub(crate) fn build_lsp_service() -> (LspService<MaestroServer>, ClientSocket) {
 /// deadlock with its client.
 pub(crate) struct ExitAwareService<S> {
     inner: S,
-    exit_sender: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    exit_sender: mpsc::UnboundedSender<()>,
 }
 
-pub(crate) fn with_exit_signal<S>(inner: S) -> (ExitAwareService<S>, oneshot::Receiver<()>) {
-    let (exit_sender, exit_receiver) = oneshot::channel();
-    (
-        ExitAwareService {
-            inner,
-            exit_sender: Arc::new(Mutex::new(Some(exit_sender))),
-        },
-        exit_receiver,
-    )
+pub(crate) fn with_exit_signal<S>(
+    inner: S,
+) -> (ExitAwareService<S>, impl Future<Output = ()> + Send) {
+    let (exit_sender, mut exit_receiver) = mpsc::unbounded();
+    (ExitAwareService { inner, exit_sender }, async move {
+        let _ = exit_receiver.next().await;
+    })
 }
 
 impl<S> Service<Request> for ExitAwareService<S>
@@ -102,12 +99,12 @@ where
     fn call(&mut self, request: Request) -> Self::Future {
         let is_exit = request.method() == "exit";
         let response = self.inner.call(request);
-        let exit_sender = Arc::clone(&self.exit_sender);
+        let exit_sender = self.exit_sender.clone();
 
         async move {
             let result = response.await;
-            if is_exit && let Some(sender) = exit_sender.lock().take() {
-                let _ = sender.send(());
+            if is_exit {
+                let _ = exit_sender.unbounded_send(());
             }
             result
         }


### PR DESCRIPTION
## Summary

- stop the Maestro transport only after tower-lsp has handled the exit notification
- apply the lifecycle behavior to both stdio and TCP transports
- add a real child-process regression that deliberately keeps client stdin open

## Root cause

tower-lsp 0.20 marks its service exited and closes the client socket, but its transport read loop continues waiting for stdin EOF. Editors commonly keep stdin open while waiting for the child to terminate, so both sides could wait indefinitely.

## Validation

- cargo check for vize_maestro and vize
- cargo fmt check
- Cargo metadata validation
- source-file length gate against the current base
- full process-level regression is included in the Actions test suite

Closes #3687

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->