### PR TITLE
fix(atelier): lower dynamic JSX v-model arguments

### DIFF
--- a/crates/vize_atelier_core/src/codegen/props.rs
+++ b/crates/vize_atelier_core/src/codegen/props.rs
@@ -6,6 +6,7 @@ mod generate;
 mod object_spread;
 mod scan;
 mod static_merge;
+mod v_model;
 
 use crate::{PropNode, RuntimeHelper};
 

--- a/crates/vize_atelier_core/src/codegen/props/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/props/directives.rs
@@ -11,6 +11,7 @@ use vize_carton::String;
 use vize_carton::ToCompactString;
 
 use super::StaticMerge;
+use super::v_model::generate_vmodel_prop;
 
 /// Check if an expression is a static literal (no runtime identifiers).
 /// Returns true for: object literals, array literals, string literals, numbers
@@ -446,56 +447,4 @@ fn generate_von_prop(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
     }
 
     super::events::generate_von_handler_value(ctx, dir);
-}
-
-/// Generate dynamic v-model on component as props
-fn generate_vmodel_prop(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
-    // Handle dynamic v-model on component
-    // Generate: [_ctx.prop]: _ctx.value, ["onUpdate:" + _ctx.prop]: handler
-    if let Some(ExpressionNode::Simple(arg_exp)) = &dir.arg
-        && !arg_exp.is_static
-    {
-        let prop_name = &arg_exp.content;
-        let value_exp = dir
-            .exp
-            .as_ref()
-            .map(|e| match e {
-                ExpressionNode::Simple(s) => s.content.as_str(),
-                ExpressionNode::Compound(c) => c.loc.source.as_str(),
-            })
-            .unwrap_or("undefined");
-
-        // [_ctx.prop]: _ctx.value
-        ctx.push("[_ctx.");
-        ctx.push(prop_name);
-        ctx.push("]: ");
-        ctx.push(value_exp);
-        ctx.push(",");
-        ctx.newline();
-
-        // ["onUpdate:" + _ctx.prop]: $event => ((_ctx.value) = $event)
-        ctx.push("[\"onUpdate:\" + _ctx.");
-        ctx.push(prop_name);
-        ctx.push("]: $event => ((");
-        ctx.push(value_exp);
-        ctx.push(") = $event)");
-
-        // Add modifiers if present
-        if !dir.modifiers.is_empty() {
-            ctx.push(",");
-            ctx.newline();
-            // [_ctx.prop + "Modifiers"]: { modifier: true }
-            ctx.push("[_ctx.");
-            ctx.push(prop_name);
-            ctx.push(" + \"Modifiers\"]: { ");
-            for (i, modifier) in dir.modifiers.iter().enumerate() {
-                if i > 0 {
-                    ctx.push(", ");
-                }
-                ctx.push(&modifier.content);
-                ctx.push(": true");
-            }
-            ctx.push(" }");
-        }
-    }
 }

--- a/crates/vize_atelier_core/src/codegen/props/v_model.rs
+++ b/crates/vize_atelier_core/src/codegen/props/v_model.rs
@@ -1,0 +1,65 @@
+//! Dynamic `v-model` on a component, emitted as computed props.
+
+use crate::{DirectiveNode, ExpressionNode};
+
+use super::super::{context::CodegenContext, expression::generate_expression};
+
+/// Generate dynamic v-model on component as props.
+///
+/// Emits `[prop]: value`, `["onUpdate:" + prop]: handler`, and, when modifiers
+/// were given, `[prop + "Modifiers"]: {…}`.
+///
+/// The argument goes through the shared expression emitter rather than being
+/// hard-prefixed with `_ctx.`: the element transform already ran
+/// `process_expression` over it, so a template argument arrives spelled
+/// `_ctx.prop`, while an opt-in Babel JSX argument (#3391) stays the raw closure
+/// identifier `@vue/babel-plugin-jsx` emits.
+pub(super) fn generate_vmodel_prop(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
+    let Some(arg) = &dir.arg else {
+        return;
+    };
+    if matches!(arg, ExpressionNode::Simple(simple) if simple.is_static) {
+        return;
+    }
+
+    let value_exp = dir
+        .exp
+        .as_ref()
+        .map(|e| match e {
+            ExpressionNode::Simple(s) => s.content.as_str(),
+            ExpressionNode::Compound(c) => c.loc.source.as_str(),
+        })
+        .unwrap_or("undefined");
+
+    // [prop]: value
+    ctx.push("[");
+    generate_expression(ctx, arg);
+    ctx.push("]: ");
+    ctx.push(value_exp);
+    ctx.push(",");
+    ctx.newline();
+
+    // ["onUpdate:" + prop]: $event => ((value) = $event)
+    ctx.push("[\"onUpdate:\" + ");
+    generate_expression(ctx, arg);
+    ctx.push("]: $event => ((");
+    ctx.push(value_exp);
+    ctx.push(") = $event)");
+
+    if !dir.modifiers.is_empty() {
+        ctx.push(",");
+        ctx.newline();
+        // [prop + "Modifiers"]: { modifier: true }
+        ctx.push("[");
+        generate_expression(ctx, arg);
+        ctx.push(" + \"Modifiers\"]: { ");
+        for (i, modifier) in dir.modifiers.iter().enumerate() {
+            if i > 0 {
+                ctx.push(", ");
+            }
+            ctx.push(&modifier.content);
+            ctx.push(": true");
+        }
+        ctx.push(" }");
+    }
+}

