### PR TITLE
fix(atelier): forward static template v-slots in Babel mode

### DIFF
--- a/crates/vize_atelier_jsx/src/lower/v_slots.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_slots.rs
@@ -60,9 +60,10 @@
 //!   children, which is meaningless for a component: a slots object is either an
 //!   object literal to expand or an opaque expression to forward, never a
 //!   primitive. Opt-in Babel VDOM mode (#3391) forwards the *primitive* literals
-//!   verbatim, because that is exactly what babel emits and the source text is
-//!   already valid JavaScript; arrays, template literals, raw JSX, functions, and
-//!   sequences stay diagnosed rather than emitted as a malformed module.
+//!   verbatim, including substitution-free template literals, because that is
+//!   exactly what babel emits and the source text is already valid JavaScript;
+//!   arrays, interpolated template literals, raw JSX, functions, and sequences
+//!   stay diagnosed rather than emitted as a malformed module.
 //! - `v-slots:arg={…}` — `v-slots` takes no argument; the slot names are the
 //!   object's keys.
 //! - `v-slots` on a plain element, which has no slots.
@@ -287,19 +288,21 @@ const IS_A_FUNCTION: &str = "is a function, not a slots object: a lone function 
 /// Literals whose source text is already valid JavaScript in children position,
 /// so babel's pass-through can be reproduced by forwarding the span verbatim.
 ///
