### PR TITLE
fix(atelier): keep custom element metadata internal

### DIFF
--- a/crates/vize_atelier_core/src/lane.rs
+++ b/crates/vize_atelier_core/src/lane.rs
@@ -16,7 +16,7 @@ mod structural_keys;
 #[path = "transform/traverse.rs"]
 pub mod traverse;
 
-use vize_carton::{Box, Bump, SmallVec, String, Vec, profile};
+use vize_carton::{Box, Bump, FxHashSet, SmallVec, String, Vec, profile};
 use vize_croquis::{Croquis, ScopeChain};
 
 use crate::errors::CompilerError;
@@ -31,7 +31,8 @@ use traverse::traverse_children;
 
 #[allow(deprecated)]
 pub use extensions::{
-    transform_with_hoisted_scope_id, transform_with_plain_element_model_argument,
+    transform_with_hoisted_scope_id, transform_with_jsx_compatibility,
+    transform_with_plain_element_model_argument,
     transform_with_template_syntax_quirks_and_hoisted_scope_id,
     transform_with_vue_parser_quirks_and_hoisted_scope_id,
 };
@@ -64,6 +65,12 @@ pub struct DirectiveTransformResult<'a> {
 /// Structural directive transform (v-if, v-for)
 pub type StructuralDirectiveTransform<'a> =
     fn(&mut TransformContext<'a>, &mut ElementNode<'a>, &DirectiveNode<'a>) -> Option<ExitFn<'a>>;
+
+#[derive(Default)]
+pub(crate) struct JsxTransformCompat {
+    pub allow_static_v_model_arg_on_element: bool,
+    pub custom_element_spans: FxHashSet<(u32, u32)>,
+}
 
 /// Transform context for AST traversal
 pub struct TransformContext<'a> {
@@ -112,13 +119,21 @@ pub struct TransformContext<'a> {
     pub errors: std::vec::Vec<CompilerError>,
     /// Enables compatibility for template syntax edge-case behavior.
     pub(crate) template_syntax_quirks: bool,
-    pub(crate) allow_static_v_model_arg_on_element: bool,
+    pub(crate) jsx_compat: JsxTransformCompat,
     /// Node was removed flag
     pub(crate) node_removed: bool,
     /// Semantic analysis summary (optional, for enhanced transforms)
     pub(crate) analysis: Option<&'a Croquis>,
     /// Scope ID to bake into static VNodes hoisted outside render scope.
     pub(crate) hoisted_scope_id: Option<String>,
+}
+
+impl TransformContext<'_> {
+    pub(crate) fn is_jsx_custom_element(&self, el: &ElementNode<'_>) -> bool {
+        self.jsx_compat
+            .custom_element_spans
+            .contains(&(el.loc.start.offset, el.loc.end.offset))
+    }
 }
 
 /// Enum for parent node types
@@ -178,7 +193,15 @@ pub fn transform<'a>(
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
 ) -> std::vec::Vec<CompilerError> {
-    transform_inner(allocator, root, options, analysis, false, None, false)
+    transform_inner(
+        allocator,
+        root,
+        options,
+        analysis,
+        false,
+        None,
+        JsxTransformCompat::default(),
+    )
 }
 
 /// Transform the root AST node with template syntax quirk compatibility enabled.
@@ -188,7 +211,15 @@ pub fn transform_with_template_syntax_quirks<'a>(
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
 ) -> std::vec::Vec<CompilerError> {
-    transform_inner(allocator, root, options, analysis, true, None, false)
+    transform_inner(
+        allocator,
+        root,
+        options,
+        analysis,
+        true,
+        None,
+        JsxTransformCompat::default(),
+    )
 }
 
 /// Transform the root AST node with Vue parser quirk compatibility enabled.
@@ -209,7 +240,7 @@ pub(crate) fn transform_inner<'a>(
     analysis: Option<&'a Croquis>,
     template_syntax_quirks: bool,
     hoisted_scope_id: Option<String>,
-    allow_static_v_model_arg_on_element: bool,
+    jsx_compat: JsxTransformCompat,
 ) -> std::vec::Vec<CompilerError> {
     let source = root.source.clone();
     let mut ctx = if let Some(analysis) = analysis {
@@ -228,7 +259,7 @@ pub(crate) fn transform_inner<'a>(
             template_syntax_quirks,
         )
     };
