### PR TITLE
fix(atelier): forward primitive v-slots values in Babel mode

### DIFF
--- a/crates/vize_atelier_jsx/src/lower/v_slots.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_slots.rs
@@ -59,7 +59,10 @@
 //!   `v-slots={1}`, `v-slots={[…]}`). Babel forwards these as the component's
 //!   children, which is meaningless for a component: a slots object is either an
 //!   object literal to expand or an opaque expression to forward, never a
-//!   primitive.
+//!   primitive. Opt-in Babel VDOM mode (#3391) forwards the *primitive* literals
+//!   verbatim, because that is exactly what babel emits and the source text is
+//!   already valid JavaScript; arrays, template literals, raw JSX, functions, and
+//!   sequences stay diagnosed rather than emitted as a malformed module.
 //! - `v-slots:arg={…}` — `v-slots` takes no argument; the slot names are the
 //!   object's keys.
 //! - `v-slots` on a plain element, which has no slots.
@@ -90,6 +93,10 @@ enum SlotsValue<'e> {
     /// is forwarded into the slots object as a spread. The span is the source to
     /// emit, with any wrapper stripped.
     Forwarded(Span),
+    /// A primitive literal (`v-slots={1}`). Native mode diagnoses it like any
+    /// other non-slots value; Babel VDOM compatibility forwards it verbatim as
+    /// the vnode's children argument, matching the plugin.
+    CompatForwarded(Span),
     /// A literal, an array, a lone function, or a quoted/missing value: babel
     /// forwards these as the component's children, which is not a slots object.
     /// The span names the offending source, the `&'static str` says why.
@@ -171,18 +178,27 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
                 }
             }
             SlotsValue::Forwarded(span) => self.forward_slots(node, span),
-            SlotsValue::Rejected(span, reason) => {
-                let source = self.mapper().slice(span);
-                self.reject_at(
-                    span,
-                    format_args!(
-                        "v-slots value `{source}` {reason}. Write the slots inline, e.g. \
-                         v-slots={{{{ default: () => <div/> }}}}, or forward a slots \
-                         object, e.g. v-slots={{slots}}."
-                    ),
-                );
+            SlotsValue::CompatForwarded(span) if self.uses_babel_vdom_compat() => {
+                self.forward_slots(node, span);
             }
+            SlotsValue::CompatForwarded(span) => {
+                self.reject_v_slots_value(span, NOT_A_SLOTS_OBJECT);
+            }
+            SlotsValue::Rejected(span, reason) => self.reject_v_slots_value(span, reason),
         }
+    }
+
+    /// Report a `v-slots` value that is not a slots object, quoting it.
+    fn reject_v_slots_value(&mut self, span: Span, reason: &'static str) {
+        let source = self.mapper().slice(span);
+        self.reject_at(
+            span,
+            format_args!(
+                "v-slots value `{source}` {reason}. Write the slots inline, e.g. \
+                 v-slots={{{{ default: () => <div/> }}}}, or forward a slots \
+                 object, e.g. v-slots={{slots}}."
+            ),
+        );
     }
 
     /// Record a forwarded slots object on `node` as a relief `slots` directive.
@@ -257,6 +273,7 @@ fn classify_v_slots_value<'e>(value: &'e JSXAttributeValue<'e>) -> SlotsValue<'e
         // The comma operator does not survive being emitted verbatim as a
         // spread (`{...a, b}` is two properties, not one spread).
         Expression::SequenceExpression(_) => SlotsValue::Rejected(inner.span(), NOT_A_SLOTS_OBJECT),
+        _ if is_primitive_literal(inner) => SlotsValue::CompatForwarded(inner.span()),
         _ if is_literal_value(inner) => SlotsValue::Rejected(inner.span(), NOT_A_SLOTS_OBJECT),
         _ => SlotsValue::Forwarded(inner.span()),
     }
@@ -266,6 +283,24 @@ const NOT_A_SLOTS_OBJECT: &str = "is not a slots object: babel forwards it as th
                                   children, which leaves the component with no slots";
 const IS_A_FUNCTION: &str = "is a function, not a slots object: a lone function is the default \
                              slot, so a spread of it contributes nothing";