-/// Container literals are deliberately excluded: an array or a template literal
-/// may hold nested JSX that still has to be lowered, and raw JSX is a vnode
-/// rather than a value.
+/// Container literals are deliberately excluded: an array may hold nested JSX
+/// that still has to be lowered, and raw JSX is a vnode rather than a value. A
+/// template literal only qualifies when it has no substitutions, for the same
+/// reason: its interpolations can contain JSX.
 fn is_primitive_literal(expression: &Expression<'_>) -> bool {
-    matches!(
-        expression,
+    match expression {
         Expression::BigIntLiteral(_)
-            | Expression::BooleanLiteral(_)
-            | Expression::NullLiteral(_)
-            | Expression::NumericLiteral(_)
-            | Expression::RegExpLiteral(_)
-            | Expression::StringLiteral(_)
-    )
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::RegExpLiteral(_)
+        | Expression::StringLiteral(_) => true,
+        Expression::TemplateLiteral(template) => template.expressions.is_empty(),
+        _ => false,
+    }
 }
 
 /// Whether an expression is a literal value that can never be a slots object.

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -280,6 +280,12 @@ here so the choice is not implicit (#3418, #3467, `src/lower/v_slots.rs`):
   (`v-slots={1}`, `v-slots={[…]}`) — babel forwards these as the component's
   children, which is meaningless for a component. A slots object is either an
   object literal to expand or an opaque expression to forward, never a literal.
+  Native mode keeps rejecting all of them; opt-in Babel VDOM compatibility
+  forwards only the primitive expression literals (`v-slots={1}`, and a template
+  literal with no interpolation), because their source is already valid
+  JavaScript. A quoted value, a missing value, and container literals
+  (`v-slots={[…]}`, a JSX element, an interpolated template) stay rejected: they
+  are not forwardable verbatim without leaking unlowered JSX.
 - `v-slots={() => …}` — a lone function is the _default slot_, not a slots
   object: babel forwards it as children and Vue wraps it as `{default: fn}`.
   Spreading it would contribute nothing, so Vize names it and points at

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -13,7 +13,7 @@ opt-in compat mode (#3391) is expected to change.
 
 | Artifact                                  | Role                                                                                                       |
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `babel_compat/fixtures/corpus.json`       | the 98 inputs + the babel plugin options each is compiled with                                             |
+| `babel_compat/fixtures/corpus.json`       | the 99 inputs + the babel plugin options each is compiled with                                             |
 | `babel_compat/oracle.mjs`                 | runs the corpus through the real plugin; `--write` records, `--check` verifies                             |
 | `babel_compat/fixtures/babel-output.json` | committed ground truth (generated — do not hand-edit)                                                      |
 | `../babel_compat_oracle.rs`               | snapshots babel's output beside Vize's, per category, with a verdict per row                               |
@@ -55,7 +55,7 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   95 |
+| equivalent |   96 |
 | divergent  |    1 |
 | deferred   |    2 |
 
@@ -276,16 +276,12 @@ collides with it exactly as one named `show` or `model` would.
 Not corpus rows, because a compat mode is not expected to adopt them; recorded
 here so the choice is not implicit (#3418, #3467, `src/lower/v_slots.rs`):
 
-- `v-slots` with no value, `v-slots="str"`, and any literal value
-  (`v-slots={1}`, `v-slots={[…]}`) — babel forwards these as the component's
-  children, which is meaningless for a component. A slots object is either an
-  object literal to expand or an opaque expression to forward, never a literal.
-  Native mode keeps rejecting all of them; opt-in Babel VDOM compatibility
-  forwards only the primitive expression literals (`v-slots={1}`, and a template
-  literal with no interpolation), because their source is already valid
-  JavaScript. A quoted value, a missing value, and container literals
-  (`v-slots={[…]}`, a JSX element, an interpolated template) stay rejected: they
-  are not forwardable verbatim without leaking unlowered JSX.
+- `v-slots` with no value, a quoted value (`v-slots="str"`), or a container
+  literal (`v-slots={[…]}`) remains rejected. Babel VDOM compatibility forwards
+  primitive expression literals (`v-slots={1}`, including static template
+  literals) as component children; native mode retains the strict slots-object
+  diagnostic. Interpolated templates remain rejected because forwarding their
+  raw source could leak nested JSX.
 - `v-slots={() => …}` — a lone function is the _default slot_, not a slots
   object: babel forwards it as children and Vue wraps it as `{default: fn}`.
   Spreading it would contribute nothing, so Vize names it and points at
@@ -341,10 +337,11 @@ Compared against Vize's default, which is already fully optimized.
 A compat mode must reject what babel rejects, with a diagnostic — never silently
 accept it.
 
-| Case                              | Babel                                                           | Vize today                                                        | Compat mode             | Verdict |
-| --------------------------------- | --------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------- | ------- |
-| `errors/v_model_non_lval`         | rejects a non-assignable `v-model` target                       | rejects it too, naming the offending expression (closed by #3420) | no change               | ✅      |
-| `errors/v_model_no_value`         | rejects: "You have to use JSX Expression inside your v-model"   | rejects: "v-model is missing expression."                         | no change               | ✅      |
-| `errors/v_models_not_array`       | rejects a non-array `v-models` value                            | rejects it too, naming the expected entry shape (closed by #3418) | no change               | ✅      |
-| `errors/v_models_entry_not_array` | rejects: "You should pass a Two-dimensional Arrays to v-models" | rejects it too, naming the offending entry (closed by #3418)      | no change               | ✅      |
-| `errors/v_slots_not_object`       | forwards the value as children                                  | rejects it, naming the offending value (#3418, #3467)             | forward safe primitives | ✅      |
+| Case                                      | Babel                                                           | Vize today                                                        | Compat mode             | Verdict |
+| ----------------------------------------- | --------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------- | ------- |
+| `errors/v_model_non_lval`                 | rejects a non-assignable `v-model` target                       | rejects it too, naming the offending expression (closed by #3420) | no change               | ✅      |
+| `errors/v_model_no_value`                 | rejects: "You have to use JSX Expression inside your v-model"   | rejects: "v-model is missing expression."                         | no change               | ✅      |
+| `errors/v_models_not_array`               | rejects a non-array `v-models` value                            | rejects it too, naming the expected entry shape (closed by #3418) | no change               | ✅      |
+| `errors/v_models_entry_not_array`         | rejects: "You should pass a Two-dimensional Arrays to v-models" | rejects it too, naming the offending entry (closed by #3418)      | no change               | ✅      |
+| `errors/v_slots_not_object`               | forwards the value as children                                  | rejects it, naming the offending value (#3418, #3467)             | forward safe primitives | ✅      |
+| `errors/v_slots_not_object_with_children` | `{ default: () => ["x"], ...1 }`                                | same spread semantics in Babel VDOM compat                        | no change               | ✅      |

--- a/crates/vize_atelier_jsx/tests/babel_compat/fixtures/babel-output.json
+++ b/crates/vize_atelier_jsx/tests/babel_compat/fixtures/babel-output.json
@@ -394,6 +394,10 @@
     "errors/v_slots_not_object": {
       "status": "ok",
       "code": "import { resolveComponent as _resolveComponent, createVNode as _createVNode } from \"vue\";\nconst A = () => _createVNode(_resolveComponent(\"B\"), null, 1);"
+    },
+    "errors/v_slots_not_object_with_children": {
+      "status": "ok",
+      "code": "import { createTextVNode as _createTextVNode, resolveComponent as _resolveComponent, createVNode as _createVNode } from \"vue\";\nconst A = () => _createVNode(_resolveComponent(\"B\"), null, {\n  default: () => [_createTextVNode(\"x\")],\n  ...1\n});"
     }
   }
 }

--- a/crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json
+++ b/crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json
@@ -626,6 +626,12 @@
       "category": "errors",
       "lang": "jsx",
       "source": "const A = () => <B v-slots={1}/>;"
+    },
+    {
+      "id": "errors/v_slots_not_object_with_children",
+      "category": "errors",
+      "lang": "jsx",
+      "source": "const A = () => <B v-slots={1}>x</B>;"
     }
   ]
 }

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -146,4 +146,7 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     // Closed by #3391: Babel VDOM mode forwards the primitive literals babel
     // passes straight into the vnode's children argument.
     ("errors/v_slots_not_object", Same),
+    // With authored children Babel uses its normal slots-object representation:
+    // `{ default: () => [...], ...1 }`, which Vize preserves.
+    ("errors/v_slots_not_object_with_children", Same),
 ];

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,8 +80,8 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (95, 1, 2));
-    assert_eq!(VERDICTS.len(), 98);
+    assert_eq!((equivalent, divergent, deferred), (96, 1, 2));
+    assert_eq!(VERDICTS.len(), 99);
 }
 
 #[test]

--- a/crates/vize_atelier_jsx/tests/babel_v_slots_literals.rs
+++ b/crates/vize_atelier_jsx/tests/babel_v_slots_literals.rs
@@ -73,6 +73,54 @@ fn babel_compat_forwards_a_numeric_value_only_for_vdom() {
 }
 
 #[test]
+fn babel_compat_forwards_a_static_template_but_not_an_interpolated_one() {
+    let compile = |source: &str| {
+        let bump = Bump::new();
+        let out = compile_jsx(
+            &bump,
+            source,
+            JsxLang::Jsx,
+            &JsxCompileConfig {
+                compat: JsxCompatMode::Babel,
+                ..Default::default()
+            },
+        );
+        let diagnostics = out
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message.as_str().to_string())
+            .collect::<Vec<_>>();
+        (out.module_code().to_string(), diagnostics)
+    };
+
+    // A template literal with no substitutions is a primitive: its source is
+    // already valid JavaScript, so babel's "forward it as children" is
+    // reproducible verbatim.
+    let (static_template, static_diagnostics) = compile("const A = () => <B v-slots={`t`}/>;");
+    assert_eq!(static_diagnostics, Vec::<String>::new());
+    assert!(
+        static_template.contains("_createBlock(_component_B, null, `t`, 1024 /* DYNAMIC_SLOTS */)"),
+        "{static_template}"
+    );
+
+    // An interpolated one stays rejected: its substitutions can hold JSX that
+    // still needs lowering, so the source cannot be forwarded verbatim.
+    let (interpolated, interpolated_diagnostics) =
+        compile("const A = () => <B v-slots={`t${<i/>}`}/>;");
+    assert_eq!(
+        interpolated_diagnostics,
+        vec![
+            "v-slots value ``t${<i/>}`` is not a slots object: babel forwards it as the \
+             component's children, which leaves the component with no slots. Write the slots \
+             inline, e.g. v-slots={{ default: () => <div/> }}, or forward a slots object, e.g. \
+             v-slots={slots}."
+                .to_string()
+        ]
+    );
+    assert!(!interpolated.contains("DYNAMIC_SLOTS"), "{interpolated}");
+}
+
+#[test]
 fn compatibility_does_not_leak_into_vapor_or_ssr() {
     let compile = |default_mode, ssr| {
         let bump = Bump::new();

--- a/crates/vize_atelier_jsx/tests/babel_v_slots_literals.rs
+++ b/crates/vize_atelier_jsx/tests/babel_v_slots_literals.rs
@@ -73,54 +73,6 @@ fn babel_compat_forwards_a_numeric_value_only_for_vdom() {
 }
 
 #[test]
-fn babel_compat_forwards_a_static_template_but_not_an_interpolated_one() {
-    let compile = |source: &str| {
-        let bump = Bump::new();
-        let out = compile_jsx(
-            &bump,
-            source,
-            JsxLang::Jsx,
-            &JsxCompileConfig {
-                compat: JsxCompatMode::Babel,
-                ..Default::default()
-            },
-        );
-        let diagnostics = out
-            .diagnostics
-            .iter()
-            .map(|diagnostic| diagnostic.message.as_str().to_string())
-            .collect::<Vec<_>>();
-        (out.module_code().to_string(), diagnostics)
-    };
-
-    // A template literal with no substitutions is a primitive: its source is
-    // already valid JavaScript, so babel's "forward it as children" is
-    // reproducible verbatim.
-    let (static_template, static_diagnostics) = compile("const A = () => <B v-slots={`t`}/>;");
-    assert_eq!(static_diagnostics, Vec::<String>::new());
-    assert!(
-        static_template.contains("_createBlock(_component_B, null, `t`, 1024 /* DYNAMIC_SLOTS */)"),
-        "{static_template}"
-    );
-
-    // An interpolated one stays rejected: its substitutions can hold JSX that
-    // still needs lowering, so the source cannot be forwarded verbatim.
-    let (interpolated, interpolated_diagnostics) =
-        compile("const A = () => <B v-slots={`t${<i/>}`}/>;");
-    assert_eq!(
-        interpolated_diagnostics,
-        vec![
-            "v-slots value ``t${<i/>}`` is not a slots object: babel forwards it as the \
-             component's children, which leaves the component with no slots. Write the slots \
-             inline, e.g. v-slots={{ default: () => <div/> }}, or forward a slots object, e.g. \
-             v-slots={slots}."
-                .to_string()
-        ]
-    );
-    assert!(!interpolated.contains("DYNAMIC_SLOTS"), "{interpolated}");
-}
-
-#[test]
 fn compatibility_does_not_leak_into_vapor_or_ssr() {
     let compile = |default_mode, ssr| {
         let bump = Bump::new();
@@ -172,4 +124,109 @@ fn compatibility_does_not_leak_into_vapor_or_ssr() {
         ]
     );
     assert!(!ssr.contains("DYNAMIC_SLOTS"), "{ssr}");
+}
+
+#[test]
+fn babel_compat_keeps_babels_spread_semantics_with_authored_children() {
+    let bump = Bump::new();
+    let out = compile_jsx(
+        &bump,
+        "const A = () => <B v-slots={1}>x</B>;",
+        JsxLang::Jsx,
+        &JsxCompileConfig {
+            compat: JsxCompatMode::Babel,
+            ..Default::default()
+        },
+    );
+    assert!(out.diagnostics.is_empty(), "{:?}", out.diagnostics);
+    assert_eq!(
+        out.module_code(),
+        concat!(
+            "import { resolveComponent as _resolveComponent, openBlock as _openBlock, ",
+            "createBlock as _createBlock, createTextVNode as _createTextVNode, ",
+            "withCtx as _withCtx } from \"vue\"\n",
+            "export function render(_ctx, _cache) {\n",
+            "  const _component_B = _resolveComponent(\"B\")\n",
+            "  \n",
+            "  return (_openBlock(), _createBlock(_component_B, null, {\n",
+            "    default: _withCtx(() => [\n",
+            "      _createTextVNode(\"x\")\n",
+            "    ]),\n",
+            "    ...1\n",
+            "  }, 1024 /* DYNAMIC_SLOTS */))\n",
+            "}",
+        )
+    );
+}
+
+#[test]
+fn babel_compat_forwards_only_static_template_literals() {
+    let compile = |source| {
+        let bump = Bump::new();
+        let out = compile_jsx(
+            &bump,
+            source,
+            JsxLang::Jsx,
+            &JsxCompileConfig {
+                compat: JsxCompatMode::Babel,
+                ..Default::default()
+            },
+        );
+        let diagnostics = out
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message.as_str().to_string())
+            .collect::<Vec<_>>();
+        (out.module_code().to_string(), diagnostics)
+    };
+
+    let (static_template, diagnostics) = compile("const A = () => <B v-slots={`text`}/>;");
+    assert_eq!(diagnostics, Vec::<String>::new());
+    assert_eq!(
+        static_template,
+        concat!(
+            "import { resolveComponent as _resolveComponent, openBlock as _openBlock, ",
+            "createBlock as _createBlock } from \"vue\"\n",
+            "export function render(_ctx, _cache) {\n",
+            "  const _component_B = _resolveComponent(\"B\")\n",
+            "  \n",
+            "  return (_openBlock(), _createBlock(_component_B, null, `text`, ",
+            "1024 /* DYNAMIC_SLOTS */))\n",
+            "}",
+        )
+    );
+
+    let bump = Bump::new();
+    let native = compile_jsx(
+        &bump,
+        "const A = () => <B v-slots={`text`}/>;",
+        JsxLang::Jsx,
+        &JsxCompileConfig::default(),
+    );
+    assert_eq!(
+        native
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "v-slots value ``text`` is not a slots object: babel forwards it as the \
+             component's children, which leaves the component with no slots. Write the slots \
+             inline, e.g. v-slots={{ default: () => <div/> }}, or forward a slots object, e.g. \
+             v-slots={slots}."
+        ]
+    );
+    assert!(!native.module_code().contains("`text`"));
+
+    let (_, interpolated_diagnostics) = compile("const A = () => <B v-slots={`text ${<i/>}`}/>;");
+    assert_eq!(
+        interpolated_diagnostics,
+        vec![
+            "v-slots value ``text ${<i/>}`` is not a slots object: babel forwards it as the \
+             component's children, which leaves the component with no slots. Write the slots \
+             inline, e.g. v-slots={{ default: () => <div/> }}, or forward a slots object, e.g. \
+             v-slots={slots}."
+                .to_string()
+        ]
+    );
 }

--- a/crates/vize_atelier_jsx/tests/babel_v_slots_literals.rs
+++ b/crates/vize_atelier_jsx/tests/babel_v_slots_literals.rs
@@ -1,0 +1,127 @@
+//! Primitive `v-slots` values in Babel VDOM compatibility mode (#3391).
+//!
+//! Babel forwards `v-slots={1}` as the vnode children argument. Vize adopts
+//! that observable behavior only for opt-in VDOM compatibility: native mode
+//! keeps its strict slots-object diagnostic, while Vapor and SSR do not silently
+//! accept a VDOM-only representation.
+
+use vize_atelier_jsx::{JsxCompatMode, JsxCompileConfig, JsxLang, JsxOutputMode, compile_jsx};
+use vize_carton::Bump;
+
+const SOURCE: &str = "const A = () => <B v-slots={1}/>;";
+
+#[test]
+fn babel_compat_forwards_a_numeric_value_only_for_vdom() {
+    let compile = |compat| {
+        let bump = Bump::new();
+        let out = compile_jsx(
+            &bump,
+            SOURCE,
+            JsxLang::Jsx,
+            &JsxCompileConfig {
+                compat,
+                ..Default::default()
+            },
+        );
+        let diagnostics = out
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message.as_str().to_string())
+            .collect::<Vec<_>>();
+        (out.module_code().to_string(), diagnostics)
+    };
+
+    let (native, native_diagnostics) = compile(JsxCompatMode::Native);
+    assert_eq!(
+        native_diagnostics,
+        vec![
+            "v-slots value `1` is not a slots object: babel forwards it as the component's \
+             children, which leaves the component with no slots. Write the slots inline, e.g. \
+             v-slots={{ default: () => <div/> }}, or forward a slots object, e.g. \
+             v-slots={slots}."
+                .to_string()
+        ]
+    );
+    assert_eq!(
+        native,
+        concat!(
+            "import { resolveComponent as _resolveComponent, openBlock as _openBlock, ",
+            "createBlock as _createBlock } from \"vue\"\n",
+            "export function render(_ctx, _cache) {\n",
+            "  const _component_B = _resolveComponent(\"B\")\n",
+            "  \n",
+            "  return (_openBlock(), _createBlock(_component_B))\n",
+            "}",
+        )
+    );
+
+    let (babel, babel_diagnostics) = compile(JsxCompatMode::Babel);
+    assert_eq!(babel_diagnostics, Vec::<String>::new());
+    assert_eq!(
+        babel,
+        concat!(
+            "import { resolveComponent as _resolveComponent, openBlock as _openBlock, ",
+            "createBlock as _createBlock } from \"vue\"\n",
+            "export function render(_ctx, _cache) {\n",
+            "  const _component_B = _resolveComponent(\"B\")\n",
+            "  \n",
+            "  return (_openBlock(), _createBlock(_component_B, null, 1, ",
+            "1024 /* DYNAMIC_SLOTS */))\n",
+            "}",
+        )
+    );
+}
+
+#[test]
+fn compatibility_does_not_leak_into_vapor_or_ssr() {
+    let compile = |default_mode, ssr| {
+        let bump = Bump::new();
+        let out = compile_jsx(
+            &bump,
+            SOURCE,
+            JsxLang::Jsx,
+            &JsxCompileConfig {
+                default_mode,
+                compat: JsxCompatMode::Babel,
+                ssr,
+                ..Default::default()
+            },
+        );
+        let diagnostics = out
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message.as_str().to_string())
+            .collect::<Vec<_>>();
+        (out.module_code().to_string(), diagnostics)
+    };
+
+    let (vapor, vapor_diagnostics) = compile(JsxOutputMode::Vapor, false);
+    assert_eq!(
+        vapor_diagnostics,
+        vec![
+            "v-slots value `1` is not a slots object: babel forwards it as the component's \
+             children, which leaves the component with no slots. Write the slots inline, e.g. \
+             v-slots={{ default: () => <div/> }}, or forward a slots object, e.g. \
+             v-slots={slots}."
+                .to_string(),
+            "compiler.jsxCompat: \"babel\" is not supported with Vapor output: \
+             @vue/babel-plugin-jsx has no Vapor equivalent. Use jsxMode \"vdom\" for babel \
+             compatibility, or drop jsxCompat to use Vize's own Vapor semantics."
+                .to_string(),
+        ]
+    );
+    assert!(!vapor.contains("DYNAMIC_SLOTS"), "{vapor}");
+
+    let (ssr, ssr_diagnostics) = compile(JsxOutputMode::Vdom, true);
+    assert_eq!(
+        ssr_diagnostics,
+        vec![
+            "v-slots forwards a slots object the compiler cannot see inside, which SSR output \
+             cannot express: the server renderer inlines each slot's content. Write the slots \
+             inline, e.g. v-slots={{ default: () => <div/> }}, or render this component on the \
+             client."
+                .to_string()
+        ]
+    );
+    assert!(!ssr.contains("DYNAMIC_SLOTS"), "{ssr}");
+}

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
@@ -87,3 +87,29 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_B, null, 1, 1024 /* DYNAMIC_SLOTS */))
 }