-    ctx.allow_static_v_model_arg_on_element = allow_static_v_model_arg_on_element;
+    ctx.jsx_compat = jsx_compat;
     ctx.hoisted_scope_id = hoisted_scope_id;
     ctx.root = Some(root as *mut _);
 

--- a/crates/vize_atelier_core/src/lane/extensions.rs
+++ b/crates/vize_atelier_core/src/lane/extensions.rs
@@ -3,7 +3,7 @@
 use vize_carton::{Bump, String};
 use vize_croquis::Croquis;
 
-use super::transform_inner;
+use super::{JsxTransformCompat, transform_inner};
 use crate::{CompilerError, RootNode, TransformOptions};
 
 /// Transform the root AST node with an explicit scope ID for hoisted VNodes.
@@ -22,7 +22,7 @@ pub fn transform_with_hoisted_scope_id<'a>(
         analysis,
         false,
         hoisted_scope_id,
-        false,
+        JsxTransformCompat::default(),
     )
 }
 
@@ -42,7 +42,7 @@ pub fn transform_with_template_syntax_quirks_and_hoisted_scope_id<'a>(
         analysis,
         true,
         hoisted_scope_id,
-        false,
+        JsxTransformCompat::default(),
     )
 }
 
@@ -73,5 +73,36 @@ pub fn transform_with_plain_element_model_argument<'a>(
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
 ) -> std::vec::Vec<CompilerError> {
-    transform_inner(allocator, root, options, analysis, false, None, true)
+    transform_inner(
+        allocator,
+        root,
+        options,
+        analysis,
+        false,
+        None,
+        JsxTransformCompat {
+            allow_static_v_model_arg_on_element: true,
+            ..Default::default()
+        },
+    )
+}
+
+/// Transform JSX with Babel-specific element and v-model classification.
+#[doc(hidden)]
+pub fn transform_with_jsx_compatibility<'a>(
+    allocator: &'a Bump,
+    root: &mut RootNode<'a>,
+    options: TransformOptions,
+    analysis: Option<&'a Croquis>,
+    allow_static_v_model_arg_on_element: bool,
+    custom_element_spans: &[(u32, u32)],
+) -> std::vec::Vec<CompilerError> {
+    let mut jsx_compat = JsxTransformCompat {
+        allow_static_v_model_arg_on_element,
+        ..Default::default()
+    };
+    jsx_compat
+        .custom_element_spans
+        .extend(custom_element_spans.iter().copied());
+    transform_inner(allocator, root, options, analysis, false, None, jsx_compat)
 }

--- a/crates/vize_atelier_core/src/transform/context.rs
+++ b/crates/vize_atelier_core/src/transform/context.rs
@@ -50,7 +50,7 @@ impl<'a> TransformContext<'a> {
             in_ssr: ssr,
             errors: std::vec::Vec::new(),
             template_syntax_quirks,
-            allow_static_v_model_arg_on_element: false,
+            jsx_compat: super::JsxTransformCompat::default(),
             node_removed: false,
             analysis: None,
             hoisted_scope_id: None,

--- a/crates/vize_atelier_core/src/transform/element.rs
+++ b/crates/vize_atelier_core/src/transform/element.rs
@@ -74,7 +74,7 @@ fn maybe_promote_element_to_component(
     ctx: &TransformContext<'_>,
     el: &mut Box<'_, ElementNode<'_>>,
 ) {
-    if el.tag_type != ElementType::Element || el.is_custom_element {
+    if el.tag_type != ElementType::Element || ctx.is_jsx_custom_element(el) {
         return;
     }
 
@@ -309,7 +309,7 @@ fn process_element_props<'a>(ctx: &mut TransformContext<'a>, el: &mut Box<'a, El
 
             if !is_component
                 && !supports_plain_element_model_argument(
-                    ctx.allow_static_v_model_arg_on_element,
+                    ctx.jsx_compat.allow_static_v_model_arg_on_element,
                     dir.arg.as_ref(),
                 )
             {

--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -250,7 +250,7 @@ pub(crate) fn compile_jsx_with_babel_customizations_inner(
     } else {
         None
     };
-    let lowered = lower_source_with_compat(
+    let (lowered, custom_element_spans) = lower_source_with_compat(
         bump,
         source,
         lang,
@@ -320,6 +320,7 @@ pub(crate) fn compile_jsx_with_babel_customizations_inner(
                         vnode_factory,
                         merge_props,
                         allow_static_v_model_arg_on_element: config.compat.is_babel(),
+                        custom_element_spans: &custom_element_spans,
                     },
                     &mut diagnostics,
                 )),

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -178,6 +178,7 @@ pub fn lower_source<'a>(bump: &'a Bump, source: &str, lang: JsxLang) -> LowerOut
         None,
         None,
     )
+    .0
 }
 
 /// Lower a module with project-level compatibility semantics.
@@ -193,7 +194,7 @@ fn lower_source_with_compat<'a>(
     default_mode: JsxOutputMode,
     transform_on_helper: Option<&str>,
     is_custom_element: Option<&BabelIsCustomElement>,
-) -> LowerOutput<'a> {
+) -> (LowerOutput<'a>, std::vec::Vec<(u32, u32)>) {
     let allocator = oxc_allocator::Allocator::default();
     let parse_source = parse::prepare_source_for_parse(source, lang);
     let parsed = parse::parse_module(&allocator, parse_source.as_ref(), lang);
@@ -217,9 +218,13 @@ fn lower_source_with_compat<'a>(
     }
     let roots = finder::lower_program_roots(&parsed.program, &mut lowerer, default_mode);
     let analysis = analyze::analyze_program(&parsed.program, source);
