### PR TITLE
docs(atelier): document the Babel JSX compatibility mode

### DIFF
--- a/crates/vize_atelier_jsx/README.md
+++ b/crates/vize_atelier_jsx/README.md
@@ -16,6 +16,58 @@ Support and deprecation guarantees are defined in the
 - `compile_to_vapor`
 - `compile_to_ssr`
 
+## `@vue/babel-plugin-jsx` compatibility mode
+
+Vize compiles JSX/TSX with its own semantics by default: a block tree, lowered
+`v-if` / `v-for`, and patch flags on every node. `@vue/babel-plugin-jsx` emits
+bare `createVNode` calls instead. For a project migrating off the babel plugin,
+`compiler.jsxCompat: "babel"` asks for the plugin's semantics instead.
+
+```jsonc
+// vize.json
+{ "compiler": { "jsxCompat": "babel" } }
+```
+
+The switch is **opt-in and off by default** — turning it on by default would
+silently change output for every existing Vize user — and it is a project-level
+setting with no per-component directive form, because it changes the shape of
+the emitted module rather than of a single render function.
+
+### Plugin option mapping
+
+The plugin's options have no config-file spelling; each is a parameter of a
+`compile_jsx_with_babel_*` entry point, and all of them are inert unless
+`jsxCompat` is `"babel"`.
+
+| `@vue/babel-plugin-jsx` | Vize                                        |
+| ----------------------- | ------------------------------------------- |
+| `transformOn`           | `BabelJsxOptions::transform_on`             |
+| `pragma`                | `compile_jsx_with_babel_pragma`             |
+| `mergeProps`            | `compile_jsx_with_babel_merge_props`        |
+| `isCustomElement`       | `BabelJsxCustomizations::is_custom_element` |
+| `enableObjectSlots`     | `compile_jsx_with_babel_object_slots`       |
+| any combination         | `compile_jsx_with_babel_customizations`     |
+
+`optimize` has no equivalent: Vize's output is always optimized, which is what
+the plugin's `optimize: true` produces. `resolveType` is not implemented yet.
+
+### Where it does not apply
+
+- **Vapor output.** `@vue/babel-plugin-jsx` is a vdom-era plugin with no Vapor
+  output shape, so `jsxCompat: "babel"` combined with `jsxMode: "vapor"` is
+  rejected with a diagnostic rather than silently ignored.
+- **SSR output.** The plugin's options describe client vnode trees, so SSR
+  compilation withholds the whole Babel lane and uses Vize's own SSR semantics.
+
+### How compatibility is measured
+
+`tests/babel_compat/` records the output of the real plugin (pinned `2.0.1`) for
+every case in `fixtures/corpus.json` and snapshots it beside Vize's, with an
+explicit per-row verdict. `tests/BABEL_COMPAT_INVENTORY.md` is the prose form of
+that table, including the deferred rows and the global divergences (module
+shape, block tree, patch flags, un-lowered control flow) that hold for nearly
+every row.
+
 ## License
 
 MIT

--- a/crates/vize_atelier_jsx/README.md
+++ b/crates/vize_atelier_jsx/README.md
@@ -33,13 +33,17 @@ silently change output for every existing Vize user — and it is a project-leve
 setting with no per-component directive form, because it changes the shape of
 the emitted module rather than of a single render function.
 
+Its scope is JSX/TSX compilation: the key is read by this crate's JSX entry
+points and by the JSX bindings that wrap them. `.vue` SFCs do not go through the
+JSX compiler, so `jsxCompat` does not change how they are compiled.
+
 ### Plugin option mapping
 
-The plugin's options have no config-file spelling; each is a parameter of a
-`compile_jsx_with_babel_*` entry point, and all of them are inert unless
-`jsxCompat` is `"babel"`.
+The plugin's options have no config-file spelling; each is a Vize option or API
+field on a `compile_jsx_with_babel_*` entry point, and all of them are inert
+unless `jsxCompat` is `"babel"`.
 
-| `@vue/babel-plugin-jsx` | Vize                                        |
+| `@vue/babel-plugin-jsx` | Vize option / API                           |
 | ----------------------- | ------------------------------------------- |
 | `transformOn`           | `BabelJsxOptions::transform_on`             |
 | `pragma`                | `compile_jsx_with_babel_pragma`             |

--- a/crates/vize_atelier_jsx/src/compat.rs
+++ b/crates/vize_atelier_jsx/src/compat.rs
@@ -6,11 +6,44 @@
 //! `createVNode` calls, never opens a block, leaves `&&` / `?:` / `.map()` as
 //! plain JavaScript, and by default emits **no** patch flags at all.
 //!
