### PR TITLE
fix(fixtures): pin the real-project LSP Corsa binary

### DIFF
--- a/tests/tooling/support/lsp/launch.ts
+++ b/tests/tooling/support/lsp/launch.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { root } from "./paths.ts";
 
@@ -32,4 +34,53 @@ export function resolveVizeLaunchCommand(
   }
 
   return ["cargo", "run", "-q", "-p", "vize", "--", "lsp"];
+}
+
+/**
+ * Absolute path to the Corsa/tsgo binary this checkout pins through
+ * `@typescript/native-preview`.
+ *
+ * The server discovers Corsa by walking the workspace root's ancestors, so a
+ * real project that installs its own `@typescript/native-preview` wins over the
+ * checkout's. Older builds reject flags the bridge sends (misskey pins a build
+ * whose `api` subcommand has no `-async`), the bridge then reports "not
+ * available", and type diagnostics silently disappear in exactly the workspaces
+ * that ship a binary. Sessions that must type check a real workspace pass this
+ * path as `CORSA_PATH`, which the resolver honors ahead of its ancestor walk.
+ *
+ * Resolution mirrors Node: read the meta package, then resolve the platform
+ * package from the meta package's real location.
+ */
+export function resolvePinnedCorsaPath(): string {
+  const rootRequire = createRequire(path.join(root, "package.json"));
+  const metaManifestPath = fs.realpathSync(
+    rootRequire.resolve("@typescript/native-preview/package.json"),
+  );
+  const metaRequire = createRequire(metaManifestPath);
+  const basePackage = `@typescript/native-preview-${process.platform}-${process.arch}`;
+  // The platform packages are optional dependencies gated on os/cpu/libc, so a
+  // host only ever has one of them installed. On Linux that is either the glibc
+  // or the musl build; probe both instead of assuming glibc.
+  const platformPackages =
+    process.platform === "linux" ? [basePackage, `${basePackage}-musl`] : [basePackage];
+  const attempted: string[] = [];
+
+  for (const platformPackage of platformPackages) {
+    let platformManifestPath: string;
+    try {
+      platformManifestPath = metaRequire.resolve(`${platformPackage}/package.json`);
+    } catch {
+      attempted.push(`${platformPackage} (not installed)`);
+      continue;
+    }
+    const binary = path.join(
+      path.dirname(platformManifestPath),
+      "lib",
+      process.platform === "win32" ? "tsgo.exe" : "tsgo",
+    );
+    if (fs.existsSync(binary)) return binary;
+    attempted.push(binary);
+  }
+
+  throw new Error(`missing pinned Corsa binary (checked ${attempted.join(", ")})`);
 }