-    LowerOutput {
-        roots,
-        analysis,
-        diagnostics: lowerer.into_diagnostics(),
-    }
+    let (diagnostics, custom_element_spans) = lowerer.into_compat_parts();
+    (
+        LowerOutput {
+            roots,
+            analysis,
+            diagnostics,
+        },
+        custom_element_spans,
+    )
 }

--- a/crates/vize_atelier_jsx/src/lower.rs
+++ b/crates/vize_atelier_jsx/src/lower.rs
@@ -40,6 +40,7 @@ pub struct Lowerer<'a, 'm, 's> {
     compat: JsxCompatMode,
     is_custom_element: Option<&'m BabelIsCustomElement>,
     scoping: Option<Scoping>,
+    custom_element_spans: std::vec::Vec<(u32, u32)>,
     transform_on_helper: Option<String>,
     babel_vdom_compat_active: bool,
     diagnostics: std::vec::Vec<JsxDiagnostic>,
@@ -70,6 +71,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             compat,
             is_custom_element,
             scoping,
+            custom_element_spans: std::vec::Vec::new(),
             transform_on_helper: transform_on_helper.map(String::from),
             babel_vdom_compat_active: false,
             diagnostics: std::vec::Vec::new(),
@@ -115,6 +117,12 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Consume the lowerer and return its diagnostics.
     pub fn into_diagnostics(self) -> std::vec::Vec<JsxDiagnostic> {
         self.diagnostics
+    }
+
+    pub(crate) fn into_compat_parts(
+        self,
+    ) -> (std::vec::Vec<JsxDiagnostic>, std::vec::Vec<(u32, u32)>) {
+        (self.diagnostics, self.custom_element_spans)
     }
 
     /// Record a diagnostic.

--- a/crates/vize_atelier_jsx/src/lower/element.rs
+++ b/crates/vize_atelier_jsx/src/lower/element.rs
@@ -41,7 +41,10 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         let loc = self.mapper().location(element.span);
         let mut node = ElementNode::new(self.bump(), tag, loc);
         let is_custom_element = custom_element_tag.is_some();
-        node.is_custom_element = is_custom_element && !bound_custom_element;
+        if is_custom_element && !bound_custom_element {
+            self.custom_element_spans
+                .push((element.span.start, element.span.end));
+        }
         node.tag_type = element_type(
             &opening.name,
             self.uses_babel_compat(),

--- a/crates/vize_atelier_jsx/src/vdom.rs
+++ b/crates/vize_atelier_jsx/src/vdom.rs
@@ -12,7 +12,7 @@
 //! `@vue/babel-plugin-jsx`-shaped output; callers can opt in.
 
 use vize_atelier_core::codegen::generate_with_vnode_factory_and_merge_props;
-use vize_atelier_core::lane::{transform, transform_with_plain_element_model_argument};
+use vize_atelier_core::lane::transform_with_jsx_compatibility;
 use vize_atelier_core::options::{CodegenMode, CodegenOptions, TransformOptions};
 // `CodegenMode::Module` is the only supported JSX target: JSX/TSX is authored
 // for bundlers, and the runtime `Function` (with-block) mode emits an empty
@@ -81,6 +81,7 @@ pub(crate) struct VdomCompatOptions<'a> {
     pub vnode_factory: Option<&'a str>,
     pub merge_props: bool,
     pub allow_static_v_model_arg_on_element: bool,
+    pub custom_element_spans: &'a [(u32, u32)],
 }
 
 impl Default for VdomCompatOptions<'_> {
