### PR TITLE
fix(atelier): align static JSX v-model arguments

### DIFF
--- a/crates/vize_atelier_core/src/codegen/element/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/element/directives.rs
@@ -24,13 +24,18 @@ fn generate_vmodel_entry(
 
     let modifiers: Vec<_> = dir.modifiers.iter().map(|m| m.content.as_str()).collect();
     let parsed_mods = parse_model_modifiers(&dir.modifiers);
-    let has_modifiers = parsed_mods.lazy || parsed_mods.number || parsed_mods.trim;
+    let active_modifiers: Vec<_> = modifiers
+        .iter()
+        .copied()
+        .filter(|modifier| dir.arg.is_some() || matches!(*modifier, "lazy" | "number" | "trim"))
+        .collect();
+    let has_modifiers = if dir.arg.is_some() {
+        !active_modifiers.is_empty()
+    } else {
+        parsed_mods.lazy || parsed_mods.number || parsed_mods.trim
+    };
 
     if has_modifiers {
-        let active_modifiers: Vec<_> = modifiers
-            .iter()
-            .filter(|m| matches!(*m, &"lazy" | &"number" | &"trim"))
-            .collect();
         let is_single_modifier = active_modifiers.len() == 1;
 
         ctx.push("  [");
@@ -45,7 +50,13 @@ fn generate_vmodel_entry(
         }
         ctx.push(",");
         ctx.newline();
-        ctx.push("    void 0,");
+        if let Some(arg) = &dir.arg {
+            ctx.push("    ");
+            generate_expression(ctx, arg);
+            ctx.push(",");
+        } else {
+            ctx.push("    void 0,");
+        }
         ctx.newline();
 
         if is_single_modifier {
@@ -74,6 +85,10 @@ fn generate_vmodel_entry(
         ctx.push(", ");
         if let Some(exp) = &dir.exp {
             generate_expression(ctx, exp);
+        }
+        if let Some(arg) = &dir.arg {
+            ctx.push(", ");
+            generate_expression(ctx, arg);
         }
         ctx.push("]");
     }

--- a/crates/vize_atelier_core/src/lane.rs
+++ b/crates/vize_atelier_core/src/lane.rs
@@ -6,6 +6,7 @@
 mod context;
 #[path = "transform/element.rs"]
 pub mod element;
+mod extensions;
 #[path = "transform/patterned_template.rs"]
 pub mod patterned_template;
 #[path = "transform/structural.rs"]
@@ -27,6 +28,13 @@ use crate::{
 };
 
 use traverse::traverse_children;
+
+#[allow(deprecated)]
+pub use extensions::{
+    transform_with_hoisted_scope_id, transform_with_plain_element_model_argument,
+    transform_with_template_syntax_quirks_and_hoisted_scope_id,
+    transform_with_vue_parser_quirks_and_hoisted_scope_id,
+};
 
 /// Transform function for nodes - returns optional exit function(s)
 pub type NodeTransform<'a> =
@@ -104,6 +112,7 @@ pub struct TransformContext<'a> {
     pub errors: std::vec::Vec<CompilerError>,
     /// Enables compatibility for template syntax edge-case behavior.
     pub(crate) template_syntax_quirks: bool,
+    pub(crate) allow_static_v_model_arg_on_element: bool,
     /// Node was removed flag
     pub(crate) node_removed: bool,
     /// Semantic analysis summary (optional, for enhanced transforms)
@@ -169,7 +178,7 @@ pub fn transform<'a>(
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
 ) -> std::vec::Vec<CompilerError> {
-    transform_inner(allocator, root, options, analysis, false, None)
+    transform_inner(allocator, root, options, analysis, false, None, false)
 }
 
 /// Transform the root AST node with template syntax quirk compatibility enabled.
@@ -179,7 +188,7 @@ pub fn transform_with_template_syntax_quirks<'a>(
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
 ) -> std::vec::Vec<CompilerError> {
-    transform_inner(allocator, root, options, analysis, true, None)
+    transform_inner(allocator, root, options, analysis, true, None, false)
 }
 
 /// Transform the root AST node with Vue parser quirk compatibility enabled.
@@ -193,56 +202,14 @@ pub fn transform_with_vue_parser_quirks<'a>(
     transform_with_template_syntax_quirks(allocator, root, options, analysis)
 }
 
