### PR TITLE
test(fixtures): compare syntax scopes with a pinned oracle

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -113,6 +113,8 @@ jobs:
             --output-dir "$FIXTURE_REPORT_DIR"
 
       - name: Check real-project syntax highlighting
+        env:
+          SYNTAX_HIGHLIGHTER_ORACLE_TIMEOUT_MS: "600000"
         run: |
           node --test --test-concurrency=1 \
             tests/tooling/real-project-syntax-highlighting.test.ts
@@ -161,7 +163,7 @@ jobs:
             echo "No syntax-highlighter report was produced." >> "$GITHUB_STEP_SUMMARY"
           fi
           syntax_divergence="$FIXTURE_REPORT_DIR/syntax-highlighter-divergence.md"
-          if [[ -f "$syntax_divergence" ]]; then
+          if [[ -s "$syntax_divergence" ]]; then
             cat "$syntax_divergence" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "No syntax-highlighter divergence report was produced." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -116,6 +116,8 @@ jobs:
         run: |
           node --test --test-concurrency=1 \
             tests/tooling/real-project-syntax-highlighting.test.ts
+          test -s "$FIXTURE_REPORT_DIR/syntax-highlighter-divergence.json"
+          test -s "$FIXTURE_REPORT_DIR/syntax-highlighter-divergence.md"
 
       - name: Check glyph formatter corpus properties
         env:
@@ -157,6 +159,12 @@ jobs:
               "$syntax_report" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "No syntax-highlighter report was produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          syntax_divergence="$FIXTURE_REPORT_DIR/syntax-highlighter-divergence.md"
+          if [[ -f "$syntax_divergence" ]]; then
+            cat "$syntax_divergence" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No syntax-highlighter divergence report was produced." >> "$GITHUB_STEP_SUMMARY"
           fi
           mapfile -t divergence_reports < <(
             find "$FIXTURE_REPORT_DIR" -maxdepth 1 -type f \

--- a/tests/_fixtures/syntax-highlighter-documented-divergences.json
+++ b/tests/_fixtures/syntax-highlighter-documented-divergences.json
@@ -1,0 +1,5 @@
+{
+  "schema": "vize.fixtureSyntaxDivergenceLedger",
+  "version": 1,
+  "entries": []
+}

--- a/tests/tooling/fixtures/THIRD_PARTY_NOTICES.md
+++ b/tests/tooling/fixtures/THIRD_PARTY_NOTICES.md
@@ -30,6 +30,40 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FO
 OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+## Shiki Vue grammar oracle
+
+The real-project semantic-scope comparison loads `@shikijs/langs/vue` version `4.0.2` as an
+independent test oracle. The ESM module is distributed by the
+[`@shikijs/langs`](https://www.npmjs.com/package/@shikijs/langs) package from
+[`shikijs/shiki`](https://github.com/shikijs/shiki/tree/v4.0.2/packages/langs) and is generated from
+the `tm-grammars` corpus. The checked integrity evidence is:
+
+- `dist/vue.mjs`: `sha256-610450422f0a3b39468c42c078ff9e2dfd2d55045d31bbbb95173eba5986962d`
+- package `LICENSE`: `sha256-7a9d8d01038aeacf9e5bcdabbddf2a7815200dce9fc1118468cc553e00ae3eee`
+
+MIT License
+
+Copyright (c) 2021 Pine Wu
+Copyright (c) 2023 Anthony Fu <https://github.com/antfu>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 ## language-sass license
 
 Copyright (c) 2014 GitHub Inc.

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -132,6 +132,8 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
     /tests\/tooling\/real-project-syntax-highlighting\.test\.ts/,
   );
   assert.match(syntaxHighlighter?.run ?? "", /--test-concurrency=1/);
+  assert.match(syntaxHighlighter?.run ?? "", /test -s .*syntax-highlighter-divergence\.json/);
+  assert.match(syntaxHighlighter?.run ?? "", /test -s .*syntax-highlighter-divergence\.md/);
   assert.ok(glyphPropertiesIndex < divergenceIndex);
   assert.equal(glyphProperties?.env?.VIZE_TEST_BIN, "target/ci/vize");
   assert.match(glyphProperties?.run ?? "", /--test-concurrency=1/);
@@ -182,6 +184,8 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(summary?.run ?? "", /summary\.md/);
   assert.match(summary?.run ?? "", /syntax-highlighter-summary\.json/);
   assert.match(summary?.run ?? "", /failedProjectCount/);
+  assert.match(summary?.run ?? "", /syntax-highlighter-divergence\.md/);
+  assert.match(summary?.run ?? "", /No syntax-highlighter divergence report was produced/);
   assert.match(summary?.run ?? "", /\*-typecheck-divergence\.md/);
   assert.match(summary?.run ?? "", /divergence_reports\[@\]/);
   assert.equal(upload?.if, "${{ always() }}");

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -131,9 +131,16 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
     syntaxHighlighter?.run ?? "",
     /tests\/tooling\/real-project-syntax-highlighting\.test\.ts/,
   );
+  assert.equal(syntaxHighlighter?.env?.SYNTAX_HIGHLIGHTER_ORACLE_TIMEOUT_MS, "600000");
   assert.match(syntaxHighlighter?.run ?? "", /--test-concurrency=1/);
-  assert.match(syntaxHighlighter?.run ?? "", /test -s .*syntax-highlighter-divergence\.json/);
-  assert.match(syntaxHighlighter?.run ?? "", /test -s .*syntax-highlighter-divergence\.md/);
+  assert.match(
+    syntaxHighlighter?.run ?? "",
+    /test -s "\$FIXTURE_REPORT_DIR\/syntax-highlighter-divergence\.json"/,
+  );
+  assert.match(
+    syntaxHighlighter?.run ?? "",
+    /test -s "\$FIXTURE_REPORT_DIR\/syntax-highlighter-divergence\.md"/,
+  );
   assert.ok(glyphPropertiesIndex < divergenceIndex);
   assert.equal(glyphProperties?.env?.VIZE_TEST_BIN, "target/ci/vize");
   assert.match(glyphProperties?.run ?? "", /--test-concurrency=1/);
@@ -184,7 +191,12 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(summary?.run ?? "", /summary\.md/);
   assert.match(summary?.run ?? "", /syntax-highlighter-summary\.json/);
   assert.match(summary?.run ?? "", /failedProjectCount/);
-  assert.match(summary?.run ?? "", /syntax-highlighter-divergence\.md/);
+  assert.match(
+    summary?.run ?? "",
+    /syntax_divergence="\$FIXTURE_REPORT_DIR\/syntax-highlighter-divergence\.md"/,
+  );
+  assert.match(summary?.run ?? "", /if \[\[ -s "\$syntax_divergence" \]\]/);
+  assert.match(summary?.run ?? "", /cat "\$syntax_divergence" >> "\$GITHUB_STEP_SUMMARY"/);
   assert.match(summary?.run ?? "", /No syntax-highlighter divergence report was produced/);
   assert.match(summary?.run ?? "", /\*-typecheck-divergence\.md/);
   assert.match(summary?.run ?? "", /divergence_reports\[@\]/);

--- a/tests/tooling/real-project-syntax-highlighting.test.ts
+++ b/tests/tooling/real-project-syntax-highlighting.test.ts
@@ -1,158 +1,29 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
-import { createHash } from "node:crypto";
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { test } from "node:test";
-import { fileURLToPath } from "node:url";
 
-import { collectVueInputPaths } from "../../tools/fixtures/tool-matrix-inputs.mjs";
-import {
-  auditTextMateSource,
-  loadVueTextMateGrammar,
-  type TextMateGrammar,
-  type TextMateGrammarEvidence,
-} from "./support/vue-textmate.ts";
+import { runRealProjectSyntaxAudit } from "./support/real-project-syntax-audit.ts";
+import { auditTextMateSource, loadVueTextMateGrammar } from "./support/vue-textmate.ts";
 
-const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
-const registryPath = path.join(root, "tests", "_fixtures", "vue-ecosystem-fixtures.json");
+test("shipped and pinned oracle grammars tokenize every selected real-project Vue file", async () => {
+  const result = await runRealProjectSyntaxAudit();
+  if (result.skipped) return;
+  assert.ok(result.artifact);
+  assert.ok(result.artifact.summary.projectCount > 0);
+});
 
-type FixtureProject = {
-  coverage: string[];
-  expectedVueFileCount: number | null;
-  fixturePath: string;
-  id: string;
-  revision: string;
-  vueGlobs: string[];
-};
-
-type ProjectEvidence = {
-  characterCount: number;
-  durationMs: number;
-  failure?: string;
-  fileCount: number;
-  id: string;
-  lineCount: number;
-  revision: string;
-  inputSha256: string;
-  status: "failed" | "ok";
-  tokenSha256: string;
-  tokenCount: number;
-};
-
-test("shipped TextMate grammar tokenizes every selected real-project Vue file", async () => {
-  const registry = JSON.parse(fs.readFileSync(registryPath, "utf8")) as {
-    projects: FixtureProject[];
-    requiredToolCoverage: string[];
-  };
-  assert.ok(
-    registry.requiredToolCoverage.includes("syntax-highlighter"),
-    "registry must require syntax-highlighter coverage",
-  );
-
-  const selection = selectProjects(registry.projects);
-  if (!selection.enforced && selection.projects.length === 0) return;
-  const vue = await loadVueTextMateGrammar();
-  let artVue: Awaited<ReturnType<typeof loadVueTextMateGrammar>> | null = null;
-  const evidence: ProjectEvidence[] = [];
-
-  try {
-    for (const project of selection.projects) {
-      const fixtureDir = path.resolve(root, project.fixturePath);
-      const startedAt = Date.now();
-      let fileCount = 0;
-      let lineCount = 0;
-      let tokenCount = 0;
-      let characterCount = 0;
-      const inputDigest = createHash("sha256");
-      const tokenDigest = createHash("sha256");
-
-      try {
-        assert.ok(
-          project.coverage.includes("syntax-highlighter"),
-          `${project.id} does not declare syntax-highlighter coverage`,
-        );
-        assert.ok(isHydrated(fixtureDir), `${project.id} fixture is not hydrated`);
-        const files = collectVueInputPaths(fixtureDir, project.vueGlobs);
-        assertFixtureFileCount(project, files);
-        fileCount = files.length;
-
-        for (const file of files) {
-          const source = fs.readFileSync(path.join(fixtureDir, file), "utf8");
-          const isArtVue = file.endsWith(".art.vue");
-          if (isArtVue && artVue == null) {
-            artVue = await loadVueTextMateGrammar("source.art-vue");
-          }
-          const grammar = isArtVue ? (artVue?.grammar as TextMateGrammar) : vue.grammar;
-          const result = auditTextMateSource(
-            grammar,
-            source,
-            isArtVue ? "source.art-vue" : "source.vue",
-            `${project.id}/${file}`,
-          );
-          lineCount += result.lineCount;
-          tokenCount += result.tokenCount;
-          characterCount += source.length;
-          inputDigest.update(`${JSON.stringify([file, source])}\n`);
-          tokenDigest.update(`${JSON.stringify([file, result.sha256])}\n`);
-        }
-        evidence.push({
-          characterCount,
-          durationMs: Date.now() - startedAt,
-          fileCount,
-          id: project.id,
-          lineCount,
-          revision: project.revision,
-          inputSha256: inputDigest.digest("hex"),
-          status: "ok",
-          tokenSha256: tokenDigest.digest("hex"),
-          tokenCount,
-        });
-      } catch (error) {
-        evidence.push({
-          characterCount,
-          durationMs: Date.now() - startedAt,
-          failure: errorMessage(error),
-          fileCount,
-          id: project.id,
-          lineCount,
-          revision: project.revision,
-          inputSha256: inputDigest.digest("hex"),
-          status: "failed",
-          tokenSha256: tokenDigest.digest("hex"),
-          tokenCount,
-        });
-      }
-    }
-  } finally {
-    vue.registry.dispose();
-    artVue?.registry.dispose();
-  }
-
-  writeEvidence(
-    selection,
-    evidence,
-    [vue.getEvidence(), artVue?.getEvidence()].filter(
-      (item): item is TextMateGrammarEvidence => item != null,
-    ),
-  );
-  const failures = evidence.filter((project) => project.status === "failed");
-  const totals = evidence.reduce(
-    (sum, project) => ({
-      files: sum.files + project.fileCount,
-      lines: sum.lines + project.lineCount,
-      tokens: sum.tokens + project.tokenCount,
-    }),
-    { files: 0, lines: 0, tokens: 0 },
-  );
-  process.stderr.write(
-    `syntax highlighter: ${evidence.length} project(s), ${totals.files} file(s), ` +
-      `${totals.lines} line(s), ${totals.tokens} token(s), ${failures.length} failure(s)\n`,
-  );
-  assert.deepEqual(
-    failures.map((project) => `${project.id}: ${project.failure}`),
-    [],
+test("real-project syntax budget includes grammar startup", async () => {
+  const timestamps = [0, 2];
+  await assert.rejects(
+    () =>
+      runRealProjectSyntaxAudit(
+        {
+          FIXTURE_SHARD_COUNT: "1",
+          FIXTURE_SHARD_INDEX: "0",
+          SYNTAX_HIGHLIGHTER_ORACLE_TIMEOUT_MS: "1",
+        },
+        () => timestamps.shift() ?? 2,
+      ),
+    /syntax oracle shard exceeded 1ms/,
   );
 });
 
@@ -225,119 +96,3 @@ test("real-project TextMate audit exercises the shipped grammar and fail-closed 
   );
   assert.notEqual(first.sha256, second.sha256, "token digest must include scope identity");
 });
-
-function selectProjects(projects: FixtureProject[]): {
-  enforced: boolean;
-  projects: FixtureProject[];
-  shardCount: number | null;
-  shardIndex: number | null;
-} {
-  const shardIndex = process.env.FIXTURE_SHARD_INDEX;
-  const shardCount = process.env.FIXTURE_SHARD_COUNT;
-  if ((shardIndex == null) !== (shardCount == null)) {
-    throw new Error("FIXTURE_SHARD_INDEX and FIXTURE_SHARD_COUNT must be set together");
-  }
-  if (shardIndex != null && shardCount != null) {
-    const index = nonNegativeInteger(shardIndex, "FIXTURE_SHARD_INDEX");
-    const count = positiveInteger(shardCount, "FIXTURE_SHARD_COUNT");
-    assert.ok(index < count, "FIXTURE_SHARD_INDEX must be less than FIXTURE_SHARD_COUNT");
-    const selected = projects.filter((_, projectIndex) => projectIndex % count === index);
-    assert.ok(selected.length > 0, `fixture shard ${index}/${count} selected no projects`);
-    return {
-      enforced: true,
-      projects: selected,
-      shardCount: count,
-      shardIndex: index,
-    };
-  }
-  return {
-    enforced: false,
-    projects: projects.filter((project) => isHydrated(path.resolve(root, project.fixturePath))),
-    shardCount: null,
-    shardIndex: null,
-  };
-}
-
-function assertFixtureFileCount(project: FixtureProject, files: string[]): void {
-  if (project.expectedVueFileCount != null) {
-    assert.equal(
-      files.length,
-      project.expectedVueFileCount,
-      `${project.id} matched ${files.length} Vue files, expected ${project.expectedVueFileCount}`,
-    );
-  }
-  if (project.expectedVueFileCount !== 0) {
-    assert.ok(files.length > 0, `${project.id} matched no Vue files`);
-  }
-}
-
-function isHydrated(fixtureDir: string): boolean {
-  return fs.existsSync(fixtureDir) && fs.readdirSync(fixtureDir).length > 0;
-}
-
-function writeEvidence(
-  selection: ReturnType<typeof selectProjects>,
-  projects: ProjectEvidence[],
-  grammars: TextMateGrammarEvidence[],
-): void {
-  const outputDir = process.env.FIXTURE_REPORT_DIR;
-  if (outputDir == null || outputDir.length === 0) return;
-  const resolvedOutputDir = path.resolve(root, outputDir);
-  fs.mkdirSync(resolvedOutputDir, { recursive: true });
-  const artifact = {
-    schema: "vize.fixtureSyntaxHighlighterReport",
-    version: 1,
-    generatedAt: new Date().toISOString(),
-    commitSha: resolveCommitSha(),
-    runtime: { name: "node", version: process.versions.node },
-    machine: {
-      arch: process.arch,
-      logicalCpuCount: os.cpus().length,
-      platform: process.platform,
-      totalMemoryBytes: os.totalmem(),
-    },
-    shard: { count: selection.shardCount, index: selection.shardIndex },
-    grammars,
-    summary: {
-      failedProjectCount: projects.filter((project) => project.status === "failed").length,
-      fileCount: projects.reduce((sum, project) => sum + project.fileCount, 0),
-      lineCount: projects.reduce((sum, project) => sum + project.lineCount, 0),
-      projectCount: projects.length,
-      tokenCount: projects.reduce((sum, project) => sum + project.tokenCount, 0),
-    },
-    projects,
-  };
-  fs.writeFileSync(
-    path.join(resolvedOutputDir, "syntax-highlighter-summary.json"),
-    `${JSON.stringify(artifact, null, 2)}\n`,
-  );
-}
-
-function resolveCommitSha(): string {
-  const environmentSha = process.env.GITHUB_SHA;
-  if (environmentSha != null) return requireCommitSha(environmentSha, "GITHUB_SHA");
-  const result = spawnSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" });
-  assert.equal(result.status, 0, "git rev-parse HEAD must succeed");
-  return requireCommitSha(result.stdout.trim(), "git rev-parse HEAD");
-}
-
-function requireCommitSha(value: string, source: string): string {
-  assert.match(value, /^[0-9a-f]{40}$/, `${source} must be a full lowercase commit SHA`);
-  return value;
-}
-
-function positiveInteger(value: string, name: string): number {
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`${name} must be positive`);
-  return parsed;
-}
-
-function nonNegativeInteger(value: string, name: string): number {
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < 0) throw new Error(`${name} must be non-negative`);
-  return parsed;
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}

