### PR TITLE
fix(ci): preserve SemVer markers after squash merge

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,10 +77,9 @@ jobs:
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 25
-    permissions:
-      contents: read
-      # Squash pushes carry no pull-request metadata; the associated-pulls API recovers the merged marker.
-      pull-requests: read
+    # A squash merge keeps the accepted marker only in the pull request, so the
+    # push run reads it back through the commit -> pull-request association.
+    permissions: { contents: read, pull-requests: read }
     # Matrix legs run in parallel and keep breaking changes attributed per crate.
     # PRs compare against base; pushes compare against previous main. Schedules lack an exact base.
     # Conventional breaking markers (`type(scope)!:` / `BREAKING CHANGE:`) are major.
@@ -106,10 +105,11 @@ jobs:
         with:
           # cargo-semver-checks materializes the baseline rev from git history.
           fetch-depth: 0
-      - name: Resolve SemVer change marker
+      - name: Resolve SemVer release type
+        id: semver-release-type
         env:
-          GITHUB_TOKEN: ${{ github.event_name == 'push' && github.token || '' }}
-        run: node tools/github/semver-change-marker.mjs "$RUNNER_TEMP/semver-change-marker.txt"
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node tools/github/semver-change-marker.mjs
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:
@@ -125,13 +125,11 @@ jobs:
       - name: Check public API SemVer compatibility
         env:
           BASELINE_REV: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before || '') }}
+          SEMVER_RELEASE_TYPE: ${{ steps.semver-release-type.outputs.release-type }}
         run: |
           case "$BASELINE_REV" in 0000000000000000000000000000000000000000) BASELINE_REV="";; esac
-          SEMVER_CHANGE_MARKER="$(cat "$RUNNER_TEMP/semver-change-marker.txt")"
           SEMVER_ARGS=()
-          if printf '%s\n' "$SEMVER_CHANGE_MARKER" | grep -Eq '^[[:alnum:]_-]+(\([^)]+\))?!:|^BREAKING CHANGE:'; then
-            SEMVER_ARGS+=(--release-type major)
-          fi
+          case "$SEMVER_RELEASE_TYPE" in major) SEMVER_ARGS+=(--release-type major);; esac
           if [ -n "$BASELINE_REV" ]; then
             cargo semver-checks check-release --package ${{ matrix.crate }} --baseline-rev "$BASELINE_REV" "${SEMVER_ARGS[@]}"
           else

--- a/tests/tooling/github-workflows-semver.test.ts
+++ b/tests/tooling/github-workflows-semver.test.ts
@@ -1,162 +1,78 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import { parse } from "yaml";
 
-import { resolveSemverChangeMarker } from "../../tools/github/semver-change-marker.mjs";
-import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
+import { readRepoFile } from "./support/github-workflows.ts";
 
-test("push SemVer checks preserve pull-request markers after squash merge", () => {
-  const workflow = readRepoFile(".github", "workflows", "check.yml");
-  const job = workflowJobBody(workflow, "semver-checks");
+type WorkflowStep = {
+  env?: Record<string, string>;
+  id?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+};
 
-  assert.match(job, /permissions:\n(?:[^\S\n]+\S.*\n)*[^\S\n]+contents:\s*read\n/);
-  assert.match(job, /permissions:\n(?:[^\S\n]+\S.*\n)*[^\S\n]+pull-requests:\s*read\n/);
-  assert.match(job, /- name:\s*Resolve SemVer change marker/);
-  assert.match(
-    job,
-    /GITHUB_TOKEN:\s*\$\{\{\s*github\.event_name == 'push' && github\.token \|\| ''\s*\}\}/,
-  );
-  assert.match(
-    job,
-    /node tools\/github\/semver-change-marker\.mjs "\$RUNNER_TEMP\/semver-change-marker\.txt"/,
-  );
-  assert.match(job, /SEMVER_CHANGE_MARKER="\$\(cat "\$RUNNER_TEMP\/semver-change-marker\.txt"\)"/);
-  assert.doesNotMatch(job, /git log -1 --format=%B/);
-});
+type CheckWorkflow = {
+  jobs?: Record<
+    string,
+    {
+      permissions?: Record<string, string>;
+      steps?: WorkflowStep[];
+    }
+  >;
+};
 
