### PR TITLE
fix(cli): prefer bundled TypeScript runtime

### DIFF
--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -58,7 +58,7 @@
     "check:fix": "vp check --fix src tests vite.config.ts",
     "fmt": "vp fmt --write src tests vite.config.ts",
     "generate:rule-types": "vp run --workspace-root generate:rule-types",
-    "test": "vp pack && vp test run tests/setup.test.ts tests/setup-oxlint-config.test.ts tests/init.test.ts tests/init-frameworks.test.ts tests/init-prompt.test.ts"
+    "test": "vp pack && vp test run tests/corsa-runtime.test.ts tests/setup.test.ts tests/setup-oxlint-config.test.ts tests/init.test.ts tests/init-frameworks.test.ts tests/init-prompt.test.ts"
   },
   "dependencies": {
     "@vizejs/native": "workspace:*",

--- a/npm/cli/src/cli.ts
+++ b/npm/cli/src/cli.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 
+import { configureBundledCorsaRuntime } from "./corsa-runtime.js";
 import { runInitCli } from "./init.js";
 import { runSetupCli } from "./setup.js";
 
@@ -20,6 +21,7 @@ try {
     // land in the same reporter as the synchronous commands.
     runInitCli(args.slice(1)).catch(fail);
   } else {
+    configureBundledCorsaRuntime();
     const native = require("@vizejs/native") as typeof import("@vizejs/native");
     native.runCli(args);
   }

--- a/npm/cli/src/corsa-runtime.ts
+++ b/npm/cli/src/corsa-runtime.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const publicCorsaEnvironmentVariables = [
+  "CORSA_PATH",
+  "CORSA_EXECUTABLE",
+  "TSGO_PATH",
+  "TSGO_EXECUTABLE",
+] as const;
+
+type RuntimeResolutionOptions = {
+  arch?: string;
+  packageRoot?: string;
+  platform?: NodeJS.Platform;
+};
+
+export function configureBundledCorsaRuntime(
+  environment: NodeJS.ProcessEnv = process.env,
+  options: RuntimeResolutionOptions = {},
+): string | null {
+  if (hasPublicRuntimeOverride(environment)) return null;
+
+  const executable = resolveBundledCorsaRuntime(options);
+  if (executable == null) return null;
+
+  environment.CORSA_PATH = executable;
+  return executable;
+}
+
+export function resolveBundledCorsaRuntime(options: RuntimeResolutionOptions = {}): string | null {
+  const packageRoot =
+    options.packageRoot ?? path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+  const platform = options.platform ?? process.platform;
+  const arch = options.arch ?? process.arch;
+
+  try {
+    const cliManifestPath = path.join(packageRoot, "package.json");
+    const cliManifest = readManifest(cliManifestPath);
+    const declaredMetaVersion = cliManifest.optionalDependencies?.["@typescript/native-preview"];
+    if (typeof declaredMetaVersion !== "string") return null;
+
+    const packageRequire = createRequire(cliManifestPath);
+    const metaManifestPath = packageRequire.resolve("@typescript/native-preview/package.json");
+    const metaManifest = readManifest(metaManifestPath);
+    if (
+      metaManifest.name !== "@typescript/native-preview" ||
+      !matchesDeclaredVersion(metaManifest.version, declaredMetaVersion)
+    ) {
+      return null;
+    }
+
+    const platformPackage = `@typescript/native-preview-${platform}-${arch}`;
+    const declaredPlatformVersion = metaManifest.optionalDependencies?.[platformPackage];
+    if (typeof declaredPlatformVersion !== "string") return null;
+
+    const metaRequire = createRequire(metaManifestPath);
+    const platformManifestPath = metaRequire.resolve(`${platformPackage}/package.json`);
+    const platformManifest = readManifest(platformManifestPath);
+    if (
+      platformManifest.name !== platformPackage ||
+      !matchesDeclaredVersion(platformManifest.version, declaredPlatformVersion)
+    ) {
+      return null;
+    }
+
+    const executable = path.join(
+      path.dirname(platformManifestPath),
+      "lib",
+      platform === "win32" ? "tsgo.exe" : "tsgo",
+    );
+    return fs.existsSync(executable) ? executable : null;
+  } catch {
+    // The runtime is optional. Existing Rust-side discovery remains the fallback.
+    return null;
+  }
+}
+
+function hasPublicRuntimeOverride(environment: NodeJS.ProcessEnv): boolean {
+  return publicCorsaEnvironmentVariables.some((name) => {
+    const value = environment[name];
+    return value != null && value !== "";
+  });
+}
+
+function matchesDeclaredVersion(actual: unknown, declared: string): boolean {
+  return typeof actual === "string" && (declared.startsWith("catalog:") || actual === declared);
+}
+
+function readManifest(filename: string): {
+  name?: string;
+  optionalDependencies?: Record<string, string>;
+  version?: string;
+} {
+  return JSON.parse(fs.readFileSync(filename, "utf8"));
+}

--- a/npm/cli/tests/corsa-runtime.test.ts
+++ b/npm/cli/tests/corsa-runtime.test.ts
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { test } from "vite-plus/test";
+
+import {
+  configureBundledCorsaRuntime,
+  publicCorsaEnvironmentVariables,
+  resolveBundledCorsaRuntime,
+} from "../src/corsa-runtime.ts";
+
+test("packed CLI prefers its compatible runtime over an older project runtime", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-cli-corsa-collision-"));
+  try {
+    const packageRoot = path.join(root, "node_modules", "vize");
+    const platformPackage = `@typescript/native-preview-${process.platform}-${process.arch}`;
+    const oldRuntime = writeNativePreview(root, platformPackage, "1.0.0", oldRuntimeSource);
+    const bundledRuntime = writeNativePreview(
+      packageRoot,
+      platformPackage,
+      "2.0.0",
+      compatibleRuntimeSource,
+    );
+    writeJson(path.join(packageRoot, "package.json"), {
+      name: "vize",
+      optionalDependencies: { "@typescript/native-preview": "2.0.0" },
+      type: "module",
+    });
+    writeNativeStub(packageRoot);
+
+    const packageDir = path.dirname(fileURLToPath(import.meta.url));
+    const builtCli = path.join(packageDir, "../dist/cli.mjs");
+    const installedCli = path.join(packageRoot, "dist", "cli.mjs");
+    fs.mkdirSync(path.dirname(installedCli), { recursive: true });
+    fs.copyFileSync(builtCli, installedCli);
+
+    const oldProbe = spawnSync(process.execPath, [oldRuntime, "--api", "--async"], {
+      encoding: "utf8",
+    });
+    assert.equal(oldProbe.status, 2);
+    assert.match(oldProbe.stderr, /flag provided but not defined: -async/u);
+
+    const environment = { ...process.env, PROJECT_LOCAL_TSGO: oldRuntime };
+    for (const name of publicCorsaEnvironmentVariables) delete environment[name];
+    const run = spawnSync(process.execPath, [installedCli, "lsp"], {
+      cwd: root,
+      encoding: "utf8",
+      env: environment,
+    });
+
+    assert.equal(run.status, 0, run.stderr);
+    const result = JSON.parse(run.stdout) as {
+      args: string[];
+      probeStatus: number | null;
+      selectedRuntime: string;
+    };
+    assert.deepEqual(result.args, ["lsp"]);
+    assert.equal(result.selectedRuntime, fs.realpathSync(bundledRuntime));
+    assert.equal(result.probeStatus, 0);
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("all public runtime overrides retain precedence", () => {
+  const fixture = createRuntimeFixture();
+  try {
+    for (const name of publicCorsaEnvironmentVariables) {
+      const environment = { [name]: "/user/configured/tsgo" };
+      const before = { ...environment };
+
+      assert.equal(
+        configureBundledCorsaRuntime(environment, { packageRoot: fixture.packageRoot }),
+        null,
+        name,
+      );
+      assert.deepEqual(environment, before, name);
+    }
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("empty public runtime variables keep resolver fallback semantics", () => {
+  const fixture = createRuntimeFixture();
+  try {
+    const environment = { TSGO_PATH: "" };
+
+    const resolved = configureBundledCorsaRuntime(environment, {
+      packageRoot: fixture.packageRoot,
+    });
+
+    assert.equal(resolved, fs.realpathSync(fixture.runtime));
+    assert.equal(environment.CORSA_PATH, resolved);
+    assert.equal(environment.TSGO_PATH, "");
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("missing bundled runtime leaves existing discovery untouched", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-cli-corsa-missing-"));
+  try {
+    const packageRoot = path.join(root, "node_modules", "vize");
+    const platformPackage = `@typescript/native-preview-${process.platform}-${process.arch}`;
+    writeNativePreview(root, platformPackage, "1.0.0", oldRuntimeSource);
+    writeJson(path.join(packageRoot, "package.json"), {
+      name: "vize",
+      optionalDependencies: { "@typescript/native-preview": "2.0.0" },
+      type: "module",
+    });
+    const environment = {};
+
+    assert.equal(resolveBundledCorsaRuntime({ packageRoot }), null);
+    assert.equal(configureBundledCorsaRuntime(environment, { packageRoot }), null);
+    assert.deepEqual(environment, {});
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
+test("missing platform executable falls back without mutating the environment", () => {
+  const fixture = createRuntimeFixture();
+  try {
+    fs.rmSync(fixture.runtime);
+    const environment = {};
+
+    assert.equal(
+      configureBundledCorsaRuntime(environment, {
+        packageRoot: fixture.packageRoot,
+      }),
+      null,
+    );
+    assert.deepEqual(environment, {});
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test("unsupported platform falls back without mutating the environment", () => {
+  const fixture = createRuntimeFixture();
+  try {
+    const environment = {};
+
+    assert.equal(
+      configureBundledCorsaRuntime(environment, {
+        arch: "unsupported",
+        packageRoot: fixture.packageRoot,
+        platform: "aix",
+      }),
+      null,
+    );
+    assert.deepEqual(environment, {});
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+function createRuntimeFixture(): {
+  cleanup(): void;
+  packageRoot: string;
+  runtime: string;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-cli-corsa-runtime-"));
+  const packageRoot = path.join(root, "node_modules", "vize");
+  const platformPackage = `@typescript/native-preview-${process.platform}-${process.arch}`;
+  const runtime = writeNativePreview(
+    packageRoot,
+    platformPackage,
+    "2.0.0",
+    compatibleRuntimeSource,
+  );
+  writeJson(path.join(packageRoot, "package.json"), {
+    name: "vize",
+    optionalDependencies: { "@typescript/native-preview": "2.0.0" },
+    type: "module",
+  });
+  return {
+    cleanup: () => fs.rmSync(root, { force: true, recursive: true }),
+    packageRoot,
+    runtime,
+  };
+}
+
+function writeNativePreview(
+  packageRoot: string,
+  platformPackage: string,
+  version: string,
+  runtimeSource: string,
+): string {
+  const scope = path.join(packageRoot, "node_modules", "@typescript");
+  writeJson(path.join(scope, "native-preview", "package.json"), {
+    name: "@typescript/native-preview",
+    optionalDependencies: { [platformPackage]: version },
+    version,
+  });
+  const platformRoot = path.join(scope, platformPackage.replace("@typescript/", ""));
+  writeJson(path.join(platformRoot, "package.json"), {
+    name: platformPackage,
+    version,
+  });
+  const runtime = path.join(
+    platformRoot,
+    "lib",
+    process.platform === "win32" ? "tsgo.exe" : "tsgo",
+  );
+  fs.mkdirSync(path.dirname(runtime), { recursive: true });
+  fs.writeFileSync(runtime, runtimeSource);
+  return runtime;
+}
+
+function writeNativeStub(packageRoot: string): void {
+  const nativeRoot = path.join(packageRoot, "node_modules", "@vizejs", "native");
+  writeJson(path.join(nativeRoot, "package.json"), {
+    main: "index.cjs",
+    name: "@vizejs/native",
+  });
+  fs.writeFileSync(
+    path.join(nativeRoot, "index.cjs"),
+    `const { spawnSync } = require("node:child_process");
+exports.runCli = (args) => {
+  const selectedRuntime = process.env.CORSA_PATH || process.env.PROJECT_LOCAL_TSGO;
+  const probe = spawnSync(process.execPath, [selectedRuntime, "--api", "--async"], {
+    encoding: "utf8",
+  });
+  process.stdout.write(JSON.stringify({ args, probeStatus: probe.status, selectedRuntime }));
+};
+`,
+  );
+}
+
+function writeJson(filename: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filename), { recursive: true });
+  fs.writeFileSync(filename, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+const oldRuntimeSource = `if (process.argv.includes("--async")) {
+  process.stderr.write("flag provided but not defined: -async\\nUsage of api:\\n  -cwd string\\n");
+  process.exit(2);
+}
+`;
+
+const compatibleRuntimeSource = `if (!process.argv.includes("--async")) process.exit(2);
+`;


### PR DESCRIPTION
## Summary

- resolve the CLI-owned TypeScript native platform binary before entering the native command runner
- preserve explicit configuration and all four public runtime environment overrides
- fall back to existing runtime discovery when the optional meta package, platform package, or executable is unavailable

## Failure before

A packed fake install with an older project-local runtime selected that incompatible binary and reproduced `flag provided but not defined: -async`. The fixed CLI selects its nested compatible runtime and completes the same API probe.

## Verification

- `vp run test` in `npm/cli` (32 tests)
- `vp check src tests vite.config.ts` in `npm/cli`
- `npm/cli/node_modules/.bin/tsc --noEmit --types node -p npm/cli/tsconfig.json`
- `cargo test -p vize_carton corsa_resolver::tests` (19 tests)
- `node --test tests/tooling/package-manifests.test.ts` (17 tests)
- resolved workspace runtime `--api --async` smoke (exit 0)

Closes #3715
Refs #3674