--- a/crates/vize_atelier_core/src/transform/element.rs
+++ b/crates/vize_atelier_core/src/transform/element.rs
@@ -16,6 +16,11 @@ use crate::{
 
 use super::{ExitFns, TransformContext};
 
+#[path = "element/directive_expressions.rs"]
+mod directive_expressions;
+
+use directive_expressions::process_directive_expressions;
+
 fn is_dynamic_component(el: &ElementNode<'_>) -> bool {
     el.tag == "component" || (el.tag == "Component" && has_is_attribute(el))
 }
@@ -133,77 +138,6 @@ fn is_registered_component(ctx: &TransformContext<'_>, tag: &str) -> bool {
 
     let pascal = capitalize(tag);
     ctx.is_component_registered(pascal.as_str())
-}
-
-/// Process directive expressions with _ctx prefix
-fn process_directive_expressions<'a>(
-    ctx: &mut TransformContext<'a>,
-    el: &mut Box<'a, ElementNode<'a>>,
-) {
-    use crate::steps::expression::{process_expression, process_inline_handler};
-
-    for prop in el.props.iter_mut() {
-        if let PropNode::Directive(dir) = prop {
-            match dir.name.as_str() {
-                "bind" | "show" | "if" | "else-if" | "for" | "memo" => {
-                    // Process value expression
-                    if let Some(exp) = &dir.exp {
-                        let processed = process_expression(ctx, exp, false);
-                        dir.exp = Some(processed);
-                    }
-                }
-                "on" => {
-                    if let Some(exp) = &dir.exp {
-                        if dir.arg.is_none() {
-                            // v-on="obj" - process as regular expression (object of handlers),
-                            // NOT as an inline handler. toHandlers() expects an object, not a function.
-                            let processed = process_expression(ctx, exp, false);
-                            dir.exp = Some(processed);
-                        } else {
-                            // v-on:event="handler" - process as inline handler
-                            let processed = process_inline_handler(ctx, exp);
-                            dir.exp = Some(processed);
-                        }
-                    }
-                }
-                "model" => {
-                    // Process v-model expression
-                    if let Some(exp) = &dir.exp {
-                        let processed = process_expression(ctx, exp, false);
-                        dir.exp = Some(processed);
-                    }
-                }
-                "slot" => {
-                    if let Some(exp) = &dir.exp {
-                        let processed = process_expression(ctx, exp, true);
-                        dir.exp = Some(processed);
-                    }
-                    if let Some(arg) = &dir.arg
-                        && let ExpressionNode::Simple(simple_arg) = arg
-                        && !simple_arg.is_static
-                    {
-                        let processed = process_expression(ctx, arg, false);
-                        dir.arg = Some(processed);
-                    }
-                }
-                _ => {
-                    // Custom directives - process value expression
-                    if let Some(exp) = &dir.exp {
-                        let processed = process_expression(ctx, exp, false);
-                        dir.exp = Some(processed);
-                    }
-                    // Process dynamic argument
-                    if let Some(arg) = &dir.arg
-                        && let ExpressionNode::Simple(simple_arg) = arg
-                        && !simple_arg.is_static
-                    {
-                        let processed = process_expression(ctx, arg, false);
-                        dir.arg = Some(processed);
-                    }
-                }
-            }
-        }
-    }
 }
 
 /// Process element properties and directives

