### PR TITLE
fix(fixtures): normalize embedded syntax scopes

### DIFF
--- a/tests/tooling/support/syntax-semantic-divergence.ts
+++ b/tests/tooling/support/syntax-semantic-divergence.ts
@@ -16,7 +16,7 @@ export const semanticCategories = Object.freeze([
 ] as const);
 
 export const semanticNormalization = Object.freeze({
-  version: 1,
+  version: 2,
   categories: semanticCategories,
   coordinates: "1-based UTF-16 columns with an exclusive end",
   omittedCategories: Object.freeze([
@@ -27,6 +27,7 @@ export const semanticNormalization = Object.freeze({
     "number",
     "operator",
     "property",
+    "selector",
     "string",
     "type",
     "variable",
@@ -37,6 +38,8 @@ export const semanticNormalization = Object.freeze({
     "expression",
     "fenced_code",
     "heading",
+    "html",
+    "inline",
     "markup",
     "meta",
     "new",
@@ -149,18 +152,21 @@ function normalizeScopes(scopes: string[], label: string): string[] {
 
 function semanticCategory(scope: string): string | null {
   if (scope.startsWith("comment")) return "comment";
+  if (scope === "attribute_value") return "string";
   if (scope.startsWith("string")) return "string";
   if (scope.startsWith("constant.numeric")) return "number";
   if (scope.startsWith("constant") || scope.startsWith("support.constant")) return "literal";
   if (scope.startsWith("keyword.operator")) return "operator";
   if (scope.startsWith("keyword") && scope.endsWith(".vue")) return "attribute";
   if (scope.startsWith("keyword") || scope.startsWith("storage")) return "keyword";
+  if (scope.startsWith("tag.")) return "tag";
   if (scope.startsWith("entity.name.tag")) return "tag";
   if (scope.startsWith("entity.name.label")) return "label";
   if (scope.startsWith("entity.name.section")) return "label";
   if (scope.startsWith("entity.name.constant")) return "literal";
   if (scope.startsWith("entity.other.keyframe-offset")) return "literal";
   if (scope.startsWith("entity.other.counter-name")) return "literal";
+  if (scope.startsWith("entity.other.attribute-selector")) return "selector";
   if (scope.startsWith("entity.other.attribute-name")) return "attribute";
   if (scope.startsWith("entity.name.function") || scope.startsWith("support.function")) {
     return "function";

--- a/tests/tooling/syntax-highlighter-divergence.test.ts
+++ b/tests/tooling/syntax-highlighter-divergence.test.ts
@@ -78,6 +78,7 @@ test("semantic comparison records exact shared, false-positive, and false-negati
 
 test("published normalization evidence is immutable canonical JSON", () => {
   assert.ok(Object.isFrozen(semanticNormalization));
+  assert.equal(semanticNormalization.version, 2);
   assert.ok(Object.isFrozen(semanticNormalization.categories));
   assert.ok(Object.isFrozen(semanticNormalization.omittedCategories));
   assert.ok(Object.isFrozen(semanticNormalization.ignoredScopeFamilies));
@@ -134,6 +135,10 @@ test("normalization ignores structural nesting but detects changed semantic scop
       "entity.name.constant.counter-name.less",
       "entity.other.keyframe-offset.percentage.css",
       "entity.other.counter-name.less",
+      "attribute_value",
+      "entity.other.attribute-selector.sass",
+      "html",
+      "inline.pug",
     ]),
     "x",
     "source.vue",
@@ -152,6 +157,14 @@ test("normalization ignores structural nesting but detects changed semantic scop
     "vue-shell.vue",
   );
   assert.deepEqual(vueShell.semanticSpans[0].categories, ["attribute"]);
+
+  const pugInlineTag = tokenizeSemanticSource(
+    grammar(["source.vue", "tag.inline.pug"]),
+    "x",
+    "source.vue",
+    "pug-inline-tag.vue",
+  );
+  assert.deepEqual(pugInlineTag.semanticSpans[0].categories, ["tag"]);
 });
 
 test("semantic tokenizer fails closed on unknown scopes, malformed spans, and timeouts", () => {


### PR DESCRIPTION
## Summary

- classify Pug attribute values as omitted strings and inline Pug tags as authored tags
- ignore structural Pug inline and embedded HTML wrapper scopes
- classify Sass attribute selectors as an omitted selector role
- bump the published semantic-normalization evidence version and keep unknown scopes fail closed

## Failure before

The full 11-shard real-project sweep failed in shards 3, 5, 6, and 9. The shipped grammar emitted previously unseen scopes in five pinned projects: attribute_value, html, inline.pug, tag.inline.pug, and entity.other.attribute-selector.sass.

## Verification

- exact five-project reproduction: Vuetify, Vuelidate, Splitpanes, Vue Cal v4, and LX Music Desktop
- 1,427 Vue files tokenized against the pinned Shiki oracle: 0 project failures
- semantic normalization and fail-closed contracts: 5/5 passed
- Vite+ formatting and type-aware lint checks passed

Refs #3674

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated syntax-highlighting validation to use the latest normalization rules.
  * Added coverage for selector scopes, inline and HTML scopes, attribute values, and tag-related scopes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->