-//! Most of that difference is invisible at runtime — 63 of the 94 cases in
-//! `tests/babel_compat/fixtures/corpus.json` are already semantically
-//! equivalent. The rest are not, and a project migrating off
-//! `@vue/babel-plugin-jsx` needs a way to ask for babel's semantics instead of
-//! Vize's. [`JsxCompatMode::Babel`] is that switch.
+//! Most of that difference is invisible at runtime; the rest is what this switch
+//! exists for, because a project migrating off `@vue/babel-plugin-jsx` needs a
+//! way to ask for babel's semantics instead of Vize's. [`JsxCompatMode::Babel`]
+//! is that switch. How closely it lands is measured against the real plugin by
+//! the differential oracle in `tests/babel_compat/`, whose row-by-row verdicts
+//! and current totals live in `tests/BABEL_COMPAT_INVENTORY.md`.
+//!
+//! # Babel plugin options
+//!
+//! The plugin's options have no config-file spelling of their own: each is a
+//! parameter of a `compile_jsx_with_babel_*` entry point, and every one of them
+//! is inert unless [`JsxCompatMode::Babel`] is selected.
+//!
+//! | `@vue/babel-plugin-jsx` option | Vize entry point |
+//! | ------------------------------ | ---------------- |
+//! | `transformOn` | [`crate::BabelJsxOptions::transform_on`] |
+//! | `pragma` | [`crate::compile_jsx_with_babel_pragma`] |
+//! | `mergeProps` | [`crate::compile_jsx_with_babel_merge_props`] |
+//! | `isCustomElement` | [`crate::BabelJsxCustomizations::is_custom_element`] |
+//! | `enableObjectSlots` | [`crate::compile_jsx_with_babel_object_slots`] |
+//! | any combination of the above | [`crate::compile_jsx_with_babel_customizations`] |
+//!
+//! `optimize` has no Vize equivalent, because Vize's output is always optimized
+//! — which is what the plugin's `optimize: true` produces. `resolveType` is
+//! deferred, along with one other row:
+//!
+//! - `options/resolve_type_on` — type-driven props/emits inference needs the
+//!   type-resolution work tracked on #1497 / #1502.
+//! - `slots/dynamic_slot_name` — a computed slot name warns and drops; it needs
+//!   dynamic-slot lowering.
+//!
+//! # Compat under SSR output
+//!
+//! `@vue/babel-plugin-jsx` emits client vnode trees, so its options describe
+//! client output only. SSR compilation therefore withholds the whole Babel lane
+//! — the `transformOn` / `enableObjectSlots` helpers, the `isCustomElement`
+//! predicate, `mergeProps: false`, and every Babel-only lowering — and falls
+//! back to Vize's own SSR semantics rather than emitting a half-applied mixture.
 //!
 //! # Why this is not a directive prologue
 //!

--- a/crates/vize_atelier_jsx/src/compat.rs
+++ b/crates/vize_atelier_jsx/src/compat.rs
@@ -16,11 +16,11 @@
 //! # Babel plugin options
 //!
 //! The plugin's options have no config-file spelling of their own: each is a
-//! parameter of a `compile_jsx_with_babel_*` entry point, and every one of them
-//! is inert unless [`JsxCompatMode::Babel`] is selected.
+//! Vize option or API field on a `compile_jsx_with_babel_*` entry point, and
+//! every one of them is inert unless [`JsxCompatMode::Babel`] is selected.
 //!
-//! | `@vue/babel-plugin-jsx` option | Vize entry point |
-//! | ------------------------------ | ---------------- |
+//! | `@vue/babel-plugin-jsx` option | Vize option / API |
+//! | ------------------------------ | ----------------- |
 //! | `transformOn` | [`crate::BabelJsxOptions::transform_on`] |
 //! | `pragma` | [`crate::compile_jsx_with_babel_pragma`] |
 //! | `mergeProps` | [`crate::compile_jsx_with_babel_merge_props`] |


### PR DESCRIPTION
Part of #3391 — plan step 4 (`docs`).

> **Draft on purpose.** A release is in flight and `origin/main` must stay at the
> tagged commit. This is held as a draft so nothing (including the Codesmith bot)
> can merge it. Mark ready when the window is clear.

`compiler.jsxCompat: "babel"` had no prose anywhere. The crate README did not
mention it, and `compat.rs`'s module docs still claimed "63 of the 94 cases in
`corpus.json` are already semantically equivalent" — a count three PRs out of
date, and the kind of number that silently rots.

This documents the switch where a crate consumer will find it:

- what it is and how to turn it on (`compiler.jsxCompat: "babel"`),
- that it is opt-in, off by default, and project-level with no per-component
  directive form, and **why**,
- the mapping from each `@vue/babel-plugin-jsx` option to its Vize entry point,
- the two rows that stay deferred (`options/resolve_type_on`,
  `slots/dynamic_slot_name`) and what each is waiting on,
- the Vapor and SSR lanes the mode deliberately does not apply to,
- where compatibility is actually measured, so the numbers live in one place.

The stale count is replaced by a pointer to the oracle and
`BABEL_COMPAT_INVENTORY.md`, which carry the live totals and are pinned by
`babel_compat_verdict_totals`, so this prose cannot drift again.

## Not done here: the docs site

`docs/content/guide/jsx.md` documents `jsxMode` but not `jsxCompat`, and it
should. It is blocked, not skipped:

- `docs/content/guide/jsx.md` is 510 lines and `configuration.md` is 434, both
  already over the CI-enforced 350-line budget, so neither may grow.
- A new page needs an entry in `docs/theme/i18n/navigation.js`, which is 599
  lines — also over budget — across five locales, so it may not grow either.

Adding the page therefore requires first splitting `navigation.js`, a single
browser-loaded IIFE holding all five locales' labels and nav groups. That is a
real refactor of unrelated theme code and does not belong in this PR. Left for a
follow-up rather than allowlisted.

## Verification

- `cargo doc -p vize_atelier_jsx --no-deps` — every intra-doc link in the new
  option-mapping table resolves (the one remaining warning, `crate::finder` in
  `mode.rs`, is pre-existing on `main`).
- `cargo test -p vize_atelier_jsx` including doctests.
- Markdown tables conform to the repo's existing padding convention.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for `@vue/babel-plugin-jsx` compatibility mode.
  * Documented configuration options, Babel option mappings, unsupported or deferred options, and SSR/Vapor limitations.
  * Added references to compatibility tests and inventory sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->