### PR TITLE
ci: extend cold-build test timeouts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -245,7 +245,7 @@ jobs:
     # several tests assert on artifacts produced by the built CLI.
     # Each of those was treated as not-needed and reintroduced a
     # regression; keeping the full bootstrap is the safe answer.
-    timeout-minutes: 15
+    timeout-minutes: 30
     env:
       NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
     steps:
@@ -333,7 +333,7 @@ jobs:
 
   test-js-packages:
     runs-on: blacksmith-32vcpu-ubuntu-2404
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
     steps:
@@ -359,7 +359,7 @@ jobs:
 
   clippy-and-test:
     runs-on: blacksmith-32vcpu-ubuntu-2404
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/criterion-bench.yml
+++ b/.github/workflows/criterion-bench.yml
@@ -46,7 +46,7 @@ jobs:
   criterion-ab:
     name: criterion-ab
     runs-on: blacksmith-32vcpu-ubuntu-2404
-    timeout-minutes: 45
+    timeout-minutes: 120
     permissions:
       contents: read
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -53,7 +53,7 @@ jobs:
     name: app-readiness
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: blacksmith-32vcpu-ubuntu-2404
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: read # required by actions/checkout
       pull-requests: read # required by dorny/paths-filter

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -144,7 +144,7 @@ test("pull requests run one path-filtered fast app readiness job", () => {
 
   assert.match(job, /if:\s*\$\{\{\s*github\.event_name == 'pull_request'\s*\}\}/);
   assert.match(job, /runs-on:\s*blacksmith-32vcpu-ubuntu-2404/);
-  assert.match(job, /timeout-minutes:\s*15/);
+  assert.match(job, /timeout-minutes:\s*30\b/);
   assert.match(job, /contents:\s*read\s*# required by actions\/checkout/);
   assert.match(job, /pull-requests:\s*read\s*# required by dorny\/paths-filter/);
   assert.match(

--- a/tests/tooling/github-workflows-benchmark.test.ts
+++ b/tests/tooling/github-workflows-benchmark.test.ts
@@ -250,7 +250,7 @@ test("criterion bench workflow runs an A/B micro-benchmark and a dialect guard",
   assert.match(workflow, /FORCE_JAVASCRIPT_ACTIONS_TO_NODE24:\s*true/);
 
   for (const [jobName, minutes] of [
-    ["criterion-ab", 45],
+    ["criterion-ab", 120],
     ["dialect-guard", 45],
   ] as const) {
     assert.match(

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -23,12 +23,12 @@ test("PR CI jobs cap runtime with explicit timeouts", () => {
     ["node-engine-compat", 20],
     ["check-vize-apps", 20],
     ["vue-parity", 30],
-    ["test-scripts", 15],
+    ["test-scripts", 30],
     ["editor-extensions", 15],
     ["editor-host-smoke", 30],
     ["build-js-packages", 30],
-    ["test-js-packages", 30],
-    ["clippy-and-test", 30],
+    ["test-js-packages", 45],
+    ["clippy-and-test", 45],
     ["coverage", 30],
     ["source-coverage", 40],
     ["branch-coverage", 45],
@@ -42,7 +42,7 @@ test("PR CI jobs cap runtime with explicit timeouts", () => {
     );
   }
 
-  assert.match(workflowJobBody(e2eWorkflow, "app-readiness"), /timeout-minutes:\s*15\b/);
+  assert.match(workflowJobBody(e2eWorkflow, "app-readiness"), /timeout-minutes:\s*30\b/);
 
   for (const [jobName, minutes] of [
     ["pr-benchmark", 30],


### PR DESCRIPTION
## Summary

- allow cold native builds in release-script, app-readiness, JS-package, Rust test, and Criterion A/B lanes to finish without hitting workflow ceilings
- raise observed 15-minute ceilings to 30 minutes, observed 30-minute ceilings to 45 minutes, and the full cold Criterion A/B path from 45 to 120 minutes
- keep workflow timeout contract tests synchronized with every explicit limit

## Failure before

- PR #3702 run 30734018465 job 91459261770 cancelled test-scripts after 15 minutes while the native debug package was still compiling; the log ended with The operation was canceled and no assertion failure
- PR #3704 run 30734392801 job 91460358170 cancelled app-readiness at the exact 15-minute ceiling immediately after the CLI build; there was no assertion failure
- PR #3704 run 30734392810 job 91460358075 cancelled test-js-packages at the exact 30-minute ceiling while its test command was still compiling; the log ended with The operation was canceled
- PR #3703 run 30734400225 job 91460478393 cancelled clippy-and-test at the exact 30-minute ceiling after displayed test suites passed and a later compilation was still running; the log ended with The operation was canceled
- PR #3703 run 30734400227 job 91460414633 cancelled criterion-ab at the exact 45-minute ceiling after the base SFC, JSX, cross-file, and formatter sweeps completed, while the base vize_patina sweep was still compiling; no regression assertion had failed

## Verification

- vp exec node --test tests/tooling/github-workflows-benchmark.test.ts tests/tooling/github-workflows-check.test.ts tests/tooling/e2e-workflow.test.ts
- vp exec actrun lint .github/workflows/criterion-bench.yml .github/workflows/check.yml .github/workflows/e2e.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased automated workflow time limits to reduce failures during longer-running checks, including end-to-end tests and benchmarks.

* **Tests**
  * Updated workflow validation tests to reflect the new timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->