### PR TITLE
test(maestro): cover LSP server restarts

### DIFF
--- a/tests/tooling/lsp-server-restart.test.ts
+++ b/tests/tooling/lsp-server-restart.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isDiagnosticsForUri } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { LspDiagnostic, PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+const malformedSource = "<template><div></div>";
+const repairedSource = "<template><div></div></template>";
+const malformedDiagnostics: LspDiagnostic[] = [
+  {
+    message: "Malformed <template> block: the closing tag is missing.",
+    range: {
+      start: { line: 0, character: 0 },
+      end: { line: 0, character: malformedSource.length },
+    },
+    severity: 1,
+    source: "vize/sfc",
+  },
+];
+
+async function openAndExpectMalformed(
+  session: LspSession,
+  uri: string,
+  version: number,
+): Promise<PublishDiagnosticsParams> {
+  session.notify("textDocument/didOpen", {
+    textDocument: {
+      uri,
+      languageId: "vue",
+      version,
+      text: malformedSource,
+    },
+  });
+
+  const publish = (await session.waitForNotification(
+    "textDocument/publishDiagnostics",
+    (params) => isDiagnosticsForUri(params, uri) && params.version === version,
+  )) as PublishDiagnosticsParams;
+  assert.equal(publish.version, version);
+  assert.deepEqual(publish.diagnostics, malformedDiagnostics);
+  return publish;
+}
+
+test("vize lsp revalidates one malformed document after graceful and forced server restarts", async (t) => {
+  const restartCases = [
+    {
+      label: "shutdown request followed by exit",
+      stop: (session: LspSession) => session.shutdown(),
+    },
+    {
+      label: "forced process kill",
+      stop: (session: LspSession) => session.kill("SIGKILL"),
+    },
+  ] as const;
+
+  for (const restartCase of restartCases) {
+    await t.test(restartCase.label, async () => {
+      const testRootDir = path.join(
+        testOutputRoot,
+        `lsp-server-restart-${restartCase.label.replaceAll(" ", "-")}`,
+      );
+      fs.mkdirSync(testRootDir, { recursive: true });
+      const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+      const filePath = path.join(workspaceDir, "Restart.vue");
+      const uri = pathToFileURL(filePath).href;
+      fs.writeFileSync(filePath, malformedSource, "utf8");
+
+      let firstSession: LspSession | undefined = new LspSession();
+      let restartedSession: LspSession | undefined;
+
+      try {
+        await firstSession.initialize(workspaceDir, {
+          editor: true,
+          lint: false,
+          typecheck: false,
+        });
+        const firstProcessId = firstSession.processId;
+        await openAndExpectMalformed(firstSession, uri, 41);
+
+        await restartCase.stop(firstSession);
+        firstSession = undefined;
+
+        restartedSession = new LspSession();
+        assert.notEqual(
+          restartedSession.processId,
+          firstProcessId,
+          "restart must launch a fresh vize lsp process",
+        );
+        await restartedSession.initialize(workspaceDir, {
+          editor: true,
+          lint: false,
+          typecheck: false,
+        });
+
+        const restartedPublishes: PublishDiagnosticsParams[] = [];
+        restartedSession.notificationObservers.push((method, params) => {
+          if (method === "textDocument/publishDiagnostics" && isDiagnosticsForUri(params, uri)) {
+            restartedPublishes.push(params);
+          }
+        });
+
+        await openAndExpectMalformed(restartedSession, uri, 1);
+
+        restartedSession.notify("textDocument/didChange", {
+          textDocument: { uri, version: 2 },
+          contentChanges: [{ text: repairedSource }],
+        });
+        const repairedPublish = (await restartedSession.waitForNotification(
+          "textDocument/publishDiagnostics",
+          (params) => isDiagnosticsForUri(params, uri) && params.version === 2,
+        )) as PublishDiagnosticsParams;
+        assert.deepEqual(repairedPublish.diagnostics, []);
+
+        restartedSession.notify("textDocument/didChange", {
+          textDocument: { uri, version: 3 },
+          contentChanges: [{ text: repairedSource }],
+        });
+        const stablePublish = (await restartedSession.waitForNotification(
+          "textDocument/publishDiagnostics",
+          (params) => isDiagnosticsForUri(params, uri) && params.version === 3,
+        )) as PublishDiagnosticsParams;
+        assert.deepEqual(stablePublish.diagnostics, []);
+
+        assert.deepEqual(
+          restartedPublishes.map(({ version, diagnostics }) => ({ version, diagnostics })),
+          [
+            { version: 1, diagnostics: malformedDiagnostics },
+            { version: 2, diagnostics: [] },
+            { version: 3, diagnostics: [] },
+          ],
+          "a fresh server must not publish stale versions or diagnostics after repair",
+        );
+      } finally {
+        if (restartedSession) {
+          await restartedSession.shutdown();
+        }
+        if (firstSession) {
+          await firstSession.shutdown();
+        }
+        fs.rmSync(workspaceDir, { recursive: true, force: true });
+        fs.rmSync(testRootDir, { recursive: true, force: true });
+      }
+    });
+  }
+});

--- a/tests/tooling/support/lsp/session.ts
+++ b/tests/tooling/support/lsp/session.ts
@@ -235,6 +235,35 @@ export class LspSession {
     }
   }
 