--- a/tests/tooling/support/lsp/session.ts
+++ b/tests/tooling/support/lsp/session.ts
@@ -58,10 +58,16 @@ export class LspSession {
   private nextId = 0;
   private stderr = "";
 
-  constructor() {
+  /**
+   * `env` entries are layered over the test runner's environment, so callers
+   * can pin server-side discovery (for example `CORSA_PATH`) without leaking
+   * that choice into unrelated sessions.
+   */
+  constructor(options: { env?: NodeJS.ProcessEnv } = {}) {
     const [command, ...args] = resolveVizeLaunchCommand();
     this.process = spawn(command, args, {
       cwd: root,
+      env: { ...process.env, ...options.env },
       stdio: ["pipe", "pipe", "pipe"],
     });
 

--- a/tests/tooling/support/lsp/session.ts
+++ b/tests/tooling/support/lsp/session.ts
@@ -58,11 +58,7 @@ export class LspSession {
   private nextId = 0;
   private stderr = "";
 
-  /**
-   * `env` entries are layered over the test runner's environment, so callers
-   * can pin server-side discovery (for example `CORSA_PATH`) without leaking
-   * that choice into unrelated sessions.
-   */
+  /** `env` layers over the runner environment, e.g. to pin `CORSA_PATH` for one session. */
   constructor(options: { env?: NodeJS.ProcessEnv } = {}) {
     const [command, ...args] = resolveVizeLaunchCommand();
     this.process = spawn(command, args, {

--- a/tests/tooling/support/real-project-lsp-audit.ts
+++ b/tests/tooling/support/real-project-lsp-audit.ts
@@ -6,6 +6,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { collectVueInputPaths } from "../../../tools/fixtures/tool-matrix-inputs.mjs";
 import { isDiagnosticsForUri, offsetToPosition } from "./lsp/assertions.ts";
+import { resolvePinnedCorsaPath } from "./lsp/launch.ts";
 import type {
   LspDiagnostic,
   LspInitializationOptions,
@@ -94,7 +95,7 @@ export async function runRealProjectLspAudit(
         return Math.min(remaining, diagnosticsTimeoutMs);
       };
       const result = await exerciseLspLifecycle(
-        dependencies.createSession?.() ?? new LspSession(),
+        dependencies.createSession?.() ?? createPinnedSession(),
         fixtureDir,
         files[0] ?? null,
         remainingMs,
@@ -120,6 +121,24 @@ export async function runRealProjectLspAudit(
       `${report.summary.failedProjectCount} failed project(s)\n`,
   );
   return { evidence, report, skipped: false } as const;
+}
+
+let pinnedCorsaPath: string | null = null;
+
+/**
+ * Start a production LSP session pinned to the Corsa binary this checkout
+ * ships.
+ *
+ * One project per shard installs its own dependencies for the typecheck
+ * baseline, and a project that pins an older `@typescript/native-preview` than
+ * this checkout (misskey does) wins the server's ancestor walk with a binary
+ * whose `api` subcommand rejects the flags the bridge sends. The bridge then
+ * reports "not available", the probe never receives its TS2322, and the wait
+ * burns the diagnostics timeout instead of proving anything about vize.
+ */
+function createPinnedSession(): LspAuditSession {
+  pinnedCorsaPath ??= resolvePinnedCorsaPath();
+  return new LspSession({ env: { CORSA_PATH: pinnedCorsaPath } });
 }
 
 export async function exerciseLspLifecycle(


### PR DESCRIPTION
Shard 10 of Real Project Matrix @ de3243b failed in `Check real-project LSP lifecycle` with `misskey: Timed out waiting for notification textDocument/publishDiagnostics` after burning the full 120s diagnostics wait. The captured server log shows why:

```
WARN vize_maestro::server::state::corsa: corsa bridge spawn failed: Failed to spawn Corsa:
     Failed to start Corsa API session: process is closed: jsonrpc reader
     (working_dir=Some(".../tests/_fixtures/_git/misskey"), corsa_path=None)
flag provided but not defined: -async
```

misskey is its shard's typecheck-performance project, so its dependencies are installed, and it pins `@typescript/native-preview` `7.0.0-dev.20260116.1` while this checkout pins `7.0.0-dev.20260602.1`. The server discovers Corsa by walking the workspace root's ancestors, finds misskey's older binary first, and that build's `api` subcommand has no `-async`. The bridge reports "not available", so the broken probe never gets its TS2322 and the audit waits out the timeout instead of measuring vize.

The fix pins the binary the checkout ships for the audit's sessions, which the resolver honors ahead of its ancestor walk:

```ts
function createPinnedSession(): LspAuditSession {
  pinnedCorsaPath ??= resolvePinnedCorsaPath();
  return new LspSession({ env: { CORSA_PATH: pinnedCorsaPath } });
}
```

`resolvePinnedCorsaPath` mirrors the resolution the editor-e2e harness already does for the same reason (`tools/editor-e2e/real-vue-workspace.mjs`): read `@typescript/native-preview` from the repo root, then the platform package's `lib/tsgo`, probing both glibc and musl on Linux and failing with the paths it checked. `LspSession` now takes an optional `env` layered over the runner's environment, so no other suite's discovery changes.

The four contract tests in `tests/tooling/real-project-lsp.test.ts` still pass; they drive a fake session, so the pinned path is only resolved on the real-workspace path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language-service audit reliability by consistently using the pinned TypeScript native binary.
  * Added platform-aware binary resolution for Linux environments, including glibc and musl variants.
  * Enhanced diagnostics when the required binary cannot be located.
  * Added support for custom environment settings when launching language-service sessions.
  * Reused the resolved binary across audit sessions for more consistent diagnostics and faster execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->