-/// Transform the root AST node with an explicit scope ID for hoisted VNodes.
-#[doc(hidden)]
-pub fn transform_with_hoisted_scope_id<'a>(
-    allocator: &'a Bump,
-    root: &mut RootNode<'a>,
-    options: TransformOptions,
-    analysis: Option<&'a Croquis>,
-    hoisted_scope_id: Option<String>,
-) -> std::vec::Vec<CompilerError> {
-    transform_inner(allocator, root, options, analysis, false, hoisted_scope_id)
-}
-
-/// Transform the root AST node with template syntax quirks and an explicit hoisted scope ID.
-#[doc(hidden)]
-pub fn transform_with_template_syntax_quirks_and_hoisted_scope_id<'a>(
-    allocator: &'a Bump,
-    root: &mut RootNode<'a>,
-    options: TransformOptions,
-    analysis: Option<&'a Croquis>,
-    hoisted_scope_id: Option<String>,
-) -> std::vec::Vec<CompilerError> {
-    transform_inner(allocator, root, options, analysis, true, hoisted_scope_id)
-}
-
-/// Transform the root AST node with Vue parser quirks and an explicit hoisted scope ID.
-#[doc(hidden)]
-#[deprecated(note = "use transform_with_template_syntax_quirks_and_hoisted_scope_id instead")]
-pub fn transform_with_vue_parser_quirks_and_hoisted_scope_id<'a>(
-    allocator: &'a Bump,
-    root: &mut RootNode<'a>,
-    options: TransformOptions,
-    analysis: Option<&'a Croquis>,
-    hoisted_scope_id: Option<String>,
-) -> std::vec::Vec<CompilerError> {
-    transform_with_template_syntax_quirks_and_hoisted_scope_id(
-        allocator,
-        root,
-        options,
-        analysis,
-        hoisted_scope_id,
-    )
-}
-
-fn transform_inner<'a>(
+pub(crate) fn transform_inner<'a>(
     allocator: &'a Bump,
     root: &mut RootNode<'a>,
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
     template_syntax_quirks: bool,
     hoisted_scope_id: Option<String>,
+    allow_static_v_model_arg_on_element: bool,
 ) -> std::vec::Vec<CompilerError> {
     let source = root.source.clone();
     let mut ctx = if let Some(analysis) = analysis {
@@ -261,6 +228,7 @@ fn transform_inner<'a>(
             template_syntax_quirks,
         )
     };
+    ctx.allow_static_v_model_arg_on_element = allow_static_v_model_arg_on_element;
     ctx.hoisted_scope_id = hoisted_scope_id;
     ctx.root = Some(root as *mut _);
 

--- a/crates/vize_atelier_core/src/lane/extensions.rs
+++ b/crates/vize_atelier_core/src/lane/extensions.rs
@@ -1,0 +1,77 @@
+//! Specialized transform entry points layered over the shared transform lane.
+
+use vize_carton::{Bump, String};
+use vize_croquis::Croquis;
+
+use super::transform_inner;
+use crate::{CompilerError, RootNode, TransformOptions};
+
+/// Transform the root AST node with an explicit scope ID for hoisted VNodes.
+#[doc(hidden)]
+pub fn transform_with_hoisted_scope_id<'a>(
+    allocator: &'a Bump,
+    root: &mut RootNode<'a>,
+    options: TransformOptions,
+    analysis: Option<&'a Croquis>,
+    hoisted_scope_id: Option<String>,
+) -> std::vec::Vec<CompilerError> {
+    transform_inner(
+        allocator,
+        root,
+        options,
+        analysis,
+        false,
+        hoisted_scope_id,
+        false,
+    )
+}
+
+/// Transform with template syntax quirks and an explicit hoisted VNode scope ID.
+#[doc(hidden)]
+pub fn transform_with_template_syntax_quirks_and_hoisted_scope_id<'a>(
+    allocator: &'a Bump,
+    root: &mut RootNode<'a>,
+    options: TransformOptions,
+    analysis: Option<&'a Croquis>,
+    hoisted_scope_id: Option<String>,
+) -> std::vec::Vec<CompilerError> {
+    transform_inner(
+        allocator,
+        root,
+        options,
+        analysis,
+        true,
+        hoisted_scope_id,
+        false,
+    )
+}
+
+/// Transform with Vue parser quirks and an explicit hoisted VNode scope ID.
+#[doc(hidden)]
+#[deprecated(note = "use transform_with_template_syntax_quirks_and_hoisted_scope_id instead")]
+pub fn transform_with_vue_parser_quirks_and_hoisted_scope_id<'a>(
+    allocator: &'a Bump,
+    root: &mut RootNode<'a>,
+    options: TransformOptions,
+    analysis: Option<&'a Croquis>,
+    hoisted_scope_id: Option<String>,
+) -> std::vec::Vec<CompilerError> {
+    transform_with_template_syntax_quirks_and_hoisted_scope_id(
+        allocator,
+        root,
+        options,
+        analysis,
+        hoisted_scope_id,
+    )
+}
+
+/// Transform with Babel JSX's static plain-element v-model argument extension.
+#[doc(hidden)]
+pub fn transform_with_plain_element_model_argument<'a>(
+    allocator: &'a Bump,
+    root: &mut RootNode<'a>,
+    options: TransformOptions,
+    analysis: Option<&'a Croquis>,
+) -> std::vec::Vec<CompilerError> {
+    transform_inner(allocator, root, options, analysis, false, None, true)
+}

