### PR TITLE
test(fixtures): exercise real-project LSP lifecycle

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -112,6 +112,15 @@ jobs:
             --timeout-ms 600000 \
             --output-dir "$FIXTURE_REPORT_DIR"
 
+      - name: Check real-project LSP lifecycle
+        env:
+          REAL_PROJECT_LSP_TIMEOUT_MS: "600000"
+          VIZE_LSP_BIN: target/ci/vize
+        run: |
+          node --test --test-concurrency=1 \
+            tests/tooling/real-project-lsp.test.ts
+          test -s "$FIXTURE_REPORT_DIR/lsp-lifecycle-summary.json"
+
       - name: Check real-project syntax highlighting
         env:
           SYNTAX_HIGHLIGHTER_ORACLE_TIMEOUT_MS: "600000"
@@ -154,6 +163,13 @@ jobs:
             cat "$FIXTURE_REPORT_DIR/summary.md" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "No fixture tool report was produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          lsp_report="$FIXTURE_REPORT_DIR/lsp-lifecycle-summary.json"
+          if [[ -s "$lsp_report" ]]; then
+            jq -r '"LSP lifecycle: \(.summary.projectCount) project(s), \(.summary.actualFileCount) actual file(s), \(.summary.vueFileCount) Vue file(s), \(.summary.failedProjectCount) failed project(s)"' \
+              "$lsp_report" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No LSP lifecycle report was produced." >> "$GITHUB_STEP_SUMMARY"
           fi
           syntax_report="$FIXTURE_REPORT_DIR/syntax-highlighter-summary.json"
           if [[ -f "$syntax_report" ]]; then

