### PR TITLE
fix(canon): consume setup bindings read by CSS v-bind

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/no_unused.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/no_unused.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use vize_carton::cstr;
 
+mod css_v_bind;
 mod define_emits_unused;
 
 #[test]

--- a/crates/vize_canon/src/batch/type_checker/tests/no_unused/css_v_bind.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/no_unused/css_v_bind.rs
@@ -1,0 +1,188 @@
+//! A setup binding read only by CSS `v-bind()` is consumed, not unused (#1876).
+//!
+//! `noUnusedLocals` narrows the generated `void <binding>;` anchors to names the
+//! template references so genuinely unused user bindings still report `TS6133`.
+//! `<style>` was outside that reach, so `div { color: v-bind(color) }` left
+//! `color` looking unreferenced and every such binding was published as a
+//! `TS6133` error the Nuxt 2 / Vue 2.7 report in #1876 could not distinguish
+//! from a real one.
+//!
+//! The expectations below are the exact diagnostic set `vue-tsc 3.3.4` produces
+//! for the same sources under the same `tsconfig.json`: nothing for the four
+//! CSS-consumed bindings, and `TS6133` for the three that no template, script,
+//! or live `v-bind()` reads.
+
+use super::super::{
+    create_project_case_without_node_modules, resolve_test_tsgo_binary,
+    snapshot_project_diagnostics,
+};
+use super::write_no_unused_tsconfig;
+
+/// Bindings a live `v-bind()` reads, in the spellings the extractor must see
+/// through: a bare name, a quoted expression, two properties of one rule, and a
+/// member expression.
+const CONSUMED_BY_CSS: &[(&str, &str)] = &[
+    (
+        "src/BareName.vue",
+        r#"<script setup lang="ts">
+const color = 'red'
+</script>
+
+<template><div /></template>
+
+<style scoped>
+div { color: v-bind(color); }
+</style>
+"#,
+    ),
+    (
+        "src/QuotedExpression.vue",
+        r#"<script setup lang="ts">
+const size = 10
+</script>
+
+<template><div /></template>
+
+<style scoped>
+div { height: v-bind("size + 'px'"); }
+</style>
+"#,
+    ),
+    (
+        "src/TwoBindings.vue",
+        r#"<script setup lang="ts">
+const fg = 'red'
+const bg = 'blue'
+</script>
+
+<template><div /></template>
+
+<style scoped>
+div { color: v-bind(fg); background: v-bind(bg); }
+</style>
+"#,
+    ),
+    (
+        "src/MemberExpression.vue",
+        r#"<script setup lang="ts">
+const theme = { color: 'red' }
+</script>
+
+<template><div /></template>
+
+<style module>
+.row { color: v-bind("theme.color"); }
+</style>
+"#,
+    ),
+];
+
+/// Bindings no live `v-bind()` reads. `CommentedOut.vue` and `QuotedText.vue`
+/// are the guard rails: the SFC parser's `v-bind()` extractor skips CSS comments
+/// and string literals, so neither spelling may rescue its binding.
+const STILL_UNUSED: &[(&str, &str)] = &[
+    (
+        "src/CommentedOut.vue",
+        r#"<script setup lang="ts">
+const color = 'red'
+</script>
+
+<template><div /></template>
+
+<style scoped>
+/* color: v-bind(color); */
+div { color: red; }
+</style>
+"#,
+    ),
+    (
+        "src/QuotedText.vue",
+        r#"<script setup lang="ts">
+const icon = 'star'
+</script>
+
+<template><div /></template>
+
+<style scoped>
+div::after { content: "v-bind(icon)"; }
+</style>
+"#,
+    ),
+    (
+        "src/BesideALiveVBind.vue",
+        r#"<script setup lang="ts">
+const color = 'red'
+const unusedLocal = 'blue'
+</script>
+
+<template><div /></template>
+
+<style scoped>
+div { color: v-bind(color); }
+</style>
+"#,
+    ),
+];
+
+#[test]
+fn css_v_bind_consumes_its_bindings_without_hiding_unused_ones() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let files: Vec<(&str, &str)> = CONSUMED_BY_CSS
+        .iter()
+        .chain(STILL_UNUSED)
+        .copied()
+        .collect();
+    let project_root = create_project_case_without_node_modules("css-v-bind-no-unused", &files);
+    write_no_unused_tsconfig(&project_root);
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    // `snapshot_project_diagnostics` sorts by (file, code, message), so the
+    // expected list is the whole diagnostic surface of the project in that
+    // order — a new finding anywhere fails this assertion.
+    assert_eq!(
+        snapshot,
+        vec![
+            unused(
+                "src/BesideALiveVBind.vue",
+                3,
+                7,
+                "'unusedLocal' is declared but its value is never read."
+            ),
+            unused(
+                "src/CommentedOut.vue",
+                2,
+                7,
+                "'color' is declared but its value is never read."
+            ),
+            unused(
+                "src/QuotedText.vue",
+                2,
+                7,
+                "'icon' is declared but its value is never read."
+            ),
+        ],
+        "expected the vue-tsc diagnostic surface for these sources"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn unused(
+    file: &str,
+    line: u32,
+    column: u32,
+    message: &str,
+) -> (vize_carton::String, Option<u32>, vize_carton::String) {
+    (
+        vize_carton::String::from(file),
+        Some(6133),
+        vize_carton::cstr!("{line}:{column}:error {message}"),
+    )
+}

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -31,6 +31,7 @@ pub use content_mapper::{
     ContentMapperDiagnostic, ContentMapperSpan, ContentMapperTransform,
     generate_vue_content_mapper_transform,
 };
+mod css_var_usage;
 mod declaration_emit;
 mod document;
 pub use document::{

--- a/crates/vize_canon/src/batch/virtual_project/css_var_usage.rs
+++ b/crates/vize_canon/src/batch/virtual_project/css_var_usage.rs
@@ -1,0 +1,109 @@
+//! Setup bindings a `<style>` block consumes through CSS `v-bind()`.
+//!
+//! Under `noUnusedLocals`/`noUnusedParameters` the generator narrows its
+//! `void <binding>;` anchors to names the template actually references, so a
+//! genuinely unused user binding still reports `TS6133`. Template scope is
+//! discovered from the template AST and the Croquis expression tables, neither
+//! of which sees `<style>`, so a binding referenced *only* from
+//! `div { color: v-bind(color); }` looked unreferenced and every such binding
+//! was published as `TS6133` — a false positive `vue-tsc` never reports,
+//! because the SFC compiler turns those expressions into a real `useCssVars`
+//! read (#1876).
+//!
+//! The expressions come from [`SfcDescriptor::css_vars`], which the SFC parser
+//! fills from `extract_css_vars`. That extractor already skips `v-bind(...)`
+//! runs inside CSS comments and string literals, so a commented-out `v-bind`
+//! contributes nothing here and its binding keeps reporting `TS6133` exactly
+//! like `vue-tsc`.
+
+use vize_atelier_sfc::SfcDescriptor;
+use vize_carton::{FxHashSet, String as CompactString};
+
+/// Identifiers referenced by every CSS `v-bind()` expression in `descriptor`.
+///
+/// Expressions are arbitrary JavaScript (`v-bind("height + 'px'")`), so each is
+/// parsed for identifiers rather than taken as a name.
+pub(super) fn collect_css_var_referenced_names(
+    descriptor: &SfcDescriptor<'_>,
+) -> FxHashSet<CompactString> {
+    let mut names = FxHashSet::default();
+    for expression in &descriptor.css_vars {
+        for identifier in vize_croquis::drawer::extract_identifiers_oxc(expression.as_ref()) {
+            names.insert(CompactString::new(identifier.as_str()));
+        }
+    }
+    names
+}
+
+#[cfg(test)]
+mod tests {
+    use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
+    use vize_carton::{FxHashSet, String as CompactString};
+
+    use super::collect_css_var_referenced_names;
+
+    fn names(source: &str) -> Vec<CompactString> {
+        let descriptor = parse_sfc(source, SfcParseOptions::default()).unwrap();
+        let mut names: Vec<_> = collect_css_var_referenced_names(&descriptor)
+            .into_iter()
+            .collect();
+        names.sort_unstable();
+        names
+    }
+
+    fn expected(values: &[&str]) -> Vec<CompactString> {
+        let mut expected: Vec<_> = values
+            .iter()
+            .map(|value| CompactString::new(*value))
+            .collect();
+        expected.sort_unstable();
+        expected
+    }
+
+    #[test]
+    fn plain_and_expression_v_binds_contribute_their_identifiers() {
+        assert_eq!(
+            names(
+                r#"<template><div /></template>
+<style scoped>
+div {
+  color: v-bind(fg);
+  background: v-bind('bg');
+  height: v-bind("size + 'px'");
+  width: v-bind("Math.min(100, ratio) + '%'");
+}
+</style>
+"#
+            ),
+            expected(&["fg", "bg", "size", "Math", "ratio"])
+        );
+    }
+
+    #[test]
+    fn commented_out_and_string_v_binds_contribute_nothing() {
+        assert_eq!(
+            names(
+                r#"<template><div /></template>
+<style scoped>
+/* color: v-bind(commented); */
+div {
+  content: "v-bind(quoted)";
+  color: red;
+}
+</style>
+"#
+            ),
+            Vec::<CompactString>::new()
+        );
+    }
+
+    #[test]
+    fn an_sfc_without_styles_has_no_css_var_names() {
+        let descriptor =
+            parse_sfc("<template><div /></template>\n", SfcParseOptions::default()).unwrap();
+        assert_eq!(
+            collect_css_var_referenced_names(&descriptor),
+            FxHashSet::default()
+        );
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -32,6 +32,7 @@ use super::diagnostics::{
 };
 use super::{
     art_usage::collect_art_template_referenced_names,
+    css_var_usage::collect_css_var_referenced_names,
     setup_props::augment_type_based_props_from_script_context,
 };
 
@@ -209,12 +210,18 @@ pub(super) fn generate_vue_virtual_ts(
         "canon.croquis.augment_type_props",
         augment_type_based_props_from_script_context(&mut croquis, descriptor, path)
     );
+    // Names the generated component surface consumes outside `<template>`:
+    // `<art>` variant templates and CSS `v-bind()` expressions. Both feed the
+    // unused-binding anchors, which are otherwise narrowed to template-referenced
+    // names so a genuinely unused binding still reports TS6133.
     let extra_template_referenced_names = codegen_options.preserve_unused_diagnostics.then(|| {
-        collect_art_template_referenced_names(
+        let mut names = collect_art_template_referenced_names(
             descriptor,
             codegen_options.template_syntax,
             codegen_options.experimental_in_tag_comments,
-        )
+        );
+        names.extend(collect_css_var_referenced_names(descriptor));
+        names
     });
 
     let hoist_shared_preamble = codegen_options.hoist_shared_preamble && !vue2_compat;


### PR DESCRIPTION
## Summary

A `<script setup>` binding referenced only from `<style>` was reported unused:

```vue
<script setup lang="ts">
const color = 'red'
</script>

<template><div /></template>

<style scoped>
div { color: v-bind(color); }
</style>
```

```text
error:2:7 [TS6133] 'color' is declared but its value is never read.
```

`vue-tsc 3.3.4` reports nothing for that file. The SFC compiler turns CSS
`v-bind()` into a real `useCssVars` read, so the binding *is* consumed — this is
a false positive, and one a user cannot tell apart from a real `TS6133`.

## Root cause

Under `noUnusedLocals`/`noUnusedParameters` (`preserve_unused_diagnostics`) the
generator narrows its `void <binding>;` anchors to names the template actually
references, so a genuinely unused user binding still surfaces as `TS6133`.

That template-scope set is built in
`crates/vize_canon/src/virtual_ts/generator/spans.rs` from the template AST and
the Croquis expression tables. Neither sees `<style>`, so a binding read only by
`v-bind()` fell outside the narrowed set, lost its anchor, and was published as
an error.

## Fix

`crates/vize_canon/src/batch/virtual_project/css_var_usage.rs` collects the
identifiers of every CSS `v-bind()` expression from `SfcDescriptor::css_vars`,
and `vue_codegen.rs` merges them into the same `extra_template_referenced_names`
channel `<art>` variant templates already use.

Blast radius is deliberately narrow — the change only ever *adds* names to the
anchor set, and only when the user's tsconfig enables the unused-symbol options.
`SfcDescriptor::css_vars` is filled by the SFC parser's `extract_css_vars`, which
already skips `v-bind(...)` runs inside CSS comments and string literals, so a
commented-out or quoted `v-bind` rescues nothing.

## Tests

`crates/vize_canon/src/batch/type_checker/tests/no_unused/css_v_bind.rs` runs the
real batch type checker over a seven-file project and asserts the **complete**
diagnostic list by equality (`assert_eq!` on the whole sorted
`(file, code, "line:column:severity message")` snapshot — no substring
matching). The expectations are the exact set `vue-tsc 3.3.4` produces for the
same sources under the same `tsconfig.json`:

| fixture | shape | expected |
| --- | --- | --- |
| `BareName.vue` | `v-bind(color)` | no diagnostic |
| `QuotedExpression.vue` | `v-bind("size + 'px'")` | no diagnostic |
| `TwoBindings.vue` | two `v-bind()` in one rule | no diagnostic |
| `MemberExpression.vue` | `v-bind("theme.color")`, `<style module>` | no diagnostic |
| `CommentedOut.vue` | `/* color: v-bind(color); */` | **`TS6133` still reported** |
| `QuotedText.vue` | `content: "v-bind(icon)"` | **`TS6133` still reported** |
| `BesideALiveVBind.vue` | live `v-bind` + a second unused binding | **`TS6133` on the unused one only** |

The last three are the true-positive controls: a genuine unused binding in the
same construct must still be reported, and it is — the fix cannot be satisfied
by blanket suppression.

`crates/vize_canon/src/batch/virtual_project/css_var_usage.rs` additionally unit
tests the collector itself (identifier extraction, comment/string exclusion, and
the no-`<style>` case).

**Proof the tests fail first:** with only the two production hunks stashed, the
new test fails with 9 diagnostics against the expected 3 —

```text
left:  [BareName.vue 'color', BesideALiveVBind.vue 'color', BesideALiveVBind.vue 'unusedLocal',
        CommentedOut.vue 'color', MemberExpression.vue 'theme', QuotedExpression.vue 'size',
        QuotedText.vue 'icon', TwoBindings.vue 'fg', TwoBindings.vue 'bg']
right: [BesideALiveVBind.vue 'unusedLocal', CommentedOut.vue 'color', QuotedText.vue 'icon']
```

Restoring the fix turns it green.

## Verification

| command | result |
| --- | --- |
| `cargo test -p vize_canon` | 784 lib + all integration tests pass, 0 failures |
| `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports` | clean |
| `rustfmt --edition 2024 --config style_edition=2024 --check` (toolchain 1.95.0) | clean |
| `vue-tsc --noEmit` vs `vize check` over an 11-file matrix | CSS `v-bind()` divergence eliminated in both directions |

**Pinned check snapshots do not move.** No test under `tests/` enables
`noUnusedLocals`/`noUnusedParameters`, so `preserve_unused_diagnostics` is `false`
for every fixture that produces a
`tests/snapshots/check/__snapshots__/*.snap` — confirmed by the anchor comment
`Reference setup bindings used by template generation` appearing 0 times across
all twelve snapshots. With that flag off, `extra_template_referenced_names` is
`None` and this change is inert.

Pre-existing local failures, unchanged by this branch (verified by re-running on
a stashed tree): `vize::commands::musea::tests::serve_plan_rejects_missing_musea_vite_plugin_setup`,
three `fmt_check_*` config-path tests, `build_respects_configured_template_syntax_quirks`,
and `tests/tooling/source-file-lengths.test.ts` (MoonBit registry lookup fails in
this sandbox: `module was not found in the registry`). Every file touched here is
well under the 350-line budget (109 / 188 / 270 / 336).

## Scope

Two adjacent `noUnusedLocals` divergences from `vue-tsc` found while building the
oracle matrix are **not** addressed here, because the correct end state is a
separate behavioural decision rather than an extension of this one:
`const props = defineProps<...>()` read as `{{ props.a }}`, and the same binding
when nothing reads it at all — `vue-tsc` reports neither, `vize check` reports
both. Filed separately rather than widened into this change.

Closes #1876

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed unused-binding diagnostics for values referenced through CSS `v-bind()` expressions.
  - CSS bindings using plain, quoted, multiple, or member-expression syntax are now recognized correctly.
  - Reduced false-positive warnings while continuing to report genuinely unused bindings and references found only in comments or text.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->