### PR TITLE
fix(canon): preserve ASI-separated event handlers

### DIFF
--- a/crates/vize/tests/check_multistatement_v_on_cli.rs
+++ b/crates/vize/tests/check_multistatement_v_on_cli.rs
@@ -1,0 +1,150 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+#[test]
+fn check_accepts_asi_separated_v_on_statements() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project = create_project();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "--no-check-props",
+            "--no-check-emits",
+            "src",
+            "--format",
+            "json",
+            "--show-virtual-ts",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap_or_else(|error| {
+        panic!("failed to parse check output: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert!(
+        output.status.success(),
+        "ASI-separated v-on statements should type-check:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(json["errorCount"], 0, "{stdout}");
+    assert!(
+        !stdout.contains("TS1005") && !stderr.contains("TS1005"),
+        "the generated handler must not contain a parse error:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let virtual_ts = json["files"]
+        .as_array()
+        .expect("check JSON should include files")
+        .iter()
+        .filter_map(|file| file["virtualTs"].as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        virtual_ts.contains("// @create handler"),
+        "the CLI should emit the statements inside a handler scope:\n{virtual_ts}"
+    );
+    assert!(
+        !virtual_ts.contains("void (\n      emit('create')"),
+        "the CLI must not parenthesize the statements as one expression:\n{virtual_ts}"
+    );
+}
+
+fn create_project() -> tempfile::TempDir {
+    let base = workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join("tests");
+    std::fs::create_dir_all(&base).unwrap();
+    let project = tempfile::Builder::new()
+        .prefix("check-multistatement-v-on-")
+        .tempdir_in(base)
+        .unwrap();
+    std::fs::create_dir_all(project.path().join("src")).unwrap();
+    link_workspace_node_modules(project.path()).unwrap();
+    std::fs::write(
+        project.path().join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project.path().join("src/App.vue"),
+        r#"<script setup lang="ts">
+const emit = defineEmits<{
+  create: []
+  close: []
+}>()
+</script>
+
+<template>
+  <Child
+    @create="
+      emit('create')
+      emit('close')
+    "
+  />
+</template>
+"#,
+    )
+    .unwrap();
+    project
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn link_workspace_node_modules(project_root: &Path) -> std::io::Result<()> {
+    let source = workspace_root().join("node_modules");
+    if !source.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace node_modules missing",
+        ));
+    }
+    symlink_dir(&source, &project_root.join("node_modules"))
+}
+
+#[cfg(unix)]
+fn symlink_dir(source: &Path, target: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(source, target)
+}
+
+#[cfg(windows)]
+fn symlink_dir(source: &Path, target: &Path) -> std::io::Result<()> {
+    std::os::windows::fs::symlink_dir(source, target)
+}

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -11,6 +11,8 @@
 mod class_component_props_tests;
 #[cfg(test)]
 mod dynamic_component_names_tests;
+#[cfg(test)]
+mod event_handler_tests;
 mod expressions;
 mod generator;
 mod helpers;

--- a/crates/vize_canon/src/virtual_ts/event_handler_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/event_handler_tests.rs
@@ -1,0 +1,96 @@
+use super::{
+    VirtualTsCheckOptions, VirtualTsGenerationOptions, VirtualTsOptions,
+    generate_virtual_ts_with_offsets_and_checks,
+};
+use vize_croquis::{Analyzer, AnalyzerOptions};
+
+fn generate_unchecked_emit_handler(script: &str, template: &str) -> vize_carton::String {
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+
+    generate_virtual_ts_with_offsets_and_checks(
+        &analyzer.finish(),
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &VirtualTsOptions::default(),
+        VirtualTsGenerationOptions {
+            check_options: VirtualTsCheckOptions {
+                check_props: false,
+                check_template_bindings: true,
+                check_emits: false,
+            },
+            ..Default::default()
+        },
+    )
+    .code
+}
+
+fn assert_parseable(code: &str) {
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed = oxc_parser::Parser::new(&allocator, code, oxc_span::SourceType::ts()).parse();
+    assert!(
+        !parsed.panicked && parsed.diagnostics.is_empty(),
+        "event handlers must generate parseable TypeScript: {:#?}\n{code}",
+        parsed.diagnostics
+    );
+}
+
+#[test]
+fn asi_separated_statement_event_handler_uses_handler_scope() {
+    let script = r#"const emit = defineEmits<{
+  create: []
+  close: []
+}>()
+"#;
+    let template = r#"<Child @create="
+  emit('create')
+  emit('close')
+" />"#;
+    let code = generate_unchecked_emit_handler(script, template);
+
+    assert!(
+        code.contains("// @create handler"),
+        "ASI-separated handlers should get an event handler scope:\n{code}"
+    );
+    assert!(
+        code.contains("emit('create')\n  emit('close')"),
+        "both authored statements should be preserved:\n{code}"
+    );
+    assert!(
+        !code.contains("void (\n  emit('create')"),
+        "ASI-separated statements must not be parenthesized as one expression:\n{code}"
+    );
+    assert!(
+        code.contains("($event: any)") && !code.contains("_listener"),
+        "disabled emit checks should keep the handler without checking its payload:\n{code}"
+    );
+    assert_parseable(&code);
+}
+
+#[test]
+fn disabled_emit_checks_preserve_expression_shaped_handlers() {
+    let code = generate_unchecked_emit_handler(
+        "function handler() {}",
+        r#"<button
+  @click="handler"
+  @focus="function () {}"
+/>"#,
+    );
+
+    assert!(
+        code.contains("void (handler);  // handler expression (emit checks disabled)")
+            && code
+                .contains("void (function () {});  // handler expression (emit checks disabled)"),
+        "expression-shaped handlers should remain expressions when emit checks are disabled:\n{code}"
+    );
+    assert!(
+        !code.contains("handler($event)") && !code.contains("_listener"),
+        "disabling emit checks must not invoke or assign the handler:\n{code}"
+    );
+    assert_parseable(&code);
+}

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -366,7 +366,7 @@ pub(super) fn generate_scope_node(
             ts.push_str(indent);
             ts.push_str("};\n");
         }
