### PR TITLE
fix(musea): pass static build env to the Vite child process

### DIFF
--- a/crates/vize/src/commands/musea/serve_plan.rs
+++ b/crates/vize/src/commands/musea/serve_plan.rs
@@ -40,6 +40,7 @@ pub(super) fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePla
     }
 
     if args.build {
+        env.push((cstr!("VIZE_MUSEA_STATIC_BUILD"), cstr!("1")));
         return Ok(ServePlan {
             program,
             args: vec![cstr!("build")],

--- a/crates/vize/src/commands/musea/tests.rs
+++ b/crates/vize/src/commands/musea/tests.rs
@@ -71,6 +71,7 @@ fn serve_plan_defaults_to_vite_dev_with_gallery_route() {
             "/__musea__"
         ]
     );
+    assert!(plan.env.is_empty());
 }
 
 #[test]
@@ -92,7 +93,7 @@ fn serve_plan_rejects_missing_musea_vite_plugin_setup() {
 }
 
 #[test]
-fn serve_plan_runs_static_build_without_forcing_musea_environment() {
+fn serve_plan_runs_static_build_with_musea_environment() {
     let temp = tempfile::tempdir().unwrap();
     let vite_bin = write_vite_bin(temp.path());
     write_musea_vite_setup(temp.path());
@@ -110,7 +111,7 @@ fn serve_plan_runs_static_build_without_forcing_musea_environment() {
 
     assert_eq!(plan.program, vite_bin);
     assert_eq!(plan.args, ["build"]);
-    assert!(plan.env.is_empty());
+    assert_eq!(plan.env, [("VIZE_MUSEA_STATIC_BUILD".into(), "1".into())]);
 }
 
 #[test]
@@ -153,7 +154,10 @@ fn serve_plan_combines_shared_config_with_static_build_environment() {
 
     assert_eq!(
         plan.env,
-        [("VIZE_CONFIG_FILE".into(), "../vize.config.ts".into())]
+        [
+            ("VIZE_CONFIG_FILE".into(), "../vize.config.ts".into()),
+            ("VIZE_MUSEA_STATIC_BUILD".into(), "1".into()),
+        ]
     );
 }
 

--- a/crates/vize/tests/musea_static_build_cli.rs
+++ b/crates/vize/tests/musea_static_build_cli.rs
@@ -1,0 +1,91 @@
+//! Regression coverage for the Vite child process used by `vize musea --build`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn write_project(root: &Path) {
+    fs::write(
+        root.join("package.json"),
+        r#"{
+  "devDependencies": {
+    "@vizejs/vite-plugin-musea": "0.315.1"
+  }
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("vite.config.mts"),
+        r#"import { musea } from "@vizejs/vite-plugin-musea";
+
+export default { plugins: [...musea({ storybookCompat: true })] };
+"#,
+    )
+    .unwrap();
+}
+
+#[cfg(unix)]
+fn write_vite_bin(root: &Path) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+
+    let bin = root.join("node_modules/.bin/vite");
+    fs::create_dir_all(bin.parent().unwrap()).unwrap();
+    fs::write(
+        &bin,
+        r#"#!/bin/sh
+if [ "$1" != "build" ]; then
+  exit 9
+fi
+if [ "${VIZE_MUSEA_STATIC_BUILD:-}" != "1" ]; then
+  printf 'Could not resolve entry module "index.html"\n' >&2
+  exit 1
+fi
+mkdir -p dist/__musea__
+printf '<!doctype html><title>Musea</title>\n' > dist/__musea__/index.html
+"#,
+    )
+    .unwrap();
+    fs::set_permissions(&bin, fs::Permissions::from_mode(0o755)).unwrap();
+    bin
+}
+
+#[cfg(windows)]
+fn write_vite_bin(root: &Path) -> PathBuf {
+    let bin = root.join("node_modules/.bin/vite.cmd");
+    fs::create_dir_all(bin.parent().unwrap()).unwrap();
+    fs::write(
+        &bin,
+        r#"@echo off
+if not "%1"=="build" exit /b 9
+if not "%VIZE_MUSEA_STATIC_BUILD%"=="1" exit /b 1
+mkdir dist\__musea__
+echo ^<!doctype html^>^<title^>Musea^</title^> > dist\__musea__\index.html
+"#,
+    )
+    .unwrap();
+    bin
+}
+
+#[test]
+fn musea_build_sets_static_mode_for_the_vite_child() {
+    let project = tempfile::tempdir().unwrap();
+    write_project(project.path());
+    let vite_bin = write_vite_bin(project.path());
+    assert!(vite_bin.is_file());
+    assert!(!project.path().join("index.html").exists());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .args(["musea", "--build"])
+        .current_dir(project.path())
+        .env("VIZE_MUSEA_STATIC_BUILD", "0")
+        .output()
+        .expect("failed to run vize musea --build");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "{stderr}");
+    assert!(
+        stderr.contains("env: VIZE_MUSEA_STATIC_BUILD=1"),
+        "{stderr}"
+    );
+    assert!(project.path().join("dist/__musea__/index.html").is_file());
+}


### PR DESCRIPTION
## Summary

- pass `VIZE_MUSEA_STATIC_BUILD=1` through the existing Musea Vite child-process environment when `--build` is selected
- keep the dev-server plan free of the static-build marker
- cover shared config composition and the full CLI-to-child-process contract

## Root cause

`vize musea --build` selected `vite build`, but its `ServePlan` did not mark the child as a Musea static build. With Storybook compatibility enabled, the Musea plugin therefore skipped its virtual static runtime input and Vite fell back to a missing root `index.html`.

## Validation

- reproduced exit 1 with the marker unset and exit 0 with it set
- added positive, negative, and combined plan tests
- added a CLI regression with no root `index.html`; the child rejects any value except `1` and emits `dist/__musea__/index.html` on success
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #3683