--- a/tests/tooling/shiki-vue-oracle.test.ts
+++ b/tests/tooling/shiki-vue-oracle.test.ts
@@ -6,7 +6,9 @@ import {
   validateOracleGrammarClosure,
   validateOraclePin,
 } from "./support/shiki-vue-oracle.ts";
+import { compareSemanticSpans } from "./support/syntax-semantic-comparison.ts";
 import { tokenizeSemanticSource } from "./support/syntax-semantic-divergence.ts";
+import { loadVueTextMateGrammar } from "./support/vue-textmate.ts";
 
 test("pinned @shikijs/langs/vue oracle carries exact independent provenance", async () => {
   const oracle = await loadPinnedShikiVueOracle();
@@ -76,6 +78,59 @@ test("oracle fails closed when source activates an unresolved embedded grammar",
     );
     assert.ok(oracle.getEvidence().unresolvedScopeSentinels.includes("source.ignore"));
   } finally {
+    oracle.registry.dispose();
+  }
+});
+
+test("shipped Art Vue grammar records intentional Vize-only spans against the oracle", async () => {
+  const artVue = await loadVueTextMateGrammar("source.art-vue");
+  const oracle = await loadPinnedShikiVueOracle();
+  try {
+    const source = [
+      '<art title="Button" component="Button">',
+      '  <variant name="typed">',
+      '    <Button :items="makeList<User>()" />',
+      "  </variant>",
+      "</art>",
+    ].join("\n");
+    const shipped = tokenizeSemanticSource(
+      artVue.grammar,
+      source,
+      "source.art-vue",
+      "vize/editor-art-vue",
+    );
+    const upstream = tokenizeSemanticSource(
+      oracle.grammar,
+      source,
+      oracle.rootScope,
+      "oracle/editor-art-vue",
+    );
+    const comparison = compareSemanticSpans(
+      "editor/Variant.art.vue",
+      source,
+      shipped.semanticSpans,
+      upstream.semanticSpans,
+    );
+
+    assert.equal(artVue.getEvidence().rootScope, "source.art-vue");
+    assert.deepEqual(
+      comparison.falsePositives.map(({ category, line, startColumn, endColumn }) => ({
+        category,
+        line,
+        startColumn,
+        endColumn,
+      })),
+      [
+        { category: "tag", line: 2, startColumn: 4, endColumn: 11 },
+        { category: "attribute", line: 2, startColumn: 12, endColumn: 16 },
+        { category: "tag", line: 3, startColumn: 6, endColumn: 12 },
+        { category: "attribute", line: 3, startColumn: 13, endColumn: 19 },
+        { category: "tag", line: 4, startColumn: 5, endColumn: 12 },
+      ],
+    );
+    assert.deepEqual(comparison.falseNegatives, []);
+  } finally {
+    artVue.registry.dispose();
     oracle.registry.dispose();
   }
 });

--- a/tests/tooling/shiki-vue-oracle.test.ts
+++ b/tests/tooling/shiki-vue-oracle.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  loadPinnedShikiVueOracle,
+  validateOracleGrammarClosure,
+  validateOraclePin,
+} from "./support/shiki-vue-oracle.ts";
+import { tokenizeSemanticSource } from "./support/syntax-semantic-divergence.ts";
+
+test("pinned @shikijs/langs/vue oracle carries exact independent provenance", async () => {
+  const oracle = await loadPinnedShikiVueOracle();
+  try {
+    const source = `<script setup lang="ts">\nconst count = 1\n</script>\n<template>{{ count }}</template>\n`;
+    const result = tokenizeSemanticSource(
+      oracle.grammar,
+      source,
+      oracle.rootScope,
+      "oracle/synthetic.vue",
+    );
+    assert.equal(result.lineCount, 5);
+    assert.ok(result.tokenCount > 5);
+    const evidence = oracle.getEvidence();
+    assert.deepEqual(
+      {
+        module: evidence.module,
+        moduleSha256: evidence.moduleSha256,
+        package: evidence.package,
+        grammarClosureSha256: evidence.grammarClosureSha256,
+        version: evidence.version,
+      },
+      {
+        module: "@shikijs/langs/vue",
+        moduleSha256: "610450422f0a3b39468c42c078ff9e2dfd2d55045d31bbbb95173eba5986962d",
+        package: "@shikijs/langs",
+        grammarClosureSha256: "9d6e6d7c4109574dec2aedcd2adb501b327c7e69943ead3adfee0ecccd379960",
+        version: "4.0.2",
+      },
+    );
+    assert.ok(evidence.requestedScopes.includes("text.html.vue"));
+  } finally {
+    oracle.registry.dispose();
+  }
+});
+
+test("oracle provenance validation fails closed on version, grammar, and license drift", () => {
+  const exact = {
+    license: "MIT",
+    licenseSha256: "7a9d8d01038aeacf9e5bcdabbddf2a7815200dce9fc1118468cc553e00ae3eee",
+    moduleSha256: "610450422f0a3b39468c42c078ff9e2dfd2d55045d31bbbb95173eba5986962d",
+    name: "@shikijs/langs",
+    version: "4.0.2",
+  };
+  assert.doesNotThrow(() => validateOraclePin(exact));
+  for (const changed of [
+    { ...exact, version: "4.0.3" },
+    { ...exact, moduleSha256: "0".repeat(64) },
+    { ...exact, licenseSha256: "0".repeat(64) },
+  ]) {
+    assert.throws(() => validateOraclePin(changed), /oracle provenance drifted/);
+  }
+  assert.throws(
+    () => validateOracleGrammarClosure([{ scopeName: "text.html.vue" }]),
+    /oracle grammar closure drifted/,
+  );
+});
+
+test("oracle fails closed when source activates an unresolved embedded grammar", async () => {
+  const oracle = await loadPinnedShikiVueOracle();
+  try {
+    const source = `<docs lang="md">\n\`\`\`ignore\nignored-file\n\`\`\`\n</docs>\n`;
+    assert.throws(
+      () =>
+        tokenizeSemanticSource(oracle.grammar, source, oracle.rootScope, "oracle/unresolved.vue"),
+      /activated unresolved oracle grammar/,
+    );
+    assert.ok(oracle.getEvidence().unresolvedScopeSentinels.includes("source.ignore"));
+  } finally {
+    oracle.registry.dispose();
+  }
+});

