### PR TITLE
fix(ci): preserve SemVer markers after squash merge

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -79,8 +79,10 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
+      pull-requests: read
     # Matrix legs run in parallel and keep breaking changes attributed per crate.
     # PRs compare against base; pushes compare against previous main. Schedules lack an exact base.
+    # Squash pushes recover the merged PR marker; direct pushes use their event commit messages.
     # Conventional breaking markers (`type(scope)!:` / `BREAKING CHANGE:`) are major.
     # Keep this list in sync with crates published by tools/moon/cmd/publish_crates.
     # Omit unpublished crates and their dependents so registry fallback cannot hit "not found".
@@ -104,6 +106,11 @@ jobs:
         with:
           # cargo-semver-checks materializes the baseline rev from git history.
           fetch-depth: 0
+      - name: Resolve SemVer change marker
+        env:
+          GITHUB_TOKEN: ${{ github.event_name == 'push' && github.token || '' }}
+        run: |
+          node tools/github/semver-change-marker.mjs "$RUNNER_TEMP/semver-change-marker.txt"
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:
@@ -119,15 +126,9 @@ jobs:
       - name: Check public API SemVer compatibility
         env:
           BASELINE_REV: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before || '') }}
-          PR_BODY: ${{ github.event_name == 'pull_request' && github.event.pull_request.body || '' }}
-          PR_TITLE: ${{ github.event_name == 'pull_request' && github.event.pull_request.title || '' }}
         run: |
           case "$BASELINE_REV" in 0000000000000000000000000000000000000000) BASELINE_REV="";; esac
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            SEMVER_CHANGE_MARKER="$(printf '%s\n%s\n' "$PR_TITLE" "$PR_BODY")"
-          else
-            SEMVER_CHANGE_MARKER="$(git log -1 --format=%B)"
-          fi
+          SEMVER_CHANGE_MARKER="$(cat "$RUNNER_TEMP/semver-change-marker.txt")"
           SEMVER_ARGS=()
           if printf '%s\n' "$SEMVER_CHANGE_MARKER" | grep -Eq '^[[:alnum:]_-]+(\([^)]+\))?!:|^BREAKING CHANGE:'; then
             SEMVER_ARGS+=(--release-type major)

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -81,8 +81,7 @@ jobs:
       contents: read
       pull-requests: read
     # Matrix legs run in parallel and keep breaking changes attributed per crate.
-    # PRs compare against base; pushes compare against previous main. Schedules lack an exact base.
-    # Squash pushes recover the merged PR marker; direct pushes use their event commit messages.
+    # PRs compare against base; pushes compare against previous main (squash pushes recover the merged PR marker, direct pushes use their commit messages). Schedules lack an exact base.
     # Conventional breaking markers (`type(scope)!:` / `BREAKING CHANGE:`) are major.
     # Keep this list in sync with crates published by tools/moon/cmd/publish_crates.
     # Omit unpublished crates and their dependents so registry fallback cannot hit "not found".

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -79,9 +79,10 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
+      # Squash pushes carry no pull-request metadata; the associated-pulls API recovers the merged marker.
       pull-requests: read
     # Matrix legs run in parallel and keep breaking changes attributed per crate.
-    # PRs compare against base; pushes compare against previous main (squash pushes recover the merged PR marker, direct pushes use their commit messages). Schedules lack an exact base.
+    # PRs compare against base; pushes compare against previous main. Schedules lack an exact base.
     # Conventional breaking markers (`type(scope)!:` / `BREAKING CHANGE:`) are major.
     # Keep this list in sync with crates published by tools/moon/cmd/publish_crates.
     # Omit unpublished crates and their dependents so registry fallback cannot hit "not found".
@@ -108,8 +109,7 @@ jobs:
       - name: Resolve SemVer change marker
         env:
           GITHUB_TOKEN: ${{ github.event_name == 'push' && github.token || '' }}
-        run: |
-          node tools/github/semver-change-marker.mjs "$RUNNER_TEMP/semver-change-marker.txt"
+        run: node tools/github/semver-change-marker.mjs "$RUNNER_TEMP/semver-change-marker.txt"
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:

--- a/tests/tooling/github-workflows-semver.test.ts
+++ b/tests/tooling/github-workflows-semver.test.ts
@@ -8,7 +8,8 @@ test("push SemVer checks preserve pull-request markers after squash merge", () =
   const workflow = readRepoFile(".github", "workflows", "check.yml");
   const job = workflowJobBody(workflow, "semver-checks");
 
-  assert.match(job, /permissions:\n\s+contents:\s*read\n\s+pull-requests:\s*read/);
+  assert.match(job, /permissions:\n(?:[^\S\n]+\S.*\n)*[^\S\n]+contents:\s*read\n/);
+  assert.match(job, /permissions:\n(?:[^\S\n]+\S.*\n)*[^\S\n]+pull-requests:\s*read\n/);
   assert.match(job, /- name:\s*Resolve SemVer change marker/);
   assert.match(
     job,
@@ -85,6 +86,59 @@ test("push marker falls back to direct-push commit messages", async () => {
   });
 
   assert.equal(marker, "fix(ci): prepare a direct push\nfix(ci)!: apply a direct breaking push");
+});
+
+test("push marker fails closed when a commit has multiple exact merged pull requests", async () => {
+  const sha = "f49c94e03ad957b1f6f51276a328acb533c21343";
+  await assert.rejects(
+    resolveSemverChangeMarker({
+      eventName: "push",
+      event: {
+        after: sha,
+        head_commit: { message: "fix(ci): ambiguous squash" },
+        repository: { full_name: "ubugeeei-prod/vize" },
+      },
+      token: "test-token",
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify([
+            { title: "fix(ci): first", merge_commit_sha: sha, merged_at: "2026-08-02T08:40:36Z" },
+            { title: "fix(ci): second", merge_commit_sha: sha, merged_at: "2026-08-02T08:41:12Z" },
+          ]),
+          { status: 200 },
+        ),
+    }),
+    /multiple exact merged pull requests/,
+  );
+});
+
+test("push marker fails closed without repository, commit, or token metadata", async () => {
+  const event = {
+    head_commit: { message: "fix(ci): direct push" },
+    repository: { full_name: "ubugeeei-prod/vize" },
+  };
+  const fetchImpl = async () => {
+    throw new Error("incomplete push metadata must not reach the associated-pulls API");
+  };
+
+  await assert.rejects(
+    resolveSemverChangeMarker({ eventName: "push", event, sha: "abc123", fetchImpl }),
+    /GITHUB_REPOSITORY, GITHUB_SHA, and GITHUB_TOKEN are required for push events/,
+  );
+  await assert.rejects(
+    resolveSemverChangeMarker({ eventName: "push", event, token: "test-token", fetchImpl }),
+    /GITHUB_REPOSITORY, GITHUB_SHA, and GITHUB_TOKEN are required for push events/,
+  );
+  await assert.rejects(
+    resolveSemverChangeMarker({
+      eventName: "push",
+      event: { head_commit: event.head_commit },
+      sha: "abc123",
+      token: "test-token",
+      fetchImpl,
+    }),
+    /GITHUB_REPOSITORY, GITHUB_SHA, and GITHUB_TOKEN are required for push events/,
+  );
 });
 
 test("pull-request marker uses event metadata without an API request", async () => {

--- a/tests/tooling/github-workflows-semver.test.ts
+++ b/tests/tooling/github-workflows-semver.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolveSemverChangeMarker } from "../../tools/github/semver-change-marker.mjs";
+import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
+
+test("push SemVer checks preserve pull-request markers after squash merge", () => {
+  const workflow = readRepoFile(".github", "workflows", "check.yml");
+  const job = workflowJobBody(workflow, "semver-checks");
+
+  assert.match(job, /permissions:\n\s+contents:\s*read\n\s+pull-requests:\s*read/);
+  assert.match(job, /- name:\s*Resolve SemVer change marker/);
+  assert.match(
+    job,
+    /GITHUB_TOKEN:\s*\$\{\{\s*github\.event_name == 'push' && github\.token \|\| ''\s*\}\}/,
+  );
+  assert.match(
+    job,
+    /node tools\/github\/semver-change-marker\.mjs "\$RUNNER_TEMP\/semver-change-marker\.txt"/,
+  );
+  assert.match(job, /SEMVER_CHANGE_MARKER="\$\(cat "\$RUNNER_TEMP\/semver-change-marker\.txt"\)"/);
+  assert.doesNotMatch(job, /git log -1 --format=%B/);
+});
+
+test("push marker uses the exact squash-merged pull request body", async () => {
+  const sha = "f49c94e03ad957b1f6f51276a328acb533c21343";
+  const calls = [];
+  const marker = await resolveSemverChangeMarker({
+    eventName: "push",
+    event: {
+      after: sha,
+      head_commit: { message: "fix(atelier): keep custom element metadata internal (#3720)" },
+      repository: { full_name: "ubugeeei-prod/vize" },
+    },
+    repository: "ubugeeei-prod/vize",
+    sha,
+    token: "test-token",
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return new Response(
+        JSON.stringify([
+          {
+            title: "fix(ci): unrelated pull request",
+            body: "BREAKING CHANGE: unrelated marker.",
+            merge_commit_sha: "0000000000000000000000000000000000000000",
+            merged_at: "2026-08-02T08:39:00Z",
+          },
+          {
+            title: "fix(atelier): keep custom element metadata internal",
+            body: "Compatibility note\n\nBREAKING CHANGE: remove an unreleased field.",
+            merge_commit_sha: sha,
+            merged_at: "2026-08-02T08:40:36Z",
+          },
+        ]),
+        { status: 200 },
+      );
+    },
+  });
+
+  assert.equal(
+    marker,
+    "fix(atelier): keep custom element metadata internal\nCompatibility note\n\nBREAKING CHANGE: remove an unreleased field.",
+  );
+  assert.equal(
+    calls[0].url,
+    `https://api.github.com/repos/ubugeeei-prod/vize/commits/${sha}/pulls`,
+  );
+  assert.equal(calls[0].init.headers.Authorization, "Bearer test-token");
+});
+
+test("push marker falls back to direct-push commit messages", async () => {
+  const marker = await resolveSemverChangeMarker({
+    eventName: "push",
+    event: {
+      after: "1234567890abcdef",
+      commits: [
+        { message: "fix(ci): prepare a direct push" },
+        { message: "fix(ci)!: apply a direct breaking push" },
+      ],
+      head_commit: { message: "fix(ci)!: apply a direct breaking push" },
+      repository: { full_name: "ubugeeei-prod/vize" },
+    },
+    token: "test-token",
+    fetchImpl: async () => new Response("[]", { status: 200 }),
+  });
+
+  assert.equal(marker, "fix(ci): prepare a direct push\nfix(ci)!: apply a direct breaking push");
+});
+
+test("pull-request marker uses event metadata without an API request", async () => {
+  const marker = await resolveSemverChangeMarker({
+    eventName: "pull_request",
+    event: {
+      pull_request: {
+        title: "fix(relief): remove an unreleased field",
+        body: "BREAKING CHANGE: remove the field before release.",
+      },
+    },
+    fetchImpl: async () => {
+      throw new Error("pull-request events must not call the associated-pulls API");
+    },
+  });
+
+  assert.equal(
+    marker,
+    "fix(relief): remove an unreleased field\nBREAKING CHANGE: remove the field before release.",
+  );
+});