-        ScopeData::EventHandler(data) if ctx.check_options.check_emits => {
+        ScopeData::EventHandler(data) if ctx.check_options.check_event_handlers() => {
             generate_event_handler_scope(ts, mappings, ctx, scope, data, indent, &inner_indent);
         }
         _ => {

--- a/crates/vize_canon/src/virtual_ts/scope/context.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/context.rs
@@ -49,6 +49,10 @@ pub(crate) struct VForPropsContext<'a> {
 pub(super) struct EventHandlerExprContext<'a> {
     pub(super) expressions_by_scope: &'a FxHashMap<u32, Vec<&'a vize_croquis::TemplateExpression>>,
     pub(super) data: &'a EventHandlerScopeData,
+    /// Whether handler assignability and payload types should be checked.
+    /// When disabled, authored handler bodies are still emitted as statements
+    /// so template-binding checks remain valid and parseable.
+    pub(super) check_emits: bool,
     pub(super) event_type: &'a str,
     /// For component `@event` handlers, the synthesized listener type
     /// (e.g. `__Child_1_test_listener`) that captures the full emit argument

--- a/crates/vize_canon/src/virtual_ts/scope/event_handler.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/event_handler.rs
@@ -20,8 +20,9 @@ pub(super) fn generate_event_handler_expressions(
     if let Some(exprs) = ctx.expressions_by_scope.get(&scope_id) {
         for expr in exprs {
             let content = expr.content.as_str();
+            let is_callable_reference = is_callable_handler_reference(content);
             let is_implicit_reference =
-                ctx.data.has_implicit_event && is_callable_handler_reference(content);
+                ctx.check_emits && ctx.data.has_implicit_event && is_callable_reference;
             let inline_callback_arg = inline_callback_event_argument(content);
             let src_start = (ctx.template_offset + expr.start) as usize;
             let src_end = (ctx.template_offset + expr.end) as usize;
@@ -55,7 +56,23 @@ pub(super) fn generate_event_handler_expressions(
             // declaration's assignability error at the declared name, so the
             // synthetic identifier is what maps back to the attribute (#3462).
             let mut listener_spans = None;
-            let gen_range = if let Some(listener_type) = ctx.event_listener_type
+            let gen_range = if !ctx.check_emits
+                && (is_callable_reference || inline_callback_arg.is_some())
+            {
+                append!(*ts, "{indent}void (", indent = handler_indent);
+                let mapped_start = ts.len();
+                ts.push_str(content);
+                let mapped_end = ts.len();
+                ts.push_str(");  // handler expression (emit checks disabled)\n");
+                mapped_start..mapped_end
+            } else if !ctx.check_emits {
+                append!(*ts, "{indent}", indent = handler_indent);
+                let mapped_start = ts.len();
+                ts.push_str(content);
+                let mapped_end = ts.len();
+                ts.push_str(";  // handler expression (emit checks disabled)\n");
+                mapped_start..mapped_end
+            } else if let Some(listener_type) = ctx.event_listener_type
                 && (is_implicit_reference || inline_callback_arg.is_some())
             {
                 let handler_name = cstr!("__vize_handler_{scope_id}_{}", expr.start);

--- a/crates/vize_canon/src/virtual_ts/scope/event_scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/event_scope.rs
@@ -26,6 +26,31 @@ pub(super) fn generate_event_handler_scope(
     let scope_id = scope.id.as_u32();
     append!(*ts, "\n{indent}// @{} handler\n", data.event_name);
 
+    if !ctx.check_options.check_emits {
+        append!(*ts, "{indent}(($event: any) => {{\n");
+        profile!(
+            "canon.virtual_ts.event_handler_expressions",
+            generate_event_handler_expressions(
+                ts,
+                mappings,
+                scope_id,
+                &EventHandlerExprContext {
+                    expressions_by_scope: ctx.expressions_by_scope,
+                    data,
+                    check_emits: false,
+                    event_type: "any",
+                    event_listener_type: None,
+                    event_name_src_range: None,
+                    template_prop_names: ctx.template_prop_names,
+                    template_offset: ctx.template_offset,
+                    indent: inner_indent,
+                },
+            )
+        );
+        append!(*ts, "{indent}}})({{}} as any);\n");
+        return;
+    }
+
     if data.target_component.is_some() {
         let event_types = generate_component_event_types(
             ts,
@@ -66,6 +91,7 @@ pub(super) fn generate_event_handler_scope(
                 &EventHandlerExprContext {
                     expressions_by_scope: ctx.expressions_by_scope,
                     data,
+                    check_emits: true,
                     event_type: event_type.as_str(),
                     event_listener_type: Some(listener_type.as_str()),
                     event_name_src_range: event_name_source_range(
@@ -98,6 +124,7 @@ pub(super) fn generate_event_handler_scope(
                 &EventHandlerExprContext {
                     expressions_by_scope: ctx.expressions_by_scope,
                     data,
+                    check_emits: true,
                     event_type,
                     // Native DOM listeners keep the identity-call shape,
                     // so there is no declared name to anchor at.

--- a/crates/vize_canon/src/virtual_ts/types.rs
+++ b/crates/vize_canon/src/virtual_ts/types.rs
@@ -115,6 +115,10 @@ impl VirtualTsCheckOptions {
     pub(crate) fn any_enabled(self) -> bool {
         self.check_props || self.check_template_bindings || self.check_emits
     }
+
+    pub(crate) fn check_event_handlers(self) -> bool {
+        self.check_emits || self.check_template_bindings
+    }
 }
 
 impl Default for VirtualTsCheckOptions {

--- a/crates/vize_croquis/src/drawer/template/directives/v_on.rs
+++ b/crates/vize_croquis/src/drawer/template/directives/v_on.rs
@@ -8,6 +8,9 @@
 use crate::drawer::Drawer;
 use crate::drawer::helpers::extract_inline_callback_params;
 use crate::scope::EventHandlerScopeData;
+use oxc_ast::ast::Statement;
+use oxc_parser::{ParseOptions, Parser};
+use oxc_span::SourceType;
 use vize_carton::{CompactString, profile, smallvec};
 use vize_relief::ExpressionNode;
 
@@ -120,7 +123,10 @@ impl Drawer {
             } else {
                 // Simple handler reference, or inline statement-list handler.
                 let has_implicit_event = content.contains("$event") || !content.contains('(');
-                let is_statement_list = is_inline_statement_list(content);
+                let is_statement_list = profile!(
+                    "croquis.template.v_on.statement_list",
+                    is_inline_statement_list(content)
+                );
 
                 if has_implicit_event || (is_statement_list && !content.contains("=>")) {
                     self.croquis.scopes.enter_event_handler_scope(
@@ -202,14 +208,79 @@ impl Drawer {
 
 fn is_inline_statement_list(content: &str) -> bool {
     let trimmed = content.trim_end();
-    if trimmed.ends_with(';') {
+    if trimmed.ends_with(';')
+        || content
+            .split(';')
+            .take(2)
+            .filter(|part| !part.trim().is_empty())
+            .count()
+            > 1
+    {
         return true;
     }
 
-    content
-        .split(';')
-        .take(2)
-        .filter(|part| !part.trim().is_empty())
-        .count()
-        > 1
+    if !content.contains(['\n', '\r']) {
+        return false;
+    }
+
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed = Parser::new(&allocator, content, SourceType::ts())
+        .with_options(ParseOptions {
+            allow_return_outside_function: true,
+            ..Default::default()
+        })
+        .parse();
+    if parsed.panicked || !parsed.diagnostics.is_empty() {
+        return false;
+    }
+
+    let mut statements = parsed
+        .program
+        .body
+        .iter()
+        .filter(|statement| !matches!(statement, Statement::EmptyStatement(_)));
+    let Some(first) = statements.next() else {
+        return false;
+    };
+    !matches!(first, Statement::ExpressionStatement(_)) || statements.next().is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_inline_statement_list;
+
+    #[test]
+    fn classifies_asi_and_semicolon_statement_lists() {
+        for content in [
+            "emit('create')\nemit('close')",
+            "emit('create')\r\nemit('close')",
+            "emit('create'); emit('close')",
+            "emit('create');",
+            "\nif (ready) run()\n",
+            "\nconst value = getValue()\n",
+            "\nreturn run()\n",
+        ] {
+            assert!(
+                is_inline_statement_list(content),
+                "expected statement-list handler: {content:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn keeps_multiline_single_expressions_out_of_statement_scopes() {
+        for content in [
+            "handler\n  .call(null)",
+            "ready\n  ? onReady()\n  : onPending()",
+            "items\n  .map(item => item.id)\n  .join(',')",
+            "({\n  key: value\n})",
+            "emit('create')\n+",
+            "emit('create')",
+        ] {
+            assert!(
+                !is_inline_statement_list(content),
+                "expected single-expression handler: {content:?}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- classify ASI-separated `v-on` bodies as handler statements with OXC while keeping multiline single expressions unchanged
- preserve a statement-safe handler scope when `--no-check-emits` is active without re-enabling payload or assignability checks
- cover the reported CLI path, generated TypeScript parsing, expression-shaped handlers, control statements, declarations, CRLF, and negative multiline expressions

## Failure before

The reported two-line handler was emitted as one parenthesized expression:

```ts
void (
  emit('create')
  emit('close')
); // VOn
```

The native TypeScript check then reported TS1005.

## Validation

- `cargo test -p vize_canon --lib` (774 passed)
- `cargo test -p vize_croquis` (267 unit, 3 integration, 7 doc tests passed)
- `cargo test -p vize_canon --test leading_semicolon_event_handler` (3 passed)
- `cargo test -p vize --test check_multistatement_v_on_cli`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `vp check`

Closes #3681

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->