### PR TITLE
fix(canon): avoid TS 7 errors from Nuxt fallback configs

### DIFF
--- a/crates/vize/src/commands/check/runner/nuxt_tsconfig.rs
+++ b/crates/vize/src/commands/check/runner/nuxt_tsconfig.rs
@@ -17,6 +17,9 @@ use crate::commands::check::tsconfig_inputs::{
     parse_jsonc_value, read_extends_entries, resolve_extended_tsconfig,
 };
 
+#[cfg(test)]
+mod legacy_options_tests;
+
 pub(super) fn resolve_checker_tsconfig_path(
     program_tsconfig_path: Option<&Path>,
     project_root: &Path,
@@ -75,6 +78,15 @@ pub(super) fn write_nuxt_fallback_tsconfig(
 
     let mut compiler_options = Map::new();
     compiler_options.insert("paths".into(), Value::Object(paths));
+    if program_tsconfig_path.is_some() {
+        // Nuxt 2 and Bridge projects commonly remain on TypeScript 5 configs
+        // that require `baseUrl` and legacy Node resolution. This wrapper is
+        // Vize's compatibility layer, so acknowledge TypeScript 6 deprecations
+        // here instead of letting the native TypeScript 7 option probe turn
+        // them into errors on this generated file. Unrelated config errors are
+        // still reported by the probe.
+        compiler_options.insert("ignoreDeprecations".into(), Value::String("6.0".into()));
+    }
 
     let mut config = Map::new();
     if let Some(tsconfig_path) = program_tsconfig_path {

--- a/crates/vize/src/commands/check/runner/nuxt_tsconfig/legacy_options_tests.rs
+++ b/crates/vize/src/commands/check/runner/nuxt_tsconfig/legacy_options_tests.rs
@@ -1,0 +1,83 @@
+use std::{path::Path, sync::atomic::AtomicUsize};
+
+use super::write_nuxt_fallback_tsconfig;
+use crate::commands::check::nuxt::NuxtPathAlias;
+
+fn case_dir(name: &str) -> std::path::PathBuf {
+    static NEXT_CASE_ID: AtomicUsize = AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("target/vize-tests")
+        .join(format!(
+            "nuxt-fallback-options-{name}-{}-{case_id}",
+            std::process::id()
+        ))
+}
+
+#[test]
+fn inherited_config_uses_the_typescript_compatibility_floor() {
+    let root = case_dir("inherited");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+    let tsconfig = root.join("tsconfig.json");
+    std::fs::write(
+        &tsconfig,
+        r#"{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "baseUrl": "."
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let wrapper = write_nuxt_fallback_tsconfig(
+        Some(&tsconfig),
+        &root,
+        &root,
+        &[NuxtPathAlias {
+            pattern: "~/*".into(),
+            targets: vec!["./*".into()],
+        }],
+    )
+    .unwrap();
+    let wrapper: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(wrapper).unwrap()).unwrap();
+
+    assert_eq!(
+        wrapper["compilerOptions"]["ignoreDeprecations"],
+        serde_json::json!("6.0")
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn wrapper_without_an_inherited_config_adds_no_compatibility_option() {
+    let root = case_dir("standalone");
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+
+    let wrapper = write_nuxt_fallback_tsconfig(
+        None,
+        &root,
+        &root,
+        &[NuxtPathAlias {
+            pattern: "~/*".into(),
+            targets: vec!["./*".into()],
+        }],
+    )
+    .unwrap();
+    let wrapper: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(wrapper).unwrap()).unwrap();
+
+    assert!(
+        wrapper["compilerOptions"]
+            .get("ignoreDeprecations")
+            .is_none()
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/vize/tests/check_nuxt_legacy_tsconfig_cli.rs
+++ b/crates/vize/tests/check_nuxt_legacy_tsconfig_cli.rs
@@ -1,0 +1,186 @@
+//! Nuxt's fallback alias wrapper must not turn a TS 5-era project config into
+//! TypeScript 7 option errors (#3682).
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use std::{
+    path::{Path, PathBuf},
+    process::{Command, Output},
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn project(name: &str, script: &str) -> PathBuf {
+    static NEXT_CASE_ID: AtomicUsize = AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, Ordering::Relaxed);
+    let root = workspace_root()
+        .join("target/vize-tests/tests")
+        .join(format!(
+            "nuxt-legacy-tsconfig-{name}-{}-{case_id}",
+            std::process::id()
+        ));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("src")).unwrap();
+    write(&root, "nuxt.config.ts", "export default {};\n");
+    write(
+        &root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"],
+      "@/*": ["./*"]
+    },
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": ["src"]
+}
+"#,
+    );
+    write(
+        &root,
+        "src/App.vue",
+        &format!(
+            r#"<script setup lang="ts">
+{script}
+</script>
+
+<template><p>Nuxt</p></template>
+"#
+        ),
+    );
+    root
+}
+
+fn write(root: &Path, relative: &str, content: &str) {
+    let path = root.join(relative);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+fn check(root: &Path, corsa_path: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "--no-check-props",
+            "--no-check-emits",
+            "--no-check-template-bindings",
+            "--format",
+            "json",
+            "src",
+        ])
+        .output()
+        .unwrap()
+}
+
+fn output_text(output: &Output) -> (String, String) {
+    (
+        String::from_utf8(output.stdout.clone()).unwrap(),
+        String::from_utf8(output.stderr.clone()).unwrap(),
+    )
+}
+
+#[test]
+fn check_accepts_a_nuxt_fallback_over_a_ts5_era_config() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let root = project("clean", "const count: number = 1;\nvoid count;");
+    let output = check(&root, &corsa_path);
+    let (stdout, stderr) = output_text(&output);
+
+    assert!(
+        output.status.success(),
+        "Nuxt fallback check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 0, "{stdout}\n{stderr}");
+    assert!(!stdout.contains("TS5102") && !stdout.contains("TS5108"));
+    assert!(!stdout.contains("tsconfig.nuxt-fallback.json"));
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn check_still_reports_source_errors_with_the_nuxt_fallback() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let root = project(
+        "source-error",
+        "const count: number = \"wrong\";\nvoid count;",
+    );
+    let output = check(&root, &corsa_path);
+    let (stdout, stderr) = output_text(&output);
+
+    assert!(!output.status.success(), "{stdout}\n{stderr}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 1, "{stdout}\n{stderr}");
+    assert_eq!(json["files"].as_array().unwrap().len(), 1, "{stdout}");
+    assert!(
+        json["files"][0]["diagnostics"][0]
+            .as_str()
+            .is_some_and(|diagnostic| diagnostic.contains("[TS2322]")),
+        "{stdout}\n{stderr}"
+    );
+    assert!(!stdout.contains("TS5102") && !stdout.contains("TS5108"));
+    assert!(!stdout.contains("tsconfig.nuxt-fallback.json"));
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn check_still_reports_unrelated_config_errors_with_the_nuxt_fallback() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let root = project("config-error", "const count: number = 1;\nvoid count;");
+    let tsconfig = root.join("tsconfig.json");
+    let content = std::fs::read_to_string(&tsconfig).unwrap().replace(
+        "\"types\": []",
+        "\"types\": [],\n    \"nosuchoption\": true",
+    );
+    std::fs::write(tsconfig, content).unwrap();
+    let output = check(&root, &corsa_path);
+    let (stdout, stderr) = output_text(&output);
+
+    assert!(!output.status.success(), "{stdout}\n{stderr}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 1, "{stdout}\n{stderr}");
+    assert!(stdout.contains("[TS5023]"), "{stdout}\n{stderr}");
+    assert!(!stdout.contains("TS5102") && !stdout.contains("TS5108"));
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/vize_canon/src/batch/executor.rs
+++ b/crates/vize_canon/src/batch/executor.rs
@@ -32,6 +32,7 @@ mod option_probe;
 mod session;
 
 use cli::{auto_server_count, check_with_cli, check_with_cli_sharded};
+use diagnostics::dedup_diagnostics;
 use fallback::{FallbackStep, warn_fallback};
 use session::IncrementalSessionState;
 #[cfg(test)]
@@ -100,6 +101,7 @@ impl CorsaExecutor {
             result.exit_code = result.exit_code.max(1);
         }
         result.diagnostics.extend(options);
+        result.diagnostics = dedup_diagnostics(result.diagnostics);
         Ok(result)
     }
 


### PR DESCRIPTION
## Summary

- mark Vize-generated Nuxt fallback wrappers with the TypeScript 6 deprecation floor so TS 5-era Nuxt 2 and Bridge configs do not become TS 7 removal errors
- deduplicate diagnostics across the main Corsa run and the option probe while retaining unrelated config errors
- cover clean, source-error, and unrelated-config-error CLI paths plus wrapper generation

## Failure before

The regression fixture reported TS5102 for `baseUrl` and TS5108 for `moduleResolution=node10` on `node_modules/.vize/cli/tsconfig.nuxt-fallback.json`. The source-error fixture reported those two errors in addition to the intended TS2322.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p vize --lib --test check_nuxt_legacy_tsconfig_cli -- -D warnings`
- `cargo test -p vize --lib commands::check::runner::nuxt_tsconfig::legacy_options_tests`
- `cargo test -p vize --test check_nuxt_legacy_tsconfig_cli`
- `cargo test -p vize --test check_nuxt_composition_api_cli`
- `cargo test -p vize_canon --test tsconfig_option_diagnostics`

Closes #3682

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->