### PR TITLE
fix(atelier): honor Babel custom element predicates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3606,6 +3606,7 @@ dependencies = [
  "oxc_ast_visit",
  "oxc_diagnostics",
  "oxc_parser",
+ "oxc_semantic",
  "oxc_span",
  "oxc_syntax",
  "serde",

--- a/crates/vize_atelier_core/src/transform/element.rs
+++ b/crates/vize_atelier_core/src/transform/element.rs
@@ -74,7 +74,7 @@ fn maybe_promote_element_to_component(
     ctx: &TransformContext<'_>,
     el: &mut Box<'_, ElementNode<'_>>,
 ) {
-    if el.tag_type != ElementType::Element {
+    if el.tag_type != ElementType::Element || el.is_custom_element {
         return;
     }
 

--- a/crates/vize_atelier_jsx/Cargo.toml
+++ b/crates/vize_atelier_jsx/Cargo.toml
@@ -29,6 +29,7 @@ oxc_allocator = { workspace = true }
 oxc_parser = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
+oxc_semantic = { workspace = true }
 oxc_syntax = { workspace = true }
 oxc_span = { workspace = true }
 oxc_diagnostics = { workspace = true }

--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -23,8 +23,9 @@ use crate::{JsxLang, JsxOutputMode, lower_source_with_compat};
 use self::babel::{collision_free_transform_on_helper, resolve_vnode_factory};
 
 pub use self::babel::{
+    BabelIsCustomElement, BabelJsxCustomizations, compile_jsx_with_babel_customizations,
     compile_jsx_with_babel_merge_props, compile_jsx_with_babel_options,
-    compile_jsx_with_babel_pragma,
+    compile_jsx_with_babel_pragma, compile_jsx_with_babel_pragma_and_merge_props,
 };
 pub use component::JsxComponent;
 
@@ -232,21 +233,23 @@ pub fn compile_jsx(
     compile_jsx_with_babel_options(bump, source, lang, config, &BabelJsxOptions::default())
 }
 
-/// Compile with the two additive Babel options combined.
-#[doc(hidden)]
-pub fn compile_jsx_with_babel_pragma_and_merge_props(
+pub(crate) fn compile_jsx_with_babel_customizations_inner(
     bump: &Bump,
     source: &str,
     lang: JsxLang,
     config: &JsxCompileConfig,
     babel_options: &BabelJsxOptions,
-    pragma: Option<&str>,
-    merge_props: bool,
+    customizations: BabelJsxCustomizations<'_>,
 ) -> JsxCompileOutput {
     let transform_on_helper =
         (config.compat.is_babel() && babel_options.transform_on && !config.ssr)
             .then(|| collision_free_transform_on_helper(source));
-    let merge_props = !config.compat.is_babel() || config.ssr || merge_props;
+    let merge_props = !config.compat.is_babel() || config.ssr || customizations.merge_props;
+    let is_custom_element = if config.compat.is_babel() && !config.ssr {
+        customizations.is_custom_element
+    } else {
+        None
+    };
     let lowered = lower_source_with_compat(
         bump,
         source,
@@ -254,6 +257,7 @@ pub fn compile_jsx_with_babel_pragma_and_merge_props(
         config.compat,
         config.default_mode,
         transform_on_helper.as_deref(),
+        is_custom_element,
     );
     let mut diagnostics = lowered.diagnostics;
     let is_ts = lang.is_typescript();
@@ -263,7 +267,7 @@ pub fn compile_jsx_with_babel_pragma_and_merge_props(
             .iter()
             .any(|root| resolve_mode(root.mode, config.default_mode) == JsxOutputMode::Vdom);
     let vnode_factory = resolve_vnode_factory(
-        pragma,
+        customizations.pragma,
         config.compat.is_babel() && has_vdom_root,
         &mut diagnostics,
     );

--- a/crates/vize_atelier_jsx/src/compile/babel.rs
+++ b/crates/vize_atelier_jsx/src/compile/babel.rs
@@ -3,9 +3,77 @@ use vize_carton::{Bump, String};
 
 use super::{
     BabelJsxOptions, JsxCompileConfig, JsxCompileOutput,
-    compile_jsx_with_babel_pragma_and_merge_props,
+    compile_jsx_with_babel_customizations_inner,
 };
 use crate::{JsxDiagnostic, JsxLang};
+
+/// Thread-safe predicate matching Babel's `isCustomElement` option.
+pub type BabelIsCustomElement = dyn Fn(&str) -> bool + Send + Sync;
+
+/// Additive Babel options that carry borrowed values or must compose together.
+#[derive(Clone, Copy)]
+pub struct BabelJsxCustomizations<'a> {
+    /// Optional vnode factory supplied by Babel's `pragma` option.
+    pub pragma: Option<&'a str>,
+    /// Whether prop segments are combined through Vue's `mergeProps` helper.
+    pub merge_props: bool,
+    /// Project-specific custom-element classifier.
+    pub is_custom_element: Option<&'a BabelIsCustomElement>,
+}
+
+impl Default for BabelJsxCustomizations<'_> {
+    fn default() -> Self {
+        Self {
+            pragma: None,
+            merge_props: true,
+            is_custom_element: None,
+        }
+    }
+}
+
+/// Compile JSX/TSX with every additive Babel customization combined.
+pub fn compile_jsx_with_babel_customizations(
+    bump: &Bump,
+    source: &str,
+    lang: JsxLang,
+    config: &JsxCompileConfig,
+    babel_options: &BabelJsxOptions,
+    customizations: BabelJsxCustomizations<'_>,
+) -> JsxCompileOutput {
+    compile_jsx_with_babel_customizations_inner(
+        bump,
+        source,
+        lang,
+        config,
+        babel_options,
+        customizations,
+    )
+}
+
+/// Compile with the additive Babel `pragma` and `mergeProps` options combined.
+#[doc(hidden)]
+pub fn compile_jsx_with_babel_pragma_and_merge_props(
+    bump: &Bump,
+    source: &str,
+    lang: JsxLang,
+    config: &JsxCompileConfig,
+    babel_options: &BabelJsxOptions,
+    pragma: Option<&str>,
+    merge_props: bool,
+) -> JsxCompileOutput {
+    compile_jsx_with_babel_customizations(
+        bump,
+        source,
+        lang,
+        config,
+        babel_options,
+        BabelJsxCustomizations {
+            pragma,
+            merge_props,
+            is_custom_element: None,
+        },
+    )
+}
 
 /// Compile JSX/TSX with explicit `@vue/babel-plugin-jsx` option compatibility.
 pub fn compile_jsx_with_babel_options(
@@ -15,14 +83,13 @@ pub fn compile_jsx_with_babel_options(
     config: &JsxCompileConfig,
     babel_options: &BabelJsxOptions,
 ) -> JsxCompileOutput {
-    compile_jsx_with_babel_pragma_and_merge_props(
+    compile_jsx_with_babel_customizations(
         bump,
         source,
         lang,
         config,
         babel_options,
-        None,
-        true,
+        BabelJsxCustomizations::default(),
     )
 }
 
@@ -35,14 +102,16 @@ pub fn compile_jsx_with_babel_pragma(
     babel_options: &BabelJsxOptions,
     pragma: Option<&str>,
 ) -> JsxCompileOutput {
-    compile_jsx_with_babel_pragma_and_merge_props(
+    compile_jsx_with_babel_customizations(
         bump,
         source,
         lang,
         config,
         babel_options,
-        pragma,
-        true,
+        BabelJsxCustomizations {
+            pragma,
+            ..Default::default()
+        },
     )
 }
 
@@ -55,14 +124,16 @@ pub fn compile_jsx_with_babel_merge_props(
     babel_options: &BabelJsxOptions,
     merge_props: bool,
 ) -> JsxCompileOutput {
-    compile_jsx_with_babel_pragma_and_merge_props(
+    compile_jsx_with_babel_customizations(
         bump,
         source,
         lang,
         config,
         babel_options,
-        None,
-        merge_props,
+        BabelJsxCustomizations {
+            merge_props,
+            ..Default::default()
+        },
     )
 }
 

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -47,6 +47,7 @@ mod forwarded_slots;
 
 pub use analyze::analyze_program as analyze_jsx_program;
 
+use oxc_semantic::SemanticBuilder;
 use vize_carton::{Bump, String};
 use vize_croquis::Croquis;
 use vize_croquis::croquis::BindingMetadata;
@@ -54,7 +55,8 @@ use vize_relief::RootNode;
 
 pub use compat::JsxCompatMode;
 pub use compile::{
-    BabelJsxOptions, JsxCompileConfig, JsxCompileOutput, JsxComponent, compile_jsx,
+    BabelIsCustomElement, BabelJsxCustomizations, BabelJsxOptions, JsxCompileConfig,
+    JsxCompileOutput, JsxComponent, compile_jsx, compile_jsx_with_babel_customizations,
     compile_jsx_with_babel_merge_props, compile_jsx_with_babel_options,
     compile_jsx_with_babel_pragma, compile_jsx_with_babel_pragma_and_merge_props, resolve_mode,
 };
@@ -174,6 +176,7 @@ pub fn lower_source<'a>(bump: &'a Bump, source: &str, lang: JsxLang) -> LowerOut
         JsxCompatMode::Native,
         JsxOutputMode::Vdom,
         None,
+        None,
     )
 }
 
@@ -189,12 +192,26 @@ fn lower_source_with_compat<'a>(
     compat: JsxCompatMode,
     default_mode: JsxOutputMode,
     transform_on_helper: Option<&str>,
+    is_custom_element: Option<&BabelIsCustomElement>,
 ) -> LowerOutput<'a> {
     let allocator = oxc_allocator::Allocator::default();
     let parse_source = parse::prepare_source_for_parse(source, lang);
     let parsed = parse::parse_module(&allocator, parse_source.as_ref(), lang);
+    let scoping = is_custom_element.map(|_| {
+        SemanticBuilder::new()
+            .build(&parsed.program)
+            .semantic
+            .into_scoping()
+    });
     let mapper = SpanMapper::new(source);
-    let mut lowerer = Lowerer::with_compat(bump, &mapper, compat, transform_on_helper);
+    let mut lowerer = Lowerer::with_compat(
+        bump,
+        &mapper,
+        compat,
+        transform_on_helper,
+        is_custom_element,
+        scoping,
+    );
     for diagnostic in parsed.diagnostics {
         lowerer.report(diagnostic);
     }

--- a/crates/vize_atelier_jsx/src/lower.rs
+++ b/crates/vize_atelier_jsx/src/lower.rs
@@ -22,11 +22,13 @@ mod v_slots;
 
 pub(crate) use style::{RawScopedStyle, ScopedStyleExpr};
 
-use oxc_ast::ast::{JSXElement, JSXFragment};
+use oxc_ast::ast::{JSXElement, JSXElementName, JSXFragment};
+use oxc_semantic::Scoping;
 use oxc_span::Span;
 use vize_carton::{Box, Bump, String, ToCompactString};
 use vize_relief::{RootNode, TemplateChildNode};
 
+use crate::BabelIsCustomElement;
 use crate::compat::JsxCompatMode;
 use crate::diagnostics::JsxDiagnostic;
 use crate::span::SpanMapper;
@@ -36,6 +38,8 @@ pub struct Lowerer<'a, 'm, 's> {
     bump: &'a Bump,
     mapper: &'m SpanMapper<'s>,
     compat: JsxCompatMode,
+    is_custom_element: Option<&'m BabelIsCustomElement>,
+    scoping: Option<Scoping>,
     transform_on_helper: Option<String>,
     babel_vdom_compat_active: bool,
     diagnostics: std::vec::Vec<JsxDiagnostic>,
@@ -48,7 +52,7 @@ pub struct Lowerer<'a, 'm, 's> {
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Build a lowerer that allocates IR in `bump` and maps spans via `mapper`.
     pub fn new(bump: &'a Bump, mapper: &'m SpanMapper<'s>) -> Self {
-        Self::with_compat(bump, mapper, JsxCompatMode::Native, None)
+        Self::with_compat(bump, mapper, JsxCompatMode::Native, None, None, None)
     }
 
     /// Build a lowerer using the requested project-level JSX semantics.
@@ -57,11 +61,15 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         mapper: &'m SpanMapper<'s>,
         compat: JsxCompatMode,
         transform_on_helper: Option<&str>,
+        is_custom_element: Option<&'m BabelIsCustomElement>,
+        scoping: Option<Scoping>,
     ) -> Self {
         Self {
             bump,
             mapper,
             compat,
+            is_custom_element,
+            scoping,
             transform_on_helper: transform_on_helper.map(String::from),
             babel_vdom_compat_active: false,
             diagnostics: std::vec::Vec::new(),
@@ -175,6 +183,28 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Select whether the current render root may use VDOM-only Babel options.
     pub(crate) fn set_current_output_mode(&mut self, mode: crate::JsxOutputMode) {
         self.babel_vdom_compat_active = mode == crate::JsxOutputMode::Vdom;
+    }
+
+    /// Whether Babel's `isCustomElement` predicate selects this JSX tag.
+    pub(crate) fn is_babel_custom_element(&self, tag: &str) -> bool {
+        tag != "Fragment"
+            && self.uses_babel_vdom_compat()
+            && self
+                .is_custom_element
+                .is_some_and(|predicate| predicate(tag))
+    }
+
+    /// Whether an authored JSX identifier resolves to a lexical JavaScript binding.
+    pub(crate) fn is_bound_jsx_identifier(&self, name: &JSXElementName<'_>) -> bool {
+        let JSXElementName::IdentifierReference(reference) = name else {
+            return false;
+        };
+        let Some(reference_id) = reference.reference_id.get() else {
+            return false;
+        };
+        self.scoping
+            .as_ref()
+            .is_some_and(|scoping| scoping.has_binding(reference_id))
     }
 
     /// Collision-free helper binding for Babel's opt-in `transformOn` lowering.

--- a/crates/vize_atelier_jsx/src/lower/element.rs
+++ b/crates/vize_atelier_jsx/src/lower/element.rs
@@ -1,7 +1,7 @@
 //! Lowering JSX elements and fragments into [`ElementNode`]s.
 
 use oxc_ast::ast::{JSXElement, JSXElementName, JSXFragment};
-use oxc_span::Span;
+use oxc_span::{GetSpan, Span};
 use vize_carton::{Box, String};
 use vize_relief::{DirectiveNode, ElementNode, ElementType, PropNode};
 
@@ -23,22 +23,37 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     pub(crate) fn lower_element_node(&mut self, element: &JSXElement<'_>) -> ElementNode<'a> {
         let opening = &element.opening_element;
         self.reject_unsupported_namespace(&opening.name);
-        // A member-expression tag is a value, so it becomes the `:is` binding of
-        // a dynamic component rather than a tag string.
-        let expression_tag = name::expression_tag_span(&opening.name);
+        let custom_element_tag =
+            name::identifier_name(&opening.name).filter(|tag| self.is_babel_custom_element(tag));
+        let bound_custom_element = custom_element_tag.is_some_and(|tag| {
+            !vize_carton::is_html_tag(tag)
+                && !vize_carton::is_svg_tag(tag)
+                && self.is_bound_jsx_identifier(&opening.name)
+        });
+        // A member-expression or bound predicate match is a value, so it becomes
+        // the `:is` binding of a dynamic component rather than a tag string.
+        let expression_tag = name::expression_tag_span(&opening.name)
+            .or_else(|| bound_custom_element.then(|| opening.name.span()));
         let tag = match expression_tag {
             Some(_) => String::from(DYNAMIC_COMPONENT_TAG),
             None => name::element_tag(&opening.name),
         };
         let loc = self.mapper().location(element.span);
         let mut node = ElementNode::new(self.bump(), tag, loc);
-        node.tag_type = element_type(&opening.name, self.uses_babel_compat());
+        let is_custom_element = custom_element_tag.is_some();
+        node.is_custom_element = is_custom_element && !bound_custom_element;
+        node.tag_type = element_type(
+            &opening.name,
+            self.uses_babel_compat(),
+            is_custom_element && !bound_custom_element,
+        );
         node.is_self_closing = element.closing_element.is_none();
         // `v-models` and `v-slots` are component-only. Native mode classifies a
         // dashed lowercase tag as an intrinsic element here, but the DOM backend
         // still resolves it with `resolveComponent`; Babel compatibility
         // classifies it as a component during lowering, matching the plugin.
-        let on_component = node.tag_type == ElementType::Component || node.tag.contains('-');
+        let on_component = !is_custom_element
+            && (node.tag_type == ElementType::Component || node.tag.contains('-'));
         node.props = self.lower_attributes(&opening.attributes, on_component);
         if let Some(span) = expression_tag {
             // First, so the emitted props object reads `<component :is="…" …>`
@@ -49,7 +64,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         // Components route through slot synthesis (object/render-prop children
         // become `<template v-slot>`s); intrinsic elements lower children
         // directly.
-        node.children = if node.tag_type == ElementType::Component {
+        node.children = if node.tag_type == ElementType::Component && !is_custom_element {
             self.lower_component_children(&element.children)
         } else {
             self.lower_element_children(&element.children)
@@ -108,8 +123,12 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     }
 }
 
-fn element_type(name: &JSXElementName<'_>, babel_compat: bool) -> ElementType {
-    if name::is_component(name, babel_compat) {
+fn element_type(
+    name: &JSXElementName<'_>,
+    babel_compat: bool,
+    is_custom_element: bool,
+) -> ElementType {
+    if !is_custom_element && name::is_component(name, babel_compat) {
         ElementType::Component
     } else {
         ElementType::Element

--- a/crates/vize_atelier_jsx/src/lower/name.rs
+++ b/crates/vize_atelier_jsx/src/lower/name.rs
@@ -38,6 +38,17 @@ pub(crate) fn element_tag(name: &JSXElementName<'_>) -> String {
     }
 }
 
+/// The authored name of an unqualified JSX identifier.
+pub(crate) fn identifier_name<'n>(name: &'n JSXElementName<'_>) -> Option<&'n str> {
+    match name {
+        JSXElementName::Identifier(id) => Some(id.name.as_str()),
+        JSXElementName::IdentifierReference(reference) => Some(reference.name.as_str()),
+        JSXElementName::NamespacedName(_)
+        | JSXElementName::MemberExpression(_)
+        | JSXElementName::ThisExpression(_) => None,
+    }
+}
+
 /// Whether a JSX element name refers to a component rather than an intrinsic
 /// (HTML/SVG) element.
 ///

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   91 |
-| divergent  |    5 |
+| equivalent |   92 |
+| divergent  |    4 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -99,11 +99,15 @@ deliberate answer, recorded here so it is not relitigated.
 | `options/merge_props_default`       | `mergeProps({class:"a"}, p, {class:c})`             | same                                         | no change                                            | ✅      |
 | `options/merge_props_false`         | one object literal with a duplicate key             | always merges via `mergeProps`               | object spread + duplicate-key semantics (#3391)      | ✅      |
 | `options/is_custom_element_default` | `<my-el/>` → `resolveComponent("my-el")`            | same                                         | no change                                            | ✅      |
-| `options/is_custom_element_fn`      | matching tag becomes a string tag                   | always resolved as a component               | add `isCustomElement`                                | ❌      |
+| `options/is_custom_element_fn`      | matching tag becomes a string tag                   | predicate-selected tag uses element lowering | additive `isCustomElement` predicate API             | ✅      |
 | `options/object_slots_default`      | `_isSlot(slots) ? slots : {default: () => [slots]}` | `toDisplayString(slots)` in the default slot | treat a lone expression child as a slot object       | ❌      |
 | `options/object_slots_false`        | `{default: () => [slots]}`                          | `toDisplayString(slots)` in the default slot | raw child, plus an `enableObjectSlots: false` option | ❌      |
 | `options/resolve_type_off`          | JSX replaced, types untouched                       | equivalent render output                     | no change                                            | ✅      |
 | `options/resolve_type_on`           | appends `{props: {...}, name: "A"}`                 | no type-driven inference                     | deferred: needs #1497 / #1502                        | ⏸       |
+
+`isCustomElement` accepts captured predicates and composes with `pragma`,
+`mergeProps`, and `transformOn` through `BabelJsxCustomizations`. As in Babel, a
+lexical JavaScript binding wins over conversion to a string tag.
 
 ## Elements and tags
 

--- a/crates/vize_atelier_jsx/tests/babel_compat/mod.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/mod.rs
@@ -13,10 +13,10 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 use vize_atelier_jsx::{
-    BabelJsxOptions, JsxCompatMode, JsxCompileConfig, JsxLang,
-    compile_jsx_with_babel_pragma_and_merge_props,
+    BabelIsCustomElement, BabelJsxCustomizations, BabelJsxOptions, JsxCompatMode, JsxCompileConfig,
+    JsxLang, compile_jsx_with_babel_customizations,
 };
-use vize_carton::Bump;
+use vize_carton::{Bump, FxHashSet};
 
 /// The relationship between Vize's default output and babel's for one case.
 ///
@@ -198,7 +198,21 @@ pub fn load_recording() -> Recording {
 /// diagnosing case is a legitimate, recordable outcome.
 pub fn vize_vdom_output(case: &Case) -> std::string::String {
     let bump = Bump::new();
-    let out = compile_jsx_with_babel_pragma_and_merge_props(
+    let custom_elements: FxHashSet<std::string::String> = case
+        .babel_options
+        .get("isCustomElement")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(serde_json::Value::as_str)
+        .map(std::string::String::from)
+        .collect();
+    let has_custom_element_option = case.babel_options.contains_key("isCustomElement");
+    let is_custom_element = move |tag: &str| custom_elements.contains(tag);
+    let is_custom_element: Option<&BabelIsCustomElement> = has_custom_element_option
+        .then_some(&is_custom_element)
+        .map(|predicate| predicate as &BabelIsCustomElement);
+    let out = compile_jsx_with_babel_customizations(
         &bump,
         &case.source,
         case.jsx_lang(),
@@ -213,13 +227,18 @@ pub fn vize_vdom_output(case: &Case) -> std::string::String {
                 .and_then(serde_json::Value::as_bool)
                 .unwrap_or_default(),
         },
-        case.babel_options
-            .get("pragma")
-            .and_then(serde_json::Value::as_str),
-        case.babel_options
-            .get("mergeProps")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(true),
+        BabelJsxCustomizations {
+            pragma: case
+                .babel_options
+                .get("pragma")
+                .and_then(serde_json::Value::as_str),
+            merge_props: case
+                .babel_options
+                .get("mergeProps")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(true),
+            is_custom_element,
+        },
     );
 
     let mut rendered = std::string::String::new();

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -18,10 +18,7 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("options/merge_props_default", Same),
     ("options/merge_props_false", Same),
     ("options/is_custom_element_default", Same),
-    (
-        "options/is_custom_element_fn",
-        Diff("no isCustomElement option"),
-    ),
+    ("options/is_custom_element_fn", Same),
     (
         "options/object_slots_default",
         Diff("lone expression child stringified"),

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (91, 5, 2));
+    assert_eq!((equivalent, divergent, deferred), (92, 4, 2));
     assert_eq!(VERDICTS.len(), 98);
 }
 

--- a/crates/vize_atelier_jsx/tests/babel_is_custom_element.rs
+++ b/crates/vize_atelier_jsx/tests/babel_is_custom_element.rs
@@ -1,0 +1,203 @@
+//! Babel-compatible `isCustomElement` classification (#3391).
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use vize_atelier_jsx::{
+    BabelIsCustomElement, BabelJsxCustomizations, BabelJsxOptions, JsxCompatMode, JsxCompileConfig,
+    JsxLang, JsxOutputMode, compile_jsx, compile_jsx_with_babel_customizations,
+};
+use vize_carton::{Bump, FxHashSet, String};
+
+static PREDICATE_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+fn babel_vdom() -> JsxCompileConfig {
+    JsxCompileConfig {
+        compat: JsxCompatMode::Babel,
+        ..Default::default()
+    }
+}
+
+fn compile(
+    source: &str,
+    config: &JsxCompileConfig,
+    is_custom_element: Option<&BabelIsCustomElement>,
+) -> (String, std::vec::Vec<String>) {
+    let bump = Bump::new();
+    let output = match is_custom_element {
+        Some(is_custom_element) => compile_jsx_with_babel_customizations(
+            &bump,
+            source,
+            JsxLang::Jsx,
+            config,
+            &BabelJsxOptions::default(),
+            BabelJsxCustomizations {
+                is_custom_element: Some(is_custom_element),
+                ..Default::default()
+            },
+        ),
+        None => compile_jsx(&bump, source, JsxLang::Jsx, config),
+    };
+    let diagnostics = output
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.message.clone())
+        .collect();
+    (output.module_code(), diagnostics)
+}
+
+#[test]
+fn matching_unbound_tag_uses_a_string_vnode_tag() {
+    let is_custom_element = |tag: &str| tag == "MyEl";
+    let (module, diagnostics) = compile(
+        "const A = () => <MyEl foo={1}/>;",
+        &babel_vdom(),
+        Some(&is_custom_element),
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert!(
+        module.contains("_createElementBlock(\"MyEl\", { foo: 1 })"),
+        "{module}"
+    );
+    assert!(!module.contains("_resolveComponent"), "{module}");
+}
+
+#[test]
+fn predicate_is_inert_outside_babel_vdom() {
+    let source = "const A = () => <MyEl foo={1}/>;";
+    let is_custom_element = |tag: &str| {
+        PREDICATE_CALLS.fetch_add(1, Ordering::Relaxed);
+        tag == "MyEl"
+    };
+
+    for config in [
+        JsxCompileConfig::default(),
+        JsxCompileConfig {
+            compat: JsxCompatMode::Babel,
+            ssr: true,
+            ..Default::default()
+        },
+        JsxCompileConfig {
+            compat: JsxCompatMode::Babel,
+            default_mode: JsxOutputMode::Vapor,
+            ..Default::default()
+        },
+    ] {
+        PREDICATE_CALLS.store(0, Ordering::Relaxed);
+        assert_eq!(
+            compile(source, &config, Some(&is_custom_element)),
+            compile(source, &config, None)
+        );
+        assert_eq!(PREDICATE_CALLS.load(Ordering::Relaxed), 0);
+    }
+}
+
+#[test]
+fn unmatched_predicate_preserves_the_babel_baseline() {
+    let source = "const A = () => <MyEl foo={1}/>;";
+    let is_custom_element = |tag: &str| tag == "OtherEl";
+    assert_eq!(
+        compile(source, &babel_vdom(), Some(&is_custom_element)),
+        compile(source, &babel_vdom(), None)
+    );
+}
+
+#[test]
+fn lexical_bindings_win_before_a_matching_predicate() {
+    let is_custom_element = |tag: &str| tag == "MyEl";
+    for source in [
+        "import MyEl from 'my-el'; const A = () => <MyEl foo={1}/>;",
+        "const MyEl = Other; const A = () => <MyEl foo={1}/>;",
+        "let MyEl = Other; const A = () => <MyEl foo={1}/>;",
+        "var MyEl = Other; const A = () => <MyEl foo={1}/>;",
+        "const A = (MyEl) => <MyEl foo={1}/>;",
+    ] {
+        let (module, diagnostics) = compile(source, &babel_vdom(), Some(&is_custom_element));
+        assert!(diagnostics.is_empty(), "{source}\n{diagnostics:?}");
+        assert!(
+            module.contains("_resolveDynamicComponent(MyEl)"),
+            "{source}\n{module}"
+        );
+        assert!(!module.contains("_resolveComponent(\"MyEl\")"), "{module}");
+        assert!(!module.contains("_createElementBlock(\"MyEl\""), "{module}");
+    }
+}
+
+#[test]
+fn custom_element_classification_controls_children_and_v_model() {
+    let is_my_el = |tag: &str| tag == "MyEl";
+    let (component, _) = compile("const A = () => <MyEl>x</MyEl>;", &babel_vdom(), None);
+    let (custom, diagnostics) = compile(
+        "const A = () => <MyEl>x</MyEl>;",
+        &babel_vdom(),
+        Some(&is_my_el),
+    );
+    assert!(
+        component.contains("default: _withCtx(() => ["),
+        "{component}"
+    );
+    assert!(
+        custom.contains("_createElementBlock(\"MyEl\", null, \"x\")"),
+        "{custom}"
+    );
+    assert!(!custom.contains("_withCtx"), "{custom}");
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+
+    let is_dashed = |tag: &str| tag == "my-el";
+    let (custom, diagnostics) = compile(
+        "const A = () => <my-el v-model={value}/>;",
+        &babel_vdom(),
+        Some(&is_dashed),
+    );
+    assert!(
+        custom.contains("_createElementBlock(\"my-el\", {"),
+        "{custom}"
+    );
+    assert!(custom.contains("\"onUpdate:modelValue\""), "{custom}");
+    assert!(!custom.contains("_resolveComponent"), "{custom}");
+    assert!(!custom.contains("\"modelValue\""), "{custom}");
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+}
+
+#[test]
+fn predicate_skips_non_identifier_and_builtin_tag_shapes() {
+    let source = concat!(
+        "const A = () => <div/>;",
+        "const B = () => <Ns.Item/>;",
+        "const C = () => <svg:circle/>;",
+        "const D = () => <Fragment/>;",
+    );
+    let is_custom_element = |_: &str| true;
+    assert_eq!(
+        compile(source, &babel_vdom(), Some(&is_custom_element)),
+        compile(source, &babel_vdom(), None)
+    );
+}
+
+#[test]
+fn captured_predicate_composes_with_other_babel_options() {
+    let mut tags = FxHashSet::default();
+    tags.insert(String::from("MyEl"));
+    let is_custom_element = move |tag: &str| tags.contains(tag);
+    let bump = Bump::new();
+    let output = compile_jsx_with_babel_customizations(
+        &bump,
+        "const A = () => <MyEl class=\"a\" {...p} class={c} on={{ click: h }}/>;",
+        JsxLang::Jsx,
+        &babel_vdom(),
+        &BabelJsxOptions { transform_on: true },
+        BabelJsxCustomizations {
+            pragma: Some("factory.h"),
+            merge_props: false,
+            is_custom_element: Some(&is_custom_element),
+        },
+    );
+    let module = output.module_code();
+
+    assert!(output.diagnostics.is_empty(), "{:?}", output.diagnostics);
+    assert!(module.contains("factory.h(\"MyEl\", {"), "{module}");
+    assert!(module.contains("...p"), "{module}");
+    assert!(module.contains("_transformOn({ click: h })"), "{module}");
+    assert!(!module.contains("_mergeProps"), "{module}");
+    assert!(!module.contains("_resolveComponent"), "{module}");
+}

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__options.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__options.snap
@@ -125,7 +125,7 @@ export function render(_ctx, _cache) {
 
 ## options/is_custom_element_fn
 ### verdict
-divergent: no isCustomElement option
+equivalent
 ### source (jsx)
 const A = () => <MyEl foo={1}/>;
 ### babel options
@@ -136,11 +136,9 @@ const A = () => _createVNode("MyEl", {
   "foo": 1
 }, null);
 ### vize (vdom, babel compat)
-import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 export function render(_ctx, _cache) {
-  const _component_MyEl = _resolveComponent("MyEl")
-
-  return (_openBlock(), _createBlock(_component_MyEl, { foo: 1 }))
+  return (_openBlock(), _createElementBlock("MyEl", { foo: 1 }))
 }
 
 ## options/object_slots_default

--- a/crates/vize_relief/src/relief/elements.rs
+++ b/crates/vize_relief/src/relief/elements.rs
@@ -20,6 +20,8 @@ pub struct ElementNode<'a> {
     pub props: Vec<'a, PropNode<'a>>,
     pub children: Vec<'a, super::TemplateChildNode<'a>>,
     pub is_self_closing: bool,
+    /// Preserve an upstream compiler's explicit custom-element classification.
+    pub is_custom_element: bool,
     pub loc: SourceLocation,
     pub inner_loc: Option<SourceLocation>,
     /// If props are hoisted, this is the index into the hoists array (1-based for _hoisted_N)
@@ -35,6 +37,7 @@ impl<'a> ElementNode<'a> {
             props: Vec::new_in(allocator),
             children: Vec::new_in(allocator),
             is_self_closing: false,
+            is_custom_element: false,
             loc,
             inner_loc: None,
             hoisted_props_index: None,


### PR DESCRIPTION
## Summary

- expose an opt-in Babel-compatible `isCustomElement` predicate that composes with `pragma`, `mergeProps`, and `transformOn`
- preserve lexical binding precedence while lowering matching unbound tags as string vnode tags
- update the exact compatibility oracle and inventory from 91/5/2 to 92/4/2

## Why

The `options/is_custom_element_fn` oracle row still resolved every matching tag through `resolveComponent`, unlike `@vue/babel-plugin-jsx`. The lowerer also needs the predicate classification before it chooses component children and directive semantics.

## Testing

- `cargo test -p vize_relief -p vize_atelier_core -p vize_atelier_jsx --all-features --quiet`
- `cargo clippy -p vize_atelier_jsx --lib --test babel_is_custom_element -- -D warnings`
- `cargo fmt --all -- --check`
- `node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check`
- `node --test tests/tooling/babel-jsx-oracle.test.ts`

Refs #3391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->