--- a/tests/tooling/real-project-lsp.test.ts
+++ b/tests/tooling/real-project-lsp.test.ts
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import type { LspDiagnostic, PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import {
+  exerciseLspLifecycle,
+  runRealProjectLspAudit,
+  selectProjects,
+} from "./support/real-project-lsp-audit.ts";
+
+test("production LSP opens and repairs a probe in every selected real project", async () => {
+  const result = await runRealProjectLspAudit();
+  if (result.skipped) return;
+  assert.ok(result.report.summary.projectCount > 0);
+  assert.equal(result.report.summary.failedProjectCount, 0);
+});
+
+test("real-project LSP lifecycle opens an authored file and restores exact diagnostics", async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "vize-real-project-lsp-"));
+  fs.writeFileSync(path.join(workspace, "App.vue"), "<template><main /></template>\n");
+  const session = new FakeLspSession();
+  try {
+    const result = await exerciseLspLifecycle(session, workspace, "App.vue");
+    assert.deepEqual(result.actualFileDiagnostics, {
+      count: 0,
+      sha256: "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+    });
+    assert.equal(result.fixedProbeDiagnostics.count, 0);
+    assert.equal(result.brokenProbeDiagnostics.count, 1);
+    assert.deepEqual(result.repairedProbeDiagnostics, result.fixedProbeDiagnostics);
+    assert.deepEqual(session.events, [
+      "initialize",
+      "textDocument/didOpen:1:App.vue",
+      "textDocument/publishDiagnostics:1:App.vue",
+      "textDocument/didOpen:1:.vize-fixture-lsp-probe.vue",
+      "textDocument/publishDiagnostics:1:.vize-fixture-lsp-probe.vue",
+      "textDocument/didChange:2:.vize-fixture-lsp-probe.vue",
+      "textDocument/publishDiagnostics:2:.vize-fixture-lsp-probe.vue",
+      "textDocument/didChange:3:.vize-fixture-lsp-probe.vue",
+      "textDocument/publishDiagnostics:3:.vize-fixture-lsp-probe.vue",
+      "textDocument/didClose:.vize-fixture-lsp-probe.vue",
+      "textDocument/didClose:App.vue",
+      "shutdown",
+    ]);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("real-project LSP lifecycle rejects diagnostic drift after repair", async () => {
+  const session = new FakeLspSession(true);
+  await assert.rejects(
+    () => exerciseLspLifecycle(session, os.tmpdir(), null),
+    /repair must restore the fixed diagnostic baseline exactly/,
+  );
+  assert.equal(session.events.at(-1), "shutdown");
+});
+
+test("real-project LSP shards are strict, balanced, and fail closed", () => {
+  const projects = Array.from({ length: 5 }, (_, index) => fixtureProject(`project-${index}`));
+  const selected = selectProjects(projects, {
+    FIXTURE_SHARD_COUNT: "2",
+    FIXTURE_SHARD_INDEX: "1",
+  });
+  assert.deepEqual(
+    selected.projects.map((project) => project.id),
+    ["project-1", "project-3"],
+  );
+  assert.throws(
+    () => selectProjects(projects, { FIXTURE_SHARD_COUNT: "2" }),
+    /must be set together/,
+  );
+  assert.throws(
+    () =>
+      selectProjects(projects, {
+        FIXTURE_SHARD_COUNT: "2",
+        FIXTURE_SHARD_INDEX: "2",
+      }),
+    /must be less than/,
+  );
+  assert.throws(
+    () =>
+      selectProjects(projects, {
+        FIXTURE_SHARD_COUNT: "8",
+        FIXTURE_SHARD_INDEX: "7",
+      }),
+    /selected no projects/,
+  );
+});
+
+class FakeLspSession {
+  readonly events: string[] = [];
+  private readonly documents = new Map<string, { text: string; version: number }>();
+  private readonly driftAfterRepair: boolean;
+
+  constructor(driftAfterRepair = false) {
+    this.driftAfterRepair = driftAfterRepair;
+  }
+
+  async initialize(): Promise<unknown> {
+    this.events.push("initialize");
+    return {};
+  }
+
+  notify(method: string, params: unknown): void {
+    const payload = params as {
+      contentChanges?: Array<{ text: string }>;
+      textDocument?: { text?: string; uri: string; version?: number };
+    };
+    const document = payload.textDocument;
+    const file = document == null ? "" : path.basename(new URL(document.uri).pathname);
+    if (method === "textDocument/didOpen" && document != null) {
+      this.documents.set(document.uri, {
+        text: document.text ?? "",
+        version: document.version ?? 0,
+      });
+      this.events.push(`${method}:${document.version}:${file}`);
+    } else if (method === "textDocument/didChange" && document != null) {
+      this.documents.set(document.uri, {
+        text: payload.contentChanges?.[0]?.text ?? "",
+        version: document.version ?? 0,
+      });
+      this.events.push(`${method}:${document.version}:${file}`);
+    } else if (method === "textDocument/didClose" && document != null) {
+      this.events.push(`${method}:${file}`);
+      this.documents.delete(document.uri);
+    }
+  }
+
+  async waitForNotification(
+    method: string,
+    predicate?: (params: unknown) => boolean,
+  ): Promise<unknown> {
+    assert.equal(method, "textDocument/publishDiagnostics");
+    const [uri, document] = [...this.documents.entries()].at(-1) ?? [];
+    assert.ok(uri && document);
+    const diagnostics = document.text.includes('= "broken"')
+      ? [injectedMismatch()]
+      : this.driftAfterRepair && document.version === 3
+        ? [unrelatedDiagnostic()]
+        : [];
+    const payload: PublishDiagnosticsParams = {
+      diagnostics,
+      uri,
+      version: document.version,
+    };
+    assert.ok(predicate?.(payload), "fake notification must satisfy the requested predicate");
+    this.events.push(`${method}:${document.version}:${path.basename(new URL(uri).pathname)}`);
+    return payload;
+  }
+
+  async shutdown(): Promise<void> {
+    this.events.push("shutdown");
+  }
+}
+
+function injectedMismatch(): LspDiagnostic {
+  return {
+    code: 2322,
+    message: "Type 'string' is not assignable to type 'number'.",
+    range: {
+      start: { line: 1, character: 6 },
+      end: { line: 1, character: 32 },
+    },
+    severity: 1,
+    source: "vize/types",
+  };
+}
+
+function unrelatedDiagnostic(): LspDiagnostic {
+  return {
+    code: 2304,
+    message: "Cannot find name 'drift'.",
+    range: {
+      start: { line: 0, character: 0 },
+      end: { line: 0, character: 5 },
+    },
+    severity: 1,
+    source: "vize/types",
+  };
+}
+
+function fixtureProject(id: string) {
+  return {
+    coverage: ["lsp"],
+    expectedVueFileCount: 1,
+    fixturePath: `tests/_fixtures/_git/${id}`,
+    id,
+    revision: "0".repeat(40),
+    vueGlobs: ["**/*.vue"],
+  };
+}

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -78,6 +78,9 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   const dependencyIndex = steps.indexOf(dependency);
   const run = steps.find((step) => step.name === "Exercise real projects with every core tool");
   const runIndex = steps.indexOf(run!);
+  const lsp = steps.find((step) => step.name === "Check real-project LSP lifecycle");
+  assert.ok(lsp, "Missing 'Check real-project LSP lifecycle' step");
+  const lspIndex = steps.indexOf(lsp);
   const syntaxHighlighter = steps.find(
     (step) => step.name === "Check real-project syntax highlighting",
   );
@@ -124,7 +127,16 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(run?.run ?? "", /--timeout-ms 600000/);
   assert.match(run?.run ?? "", /--output-dir "\$FIXTURE_REPORT_DIR"/);
   assert.ok(
-    runIndex < syntaxHighlighterIndex && syntaxHighlighterIndex < glyphPropertiesIndex,
+    runIndex < lspIndex && lspIndex < syntaxHighlighterIndex,
+    "the hydrated fixture corpus must run through the production LSP before syntax audit",
+  );
+  assert.equal(lsp.env?.VIZE_LSP_BIN, "target/ci/vize");
+  assert.equal(lsp.env?.REAL_PROJECT_LSP_TIMEOUT_MS, "600000");
+  assert.match(lsp.run ?? "", /tests\/tooling\/real-project-lsp\.test\.ts/);
+  assert.match(lsp.run ?? "", /--test-concurrency=1/);
+  assert.match(lsp.run ?? "", /test -s "\$FIXTURE_REPORT_DIR\/lsp-lifecycle-summary\.json"/);
+  assert.ok(
+    syntaxHighlighterIndex < glyphPropertiesIndex,
     "the hydrated fixture corpus must run through the shipped syntax highlighter",
   );
   assert.match(
@@ -189,6 +201,9 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   }
   assert.equal(summary?.if, "${{ always() }}");
   assert.match(summary?.run ?? "", /summary\.md/);
+  assert.match(summary?.run ?? "", /lsp-lifecycle-summary\.json/);
+  assert.match(summary?.run ?? "", /actualFileCount/);
+  assert.match(summary?.run ?? "", /No LSP lifecycle report was produced/);
   assert.match(summary?.run ?? "", /syntax-highlighter-summary\.json/);
   assert.match(summary?.run ?? "", /failedProjectCount/);
   assert.match(

--- a/tests/tooling/support/real-project-lsp-audit.ts
+++ b/tests/tooling/support/real-project-lsp-audit.ts
@@ -1,0 +1,298 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { collectVueInputPaths } from "../../../tools/fixtures/tool-matrix-inputs.mjs";
+import { isDiagnosticsForUri, offsetToPosition } from "./lsp/assertions.ts";
+import type {
+  LspDiagnostic,
+  LspInitializationOptions,
+  PublishDiagnosticsParams,
+} from "./lsp/protocol.ts";
+import { LspSession } from "./lsp/session.ts";
+import {
+  assertFixtureFileCount,
+  createLspReport,
+  emptyLspEvidence,
+  errorMessage,
+  isHydrated,
+  positiveInteger,
+  selectProjects,
+  writeLspReport,
+  type DiagnosticEvidence,
+  type FixtureProject,
+  type LspProjectEvidence,
+} from "./real-project-lsp-report.ts";
+
+export { selectProjects } from "./real-project-lsp-report.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const registryPath = path.join(root, "tests", "_fixtures", "vue-ecosystem-fixtures.json");
+const defaultShardTimeoutMs = 600_000;
+const diagnosticsTimeoutMs = 120_000;
+const probeName = "__vize_fixture_lsp_probe__";
+const fixedProbeSource = `<script setup lang="ts">
+const ${probeName}: number = 1
+</script>
+<template>{{ ${probeName} }}</template>
+`;
+const brokenProbeSource = fixedProbeSource.replace("= 1", '= "broken"');
+
+type LspAuditSession = {
+  initialize(workspaceDir: string, options?: LspInitializationOptions): Promise<unknown>;
+  notify(method: string, params: unknown): void;
+  shutdown(): Promise<void>;
+  waitForNotification(
+    method: string,
+    predicate?: (params: unknown) => boolean,
+    timeoutMs?: number,
+  ): Promise<unknown>;
+};
+
+type AuditDependencies = {
+  createSession?: () => LspAuditSession;
+  now?: () => number;
+};
+
+export async function runRealProjectLspAudit(
+  environment: NodeJS.ProcessEnv = process.env,
+  dependencies: AuditDependencies = {},
+) {
+  const registry = JSON.parse(fs.readFileSync(registryPath, "utf8")) as {
+    projects: FixtureProject[];
+    requiredToolCoverage: string[];
+  };
+  assert.ok(registry.requiredToolCoverage.includes("lsp"));
+  const selection = selectProjects(registry.projects, environment);
+  if (!selection.enforced && selection.projects.length === 0) return { skipped: true } as const;
+
+  const now = dependencies.now ?? Date.now;
+  const timeoutMs = positiveInteger(
+    environment.REAL_PROJECT_LSP_TIMEOUT_MS ?? String(defaultShardTimeoutMs),
+    "REAL_PROJECT_LSP_TIMEOUT_MS",
+  );
+  const deadline = now() + timeoutMs;
+  const evidence: LspProjectEvidence[] = [];
+
+  for (const project of selection.projects) {
+    assertBeforeDeadline(deadline, timeoutMs, now);
+    const startedAt = now();
+    const projectEvidence = emptyLspEvidence(project);
+    try {
+      assert.ok(project.coverage.includes("lsp"), `${project.id} does not declare lsp coverage`);
+      const fixtureDir = path.resolve(root, project.fixturePath);
+      assert.ok(isHydrated(fixtureDir), `${project.id} fixture is not hydrated`);
+      const files = collectVueInputPaths(fixtureDir, project.vueGlobs);
+      assertFixtureFileCount(project, files);
+      projectEvidence.vueFileCount = files.length;
+      projectEvidence.actualFile = files[0] ?? null;
+      const remainingMs = () => {
+        const remaining = deadline - now();
+        assert.ok(remaining > 0, `LSP fixture shard exceeded ${timeoutMs}ms`);
+        return Math.min(remaining, diagnosticsTimeoutMs);
+      };
+      const result = await exerciseLspLifecycle(
+        dependencies.createSession?.() ?? new LspSession(),
+        fixtureDir,
+        files[0] ?? null,
+        remainingMs,
+      );
+      Object.assign(projectEvidence, result, { status: "ok" as const });
+    } catch (error) {
+      projectEvidence.failure = errorMessage(error);
+    }
+    projectEvidence.durationMs = now() - startedAt;
+    evidence.push(projectEvidence);
+  }
+
+  const failed = evidence.filter((project) => project.status === "failed");
+  const report = createLspReport(selection, evidence, environment);
+  writeLspReport(report, environment);
+  assert.deepEqual(
+    failed.map((project) => `${project.id}: ${project.failure}`),
+    [],
+  );
+  process.stderr.write(
+    `LSP lifecycle: ${report.summary.projectCount} project(s), ` +
+      `${report.summary.actualFileCount} actual file(s), ` +
+      `${report.summary.failedProjectCount} failed project(s)\n`,
+  );
+  return { evidence, report, skipped: false } as const;
+}
+
+export async function exerciseLspLifecycle(
+  session: LspAuditSession,
+  workspaceDir: string,
+  actualFile: string | null,
+  timeoutMs: () => number = () => diagnosticsTimeoutMs,
+) {
+  const openUris: string[] = [];
+  let primaryError: unknown = null;
+  let shutdownError: unknown = null;
+  let result: {
+    actualFileDiagnostics: DiagnosticEvidence | null;
+    brokenProbeDiagnostics: DiagnosticEvidence;
+    fixedProbeDiagnostics: DiagnosticEvidence;
+    repairedProbeDiagnostics: DiagnosticEvidence;
+  } | null = null;
+  try {
+    await session.initialize(workspaceDir, {
+      completion: true,
+      editor: true,
+      typecheck: true,
+    });
+
+    let actualFileDiagnostics: DiagnosticEvidence | null = null;
+    if (actualFile != null) {
+      const absolute = path.join(workspaceDir, actualFile);
+      const uri = pathToFileURL(absolute).href;
+      const source = fs.readFileSync(absolute, "utf8");
+      openDocument(session, uri, source, 1);
+      openUris.push(uri);
+      const diagnostics = await waitForDiagnostics(session, uri, 1, timeoutMs());
+      actualFileDiagnostics = diagnosticEvidence(diagnostics.diagnostics);
+    }
+
+    const probeUri = pathToFileURL(path.join(workspaceDir, ".vize-fixture-lsp-probe.vue")).href;
+    openDocument(session, probeUri, fixedProbeSource, 1);
+    openUris.push(probeUri);
+    const fixed = await waitForDiagnostics(session, probeUri, 1, timeoutMs());
+
+    changeDocument(session, probeUri, brokenProbeSource, 2);
+    const broken = await waitForDiagnostics(
+      session,
+      probeUri,
+      2,
+      timeoutMs(),
+      (diagnostics) => injectedMismatches(diagnostics).length === 1,
+    );
+    const mismatches = injectedMismatches(broken.diagnostics);
+    assert.equal(mismatches.length, 1, JSON.stringify(broken.diagnostics));
+    assert.equal(String(mismatches[0]?.code).replace(/^TS/, ""), "2322");
+    assert.equal(mismatches[0]?.source, "vize/types");
+    assert.equal(mismatches[0]?.severity, 1);
+    const probeOffset = brokenProbeSource.indexOf(probeName);
+    const probeStart = offsetToPosition(brokenProbeSource, probeOffset);
+    assert.deepEqual(mismatches[0]?.range?.start, probeStart);
+    assert.deepEqual(mismatches[0]?.range?.end, {
+      line: probeStart.line,
+      character: probeStart.character + probeName.length,
+    });
+
+    changeDocument(session, probeUri, fixedProbeSource, 3);
+    const repaired = await waitForDiagnostics(
+      session,
+      probeUri,
+      3,
+      timeoutMs(),
+      (diagnostics) => injectedMismatches(diagnostics).length === 0,
+    );
+    assert.deepEqual(
+      normalizeDiagnostics(repaired.diagnostics),
+      normalizeDiagnostics(fixed.diagnostics),
+      "repair must restore the fixed diagnostic baseline exactly",
+    );
+
+    result = {
+      actualFileDiagnostics,
+      brokenProbeDiagnostics: diagnosticEvidence(broken.diagnostics),
+      fixedProbeDiagnostics: diagnosticEvidence(fixed.diagnostics),
+      repairedProbeDiagnostics: diagnosticEvidence(repaired.diagnostics),
+    };
+  } catch (error) {
+    primaryError = error;
+  } finally {
+    for (const uri of openUris.reverse()) {
+      try {
+        session.notify("textDocument/didClose", { textDocument: { uri } });
+      } catch {
+        // Shutdown below retains the primary protocol failure with server stderr.
+      }
+    }
+    try {
+      await session.shutdown();
+    } catch (error) {
+      shutdownError = error;
+    }
+  }
+  if (primaryError != null) throw primaryError;
+  if (shutdownError != null) throw shutdownError;
+  assert.ok(result);
+  return result;
+}
+
+function openDocument(session: LspAuditSession, uri: string, text: string, version: number): void {
+  session.notify("textDocument/didOpen", {
+    textDocument: { languageId: "vue", text, uri, version },
+  });
+}
+
+function changeDocument(
+  session: LspAuditSession,
+  uri: string,
+  text: string,
+  version: number,
+): void {
+  session.notify("textDocument/didChange", {
+    contentChanges: [{ text }],
+    textDocument: { uri, version },
+  });
+}
+
+async function waitForDiagnostics(
+  session: LspAuditSession,
+  uri: string,
+  version: number,
+  timeoutMs: number,
+  predicate?: (diagnostics: LspDiagnostic[]) => boolean,
+): Promise<PublishDiagnosticsParams> {
+  return (await session.waitForNotification(
+    "textDocument/publishDiagnostics",
+    (params) => {
+      if (!isDiagnosticsForUri(params, uri)) return false;
+      const diagnostics = params as PublishDiagnosticsParams;
+      return (
+        diagnostics.version === version && (predicate == null || predicate(diagnostics.diagnostics))
+      );
+    },
+    timeoutMs,
+  )) as PublishDiagnosticsParams;
+}
+
+function injectedMismatches(diagnostics: LspDiagnostic[]): LspDiagnostic[] {
+  return diagnostics.filter(
+    (diagnostic) =>
+      String(diagnostic.code).replace(/^TS/, "") === "2322" &&
+      /string.*not assignable.*number/i.test(diagnostic.message ?? ""),
+  );
+}
+
+export function normalizeDiagnostics(diagnostics: LspDiagnostic[]): string[] {
+  return diagnostics
+    .map((diagnostic) =>
+      JSON.stringify({
+        code: diagnostic.code,
+        message: diagnostic.message,
+        range: diagnostic.range,
+        severity: diagnostic.severity,
+        source: diagnostic.source,
+      }),
+    )
+    .sort();
+}
+
+function diagnosticEvidence(diagnostics: LspDiagnostic[]): DiagnosticEvidence {
+  const normalized = normalizeDiagnostics(diagnostics);
+  return {
+    count: normalized.length,
+    sha256: createHash("sha256")
+      .update(`${normalized.join("\n")}\n`)
+      .digest("hex"),
+  };
+}
+
+function assertBeforeDeadline(deadline: number, timeoutMs: number, now: () => number): void {
+  assert.ok(now() < deadline, `LSP fixture shard exceeded ${timeoutMs}ms`);
+}

--- a/tests/tooling/support/real-project-lsp-report.ts
+++ b/tests/tooling/support/real-project-lsp-report.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const reportName = "lsp-lifecycle-summary.json";
+
+export type FixtureProject = {
+  coverage: string[];
+  expectedVueFileCount: number | null;
+  fixturePath: string;
+  id: string;
+  revision: string;
+  vueGlobs: string[];
+};
+
+export type DiagnosticEvidence = {
+  count: number;
+  sha256: string;
+};
+
+export type LspProjectEvidence = {
+  actualFile: string | null;
+  actualFileDiagnostics: DiagnosticEvidence | null;
+  brokenProbeDiagnostics: DiagnosticEvidence | null;
+  durationMs: number;
+  failure?: string;
+  fixedProbeDiagnostics: DiagnosticEvidence | null;
+  id: string;
+  repairedProbeDiagnostics: DiagnosticEvidence | null;
+  revision: string;
+  status: "failed" | "ok";
+  vueFileCount: number;
+};
+
+export function selectProjects(projects: FixtureProject[], environment: NodeJS.ProcessEnv) {
+  const shardIndex = environment.FIXTURE_SHARD_INDEX;
+  const shardCount = environment.FIXTURE_SHARD_COUNT;
+  if ((shardIndex == null) !== (shardCount == null)) {
+    throw new Error("FIXTURE_SHARD_INDEX and FIXTURE_SHARD_COUNT must be set together");
+  }
+  if (shardIndex != null && shardCount != null) {
+    const index = nonNegativeInteger(shardIndex, "FIXTURE_SHARD_INDEX");
+    const count = positiveInteger(shardCount, "FIXTURE_SHARD_COUNT");
+    assert.ok(index < count, "FIXTURE_SHARD_INDEX must be less than FIXTURE_SHARD_COUNT");
+    const selected = projects.filter((_, projectIndex) => projectIndex % count === index);
+    assert.ok(selected.length > 0, `fixture shard ${index}/${count} selected no projects`);
+    return { enforced: true, projects: selected, shardCount: count, shardIndex: index };
+  }
+  return {
+    enforced: false,
+    projects: projects.filter((project) => isHydrated(path.resolve(root, project.fixturePath))),
+    shardCount: null,
+    shardIndex: null,
+  };
+}
+
+export function createLspReport(
+  selection: ReturnType<typeof selectProjects>,
+  projects: LspProjectEvidence[],
+  environment: NodeJS.ProcessEnv,
+) {
+  return {
+    schema: "vize.realProjectLspLifecycle",
+    version: 1,
+    commitSha: resolveCommitSha(environment),
+    shard: { count: selection.shardCount, index: selection.shardIndex },
+    summary: {
+      projectCount: projects.length,
+      actualFileCount: projects.filter((project) => project.actualFile != null).length,
+      vueFileCount: projects.reduce((total, project) => total + project.vueFileCount, 0),
+      failedProjectCount: projects.filter((project) => project.status === "failed").length,
+    },
+    projects,
+  };
+}
+
+export function writeLspReport(
+  report: ReturnType<typeof createLspReport>,
+  environment: NodeJS.ProcessEnv,
+): void {
+  const configured = environment.FIXTURE_REPORT_DIR;
+  if (configured == null || configured.length === 0) return;
+  const outputDir = path.resolve(root, configured);
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(path.join(outputDir, reportName), `${JSON.stringify(report, null, 2)}\n`);
+}
+
+export function emptyLspEvidence(project: FixtureProject): LspProjectEvidence {
+  return {
+    actualFile: null,
+    actualFileDiagnostics: null,
+    brokenProbeDiagnostics: null,
+    durationMs: 0,
+    fixedProbeDiagnostics: null,
+    id: project.id,
+    repairedProbeDiagnostics: null,
+    revision: project.revision,
+    status: "failed",
+    vueFileCount: 0,
+  };
+}
+
+export function assertFixtureFileCount(project: FixtureProject, files: string[]): void {
+  if (project.expectedVueFileCount != null) {
+    assert.equal(
+      files.length,
+      project.expectedVueFileCount,
+      `${project.id} matched ${files.length} Vue files, expected ${project.expectedVueFileCount}`,
+    );
+  }
+  if (project.expectedVueFileCount !== 0) {
+    assert.ok(files.length > 0, `${project.id} matched no files`);
+  }
+}
+
+export function isHydrated(directory: string): boolean {
+  return fs.existsSync(directory) && fs.readdirSync(directory).length > 0;
+}
+
+export function positiveInteger(value: string, name: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`${name} must be positive`);
+  return parsed;
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function nonNegativeInteger(value: string, name: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) throw new Error(`${name} must be non-negative`);
+  return parsed;
+}
+
+function resolveCommitSha(environment: NodeJS.ProcessEnv): string {
+  const value = environment.GITHUB_SHA;
+  if (value != null) return requireCommitSha(value, "GITHUB_SHA");
+  const result = spawnSync("git", ["rev-parse", "HEAD"], { cwd: root, encoding: "utf8" });
+  assert.equal(result.status, 0, "git rev-parse HEAD must succeed");
+  return requireCommitSha(result.stdout.trim(), "git rev-parse HEAD");
+}
+
+function requireCommitSha(value: string, source: string): string {
+  assert.match(value, /^[0-9a-f]{40}$/, `${source} must be a full lowercase commit SHA`);
+  return value;
+}


### PR DESCRIPTION
## Summary

- run the production vize lsp server once for every fixture project that declares LSP coverage
- open an authored Vue file when present, then exercise an in-workspace fixed, broken, and repaired document lifecycle
- require the exact TS2322 code, source, severity, and authored range, byte-stable repair diagnostics, versioned publications, and clean shutdown
- publish a per-shard JSON artifact and fail closed on hydration, file-count, timeout, protocol, diagnostic, or shutdown failures

## Failure before

All 133 registered projects declared LSP coverage, but the real-project workflow only executed compiler, typechecker, linter, formatter, and syntax-highlighter surfaces. No production LSP process opened those workspaces or proved edit-and-repair behavior.

## Verification

- failure-before workflow contract rejected the missing LSP step
- lifecycle and workflow contracts: 6/6 passed
- production CLI matrix: create-vue, Vue 2 vue2-elm, and zero-Vue-file docsify all passed; 97 registered Vue files discovered, 0 failed projects
- exact broken diagnostic and repaired baseline assertions passed
- Vite+ formatting and type-aware lint checks passed

Closes #3674

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->