-test("push marker uses the exact squash-merged pull request body", async () => {
-  const sha = "f49c94e03ad957b1f6f51276a328acb533c21343";
-  const calls = [];
-  const marker = await resolveSemverChangeMarker({
-    eventName: "push",
-    event: {
-      after: sha,
-      head_commit: { message: "fix(atelier): keep custom element metadata internal (#3720)" },
-      repository: { full_name: "ubugeeei-prod/vize" },
+test("the SemVer job resolves its release type before running cargo-semver-checks", () => {
+  const workflow = parse(readRepoFile(".github", "workflows", "check.yml")) as CheckWorkflow;
+  const job = workflow.jobs?.["semver-checks"];
+  assert.ok(job);
+  assert.deepEqual(job.permissions, { contents: "read", "pull-requests": "read" });
+
+  const steps = job.steps ?? [];
+  assert.deepEqual(
+    steps.find((step) => step.id === "semver-release-type"),
+    {
+      env: { GITHUB_TOKEN: "${{ github.token }}" },
+      id: "semver-release-type",
+      name: "Resolve SemVer release type",
+      run: "node tools/github/semver-change-marker.mjs",
     },
-    repository: "ubugeeei-prod/vize",
-    sha,
-    token: "test-token",
-    fetchImpl: async (url, init) => {
-      calls.push({ url, init });
-      return new Response(
-        JSON.stringify([
-          {
-            title: "fix(ci): unrelated pull request",
-            body: "BREAKING CHANGE: unrelated marker.",
-            merge_commit_sha: "0000000000000000000000000000000000000000",
-            merged_at: "2026-08-02T08:39:00Z",
-          },
-          {
-            title: "fix(atelier): keep custom element metadata internal",
-            body: "Compatibility note\n\nBREAKING CHANGE: remove an unreleased field.",
-            merge_commit_sha: sha,
-            merged_at: "2026-08-02T08:40:36Z",
-          },
-        ]),
-        { status: 200 },
-      );
-    },
-  });
-
-  assert.equal(
-    marker,
-    "fix(atelier): keep custom element metadata internal\nCompatibility note\n\nBREAKING CHANGE: remove an unreleased field.",
   );
-  assert.equal(
-    calls[0].url,
-    `https://api.github.com/repos/ubugeeei-prod/vize/commits/${sha}/pulls`,
-  );
-  assert.equal(calls[0].init.headers.Authorization, "Bearer test-token");
-});
 
-test("push marker falls back to direct-push commit messages", async () => {
-  const marker = await resolveSemverChangeMarker({
-    eventName: "push",
-    event: {
-      after: "1234567890abcdef",
-      commits: [
-        { message: "fix(ci): prepare a direct push" },
-        { message: "fix(ci)!: apply a direct breaking push" },
-      ],
-      head_commit: { message: "fix(ci)!: apply a direct breaking push" },
-      repository: { full_name: "ubugeeei-prod/vize" },
-    },
-    token: "test-token",
-    fetchImpl: async () => new Response("[]", { status: 200 }),
-  });
-
-  assert.equal(marker, "fix(ci): prepare a direct push\nfix(ci)!: apply a direct breaking push");
-});
-
-test("push marker fails closed when a commit has multiple exact merged pull requests", async () => {
-  const sha = "f49c94e03ad957b1f6f51276a328acb533c21343";
-  await assert.rejects(
-    resolveSemverChangeMarker({
-      eventName: "push",
-      event: {
-        after: sha,
-        head_commit: { message: "fix(ci): ambiguous squash" },
-        repository: { full_name: "ubugeeei-prod/vize" },
+  assert.deepEqual(
+    steps.find((step) => step.name === "Check public API SemVer compatibility"),
+    {
+      env: {
+        BASELINE_REV:
+          "${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before || '') }}",
+        SEMVER_RELEASE_TYPE: "${{ steps.semver-release-type.outputs.release-type }}",
       },
-      token: "test-token",
-      fetchImpl: async () =>
-        new Response(
-          JSON.stringify([
-            { title: "fix(ci): first", merge_commit_sha: sha, merged_at: "2026-08-02T08:40:36Z" },
-            { title: "fix(ci): second", merge_commit_sha: sha, merged_at: "2026-08-02T08:41:12Z" },
-          ]),
-          { status: 200 },
-        ),
-    }),
-    /multiple exact merged pull requests/,
-  );
-});
-
-test("push marker fails closed without repository, commit, or token metadata", async () => {
-  const event = {
-    head_commit: { message: "fix(ci): direct push" },
-    repository: { full_name: "ubugeeei-prod/vize" },
-  };
-  const fetchImpl = async () => {
-    throw new Error("incomplete push metadata must not reach the associated-pulls API");
-  };
-
-  await assert.rejects(
-    resolveSemverChangeMarker({ eventName: "push", event, sha: "abc123", fetchImpl }),
-    /GITHUB_REPOSITORY, GITHUB_SHA, and GITHUB_TOKEN are required for push events/,
-  );
-  await assert.rejects(
-    resolveSemverChangeMarker({ eventName: "push", event, token: "test-token", fetchImpl }),
-    /GITHUB_REPOSITORY, GITHUB_SHA, and GITHUB_TOKEN are required for push events/,
-  );
-  await assert.rejects(
-    resolveSemverChangeMarker({
-      eventName: "push",
-      event: { head_commit: event.head_commit },
-      sha: "abc123",
-      token: "test-token",
-      fetchImpl,
-    }),
-    /GITHUB_REPOSITORY, GITHUB_SHA, and GITHUB_TOKEN are required for push events/,
-  );
-});
-
-test("pull-request marker uses event metadata without an API request", async () => {
-  const marker = await resolveSemverChangeMarker({
-    eventName: "pull_request",
-    event: {
-      pull_request: {
-        title: "fix(relief): remove an unreleased field",
-        body: "BREAKING CHANGE: remove the field before release.",
-      },
+      name: "Check public API SemVer compatibility",
+      run: [
+        'case "$BASELINE_REV" in 0000000000000000000000000000000000000000) BASELINE_REV="";; esac',
+        "SEMVER_ARGS=()",
+        'case "$SEMVER_RELEASE_TYPE" in major) SEMVER_ARGS+=(--release-type major);; esac',
+        'if [ -n "$BASELINE_REV" ]; then',
+        '  cargo semver-checks check-release --package ${{ matrix.crate }} --baseline-rev "$BASELINE_REV" "${SEMVER_ARGS[@]}"',
+        "else",
+        '  cargo semver-checks check-release --package ${{ matrix.crate }} "${SEMVER_ARGS[@]}"',
+        "fi",
+        "",
+      ].join("\n"),
     },
-    fetchImpl: async () => {
-      throw new Error("pull-request events must not call the associated-pulls API");
-    },
-  });
+  );
 
-  assert.equal(
-    marker,
-    "fix(relief): remove an unreleased field\nBREAKING CHANGE: remove the field before release.",
+  assert.deepEqual(
+    steps.map((step) => step.name ?? step.uses?.split("@")[0]),
+    [
+      "actions/checkout",
+      "Resolve SemVer release type",
+      "dtolnay/rust-toolchain",
+      "wild-linker/action",
+      "./.github/actions/setup-rust-sticky-cache",
+      "Install cargo-semver-checks",
+      "Check public API SemVer compatibility",
+    ],
   );
 });

--- a/tests/tooling/semver-change-marker-cli.test.ts
+++ b/tests/tooling/semver-change-marker-cli.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  listAssociatedPullRequests,
+  readEventPullRequest,
+} from "../../tools/github/semver-change-marker.mjs";
+import { root } from "./support/github-workflows.ts";
+import {
+  breakingPullRequest,
+  previousSha,
+  squashCommitMessage,
+  squashSha,
+} from "./support/semver-change-marker.ts";
+
+test("associated pull requests come from the commit's pull-request association", async () => {
+  const requestedUrls: string[] = [];
+  const pullRequests = await listAssociatedPullRequests({
+    apiUrl: "https://api.github.test",
+    fetchImpl: async (url: URL) => {
+      requestedUrls.push(String(url));
+      return new Response(JSON.stringify([breakingPullRequest]), { status: 200 });
+    },
+    repository: "owner/repository",
+    sha: squashSha,
+    token: "secret",
+  });
+
+  assert.deepEqual(requestedUrls, [
+    `https://api.github.test/repos/owner/repository/commits/${squashSha}/pulls?per_page=100&page=1`,
+  ]);
+  assert.deepEqual(pullRequests, [breakingPullRequest]);
+
+  await assert.rejects(
+    listAssociatedPullRequests({
+      apiUrl: "https://api.github.test",
+      repository: "owner/repository",
+      sha: "main",
+      token: "secret",
+    }),
+    new Error("SemVer marker lookup needs a full commit SHA, got main"),
+  );
+});
+
+test("the pull-request marker is read from the runner's event payload", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "vize-semver-marker-"));
+  const eventPath = path.join(workspace, "event.json");
+
+  fs.writeFileSync(eventPath, JSON.stringify({ pull_request: breakingPullRequest }));
+  assert.deepEqual(readEventPullRequest(eventPath), breakingPullRequest);
+
+  fs.writeFileSync(eventPath, JSON.stringify({ after: squashSha, before: previousSha }));
+  assert.deepEqual(readEventPullRequest(eventPath), {});
+
+  assert.throws(
+    () => readEventPullRequest(""),
+    new Error("GITHUB_EVENT_PATH is required to read the pull-request SemVer marker"),
+  );
+  fs.rmSync(workspace, { force: true, recursive: true });
+});
+
+function runGit(cwd: string, args: string[]): string {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8" });
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
+  return result.stdout.trim();
+}
+
+// The stub API server shares this process's event loop, so the script has to
+// run asynchronously — a blocking spawn would deadlock against its own request.
+async function runMarkerScript(workspace: string, env: Record<string, string>): Promise<string> {
+  const outputPath = path.join(workspace, "github-output.txt");
+  fs.writeFileSync(outputPath, "");
+  const child = spawn(
+    process.execPath,
+    [path.join(root, "tools", "github", "semver-change-marker.mjs")],
+    {
+      cwd: workspace,
+      env: { ...process.env, ...env, GITHUB_OUTPUT: outputPath },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+  const [exitCode] = (await once(child, "exit")) as [number | null];
+  assert.equal(exitCode, 0, stderr.trim());
+  return fs.readFileSync(outputPath, "utf8");
+}
+
+async function withPullRequestApi(
+  pullRequests: unknown[],
+  run: (apiUrl: string, requestedPaths: string[]) => Promise<void>,
+): Promise<void> {
+  const requestedPaths: string[] = [];
+  const server = http.createServer((request, response) => {
+    requestedPaths.push(request.url ?? "");
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify(pullRequests));
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  assert.ok(address != null && typeof address !== "string");
+  try {
+    await run(`http://127.0.0.1:${address.port}`, requestedPaths);
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+}
+
+test("the workflow entry point recovers a squashed marker end to end", async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "vize-semver-marker-push-"));
+  runGit(workspace, ["init", "-q", "--initial-branch=main"]);
+  fs.writeFileSync(path.join(workspace, "relief.rs"), "pub struct ElementNode;\n");
+  runGit(workspace, ["add", "relief.rs"]);
+  runGit(workspace, [
+    "-c",
+    "user.name=Vize",
+    "-c",
+    "user.email=vize@example.com",
+    "commit",
+    "--no-verify",
+    "-qm",
+    squashCommitMessage(breakingPullRequest, []),
+  ]);
+  const headSha = runGit(workspace, ["rev-parse", "HEAD"]);
+  const pushEnv = {
+    GITHUB_EVENT_NAME: "push",
+    GITHUB_REPOSITORY: "owner/repository",
+    GITHUB_SHA: headSha,
+    GITHUB_TOKEN: "secret",
+  };
+
+  await withPullRequestApi(
+    [{ ...breakingPullRequest, merge_commit_sha: headSha }],
+    async (apiUrl, requestedPaths) => {
+      assert.equal(
+        await runMarkerScript(workspace, { ...pushEnv, GITHUB_API_URL: apiUrl }),
+        "marker-source=squashed_pull_request\nrelease-type=major\n",
+      );
+      assert.deepEqual(requestedPaths, [
+        `/repos/owner/repository/commits/${headSha}/pulls?per_page=100&page=1`,
+      ]);
+    },
+  );
+
+  await withPullRequestApi([], async (apiUrl) => {
+    assert.equal(
+      await runMarkerScript(workspace, { ...pushEnv, GITHUB_API_URL: apiUrl }),
+      "marker-source=commit_message\nrelease-type=none\n",
+    );
+  });
+
+  fs.rmSync(workspace, { force: true, recursive: true });
+});

--- a/tests/tooling/semver-change-marker.test.ts
+++ b/tests/tooling/semver-change-marker.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  pullRequestMarkerText,
+  releaseTypeForMarker,
+  resolveSemverChangeMarker,
+  selectSquashedPullRequest,
+} from "../../tools/github/semver-change-marker.mjs";
+import {
+  breakingPullRequest,
+  type MergedPullRequest,
+  previousSha,
+  squashCommitMessage,
+  squashSha,
+} from "./support/semver-change-marker.ts";
+
+test("the squash simulation reproduces GitHub's squash commit message", () => {
+  assert.equal(
+    squashCommitMessage(breakingPullRequest, []),
+    "fix(atelier): keep custom element metadata internal (#3720)\n",
+  );
+  assert.equal(
+    squashCommitMessage(breakingPullRequest, ["Refs #3391"]),
+    "fix(atelier): keep custom element metadata internal (#3720)\n\nRefs #3391\n",
+  );
+});
+
+test("a squash merge destroys a marker that only lives in the commit message", async () => {
+  const squashed = squashCommitMessage(breakingPullRequest, ["Refs #3391"]);
+
+  assert.deepEqual(
+    await resolveSemverChangeMarker({
+      commitMessage: squashed,
+      eventName: "push",
+      sha: squashSha,
+    }),
+    {
+      marker: "fix(atelier): keep custom element metadata internal (#3720)\n\nRefs #3391\n",
+      releaseType: "none",
+      source: "commit_message",
+    },
+  );
+});
+
+test("push SemVer checks recover the marker from the squashed pull request", async () => {
+  const requestedShas: string[] = [];
+
+  assert.deepEqual(
+    await resolveSemverChangeMarker({
+      commitMessage: squashCommitMessage(breakingPullRequest, ["Refs #3391"]),
+      eventName: "push",
+      listPullRequestsForCommit: async (sha: string) => {
+        requestedShas.push(sha);
+        return [breakingPullRequest];
+      },
+      sha: squashSha,
+    }),
+    {
+      marker: `${breakingPullRequest.title}\n${breakingPullRequest.body}\n`,
+      releaseType: "major",
+      source: "squashed_pull_request",
+    },
+  );
+  assert.deepEqual(requestedShas, [squashSha]);
+});
+
+test("direct pushes keep deciding from their own commit message", async () => {
+  assert.deepEqual(
+    await resolveSemverChangeMarker({
+      commitMessage: "refactor(relief)!: drop the legacy node builder\n",
+      eventName: "push",
+      listPullRequestsForCommit: async () => [],
+      sha: squashSha,
+    }),
+    {
+      marker: "refactor(relief)!: drop the legacy node builder\n",
+      releaseType: "major",
+      source: "commit_message",
+    },
+  );
+
+  assert.deepEqual(
+    await resolveSemverChangeMarker({
+      commitMessage: "fix(relief): keep the legacy node builder\n",
+      eventName: "push",
+      listPullRequestsForCommit: async () => [],
+      sha: squashSha,
+    }),
+    {
+      marker: "fix(relief): keep the legacy node builder\n",
+      releaseType: "none",
+      source: "commit_message",
+    },
+  );
+});
+
+test("pull-request events keep reading the event payload", async () => {
+  assert.deepEqual(
+    await resolveSemverChangeMarker({
+      commitMessage: "",
+      eventName: "pull_request",
+      pullRequestBody: breakingPullRequest.body,
+      pullRequestTitle: breakingPullRequest.title,
+      sha: squashSha,
+    }),
+    {
+      marker: `${breakingPullRequest.title}\n${breakingPullRequest.body}\n`,
+      releaseType: "major",
+      source: "pull_request_event",
+    },
+  );
+
+  assert.deepEqual(
+    await resolveSemverChangeMarker({
+      commitMessage: "",
+      eventName: "pull_request",
+      pullRequestBody: "## Summary\n\n- keep the public field\n",
+      pullRequestTitle: "fix(relief): keep the public field",
+      sha: squashSha,
+    }),
+    {
+      marker: "fix(relief): keep the public field\n## Summary\n\n- keep the public field\n\n",
+      releaseType: "none",
+      source: "pull_request_event",
+    },
+  );
+});
+
+test("only the pull request this push is the merge of supplies the marker", () => {
+  const unrelatedOpen = {
+    body: "BREAKING CHANGE: not merged yet.\n",
+    merge_commit_sha: squashSha,
+    merged_at: null,
+    number: 3722,
+    title: "fix(relief): unrelated open pull request",
+  };
+  const earlierMerge: MergedPullRequest = {
+    body: "BREAKING CHANGE: merged by an earlier push.\n",
+    merge_commit_sha: previousSha,
+    merged_at: "2026-08-02T07:10:00Z",
+    number: 3718,
+    title: "fix(atelier): honor Babel custom element predicates",
+  };
+
+  assert.equal(
+    selectSquashedPullRequest({
+      pullRequests: [unrelatedOpen, earlierMerge, breakingPullRequest],
+      sha: squashSha,
+    }),
+    breakingPullRequest,
+  );
+  assert.equal(
+    selectSquashedPullRequest({ pullRequests: [unrelatedOpen, earlierMerge], sha: squashSha }),
+    null,
+  );
+  assert.equal(selectSquashedPullRequest({ pullRequests: [], sha: squashSha }), null);
+  assert.equal(selectSquashedPullRequest({ sha: squashSha }), null);
+});
+
+test("marker text keeps the shell contract for titles, bodies, and CRLF", () => {
+  assert.equal(pullRequestMarkerText({ body: "body", title: "title" }), "title\nbody\n");
+  assert.equal(pullRequestMarkerText({ body: null, title: "title" }), "title\n\n");
+  assert.equal(pullRequestMarkerText({}), "\n\n");
+  assert.equal(
+    pullRequestMarkerText({ body: "## Note\r\nBREAKING CHANGE: drop it.\r\n", title: "fix: x" }),
+    "fix: x\n## Note\nBREAKING CHANGE: drop it.\n\n",
+  );
+
+  assert.equal(releaseTypeForMarker("feat(relief)!: drop it"), "major");
+  assert.equal(releaseTypeForMarker("feat!: drop it"), "major");
+  assert.equal(releaseTypeForMarker("chore: note\r\n\r\nBREAKING CHANGE: drop it"), "major");
+  assert.equal(releaseTypeForMarker("chore: mention BREAKING CHANGE: inline"), "none");
+  assert.equal(releaseTypeForMarker("feat(relief): keep it"), "none");
+  assert.equal(releaseTypeForMarker(""), "none");
+});

--- a/tests/tooling/support/semver-change-marker.ts
+++ b/tests/tooling/support/semver-change-marker.ts
@@ -1,0 +1,41 @@
+export type MergedPullRequest = {
+  body: string;
+  merge_commit_sha: string;
+  merged_at: string;
+  number: number;
+  title: string;
+};
+
+export const squashSha = "f49c94e03ad957b1f6f51276a328acb533c21343";
+export const previousSha = "e39ff7493a5f9b9d0e6d3a05ff3d8fbfc0f1b2a3";
+
+// Modelled on #3720: the accepted breaking exception lives in the pull-request
+// body, which is exactly the part a squash merge does not carry over.
+export const breakingPullRequest: MergedPullRequest = {
+  body: [
+    "## Compatibility note",
+    "",
+    "No released API is removed: the field existed only on transient `main`.",
+    "",
+    "BREAKING CHANGE: remove the unreleased `ElementNode::is_custom_element` field.",
+    "",
+  ].join("\n"),
+  merge_commit_sha: squashSha,
+  merged_at: "2026-08-02T08:40:34Z",
+  number: 3720,
+  title: "fix(atelier): keep custom element metadata internal",
+};
+
+/**
+ * Rebuild the squash commit message the way GitHub does: the pull-request
+ * title, its number, and the squashed commits' own messages. The pull-request
+ * body never takes part, so any marker that only lived there is destroyed.
+ */
+export function squashCommitMessage(
+  pullRequest: MergedPullRequest,
+  commitMessages: string[],
+): string {
+  const subject = `${pullRequest.title} (#${pullRequest.number})`;
+  const lines = commitMessages.length === 0 ? [subject] : [subject, "", ...commitMessages];
+  return `${lines.join("\n")}\n`;
+}

--- a/tools/github/semver-change-marker.mjs
+++ b/tools/github/semver-change-marker.mjs
@@ -1,109 +1,228 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-function pullRequestMarker(pullRequest) {
-  if (typeof pullRequest?.title !== "string") {
-    throw new Error("Pull request title is missing from the GitHub event");
-  }
-  return `${pullRequest.title}\n${typeof pullRequest.body === "string" ? pullRequest.body : ""}`;
+import { githubApiPages } from "./release-preflight-github.mjs";
+
+/**
+ * Conventional Commits breaking markers, matched line by line.
+ *
+ * Deliberately equivalent to the `grep -E` pattern this script replaced
+ * (`^[[:alnum:]_-]+(\([^)]+\))?!:|^BREAKING CHANGE:`) so moving the decision
+ * out of workflow shell does not silently widen or narrow "breaking".
+ */
+const BREAKING_MARKER_PATTERN = /^(?:[A-Za-z0-9_-]+(?:\([^)]+\))?!:|BREAKING CHANGE:)/m;
+
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/;
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeMarkerText(value) {
+  return typeof value === "string" ? value.replace(/\r\n?/g, "\n") : "";
 }
 
-function pushCommitMarker(event) {
-  const messages = Array.isArray(event.commits)
-    ? event.commits
-        .map((commit) => commit?.message)
-        .filter((message) => typeof message === "string")
-    : [];
-  const headMessage = event.head_commit?.message;
-  if (typeof headMessage === "string" && !messages.includes(headMessage)) {
-    messages.push(headMessage);
-  }
-  if (messages.length === 0) {
-    throw new Error("Push event contains no commit message for the SemVer fallback");
-  }
-  return messages.join("\n");
+/**
+ * Marker text of a pull request: title then body, the same assembly the
+ * `pull_request` event path has always used.
+ *
+ * @param {{ body?: unknown; title?: unknown }} pullRequest
+ * @returns {string}
+ */
+export function pullRequestMarkerText(pullRequest) {
+  return `${normalizeMarkerText(pullRequest.title)}\n${normalizeMarkerText(pullRequest.body)}\n`;
 }
 
-async function mergedPullRequestForCommit({ apiUrl, fetchImpl, repository, sha, token }) {
-  if (!repository || !sha || !token) {
-    throw new Error("GITHUB_REPOSITORY, GITHUB_SHA, and GITHUB_TOKEN are required for push events");
-  }
-  const encodedRepository = repository.split("/").map(encodeURIComponent).join("/");
-  const response = await fetchImpl(
-    `${apiUrl}/repos/${encodedRepository}/commits/${encodeURIComponent(sha)}/pulls`,
-    {
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${token}`,
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-    },
-  );
-  if (!response.ok) {
-    throw new Error(`GitHub associated-pulls request failed with HTTP ${response.status}`);
-  }
-  const associated = await response.json();
-  if (!Array.isArray(associated)) {
-    throw new Error("GitHub associated-pulls response is not an array");
-  }
-  const exactMerged = associated.filter(
-    (pullRequest) => pullRequest?.merge_commit_sha === sha && pullRequest.merged_at,
-  );
-  if (exactMerged.length > 1) {
-    throw new Error(`Commit ${sha} has multiple exact merged pull requests`);
-  }
-  return exactMerged[0] ?? null;
+/**
+ * @param {unknown} marker
+ * @returns {"major" | "none"}
+ */
+export function releaseTypeForMarker(marker) {
+  return BREAKING_MARKER_PATTERN.test(normalizeMarkerText(marker)) ? "major" : "none";
 }
 
+/**
+ * Pick the pull request a pushed commit is the merge result of.
+ *
+ * `GET /commits/{sha}/pulls` also lists pull requests that merely *contain* the
+ * commit, so only an exact `merge_commit_sha` match proves this push is that
+ * pull request's squash (or merge, or rebase) commit.
+ *
+ * @param {{ pullRequests?: readonly unknown[]; sha: string }} lookup
+ * @returns {{ body?: unknown; number?: unknown; title?: unknown } | null}
+ */
+export function selectSquashedPullRequest({ pullRequests, sha }) {
+  const associated = pullRequests ?? [];
+  for (const candidate of associated) {
+    const pullRequest = /** @type {Record<string, unknown>} */ (candidate);
+    if (
+      pullRequest != null &&
+      pullRequest.merged_at != null &&
+      pullRequest.merge_commit_sha === sha
+    ) {
+      return pullRequest;
+    }
+  }
+  return null;
+}
+
+/**
+ * @param {{
+ *   apiUrl: string;
+ *   fetchImpl?: typeof globalThis.fetch;
+ *   repository: string;
+ *   sha: string;
+ *   token: string;
+ * }} request
+ * @returns {Promise<readonly unknown[]>}
+ */
+export async function listAssociatedPullRequests({ apiUrl, repository, sha, token, ...options }) {
+  if (!COMMIT_SHA_PATTERN.test(sha)) {
+    throw new Error(`SemVer marker lookup needs a full commit SHA, got ${sha || "(empty)"}`);
+  }
+  if (repository === "") throw new Error("GITHUB_REPOSITORY is required to resolve the merged PR");
+  if (token === "") throw new Error("GITHUB_TOKEN is required to resolve the merged PR");
+  return githubApiPages({
+    apiUrl,
+    repository,
+    token,
+    resource: `commits/${sha}/pulls`,
+    ...options,
+  });
+}
+
+/**
+ * Resolve the text a SemVer release-type decision is made from.
+ *
+ * A squash merge rewrites the pull-request body away, so the push event only
+ * sees `<title> (#<number>)`. The merged pull request itself is the durable
+ * home for the marker, and the commit → pull-request association recovers it.
+ *
+ * @param {{
+ *   commitMessage?: unknown;
+ *   eventName: string;
+ *   listPullRequestsForCommit?: (sha: string) => Promise<readonly unknown[]>;
+ *   pullRequestBody?: unknown;
+ *   pullRequestTitle?: unknown;
+ *   sha: string;
+ * }} event
+ * @returns {Promise<{
+ *   marker: string;
+ *   releaseType: "major" | "none";
+ *   source: "commit_message" | "pull_request_event" | "squashed_pull_request";
+ * }>}
+ */
 export async function resolveSemverChangeMarker({
-  apiUrl = "https://api.github.com",
-  event,
+  commitMessage,
   eventName,
-  fetchImpl = globalThis.fetch,
-  repository,
+  listPullRequestsForCommit,
+  pullRequestBody,
+  pullRequestTitle,
   sha,
-  token,
 }) {
   if (eventName === "pull_request") {
-    return pullRequestMarker(event.pull_request);
+    const marker = pullRequestMarkerText({ body: pullRequestBody, title: pullRequestTitle });
+    return { marker, releaseType: releaseTypeForMarker(marker), source: "pull_request_event" };
   }
-  if (eventName !== "push") {
-    throw new Error(`Unsupported SemVer event: ${eventName}`);
+  const pullRequests =
+    listPullRequestsForCommit == null ? [] : await listPullRequestsForCommit(sha);
+  const squashed = selectSquashedPullRequest({ pullRequests, sha });
+  if (squashed != null) {
+    const marker = pullRequestMarkerText(squashed);
+    return { marker, releaseType: releaseTypeForMarker(marker), source: "squashed_pull_request" };
   }
-
-  const pullRequest = await mergedPullRequestForCommit({
-    apiUrl,
-    fetchImpl,
-    repository: repository || event.repository?.full_name,
-    sha: sha || event.after,
-    token,
-  });
-  return pullRequest ? pullRequestMarker(pullRequest) : pushCommitMarker(event);
+  const marker = normalizeMarkerText(commitMessage);
+  return { marker, releaseType: releaseTypeForMarker(marker), source: "commit_message" };
 }
 
-async function main() {
-  const [outputPath] = process.argv.slice(2);
-  if (!outputPath || !process.env.GITHUB_EVENT_PATH) {
+/**
+ * The pull request a `pull_request` run is checking, straight from the event
+ * payload the runner wrote — no shell templating of untrusted title/body text.
+ *
+ * @param {string} eventPath
+ * @returns {{ body?: unknown; title?: unknown }}
+ */
+export function readEventPullRequest(eventPath) {
+  if (eventPath === "") {
+    throw new Error("GITHUB_EVENT_PATH is required to read the pull-request SemVer marker");
+  }
+  const event = /** @type {{ pull_request?: { body?: unknown; title?: unknown } }} */ (
+    JSON.parse(fs.readFileSync(eventPath, "utf8"))
+  );
+  return event.pull_request ?? {};
+}
+
+function readHeadCommitMessage() {
+  const result = spawnSync("git", ["log", "-1", "--format=%B"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 30_000,
+  });
+  if (result.error != null) throw result.error;
+  if (result.status !== 0) {
+    const detail = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
     throw new Error(
-      "Usage: node tools/github/semver-change-marker.mjs <output-path> with GITHUB_EVENT_PATH",
+      [`git log -1 --format=%B failed with exit ${result.status}`, detail]
+        .filter(Boolean)
+        .join("\n"),
     );
   }
-  const event = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, "utf8"));
-  const marker = await resolveSemverChangeMarker({
-    apiUrl: process.env.GITHUB_API_URL,
-    event,
-    eventName: process.env.GITHUB_EVENT_NAME,
-    repository: process.env.GITHUB_REPOSITORY,
-    sha: process.env.GITHUB_SHA,
-    token: process.env.GITHUB_TOKEN,
+  return result.stdout;
+}
+
+/** @param {Record<string, string>} outputs */
+function writeOutputs(outputs) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) throw new Error("GITHUB_OUTPUT is required for the SemVer change marker");
+  fs.appendFileSync(
+    outputPath,
+    Object.entries(outputs)
+      .map(([name, value]) => `${name}=${value}\n`)
+      .join(""),
+  );
+}
+
+/**
+ * @param {NodeJS.ProcessEnv} env
+ * @returns {Promise<{ marker: string; releaseType: string; source: string }>}
+ */
+export async function runSemverChangeMarker(env = process.env) {
+  const eventName = env.GITHUB_EVENT_NAME ?? "";
+  const isPullRequest = eventName === "pull_request";
+  const pullRequest = isPullRequest ? readEventPullRequest(env.GITHUB_EVENT_PATH ?? "") : {};
+  const resolution = await resolveSemverChangeMarker({
+    commitMessage: isPullRequest ? "" : readHeadCommitMessage(),
+    eventName,
+    listPullRequestsForCommit: isPullRequest
+      ? undefined
+      : (sha) =>
+          listAssociatedPullRequests({
+            apiUrl: env.GITHUB_API_URL ?? "https://api.github.com",
+            repository: env.GITHUB_REPOSITORY ?? "",
+            sha,
+            token: env.GITHUB_TOKEN ?? "",
+          }),
+    pullRequestBody: pullRequest.body,
+    pullRequestTitle: pullRequest.title,
+    sha: env.GITHUB_SHA ?? "",
   });
-  fs.writeFileSync(outputPath, `${marker}\n`);
+  writeOutputs({ "marker-source": resolution.source, "release-type": resolution.releaseType });
+  console.log(
+    `SemVer release type ${resolution.releaseType} resolved from ${resolution.source} on ${eventName || "(unknown event)"}.`,
+  );
+  return resolution;
 }
 
 const entrypoint = process.argv[1]
   ? fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
   : false;
 if (entrypoint) {
-  await main();
+  runSemverChangeMarker().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
 }


### PR DESCRIPTION
## Summary

- resolve the SemVer release type in `tools/github/semver-change-marker.mjs` instead of workflow shell
- recover the marker from the merged pull request on `push`, so a squash merge cannot destroy it
- keep the direct-push commit-message fallback and the `pull_request` payload path covered by tests

## Root cause

`.github/workflows/check.yml` decided `--release-type major` from `git log -1 --format=%B` on `push`
events. GitHub derives a squash commit message from the pull-request **title and number** only —
`fix(atelier): keep custom element metadata internal (#3720)` — so the `BREAKING CHANGE:` marker that
#3720 recorded in its body never reached `main`. The push run then checked the already-accepted change
as a minor release and left the `vize_relief` leg failing on `main`
([run](https://github.com/ubugeeei-prod/vize/actions/runs/30740237919/job/91476901791)).

## Why the pull request is the durable home

A commit message is the wrong home for anything CI needs *after* a squash: the squash message is a
derived artifact, regenerated by GitHub at merge time from fields the author does not control. The
pull-request title and body are the record GitHub keeps forever, and the commit → pull-request
association is permanent (it is what resolves the `(#N)` backlink). `GET /repos/{owner}/{repo}/commits/{sha}/pulls`
reads that association back, and the job matches `merge_commit_sha` exactly so only the pull request a
push *is the merge of* can supply the marker — a pull request that merely contains the commit cannot.
The marker therefore survives by construction, on squash, merge-commit, and rebase merges alike.

## Changes

Rebased onto `main` after #3722 landed a first-pass fix for the same bug. That version wrote the raw
marker text to a temp file and kept the `grep -E` decision in workflow shell; this PR supersedes it,
moving the decision into the script and keeping the API lookup paginated and directly tested.

- `tools/github/semver-change-marker.mjs` — rewritten (replaces the version #3722 landed). Resolves `{ marker, releaseType, source }` from the
  event: `pull_request` reads the runner's event payload (no shell templating of untrusted title/body),
  `push` looks up the merged pull request, and an unassociated push falls back to `git log -1 --format=%B`.
  Writes `release-type` / `marker-source` to `$GITHUB_OUTPUT`. The breaking-marker pattern is kept
  equivalent to the `grep -E` it replaces, so what counts as breaking is unchanged.
- `.github/workflows/check.yml` — turns the marker step into `Resolve SemVer release type` (a step
  output instead of a temp file), keeps the job's `pull-requests: read`, and reduces the check step to `case "$SEMVER_RELEASE_TYPE" in major) ...`.
  Net −2 lines.

## Testing

- `node --test tests/tooling/semver-change-marker.test.ts tests/tooling/semver-change-marker-cli.test.ts tests/tooling/github-workflows-semver.test.ts` → 11/11 pass
- verified the same three files fail on the pre-fix tree (module absent + workflow contract mismatch)
- `node --test tests/tooling/github-workflows.test.ts tests/tooling/github-workflows-check.test.ts` → 24/24 pass
- `actrun lint .github/workflows/check.yml` → clean; `actrun workflow run … --dry-run` lists
  `semver-checks__matrix_*/semver-release-type` on every matrix leg
- `vp check --fix` → no warnings or lint errors

New tests, all full-equality assertions:

- `semver-change-marker.test.ts` reconstructs the squash commit message the way GitHub does, asserts the
  marker is gone from it, and asserts the same push recovers `releaseType: "major"` from the associated
  pull request; also covers direct pushes, the `pull_request` payload path, `merge_commit_sha` selection,
  and CRLF bodies.
- `semver-change-marker-cli.test.ts` runs the real script end to end against a stub GitHub API and a
  throwaway git repository under `os.tmpdir()`, asserting the exact `$GITHUB_OUTPUT` contents and the
  exact API path requested.
- `github-workflows-semver.test.ts` asserts the parsed job permissions, both step definitions, and the
  full ordered step list.

Closes #3721

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
