### PR TITLE
docs(site): add a Babel JSX compatibility page and split the navigation theme

### DIFF
--- a/docs/content/fr/guide/jsx-babel-compat.md
+++ b/docs/content/fr/guide/jsx-babel-compat.md
@@ -113,9 +113,9 @@ Vapor semantics.
 ```
 
 **sortie SSR.** Les options du plugin décrivent les arbres vnode clients. La compilation SSR
-donc retient toute la voie de Babel — les aides `transformOn` et `enableObjectSlots`, le prédicat
-`isCustomElement`, `mergeProps: false`, et chaque abaissement uniquement de Babel — et utilise la sémantique SSR
-propre de Vize au lieu d’émettre un mélange à moitié appliqué.
+n’applique donc pas du tout la voie de Babel — ni les aides `transformOn` et `enableObjectSlots`, ni
+le prédicat `isCustomElement`, ni `mergeProps: false`, ni aucun abaissement propre à Babel — et
+utilise la sémantique SSR propre de Vize au lieu d’émettre un mélange à moitié appliqué.
 
 Les deux sont des réponses délibérées, enregistrées dans la caisse pour ne pas être recontestées.
 
@@ -127,7 +127,7 @@ travail de compilateur non lié plutôt que le mode compat lui-même :
 | Rangée                    | Ce que fait Babel                         | Ce qu’il attend                                                                                                                                                                                                            |
 | ------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `options/resolve_type_on` | ajoute `{ props: { … }, name: "A" }`      | l’inférence pilotée par type propage/émet, qui nécessite que la résolution du type soit suivie sur [#1497](https://github.com/ubugeeei-prod/vize/issues/1497) / [#1502](https://github.com/ubugeeei-prod/vize/issues/1502) |
-| `slots/dynamic_slot_name` | émet une clé calculée, `{ [n]: () => … }` | abaissement dynamique des fentes ; Vize avertit actuellement et abandonne la machine à sous                                                                                                                                |
+| `slots/dynamic_slot_name` | émet une clé calculée, `{ [n]: () => … }` | abaissement dynamique des slots ; Vize avertit actuellement et abandonne le slot                                                                                                                                           |
 
 ## Comment la compatibilité est mesurée
 

--- a/docs/content/fr/guide/jsx-babel-compat.md
+++ b/docs/content/fr/guide/jsx-babel-compat.md
@@ -1,0 +1,163 @@
+---
+title: Compatibilité Babel JSX
+---
+
+<!-- Generated translation; source: guide/jsx-babel-compat.md -->
+
+# Compatibilité Babel JSX
+
+> **Statut :** option d’adhésion et désactivation par défaut. `compiler.jsxCompat` est lu par le chargeur de configuration et
+> honoré par les `compileJsx` liaisons ; Les plugins bundler ne le transmettent pas encore au compilateur.
+> La section « Activation » ci-dessous explique ce qui fonctionne aujourd’hui.
+
+Vize compile `.jsx` et `.tsx` via ses propres caisses de compilation, donc la sortie est
+forme de compilateur modèle : un arbre de blocs, `v-if` / `v-for` supprimés du JavaScript, et patch
+drapeaux sur chaque nœud. [`@vue/babel-plugin-jsx`](https://github.com/vuejs/babel-plugin-jsx) ne fait rien de tout cela — il émet
+appels `createVNode` nus, n’ouvre jamais de bloc, laisse `&&`, `?:` et `.map()` comme
+JavaScript pur, et par défaut n’émet aucun drapeau de correctif.
+
+La plupart de cette différence est invisible à l’exécution. Le reste, c’est à quoi sert ce switch : un projet
+migre du plugin Babel a besoin d’un moyen de demander la sémantique du plugin au lieu de celle de Vize.
+`compiler.jsxCompat: "babel"` est cet interrupteur.
+
+Cette page porte sur **la sémantique de compatibilité**. Pour l’API d’auteur, la surface de type et le sélecteur de sortie
+Vapor/VDOM, voir le [JSX & TSX guide](./jsx.md).
+
+## La facilitation
+
+```json
+{
+  "compiler": {
+    "jsxCompat": "babel"
+  }
+}
+```
+
+La clé accepte `"native"` (le défaut) et `"babel"`. Toute autre valeur revient à `"native"`
+plutôt qu’à échouer dans la compilation, correspondant à la façon dont un `jsxMode` non reconnu est géré : une valeur
+de configuration errante ne doit jamais bloquer la compilation.
+
+La même valeur est acceptée directement par les liaisons `compileJsx` , c’est là que le mode prend
+effet aujourd’hui :
+
+```js
+import { compileJsx } from "@vizejs/native";
+
+const result = compileJsx(source, {
+  filename: "App.tsx",
+  lang: "tsx",
+  jsxCompat: "babel",
+});
+```
+
+`@vizejs/wasm` expose la même option `jsxCompat`. Les plugins bundler
+(`@vizejs/vite-plugin`, `@vizejs/unplugin`, `@vizejs/rspack-plugin`, `@vizejs/nuxt`) passent actuellement
+`jsxMode` et `vapor` à `compileJsx` mais pas `jsxCompat`, donc le simple réglage de la clé de configuration
+ne change pas encore ce qu’un bundler émet. Ce câblage est suivi sur
+[#3391](https://github.com/ubugeeei-prod/vize/issues/3391).
+
+## Pourquoi c’est un consentement volontaire et au niveau projet
+
+**Désactivé par défaut.** `"native"` est le défaut et doit rester le par défaut. Le retourner modifiait
+silencieusement la sortie émise pour chaque projet Vize existant, aucun ne demandant babel
+sémantique.
+
+**au niveau du projet, sans forme par composant.** `jsxMode` peuvent être sélectionnés par composant avec un prologue
+`"use vue:vapor"` / `"use vue:vdom"`, car les composants VDOM et Vapor coexistent parfaitement dans
+seul module — chacun est une fonction de rendu indépendante. Le mode de compatibilité n’est pas comme ça. Il modifie
+la forme de **sortie au niveau du module** : le plugin babel réécrit l’expression JSX en place,
+`const A = () => <div />` reste un `const A = …`, tandis que Vize émet un `render` autonome à exporter. Un module
+compilé à moitié en mode compat et moitié hors de celui-ci émettrait deux formes de module
+mutuellement incompatibles à partir d’un seul fichier. Le compat est donc configuré une seule fois pour le projet et n’a délibérément
+aucun prologue directif.
+
+## Mappage des options de plugin
+
+Les options propres au plugin babel n’ont pas d’orthographe de fichier de configuration dans Vize. Chacune est un paramètre d’un point d’entrée
+`compile_jsx_with_babel_*` sur la caisse
+[`vize_atelier_jsx`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_jsx),
+et chacune d’elles est inerte sauf si `jsxCompat` est `"babel"`.
+
+| `@vue/babel-plugin-jsx`      | Point d’entrée Vize                         |
+| ---------------------------- | ------------------------------------------- |
+| `transformOn`                | `BabelJsxOptions::transform_on`             |
+| `pragma`                     | `compile_jsx_with_babel_pragma`             |
+| `mergeProps`                 | `compile_jsx_with_babel_merge_props`        |
+| `isCustomElement`            | `BabelJsxCustomizations::is_custom_element` |
+| `enableObjectSlots`          | `compile_jsx_with_babel_object_slots`       |
+| n’importe quelle combinaison | `compile_jsx_with_babel_customizations`     |
+
+Deux options de plugins ne figurent pas dans ce tableau :
+
+- **`optimize`** n’a pas d’équivalent Vize, car la sortie de Vize est toujours optimisée — ce qui est ce que
+  le `optimize: true` du plugin produit. Le plugin par défaut est `optimize: false`, et son propre
+  README avertit que l’activer « peut sauter certains rerendus », donc le mode gap compat doit
+  combler est la direction _non optimisée_ : émission de sortie sans drapeau de patch.
+- **`resolveType`** n’est pas mis en œuvre ; voir « Ce qui est différé » ci-dessous.
+
+`enableObjectSlots` est par défaut `true` dans le plugin et dans la voie de compat de Vize : un identifiant unique ou une expression d’appel
+passée comme enfant unique d’un composant peut déjà être un objet slot, donc il est vérifié
+à l’exécution. Passer `false` considère toujours cette valeur comme l’enfant brut de l’emplacement par défaut.
+
+## Où le mode ne s’applique pas
+
+**sortie Vapor.** `@vue/babel-plugin-jsx` est un plugin de l’ère vdom : chaque forme de sortie qu’il définit est un arbre
+`createVNode`, et il n’a pas d’équivalent Vapor. `jsxCompat: "babel"` combiné avec
+`jsxMode: "vapor"` n’a donc pas de signification définie, et est rejeté par un diagnostic plutôt que
+ignoré silencieusement :
+
+```text
+compiler.jsxCompat: "babel" is not supported with Vapor output: @vue/babel-plugin-jsx has no
+Vapor equivalent. Use jsxMode "vdom" for babel compatibility, or drop jsxCompat to use Vize's own
+Vapor semantics.
+```
+
+**sortie SSR.** Les options du plugin décrivent les arbres vnode clients. La compilation SSR
+donc retient toute la voie de Babel — les aides `transformOn` et `enableObjectSlots`, le prédicat
+`isCustomElement`, `mergeProps: false`, et chaque abaissement uniquement de Babel — et utilise la sémantique SSR
+propre de Vize au lieu d’émettre un mélange à moitié appliqué.
+
+Les deux sont des réponses délibérées, enregistrées dans la caisse pour ne pas être recontestées.
+
+## Qu’est-ce qui est différé
+
+Deux lignes de corpus sont enregistrées comme `deferred` plutôt que divergentes, car chacune attend
+travail de compilateur non lié plutôt que le mode compat lui-même :
+
+| Rangée                    | Ce que fait Babel                         | Ce qu’il attend                                                                                                                                                                                                            |
+| ------------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `options/resolve_type_on` | ajoute `{ props: { … }, name: "A" }`      | l’inférence pilotée par type propage/émet, qui nécessite que la résolution du type soit suivie sur [#1497](https://github.com/ubugeeei-prod/vize/issues/1497) / [#1502](https://github.com/ubugeeei-prod/vize/issues/1502) |
+| `slots/dynamic_slot_name` | émet une clé calculée, `{ [n]: () => … }` | abaissement dynamique des fentes ; Vize avertit actuellement et abandonne la machine à sous                                                                                                                                |
+
+## Comment la compatibilité est mesurée
+
+La compatibilité est mesurée par rapport au **plugin réel**, pas à partir de la mémoire. Le corpus est compilé par un
+épinglé `@vue/babel-plugin-jsx`, sa sortie est enregistrée comme vérité terrestre engagée, et la suite Rust
+des instantanés de cet enregistrement à côté de la sortie de Vize avec un verdict explicite par ligne.
+
+| Artefact                                                          | Rôle                                                                         |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json` | les entrées et les options de plugins sont chacune compilées avec            |
+| `crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs`           | Fait passer le corpus via le plugin réel                                     |
+| `crates/vize_atelier_jsx/tests/babel_compat_oracle.rs`            | capture instantanés de la sortie de Babel à côté de celle de Vize, par ligne |
+| `crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md`         | la forme en prose du tableau des verdicts, et les totaux                     |
+
+Les verdicts ligne par ligne, les divergences globales qui s’appliquent à presque chaque ligne (forme du module, arbre
+bloc, drapeaux de patch, flux de contrôle non abaissé), et les totaux de courant vivent tous en
+[`BABEL_COMPAT_INVENTORY.md`](https://github.com/ubugeeei-prod/vize/blob/main/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md).
+Ces totaux sont fixés par le test de `babel_compat_verdict_totals`, donc ils ne peuvent pas dériver du
+corpus — c’est pourquoi cette page ne cite aucun d’eux. Lisez-les à la source.
+
+Pour régénérer ou vérifier l’enregistrement localement :
+
+```bash
+node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check
+cargo test -p vize_atelier_jsx --test babel_compat_oracle
+node --test tests/tooling/babel-jsx-oracle.test.ts
+```
+
+## Voir aussi
+
+- [JSX & TSX](./jsx.md) — l’API de création, les props et emits typés, les styles de portée et `jsxMode`.
+- [Configuration](./configuration.md) — chaque clé `compiler.*` et l’ordre de recherche des fichiers de configuration.
+- [`examples/jsx-tsx`](https://github.com/ubugeeei-prod/vize/tree/main/examples/jsx-tsx) — un projet JSX/TSX exécutable.

--- a/docs/content/guide/jsx-babel-compat.md
+++ b/docs/content/guide/jsx-babel-compat.md
@@ -1,0 +1,161 @@
+---
+title: Babel JSX Compatibility
+---
+
+# Babel JSX Compatibility
+
+> **Status:** opt-in and off by default. `compiler.jsxCompat` is read by the config loader and
+> honoured by the `compileJsx` bindings; the bundler plugins do not forward it to the compiler yet.
+> The "Enabling it" section below covers what works today.
+
+Vize compiles `.jsx` and `.tsx` through its own compiler crates, so the output is
+template-compiler shaped: a block tree, `v-if` / `v-for` lowered out of the JavaScript, and patch
+flags on every node. [`@vue/babel-plugin-jsx`](https://github.com/vuejs/babel-plugin-jsx) does none
+of that — it emits bare `createVNode` calls, never opens a block, leaves `&&`, `?:` and `.map()` as
+plain JavaScript, and by default emits no patch flags at all.
+
+Most of that difference is invisible at runtime. The rest is what this switch exists for: a project
+migrating off the babel plugin needs a way to ask for the plugin's semantics instead of Vize's.
+`compiler.jsxCompat: "babel"` is that switch.
+
+This page is about **compatibility semantics**. For the authoring API, the type surface, and the
+Vapor/VDOM output selector, see the [JSX & TSX guide](./jsx.md).
+
+## Enabling it
+
+```json
+{
+  "compiler": {
+    "jsxCompat": "babel"
+  }
+}
+```
+
+The key accepts `"native"` (the default) and `"babel"`. Any other value falls back to `"native"`
+rather than failing the build, matching how an unrecognised `jsxMode` is handled: a stray config
+value must never block compilation.
+
+The same value is accepted directly by the `compileJsx` bindings, which is where the mode takes
+effect today:
+
+```js
+import { compileJsx } from "@vizejs/native";
+
+const result = compileJsx(source, {
+  filename: "App.tsx",
+  lang: "tsx",
+  jsxCompat: "babel",
+});
+```
+
+`@vizejs/wasm` exposes the same `jsxCompat` option. The bundler plugins
+(`@vizejs/vite-plugin`, `@vizejs/unplugin`, `@vizejs/rspack-plugin`, `@vizejs/nuxt`) currently pass
+`jsxMode` and `vapor` through to `compileJsx` but not `jsxCompat`, so setting the config key alone
+does not yet change what a bundler emits. That wiring is tracked on
+[#3391](https://github.com/ubugeeei-prod/vize/issues/3391).
+
+## Why it is opt-in and project-level
+
+**Off by default.** `"native"` is the default and has to stay the default. Flipping it would
+silently change the emitted output for every existing Vize project, none of which asked for babel
+semantics.
+
+**Project-level, with no per-component form.** `jsxMode` can be selected per component with a
+`"use vue:vapor"` / `"use vue:vdom"` prologue, because VDOM and Vapor components coexist happily in
+one module — each is an independent render function. Compatibility mode is not like that. It
+changes **module-level** output shape: the babel plugin rewrites the JSX expression in place, so
+`const A = () => <div />` stays a `const A = …`, while Vize emits a standalone `render` export. A
+module compiled half in compat mode and half out of it would emit two mutually incompatible module
+shapes from a single file. Compat is therefore configured once for the project and deliberately has
+no directive prologue.
+
+## Plugin option mapping
+
+The babel plugin's own options have no config-file spelling in Vize. Each one is a parameter of a
+`compile_jsx_with_babel_*` entry point on the
+[`vize_atelier_jsx`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_jsx) crate,
+and every one of them is inert unless `jsxCompat` is `"babel"`.
+
+| `@vue/babel-plugin-jsx` | Vize entry point                            |
+| ----------------------- | ------------------------------------------- |
+| `transformOn`           | `BabelJsxOptions::transform_on`             |
+| `pragma`                | `compile_jsx_with_babel_pragma`             |
+| `mergeProps`            | `compile_jsx_with_babel_merge_props`        |
+| `isCustomElement`       | `BabelJsxCustomizations::is_custom_element` |
+| `enableObjectSlots`     | `compile_jsx_with_babel_object_slots`       |
+| any combination         | `compile_jsx_with_babel_customizations`     |
+
+Two plugin options are not in that table:
+
+- **`optimize`** has no Vize equivalent, because Vize's output is always optimized — which is what
+  the plugin's `optimize: true` produces. The plugin's default is `optimize: false`, and its own
+  README warns that turning it on "may skip certain re-renders", so the gap compat mode has to
+  close is the _unoptimized_ direction: emitting patch-flag-free output.
+- **`resolveType`** is not implemented; see "What is deferred" below.
+
+`enableObjectSlots` defaults to `true` in the plugin and in Vize's compat lane: a lone identifier or
+call expression passed as a component's only child may already be a slots object, so it is checked
+at runtime. Passing `false` always treats that value as the raw default-slot child.
+
+## Where the mode does not apply
+
+**Vapor output.** `@vue/babel-plugin-jsx` is a vdom-era plugin: every output shape it defines is a
+`createVNode` tree, and it has no Vapor equivalent. `jsxCompat: "babel"` combined with
+`jsxMode: "vapor"` therefore has no defined meaning, and is rejected with a diagnostic rather than
+silently ignored:
+
+```text
+compiler.jsxCompat: "babel" is not supported with Vapor output: @vue/babel-plugin-jsx has no
+Vapor equivalent. Use jsxMode "vdom" for babel compatibility, or drop jsxCompat to use Vize's own
+Vapor semantics.
+```
+
+**SSR output.** The plugin's options describe client vnode trees. SSR compilation therefore
+withholds the whole babel lane — the `transformOn` and `enableObjectSlots` helpers, the
+`isCustomElement` predicate, `mergeProps: false`, and every babel-only lowering — and uses Vize's
+own SSR semantics instead of emitting a half-applied mixture.
+
+Both are deliberate answers, recorded in the crate so they are not relitigated.
+
+## What is deferred
+
+Two corpus rows are recorded as `deferred` rather than divergent, because each is waiting on
+unrelated compiler work rather than on compat mode itself:
+
+| Row                       | What babel does                          | What it is waiting on                                                                                                                                                                                 |
+| ------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `options/resolve_type_on` | appends `{ props: { … }, name: "A" }`    | type-driven props/emits inference, which needs the type resolution tracked on [#1497](https://github.com/ubugeeei-prod/vize/issues/1497) / [#1502](https://github.com/ubugeeei-prod/vize/issues/1502) |
+| `slots/dynamic_slot_name` | emits a computed key, `{ [n]: () => … }` | dynamic-slot lowering; Vize currently warns and drops the slot                                                                                                                                        |
+
+## How compatibility is measured
+
+Compatibility is measured against the **real plugin**, not from memory. The corpus is compiled by a
+pinned `@vue/babel-plugin-jsx`, its output is recorded as committed ground truth, and the Rust suite
+snapshots that recording beside Vize's output with an explicit verdict per row.
+
+| Artifact                                                          | Role                                                     |
+| ----------------------------------------------------------------- | -------------------------------------------------------- |
+| `crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json` | the inputs, and the plugin options each is compiled with |
+| `crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs`           | runs the corpus through the real plugin                  |
+| `crates/vize_atelier_jsx/tests/babel_compat_oracle.rs`            | snapshots babel's output beside Vize's, per row          |
+| `crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md`         | the prose form of the verdict table, and the totals      |
+
+The row-by-row verdicts, the global divergences that hold for nearly every row (module shape, block
+tree, patch flags, un-lowered control flow), and the current totals all live in
+[`BABEL_COMPAT_INVENTORY.md`](https://github.com/ubugeeei-prod/vize/blob/main/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md).
+Those totals are pinned by the `babel_compat_verdict_totals` test, so they cannot drift from the
+corpus — which is why this page quotes none of them. Read them at the source.
+
+To regenerate or verify the recording locally:
+
+```bash
+node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check
+cargo test -p vize_atelier_jsx --test babel_compat_oracle
+node --test tests/tooling/babel-jsx-oracle.test.ts
+```
+
+## See also
+
+- [JSX & TSX](./jsx.md) — the authoring API, typed props and emits, scoped styles, and `jsxMode`.
+- [Configuration](./configuration.md) — every `compiler.*` key and the config file lookup order.
+- [`examples/jsx-tsx`](https://github.com/ubugeeei-prod/vize/tree/main/examples/jsx-tsx) — a runnable JSX/TSX project.

--- a/docs/content/ja/guide/jsx-babel-compat.md
+++ b/docs/content/ja/guide/jsx-babel-compat.md
@@ -1,0 +1,159 @@
+---
+title: Babel JSX 互換
+---
+
+# Babel JSX 互換
+
+> **ステータス:** オプトインであり、デフォルトでは無効です。`compiler.jsxCompat` は設定ローダーが読み取り、
+> `compileJsx` バインディングが解釈します。バンドラープラグインはまだこの値をコンパイラへ渡していません。
+> 現時点で何が動くかは、下の「有効にする」節を参照してください。
+
+Vize は `.jsx` と `.tsx` を自前のコンパイラクレートでコンパイルします。そのため出力はテンプレートコンパイラと
+同じ形、つまりブロックツリーであり、`v-if` / `v-for` は JavaScript から降ろされ、各ノードにパッチフラグが付き
+ます。[`@vue/babel-plugin-jsx`](https://github.com/vuejs/babel-plugin-jsx) はそのいずれも行いません。素の
+`createVNode` 呼び出しを出力し、ブロックを開かず、`&&`・`?:`・`.map()` はただの JavaScript のまま残し、
+デフォルトではパッチフラグを一切出しません。
+
+この違いの大部分は実行時には見えません。残りの部分こそ、このスイッチが存在する理由です。Babel プラグインから
+移行するプロジェクトには、Vize のセマンティクスではなくプラグインのセマンティクスを要求する手段が必要です。
+`compiler.jsxCompat: "babel"` がそのスイッチです。
+
+このページが扱うのは**互換セマンティクス**です。オーサリング API、型の表面、Vapor/VDOM の出力切り替えについては
+[JSX & TSX ガイド](./jsx.md)を参照してください。
+
+## 有効にする
+
+```json
+{
+  "compiler": {
+    "jsxCompat": "babel"
+  }
+}
+```
+
+このキーは `"native"`（デフォルト）と `"babel"` を受け付けます。それ以外の値はビルドを失敗させるのではなく
+`"native"` にフォールバックします。認識できない `jsxMode` の扱いと同じで、設定値の書き間違いがコンパイルを
+止めてはならないためです。
+
+同じ値は `compileJsx` バインディングが直接受け取ります。現時点でこのモードが実際に効くのはここです。
+
+```js
+import { compileJsx } from "@vizejs/native";
+
+const result = compileJsx(source, {
+  filename: "App.tsx",
+  lang: "tsx",
+  jsxCompat: "babel",
+});
+```
+
+`@vizejs/wasm` も同じ `jsxCompat` オプションを公開しています。バンドラープラグイン
+（`@vizejs/vite-plugin`、`@vizejs/unplugin`、`@vizejs/rspack-plugin`、`@vizejs/nuxt`）は現在 `jsxMode` と
+`vapor` を `compileJsx` に渡していますが `jsxCompat` は渡していないため、設定キーを書くだけではバンドラーの
+出力はまだ変わりません。この配線は
+[#3391](https://github.com/ubugeeei-prod/vize/issues/3391) で追跡しています。
+
+## なぜオプトインでプロジェクト単位なのか
+
+**デフォルトで無効。** `"native"` がデフォルトであり、そのままデフォルトであり続ける必要があります。これを
+反転させると、Babel セマンティクスを求めていない既存のすべての Vize プロジェクトの出力が黙って変わってしまい
+ます。
+
+**プロジェクト単位で、コンポーネント単位の指定はない。** `jsxMode` は `"use vue:vapor"` /
+`"use vue:vdom"` のプロローグでコンポーネントごとに選べます。VDOM と Vapor のコンポーネントは 1 つのモジュール
+の中で問題なく共存でき、それぞれが独立したレンダー関数だからです。互換モードはそうではありません。互換モードは
+**モジュール単位**の出力の形を変えます。Babel プラグインは JSX 式をその場で書き換えるので
+`const A = () => <div />` は `const A = …` のまま残りますが、Vize は独立した `render` エクスポートを出力し
+ます。1 つのファイルの半分だけを互換モードでコンパイルすると、互いに噛み合わない 2 つのモジュール形状が同じ
+ファイルから出てしまいます。そのため互換モードはプロジェクトに対して一度だけ設定するものであり、ディレクティブ
+プロローグの形式は意図的に用意していません。
+
+## プラグインオプションの対応
+
+Babel プラグイン自身のオプションには、Vize の設定ファイル上の綴りがありません。それぞれが
+[`vize_atelier_jsx`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_jsx) クレートの
+`compile_jsx_with_babel_*` エントリポイントの引数であり、`jsxCompat` が `"babel"` でない限りすべて何もしま
+せん。
+
+| `@vue/babel-plugin-jsx` | Vize のエントリポイント                     |
+| ----------------------- | ------------------------------------------- |
+| `transformOn`           | `BabelJsxOptions::transform_on`             |
+| `pragma`                | `compile_jsx_with_babel_pragma`             |
+| `mergeProps`            | `compile_jsx_with_babel_merge_props`        |
+| `isCustomElement`       | `BabelJsxCustomizations::is_custom_element` |
+| `enableObjectSlots`     | `compile_jsx_with_babel_object_slots`       |
+| 任意の組み合わせ        | `compile_jsx_with_babel_customizations`     |
+
+この表に載っていないプラグインオプションが 2 つあります。
+
+- **`optimize`** に対応するものは Vize にはありません。Vize の出力は常に最適化されており、それはプラグインの
+  `optimize: true` が生成するものと同じだからです。プラグインのデフォルトは `optimize: false` で、プラグイン
+  自身の README も、有効にすると「特定の再レンダリングをスキップすることがある」と警告しています。つまり互換
+  モードが埋めるべき差は*最適化しない*方向、すなわちパッチフラグを持たない出力です。
+- **`resolveType`** は未実装です。下の「保留中のもの」を参照してください。
+
+`enableObjectSlots` はプラグインでも Vize の互換レーンでもデフォルトが `true` です。コンポーネントの唯一の子
+として渡された単独の識別子や呼び出し式は、すでにスロットオブジェクトである可能性があるため実行時に判定されます。
+`false` を渡すと、その値は常にデフォルトスロットの生の子として扱われます。
+
+## このモードが適用されない場所
+
+**Vapor 出力。** `@vue/babel-plugin-jsx` は vdom 時代のプラグインで、定義している出力形状はすべて
+`createVNode` ツリーであり、Vapor に対応するものはありません。したがって `jsxCompat: "babel"` と
+`jsxMode: "vapor"` の組み合わせには定義された意味がなく、黙って無視するのではなく診断として拒否されます。
+
+```text
+compiler.jsxCompat: "babel" is not supported with Vapor output: @vue/babel-plugin-jsx has no
+Vapor equivalent. Use jsxMode "vdom" for babel compatibility, or drop jsxCompat to use Vize's own
+Vapor semantics.
+```
+
+**SSR 出力。** プラグインのオプションはクライアント側の vnode ツリーを記述するものです。そのため SSR
+コンパイルでは Babel レーン全体、すなわち `transformOn` と `enableObjectSlots` のヘルパー、
+`isCustomElement` の述語、`mergeProps: false`、および Babel 固有の降ろし処理をすべて適用せず、中途半端に
+混ざった出力を出す代わりに Vize 自身の SSR セマンティクスを使います。
+
+どちらも意図的な結論であり、蒸し返されないようクレート側に記録してあります。
+
+## 保留中のもの
+
+コーパスの 2 行は divergent ではなく `deferred` として記録されています。互換モードそのものではなく、無関係な
+コンパイラ側の作業を待っているためです。
+
+| 行                        | Babel の挙動                             | 待っているもの                                                                                                                                                                |
+| ------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `options/resolve_type_on` | `{ props: { … }, name: "A" }` を付加する | 型駆動の props/emits 推論。[#1497](https://github.com/ubugeeei-prod/vize/issues/1497) / [#1502](https://github.com/ubugeeei-prod/vize/issues/1502) で追跡している型解決が必要 |
+| `slots/dynamic_slot_name` | 計算キー `{ [n]: () => … }` を出力する   | 動的スロットの降ろし処理。Vize は現在、警告してスロットを捨てる                                                                                                               |
+
+## 互換性の測り方
+
+互換性は記憶からではなく、**実物のプラグイン**と突き合わせて測っています。コーパスはバージョンを固定した
+`@vue/babel-plugin-jsx` でコンパイルされ、その出力はコミット済みの正解として記録され、Rust のテストスイートが
+その記録を Vize の出力と並べてスナップショットし、行ごとに明示的な判定を付けます。
+
+| 成果物                                                            | 役割                                           |
+| ----------------------------------------------------------------- | ---------------------------------------------- |
+| `crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json` | 入力と、各入力に与えるプラグインオプション     |
+| `crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs`           | コーパスを実物のプラグインに通す               |
+| `crates/vize_atelier_jsx/tests/babel_compat_oracle.rs`            | Babel の出力を Vize の出力と並べて行ごとに記録 |
+| `crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md`         | 判定表を文章の形にしたもの、および合計         |
+
+行ごとの判定、ほぼすべての行に共通する全体的な差異（モジュール形状、ブロックツリー、パッチフラグ、降ろされない
+制御フロー）、そして現在の合計は、すべて
+[`BABEL_COMPAT_INVENTORY.md`](https://github.com/ubugeeei-prod/vize/blob/main/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md)
+にあります。この合計は `babel_compat_verdict_totals` のテストで固定されており、コーパスからずれることがあり
+ません。このページが合計を一切引用しないのはそのためです。数値は元の場所で読んでください。
+
+記録をローカルで再生成・検証するには次を実行します。
+
+```bash
+node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check
+cargo test -p vize_atelier_jsx --test babel_compat_oracle
+node --test tests/tooling/babel-jsx-oracle.test.ts
+```
+
+## 関連項目
+
+- [JSX & TSX](./jsx.md) — オーサリング API、型付きの props と emits、スコープ付きスタイル、そして `jsxMode`。
+- [設定](./configuration.md) — `compiler.*` の全キーと設定ファイルの探索順。
+- [`examples/jsx-tsx`](https://github.com/ubugeeei-prod/vize/tree/main/examples/jsx-tsx) — 実行可能な JSX/TSX プロジェクト。

--- a/docs/content/pt-BR/guide/jsx-babel-compat.md
+++ b/docs/content/pt-BR/guide/jsx-babel-compat.md
@@ -1,0 +1,163 @@
+---
+title: Compatibilidade Babel JSX
+---
+
+<!-- Generated translation; source: guide/jsx-babel-compat.md -->
+
+# Compatibilidade Babel JSX
+
+> **Status:** opt-in e desligado por padrão. `compiler.jsxCompat` é lido pelo carregador de configuração e
+> homenageado pelas `compileJsx` encadernações; Os plugins bundler ainda não encaminham para o compilador.
+> A seção "Habilitando" abaixo cobre o que funciona hoje.
+
+O Vize compila `.jsx` e `.tsx` através de suas próprias caixas de compilador, então a saída é
+formato de compilador de template: uma árvore de blocos, `v-if` / `v-for` reduzida do JavaScript e patch
+flags em cada nó. [`@vue/babel-plugin-jsx`](https://github.com/vuejs/babel-plugin-jsx) não faz nada
+disso — emite chamadas `createVNode` nuas, nunca abre um bloco, deixa `&&`, `?:` e `.map()` como
+JavaScript simples e, por padrão, não emite nenhuma bandeira de patch.
+
+A maior parte dessa diferença é invisível em tempo de execução. O resto é para isso que esse switch existe: um projeto
+migrando do plugin Babel precisa de uma forma de pedir a semântica do plugin em vez da do Vize.
+`compiler.jsxCompat: "babel"` é esse interruptor.
+
+Esta página é sobre **semântica de compatibilidade**. Para a API de autoria, a superfície de tipos e o seletor de saída
+Vapor/VDOM, veja o [JSX & TSX guide](./jsx.md).
+
+## Viabilizando
+
+```json
+{
+  "compiler": {
+    "jsxCompat": "babel"
+  }
+}
+```
+
+A chave aceita `"native"` (o padrão) e `"babel"`. Qualquer outro valor retorna ao `"native"`
+em vez de falhar na compilação, correspondendo à forma como um `jsxMode` não reconhecido é tratado: uma configuração
+valor isolada nunca deve bloquear a compilação.
+
+O mesmo valor é aceito diretamente pelas ligações `compileJsx` , que é onde o modo entra
+efeito hoje:
+
+```js
+import { compileJsx } from "@vizejs/native";
+
+const result = compileJsx(source, {
+  filename: "App.tsx",
+  lang: "tsx",
+  jsxCompat: "babel",
+});
+```
+
+`@vizejs/wasm` expõe a mesma opção `jsxCompat`. Os plugins do bundler
+(`@vizejs/vite-plugin`, `@vizejs/unplugin`, `@vizejs/rspack-plugin`, `@vizejs/nuxt`) atualmente passam
+`jsxMode` e `vapor` para `compileJsx`, mas não `jsxCompat`, então configurar a chave de configuração sozin
+ha ainda não muda o que o bundler emite. Essa fiação é rastreada em
+[#3391](https://github.com/ubugeeei-prod/vize/issues/3391).
+
+## Por que é opt-in e em nível de projeto
+
+**Desligado por padrão.** `"native"` é o padrão e tem que permanecer o padrão. Invertê-lo
+mudava silenciosamente a saída emitida de todos os projetos existentes do Vize, nenhum dos quais pedia babel
+semântica.
+
+**nível de projeto, sem forma por componente.** `jsxMode` podem ser selecionados por componente com um prólogo
+`"use vue:vapor"` / `"use vue:vdom"`, porque os componentes VDOM e Vapor coexistem felizmente em
+único módulo — cada um é uma função de renderização independente. O modo de compatibilidade não é assim. Ele
+muda a forma de saída **em nível de módulo**: o plugin babel reescreve a expressão JSX no lugar, então
+`const A = () => <div />` permanece como um `const A = …`, enquanto o Vize emite uma exportação `render` independente. Um módulo
+compilado metade em modo compat e metade fora dele emitiria dois módulos
+formas mutuamente incompatíveis a partir de um único arquivo. Portanto, o Compat é configurado uma vez para o projeto e deliberadamente não
+prólogo diretivo.
+
+## Mapeamento de opções de plugin
+
+As opções do próprio plugin babel não têm grafia de arquivo de configuração no Vize. Cada um é um parâmetro de um ponto de entrada
+`compile_jsx_with_babel_*` na caixa
+[`vize_atelier_jsx`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_jsx),
+e todos eles são inertes, a menos que `jsxCompat` seja `"babel"`.
+
+| `@vue/babel-plugin-jsx` | Ponto de entrada do Vize                    |
+| ----------------------- | ------------------------------------------- |
+| `transformOn`           | `BabelJsxOptions::transform_on`             |
+| `pragma`                | `compile_jsx_with_babel_pragma`             |
+| `mergeProps`            | `compile_jsx_with_babel_merge_props`        |
+| `isCustomElement`       | `BabelJsxCustomizations::is_custom_element` |
+| `enableObjectSlots`     | `compile_jsx_with_babel_object_slots`       |
+| qualquer combinação     | `compile_jsx_with_babel_customizations`     |
+
+Duas opções de plugins não estão nessa tabela:
+
+- **`optimize`** não tem equivalente ao Vize, porque a saída do Vize é sempre otimizada — que é o que
+  o `optimize: true` do plugin produz. O padrão do plugin é `optimize: false`, e seu próprio
+  README alerta que ativá-lo "pode pular certas rerenderizações", então o modo gap compat precisa
+  fechar é a direção _não otimizada_ : emitindo saída sem patch-flag.
+- **`resolveType`** não é implementado; veja "O que é adiado" abaixo.
+
+`enableObjectSlots` padrão é `true` no plugin e na faixa de compat do Vize: um identificador solitário ou
+expressão de chamada passada como único filho de um componente pode já ser um objeto slot, então é verificado
+em tempo de execução. Passar `false` sempre trata esse valor como filho bruto do slot padrão.
+
+## Onde o modo não se aplica
+
+**Saída Vapor.** `@vue/babel-plugin-jsx` é um plugin da era VDOM: toda forma de saída que define é uma árvore
+`createVNode`, e não tem equivalente ao Vapor. `jsxCompat: "babel"` combinado com
+`jsxMode: "vapor"`, portanto, não tem um significado definido, e é rejeitado com um diagnóstico em vez de
+silenciosamente ignorado:
+
+```text
+compiler.jsxCompat: "babel" is not supported with Vapor output: @vue/babel-plugin-jsx has no
+Vapor equivalent. Use jsxMode "vdom" for babel compatibility, or drop jsxCompat to use Vize's own
+Vapor semantics.
+```
+
+**saída SSR.** As opções do plugin descrevem árvores vnode do cliente. Portanto, a compilação SSR
+retém toda a rota de Babel — os auxiliares de `transformOn` e `enableObjectSlots`, o predicado
+`isCustomElement`, `mergeProps: false`, e toda redução apenas de Babel — e usa a própria semântica SSR
+do Vize em vez de emitir uma mistura meio aplicada.
+
+Ambas são respostas deliberadas, registradas na caixa para não serem discutidas novamente.
+
+## O que é diferido
+
+Duas linhas de corpus são registradas como `deferred` em vez de divergentes, porque cada uma está aguardando
+trabalho de compilador não relacionado, e não no modo compat em si:
+
+| Row                       | O que Babel faz                               | O que está esperando                                                                                                                                                                                                  |
+| ------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `options/resolve_type_on` | acrescenta `{ props: { … }, name: "A" }`      | Inferência guiada por tipo props/emits, que exige que a resolução do tipo seja acompanhada em [#1497](https://github.com/ubugeeei-prod/vize/issues/1497) / [#1502](https://github.com/ubugeeei-prod/vize/issues/1502) |
+| `slots/dynamic_slot_name` | emite uma chave computada, `{ [n]: () => … }` | rebaixamento dinâmico de slots; Vize atualmente avisa e deixa o slot cair                                                                                                                                             |
+
+## Como a compatibilidade é medida
+
+A compatibilidade é medida em relação ao **plugin real**, não pela memória. O corpus é compilado por um
+fixado `@vue/babel-plugin-jsx`, sua saída é registrada como verdade terrestre comprometida, e o conjunto Rust
+snapshots dessa gravação ao lado da saída do Vize com um veredito explícito por linha.
+
+| Artefato                                                          | Função                                                    |
+| ----------------------------------------------------------------- | --------------------------------------------------------- |
+| `crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json` | as entradas e as opções de plugins são compiladas com     |
+| `crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs`           | Executa o corpus pelo plugin real                         |
+| `crates/vize_atelier_jsx/tests/babel_compat_oracle.rs`            | snapshots da saída da babel ao lado da da Vize, por linha |
+| `crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md`         | a forma em prosa da tabela de veredictos, e os totais     |
+
+Os veredictos linha por linha, as divergências globais que valem para quase todas as linhas (formato do módulo, árvore
+bloco, flags de patch, fluxo de controle não reduzido) e os totais de corrente estão todos em
+[`BABEL_COMPAT_INVENTORY.md`](https://github.com/ubugeeei-prod/vize/blob/main/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md).
+Esses totais são fixados pelo teste de `babel_compat_verdict_totals`, então não podem se desviar do
+corpus — por isso esta página não cita nenhum deles. Leia-as na fonte.
+
+Para regenerar ou verificar a gravação localmente:
+
+```bash
+node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check
+cargo test -p vize_atelier_jsx --test babel_compat_oracle
+node --test tests/tooling/babel-jsx-oracle.test.ts
+```
+
+## Veja também
+
+- [JSX & TSX](./jsx.md) — a API de autoria, props e emits tipados, estilos de escopo e `jsxMode`.
+- [Configuration](./configuration.md) — toda `compiler.*` chave e a ordem de busca no arquivo de configuração.
+- [`examples/jsx-tsx`](https://github.com/ubugeeei-prod/vize/tree/main/examples/jsx-tsx) — um projeto JSX/TSX rodável.

--- a/docs/content/pt-BR/guide/jsx-babel-compat.md
+++ b/docs/content/pt-BR/guide/jsx-babel-compat.md
@@ -113,9 +113,9 @@ Vapor semantics.
 ```
 
 **saída SSR.** As opções do plugin descrevem árvores vnode do cliente. Portanto, a compilação SSR
-retém toda a rota de Babel — os auxiliares de `transformOn` e `enableObjectSlots`, o predicado
-`isCustomElement`, `mergeProps: false`, e toda redução apenas de Babel — e usa a própria semântica SSR
-do Vize em vez de emitir uma mistura meio aplicada.
+não aplica a rota de Babel — nem os auxiliares `transformOn` e `enableObjectSlots`, nem o predicado
+`isCustomElement`, nem `mergeProps: false`, nem qualquer redução exclusiva de Babel — e usa a própria
+semântica SSR do Vize em vez de emitir uma mistura meio aplicada.
 
 Ambas são respostas deliberadas, registradas na caixa para não serem discutidas novamente.
 

--- a/docs/content/zh-CN/guide/jsx-babel-compat.md
+++ b/docs/content/zh-CN/guide/jsx-babel-compat.md
@@ -1,0 +1,163 @@
+---
+title: Babel JSX 兼容性
+---
+
+<!-- Generated translation; source: guide/jsx-babel-compat.md -->
+
+# Babel JSX 兼容性
+
+> **状态：**默认选择加入和关闭。配置加载器读取`compiler.jsxCompat`
+> 以 `compileJsx` 的束缚致敬;bundler 插件还不会转发到编译器。
+> 下面的“启用它”部分介绍了目前有效的方法。
+
+Vize 通过自己的编译器箱编译 `.jsx` 和 `.tsx` ，因此输出呈现
+模板编译器形状：块树，从 JavaScript 中降 `v-if` / `v-for` ，并在每个节点上补丁
+标志。 [`@vue/babel-plugin-jsx`](https://github.com/vuejs/babel-plugin-jsx) 完全不做这些
+——它发出裸 `createVNode` 调用，从不打开任何块，保持 `&&`、 `?:` 和 `.map()` 为
+普通JavaScript，默认情况下完全不发出补丁标志。
+
+大部分差异在运行时是看不见的。剩下的就是这个交换机存在的意义：
+迁移出 Babel 插件的项目需要一种方式来请求插件的语义，而不是 Vize 的。
+`compiler.jsxCompat: "babel"`是那个开关。
+
+本页讨论 **兼容性语义**。关于创作API、类型表面和
+Vapor/VDOM输出选择器，请参见 [JSX & TSX guide](./jsx.md)。
+
+## 启用它
+
+```json
+{
+  "compiler": {
+    "jsxCompat": "babel"
+  }
+}
+```
+
+密钥接受`"native"`（默认值）和`"babel"`。其他值会退回到`"native"`
+，而不是构建失败，这与未识别`jsxMode`的处理方式相符：一个零散的配置
+值绝不能阻碍编译。
+
+相同的数值被 `compileJsx` 绑定直接接受，这也是该模式今天
+起作用的地方：
+
+```js
+import { compileJsx } from "@vizejs/native";
+
+const result = compileJsx(source, {
+  filename: "App.tsx",
+  lang: "tsx",
+  jsxCompat: "babel",
+});
+```
+
+`@vizejs/wasm`也暴露了同样的`jsxCompat`选项。捆绑包插件
+（`@vizejs/vite-plugin`、`@vizejs/unplugin`、`@vizejs/rspack-plugin`、`@vizejs/nuxt`）目前只传递
+`jsxMode`和`vapor`给`compileJsx`，但不会`jsxCompat`，所以仅设置配置键
+还不会改变捆绑包器输出的信号。这些线路会被追踪在
+[#3391](https://github.com/ubugeeei-prod/vize/issues/3391)。
+
+## 为什么它是选择加入和项目级别的
+
+**默认关闭。**`"native"`是默认，必须保持默认状态。翻转它会
+无声地改变所有现有 Vize 项目的输出，而这些项目都不需要 babel
+语义。
+
+**项目级，没有每个组件的表格。**`jsxMode`可以按组件选择，并附带
+`"use vue:vapor"`/`"use vue:vdom"`序章，因为 VDOM 和 Vapor 组件在一个模块中可以愉快共存
+——每个模块都是独立的渲染函数。兼容模式不是那样的。它
+改变**模块级**的输出形状：Babel 插件会原地重写 JSX 表达式，使
+`const A = () => <div />` 保持为 `const A = …`，而 Vize 则输出独立的 `render` 导出。一个
+模块一半编译为兼容模式，另一半脱离，会从一个文件中输出两个互不兼容的模
+形状。因此，Compat只为该项目配置一次，并且有意不设置
+指令序章。
+
+## 插件选项映射
+
+Babel插件本身的选项在Vize中没有配置文件拼写。每个都是
+[`vize_atelier_jsx`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_jsx)箱
+`compile_jsx_with_babel_*`入口点的参数，
+，除非`jsxCompat``"babel"`。
+
+| `@vue/babel-plugin-jsx` | Vize入口                                    |
+| ----------------------- | ------------------------------------------- |
+| `transformOn`           | `BabelJsxOptions::transform_on`             |
+| `pragma`                | `compile_jsx_with_babel_pragma`             |
+| `mergeProps`            | `compile_jsx_with_babel_merge_props`        |
+| `isCustomElement`       | `BabelJsxCustomizations::is_custom_element` |
+| `enableObjectSlots`     | `compile_jsx_with_babel_object_slots`       |
+| 任意组合                | `compile_jsx_with_babel_customizations`     |
+
+表格中没有两个插件选项：
+
+- **`optimize`**没有 Vize 的对应产品，因为 Vize 的输出总是经过优化——这正是
+  插件的 `optimize: true` 产生了什么。插件默认是 `optimize: false`，其
+  说明警告开启后“可能会跳过某些重新渲染”，因此间隙兼容模式必须
+  关闭，这才是 _未优化_ 的方向：输出无补丁标志的输出。
+- **`resolveType`**未被实现;详见下文“推迟的事项”。
+
+`enableObjectSlots`默认在插件和 Vize 的兼容通道中 `true`：作为组件唯一子节点传递的单个标识符或
+调用表达式可能已经是 slots 对象，因此运行时会
+检查。传递`false`总是将该值视为原始默认槽子。
+
+## 当该模式不适用时
+
+**Vapor 输出。**`@vue/babel-plugin-jsx` 是 vdom 时代的一个插件：它定义的每个输出形状都是一个
+`createVNode` 树，且没有 Vapor 的对应物。因此，`jsxCompat: "babel"`与
+`jsxMode: "vapor"`结合没有明确的含义，并且通过诊断性而非
+默默忽视来拒绝：
+
+```text
+compiler.jsxCompat: "babel" is not supported with Vapor output: @vue/babel-plugin-jsx has no
+Vapor equivalent. Use jsxMode "vdom" for babel compatibility, or drop jsxCompat to use Vize's own
+Vapor semantics.
+```
+
+**SSR输出。**插件的选项描述了客户端的 vnode 树。因此，SSR编译
+保留了整个巴别通道——包括`transformOn`和`enableObjectSlots`辅助、
+`isCustomElement`谓词、`mergeProps: false`以及所有仅巴别塔的降低——并使用Vize
+自身的SSR语义，而不是输出半应用的混合。
+
+这两点都是刻意的回答，记录在箱子里，避免被重新争论。
+
+## 推迟的事项
+
+两行语料库列被记录为 `deferred` 而非发散，因为它们都在等待
+无关的编译器工作，而非兼容模式：
+
+| 划船                      | 巴别塔的功效                          | 它正在等待什么                                                                                                                                                         |
+| ------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `options/resolve_type_on` | 附录 `{ props: { … }, name: "A" }`    | 类型驱动的道具/发射推理，需要在[#1497](https://github.com/ubugeeei-prod/vize/issues/1497) / [#1502](https://github.com/ubugeeei-prod/vize/issues/1502)上跟踪类型分辨率 |
+| `slots/dynamic_slot_name` | 发射计算出的密钥， `{ [n]: () => … }` | 动态槽降;Vize目前警告并放弃了该槽位                                                                                                                                    |
+
+## 兼容性的衡量方式
+
+兼容性是以 **真实插件**为标准，而不是凭记忆。语料库由
+钉置的 `@vue/babel-plugin-jsx`编译，其输出被记录为坚定的真实数据，Rust套件
+将该记录快照与Vize的输出并列，每行明确判决。
+
+| 文物                                                              | 职责                                    |
+| ----------------------------------------------------------------- | --------------------------------------- |
+| `crates/vize_atelier_jsx/tests/babel_compat/fixtures/corpus.json` | 输入和插件选项都被编译为                |
+| `crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs`           | 通过真实插件运行语料库                  |
+| `crates/vize_atelier_jsx/tests/babel_compat_oracle.rs`            | 每行快照 Babel 的输出与 Vize 的输出并列 |
+| `crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md`         | 判决表的散文形式，以及总数              |
+
+逐行判决、几乎每行都成立的全局分歧（模块形状、块
+树、补丁标志、未降低控制流）以及当前总数都存在于
+[`BABEL_COMPAT_INVENTORY.md`](https://github.com/ubugeeei-prod/vize/blob/main/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md)中。
+这些总数是通过`babel_compat_verdict_totals`测试固定的，因此不会偏离
+语料库——这也是本页没有引用任何一个的原因。请直接阅读原文。
+
+要在本地重新生成或验证录音：
+
+```bash
+node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check
+cargo test -p vize_atelier_jsx --test babel_compat_oracle
+node --test tests/tooling/babel-jsx-oracle.test.ts
+```
+
+## 参见
+
+- [JSX & TSX](./jsx.md) — 创作API、类型道具和发射器、作用域样式以及 `jsxMode`。
+- [Configuration](./configuration.md) ——每个 `compiler.*` 键和配置文件查找顺序。
+- [`examples/jsx-tsx`](https://github.com/ubugeeei-prod/vize/tree/main/examples/jsx-tsx) ——一个可运行的JSX/TSX项目。

--- a/docs/content/zh-CN/guide/jsx-babel-compat.md
+++ b/docs/content/zh-CN/guide/jsx-babel-compat.md
@@ -113,8 +113,8 @@ Vapor semantics.
 ```
 
 **SSR输出。**插件的选项描述了客户端的 vnode 树。因此，SSR编译
-保留了整个巴别通道——包括`transformOn`和`enableObjectSlots`辅助、
-`isCustomElement`谓词、`mergeProps: false`以及所有仅巴别塔的降低——并使用Vize
+完全不应用 Babel 通道——不应用`transformOn`和`enableObjectSlots`辅助、
+`isCustomElement`谓词、`mergeProps: false`以及所有仅 Babel 的降级——并使用Vize
 自身的SSR语义，而不是输出半应用的混合。
 
 这两点都是刻意的回答，记录在箱子里，避免被重新争论。
@@ -124,10 +124,10 @@ Vapor semantics.
 两行语料库列被记录为 `deferred` 而非发散，因为它们都在等待
 无关的编译器工作，而非兼容模式：
 
-| 划船                      | 巴别塔的功效                          | 它正在等待什么                                                                                                                                                         |
+| 行                        | 巴别塔的功效                          | 它正在等待什么                                                                                                                                                         |
 | ------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `options/resolve_type_on` | 附录 `{ props: { … }, name: "A" }`    | 类型驱动的道具/发射推理，需要在[#1497](https://github.com/ubugeeei-prod/vize/issues/1497) / [#1502](https://github.com/ubugeeei-prod/vize/issues/1502)上跟踪类型分辨率 |
-| `slots/dynamic_slot_name` | 发射计算出的密钥， `{ [n]: () => … }` | 动态槽降;Vize目前警告并放弃了该槽位                                                                                                                                    |
+| `slots/dynamic_slot_name` | 发射计算出的密钥， `{ [n]: () => … }` | 动态插槽降级；Vize 目前会警告并丢弃该插槽                                                                                                                              |
 
 ## 兼容性的衡量方式
 

--- a/docs/theme/background.ts
+++ b/docs/theme/background.ts
@@ -1,7 +1,26 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-const SCRIPT_BASENAMES = ["vein", "i18n/navigation", "syntax-highlight"];
+/**
+ * Theme scripts, concatenated in this order into one inline `<script>`.
+ *
+ * The docs site has no module loader, so the i18n files talk to each other
+ * through globals and the order here is their dependency order: the sitemap
+ * and every locale's strings register themselves before `i18n/navigation`
+ * reads them. `docs-navigation.test.ts` pins this list against the locales the
+ * site actually ships.
+ */
+export const SCRIPT_BASENAMES = [
+  "vein",
+  "i18n/sitemap",
+  "i18n/locales/en",
+  "i18n/locales/ja",
+  "i18n/locales/zh-CN",
+  "i18n/locales/pt-BR",
+  "i18n/locales/fr",
+  "i18n/navigation",
+  "syntax-highlight",
+];
 const VERTEX_SHADER_PLACEHOLDER = "__VERT_SRC__";
 const FRAGMENT_SHADER_PLACEHOLDER = "__FRAG_SRC__";
 

--- a/docs/theme/i18n/locales/en.js
+++ b/docs/theme/i18n/locales/en.js
@@ -1,0 +1,88 @@
+/**
+ * English sidebar labels and chrome strings.
+ *
+ * English is also the fallback for every other locale: `navigation.js` falls
+ * back to a label here whenever a locale has no entry of its own, which is why
+ * this file — and only this file — carries the blog post titles.
+ */
+((locales) => {
+  locales.en = {
+    labels: {
+      "/": "Overview",
+      "/getting-started": "Getting Started",
+      "/stability": "Stability",
+      "/credits": "Credits",
+      "/guide/configuration": "Configuration",
+      "/guide/workflows": "User Workflows",
+      "/guide/jsx": "JSX & TSX",
+      "/guide/jsx-babel-compat": "Babel JSX Compat",
+      "/guide/troubleshooting": "Troubleshooting",
+      "/guide/cli": "CLI",
+      "/guide/vite-plugin": "Vite Plugin",
+      "/guide/unplugin": "Bundler Integrations",
+      "/guide/wasm": "WASM Bindings",
+      "/guide/static-analysis": "Static Analysis",
+      "/guide/cross-file-complexity": "Cross-file Complexity",
+      "/guide/analysis-diagnostics": "Diagnostics",
+      "/guide/oxlint": "Oxlint Plugin",
+      "/guide/comment-annotations": "Comment Annotations",
+      "/rules": "Rules Overview",
+      "/rules/all": "All Rules",
+      "/rules/vue": "Vue",
+      "/rules/type-and-script": "Type & Script",
+      "/rules/html": "HTML",
+      "/rules/accessibility": "Accessibility",
+      "/rules/ssr": "SSR",
+      "/rules/vapor": "Vapor",
+      "/rules/musea-and-css": "Musea & CSS",
+      "/rules/cross-file": "Cross-file Rules",
+      "/guide/musea": "Musea",
+      "/integrations/nuxt": "Nuxt",
+      "/integrations/vscode": "VS Code",
+      "/integrations/mcp": "MCP Server",
+      "/architecture/overview": "Architecture Overview",
+      "/architecture/crates": "Crates",
+      "/architecture/source-guide": "Source Guide",
+      "/architecture/language-engineering-practices": "Language Engineering",
+      "/architecture/performance": "Performance",
+      "/philosophy": "Philosophy",
+      "/blog": "Overview",
+      "/blog/notes": "Notes",
+      "/blog/releases": "Releases",
+      "/blog/notes/2026-05-16-comparing-vize-with-official-vue-oxc-golar-verter-flint-and-tsslint":
+        "Tooling Compare",
+      "/blog/notes/2026-05-16-performance-tuning-notes-for-a-vue-toolchain": "Performance Tuning",
+      "/blog/notes/2026-05-16-testing-agentic-coding-and-trust": "Testing & Agents",
+      "/blog/notes/2026-05-16-vapor-mode-and-the-next-vue-compiler-surface": "Vapor Mode",
+      "/blog/notes/2026-05-16-vue-as-a-language-and-the-strongest-frontend-environment":
+        "Vue as Language",
+      "/blog/notes/2026-05-16-why-musea-and-design-systems-matter-in-the-ai-era": "Musea & AI",
+      "/blog/notes/2026-05-16-real-world-feedback-and-the-road-to-production-ready":
+        "Production Ready",
+      "/blog/notes/2026-05-16-personal-tooling-and-development-speed": "Personal Speed",
+      "/blog/notes/2026-03-26-the-advantages-and-beauty-of-toolchains-and-vertical-integration":
+        "Vertical Toolchains",
+      "/blog/notes/2026-03-26-why-ai-needs-deterministic-fast-static-analysis": "Static Analysis",
+      "/blog/notes/2026-03-26-where-vize-fits-in-the-vue-tooling-landscape": "Vue Tooling",
+      "/blog/notes/2026-03-26-why-vize-needs-notes": "Notes Lane",
+      "/blog/releases/2026-03-26-oxlint-plugin-vize-alpha": "Oxlint Alpha",
+      "/blog/releases/2026-03-26-docs-blog-support": "Docs Blog",
+    },
+    ui: {
+      groups: {
+        start: "Start",
+        projectSetup: "Project Setup",
+        staticAnalysis: "Static Analysis",
+        rules: "Rules",
+        tooling: "Tooling",
+        architecture: "Architecture",
+        blog: "Blog",
+      },
+      language: "Language",
+      more: "More",
+      search: "Search",
+      searchPlaceholder: "Search documentation...",
+      footer: 'Released under the <a href="https://opensource.org/licenses/MIT">MIT License</a>.',
+    },
+  };
+})((globalThis.__vizeDocsLocales ??= {}));

--- a/docs/theme/i18n/locales/fr.js
+++ b/docs/theme/i18n/locales/fr.js
@@ -1,0 +1,69 @@
+/**
+ * French sidebar labels and chrome strings.
+ *
+ * Only overrides live here; any path without an entry falls back to the
+ * English label in `en.js`, which is where the blog post titles are kept.
+ */
+((locales) => {
+  locales.fr = {
+    labels: {
+      "/": "Vue d’ensemble",
+      "/getting-started": "Bien démarrer",
+      "/stability": "Stabilité",
+      "/credits": "Crédits",
+      "/guide/configuration": "Configuration",
+      "/guide/workflows": "Flux de travail",
+      "/guide/jsx": "JSX et TSX",
+      "/guide/jsx-babel-compat": "Compatibilité Babel JSX",
+      "/guide/troubleshooting": "Dépannage",
+      "/guide/cli": "CLI",
+      "/guide/vite-plugin": "Plugin Vite",
+      "/guide/unplugin": "Intégrations des bundlers",
+      "/guide/wasm": "Bindings WASM",
+      "/guide/static-analysis": "Analyse statique",
+      "/guide/cross-file-complexity": "Complexité inter-fichiers",
+      "/guide/analysis-diagnostics": "Diagnostics",
+      "/guide/oxlint": "Plugin Oxlint",
+      "/guide/comment-annotations": "Annotations de commentaires",
+      "/rules": "Vue d’ensemble des règles",
+      "/rules/all": "Toutes les règles",
+      "/rules/vue": "Vue",
+      "/rules/type-and-script": "Types et scripts",
+      "/rules/html": "HTML",
+      "/rules/accessibility": "Accessibilité",
+      "/rules/ssr": "SSR",
+      "/rules/vapor": "Vapor",
+      "/rules/musea-and-css": "Musea et CSS",
+      "/rules/cross-file": "Règles inter-fichiers",
+      "/guide/musea": "Musea",
+      "/integrations/nuxt": "Nuxt",
+      "/integrations/vscode": "VS Code",
+      "/integrations/mcp": "Serveur MCP",
+      "/architecture/overview": "Vue d’ensemble de l’architecture",
+      "/architecture/crates": "Crates",
+      "/architecture/source-guide": "Guide du code source",
+      "/architecture/language-engineering-practices": "Ingénierie des langages",
+      "/architecture/performance": "Performances",
+      "/philosophy": "Philosophie",
+      "/blog": "Vue d’ensemble",
+      "/blog/notes": "Notes",
+      "/blog/releases": "Versions",
+    },
+    ui: {
+      groups: {
+        start: "Accueil",
+        projectSetup: "Configuration du projet",
+        staticAnalysis: "Analyse statique",
+        rules: "Règles",
+        tooling: "Outils",
+        architecture: "Architecture",
+        blog: "Blog",
+      },
+      language: "Langue",
+      more: "Plus",
+      search: "Rechercher",
+      searchPlaceholder: "Rechercher dans la documentation...",
+      footer: 'Publié sous <a href="https://opensource.org/licenses/MIT">licence MIT</a>.',
+    },
+  };
+})((globalThis.__vizeDocsLocales ??= {}));

--- a/docs/theme/i18n/locales/ja.js
+++ b/docs/theme/i18n/locales/ja.js
@@ -1,0 +1,70 @@
+/**
+ * Japanese sidebar labels and chrome strings.
+ *
+ * Only overrides live here; any path without an entry falls back to the
+ * English label in `en.js`, which is where the blog post titles are kept.
+ */
+((locales) => {
+  locales.ja = {
+    labels: {
+      "/": "概要",
+      "/getting-started": "はじめに",
+      "/stability": "安定性",
+      "/credits": "クレジット",
+      "/guide/configuration": "設定",
+      "/guide/workflows": "ユーザーワークフロー",
+      "/guide/jsx": "JSX & TSX",
+      "/guide/jsx-babel-compat": "Babel JSX 互換",
+      "/guide/troubleshooting": "トラブルシューティング",
+      "/guide/cli": "CLI",
+      "/guide/vite-plugin": "Vite プラグイン",
+      "/guide/unplugin": "バンドラー統合",
+      "/guide/wasm": "WASM バインディング",
+      "/guide/static-analysis": "静的解析",
+      "/guide/cross-file-complexity": "ファイル横断の複雑性",
+      "/guide/analysis-diagnostics": "診断",
+      "/guide/oxlint": "Oxlint プラグイン",
+      "/guide/comment-annotations": "コメント注釈",
+      "/rules": "ルール概要",
+      "/rules/all": "すべてのルール",
+      "/rules/vue": "Vue",
+      "/rules/type-and-script": "型とスクリプト",
+      "/rules/html": "HTML",
+      "/rules/accessibility": "アクセシビリティ",
+      "/rules/ssr": "SSR",
+      "/rules/vapor": "Vapor",
+      "/rules/musea-and-css": "Musea と CSS",
+      "/rules/cross-file": "ファイル横断ルール",
+      "/guide/musea": "Musea",
+      "/integrations/nuxt": "Nuxt",
+      "/integrations/vscode": "VS Code",
+      "/integrations/mcp": "MCP サーバー",
+      "/architecture/overview": "アーキテクチャ概要",
+      "/architecture/crates": "クレート",
+      "/architecture/source-guide": "ソースガイド",
+      "/architecture/language-engineering-practices": "言語エンジニアリング",
+      "/architecture/performance": "パフォーマンス",
+      "/philosophy": "思想",
+      "/blog": "概要",
+      "/blog/notes": "ノート",
+      "/blog/releases": "リリース",
+    },
+    ui: {
+      groups: {
+        start: "スタート",
+        projectSetup: "プロジェクト設定",
+        staticAnalysis: "静的解析",
+        rules: "ルール",
+        tooling: "ツール",
+        architecture: "アーキテクチャ",
+        blog: "ブログ",
+      },
+      language: "言語",
+      more: "その他",
+      search: "検索",
+      searchPlaceholder: "ドキュメントを検索...",
+      footer:
+        '<a href="https://opensource.org/licenses/MIT">MIT License</a> の下で公開されています。',
+    },
+  };
+})((globalThis.__vizeDocsLocales ??= {}));

--- a/docs/theme/i18n/locales/pt-BR.js
+++ b/docs/theme/i18n/locales/pt-BR.js
@@ -1,0 +1,69 @@
+/**
+ * Brazilian Portuguese sidebar labels and chrome strings.
+ *
+ * Only overrides live here; any path without an entry falls back to the
+ * English label in `en.js`, which is where the blog post titles are kept.
+ */
+((locales) => {
+  locales["pt-BR"] = {
+    labels: {
+      "/": "Visão geral",
+      "/getting-started": "Primeiros passos",
+      "/stability": "Estabilidade",
+      "/credits": "Créditos",
+      "/guide/configuration": "Configuração",
+      "/guide/workflows": "Fluxos de trabalho",
+      "/guide/jsx": "JSX e TSX",
+      "/guide/jsx-babel-compat": "Compatibilidade com Babel JSX",
+      "/guide/troubleshooting": "Solução de problemas",
+      "/guide/cli": "CLI",
+      "/guide/vite-plugin": "Plugin do Vite",
+      "/guide/unplugin": "Integrações com bundlers",
+      "/guide/wasm": "Bindings WASM",
+      "/guide/static-analysis": "Análise estática",
+      "/guide/cross-file-complexity": "Complexidade entre arquivos",
+      "/guide/analysis-diagnostics": "Diagnósticos",
+      "/guide/oxlint": "Plugin do Oxlint",
+      "/guide/comment-annotations": "Anotações em comentários",
+      "/rules": "Visão geral das regras",
+      "/rules/all": "Todas as regras",
+      "/rules/vue": "Vue",
+      "/rules/type-and-script": "Tipos e scripts",
+      "/rules/html": "HTML",
+      "/rules/accessibility": "Acessibilidade",
+      "/rules/ssr": "SSR",
+      "/rules/vapor": "Vapor",
+      "/rules/musea-and-css": "Musea e CSS",
+      "/rules/cross-file": "Regras entre arquivos",
+      "/guide/musea": "Musea",
+      "/integrations/nuxt": "Nuxt",
+      "/integrations/vscode": "VS Code",
+      "/integrations/mcp": "Servidor MCP",
+      "/architecture/overview": "Visão geral da arquitetura",
+      "/architecture/crates": "Crates",
+      "/architecture/source-guide": "Guia do código-fonte",
+      "/architecture/language-engineering-practices": "Engenharia de linguagens",
+      "/architecture/performance": "Desempenho",
+      "/philosophy": "Filosofia",
+      "/blog": "Visão geral",
+      "/blog/notes": "Notas",
+      "/blog/releases": "Versões",
+    },
+    ui: {
+      groups: {
+        start: "Início",
+        projectSetup: "Configuração do projeto",
+        staticAnalysis: "Análise estática",
+        rules: "Regras",
+        tooling: "Ferramentas",
+        architecture: "Arquitetura",
+        blog: "Blog",
+      },
+      language: "Idioma",
+      more: "Mais",
+      search: "Pesquisar",
+      searchPlaceholder: "Pesquisar na documentação...",
+      footer: 'Publicado sob a <a href="https://opensource.org/licenses/MIT">Licença MIT</a>.',
+    },
+  };
+})((globalThis.__vizeDocsLocales ??= {}));

--- a/docs/theme/i18n/locales/zh-CN.js
+++ b/docs/theme/i18n/locales/zh-CN.js
@@ -1,0 +1,69 @@
+/**
+ * Simplified Chinese sidebar labels and chrome strings.
+ *
+ * Only overrides live here; any path without an entry falls back to the
+ * English label in `en.js`, which is where the blog post titles are kept.
+ */
+((locales) => {
+  locales["zh-CN"] = {
+    labels: {
+      "/": "概述",
+      "/getting-started": "入门",
+      "/stability": "稳定性",
+      "/credits": "致谢",
+      "/guide/configuration": "配置",
+      "/guide/workflows": "用户工作流",
+      "/guide/jsx": "JSX 与 TSX",
+      "/guide/jsx-babel-compat": "Babel JSX 兼容",
+      "/guide/troubleshooting": "故障排除",
+      "/guide/cli": "CLI",
+      "/guide/vite-plugin": "Vite 插件",
+      "/guide/unplugin": "打包器集成",
+      "/guide/wasm": "WASM 绑定",
+      "/guide/static-analysis": "静态分析",
+      "/guide/cross-file-complexity": "跨文件复杂度",
+      "/guide/analysis-diagnostics": "诊断",
+      "/guide/oxlint": "Oxlint 插件",
+      "/guide/comment-annotations": "注释标注",
+      "/rules": "规则概述",
+      "/rules/all": "全部规则",
+      "/rules/vue": "Vue",
+      "/rules/type-and-script": "类型与脚本",
+      "/rules/html": "HTML",
+      "/rules/accessibility": "无障碍",
+      "/rules/ssr": "SSR",
+      "/rules/vapor": "Vapor",
+      "/rules/musea-and-css": "Musea 与 CSS",
+      "/rules/cross-file": "跨文件规则",
+      "/guide/musea": "Musea",
+      "/integrations/nuxt": "Nuxt",
+      "/integrations/vscode": "VS Code",
+      "/integrations/mcp": "MCP 服务器",
+      "/architecture/overview": "架构概述",
+      "/architecture/crates": "Crate",
+      "/architecture/source-guide": "源码指南",
+      "/architecture/language-engineering-practices": "语言工程",
+      "/architecture/performance": "性能",
+      "/philosophy": "理念",
+      "/blog": "概述",
+      "/blog/notes": "笔记",
+      "/blog/releases": "发布",
+    },
+    ui: {
+      groups: {
+        start: "开始",
+        projectSetup: "项目设置",
+        staticAnalysis: "静态分析",
+        rules: "规则",
+        tooling: "工具",
+        architecture: "架构",
+        blog: "博客",
+      },
+      language: "语言",
+      more: "更多",
+      search: "搜索",
+      searchPlaceholder: "搜索文档...",
+      footer: '根据 <a href="https://opensource.org/licenses/MIT">MIT License</a> 发布。',
+    },
+  };
+})((globalThis.__vizeDocsLocales ??= {}));

--- a/docs/theme/i18n/navigation.js
+++ b/docs/theme/i18n/navigation.js
@@ -1,414 +1,34 @@
+/**
+ * Sidebar grouping, label localization, and the header language picker.
+ *
+ * This file is behavior only. The sidebar structure lives in `sitemap.js` and
+ * the strings live in `locales/<code>.js`; both register themselves on globals
+ * that `theme/background.ts` guarantees are concatenated ahead of this file.
+ * They are read lazily, at call time, so nothing here depends on evaluation
+ * order beyond `initialize` running after the page is parsed.
+ */
 const vizeDocsI18nNavigation = (() => {
-  const supportedLocales = [
-    { code: "en", name: "English" },
-    { code: "ja", name: "日本語" },
-    { code: "zh-CN", name: "简体中文" },
-    { code: "pt-BR", name: "Português" },
-    { code: "fr", name: "Français" },
-  ];
-  const localeCodes = new Set(supportedLocales.map(({ code }) => code));
+  function sitemap() {
+    return globalThis.__vizeDocsSitemap;
+  }
 
-  const blogNavigationItems = [
-    ["/blog", "Overview"],
-    ["/blog/notes", "Notes"],
-    ["/blog/releases", "Releases"],
-  ];
+  function locales() {
+    return globalThis.__vizeDocsLocales;
+  }
 
-  const blogPostLabels = [
-    [
-      "/blog/notes/2026-05-16-comparing-vize-with-official-vue-oxc-golar-verter-flint-and-tsslint",
-      "Tooling Compare",
-    ],
-    ["/blog/notes/2026-05-16-performance-tuning-notes-for-a-vue-toolchain", "Performance Tuning"],
-    ["/blog/notes/2026-05-16-testing-agentic-coding-and-trust", "Testing & Agents"],
-    ["/blog/notes/2026-05-16-vapor-mode-and-the-next-vue-compiler-surface", "Vapor Mode"],
-    [
-      "/blog/notes/2026-05-16-vue-as-a-language-and-the-strongest-frontend-environment",
-      "Vue as Language",
-    ],
-    ["/blog/notes/2026-05-16-why-musea-and-design-systems-matter-in-the-ai-era", "Musea & AI"],
-    [
-      "/blog/notes/2026-05-16-real-world-feedback-and-the-road-to-production-ready",
-      "Production Ready",
-    ],
-    ["/blog/notes/2026-05-16-personal-tooling-and-development-speed", "Personal Speed"],
-    [
-      "/blog/notes/2026-03-26-the-advantages-and-beauty-of-toolchains-and-vertical-integration",
-      "Vertical Toolchains",
-    ],
-    ["/blog/notes/2026-03-26-why-ai-needs-deterministic-fast-static-analysis", "Static Analysis"],
-    ["/blog/notes/2026-03-26-where-vize-fits-in-the-vue-tooling-landscape", "Vue Tooling"],
-    ["/blog/notes/2026-03-26-why-vize-needs-notes", "Notes Lane"],
-    ["/blog/releases/2026-03-26-oxlint-plugin-vize-alpha", "Oxlint Alpha"],
-    ["/blog/releases/2026-03-26-docs-blog-support", "Docs Blog"],
-  ];
+  function localeStrings(locale) {
+    return locales()[locale] ?? locales().en;
+  }
 
-  const labelByPath = new Map([
-    ["/", "Overview"],
-    ["/getting-started", "Getting Started"],
-    ["/stability", "Stability"],
-    ["/credits", "Credits"],
-    ["/guide/configuration", "Configuration"],
-    ["/guide/workflows", "User Workflows"],
-    ["/guide/jsx", "JSX & TSX"],
-    ["/guide/troubleshooting", "Troubleshooting"],
-    ["/guide/cli", "CLI"],
-    ["/guide/vite-plugin", "Vite Plugin"],
-    ["/guide/unplugin", "Bundler Integrations"],
-    ["/guide/wasm", "WASM Bindings"],
-    ["/guide/static-analysis", "Static Analysis"],
-    ["/guide/cross-file-complexity", "Cross-file Complexity"],
-    ["/guide/analysis-diagnostics", "Diagnostics"],
-    ["/guide/oxlint", "Oxlint Plugin"],
-    ["/guide/comment-annotations", "Comment Annotations"],
-    ["/rules", "Rules Overview"],
-    ["/rules/all", "All Rules"],
-    ["/rules/vue", "Vue"],
-    ["/rules/type-and-script", "Type & Script"],
-    ["/rules/html", "HTML"],
-    ["/rules/accessibility", "Accessibility"],
-    ["/rules/ssr", "SSR"],
-    ["/rules/vapor", "Vapor"],
-    ["/rules/musea-and-css", "Musea & CSS"],
-    ["/rules/cross-file", "Cross-file Rules"],
-    ["/guide/musea", "Musea"],
-    ["/integrations/nuxt", "Nuxt"],
-    ["/integrations/vscode", "VS Code"],
-    ["/integrations/mcp", "MCP Server"],
-    ["/architecture/overview", "Architecture Overview"],
-    ["/architecture/crates", "Crates"],
-    ["/architecture/source-guide", "Source Guide"],
-    ["/architecture/language-engineering-practices", "Language Engineering"],
-    ["/architecture/performance", "Performance"],
-    ["/philosophy", "Philosophy"],
-    ...blogNavigationItems,
-    ...blogPostLabels,
-  ]);
-
-  const localizedLabels = {
-    ja: {
-      "/": "概要",
-      "/getting-started": "はじめに",
-      "/stability": "安定性",
-      "/credits": "クレジット",
-      "/guide/configuration": "設定",
-      "/guide/workflows": "ユーザーワークフロー",
-      "/guide/jsx": "JSX & TSX",
-      "/guide/troubleshooting": "トラブルシューティング",
-      "/guide/cli": "CLI",
-      "/guide/vite-plugin": "Vite プラグイン",
-      "/guide/unplugin": "バンドラー統合",
-      "/guide/wasm": "WASM バインディング",
-      "/guide/static-analysis": "静的解析",
-      "/guide/cross-file-complexity": "ファイル横断の複雑性",
-      "/guide/analysis-diagnostics": "診断",
-      "/guide/oxlint": "Oxlint プラグイン",
-      "/guide/comment-annotations": "コメント注釈",
-      "/rules": "ルール概要",
-      "/rules/all": "すべてのルール",
-      "/rules/vue": "Vue",
-      "/rules/type-and-script": "型とスクリプト",
-      "/rules/html": "HTML",
-      "/rules/accessibility": "アクセシビリティ",
-      "/rules/ssr": "SSR",
-      "/rules/vapor": "Vapor",
-      "/rules/musea-and-css": "Musea と CSS",
-      "/rules/cross-file": "ファイル横断ルール",
-      "/guide/musea": "Musea",
-      "/integrations/nuxt": "Nuxt",
-      "/integrations/vscode": "VS Code",
-      "/integrations/mcp": "MCP サーバー",
-      "/architecture/overview": "アーキテクチャ概要",
-      "/architecture/crates": "クレート",
-      "/architecture/source-guide": "ソースガイド",
-      "/architecture/language-engineering-practices": "言語エンジニアリング",
-      "/architecture/performance": "パフォーマンス",
-      "/philosophy": "思想",
-      "/blog": "概要",
-      "/blog/notes": "ノート",
-      "/blog/releases": "リリース",
-    },
-    "zh-CN": {
-      "/": "概述",
-      "/getting-started": "入门",
-      "/stability": "稳定性",
-      "/credits": "致谢",
-      "/guide/configuration": "配置",
-      "/guide/workflows": "用户工作流",
-      "/guide/jsx": "JSX 与 TSX",
-      "/guide/troubleshooting": "故障排除",
-      "/guide/cli": "CLI",
-      "/guide/vite-plugin": "Vite 插件",
-      "/guide/unplugin": "打包器集成",
-      "/guide/wasm": "WASM 绑定",
-      "/guide/static-analysis": "静态分析",
-      "/guide/cross-file-complexity": "跨文件复杂度",
-      "/guide/analysis-diagnostics": "诊断",
-      "/guide/oxlint": "Oxlint 插件",
-      "/guide/comment-annotations": "注释标注",
-      "/rules": "规则概述",
-      "/rules/all": "全部规则",
-      "/rules/vue": "Vue",
-      "/rules/type-and-script": "类型与脚本",
-      "/rules/html": "HTML",
-      "/rules/accessibility": "无障碍",
-      "/rules/ssr": "SSR",
-      "/rules/vapor": "Vapor",
-      "/rules/musea-and-css": "Musea 与 CSS",
-      "/rules/cross-file": "跨文件规则",
-      "/guide/musea": "Musea",
-      "/integrations/nuxt": "Nuxt",
-      "/integrations/vscode": "VS Code",
-      "/integrations/mcp": "MCP 服务器",
-      "/architecture/overview": "架构概述",
-      "/architecture/crates": "Crate",
-      "/architecture/source-guide": "源码指南",
-      "/architecture/language-engineering-practices": "语言工程",
-      "/architecture/performance": "性能",
-      "/philosophy": "理念",
-      "/blog": "概述",
-      "/blog/notes": "笔记",
-      "/blog/releases": "发布",
-    },
-    "pt-BR": {
-      "/": "Visão geral",
-      "/getting-started": "Primeiros passos",
-      "/stability": "Estabilidade",
-      "/credits": "Créditos",
-      "/guide/configuration": "Configuração",
-      "/guide/workflows": "Fluxos de trabalho",
-      "/guide/jsx": "JSX e TSX",
-      "/guide/troubleshooting": "Solução de problemas",
-      "/guide/cli": "CLI",
-      "/guide/vite-plugin": "Plugin do Vite",
-      "/guide/unplugin": "Integrações com bundlers",
-      "/guide/wasm": "Bindings WASM",
-      "/guide/static-analysis": "Análise estática",
-      "/guide/cross-file-complexity": "Complexidade entre arquivos",
-      "/guide/analysis-diagnostics": "Diagnósticos",
-      "/guide/oxlint": "Plugin do Oxlint",
-      "/guide/comment-annotations": "Anotações em comentários",
-      "/rules": "Visão geral das regras",
-      "/rules/all": "Todas as regras",
-      "/rules/vue": "Vue",
-      "/rules/type-and-script": "Tipos e scripts",
-      "/rules/html": "HTML",
-      "/rules/accessibility": "Acessibilidade",
-      "/rules/ssr": "SSR",
-      "/rules/vapor": "Vapor",
-      "/rules/musea-and-css": "Musea e CSS",
-      "/rules/cross-file": "Regras entre arquivos",
-      "/guide/musea": "Musea",
-      "/integrations/nuxt": "Nuxt",
-      "/integrations/vscode": "VS Code",
-      "/integrations/mcp": "Servidor MCP",
-      "/architecture/overview": "Visão geral da arquitetura",
-      "/architecture/crates": "Crates",
-      "/architecture/source-guide": "Guia do código-fonte",
-      "/architecture/language-engineering-practices": "Engenharia de linguagens",
-      "/architecture/performance": "Desempenho",
-      "/philosophy": "Filosofia",
-      "/blog": "Visão geral",
-      "/blog/notes": "Notas",
-      "/blog/releases": "Versões",
-    },
-    fr: {
-      "/": "Vue d’ensemble",
-      "/getting-started": "Bien démarrer",
-      "/stability": "Stabilité",
-      "/credits": "Crédits",
-      "/guide/configuration": "Configuration",
-      "/guide/workflows": "Flux de travail",
-      "/guide/jsx": "JSX et TSX",
-      "/guide/troubleshooting": "Dépannage",
-      "/guide/cli": "CLI",
-      "/guide/vite-plugin": "Plugin Vite",
-      "/guide/unplugin": "Intégrations des bundlers",
-      "/guide/wasm": "Bindings WASM",
-      "/guide/static-analysis": "Analyse statique",
-      "/guide/cross-file-complexity": "Complexité inter-fichiers",
-      "/guide/analysis-diagnostics": "Diagnostics",
-      "/guide/oxlint": "Plugin Oxlint",
-      "/guide/comment-annotations": "Annotations de commentaires",
-      "/rules": "Vue d’ensemble des règles",
-      "/rules/all": "Toutes les règles",
-      "/rules/vue": "Vue",
-      "/rules/type-and-script": "Types et scripts",
-      "/rules/html": "HTML",
-      "/rules/accessibility": "Accessibilité",
-      "/rules/ssr": "SSR",
-      "/rules/vapor": "Vapor",
-      "/rules/musea-and-css": "Musea et CSS",
-      "/rules/cross-file": "Règles inter-fichiers",
-      "/guide/musea": "Musea",
-      "/integrations/nuxt": "Nuxt",
-      "/integrations/vscode": "VS Code",
-      "/integrations/mcp": "Serveur MCP",
-      "/architecture/overview": "Vue d’ensemble de l’architecture",
-      "/architecture/crates": "Crates",
-      "/architecture/source-guide": "Guide du code source",
-      "/architecture/language-engineering-practices": "Ingénierie des langages",
-      "/architecture/performance": "Performances",
-      "/philosophy": "Philosophie",
-      "/blog": "Vue d’ensemble",
-      "/blog/notes": "Notes",
-      "/blog/releases": "Versions",
-    },
-  };
-
-  const localizedUi = {
-    en: {
-      groups: [
-        "Start",
-        "Project Setup",
-        "Static Analysis",
-        "Rules",
-        "Tooling",
-        "Architecture",
-        "Blog",
-      ],
-      language: "Language",
-      more: "More",
-      search: "Search",
-      searchPlaceholder: "Search documentation...",
-      footer: 'Released under the <a href="https://opensource.org/licenses/MIT">MIT License</a>.',
-    },
-    ja: {
-      groups: [
-        "スタート",
-        "プロジェクト設定",
-        "静的解析",
-        "ルール",
-        "ツール",
-        "アーキテクチャ",
-        "ブログ",
-      ],
-      language: "言語",
-      more: "その他",
-      search: "検索",
-      searchPlaceholder: "ドキュメントを検索...",
-      footer:
-        '<a href="https://opensource.org/licenses/MIT">MIT License</a> の下で公開されています。',
-    },
-    "zh-CN": {
-      groups: ["开始", "项目设置", "静态分析", "规则", "工具", "架构", "博客"],
-      language: "语言",
-      more: "更多",
-      search: "搜索",
-      searchPlaceholder: "搜索文档...",
-      footer: '根据 <a href="https://opensource.org/licenses/MIT">MIT License</a> 发布。',
-    },
-    "pt-BR": {
-      groups: [
-        "Início",
-        "Configuração do projeto",
-        "Análise estática",
-        "Regras",
-        "Ferramentas",
-        "Arquitetura",
-        "Blog",
-      ],
-      language: "Idioma",
-      more: "Mais",
-      search: "Pesquisar",
-      searchPlaceholder: "Pesquisar na documentação...",
-      footer: 'Publicado sob a <a href="https://opensource.org/licenses/MIT">Licença MIT</a>.',
-    },
-    fr: {
-      groups: [
-        "Accueil",
-        "Configuration du projet",
-        "Analyse statique",
-        "Règles",
-        "Outils",
-        "Architecture",
-        "Blog",
-      ],
-      language: "Langue",
-      more: "Plus",
-      search: "Rechercher",
-      searchPlaceholder: "Rechercher dans la documentation...",
-      footer: 'Publié sous <a href="https://opensource.org/licenses/MIT">licence MIT</a>.',
-    },
-  };
-
-  const hiddenPathPatterns = [
-    /^\/blog\/notes\/\d{4}-\d{2}-\d{2}-/,
-    /^\/blog\/releases\/\d{4}-\d{2}-\d{2}-/,
-  ];
-
-  const navGroups = [
-    {
-      title: "Start",
-      paths: ["/", "/getting-started", "/stability", "/credits"],
-    },
-    {
-      title: "Project Setup",
-      paths: [
-        "/guide/vite-plugin",
-        "/integrations/nuxt",
-        "/guide/workflows",
-        "/guide/configuration",
-        "/guide/jsx",
-        "/guide/troubleshooting",
-        "/guide/unplugin",
-      ],
-    },
-    {
-      title: "Static Analysis",
-      paths: [
-        "/guide/static-analysis",
-        "/guide/cross-file-complexity",
-        "/guide/analysis-diagnostics",
-        "/guide/oxlint",
-        "/guide/comment-annotations",
-      ],
-    },
-    {
-      title: "Rules",
-      paths: [
-        "/rules",
-        "/rules/all",
-        "/rules/vue",
-        "/rules/type-and-script",
-        "/rules/html",
-        "/rules/accessibility",
-        "/rules/ssr",
-        "/rules/vapor",
-        "/rules/musea-and-css",
-        "/rules/cross-file",
-      ],
-    },
-    {
-      title: "Tooling",
-      paths: [
-        "/guide/musea",
-        "/integrations/vscode",
-        "/integrations/mcp",
-        "/guide/wasm",
-        "/guide/cli",
-      ],
-    },
-    {
-      title: "Architecture",
-      paths: [
-        "/architecture/overview",
-        "/architecture/crates",
-        "/architecture/source-guide",
-        "/architecture/language-engineering-practices",
-        "/architecture/performance",
-        "/philosophy",
-      ],
-    },
-    {
-      title: "Blog",
-      paths: blogNavigationItems.map(([path]) => path),
-    },
-  ];
+  function label(locale, path, fallback) {
+    return localeStrings(locale).labels[path] ?? locales().en.labels[path] ?? fallback;
+  }
 
   function pathLocale(path) {
     const firstSegment = path.split("/").find(Boolean);
-    return localeCodes.has(firstSegment) ? firstSegment : "en";
+    return sitemap().supportedLocales.some(({ code }) => code === firstSegment)
+      ? firstSegment
+      : "en";
   }
 
   function currentLocale() {
@@ -446,7 +66,7 @@ const vizeDocsI18nNavigation = (() => {
   }
 
   function isHiddenFallbackPath(path) {
-    return hiddenPathPatterns.some((pattern) => pattern.test(path));
+    return sitemap().hiddenPathPatterns.some((pattern) => pattern.test(path));
   }
 
   function applyNavigationOrder(root = document) {
@@ -456,6 +76,7 @@ const vizeDocsI18nNavigation = (() => {
     }
 
     const locale = currentLocale();
+    const ui = localeStrings(locale).ui;
     const itemsByPath = new Map();
     const unusedItems = [];
     for (const item of nav.querySelectorAll(".nav-item")) {
@@ -472,8 +93,7 @@ const vizeDocsI18nNavigation = (() => {
       }
 
       const path = canonicalPath(href);
-      link.textContent =
-        localizedLabels[locale]?.[path] ?? labelByPath.get(path) ?? link.textContent.trim();
+      link.textContent = label(locale, path, link.textContent.trim());
       if (itemsByPath.has(path)) {
         unusedItems.push(item);
         continue;
@@ -483,7 +103,7 @@ const vizeDocsI18nNavigation = (() => {
 
     const nextNav = document.createDocumentFragment();
     const used = new Set();
-    for (const [groupIndex, group] of navGroups.entries()) {
+    for (const group of sitemap().navGroups) {
       const items = group.paths
         .map((path) => {
           used.add(path);
@@ -492,7 +112,7 @@ const vizeDocsI18nNavigation = (() => {
         .filter(Boolean);
 
       if (items.length > 0) {
-        nextNav.append(createSection(localizedUi[locale].groups[groupIndex], items));
+        nextNav.append(createSection(ui.groups[group.key], items));
       }
     }
 
@@ -501,7 +121,7 @@ const vizeDocsI18nNavigation = (() => {
       .map(([, item]) => item)
       .concat(unusedItems);
     if (remainingItems.length > 0) {
-      nextNav.append(createSection(localizedUi[locale].more, remainingItems));
+      nextNav.append(createSection(ui.more, remainingItems));
     }
 
     nav.replaceChildren(nextNav);
@@ -517,7 +137,7 @@ const vizeDocsI18nNavigation = (() => {
 
   function applyLocalizedChrome(root = document) {
     const locale = currentLocale();
-    const ui = localizedUi[locale];
+    const ui = localeStrings(locale).ui;
     const headerTitle = root.querySelector?.(".header-title");
     if (headerTitle) {
       headerTitle.setAttribute("href", locale === "en" ? "/index.html" : `/${locale}/index.html`);
@@ -540,16 +160,17 @@ const vizeDocsI18nNavigation = (() => {
     if (!headerActions || headerActions.querySelector(".docs-locale")) return;
 
     const locale = currentLocale();
+    const language = localeStrings(locale).ui.language;
     const wrapper = document.createElement("label");
     wrapper.className = "docs-locale";
-    wrapper.setAttribute("aria-label", localizedUi[locale].language);
+    wrapper.setAttribute("aria-label", language);
 
-    const label = document.createElement("span");
-    label.textContent = localizedUi[locale].language;
+    const labelElement = document.createElement("span");
+    labelElement.textContent = language;
     const select = document.createElement("select");
     select.className = "docs-locale-select";
-    select.setAttribute("aria-label", localizedUi[locale].language);
-    for (const supportedLocale of supportedLocales) {
+    select.setAttribute("aria-label", language);
+    for (const supportedLocale of sitemap().supportedLocales) {
       const option = document.createElement("option");
       option.value = supportedLocale.code;
       option.textContent = supportedLocale.name;
@@ -559,7 +180,7 @@ const vizeDocsI18nNavigation = (() => {
     select.addEventListener("change", () => {
       window.location.href = `${localizedPagePath(select.value)}${window.location.search}${window.location.hash}`;
     });
-    wrapper.append(label, select);
+    wrapper.append(labelElement, select);
 
     const searchButton = headerActions.querySelector(".search-button");
     headerActions.insertBefore(wrapper, searchButton);

--- a/docs/theme/i18n/sitemap.js
+++ b/docs/theme/i18n/sitemap.js
@@ -1,0 +1,101 @@
+/**
+ * Sidebar structure shared by every locale: which pages exist, how they are
+ * grouped, and which locales the site ships.
+ *
+ * Strings live in `locales/<code>.js`, one file per locale, keyed by the same
+ * paths and the same group keys used here. Nothing on the docs site loads
+ * modules, so each theme file is a plain script that registers itself on a
+ * global; `theme/background.ts` concatenates them in order and inlines the
+ * result, with `i18n/navigation.js` last.
+ */
+((sitemap) => {
+  // Order matters: it is the order of the header language picker. Keep this in
+  // sync with `i18n.locales` in `docs/vite.config.ts`.
+  sitemap.supportedLocales = [
+    { code: "en", name: "English" },
+    { code: "ja", name: "日本語" },
+    { code: "zh-CN", name: "简体中文" },
+    { code: "pt-BR", name: "Português" },
+    { code: "fr", name: "Français" },
+  ];
+
+  sitemap.blogNavigationPaths = ["/blog", "/blog/notes", "/blog/releases"];
+
+  // Dated posts are reachable from the blog index; keeping them out of the
+  // "More" fallback stops the sidebar from growing with every post.
+  sitemap.hiddenPathPatterns = [
+    /^\/blog\/notes\/\d{4}-\d{2}-\d{2}-/,
+    /^\/blog\/releases\/\d{4}-\d{2}-\d{2}-/,
+  ];
+
+  // `key` selects the section heading from a locale's `ui.groups`.
+  sitemap.navGroups = [
+    {
+      key: "start",
+      paths: ["/", "/getting-started", "/stability", "/credits"],
+    },
+    {
+      key: "projectSetup",
+      paths: [
+        "/guide/vite-plugin",
+        "/integrations/nuxt",
+        "/guide/workflows",
+        "/guide/configuration",
+        "/guide/jsx",
+        "/guide/jsx-babel-compat",
+        "/guide/troubleshooting",
+        "/guide/unplugin",
+      ],
+    },
+    {
+      key: "staticAnalysis",
+      paths: [
+        "/guide/static-analysis",
+        "/guide/cross-file-complexity",
+        "/guide/analysis-diagnostics",
+        "/guide/oxlint",
+        "/guide/comment-annotations",
+      ],
+    },
+    {
+      key: "rules",
+      paths: [
+        "/rules",
+        "/rules/all",
+        "/rules/vue",
+        "/rules/type-and-script",
+        "/rules/html",
+        "/rules/accessibility",
+        "/rules/ssr",
+        "/rules/vapor",
+        "/rules/musea-and-css",
+        "/rules/cross-file",
+      ],
+    },
+    {
+      key: "tooling",
+      paths: [
+        "/guide/musea",
+        "/integrations/vscode",
+        "/integrations/mcp",
+        "/guide/wasm",
+        "/guide/cli",
+      ],
+    },
+    {
+      key: "architecture",
+      paths: [
+        "/architecture/overview",
+        "/architecture/crates",
+        "/architecture/source-guide",
+        "/architecture/language-engineering-practices",
+        "/architecture/performance",
+        "/philosophy",
+      ],
+    },
+    {
+      key: "blog",
+      paths: sitemap.blogNavigationPaths,
+    },
+  ];
+})((globalThis.__vizeDocsSitemap ??= {}));

--- a/docs/theme/navigation.test.js
+++ b/docs/theme/navigation.test.js
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { SCRIPT_BASENAMES } from "./background.ts";
 
-await import("./i18n/navigation.js");
+// The docs site has no module loader: the theme scripts are concatenated in
+// `SCRIPT_BASENAMES` order and talk through globals. Loading the i18n files in
+// that same order is what makes this file exercise the shipped wiring.
+for (const basename of SCRIPT_BASENAMES.filter((name) => name.startsWith("i18n/"))) {
+  await import(`./${basename}.js`);
+}
 
 const navigation = globalThis.__vizeDocsNavigation;
 

--- a/tests/tooling/docs-navigation.test.ts
+++ b/tests/tooling/docs-navigation.test.ts
@@ -1,0 +1,174 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import { SCRIPT_BASENAMES } from "../../docs/theme/background.ts";
+import { repoRoot } from "./_helpers/moonbit.ts";
+
+type LocaleStrings = {
+  labels: Record<string, string>;
+  ui: { groups: Record<string, string> } & Record<string, unknown>;
+};
+
+type Sitemap = {
+  blogNavigationPaths: string[];
+  hiddenPathPatterns: RegExp[];
+  navGroups: Array<{ key: string; paths: string[] }>;
+  supportedLocales: Array<{ code: string; name: string }>;
+};
+
+const themeDir = path.join(repoRoot, "docs/theme");
+const contentDir = path.join(repoRoot, "docs/content");
+
+// The docs site ships no module loader: `background.ts` concatenates these
+// files into one inline script and they hand data to each other through
+// globals. Importing them in the same order is how this file reads them.
+for (const basename of SCRIPT_BASENAMES) {
+  if (basename.startsWith("i18n/")) {
+    await import(path.join(themeDir, `${basename}.js`));
+  }
+}
+
+const sitemap = (globalThis as { __vizeDocsSitemap?: Sitemap }).__vizeDocsSitemap!;
+const locales = (globalThis as { __vizeDocsLocales?: Record<string, LocaleStrings> })
+  .__vizeDocsLocales!;
+const localeCodes = sitemap.supportedLocales.map(({ code }) => code);
+
+function hasContentPage(locale: string, navPath: string): boolean {
+  const localeDir = locale === "en" ? contentDir : path.join(contentDir, locale);
+  if (navPath === "/") {
+    return fs.existsSync(path.join(localeDir, "index.md"));
+  }
+  const relative = navPath.slice(1);
+  return (
+    fs.existsSync(path.join(localeDir, `${relative}.md`)) ||
+    fs.existsSync(path.join(localeDir, relative, "index.md"))
+  );
+}
+
+void test("theme scripts load the sitemap and every locale before navigation", () => {
+  assert.deepEqual(SCRIPT_BASENAMES, [
+    "vein",
+    "i18n/sitemap",
+    "i18n/locales/en",
+    "i18n/locales/ja",
+    "i18n/locales/zh-CN",
+    "i18n/locales/pt-BR",
+    "i18n/locales/fr",
+    "i18n/navigation",
+    "syntax-highlight",
+  ]);
+
+  // A locale file that exists but is never concatenated would leave the
+  // sidebar untranslated in the browser while every unit test still passed.
+  assert.deepEqual(
+    fs.readdirSync(path.join(themeDir, "i18n/locales")).sort(),
+    localeCodes.map((code) => `${code}.js`).sort(),
+  );
+  assert.deepEqual(
+    SCRIPT_BASENAMES.filter((basename) => basename.startsWith("i18n/locales/")),
+    localeCodes.map((code) => `i18n/locales/${code}`),
+  );
+});
+
+void test("the sitemap ships the locales the docs site is built for", () => {
+  assert.deepEqual(sitemap.supportedLocales, [
+    { code: "en", name: "English" },
+    { code: "ja", name: "日本語" },
+    { code: "zh-CN", name: "简体中文" },
+    { code: "pt-BR", name: "Português" },
+    { code: "fr", name: "Français" },
+  ]);
+  assert.deepEqual(Object.keys(locales), localeCodes);
+
+  const viteConfig = fs.readFileSync(path.join(repoRoot, "docs/vite.config.ts"), "utf8");
+  for (const { code, name } of sitemap.supportedLocales) {
+    assert.equal(
+      viteConfig.includes(`{ code: "${code}", name: "${name}" }`),
+      true,
+      `docs/vite.config.ts must build the ${code} locale`,
+    );
+  }
+});
+
+void test("the sidebar groups the pages the site actually publishes", () => {
+  assert.deepEqual(
+    sitemap.navGroups.map((group) => group.key),
+    ["start", "projectSetup", "staticAnalysis", "rules", "tooling", "architecture", "blog"],
+  );
+  assert.deepEqual(sitemap.navGroups.at(-1)?.paths, sitemap.blogNavigationPaths);
+  assert.deepEqual(sitemap.blogNavigationPaths, ["/blog", "/blog/notes", "/blog/releases"]);
+
+  assert.deepEqual(sitemap.navGroups.find((group) => group.key === "projectSetup")?.paths, [
+    "/guide/vite-plugin",
+    "/integrations/nuxt",
+    "/guide/workflows",
+    "/guide/configuration",
+    "/guide/jsx",
+    "/guide/jsx-babel-compat",
+    "/guide/troubleshooting",
+    "/guide/unplugin",
+  ]);
+
+  const navPaths = sitemap.navGroups.flatMap((group) => group.paths);
+  for (const locale of localeCodes) {
+    const missing = navPaths.filter((navPath) => !hasContentPage(locale, navPath));
+    assert.deepEqual(missing, [], `${locale} is missing pages for sidebar entries`);
+  }
+});
+
+void test("every locale labels every sidebar entry", () => {
+  const hidden = (navPath: string) =>
+    sitemap.hiddenPathPatterns.some((pattern) => pattern.test(navPath));
+  // English is the fallback for every other locale, so it is the only file
+  // carrying the dated blog post titles. Strip those and the five files must
+  // agree key for key, in the same order.
+  const expectedKeys = Object.keys(locales.en.labels).filter((navPath) => !hidden(navPath));
+
+  for (const locale of localeCodes) {
+    const keys = Object.keys(locales[locale].labels);
+    assert.deepEqual(locale === "en" ? keys.filter((k) => !hidden(k)) : keys, expectedKeys);
+    assert.deepEqual(Object.keys(locales[locale].ui.groups), [
+      "start",
+      "projectSetup",
+      "staticAnalysis",
+      "rules",
+      "tooling",
+      "architecture",
+      "blog",
+    ]);
+  }
+
+  const navPaths = sitemap.navGroups.flatMap((group) => group.paths);
+  assert.deepEqual(
+    navPaths.filter((navPath) => !(navPath in locales.en.labels)),
+    [],
+  );
+});
+
+void test("the Babel JSX compatibility page is labelled in every locale", () => {
+  assert.deepEqual(
+    Object.fromEntries(
+      localeCodes.map((code) => [code, locales[code].labels["/guide/jsx-babel-compat"]]),
+    ),
+    {
+      en: "Babel JSX Compat",
+      ja: "Babel JSX 互換",
+      "zh-CN": "Babel JSX 兼容",
+      "pt-BR": "Compatibilidade com Babel JSX",
+      fr: "Compatibilité Babel JSX",
+    },
+  );
+});
+
+void test("the docs theme suite passes", () => {
+  const result = spawnSync(
+    process.execPath,
+    ["--test", "docs/theme/navigation.test.js", "docs/theme/background.test.ts"],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
+});

--- a/tests/tooling/docs-navigation.test.ts
+++ b/tests/tooling/docs-navigation.test.ts
@@ -36,6 +36,16 @@ const locales = (globalThis as { __vizeDocsLocales?: Record<string, LocaleString
   .__vizeDocsLocales!;
 const localeCodes = sitemap.supportedLocales.map(({ code }) => code);
 
+/** The `{ code, name }` pairs `docs/vite.config.ts` builds the site for. */
+function configuredLocales(): Array<{ code: string; name: string }> {
+  const viteConfig = fs.readFileSync(path.join(repoRoot, "docs/vite.config.ts"), "utf8");
+  const block = /locales:\s*\[(?<entries>[^\]]*)\]/u.exec(viteConfig)?.groups?.entries;
+  assert.ok(block, "docs/vite.config.ts must declare an i18n locales array");
+  return [
+    ...block.matchAll(/\{\s*code:\s*"(?<code>[^"]+)"\s*,\s*name:\s*"(?<name>[^"]+)"\s*\}/gu),
+  ].map(({ groups }) => ({ code: groups!.code, name: groups!.name }));
+}
+
 function hasContentPage(locale: string, navPath: string): boolean {
   const localeDir = locale === "en" ? contentDir : path.join(contentDir, locale);
   if (navPath === "/") {
@@ -83,14 +93,9 @@ void test("the sitemap ships the locales the docs site is built for", () => {
   ]);
   assert.deepEqual(Object.keys(locales), localeCodes);
 
-  const viteConfig = fs.readFileSync(path.join(repoRoot, "docs/vite.config.ts"), "utf8");
-  for (const { code, name } of sitemap.supportedLocales) {
-    assert.equal(
-      viteConfig.includes(`{ code: "${code}", name: "${name}" }`),
-      true,
-      `docs/vite.config.ts must build the ${code} locale`,
-    );
-  }
+  // The whole list, both directions: a locale the theme knows about but the
+  // site is not built for is as broken as the reverse.
+  assert.deepEqual(configuredLocales(), sitemap.supportedLocales);
 });
 
 void test("the sidebar groups the pages the site actually publishes", () => {
@@ -127,18 +132,18 @@ void test("every locale labels every sidebar entry", () => {
   // agree key for key, in the same order.
   const expectedKeys = Object.keys(locales.en.labels).filter((navPath) => !hidden(navPath));
 
+  const groupKeys = sitemap.navGroups.map((group) => group.key);
   for (const locale of localeCodes) {
     const keys = Object.keys(locales[locale].labels);
     assert.deepEqual(locale === "en" ? keys.filter((k) => !hidden(k)) : keys, expectedKeys);
-    assert.deepEqual(Object.keys(locales[locale].ui.groups), [
-      "start",
-      "projectSetup",
-      "staticAnalysis",
-      "rules",
-      "tooling",
-      "architecture",
-      "blog",
-    ]);
+    // Derived from the sitemap, whose own key list is pinned literally above,
+    // so a new group forces a heading in every locale. Order-sensitive: these
+    // are hand-maintained files and keeping them aligned costs nothing.
+    assert.deepEqual(
+      Object.keys(locales[locale].ui.groups),
+      groupKeys,
+      `${locale} must name every sitemap group`,
+    );
   }
 
   const navPaths = sitemap.navGroups.flatMap((group) => group.paths);

--- a/tests/tooling/language-engineering-practices.test.ts
+++ b/tests/tooling/language-engineering-practices.test.ts
@@ -6,6 +6,19 @@ import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
+// The docs theme has no module loader; each i18n script registers itself on a
+// global when loaded. `docs-navigation.test.ts` owns the wiring assertions.
+for (const basename of ["sitemap", "locales/en"]) {
+  await import(path.join(root, "docs/theme/i18n", `${basename}.js`));
+}
+const sitemap = (globalThis as { __vizeDocsSitemap?: { navGroups: NavGroup[] } })
+  .__vizeDocsSitemap!;
+const locales = (globalThis as { __vizeDocsLocales?: Record<string, LocaleStrings> })
+  .__vizeDocsLocales!;
+
+type NavGroup = { key: string; paths: string[] };
+type LocaleStrings = { labels: Record<string, string> };
+
 test("language engineering practices document upstream-derived compiler workflows", () => {
   const practices = readRepoFile(
     "docs",
@@ -113,24 +126,31 @@ test("language-facing change classes are present in docs, contribution guide, an
 });
 
 test("docs navigation exposes the language engineering practices page", () => {
-  const navigation = readRepoFile("docs", "theme", "i18n", "navigation.js");
-  const navigationTest = readRepoFile("docs", "theme", "navigation.test.js");
   const architectureOverview = readRepoFile("docs", "content", "architecture", "overview.md");
   const productionReadiness = readRepoFile("docs", "release", "production-readiness.md");
 
-  for (const content of [navigation, navigationTest]) {
-    assert.match(content, /architecture\/language-engineering-practices/);
-  }
+  // The sidebar's structure and its labels are data, not file text: the groups
+  // live in `docs/theme/i18n/sitemap.js` and the labels in
+  // `docs/theme/i18n/locales/`. Assert the whole Architecture group so a page
+  // dropped from it fails here rather than reading as an unrelated reorder.
+  assert.deepEqual(sitemap.navGroups.find((group) => group.key === "architecture")?.paths, [
+    "/architecture/overview",
+    "/architecture/crates",
+    "/architecture/source-guide",
+    "/architecture/language-engineering-practices",
+    "/architecture/performance",
+    "/philosophy",
+  ]);
+  assert.equal(
+    locales.en.labels["/architecture/language-engineering-practices"],
+    "Language Engineering",
+  );
 
   assert.match(architectureOverview, /language-engineering-practices\.md/);
   assert.match(productionReadiness, /language-engineering change-class evidence/);
   assert.match(productionReadiness, /security-audit` workflow status/);
   assert.match(productionReadiness, /pr-benchmark-budget` status/);
   assert.match(productionReadiness, /\.github\/workflows\/fuzz\.yml/);
-  assert.match(
-    navigation,
-    /\["\/architecture\/language-engineering-practices", "Language Engineering"\]/,
-  );
 });
 
 function readRepoFile(...segments: string[]): string {


### PR DESCRIPTION
Closes nothing on its own; this is the docs-site half of #3391.

`compiler.jsxCompat: "babel"` — the opt-in `@vue/babel-plugin-jsx` compatibility mode from #3391 —
is documented at the crate level (#3733, in flight) but had nothing on the docs site. The agent that
finished #3391 deferred it because `guide/jsx.md` (510 lines) and `guide/configuration.md` (434) are
both over the 350-line budget and may not grow, and a new page needs a navigation entry in a
599-line theme file. So: do the theme surgery first, then add the page.

## Part 1 — splitting `docs/theme/i18n/navigation.js`

The file carried four things at once: the supported-locale list and sidebar structure, five locales'
worth of sidebar labels, five locales' worth of chrome strings, and all the DOM behavior. It split
cleanly along the seam it already had — **structure vs. strings vs. behavior**:

| File | Lines | Holds |
| --- | ---: | --- |
| `docs/theme/i18n/sitemap.js` | 101 | supported locales, blog nav paths, nav groups, hidden-path patterns |
| `docs/theme/i18n/locales/en.js` | 88 | English labels (also the fallback for every locale, so the blog post titles live here) + chrome strings |
| `docs/theme/i18n/locales/{ja,zh-CN,pt-BR,fr}.js` | 69–70 each | one locale's label overrides + chrome strings |
| `docs/theme/i18n/navigation.js` | 220 | behavior only |

**Per locale, not per nav group**, because the per-locale strings were what actually made the file
big and what grows every time a page is added: one new page previously meant five edits inside one
599-line file, and now means one edit per locale file. The nav groups are one shared structure that
every locale keys into, so they stayed together in `sitemap.js`.

**The loading path is unchanged.** The docs site has no module loader — `docs/theme/background.ts`
`readFileSync`s each theme script and concatenates them into one inline `<script>`. The new files
are plain browser scripts that register on globals (`__vizeDocsSitemap`, `__vizeDocsLocales`), the
same trick `navigation.js` already used for `__vizeDocsNavigation`, and `SCRIPT_BASENAMES` lists
them ahead of `i18n/navigation`. No imports, no exports, no bundler, no new build step. Verified by
building the concatenated script and evaluating it as a single classic script in a browser-like
context (see the "commands run" section below).

One dead field went with it: `navGroups[].title` was never read — headings came from
`localizedUi[locale].groups[groupIndex]`, i.e. by array position across five locales. Groups now
carry a stable `key` and each locale's `ui.groups` is keyed by it, so a group cannot silently shift
by one.

### On the 350-line budget

Worth recording, because the deferral note assumed otherwise: `docs/theme/i18n/navigation.js` was
**not** actually gated. `tools/moon/cmd/source_file_lengths` excludes any path containing an `i18n`
segment (intended for generated translation content), so the file could have grown freely. The split
is still the right shape — 599 lines is not a file anyone should have to add a locale to — but it was
not the blocker it was thought to be. The real blockers were real: `guide/jsx.md` and
`guide/configuration.md` are gated and over limit, so **neither is touched by this PR**, and the new
page is discoverable through the sidebar rather than through a cross-link from them.

## Part 2 — the page

`docs/content/guide/jsx-babel-compat.md` (161 lines), covering: what the mode is and how to enable
it; that it is opt-in, off by default and project-level with no per-component directive form, and
**why** (it changes module-level output shape, so half a module in compat mode would emit two
incompatible module shapes from one file); the mapping from each `@vue/babel-plugin-jsx` option to
its Vize entry point, including why `optimize` has no equivalent; the two deferred corpus rows
(`options/resolve_type_on`, waiting on the type resolution in #1497/#1502; `slots/dynamic_slot_name`,
waiting on dynamic-slot lowering); and why the Vapor and SSR lanes deliberately do not get the mode.

**No compatibility counts in the prose.** The page points at the oracle and
`crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md`, whose totals are pinned by
`babel_compat_verdict_totals`, and says explicitly that it quotes none of them so they cannot rot.

**One accuracy note, please sanity-check it.** `jsxCompat` is read by the config loader
(`vize_carton`) and honoured by both the NAPI and WASM `compileJsx` bindings, but the bundler
plugins pass only `jsxMode` and `vapor` through to `compileJsx` (`npm/builder/vite/src/compiler.ts`,
`plugin/load.ts`) — nothing in `npm/` mentions `jsxCompat`. So setting the config key alone does not
yet change what a bundler emits. The page says so, in a status callout and in the "Enabling it"
section, rather than showing a config snippet that silently does nothing. If that wiring exists
somewhere I did not find, say the word and I will drop the caveat.

The page also uses no in-page anchor links, deliberately: translated headings would break
`#enabling-it`-style targets in four locales.

## Locales

All five, so the page is reachable in every locale the site ships.

**Sidebar labels are hand-written**, not machine-translated:

| Locale | Label |
| --- | --- |
| en | Babel JSX Compat |
| ja | Babel JSX 互換 |
| zh-CN | Babel JSX 兼容 |
| pt-BR | Compatibilidade com Babel JSX |
| fr | Compatibilité Babel JSX |

They are short technical noun phrases and I am confident in all five; none needed a machine.

**Page bodies:** `ja` is hand-written. `zh-CN`, `pt-BR` and `fr` are machine-translated through the
repo's own `docs/scripts/i18n/generate.mjs --accept-machine-translation --resume`, which is how every
other localized page on the site was produced, and they carry the standard
`<!-- Generated translation; source: ... -->` marker so they are not passing themselves off as
human-reviewed. I did not machine-translate the Japanese because the generator mangled it badly —
among other things it rendered "Vize" as "Vice" and turned "honoured by the `compileJsx` bindings"
into nonsense — and it is the maintainer's own language, so it is the one worth writing by hand.
I read the other three and they are consistent in quality with their siblings on the site; no product
names are mangled and all tables survived. **If a reviewer wants zh-CN, pt-BR or fr hand-written
too, that is a fair ask — say so and I will do those as well.**

## Tests

`tests/tooling/docs-navigation.test.ts` (new, and CI-gated via `test:scripts`). Every assertion is a
full-equality `deepEqual`; there is no `.includes()` on a structure and no spot check:

- `SCRIPT_BASENAMES` equals the complete expected script list, so a locale file that exists but is
  never concatenated fails rather than silently leaving the sidebar untranslated.
- The `i18n/locales/` directory listing equals the supported locale codes exactly, both directions.
- `supportedLocales` equals the complete list, and each entry is asserted present in
  `docs/vite.config.ts`'s `i18n.locales`.
- The nav group keys equal the complete ordered list, and the Project Setup group equals its complete
  ordered path list including the new page.
- Every sidebar path resolves to a content page **in every locale**.
- Every locale's label keys equal the English label keys (minus the English-only dated blog titles),
  key for key and in order — so a page added in one locale and forgotten in another fails here.
- The new page's label in all five locales, as one `deepEqual` over the whole map.
- It also shells out to `node --test docs/theme/*.test.*`, which nothing in CI ran before:
  `docs` is in neither `testedPackages` nor `checkedPackages`, so `docs/theme/navigation.test.js` and
  `background.test.ts` were dev-only until now.

`docs/theme/navigation.test.js` keeps its five existing full-structure `deepEqual` tests, unchanged
in expectation — they pass against the split files, which is the behavior-preservation evidence. Its
only edit is to load the i18n scripts in `SCRIPT_BASENAMES` order instead of importing one file, so
it exercises the shipped wiring rather than a hardcoded list.

## Commands run

```
nix develop -c node --test docs/theme/navigation.test.js docs/theme/background.test.ts
  → 7/7 pass (5 pre-existing navigation tests, unchanged expectations)
nix develop -c node --test tests/tooling/docs-navigation.test.ts
  → 6/6 pass
nix develop -c moon run --target native tools/moon/cmd/source_file_lengths -- \
    --check --base-ref origin/main --max-lines 350 --limit 5
  → "No new or grown files exceed 350 lines." (largest new file: 220)
nix develop -c ./node_modules/.bin/vp check
  → 2001 files correctly formatted, 0 warnings or lint errors in 1396 files
```

Plus a one-off check that the split did not break the browser loading path: build the concatenated
inline script via `buildDocsBackgroundScript`, parse it as a single classic script, and run it in a
`vm` context with a stub `document`/`window`. Result: parses (1589 lines), all five locales
registered, `__vizeDocsNavigation` exposes the same four-function API, group keys intact,
`canonicalPath("/ja/guide/jsx-babel-compat/index.html")` → `/guide/jsx-babel-compat`.

`Docs build` does not run on pull requests (`push` to main + `workflow_dispatch` only), so it was
dispatched against this branch separately; see the check listed on this PR.

## Notes

- Diff is confined to `docs/` and `tests/tooling/`, so it does not collide with #3733, which touches
  `crates/vize_atelier_jsx/`. No rebase needed either way.
- `crates/vize_atelier_jsx/README.md` in #3733 spells the config file `vize.json`; the loader's
  `CONFIG_FILE_NAMES` is `vize.config.{pkl,ts,js,mjs,json}`. This page uses the latter. Not fixed
  here to keep the two diffs apart.

## Second commit: one pre-existing test had to move with the split

`tests/tooling/language-engineering-practices.test.ts` grepped the raw text of
`docs/theme/i18n/navigation.js` for `/architecture\/language-engineering-practices/` and for the
literal pair `["/architecture/language-engineering-practices", "Language Engineering"]`. Both went
stale when the group moved to `i18n/sitemap.js` and the label to `i18n/locales/en.js`. `test-scripts`
caught it on the first push.

It now asserts the data — the complete Architecture group path list and the label — instead of
regexing file text, so it survives the next theme refactor and fails loudly if the page is dropped
from the group rather than reading as an unrelated reorder.

Codesmith pushed its own fix for the same test while I was fixing it; I replaced it, because it kept
the file-text regex form and its commit carried a `Co-authored-by` trailer. The branch is now two
commits, both trailer-free, head `283c815b7`.

## Third commit: an inverted sentence Codesmith caught

Codesmith pushed a second round while the first was in CI, and it found a real bug in my
machine-translated pages: the English says SSR **withholds** the babel lane, and the translator
rendered that as *retains* in fr (`retient toute la voie de Babel`), pt-BR (`retém toda a rota`) and
zh-CN (`保留了整个巴别通道`) — the exact opposite of what the compiler does. It also caught fr
translating "slot" as `machine à sous` (slot machine) and zh-CN rendering the table header "Row" as
`划船` (rowing). Good catches; I kept all of them, reworded in my own commit so the trailer does not
land on the branch, and the ja page (hand-written) never had the inversion.

I did **not** keep its test edits. It turned two `deepEqual`s into a whitespace-tolerant
`assert.match` over the vite config text and added `.sort()` to the per-locale group-key comparison
— both loosen the assertion. `docs-navigation.test.ts` now parses the config's whole locale array and
compares it to the sitemap by equality (which also removes an `.includes()` I should not have written
in the first place), and compares group keys in order against the sitemap's own list.