--- a/tools/github/semver-change-marker.mjs
+++ b/tools/github/semver-change-marker.mjs
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+function pullRequestMarker(pullRequest) {
+  if (typeof pullRequest?.title !== "string") {
+    throw new Error("Pull request title is missing from the GitHub event");
+  }
+  return `${pullRequest.title}\n${typeof pullRequest.body === "string" ? pullRequest.body : ""}`;
+}
+
+function pushCommitMarker(event) {
+  const messages = Array.isArray(event.commits)
+    ? event.commits
+        .map((commit) => commit?.message)
+        .filter((message) => typeof message === "string")
+    : [];
+  const headMessage = event.head_commit?.message;
+  if (typeof headMessage === "string" && !messages.includes(headMessage)) {
+    messages.push(headMessage);
+  }
+  if (messages.length === 0) {
+    throw new Error("Push event contains no commit message for the SemVer fallback");
+  }
+  return messages.join("\n");
+}
+
+async function mergedPullRequestForCommit({ apiUrl, fetchImpl, repository, sha, token }) {
+  if (!repository || !sha || !token) {
+    throw new Error("GITHUB_REPOSITORY, GITHUB_SHA, and GITHUB_TOKEN are required for push events");
+  }
+  const encodedRepository = repository.split("/").map(encodeURIComponent).join("/");
+  const response = await fetchImpl(
+    `${apiUrl}/repos/${encodedRepository}/commits/${encodeURIComponent(sha)}/pulls`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`GitHub associated-pulls request failed with HTTP ${response.status}`);
+  }
+  const associated = await response.json();
+  if (!Array.isArray(associated)) {
+    throw new Error("GitHub associated-pulls response is not an array");
+  }
+  const exactMerged = associated.filter(
+    (pullRequest) => pullRequest?.merge_commit_sha === sha && pullRequest.merged_at,
+  );
+  if (exactMerged.length > 1) {
+    throw new Error(`Commit ${sha} has multiple exact merged pull requests`);
+  }
+  return exactMerged[0] ?? null;
+}
+
+export async function resolveSemverChangeMarker({
+  apiUrl = "https://api.github.com",
+  event,
+  eventName,
+  fetchImpl = globalThis.fetch,
+  repository,
+  sha,
+  token,
+}) {
+  if (eventName === "pull_request") {
+    return pullRequestMarker(event.pull_request);
+  }
+  if (eventName !== "push") {
+    throw new Error(`Unsupported SemVer event: ${eventName}`);
+  }
+
+  const pullRequest = await mergedPullRequestForCommit({
+    apiUrl,
+    fetchImpl,
+    repository: repository || event.repository?.full_name,
+    sha: sha || event.after,
+    token,
+  });
+  return pullRequest ? pullRequestMarker(pullRequest) : pushCommitMarker(event);
+}
+
+async function main() {
+  const [outputPath] = process.argv.slice(2);
+  if (!outputPath || !process.env.GITHUB_EVENT_PATH) {
+    throw new Error(
+      "Usage: node tools/github/semver-change-marker.mjs <output-path> with GITHUB_EVENT_PATH",
+    );
+  }
+  const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
+  const marker = await resolveSemverChangeMarker({
+    apiUrl: process.env.GITHUB_API_URL,
+    event,
+    eventName: process.env.GITHUB_EVENT_NAME,
+    repository: process.env.GITHUB_REPOSITORY,
+    sha: process.env.GITHUB_SHA,
+    token: process.env.GITHUB_TOKEN,
+  });
+  fs.writeFileSync(outputPath, `${marker}\n`);
+}
+
+const entrypoint = process.argv[1]
+  ? fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  : false;
+if (entrypoint) {
+  await main();
+}


### PR DESCRIPTION
## Summary

- recover the exact merged pull request title and body before classifying a push SemVer check
- preserve direct-push commit-message fallback and pull-request event behavior
- add a fail-closed resolver plus workflow contract coverage for the #3720 squash case

## Root cause

GitHub push events do not contain pull-request metadata, and the repository's squash commit message does not include the pull-request body. The push SemVer matrix therefore lost the accepted `BREAKING CHANGE:` marker and checked the same API change as a minor release.

## Validation

- `vp check tools/github/semver-change-marker.mjs tests/tooling/github-workflows-semver.test.ts .github/workflows/check.yml`
- `node --test --test-concurrency=1 tests/tooling/github-workflows*.test.ts` (76 tests)
- `actrun lint .github/workflows/check.yml`
- `actrun workflow run .github/workflows/check.yml --dry-run`
- verified the associated-pulls API returns #3720 and its breaking marker for `f49c94e`

Closes #3721

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release checks to reliably identify semantic version changes for pull requests, direct pushes, and squash-merged changes.
  * Added validation and fallback handling for missing, ambiguous, or unsupported release event data.

* **Tests**
  * Added coverage for pull-request, push, and squash-merge workflows.
  * Verified permissions, authentication, API handling, and marker resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->