### PR TITLE
fix(patina): accept object-bound v-for keys

### DIFF
--- a/crates/vize_patina/src/rules/vue/require_v_for_key.rs
+++ b/crates/vize_patina/src/rules/vue/require_v_for_key.rs
@@ -20,8 +20,12 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
-use crate::markup::{MarkupContext, MarkupElement, MarkupList, MarkupRule};
+use crate::markup::{MarkupBindingKind, MarkupContext, MarkupElement, MarkupList, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, PropertyKey};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
 use vize_relief::{DirectiveNode, ElementNode, ExpressionNode, PropNode};
 
 static META: RuleMeta = RuleMeta {
@@ -46,7 +50,7 @@ impl RequireVForKey {
         if element.is_tag("template") {
             return;
         }
-        if element.has_key_binding() {
+        if element.has_key_binding() || has_object_bound_key(element) {
             return;
         }
 
@@ -57,6 +61,79 @@ impl RequireVForKey {
         let help = ctx.lint().t("vue/require-v-for-key.help");
         ctx.lint()
             .error_at_with_help(message, element.range(), help);
+    }
+}
+
+fn has_object_bound_key(element: &MarkupElement<'_>) -> bool {
+    let mut found = false;
+    element.walk_bindings(&mut |binding| {
+        if !found
+            && binding.kind() == MarkupBindingKind::Bind
+            && binding.arg_name().is_none()
+            && binding.expression().is_some_and(object_has_static_key)
+        {
+            found = true;
+        }
+    });
+    found
+}
+
+fn object_has_static_key(source: &str) -> bool {
+    let source = source.trim();
+    if !matches!(source.as_bytes().first(), Some(b'{') | Some(b'(')) {
+        return false;
+    }
+
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path("template.ts").unwrap_or_else(|_| SourceType::ts());
+    let Ok(expression) = Parser::new(&allocator, source, source_type).parse_expression() else {
+        return false;
+    };
+    if expression.span().end as usize != source.len() {
+        return false;
+    }
+
+    let Some(root) = object_expression(&expression) else {
+        return false;
+    };
+    let mut objects = vec![root];
+    while let Some(object) = objects.pop() {
+        for property in &object.properties {
+            match property {
+                ObjectPropertyKind::ObjectProperty(property) => {
+                    if is_static_key(&property.key) {
+                        return true;
+                    }
+                }
+                ObjectPropertyKind::SpreadProperty(spread) => {
+                    if let Some(object) = object_expression(&spread.argument) {
+                        objects.push(object);
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+fn object_expression<'a>(expression: &'a Expression<'a>) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            object_expression(&parenthesized.expression)
+        }
+        Expression::TSAsExpression(ts_as) => object_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(satisfies) => object_expression(&satisfies.expression),
+        Expression::TSNonNullExpression(non_null) => object_expression(&non_null.expression),
+        _ => None,
+    }
+}
+
+fn is_static_key(key: &PropertyKey<'_>) -> bool {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => identifier.name == "key",
+        PropertyKey::StringLiteral(literal) => literal.value == "key",
+        _ => false,
     }
 }
 
@@ -144,7 +221,9 @@ impl Rule for RequireVForKey {
                 {
                     return s.content.as_str() == "key";
                 }
-                false
+                dir.name.as_str() == "bind"
+                    && dir.arg.is_none()
+                    && matches!(&dir.exp, Some(ExpressionNode::Simple(expression)) if object_has_static_key(expression.content.as_str()))
             }
         });
 

--- a/crates/vize_patina/tests/fixtures/require-v-for-key-object-bind.json
+++ b/crates/vize_patina/tests/fixtures/require-v-for-key-object-bind.json
@@ -1,0 +1,80 @@
+[
+  {
+    "id": "elk-common-paginator",
+    "eslintDiagnostics": 0,
+    "patinaDiagnostics": 0,
+    "source": "<template>\n  <slot>\n    <template v-else>\n      <slot\n        v-for=\"(item, index) of items\"\n        v-bind=\"{ key: (item as U)[keyProp as keyof U] }\"\n        :item=\"item as U\"\n        :older=\"items[index + 1] as U\"\n        :newer=\"items[index - 1] as U\"\n        :index=\"index\"\n        :items=\"items as U[]\"\n      />\n    </template>\n  </slot>\n</template>"
+  },
+  {
+    "id": "direct-bind-key",
+    "eslintDiagnostics": 0,
+    "patinaDiagnostics": 0,
+    "source": "<template><div v-for=\"item in items\" :key=\"item.id\" /></template>"
+  },
+  {
+    "id": "static-object-key",
+    "eslintDiagnostics": 1,
+    "patinaDiagnostics": 0,
+    "source": "<template><div v-for=\"item in items\" v-bind=\"{ key: item.id }\" /></template>"
+  },
+  {
+    "id": "string-literal-object-key",
+    "eslintDiagnostics": 1,
+    "patinaDiagnostics": 0,
+    "source": "<template><div v-for=\"item in items\" v-bind=\"{ 'key': item.id }\" /></template>"
+  },
+  {
+    "id": "shorthand-object-key",
+    "eslintDiagnostics": 1,
+    "patinaDiagnostics": 0,
+    "source": "<template><div v-for=\"item in items\" v-bind=\"{ key }\" /></template>"
+  },
+  {
+    "id": "computed-static-object-key",
+    "eslintDiagnostics": 1,
+    "patinaDiagnostics": 0,
+    "source": "<template><div v-for=\"item in items\" v-bind=\"{ ['key']: item.id }\" /></template>"
+  },
+  {
+    "id": "nested-static-spread-key",
+    "eslintDiagnostics": 1,
+    "patinaDiagnostics": 0,
+    "source": "<template><div v-for=\"item in items\" v-bind=\"{ ...{ key: item.id } }\" /></template>"
+  },
+  {
+    "id": "explicit-key-after-dynamic-spread",
+    "eslintDiagnostics": 1,
+    "patinaDiagnostics": 0,
+    "source": "<template><div v-for=\"item in items\" v-bind=\"{ ...attrs, key: item.id }\" /></template>"
+  },
+  {
+    "id": "object-without-key",
+    "eslintDiagnostics": 1,
+    "patinaDiagnostics": 1,
+    "source": "<template><div v-for=\"item in items\" v-bind=\"{ id: item.id }\" /></template>"
+  },
+  {
+    "id": "dynamic-computed-key",
+    "eslintDiagnostics": 1,
+    "patinaDiagnostics": 1,
+    "source": "<template><div v-for=\"item in items\" v-bind=\"{ [keyName]: item.id }\" /></template>"
+  },
+  {
+    "id": "dynamic-spread-only",
+    "eslintDiagnostics": 1,
+    "patinaDiagnostics": 1,
+    "source": "<template><div v-for=\"item in items\" v-bind=\"{ ...attrs }\" /></template>"
+  },
+  {
+    "id": "static-spread-without-key",
+    "eslintDiagnostics": 1,
+    "patinaDiagnostics": 1,
+    "source": "<template><div v-for=\"item in items\" v-bind=\"{ ...{ id: item.id } }\" /></template>"
+  },
+  {
+    "id": "key-on-different-element",
+    "eslintDiagnostics": 1,
+    "patinaDiagnostics": 1,
+    "source": "<template><section><div v-for=\"item in items\" v-bind=\"{ id: item.id }\" /><span v-bind=\"{ key: item.id }\" /></section></template>"
+  }
+]

--- a/crates/vize_patina/tests/require_v_for_key_object_bind.rs
+++ b/crates/vize_patina/tests/require_v_for_key_object_bind.rs
@@ -1,0 +1,49 @@
+use serde_json::Value;
+use vize_patina::rules::vue::RequireVForKey;
+use vize_patina::{LintResult, Linter, RuleRegistry};
+
+const CASES: &str = include_str!("fixtures/require-v-for-key-object-bind.json");
+const RULE: &str = "vue/require-v-for-key";
+
+fn linter() -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(Box::new(RequireVForKey));
+    Linter::with_registry(registry)
+}
+
+fn rule_diagnostics(result: &LintResult) -> usize {
+    result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.rule_name == RULE)
+        .count()
+}
+
+#[test]
+fn object_bound_key_matrix_matches_the_recorded_contract() {
+    let cases: Value = serde_json::from_str(CASES).unwrap();
+    let linter = linter();
+
+    for case in cases.as_array().unwrap() {
+        let id = case["id"].as_str().unwrap();
+        let source = case["source"].as_str().unwrap();
+        let expected = case["patinaDiagnostics"].as_u64().unwrap() as usize;
+        let result = linter.lint_sfc(source, id);
+
+        assert_eq!(rule_diagnostics(&result), expected, "{id}");
+    }
+}
+
+#[test]
+fn pinned_elk_reproduction_has_zero_false_positives_and_false_negatives() {
+    let cases: Value = serde_json::from_str(CASES).unwrap();
+    let elk = &cases.as_array().unwrap()[0];
+    assert_eq!(elk["id"], "elk-common-paginator");
+
+    let expected = elk["eslintDiagnostics"].as_u64().unwrap() as usize;
+    let result = linter().lint_sfc(elk["source"].as_str().unwrap(), "CommonPaginator.vue");
+    let actual = rule_diagnostics(&result);
+
+    assert_eq!(actual, expected, "false-positive or false-negative drift");
+    assert_eq!(actual, 0, "the pinned Elk reproduction must stay clean");
+}