--- a/tests/tooling/support/real-project-syntax-audit.ts
+++ b/tests/tooling/support/real-project-syntax-audit.ts
@@ -1,18 +1,18 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { collectVueInputPaths } from "../../../tools/fixtures/tool-matrix-inputs.mjs";
-import { loadPinnedShikiVueOracle } from "./shiki-vue-oracle.ts";
 import {
-  createDivergenceArtifact,
-  renderDivergenceMarkdown,
-  type ProjectArtifact,
-} from "./syntax-divergence-artifact.ts";
+  resolveCommitSha,
+  writeDivergenceEvidence,
+  writeStructuralEvidence,
+  type ProjectEvidence,
+} from "./real-project-syntax-report.ts";
+import { loadPinnedShikiVueOracle } from "./shiki-vue-oracle.ts";
+import { createDivergenceArtifact, type ProjectArtifact } from "./syntax-divergence-artifact.ts";
 import {
   applyDocumentedDivergences,
   compareSemanticSpans,
@@ -43,20 +43,6 @@ type FixtureProject = {
   id: string;
   revision: string;
   vueGlobs: string[];
-};
-
-type ProjectEvidence = {
-  characterCount: number;
-  durationMs: number;
-  failure?: string;
-  fileCount: number;
-  id: string;
-  inputSha256: string;
-  lineCount: number;
-  revision: string;
-  status: "failed" | "ok";
-  tokenCount: number;
-  tokenSha256: string;
 };
 
 export async function runRealProjectSyntaxAudit(environment = process.env, now = Date.now) {
@@ -180,7 +166,7 @@ export async function runRealProjectSyntaxAudit(environment = process.env, now =
   }
 
   writeStructuralEvidence(
-    selection,
+    { count: selection.shardCount, index: selection.shardIndex },
     evidence,
     [vizeVue.getEvidence(), vizeArt?.getEvidence()].filter(
       (item): item is TextMateGrammarEvidence => item != null,
@@ -237,67 +223,6 @@ function selectProjects(projects: FixtureProject[], environment: NodeJS.ProcessE
   };
 }
 
-function writeStructuralEvidence(
-  selection: ReturnType<typeof selectProjects>,
-  projects: ProjectEvidence[],
-  grammars: TextMateGrammarEvidence[],
-  environment: NodeJS.ProcessEnv,
-): void {
-  const outputDir = outputDirectory(environment);
-  if (outputDir == null) return;
-  const artifact = {
-    schema: "vize.fixtureSyntaxHighlighterReport",
-    version: 1,
-    generatedAt: new Date().toISOString(),
-    commitSha: resolveCommitSha(environment),
-    runtime: { name: "node", version: process.versions.node },
-    machine: {
-      arch: process.arch,
-      logicalCpuCount: os.cpus().length,
-      platform: process.platform,
-      totalMemoryBytes: os.totalmem(),
-    },
-    shard: { count: selection.shardCount, index: selection.shardIndex },
-    grammars,
-    summary: {
-      failedProjectCount: projects.filter((project) => project.status === "failed").length,
-      fileCount: projects.reduce((sum, project) => sum + project.fileCount, 0),
-      lineCount: projects.reduce((sum, project) => sum + project.lineCount, 0),
-      projectCount: projects.length,
-      tokenCount: projects.reduce((sum, project) => sum + project.tokenCount, 0),
-    },
-    projects,
-  };
-  fs.writeFileSync(
-    path.join(outputDir, "syntax-highlighter-summary.json"),
-    `${JSON.stringify(artifact, null, 2)}\n`,
-  );
-}
-
-function writeDivergenceEvidence(
-  artifact: ReturnType<typeof createDivergenceArtifact>,
-  environment: NodeJS.ProcessEnv,
-): void {
-  const outputDir = outputDirectory(environment);
-  if (outputDir == null) return;
-  fs.writeFileSync(
-    path.join(outputDir, "syntax-highlighter-divergence.json"),
-    `${JSON.stringify(artifact, null, 2)}\n`,
-  );
-  fs.writeFileSync(
-    path.join(outputDir, "syntax-highlighter-divergence.md"),
-    renderDivergenceMarkdown(artifact),
-  );
-}
-
-function outputDirectory(environment: NodeJS.ProcessEnv): string | null {
-  const value = environment.FIXTURE_REPORT_DIR;
-  if (value == null || value.length === 0) return null;
-  const outputDir = path.resolve(root, value);
-  fs.mkdirSync(outputDir, { recursive: true });
-  return outputDir;
-}
-
 function emptyEvidence(project: FixtureProject): ProjectEvidence {
   return {
     characterCount: 0,
@@ -328,19 +253,6 @@ function assertFixtureFileCount(project: FixtureProject, files: string[]): void 
 
 function isHydrated(directory: string): boolean {
   return fs.existsSync(directory) && fs.readdirSync(directory).length > 0;
-}
-
-function resolveCommitSha(environment: NodeJS.ProcessEnv): string {
-  const value = environment.GITHUB_SHA;
-  if (value != null) return requireCommitSha(value, "GITHUB_SHA");
-  const result = spawnSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" });
-  assert.equal(result.status, 0, "git rev-parse HEAD must succeed");
-  return requireCommitSha(result.stdout.trim(), "git rev-parse HEAD");
-}
-
-function requireCommitSha(value: string, source: string): string {
-  assert.match(value, /^[0-9a-f]{40}$/, `${source} must be a full lowercase commit SHA`);
-  return value;
 }
 
 function positiveInteger(value: string, name: string): number {

--- a/tests/tooling/support/real-project-syntax-audit.ts
+++ b/tests/tooling/support/real-project-syntax-audit.ts
@@ -1,0 +1,349 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { collectVueInputPaths } from "../../../tools/fixtures/tool-matrix-inputs.mjs";
+import { loadPinnedShikiVueOracle } from "./shiki-vue-oracle.ts";
+import {
+  createDivergenceArtifact,
+  renderDivergenceMarkdown,
+  type ProjectArtifact,
+} from "./syntax-divergence-artifact.ts";
+import {
+  applyDocumentedDivergences,
+  compareSemanticSpans,
+  validateLedger,
+  type DivergenceRecord,
+} from "./syntax-semantic-comparison.ts";
+import { sha256, tokenizeSemanticSource } from "./syntax-semantic-divergence.ts";
+import { createSyntaxAuditDeadline } from "./syntax-audit-deadline.ts";
+import {
+  loadVueTextMateGrammar,
+  type TextMateGrammar,
+  type TextMateGrammarEvidence,
+} from "./vue-textmate.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const registryPath = path.join(root, "tests", "_fixtures", "vue-ecosystem-fixtures.json");
+const ledgerPath = path.join(
+  root,
+  "tests",
+  "_fixtures",
+  "syntax-highlighter-documented-divergences.json",
+);
+
+type FixtureProject = {
+  coverage: string[];
+  expectedVueFileCount: number | null;
+  fixturePath: string;
+  id: string;
+  revision: string;
+  vueGlobs: string[];
+};
+
+type ProjectEvidence = {
+  characterCount: number;
+  durationMs: number;
+  failure?: string;
+  fileCount: number;
+  id: string;
+  inputSha256: string;
+  lineCount: number;
+  revision: string;
+  status: "failed" | "ok";
+  tokenCount: number;
+  tokenSha256: string;
+};
+
+export async function runRealProjectSyntaxAudit(environment = process.env, now = Date.now) {
+  const checkDeadline = createSyntaxAuditDeadline(environment, now);
+  const registry = JSON.parse(fs.readFileSync(registryPath, "utf8")) as {
+    projects: FixtureProject[];
+    requiredToolCoverage: string[];
+  };
+  assert.ok(registry.requiredToolCoverage.includes("syntax-highlighter"));
+  const selection = selectProjects(registry.projects, environment);
+  if (!selection.enforced && selection.projects.length === 0) return { skipped: true };
+  const rawLedger = fs.readFileSync(ledgerPath, "utf8");
+  const ledger = JSON.parse(rawLedger) as unknown;
+  validateLedger(ledger, new Set(registry.projects.map((project) => project.id)));
+  const vizeVue = await loadVueTextMateGrammar();
+  const oracle = await loadPinnedShikiVueOracle();
+  let vizeArt: Awaited<ReturnType<typeof loadVueTextMateGrammar>> | null = null;
+  const evidence: ProjectEvidence[] = [];
+  const projectArtifacts: ProjectArtifact[] = [];
+
+  try {
+    checkDeadline();
+    for (const project of selection.projects) {
+      const fixtureDir = path.resolve(root, project.fixturePath);
+      const startedAt = Date.now();
+      const structural = emptyEvidence(project);
+      try {
+        assert.ok(project.coverage.includes("syntax-highlighter"));
+        assert.ok(isHydrated(fixtureDir), `${project.id} fixture is not hydrated`);
+        const files = collectVueInputPaths(fixtureDir, project.vueGlobs);
+        assertFixtureFileCount(project, files);
+        structural.fileCount = files.length;
+        const inputDigest = createHash("sha256");
+        const tokenDigest = createHash("sha256");
+        const comparisonDigest = createHash("sha256");
+        const falsePositives: DivergenceRecord[] = [];
+        const falseNegatives: DivergenceRecord[] = [];
+        let semanticSpanCount = 0;
+
+        for (const file of files) {
+          checkDeadline();
+          const source = fs.readFileSync(path.join(fixtureDir, file), "utf8");
+          const isArtVue = file.endsWith(".art.vue");
+          if (isArtVue && vizeArt == null) {
+            vizeArt = await loadVueTextMateGrammar("source.art-vue");
+            checkDeadline();
+          }
+          const vizeGrammar = isArtVue ? (vizeArt?.grammar as TextMateGrammar) : vizeVue.grammar;
+          const vizeRoot = isArtVue ? "source.art-vue" : "source.vue";
+          const label = `${project.id}/${file}`;
+          const vize = tokenizeSemanticSource(
+            vizeGrammar,
+            source,
+            vizeRoot,
+            `vize:${label}`,
+            checkDeadline,
+          );
+          const baseline = tokenizeSemanticSource(
+            oracle.grammar,
+            source,
+            oracle.rootScope,
+            `oracle:${label}`,
+            checkDeadline,
+          );
+          assert.equal(vize.lineCount, baseline.lineCount, `${label}: line count drift`);
+          const comparison = compareSemanticSpans(
+            file,
+            source,
+            vize.semanticSpans,
+            baseline.semanticSpans,
+          );
+          checkDeadline();
+          falsePositives.push(...comparison.falsePositives);
+          falseNegatives.push(...comparison.falseNegatives);
+          semanticSpanCount +=
+            comparison.shared.length +
+            comparison.falsePositives.length +
+            comparison.falseNegatives.length;
+          structural.characterCount += source.length;
+          structural.lineCount += vize.lineCount;
+          structural.tokenCount += vize.tokenCount;
+          inputDigest.update(`${JSON.stringify([file, source])}\n`);
+          tokenDigest.update(`${JSON.stringify([file, vize.tokenSha256])}\n`);
+          comparisonDigest.update(`${JSON.stringify([file, comparison.sha256])}\n`);
+        }
+        structural.inputSha256 = inputDigest.digest("hex");
+        structural.tokenSha256 = tokenDigest.digest("hex");
+        const classified = applyDocumentedDivergences(
+          project.id,
+          { falseNegatives, falsePositives, sha256: "", shared: [] },
+          ledger,
+        );
+        projectArtifacts.push({
+          id: project.id,
+          revision: project.revision,
+          fileCount: files.length,
+          inputSha256: structural.inputSha256,
+          semanticSpanCount,
+          comparisonSha256: comparisonDigest.digest("hex"),
+          falsePositives: classified.falsePositives,
+          falseNegatives: classified.falseNegatives,
+          documentedDivergences: classified.documented,
+        });
+        checkDeadline();
+        structural.status = "ok";
+      } catch (error) {
+        structural.failure = errorMessage(error);
+      }
+      structural.durationMs = Date.now() - startedAt;
+      evidence.push(structural);
+    }
+  } finally {
+    vizeVue.registry.dispose();
+    vizeArt?.registry.dispose();
+    oracle.registry.dispose();
+  }
+
+  writeStructuralEvidence(
+    selection,
+    evidence,
+    [vizeVue.getEvidence(), vizeArt?.getEvidence()].filter(
+      (item): item is TextMateGrammarEvidence => item != null,
+    ),
+    environment,
+  );
+  const failures = evidence.filter((project) => project.status === "failed");
+  assert.deepEqual(
+    failures.map((project) => `${project.id}: ${project.failure}`),
+    [],
+  );
+  const commitSha = resolveCommitSha(environment);
+  checkDeadline();
+  const artifact = createDivergenceArtifact({
+    commitSha,
+    grammars: {
+      oracle: oracle.getEvidence(),
+      vize: [vizeVue.getEvidence(), vizeArt?.getEvidence()].filter(Boolean),
+    },
+    ledger: {
+      path: path.relative(root, ledgerPath).replaceAll("\\", "/"),
+      sha256: sha256(rawLedger),
+    },
+    projects: projectArtifacts,
+    shard: { count: selection.shardCount, index: selection.shardIndex },
+  });
+  writeDivergenceEvidence(artifact, environment);
+  process.stderr.write(
+    `syntax oracle: ${artifact.summary.projectCount} project(s), ${artifact.summary.fileCount} file(s), ` +
+      `${artifact.summary.falsePositiveCount} FP, ${artifact.summary.falseNegativeCount} FN\n`,
+  );
+  return { artifact, evidence, skipped: false };
+}
+
+function selectProjects(projects: FixtureProject[], environment: NodeJS.ProcessEnv) {
+  const shardIndex = environment.FIXTURE_SHARD_INDEX;
+  const shardCount = environment.FIXTURE_SHARD_COUNT;
+  if ((shardIndex == null) !== (shardCount == null)) {
+    throw new Error("FIXTURE_SHARD_INDEX and FIXTURE_SHARD_COUNT must be set together");
+  }
+  if (shardIndex != null && shardCount != null) {
+    const index = nonNegativeInteger(shardIndex, "FIXTURE_SHARD_INDEX");
+    const count = positiveInteger(shardCount, "FIXTURE_SHARD_COUNT");
+    assert.ok(index < count, "FIXTURE_SHARD_INDEX must be less than FIXTURE_SHARD_COUNT");
+    const selected = projects.filter((_, projectIndex) => projectIndex % count === index);
+    assert.ok(selected.length > 0, `fixture shard ${index}/${count} selected no projects`);
+    return { enforced: true, projects: selected, shardCount: count, shardIndex: index };
+  }
+  return {
+    enforced: false,
+    projects: projects.filter((project) => isHydrated(path.resolve(root, project.fixturePath))),
+    shardCount: null,
+    shardIndex: null,
+  };
+}
+
+function writeStructuralEvidence(
+  selection: ReturnType<typeof selectProjects>,
+  projects: ProjectEvidence[],
+  grammars: TextMateGrammarEvidence[],
+  environment: NodeJS.ProcessEnv,
+): void {
+  const outputDir = outputDirectory(environment);
+  if (outputDir == null) return;
+  const artifact = {
+    schema: "vize.fixtureSyntaxHighlighterReport",
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    commitSha: resolveCommitSha(environment),
+    runtime: { name: "node", version: process.versions.node },
+    machine: {
+      arch: process.arch,
+      logicalCpuCount: os.cpus().length,
+      platform: process.platform,
+      totalMemoryBytes: os.totalmem(),
+    },
+    shard: { count: selection.shardCount, index: selection.shardIndex },
+    grammars,
+    summary: {
+      failedProjectCount: projects.filter((project) => project.status === "failed").length,
+      fileCount: projects.reduce((sum, project) => sum + project.fileCount, 0),
+      lineCount: projects.reduce((sum, project) => sum + project.lineCount, 0),
+      projectCount: projects.length,
+      tokenCount: projects.reduce((sum, project) => sum + project.tokenCount, 0),
+    },
+    projects,
+  };
+  fs.writeFileSync(
+    path.join(outputDir, "syntax-highlighter-summary.json"),
+    `${JSON.stringify(artifact, null, 2)}\n`,
+  );
+}
+
+function writeDivergenceEvidence(
+  artifact: ReturnType<typeof createDivergenceArtifact>,
+  environment: NodeJS.ProcessEnv,
+): void {
+  const outputDir = outputDirectory(environment);
+  if (outputDir == null) return;
+  fs.writeFileSync(
+    path.join(outputDir, "syntax-highlighter-divergence.json"),
+    `${JSON.stringify(artifact, null, 2)}\n`,
+  );
+  fs.writeFileSync(
+    path.join(outputDir, "syntax-highlighter-divergence.md"),
+    renderDivergenceMarkdown(artifact),
+  );
+}
+
+function outputDirectory(environment: NodeJS.ProcessEnv): string | null {
+  const value = environment.FIXTURE_REPORT_DIR;
+  if (value == null || value.length === 0) return null;
+  const outputDir = path.resolve(root, value);
+  fs.mkdirSync(outputDir, { recursive: true });
+  return outputDir;
+}
+
+function emptyEvidence(project: FixtureProject): ProjectEvidence {
+  return {
+    characterCount: 0,
+    durationMs: 0,
+    fileCount: 0,
+    id: project.id,
+    inputSha256: sha256(""),
+    lineCount: 0,
+    revision: project.revision,
+    status: "failed",
+    tokenCount: 0,
+    tokenSha256: sha256(""),
+  };
+}
+
+function assertFixtureFileCount(project: FixtureProject, files: string[]): void {
+  if (project.expectedVueFileCount != null)
+    assert.equal(files.length, project.expectedVueFileCount);
+  if (project.expectedVueFileCount !== 0)
+    assert.ok(files.length > 0, `${project.id} matched no files`);
+}
+
+function isHydrated(directory: string): boolean {
+  return fs.existsSync(directory) && fs.readdirSync(directory).length > 0;
+}
+
+function resolveCommitSha(environment: NodeJS.ProcessEnv): string {
+  const value = environment.GITHUB_SHA;
+  if (value != null) return requireCommitSha(value, "GITHUB_SHA");
+  const result = spawnSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" });
+  assert.equal(result.status, 0, "git rev-parse HEAD must succeed");
+  return requireCommitSha(result.stdout.trim(), "git rev-parse HEAD");
+}
+
+function requireCommitSha(value: string, source: string): string {
+  assert.match(value, /^[0-9a-f]{40}$/, `${source} must be a full lowercase commit SHA`);
+  return value;
+}
+
+function positiveInteger(value: string, name: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`${name} must be positive`);
+  return parsed;
+}
+
+function nonNegativeInteger(value: string, name: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) throw new Error(`${name} must be non-negative`);
+  return parsed;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/tests/tooling/support/real-project-syntax-audit.ts
+++ b/tests/tooling/support/real-project-syntax-audit.ts
@@ -72,7 +72,10 @@ export async function runRealProjectSyntaxAudit(environment = process.env, now =
   const ledger = JSON.parse(rawLedger) as unknown;
   validateLedger(ledger, new Set(registry.projects.map((project) => project.id)));
   const vizeVue = await loadVueTextMateGrammar();
-  const oracle = await loadPinnedShikiVueOracle();
+  const oracle = await loadPinnedShikiVueOracle().catch((error: unknown) => {
+    vizeVue.registry.dispose();
+    throw error;
+  });
   let vizeArt: Awaited<ReturnType<typeof loadVueTextMateGrammar>> | null = null;
   const evidence: ProjectEvidence[] = [];
   const projectArtifacts: ProjectArtifact[] = [];
@@ -83,14 +86,14 @@ export async function runRealProjectSyntaxAudit(environment = process.env, now =
       const fixtureDir = path.resolve(root, project.fixturePath);
       const startedAt = Date.now();
       const structural = emptyEvidence(project);
+      const inputDigest = createHash("sha256");
+      const tokenDigest = createHash("sha256");
       try {
         assert.ok(project.coverage.includes("syntax-highlighter"));
         assert.ok(isHydrated(fixtureDir), `${project.id} fixture is not hydrated`);
         const files = collectVueInputPaths(fixtureDir, project.vueGlobs);
         assertFixtureFileCount(project, files);
         structural.fileCount = files.length;
-        const inputDigest = createHash("sha256");
-        const tokenDigest = createHash("sha256");
         const comparisonDigest = createHash("sha256");
         const falsePositives: DivergenceRecord[] = [];
         const falseNegatives: DivergenceRecord[] = [];
@@ -142,8 +145,8 @@ export async function runRealProjectSyntaxAudit(environment = process.env, now =
           tokenDigest.update(`${JSON.stringify([file, vize.tokenSha256])}\n`);
           comparisonDigest.update(`${JSON.stringify([file, comparison.sha256])}\n`);
         }
-        structural.inputSha256 = inputDigest.digest("hex");
-        structural.tokenSha256 = tokenDigest.digest("hex");
+        structural.inputSha256 = inputDigest.copy().digest("hex");
+        structural.tokenSha256 = tokenDigest.copy().digest("hex");
         const classified = applyDocumentedDivergences(
           project.id,
           { falseNegatives, falsePositives, sha256: "", shared: [] },
@@ -165,6 +168,8 @@ export async function runRealProjectSyntaxAudit(environment = process.env, now =
       } catch (error) {
         structural.failure = errorMessage(error);
       }
+      structural.inputSha256 = inputDigest.digest("hex");
+      structural.tokenSha256 = tokenDigest.digest("hex");
       structural.durationMs = Date.now() - startedAt;
       evidence.push(structural);
     }
@@ -309,10 +314,16 @@ function emptyEvidence(project: FixtureProject): ProjectEvidence {
 }
 
 function assertFixtureFileCount(project: FixtureProject, files: string[]): void {
-  if (project.expectedVueFileCount != null)
-    assert.equal(files.length, project.expectedVueFileCount);
-  if (project.expectedVueFileCount !== 0)
+  if (project.expectedVueFileCount != null) {
+    assert.equal(
+      files.length,
+      project.expectedVueFileCount,
+      `${project.id} matched ${files.length} Vue files, expected ${project.expectedVueFileCount}`,
+    );
+  }
+  if (project.expectedVueFileCount !== 0) {
     assert.ok(files.length > 0, `${project.id} matched no files`);
+  }
 }
 
 function isHydrated(directory: string): boolean {

--- a/tests/tooling/support/real-project-syntax-report.ts
+++ b/tests/tooling/support/real-project-syntax-report.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { renderDivergenceMarkdown, type DivergenceArtifact } from "./syntax-divergence-artifact.ts";
+import type { TextMateGrammarEvidence } from "./vue-textmate.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+export type ProjectEvidence = {
+  characterCount: number;
+  durationMs: number;
+  failure?: string;
+  fileCount: number;
+  id: string;
+  inputSha256: string;
+  lineCount: number;
+  revision: string;
+  status: "failed" | "ok";
+  tokenCount: number;
+  tokenSha256: string;
+};
+
+export type ShardSelection = {
+  count: number | null;
+  index: number | null;
+};
+
+export function writeStructuralEvidence(
+  shard: ShardSelection,
+  projects: ProjectEvidence[],
+  grammars: TextMateGrammarEvidence[],
+  environment: NodeJS.ProcessEnv,
+): void {
+  const outputDir = outputDirectory(environment);
+  if (outputDir == null) return;
+  const artifact = {
+    schema: "vize.fixtureSyntaxHighlighterReport",
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    commitSha: resolveCommitSha(environment),
+    runtime: { name: "node", version: process.versions.node },
+    machine: {
+      arch: process.arch,
+      logicalCpuCount: os.cpus().length,
+      platform: process.platform,
+      totalMemoryBytes: os.totalmem(),
+    },
+    shard,
+    grammars,
+    summary: {
+      failedProjectCount: projects.filter((project) => project.status === "failed").length,
+      fileCount: projects.reduce((sum, project) => sum + project.fileCount, 0),
+      lineCount: projects.reduce((sum, project) => sum + project.lineCount, 0),
+      projectCount: projects.length,
+      tokenCount: projects.reduce((sum, project) => sum + project.tokenCount, 0),
+    },
+    projects,
+  };
+  fs.writeFileSync(
+    path.join(outputDir, "syntax-highlighter-summary.json"),
+    `${JSON.stringify(artifact, null, 2)}\n`,
+  );
+}
+
+export function writeDivergenceEvidence(
+  artifact: DivergenceArtifact,
+  environment: NodeJS.ProcessEnv,
+): void {
+  const outputDir = outputDirectory(environment);
+  if (outputDir == null) return;
+  fs.writeFileSync(
+    path.join(outputDir, "syntax-highlighter-divergence.json"),
+    `${JSON.stringify(artifact, null, 2)}\n`,
+  );
+  fs.writeFileSync(
+    path.join(outputDir, "syntax-highlighter-divergence.md"),
+    renderDivergenceMarkdown(artifact),
+  );
+}
+
+export function resolveCommitSha(environment: NodeJS.ProcessEnv): string {
+  const value = environment.GITHUB_SHA;
+  if (value != null) return requireCommitSha(value, "GITHUB_SHA");
+  const result = spawnSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" });
+  assert.equal(result.status, 0, "git rev-parse HEAD must succeed");
+  return requireCommitSha(result.stdout.trim(), "git rev-parse HEAD");
+}
+
+function outputDirectory(environment: NodeJS.ProcessEnv): string | null {
+  const value = environment.FIXTURE_REPORT_DIR;
+  if (value == null || value.length === 0) return null;
+  const outputDir = path.resolve(root, value);
+  fs.mkdirSync(outputDir, { recursive: true });
+  return outputDir;
+}
+
+function requireCommitSha(value: string, source: string): string {
+  assert.match(value, /^[0-9a-f]{40}$/, `${source} must be a full lowercase commit SHA`);
+  return value;
+}

--- a/tests/tooling/support/shiki-vue-oracle.ts
+++ b/tests/tooling/support/shiki-vue-oracle.ts
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  onigurumaModulePath,
+  onigurumaWasmPath,
+  shikiLanguageModulePath,
+  textmateDependencyVersions,
+  textmateModulePath,
+} from "./textmate-deps.ts";
+import { canonicalJson } from "./syntax-evidence.ts";
+import type { TextMateGrammar } from "./vue-textmate.ts";
+
+const packageName = "@shikijs/langs";
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const packageVersion = "4.0.2";
+const vueModuleSha256 = "610450422f0a3b39468c42c078ff9e2dfd2d55045d31bbbb95173eba5986962d";
+const licenseSha256 = "7a9d8d01038aeacf9e5bcdabbddf2a7815200dce9fc1118468cc553e00ae3eee";
+const grammarClosureSha256 = "9d6e6d7c4109574dec2aedcd2adb501b327c7e69943ead3adfee0ecccd379960";
+export const shikiVueOracleProvenance = {
+  grammarClosureSha256,
+  licenseSha256,
+  module: `${packageName}/vue`,
+  moduleSha256: vueModuleSha256,
+  package: packageName,
+  version: packageVersion,
+} as const;
+type BundledGrammar = {
+  embeddedLangsLazy?: string[];
+  injectTo?: string[];
+  scopeName?: string;
+};
+
+export type OracleEvidence = {
+  configuredGrammarSha256: string;
+  dependencyVersions: typeof textmateDependencyVersions;
+  grammarClosureSha256: string;
+  licenseSha256: string;
+  module: string;
+  moduleSha256: string;
+  package: string;
+  requestedScopes: string[];
+  rootScope: string;
+  unresolvedScopeSentinels: string[];
+  version: string;
+};
+
+export async function loadPinnedShikiVueOracle(
+  services: {
+    modulePath?: string;
+    readFile?: typeof fs.readFileSync;
+  } = {},
+) {
+  const modulePath = services.modulePath ?? shikiLanguageModulePath("vue");
+  const readFile = services.readFile ?? fs.readFileSync;
+  const manifestPath = findPackageManifest(modulePath, packageName);
+  const manifest = JSON.parse(readFile(manifestPath, "utf8") as string) as {
+    license?: string;
+    name?: string;
+    version?: string;
+  };
+  const licensePath = path.join(path.dirname(manifestPath), "LICENSE");
+  const moduleSha = sha256(readFile(modulePath));
+  const licenseSha = sha256(readFile(licensePath));
+  validateOraclePin({
+    license: manifest.license,
+    licenseSha256: licenseSha,
+    moduleSha256: moduleSha,
+    name: manifest.name,
+    version: manifest.version,
+  });
+
+  const [{ Registry }, { createOnigurumaEngine }, vueModule] = await Promise.all([
+    import(pathToFileURL(textmateModulePath).href),
+    import(pathToFileURL(onigurumaModulePath).href),
+    import(pathToFileURL(modulePath).href),
+  ]);
+  const engine = await createOnigurumaEngine(readFile(onigurumaWasmPath));
+  // The Vue grammar contains a historical PostCSS include that is not listed
+  // in its generated embeddedLangsLazy metadata.
+  const grammarList = await loadLanguageClosure(vueModule.default, ["postcss", "twig"]);
+  validateOracleGrammarClosure(grammarList);
+  const grammars = new Map<string, BundledGrammar>();
+  for (const grammar of grammarList) {
+    if (typeof grammar.scopeName === "string") grammars.set(grammar.scopeName, grammar);
+  }
+  const unresolvedScopeSentinels = new Set<string>();
+  grammars.set(
+    "source.js.regexp",
+    readJsonGrammar("tests/tooling/fixtures/javascript-regexp.tmLanguage.json"),
+  );
+  grammars.set("source.sassdoc", readJsonGrammar("tests/tooling/fixtures/sassdoc.tmLanguage.json"));
+  addScopeAlias(grammars, "source.postcss", "source.css.postcss");
+  addScopeAlias(grammars, "source.less", "source.css.less");
+  addScopeAlias(grammars, "source.twig", "text.html.twig");
+  const rootScope = "text.html.vue";
+  const rootGrammar = grammarList.find(
+    (grammar) => grammar.scopeName === rootScope && (grammar as { name?: string }).name === "vue",
+  );
+  assert.ok(rootGrammar, `pinned ${packageName}/vue has no ${rootScope} grammar`);
+  grammars.set(rootScope, rootGrammar);
+  const requestedScopes = new Set<string>();
+  const injections = new Map<string, string[]>();
+  for (const grammar of grammarList) {
+    if (typeof grammar.scopeName !== "string") continue;
+    for (const target of grammar.injectTo ?? []) {
+      const values = injections.get(target) ?? [];
+      if (!values.includes(grammar.scopeName)) values.push(grammar.scopeName);
+      injections.set(target, values);
+    }
+  }
+  const registry = new Registry({
+    getInjections(scopeName: string) {
+      return [...(injections.get(scopeName) ?? [])].sort(byteOrder);
+    },
+    loadGrammar(scopeName: string) {
+      requestedScopes.add(scopeName);
+      let grammar = grammars.get(scopeName);
+      if (grammar == null) {
+        unresolvedScopeSentinels.add(scopeName);
+        grammar = unresolvedSentinelGrammar(scopeName);
+        grammars.set(scopeName, grammar);
+      }
+      return grammar;
+    },
+    onigLib: {
+      createOnigScanner(patterns: Array<string | RegExp>) {
+        return engine.createScanner(patterns);
+      },
+      createOnigString(value: string) {
+        return engine.createString(value);
+      },
+    },
+  });
+  let grammar: TextMateGrammar | null;
+  try {
+    grammar = registry.loadGrammar(rootScope) as TextMateGrammar | null;
+  } catch (error) {
+    registry.dispose();
+    throw error;
+  }
+  assert.ok(grammar, `failed to load pinned oracle grammar ${rootScope}`);
+  return {
+    getEvidence: (): OracleEvidence => ({
+      configuredGrammarSha256: sha256(
+        JSON.stringify([...grammars.entries()].sort(([left], [right]) => byteOrder(left, right))),
+      ),
+      dependencyVersions: textmateDependencyVersions,
+      grammarClosureSha256,
+      licenseSha256: licenseSha,
+      module: `${packageName}/vue`,
+      moduleSha256: moduleSha,
+      package: packageName,
+      requestedScopes: [...requestedScopes].sort(byteOrder),
+      rootScope,
+      unresolvedScopeSentinels: [...unresolvedScopeSentinels].sort(byteOrder),
+      version: manifest.version as string,
+    }),
+    grammar,
+    registry,
+    rootScope,
+  };
+}
+
+export function validateOracleGrammarClosure(value: unknown): void {
+  assert.ok(Array.isArray(value) && value.length > 0, "oracle grammar closure must be non-empty");
+  assert.equal(
+    sha256(canonicalJson(value)),
+    grammarClosureSha256,
+    "oracle grammar closure drifted",
+  );
+}
+
+export function validateOraclePin(evidence: {
+  license?: string;
+  licenseSha256: string;
+  moduleSha256: string;
+  name?: string;
+  version?: string;
+}): void {
+  assert.deepEqual(
+    evidence,
+    {
+      license: "MIT",
+      licenseSha256,
+      moduleSha256: vueModuleSha256,
+      name: packageName,
+      version: packageVersion,
+    },
+    "pinned @shikijs/langs/vue oracle provenance drifted",
+  );
+}
+
+function findPackageManifest(modulePath: string, expectedName: string): string {
+  let directory = path.dirname(modulePath);
+  while (directory !== path.dirname(directory)) {
+    const candidate = path.join(directory, "package.json");
+    if (fs.existsSync(candidate)) {
+      const manifest = JSON.parse(fs.readFileSync(candidate, "utf8")) as { name?: string };
+      if (manifest.name === expectedName) return candidate;
+    }
+    directory = path.dirname(directory);
+  }
+  throw new Error(`could not resolve ${expectedName} provenance from ${modulePath}`);
+}
+
+function addScopeAlias(
+  grammars: Map<string, BundledGrammar>,
+  alias: string,
+  canonical: string,
+): void {
+  if (!grammars.has(alias) && grammars.has(canonical))
+    grammars.set(alias, grammars.get(canonical)!);
+}
+
+async function loadLanguageClosure(
+  initial: unknown,
+  requiredNames: string[],
+): Promise<BundledGrammar[]> {
+  const grammars = (Array.isArray(initial) ? initial : [initial]).filter(
+    (grammar): grammar is BundledGrammar => grammar != null && typeof grammar === "object",
+  );
+  const loadedNames = new Set(["vue"]);
+  let pending = [
+    ...requiredNames.filter((name) => {
+      if (loadedNames.has(name)) return false;
+      loadedNames.add(name);
+      return true;
+    }),
+    ...collectLazyNames(grammars, loadedNames),
+  ].sort(byteOrder);
+  while (pending.length > 0) {
+    const names = pending;
+    pending = [];
+    const modules = await Promise.all(
+      names.map((name) => import(pathToFileURL(shikiLanguageModulePath(name)).href)),
+    );
+    const added = modules
+      .flatMap((module) => (Array.isArray(module.default) ? module.default : [module.default]))
+      .filter(
+        (grammar): grammar is BundledGrammar => grammar != null && typeof grammar === "object",
+      );
+    grammars.push(...added);
+    pending.push(...collectLazyNames(added, loadedNames));
+  }
+  return grammars;
+}
+
+function collectLazyNames(grammars: BundledGrammar[], loadedNames: Set<string>): string[] {
+  const names = new Set<string>();
+  for (const grammar of grammars) {
+    for (const name of grammar.embeddedLangsLazy ?? []) {
+      if (loadedNames.has(name)) continue;
+      loadedNames.add(name);
+      names.add(name);
+    }
+  }
+  return [...names].sort(byteOrder);
+}
+
+function unresolvedSentinelGrammar(scopeName: string): BundledGrammar {
+  return {
+    scopeName,
+    patterns: [
+      {
+        match: ".+",
+        name: `invalid.unresolved-oracle-grammar.${scopeName}`,
+      },
+    ],
+  } as BundledGrammar;
+}
+
+function readJsonGrammar(relativePath: string): BundledGrammar {
+  return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf8")) as BundledGrammar;
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function byteOrder(left: string, right: string): number {
+  return Buffer.from(left).compare(Buffer.from(right));
+}

--- a/tests/tooling/support/shiki-vue-oracle.ts
+++ b/tests/tooling/support/shiki-vue-oracle.ts
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -11,7 +10,7 @@ import {
   textmateDependencyVersions,
   textmateModulePath,
 } from "./textmate-deps.ts";
-import { canonicalJson } from "./syntax-evidence.ts";
+import { byteOrder, canonicalJson, sha256 } from "./syntax-evidence.ts";
 import type { TextMateGrammar } from "./vue-textmate.ts";
 
 const packageName = "@shikijs/langs";
@@ -56,7 +55,7 @@ export async function loadPinnedShikiVueOracle(
 ) {
   const modulePath = services.modulePath ?? shikiLanguageModulePath("vue");
   const readFile = services.readFile ?? fs.readFileSync;
-  const manifestPath = findPackageManifest(modulePath, packageName);
+  const manifestPath = findPackageManifest(modulePath, packageName, readFile);
   const manifest = JSON.parse(readFile(manifestPath, "utf8") as string) as {
     license?: string;
     name?: string;
@@ -138,11 +137,11 @@ export async function loadPinnedShikiVueOracle(
   let grammar: TextMateGrammar | null;
   try {
     grammar = registry.loadGrammar(rootScope) as TextMateGrammar | null;
+    assert.ok(grammar, `failed to load pinned oracle grammar ${rootScope}`);
   } catch (error) {
     registry.dispose();
     throw error;
   }
-  assert.ok(grammar, `failed to load pinned oracle grammar ${rootScope}`);
   return {
     getEvidence: (): OracleEvidence => ({
       configuredGrammarSha256: sha256(
@@ -194,12 +193,16 @@ export function validateOraclePin(evidence: {
   );
 }
 
-function findPackageManifest(modulePath: string, expectedName: string): string {
+function findPackageManifest(
+  modulePath: string,
+  expectedName: string,
+  readFile: typeof fs.readFileSync = fs.readFileSync,
+): string {
   let directory = path.dirname(modulePath);
   while (directory !== path.dirname(directory)) {
     const candidate = path.join(directory, "package.json");
     if (fs.existsSync(candidate)) {
-      const manifest = JSON.parse(fs.readFileSync(candidate, "utf8")) as { name?: string };
+      const manifest = JSON.parse(readFile(candidate, "utf8") as string) as { name?: string };
       if (manifest.name === expectedName) return candidate;
     }
     directory = path.dirname(directory);
@@ -275,12 +278,4 @@ function unresolvedSentinelGrammar(scopeName: string): BundledGrammar {
 
 function readJsonGrammar(relativePath: string): BundledGrammar {
   return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf8")) as BundledGrammar;
-}
-
-function sha256(value: string | Buffer): string {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function byteOrder(left: string, right: string): number {
-  return Buffer.from(left).compare(Buffer.from(right));
 }

--- a/tests/tooling/support/syntax-audit-deadline.ts
+++ b/tests/tooling/support/syntax-audit-deadline.ts
@@ -1,0 +1,13 @@
+export function createSyntaxAuditDeadline(
+  environment: NodeJS.ProcessEnv,
+  now: () => number = Date.now,
+): () => void {
+  const name = "SYNTAX_HIGHLIGHTER_ORACLE_TIMEOUT_MS";
+  const timeoutMs = Number(environment[name] ?? "600000");
+  if (!Number.isInteger(timeoutMs) || timeoutMs <= 0) throw new Error(`${name} must be positive`);
+  const startedAt = now();
+  return () => {
+    if (now() - startedAt > timeoutMs)
+      throw new Error(`syntax oracle shard exceeded ${timeoutMs}ms`);
+  };
+}

--- a/tests/tooling/support/syntax-divergence-artifact.ts
+++ b/tests/tooling/support/syntax-divergence-artifact.ts
@@ -6,6 +6,7 @@ import {
   semanticNormalization,
   sha256,
 } from "./syntax-semantic-divergence.ts";
+import { assertNormalizedPath, byteOrder } from "./syntax-evidence.ts";
 import { shikiVueOracleProvenance } from "./shiki-vue-oracle.ts";
 import { textmateDependencyVersions } from "./textmate-deps.ts";
 
@@ -53,17 +54,7 @@ export type DivergenceArtifact = {
 };
 
 export function createDivergenceArtifact(input: DivergenceArtifactInput): DivergenceArtifact {
-  const summary = {
-    documentedDivergenceCount: sum(input.projects, "documentedDivergences"),
-    falseNegativeCount: sum(input.projects, "falseNegatives"),
-    falsePositiveCount: sum(input.projects, "falsePositives"),
-    fileCount: input.projects.reduce((total, project) => total + project.fileCount, 0),
-    projectCount: input.projects.length,
-    semanticSpanCount: input.projects.reduce(
-      (total, project) => total + project.semanticSpanCount,
-      0,
-    ),
-  };
+  const summary = summarize(input.projects);
   const body: Omit<DivergenceArtifact, "sha256"> = {
     schema: "vize.fixtureSyntaxHighlighterDivergence",
     version: 1,
@@ -105,9 +96,13 @@ export function validateDivergenceArtifact(value: unknown): asserts value is Div
   validateShard(artifact.shard);
   validateGrammars(artifact.grammars);
   assertRecord(artifact.ledger, "artifact ledger");
-  assert.deepEqual(Object.keys(artifact.ledger), ["path", "sha256"]);
+  assert.deepEqual(
+    Object.keys(artifact.ledger),
+    ["path", "sha256"],
+    "unexpected artifact ledger fields",
+  );
   assert.match(artifact.ledger?.sha256, /^[0-9a-f]{64}$/);
-  assertNormalizedPath(artifact.ledger?.path);
+  assertNormalizedPath(artifact.ledger?.path, "artifact path");
   assert.ok(Array.isArray(artifact.projects) && artifact.projects.length > 0);
   const projectIds = new Set<string>();
   for (const project of artifact.projects) {
@@ -115,20 +110,11 @@ export function validateDivergenceArtifact(value: unknown): asserts value is Div
     assert.ok(!projectIds.has(project.id), `duplicate artifact project ${project.id}`);
     projectIds.add(project.id);
   }
-  assert.deepEqual(artifact.summary, {
-    documentedDivergenceCount: sum(artifact.projects, "documentedDivergences"),
-    falseNegativeCount: sum(artifact.projects, "falseNegatives"),
-    falsePositiveCount: sum(artifact.projects, "falsePositives"),
-    fileCount: artifact.projects.reduce(
-      (total: number, project: ProjectArtifact) => total + project.fileCount,
-      0,
-    ),
-    projectCount: artifact.projects.length,
-    semanticSpanCount: artifact.projects.reduce(
-      (total: number, project: ProjectArtifact) => total + project.semanticSpanCount,
-      0,
-    ),
-  });
+  assert.deepEqual(
+    artifact.summary,
+    summarize(artifact.projects),
+    "syntax divergence artifact summary mismatch",
+  );
   const { sha256: digest, ...body } = artifact;
   assert.equal(digest, sha256(canonicalJson(body)), "syntax divergence artifact digest mismatch");
 }
@@ -188,6 +174,7 @@ function validateShard(value: unknown): void {
   }
   assert.ok(
     typeof shard.count === "number" && Number.isSafeInteger(shard.count) && shard.count > 0,
+    "artifact shard count must be a positive integer",
   );
   assert.ok(
     typeof shard.index === "number" &&
@@ -262,7 +249,7 @@ function validateRecord(value: unknown, collection: string, projectId: string): 
       "startColumn",
     ].sort(),
   );
-  assertNormalizedPath(record.file);
+  assertNormalizedPath(record.file, "artifact path");
   assert.ok(
     semanticCategories.includes(record.category),
     `unknown artifact semantic category ${String(record.category)}`,
@@ -288,15 +275,15 @@ function sum(projects: ProjectArtifact[], key: keyof ProjectArtifact): number {
   return projects.reduce((total, project) => total + (project[key] as unknown[]).length, 0);
 }
 
-function assertNormalizedPath(value: unknown): void {
-  assert.ok(
-    typeof value === "string" &&
-      value.length > 0 &&
-      !value.startsWith("/") &&
-      !value.includes("\\") &&
-      !value.split("/").some((part) => part === "" || part === "." || part === ".."),
-    `invalid artifact path ${String(value)}`,
-  );
+function summarize(projects: ProjectArtifact[]): DivergenceSummary {
+  return {
+    documentedDivergenceCount: sum(projects, "documentedDivergences"),
+    falseNegativeCount: sum(projects, "falseNegatives"),
+    falsePositiveCount: sum(projects, "falsePositives"),
+    fileCount: projects.reduce((total, project) => total + project.fileCount, 0),
+    projectCount: projects.length,
+    semanticSpanCount: projects.reduce((total, project) => total + project.semanticSpanCount, 0),
+  };
 }
 
 function assertRecord(value: unknown, label: string): void {
@@ -314,8 +301,4 @@ function assertStringSet(value: unknown, label: string): void {
     [...new Set(strings)].sort(byteOrder),
     `${label} must be sorted and unique`,
   );
-}
-
-function byteOrder(left: string, right: string): number {
-  return Buffer.from(left).compare(Buffer.from(right));
 }

--- a/tests/tooling/support/syntax-divergence-artifact.ts
+++ b/tests/tooling/support/syntax-divergence-artifact.ts
@@ -1,0 +1,321 @@
+import assert from "node:assert/strict";
+
+import {
+  canonicalJson,
+  semanticCategories,
+  semanticNormalization,
+  sha256,
+} from "./syntax-semantic-divergence.ts";
+import { shikiVueOracleProvenance } from "./shiki-vue-oracle.ts";
+import { textmateDependencyVersions } from "./textmate-deps.ts";
+
+export type ProjectArtifact = {
+  comparisonSha256: string;
+  documentedDivergences: unknown[];
+  falseNegatives: unknown[];
+  falsePositives: unknown[];
+  fileCount: number;
+  id: string;
+  inputSha256: string;
+  revision: string;
+  semanticSpanCount: number;
+};
+
+type DivergenceArtifactInput = {
+  commitSha: string;
+  grammars: unknown;
+  ledger: { path: string; sha256: string };
+  projects: ProjectArtifact[];
+  shard: { count: number | null; index: number | null };
+};
+
+type DivergenceSummary = {
+  documentedDivergenceCount: number;
+  falseNegativeCount: number;
+  falsePositiveCount: number;
+  fileCount: number;
+  projectCount: number;
+  semanticSpanCount: number;
+};
+
+export type DivergenceArtifact = {
+  commitSha: string;
+  grammars: unknown;
+  ledger: DivergenceArtifactInput["ledger"];
+  mode: "record-only";
+  normalization: typeof semanticNormalization;
+  projects: ProjectArtifact[];
+  schema: "vize.fixtureSyntaxHighlighterDivergence";
+  sha256: string;
+  shard: DivergenceArtifactInput["shard"];
+  summary: DivergenceSummary;
+  version: 1;
+};
+
+export function createDivergenceArtifact(input: DivergenceArtifactInput): DivergenceArtifact {
+  const summary = {
+    documentedDivergenceCount: sum(input.projects, "documentedDivergences"),
+    falseNegativeCount: sum(input.projects, "falseNegatives"),
+    falsePositiveCount: sum(input.projects, "falsePositives"),
+    fileCount: input.projects.reduce((total, project) => total + project.fileCount, 0),
+    projectCount: input.projects.length,
+    semanticSpanCount: input.projects.reduce(
+      (total, project) => total + project.semanticSpanCount,
+      0,
+    ),
+  };
+  const body: Omit<DivergenceArtifact, "sha256"> = {
+    schema: "vize.fixtureSyntaxHighlighterDivergence",
+    version: 1,
+    mode: "record-only",
+    commitSha: input.commitSha,
+    shard: input.shard,
+    normalization: semanticNormalization,
+    grammars: input.grammars,
+    ledger: input.ledger,
+    summary,
+    projects: input.projects,
+  };
+  const artifact: DivergenceArtifact = { ...body, sha256: sha256(canonicalJson(body)) };
+  validateDivergenceArtifact(artifact);
+  return artifact;
+}
+
+export function validateDivergenceArtifact(value: unknown): asserts value is DivergenceArtifact {
+  assert.ok(value != null && typeof value === "object" && !Array.isArray(value));
+  const artifact = value as Record<string, any>;
+  assert.deepEqual(Object.keys(artifact), [
+    "schema",
+    "version",
+    "mode",
+    "commitSha",
+    "shard",
+    "normalization",
+    "grammars",
+    "ledger",
+    "summary",
+    "projects",
+    "sha256",
+  ]);
+  assert.equal(artifact.schema, "vize.fixtureSyntaxHighlighterDivergence");
+  assert.equal(artifact.version, 1);
+  assert.equal(artifact.mode, "record-only");
+  assert.match(artifact.commitSha, /^[0-9a-f]{40}$/);
+  assert.deepEqual(artifact.normalization, semanticNormalization);
+  validateShard(artifact.shard);
+  validateGrammars(artifact.grammars);
+  assertRecord(artifact.ledger, "artifact ledger");
+  assert.deepEqual(Object.keys(artifact.ledger), ["path", "sha256"]);
+  assert.match(artifact.ledger?.sha256, /^[0-9a-f]{64}$/);
+  assertNormalizedPath(artifact.ledger?.path);
+  assert.ok(Array.isArray(artifact.projects) && artifact.projects.length > 0);
+  const projectIds = new Set<string>();
+  for (const project of artifact.projects) {
+    validateProject(project);
+    assert.ok(!projectIds.has(project.id), `duplicate artifact project ${project.id}`);
+    projectIds.add(project.id);
+  }
+  assert.deepEqual(artifact.summary, {
+    documentedDivergenceCount: sum(artifact.projects, "documentedDivergences"),
+    falseNegativeCount: sum(artifact.projects, "falseNegatives"),
+    falsePositiveCount: sum(artifact.projects, "falsePositives"),
+    fileCount: artifact.projects.reduce(
+      (total: number, project: ProjectArtifact) => total + project.fileCount,
+      0,
+    ),
+    projectCount: artifact.projects.length,
+    semanticSpanCount: artifact.projects.reduce(
+      (total: number, project: ProjectArtifact) => total + project.semanticSpanCount,
+      0,
+    ),
+  });
+  const { sha256: digest, ...body } = artifact;
+  assert.equal(digest, sha256(canonicalJson(body)), "syntax divergence artifact digest mismatch");
+}
+
+export function renderDivergenceMarkdown(artifact: DivergenceArtifact): string {
+  const { summary } = artifact;
+  return `${[
+    "## Syntax highlighter semantic divergence",
+    "",
+    `Commit: ${artifact.commitSha}`,
+    `Mode: ${artifact.mode}`,
+    `Projects: ${summary.projectCount}`,
+    `Vue files: ${summary.fileCount}`,
+    `Semantic spans: ${summary.semanticSpanCount}`,
+    `False positives: ${summary.falsePositiveCount}`,
+    `False negatives: ${summary.falseNegativeCount}`,
+    `Documented divergences: ${summary.documentedDivergenceCount}`,
+    `Digest: ${artifact.sha256}`,
+    "",
+  ].join("\n")}`;
+}
+
+function validateProject(project: Record<string, any>): void {
+  assert.deepEqual(Object.keys(project), [
+    "id",
+    "revision",
+    "fileCount",
+    "inputSha256",
+    "semanticSpanCount",
+    "comparisonSha256",
+    "falsePositives",
+    "falseNegatives",
+    "documentedDivergences",
+  ]);
+  assert.match(project.id, /^[a-z0-9][a-z0-9-]*$/);
+  assert.match(project.revision, /^[0-9a-f]{40}$/);
+  assert.match(project.inputSha256, /^[0-9a-f]{64}$/);
+  assert.match(project.comparisonSha256, /^[0-9a-f]{64}$/);
+  assert.ok(Number.isSafeInteger(project.fileCount) && project.fileCount >= 0);
+  assert.ok(Number.isSafeInteger(project.semanticSpanCount) && project.semanticSpanCount >= 0);
+  for (const key of ["falsePositives", "falseNegatives", "documentedDivergences"]) {
+    assert.ok(Array.isArray(project[key]));
+    for (const record of project[key]) {
+      validateRecord(record, key, project.id);
+    }
+  }
+}
+
+function validateShard(value: unknown): void {
+  assertRecord(value, "artifact shard");
+  const shard = value as Record<string, unknown>;
+  assert.deepEqual(Object.keys(shard), ["count", "index"]);
+  if (shard.count === null || shard.index === null) {
+    assert.equal(shard.count, null, "unsharded artifact count must be null");
+    assert.equal(shard.index, null, "unsharded artifact index must be null");
+    return;
+  }
+  assert.ok(
+    typeof shard.count === "number" && Number.isSafeInteger(shard.count) && shard.count > 0,
+  );
+  assert.ok(
+    typeof shard.index === "number" &&
+      Number.isSafeInteger(shard.index) &&
+      shard.index >= 0 &&
+      shard.index < shard.count,
+    "artifact shard index must be within count",
+  );
+}
+
+function validateGrammars(value: unknown): void {
+  assertRecord(value, "artifact grammars");
+  const grammars = value as Record<string, any>;
+  assert.deepEqual(Object.keys(grammars), ["oracle", "vize"]);
+  const oracle = grammars.oracle;
+  assertRecord(oracle, "oracle grammar evidence");
+  assert.deepEqual(Object.keys(oracle), [
+    "configuredGrammarSha256",
+    "dependencyVersions",
+    "grammarClosureSha256",
+    "licenseSha256",
+    "module",
+    "moduleSha256",
+    "package",
+    "requestedScopes",
+    "rootScope",
+    "unresolvedScopeSentinels",
+    "version",
+  ]);
+  assert.match(oracle.configuredGrammarSha256, /^[0-9a-f]{64}$/);
+  assert.deepEqual(oracle.dependencyVersions, textmateDependencyVersions);
+  for (const [key, expected] of Object.entries(shikiVueOracleProvenance)) {
+    assert.equal(oracle[key], expected, `oracle ${key} provenance drifted`);
+  }
+  assert.equal(oracle.rootScope, "text.html.vue");
+  assertStringSet(oracle.requestedScopes, "oracle requested scopes");
+  assert.ok(oracle.requestedScopes.includes(oracle.rootScope));
+  assertStringSet(oracle.unresolvedScopeSentinels, "oracle unresolved scope sentinels");
+  assert.ok(Array.isArray(grammars.vize) && grammars.vize.length >= 1 && grammars.vize.length <= 2);
+  const roots: string[] = [];
+  for (const grammar of grammars.vize) {
+    assertRecord(grammar, "Vize grammar evidence");
+    assert.deepEqual(Object.keys(grammar), [
+      "configuredGrammarSha256",
+      "dependencyVersions",
+      "requestedScopes",
+      "rootScope",
+    ]);
+    assert.match(grammar.configuredGrammarSha256, /^[0-9a-f]{64}$/);
+    assert.deepEqual(grammar.dependencyVersions, textmateDependencyVersions);
+    assertStringSet(grammar.requestedScopes, "Vize requested scopes");
+    assert.ok(grammar.requestedScopes.includes(grammar.rootScope));
+    roots.push(grammar.rootScope);
+  }
+  assert.deepEqual(roots, roots.length === 1 ? ["source.vue"] : ["source.vue", "source.art-vue"]);
+}
+
+function validateRecord(value: unknown, collection: string, projectId: string): void {
+  assert.ok(value != null && typeof value === "object" && !Array.isArray(value));
+  const record = value as Record<string, any>;
+  const documented = collection === "documentedDivergences";
+  assert.deepEqual(
+    Object.keys(record).sort(),
+    [
+      "category",
+      "endColumn",
+      "file",
+      ...(documented ? ["issue"] : []),
+      "kind",
+      "line",
+      ...(documented ? ["project", "reason"] : []),
+      "startColumn",
+    ].sort(),
+  );
+  assertNormalizedPath(record.file);
+  assert.ok(
+    semanticCategories.includes(record.category),
+    `unknown artifact semantic category ${String(record.category)}`,
+  );
+  const expectedKind = collection === "falsePositives" ? "false-positive" : "false-negative";
+  if (!documented) assert.equal(record.kind, expectedKind);
+  else {
+    assert.ok(record.kind === "false-positive" || record.kind === "false-negative");
+    assert.equal(record.project, projectId);
+    assert.ok(Number.isSafeInteger(record.issue) && record.issue > 0);
+    assert.ok(typeof record.reason === "string" && record.reason.trim().length >= 40);
+  }
+  assert.ok(Number.isSafeInteger(record.line) && record.line > 0);
+  assert.ok(
+    Number.isSafeInteger(record.startColumn) &&
+      Number.isSafeInteger(record.endColumn) &&
+      record.startColumn > 0 &&
+      record.endColumn > record.startColumn,
+  );
+}
+
+function sum(projects: ProjectArtifact[], key: keyof ProjectArtifact): number {
+  return projects.reduce((total, project) => total + (project[key] as unknown[]).length, 0);
+}
+
+function assertNormalizedPath(value: unknown): void {
+  assert.ok(
+    typeof value === "string" &&
+      value.length > 0 &&
+      !value.startsWith("/") &&
+      !value.includes("\\") &&
+      !value.split("/").some((part) => part === "" || part === "." || part === ".."),
+    `invalid artifact path ${String(value)}`,
+  );
+}
+
+function assertRecord(value: unknown, label: string): void {
+  assert.ok(value != null && typeof value === "object" && !Array.isArray(value), label);
+}
+
+function assertStringSet(value: unknown, label: string): void {
+  assert.ok(
+    Array.isArray(value) && value.every((item) => typeof item === "string" && item.length > 0),
+    label,
+  );
+  const strings = value as string[];
+  assert.deepEqual(
+    strings,
+    [...new Set(strings)].sort(byteOrder),
+    `${label} must be sorted and unique`,
+  );
+}
+
+function byteOrder(left: string, right: string): number {
+  return Buffer.from(left).compare(Buffer.from(right));
+}

--- a/tests/tooling/support/syntax-evidence.ts
+++ b/tests/tooling/support/syntax-evidence.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 
 export function canonicalJson(value: unknown): string {
@@ -5,14 +6,32 @@ export function canonicalJson(value: unknown): string {
   if (value != null && typeof value === "object") {
     return `{${Object.keys(value)
       .sort()
+      .filter((key) => (value as Record<string, unknown>)[key] !== undefined)
       .map(
         (key) => `${JSON.stringify(key)}:${canonicalJson((value as Record<string, unknown>)[key])}`,
       )
       .join(",")}}`;
   }
-  return JSON.stringify(value);
+  const serialized = JSON.stringify(value);
+  if (serialized === undefined) throw new TypeError("value is not JSON-serializable");
+  return serialized;
 }
 
 export function sha256(value: string | Buffer): string {
   return createHash("sha256").update(value).digest("hex");
+}
+
+export function byteOrder(left: string, right: string): number {
+  return Buffer.from(left).compare(Buffer.from(right));
+}
+
+export function assertNormalizedPath(value: unknown, label = "path"): asserts value is string {
+  assert.ok(
+    typeof value === "string" &&
+      value.length > 0 &&
+      !value.startsWith("/") &&
+      !value.includes("\\") &&
+      !value.split("/").some((part) => part === "" || part === "." || part === ".."),
+    `invalid ${label} ${String(value)}`,
+  );
 }

--- a/tests/tooling/support/syntax-evidence.ts
+++ b/tests/tooling/support/syntax-evidence.ts
@@ -1,0 +1,18 @@
+import { createHash } from "node:crypto";
+
+export function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value != null && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map(
+        (key) => `${JSON.stringify(key)}:${canonicalJson((value as Record<string, unknown>)[key])}`,
+      )
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}

--- a/tests/tooling/support/syntax-semantic-comparison.ts
+++ b/tests/tooling/support/syntax-semantic-comparison.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-import { canonicalJson, sha256 } from "./syntax-evidence.ts";
+import { assertNormalizedPath, canonicalJson, sha256 } from "./syntax-evidence.ts";
 import { semanticCategories, type SemanticSpan } from "./syntax-semantic-divergence.ts";
 
 export type DivergenceRecord = {
@@ -27,10 +27,12 @@ export function compareSemanticSpans(
   const shared: Array<Omit<DivergenceRecord, "kind">> = [];
   const falsePositives: DivergenceRecord[] = [];
   const falseNegatives: DivergenceRecord[] = [];
+  const vizeByLine = groupByLine(vize);
+  const oracleByLine = groupByLine(oracle);
   for (const [lineIndex, line] of source.split("\n").entries()) {
     const lineNumber = lineIndex + 1;
-    const left = vize.filter((span) => span.line === lineNumber);
-    const right = oracle.filter((span) => span.line === lineNumber);
+    const left = vizeByLine.get(lineNumber) ?? [];
+    const right = oracleByLine.get(lineNumber) ?? [];
     const boundaries = new Set([1, line.length + 1]);
     for (const span of [...left, ...right]) {
       boundaries.add(span.startColumn);
@@ -99,8 +101,12 @@ export function validateLedger(
 ): DocumentedDivergence[] {
   assert.ok(value != null && typeof value === "object" && !Array.isArray(value));
   const ledger = value as { entries?: unknown; schema?: unknown; version?: unknown };
-  assert.equal(ledger.schema, "vize.fixtureSyntaxDivergenceLedger");
-  assert.equal(ledger.version, 1);
+  assert.equal(
+    ledger.schema,
+    "vize.fixtureSyntaxDivergenceLedger",
+    "unexpected syntax divergence ledger schema",
+  );
+  assert.equal(ledger.version, 1, "unexpected syntax divergence ledger version");
   const entries = ledger.entries;
   assert.ok(Array.isArray(entries), "syntax divergence ledger entries must be an array");
   const identities = new Set<string>();
@@ -123,7 +129,7 @@ export function validateLedger(
       knownProjectIds == null || knownProjectIds.has(entry.project),
       `unknown syntax divergence ledger project ${entry.project}`,
     );
-    assertNormalizedPath(entry.file);
+    assertNormalizedPath(entry.file, "ledger path");
     assert.ok(semanticCategories.includes(entry.category as (typeof semanticCategories)[number]));
     assert.ok(entry.kind === "false-positive" || entry.kind === "false-negative");
     for (const field of ["line", "startColumn", "endColumn"] as const) {
@@ -165,6 +171,16 @@ function categoriesAt(spans: SemanticSpan[], column: number): string[] {
   );
 }
 
+function groupByLine(spans: SemanticSpan[]): Map<number, SemanticSpan[]> {
+  const byLine = new Map<number, SemanticSpan[]>();
+  for (const span of spans) {
+    const bucket = byLine.get(span.line);
+    if (bucket == null) byLine.set(span.line, [span]);
+    else bucket.push(span);
+  }
+  return byLine;
+}
+
 function difference(left: string[], right: string[]): string[] {
   const excluded = new Set(right);
   return left.filter((category) => !excluded.has(category));
@@ -184,15 +200,4 @@ function recordIdentity(record: Omit<DivergenceRecord, "kind"> & { kind?: string
     record.endColumn,
     record.category,
   ].join(":");
-}
-
-function assertNormalizedPath(value: string): void {
-  assert.equal(typeof value, "string");
-  assert.ok(
-    value.length > 0 &&
-      !value.startsWith("/") &&
-      !value.includes("\\") &&
-      !value.split("/").some((part) => part === "" || part === "." || part === ".."),
-    `invalid ledger path ${value}`,
-  );
 }

--- a/tests/tooling/support/syntax-semantic-comparison.ts
+++ b/tests/tooling/support/syntax-semantic-comparison.ts
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+
+import { canonicalJson, sha256 } from "./syntax-evidence.ts";
+import { semanticCategories, type SemanticSpan } from "./syntax-semantic-divergence.ts";
+
+export type DivergenceRecord = {
+  category: string;
+  endColumn: number;
+  file: string;
+  kind: "false-negative" | "false-positive";
+  line: number;
+  startColumn: number;
+};
+
+export type DocumentedDivergence = DivergenceRecord & {
+  issue: number;
+  project: string;
+  reason: string;
+};
+
+export function compareSemanticSpans(
+  file: string,
+  source: string,
+  vize: SemanticSpan[],
+  oracle: SemanticSpan[],
+) {
+  const shared: Array<Omit<DivergenceRecord, "kind">> = [];
+  const falsePositives: DivergenceRecord[] = [];
+  const falseNegatives: DivergenceRecord[] = [];
+  for (const [lineIndex, line] of source.split("\n").entries()) {
+    const lineNumber = lineIndex + 1;
+    const left = vize.filter((span) => span.line === lineNumber);
+    const right = oracle.filter((span) => span.line === lineNumber);
+    const boundaries = new Set([1, line.length + 1]);
+    for (const span of [...left, ...right]) {
+      boundaries.add(span.startColumn);
+      boundaries.add(span.endColumn);
+    }
+    const ordered = [...boundaries].sort((a, b) => a - b);
+    for (let index = 0; index + 1 < ordered.length; index += 1) {
+      const startColumn = ordered[index];
+      const endColumn = ordered[index + 1];
+      if (startColumn === endColumn) continue;
+      const leftCategories = categoriesAt(left, startColumn);
+      const rightCategories = categoriesAt(right, startColumn);
+      for (const category of intersection(leftCategories, rightCategories)) {
+        appendRecord(shared, { category, file, line: lineNumber, startColumn, endColumn });
+      }
+      for (const category of difference(leftCategories, rightCategories)) {
+        appendRecord(falsePositives, {
+          category,
+          file,
+          kind: "false-positive",
+          line: lineNumber,
+          startColumn,
+          endColumn,
+        });
+      }
+      for (const category of difference(rightCategories, leftCategories)) {
+        appendRecord(falseNegatives, {
+          category,
+          file,
+          kind: "false-negative",
+          line: lineNumber,
+          startColumn,
+          endColumn,
+        });
+      }
+    }
+  }
+  const classified = { shared, falsePositives, falseNegatives };
+  return { ...classified, sha256: sha256(canonicalJson(classified)) };
+}
+
+export function applyDocumentedDivergences(
+  project: string,
+  comparison: ReturnType<typeof compareSemanticSpans>,
+  ledger: unknown,
+) {
+  const entries = validateLedger(ledger).filter((entry) => entry.project === project);
+  const falsePositives = [...comparison.falsePositives];
+  const falseNegatives = [...comparison.falseNegatives];
+  const documented: DocumentedDivergence[] = [];
+  for (const entry of entries) {
+    const records = entry.kind === "false-positive" ? falsePositives : falseNegatives;
+    const index = records.findIndex((record) => recordIdentity(record) === recordIdentity(entry));
+    if (index < 0) {
+      throw new Error(`stale syntax divergence ledger entry: ${recordIdentity(entry)}`);
+    }
+    records.splice(index, 1);
+    documented.push(entry);
+  }
+  return { falseNegatives, falsePositives, documented };
+}
+
+export function validateLedger(
+  value: unknown,
+  knownProjectIds?: ReadonlySet<string>,
+): DocumentedDivergence[] {
+  assert.ok(value != null && typeof value === "object" && !Array.isArray(value));
+  const ledger = value as { entries?: unknown; schema?: unknown; version?: unknown };
+  assert.equal(ledger.schema, "vize.fixtureSyntaxDivergenceLedger");
+  assert.equal(ledger.version, 1);
+  const entries = ledger.entries;
+  assert.ok(Array.isArray(entries), "syntax divergence ledger entries must be an array");
+  const identities = new Set<string>();
+  return entries.map((raw, index) => {
+    assert.ok(raw != null && typeof raw === "object" && !Array.isArray(raw));
+    const entry = raw as DocumentedDivergence;
+    assert.deepEqual(Object.keys(entry).sort(), [
+      "category",
+      "endColumn",
+      "file",
+      "issue",
+      "kind",
+      "line",
+      "project",
+      "reason",
+      "startColumn",
+    ]);
+    assert.match(entry.project, /^[a-z0-9][a-z0-9-]*$/);
+    assert.ok(
+      knownProjectIds == null || knownProjectIds.has(entry.project),
+      `unknown syntax divergence ledger project ${entry.project}`,
+    );
+    assertNormalizedPath(entry.file);
+    assert.ok(semanticCategories.includes(entry.category as (typeof semanticCategories)[number]));
+    assert.ok(entry.kind === "false-positive" || entry.kind === "false-negative");
+    for (const field of ["line", "startColumn", "endColumn"] as const) {
+      assert.ok(Number.isSafeInteger(entry[field]) && entry[field] > 0, `ledger ${index}.${field}`);
+    }
+    assert.ok(entry.endColumn > entry.startColumn, `ledger ${index} has empty range`);
+    assert.ok(Number.isSafeInteger(entry.issue) && entry.issue > 0, `ledger ${index}.issue`);
+    assert.ok(entry.reason.replace(/\s+/g, " ").trim().length >= 40, `ledger ${index}.reason`);
+    const identity = `${entry.project}\0${recordIdentity(entry)}`;
+    assert.ok(!identities.has(identity), `duplicate syntax divergence ledger entry ${identity}`);
+    identities.add(identity);
+    return { ...entry, reason: entry.reason.replace(/\s+/g, " ").trim() };
+  });
+}
+
+function appendRecord<
+  T extends {
+    category: string;
+    endColumn: number;
+    file: string;
+    line: number;
+    startColumn: number;
+  },
+>(records: T[], record: T): void {
+  const previous = records.at(-1);
+  if (
+    previous?.file === record.file &&
+    previous.line === record.line &&
+    previous.endColumn === record.startColumn &&
+    previous.category === record.category
+  ) {
+    previous.endColumn = record.endColumn;
+  } else records.push(record);
+}
+
+function categoriesAt(spans: SemanticSpan[], column: number): string[] {
+  return (
+    spans.find((span) => span.startColumn <= column && column < span.endColumn)?.categories ?? []
+  );
+}
+
+function difference(left: string[], right: string[]): string[] {
+  const excluded = new Set(right);
+  return left.filter((category) => !excluded.has(category));
+}
+
+function intersection(left: string[], right: string[]): string[] {
+  const included = new Set(right);
+  return left.filter((category) => included.has(category));
+}
+
+function recordIdentity(record: Omit<DivergenceRecord, "kind"> & { kind?: string }): string {
+  return [
+    record.kind,
+    record.file,
+    record.line,
+    record.startColumn,
+    record.endColumn,
+    record.category,
+  ].join(":");
+}
+
+function assertNormalizedPath(value: string): void {
+  assert.equal(typeof value, "string");
+  assert.ok(
+    value.length > 0 &&
+      !value.startsWith("/") &&
+      !value.includes("\\") &&
+      !value.split("/").some((part) => part === "" || part === "." || part === ".."),
+    `invalid ledger path ${value}`,
+  );
+}

--- a/tests/tooling/support/syntax-semantic-divergence.ts
+++ b/tests/tooling/support/syntax-semantic-divergence.ts
@@ -8,12 +8,18 @@ export { canonicalJson, sha256 } from "./syntax-evidence.ts";
 
 export const semanticLineTimeoutMs = 1_000;
 
-export const semanticCategories = ["attribute", "comment", "invalid", "tag"] as const;
+export const semanticCategories = Object.freeze([
+  "attribute",
+  "comment",
+  "invalid",
+  "tag",
+] as const);
 
-export const semanticNormalization = {
+export const semanticNormalization = Object.freeze({
   version: 1,
   categories: semanticCategories,
-  omittedCategories: [
+  coordinates: "1-based UTF-16 columns with an exclusive end",
+  omittedCategories: Object.freeze([
     "function",
     "keyword",
     "label",
@@ -24,8 +30,8 @@ export const semanticNormalization = {
     "string",
     "type",
     "variable",
-  ],
-  ignoredScopeFamilies: [
+  ]),
+  ignoredScopeFamilies: Object.freeze([
     "case-clause",
     "cast",
     "expression",
@@ -42,10 +48,10 @@ export const semanticNormalization = {
     "switch-statement",
     "text",
     "vue",
-  ],
+  ]),
   rationale:
     "Compare Vue shell roles. Shiki 4.0.2 leaves interpolations unscoped and treats many directives as HTML attributes, so directive names normalize to attributes while embedded-language and string scopes are omitted.",
-};
+});
 
 export type SemanticSpan = {
   categories: string[];
@@ -151,7 +157,10 @@ function semanticCategory(scope: string): string | null {
   if (scope.startsWith("keyword") || scope.startsWith("storage")) return "keyword";
   if (scope.startsWith("entity.name.tag")) return "tag";
   if (scope.startsWith("entity.name.label")) return "label";
+  if (scope.startsWith("entity.name.section")) return "label";
+  if (scope.startsWith("entity.name.constant")) return "literal";
   if (scope.startsWith("entity.other.keyframe-offset")) return "literal";
+  if (scope.startsWith("entity.other.counter-name")) return "literal";
   if (scope.startsWith("entity.other.attribute-name")) return "attribute";
   if (scope.startsWith("entity.name.function") || scope.startsWith("support.function")) {
     return "function";
@@ -168,6 +177,7 @@ function semanticCategory(scope: string): string | null {
   ) {
     return "property";
   }
+  if (scope.startsWith("support.other.variable")) return "variable";
   if (scope.startsWith("variable") || scope.startsWith("support.variable")) return "variable";
   if (scope.startsWith("invalid")) return "invalid";
   return null;

--- a/tests/tooling/support/syntax-semantic-divergence.ts
+++ b/tests/tooling/support/syntax-semantic-divergence.ts
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+
+import { canonicalJson } from "./syntax-evidence.ts";
+import type { TextMateGrammar } from "./vue-textmate.ts";
+
+export { canonicalJson, sha256 } from "./syntax-evidence.ts";
+
+export const semanticLineTimeoutMs = 1_000;
+
+export const semanticCategories = ["attribute", "comment", "invalid", "tag"] as const;
+
+export const semanticNormalization = {
+  version: 1,
+  categories: semanticCategories,
+  omittedCategories: [
+    "function",
+    "keyword",
+    "label",
+    "literal",
+    "number",
+    "operator",
+    "property",
+    "string",
+    "type",
+    "variable",
+  ],
+  ignoredScopeFamilies: [
+    "case-clause",
+    "cast",
+    "expression",
+    "fenced_code",
+    "heading",
+    "markup",
+    "meta",
+    "new",
+    "punctuation",
+    "self-closing-tag",
+    "source",
+    "switch-block",
+    "switch-expression",
+    "switch-statement",
+    "text",
+    "vue",
+  ],
+  rationale:
+    "Compare Vue shell roles. Shiki 4.0.2 leaves interpolations unscoped and treats many directives as HTML attributes, so directive names normalize to attributes while embedded-language and string scopes are omitted.",
+};
+
+export type SemanticSpan = {
+  categories: string[];
+  endColumn: number;
+  line: number;
+  startColumn: number;
+};
+
+export function tokenizeSemanticSource(
+  grammar: TextMateGrammar,
+  source: string,
+  rootScope: string,
+  label: string,
+  checkDeadline: () => void = () => {},
+): { lineCount: number; semanticSpans: SemanticSpan[]; tokenCount: number; tokenSha256: string } {
+  const lines = source.split("\n");
+  const semanticSpans: SemanticSpan[] = [];
+  const tokenDigest = createHash("sha256");
+  let ruleStack: unknown = null;
+  let tokenCount = 0;
+  let nonRootTokenCount = 0;
+
+  for (const [lineIndex, line] of lines.entries()) {
+    checkDeadline();
+    const result = grammar.tokenizeLine(line, ruleStack, semanticLineTimeoutMs);
+    checkDeadline();
+    if (result.stoppedEarly) {
+      throw new Error(`${label}:${lineIndex + 1}: exceeded ${semanticLineTimeoutMs}ms`);
+    }
+    if (result.tokens.length === 0) throw new Error(`${label}:${lineIndex + 1}: no tokens`);
+    let end = 0;
+    for (const [tokenIndex, token] of result.tokens.entries()) {
+      validateToken(token, end, line.length, rootScope, `${label}:${lineIndex + 1}:${tokenIndex}`);
+      const categories = normalizeScopes(token.scopes, `${label}:${lineIndex + 1}:${tokenIndex}`);
+      const authoredEnd = Math.min(token.endIndex, line.length);
+      if (authoredEnd > token.startIndex) {
+        appendSpan(semanticSpans, {
+          categories,
+          line: lineIndex + 1,
+          startColumn: token.startIndex + 1,
+          endColumn: authoredEnd + 1,
+        });
+      }
+      if (token.scopes.some((scope) => scope !== rootScope)) nonRootTokenCount += 1;
+      tokenDigest.update(
+        `${JSON.stringify([lineIndex, token.startIndex, token.endIndex, token.scopes])}\n`,
+      );
+      end = token.endIndex;
+      tokenCount += 1;
+    }
+    if (end !== line.length && end !== line.length + 1) {
+      throw new Error(`${label}:${lineIndex + 1}: stopped at ${end}/${line.length}`);
+    }
+    ruleStack = result.ruleStack;
+    checkDeadline();
+  }
+  if (source.trim().length > 0 && nonRootTokenCount === 0) {
+    throw new Error(`${label}: non-empty source produced only the root scope`);
+  }
+  return {
+    lineCount: lines.length,
+    semanticSpans,
+    tokenCount,
+    tokenSha256: tokenDigest.digest("hex"),
+  };
+}
+
+function normalizeScopes(scopes: string[], label: string): string[] {
+  assert.ok(Array.isArray(scopes) && scopes.length > 0, `${label}: missing scopes`);
+  const categories = new Set<string>();
+  for (const scope of scopes) {
+    assert.equal(typeof scope, "string", `${label}: scope must be a string`);
+    if (scope.includes("invalid.unresolved-oracle-grammar")) {
+      throw new Error(`${label}: activated unresolved oracle grammar ${scope}`);
+    }
+    if (/^punctuation\.(?:definition\.directive|attribute-shorthand\.[^.]+)\..*vue$/.test(scope)) {
+      categories.add("attribute");
+      continue;
+    }
+    const topLevel = scope.split(".", 1)[0];
+    if (semanticNormalization.ignoredScopeFamilies.includes(topLevel)) continue;
+    const category = semanticCategory(scope);
+    if (category == null) throw new Error(`${label}: unknown semantic scope ${scope}`);
+    if (semanticCategories.includes(category as (typeof semanticCategories)[number])) {
+      categories.add(category);
+    } else {
+      assert.ok(
+        semanticNormalization.omittedCategories.includes(category),
+        `${label}: ${category}`,
+      );
+    }
+  }
+  return [...categories].sort();
+}
+
+function semanticCategory(scope: string): string | null {
+  if (scope.startsWith("comment")) return "comment";
+  if (scope.startsWith("string")) return "string";
+  if (scope.startsWith("constant.numeric")) return "number";
+  if (scope.startsWith("constant") || scope.startsWith("support.constant")) return "literal";
+  if (scope.startsWith("keyword.operator")) return "operator";
+  if (scope.startsWith("keyword") && scope.endsWith(".vue")) return "attribute";
+  if (scope.startsWith("keyword") || scope.startsWith("storage")) return "keyword";
+  if (scope.startsWith("entity.name.tag")) return "tag";
+  if (scope.startsWith("entity.name.label")) return "label";
+  if (scope.startsWith("entity.other.keyframe-offset")) return "literal";
+  if (scope.startsWith("entity.other.attribute-name")) return "attribute";
+  if (scope.startsWith("entity.name.function") || scope.startsWith("support.function")) {
+    return "function";
+  }
+  if (
+    /^(?:entity\.name\.(?:class|enum|interface|struct|type)|support\.(?:class|type))/.test(scope)
+  ) {
+    return "type";
+  }
+  if (scope.startsWith("entity.other.inherited-class")) return "type";
+  if (
+    scope.startsWith("variable.other.property") ||
+    scope.startsWith("support.variable.property")
+  ) {
+    return "property";
+  }
+  if (scope.startsWith("variable") || scope.startsWith("support.variable")) return "variable";
+  if (scope.startsWith("invalid")) return "invalid";
+  return null;
+}
+
+function validateToken(
+  token: { endIndex: number; scopes: string[]; startIndex: number },
+  expectedStart: number,
+  lineLength: number,
+  rootScope: string,
+  label: string,
+): void {
+  assert.ok(Number.isSafeInteger(token.startIndex) && Number.isSafeInteger(token.endIndex));
+  assert.ok(token.startIndex === expectedStart && token.endIndex > token.startIndex, label);
+  assert.ok(token.endIndex <= lineLength + 1, `${label}: token exceeds line`);
+  assert.equal(token.scopes[0], rootScope, `${label}: lost root scope ${rootScope}`);
+}
+
+function appendSpan(records: SemanticSpan[], record: SemanticSpan): void {
+  const previous = records.at(-1);
+  if (
+    previous?.line === record.line &&
+    previous.endColumn === record.startColumn &&
+    canonicalJson(previous.categories) === canonicalJson(record.categories)
+  ) {
+    previous.endColumn = record.endColumn;
+  } else records.push(record);
+}

--- a/tests/tooling/syntax-divergence-artifact.test.ts
+++ b/tests/tooling/syntax-divergence-artifact.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import { shikiVueOracleProvenance } from "./support/shiki-vue-oracle.ts";
 import {
   createDivergenceArtifact,
+  renderDivergenceMarkdown,
   validateDivergenceArtifact,
 } from "./support/syntax-divergence-artifact.ts";
 import { textmateDependencyVersions } from "./support/textmate-deps.ts";
@@ -18,7 +19,7 @@ test("divergence artifacts are deterministic and reject malformed records", () =
   malformed.summary.fileCount = 2;
   assert.throws(
     () => validateDivergenceArtifact(malformed),
-    /Expected values to be strictly deep-equal/,
+    /syntax divergence artifact summary mismatch/,
   );
   const malformedRecord = structuredClone(first);
   malformedRecord.projects[0].falsePositives = [
@@ -37,23 +38,57 @@ test("divergence artifacts are deterministic and reject malformed records", () =
   );
 });
 
+test("divergence markdown reports the summary and digest", () => {
+  const artifact = createDivergenceArtifact(validInput());
+  const markdown = renderDivergenceMarkdown(artifact);
+  assert.match(markdown, new RegExp(`Commit: ${artifact.commitSha}`));
+  assert.match(markdown, /Projects: 1/);
+  assert.match(markdown, /Vue files: 1/);
+  assert.match(markdown, new RegExp(`Digest: ${artifact.sha256}`));
+});
+
 test("divergence artifacts reject malformed provenance and topology", () => {
   const input = validInput();
-  for (const invalid of [
-    { ...input, grammars: null },
-    { ...input, shard: { count: null, index: 0 } },
-    { ...input, shard: { count: -1, index: 999 } },
-    { ...input, projects: [...input.projects, structuredClone(input.projects[0])] },
-    { ...input, ledger: { ...input.ledger, unexpected: true } },
+  const cases = [
     {
-      ...input,
-      grammars: {
-        ...input.grammars,
-        oracle: { ...input.grammars.oracle, grammarClosureSha256: "0".repeat(64) },
-      },
+      label: "missing grammars",
+      value: { ...input, grammars: null },
+      expected: /artifact grammars/,
     },
-  ]) {
-    assert.throws(() => createDivergenceArtifact(invalid));
+    {
+      label: "half-null shard",
+      value: { ...input, shard: { count: null, index: 0 } },
+      expected: /unsharded artifact index must be null/,
+    },
+    {
+      label: "negative shard count",
+      value: { ...input, shard: { count: -1, index: 999 } },
+      expected: /artifact shard count must be a positive integer/,
+    },
+    {
+      label: "duplicate project",
+      value: { ...input, projects: [...input.projects, structuredClone(input.projects[0])] },
+      expected: /duplicate artifact project fixture/,
+    },
+    {
+      label: "unexpected ledger field",
+      value: { ...input, ledger: { ...input.ledger, unexpected: true } },
+      expected: /unexpected artifact ledger fields/,
+    },
+    {
+      label: "oracle provenance drift",
+      value: {
+        ...input,
+        grammars: {
+          ...input.grammars,
+          oracle: { ...input.grammars.oracle, grammarClosureSha256: "0".repeat(64) },
+        },
+      },
+      expected: /oracle grammarClosureSha256 provenance drifted/,
+    },
+  ];
+  for (const { label, value, expected } of cases) {
+    assert.throws(() => createDivergenceArtifact(value), expected, label);
   }
 });
 

--- a/tests/tooling/syntax-divergence-artifact.test.ts
+++ b/tests/tooling/syntax-divergence-artifact.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { shikiVueOracleProvenance } from "./support/shiki-vue-oracle.ts";
+import {
+  createDivergenceArtifact,
+  validateDivergenceArtifact,
+} from "./support/syntax-divergence-artifact.ts";
+import { textmateDependencyVersions } from "./support/textmate-deps.ts";
+
+test("divergence artifacts are deterministic and reject malformed records", () => {
+  const input = validInput();
+  const first = createDivergenceArtifact(input);
+  const second = createDivergenceArtifact(input);
+  assert.deepEqual(first, second);
+
+  const malformed = structuredClone(first);
+  malformed.summary.fileCount = 2;
+  assert.throws(
+    () => validateDivergenceArtifact(malformed),
+    /Expected values to be strictly deep-equal/,
+  );
+  const malformedRecord = structuredClone(first);
+  malformedRecord.projects[0].falsePositives = [
+    {
+      category: "mystery",
+      endColumn: 2,
+      file: "src/App.vue",
+      kind: "false-positive",
+      line: 1,
+      startColumn: 1,
+    },
+  ];
+  assert.throws(
+    () => validateDivergenceArtifact(malformedRecord),
+    /unknown artifact semantic category mystery/,
+  );
+});
+
+test("divergence artifacts reject malformed provenance and topology", () => {
+  const input = validInput();
+  for (const invalid of [
+    { ...input, grammars: null },
+    { ...input, shard: { count: null, index: 0 } },
+    { ...input, shard: { count: -1, index: 999 } },
+    { ...input, projects: [...input.projects, structuredClone(input.projects[0])] },
+    { ...input, ledger: { ...input.ledger, unexpected: true } },
+    {
+      ...input,
+      grammars: {
+        ...input.grammars,
+        oracle: { ...input.grammars.oracle, grammarClosureSha256: "0".repeat(64) },
+      },
+    },
+  ]) {
+    assert.throws(() => createDivergenceArtifact(invalid));
+  }
+});
+
+function validInput() {
+  return {
+    commitSha: "a".repeat(40),
+    grammars: grammarEvidence(),
+    ledger: {
+      path: "tests/_fixtures/syntax-highlighter-documented-divergences.json",
+      sha256: "b".repeat(64),
+    },
+    projects: [
+      {
+        id: "fixture",
+        revision: "c".repeat(40),
+        fileCount: 1,
+        inputSha256: "d".repeat(64),
+        semanticSpanCount: 3,
+        comparisonSha256: "e".repeat(64),
+        falsePositives: [],
+        falseNegatives: [],
+        documentedDivergences: [],
+      },
+    ],
+    shard: { count: 11, index: 1 },
+  };
+}
+
+function grammarEvidence() {
+  const provenance = shikiVueOracleProvenance;
+  return {
+    oracle: {
+      configuredGrammarSha256: "f".repeat(64),
+      dependencyVersions: textmateDependencyVersions,
+      grammarClosureSha256: provenance.grammarClosureSha256,
+      licenseSha256: provenance.licenseSha256,
+      module: provenance.module,
+      moduleSha256: provenance.moduleSha256,
+      package: provenance.package,
+      requestedScopes: ["text.html.vue"],
+      rootScope: "text.html.vue",
+      unresolvedScopeSentinels: [],
+      version: provenance.version,
+    },
+    vize: [
+      {
+        configuredGrammarSha256: "1".repeat(64),
+        dependencyVersions: textmateDependencyVersions,
+        requestedScopes: ["source.vue"],
+        rootScope: "source.vue",
+      },
+    ],
+  };
+}

--- a/tests/tooling/syntax-highlighter-divergence.test.ts
+++ b/tests/tooling/syntax-highlighter-divergence.test.ts
@@ -1,0 +1,259 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  applyDocumentedDivergences,
+  compareSemanticSpans,
+  validateLedger,
+} from "./support/syntax-semantic-comparison.ts";
+import {
+  semanticNormalization,
+  tokenizeSemanticSource,
+  type SemanticSpan,
+} from "./support/syntax-semantic-divergence.ts";
+import { createSyntaxAuditDeadline } from "./support/syntax-audit-deadline.ts";
+
+const shared: SemanticSpan = {
+  categories: ["tag"],
+  line: 1,
+  startColumn: 1,
+  endColumn: 4,
+};
+const vizeOnly: SemanticSpan = {
+  categories: ["comment"],
+  line: 1,
+  startColumn: 5,
+  endColumn: 8,
+};
+const oracleOnly: SemanticSpan = {
+  categories: ["invalid"],
+  line: 1,
+  startColumn: 5,
+  endColumn: 8,
+};
+
+test("semantic comparison records exact shared, false-positive, and false-negative spans", () => {
+  const comparison = compareSemanticSpans(
+    "src/App.vue",
+    "abc def",
+    [shared, vizeOnly],
+    [shared, oracleOnly],
+  );
+  assert.deepEqual(comparison.shared, [
+    {
+      category: "tag",
+      file: "src/App.vue",
+      line: 1,
+      startColumn: 1,
+      endColumn: 4,
+    },
+  ]);
+  assert.deepEqual(comparison.falsePositives, [
+    {
+      category: "comment",
+      file: "src/App.vue",
+      kind: "false-positive",
+      line: 1,
+      startColumn: 5,
+      endColumn: 8,
+    },
+  ]);
+  assert.deepEqual(comparison.falseNegatives, [
+    {
+      category: "invalid",
+      file: "src/App.vue",
+      kind: "false-negative",
+      line: 1,
+      startColumn: 5,
+      endColumn: 8,
+    },
+  ]);
+  assert.match(comparison.sha256, /^[0-9a-f]{64}$/);
+  assert.equal(
+    compareSemanticSpans("src/App.vue", "abc def", [shared, vizeOnly], [shared, oracleOnly]).sha256,
+    comparison.sha256,
+  );
+});
+
+test("normalization ignores structural nesting but detects changed semantic scopes", () => {
+  const structuralA = tokenizeSemanticSource(
+    grammar(["source.vue", "meta.tag.vue", "punctuation.definition.tag.vue"]),
+    "x",
+    "source.vue",
+    "structural-a.vue",
+  );
+  const structuralB = tokenizeSemanticSource(
+    grammar(["text.html.vue", "text.html.derivative", "meta.element.vue"]),
+    "x",
+    "text.html.vue",
+    "structural-b.vue",
+  );
+  assert.deepEqual(structuralA.semanticSpans, structuralB.semanticSpans);
+  assert.match(semanticNormalization.rationale, /directives as HTML attributes/);
+
+  const tag = tokenizeSemanticSource(
+    grammar(["source.vue", "entity.name.tag.html.vue"]),
+    "x",
+    "source.vue",
+    "tag.vue",
+  );
+  const attribute = tokenizeSemanticSource(
+    grammar(["text.html.vue", "entity.other.attribute-name.html.vue"]),
+    "x",
+    "text.html.vue",
+    "attribute.vue",
+  );
+  const changed = compareSemanticSpans(
+    "src/Changed.vue",
+    "x",
+    tag.semanticSpans,
+    attribute.semanticSpans,
+  );
+  assert.equal(changed.falsePositives[0].category, "tag");
+  assert.equal(changed.falseNegatives[0].category, "attribute");
+
+  const knownTextMateScopes = tokenizeSemanticSource(
+    grammar([
+      "source.vue",
+      "new.expr.ts",
+      "entity.other.inherited-class.ts",
+      "support.constant.property-value.css",
+      "support.variable.property.ts",
+      "entity.name.label.ts",
+      "entity.other.keyframe-offset.percentage.css",
+    ]),
+    "x",
+    "source.vue",
+    "known-textmate-scopes.vue",
+  );
+  assert.deepEqual(knownTextMateScopes.semanticSpans[0].categories, []);
+
+  const vueShell = tokenizeSemanticSource(
+    grammar([
+      "source.vue",
+      "punctuation.attribute-shorthand.bind.html.vue",
+      "keyword.control.conditional.vue",
+    ]),
+    "x",
+    "source.vue",
+    "vue-shell.vue",
+  );
+  assert.deepEqual(vueShell.semanticSpans[0].categories, ["attribute"]);
+});
+
+test("semantic tokenizer fails closed on unknown scopes, malformed spans, and timeouts", () => {
+  assert.throws(
+    () =>
+      tokenizeSemanticSource(
+        grammar(["source.vue", "mystery.semantic.vue"]),
+        "x",
+        "source.vue",
+        "unknown.vue",
+      ),
+    /unknown semantic scope mystery\.semantic\.vue/,
+  );
+  assert.throws(
+    () =>
+      tokenizeSemanticSource(
+        {
+          tokenizeLine() {
+            return {
+              ruleStack: null,
+              tokens: [{ startIndex: 1, endIndex: 2, scopes: ["source.vue"] }],
+            };
+          },
+        },
+        "x",
+        "source.vue",
+        "gap.vue",
+      ),
+    /gap\.vue:1:0/,
+  );
+  assert.throws(
+    () =>
+      tokenizeSemanticSource(
+        {
+          tokenizeLine() {
+            return {
+              ruleStack: null,
+              stoppedEarly: true,
+              tokens: [{ startIndex: 0, endIndex: 1, scopes: ["source.vue"] }],
+            };
+          },
+        },
+        "x",
+        "source.vue",
+        "slow.vue",
+      ),
+    /exceeded 1000ms/,
+  );
+  const timestamps = [0, 0, 0, 2];
+  const deadline = createSyntaxAuditDeadline(
+    { SYNTAX_HIGHLIGHTER_ORACLE_TIMEOUT_MS: "1" },
+    () => timestamps.shift() ?? 2,
+  );
+  assert.throws(
+    () =>
+      tokenizeSemanticSource(
+        grammar(["source.vue", "entity.name.tag.html.vue"]),
+        "x",
+        "source.vue",
+        "deadline.vue",
+        deadline,
+      ),
+    /syntax oracle shard exceeded 1ms/,
+  );
+});
+
+test("intentional divergence ledger is exact and stale entries fail closed", () => {
+  const comparison = compareSemanticSpans(
+    "src/App.vue",
+    "abc def",
+    [shared, vizeOnly],
+    [shared, oracleOnly],
+  );
+  const entry = {
+    project: "fixture",
+    file: "src/App.vue",
+    kind: "false-positive" as const,
+    category: "comment",
+    line: 1,
+    startColumn: 5,
+    endColumn: 8,
+    issue: 3677,
+    reason: "Art Vue deliberately assigns a Vize-only semantic role at this exact authored span.",
+  };
+  const ledger = ledgerWith(entry);
+  assert.deepEqual(validateLedger(ledger), [entry]);
+  const classified = applyDocumentedDivergences("fixture", comparison, ledger);
+  assert.equal(classified.falsePositives.length, 0);
+  assert.equal(classified.falseNegatives.length, 1);
+  assert.deepEqual(classified.documented, [entry]);
+  assert.throws(
+    () => applyDocumentedDivergences("fixture", comparison, ledgerWith({ ...entry, line: 2 })),
+    /stale syntax divergence ledger entry/,
+  );
+  assert.throws(
+    () => validateLedger({ schema: "wrong", version: 1, entries: [] }),
+    /Expected values to be strictly equal/,
+  );
+  assert.throws(
+    () => validateLedger(ledger, new Set(["another-fixture"])),
+    /unknown syntax divergence ledger project fixture/,
+  );
+});
+
+function grammar(scopes: string[]) {
+  return {
+    tokenizeLine(line: string) {
+      return {
+        ruleStack: null,
+        tokens: [{ startIndex: 0, endIndex: Math.max(line.length, 1), scopes }],
+      };
+    },
+  };
+}
+
+function ledgerWith(entry: object) {
+  return { schema: "vize.fixtureSyntaxDivergenceLedger", version: 1, entries: [entry] };
+}

--- a/tests/tooling/syntax-highlighter-divergence.test.ts
+++ b/tests/tooling/syntax-highlighter-divergence.test.ts
@@ -7,6 +7,7 @@ import {
   validateLedger,
 } from "./support/syntax-semantic-comparison.ts";
 import {
+  canonicalJson,
   semanticNormalization,
   tokenizeSemanticSource,
   type SemanticSpan,
@@ -75,6 +76,15 @@ test("semantic comparison records exact shared, false-positive, and false-negati
   );
 });
 
+test("published normalization evidence is immutable canonical JSON", () => {
+  assert.ok(Object.isFrozen(semanticNormalization));
+  assert.ok(Object.isFrozen(semanticNormalization.categories));
+  assert.ok(Object.isFrozen(semanticNormalization.omittedCategories));
+  assert.ok(Object.isFrozen(semanticNormalization.ignoredScopeFamilies));
+  assert.equal(canonicalJson({ omitted: undefined, retained: 1 }), '{"retained":1}');
+  assert.throws(() => canonicalJson(undefined), /value is not JSON-serializable/);
+});
+
 test("normalization ignores structural nesting but detects changed semantic scopes", () => {
   const structuralA = tokenizeSemanticSource(
     grammar(["source.vue", "meta.tag.vue", "punctuation.definition.tag.vue"]),
@@ -89,7 +99,6 @@ test("normalization ignores structural nesting but detects changed semantic scop
     "structural-b.vue",
   );
   assert.deepEqual(structuralA.semanticSpans, structuralB.semanticSpans);
-  assert.match(semanticNormalization.rationale, /directives as HTML attributes/);
 
   const tag = tokenizeSemanticSource(
     grammar(["source.vue", "entity.name.tag.html.vue"]),
@@ -119,8 +128,12 @@ test("normalization ignores structural nesting but detects changed semantic scop
       "entity.other.inherited-class.ts",
       "support.constant.property-value.css",
       "support.variable.property.ts",
+      "support.other.variable.less",
       "entity.name.label.ts",
+      "entity.name.section.markdown",
+      "entity.name.constant.counter-name.less",
       "entity.other.keyframe-offset.percentage.css",
+      "entity.other.counter-name.less",
     ]),
     "x",
     "source.vue",
@@ -235,7 +248,7 @@ test("intentional divergence ledger is exact and stale entries fail closed", () 
   );
   assert.throws(
     () => validateLedger({ schema: "wrong", version: 1, entries: [] }),
-    /Expected values to be strictly equal/,
+    /unexpected syntax divergence ledger schema/,
   );
   assert.throws(
     () => validateLedger(ledger, new Set(["another-fixture"])),


### PR DESCRIPTION
## Summary

- pin the Shiki 4.0.2 Vue grammar, module and license digests, grammar-closure digest, and redistribution notice
- compare the shipped Vue and Art Vue grammars against the same upstream tokenization inputs using canonical semantic spans
- publish deterministic per-shard JSON and Markdown with exact false-positive and false-negative ranges
- fail closed on missing fixture inputs, unresolved embedded grammars, malformed evidence, stale ledger entries, timeouts, and provenance drift

## Failure before

The existing structural audit accepted both a tag-scoped token and an attribute-scoped token with one contiguous token each. Their digests differed, but there was no semantic classification and therefore no exact false-positive or false-negative evidence.

## Verification

- 24 hydrated projects, 3,875 Vue files: 298 false positives and 12,933 false negatives classified in 61 seconds
- vue-termui shard, 73 files: two independent runs produced byte-identical JSON and Markdown artifacts
- pinned-oracle, changed-scope, broken-oracle, unresolved-grammar, ledger, malformed-artifact, deadline, workflow, Vue, and Art Vue tests pass
- targeted Vite+ formatting and type-aware lint checks pass

Closes #3677
Refs #3674

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Vue syntax-highlighting audits comparing project files against a pinned reference grammar.
  * Added deterministic JSON and Markdown divergence reports with documented discrepancy tracking.
  * Added validation for grammar provenance, integrity, tokenization, project coverage, and audit timeouts.
  * Added GitHub Actions summaries showing generated divergence reports or clearly indicating when reports are unavailable.

* **Tests**
  * Expanded coverage for syntax comparisons, divergence artifacts, grammar integrity, timeout handling, and report validation.
  * Added provenance documentation for the third-party syntax grammar reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->