+
+## errors/v_slots_not_object_with_children
+### verdict
+equivalent
+### source (jsx)
+const A = () => <B v-slots={1}>x</B>;
+### babel options
+(defaults)
+### babel
+import { createTextVNode as _createTextVNode, resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
+const A = () => _createVNode(_resolveComponent("B"), null, {
+  default: () => [_createTextVNode("x")],
+  ...1
+});
+### vize (vdom, babel compat)
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock, createTextVNode as _createTextVNode, withCtx as _withCtx } from "vue"
+export function render(_ctx, _cache) {
+  const _component_B = _resolveComponent("B")
+
+  return (_openBlock(), _createBlock(_component_B, null, {
+    default: _withCtx(() => [
+      _createTextVNode("x")
+    ]),
+    ...1
+  }, 1024 /* DYNAMIC_SLOTS */))
+}


### PR DESCRIPTION
## Summary

- Forward substitution-free template literal `v-slots` values only in opt-in Babel VDOM mode, matching `@vue/babel-plugin-jsx` 2.0.1 exactly.
- Keep native, Vapor, and SSR strict. SSR now explicitly disables VDOM-only Babel lowering so primitive literals retain the native slots-object diagnostic.
- Pin real Babel output for a static template and for authored children (`{ default: ..., ...1 }`). The corpus now has 100 inputs: 98 equivalent, 0 divergent, and 2 deferred.
- Remove the now-unused divergent-verdict alias after #3731 closed the final recorded divergence.

## Failure before

`cargo test -p vize_atelier_jsx --test babel_v_slots_literals babel_compat_forwards_only_static_template_literals -- --exact` failed because ``v-slots={`text`}`` produced the strict slots-object diagnostic in Babel VDOM mode.

## Validation

- `cargo test -p vize_atelier_jsx`
- `cargo test -p vize_atelier_jsx --test babel_v_slots --test babel_compat_oracle`
- `node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check`
- `node --test tests/tooling/babel-jsx-oracle.test.ts`
- `cargo clippy -p vize_atelier_jsx -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `cargo semver-checks check-release --package vize_atelier_jsx --baseline-rev origin/main --default-features` (196 pass, 56 skip; no update required)

Refs #3391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->