@@ -90,6 +91,7 @@ impl Default for VdomCompatOptions<'_> {
             vnode_factory: None,
             merge_props: true,
             allow_static_v_model_arg_on_element: false,
+            custom_element_spans: &[],
         }
     }
 }
@@ -175,11 +177,14 @@ pub(crate) fn compile_root_to_vdom(
         binding_metadata: None,
         ..Default::default()
     };
-    let errors = if compat.allow_static_v_model_arg_on_element {
-        transform_with_plain_element_model_argument(bump, &mut root, transform_opts, Some(analysis))
-    } else {
-        transform(bump, &mut root, transform_opts, Some(analysis))
-    };
+    let errors = transform_with_jsx_compatibility(
+        bump,
+        &mut root,
+        transform_opts,
+        Some(analysis),
+        compat.allow_static_v_model_arg_on_element,
+        compat.custom_element_spans,
+    );
     diagnostics.extend(errors.iter().map(compiler_error_to_diagnostic));
 
     let codegen_opts = CodegenOptions {

--- a/crates/vize_atelier_jsx/tests/babel_is_custom_element.rs
+++ b/crates/vize_atelier_jsx/tests/babel_is_custom_element.rs
@@ -121,6 +121,15 @@ fn lexical_bindings_win_before_a_matching_predicate() {
         assert!(!module.contains("_resolveComponent(\"MyEl\")"), "{module}");
         assert!(!module.contains("_createElementBlock(\"MyEl\""), "{module}");
     }
+
+    let source = "const A = () => <MyEl/>; const B = (MyEl) => <MyEl/>;";
+    let (module, diagnostics) = compile(source, &babel_vdom(), Some(&is_custom_element));
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert!(module.contains("_createElementBlock(\"MyEl\""), "{module}");
+    assert!(
+        module.contains("_resolveDynamicComponent(MyEl)"),
+        "{module}"
+    );
 }
 
 #[test]

--- a/crates/vize_relief/src/relief/elements.rs
+++ b/crates/vize_relief/src/relief/elements.rs
@@ -20,8 +20,6 @@ pub struct ElementNode<'a> {
     pub props: Vec<'a, PropNode<'a>>,
     pub children: Vec<'a, super::TemplateChildNode<'a>>,
     pub is_self_closing: bool,
-    /// Preserve an upstream compiler's explicit custom-element classification.
-    pub is_custom_element: bool,
     pub loc: SourceLocation,
     pub inner_loc: Option<SourceLocation>,
     /// If props are hoisted, this is the index into the hoists array (1-based for _hoisted_N)
@@ -37,7 +35,6 @@ impl<'a> ElementNode<'a> {
             props: Vec::new_in(allocator),
             children: Vec::new_in(allocator),
             is_self_closing: false,
-            is_custom_element: false,
             loc,
             inner_loc: None,
             hoisted_props_index: None,


### PR DESCRIPTION
## Summary

- keep Babel custom-element classification in a private transform sidecar keyed by exact source spans
- restore the public `ElementNode` shape after the transient field added by #3718
- cover unbound custom elements and same-named lexical bindings in one module

## Root cause

#3718 used a new public `ElementNode::is_custom_element` field as an internal compiler marker. External struct literals would need to name that field, so the non-required `vize_relief` semver check correctly rejected it after auto-merge had already completed.

## Compatibility note

No released API is removed: the field existed only on transient `main` after #3718. The marker below tells the PR-base semver job that removing that unreleased field is intentional.

BREAKING CHANGE: remove the unreleased `ElementNode::is_custom_element` field introduced by #3718 before the next release.

## Testing

- `cargo test -p vize_relief -p vize_atelier_core -p vize_atelier_jsx --all-features --quiet`
- `cargo test -p vize_atelier_jsx --test babel_is_custom_element --test babel_compat_oracle`
- `cargo clippy -p vize_atelier_jsx --lib --test babel_is_custom_element -- -D warnings`
- `cargo semver-checks check-release --package vize_relief --baseline-rev origin/main --release-type major`
- `cargo semver-checks check-release --package vize_atelier_core --baseline-rev origin/main`
- `cargo fmt --all -- --check`
- `node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check`
- `node --test tests/tooling/babel-jsx-oracle.test.ts`

Refs #3391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->