+
+/// Literals whose source text is already valid JavaScript in children position,
+/// so babel's pass-through can be reproduced by forwarding the span verbatim.
+///
+/// Container literals are deliberately excluded: an array or a template literal
+/// may hold nested JSX that still has to be lowered, and raw JSX is a vnode
+/// rather than a value.
+fn is_primitive_literal(expression: &Expression<'_>) -> bool {
+    matches!(
+        expression,
+        Expression::BigIntLiteral(_)
+            | Expression::BooleanLiteral(_)
+            | Expression::NullLiteral(_)
+            | Expression::NumericLiteral(_)
+            | Expression::RegExpLiteral(_)
+            | Expression::StringLiteral(_)
+    )
+}
 
 /// Whether an expression is a literal value that can never be a slots object.
 ///

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   94 |
-| divergent  |    2 |
+| equivalent |   95 |
+| divergent  |    1 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -335,10 +335,10 @@ Compared against Vize's default, which is already fully optimized.
 A compat mode must reject what babel rejects, with a diagnostic — never silently
 accept it.
 
-| Case                              | Babel                                                           | Vize today                                                        | Compat mode    | Verdict |
-| --------------------------------- | --------------------------------------------------------------- | ----------------------------------------------------------------- | -------------- | ------- |
-| `errors/v_model_non_lval`         | rejects a non-assignable `v-model` target                       | rejects it too, naming the offending expression (closed by #3420) | no change      | ✅      |
-| `errors/v_model_no_value`         | rejects: "You have to use JSX Expression inside your v-model"   | rejects: "v-model is missing expression."                         | no change      | ✅      |
-| `errors/v_models_not_array`       | rejects a non-array `v-models` value                            | rejects it too, naming the expected entry shape (closed by #3418) | no change      | ✅      |
-| `errors/v_models_entry_not_array` | rejects: "You should pass a Two-dimensional Arrays to v-models" | rejects it too, naming the offending entry (closed by #3418)      | no change      | ✅      |
-| `errors/v_slots_not_object`       | forwards the value as children                                  | rejects it, naming the offending value (#3418, #3467)             | keep rejecting | ❌      |
+| Case                              | Babel                                                           | Vize today                                                        | Compat mode             | Verdict |
+| --------------------------------- | --------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------- | ------- |
+| `errors/v_model_non_lval`         | rejects a non-assignable `v-model` target                       | rejects it too, naming the offending expression (closed by #3420) | no change               | ✅      |
+| `errors/v_model_no_value`         | rejects: "You have to use JSX Expression inside your v-model"   | rejects: "v-model is missing expression."                         | no change               | ✅      |
+| `errors/v_models_not_array`       | rejects a non-array `v-models` value                            | rejects it too, naming the expected entry shape (closed by #3418) | no change               | ✅      |
+| `errors/v_models_entry_not_array` | rejects: "You should pass a Two-dimensional Arrays to v-models" | rejects it too, naming the offending entry (closed by #3418)      | no change               | ✅      |
+| `errors/v_slots_not_object`       | forwards the value as children                                  | rejects it, naming the offending value (#3418, #3467)             | forward safe primitives | ✅      |

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -143,8 +143,7 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     // two-dimensional array.
     ("errors/v_models_not_array", Same),
     ("errors/v_models_entry_not_array", Same),
-    (
-        "errors/v_slots_not_object",
-        Diff("non-object v-slots value rejected; babel forwards it"),
-    ),
+    // Closed by #3391: Babel VDOM mode forwards the primitive literals babel
+    // passes straight into the vnode's children argument.
+    ("errors/v_slots_not_object", Same),
 ];

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (94, 2, 2));
+    assert_eq!((equivalent, divergent, deferred), (95, 1, 2));
     assert_eq!(VERDICTS.len(), 98);
 }
 

--- a/crates/vize_atelier_jsx/tests/babel_v_slots.rs
+++ b/crates/vize_atelier_jsx/tests/babel_v_slots.rs
@@ -1,0 +1,177 @@
+//! `v-slots` values that `@vue/babel-plugin-jsx` forwards rather than expands
+//! (#3391, oracle row `errors/v_slots_not_object`).
+//!
+//! Babel never validates a `v-slots` value: it hands whatever it finds to
+//! `createVNode` as the children argument, so `<B v-slots={1}/>` compiles to
+//! `createVNode(B, null, 1)`. Vize rejects that by default, because for a
+//! component a slots object is either an object literal to expand or an opaque
+//! expression to forward — never a primitive — and silently rendering nothing is
+//! the failure shape #3418 exists to remove.
+//!
+//! Opt-in Babel VDOM mode reproduces the pass-through for the literals whose
+//! source text is already valid JavaScript in children position. Everything
+//! babel would forward as a *container* (arrays, template literals, raw JSX,
+//! functions, sequences) stays diagnosed rather than emitted as a malformed
+//! module.
+
+use vize_atelier_jsx::{JsxCompatMode, JsxCompileConfig, JsxLang, JsxOutputMode, compile_jsx};
+use vize_carton::Bump;
+
+/// The diagnostic every non-slots-object `v-slots` value produces.
+fn not_a_slots_object(value: &str) -> String {
+    format!(
+        "v-slots value `{value}` is not a slots object: babel forwards it as the component's \
+         children, which leaves the component with no slots. Write the slots inline, e.g. \
+         v-slots={{{{ default: () => <div/> }}}}, or forward a slots object, e.g. \
+         v-slots={{slots}}."
+    )
+}
+
+/// A `B` component render whose children argument is `children`, or a bare
+/// `createBlock(B)` when the value was dropped.
+fn render_module(children: Option<&str>) -> String {
+    let call = match children {
+        Some(children) => {
+            format!("_createBlock(_component_B, null, {children}, 1024 /* DYNAMIC_SLOTS */)")
+        }
+        None => "_createBlock(_component_B)".to_string(),
+    };
+    format!(
+        concat!(
+            "import {{ resolveComponent as _resolveComponent, openBlock as _openBlock, ",
+            "createBlock as _createBlock }} from \"vue\"\n",
+            "export function render(_ctx, _cache) {{\n",
+            "  const _component_B = _resolveComponent(\"B\")\n",
+            "  \n",
+            "  return (_openBlock(), {call})\n",
+            "}}",
+        ),
+        call = call
+    )
+}
+
+fn compile(source: &str, compat: JsxCompatMode, mode: JsxOutputMode) -> (String, Vec<String>) {
+    let bump = Bump::new();
+    let out = compile_jsx(
+        &bump,
+        source,
+        JsxLang::Jsx,
+        &JsxCompileConfig {
+            compat,
+            default_mode: mode,
+            ..Default::default()
+        },
+    );
+    (
+        out.module_code().to_string(),
+        out.diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message.to_string())
+            .collect(),
+    )
+}
+
+/// Every primitive literal spelling babel passes straight through.
+const PRIMITIVES: [&str; 6] = ["1", "true", "null", "\"text\"", "1n", "/re/g"];
+
+#[test]
+fn primitive_v_slots_values_are_forwarded_in_babel_vdom() {
+    for value in PRIMITIVES {
+        let source = format!("const A = () => <B v-slots={{{value}}}/>;");
+        let (module, diagnostics) =
+            compile(source.as_str(), JsxCompatMode::Babel, JsxOutputMode::Vdom);
+        assert_eq!(diagnostics, Vec::<String>::new(), "{value}");
+        assert_eq!(module, render_module(Some(value)), "{value}");
+    }
+}
+
+#[test]
+fn native_mode_still_rejects_every_primitive_v_slots_value() {
+    // The switch is opt-in: default Vize output and diagnostics are unchanged.
+    for value in PRIMITIVES {
+        let source = format!("const A = () => <B v-slots={{{value}}}/>;");
+        let (module, diagnostics) =
+            compile(source.as_str(), JsxCompatMode::Native, JsxOutputMode::Vdom);
+        assert_eq!(diagnostics, vec![not_a_slots_object(value)], "{value}");
+        assert_eq!(module, render_module(None), "{value}");
+    }
+}
+
+#[test]
+fn babel_vapor_output_keeps_rejecting_primitive_v_slots_values() {
+    // Compat mode is a VDOM-only contract, so the Vapor request is diagnosed and
+    // the value is still rejected rather than half-applied.
+    let (module, diagnostics) = compile(
+        "const A = () => <B v-slots={1}/>;",
+        JsxCompatMode::Babel,
+        JsxOutputMode::Vapor,
+    );
+    assert_eq!(
+        diagnostics,
+        vec![
+            not_a_slots_object("1"),
+            "compiler.jsxCompat: \"babel\" is not supported with Vapor output: \
+             @vue/babel-plugin-jsx has no Vapor equivalent. Use jsxMode \"vdom\" for babel \
+             compatibility, or drop jsxCompat to use Vize's own Vapor semantics."
+                .to_string()
+        ]
+    );
+    assert_eq!(
+        module,
+        concat!(
+            "import { resolveComponent as _resolveComponent, createComponentWithFallback as ",
+            "_createComponentWithFallback } from 'vue';\n",
+            "\n",
+            "export function render(_ctx) {\n",
+            "  const _component_B = _resolveComponent(\"B\")\n",
+            "  const n0 = _createComponentWithFallback(_component_B, null, null, true)\n",
+            "  return n0\n",
+            "}\n",
+        )
+    );
+}
+
+#[test]
+fn container_and_function_v_slots_values_stay_diagnosed_in_babel_vdom() {
+    // These are the shapes whose source text is not a self-contained value:
+    // arrays and template literals may hold nested JSX, raw JSX is a vnode, a
+    // lone function is the default slot, and the comma operator changes meaning
+    // when spliced into an argument list. Forwarding them verbatim would emit a
+    // module that does not mean what babel's does, so they keep their error.
+    for (value, message) in [
+        ("[a, b]", not_a_slots_object("[a, b]")),
+        ("<i/>", not_a_slots_object("<i/>")),
+        ("`t${x}`", not_a_slots_object("`t${x}`")),
+        ("(a, b)", not_a_slots_object("a, b")),
+        (
+            "() => <i/>",
+            "v-slots value `() => <i/>` is a function, not a slots object: a lone function is \
+             the default slot, so a spread of it contributes nothing. Write the slots inline, \
+             e.g. v-slots={{ default: () => <div/> }}, or forward a slots object, e.g. \
+             v-slots={slots}."
+                .to_string(),
+        ),
+    ] {
+        let source = format!("const A = () => <B v-slots={{{value}}}/>;");
+        let (module, diagnostics) =
+            compile(source.as_str(), JsxCompatMode::Babel, JsxOutputMode::Vdom);
+        assert_eq!(diagnostics, vec![message], "{value}");
+        assert_eq!(module, render_module(None), "{value}");
+    }
+}
+
+#[test]
+fn a_quoted_v_slots_attribute_is_rejected_in_both_modes() {
+    // `v-slots="str"` is an attribute string, not an expression: babel's own
+    // reading of it is a plain string child, but Vize has no oracle row pinning
+    // that, so the existing diagnostic stands in both modes.
+    for compat in [JsxCompatMode::Native, JsxCompatMode::Babel] {
+        let (module, diagnostics) = compile(
+            "const A = () => <B v-slots=\"str\"/>;",
+            compat,
+            JsxOutputMode::Vdom,
+        );
+        assert_eq!(diagnostics, vec![not_a_slots_object("\"str\"")]);
+        assert_eq!(module, render_module(None));
+    }
+}

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
@@ -72,7 +72,7 @@ export function render(_ctx, _cache) {
 
 ## errors/v_slots_not_object
 ### verdict
-divergent: non-object v-slots value rejected; babel forwards it
+equivalent
 ### source (jsx)
 const A = () => <B v-slots={1}/>;
 ### babel options
@@ -81,10 +81,9 @@ const A = () => <B v-slots={1}/>;
 import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
 const A = () => _createVNode(_resolveComponent("B"), null, 1);
 ### vize (vdom, babel compat)
-<Error> v-slots value `1` is not a slots object: babel forwards it as the component's children, which leaves the component with no slots. Write the slots inline, e.g. v-slots={{ default: () => <div/> }}, or forward a slots object, e.g. v-slots={slots}.
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
 
-  return (_openBlock(), _createBlock(_component_B))
+  return (_openBlock(), _createBlock(_component_B, null, 1, 1024 /* DYNAMIC_SLOTS */))
 }


### PR DESCRIPTION
Part of #3391.

`@vue/babel-plugin-jsx` never validates a `v-slots` value — it hands whatever it
finds to `createVNode` as the children argument, so `<B v-slots={1}/>` compiles
to `createVNode(B, null, 1)`. Vize rejects that by default, because for a
component a slots object is either an object literal to expand or an opaque
expression to forward, never a primitive.

Opt-in Babel VDOM mode now reproduces the pass-through for the literals whose
source text is already a self-contained JavaScript value (number, string,
boolean, `null`, bigint, regexp).

Arrays, template literals, raw JSX, lone functions, and sequences keep their
diagnostic. Their source is not a value that can be spliced into an argument
list — an array or template literal may hold nested JSX that still needs
lowering, raw JSX is a vnode, a lone function is the default slot, and the comma
operator changes meaning — so forwarding them verbatim would emit a module that
does not mean what babel's does.

**Default behavior is unchanged**: native mode still rejects every one of these
values with the same message, and Babel + Vapor still rejects them too (compat
mode is a VDOM-only contract).

## Oracle row closed

`errors/v_slots_not_object` flips from `divergent` to `equivalent`. Verdict
totals are now **95 equivalent, 1 divergent, 2 deferred** — recounted from
`verdicts.rs` after rebasing over #3728 rather than derived arithmetically, and
cross-checked against the inventory's own row marks (95 ✅ / 1 ❌ / 2 ⏸).

## Verification

`crates/vize_atelier_jsx/tests/babel_v_slots.rs` asserts the **complete**
generated module and the **complete** diagnostic list with `assert_eq!` for every
forwarded and every still-rejected shape, in native, Babel VDOM, and Babel Vapor
mode. No substring matching. The oracle snapshot shows the new output beside the
recorded `@vue/babel-plugin-jsx` 2.0.1 output.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3729"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->