### PR TITLE
ci(fixtures): pin LSP typecheck runtime

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -118,6 +118,10 @@ jobs:
           REAL_PROJECT_LSP_TIMEOUT_MS: "600000"
           VIZE_LSP_BIN: target/ci/vize
         run: |
+          if [ ! -x "$CORSA_PATH" ]; then
+            echo "::error title=Missing typecheck runtime::vp install produced no executable at $CORSA_PATH"
+            exit 1
+          fi
           node --test --test-concurrency=1 \
             tests/tooling/real-project-lsp.test.ts
           test -s "$FIXTURE_REPORT_DIR/lsp-lifecycle-summary.json"

--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -114,6 +114,7 @@ jobs:
 
       - name: Check real-project LSP lifecycle
         env:
+          CORSA_PATH: ${{ github.workspace }}/node_modules/.bin/tsgo
           REAL_PROJECT_LSP_TIMEOUT_MS: "600000"
           VIZE_LSP_BIN: target/ci/vize
         run: |

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -130,8 +130,11 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
     runIndex < lspIndex && lspIndex < syntaxHighlighterIndex,
     "the hydrated fixture corpus must run through the production LSP before syntax audit",
   );
-  assert.equal(lsp.env?.VIZE_LSP_BIN, "target/ci/vize");
-  assert.equal(lsp.env?.REAL_PROJECT_LSP_TIMEOUT_MS, "600000");
+  assert.deepEqual(lsp.env, {
+    CORSA_PATH: "${{ github.workspace }}/node_modules/.bin/tsgo",
+    REAL_PROJECT_LSP_TIMEOUT_MS: "600000",
+    VIZE_LSP_BIN: "target/ci/vize",
+  });
   assert.match(lsp.run ?? "", /tests\/tooling\/real-project-lsp\.test\.ts/);
   assert.match(lsp.run ?? "", /--test-concurrency=1/);
   assert.match(lsp.run ?? "", /test -s "\$FIXTURE_REPORT_DIR\/lsp-lifecycle-summary\.json"/);

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -135,6 +135,8 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
     REAL_PROJECT_LSP_TIMEOUT_MS: "600000",
     VIZE_LSP_BIN: "target/ci/vize",
   });
+  assert.match(lsp.run ?? "", /if \[ ! -x "\$CORSA_PATH" \]; then/);
+  assert.match(lsp.run ?? "", /::error title=Missing typecheck runtime::/);
   assert.match(lsp.run ?? "", /tests\/tooling\/real-project-lsp\.test\.ts/);
   assert.match(lsp.run ?? "", /--test-concurrency=1/);
   assert.match(lsp.run ?? "", /test -s "\$FIXTURE_REPORT_DIR\/lsp-lifecycle-summary\.json"/);


### PR DESCRIPTION
## Summary

- pin the real-project LSP lifecycle to the repository-owned TypeScript native runtime
- prevent hydrated fixtures from substituting an older, protocol-incompatible runtime
- assert the complete fail-closed workflow environment

## Tests

- `node --test tests/tooling/real-project-matrix-workflow.test.ts`
- `vp fmt --check .github/workflows/real-project-matrix.yml tests/tooling/real-project-matrix-workflow.test.ts`
- full 11-shard real-project matrix pending

Refs #3674

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LSP workflow configuration by setting the correct workspace executable path.
  * Updated workflow validation to ensure the complete environment configuration is checked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->