### PR TITLE
fix(nuxt): resolve classic plugin bindings

### DIFF
--- a/crates/vize/src/commands/check/nuxt/plugins/extract.rs
+++ b/crates/vize/src/commands/check/nuxt/plugins/extract.rs
@@ -1,5 +1,7 @@
 //! AST extraction for Nuxt plugin provide/inject keys.
 
+mod bindings;
+
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     Argument, BindingPattern, ExportDefaultDeclarationKind, Expression, Function, ObjectExpression,
@@ -9,6 +11,7 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_carton::String;
 
+use self::bindings::{StaticPlugin, resolve_static_plugin_from_export};
 use super::super::parsing::{
     collect_object_keys, extract_call_expression_from_export, extract_expression,
     extract_object_expression, find_object_property,
@@ -28,7 +31,7 @@ pub(in crate::commands::check::nuxt) fn extract_plugin_provide_keys_from_source(
         let Statement::ExportDefaultDeclaration(export) = statement else {
             continue;
         };
-        collect_plugin_keys_from_default_export(&export.declaration, &mut keys);
+        collect_plugin_keys_from_default_export(&export.declaration, &ret.program.body, &mut keys);
     }
 
     keys
@@ -36,6 +39,7 @@ pub(in crate::commands::check::nuxt) fn extract_plugin_provide_keys_from_source(
 
 fn collect_plugin_keys_from_default_export(
     declaration: &ExportDefaultDeclarationKind<'_>,
+    program_body: &[Statement<'_>],
     keys: &mut Vec<String>,
 ) {
     if let Some(call) = extract_call_expression_from_export(declaration) {
@@ -51,51 +55,12 @@ fn collect_plugin_keys_from_default_export(
         return;
     }
 
-    match declaration {
-        ExportDefaultDeclarationKind::ArrowFunctionExpression(arrow) => {
-            collect_plugin_keys_from_arrow_function(arrow, keys);
-        }
-        ExportDefaultDeclarationKind::FunctionDeclaration(function)
-        | ExportDefaultDeclarationKind::FunctionExpression(function) => {
+    match resolve_static_plugin_from_export(declaration, program_body) {
+        Some(StaticPlugin::Arrow(arrow)) => collect_plugin_keys_from_arrow_function(arrow, keys),
+        Some(StaticPlugin::Function(function)) => {
             collect_plugin_keys_from_function(function, keys);
         }
-        ExportDefaultDeclarationKind::ParenthesizedExpression(parenthesized) => {
-            collect_plugin_keys_from_expression(&parenthesized.expression, keys);
-        }
-        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
-            collect_plugin_keys_from_expression(&ts_as.expression, keys);
-        }
-        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
-            collect_plugin_keys_from_expression(&ts_satisfies.expression, keys);
-        }
-        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
-            collect_plugin_keys_from_expression(&ts_non_null.expression, keys);
-        }
-        _ => {}
-    }
-}
-
-fn collect_plugin_keys_from_expression(expression: &Expression<'_>, keys: &mut Vec<String>) {
-    match expression {
-        Expression::ArrowFunctionExpression(arrow) => {
-            collect_plugin_keys_from_arrow_function(arrow, keys);
-        }
-        Expression::FunctionExpression(function) => {
-            collect_plugin_keys_from_function(function, keys)
-        }
-        Expression::ParenthesizedExpression(parenthesized) => {
-            collect_plugin_keys_from_expression(&parenthesized.expression, keys);
-        }
-        Expression::TSAsExpression(ts_as) => {
-            collect_plugin_keys_from_expression(&ts_as.expression, keys);
-        }
-        Expression::TSSatisfiesExpression(ts_satisfies) => {
-            collect_plugin_keys_from_expression(&ts_satisfies.expression, keys);
-        }
-        Expression::TSNonNullExpression(ts_non_null) => {
-            collect_plugin_keys_from_expression(&ts_non_null.expression, keys);
-        }
-        _ => {}
+        None => {}
     }
 }
 
@@ -303,40 +268,5 @@ fn collect_plugin_keys_from_object(object: &ObjectExpression<'_>, keys: &mut Vec
             }
             _ => {}
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::extract_plugin_provide_keys_from_source;
-
-    #[test]
-    fn extracts_nuxt2_inject_keys_from_callback_plugin() {
-        let source = r#"
-export default defineNuxtPlugin((_context, register) => {
-  register('logger', { info(message) { return message.length } })
-  if (true) {
-    register(`auth`, {})
-  }
-})
-"#;
-
-        let keys = extract_plugin_provide_keys_from_source(source);
-        assert_eq!(keys, vec!["logger", "auth"]);
-    }
-
-    #[test]
-    fn extracts_nuxt2_inject_keys_from_raw_export_plugin() {
-        let source = r#"
-export default (_context, inject) => {
-  inject('logger', { info(message) { return message.length } })
-  if (true) {
-    inject(`auth`, {})
-  }
-}
-"#;
-
-        let keys = extract_plugin_provide_keys_from_source(source);
-        assert_eq!(keys, vec!["logger", "auth"]);
     }
 }

--- a/crates/vize/src/commands/check/nuxt/plugins/extract/bindings.rs
+++ b/crates/vize/src/commands/check/nuxt/plugins/extract/bindings.rs
@@ -1,0 +1,122 @@
+//! Conservative resolution of classic Nuxt 2 plugin bindings.
+
+use oxc_ast::ast::{
+    BindingPattern, ExportDefaultDeclarationKind, Expression, Function, Statement,
+    VariableDeclarationKind,
+};
+
+pub(super) enum StaticPlugin<'a> {
+    Arrow(&'a oxc_ast::ast::ArrowFunctionExpression<'a>),
+    Function(&'a Function<'a>),
+}
+
+pub(super) fn resolve_static_plugin_from_export<'a>(
+    declaration: &'a ExportDefaultDeclarationKind<'a>,
+    program_body: &'a [Statement<'a>],
+) -> Option<StaticPlugin<'a>> {
+    match declaration {
+        ExportDefaultDeclarationKind::ArrowFunctionExpression(arrow) => {
+            Some(StaticPlugin::Arrow(arrow))
+        }
+        ExportDefaultDeclarationKind::FunctionDeclaration(function)
+        | ExportDefaultDeclarationKind::FunctionExpression(function) => {
+            Some(StaticPlugin::Function(function))
+        }
+        ExportDefaultDeclarationKind::Identifier(identifier) => {
+            resolve_static_plugin(program_body, identifier.name.as_str())
+        }
+        ExportDefaultDeclarationKind::ParenthesizedExpression(parenthesized) => {
+            resolve_static_plugin_from_export_expression(&parenthesized.expression, program_body)
+        }
+        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
+            resolve_static_plugin_from_export_expression(&ts_as.expression, program_body)
+        }
+        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
+            resolve_static_plugin_from_export_expression(&ts_satisfies.expression, program_body)
+        }
+        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
+            resolve_static_plugin_from_export_expression(&ts_non_null.expression, program_body)
+        }
+        _ => None,
+    }
+}
+
+fn resolve_static_plugin_from_export_expression<'a>(
+    expression: &'a Expression<'a>,
+    program_body: &'a [Statement<'a>],
+) -> Option<StaticPlugin<'a>> {
+    match expression {
+        Expression::Identifier(identifier) => {
+            resolve_static_plugin(program_body, identifier.name.as_str())
+        }
+        Expression::ParenthesizedExpression(parenthesized) => {
+            resolve_static_plugin_from_export_expression(&parenthesized.expression, program_body)
+        }
+        Expression::TSAsExpression(ts_as) => {
+            resolve_static_plugin_from_export_expression(&ts_as.expression, program_body)
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            resolve_static_plugin_from_export_expression(&ts_satisfies.expression, program_body)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            resolve_static_plugin_from_export_expression(&ts_non_null.expression, program_body)
+        }
+        _ => static_plugin_from_expression(expression),
+    }
+}
+
+/// Resolve direct local declarations only. Mutable/imported bindings, aliases,
+/// and dynamic initializers stay unknown so they cannot fabricate inject keys.
+fn resolve_static_plugin<'a>(
+    program_body: &'a [Statement<'a>],
+    name: &str,
+) -> Option<StaticPlugin<'a>> {
+    for statement in program_body {
+        match statement {
+            Statement::VariableDeclaration(declaration)
+                if declaration.kind == VariableDeclarationKind::Const =>
+            {
+                for declarator in &declaration.declarations {
+                    let BindingPattern::BindingIdentifier(identifier) = &declarator.id else {
+                        continue;
+                    };
+                    if identifier.name.as_str() != name {
+                        continue;
+                    }
+                    return declarator
+                        .init
+                        .as_ref()
+                        .and_then(static_plugin_from_expression);
+                }
+            }
+            Statement::FunctionDeclaration(function)
+                if function
+                    .id
+                    .as_ref()
+                    .is_some_and(|identifier| identifier.name.as_str() == name) =>
+            {
+                return Some(StaticPlugin::Function(function));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn static_plugin_from_expression<'a>(expression: &'a Expression<'a>) -> Option<StaticPlugin<'a>> {
+    match expression {
+        Expression::ArrowFunctionExpression(arrow) => Some(StaticPlugin::Arrow(arrow)),
+        Expression::FunctionExpression(function) => Some(StaticPlugin::Function(function)),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            static_plugin_from_expression(&parenthesized.expression)
+        }
+        Expression::TSAsExpression(ts_as) => static_plugin_from_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            static_plugin_from_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            static_plugin_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}

--- a/crates/vize/src/commands/check/nuxt/plugins/tests.rs
+++ b/crates/vize/src/commands/check/nuxt/plugins/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    collect_plugin_injection_stubs, render_module_augmentation_stub,
-    render_nuxt_composition_api_augmentation_stub, render_nuxt_injected_properties_stub,
-    render_nuxt_types_augmentation_stub,
+    collect_plugin_injection_stubs, extract_plugin_provide_keys_from_source,
+    render_module_augmentation_stub, render_nuxt_composition_api_augmentation_stub,
+    render_nuxt_injected_properties_stub, render_nuxt_types_augmentation_stub,
 };
 use vize_carton::FxHashSet;
 
@@ -60,4 +60,102 @@ fn renders_use_context_injection_augmentations() {
     assert!(
         composition.contains("interface UseContextReturn extends __VizeNuxtInjectedProperties")
     );
+}
+
+#[test]
+fn extracts_classic_nuxt2_plugin_bindings() {
+    let cases = [
+        (
+            "direct export control",
+            r#"
+export default (_context, provide) => {
+  provide("direct", {})
+  if (true) provide(`auth`, {})
+}
+"#,
+            vec!["direct", "auth"],
+        ),
+        (
+            "defineNuxtPlugin control",
+            r#"
+export default defineNuxtPlugin((_context, provide) => {
+  provide("defined", {})
+  if (true) provide(`auth`, {})
+})
+"#,
+            vec!["defined", "auth"],
+        ),
+        (
+            "typed const binding",
+            r#"
+const plugin: Plugin = (_context, provide) => provide("auth", {})
+export default plugin
+"#,
+            vec!["auth"],
+        ),
+        (
+            "named function binding",
+            r#"
+export default plugin
+function plugin(_context, provide) { provide("logger", {}) }
+"#,
+            vec!["logger"],
+        ),
+        (
+            "function expression binding",
+            r#"
+const plugin: Plugin = function (_context, provide) { provide("dayjs", {}) }
+export default plugin
+"#,
+            vec!["dayjs"],
+        ),
+        (
+            "wrapped const binding",
+            r#"
+const plugin = (((_context, provide) => provide("gtm", {})) satisfies Plugin)!
+export default (plugin as Plugin)
+"#,
+            vec!["gtm"],
+        ),
+    ];
+
+    for (name, source, expected) in cases {
+        assert_eq!(
+            extract_plugin_provide_keys_from_source(source),
+            expected,
+            "{name}"
+        );
+    }
+}
+
+#[test]
+fn ignores_non_static_nuxt2_plugin_bindings() {
+    let cases = [
+        r#"
+let plugin: Plugin = (_context, provide) => provide("mutable", {})
+export default plugin
+"#,
+        r#"
+import plugin from "./external"
+export default (plugin satisfies Plugin)
+"#,
+        r#"
+const implementation = (_context, provide) => provide("alias", {})
+const plugin = implementation
+export default plugin
+"#,
+        r#"
+const plugin = enabled
+  ? (_context, provide) => provide("enabled", {})
+  : (_context, provide) => provide("disabled", {})
+export default plugin
+"#,
+    ];
+
+    for source in cases {
+        assert!(
+            extract_plugin_provide_keys_from_source(source).is_empty(),
+            "unexpected static inference for:\n{source}"
+        );
+    }
 }

--- a/crates/vize/tests/check_nuxt2_classic_plugin_bindings_cli.rs
+++ b/crates/vize/tests/check_nuxt2_classic_plugin_bindings_cli.rs
@@ -1,0 +1,157 @@
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
+use vize_carton::cstr;
+
+#[test]
+fn check_nuxt2_use_context_sees_classic_plugin_binding_injections() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_project();
+
+    write_file(&project_root, "nuxt.config.ts", "export default {}\n");
+    write_file(
+        &project_root,
+        "tsconfig.json",
+        r##"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["pages/**/*.vue", "plugins/**/*.ts", "types/**/*.d.ts"]
+}"##,
+    );
+    write_file(
+        &project_root,
+        "types/nuxt.d.ts",
+        r##"declare module "@nuxt/types" {
+  export interface Context {
+    app: NuxtAppOptions;
+  }
+  export interface NuxtAppOptions {}
+  export type Plugin = (
+    context: Context,
+    provide: (key: string, value: unknown) => void
+  ) => void;
+}
+
+declare module "@nuxtjs/composition-api" {
+  export interface UseContextReturn
+    extends Omit<import("@nuxt/types").Context, "route" | "query" | "from" | "params"> {}
+  export function useContext(): UseContextReturn;
+}
+
+declare module "#app" {
+  export interface NuxtApp {}
+}
+"##,
+    );
+    write_file(
+        &project_root,
+        "plugins/auth.ts",
+        r#"import type { Plugin } from "@nuxt/types";
+
+const plugin: Plugin = (_context, provide) => {
+  provide("auth", {
+    loggedIn: true,
+  });
+};
+
+export default plugin;
+"#,
+    );
+    write_file(
+        &project_root,
+        "pages/index.vue",
+        r#"<script setup lang="ts">
+import { useContext } from "@nuxtjs/composition-api";
+
+const context = useContext();
+context.$auth.loggedIn;
+context.app.$auth.loggedIn;
+</script>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "pages",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "classic Nuxt2 plugin bindings should type-check\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    assert_eq!(json["errorCount"], 0, "{stdout}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn create_project() -> PathBuf {
+    let project_root = workspace_root()
+        .join("target")
+        .join("vize-tests")
+        .join(cstr!("nuxt2-classic-plugin-bindings-{}", std::process::id()).as_str());
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    let node_modules = workspace_root().join("node_modules");
+    if node_modules.exists() {
+        symlink_path(&node_modules, &project_root.join("node_modules")).unwrap();
+    }
+    project_root
+}
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(file_path, content).unwrap();
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("CORSA_PATH") {
+        let path = PathBuf::from(path);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    let candidate = workspace_root().join("node_modules/.bin/tsgo");
+    candidate.exists().then_some(candidate)
+}
+
+fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(source, target)
+    }
+}


### PR DESCRIPTION
## Summary

- resolve classic Nuxt 2 `Plugin` bindings from local `const` initializers and named function declarations
- preserve conservative behavior for mutable, imported, aliased, and dynamic bindings
- add an end-to-end `vize check` regression for composition-api `useContext()` injections

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy -p vize --lib --bin vize -- -D warnings -D clippy::wildcard_imports`
- `cargo test -p vize --lib` (407 passed)
- Nuxt 2 classic and direct-export CLI regressions
- `vp run source:lengths --check --base-ref origin/main`

Closes #2666

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->