### PR TITLE
fix(canon): deduplicate Nuxt globals from setup spreads

### DIFF
--- a/crates/vize/tests/check_nuxt_composition_api_cli.rs
+++ b/crates/vize/tests/check_nuxt_composition_api_cli.rs
@@ -38,17 +38,10 @@ fn write(root: &Path, rel: &str, content: &str) {
     std::fs::write(path, content).unwrap();
 }
 
-#[test]
-fn check_resolves_nuxt2_composition_api_named_exports_in_sfc() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
-        return;
-    };
-    let project_root = unique_case_dir("exports");
-    let _ = std::fs::remove_dir_all(&project_root);
-    std::fs::create_dir_all(project_root.join("components")).unwrap();
-    write(&project_root, "nuxt.config.ts", "export default {};\n");
+fn write_nuxt_project_scaffold(project_root: &Path) {
+    write(project_root, "nuxt.config.ts", "export default {};\n");
     write(
-        &project_root,
+        project_root,
         "tsconfig.json",
         r#"{
   "compilerOptions": {
@@ -62,7 +55,7 @@ fn check_resolves_nuxt2_composition_api_named_exports_in_sfc() {
 }"#,
     );
     write(
-        &project_root,
+        project_root,
         "node_modules/@nuxtjs/composition-api/package.json",
         r#"{
   "name": "@nuxtjs/composition-api",
@@ -80,18 +73,32 @@ fn check_resolves_nuxt2_composition_api_named_exports_in_sfc() {
 }"#,
     );
     write(
-        &project_root,
+        project_root,
         "node_modules/@nuxtjs/composition-api/dist/runtime/index.d.ts",
         r#"export declare function defineComponent<T>(options: T): T;
 export declare function ref<T>(value: T): { value: T };
 export declare function computed<T>(getter: () => T): { value: T };
 export type PropType<T> = { new (...args: never[]): T } | { (): T };
 export declare function useContext(): { app: unknown };
-export declare function useFetch<T>(callback: () => T): { fetch: () => Promise<T> };
+export declare function useFetch<T>(callback: () => T): {
+  fetch: () => Promise<T>;
+  $fetch: () => Promise<T>;
+};
 export declare function useStore(): { state: unknown };
 export declare function useRoute(): { value: { path: string } };
 "#,
     );
+}
+
+#[test]
+fn check_resolves_nuxt2_composition_api_named_exports_in_sfc() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("exports");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("components")).unwrap();
+    write_nuxt_project_scaffold(&project_root);
     write(
         &project_root,
         "components/AppDialog.vue",
@@ -159,6 +166,75 @@ export default defineComponent({
     assert!(
         !stdout.contains("TS2307") && !stdout.contains("@nuxtjs/composition-api"),
         "composition-api exports should resolve through Nuxt fallback paths:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn check_deduplicates_nuxt_global_with_setup_return_spread() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("global-spread");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("components")).unwrap();
+    write_nuxt_project_scaffold(&project_root);
+    write(
+        &project_root,
+        "components/UseFetchButton.vue",
+        r#"<script lang="ts">
+import { defineComponent, useFetch } from "@nuxtjs/composition-api";
+
+export default defineComponent({
+  setup() {
+    const { $fetch } = useFetch(async () => {});
+    const refreshFromSetup = () => $fetch();
+    const extra = {};
+
+    return { refreshFromSetup, ...extra };
+  },
+});
+</script>
+
+<template>
+  <button @click="$fetch">Refresh</button>
+</template>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "components/UseFetchButton.vue",
+            "--format",
+            "json",
+            "--show-virtual-ts",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    assert_eq!(
+        stderr.matches("var $fetch:").count(),
+        1,
+        "the setup-spread fallback should declare $fetch exactly once:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("const $fetch: __VizeInstanceGlobal<'$fetch'>"),
+        "the instance-global pass must not redeclare $fetch:\n{stderr}"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -797,6 +797,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                         ScopeGenerationOptions {
                             check_options,
                             virtual_ts_options: options,
+                            setup_spread_bindings: template_ref_unwraps.setup_spread_bindings(),
                             template_ast,
                             check_unresolved_global_components: has_script_reference_types,
                             legacy_vue2,
@@ -804,7 +805,6 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                     )
                 );
             }
-
             // Declare unresolved components (auto-imported or built-in) as `any`.
             // Names known to be provided by ambient project declarations stay
             // unshadowed so their actual component prop types are preserved.

--- a/crates/vize_canon/src/virtual_ts/generator/template_refs.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/template_refs.rs
@@ -54,6 +54,10 @@ impl TemplateRefUnwraps {
         }
     }
 
+    pub(super) fn setup_spread_bindings(&self) -> &[String] {
+        &self.options_api_setup_bindings
+    }
+
     pub(super) fn emit_type_captures(&self, mut ts: &mut String) {
         if !self.setup_bindings.is_empty() {
             ts.push_str("  // Ref type captures (before template scope shadows them)\n");

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -119,13 +119,7 @@ pub(crate) fn generate_scope_closures(
     if check_options.check_template_bindings {
         profile!(
             "canon.virtual_ts.instance_global_refs",
-            generate_instance_global_refs(
-                ts,
-                mappings,
-                summary,
-                template_offset,
-                virtual_ts_options
-            )
+            generate_instance_global_refs(ts, mappings, summary, template_offset, &options)
         );
     }
 

--- a/crates/vize_canon/src/virtual_ts/scope/context.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/context.rs
@@ -27,6 +27,9 @@ pub(crate) struct ScopeGenContext<'a> {
 pub(crate) struct ScopeGenerationOptions<'a, 'template> {
     pub(crate) check_options: VirtualTsCheckOptions,
     pub(crate) virtual_ts_options: &'a VirtualTsOptions,
+    /// Names already declared by the conservative Options API setup-spread fallback.
+    /// Instance-global generation shares the same template scope and must not redeclare them.
+    pub(crate) setup_spread_bindings: &'a [String],
     pub(crate) template_ast: Option<&'a vize_relief::RootNode<'template>>,
     pub(crate) check_unresolved_global_components: bool,
     pub(crate) legacy_vue2: bool,

--- a/crates/vize_canon/src/virtual_ts/scope/globals.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/globals.rs
@@ -9,6 +9,8 @@ use vize_croquis::{BindingMetadata, Croquis, analyzer::extract_identifiers_oxc};
 
 use crate::virtual_ts::types::{VirtualTsOptions, VizeMapping};
 
+use super::context::ScopeGenerationOptions;
+
 /// Handle undefined references from template.
 pub(super) fn generate_undefined_refs(
     ts: &mut String,
@@ -74,13 +76,19 @@ pub(super) fn generate_instance_global_refs(
     mappings: &mut Vec<VizeMapping>,
     summary: &Croquis,
     template_offset: u32,
-    options: &VirtualTsOptions,
+    scope_options: &ScopeGenerationOptions<'_, '_>,
 ) {
     if summary.undefined_refs.is_empty() && summary.template_expressions.is_empty() {
         return;
     }
 
-    let mut emitter = InstanceGlobalRefsEmitter::new(ts, mappings, summary, options);
+    let mut emitter = InstanceGlobalRefsEmitter::new(
+        ts,
+        mappings,
+        summary,
+        scope_options.virtual_ts_options,
+        scope_options.setup_spread_bindings,
+    );
     for undef in &summary.undefined_refs {
         let src_start = (template_offset + undef.offset) as usize;
         let src_end = src_start + undef.name.len();
@@ -105,6 +113,7 @@ struct InstanceGlobalRefsEmitter<'a> {
     mappings: &'a mut Vec<VizeMapping>,
     options: &'a VirtualTsOptions,
     bindings: &'a BindingMetadata,
+    synthetic_setup_bindings: FxHashSet<&'a str>,
     type_export_names: FxHashSet<&'a str>,
     seen_names: FxHashSet<String>,
     emitted_header: bool,
@@ -116,12 +125,17 @@ impl<'a> InstanceGlobalRefsEmitter<'a> {
         mappings: &'a mut Vec<VizeMapping>,
         summary: &'a Croquis,
         options: &'a VirtualTsOptions,
+        synthetic_setup_bindings: &'a [String],
     ) -> Self {
         Self {
             ts,
             mappings,
             options,
             bindings: &summary.bindings,
+            synthetic_setup_bindings: synthetic_setup_bindings
+                .iter()
+                .map(|name| name.as_str())
+                .collect(),
             type_export_names: summary
                 .type_exports
                 .iter()
@@ -135,6 +149,7 @@ impl<'a> InstanceGlobalRefsEmitter<'a> {
     fn emit(&mut self, name: &str, src_start: usize, src_end: usize) {
         if !is_template_instance_global_name(name)
             || self.bindings.contains(name)
+            || self.synthetic_setup_bindings.contains(name)
             || self.type_export_names.contains(name)
             || is_declared_template_context_name(name, self.options)
             || !self.seen_names.insert(name.into())

--- a/crates/vize_canon/src/virtual_ts/tests/options_api_setup_spread.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/options_api_setup_spread.rs
@@ -59,3 +59,95 @@ export default defineComponent({
         );
     }
 }
+
+#[test]
+fn options_api_setup_return_spread_deduplicates_instance_globals() {
+    let script = r#"import { defineComponent, useFetch } from '@nuxtjs/composition-api'
+
+export default defineComponent({
+    setup() {
+        const { $fetch } = useFetch(async () => {})
+        const refreshFromSetup = () => $fetch()
+        const extra = {}
+
+        return { refreshFromSetup, ...extra }
+    },
+})
+"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, r#"<button @click="$fetch">Refresh</button>"#);
+    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full())
+        .with_options_api();
+    analyzer.analyze_script_plain(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        output
+            .code
+            .contains(r#"type __R_$fetch = __VizeOptionsSetupBinding<"$fetch">;"#),
+        "spread fallback should preserve the setup-return binding type:\n{}",
+        output.code
+    );
+    assert_eq!(
+        output.code.matches("var $fetch:").count(),
+        1,
+        "the spread setup binding should be declared exactly once:\n{}",
+        output.code
+    );
+    assert!(
+        !output
+            .code
+            .contains("const $fetch: __VizeInstanceGlobal<'$fetch'>"),
+        "an instance-global declaration must not duplicate the spread setup binding:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn options_api_without_setup_spread_keeps_instance_global() {
+    let script = r#"import { defineComponent } from '@nuxtjs/composition-api'
+
+export default defineComponent({
+    setup() {
+        return { refreshFromSetup: () => {} }
+    },
+})
+"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, r#"<button @click="$fetch">Refresh</button>"#);
+    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full())
+        .with_options_api();
+    analyzer.analyze_script_plain(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        output
+            .code
+            .contains("const $fetch: __VizeInstanceGlobal<'$fetch'>"),
+        "instance globals should remain available without a spread setup return:\n{}",
+        output.code
+    );
+    assert!(
+        !output.code.contains("type __R_$fetch"),
+        "a non-spread setup return must not infer an unrelated setup binding:\n{}",
+        output.code
+    );
+}


### PR DESCRIPTION
## Summary

- carry synthetic Options API setup-spread bindings into template scope generation
- skip instance-global declarations that would redeclare those bindings
- preserve instance-global generation when no setup spread supplies the name
- cover the exact `$fetch` reproduction in virtual TS and the Nuxt CLI path

## Root cause

The conservative setup-spread fallback emitted a template-local `var $fetch`, but the later instance-global pass only knew about Croquis bindings. Because the synthetic binding was not in that metadata, the same template scope also received `const $fetch`, producing TS2300.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- confirmed the new exact regression failed before the fix with both generated declarations
- added positive, negative, and CLI regression coverage for GitHub Actions

Closes #3689