+  /**
+   * Abruptly terminate the production server and wait until the child is
+   * actually gone. Restart oracles use this instead of racing a fresh server
+   * against an old process that has only received a signal.
+   */
+  async kill(signal: NodeJS.Signals = "SIGKILL"): Promise<void> {
+    if (this.process.exitCode != null || this.process.signalCode != null) {
+      return;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const onExit = () => {
+        clearTimeout(timeout);
+        resolve();
+      };
+      const timeout = setTimeout(() => {
+        this.process.off("exit", onExit);
+        reject(new Error(`Timed out waiting for vize lsp to exit after ${signal}`));
+      }, 5000);
+
+      this.process.once("exit", onExit);
+      if (!this.process.kill(signal)) {
+        clearTimeout(timeout);
+        this.process.off("exit", onExit);
+        reject(new Error(`Failed to send ${signal} to vize lsp`));
+      }
+    });
+  }
+
   private send(message: JsonRpcMessage): void {
     const payload = JSON.stringify(message);
     const frame = `Content-Length: ${Buffer.byteLength(payload, "utf8")}\r\n\r\n${payload}`;

--- a/tests/tooling/support/lsp/session.ts
+++ b/tests/tooling/support/lsp/session.ts
@@ -211,27 +211,12 @@ export class LspSession {
     try {
       await this.request("shutdown", undefined, 10000);
     } finally {
-      const exited = new Promise<void>((resolve) => {
-        if (this.process.exitCode != null || this.process.signalCode != null) {
-          resolve();
-          return;
-        }
-
-        const timeout = setTimeout(() => {
-          if (!this.process.kill("SIGKILL")) {
-            resolve();
-          }
-        }, 5000);
-
-        this.process.once("exit", () => {
-          clearTimeout(timeout);
-          resolve();
-        });
-      });
-
+      const exited = this.waitForExit(5000);
       this.notify("exit", undefined);
       this.process.stdin.end();
-      await exited;
+      if (!(await exited)) {
+        await this.kill().catch(() => undefined);
+      }
     }
   }
 
@@ -245,22 +230,28 @@ export class LspSession {
       return;
     }
 
-    await new Promise<void>((resolve, reject) => {
+    const exited = this.waitForExit(5000);
+    assert.ok(this.process.kill(signal), `Failed to send ${signal} to vize lsp`);
+    assert.ok(await exited, `Timed out waiting for vize lsp to exit after ${signal}`);
+  }
+
+  /** Resolve `true` once the child exits, or `false` if it is still alive after `timeoutMs`. */
+  private waitForExit(timeoutMs: number): Promise<boolean> {
+    if (this.process.exitCode != null || this.process.signalCode != null) {
+      return Promise.resolve(true);
+    }
+
+    return new Promise((resolve) => {
       const onExit = () => {
         clearTimeout(timeout);
-        resolve();
+        resolve(true);
       };
       const timeout = setTimeout(() => {
         this.process.off("exit", onExit);
-        reject(new Error(`Timed out waiting for vize lsp to exit after ${signal}`));
-      }, 5000);
+        resolve(false);
+      }, timeoutMs);
 
       this.process.once("exit", onExit);
-      if (!this.process.kill(signal)) {
-        clearTimeout(timeout);
-        this.process.off("exit", onExit);
-        reject(new Error(`Failed to send ${signal} to vize lsp`));
-      }
     });
   }
 


### PR DESCRIPTION
## Summary

- drive the production stdio language server through graceful shutdown/exit and forced SIGKILL restart paths
- reopen the same malformed Vue document in a fresh process and require the exact diagnostic with a reset document version
- repair the restarted overlay, add a stable no-op fence, and reject stale diagnostic versions or payloads
- let the shared session helper force-stop a child only after its process has actually exited

## Failure before

- the production LSP suite never started a second server after terminating the first one, so restart state was unobserved
- the new forced-restart case failed before the session helper was added with TypeError: session.kill is not a function

## Verification

- vp check tests/tooling/lsp-server-restart.test.ts tests/tooling/support/lsp/session.ts
- vp exec oxfmt --check tests/tooling/lsp-server-restart.test.ts tests/tooling/support/lsp/session.ts
- production target oracle: 3 passed, 0 failed
- full production LSP suite: 2,212 passed, 0 failed

Refs #2971

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->