--- a/tests/snapshots/lint/__snapshots__/elk-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/elk-lint.snap
@@ -629,20 +629,9 @@
         "endLine": 87,
         "endColumn": 43,
         "help": "Shorthand: <template #header> (default)\nLongform: <template v-slot:header>\nChoose one style and be consistent."
-      },
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <slot>",
-        "line": 106,
-        "column": 11,
-        "endLine": 106,
-        "endColumn": 41,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
       }
     ],
-    "errorCount": 1,
+    "errorCount": 0,
     "warningCount": 1
   },
   {

--- a/tests/tooling/patina-require-v-for-key-oracle.test.ts
+++ b/tests/tooling/patina-require-v-for-key-oracle.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const benchManifest = path.join(repoRoot, "bench", "package.json");
+const requireFromBench = createRequire(benchManifest);
+const { ESLint } = requireFromBench("eslint") as typeof import("eslint");
+const pluginVue = requireFromBench("eslint-plugin-vue");
+const vueParser = requireFromBench("vue-eslint-parser");
+const typescriptParser = requireFromBench("@typescript-eslint/parser");
+const cases = JSON.parse(
+  fs.readFileSync(
+    path.join(
+      repoRoot,
+      "crates",
+      "vize_patina",
+      "tests",
+      "fixtures",
+      "require-v-for-key-object-bind.json",
+    ),
+    "utf8",
+  ),
+) as Array<{ id: string; eslintDiagnostics: number; source: string }>;
+
+test("require-v-for-key matrix stays pinned to eslint-plugin-vue 10.9.2", async () => {
+  assert.equal(requireFromBench("eslint-plugin-vue/package.json").version, "10.9.2");
+  assert.equal(requireFromBench("vue-eslint-parser/package.json").version, "10.4.1");
+
+  const eslint = new ESLint({
+    cwd: repoRoot,
+    overrideConfigFile: true,
+    overrideConfig: [
+      {
+        files: ["**/*.vue"],
+        languageOptions: {
+          parser: vueParser,
+          parserOptions: {
+            parser: typescriptParser,
+            ecmaVersion: "latest",
+            sourceType: "module",
+          },
+        },
+        plugins: { vue: pluginVue },
+        rules: { "vue/require-v-for-key": "error" },
+      },
+    ],
+  });
+
+  for (const fixture of cases) {
+    const [result] = await eslint.lintText(fixture.source, {
+      filePath: path.join(repoRoot, "oracle", `${fixture.id}.vue`),
+    });
+    const diagnostics = result.messages.filter(
+      (message) => message.ruleId === "vue/require-v-for-key",
+    );
+    const parserErrors = result.messages.filter((message) => message.ruleId == null);
+
+    assert.deepEqual(parserErrors, [], `${fixture.id}: parser errors`);
+    assert.equal(diagnostics.length, fixture.eslintDiagnostics, fixture.id);
+  }
+});


### PR DESCRIPTION
## Summary

- recognize statically provable `key` properties in argumentless object-form `v-bind`
- inspect only explicit object literals and literal spreads, while keeping computed names and dynamic spreads conservative
- pin the exact Elk regression plus an eslint-plugin-vue 10.9.2 oracle matrix

## Root cause

`vue/require-v-for-key` only checked direct `key` and `:key` attributes. Elk's `CommonPaginator.vue` provides its key through `v-bind="{ key: ... }"`, so Patina emitted a false positive. The regression failed before this change and now passes.

The upstream rule is silent for the exact Elk slot because it skips the slot element itself; native-element cases deliberately verify Patina's object-binding support beyond that incidental behavior.

## Validation

- `cargo test -p vize_patina` (2,456 passed, 0 failed)
- `cargo clippy -p vize_patina --lib -- -D warnings`
- `cargo clippy -p vize_patina --test require_v_for_key_object_bind -- -D warnings`
- `node --test tests/tooling/patina-require-v-for-key-oracle.test.ts tests/tooling/snapshot-baselines.test.ts`
- `vp check` on the added Rust and TypeScript tests
- pinned Elk `e0aaee6868d870a5af431bf71d75fcfbc3c4f25a`: 253 files, 0 false positives, 0 false negatives

Closes #3678

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->