--- a/crates/vize_atelier_core/src/transform/context.rs
+++ b/crates/vize_atelier_core/src/transform/context.rs
@@ -50,6 +50,7 @@ impl<'a> TransformContext<'a> {
             in_ssr: ssr,
             errors: std::vec::Vec::new(),
             template_syntax_quirks,
+            allow_static_v_model_arg_on_element: false,
             node_removed: false,
             analysis: None,
             hoisted_scope_id: None,
@@ -299,7 +300,6 @@ impl<'a> TransformContext<'a> {
     }
 
     /// Register a Vue 2 pipe filter (maintains first-seen order for codegen).
-    ///
     /// Legacy-only; only ever called from the dialect-gated filter rewrite.
     #[cfg(feature = "legacy")]
     pub(crate) fn add_filter(&mut self, filter: impl Into<String>) {

--- a/crates/vize_atelier_core/src/transform/element.rs
+++ b/crates/vize_atelier_core/src/transform/element.rs
@@ -4,7 +4,10 @@ use vize_carton::{Box, String, Vec, capitalize, is_builtin_directive, is_native_
 
 use crate::errors::ErrorCode;
 use crate::steps::expression::process_inline_handler;
-use crate::steps::v_model::generate_model_assignment_handler;
+use crate::steps::v_model::{
+    generate_model_assignment_handler, model_update_listener_name,
+    supports_plain_element_model_argument,
+};
 use crate::steps::v_slot::validate_v_slot_usage;
 use crate::{
     ConstantType, DirectiveNode, ElementNode, ElementType, ExpressionNode, InterpolationNode,
@@ -304,10 +307,12 @@ fn process_element_props<'a>(ctx: &mut TransformContext<'a>, el: &mut Box<'a, El
                 continue;
             }
 
-            // v-model with an argument (static or dynamic) is a component-only
-            // feature. On a plain element Vue raises a hard compile error and
-            // generates no binding, so reject it here before emitting anything.
-            if !is_component && dir.arg.is_some() {
+            if !is_component
+                && !supports_plain_element_model_argument(
+                    ctx.allow_static_v_model_arg_on_element,
+                    dir.arg.as_ref(),
+                )
+            {
                 ctx.on_error(ErrorCode::VModelArgOnElement, Some(dir.loc.clone()));
                 invalid_model_indices.push(idx);
                 continue;
@@ -337,21 +342,8 @@ fn process_element_props<'a>(ctx: &mut TransformContext<'a>, el: &mut Box<'a, El
                     }
                 });
 
-            // Create event name
-            let event_name = if is_component {
-                let mut name = String::with_capacity(9 + prop_name.len());
-                name.push_str("onUpdate:");
-                name.push_str(prop_name.as_str());
-                name
-            } else {
-                // For native elements, use input event (or change for lazy)
-                let has_lazy = dir.modifiers.iter().any(|m| m.content == "lazy");
-                if has_lazy {
-                    String::new("onChange")
-                } else {
-                    String::new("onInput")
-                }
-            };
+            let named_model = is_component || dir.arg.is_some();
+            let event_name = model_update_listener_name(named_model.then_some(prop_name.as_str()));
 
             // Build handler expression
             let handler = if is_component {
@@ -565,7 +557,7 @@ fn process_element_props<'a>(ctx: &mut TransformContext<'a>, el: &mut Box<'a, El
     } else {
         // For native elements: process in reverse order to preserve indices during insertion
         for data in vmodel_data.iter().rev() {
-            // Keep v-model directive, insert onUpdate:modelValue handler right after it
+            // Keep v-model directive, insert its update handler right after it.
             let handler =
                 generate_model_assignment_handler(ctx, data.raw_value_exp.as_str(), "$event");
             let raw_handler_expr = ExpressionNode::Simple(Box::new_in(
@@ -578,7 +570,11 @@ fn process_element_props<'a>(ctx: &mut TransformContext<'a>, el: &mut Box<'a, El
                     name: String::new("on"),
                     raw_name: None,
                     arg: Some(ExpressionNode::Simple(Box::new_in(
-                        SimpleExpressionNode::new("update:modelValue", true, data.dir_loc.clone()),
+                        SimpleExpressionNode::new(
+                            &data.event_name[2..],
+                            true,
+                            data.dir_loc.clone(),
+                        ),
                         allocator,
                     ))),
                     exp: Some(processed_handler),

--- a/crates/vize_atelier_core/src/transforms/v_model.rs
+++ b/crates/vize_atelier_core/src/transforms/v_model.rs
@@ -61,6 +61,22 @@ pub(crate) fn generate_model_assignment_handler(
     handler
 }
 
+pub(crate) fn supports_plain_element_model_argument(
+    allow_static: bool,
+    arg: Option<&ExpressionNode<'_>>,
+) -> bool {
+    arg.is_none()
+        || (allow_static && matches!(arg, Some(ExpressionNode::Simple(arg)) if arg.is_static))
+}
+
+pub(crate) fn model_update_listener_name(argument: Option<&str>) -> String {
+    let argument = argument.unwrap_or("modelValue");
+    let mut name = String::with_capacity(9 + argument.len());
+    name.push_str("onUpdate:");
+    name.push_str(argument);
+    name
+}
+
 /// Parse v-model modifiers from directive modifiers
 pub fn parse_model_modifiers(modifiers: &Vec<'_, SimpleExpressionNode<'_>>) -> VModelModifiers {
     let mut result = VModelModifiers::default();

--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -315,6 +315,7 @@ pub fn compile_jsx_with_babel_pragma_and_merge_props(
                         transform_on_helper: transform_on_helper.as_deref(),
                         vnode_factory,
                         merge_props,
+                        allow_static_v_model_arg_on_element: config.compat.is_babel(),
                     },
                     &mut diagnostics,
                 )),

--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -22,7 +22,9 @@ use vize_relief::{
 
 use super::Lowerer;
 use super::expr::container_expr_span;
-use super::v_model::{ModelArrayLowering, split_underscore_model_modifiers};
+use super::v_model::{
+    ModelArrayLowering, split_model_arg_modifiers, split_underscore_model_modifiers,
+};
 
 enum DirectiveAttributeLowering<'a> {
     NotDirective,
@@ -50,7 +52,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
                     if self.try_lower_v_models(attr, on_component, &mut props) {
                         continue;
                     }
-                    self.lower_attribute(attr)
+                    self.lower_attribute(attr, on_component)
                 }
                 JSXAttributeItem::SpreadAttribute(spread) => {
                     Some(self.lower_spread_attribute(spread))
@@ -74,7 +76,11 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     }
 
     /// Lower one attribute, or `None` when it was rejected with a diagnostic.
-    fn lower_attribute(&mut self, attr: &JSXAttribute<'_>) -> Option<PropNode<'a>> {
+    fn lower_attribute(
+        &mut self,
+        attr: &JSXAttribute<'_>,
+        on_component: bool,
+    ) -> Option<PropNode<'a>> {
         let loc = self.mapper().location(attr.span);
 
         // `v-model` writes back through an assignment, so its target must be
@@ -92,7 +98,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         }
 
         // Directive forms: `v-model`, `v-show`, `v-on:click`, custom `v-foo:arg`.
-        match self.try_directive_attribute(attr, &loc) {
+        match self.try_directive_attribute(attr, &loc, on_component) {
             DirectiveAttributeLowering::Lowered(directive) => return Some(directive),
             DirectiveAttributeLowering::Rejected => return None,
             DirectiveAttributeLowering::NotDirective => {}
@@ -203,6 +209,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         &mut self,
         attr: &JSXAttribute<'_>,
         loc: &SourceLocation,
+        on_component: bool,
     ) -> DirectiveAttributeLowering<'a> {
         let (raw_name, arg) = match &attr.name {
             JSXAttributeName::NamespacedName(named) => {
@@ -223,6 +230,30 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
                 (raw_name, None)
             }
         };
+
+        // Babel encodes `v-model:foo.trim` as `v-model:foo_trim` because JSX
+        // attribute names cannot contain dots. This spelling is special only
+        // for Babel-compatible plain elements; component arguments retain the
+        // authored underscore name and their established lowering.
+        if self.uses_babel_vdom_compat()
+            && !on_component
+            && raw_name == "model"
+            && let Some((arg_name, arg_span)) = arg
+            && let Some((model_arg, suffix_mods)) = split_model_arg_modifiers(arg_name)
+        {
+            let mut directive = DirectiveNode::new(self.bump(), "model", loc.clone());
+            directive.arg = Some(self.static_expr(model_arg, arg_span));
+            directive.exp = self.directive_value_expr(attr.value.as_ref());
+            for modifier in suffix_mods {
+                directive
+                    .modifiers
+                    .push(SimpleExpressionNode::new(modifier, false, loc.clone()));
+            }
+            return DirectiveAttributeLowering::Lowered(PropNode::Directive(Box::new_in(
+                directive,
+                self.bump(),
+            )));
+        }
 
         // `v-model_lazy` / `v-model_number_lazy` — babel-plugin-jsx encodes
         // v-model modifiers as `_<mod>` name suffixes (JSX attribute names cannot

--- a/crates/vize_atelier_jsx/src/lower/v_model.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_model.rs
@@ -259,3 +259,17 @@ pub(crate) fn split_underscore_model_modifiers(
     }
     Some(("model", mods))
 }
+
+/// Split Babel's namespaced argument/modifier spelling:
+/// `v-model:argument_trim` -> `("argument", ["trim"])`.
+pub(crate) fn split_model_arg_modifiers(name: &str) -> Option<(&str, std::vec::Vec<&str>)> {
+    let (arg, rest) = name.split_once('_')?;
+    if arg.is_empty() || rest.is_empty() {
+        return None;
+    }
+    let modifiers: std::vec::Vec<_> = rest.split('_').collect();
+    if modifiers.iter().any(|modifier| modifier.is_empty()) {
+        return None;
+    }
+    Some((arg, modifiers))
+}

--- a/crates/vize_atelier_jsx/src/vdom.rs
+++ b/crates/vize_atelier_jsx/src/vdom.rs
@@ -12,7 +12,7 @@
 //! `@vue/babel-plugin-jsx`-shaped output; callers can opt in.
 
 use vize_atelier_core::codegen::generate_with_vnode_factory_and_merge_props;
-use vize_atelier_core::lane::transform;
+use vize_atelier_core::lane::{transform, transform_with_plain_element_model_argument};
 use vize_atelier_core::options::{CodegenMode, CodegenOptions, TransformOptions};
 // `CodegenMode::Module` is the only supported JSX target: JSX/TSX is authored
 // for bundlers, and the runtime `Function` (with-block) mode emits an empty
@@ -80,6 +80,7 @@ pub(crate) struct VdomCompatOptions<'a> {
     pub transform_on_helper: Option<&'a str>,
     pub vnode_factory: Option<&'a str>,
     pub merge_props: bool,
+    pub allow_static_v_model_arg_on_element: bool,
 }
 
 impl Default for VdomCompatOptions<'_> {
@@ -88,6 +89,7 @@ impl Default for VdomCompatOptions<'_> {
             transform_on_helper: None,
             vnode_factory: None,
             merge_props: true,
+            allow_static_v_model_arg_on_element: false,
         }
     }
 }
@@ -173,7 +175,11 @@ pub(crate) fn compile_root_to_vdom(
         binding_metadata: None,
         ..Default::default()
     };
-    let errors = transform(bump, &mut root, transform_opts, Some(analysis));
+    let errors = if compat.allow_static_v_model_arg_on_element {
+        transform_with_plain_element_model_argument(bump, &mut root, transform_opts, Some(analysis))
+    } else {
+        transform(bump, &mut root, transform_opts, Some(analysis))
+    };
     diagnostics.extend(errors.iter().map(compiler_error_to_diagnostic));
 
     let codegen_opts = CodegenOptions {

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   89 |
-| divergent  |    7 |
+| equivalent |   91 |
+| divergent  |    5 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -179,10 +179,10 @@ Recorded so the verdicts are not read as byte equality (#3421,
 | Case                                       | Babel                                                          | Vize today                                                      | Compat mode             | Verdict |
 | ------------------------------------------ | -------------------------------------------------------------- | --------------------------------------------------------------- | ----------------------- | ------- |
 | `directives/v_model_input`                 | `withDirectives(…, [[vModelText, val]])`                       | same                                                            | no change               | ✅      |
-| `directives/v_model_arg`                   | `[[vModelText, val, "foo"]]` + `onUpdate:foo`                  | rejected: "v-model argument is not supported on plain elements" | accept and pass the arg | ❌      |
+| `directives/v_model_arg`                   | `[[vModelText, val, "foo"]]` + `onUpdate:foo`                  | rejected outside Babel VDOM compatibility mode                  | accepts and passes the arg in Babel VDOM mode | ✅      |
 | `directives/v_model_modifier_array`        | `[[vModelText, val, void 0, {trim: true}]]`                    | same                                                            | no change               | ✅      |
 | `directives/v_model_underscore`            | `{lazy: true}` modifiers                                       | same                                                            | no change               | ✅      |
-| `directives/v_model_arg_underscore`        | `[[vModelText, val, "foo", {trim: true}]]`                     | rejected as above                                               | accept and pass the arg | ❌      |
+| `directives/v_model_arg_underscore`        | `[[vModelText, val, "foo", {trim: true}]]`                     | rejected outside Babel VDOM compatibility mode                  | accepts arg and modifiers in Babel VDOM mode | ✅      |
 | `directives/v_model_component`             | `modelValue` + `onUpdate:modelValue` props                     | same                                                            | no change               | ✅      |
 | `directives/v_model_component_arg_mods`    | `argument`, `argumentModifiers`, `onUpdate:argument`           | same props, different literal order                             | no change               | ✅      |
 | `directives/v_model_component_dynamic_arg` | computed prop + `"onUpdate:" + bar`                            | rejected: dynamic arguments need computed prop lowering (#3466) | add computed prop IR    | ❌      |

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -176,26 +176,26 @@ Recorded so the verdicts are not read as byte equality (#3421,
 
 ## Directives
 
-| Case                                       | Babel                                                          | Vize today                                                      | Compat mode             | Verdict |
-| ------------------------------------------ | -------------------------------------------------------------- | --------------------------------------------------------------- | ----------------------- | ------- |
-| `directives/v_model_input`                 | `withDirectives(…, [[vModelText, val]])`                       | same                                                            | no change               | ✅      |
+| Case                                       | Babel                                                          | Vize today                                                      | Compat mode                                   | Verdict |
+| ------------------------------------------ | -------------------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------- | ------- |
+| `directives/v_model_input`                 | `withDirectives(…, [[vModelText, val]])`                       | same                                                            | no change                                     | ✅      |
 | `directives/v_model_arg`                   | `[[vModelText, val, "foo"]]` + `onUpdate:foo`                  | rejected outside Babel VDOM compatibility mode                  | accepts and passes the arg in Babel VDOM mode | ✅      |
-| `directives/v_model_modifier_array`        | `[[vModelText, val, void 0, {trim: true}]]`                    | same                                                            | no change               | ✅      |
-| `directives/v_model_underscore`            | `{lazy: true}` modifiers                                       | same                                                            | no change               | ✅      |
-| `directives/v_model_arg_underscore`        | `[[vModelText, val, "foo", {trim: true}]]`                     | rejected outside Babel VDOM compatibility mode                  | accepts arg and modifiers in Babel VDOM mode | ✅      |
-| `directives/v_model_component`             | `modelValue` + `onUpdate:modelValue` props                     | same                                                            | no change               | ✅      |
-| `directives/v_model_component_arg_mods`    | `argument`, `argumentModifiers`, `onUpdate:argument`           | same props, different literal order                             | no change               | ✅      |
-| `directives/v_model_component_dynamic_arg` | computed prop + `"onUpdate:" + bar`                            | rejected: dynamic arguments need computed prop lowering (#3466) | add computed prop IR    | ❌      |
-| `directives/v_models`                      | expands to one prop pair per entry                             | same, via one `model` directive per entry (#3418)               | no change               | ✅      |
-| `directives/v_models_mods`                 | adds `<arg>Modifiers` per entry                                | same props, different literal order (#3418)                     | no change               | ✅      |
-| `directives/v_show_element`                | `[[vShow, vis]]`                                               | same                                                            | no change               | ✅      |
-| `directives/v_show_component`              | `[[vShow, vis]]` on the component vnode                        | same                                                            | no change               | ✅      |
-| `directives/v_html`                        | `{innerHTML: h}`                                               | same                                                            | no change               | ✅      |
-| `directives/v_html_with_children`          | keeps the children too                                         | same                                                            | no change               | ✅      |
-| `directives/v_text`                        | `{textContent: t}` raw                                         | `textContent: toDisplayString(t)`                               | raw in compat mode      | ✅      |
-| `directives/v_custom_arg`                  | `[[resolveDirective("custom"), val, "arg"]]`                   | same                                                            | no change               | ✅      |
-| `directives/v_custom_array`                | unpacks `[val, 'arg', ['a','b']]` into value / arg / modifiers | same (#3421)                                                    | no change               | ✅      |
-| `directives/v_dashed_custom`               | `resolveDirective("unknown-thing")`                            | same                                                            | no change               | ✅      |
+| `directives/v_model_modifier_array`        | `[[vModelText, val, void 0, {trim: true}]]`                    | same                                                            | no change                                     | ✅      |
+| `directives/v_model_underscore`            | `{lazy: true}` modifiers                                       | same                                                            | no change                                     | ✅      |
+| `directives/v_model_arg_underscore`        | `[[vModelText, val, "foo", {trim: true}]]`                     | rejected outside Babel VDOM compatibility mode                  | accepts arg and modifiers in Babel VDOM mode  | ✅      |
+| `directives/v_model_component`             | `modelValue` + `onUpdate:modelValue` props                     | same                                                            | no change                                     | ✅      |
+| `directives/v_model_component_arg_mods`    | `argument`, `argumentModifiers`, `onUpdate:argument`           | same props, different literal order                             | no change                                     | ✅      |
+| `directives/v_model_component_dynamic_arg` | computed prop + `"onUpdate:" + bar`                            | rejected: dynamic arguments need computed prop lowering (#3466) | add computed prop IR                          | ❌      |
+| `directives/v_models`                      | expands to one prop pair per entry                             | same, via one `model` directive per entry (#3418)               | no change                                     | ✅      |
+| `directives/v_models_mods`                 | adds `<arg>Modifiers` per entry                                | same props, different literal order (#3418)                     | no change                                     | ✅      |
+| `directives/v_show_element`                | `[[vShow, vis]]`                                               | same                                                            | no change                                     | ✅      |
+| `directives/v_show_component`              | `[[vShow, vis]]` on the component vnode                        | same                                                            | no change                                     | ✅      |
+| `directives/v_html`                        | `{innerHTML: h}`                                               | same                                                            | no change                                     | ✅      |
+| `directives/v_html_with_children`          | keeps the children too                                         | same                                                            | no change                                     | ✅      |
+| `directives/v_text`                        | `{textContent: t}` raw                                         | `textContent: toDisplayString(t)`                               | raw in compat mode                            | ✅      |
+| `directives/v_custom_arg`                  | `[[resolveDirective("custom"), val, "arg"]]`                   | same                                                            | no change                                     | ✅      |
+| `directives/v_custom_array`                | unpacks `[val, 'arg', ['a','b']]` into value / arg / modifiers | same (#3421)                                                    | no change                                     | ✅      |
+| `directives/v_dashed_custom`               | `resolveDirective("unknown-thing")`                            | same                                                            | no change                                     | ✅      |
 
 ### `v-models` spellings Vize rejects and babel accepts
 

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -76,16 +76,10 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("events/capture_passive", Same),
     // -- directives ------------------------------------------------------
     ("directives/v_model_input", Same),
-    (
-        "directives/v_model_arg",
-        Diff("v-model arg rejected on elements"),
-    ),
+    ("directives/v_model_arg", Same),
     ("directives/v_model_modifier_array", Same),
     ("directives/v_model_underscore", Same),
-    (
-        "directives/v_model_arg_underscore",
-        Diff("v-model arg rejected on elements"),
-    ),
+    ("directives/v_model_arg_underscore", Same),
     ("directives/v_model_component", Same),
     ("directives/v_model_component_arg_mods", Same),
     (

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (89, 7, 2));
+    assert_eq!((equivalent, divergent, deferred), (91, 5, 2));
     assert_eq!(VERDICTS.len(), 98);
 }
 

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
@@ -26,7 +26,7 @@ export function render(_ctx, _cache) {
 
 ## directives/v_model_arg
 ### verdict
-divergent: v-model arg rejected on elements
+equivalent
 ### source (jsx)
 const A = () => <input v-model:foo={val}/>;
 ### babel options
@@ -37,10 +37,13 @@ const A = () => _withDirectives(_createVNode("input", {
   "onUpdate:foo": $event => val = $event
 }, null), [[_vModelText, val, "foo"]]);
 ### vize (vdom, babel compat)
-<Error> v-model argument is not supported on plain elements.
-import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("input"))
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+    "onUpdate:foo": $event => ((val) = $event)
+  }, null, 40 /* PROPS, NEED_HYDRATION */, ["onUpdate:foo"])), [
+    [_vModelText, val, "foo"]
+  ])
 }
 
 ## directives/v_model_modifier_array
@@ -103,7 +106,7 @@ export function render(_ctx, _cache) {
 
 ## directives/v_model_arg_underscore
 ### verdict
-divergent: v-model arg rejected on elements
+equivalent
 ### source (jsx)
 const A = () => <input v-model:foo_trim={val}/>;
 ### babel options
@@ -116,10 +119,18 @@ const A = () => _withDirectives(_createVNode("input", {
   trim: true
 }]]);
 ### vize (vdom, babel compat)
-<Error> v-model argument is not supported on plain elements.
-import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("input"))
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+    "onUpdate:foo": $event => ((val) = $event)
+  }, null, 40 /* PROPS, NEED_HYDRATION */, ["onUpdate:foo"])), [
+    [
+      _vModelText,
+      val,
+      "foo",
+      { trim: true }
+    ]
+  ])
 }
 
 ## directives/v_model_component

--- a/crates/vize_atelier_jsx/tests/v_model_argument.rs
+++ b/crates/vize_atelier_jsx/tests/v_model_argument.rs
@@ -4,10 +4,151 @@
 //! Until that codegen exists, lowering must reject the input instead of
 //! silently binding `modelValue` and changing the component contract.
 
-use vize_atelier_jsx::{JsxLang, VdomCompileOptions, compile_to_vdom, lower_source};
+use vize_atelier_jsx::{
+    JsxCompatMode, JsxCompileConfig, JsxLang, VdomCompileOptions, compile_jsx, compile_to_vdom,
+    lower_source,
+};
 use vize_carton::Bump;
 
 const SOURCE: &str = "const A = () => <B v-model={[foo, bar]}/>;";
+const ELEMENT_ARG: &str = "const A = () => <input v-model:foo={val}/>;";
+const ELEMENT_ARG_MODIFIER: &str = "const A = () => <input v-model:foo_trim={val}/>;";
+const COMPONENT_ARG_MODIFIER: &str = "const A = () => <B v-model:foo_trim={val}/>;";
+const REJECTED_ELEMENT_MODULE: &str = concat!(
+    "import { openBlock as _openBlock, createElementBlock as _createElementBlock } from \"vue\"\n",
+    "export function render(_ctx, _cache) {\n",
+    "  return (_openBlock(), _createElementBlock(\"input\"))\n",
+    "}",
+);
+
+#[test]
+fn babel_compat_plain_element_static_arguments_match_the_oracle() {
+    let cases = [
+        (
+            ELEMENT_ARG,
+            concat!(
+                "import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from \"vue\"\n",
+                "export function render(_ctx, _cache) {\n",
+                "  return _withDirectives((_openBlock(), _createElementBlock(\"input\", {\n",
+                "    \"onUpdate:foo\": $event => ((val) = $event)\n",
+                "  }, null, 40 /* PROPS, NEED_HYDRATION */, [\"onUpdate:foo\"])), [\n",
+                "    [_vModelText, val, \"foo\"]\n",
+                "  ])\n",
+                "}",
+            ),
+        ),
+        (
+            ELEMENT_ARG_MODIFIER,
+            concat!(
+                "import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from \"vue\"\n",
+                "export function render(_ctx, _cache) {\n",
+                "  return _withDirectives((_openBlock(), _createElementBlock(\"input\", {\n",
+                "    \"onUpdate:foo\": $event => ((val) = $event)\n",
+                "  }, null, 40 /* PROPS, NEED_HYDRATION */, [\"onUpdate:foo\"])), [\n",
+                "    [\n",
+                "      _vModelText,\n",
+                "      val,\n",
+                "      \"foo\",\n",
+                "      { trim: true }\n",
+                "    ]\n",
+                "  ])\n",
+                "}",
+            ),
+        ),
+    ];
+
+    for (source, expected) in cases {
+        let bump = Bump::new();
+        let output = compile_jsx(
+            &bump,
+            source,
+            JsxLang::Jsx,
+            &JsxCompileConfig {
+                compat: JsxCompatMode::Babel,
+                ..Default::default()
+            },
+        );
+
+        assert!(output.diagnostics.is_empty(), "{:?}", output.diagnostics);
+        assert_eq!(output.module_code(), expected);
+    }
+}
+
+#[test]
+fn native_plain_element_argument_rejection_is_unchanged() {
+    for source in [ELEMENT_ARG, ELEMENT_ARG_MODIFIER] {
+        let bump = Bump::new();
+        let output = compile_jsx(&bump, source, JsxLang::Jsx, &JsxCompileConfig::default());
+
+        assert_eq!(output.diagnostics.len(), 1);
+        assert_eq!(
+            output.diagnostics[0].message.as_str(),
+            "v-model argument is not supported on plain elements."
+        );
+        assert_eq!(output.module_code(), REJECTED_ELEMENT_MODULE);
+    }
+}
+
+#[test]
+fn babel_compat_component_argument_behavior_is_unchanged() {
+    let bump = Bump::new();
+    let output = compile_jsx(
+        &bump,
+        COMPONENT_ARG_MODIFIER,
+        JsxLang::Jsx,
+        &JsxCompileConfig {
+            compat: JsxCompatMode::Babel,
+            ..Default::default()
+        },
+    );
+
+    assert!(output.diagnostics.is_empty(), "{:?}", output.diagnostics);
+    assert_eq!(
+        output.module_code(),
+        concat!(
+            "import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from \"vue\"\n",
+            "export function render(_ctx, _cache) {\n",
+            "  const _component_B = _resolveComponent(\"B\")\n",
+            "  \n",
+            "  return (_openBlock(), _createBlock(_component_B, {\n",
+            "    foo_trim: val,\n",
+            "    \"onUpdate:foo_trim\": $event => ((val) = $event)\n",
+            "  }, null, 8 /* PROPS */, [\"foo_trim\", \"onUpdate:foo_trim\"]))\n",
+            "}",
+        )
+    );
+}
+
+#[test]
+fn babel_compat_dynamic_component_argument_rejection_is_unchanged() {
+    let bump = Bump::new();
+    let output = compile_jsx(
+        &bump,
+        SOURCE,
+        JsxLang::Jsx,
+        &JsxCompileConfig {
+            compat: JsxCompatMode::Babel,
+            ..Default::default()
+        },
+    );
+
+    assert_eq!(output.diagnostics.len(), 1);
+    assert_eq!(
+        output.diagnostics[0].message.as_str(),
+        "v-model argument `bar` must be a string literal; dynamic arguments are not supported."
+    );
+    assert_eq!(
+        output.module_code(),
+        concat!(
+            "import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from \"vue\"\n",
+            "export function render(_ctx, _cache) {\n",
+            "  const _component_B = _resolveComponent(\"B\")\n",
+            "  \n",
+            "  return (_openBlock(), _createBlock(_component_B))\n",
+            "}",
+        )
+    );
+}
 
 #[test]
 fn dynamic_array_argument_is_rejected_without_model_value_fallback() {


### PR DESCRIPTION
## Summary

- match Babel 2.0.1 for static plain-element v-model arguments and modifiers in opt-in VDOM compatibility mode
- preserve native, component, and dynamic-argument behavior
- update the differential inventory from 89/7/2 to 91/5/2

## Validation

- full core, DOM, JSX, and relief test suites
- workspace clippy with warnings denied
- Babel oracle re-derivation and exact module assertions
- source-length comparison against main
- cargo-semver-checks for vize_atelier_core

Refs #3391