### PR TITLE
fix(atelier): preserve Babel object slot children

### DIFF
--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -5,27 +5,34 @@
 
 mod babel;
 mod component;
+mod preamble;
 mod render_exports;
 #[cfg(test)]
 mod tests;
 
-use vize_carton::{Bump, FxHashSet, String};
+use vize_carton::{Bump, String};
 use vize_croquis::Croquis;
 
 use crate::compat::{JsxCompatMode, unsupported_with_vapor};
 use crate::diagnostics::JsxDiagnostic;
 use crate::forwarded_slots::{SlotsForwardingBackend, reject_forwarded_slots};
+use crate::lower::BabelLoweringOptions;
 use crate::ssr::compile_lowered_root_to_ssr;
 use crate::vapor::{VaporCompileOptions, compile_root_to_vapor};
 use crate::vdom::{VdomCompatOptions, VdomCompileOptions, compile_root_to_vdom};
 use crate::{JsxLang, JsxOutputMode, lower_source_with_compat};
 
-use self::babel::{collision_free_transform_on_helper, resolve_vnode_factory};
+use self::preamble::merge_preambles;
+
+use self::babel::{
+    collision_free_object_slot_helpers, collision_free_transform_on_helper, resolve_vnode_factory,
+};
 
 pub use self::babel::{
     BabelIsCustomElement, BabelJsxCustomizations, compile_jsx_with_babel_customizations,
-    compile_jsx_with_babel_merge_props, compile_jsx_with_babel_options,
-    compile_jsx_with_babel_pragma, compile_jsx_with_babel_pragma_and_merge_props,
+    compile_jsx_with_babel_merge_props, compile_jsx_with_babel_object_slots,
+    compile_jsx_with_babel_options, compile_jsx_with_babel_pragma,
+    compile_jsx_with_babel_pragma_and_merge_props,
 };
 pub use component::JsxComponent;
 
@@ -113,106 +120,6 @@ impl JsxCompileOutput {
     }
 }
 
-/// Merge a sequence of per-component preambles into one deduplicated preamble.
-///
-/// Each VDOM preamble is a line-oriented block — typically a single
-/// `import { name as _alias, … } from "vue"` statement (default JSX options emit
-/// no hoists, but any extra lines are preserved verbatim). Concatenating several
-/// components' preambles as-is would redeclare the same `_alias` bindings, which
-/// is an ESM error, so this collapses every `import … from "<src>"` line into a
-/// single import per source carrying the union of its specifiers in first-seen
-/// order. Non-import lines (e.g. static hoists) are kept verbatim, deduplicated,
-/// and appended after the merged imports.
-fn merge_preambles<'a>(preambles: impl Iterator<Item = &'a str>) -> String {
-    // Imports grouped by source module, each preserving first-seen specifier
-    // order; sources themselves preserve first-seen order via `import_sources`.
-    let mut import_sources: Vec<&str> = Vec::new();
-    let mut import_specifiers: Vec<Vec<&str>> = Vec::new();
-    let mut seen_specifiers: FxHashSet<(&str, &str)> = FxHashSet::default();
-    let mut extra_lines: Vec<&str> = Vec::new();
-    let mut seen_extra: FxHashSet<&str> = FxHashSet::default();
-
-    for preamble in preambles {
-        for line in preamble.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            match parse_named_import(trimmed) {
-                Some((specifiers, source)) => {
-                    let group = match import_sources.iter().position(|s| *s == source) {
-                        Some(index) => index,
-                        None => {
-                            import_sources.push(source);
-                            import_specifiers.push(Vec::new());
-                            import_sources.len() - 1
-                        }
-                    };
-                    for specifier in specifiers.split(',') {
-                        let specifier = specifier.trim();
-                        if specifier.is_empty() {
-                            continue;
-                        }
-                        if seen_specifiers.insert((source, specifier)) {
-                            import_specifiers[group].push(specifier);
-                        }
-                    }
-                }
-                None => {
-                    if seen_extra.insert(trimmed) {
-                        extra_lines.push(trimmed);
-                    }
-                }
-            }
-        }
-    }
-
-    let mut merged = String::default();
-    for (source, specifiers) in import_sources.iter().zip(import_specifiers.iter()) {
-        merged.push_str("import { ");
-        for (i, specifier) in specifiers.iter().enumerate() {
-            if i > 0 {
-                merged.push_str(", ");
-            }
-            merged.push_str(specifier);
-        }
-        merged.push_str(" } from \"");
-        merged.push_str(source);
-        merged.push_str("\"\n");
-    }
-    for line in extra_lines {
-        merged.push_str(line);
-        merged.push('\n');
-    }
-    merged
-}
-
-/// Parse a `import { a as _a, b as _b } from "src"` line into its
-/// specifier list (the text between the braces) and source module. Returns
-/// `None` for any line that is not a brace-style named import (so it is kept
-/// verbatim by [`merge_preambles`]).
-fn parse_named_import(line: &str) -> Option<(&str, &str)> {
-    let rest = line.strip_prefix("import")?;
-    let open = rest.find('{')?;
-    let close = rest.find('}')?;
-    if close < open {
-        return None;
-    }
-    let specifiers = &rest[open + 1..close];
-
-    let after = &rest[close + 1..];
-    let from = after.find("from")?;
-    let quoted = after[from + "from".len()..].trim();
-    let bytes = quoted.as_bytes();
-    let quote = *bytes.first()?;
-    if quote != b'"' && quote != b'\'' {
-        return None;
-    }
-    let inner = &quoted[1..];
-    let end = inner.find(quote as char)?;
-    Some((specifiers, &inner[..end]))
-}
-
 /// Resolve the effective output mode for a component: an explicit per-component
 /// directive wins, otherwise the configured default applies.
 pub fn resolve_mode(
@@ -244,6 +151,9 @@ pub(crate) fn compile_jsx_with_babel_customizations_inner(
     let transform_on_helper =
         (config.compat.is_babel() && babel_options.transform_on && !config.ssr)
             .then(|| collision_free_transform_on_helper(source));
+    let object_slot_helpers =
+        (config.compat.is_babel() && !config.ssr && customizations.enable_object_slots)
+            .then(|| collision_free_object_slot_helpers(source));
     let merge_props = !config.compat.is_babel() || config.ssr || customizations.merge_props;
     let is_custom_element = if config.compat.is_babel() && !config.ssr {
         customizations.is_custom_element
@@ -256,8 +166,13 @@ pub(crate) fn compile_jsx_with_babel_customizations_inner(
         lang,
         config.compat,
         config.default_mode,
-        transform_on_helper.as_deref(),
-        is_custom_element,
+        BabelLoweringOptions {
+            transform_on_helper: transform_on_helper.as_deref(),
+            object_slots_helper: object_slot_helpers
+                .as_ref()
+                .map(|helpers| helpers.is_slot.as_str()),
+            is_custom_element,
+        },
     );
     let mut diagnostics = lowered.diagnostics;
     let is_ts = lang.is_typescript();
@@ -317,6 +232,9 @@ pub(crate) fn compile_jsx_with_babel_customizations_inner(
                     &config.vdom,
                     VdomCompatOptions {
                         transform_on_helper: transform_on_helper.as_deref(),
+                        object_slots_helpers: object_slot_helpers
+                            .as_ref()
+                            .map(|helpers| (helpers.is_slot.as_str(), helpers.is_vnode.as_str())),
                         vnode_factory,
                         merge_props,
                         allow_static_v_model_arg_on_element: config.compat.is_babel(),

--- a/crates/vize_atelier_jsx/src/compile/babel.rs
+++ b/crates/vize_atelier_jsx/src/compile/babel.rs
@@ -19,6 +19,10 @@ pub struct BabelJsxCustomizations<'a> {
     pub merge_props: bool,
     /// Project-specific custom-element classifier.
     pub is_custom_element: Option<&'a BabelIsCustomElement>,
+    /// Whether a lone identifier or call child of a component is checked at
+    /// runtime for already being a slots object, matching Babel's
+    /// `enableObjectSlots` (default `true`).
+    pub enable_object_slots: bool,
 }
 
 impl Default for BabelJsxCustomizations<'_> {
@@ -27,6 +31,7 @@ impl Default for BabelJsxCustomizations<'_> {
             pragma: None,
             merge_props: true,
             is_custom_element: None,
+            enable_object_slots: true,
         }
     }
 }
@@ -70,7 +75,7 @@ pub fn compile_jsx_with_babel_pragma_and_merge_props(
         BabelJsxCustomizations {
             pragma,
             merge_props,
-            is_custom_element: None,
+            ..Default::default()
         },
     )
 }
