### PR TITLE
fix(atelier): forward static template v-slots in Babel mode

### DIFF
--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -167,6 +167,7 @@ pub(crate) fn compile_jsx_with_babel_customizations_inner(
         config.compat,
         config.default_mode,
         BabelLoweringOptions {
+            vdom_compat: !config.ssr,
             transform_on_helper: transform_on_helper.as_deref(),
             object_slots_helper: object_slot_helpers
                 .as_ref()

--- a/crates/vize_atelier_jsx/src/lower.rs
+++ b/crates/vize_atelier_jsx/src/lower.rs
@@ -41,6 +41,9 @@ use crate::span::SpanMapper;
 /// site instead of widening three signatures each time.
 #[derive(Clone, Copy, Default)]
 pub(crate) struct BabelLoweringOptions<'m> {
+    /// Whether the current compilation can emit Babel-compatible VDOM output.
+    /// SSR has its own backend and must not inherit VDOM-only lowering rules.
+    pub vdom_compat: bool,
     /// Collision-free `_transformOn` binding, when `transformOn` is enabled.
     pub transform_on_helper: Option<&'m str>,
     /// Collision-free `_isSlot` binding, when `enableObjectSlots` is enabled.
@@ -65,6 +68,7 @@ pub struct Lowerer<'a, 'm, 's> {
     babel_vdom_lane: bool,
     transform_on_helper: Option<String>,
     object_slots_helper: Option<String>,
+    babel_vdom_compat_allowed: bool,
     babel_vdom_compat_active: bool,
     diagnostics: std::vec::Vec<JsxDiagnostic>,
     /// `<style scoped>` blocks extracted from the render root currently being
@@ -103,6 +107,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             babel_vdom_lane: babel.vdom_lane,
             transform_on_helper: babel.transform_on_helper.map(String::from),
             object_slots_helper: babel.object_slots_helper.map(String::from),
+            babel_vdom_compat_allowed: babel.vdom_compat,
             babel_vdom_compat_active: false,
             diagnostics: std::vec::Vec::new(),
             pending_styles: std::vec::Vec::new(),
@@ -215,7 +220,7 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
 
     /// Whether Babel-only VDOM child semantics apply to the current render root.
     pub(crate) fn uses_babel_vdom_compat(&self) -> bool {
-        self.uses_babel_compat() && self.babel_vdom_compat_active
+        self.uses_babel_compat() && self.babel_vdom_compat_allowed && self.babel_vdom_compat_active
     }
 
     /// Select whether the current render root may use VDOM-only Babel options.

--- a/crates/vize_atelier_jsx/src/lower/v_slots.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_slots.rs
@@ -59,10 +59,11 @@
 //!   `v-slots={1}`, `v-slots={[…]}`). Babel forwards these as the component's
 //!   children, which is meaningless for a component: a slots object is either an
 //!   object literal to expand or an opaque expression to forward, never a
-//!   primitive. Opt-in Babel VDOM mode (#3391) forwards the *primitive* literals
-//!   verbatim, because that is exactly what babel emits and the source text is
-//!   already valid JavaScript; arrays, template literals, raw JSX, functions, and
-//!   sequences stay diagnosed rather than emitted as a malformed module.
+//!   primitive. Opt-in Babel VDOM mode (#3391) forwards the *self-contained*
+//!   literals verbatim, including substitution-free template literals, because
+//!   that is exactly what babel emits and the source text is already valid JavaScript;
+//!   arrays, interpolated template literals, raw JSX, functions, and sequences
+//!   stay diagnosed rather than emitted as a malformed module.
 //! - `v-slots:arg={…}` — `v-slots` takes no argument; the slot names are the
 //!   object's keys.
 //! - `v-slots` on a plain element, which has no slots.
@@ -93,9 +94,10 @@ enum SlotsValue<'e> {
     /// is forwarded into the slots object as a spread. The span is the source to
     /// emit, with any wrapper stripped.
     Forwarded(Span),
-    /// A primitive literal (`v-slots={1}`). Native mode diagnoses it like any
-    /// other non-slots value; Babel VDOM compatibility forwards it verbatim as
-    /// the vnode's children argument, matching the plugin.
+    /// A self-contained literal (`v-slots={1}` or a substitution-free template
+    /// literal). Native mode diagnoses it like any other non-slots value; Babel
+    /// VDOM compatibility forwards it verbatim as the vnode's children
+    /// argument, matching the plugin.
     CompatForwarded(Span),
     /// A literal, an array, a lone function, or a quoted/missing value: babel
     /// forwards these as the component's children, which is not a slots object.
@@ -273,7 +275,7 @@ fn classify_v_slots_value<'e>(value: &'e JSXAttributeValue<'e>) -> SlotsValue<'e
         // The comma operator does not survive being emitted verbatim as a
         // spread (`{...a, b}` is two properties, not one spread).
         Expression::SequenceExpression(_) => SlotsValue::Rejected(inner.span(), NOT_A_SLOTS_OBJECT),
-        _ if is_primitive_literal(inner) => SlotsValue::CompatForwarded(inner.span()),
+        _ if is_compat_forwardable_literal(inner) => SlotsValue::CompatForwarded(inner.span()),
         _ if is_literal_value(inner) => SlotsValue::Rejected(inner.span(), NOT_A_SLOTS_OBJECT),
         _ => SlotsValue::Forwarded(inner.span()),
     }
@@ -287,19 +289,21 @@ const IS_A_FUNCTION: &str = "is a function, not a slots object: a lone function 
 /// Literals whose source text is already valid JavaScript in children position,
 /// so babel's pass-through can be reproduced by forwarding the span verbatim.
 ///
-/// Container literals are deliberately excluded: an array or a template literal
-/// may hold nested JSX that still has to be lowered, and raw JSX is a vnode
-/// rather than a value.
-fn is_primitive_literal(expression: &Expression<'_>) -> bool {
-    matches!(
-        expression,
+/// Container literals are deliberately excluded: an array may hold nested JSX
+/// that still has to be lowered, and raw JSX is a vnode rather than a value. A
+/// template literal only qualifies when it has no substitutions, for the same
+/// reason: its interpolations can contain JSX.
+fn is_compat_forwardable_literal(expression: &Expression<'_>) -> bool {
+    match expression {
         Expression::BigIntLiteral(_)
-            | Expression::BooleanLiteral(_)
-            | Expression::NullLiteral(_)
-            | Expression::NumericLiteral(_)
-            | Expression::RegExpLiteral(_)
-            | Expression::StringLiteral(_)
-    )
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::RegExpLiteral(_)
+        | Expression::StringLiteral(_) => true,
+        Expression::TemplateLiteral(template) => template.expressions.is_empty(),
+        _ => false,
+    }
 }
 
 /// Whether an expression is a literal value that can never be a slots object.

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -13,7 +13,7 @@ opt-in compat mode (#3391) is expected to change.
 
 | Artifact                                  | Role                                                                                                       |
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `babel_compat/fixtures/corpus.json`       | the 98 inputs + the babel plugin options each is compiled with                                             |
+| `babel_compat/fixtures/corpus.json`       | the 100 inputs + the babel plugin options each is compiled with                                            |
 | `babel_compat/oracle.mjs`                 | runs the corpus through the real plugin; `--write` records, `--check` verifies                             |
 | `babel_compat/fixtures/babel-output.json` | committed ground truth (generated — do not hand-edit)                                                      |
 | `../babel_compat_oracle.rs`               | snapshots babel's output beside Vize's, per category, with a verdict per row                               |
@@ -55,7 +55,7 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   96 |
+| equivalent |   98 |
 | divergent  |    0 |
 | deferred   |    2 |
 
@@ -271,15 +271,18 @@ stale — but that check is not committed and does not run in CI (#3391).
 `resolveDirective("slots")` lookup #3418 removed. A user directive named `slots`
 collides with it exactly as one named `show` or `model` would.
 
-### `v-slots` spellings Vize rejects and babel accepts
+### `v-slots` spellings where native Vize is stricter than babel
 
-Not corpus rows, because a compat mode is not expected to adopt them; recorded
-here so the choice is not implicit (#3418, #3467, `src/lower/v_slots.rs`):
+Native mode rejects all the shapes below. Babel VDOM compatibility adopts only
+corpus-pinned self-contained literals; the remaining exclusions stay explicit
+(#3418, #3467, `src/lower/v_slots.rs`):
 
-- `v-slots` with no value, `v-slots="str"`, and any literal value
-  (`v-slots={1}`, `v-slots={[…]}`) — babel forwards these as the component's
-  children, which is meaningless for a component. A slots object is either an
-  object literal to expand or an opaque expression to forward, never a literal.
+- `v-slots` with no value, a quoted value (`v-slots="str"`), or a container
+  literal (`v-slots={[…]}`) remains rejected. Babel VDOM compatibility forwards
+  self-contained expression literals (`v-slots={1}`, including static template
+  literals) as component children; native mode retains the strict slots-object
+  diagnostic. Interpolated templates remain rejected because forwarding their
+  raw source could leak nested JSX.
 - `v-slots={() => …}` — a lone function is the _default slot_, not a slots
   object: babel forwards it as children and Vue wraps it as `{default: fn}`.
   Spreading it would contribute nothing, so Vize names it and points at
@@ -330,15 +333,17 @@ Compared against Vize's default, which is already fully optimized.
 | `optimize/fragment`              | no flag                               | `64 /* STABLE_FRAGMENT */`            | no change          | ✅      |
 | `optimize/map_list`              | raw array child                       | `renderList` + `KEYED_FRAGMENT`       | no change          | ✅      |
 
-## Inputs babel rejects
+## Error cases and permissive babel edges
 
-A compat mode must reject what babel rejects, with a diagnostic — never silently
-accept it.
+The corpus pins rejection parity and babel-permissive edges. Compat mode must not
+silently accept a babel error; permissive rows document opt-in VDOM behavior.
 
-| Case                              | Babel                                                           | Vize today                                                        | Compat mode             | Verdict |
-| --------------------------------- | --------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------- | ------- |
-| `errors/v_model_non_lval`         | rejects a non-assignable `v-model` target                       | rejects it too, naming the offending expression (closed by #3420) | no change               | ✅      |
-| `errors/v_model_no_value`         | rejects: "You have to use JSX Expression inside your v-model"   | rejects: "v-model is missing expression."                         | no change               | ✅      |
-| `errors/v_models_not_array`       | rejects a non-array `v-models` value                            | rejects it too, naming the expected entry shape (closed by #3418) | no change               | ✅      |
-| `errors/v_models_entry_not_array` | rejects: "You should pass a Two-dimensional Arrays to v-models" | rejects it too, naming the offending entry (closed by #3418)      | no change               | ✅      |
-| `errors/v_slots_not_object`       | forwards the value as children                                  | rejects it, naming the offending value (#3418, #3467)             | forward safe primitives | ✅      |
+| Case                                      | Babel                                                           | Vize today                                                        | Compat mode             | Verdict |
+| ----------------------------------------- | --------------------------------------------------------------- | ----------------------------------------------------------------- | ----------------------- | ------- |
+| `errors/v_model_non_lval`                 | rejects a non-assignable `v-model` target                       | rejects it too, naming the offending expression (closed by #3420) | no change               | ✅      |
+| `errors/v_model_no_value`                 | rejects: "You have to use JSX Expression inside your v-model"   | rejects: "v-model is missing expression."                         | no change               | ✅      |
+| `errors/v_models_not_array`               | rejects a non-array `v-models` value                            | rejects it too, naming the expected entry shape (closed by #3418) | no change               | ✅      |
+| `errors/v_models_entry_not_array`         | rejects: "You should pass a Two-dimensional Arrays to v-models" | rejects it too, naming the offending entry (closed by #3418)      | no change               | ✅      |
+| `errors/v_slots_not_object`               | forwards the value as children                                  | rejects it, naming the offending value (#3418, #3467)             | forward safe primitives | ✅      |
+| `errors/v_slots_static_template`          | forwards the static template as children                        | same in Babel VDOM compat; native still rejects                   | forward literal         | ✅      |
+| `errors/v_slots_not_object_with_children` | `{ default: () => ["x"], ...1 }`                                | same spread semantics in Babel VDOM compat                        | no change               | ✅      |

--- a/crates/vize_atelier_jsx/tests/babel_compat/fixtures/babel-output.json
+++ b/crates/vize_atelier_jsx/tests/babel_compat/fixtures/babel-output.json
@@ -394,6 +394,14 @@
     "errors/v_slots_not_object": {
       "status": "ok",
       "code": "import { resolveComponent as _resolveComponent, createVNode as _createVNode } from \"vue\";\nconst A = () => _createVNode(_resolveComponent(\"B\"), null, 1);"
+    },
+    "errors/v_slots_static_template": {
+      "status": "ok",
+      "code": "import { resolveComponent as _resolveComponent, createVNode as _createVNode } from \"vue\";\nconst A = () => _createVNode(_resolveComponent(\"B\"), null, `text`);"
+    },
+    "errors/v_slots_not_object_with_children": {
+      "status": "ok",
+      "code": "import { createTextVNode as _createTextVNode, resolveComponent as _resolveComponent, createVNode as _createVNode } from \"vue\";\nconst A = () => _createVNode(_resolveComponent(\"B\"), null, {\n  default: () => [_createTextVNode(\"x\")],\n  ...1\n});"
     }
   }
 }

--- a/crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json
+++ b/crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json
@@ -626,6 +626,18 @@
       "category": "errors",
       "lang": "jsx",
       "source": "const A = () => <B v-slots={1}/>;"
+    },
+    {
+      "id": "errors/v_slots_static_template",
+      "category": "errors",
+      "lang": "jsx",
+      "source": "const A = () => <B v-slots={`text`}/>;"
+    },
+    {
+      "id": "errors/v_slots_not_object_with_children",
+      "category": "errors",
+      "lang": "jsx",
+      "source": "const A = () => <B v-slots={1}>x</B>;"
     }
   ]
 }

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -7,7 +7,7 @@
 //! Reasons here are short labels; the inventory row carries the full prose.
 
 use super::Verdict;
-use super::Verdict::{Deferred as Todo, Divergent as Diff, Equivalent as Same};
+use super::Verdict::{Deferred as Todo, Equivalent as Same};
 
 /// One entry per corpus case, in corpus order.
 pub const VERDICTS: &[(&str, Verdict)] = &[
@@ -145,4 +145,7 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     // Closed by #3391: Babel VDOM mode forwards the primitive literals babel
     // passes straight into the vnode's children argument.
     ("errors/v_slots_not_object", Same),
+    ("errors/v_slots_static_template", Same),
+    // Authored children make Babel spread the primitive after the default slot.
+    ("errors/v_slots_not_object_with_children", Same),
 ];

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,8 +80,8 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (96, 0, 2));
-    assert_eq!(VERDICTS.len(), 98);
+    assert_eq!((equivalent, divergent, deferred), (98, 0, 2));
+    assert_eq!(VERDICTS.len(), 100);
 }
 
 #[test]

--- a/crates/vize_atelier_jsx/tests/babel_v_slots.rs
+++ b/crates/vize_atelier_jsx/tests/babel_v_slots.rs
@@ -10,9 +10,9 @@
 //!
 //! Opt-in Babel VDOM mode reproduces the pass-through for the literals whose
 //! source text is already valid JavaScript in children position. Everything
-//! babel would forward as a *container* (arrays, template literals, raw JSX,
-//! functions, sequences) stays diagnosed rather than emitted as a malformed
-//! module.
+//! babel would forward as a *container* (arrays, interpolated template literals,
+//! raw JSX, functions, sequences) stays diagnosed rather than emitted as a
+//! malformed module.
 
 use vize_atelier_jsx::{JsxCompatMode, JsxCompileConfig, JsxLang, JsxOutputMode, compile_jsx};
 use vize_carton::Bump;
@@ -50,18 +50,9 @@ fn render_module(children: Option<&str>) -> String {
     )
 }
 
-fn compile(source: &str, compat: JsxCompatMode, mode: JsxOutputMode) -> (String, Vec<String>) {
+fn compile_with_config(source: &str, config: &JsxCompileConfig) -> (String, Vec<String>) {
     let bump = Bump::new();
-    let out = compile_jsx(
-        &bump,
-        source,
-        JsxLang::Jsx,
-        &JsxCompileConfig {
-            compat,
-            default_mode: mode,
-            ..Default::default()
-        },
-    );
+    let out = compile_jsx(&bump, source, JsxLang::Jsx, config);
     (
         out.module_code().to_string(),
         out.diagnostics
@@ -71,12 +62,23 @@ fn compile(source: &str, compat: JsxCompatMode, mode: JsxOutputMode) -> (String,
     )
 }
 
-/// Every primitive literal spelling babel passes straight through.
-const PRIMITIVES: [&str; 6] = ["1", "true", "null", "\"text\"", "1n", "/re/g"];
+fn compile(source: &str, compat: JsxCompatMode, mode: JsxOutputMode) -> (String, Vec<String>) {
+    compile_with_config(
+        source,
+        &JsxCompileConfig {
+            compat,
+            default_mode: mode,
+            ..Default::default()
+        },
+    )
+}
+
+/// Every self-contained literal spelling babel passes straight through.
+const FORWARDABLE_LITERALS: [&str; 7] = ["1", "true", "null", "\"text\"", "1n", "/re/g", "`text`"];
 
 #[test]
-fn primitive_v_slots_values_are_forwarded_in_babel_vdom() {
-    for value in PRIMITIVES {
+fn self_contained_v_slots_literals_are_forwarded_in_babel_vdom() {
+    for value in FORWARDABLE_LITERALS {
         let source = format!("const A = () => <B v-slots={{{value}}}/>;");
         let (module, diagnostics) =
             compile(source.as_str(), JsxCompatMode::Babel, JsxOutputMode::Vdom);
@@ -86,9 +88,9 @@ fn primitive_v_slots_values_are_forwarded_in_babel_vdom() {
 }
 
 #[test]
-fn native_mode_still_rejects_every_primitive_v_slots_value() {
+fn native_mode_still_rejects_every_forwardable_v_slots_literal() {
     // The switch is opt-in: default Vize output and diagnostics are unchanged.
-    for value in PRIMITIVES {
+    for value in FORWARDABLE_LITERALS {
         let source = format!("const A = () => <B v-slots={{{value}}}/>;");
         let (module, diagnostics) =
             compile(source.as_str(), JsxCompatMode::Native, JsxOutputMode::Vdom);
@@ -98,46 +100,64 @@ fn native_mode_still_rejects_every_primitive_v_slots_value() {
 }
 
 #[test]
-fn babel_vapor_output_keeps_rejecting_primitive_v_slots_values() {
+fn babel_vapor_output_keeps_rejecting_forwardable_v_slots_literals() {
     // Compat mode is a VDOM-only contract, so the Vapor request is diagnosed and
     // the value is still rejected rather than half-applied.
-    let (module, diagnostics) = compile(
-        "const A = () => <B v-slots={1}/>;",
-        JsxCompatMode::Babel,
-        JsxOutputMode::Vapor,
+    let expected_module = concat!(
+        "import { resolveComponent as _resolveComponent, createComponentWithFallback as ",
+        "_createComponentWithFallback } from 'vue';\n",
+        "\n",
+        "export function render(_ctx) {\n",
+        "  const _component_B = _resolveComponent(\"B\")\n",
+        "  const n0 = _createComponentWithFallback(_component_B, null, null, true)\n",
+        "  return n0\n",
+        "}\n",
     );
-    assert_eq!(
-        diagnostics,
-        vec![
-            not_a_slots_object("1"),
-            "compiler.jsxCompat: \"babel\" is not supported with Vapor output: \
-             @vue/babel-plugin-jsx has no Vapor equivalent. Use jsxMode \"vdom\" for babel \
-             compatibility, or drop jsxCompat to use Vize's own Vapor semantics."
-                .to_string()
-        ]
-    );
-    assert_eq!(
-        module,
-        concat!(
-            "import { resolveComponent as _resolveComponent, createComponentWithFallback as ",
-            "_createComponentWithFallback } from 'vue';\n",
-            "\n",
-            "export function render(_ctx) {\n",
-            "  const _component_B = _resolveComponent(\"B\")\n",
-            "  const n0 = _createComponentWithFallback(_component_B, null, null, true)\n",
-            "  return n0\n",
-            "}\n",
-        )
-    );
+    for value in ["1", "`text`"] {
+        let source = format!("const A = () => <B v-slots={{{value}}}/>;");
+        let (module, diagnostics) =
+            compile(source.as_str(), JsxCompatMode::Babel, JsxOutputMode::Vapor);
+        assert_eq!(
+            diagnostics,
+            vec![
+                not_a_slots_object(value),
+                "compiler.jsxCompat: \"babel\" is not supported with Vapor output: \
+                 @vue/babel-plugin-jsx has no Vapor equivalent. Use jsxMode \"vdom\" for babel \
+                 compatibility, or drop jsxCompat to use Vize's own Vapor semantics."
+                    .to_string()
+            ],
+            "{value}"
+        );
+        assert_eq!(module, expected_module, "{value}");
+    }
+}
+
+#[test]
+fn babel_ssr_output_keeps_rejecting_forwardable_v_slots_literals() {
+    let config = JsxCompileConfig {
+        compat: JsxCompatMode::Babel,
+        ssr: true,
+        ..Default::default()
+    };
+    let (bare_module, bare_diagnostics) = compile_with_config("const A = () => <B/>;", &config);
+    assert_eq!(bare_diagnostics, Vec::<String>::new());
+
+    for value in ["1", "`text`"] {
+        let source = format!("const A = () => <B v-slots={{{value}}}/>;");
+        let (module, diagnostics) = compile_with_config(source.as_str(), &config);
+        assert_eq!(diagnostics, vec![not_a_slots_object(value)], "{value}");
+        assert_eq!(module, bare_module, "{value}");
+    }
 }
 
 #[test]
 fn container_and_function_v_slots_values_stay_diagnosed_in_babel_vdom() {
     // These are the shapes whose source text is not a self-contained value:
-    // arrays and template literals may hold nested JSX, raw JSX is a vnode, a
-    // lone function is the default slot, and the comma operator changes meaning
-    // when spliced into an argument list. Forwarding them verbatim would emit a
-    // module that does not mean what babel's does, so they keep their error.
+    // arrays and interpolated template literals may hold nested JSX, raw JSX is
+    // a vnode, a lone function is the default slot, and the comma operator
+    // changes meaning when spliced into an argument list. Forwarding them
+    // verbatim would emit a module that does not mean what babel's does, so they
+    // keep their error.
     for (value, message) in [
         ("[a, b]", not_a_slots_object("[a, b]")),
         ("<i/>", not_a_slots_object("<i/>")),

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__errors.snap
@@ -87,3 +87,47 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_B, null, 1, 1024 /* DYNAMIC_SLOTS */))
 }
+
+## errors/v_slots_static_template
+### verdict
+equivalent
+### source (jsx)
+const A = () => <B v-slots={`text`}/>;
+### babel options
+(defaults)
+### babel
+import { resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
+const A = () => _createVNode(_resolveComponent("B"), null, `text`);
+### vize (vdom, babel compat)
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+export function render(_ctx, _cache) {
+  const _component_B = _resolveComponent("B")
+
+  return (_openBlock(), _createBlock(_component_B, null, `text`, 1024 /* DYNAMIC_SLOTS */))
+}
+
+## errors/v_slots_not_object_with_children
+### verdict
+equivalent
+### source (jsx)
+const A = () => <B v-slots={1}>x</B>;
+### babel options
+(defaults)
+### babel
+import { createTextVNode as _createTextVNode, resolveComponent as _resolveComponent, createVNode as _createVNode } from "vue";
+const A = () => _createVNode(_resolveComponent("B"), null, {
+  default: () => [_createTextVNode("x")],
+  ...1
+});
+### vize (vdom, babel compat)
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock, createTextVNode as _createTextVNode, withCtx as _withCtx } from "vue"
+export function render(_ctx, _cache) {
+  const _component_B = _resolveComponent("B")
+
+  return (_openBlock(), _createBlock(_component_B, null, {
+    default: _withCtx(() => [
+      _createTextVNode("x")
+    ]),
+    ...1
+  }, 1024 /* DYNAMIC_SLOTS */))
+}


### PR DESCRIPTION
## Summary

- Forward substitution-free template literal `v-slots` values only in opt-in Babel VDOM mode, matching `@vue/babel-plugin-jsx` 2.0.1 exactly.
- Keep native, Vapor, and SSR strict. SSR now explicitly disables VDOM-only Babel lowering so primitive literals retain the native slots-object diagnostic.
- Pin real Babel output for a static template and for authored children (`{ default: ..., ...1 }`). The corpus now has 100 inputs: 98 equivalent, 0 divergent, and 2 deferred.
- Remove the now-unused divergent-verdict alias after #3731 closed the final recorded divergence.

## Failure before

`cargo test -p vize_atelier_jsx --test babel_v_slots_literals babel_compat_forwards_only_static_template_literals -- --exact` failed because ``v-slots={`text`}`` produced the strict slots-object diagnostic in Babel VDOM mode.

## Validation

- `cargo test -p vize_atelier_jsx`
- `cargo test -p vize_atelier_jsx --test babel_v_slots --test babel_compat_oracle`
- `node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check`
- `node --test tests/tooling/babel-jsx-oracle.test.ts`
- `cargo clippy -p vize_atelier_jsx -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `cargo semver-checks check-release --package vize_atelier_jsx --baseline-rev origin/main --default-features` (196 pass, 56 skip; no update required)

Refs #3391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Babel VDOM compatibility for `v-slots`.
  - Static template literals and safe primitive values can now be forwarded in supported client-side builds.
  - Added compatibility handling for non-object slot values when used with children.

- **Bug Fixes**
  - Prevented VDOM compatibility behavior from being applied to SSR and unsupported compilation modes.
  - Continued rejecting dynamic, function-based, array, JSX, and other unsafe slot values.

- **Tests**
  - Expanded compatibility coverage and verification to 100 cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->