### PR TITLE
fix(ci): harden SemVer marker API recovery

### DIFF
--- a/tests/tooling/github-workflows-semver.test.ts
+++ b/tests/tooling/github-workflows-semver.test.ts
@@ -141,6 +141,77 @@ test("push marker fails closed without repository, commit, or token metadata", a
   );
 });
 
+test("branch-deletion pushes skip the associated-pulls request", async () => {
+  const marker = await resolveSemverChangeMarker({
+    eventName: "push",
+    event: {
+      after: "0000000000000000000000000000000000000000",
+      commits: [],
+      deleted: true,
+      repository: { full_name: "ubugeeei-prod/vize" },
+    },
+    token: "test-token",
+    fetchImpl: async () => {
+      throw new Error("branch deletions must not call the associated-pulls API");
+    },
+  });
+
+  assert.equal(marker, "");
+});
+
+test("associated-pulls requests retry network errors and transient server failures", async () => {
+  let attempts = 0;
+  const delays = [];
+  const marker = await resolveSemverChangeMarker({
+    eventName: "push",
+    event: {
+      after: "1234567890abcdef",
+      commits: [{ message: "fix(ci): retry transient associated-pulls failures" }],
+      repository: { full_name: "ubugeeei-prod/vize" },
+    },
+    token: "test-token",
+    fetchImpl: async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("temporary network failure");
+      if (attempts === 2) return new Response("temporary server failure", { status: 503 });
+      return new Response("[]", { status: 200 });
+    },
+    sleepImpl: async (delay) => {
+      delays.push(delay);
+    },
+  });
+
+  assert.equal(marker, "fix(ci): retry transient associated-pulls failures");
+  assert.equal(attempts, 3);
+  assert.deepEqual(delays, [100, 200]);
+});
+
+test("associated-pulls requests do not retry non-transient failures", async () => {
+  let attempts = 0;
+
+  await assert.rejects(
+    resolveSemverChangeMarker({
+      eventName: "push",
+      event: {
+        after: "1234567890abcdef",
+        commits: [{ message: "fix(ci): no fallback" }],
+        repository: { full_name: "ubugeeei-prod/vize" },
+      },
+      token: "test-token",
+      fetchImpl: async () => {
+        attempts += 1;
+        return new Response("not found", { status: 404 });
+      },
+      sleepImpl: async () => {
+        throw new Error("non-transient failures must not sleep");
+      },
+    }),
+    /HTTP 404/,
+  );
+
+  assert.equal(attempts, 1);
+});
+
 test("pull-request marker uses event metadata without an API request", async () => {
   const marker = await resolveSemverChangeMarker({
     eventName: "pull_request",

--- a/tools/github/semver-change-marker.mjs
+++ b/tools/github/semver-change-marker.mjs
@@ -20,26 +20,55 @@ function pushCommitMarker(event) {
     messages.push(headMessage);
   }
   if (messages.length === 0) {
+    if (event.deleted === true) return "";
     throw new Error("Push event contains no commit message for the SemVer fallback");
   }
   return messages.join("\n");
 }
 
-async function mergedPullRequestForCommit({ apiUrl, fetchImpl, repository, sha, token }) {
+const retryDelays = [100, 200];
+
+async function fetchAssociatedPullRequests({ fetchImpl, init, sleepImpl, url }) {
+  for (let attempt = 0; ; attempt += 1) {
+    let response;
+    try {
+      response = await fetchImpl(url, init);
+    } catch (error) {
+      if (attempt === retryDelays.length) throw error;
+      await sleepImpl(retryDelays[attempt]);
+      continue;
+    }
+    const transient = response.status >= 500 && response.status < 600;
+    if (!transient || attempt === retryDelays.length) return response;
+    await sleepImpl(retryDelays[attempt]);
+  }
+}
+
+async function mergedPullRequestForCommit({
+  apiUrl,
+  fetchImpl,
+  repository,
+  sha,
+  sleepImpl,
+  token,
+}) {
+  if (typeof sha === "string" && /^0+$/.test(sha)) return null;
   if (!repository || !sha || !token) {
     throw new Error("GITHUB_REPOSITORY, GITHUB_SHA, and GITHUB_TOKEN are required for push events");
   }
   const encodedRepository = repository.split("/").map(encodeURIComponent).join("/");
-  const response = await fetchImpl(
-    `${apiUrl}/repos/${encodedRepository}/commits/${encodeURIComponent(sha)}/pulls`,
-    {
+  const response = await fetchAssociatedPullRequests({
+    fetchImpl,
+    init: {
       headers: {
         Accept: "application/vnd.github+json",
         Authorization: `Bearer ${token}`,
         "X-GitHub-Api-Version": "2022-11-28",
       },
     },
-  );
+    sleepImpl,
+    url: `${apiUrl}/repos/${encodedRepository}/commits/${encodeURIComponent(sha)}/pulls`,
+  });
   if (!response.ok) {
     throw new Error(`GitHub associated-pulls request failed with HTTP ${response.status}`);
   }
@@ -63,6 +92,7 @@ export async function resolveSemverChangeMarker({
   fetchImpl = globalThis.fetch,
   repository,
   sha,
+  sleepImpl = (delay) => new Promise((resolve) => setTimeout(resolve, delay)),
   token,
 }) {
   if (eventName === "pull_request") {
@@ -77,6 +107,7 @@ export async function resolveSemverChangeMarker({
     fetchImpl,
     repository: repository || event.repository?.full_name,
     sha: sha || event.after,
+    sleepImpl,
     token,
   });
   return pullRequest ? pullRequestMarker(pullRequest) : pushCommitMarker(event);


### PR DESCRIPTION
## Summary

- skip associated-pulls lookups for all-zero branch-deletion SHAs
- retry network errors and 5xx responses with a bounded 100ms/200ms backoff
- keep non-transient HTTP failures fail-closed and add focused regression coverage

## Validation

- `vp check --fix` (0 errors; existing unrelated warnings only)
- `node --test tests/tooling/github-workflows-semver.test.ts` (9 tests)
- `node --test tests/tooling/github-workflows-*.test.ts` (71 tests)
- `actrun lint .github/workflows/check.yml`
- `actrun workflow run .github/workflows/check.yml --dry-run`

Closes #3725

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->