@@ -137,6 +142,32 @@ pub fn compile_jsx_with_babel_merge_props(
     )
 }
 
+/// Compile JSX/TSX with an explicit Babel-compatible `enableObjectSlots` value.
+///
+/// The plugin defaults this option to `true`: a lone identifier or call child
+/// of a component may already be a slots object and is checked at runtime.
+/// Passing `false` always wraps that value as the raw default-slot child.
+pub fn compile_jsx_with_babel_object_slots(
+    bump: &Bump,
+    source: &str,
+    lang: JsxLang,
+    config: &JsxCompileConfig,
+    babel_options: &BabelJsxOptions,
+    enable_object_slots: bool,
+) -> JsxCompileOutput {
+    compile_jsx_with_babel_customizations(
+        bump,
+        source,
+        lang,
+        config,
+        babel_options,
+        BabelJsxCustomizations {
+            enable_object_slots,
+            ..Default::default()
+        },
+    )
+}
+
 pub(super) fn resolve_vnode_factory<'a>(
     pragma: Option<&'a str>,
     active: bool,
@@ -174,6 +205,27 @@ fn valid_pragma_expression(pragma: &str) -> bool {
 /// analysis pass.
 pub(super) fn collision_free_transform_on_helper(source: &str) -> String {
     let mut helper = String::from("_transformOn");
+    while source.contains(helper.as_str()) {
+        helper.push('_');
+    }
+    helper
+}
+
+/// Collision-free local bindings used by Babel's object-slot discriminator.
+pub(super) struct ObjectSlotHelpers {
+    pub is_slot: String,
+    pub is_vnode: String,
+}
+
+pub(super) fn collision_free_object_slot_helpers(source: &str) -> ObjectSlotHelpers {
+    ObjectSlotHelpers {
+        is_slot: collision_free_helper(source, "_isSlot"),
+        is_vnode: collision_free_helper(source, "_isVNode"),
+    }
+}
+
+fn collision_free_helper(source: &str, base: &str) -> String {
+    let mut helper = String::from(base);
     while source.contains(helper.as_str()) {
         helper.push('_');
     }

--- a/crates/vize_atelier_jsx/src/compile/preamble.rs
+++ b/crates/vize_atelier_jsx/src/compile/preamble.rs
@@ -1,0 +1,159 @@
+//! Deduplicating the per-component runtime-helper preambles of one module.
+
+use vize_carton::{FxHashSet, String};
+
+/// Merge a sequence of per-component preambles into one deduplicated preamble.
+///
+/// Each VDOM preamble is a line-oriented block — typically a single
+/// `import { name as _alias, … } from "vue"` statement (default JSX options emit
+/// no hoists, but any extra lines are preserved verbatim). Concatenating several
+/// components' preambles as-is would redeclare the same `_alias` bindings, which
+/// is an ESM error, so this collapses every `import … from "<src>"` line into a
+/// single import per source carrying the union of its specifiers in first-seen
+/// order. Non-import lines (e.g. static hoists) are kept verbatim, deduplicated,
+/// and appended after the merged imports.
+pub(super) fn merge_preambles<'a>(preambles: impl Iterator<Item = &'a str>) -> String {
+    // Imports grouped by source module, each preserving first-seen specifier
+    // order; sources themselves preserve first-seen order via `import_sources`.
+    let mut import_sources: Vec<&str> = Vec::new();
+    let mut import_specifiers: Vec<Vec<&str>> = Vec::new();
+    let mut seen_specifiers: FxHashSet<(&str, &str)> = FxHashSet::default();
+    let mut extra_lines: Vec<&str> = Vec::new();
+    let mut seen_extra: FxHashSet<&str> = FxHashSet::default();
+
+    for preamble in preambles {
+        for line in preamble.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match parse_named_import(trimmed) {
+                Some((specifiers, source)) => {
+                    let group = match import_sources.iter().position(|s| *s == source) {
+                        Some(index) => index,
+                        None => {
+                            import_sources.push(source);
+                            import_specifiers.push(Vec::new());
+                            import_sources.len() - 1
+                        }
+                    };
+                    for specifier in specifiers.split(',') {
+                        let specifier = specifier.trim();
+                        if specifier.is_empty() {
+                            continue;
+                        }
+                        if seen_specifiers.insert((source, specifier)) {
+                            import_specifiers[group].push(specifier);
+                        }
+                    }
+                }
+                None => {
+                    if seen_extra.insert(trimmed) {
+                        extra_lines.push(trimmed);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut merged = String::default();
+    for (source, specifiers) in import_sources.iter().zip(import_specifiers.iter()) {
+        merged.push_str("import { ");
+        for (i, specifier) in specifiers.iter().enumerate() {
+            if i > 0 {
+                merged.push_str(", ");
+            }
+            merged.push_str(specifier);
+        }
+        merged.push_str(" } from \"");
+        merged.push_str(source);
+        merged.push_str("\"\n");
+    }
+    for line in extra_lines {
+        merged.push_str(line);
+        merged.push('\n');
+    }
+    merged
+}
+
+/// Parse a `import { a as _a, b as _b } from "src"` line into its
+/// specifier list (the text between the braces) and source module. Returns
+/// `None` for any line that is not a brace-style named import (so it is kept
+/// verbatim by [`merge_preambles`]).
+fn parse_named_import(line: &str) -> Option<(&str, &str)> {
+    let rest = line.strip_prefix("import")?;
+    let open = rest.find('{')?;
+    let close = rest.find('}')?;
+    if close < open {
+        return None;
+    }
+    let specifiers = &rest[open + 1..close];
+
+    let after = &rest[close + 1..];
+    let from = after.find("from")?;
+    let quoted = after[from + "from".len()..].trim();
+    let bytes = quoted.as_bytes();
+    let quote = *bytes.first()?;
+    if quote != b'"' && quote != b'\'' {
+        return None;
+    }
+    let inner = &quoted[1..];
+    let end = inner.find(quote as char)?;
+    Some((specifiers, &inner[..end]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{merge_preambles, parse_named_import};
+
+    #[test]
+    fn parses_named_import_specifiers_and_source() {
+        assert_eq!(
+            parse_named_import("import { a as _a, b as _b } from \"vue\""),
+            Some((" a as _a, b as _b ", "vue"))
+        );
+        // Single-quoted source is accepted too.
+        assert_eq!(
+            parse_named_import("import { x } from 'vue'"),
+            Some((" x ", "vue"))
+        );
+        // Non-imports and namespace/default imports are not brace-named imports.
+        assert_eq!(parse_named_import("const _hoisted = 1"), None);
+        assert_eq!(parse_named_import("import Foo from \"bar\""), None);
+    }
+
+    #[test]
+    fn merge_preambles_dedups_overlapping_vue_imports() {
+        // Two components importing overlapping helpers from "vue" must collapse to
+        // one import with each binding declared exactly once (concatenating the
+        // raw lines would redeclare `_createElementBlock`, an ESM error).
+        let merged = merge_preambles(
+            [
+                "import { createElementBlock as _createElementBlock } from \"vue\"\n",
+                "import { createElementBlock as _createElementBlock, toDisplayString as _toDisplayString } from \"vue\"\n",
+            ]
+            .into_iter(),
+        );
+        assert_eq!(
+            merged,
+            "import { createElementBlock as _createElementBlock, toDisplayString as _toDisplayString } from \"vue\"\n"
+        );
+    }
+
+    #[test]
+    fn merge_preambles_keeps_distinct_sources_and_hoists() {
+        // Distinct sources each get their own import (first-seen order), and a
+        // non-import hoist line is preserved verbatim after the imports.
+        let merged = merge_preambles(
+            [
+                "import { a as _a } from \"vue\"\nconst _hoisted = 1\n",
+                "import { b as _b } from \"other\"\n",
+            ]
+            .into_iter(),
+        );
+        assert_eq!(
+            merged,
+            "import { a as _a } from \"vue\"\nimport { b as _b } from \"other\"\nconst _hoisted = 1\n"
+        );
+    }
+}

--- a/crates/vize_atelier_jsx/src/compile/tests.rs
+++ b/crates/vize_atelier_jsx/src/compile/tests.rs
@@ -6,57 +6,6 @@
 use super::*;
 
 #[test]
-fn parses_named_import_specifiers_and_source() {
-    assert_eq!(
-        parse_named_import("import { a as _a, b as _b } from \"vue\""),
-        Some((" a as _a, b as _b ", "vue"))
-    );
-    // Single-quoted source is accepted too.
-    assert_eq!(
-        parse_named_import("import { x } from 'vue'"),
-        Some((" x ", "vue"))
-    );
-    // Non-imports and namespace/default imports are not brace-named imports.
-    assert_eq!(parse_named_import("const _hoisted = 1"), None);
-    assert_eq!(parse_named_import("import Foo from \"bar\""), None);
-}
-
-#[test]
-fn merge_preambles_dedups_overlapping_vue_imports() {
-    // Two components importing overlapping helpers from "vue" must collapse to
-    // one import with each binding declared exactly once (concatenating the
-    // raw lines would redeclare `_createElementBlock`, an ESM error).
-    let merged = merge_preambles(
-        [
-            "import { createElementBlock as _createElementBlock } from \"vue\"\n",
-            "import { createElementBlock as _createElementBlock, toDisplayString as _toDisplayString } from \"vue\"\n",
-        ]
-        .into_iter(),
-    );
-    assert_eq!(
-        merged,
-        "import { createElementBlock as _createElementBlock, toDisplayString as _toDisplayString } from \"vue\"\n"
-    );
-}
-
-#[test]
-fn merge_preambles_keeps_distinct_sources_and_hoists() {
-    // Distinct sources each get their own import (first-seen order), and a
-    // non-import hoist line is preserved verbatim after the imports.
-    let merged = merge_preambles(
-        [
-            "import { a as _a } from \"vue\"\nconst _hoisted = 1\n",
-            "import { b as _b } from \"other\"\n",
-        ]
-        .into_iter(),
-    );
-    assert_eq!(
-        merged,
-        "import { a as _a } from \"vue\"\nimport { b as _b } from \"other\"\nconst _hoisted = 1\n"
-    );
-}
-
-#[test]
 fn module_code_prepends_merged_preamble_to_render_code() {
     // A single VDOM component's module string is its preamble followed by the
     // render code, so the emitted helpers are actually imported.

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -57,11 +57,13 @@ pub use compat::JsxCompatMode;
 pub use compile::{
     BabelIsCustomElement, BabelJsxCustomizations, BabelJsxOptions, JsxCompileConfig,
     JsxCompileOutput, JsxComponent, compile_jsx, compile_jsx_with_babel_customizations,
-    compile_jsx_with_babel_merge_props, compile_jsx_with_babel_options,
-    compile_jsx_with_babel_pragma, compile_jsx_with_babel_pragma_and_merge_props, resolve_mode,
+    compile_jsx_with_babel_merge_props, compile_jsx_with_babel_object_slots,
+    compile_jsx_with_babel_options, compile_jsx_with_babel_pragma,
+    compile_jsx_with_babel_pragma_and_merge_props, resolve_mode,
 };
 pub use diagnostics::{JsxDiagnostic, Severity};
 pub use lang::JsxLang;
+use lower::BabelLoweringOptions;
 pub use lower::Lowerer;
 pub use mode::JsxOutputMode;
 pub use parse::{ParsedModule, parse_module};
@@ -175,8 +177,7 @@ pub fn lower_source<'a>(bump: &'a Bump, source: &str, lang: JsxLang) -> LowerOut
         lang,
         JsxCompatMode::Native,
         JsxOutputMode::Vdom,
-        None,
-        None,
+        BabelLoweringOptions::default(),
     )
     .0
 }
@@ -192,27 +193,19 @@ fn lower_source_with_compat<'a>(
     lang: JsxLang,
     compat: JsxCompatMode,
     default_mode: JsxOutputMode,
-    transform_on_helper: Option<&str>,
-    is_custom_element: Option<&BabelIsCustomElement>,
+    babel: BabelLoweringOptions<'_>,
 ) -> (LowerOutput<'a>, std::vec::Vec<(u32, u32)>) {
     let allocator = oxc_allocator::Allocator::default();
     let parse_source = parse::prepare_source_for_parse(source, lang);
     let parsed = parse::parse_module(&allocator, parse_source.as_ref(), lang);
-    let scoping = is_custom_element.map(|_| {
+    let scoping = babel.is_custom_element.map(|_| {
         SemanticBuilder::new()
             .build(&parsed.program)
             .semantic
             .into_scoping()
     });
     let mapper = SpanMapper::new(source);
-    let mut lowerer = Lowerer::with_compat(
-        bump,
-        &mapper,
-        compat,
-        transform_on_helper,
-        is_custom_element,
-        scoping,
-    );
+    let mut lowerer = Lowerer::with_compat(bump, &mapper, compat, babel, scoping);
     for diagnostic in parsed.diagnostics {
         lowerer.report(diagnostic);
     }

--- a/crates/vize_atelier_jsx/src/lower.rs
+++ b/crates/vize_atelier_jsx/src/lower.rs
@@ -7,6 +7,7 @@
 //! allocator and outlives parsing.
 
 mod attr;
+mod babel_slot;
 mod child;
 mod control_flow;
 mod element;
@@ -33,6 +34,21 @@ use crate::compat::JsxCompatMode;
 use crate::diagnostics::JsxDiagnostic;
 use crate::span::SpanMapper;
 
+/// The `@vue/babel-plugin-jsx` options that change *lowering* rather than code
+/// generation (#3391).
+///
+/// Grouped into one value so adding a Babel option stays additive at every call
+/// site instead of widening three signatures each time.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct BabelLoweringOptions<'m> {
+    /// Collision-free `_transformOn` binding, when `transformOn` is enabled.
+    pub transform_on_helper: Option<&'m str>,
+    /// Collision-free `_isSlot` binding, when `enableObjectSlots` is enabled.
+    pub object_slots_helper: Option<&'m str>,
+    /// Project-specific custom-element classifier from `isCustomElement`.
+    pub is_custom_element: Option<&'m BabelIsCustomElement>,
+}
+
 /// Lowers OXC JSX nodes into Vize IR against a single source text.
 pub struct Lowerer<'a, 'm, 's> {
     bump: &'a Bump,
@@ -42,6 +58,7 @@ pub struct Lowerer<'a, 'm, 's> {
     scoping: Option<Scoping>,
     custom_element_spans: std::vec::Vec<(u32, u32)>,
     transform_on_helper: Option<String>,
+    object_slots_helper: Option<String>,
     babel_vdom_compat_active: bool,
     diagnostics: std::vec::Vec<JsxDiagnostic>,
     /// `<style scoped>` blocks extracted from the render root currently being
@@ -53,7 +70,13 @@ pub struct Lowerer<'a, 'm, 's> {
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Build a lowerer that allocates IR in `bump` and maps spans via `mapper`.
     pub fn new(bump: &'a Bump, mapper: &'m SpanMapper<'s>) -> Self {
-        Self::with_compat(bump, mapper, JsxCompatMode::Native, None, None, None)
+        Self::with_compat(
+            bump,
+            mapper,
+            JsxCompatMode::Native,
+            BabelLoweringOptions::default(),
+            None,
+        )
     }
 
     /// Build a lowerer using the requested project-level JSX semantics.
@@ -61,18 +84,18 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         bump: &'a Bump,
         mapper: &'m SpanMapper<'s>,
         compat: JsxCompatMode,
-        transform_on_helper: Option<&str>,
-        is_custom_element: Option<&'m BabelIsCustomElement>,
+        babel: BabelLoweringOptions<'m>,
         scoping: Option<Scoping>,
     ) -> Self {
         Self {
             bump,
             mapper,
             compat,
-            is_custom_element,
+            is_custom_element: babel.is_custom_element,
             scoping,
             custom_element_spans: std::vec::Vec::new(),
-            transform_on_helper: transform_on_helper.map(String::from),
+            transform_on_helper: babel.transform_on_helper.map(String::from),
+            object_slots_helper: babel.object_slots_helper.map(String::from),
             babel_vdom_compat_active: false,
             diagnostics: std::vec::Vec::new(),
             pending_styles: std::vec::Vec::new(),
@@ -219,6 +242,15 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     pub(crate) fn transform_on_helper(&self) -> Option<&str> {
         if self.babel_vdom_compat_active {
             self.transform_on_helper.as_deref()
+        } else {
+            None
+        }
+    }
+
+    /// Collision-free helper binding for Babel's default object-slot check.
+    pub(crate) fn object_slots_helper(&self) -> Option<&str> {
+        if self.babel_vdom_compat_active {
+            self.object_slots_helper.as_deref()
         } else {
             None
         }

--- a/crates/vize_atelier_jsx/src/lower/babel_slot.rs
+++ b/crates/vize_atelier_jsx/src/lower/babel_slot.rs
@@ -1,0 +1,161 @@
+//! `@vue/babel-plugin-jsx`'s treatment of a component's lone expression child
+//! (#3391), used only in opt-in Babel VDOM compatibility mode.
+//!
+//! Native Vize lowers such a child like any other component child, so it becomes
+//! an implicit default slot and is stringified through `toDisplayString`. Babel
+//! instead passes the value straight into the vnode's children argument:
+//!
+//! - with `enableObjectSlots: true` (its default) an identifier or a call result
+//!   might *already* be a slots object, so it is discriminated at runtime by the
+//!   plugin's `_isSlot` helper — a call is wrapped in an IIFE so it is evaluated
+//!   exactly once;
+//! - everything else — and every child under `enableObjectSlots: false` —
+//!   becomes the raw value of an unescaped `default` slot.
+//!
+//! Object and render-prop children never reach here: they are the slot idiom
+//! [`super::slot`] lowers into `<template v-slot>` children.
+
+use oxc_ast::ast::{Expression, JSXChild, JSXExpressionContainer};
+use oxc_span::{GetSpan, Span};
+use vize_carton::{Box, String};
+use vize_relief::{ElementNode, ExpressionNode, SimpleExpressionNode};
+
+use super::Lowerer;
+use super::slot::is_whitespace_child;
+
+impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// Lower a component's sole expression child the way Babel does, reporting
+    /// whether it consumed the child. `false` leaves ordinary child lowering to
+    /// the caller.
+    pub(crate) fn lower_babel_sole_expression_child(
+        &mut self,
+        node: &mut ElementNode<'a>,
+        container: &JSXExpressionContainer<'_>,
+        has_v_slots: bool,
+    ) -> bool {
+        let Some(expression) = container.expression.as_expression() else {
+            return false;
+        };
+
+        // `cond && <x/>` and friends are still lowered to v-if / v-for: they
+        // render the same DOM as babel's untouched JavaScript.
+        if let Some(child) = self.lower_control_flow_child(&container.expression, container.span) {
+            node.children.push(child);
+            return true;
+        }
+
+        // An explicit `v-slots` attribute owns the slots object, so ordinary
+        // children stay children instead of becoming the slots argument.
+        if has_v_slots {
+            node.children
+                .push(self.raw_expression_child(expression.span(), container.span));
+            return true;
+        }
+
+        let inner = expression.get_inner_expression();
+        if let Some(helper) = self.object_slots_helper().map(String::from) {
+            let slots = match inner {
+                Expression::Identifier(_) => {
+                    Some(self.identifier_object_slots_expression(helper.as_str(), inner))
+                }
+                Expression::CallExpression(_) => {
+                    Some(self.call_object_slots_expression(helper.as_str(), expression))
+                }
+                _ => None,
+            };
+            if let Some(slots) = slots {
+                self.forward_slots_expression(node, slots);
+                return true;
+            }
+        }
+
+        // The comma operator has to keep its parentheses: `{ default: () => [a,
+        // b] }` would otherwise be two array elements rather than one sequence.
+        let slots = self.raw_default_slots_expression(
+            expression,
+            matches!(inner, Expression::SequenceExpression(_)),
+        );
+        self.forward_slots_expression(node, slots);
+        true
+    }
+
+    /// `_isSlot(x) ? x : { default: () => [x] }` — Babel's identifier form,
+    /// which is safe to repeat because an identifier has no side effects.
+    fn identifier_object_slots_expression(
+        &self,
+        helper: &str,
+        expression: &Expression<'_>,
+    ) -> ExpressionNode<'a> {
+        let source = self.mapper().slice(expression.span());
+        let mut content = String::with_capacity(helper.len() + source.len() * 3 + 40);
+        content.push_str(helper);
+        content.push('(');
+        content.push_str(source);
+        content.push_str(") ? ");
+        content.push_str(source);
+        content.push_str(" : { default: () => [");
+        content.push_str(source);
+        content.push_str("] }");
+        self.generated_slot_expression(content, expression.span())
+    }
+
+    /// The same check for a call, bound through an IIFE so the call itself is
+    /// evaluated exactly once.
+    fn call_object_slots_expression(
+        &self,
+        helper: &str,
+        expression: &Expression<'_>,
+    ) -> ExpressionNode<'a> {
+        let source = self.mapper().slice(expression.span());
+        let mut content = String::with_capacity(helper.len() + source.len() + 80);
+        content.push_str("(_slot => ");
+        content.push_str(helper);
+        content.push_str("(_slot) ? _slot : { default: () => [_slot] })(");
+        content.push_str(source);
+        content.push(')');
+        self.generated_slot_expression(content, expression.span())
+    }
+
+    /// `{ default: () => [x] }` — the raw default-slot value.
+    fn raw_default_slots_expression(
+        &self,
+        expression: &Expression<'_>,
+        parenthesize: bool,
+    ) -> ExpressionNode<'a> {
+        let source = self.mapper().slice(expression.span());
+        let mut content = String::with_capacity(source.len() + 28);
+        content.push_str("{ default: () => [");
+        if parenthesize {
+            content.push('(');
+        }
+        content.push_str(source);
+        if parenthesize {
+            content.push(')');
+        }
+        content.push_str("] }");
+        self.generated_slot_expression(content, expression.span())
+    }
+
+    fn generated_slot_expression(&self, content: String, span: Span) -> ExpressionNode<'a> {
+        ExpressionNode::Simple(Box::new_in(
+            SimpleExpressionNode::new(content, false, self.mapper().location(span)),
+            self.bump(),
+        ))
+    }
+}
+
+/// The component's only meaningful child when it is a single expression
+/// container, ignoring whitespace-only text.
+pub(super) fn sole_expression_container<'o>(
+    children: &'o [JSXChild<'o>],
+) -> Option<&'o JSXExpressionContainer<'o>> {
+    let mut meaningful = children.iter().filter(|child| !is_whitespace_child(child));
+    let only = meaningful.next()?;
+    if meaningful.next().is_some() {
+        return None;
+    }
+    match only {
+        JSXChild::ExpressionContainer(container) => Some(container),
+        _ => None,
+    }
+}

--- a/crates/vize_atelier_jsx/src/lower/child.rs
+++ b/crates/vize_atelier_jsx/src/lower/child.rs
@@ -173,7 +173,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// JavaScript expressions as compound expressions; a single dynamic part
     /// is the narrowest existing IR shape that keeps this JSX-only distinction
     /// out of the public relief node surface.
-    fn raw_expression_child(
+    pub(crate) fn raw_expression_child(
         &self,
         expression_span: oxc_span::Span,
         container_span: oxc_span::Span,

--- a/crates/vize_atelier_jsx/src/lower/element.rs
+++ b/crates/vize_atelier_jsx/src/lower/element.rs
@@ -1,6 +1,6 @@
 //! Lowering JSX elements and fragments into [`ElementNode`]s.
 
-use oxc_ast::ast::{JSXElement, JSXElementName, JSXFragment};
+use oxc_ast::ast::{JSXAttributeItem, JSXElement, JSXElementName, JSXFragment};
 use oxc_span::{GetSpan, Span};
 use vize_carton::{Box, String};
 use vize_relief::{DirectiveNode, ElementNode, ElementType, PropNode};
@@ -57,6 +57,9 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         // classifies it as a component during lowering, matching the plugin.
         let on_component = !is_custom_element
             && (node.tag_type == ElementType::Component || node.tag.contains('-'));
+        let has_v_slots = opening.attributes.iter().any(|item| {
+            matches!(item, JSXAttributeItem::Attribute(attr) if self.is_v_slots_attribute(attr))
+        });
         node.props = self.lower_attributes(&opening.attributes, on_component);
         if let Some(span) = expression_tag {
             // First, so the emitted props object reads `<component :is="…" …>`
@@ -67,11 +70,11 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         // Components route through slot synthesis (object/render-prop children
         // become `<template v-slot>`s); intrinsic elements lower children
         // directly.
-        node.children = if node.tag_type == ElementType::Component && !is_custom_element {
-            self.lower_component_children(&element.children)
+        if node.tag_type == ElementType::Component && !is_custom_element {
+            self.lower_component_children_into(&mut node, &element.children, has_v_slots);
         } else {
-            self.lower_element_children(&element.children)
-        };
+            node.children = self.lower_element_children(&element.children);
+        }
         // `v-slots` contributes slot templates, appended after the element's own
         // children so those still become the `default` slot when the slots object
         // does not name one (#3418).

--- a/crates/vize_atelier_jsx/src/lower/slot.rs
+++ b/crates/vize_atelier_jsx/src/lower/slot.rs
@@ -10,11 +10,12 @@
 //! build the slots object from those templates.
 //!
 //! Plain element/text children of a component are left untouched: the backends
-//! already treat them as an implicit default slot.
+//! already treat them as an implicit default slot. Opt-in Babel VDOM mode
+//! instead routes a lone expression child through [`super::babel_slot`].
 
 use oxc_ast::ast::{
-    ArrowFunctionExpression, Expression, Function, JSXChild, JSXExpression, ObjectPropertyKind,
-    PropertyKey, Statement,
+    ArrowFunctionExpression, Expression, Function, JSXChild, ObjectPropertyKind, PropertyKey,
+    Statement,
 };
 use oxc_span::{GetSpan, Span};
 use vize_carton::{Box, Vec};
@@ -22,6 +23,7 @@ use vize_relief::ElementType;
 use vize_relief::{DirectiveNode, ElementNode, PropNode, TemplateChildNode, TextNode};
 
 use super::Lowerer;
+use super::babel_slot::sole_expression_container;
 use crate::diagnostics::JsxDiagnostic;
 
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
@@ -32,14 +34,30 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// arrow/function, synthesize `<template v-slot>` children. Otherwise fall
     /// back to ordinary child lowering (which becomes an implicit default slot
     /// in the backends).
-    pub(crate) fn lower_component_children(
+    pub(crate) fn lower_component_children_into(
         &mut self,
+        node: &mut ElementNode<'a>,
         children: &[JSXChild<'_>],
-    ) -> Vec<'a, TemplateChildNode<'a>> {
-        if let Some(slots) = self.try_lower_slot_idiom(children) {
-            return slots;
+        has_v_slots: bool,
+    ) {
+        if !(self.uses_babel_vdom_compat() && has_v_slots)
+            && let Some(slots) = self.try_lower_slot_idiom(children)
+        {
+            node.children = slots;
+            return;
         }
-        self.lower_children(children)
+
+        // Babel passes a component's lone expression child straight into the
+        // vnode's children argument rather than making it an implicit default
+        // slot; `babel_slot` owns that shape.
+        if self.uses_babel_vdom_compat()
+            && let Some(container) = sole_expression_container(children)
+            && self.lower_babel_sole_expression_child(node, container, has_v_slots)
+        {
+            return;
+        }
+
+        node.children = self.lower_children(children);
     }
 
     /// Detect and lower the slot idiom, returning `None` when the children are
@@ -57,25 +75,14 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         let JSXChild::ExpressionContainer(container) = only else {
             return None;
         };
-        match &container.expression {
-            JSXExpression::ObjectExpression(object) => Some(self.lower_object_slots(object)),
-            JSXExpression::ArrowFunctionExpression(arrow) => {
+        let expression = container.expression.as_expression()?;
+        match expression.get_inner_expression() {
+            Expression::ObjectExpression(object) => Some(self.lower_object_slots(object)),
+            Expression::ArrowFunctionExpression(arrow) => {
                 Some(self.lower_default_scoped_slot(arrow.as_ref().into()))
             }
-            JSXExpression::FunctionExpression(func) => {
+            Expression::FunctionExpression(func) => {
                 Some(self.lower_default_scoped_slot(func.as_ref().into()))
-            }
-            JSXExpression::ParenthesizedExpression(paren) => {
-                match paren.expression.get_inner_expression() {
-                    Expression::ObjectExpression(object) => Some(self.lower_object_slots(object)),
-                    Expression::ArrowFunctionExpression(arrow) => {
-                        Some(self.lower_default_scoped_slot(arrow.as_ref().into()))
-                    }
-                    Expression::FunctionExpression(func) => {
-                        Some(self.lower_default_scoped_slot(func.as_ref().into()))
-                    }
-                    _ => None,
-                }
             }
             _ => None,
         }
@@ -313,6 +320,6 @@ fn static_key<'o>(key: &'o PropertyKey<'o>) -> Option<(&'o str, Span)> {
 }
 
 /// Whether a child is whitespace-only text (dropped before slot detection).
-fn is_whitespace_child(child: &JSXChild<'_>) -> bool {
+pub(super) fn is_whitespace_child(child: &JSXChild<'_>) -> bool {
     matches!(child, JSXChild::Text(text) if text.value.as_str().trim().is_empty())
 }

--- a/crates/vize_atelier_jsx/src/lower/v_slots.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_slots.rs
@@ -76,7 +76,7 @@ use oxc_ast::ast::{
 };
 use oxc_span::{GetSpan, Span};
 use vize_carton::Box;
-use vize_relief::{DirectiveNode, ElementNode, PropNode};
+use vize_relief::{DirectiveNode, ElementNode, ExpressionNode, PropNode};
 
 use super::Lowerer;
 use super::expr::container_expr_span;
@@ -192,9 +192,18 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// (#3467). Keeping it a directive rather than a synthesized child is what
     /// lets the value stay opaque: there are no entries to build templates from.
     fn forward_slots(&mut self, node: &mut ElementNode<'a>, span: Span) {
-        let loc = self.mapper().location(span);
+        let expression = self.dyn_expr(span);
+        self.forward_slots_expression(node, expression);
+    }
+
+    pub(crate) fn forward_slots_expression(
+        &self,
+        node: &mut ElementNode<'a>,
+        expression: ExpressionNode<'a>,
+    ) {
+        let loc = expression.loc().clone();
         let mut directive = DirectiveNode::new(self.bump(), "slots", loc);
-        directive.exp = Some(self.dyn_expr(span));
+        directive.exp = Some(expression);
         node.props
             .push(PropNode::Directive(Box::new_in(directive, self.bump())));
     }

--- a/crates/vize_atelier_jsx/src/vdom.rs
+++ b/crates/vize_atelier_jsx/src/vdom.rs
@@ -78,6 +78,7 @@ pub struct VdomOutput {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct VdomCompatOptions<'a> {
     pub transform_on_helper: Option<&'a str>,
+    pub object_slots_helpers: Option<(&'a str, &'a str)>,
     pub vnode_factory: Option<&'a str>,
     pub merge_props: bool,
     pub allow_static_v_model_arg_on_element: bool,
@@ -88,6 +89,7 @@ impl Default for VdomCompatOptions<'_> {
     fn default() -> Self {
         Self {
             transform_on_helper: None,
+            object_slots_helpers: None,
             vnode_factory: None,
             merge_props: true,
             allow_static_v_model_arg_on_element: false,
@@ -215,6 +217,22 @@ pub(crate) fn compile_root_to_vdom(
         preamble.push_str("import ");
         preamble.push_str(helper);
         preamble.push_str(" from \"@vue/babel-helper-vue-transform-on\"\n");
+    }
+    if let Some((is_slot, is_vnode)) = compat.object_slots_helpers
+        && result.code.contains(is_slot)
+    {
+        if !preamble.is_empty() && !preamble.ends_with('\n') {
+            preamble.push('\n');
+        }
+        preamble.push_str("import { isVNode as ");
+        preamble.push_str(is_vnode);
+        preamble.push_str(" } from \"vue\"\n");
+        preamble.push_str("function ");
+        preamble.push_str(is_slot);
+        preamble.push_str("(s) {\n  return typeof s === 'function' || ");
+        preamble.push_str("Object.prototype.toString.call(s) === '[object Object]' && !");
+        preamble.push_str(is_vnode);
+        preamble.push_str("(s);\n}\n");
     }
 
     VdomComponent {

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   92 |
-| divergent  |    4 |
+| equivalent |   94 |
+| divergent  |    2 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -100,8 +100,8 @@ deliberate answer, recorded here so it is not relitigated.
 | `options/merge_props_false`         | one object literal with a duplicate key             | always merges via `mergeProps`               | object spread + duplicate-key semantics (#3391)      | ✅      |
 | `options/is_custom_element_default` | `<my-el/>` → `resolveComponent("my-el")`            | same                                         | no change                                            | ✅      |
 | `options/is_custom_element_fn`      | matching tag becomes a string tag                   | predicate-selected tag uses element lowering | additive `isCustomElement` predicate API             | ✅      |
-| `options/object_slots_default`      | `_isSlot(slots) ? slots : {default: () => [slots]}` | `toDisplayString(slots)` in the default slot | treat a lone expression child as a slot object       | ❌      |
-| `options/object_slots_false`        | `{default: () => [slots]}`                          | `toDisplayString(slots)` in the default slot | raw child, plus an `enableObjectSlots: false` option | ❌      |
+| `options/object_slots_default`      | `_isSlot(slots) ? slots : {default: () => [slots]}` | `toDisplayString(slots)` in the default slot | runtime slot-object check; calls evaluate once       | ✅      |
+| `options/object_slots_false`        | `{default: () => [slots]}`                          | `toDisplayString(slots)` in the default slot | additive option preserves the raw default-slot child | ✅      |
 | `options/resolve_type_off`          | JSX replaced, types untouched                       | equivalent render output                     | no change                                            | ✅      |
 | `options/resolve_type_on`           | appends `{props: {...}, name: "A"}`                 | no type-driven inference                     | deferred: needs #1497 / #1502                        | ⏸       |
 

--- a/crates/vize_atelier_jsx/tests/babel_compat/mod.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/mod.rs
@@ -238,6 +238,11 @@ pub fn vize_vdom_output(case: &Case) -> std::string::String {
                 .and_then(serde_json::Value::as_bool)
                 .unwrap_or(true),
             is_custom_element,
+            enable_object_slots: case
+                .babel_options
+                .get("enableObjectSlots")
+                .and_then(serde_json::Value::as_bool)
+                .unwrap_or(true),
         },
     );
 

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -19,14 +19,11 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("options/merge_props_false", Same),
     ("options/is_custom_element_default", Same),
     ("options/is_custom_element_fn", Same),
-    (
-        "options/object_slots_default",
-        Diff("lone expression child stringified"),
-    ),
-    (
-        "options/object_slots_false",
-        Diff("lone expression child stringified"),
-    ),
+    // Closed by #3391: Babel compat distinguishes possible slot objects at
+    // runtime by default, and preserves the lone expression as a raw
+    // default-slot child when `enableObjectSlots` is disabled.
+    ("options/object_slots_default", Same),
+    ("options/object_slots_false", Same),
     ("options/resolve_type_off", Same),
     (
         "options/resolve_type_on",

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (92, 4, 2));
+    assert_eq!((equivalent, divergent, deferred), (94, 2, 2));
     assert_eq!(VERDICTS.len(), 98);
 }
 

--- a/crates/vize_atelier_jsx/tests/babel_is_custom_element.rs
+++ b/crates/vize_atelier_jsx/tests/babel_is_custom_element.rs
@@ -225,6 +225,7 @@ fn captured_predicate_composes_with_other_babel_options() {
             pragma: Some("factory.h"),
             merge_props: false,
             is_custom_element: Some(&is_custom_element),
+            ..Default::default()
         },
     );
     let module = output.module_code();

--- a/crates/vize_atelier_jsx/tests/babel_object_slots.rs
+++ b/crates/vize_atelier_jsx/tests/babel_object_slots.rs
@@ -1,0 +1,322 @@
+//! Babel JSX object-slot compatibility (#3391).
+//!
+//! The plugin treats a lone component child specially: identifiers and call
+//! results may already be a slots object, while every other value becomes the
+//! raw default-slot child. `enableObjectSlots: false` disables only the runtime
+//! slots-object check. Native, Vapor, and SSR output must remain untouched.
+
+use vize_atelier_jsx::{
+    BabelJsxOptions, JsxCompatMode, JsxCompileConfig, JsxLang, JsxOutputMode, compile_jsx,
+    compile_jsx_with_babel_object_slots,
+};
+use vize_carton::Bump;
+
+const LONE_IDENTIFIER_CHILD: &str = "const A = () => <B>{slots}</B>;";
+
+/// The plugin's own `_isSlot` discriminator, emitted once per module.
+const IS_SLOT_HELPER: &str = concat!(
+    "function _isSlot(s) {\n",
+    "return typeof s === 'function' || Object.prototype.toString.call(s) === ",
+    "'[object Object]' && !_isVNode(s);\n",
+    "}\n",
+);
+
+fn compile(
+    source: &str,
+    compat: JsxCompatMode,
+    mode: JsxOutputMode,
+    enable_object_slots: bool,
+) -> (String, Vec<String>) {
+    let bump = Bump::new();
+    let output = compile_jsx_with_babel_object_slots(
+        &bump,
+        source,
+        JsxLang::Tsx,
+        &JsxCompileConfig {
+            compat,
+            default_mode: mode,
+            ..Default::default()
+        },
+        &BabelJsxOptions::default(),
+        enable_object_slots,
+    );
+    (
+        output.module_code().to_string(),
+        output
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message.to_string())
+            .collect(),
+    )
+}
+
+fn compile_default(source: &str, compat: JsxCompatMode) -> String {
+    let bump = Bump::new();
+    compile_jsx(
+        &bump,
+        source,
+        JsxLang::Tsx,
+        &JsxCompileConfig {
+            compat,
+            ..Default::default()
+        },
+    )
+    .module_code()
+    .to_string()
+}
+
+#[test]
+fn option_is_babel_vdom_only_and_true_is_the_babel_default() {
+    // Native output is byte-identical whichever way the option is set, and
+    // Babel's own default is `true`, so the plain entry point already agrees.
+    let native_default = compile_default(LONE_IDENTIFIER_CHILD, JsxCompatMode::Native);
+    for enabled in [true, false] {
+        let (native, diagnostics) = compile(
+            LONE_IDENTIFIER_CHILD,
+            JsxCompatMode::Native,
+            JsxOutputMode::Vdom,
+            enabled,
+        );
+        assert_eq!(native, native_default);
+        assert_eq!(diagnostics, Vec::<String>::new());
+    }
+
+    let (babel, diagnostics) = compile(
+        LONE_IDENTIFIER_CHILD,
+        JsxCompatMode::Babel,
+        JsxOutputMode::Vdom,
+        true,
+    );
+    assert_eq!(diagnostics, Vec::<String>::new());
+    assert_eq!(
+        babel,
+        compile_default(LONE_IDENTIFIER_CHILD, JsxCompatMode::Babel)
+    );
+
+    // Vapor has no Babel equivalent, so both settings produce the same
+    // unsupported-mode diagnostic and the same Vize-native Vapor module.
+    let (vapor_on, vapor_on_diagnostics) = compile(
+        LONE_IDENTIFIER_CHILD,
+        JsxCompatMode::Babel,
+        JsxOutputMode::Vapor,
+        true,
+    );
+    let (vapor_off, vapor_off_diagnostics) = compile(
+        LONE_IDENTIFIER_CHILD,
+        JsxCompatMode::Babel,
+        JsxOutputMode::Vapor,
+        false,
+    );
+    assert_eq!(vapor_on, vapor_off);
+    assert_eq!(vapor_on_diagnostics, vapor_off_diagnostics);
+    assert_eq!(
+        vapor_on_diagnostics,
+        vec![
+            "compiler.jsxCompat: \"babel\" is not supported with Vapor output: \
+             @vue/babel-plugin-jsx has no Vapor equivalent. Use jsxMode \"vdom\" for babel \
+             compatibility, or drop jsxCompat to use Vize's own Vapor semantics."
+                .to_string()
+        ]
+    );
+}
+
+#[test]
+fn identifier_children_switch_between_runtime_slots_and_a_raw_default() {
+    let (enabled, diagnostics) = compile(
+        LONE_IDENTIFIER_CHILD,
+        JsxCompatMode::Babel,
+        JsxOutputMode::Vdom,
+        true,
+    );
+    assert_eq!(diagnostics, Vec::<String>::new());
+    assert_eq!(
+        enabled,
+        format!(
+            concat!(
+                "import {{ resolveComponent as _resolveComponent, openBlock as _openBlock, ",
+                "createBlock as _createBlock, isVNode as _isVNode }} from \"vue\"\n",
+                "{}",
+                "export function render(_ctx, _cache) {{\n",
+                "  const _component_B = _resolveComponent(\"B\")\n",
+                "  \n",
+                "  return (_openBlock(), _createBlock(_component_B, null, ",
+                "_isSlot(slots) ? slots : {{ default: () => [slots] }}, ",
+                "1024 /* DYNAMIC_SLOTS */))\n",
+                "}}",
+            ),
+            IS_SLOT_HELPER
+        )
+    );
+
+    let (disabled, diagnostics) = compile(
+        LONE_IDENTIFIER_CHILD,
+        JsxCompatMode::Babel,
+        JsxOutputMode::Vdom,
+        false,
+    );
+    assert_eq!(diagnostics, Vec::<String>::new());
+    assert_eq!(
+        disabled,
+        concat!(
+            "import { resolveComponent as _resolveComponent, openBlock as _openBlock, ",
+            "createBlock as _createBlock } from \"vue\"\n",
+            "export function render(_ctx, _cache) {\n",
+            "  const _component_B = _resolveComponent(\"B\")\n",
+            "  \n",
+            "  return (_openBlock(), _createBlock(_component_B, null, ",
+            "{ default: () => [slots] }, 1024 /* DYNAMIC_SLOTS */))\n",
+            "}",
+        )
+    );
+}
+
+#[test]
+fn call_children_are_wrapped_so_the_call_evaluates_once() {
+    let (call, diagnostics) = compile(
+        "const A = () => <B>{getSlots()}</B>;",
+        JsxCompatMode::Babel,
+        JsxOutputMode::Vdom,
+        true,
+    );
+    assert_eq!(diagnostics, Vec::<String>::new());
+    assert_eq!(
+        call,
+        format!(
+            concat!(
+                "import {{ resolveComponent as _resolveComponent, openBlock as _openBlock, ",
+                "createBlock as _createBlock, isVNode as _isVNode }} from \"vue\"\n",
+                "{}",
+                "export function render(_ctx, _cache) {{\n",
+                "  const _component_B = _resolveComponent(\"B\")\n",
+                "  \n",
+                "  return (_openBlock(), _createBlock(_component_B, null, ",
+                "(_slot => _isSlot(_slot) ? _slot : {{ default: () => [_slot] }})(getSlots()), ",
+                "1024 /* DYNAMIC_SLOTS */))\n",
+                "}}",
+            ),
+            IS_SLOT_HELPER
+        )
+    );
+}
+
+#[test]
+fn non_candidate_children_stay_raw_default_slot_values() {
+    // Babel only probes identifiers and calls; everything else is the raw
+    // default-slot child, never stringified through `toDisplayString`.
+    for (child, expected) in [
+        ("state.slots", "{ default: () => [state.slots] }"),
+        ("1", "{ default: () => [1] }"),
+        ("ok ? a : b", "{ default: () => [ok ? a : b] }"),
+        ("(a, b)", "{ default: () => [((a, b))] }"),
+    ] {
+        let source = format!("const A = () => <B>{{{child}}}</B>;");
+        let (output, diagnostics) = compile(
+            source.as_str(),
+            JsxCompatMode::Babel,
+            JsxOutputMode::Vdom,
+            true,
+        );
+        assert_eq!(diagnostics, Vec::<String>::new(), "{child}");
+        assert_eq!(
+            output,
+            format!(
+                concat!(
+                    "import {{ resolveComponent as _resolveComponent, openBlock as _openBlock, ",
+                    "createBlock as _createBlock }} from \"vue\"\n",
+                    "export function render(_ctx, _cache) {{\n",
+                    "  const _component_B = _resolveComponent(\"B\")\n",
+                    "  \n",
+                    "  return (_openBlock(), _createBlock(_component_B, null, {}, ",
+                    "1024 /* DYNAMIC_SLOTS */))\n",
+                    "}}",
+                ),
+                expected
+            ),
+            "{child}"
+        );
+    }
+}
+
+#[test]
+fn helpers_are_emitted_once_and_explicit_v_slots_keeps_ordinary_children() {
+    let (output, diagnostics) = compile(
+        concat!(
+            "const A = () => <B>{slots}</B>;\n",
+            "const C = () => <B>{otherSlots}</B>;\n",
+            "const D = () => <B v-slots={forwarded}>{value}</B>;",
+        ),
+        JsxCompatMode::Babel,
+        JsxOutputMode::Vdom,
+        true,
+    );
+    assert_eq!(diagnostics, Vec::<String>::new());
+    assert_eq!(
+        output,
+        format!(
+            concat!(
+                "import {{ resolveComponent as _resolveComponent, openBlock as _openBlock, ",
+                "createBlock as _createBlock, isVNode as _isVNode, withCtx as _withCtx }} ",
+                "from \"vue\"\n",
+                "{}",
+                "export function A(_ctx, _cache) {{\n",
+                "  const _component_B = _resolveComponent(\"B\")\n",
+                "  \n",
+                "  return (_openBlock(), _createBlock(_component_B, null, ",
+                "_isSlot(slots) ? slots : {{ default: () => [slots] }}, ",
+                "1024 /* DYNAMIC_SLOTS */))\n",
+                "}}\n",
+                "export function C(_ctx, _cache) {{\n",
+                "  const _component_B = _resolveComponent(\"B\")\n",
+                "  \n",
+                "  return (_openBlock(), _createBlock(_component_B, null, ",
+                "_isSlot(otherSlots) ? otherSlots : {{ default: () => [otherSlots] }}, ",
+                "1024 /* DYNAMIC_SLOTS */))\n",
+                "}}\n",
+                "export function D(_ctx, _cache) {{\n",
+                "  const _component_B = _resolveComponent(\"B\")\n",
+                "  \n",
+                "  return (_openBlock(), _createBlock(_component_B, null, {{\n",
+                "    default: _withCtx(() => [\n",
+                "      value\n",
+                "    ]),\n",
+                "    ...forwarded\n",
+                "  }}, 1024 /* DYNAMIC_SLOTS */))\n",
+                "}}",
+            ),
+            IS_SLOT_HELPER
+        )
+    );
+}
+
+#[test]
+fn helper_bindings_are_collision_free_and_typescript_is_stripped() {
+    let (output, diagnostics) = compile(
+        concat!(
+            "const _isSlot = existing; const _isVNode = existingVNode;\n",
+            "type Slots = Record<string, unknown>;\n",
+            "const A = () => <B>{slots as Slots}</B>;",
+        ),
+        JsxCompatMode::Babel,
+        JsxOutputMode::Vdom,
+        true,
+    );
+    assert_eq!(diagnostics, Vec::<String>::new());
+    assert_eq!(
+        output,
+        concat!(
+            "import { resolveComponent as _resolveComponent, openBlock as _openBlock, ",
+            "createBlock as _createBlock, isVNode as _isVNode_ } from \"vue\"\n",
+            "function _isSlot_(s) {\n",
+            "return typeof s === 'function' || Object.prototype.toString.call(s) === ",
+            "'[object Object]' && !_isVNode_(s);\n",
+            "}\n",
+            "export function render(_ctx, _cache) {\n",
+            "  const _component_B = _resolveComponent(\"B\")\n",
+            "  \n",
+            "  return (_openBlock(), _createBlock(_component_B, null, ",
+            "_isSlot_(slots) ? slots : { default: () => [slots] }, ",
+            "1024 /* DYNAMIC_SLOTS */))\n",
+            "}",
+        )
+    );
+}

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__options.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__options.snap
@@ -143,7 +143,7 @@ export function render(_ctx, _cache) {
 
 ## options/object_slots_default
 ### verdict
-divergent: lone expression child stringified
+equivalent
 ### source (jsx)
 const A = () => <B>{slots}</B>;
 ### babel options
@@ -157,21 +157,19 @@ const A = () => _createVNode(_resolveComponent("B"), null, _isSlot(slots) ? slot
   default: () => [slots]
 });
 ### vize (vdom, babel compat)
-import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock, createTextVNode as _createTextVNode, withCtx as _withCtx } from "vue"
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock, isVNode as _isVNode } from "vue"
+function _isSlot(s) {
+return typeof s === 'function' || Object.prototype.toString.call(s) === '[object Object]' && !_isVNode(s);
+}
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
 
-  return (_openBlock(), _createBlock(_component_B, null, {
-    default: _withCtx(() => [
-      _createTextVNode(_toDisplayString(slots), 1 /* TEXT */)
-    ]),
-    _: 1 /* STABLE */
-  }))
+  return (_openBlock(), _createBlock(_component_B, null, _isSlot(slots) ? slots : { default: () => [slots] }, 1024 /* DYNAMIC_SLOTS */))
 }
 
 ## options/object_slots_false
 ### verdict
-divergent: lone expression child stringified
+equivalent
 ### source (jsx)
 const A = () => <B>{slots}</B>;
 ### babel options
@@ -182,16 +180,11 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
   default: () => [slots]
 });
 ### vize (vdom, babel compat)
-import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock, createTextVNode as _createTextVNode, withCtx as _withCtx } from "vue"
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
 
-  return (_openBlock(), _createBlock(_component_B, null, {
-    default: _withCtx(() => [
-      _createTextVNode(_toDisplayString(slots), 1 /* TEXT */)
-    ]),
-    _: 1 /* STABLE */
-  }))
+  return (_openBlock(), _createBlock(_component_B, null, { default: () => [slots] }, 1024 /* DYNAMIC_SLOTS */))
 }
 
 ## options/resolve_type_off


### PR DESCRIPTION
Part of #3391.

`@vue/babel-plugin-jsx` passes a component's lone expression child straight into
the vnode's children argument. With its default `enableObjectSlots: true` an
identifier or a call result may already *be* a slots object, so the plugin
discriminates it at runtime with its `_isSlot` helper — a call is wrapped in an
IIFE so it is evaluated exactly once. Every other child becomes the raw value of
an unescaped `default` slot.

Vize stringified all of them through `toDisplayString`, mounting text where babel
mounts slots. Opt-in Babel VDOM mode now reproduces both shapes, and
`compile_jsx_with_babel_object_slots` exposes `enableObjectSlots: false` so the
runtime check can be skipped.

**Default behavior is unchanged**: the switch is off by default, the new option
is inert outside Babel VDOM mode, and `tests/compat_mode.rs` still passes.

## Oracle rows closed

`options/object_slots_default` and `options/object_slots_false` flip from
`divergent` to `equivalent`, taking the verdict totals to **94 equivalent, 2
divergent, 2 deferred** (counted from `verdicts.rs`, not derived arithmetically;
`babel_compat_verdict_totals` and `BABEL_COMPAT_INVENTORY.md` agree).

## Verification

- `crates/vize_atelier_jsx/tests/babel_object_slots.rs` asserts the **complete**
  generated module with `assert_eq!` for every case — no substring matching.
- `babel_compat_oracle.rs` snapshots the new output beside the recorded
  `@vue/babel-plugin-jsx` 2.0.1 output for both rows.

## Source-length budget

`lower/slot.rs` and `compile.rs` crossed 350 lines, so the Babel lone-child
lowering moved to `lower/babel_slot.rs` and preamble merging to
`compile/preamble.rs`. Nothing was allowlisted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->