### PR TITLE
fix(canon): consume defineEmits binding for template $emit

### DIFF
--- a/crates/vize/tests/check_legacy_vue2_no_unused_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_no_unused_cli.rs
@@ -5,6 +5,57 @@ use std::{path::Path, process::Command};
 use vize_carton::cstr;
 
 #[test]
+fn legacy_vue2_template_emit_marks_define_emits_result_as_used() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project("legacy-vue2-template-emit-result-binding");
+    std::fs::write(
+        project_root.join("src/App.vue"),
+        r#"<script setup lang="ts">
+const emit = defineEmits<{
+  (event: 'click'): void
+}>()
+</script>
+
+<template>
+  <button @click="$emit('click')">Click</button>
+</template>
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+            "src/App.vue",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "template $emit should consume the defineEmits result binding\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(
+        json["errorCount"], 0,
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn legacy_vue2_typed_emits_do_not_report_unused_loose_emit_helper() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
         return;
@@ -145,6 +196,9 @@ fn create_project(name: &str) -> std::path::PathBuf {
     std::fs::write(
         project_root.join("vize.config.json"),
         r#"{
+  "vue": {
+    "version": "2.7"
+  },
   "typeChecker": {
     "legacyVue2": true
   }

--- a/crates/vize_canon/src/batch/type_checker/tests/no_unused.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/no_unused.rs
@@ -4,6 +4,8 @@ use super::{
 };
 use vize_carton::cstr;
 
+mod define_emits_unused;
+
 #[test]
 fn batch_type_checker_marks_art_bindings_as_used_with_no_unused_locals() {
     if resolve_test_tsgo_binary().is_none() {

--- a/crates/vize_canon/src/batch/type_checker/tests/no_unused/define_emits_unused.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/no_unused/define_emits_unused.rs
@@ -1,0 +1,118 @@
+use super::super::{
+    create_project_case_without_node_modules, resolve_test_tsgo_binary,
+    snapshot_project_diagnostics,
+};
+use super::write_no_unused_tsconfig;
+
+#[test]
+fn define_emits_no_unused_matrix_preserves_only_real_template_usage() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case_without_node_modules(
+        "define-emits-template-dollar-emit-no-unused",
+        &[
+            (
+                "src/DollarEmit.vue",
+                r#"<script setup lang="ts">
+const emit = defineEmits<{ click: [] }>()
+const unusedLocal = 1
+</script>
+
+<template><button @click="$emit('click')" /></template>
+"#,
+            ),
+            (
+                "src/RenamedEmit.vue",
+                r#"<script setup lang="ts">
+const dispatch = defineEmits<{ save: [] }>()
+</script>
+
+<template><button @click="$emit('save')" /></template>
+"#,
+            ),
+            (
+                "src/DirectTemplateEmit.vue",
+                r#"<script setup lang="ts">
+const emit = defineEmits<{ click: [] }>()
+</script>
+
+<template><button @click="emit('click')" /></template>
+"#,
+            ),
+            (
+                "src/DirectScriptEmit.vue",
+                r#"<script setup lang="ts">
+const emit = defineEmits<{ ready: [] }>()
+emit('ready')
+</script>
+
+<template><main /></template>
+"#,
+            ),
+            (
+                "src/UnusedEmit.vue",
+                r#"<script setup lang="ts">
+const emit = defineEmits<{ click: [] }>()
+</script>
+
+<template><button /></template>
+"#,
+            ),
+            (
+                "src/OptionsApi.vue",
+                r#"<script lang="ts">
+const emit = 1
+
+export default {
+  emits: ['click'],
+}
+</script>
+
+<template><button @click="$emit('click')" /></template>
+"#,
+            ),
+        ],
+    );
+    write_no_unused_tsconfig(&project_root);
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    for (file, binding) in [
+        ("src/DollarEmit.vue", "emit"),
+        ("src/RenamedEmit.vue", "dispatch"),
+        ("src/DirectTemplateEmit.vue", "emit"),
+        ("src/DirectScriptEmit.vue", "emit"),
+    ] {
+        assert!(
+            !has_unused_binding(&snapshot, file, binding),
+            "{file} should consume `{binding}`, got: {snapshot:#?}"
+        );
+    }
+    for (file, binding) in [
+        ("src/DollarEmit.vue", "unusedLocal"),
+        ("src/UnusedEmit.vue", "emit"),
+        ("src/OptionsApi.vue", "emit"),
+    ] {
+        assert!(
+            has_unused_binding(&snapshot, file, binding),
+            "{file} should still report truly unused `{binding}`, got: {snapshot:#?}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn has_unused_binding(
+    snapshot: &[(vize_carton::String, Option<u32>, vize_carton::String)],
+    file: &str,
+    binding: &str,
+) -> bool {
+    snapshot.iter().any(|(candidate_file, code, message)| {
+        candidate_file == file && *code == Some(6133) && message.contains(binding)
+    })
+}

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -10,6 +10,8 @@
 #[cfg(test)]
 mod class_component_props_tests;
 #[cfg(test)]
+mod define_emits_usage_tests;
+#[cfg(test)]
 mod dynamic_component_names_tests;
 #[cfg(test)]
 mod event_handler_tests;

--- a/crates/vize_canon/src/virtual_ts/define_emits_usage_tests.rs
+++ b/crates/vize_canon/src/virtual_ts/define_emits_usage_tests.rs
@@ -1,0 +1,133 @@
+use crate::virtual_ts::{
+    VirtualTsGenerationOptions, VirtualTsOptions, generate_virtual_ts_with_offsets_and_checks,
+};
+use vize_carton::{String, config::VueVersion};
+use vize_croquis::{Analyzer, AnalyzerOptions};
+
+const EMIT_ANCHOR_COMMENT: &str = "// Reference defineEmits result used through template $emit";
+const EMIT_ANCHOR: &str =
+    "\n  // Reference defineEmits result used through template $emit\n  void emit;\n";
+
+#[test]
+fn template_dollar_emit_references_define_emits_result_for_vue2_and_vue3() {
+    let script = r#"const emit = defineEmits<{
+  (event: 'click'): void
+}>()
+"#;
+
+    for dialect in [VueVersion::V2_7, VueVersion::V3] {
+        let code = generate_setup(script, r#"<button @click="$emit('click')" />"#, dialect);
+        assert_eq!(
+            code.matches(EMIT_ANCHOR).count(),
+            1,
+            "expected one exact defineEmits anchor for {dialect:?}:\n{code}"
+        );
+    }
+}
+
+#[test]
+fn template_dollar_emit_references_renamed_define_emits_result() {
+    let code = generate_setup(
+        r#"const dispatch = defineEmits<{
+  (event: 'save'): void
+}>()
+"#,
+        r#"<button @click="$emit('save')" />"#,
+        VueVersion::V3,
+    );
+
+    assert!(code.contains(
+        "\n  // Reference defineEmits result used through template $emit\n  void dispatch;\n"
+    ));
+    assert!(!code.contains("void emit;"));
+}
+
+#[test]
+fn direct_emit_usage_does_not_need_the_dollar_emit_anchor() {
+    let template_usage = generate_setup(
+        "const emit = defineEmits<{ click: [] }>()",
+        r#"<button @click="emit('click')" />"#,
+        VueVersion::V3,
+    );
+    assert!(!template_usage.contains(EMIT_ANCHOR_COMMENT));
+    assert!(template_usage.contains("void emit;"));
+
+    let script_usage = generate_setup(
+        r#"const emit = defineEmits<{ click: [] }>()
+emit('click')
+"#,
+        "<button />",
+        VueVersion::V3,
+    );
+    assert!(!script_usage.contains(EMIT_ANCHOR_COMMENT));
+    assert!(!script_usage.contains("void emit;"));
+}
+
+#[test]
+fn unused_define_emits_result_stays_unanchored() {
+    let code = generate_setup(
+        "const emit = defineEmits<{ click: [] }>()",
+        "<button />",
+        VueVersion::V3,
+    );
+
+    assert!(!code.contains(EMIT_ANCHOR_COMMENT));
+    assert!(!code.contains("void emit;"));
+}
+
+#[test]
+fn options_api_dollar_emit_does_not_consume_an_unrelated_binding() {
+    let script = r#"const emit = 1
+export default {
+  emits: ['click'],
+}
+"#;
+    let template = r#"<button @click="$emit('click')" />"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full()).with_options_api();
+    analyzer.analyze_script_plain(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let code = generate_virtual_ts_with_offsets_and_checks(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &VirtualTsOptions::default(),
+        VirtualTsGenerationOptions {
+            preserve_unused_diagnostics: true,
+            options_api: true,
+            ..Default::default()
+        },
+    )
+    .code;
+
+    assert!(!code.contains(EMIT_ANCHOR_COMMENT));
+    assert!(!code.contains("void emit;"));
+}
+
+fn generate_setup(script: &str, template: &str, dialect: VueVersion) -> String {
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    generate_virtual_ts_with_offsets_and_checks(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &VirtualTsOptions::default(),
+        VirtualTsGenerationOptions {
+            dialect,
+            preserve_unused_diagnostics: true,
+            ..Default::default()
+        },
+    )
+    .code
+}

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -6,11 +6,11 @@ mod generics;
 mod global_components;
 mod imports;
 mod legacy_vue2;
+mod macro_anchors;
 mod options_api;
 mod options_api_bridge;
 mod options_api_props_identifiers;
 mod options_api_support;
-mod props_anchors;
 mod script_module;
 mod setup_helpers;
 mod setup_props;
@@ -28,11 +28,11 @@ use self::imports::{
     extract_declared_name,
 };
 pub use self::legacy_vue2::generate_virtual_ts_with_offsets_legacy_vue2;
+use self::macro_anchors::emit_setup_scope_macro_anchors;
 use self::options_api::{find_default_export_targets, generate_options_api_variables};
 use self::options_api_bridge::generate_options_api_bridge;
 use self::options_api_props_identifiers::PropsConstAssertions;
 use self::options_api_support::find_options_api_props;
-use self::props_anchors::emit_setup_scope_prop_anchors;
 use self::setup_helpers::emit_setup_helpers;
 use self::setup_props::generate_setup_props;
 use self::setup_type_exports::SetupTypeExportsPlan;
@@ -871,7 +871,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         );
     }
 
-    emit_setup_scope_prop_anchors(
+    emit_setup_scope_macro_anchors(
         &mut ts,
         summary,
         script_content,

--- a/crates/vize_canon/src/virtual_ts/generator/macro_anchors.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/macro_anchors.rs
@@ -1,4 +1,4 @@
-//! Setup-scope anchors for props bindings shadowed by template generation.
+//! Setup-scope anchors for compiler-macro bindings consumed by template generation.
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{Argument, BindingPattern, CallExpression, Expression, VariableDeclarator};
@@ -8,12 +8,12 @@ use oxc_span::SourceType;
 use vize_carton::{CompactString, FxHashSet, String, append, profile};
 use vize_croquis::{
     Croquis,
-    macros::{DEFINE_PROPS, WITH_DEFAULTS},
+    macros::{DEFINE_EMITS, DEFINE_PROPS, WITH_DEFAULTS},
 };
 
 use crate::virtual_ts::props::{strip_outer_angle_brackets, type_reference_lookup_key};
 
-pub(super) fn emit_setup_scope_prop_anchors(
+pub(super) fn emit_setup_scope_macro_anchors(
     ts: &mut String,
     summary: &Croquis,
     script_content: Option<&str>,
@@ -21,6 +21,7 @@ pub(super) fn emit_setup_scope_prop_anchors(
     preserve_unused_diagnostics: bool,
 ) {
     if preserve_unused_diagnostics {
+        emit_define_emits_result_anchors(ts, summary, script_content, template_referenced_names);
         let bindings = profile!(
             "canon.virtual_ts.collect_define_props_result_anchors",
             collect_define_props_result_anchor_names(
@@ -61,6 +62,83 @@ pub(super) fn emit_setup_scope_prop_anchors(
         }
         ts.push('\n');
     }
+}
+
+fn emit_define_emits_result_anchors(
+    ts: &mut String,
+    summary: &Croquis,
+    script_content: Option<&str>,
+    template_referenced_names: Option<&FxHashSet<String>>,
+) {
+    if summary.macros.define_emits().is_none()
+        || !template_referenced_names.is_some_and(|names| names.contains("$emit"))
+    {
+        return;
+    }
+    let Some(script) = script_content else {
+        return;
+    };
+
+    let bindings = profile!(
+        "canon.virtual_ts.collect_define_emits_result_anchors",
+        collect_define_emits_result_bindings(script)
+    );
+    let mut names = summary
+        .bindings
+        .bindings
+        .keys()
+        .map(|name| name.as_str())
+        .filter(|name| bindings.iter().any(|candidate| candidate.as_str() == *name))
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+    if names.is_empty() {
+        return;
+    }
+
+    ts.push_str("\n  // Reference defineEmits result used through template $emit\n  ");
+    for (index, name) in names.iter().enumerate() {
+        if index > 0 {
+            ts.push(' ');
+        }
+        append!(*ts, "void {name};");
+    }
+    ts.push('\n');
+}
+
+fn collect_define_emits_result_bindings(script: &str) -> FxHashSet<CompactString> {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
+    let mut collector = DefineEmitsResultBindingCollector::default();
+    collector.visit_program(&parsed.program);
+    collector.bindings
+}
+
+#[derive(Default)]
+struct DefineEmitsResultBindingCollector {
+    bindings: FxHashSet<CompactString>,
+}
+
+impl<'a> Visit<'a> for DefineEmitsResultBindingCollector {
+    fn visit_variable_declarator(&mut self, declarator: &VariableDeclarator<'a>) {
+        if let BindingPattern::BindingIdentifier(binding) = &declarator.id
+            && declarator.init.as_ref().is_some_and(is_define_emits_call)
+        {
+            self.bindings
+                .insert(CompactString::new(binding.name.as_str()));
+        }
+
+        walk::walk_variable_declarator(self, declarator);
+    }
+}
+
+fn is_define_emits_call(expression: &Expression<'_>) -> bool {
+    let Expression::CallExpression(call) = expression else {
+        return false;
+    };
+    matches!(
+        &call.callee,
+        Expression::Identifier(identifier) if identifier.name.as_str() == DEFINE_EMITS
+    )
 }
 
 fn collect_define_props_result_anchor_names<'a>(


### PR DESCRIPTION
## Summary

- recognize the assigned defineEmits result with an OXC AST walk
- reference only that binding when the template consumes the component emitter through $emit
- preserve TS6133 for truly unused bindings and unrelated Options API locals

## Tests

- Vue 2.7 CLI regression with noUnusedLocals
- Vue 2.7 and Vue 3 exact virtual TypeScript assertions
- Corsa matrix for $emit, renamed and direct bindings, unused bindings, and Options API
- full vize_canon unit suite: 780 passed
- strict Canon library Clippy and Rust formatting

Refs #1876

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->