### PR TITLE
fix(ci): fail test-report when a needed job did not succeed

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,9 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # Schedule trigger for slow jobs (nix-flake, playground-test) that should
-  # run on a cadence but no longer block PR review. See the conditional
-  # `if:` guards on those jobs.
+  # Daily cadence for nix-flake and source-coverage; both skip pull requests.
   schedule:
     # 03:11 UTC daily (~12:11 JST). Offset from native-smoke and e2e to spread
     # GitHub Actions concurrency budget.
@@ -535,8 +533,6 @@ jobs:
     timeout-minutes: 30
     needs:
       - build-js-packages
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -666,6 +662,10 @@ jobs:
           name: test-inventory
           path: test-inventory.json
           retention-days: 14
+      # Runs last so the inventory is collected and uploaded either way.
+      - name: Require every needed job to succeed
+        env: { NEEDS_JSON: "${{ toJSON(needs) }}" }
+        run: node tools/github/require-needs-success.mjs
 
   test-report-comment:
     name: test-report-comment

--- a/tests/tooling/github-workflows-check-gate.test.ts
+++ b/tests/tooling/github-workflows-check-gate.test.ts
@@ -1,0 +1,283 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "node:test";
+import { parse } from "yaml";
+
+import {
+  aggregateNeedsResults,
+  PULL_REQUEST_SKIPPED_JOBS,
+} from "../../tools/github/require-needs-success.mjs";
+import { readRepoFile, root } from "./support/github-workflows.ts";
+
+interface WorkflowStep {
+  name?: string;
+  uses?: string;
+  run?: string;
+  env?: Record<string, string>;
+}
+
+interface WorkflowJob {
+  if?: string;
+  needs?: string[];
+  steps?: WorkflowStep[];
+}
+
+interface Workflow {
+  jobs?: Record<string, WorkflowJob>;
+}
+
+/**
+ * The jobs `test-report` aggregates, in workflow order. Kept literal so the
+ * expected gate messages below stay stable; the workflow's own list is asserted
+ * against this one in "test-report depends on the jobs the ruleset does not
+ * require directly".
+ */
+const NEEDED_JOBS = [
+  "nix-flake",
+  "fmt-rust",
+  "check-js",
+  "security-audit",
+  "semver-checks",
+  "node-engine-compat",
+  "check-vize-apps",
+  "vue-parity",
+  "test-scripts",
+  "editor-extensions",
+  "editor-host-smoke",
+  "build-js-packages",
+  "test-js-packages",
+  "clippy-and-test",
+  "coverage",
+  "source-coverage",
+  "branch-coverage",
+  "playground-test",
+];
+
+/**
+ * Each `if:` guard used by a job in `test-report`'s `needs:` list, classified by
+ * whether the job runs on a pull request. An unclassified guard fails the drift
+ * test rather than being guessed at, because guessing wrong either blocks every
+ * pull request or reopens the hole this gate closes.
+ */
+const PULL_REQUEST_BEHAVIOUR_BY_GUARD = new Map([
+  ["", "runs"],
+  ["${{ github.event_name != 'pull_request' }}", "skips"],
+  ["${{ github.event_name == 'pull_request' || github.event_name == 'push' }}", "runs"],
+]);
+
+function readCheckWorkflow(): Workflow {
+  return parse(readRepoFile(".github", "workflows", "check.yml")) as Workflow;
+}
+
+function checkWorkflowJob(name: string): WorkflowJob {
+  const job = readCheckWorkflow().jobs?.[name];
+  assert.ok(job, `missing check.yml job ${name}`);
+  return job;
+}
+
+function needsContext(overrides: Record<string, string> = {}): Record<string, { result: string }> {
+  return Object.fromEntries(
+    NEEDED_JOBS.map((job) => [job, { result: overrides[job] ?? "success" }]),
+  );
+}
+
+/** The result shape of a healthy pull request: the two event-gated jobs skip. */
+function pullRequestContext(
+  overrides: Record<string, string> = {},
+): Record<string, { result: string }> {
+  return needsContext({ "nix-flake": "skipped", "source-coverage": "skipped", ...overrides });
+}
+
+test("test-report passes when every needed job succeeded", () => {
+  assert.deepEqual(aggregateNeedsResults(needsContext()), {
+    exitCode: 0,
+    message:
+      "test-report gate: all 18 needed jobs are accounted for. 18 succeeded; 0 skipped on a pull request by design.",
+  });
+});
+
+test("test-report passes when only the event-gated jobs skipped", () => {
+  assert.deepEqual(aggregateNeedsResults(pullRequestContext()), {
+    exitCode: 0,
+    message:
+      "test-report gate: all 18 needed jobs are accounted for. 16 succeeded; 2 skipped on a pull request by design: nix-flake, source-coverage.",
+  });
+});
+
+test("test-report fails when a needed job failed", () => {
+  assert.deepEqual(aggregateNeedsResults(pullRequestContext({ "vue-parity": "failure" })), {
+    exitCode: 1,
+    message: [
+      "test-report gate: 1 of 18 needed jobs did not succeed.",
+      "  - vue-parity: failure",
+      "test-report is a required status check, so it must not pass while a job it aggregates is red.",
+      "Only these jobs may skip on a pull request: nix-flake, source-coverage.",
+    ].join("\n"),
+  });
+});
+
+test("test-report fails when a needed job was cancelled", () => {
+  assert.deepEqual(
+    aggregateNeedsResults(pullRequestContext({ "editor-host-smoke": "cancelled" })),
+    {
+      exitCode: 1,
+      message: [
+        "test-report gate: 1 of 18 needed jobs did not succeed.",
+        "  - editor-host-smoke: cancelled",
+        "test-report is a required status check, so it must not pass while a job it aggregates is red.",
+        "Only these jobs may skip on a pull request: nix-flake, source-coverage.",
+      ].join("\n"),
+    },
+  );
+});
+
+test("test-report fails when a job skips because its own dependency failed", () => {
+  const needs = pullRequestContext({
+    "build-js-packages": "failure",
+    "playground-test": "skipped",
+  });
+
+  assert.deepEqual(aggregateNeedsResults(needs), {
+    exitCode: 1,
+    message: [
+      "test-report gate: 2 of 18 needed jobs did not succeed.",
+      "  - build-js-packages: failure",
+      "  - playground-test: skipped",
+      "test-report is a required status check, so it must not pass while a job it aggregates is red.",
+      "Only these jobs may skip on a pull request: nix-flake, source-coverage.",
+    ].join("\n"),
+  });
+});
+
+test("test-report fails when an event-gated job ran and failed", () => {
+  assert.deepEqual(aggregateNeedsResults(needsContext({ "source-coverage": "failure" })), {
+    exitCode: 1,
+    message: [
+      "test-report gate: 1 of 18 needed jobs did not succeed.",
+      "  - source-coverage: failure",
+      "test-report is a required status check, so it must not pass while a job it aggregates is red.",
+      "Only these jobs may skip on a pull request: nix-flake, source-coverage.",
+    ].join("\n"),
+  });
+});
+
+test("test-report rejects a needs context it cannot read", () => {
+  assert.throws(() => aggregateNeedsResults({}), {
+    message: "The needs context is empty: test-report must depend on the jobs it gates",
+  });
+  assert.throws(() => aggregateNeedsResults([]), {
+    message: "The needs context must be an object of job results",
+  });
+  assert.throws(() => aggregateNeedsResults({ "vue-parity": {} }), {
+    message: "Job vue-parity reported no result in the needs context",
+  });
+});
+
+test("the test-report gate step exits non-zero for a red dependency", () => {
+  const failing = spawnSync(process.execPath, ["tools/github/require-needs-success.mjs"], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NEEDS_JSON: JSON.stringify(pullRequestContext({ "vue-parity": "failure" })),
+    },
+  });
+
+  assert.equal(failing.status, 1);
+  assert.equal(failing.stdout, "");
+  assert.equal(
+    failing.stderr,
+    `${[
+      "test-report gate: 1 of 18 needed jobs did not succeed.",
+      "  - vue-parity: failure",
+      "test-report is a required status check, so it must not pass while a job it aggregates is red.",
+      "Only these jobs may skip on a pull request: nix-flake, source-coverage.",
+    ].join("\n")}\n`,
+  );
+
+  const passing = spawnSync(process.execPath, ["tools/github/require-needs-success.mjs"], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, NEEDS_JSON: JSON.stringify(pullRequestContext()) },
+  });
+
+  assert.equal(passing.status, 0);
+  assert.equal(passing.stderr, "");
+  assert.equal(
+    passing.stdout,
+    "test-report gate: all 18 needed jobs are accounted for. 16 succeeded; 2 skipped on a pull request by design: nix-flake, source-coverage.\n",
+  );
+});
+
+test("the test-report gate step reports a missing needs payload", () => {
+  const { NEEDS_JSON: _ignored, ...env } = process.env;
+  const result = spawnSync(process.execPath, ["tools/github/require-needs-success.mjs"], {
+    cwd: root,
+    encoding: "utf8",
+    env,
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(result.stdout, "");
+  assert.equal(
+    result.stderr,
+    "NEEDS_JSON is required: pass ${{ toJSON(needs) }} to tools/github/require-needs-success.mjs\n",
+  );
+});
+
+test("the pull-request skip list matches the check workflow's event guards", () => {
+  const workflow = readCheckWorkflow();
+  const unclassified: string[] = [];
+  const skipsPullRequests: string[] = [];
+
+  for (const jobName of NEEDED_JOBS) {
+    const job = workflow.jobs?.[jobName];
+    assert.ok(job, `missing check.yml job ${jobName}`);
+    const guard = job.if ?? "";
+    const behaviour = PULL_REQUEST_BEHAVIOUR_BY_GUARD.get(guard);
+    if (behaviour === undefined) {
+      unclassified.push(`${jobName}: ${guard}`);
+      continue;
+    }
+    if (behaviour === "skips") {
+      skipsPullRequests.push(jobName);
+    }
+  }
+
+  assert.deepEqual(unclassified, []);
+  assert.deepEqual(skipsPullRequests, ["nix-flake", "source-coverage"]);
+  assert.deepEqual(Object.keys(PULL_REQUEST_SKIPPED_JOBS), skipsPullRequests);
+});
+
+test("test-report depends on the jobs the ruleset does not require directly", () => {
+  assert.deepEqual(checkWorkflowJob("test-report").needs, NEEDED_JOBS);
+});
+
+test("test-report collects the inventory before it enforces the gate", () => {
+  const steps = checkWorkflowJob("test-report").steps ?? [];
+
+  assert.deepEqual(
+    steps.map((step) => ({
+      name: step.name ?? null,
+      uses: step.uses?.replace(/@[0-9a-f]{40}$/, "") ?? null,
+      run: step.run ?? null,
+      env: step.env ?? null,
+    })),
+    [
+      { name: null, uses: "actions/checkout", run: null, env: null },
+      {
+        name: "Collect test inventory",
+        uses: null,
+        run: 'node bench/test-inventory.mjs --json test-inventory.json --markdown "$GITHUB_STEP_SUMMARY"',
+        env: null,
+      },
+      { name: "Upload test inventory", uses: "actions/upload-artifact", run: null, env: null },
+      {
+        name: "Require every needed job to succeed",
+        uses: null,
+        run: "node tools/github/require-needs-success.mjs",
+        env: { NEEDS_JSON: "${{ toJSON(needs) }}" },
+      },
+    ],
+  );
+});

--- a/tools/github/require-needs-success.mjs
+++ b/tools/github/require-needs-success.mjs
@@ -1,0 +1,121 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Jobs in the `test-report` dependency list that skip on every pull request by
+ * design, mapped to the reason they skip.
+ *
+ * `test-report` itself only runs on `pull_request`, so this is the complete set
+ * of legitimate skips: both entries are gated by
+ * `if: ${{ github.event_name != 'pull_request' }}` in `.github/workflows/check.yml`
+ * and therefore never run in the event that `test-report` aggregates.
+ *
+ * Every other needed job runs on pull requests, so a `skipped` result there means
+ * the job never ran at all — `playground-test`, for instance, is skipped when the
+ * `build-js-packages` job it needs fails. Those skips are failures for gating
+ * purposes: the work they were meant to gate was not done.
+ *
+ * `tests/tooling/github-workflows-check-gate.test.ts` re-derives this list from
+ * the workflow's `if:` guards, so adding a pull-request-skipping job to
+ * `test-report`'s `needs:` fails that test until the job is classified here.
+ */
+export const PULL_REQUEST_SKIPPED_JOBS = Object.freeze({
+  "nix-flake": "runs on push and schedule only",
+  "source-coverage": "runs on push and schedule only",
+});
+
+function sortedEntries(needs) {
+  return Object.entries(needs).sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  );
+}
+
+function formatNames(names) {
+  return names.join(", ");
+}
+
+/**
+ * Decides whether the `test-report` aggregator may report success.
+ *
+ * `test-report` runs with `if: always()` so that it still collects the test
+ * inventory when a dependency fails. Without this check its own steps succeed
+ * and the required status check reports success while any of the jobs it
+ * aggregates is red, which makes the whole check suite advisory.
+ *
+ * @param {Record<string, { result?: string }>} needs Parsed `toJSON(needs)` payload.
+ * @param {Record<string, string>} skippableJobs Jobs allowed to report `skipped`.
+ * @returns {{ exitCode: number, message: string }}
+ */
+export function aggregateNeedsResults(needs, skippableJobs = PULL_REQUEST_SKIPPED_JOBS) {
+  if (needs === null || typeof needs !== "object" || Array.isArray(needs)) {
+    throw new Error("The needs context must be an object of job results");
+  }
+  const entries = sortedEntries(needs);
+  if (entries.length === 0) {
+    throw new Error("The needs context is empty: test-report must depend on the jobs it gates");
+  }
+
+  const succeeded = [];
+  const skippedByDesign = [];
+  const unresolved = [];
+  for (const [job, value] of entries) {
+    const result = value === null || typeof value !== "object" ? undefined : value.result;
+    if (typeof result !== "string" || result === "") {
+      throw new Error(`Job ${job} reported no result in the needs context`);
+    }
+    if (result === "success") {
+      succeeded.push(job);
+    } else if (result === "skipped" && Object.hasOwn(skippableJobs, job)) {
+      skippedByDesign.push(job);
+    } else {
+      unresolved.push(`  - ${job}: ${result}`);
+    }
+  }
+
+  const allowed = formatNames(Object.keys(skippableJobs).sort());
+  if (unresolved.length > 0) {
+    return {
+      exitCode: 1,
+      message: [
+        `test-report gate: ${unresolved.length} of ${entries.length} needed jobs did not succeed.`,
+        ...unresolved,
+        "test-report is a required status check, so it must not pass while a job it aggregates is red.",
+        `Only these jobs may skip on a pull request: ${allowed}.`,
+      ].join("\n"),
+    };
+  }
+
+  const skipped =
+    skippedByDesign.length === 0
+      ? "0 skipped on a pull request by design."
+      : `${skippedByDesign.length} skipped on a pull request by design: ${formatNames(skippedByDesign)}.`;
+  return {
+    exitCode: 0,
+    message: `test-report gate: all ${entries.length} needed jobs are accounted for. ${succeeded.length} succeeded; ${skipped}`,
+  };
+}
+
+function main() {
+  const raw = process.env.NEEDS_JSON;
+  if (!raw) {
+    console.error(
+      "NEEDS_JSON is required: pass ${{ toJSON(needs) }} to tools/github/require-needs-success.mjs",
+    );
+    process.exitCode = 1;
+    return;
+  }
+  const { exitCode, message } = aggregateNeedsResults(JSON.parse(raw));
+  if (exitCode === 0) {
+    console.log(message);
+    return;
+  }
+  console.error(message);
+  process.exitCode = exitCode;
+}
+
+const entrypoint = process.argv[1]
+  ? fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+  : false;
+if (entrypoint) {
+  main();
+}


### PR DESCRIPTION
## The gate that cannot fail

`test-report` is a required status check. It `needs:` the eighteen jobs in `check.yml` and runs with
`if: ${{ always() && github.event_name == 'pull_request' }}`, so GitHub starts it even when those jobs
are red. Nothing in it inspected `needs.*.result` — its three steps were checkout, collect inventory,
upload artifact — so all three succeeded and the required check reported **success while any or all
of its eighteen dependencies were failing**.

`vue-parity` and `editor-host-smoke` are not in the branch ruleset's required checks. Between them
they carry the divergence ledger (`test:check:fixtures` and the compat ratchet), the glyph formatter
corpus, the LSP incremental-latency and churn budgets, the packaged-VSIX host smoke, and the
Neovim/Vim specs. A pull request with any of that red was mergeable.

## The fix

`tools/github/require-needs-success.mjs` reads `toJSON(needs)` and exits non-zero unless every needed
job reported `success`. It runs as the **last** step of `test-report`, after the inventory is
collected and uploaded, so `test-report-comment` still gets its artifact when the gate fails.

### Which skips are legitimate

`skipped` is not uniformly benign, and blanket-allowing it would have reopened the hole from the other
side. `test-report` only runs on `pull_request`, so the question is exactly "which needed jobs never
run on a pull request":

| Job | `if:` guard | Verdict |
| --- | --- | --- |
| `nix-flake` | `github.event_name != 'pull_request'` | legitimate skip — push/schedule only |
| `source-coverage` | `github.event_name != 'pull_request'` | legitimate skip — push/schedule only |
| `semver-checks` | `github.event_name == 'pull_request' \|\| ... == 'push'` | runs on PRs — skip is a failure |
| the other 15 | no guard | run on PRs — skip is a failure |

So the allowlist is exactly `{nix-flake, source-coverage}`. Every other `skipped` means the job never
ran: `playground-test`, for instance, is skipped whenever the `build-js-packages` it needs fails, and
reading that as a pass is precisely the defect being fixed. `cancelled` fails too — a superseded run's
results attach to the old head SHA, which gates nothing, so this cannot spuriously block a PR.

The allowlist does not free-float. `tests/tooling/github-workflows-check-gate.test.ts` re-derives it
from the workflow's own `if:` guards and **refuses to classify a guard it has not seen**, so adding a
pull-request-skipping job to `needs:` fails the test until the job is classified deliberately.

## Verification

Unit coverage asserts the complete outcome (`{exitCode, message}`) by full equality — no substring or
regex matching — for: all-success, the healthy pull-request shape, a failed job, a cancelled job, an
upstream-cascade skip, an event-gated job that ran and failed, and three malformed `needs` payloads.
Two more spawn the script for real and assert exit code plus complete stdout/stderr. A final test
asserts `test-report`'s complete step list in order, pinning that the inventory still runs first.

Both negative controls were confirmed locally: deleting `source-coverage`'s `if:` guard fails the
drift test (`['nix-flake'] !== ['nix-flake', 'source-coverage']`), and changing `nix-flake`'s guard to
`github.event_name == 'schedule'` fails it as an unclassified guard.

**Real-run proof:** [proof PR #3753](https://github.com/ubugeeei-prod/vize/pull/3753) at head b50dae344c5ad707b4c3b2acc0962c9c831a0b55 intentionally made fmt-rust the sole red dependency. The [fmt-rust job](https://github.com/ubugeeei-prod/vize/actions/runs/30757496285/job/91522091740) failed, and the [test-report job](https://github.com/ubugeeei-prod/vize/actions/runs/30757496285/job/91522547640) independently failed after reporting exactly 1 of 18 needed jobs did not succeed and fmt-rust: failure. The inventory artifact was uploaded before the gate failed, and test-report-comment remained green.

## Line budget

`check.yml` is 702 lines, already over the 350-line budget, so it may not grow. It is still 702 lines.
The step's three lines are paid for by dropping `playground-test`'s `permissions: contents: read`,
which restates the workflow-level default verbatim, and by correcting the stale schedule comment — it
named `playground-test` as a job that skips pull requests, which stopped being true when it became a
required check; `source-coverage` is the job it meant.

The pin lives in a new `github-workflows-check-gate.test.ts` rather than in
`github-workflows-check.test.ts` as #3749 suggested, because that file is 333 lines and this needs
~280.

## ⚠️ Still needs a repository-settings change (a human must do this)

**This PR closes the hole from one side only.** The aggregator now fails when a dependency fails, but
the ruleset still does not require the jobs directly. Please add to ruleset `11865194`
(`default`) → `required_status_checks`:

- **`vue-parity`**
- **`editor-host-smoke`**

and consider `test-js-packages`, `semver-checks`, `security-audit`, `node-engine-compat`, and
`editor-extensions`, which are likewise absent. Belt and braces: the ruleset entry survives someone
editing the aggregator, and the aggregator covers jobs added later that nobody remembers to add to the
ruleset. I cannot change repository settings from a pull request.

Closes #3749

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
