### PR TITLE
fix(release): survive main moving under a release in flight

### DIFF
--- a/bench/compare-pr-lanes.mjs
+++ b/bench/compare-pr-lanes.mjs
@@ -31,6 +31,50 @@ export function laneEnvironment(threads, base) {
   return env;
 }
 
+/**
+ * Budget for the two lanes whose measured noise is wider than the shared 5%.
+ *
+ * The 5% default was sized (#1411) for lanes that take 120-190ms on the
+ * 1000-file corpus. `lint-max` and `fmt-max` clear that same corpus in 37-39ms
+ * with the Rayon pool unpinned, so 5% of their wall time is under 2ms -- inside
+ * process startup and scheduler jitter on a shared 32-vCPU runner. Every
+ * release commit gives a free null measurement, because its diff is version
+ * strings in manifests, `Cargo.lock`, `editors/*` and READMEs and cannot change
+ * throughput. Over the seven such comparisons run since #3622 introduced the
+ * paired estimator (v0.313.0 through v0.317.0):
+ *
+ * | lane             | base median | change on a no-code diff | sd    |
+ * | ---------------- | ----------: | ------------------------ | ----: |
+ * | Format (max)     |      38.9ms | -3.93% .. +4.49%         |  2.58 |
+ * | Lint (max)       |      37.1ms | -3.46% .. +0.60%         |  1.37 |
+ * | Type check (1T)  |     830.2ms | -1.05% .. +3.29%         |  1.46 |
+ * | Lint (1T)        |     122.5ms | -2.78% .. +1.90%         |  1.51 |
+ * | Compile SFC      |     189.9ms | -2.55% .. +1.62%         |  1.41 |
+ * | Type check (max) |     839.2ms | -2.45% .. +0.68%         |  1.08 |
+ * | Format (1T)      |     147.4ms | -1.72% .. +1.23%         |  1.20 |
+ *
+ * `Format (max)` reached +4.49% on a commit that changed no code: 0.5 points
+ * short of cancelling a release. (v0.312.0's gate did cancel one, reporting
+ * +5.37%, but that predates #3622 -- rescoring that run's own samples with the
+ * paired estimator gives -3.93%.) A budget sitting inside its lane's noise band
+ * reports coin flips, not regressions.
+ *
+ * 10% is 2.2x the widest excursion measured on a diff that changes no code, and
+ * more than three standard deviations above the noisier of the two lanes. It
+ * stays far below what these lanes exist to catch: #3460's published
+ * `vize lint (max)` moved +16% and `vize fmt (max)` +58% over a window the
+ * pinned lanes scored as neutral-to-better, and both still fail at 10%.
+ *
+ * `check-max` is unpinned too but keeps the 5% default: at 839ms it is nowhere
+ * near the noise floor, and the same seven comparisons put it inside +-2.45%.
+ */
+export const UNPINNED_FAST_LANE_THRESHOLD_PERCENT = 10;
+
+/** The regression budget one lane is judged against. */
+export function laneThresholdPercent(task, defaultThresholdPercent) {
+  return task.thresholdPercent ?? defaultThresholdPercent;
+}
+
 export function makeTasks(inputDir, taskFilter) {
   const tsconfig = join(inputDir, "tsconfig.json");
   const pattern = ".";
@@ -58,6 +102,7 @@ export function makeTasks(inputDir, taskFilter) {
       label: "Lint (max)",
       args: ["lint", pattern, "--quiet"],
       threads: "max",
+      thresholdPercent: UNPINNED_FAST_LANE_THRESHOLD_PERCENT,
       allowNonZeroExit: true,
     },
     {
@@ -83,6 +128,7 @@ export function makeTasks(inputDir, taskFilter) {
       label: "Format (max)",
       args: ["fmt", "*.vue", "--check"],
       threads: "max",
+      thresholdPercent: UNPINNED_FAST_LANE_THRESHOLD_PERCENT,
       allowNonZeroExit: true,
     },
     {

--- a/bench/compare-pr-results.mjs
+++ b/bench/compare-pr-results.mjs
@@ -1,6 +1,32 @@
 /**
- * Pure result classification and confirmation for the PR benchmark gate.
+ * Pure result classification, formatting, and confirmation for the PR
+ * benchmark gate.
  */
+
+export function formatRate(value) {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+  return `${value.toFixed(3)}x`;
+}
+
+export function formatPercent(value) {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+/**
+ * One budget failure, naming the budget it broke. Lanes no longer share a
+ * single threshold, so a bare rate does not say what the gate compared against.
+ */
+export function formatRegressionLine(regression) {
+  const budget =
+    regression.thresholdPercent == null ? "" : ` over a ${regression.thresholdPercent}% budget`;
+  return `- ${regression.label}: ${formatRate(regression.rate)} (${formatPercent(regression.changePercent)})${budget}`;
+}
 
 function median(values) {
   const sorted = [...values].sort((a, b) => a - b);
@@ -37,6 +63,7 @@ export function summarizeBenchmarkRuns({ id, label, baseRuns, headRuns, threshol
     rate,
     changePercent,
     status,
+    thresholdPercent,
     baseRuns,
     headRuns,
     pairRates,
@@ -58,7 +85,9 @@ export function confirmRegressions(measurements, remeasure, thresholdPercent) {
       label: result.label,
       baseRuns: [...result.baseRuns, ...confirmation.baseRuns],
       headRuns: [...result.headRuns, ...confirmation.headRuns],
-      thresholdPercent,
+      // A lane is judged against its own budget, so pooling the confirmation
+      // samples must not silently re-judge it against the shared default.
+      thresholdPercent: result.thresholdPercent ?? thresholdPercent,
     });
     return {
       ...combined,

--- a/bench/compare-pr.mjs
+++ b/bench/compare-pr.mjs
@@ -12,8 +12,14 @@ import { basename, delimiter, dirname, join, parse, resolve } from "node:path";
 import { performance } from "node:perf_hooks";
 import { pathToFileURL } from "node:url";
 
-import { laneEnvironment, makeTasks } from "./compare-pr-lanes.mjs";
-import { confirmRegressions, summarizeBenchmarkRuns } from "./compare-pr-results.mjs";
+import { laneEnvironment, laneThresholdPercent, makeTasks } from "./compare-pr-lanes.mjs";
+import {
+  confirmRegressions,
+  formatPercent,
+  formatRate,
+  formatRegressionLine,
+  summarizeBenchmarkRuns,
+} from "./compare-pr-results.mjs";
 
 const DEFAULT_RUNS = 5;
 const DEFAULT_WARMUPS = 1;
@@ -71,23 +77,8 @@ function formatMs(ms) {
   })}ms`;
 }
 
-function formatRate(value) {
-  if (!Number.isFinite(value)) {
-    return "n/a";
-  }
-  return `${value.toFixed(3)}x`;
-}
-
 function formatRunList(values) {
   return values.map(formatMs).join(", ");
-}
-
-function formatPercent(value) {
-  if (!Number.isFinite(value)) {
-    return "n/a";
-  }
-  const sign = value > 0 ? "+" : "";
-  return `${sign}${value.toFixed(2)}%`;
 }
 
 function pathWithNodeBins(cwd) {
@@ -159,7 +150,7 @@ function measureTask(task, baseBin, headBin, options) {
     label: task.label,
     baseRuns,
     headRuns,
-    thresholdPercent: options.thresholdPercent,
+    thresholdPercent: laneThresholdPercent(task, options.thresholdPercent),
   });
 }
 
@@ -171,6 +162,7 @@ export function createBenchmarkBudget(results) {
       label: result.label,
       rate: result.rate,
       changePercent: result.changePercent,
+      thresholdPercent: result.thresholdPercent,
     }));
 
   return {
@@ -178,6 +170,20 @@ export function createBenchmarkBudget(results) {
     regressionCount: regressions.length,
     regressions,
   };
+}
+
+/**
+ * Lanes judged against something other than the shared default, so a report
+ * never implies one budget covered every row. Derived from the results rather
+ * than restated, so it cannot drift from what actually gated the run.
+ */
+export function laneBudgetOverrides(results, defaultThresholdPercent) {
+  return results
+    .filter(
+      (result) =>
+        result.thresholdPercent != null && result.thresholdPercent !== defaultThresholdPercent,
+    )
+    .map((result) => `${result.label} ${result.thresholdPercent}%`);
 }
 
 export function renderMarkdown(data) {
@@ -188,8 +194,9 @@ export function renderMarkdown(data) {
   lines.push(
     `Base: \`${data.baseLabel}\`  Head: \`${data.headLabel}\`  Input: ${data.fileCount.toLocaleString()} generated SFC files`,
   );
+  const overrides = laneBudgetOverrides(data.results, data.thresholdPercent);
   lines.push(
-    `Median of ${data.runs} adjacent head/base pairs after ${data.warmups} warmup pair(s). Any threshold breach receives ${data.runs} fresh confirmation pairs, and the final rate is the paired median over all samples. Times are shown in milliseconds to 0.001ms. Rate below 1.000x is faster. Regression threshold: ${data.thresholdPercent}%.`,
+    `Median of ${data.runs} adjacent head/base pairs after ${data.warmups} warmup pair(s). Any threshold breach receives ${data.runs} fresh confirmation pairs, and the final rate is the paired median over all samples. Times are shown in milliseconds to 0.001ms. Rate below 1.000x is faster. Regression threshold: ${data.thresholdPercent}%${overrides.length === 0 ? "" : `, except ${overrides.join(", ")}`}.`,
   );
   lines.push(
     `Budget: ${budget.status}${budget.regressionCount > 0 ? ` (${budget.regressionCount} regression${budget.regressionCount === 1 ? "" : "s"})` : ""}.`,
@@ -206,9 +213,7 @@ export function renderMarkdown(data) {
     lines.push("");
     lines.push("Regression budget failures:");
     for (const regression of budget.regressions) {
-      lines.push(
-        `- ${regression.label}: ${formatRate(regression.rate)} (${formatPercent(regression.changePercent)})`,
-      );
+      lines.push(formatRegressionLine(regression));
     }
   }
   lines.push("");

--- a/bench/enforce-pr-budget.mjs
+++ b/bench/enforce-pr-budget.mjs
@@ -7,6 +7,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
+import { formatRegressionLine } from "./compare-pr-results.mjs";
 import { createBenchmarkBudget } from "./compare-pr.mjs";
 
 export const DEFAULT_SKIP_OVERRIDE_LABEL = "ci:allow-skipped-benchmark";
@@ -36,21 +37,6 @@ function requireArg(args, key) {
     throw new Error(`Missing required argument: --${key}`);
   }
   return value;
-}
-
-function formatPercent(value) {
-  if (!Number.isFinite(value)) {
-    return "n/a";
-  }
-  const sign = value > 0 ? "+" : "";
-  return `${sign}${value.toFixed(2)}%`;
-}
-
-function formatRate(value) {
-  if (!Number.isFinite(value)) {
-    return "n/a";
-  }
-  return `${value.toFixed(3)}x`;
 }
 
 function parseLabelsJson(value) {
@@ -94,12 +80,7 @@ export function enforceBenchmarkBudget(data, options = {}) {
     };
   }
 
-  const failures = budget.regressions
-    .map(
-      (regression) =>
-        `- ${regression.label}: ${formatRate(regression.rate)} (${formatPercent(regression.changePercent)})`,
-    )
-    .join("\n");
+  const failures = budget.regressions.map(formatRegressionLine).join("\n");
 
   return {
     ok: false,

--- a/tests/tooling/benchmark-lane-budget.test.ts
+++ b/tests/tooling/benchmark-lane-budget.test.ts
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  UNPINNED_FAST_LANE_THRESHOLD_PERCENT,
+  laneThresholdPercent,
+  makeTasks,
+} from "../../bench/compare-pr-lanes.mjs";
+import { confirmRegressions, summarizeBenchmarkRuns } from "../../bench/compare-pr-results.mjs";
+import { createBenchmarkBudget, renderMarkdown } from "../../bench/compare-pr.mjs";
+import { enforceBenchmarkBudget } from "../../bench/enforce-pr-budget.mjs";
+import { readRepoFile } from "./support/github-workflows.ts";
+
+const DEFAULT_THRESHOLD_PERCENT = 5;
+
+/**
+ * Real samples from the `Benchmark` gate of a release commit, whose diff is
+ * version strings in manifests, `Cargo.lock`, `editors/*` and READMEs. Nothing
+ * in it reaches the measured binary's throughput, so every point of the rate it
+ * produces is runner noise.
+ *
+ * v0.315.1, run 30713745830 (70aaa2e5...f97253d5), lane `fmt-max`.
+ */
+const manifestOnlyFormatMax = {
+  id: "fmt-max",
+  label: "Format (max)",
+  baseRuns: [
+    39.97164899999916, 37.96923400000014, 36.34706499999993, 37.50640199999907, 35.47929900000054,
+    40.74189099999967, 36.78259699999944, 36.578010999999606, 37.464882000000216,
+    44.984419000000344,
+  ],
+  headRuns: [
+    38.40237999999954, 37.779505999998946, 38.43414000000121, 37.437221000000136, 37.85763399999996,
+    34.46102900000005, 39.0690969999996, 37.8511010000002, 39.52768199999991, 49.52019099999961,
+  ],
+};
+
+/** The same shape of no-code diff, at the rate that cancelled v0.312.0. */
+const releaseCancellingLintMax = {
+  id: "lint-max",
+  label: "Lint (max)",
+  baseRuns: Array(10).fill(37),
+  headRuns: Array(10).fill(37 * 1.0537),
+};
+
+const twentyPercentRegression = {
+  id: "lint-max",
+  label: "Lint (max)",
+  baseRuns: Array(10).fill(37),
+  headRuns: Array(10).fill(37 * 1.2),
+};
+
+test("only the two sub-40ms unpinned lanes carry a widened budget", () => {
+  assert.deepEqual(
+    makeTasks("/nonexistent-input-dir", "").map((task) => [
+      task.id,
+      task.threads ?? 1,
+      laneThresholdPercent(task, DEFAULT_THRESHOLD_PERCENT),
+    ]),
+    [
+      ["compile", 1, 5],
+      ["lint", 1, 5],
+      ["lint-max", "max", 10],
+      ["fmt", 1, 5],
+      ["fmt-max", "max", 10],
+    ],
+  );
+  assert.equal(UNPINNED_FAST_LANE_THRESHOLD_PERCENT, 10);
+});
+
+test("the workflow still supplies the 5% default the pinned lanes are sized for", () => {
+  const workflow = readRepoFile(".github", "workflows", "benchmark.yml");
+  assert.equal(
+    workflow.includes("\n  VIZE_BENCH_REGRESSION_THRESHOLD_PERCENT: 5\n"),
+    true,
+    "pinned lanes must keep the 5% budget the lane catalogue documents",
+  );
+});
+
+test("a manifest-only release diff does not fail the budget", () => {
+  const result = summarizeBenchmarkRuns({
+    ...manifestOnlyFormatMax,
+    thresholdPercent: UNPINNED_FAST_LANE_THRESHOLD_PERCENT,
+  });
+
+  assert.equal(result.changePercent, 4.4932176205962016);
+  assert.equal(result.status, "stable");
+  assert.deepEqual(createBenchmarkBudget([result]), {
+    status: "passed",
+    regressionCount: 0,
+    regressions: [],
+  });
+  assert.deepEqual(enforceBenchmarkBudget({ results: [result] }), {
+    ok: true,
+    message: "Benchmark budget passed.",
+  });
+
+  // The same samples land 0.51 points inside the budget the pinned lanes use,
+  // which is why this lane needed its own.
+  assert.equal(
+    summarizeBenchmarkRuns({
+      ...manifestOnlyFormatMax,
+      thresholdPercent: DEFAULT_THRESHOLD_PERCENT,
+    }).status,
+    "stable",
+  );
+});
+
+test("the no-code rate that cancelled v0.312.0 no longer fails its lane", () => {
+  const atLaneBudget = summarizeBenchmarkRuns({
+    ...releaseCancellingLintMax,
+    thresholdPercent: UNPINNED_FAST_LANE_THRESHOLD_PERCENT,
+  });
+  assert.equal(atLaneBudget.changePercent, 5.370000000000008);
+  assert.equal(atLaneBudget.status, "stable");
+  assert.deepEqual(createBenchmarkBudget([atLaneBudget]), {
+    status: "passed",
+    regressionCount: 0,
+    regressions: [],
+  });
+
+  // Unchanged for the lanes the 5% figure was actually calibrated on.
+  assert.equal(
+    summarizeBenchmarkRuns({
+      ...releaseCancellingLintMax,
+      id: "lint",
+      label: "Lint (1T)",
+      thresholdPercent: DEFAULT_THRESHOLD_PERCENT,
+    }).status,
+    "regression",
+  );
+});
+
+test("a 20% regression still fails the widened lane budget", () => {
+  const initial = summarizeBenchmarkRuns({
+    ...twentyPercentRegression,
+    thresholdPercent: UNPINNED_FAST_LANE_THRESHOLD_PERCENT,
+  });
+  assert.equal(initial.changePercent, 19.999999999999996);
+  assert.equal(initial.status, "regression");
+
+  // Confirmation pools the samples; it must keep judging the lane against the
+  // lane's own budget rather than falling back to the shared default.
+  const [confirmed] = confirmRegressions(
+    [{ task: twentyPercentRegression, result: initial }],
+    () =>
+      summarizeBenchmarkRuns({
+        ...twentyPercentRegression,
+        thresholdPercent: UNPINNED_FAST_LANE_THRESHOLD_PERCENT,
+      }),
+    DEFAULT_THRESHOLD_PERCENT,
+  );
+  assert.equal(confirmed.thresholdPercent, UNPINNED_FAST_LANE_THRESHOLD_PERCENT);
+  assert.equal(confirmed.status, "regression");
+  assert.deepEqual(createBenchmarkBudget([confirmed]), {
+    status: "failed",
+    regressionCount: 1,
+    regressions: [
+      {
+        id: "lint-max",
+        label: "Lint (max)",
+        rate: 1.2,
+        changePercent: 19.999999999999996,
+        thresholdPercent: 10,
+      },
+    ],
+  });
+  assert.deepEqual(enforceBenchmarkBudget({ results: [confirmed] }), {
+    ok: false,
+    message:
+      "Benchmark regression budget failed for 1 task(s) after paired confirmation:\n" +
+      "- Lint (max): 1.200x (+20.00%) over a 10% budget",
+  });
+});
+
+test("the report names every lane judged against something other than the default", () => {
+  const results = [
+    summarizeBenchmarkRuns({
+      ...manifestOnlyFormatMax,
+      thresholdPercent: UNPINNED_FAST_LANE_THRESHOLD_PERCENT,
+    }),
+    summarizeBenchmarkRuns({
+      ...releaseCancellingLintMax,
+      id: "lint",
+      label: "Lint (1T)",
+      thresholdPercent: DEFAULT_THRESHOLD_PERCENT,
+    }),
+  ];
+  const markdown = renderMarkdown({
+    baseLabel: "base",
+    headLabel: "head",
+    fileCount: 1000,
+    runs: 10,
+    warmups: 2,
+    thresholdPercent: DEFAULT_THRESHOLD_PERCENT,
+    results,
+  });
+  assert.equal(
+    markdown.split("\n").find((line) => line.startsWith("Median of ")),
+    "Median of 10 adjacent head/base pairs after 2 warmup pair(s). Any threshold breach receives " +
+      "10 fresh confirmation pairs, and the final rate is the paired median over all samples. " +
+      "Times are shown in milliseconds to 0.001ms. Rate below 1.000x is faster. " +
+      "Regression threshold: 5%, except Format (max) 10%.",
+  );
+});

--- a/tests/tooling/release-preflight-core.test.ts
+++ b/tests/tooling/release-preflight-core.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test";
 import {
   assertReleaseCommitIsOnMainFirstParent,
   assertReleaseMetadata,
+  assertReleaseVersionStillOwnsMain,
   findReleaseBlockers,
   remoteTagCommit,
   workspaceVersionFromCargoToml,
@@ -94,7 +95,41 @@ test("release commit may remain on main's first-parent history when main advance
 test("release commit rejects ancestry that exists only through a merge's second parent", () => {
   assert.throws(
     () => assertReleaseCommitIsOnMainFirstParent("c".repeat(40), "b".repeat(40), false),
-    /not on the first-parent history of current origin\/main/,
+    new Error(
+      `Release commit ${"c".repeat(40)} is not on the first-parent history of current origin/main ${"b".repeat(40)}`,
+    ),
+  );
+});
+
+// The merge automation lands PRs throughout the preflight's 30-40 minute gate
+// wait, and none of them changes what this release publishes: the artifacts are
+// built from the immutable tagged tree and every required gate is evaluated at
+// the release SHA. A second release commit is different -- it moves the version
+// line on, and finishing the older release then ships a lower version after a
+// higher one.
+test("ordinary drift on main keeps the release, a newer release takes it away", () => {
+  const mainSha = "b".repeat(40);
+  assert.doesNotThrow(() =>
+    assertReleaseVersionStillOwnsMain({
+      tag: "v1.2.3",
+      sha,
+      mainSha,
+      releaseVersion: "1.2.3",
+      mainVersion: "1.2.3",
+    }),
+  );
+  assert.throws(
+    () =>
+      assertReleaseVersionStillOwnsMain({
+        tag: "v1.2.3",
+        sha,
+        mainSha,
+        releaseVersion: "1.2.3",
+        mainVersion: "1.3.0",
+      }),
+    new Error(
+      `Release v1.2.3 (${sha}) is superseded: origin/main ${mainSha} is at workspace version 1.3.0, not 1.2.3. Publishing it now would ship an older version after a newer one; cut the next release instead.`,
+    ),
   );
 });
 

--- a/tests/tooling/release-preflight-runner.test.ts
+++ b/tests/tooling/release-preflight-runner.test.ts
@@ -49,6 +49,7 @@ test("target-only mode verifies HEAD, main first-parent history, and the peeled 
       "  console.log(`${process.env.TEST_TAG_OBJECT}\\trefs/tags/${process.env.TEST_TAG}`);",
       "  console.log(`${process.env.TEST_TAG_SHA}\\trefs/tags/${process.env.TEST_TAG}^{}`);",
       "} else if (command === 'rev-list --first-parent refs/remotes/origin/main') console.log(process.env.TEST_MAIN_FIRST_PARENT_HISTORY);",
+      "else if (command === 'show refs/remotes/origin/main:Cargo.toml') process.stdout.write(process.env.TEST_MAIN_CARGO_TOML);",
       "else if (args[0] === 'rev-list') console.log(`${process.env.TEST_RELEASE_SHA} ${process.env.TEST_BASE_SHA}`);",
       "else if (args[0] === 'merge-base') process.exit(0);",
       "else process.exit(2);",
@@ -68,6 +69,7 @@ test("target-only mode verifies HEAD, main first-parent history, and the peeled 
         TEST_RELEASE_SHA: sha,
         TEST_MAIN_SHA: sha,
         TEST_MAIN_FIRST_PARENT_HISTORY: [sha, "b".repeat(40)].join("\n"),
+        TEST_MAIN_CARGO_TOML: `[workspace.package]\nversion = "${version}"\n`,
         TEST_TAG: `v${version}`,
         TEST_TAG_OBJECT: "c".repeat(40),
         TEST_TAG_SHA: sha,
@@ -77,26 +79,55 @@ test("target-only mode verifies HEAD, main first-parent history, and the peeled 
       },
     });
 
+  const outcome = (result: ReturnType<typeof run>) => [result.status, result.stderr];
+
   try {
     const success = run();
-    assert.equal(success.status, 0, `${success.stderr}\n${success.stdout}`.trim());
-    const advancedMain = run({ TEST_MAIN_SHA: "d".repeat(40) });
-    assert.equal(advancedMain.status, 0, `${advancedMain.stderr}\n${advancedMain.stdout}`.trim());
-    const headMismatch = run({ TEST_HEAD_SHA: "f".repeat(40) });
-    assert.equal(headMismatch.status, 1);
-    assert.match(headMismatch.stderr, /Checked out HEAD .* does not match release event SHA/);
-    const secondParentOnly = run({
-      TEST_MAIN_SHA: "d".repeat(40),
-      TEST_MAIN_FIRST_PARENT_HISTORY: ["d".repeat(40), "b".repeat(40)].join("\n"),
-    });
-    assert.equal(secondParentOnly.status, 1);
-    assert.match(
-      secondParentOnly.stderr,
-      /not on the first-parent history of current origin\/main/,
+    assert.deepEqual(outcome(success), [0, ""], `${success.stderr}\n${success.stdout}`.trim());
+
+    // The repository's merge automation lands PRs throughout the 30-40 minute
+    // gate wait. Ordinary drift keeps the workspace version, so the release
+    // still owns its version line and the gates measured at the tag still say
+    // what they said.
+    assert.deepEqual(outcome(run({ TEST_MAIN_SHA: "d".repeat(40) })), [0, ""]);
+
+    // A second release commit is the one kind of drift that does invalidate
+    // this one: finishing now publishes a lower version after a higher one.
+    assert.deepEqual(
+      outcome(
+        run({
+          TEST_MAIN_SHA: "d".repeat(40),
+          TEST_MAIN_CARGO_TOML: '[workspace.package]\nversion = "99.99.99"\n',
+        }),
+      ),
+      [
+        1,
+        `Release v${version} (${sha}) is superseded: origin/main ${"d".repeat(40)} is at workspace version 99.99.99, not ${version}. Publishing it now would ship an older version after a newer one; cut the next release instead.\n`,
+      ],
     );
-    const tagMismatch = run({ TEST_TAG_SHA: "e".repeat(40) });
-    assert.equal(tagMismatch.status, 1);
-    assert.match(tagMismatch.stderr, /Remote tag .* points to/);
+
+    assert.deepEqual(outcome(run({ TEST_HEAD_SHA: "f".repeat(40) })), [
+      1,
+      `Checked out HEAD ${"f".repeat(40)} does not match release event SHA ${sha}\n`,
+    ]);
+
+    assert.deepEqual(
+      outcome(
+        run({
+          TEST_MAIN_SHA: "d".repeat(40),
+          TEST_MAIN_FIRST_PARENT_HISTORY: ["d".repeat(40), "b".repeat(40)].join("\n"),
+        }),
+      ),
+      [
+        1,
+        `Release commit ${sha} is not on the first-parent history of current origin/main ${"d".repeat(40)}\n`,
+      ],
+    );
+
+    assert.deepEqual(outcome(run({ TEST_TAG_SHA: "e".repeat(40) })), [
+      1,
+      `Remote tag v${version} points to ${"e".repeat(40)}, expected ${sha}\n`,
+    ]);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/tools/github/release-preflight-core.mjs
+++ b/tools/github/release-preflight-core.mjs
@@ -65,6 +65,49 @@ export function assertReleaseCommitIsOnMainFirstParent(sha, mainSha, isOnFirstPa
 }
 
 /**
+ * What "the drift does not affect the release" means.
+ *
+ * The preflight waits 30-40 minutes for eight workflows to report success at
+ * the exact release SHA, and the repository's merge automation lands PRs
+ * throughout that window. #3540 stopped demanding an exact `main` tip and
+ * settled for first-parent ancestry, which removed the failure mode but left
+ * the acceptance rule saying nothing: any commit ever on `main` was accepted.
+ *
+ * Ordinary drift genuinely cannot affect a release. Everything the release
+ * publishes is built from the tagged tree; the tag is immutable and verified to
+ * still resolve to `sha`; every required gate is evaluated at `sha`, not at
+ * `main`; and release-blocking issues are evaluated live. A fix merged after
+ * the tag simply ships in the next version.
+ *
+ * One kind of drift is different: another release. A second `chore: release`
+ * commit means `main` has moved the version line on, and finishing the older
+ * release then publishes a lower version *after* a higher one -- npm's `latest`
+ * dist-tag, the crates.io release order and the "latest" GitHub Release all end
+ * up describing the superseded build. v0.316.0 and v0.317.0 were tagged seven
+ * minutes apart and were in flight together, so this is the live case, not a
+ * hypothetical.
+ *
+ * The workspace version at `main`'s tip is what makes that decidable: only the
+ * release tool writes it, and it is exactly "which release owns `main` now".
+ * Equal means the drift is ordinary work and the release still owns its
+ * version; different means a newer release has taken over and this one must not
+ * publish. Checking it before the gate wait also stops the superseded release
+ * in seconds instead of after 35 minutes of CI.
+ */
+export function assertReleaseVersionStillOwnsMain({
+  tag,
+  sha,
+  mainSha,
+  releaseVersion,
+  mainVersion,
+}) {
+  if (mainVersion === releaseVersion) return;
+  throw new Error(
+    `Release ${tag} (${sha}) is superseded: origin/main ${mainSha} is at workspace version ${mainVersion}, not ${releaseVersion}. Publishing it now would ship an older version after a newer one; cut the next release instead.`,
+  );
+}
+
+/**
  * Issues that must be closed before `tag` may ship.
  *
  * A `fix(fuzz):` reproducer blocks every release: it is a live defect, not a

--- a/tools/github/release-preflight.mjs
+++ b/tools/github/release-preflight.mjs
@@ -13,8 +13,10 @@ import {
 import {
   assertReleaseCommitIsOnMainFirstParent,
   assertReleaseMetadata,
+  assertReleaseVersionStillOwnsMain,
   findReleaseBlockers,
   remoteTagCommit,
+  workspaceVersionFromCargoToml,
 } from "./release-preflight-core.mjs";
 import {
   assertRequiredWorkflowJobs,
@@ -49,7 +51,7 @@ function runGit(args, acceptedExitCodes = [0], cwd = root) {
   return result;
 }
 
-function verifyGitReleaseTarget(tag, sha) {
+function verifyGitReleaseTarget(tag, sha, version) {
   const head = runGit(["rev-parse", "HEAD"]).stdout.trim();
   if (head !== sha) {
     throw new Error(`Checked out HEAD ${head} does not match release event SHA ${sha}`);
@@ -64,6 +66,17 @@ function verifyGitReleaseTarget(tag, sha) {
     .stdout.trim()
     .split(/\r?\n/);
   assertReleaseCommitIsOnMainFirstParent(sha, mainSha, mainFirstParentHistory.includes(sha));
+  // ...and the one kind of drift that does invalidate this release: another
+  // release taking over the version line. See assertReleaseVersionStillOwnsMain.
+  assertReleaseVersionStillOwnsMain({
+    tag,
+    sha,
+    mainSha,
+    releaseVersion: version,
+    mainVersion: workspaceVersionFromCargoToml(
+      runGit(["show", "refs/remotes/origin/main:Cargo.toml"]).stdout,
+    ),
+  });
 
   const remoteTag = runGit([
     "ls-remote",
@@ -129,7 +142,7 @@ export function verifyReleaseTarget(env = process.env) {
     cargoToml: fs.readFileSync(path.join(root, "Cargo.toml"), "utf8"),
     packageManifests: readPackageManifests(),
   });
-  verifyGitReleaseTarget(tag, sha);
+  verifyGitReleaseTarget(tag, sha, version);
   return { tag, sha, version, baseSha: releaseParentSha(sha) };
 }
 
@@ -218,7 +231,7 @@ export async function verifyReleasePreflight(env = process.env, { bootstrap = tr
         .join("\n")}`,
     );
   }
-  verifyGitReleaseTarget(tag, sha);
+  verifyGitReleaseTarget(tag, sha, version);
   console.log(`Release preflight passed for ${tag} (${sha}) at workspace version ${version}.`);
   console.log(`Required workflows: ${requiredReleaseWorkflows.join(", ")}`);
 }


### PR DESCRIPTION
Closes #3732

## First: one premise in the issue is out of date

The issue says the preflight "calls `assertReleaseCommitIsCurrentMain(sha, mainSha)`, ... a strict
`sha !== mainSha` throw". That function no longer exists. #3540 (`fix(release): accept former main
tips in preflight`, merged 2026-07-31 14:01Z) replaced it with
`assertReleaseCommitIsOnMainFirstParent`, which accepts any commit on `main`'s first-parent history.

That is checkable against the record rather than argued:

- The last release actually killed by drift was run
  [30607798766](https://github.com/ubugeeei-prod/vize/actions/runs/30607798766), whose preflight log
  reads `Release commit 0f0f418bee0b16e589d269aee7a068df2cf00791 is not the current origin/main
  375b0fb5b0d04af9014d81ef865d17dba02f3b0a`. That string has not appeared in a preflight log since
  #3540 landed.
- The later failures in the issue's table have different causes in their logs:
  v0.313.0 `- Real Project Matrix: completed/failure`, v0.313.1 `- App E2E: completed/failure`,
  v0.312.0 `- Benchmark: completed/failure`, v0.315.0 `Release @vizejs/nuxt-lint-config to npm`.
- **v0.316.0 and v0.317.0 are both still running as I write this**, with `main` three commits past
  v0.316.0 (`2be269255` -> `7302f7215` -> `83b6953b0` -> `8e9c10e18`) and one past v0.317.0,
  including the bot-authored and bot-merged #3734. Neither preflight has failed the `main` check.

So the drift *symptom* is already gone. What #3540 left behind is an acceptance rule with no content:
"this commit was on `main` at some point" admits everything, including cases that really should stop
a release. The issue asks for "a real answer for what 'does not affect the release' means". This PR
supplies it, and the tests that were never written for either version of the rule.

## Half 1: what drift is safe, and why it survives an actor we do not control

**Chosen: keep the ancestry allowance, and name the single exception.**

Ordinary drift cannot affect a release, and the reason is structural rather than statistical:

- the published artifacts (crates, npm packages, editor extensions, wasm, CLI binaries) are built
  from the tagged tree, and the tag is immutable and re-verified to still resolve to `sha`;
- every required gate is a `head_sha == release SHA` run, selected by `latestRequiredWorkflowRun`. A
  commit landing on `main` afterwards is not in the tree those gates measured, so it cannot make
  their verdicts stale;
- release-blocking issues are evaluated live at preflight time, not at tag time, so a defect found
  during the window still stops the release.

A fix merged after the tag simply ships in the next version. That is what a version *is*.

One kind of drift is not like that: **another release**. A second `chore: release` commit moves the
version line on, and finishing the older release then publishes a lower version after a higher one --
npm's `latest` dist-tag, the crates.io publish order and the "latest" GitHub Release all end up
describing the superseded build. Not hypothetical: v0.316.0 and v0.317.0 were tagged seven minutes
apart and are in flight together right now, and today's rule lets both publish.

The decidable form of that: **the workspace version at `main`'s tip must still be the version being
released.** Only `tools/moon/cmd/release` writes `[workspace.package].version`, and
`release-local-guard.mjs` requires an exact `main` tip before it does, so that field is precisely
"which release owns `main` now". Equal means the drift is ordinary work; different means a newer
release has taken over. `verifyGitReleaseTarget` reads it with
`git show refs/remotes/origin/main:Cargo.toml` -- no extra fetch, no tag enumeration, no commit
message parsing.

**Why this survives an actor we cannot control.** It requires nothing of the bot. It does not ask it
to observe a flag, respect a queue, or delay a merge. The bot may open and merge PRs at any rate,
including inside the window, and the release still passes -- because the release stopped depending on
`main`'s tip for anything except the one property the bot cannot produce. Only the release tool
changes the workspace version, and it only runs when a human cuts a release.

It also fails *fast*: the check runs in `verifyReleaseTarget`, before `bootstrapRequiredWorkflowRuns`,
so a superseded release stops in seconds rather than after 35 minutes of CI.

**Rejected:**

- *A merge queue.* Correct in principle and the largest change available: it serialises every merge in
  the repository to fix a constraint that exists for ~35 minutes per release, needs branch-protection
  and repository settings this PR cannot carry, and adds latency to every PR. It also does not address
  a second release being cut while the first is in flight, which is the failure this PR actually stops.
- *A repository-level "release in progress" flag.* Only works if the merge automation reads it.
  Nothing in this repository shows where that bot's merge decision is made, so it is unproven -- and
  #3734 was authored *and* merged by it inside a window that had no open non-draft PRs when the tag
  was cut. A fix whose correctness depends on an unobservable actor's cooperation is not a fix.
- *Dropping the ancestry requirement entirely.* Would accept a release commit that reached `main` only
  through a merge's second parent, i.e. one that was never a `main` tip. First-parent membership is the
  proof that this commit was, at some moment, exactly what the repository shipped. Keep it.
- *Requiring the drift to touch no published paths.* This is the reading of "does not affect the
  release" the issue text suggests, and it is the wrong one: it rejects every ordinary merge (the
  bot's PRs touch `crates/**`), which is the failure mode we are removing. The release does not
  contain post-tag commits, so their paths are irrelevant.

## Half 2: a required gate that cannot fail on a no-op commit

`lint-max` and `fmt-max` clear the 1000-file corpus in 37-39ms with the Rayon pool unpinned. The 5%
budget was sized (#1411) for lanes taking 120-190ms, so on these two it is under 2ms of wall time --
inside process startup and scheduler jitter on a shared 32-vCPU runner.

Every release commit is a free null measurement: its diff is version strings in manifests,
`Cargo.lock`, `editors/*` and READMEs, and cannot change throughput. Across the seven such
comparisons run since #3622 introduced the paired estimator (v0.313.0 .. v0.317.0), read from the
`pr-benchmark` artifacts:

| lane | base median | change on a diff that changes no code | sd |
| --- | ---: | --- | ---: |
| Format (max) | 38.9ms | -3.93% .. **+4.49%** | 2.58 |
| Lint (max) | 37.1ms | -3.46% .. +0.60% | 1.37 |
| Type check (1T) | 830.2ms | -1.05% .. +3.29% | 1.46 |
| Lint (1T) | 122.5ms | -2.78% .. +1.90% | 1.51 |
| Compile SFC | 189.9ms | -2.55% .. +1.62% | 1.41 |
| Type check (max) | 839.2ms | -2.45% .. +0.68% | 1.08 |
| Format (1T) | 147.4ms | -1.72% .. +1.23% | 1.20 |

`Format (max)` reached **+4.49%** on v0.315.1's release commit
([run 30713745830](https://github.com/ubugeeei-prod/vize/actions/runs/30713745830)) -- half a point
short of cancelling a release for a commit that changed no code.

On v0.312.0's `+5.37%`: that verdict predates #3622. Rescoring that comparison's own samples with
today's paired estimator gives **-3.93%**, so the specific number in the issue is already fixed. The
lane's noise band still sitting inside the budget is the part that is not.

**Chosen: size these two lanes' budget from that measured distribution -- 10%.** That is 2.2x the
widest excursion ever measured on a no-code diff (4.49%) and more than three standard deviations
above the noisier lane's distribution. `check-max` is unpinned too but keeps 5%: at 839ms it is
nowhere near the noise floor and the same seven comparisons put it inside +-2.45%. The pinned lanes
are untouched.

**A genuine 20% regression still fails, explicitly:** 20% clears the 10% budget by 10 points. To pass,
the pooled paired median would have to be dragged 10 points below the truth; the largest excursion
ever observed on these lanes is 4.49 points and their sd is at most 2.58, so that is roughly a 4-sigma
event -- and #3622's confirmation protocol re-measures a breach and judges the pooled 20 pairs, which
narrows the distribution further. The regressions these lanes were added for (#3460: published
`vize lint (max)` +16%, `vize fmt (max)` +58%) also still fail. `benchmark-lane-budget.test.ts`
asserts the 20% case end to end, through confirmation, down to the exact enforcement message.

**Rejected:**

- *Exempting version-bump-only commits.* Only helps release commits; PRs keep flaking on the same
  lanes. "Provably version-only" also needs content inspection of `Cargo.toml`/`Cargo.lock`/
  `package.json` diffs -- more machinery and more ways to be wrong than a measured budget.
- *Re-measuring once before failing.* Already landed as #3622 and kept; it is why the numbers above
  are as tight as they are. It cannot rescue a lane whose noise band straddles its own threshold --
  pooling only shrinks sd by sqrt(2).
- *Making the max lanes report-only.* Discards exactly the protection #3598 added. #3460's +16% and
  +58% were invisible to the pinned lanes; a report-only lane makes them invisible again.
- *Growing the corpus so the max lanes are slower.* One corpus is shared by all lanes, so this
  lengthens every lane and the whole gate to fix two of them.

## Also investigated, not fixed here

`App E2E` (v0.313.1, [run 30703020598](https://github.com/ubugeeei-prod/vize/actions/runs/30703020598),
job `app-e2e (build)`) and `Real Project Matrix` (v0.313.0,
[run 30700978696](https://github.com/ubugeeei-prod/vize/actions/runs/30700978696), job
`real projects (8/11)`) each killed a release. Their characterisation follows in a comment on this
PR rather than being folded in here: a flaky gate and a mis-sized budget are different defects.

## Tests

- `tests/tooling/release-preflight-runner.test.ts` -- drives the real `--target-only` CLI over a fake
  `git`, asserting `[exitCode, stderr]` by full equality for: exact `main` tip, drift with the version
  unchanged (accepted), drift that bumped the workspace version (rejected as superseded), HEAD/event-SHA
  mismatch, ancestry only through a merge's second parent, and a tag pointing elsewhere. The three
  pre-existing `assert.match` checks are converted to full equality.
- `tests/tooling/release-preflight-core.test.ts` -- `assertReleaseVersionStillOwnsMain` accepts equal
  versions and rejects a superseded one, asserted against the complete `Error`; the first-parent
  rejection is likewise converted from a regex to the complete `Error`.
- `tests/tooling/benchmark-lane-budget.test.ts` (new) -- the lane catalogue's resolved budgets by full
  equality; a real manifest-only sample (v0.315.1's `fmt-max` run times, +4.49%) passing, with the
  whole budget object and enforcement result asserted; the +5.37% rate that cancelled v0.312.0 passing
  on its own lane while still failing on a pinned lane; a 20% regression failing through confirmation,
  down to the exact `Benchmark regression budget failed for 1 task(s) after paired confirmation:` /
  `- Lint (max): 1.200x (+20.00%) over a 10% budget`; and the report naming every lane judged against
  a non-default budget.

No `.contains()`/`.includes()`/substring/regex-on-a-known-string in any new assertion. No workspace
outside `os.tmpdir()`, no build-artifact checks, and `.github/workflows/check.yml` is untouched.

## Commands run

| command | result |
| --- | --- |
| `node --test` over the benchmark, release-preflight, npm-bootstrap, github-workflows, criterion and check-bench tooling tests | 98 tests, 96 pass, 0 fail |
| `nix develop -c node --test tests/tooling/source-file-lengths.test.ts` | 7 pass, 0 fail (after `nix develop -c moon update`) |
| `nix develop -c ./node_modules/.bin/vp check --fix` | formatting clean; no warnings or lint errors across 1389 files |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->