--- a/crates/vize_atelier_core/src/transform/element/directive_expressions.rs
+++ b/crates/vize_atelier_core/src/transform/element/directive_expressions.rs
@@ -1,0 +1,91 @@
+//! `_ctx`-prefixing of the expressions carried by an element's directives.
+//!
+//! Split out of [`super::element`] so that module stays inside the per-file
+//! source-length budget.
+
+use vize_carton::Box;
+
+use crate::steps::expression::{process_expression, process_inline_handler};
+use crate::{ElementNode, ExpressionNode, PropNode};
+
+use super::TransformContext;
+
+/// Process directive expressions with _ctx prefix
+pub(super) fn process_directive_expressions<'a>(
+    ctx: &mut TransformContext<'a>,
+    el: &mut Box<'a, ElementNode<'a>>,
+) {
+    for prop in el.props.iter_mut() {
+        if let PropNode::Directive(dir) = prop {
+            match dir.name.as_str() {
+                "bind" | "show" | "if" | "else-if" | "for" | "memo" => {
+                    // Process value expression
+                    if let Some(exp) = &dir.exp {
+                        let processed = process_expression(ctx, exp, false);
+                        dir.exp = Some(processed);
+                    }
+                }
+                "on" => {
+                    if let Some(exp) = &dir.exp {
+                        if dir.arg.is_none() {
+                            // v-on="obj" - process as regular expression (object of handlers),
+                            // NOT as an inline handler. toHandlers() expects an object, not a function.
+                            let processed = process_expression(ctx, exp, false);
+                            dir.exp = Some(processed);
+                        } else {
+                            // v-on:event="handler" - process as inline handler
+                            let processed = process_inline_handler(ctx, exp);
+                            dir.exp = Some(processed);
+                        }
+                    }
+                }
+                "model" => {
+                    // Process v-model expression
+                    if let Some(exp) = &dir.exp {
+                        let processed = process_expression(ctx, exp, false);
+                        dir.exp = Some(processed);
+                    }
+                    // A dynamic argument (`v-model:[prop]`, or Babel JSX's
+                    // `v-model={[value, prop]}`) is an expression too, and
+                    // codegen emits it verbatim, so it has to be prefixed here
+                    // exactly like the value is.
+                    if let Some(arg) = &dir.arg
+                        && let ExpressionNode::Simple(simple_arg) = arg
+                        && !simple_arg.is_static
+                    {
+                        let processed = process_expression(ctx, arg, false);
+                        dir.arg = Some(processed);
+                    }
+                }
+                "slot" => {
+                    if let Some(exp) = &dir.exp {
+                        let processed = process_expression(ctx, exp, true);
+                        dir.exp = Some(processed);
+                    }
+                    if let Some(arg) = &dir.arg
+                        && let ExpressionNode::Simple(simple_arg) = arg
+                        && !simple_arg.is_static
+                    {
+                        let processed = process_expression(ctx, arg, false);
+                        dir.arg = Some(processed);
+                    }
+                }
+                _ => {
+                    // Custom directives - process value expression
+                    if let Some(exp) = &dir.exp {
+                        let processed = process_expression(ctx, exp, false);
+                        dir.exp = Some(processed);
+                    }
+                    // Process dynamic argument
+                    if let Some(arg) = &dir.arg
+                        && let ExpressionNode::Simple(simple_arg) = arg
+                        && !simple_arg.is_static
+                    {
+                        let processed = process_expression(ctx, arg, false);
+                        dir.arg = Some(processed);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/vize_atelier_core/tests/dynamic_v_model_argument.rs
+++ b/crates/vize_atelier_core/tests/dynamic_v_model_argument.rs
@@ -1,0 +1,105 @@
+//! `v-model:[arg]` on a component (#3391).
+//!
+//! Codegen emits the dynamic argument through the shared expression emitter
+//! rather than hard-prefixing it with `_ctx.`, so the argument has to be
+//! prefixed by the element transform exactly like the bound value is. These
+//! tests pin the template lane's output so that stays true: with
+//! `prefix_identifiers`, both the key and the update-listener name read
+//! `_ctx.arg`; without it — the shape the JSX lane compiles with — they stay the
+//! raw closure identifiers.
+
+use vize_atelier_core::{
+    CodegenOptions, CodegenResult, TransformOptions, generate, parse, transform,
+};
+use vize_carton::String;
+
+const SOURCE: &str = r#"<Comp v-model:[arg]="value"/>"#;
+const SOURCE_WITH_MODIFIERS: &str = r#"<Comp v-model:[arg].trim="value"/>"#;
+
+fn result_output(result: &CodegenResult) -> String {
+    let mut output = String::with_capacity(result.preamble.len() + result.code.len() + 1);
+    output.push_str(&result.preamble);
+    output.push('\n');
+    output.push_str(&result.code);
+    output
+}
+
+fn compile(source: &str, prefix_identifiers: bool) -> String {
+    let allocator = bumpalo::Bump::new();
+    let (mut root, errors) = parse(&allocator, source);
+    assert!(errors.is_empty(), "Parse errors: {errors:?}");
+    transform(
+        &allocator,
+        &mut root,
+        TransformOptions {
+            prefix_identifiers,
+            ..Default::default()
+        },
+        None,
+    );
+    result_output(&generate(
+        &root,
+        CodegenOptions {
+            prefix_identifiers,
+            ..Default::default()
+        },
+    ))
+}
+
+#[test]
+fn prefixed_templates_render_the_argument_through_ctx() {
+    assert_eq!(
+        compile(SOURCE, true),
+        concat!(
+            "const { resolveComponent: _resolveComponent, normalizeProps: _normalizeProps, ",
+            "openBlock: _openBlock, createBlock: _createBlock } = Vue\n",
+            "\n",
+            "function render(_ctx, _cache, $props, $setup, $data, $options) {\n",
+            "  const _component_Comp = _resolveComponent(\"Comp\")\n",
+            "  \n",
+            "  return (_openBlock(), _createBlock(_component_Comp, _normalizeProps({ ",
+            "[_ctx.arg]: _ctx.value,\n",
+            "  [\"onUpdate:\" + _ctx.arg]: $event => ((_ctx.value) = $event) }), null, ",
+            "16 /* FULL_PROPS */))\n",
+            "}",
+        )
+    );
+}
+
+#[test]
+fn prefixed_templates_render_the_modifiers_key_through_ctx() {
+    assert_eq!(
+        compile(SOURCE_WITH_MODIFIERS, true),
+        concat!(
+            "const { resolveComponent: _resolveComponent, normalizeProps: _normalizeProps, ",
+            "openBlock: _openBlock, createBlock: _createBlock } = Vue\n",
+            "\n",
+            "function render(_ctx, _cache, $props, $setup, $data, $options) {\n",
+            "  const _component_Comp = _resolveComponent(\"Comp\")\n",
+            "  \n",
+            "  return (_openBlock(), _createBlock(_component_Comp, _normalizeProps({ ",
+            "[_ctx.arg]: _ctx.value,\n",
+            "  [\"onUpdate:\" + _ctx.arg]: $event => ((_ctx.value) = $event),\n",
+            "  [_ctx.arg + \"Modifiers\"]: { trim: true } }), null, 16 /* FULL_PROPS */))\n",
+            "}",
+        )
+    );
+}
+
+#[test]
+fn unprefixed_templates_keep_the_argument_as_authored() {
+    assert_eq!(
+        compile(SOURCE, false),
+        concat!(
+            "const { resolveComponent: _resolveComponent, normalizeProps: _normalizeProps, ",
+            "openBlock: _openBlock, createBlock: _createBlock } = Vue\n",
+            "\n",
+            "function render(_ctx, _cache, $props, $setup, $data, $options) {\n",
+            "  const _component_Comp = _resolveComponent(\"Comp\")\n",
+            "  \n",
+            "  return (_openBlock(), _createBlock(_component_Comp, _normalizeProps({ [arg]: value,\n",
+            "  [\"onUpdate:\" + arg]: $event => ((value) = $event) }), null, 16 /* FULL_PROPS */))\n",
+            "}",
+        )
+    );
+}

--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -172,6 +172,7 @@ pub(crate) fn compile_jsx_with_babel_customizations_inner(
                 .as_ref()
                 .map(|helpers| helpers.is_slot.as_str()),
             is_custom_element,
+            vdom_lane: !config.ssr,
         },
     );
     let mut diagnostics = lowered.diagnostics;

--- a/crates/vize_atelier_jsx/src/lower.rs
+++ b/crates/vize_atelier_jsx/src/lower.rs
@@ -47,6 +47,11 @@ pub(crate) struct BabelLoweringOptions<'m> {
     pub object_slots_helper: Option<&'m str>,
     /// Project-specific custom-element classifier from `isCustomElement`.
     pub is_custom_element: Option<&'m BabelIsCustomElement>,
+    /// Whether the Babel VDOM lane may apply at all. Babel's options are a
+    /// client-VDOM contract, so the compiler switches this off for SSR exactly
+    /// as it withholds the `transformOn` / `enableObjectSlots` /
+    /// `isCustomElement` inputs there.
+    pub vdom_lane: bool,
 }
 
 /// Lowers OXC JSX nodes into Vize IR against a single source text.
@@ -57,6 +62,7 @@ pub struct Lowerer<'a, 'm, 's> {
     is_custom_element: Option<&'m BabelIsCustomElement>,
     scoping: Option<Scoping>,
     custom_element_spans: std::vec::Vec<(u32, u32)>,
+    babel_vdom_lane: bool,
     transform_on_helper: Option<String>,
     object_slots_helper: Option<String>,
     babel_vdom_compat_active: bool,
@@ -94,6 +100,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             is_custom_element: babel.is_custom_element,
             scoping,
             custom_element_spans: std::vec::Vec::new(),
+            babel_vdom_lane: babel.vdom_lane,
             transform_on_helper: babel.transform_on_helper.map(String::from),
             object_slots_helper: babel.object_slots_helper.map(String::from),
             babel_vdom_compat_active: false,
@@ -213,7 +220,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
 
     /// Select whether the current render root may use VDOM-only Babel options.
     pub(crate) fn set_current_output_mode(&mut self, mode: crate::JsxOutputMode) {
-        self.babel_vdom_compat_active = mode == crate::JsxOutputMode::Vdom;
+        self.babel_vdom_compat_active = self.babel_vdom_lane && mode == crate::JsxOutputMode::Vdom;
     }
 
     /// Whether Babel's `isCustomElement` predicate selects this JSX tag.

--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -285,7 +285,8 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             && arg.is_none()
             && let Some(array) = self.array_literal_value(attr.value.as_ref())
         {
-            match self.lower_model_array(array, loc) {
+            match self.lower_model_array(array, loc, self.uses_babel_vdom_compat() && on_component)
+            {
                 ModelArrayLowering::Lowered(prop) => {
                     return DirectiveAttributeLowering::Lowered(prop);
                 }

--- a/crates/vize_atelier_jsx/src/lower/v_model.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_model.rs
@@ -121,16 +121,21 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// `model` directive. Layout (per babel-plugin-jsx):
     ///   - element 0: the model expression (required)  -> `exp`
     ///   - a trailing array-literal element: modifiers  -> `directive.modifiers`
-    ///   - an intermediate string-literal element: arg  -> `directive.arg`
+    ///   - an intermediate element: arg  -> `directive.arg`
     ///
     /// Returns [`ModelArrayLowering::Unrecognized`] for shapes we cannot
     /// confidently destructure (e.g. empty array, spread/hole elements).
-    /// Recognized dynamic arguments are rejected instead of being silently
-    /// discarded: representing them requires computed prop codegen (#3466).
+    ///
+    /// A *dynamic* argument (anything but a string literal) needs computed prop
+    /// and update-listener keys, which only components support, so it is
+    /// accepted when `allow_dynamic_arg` says the caller is lowering a component
+    /// in opt-in Babel VDOM mode and rejected everywhere else rather than being
+    /// silently discarded (#3466).
     pub(crate) fn lower_model_array(
         &mut self,
         array: &oxc_ast::ast::ArrayExpression<'_>,
         loc: &SourceLocation,
+        allow_dynamic_arg: bool,
     ) -> ModelArrayLowering<'a> {
         // Collect the plain (non-hole, non-spread) expression elements.
         let mut elems: std::vec::Vec<&Expression<'_>> = std::vec::Vec::new();
@@ -157,13 +162,14 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             _ => None,
         };
 
-        // An intermediate string-literal element (index 1, before any modifiers
-        // array) is the arg: the bound prop name for component v-model.
+        // An intermediate element (index 1, before any modifiers array) is the
+        // arg: the bound prop name for component v-model.
         let arg = if modifiers_idx == Some(1) {
             None
         } else {
             match elems.get(1).copied() {
-                Some(Expression::StringLiteral(string)) => Some(string),
+                Some(expression @ Expression::StringLiteral(_)) => Some(expression),
+                Some(expression) if allow_dynamic_arg => Some(expression),
                 Some(expression) => {
                     let span = expression.span();
                     let source = self.mapper().slice(span);
@@ -182,8 +188,13 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
 
         let mut directive = DirectiveNode::new(self.bump(), "model", loc.clone());
         directive.exp = Some(self.dyn_expr(value_expr.span()));
-        if let Some(string) = arg {
-            directive.arg = Some(self.static_expr(string.value.as_str(), string.span));
+        if let Some(argument) = arg {
+            directive.arg = Some(match argument {
+                Expression::StringLiteral(string) => {
+                    self.static_expr(string.value.as_str(), string.span)
+                }
+                expression => self.dyn_expr(expression.span()),
+            });
         }
 
         if let Some(idx) = modifiers_idx

--- a/crates/vize_atelier_jsx/src/lower/v_models.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_models.rs
@@ -195,7 +195,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
                 }
             }
 
-            match self.lower_model_array(entry, &loc) {
+            match self.lower_model_array(entry, &loc, self.uses_babel_vdom_compat()) {
                 ModelArrayLowering::Lowered(prop) => lowered.push(prop),
                 ModelArrayLowering::Rejected => rejected = true,
                 ModelArrayLowering::Unrecognized => {

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,8 +55,8 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   95 |
-| divergent  |    1 |
+| equivalent |   96 |
+| divergent  |    0 |
 | deferred   |    2 |
 
 ## Global divergences
@@ -189,7 +189,7 @@ Recorded so the verdicts are not read as byte equality (#3421,
 | `directives/v_model_arg_underscore`        | `[[vModelText, val, "foo", {trim: true}]]`                     | rejected outside Babel VDOM compatibility mode                  | accepts arg and modifiers in Babel VDOM mode  | ✅      |
 | `directives/v_model_component`             | `modelValue` + `onUpdate:modelValue` props                     | same                                                            | no change                                     | ✅      |
 | `directives/v_model_component_arg_mods`    | `argument`, `argumentModifiers`, `onUpdate:argument`           | same props, different literal order                             | no change                                     | ✅      |
-| `directives/v_model_component_dynamic_arg` | computed prop + `"onUpdate:" + bar`                            | rejected: dynamic arguments need computed prop lowering (#3466) | add computed prop IR                          | ❌      |
+| `directives/v_model_component_dynamic_arg` | computed prop + `"onUpdate:" + bar`                            | rejected: dynamic arguments need computed prop lowering (#3466) | same computed props in Babel VDOM mode        | ✅      |
 | `directives/v_models`                      | expands to one prop pair per entry                             | same, via one `model` directive per entry (#3418)               | no change                                     | ✅      |
 | `directives/v_models_mods`                 | adds `<arg>Modifiers` per entry                                | same props, different literal order (#3418)                     | no change                                     | ✅      |
 | `directives/v_show_element`                | `[[vShow, vis]]`                                               | same                                                            | no change                                     | ✅      |

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -76,10 +76,9 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("directives/v_model_arg_underscore", Same),
     ("directives/v_model_component", Same),
     ("directives/v_model_component_arg_mods", Same),
-    (
-        "directives/v_model_component_dynamic_arg",
-        Diff("dynamic v-model argument diagnosed; needs computed prop lowering"),
-    ),
+    // Closed by #3391: a dynamic argument on a component lowers to computed
+    // prop and update-listener keys, as babel emits.
+    ("directives/v_model_component_dynamic_arg", Same),
     // Closed by #3418: `v-models` expands to one model binding per entry.
     ("directives/v_models", Same),
     ("directives/v_models_mods", Same),

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (95, 1, 2));
+    assert_eq!((equivalent, divergent, deferred), (96, 0, 2));
     assert_eq!(VERDICTS.len(), 98);
 }
 

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__directives.snap
@@ -187,7 +187,7 @@ export function render(_ctx, _cache) {
 
 ## directives/v_model_component_dynamic_arg
 ### verdict
-divergent: dynamic v-model argument diagnosed; needs computed prop lowering
+equivalent
 ### source (jsx)
 const A = () => <B v-model={[foo, bar]}/>;
 ### babel options
@@ -199,12 +199,12 @@ const A = () => _createVNode(_resolveComponent("B"), {
   ["onUpdate:" + bar]: $event => foo = $event
 }, null);
 ### vize (vdom, babel compat)
-<Error> v-model argument `bar` must be a string literal; dynamic arguments are not supported.
-import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+import { resolveComponent as _resolveComponent, normalizeProps as _normalizeProps, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
 
-  return (_openBlock(), _createBlock(_component_B))
+  return (_openBlock(), _createBlock(_component_B, _normalizeProps({ [bar]: foo,
+  ["onUpdate:" + bar]: $event => ((foo) = $event) }), null, 16 /* FULL_PROPS */))
 }
 
 ## directives/v_models

--- a/crates/vize_atelier_jsx/tests/v_model_argument.rs
+++ b/crates/vize_atelier_jsx/tests/v_model_argument.rs
@@ -1,8 +1,10 @@
-//! `v-model` array-form argument validation (#3466).
+//! `v-model` array-form argument validation (#3466, #3391).
 //!
 //! A non-literal argument needs computed prop keys and update-listener names.
-//! Until that codegen exists, lowering must reject the input instead of
-//! silently binding `modelValue` and changing the component contract.
+//! Opt-in Babel VDOM mode emits those for a **component**, matching
+//! `@vue/babel-plugin-jsx`. Everywhere else — native mode, Vapor, SSR, and any
+//! plain element — lowering rejects the input instead of silently binding
+//! `modelValue` and changing the component contract.
 
 use vize_atelier_jsx::{
     JsxCompatMode, JsxCompileConfig, JsxLang, VdomCompileOptions, compile_jsx, compile_to_vdom,
@@ -14,6 +16,8 @@ const SOURCE: &str = "const A = () => <B v-model={[foo, bar]}/>;";
 const ELEMENT_ARG: &str = "const A = () => <input v-model:foo={val}/>;";
 const ELEMENT_ARG_MODIFIER: &str = "const A = () => <input v-model:foo_trim={val}/>;";
 const COMPONENT_ARG_MODIFIER: &str = "const A = () => <B v-model:foo_trim={val}/>;";
+const DYNAMIC_ARGUMENT_ERROR: &str =
+    "v-model argument `bar` must be a string literal; dynamic arguments are not supported.";
 const REJECTED_ELEMENT_MODULE: &str = concat!(
     "import { openBlock as _openBlock, createElementBlock as _createElementBlock } from \"vue\"\n",
     "export function render(_ctx, _cache) {\n",
@@ -120,7 +124,11 @@ fn babel_compat_component_argument_behavior_is_unchanged() {
 }
 
 #[test]
-fn babel_compat_dynamic_component_argument_rejection_is_unchanged() {
+fn babel_compat_dynamic_component_argument_emits_computed_prop_keys() {
+    // Babel emits `{[bar]: foo, ["onUpdate:" + bar]: $event => foo = $event}`.
+    // Vize reaches the same props through its dynamic-prop path, so the
+    // argument is never `_ctx.`-prefixed: a JSX component closes over module
+    // scope, not a render context.
     let bump = Bump::new();
     let output = compile_jsx(
         &bump,
@@ -132,21 +140,111 @@ fn babel_compat_dynamic_component_argument_rejection_is_unchanged() {
         },
     );
 
-    assert_eq!(output.diagnostics.len(), 1);
-    assert_eq!(
-        output.diagnostics[0].message.as_str(),
-        "v-model argument `bar` must be a string literal; dynamic arguments are not supported."
-    );
+    assert!(output.diagnostics.is_empty(), "{:?}", output.diagnostics);
     assert_eq!(
         output.module_code(),
         concat!(
-            "import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from \"vue\"\n",
+            "import { resolveComponent as _resolveComponent, normalizeProps as _normalizeProps, openBlock as _openBlock, createBlock as _createBlock } from \"vue\"\n",
             "export function render(_ctx, _cache) {\n",
             "  const _component_B = _resolveComponent(\"B\")\n",
             "  \n",
-            "  return (_openBlock(), _createBlock(_component_B))\n",
+            "  return (_openBlock(), _createBlock(_component_B, _normalizeProps({ [bar]: foo,\n",
+            "  [\"onUpdate:\" + bar]: $event => ((foo) = $event) }), null, 16 /* FULL_PROPS */))\n",
             "}",
         )
+    );
+}
+
+#[test]
+fn babel_compat_dynamic_component_argument_carries_modifiers_and_member_paths() {
+    for (source, key) in [
+        (
+            "const A = () => <B v-model={[foo, bar, ['trim']]}/>;",
+            concat!(
+                "{ [bar]: foo,\n",
+                "  [\"onUpdate:\" + bar]: $event => ((foo) = $event),\n",
+                "  [bar + \"Modifiers\"]: { trim: true } }",
+            ),
+        ),
+        (
+            "const A = () => <B v-model={[foo, a.b]}/>;",
+            concat!(
+                "{ [a.b]: foo,\n",
+                "  [\"onUpdate:\" + a.b]: $event => ((foo) = $event) }",
+            ),
+        ),
+    ] {
+        let bump = Bump::new();
+        let output = compile_jsx(
+            &bump,
+            source,
+            JsxLang::Jsx,
+            &JsxCompileConfig {
+                compat: JsxCompatMode::Babel,
+                ..Default::default()
+            },
+        );
+        assert!(output.diagnostics.is_empty(), "{:?}", output.diagnostics);
+        assert_eq!(
+            output.module_code(),
+            format!(
+                concat!(
+                    "import {{ resolveComponent as _resolveComponent, normalizeProps as _normalizeProps, openBlock as _openBlock, createBlock as _createBlock }} from \"vue\"\n",
+                    "export function render(_ctx, _cache) {{\n",
+                    "  const _component_B = _resolveComponent(\"B\")\n",
+                    "  \n",
+                    "  return (_openBlock(), _createBlock(_component_B, _normalizeProps({}), null, 16 /* FULL_PROPS */))\n",
+                    "}}",
+                ),
+                key
+            ),
+            "{source}"
+        );
+    }
+}
+
+#[test]
+fn babel_compat_dynamic_argument_stays_rejected_off_the_vdom_component_lane() {
+    // A plain element has no computed-prop shape to emit into, and compat mode
+    // is a VDOM-only contract, so Vapor and SSR keep the native rejection.
+    let element = "const A = () => <input v-model={[foo, bar]}/>;";
+    let bump = Bump::new();
+    let output = compile_jsx(
+        &bump,
+        element,
+        JsxLang::Jsx,
+        &JsxCompileConfig {
+            compat: JsxCompatMode::Babel,
+            ..Default::default()
+        },
+    );
+    assert_eq!(
+        output
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message.to_string())
+            .collect::<Vec<_>>(),
+        vec![DYNAMIC_ARGUMENT_ERROR.to_string()]
+    );
+    assert_eq!(output.module_code(), REJECTED_ELEMENT_MODULE);
+
+    let bump = Bump::new();
+    let ssr = compile_jsx(
+        &bump,
+        SOURCE,
+        JsxLang::Jsx,
+        &JsxCompileConfig {
+            compat: JsxCompatMode::Babel,
+            ssr: true,
+            ..Default::default()
+        },
+    );
+    assert_eq!(
+        ssr.diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.message.to_string())
+            .collect::<Vec<_>>(),
+        vec![DYNAMIC_ARGUMENT_ERROR.to_string()]
     );
 }
 
@@ -161,10 +259,7 @@ fn dynamic_array_argument_is_rejected_without_model_value_fallback() {
         .collect();
 
     assert_eq!(errors.len(), 1);
-    assert_eq!(
-        errors[0].message.as_str(),
-        "v-model argument `bar` must be a string literal; dynamic arguments are not supported."
-    );
+    assert_eq!(errors[0].message.as_str(), DYNAMIC_ARGUMENT_ERROR);
     assert_eq!(
         &SOURCE[errors[0].start as usize..errors[0].end as usize],
         "bar"


### PR DESCRIPTION
Closes #3391.

`@vue/babel-plugin-jsx` accepts a dynamic `v-model` argument on a component and
emits computed keys for it:

```js
// <B v-model={[foo, bar]}/>
createVNode(B, { [bar]: foo, ["onUpdate:" + bar]: $event => foo = $event })
```

Vize rejected the shape rather than silently binding `modelValue`, because
representing it needs computed prop and update-listener keys. Vue's own dynamic
`v-model:[arg]` path already builds exactly those props, so opt-in Babel VDOM
mode now routes a component's dynamic argument through it.

Two supporting changes make that work:

- **Codegen no longer hard-prefixes the argument with `_ctx.`.** The element
  transform prefixes it alongside the bound value instead, so a template still
  emits `[_ctx.arg]` / `["onUpdate:" + _ctx.arg]` while a JSX closure keeps the
  raw identifier babel emits. `crates/vize_atelier_core/tests/dynamic_v_model_argument.rs`
  pins both directions with full-equality assertions — `v-model:[arg]` on a
  component had no test at all before this.
- **The Babel VDOM lane is now explicitly withheld from SSR.** It was leaking
  into SSR compilation, where the backend emits `[_ctx.arg || ""]` and would have
  produced broken output for this row. The compiler already withholds
  `transformOn`, `enableObjectSlots`, and `isCustomElement` under SSR; the
  lowering-side flag now matches.

Plain elements, Vapor, SSR, and native mode keep the existing diagnostic.

## Oracle row closed — the last one

`directives/v_model_component_dynamic_arg` flips from `divergent` to
`equivalent`. Verdict totals are now **96 equivalent, 0 divergent, 2 deferred**,
recounted from `verdicts.rs` after rebasing over #3729 rather than derived
arithmetically, and cross-checked against the inventory's own row marks
(96 ✅ / 0 ❌ / 2 ⏸).

The two deferred rows are the ones #3391 itself defers: `options/resolve_type_on`
(needs the type resolution in #1497 / #1502) and `slots/dynamic_slot_name`
(needs dynamic-slot lowering).

## Source-length budget

`transform/element.rs` (804) and `codegen/props/directives.rs` (501) were already
over the 350-line limit, so growing them would fail the gate. Both were split
instead — `transform/element/directive_expressions.rs` and
`codegen/props/v_model.rs` — leaving them at 738 and 450. Nothing was
allowlisted.

## Verification

- `cargo test --workspace` (only pre-existing `vize::commands::musea` failure,
  which also fails on `main` in a checkout without `node_modules`)
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `rustfmt --edition 2024 --config style_edition=2024 --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic `v-model:[argument]` bindings on components.
  * Generated bindings now include computed prop names, update handlers, and modifiers.

* **Bug Fixes**
  * Improved expression handling and identifier prefixing for dynamic `v-model` arguments.
  * Preserved rejection of dynamic arguments on plain elements and during SSR.

* **Tests**
  * Expanded coverage for dynamic component bindings and Babel compatibility.
  * Updated compatibility results to reflect full support for this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->