### PR TITLE
fix(typecheck): restore the ambient type environment to the divergence baseline

### DIFF
--- a/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
@@ -17,6 +17,32 @@ export const commitSha = "a".repeat(40);
 export const sharedVizeDiagnostic = "error:1:1 [TS2322] shared";
 export const sharedBaselineOutput = "src/App.vue(1,1): error TS2322: shared\n";
 
+/**
+ * The classification #3738 added to every failing verdict. A reader of run
+ * 30738583070 could not tell a Vize finding from a broken baseline, so both
+ * failure messages now name which one they are before quoting the numbers.
+ */
+export const instrumentClassification =
+  "instrument failure, the vue-tsc baseline did not measure Vize";
+
+export function divergenceClassification(sharedVueFileCount: number) {
+  return (
+    "Vize divergence, the vue-tsc baseline loaded cleanly over the same " +
+    `${sharedVueFileCount} Vue files`
+  );
+}
+
+export function unusableFailure(reason: string) {
+  return `Typecheck divergence baseline is unusable for fixture — ${instrumentClassification}: ${reason}`;
+}
+
+export function breachFailure(sharedVueFileCount: number, breaches: string) {
+  return (
+    "Typecheck divergence budget breached for fixture — " +
+    `${divergenceClassification(sharedVueFileCount)}: ${breaches}`
+  );
+}
+
 export type FixtureOptions = {
   /** Diagnostics the fake `vize check` artifact reports for `src/App.vue`. */
   vizeDiagnostics?: string[];

--- a/tests/tooling/typecheck-baseline-project.test.ts
+++ b/tests/tooling/typecheck-baseline-project.test.ts
@@ -79,6 +79,65 @@ test("materialized baseline extends an explicit generated project", () => {
   }
 });
 
+test(
+  "materialized baseline keeps the fixture's ambient declarations in the program",
+  { skip: !fs.existsSync(vueTsc) },
+  () => {
+    // #3738. A `files` list seeds the program with those roots and nothing else,
+    // so an ambient declaration — never imported, by definition — leaves the
+    // program and the baseline reports the fixture's own globals as undeclared.
+    // Both declarations here are the two shapes that failed on run 30738583070:
+    // one under a plain directory (lx-music-desktop's `src/**/*.d.ts`), one under
+    // a dot-directory that a TypeScript wildcard segment never descends into
+    // (elk's `.nuxt/imports.d.ts`).
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), "vize-ambient-baseline-project-"));
+    const fixtureRoot = path.join(temp, "fixture");
+    const reportDir = path.join(temp, "report");
+    fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+    fs.mkdirSync(path.join(fixtureRoot, ".generated"));
+    fs.mkdirSync(reportDir);
+    fs.writeFileSync(
+      path.join(fixtureRoot, ".generated/tsconfig.json"),
+      `${JSON.stringify({ compilerOptions: { strict: true, noEmit: true } })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "src/globals.d.ts"),
+      "declare namespace Authored { type Id = string }\n",
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, ".generated/imports.d.ts"),
+      "declare function generatedHelper(): number\n",
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "src/App.vue"),
+      '<script setup lang="ts">const id: Authored.Id = String(generatedHelper())</script>\n',
+    );
+
+    try {
+      const project = materializeBaselineProject(
+        fixtureRoot,
+        reportDir,
+        {
+          id: "fixture",
+          tsconfig: "tsconfig.json",
+          typecheckPerformance: { baseline: { tsconfig: ".generated/tsconfig.json" } },
+        },
+        { fileCount: 1, files: [{ file: "src/App.vue" }] },
+      );
+      const result = runVueTsc(project.path, fixtureRoot);
+      const diagnostics = result.stdout.split("\n").filter((line) => /: error TS\d+: /u.test(line));
+      assert.deepEqual(diagnostics, []);
+      assert.equal(result.status, 0, result.stderr);
+      // Both ambient roots reached the program, not just the compared SFC.
+      const program = result.stdout.split("\n").map((line) => line.trimEnd());
+      assert.equal(program.includes(path.join(fixtureRoot, "src/globals.d.ts")), true);
+      assert.equal(program.includes(path.join(fixtureRoot, ".generated/imports.d.ts")), true);
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  },
+);
+
 function runVueTsc(project: string, cwd: string) {
   return spawnSync(vueTsc, ["--noEmit", "--pretty", "false", "--listFiles", "-p", project], {
     cwd,

--- a/tests/tooling/typecheck-divergence-baseline-configuration.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline-configuration.test.ts
@@ -9,6 +9,7 @@ import {
   run,
   setup,
   sharedBaselineOutput,
+  unusableFailure,
   writeVueTsc,
 } from "./_helpers/typecheck-divergence-report-fixture.ts";
 
@@ -52,10 +53,7 @@ test("a baseline that could not read its extended config is unusable, not a pass
   try {
     const result = run(fixture);
     assert.equal(result.status, 1);
-    assert.equal(
-      result.stderr,
-      `Typecheck divergence baseline is unusable for fixture: ${configuredBaselineReason(detail)}\n`,
-    );
+    assert.equal(result.stderr, `${unusableFailure(configuredBaselineReason(detail))}\n`);
 
     const artifact = readJson(artifactPath(fixture, "json"));
     assert.deepEqual(artifact.baseline.configuration, {
@@ -109,10 +107,7 @@ test("a config error reported against the fixture tsconfig is unusable", () => {
   try {
     const result = run(fixture);
     assert.equal(result.status, 1);
-    assert.equal(
-      result.stderr,
-      `Typecheck divergence baseline is unusable for fixture: ${configuredBaselineReason(detail)}\n`,
-    );
+    assert.equal(result.stderr, `${unusableFailure(configuredBaselineReason(detail))}\n`);
     const artifact = readJson(artifactPath(fixture, "json"));
     assert.deepEqual(artifact.baseline.configuration, {
       diagnostics: [
@@ -154,10 +149,7 @@ test("a config error against the materialized baseline project is unusable", () 
     );
     const result = run(fixture);
     assert.equal(result.status, 1);
-    assert.equal(
-      result.stderr,
-      `Typecheck divergence baseline is unusable for fixture: ${configuredBaselineReason(detail)}\n`,
-    );
+    assert.equal(result.stderr, `${unusableFailure(configuredBaselineReason(detail))}\n`);
     const artifact = readJson(artifactPath(fixture, "json"));
     assert.deepEqual(artifact.baseline.configuration, {
       diagnostics: [
@@ -221,6 +213,59 @@ test("an ordinary non-Vue diagnostic is not a configuration failure", () => {
     });
     assert.equal(artifact.divergence.summary.baselineExcludedNonVueCount, 1);
     assert.equal(artifact.divergence.summary.sharedCount, 1);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("a file-list error against a Vue file is unusable, not a false negative", () => {
+  // #3738, the element-plus shape. `TS6307` is reported against the source file,
+  // so it read as an ordinary type error while saying the opposite: the file is
+  // in the program without being in the project's file list. On run 30738583070
+  // element-plus's baseline emitted 208 of these and the ledger scored every one
+  // as a Vize false negative — 88% of that shard's false-negative breach — while
+  // the real finding was that the materialized project never listed the `.ts`
+  // files its SFCs import.
+  const detail =
+    "src/App.vue(1,1): error TS6307: File '/fixture/src/util.ts' is not listed within the " +
+    "file list of project '/fixture/fixture-vue-tsc.tsconfig.json'. Projects must list all " +
+    "files or use an 'include' pattern.";
+  const fixture = setup({ baselineOutput: `${detail}\n${sharedBaselineOutput}` });
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.equal(result.stderr, `${unusableFailure(configuredBaselineReason(detail))}\n`);
+    const artifact = readJson(artifactPath(fixture, "json"));
+    assert.deepEqual(artifact.baseline.configuration, {
+      diagnostics: [
+        {
+          code: 6307,
+          column: 1,
+          file: "src/App.vue",
+          line: 1,
+          message:
+            "File '/fixture/src/util.ts' is not listed within the file list of project " +
+            "'/fixture/fixture-vue-tsc.tsconfig.json'. Projects must list all files or use " +
+            "an 'include' pattern.",
+          severity: "error",
+        },
+      ],
+      errorCount: 1,
+      unusableReason: configuredBaselineReason(detail),
+      verdict: "unusable",
+    });
+    assert.deepEqual(artifact.budget, {
+      maxFalsePositiveRatio: 0.05,
+      maxFalseNegativeRatio: 0.05,
+      falsePositivePassed: true,
+      falseNegativePassed: false,
+      unusableReason: configuredBaselineReason(detail),
+      verdict: "unusable",
+      passed: false,
+    });
+    // Still counted as a scoreable false negative in the divergence lens: the
+    // verdict is what refuses to read it as one, so the evidence stays intact.
+    assert.equal(artifact.divergence.summary.falseNegativeCount, 1);
   } finally {
     cleanup(fixture);
   }

--- a/tests/tooling/typecheck-divergence-baseline.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline.test.ts
@@ -4,13 +4,16 @@ import path from "node:path";
 import { test } from "node:test";
 
 import {
+  breachFailure,
   cleanup,
   commitSha,
+  instrumentClassification,
   readJson,
   root,
   run,
   setup,
   sharedVizeDiagnostic,
+  unusableFailure,
 } from "./_helpers/typecheck-divergence-report-fixture.ts";
 
 /**
@@ -38,10 +41,7 @@ test("an empty vue-tsc baseline is unusable, not a false-positive breach", () =>
   try {
     const result = run(fixture);
     assert.equal(result.status, 1);
-    assert.equal(
-      result.stderr,
-      `Typecheck divergence baseline is unusable for fixture: ${emptyBaselineReason}\n`,
-    );
+    assert.equal(result.stderr, `${unusableFailure(emptyBaselineReason)}\n`);
     const artifact = readJson(artifactPath(fixture, "json"));
     assert.deepEqual(artifact.budget, {
       maxFalsePositiveRatio: 0.05,
@@ -77,6 +77,7 @@ test("an empty vue-tsc baseline is unusable, not a false-positive breach", () =>
         "Unexpected Vue files: 0",
         "Ignored dependency Vue files: 0",
         `Budget verdict: unusable (${emptyBaselineReason})`,
+        `Classification: ${instrumentClassification}`,
         "Budget passed: false",
         `Digest: ${artifact.divergence.sha256}`,
         "",
@@ -99,8 +100,9 @@ test("two sides that never meet are unusable, not a breach of both budgets", () 
     assert.equal(result.status, 1);
     assert.equal(
       result.stderr,
-      "Typecheck divergence baseline is unusable for fixture: " +
-        "vize reported 1 and vue-tsc reported 1 diagnostics with none in common\n",
+      `${unusableFailure(
+        "vize reported 1 and vue-tsc reported 1 diagnostics with none in common",
+      )}\n`,
     );
     assert.deepEqual(readJson(artifactPath(fixture, "json")).budget, {
       maxFalsePositiveRatio: 0.05,
@@ -149,7 +151,7 @@ test("--budget-mode record-only reports an unusable baseline as a warning", () =
         `Wrote ${path.relative(root, artifactPath(fixture, "json"))}`,
         `Wrote ${path.relative(root, artifactPath(fixture, "md"))}`,
         "::warning title=Typecheck divergence budget not enforced::" +
-          `Typecheck divergence baseline is unusable for fixture: ${emptyBaselineReason}`,
+          unusableFailure(emptyBaselineReason),
         "",
       ].join("\n"),
     );
@@ -169,8 +171,7 @@ test("a diagnostic-free baseline is a real breach when it covered every Vue file
     assert.equal(result.status, 1);
     assert.equal(
       result.stderr,
-      "Typecheck divergence budget breached for fixture: " +
-        "2 false positives (ratio 1) exceed maxFalsePositiveRatio 0.05\n",
+      `${breachFailure(1, "2 false positives (ratio 1) exceed maxFalsePositiveRatio 0.05")}\n`,
     );
     const artifact = readJson(artifactPath(fixture, "json"));
     assert.equal(artifact.baseline.coverage.verdict, "usable");

--- a/tests/tooling/typecheck-divergence-budget.test.ts
+++ b/tests/tooling/typecheck-divergence-budget.test.ts
@@ -4,8 +4,10 @@ import path from "node:path";
 import { test } from "node:test";
 
 import {
+  breachFailure,
   cleanup,
   commitSha,
+  divergenceClassification,
   readJson,
   root,
   run,
@@ -59,7 +61,7 @@ test("a false-positive budget breach fails the divergence report", () => {
     assert.equal(result.status, 1);
     assert.equal(
       result.stderr,
-      "Typecheck divergence budget breached for fixture: 1 false positives (ratio 0.5) exceed maxFalsePositiveRatio 0.05\n",
+      `${breachFailure(1, "1 false positives (ratio 0.5) exceed maxFalsePositiveRatio 0.05")}\n`,
     );
     const artifact = readJson(artifactPath(fixture, "json"));
     assert.deepEqual(artifact.budget, {
@@ -97,6 +99,7 @@ test("a false-positive budget breach fails the divergence report", () => {
         "Unexpected Vue files: 0",
         "Ignored dependency Vue files: 0",
         "Budget verdict: breached",
+        `Classification: ${divergenceClassification(1)}`,
         "Budget passed: false",
         `Digest: ${artifact.divergence.sha256}`,
         "",
@@ -114,7 +117,7 @@ test("a false-negative budget breach fails the divergence report", () => {
     assert.equal(result.status, 1);
     assert.equal(
       result.stderr,
-      "Typecheck divergence budget breached for fixture: 1 false negatives (ratio 0.5) exceed maxFalseNegativeRatio 0.05\n",
+      `${breachFailure(1, "1 false negatives (ratio 0.5) exceed maxFalseNegativeRatio 0.05")}\n`,
     );
     assert.deepEqual(readJson(artifactPath(fixture, "json")).budget, {
       maxFalsePositiveRatio: 0.05,
@@ -140,9 +143,11 @@ test("a breach of both budgets reports both sides", () => {
     assert.equal(result.status, 1);
     assert.equal(
       result.stderr,
-      "Typecheck divergence budget breached for fixture: " +
+      `${breachFailure(
+        1,
         "1 false positives (ratio 0.5) exceed maxFalsePositiveRatio 0.05; " +
-        "1 false negatives (ratio 0.5) exceed maxFalseNegativeRatio 0.05\n",
+          "1 false negatives (ratio 0.5) exceed maxFalseNegativeRatio 0.05",
+      )}\n`,
     );
   } finally {
     cleanup(fixture);
@@ -186,8 +191,7 @@ test("--budget-mode record-only records a breach without failing the job", () =>
     assert.equal(
       result.stdout,
       `${wroteLines(fixture)}::warning title=Typecheck divergence budget not enforced::` +
-        "Typecheck divergence budget breached for fixture: " +
-        "1 false positives (ratio 0.5) exceed maxFalsePositiveRatio 0.05\n",
+        `${breachFailure(1, "1 false positives (ratio 0.5) exceed maxFalsePositiveRatio 0.05")}\n`,
     );
     // Recording is not forgiving: the artifact still carries the failing verdict.
     assert.deepEqual(readJson(artifactPath(fixture, "json")).budget, {
@@ -207,9 +211,10 @@ test("--budget-mode record-only records a breach without failing the job", () =>
 test("--budget-mode enforce is the default and fails the job", () => {
   const fixture = setup({ vizeDiagnostics: [sharedVizeDiagnostic, vizeOnly] });
   try {
-    const expected =
-      "Typecheck divergence budget breached for fixture: " +
-      "1 false positives (ratio 0.5) exceed maxFalsePositiveRatio 0.05\n";
+    const expected = `${breachFailure(
+      1,
+      "1 false positives (ratio 0.5) exceed maxFalsePositiveRatio 0.05",
+    )}\n`;
     const explicit = run(fixture, {}, ["--budget-mode", "enforce"]);
     assert.equal(explicit.status, 1);
     assert.equal(explicit.stderr, expected);

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -113,6 +113,7 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
       cwd: fixture.fixtureRoot,
       args: ["--noEmit", "--pretty", "false", "--listFiles", "-p", baselineProject],
     });
+    const fixtureBase = path.relative(fixture.reportDir, fixture.fixtureRoot).replaceAll("\\", "/");
     assert.deepEqual(readJson(baselineProject), {
       extends: path
         .relative(fixture.reportDir, path.join(fixture.fixtureRoot, ".generated/tsconfig.json"))
@@ -122,7 +123,10 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
           .relative(fixture.reportDir, path.join(fixture.fixtureRoot, "src/App.vue"))
           .replaceAll("\\", "/"),
       ],
-      include: [],
+      // #3738: ambient declarations are the fixture's type environment, and a
+      // `files`-only program drops every one of them.
+      include: [`${fixtureBase}/**/*.d.ts`],
+      exclude: [`${fixtureBase}/**/node_modules/**`, `${fixtureBase}/**/dist/**`],
       references: [],
     });
     const markdown = fs.readFileSync(

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -114,10 +114,11 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
       args: ["--noEmit", "--pretty", "false", "--listFiles", "-p", baselineProject],
     });
     const fixtureBase = path.relative(fixture.reportDir, fixture.fixtureRoot).replaceAll("\\", "/");
+    // The elk shape: the baseline config is generated into a dot-directory, which
+    // a TypeScript wildcard segment never descends into, so it is globbed by name.
+    const generatedBase = `${fixtureBase}/.generated`;
     assert.deepEqual(readJson(baselineProject), {
-      extends: path
-        .relative(fixture.reportDir, path.join(fixture.fixtureRoot, ".generated/tsconfig.json"))
-        .replaceAll("\\", "/"),
+      extends: `${generatedBase}/tsconfig.json`,
       files: [
         path
           .relative(fixture.reportDir, path.join(fixture.fixtureRoot, "src/App.vue"))
@@ -125,8 +126,13 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
       ],
       // #3738: ambient declarations are the fixture's type environment, and a
       // `files`-only program drops every one of them.
-      include: [`${fixtureBase}/**/*.d.ts`],
-      exclude: [`${fixtureBase}/**/node_modules/**`, `${fixtureBase}/**/dist/**`],
+      include: [`${fixtureBase}/**/*.d.ts`, `${generatedBase}/**/*.d.ts`],
+      exclude: [
+        `${fixtureBase}/**/node_modules/**`,
+        `${fixtureBase}/**/dist/**`,
+        `${generatedBase}/**/node_modules/**`,
+        `${generatedBase}/**/dist/**`,
+      ],
       references: [],
     });
     const markdown = fs.readFileSync(

--- a/tools/fixtures/typecheck-baseline-configuration.mjs
+++ b/tools/fixtures/typecheck-baseline-configuration.mjs
@@ -23,16 +23,28 @@
  * did manage to resolve — no `strict`, no `paths`, no `types` — checks the files
  * anyway, and the ledger scores that against Vize as a real measurement.
  *
- * So this is deliberately narrow: only a diagnostic with no file at all, or one
- * reported against a `tsconfig`/`jsconfig` JSON file, is a configuration
- * diagnostic. Misskey's 94 excluded non-Vue diagnostics are `.ts` source errors
- * and stay scoreable; a fixture whose baseline could not read its own config
- * does not.
+ * So this is deliberately narrow: only a diagnostic with no file at all, one
+ * reported against a `tsconfig`/`jsconfig` JSON file, or one whose code says the
+ * program could not be built as asked, is a configuration diagnostic. Misskey's
+ * 94 excluded non-Vue diagnostics are `.ts` source errors and stay scoreable; a
+ * fixture whose baseline could not read its own config does not.
+ *
+ * That third arm is #3738. `TS6307` and `TS6059` are reported against a *source*
+ * file rather than the config, so they read as ordinary type errors while saying
+ * the opposite: that the file is in the program without being in the project's
+ * file list, or outside its `rootDir`. Neither is a claim about the code. On run
+ * 30738583070 element-plus's baseline emitted 208 `TS6307`, which the ledger
+ * scored as 208 Vize false negatives — 88% of that shard's false-negative
+ * breach — and vuetify's emitted 1252 `TS6059` naming the report directory as
+ * its `rootDir`. A baseline that cannot say which files it is checking is not a
+ * baseline.
  */
 
 const diagnosticPattern = /^(.+)\((\d+),(\d+)\): (error|warning) TS(\d+): (.+)$/u;
 const projectPattern = /^(error|warning) TS(\d+): (.+)$/u;
 const configurationFilePattern = /[jt]sconfig[^/]*\.json$/u;
+/** TS6307: not listed within the file list of project. TS6059: not under 'rootDir'. */
+const programConstructionCodes = new Set([6059, 6307]);
 
 export function evaluateBaselineConfiguration(vueTscOutput) {
   if (typeof vueTscOutput !== "string") throw new Error("vue-tsc output must be a string");
@@ -41,7 +53,8 @@ export function evaluateBaselineConfiguration(vueTscOutput) {
     const positioned = diagnosticPattern.exec(line);
     if (positioned != null) {
       const file = positioned[1].replaceAll("\\", "/");
-      if (!configurationFilePattern.test(file)) continue;
+      const code = Number(positioned[5]);
+      if (!configurationFilePattern.test(file) && !programConstructionCodes.has(code)) continue;
       diagnostics.push({
         code: Number(positioned[5]),
         column: Number(positioned[3]),

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -7,17 +7,39 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
  * The fixture's pinned tsconfig remains the source of compiler options, while
  * `files` replaces solution-style or incomplete include lists. This makes the
  * baseline compare the same authored SFCs instead of silently checking none.
+ *
+ * `files` alone is not enough, though, and #3738 is what that costs. A `files`
+ * list seeds the program with those roots and nothing else, so every ambient
+ * declaration the fixture owns — `declare global`, `declare namespace`, module
+ * augmentation — falls out of the program unless some SFC happens to import it,
+ * which ambient files by definition are not imported. The baseline then reports
+ * the project's own globals as undeclared and the ledger scores that against
+ * Vize: on run 30738583070 all 24 of lx-music-desktop's "false negatives" were
+ * `Cannot find namespace 'LX'` or `Property 'lx' does not exist on 'Window'`,
+ * both declared in its `src/**\/*.d.ts`, and restoring the glob below takes the
+ * baseline from 25 diagnostics over the Vue corpus to 1 — the one Vize agrees
+ * with. `elk`, `voicevox`, `vuestic-admin` and `misskey` fail the same way.
+ *
+ * Declaration files are the right thing to add back and the only thing:
+ * they are the fixture's type *environment*, never the comparison's subject, so
+ * they cannot change which SFCs are checked, and every diagnostic reported
+ * inside one is already excluded from scoring for being non-Vue. `exclude` is
+ * ours rather than the fixture's for the same reason — the glob is ours, and it
+ * must not reach into installed or built output. It cannot narrow the compared
+ * corpus, because `exclude` never applies to `files`.
  */
 export function materializeBaselineProject(fixtureRoot, reportDir, project, vizeReport) {
   const outputPath = join(reportDir, `${project.id}-vue-tsc.tsconfig.json`);
   const configDir = dirname(outputPath);
   const sourceProject = project.typecheckPerformance?.baseline?.tsconfig ?? project.tsconfig;
+  const fixtureBase = configRelativePath(configDir, fixtureRoot);
   const config = {
     extends: configRelativePath(configDir, resolve(fixtureRoot, sourceProject)),
     files: vizeReport.files
       .slice(0, vizeReport.fileCount)
       .map((entry) => configRelativePath(configDir, resolve(fixtureRoot, entry.file))),
-    include: [],
+    include: [`${fixtureBase}/**/*.d.ts`],
+    exclude: [`${fixtureBase}/**/node_modules/**`, `${fixtureBase}/**/dist/**`],
     references: [],
   };
   const source = `${JSON.stringify(config, null, 2)}\n`;

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -27,19 +27,32 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path";
  * ours rather than the fixture's for the same reason — the glob is ours, and it
  * must not reach into installed or built output. It cannot narrow the compared
  * corpus, because `exclude` never applies to `files`.
+ *
+ * The source config's own directory is globbed as well as the fixture root,
+ * because a TypeScript wildcard segment never descends into a dot-directory:
+ * `<fixture>/**\/*.d.ts` misses `.nuxt/imports.d.ts` while `<fixture>/.nuxt/**`
+ * matches it, the segment being literal. That is the whole of elk's generated
+ * type environment, and every project whose baseline config is generated into a
+ * dot-directory has the same shape. For the rest the second root is already
+ * inside the first and adds nothing.
  */
 export function materializeBaselineProject(fixtureRoot, reportDir, project, vizeReport) {
   const outputPath = join(reportDir, `${project.id}-vue-tsc.tsconfig.json`);
   const configDir = dirname(outputPath);
   const sourceProject = project.typecheckPerformance?.baseline?.tsconfig ?? project.tsconfig;
-  const fixtureBase = configRelativePath(configDir, fixtureRoot);
+  const sourcePath = resolve(fixtureRoot, sourceProject);
+  const ambientRoots = [
+    ...new Set(
+      [fixtureRoot, dirname(sourcePath)].map((root) => configRelativePath(configDir, root)),
+    ),
+  ];
   const config = {
-    extends: configRelativePath(configDir, resolve(fixtureRoot, sourceProject)),
+    extends: configRelativePath(configDir, sourcePath),
     files: vizeReport.files
       .slice(0, vizeReport.fileCount)
       .map((entry) => configRelativePath(configDir, resolve(fixtureRoot, entry.file))),
-    include: [`${fixtureBase}/**/*.d.ts`],
-    exclude: [`${fixtureBase}/**/node_modules/**`, `${fixtureBase}/**/dist/**`],
+    include: ambientRoots.map((root) => `${root}/**/*.d.ts`),
+    exclude: ambientRoots.flatMap((root) => [`${root}/**/node_modules/**`, `${root}/**/dist/**`]),
     references: [],
   };
   const source = `${JSON.stringify(config, null, 2)}\n`;

--- a/tools/fixtures/typecheck-divergence-budget.mjs
+++ b/tools/fixtures/typecheck-divergence-budget.mjs
@@ -100,14 +100,41 @@ export function assertBudgetPassed(artifact, budgetMode = "enforce") {
   const mode = parseBudgetMode(budgetMode);
   const budget = artifact.budget;
   if (budget.verdict === "passed") return;
-  const detail =
+  const detail = `${
     budget.verdict === "unusable"
-      ? `Typecheck divergence baseline is unusable for ${artifact.project}: ${budget.unusableReason}`
-      : `Typecheck divergence budget breached for ${artifact.project}: ${describeBreaches(artifact).join("; ")}`;
+      ? `Typecheck divergence baseline is unusable for ${artifact.project}`
+      : `Typecheck divergence budget breached for ${artifact.project}`
+  } — ${describeClassification(artifact)}: ${
+    budget.verdict === "unusable" ? budget.unusableReason : describeBreaches(artifact).join("; ")
+  }`;
   if (mode === "enforce") throw new Error(detail);
   // A GitHub workflow command, so a release run that records an unusable
   // baseline still shows a warning on the run instead of a silent green tick.
   process.stdout.write(`::warning title=Typecheck divergence budget not enforced::${detail}\n`);
+}
+
+/**
+ * Answer the only question a failing shard leaves the reader with (#3738): is
+ * this Vize being wrong, or the instrument being broken?
+ *
+ * The auditor of run 30738583070 could not tell, and read the answer off the
+ * ratios — 0.87 to 0.99 looked like two programs, 0.06 looked like a compiler.
+ * That inference is not available from a ratio, and it was wrong in both
+ * directions on that run. The verdict already carries the answer, because every
+ * `unusable` reason is a proof that the baseline did not measure Vize; it just
+ * was not stated. So state it, on the failure and in the step summary, and say
+ * what the usable case rests on rather than leaving it implied.
+ */
+export function describeClassification(artifact) {
+  const budget = artifact.budget;
+  if (budget.verdict === "unusable") {
+    return "instrument failure, the vue-tsc baseline did not measure Vize";
+  }
+  const coverage = artifact.baseline.coverage;
+  return (
+    "Vize divergence, the vue-tsc baseline loaded cleanly over the same " +
+    `${coverage.sharedVueFileCount} Vue files`
+  );
 }
 
 function describeBreaches(artifact) {

--- a/tools/fixtures/typecheck-divergence-markdown.mjs
+++ b/tools/fixtures/typecheck-divergence-markdown.mjs
@@ -1,3 +1,5 @@
+import { describeClassification } from "./typecheck-divergence-budget.mjs";
+
 /**
  * The human-readable half of a divergence run, split out of
  * `typecheck-divergence-report.mjs` so the report script stays inside the
@@ -8,6 +10,10 @@
  * the Vue-file coverage, and — since #3513 — how many configuration diagnostics
  * the baseline emitted. A shard that measured nothing has to say so here, not
  * only in the JSON nobody opens.
+ *
+ * Since #3738 it also prints the classification, because the numbers alone do
+ * not carry it: 568 false positives measured against a baseline that never
+ * loaded and 39 measured against one that did read identically in this table.
  */
 export function renderMarkdown(artifact) {
   const summary = artifact.divergence.summary;
@@ -35,6 +41,7 @@ export function renderMarkdown(artifact) {
     `Unexpected Vue files: ${coverage.unexpectedVueFiles.length}`,
     `Ignored dependency Vue files: ${coverage.ignoredDependencyVueFileCount}`,
     `Budget verdict: ${describeVerdict(artifact.budget)}`,
+    `Classification: ${describeClassification(artifact)}`,
     `Budget passed: ${artifact.budget.passed}`,
     `Digest: ${artifact.divergence.sha256}`,
     "",


### PR DESCRIPTION
Closes #3738 for the part that is fixable; the rest is diagnosed below with evidence, not widened away.

Every number here comes from the 11 shard artifacts of run
[30738583070](https://github.com/ubugeeei-prod/vize/actions/runs/30738583070) plus a local re-run of
the lx-music-desktop baseline against the pinned fixture with the same vue-tsc 3.3.4 / TypeScript
6.0.3.

## The answer to the open question

**The FP/FN ratio does not classify these shards, and it was wrong in both directions.** Six of the
eleven were already `unusable`; of the five "breaches", three are the instrument and two are real —
and the one the auditor picked out as "the honest measurement" (misskey, 0.064 / 0.090) is roughly
45% instrument, while one at 0.94 / 0.91 (reka-ui) is genuine.

The cause is not exotic. `materializeBaselineProject` writes
`files: [<Vize's exact Vue corpus>], include: []`. A `files` list seeds the program with those roots
and nothing else, so every ambient declaration the fixture owns — `declare global`,
`declare namespace`, module augmentation — leaves the program, because an ambient file is by
definition never imported. The baseline then reports the project's own globals as undeclared, and
the ledger scores that against Vize.

`baseline.coverage` could never see this: it compares `--listFiles` against a `files` array that
*was* Vize's file list, so it matches by construction. Its own header says so. The Vue corpora were
identical on all 11 shards (same SHA-256, 0 missing, 0 unexpected). What differed was the type
environment.

## Per-project split

| # | project | verdict on that run | classification | evidence |
|---|---|---|---|---|
| 0 | vue-vben-admin | unusable | **instrument** | `TS2688 '@vben/types/global'`. The config sets no `typeRoots`, so `types` resolves by walking `node_modules` up from the *synthesized* config in `real-project-results/shard-0/` and never reaches the fixture. `pnpm install` exited 0. |
| 1 | hoppscotch | unusable | **instrument** | 7 × `TS2688` for `vite/client`, `unplugin-icons/types/vue`, `unplugin-fonts/client`, `vite-plugin-pages/client`, `vite-plugin-vue-layouts/client`, `vite-plugin-pwa/client` and the relative `./src/types/kernel.d.ts` — same cause, all installed. Plus `TS5107 moduleResolution=node10`. |
| 2 | element-plus | breach 568 FP / 235 FN | **instrument**, with a real residue | 208 of the 235 FN (88%) are `TS6307` "not listed within the file list of project" — `tsconfig.web.json` is `composite: true` with `include: ["packages", "typings/env.d.ts", "typings/style.d.ts"]`, replaced by `[]`. Residue: 444 FP `TS2304 Cannot find name 'ariaLabel'` in date-picker / time-picker / dropdown / pagination, and 3 FP `TS6307` against **Vize's own** `node_modules/.vize/canon/tsconfig.shard0.json` — Vize's program construction is broken here too. |
| 3 | lx-music-desktop | breach 24 FN | **instrument — fixed here** | All 24 are `TS2503 Cannot find namespace 'LX'`, `TS2339 Property 'lx' does not exist on 'Window'`, `TS2339 Property '$t' does not exist`, declared in `src/**/*.d.ts`. Measured below. |
| 4 | reka-ui | breach 77 FP / 53 FN | **real** | Three systematic classes, not a program difference: 55 FP `TS2322 ComputedRef<boolean \| undefined>` not assignable to `ComputedRef<boolean>` (optional prop with default), 23 FN `TS7006` implicit-any parameters, 22 FN `TS1117` duplicate object-literal keys — a purely syntactic check no ambient type can affect. Instrument tail: 1 FN `TS2339 ImportMeta.env`. |
| 5 | primevue | unusable | **instrument** | `TS5101 baseUrl`, `TS5107 moduleResolution=node10`, `TS5107 target=ES5` — TypeScript 6.0 deprecations-as-errors with no `ignoreDeprecations`. Baseline produced 0 diagnostics against Vize's 1174. |
| 6 | vuetify | unusable | **instrument** | `TS5101 downlevelIteration`, *and* 1252 × `TS6059` "is not under 'rootDir' '/home/runner/_work/vize/vize/real-project-results/shard-6'" — the synthesized config's own directory became the project's `rootDir`, so every fixture file is outside it. |
| 7 | vuestic-admin | unusable | **instrument** | `include: ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue", "vite.config.ts", "node_modules/vuestic-ui"]` replaced by `[]`; the baseline lost the component library and its own declarations and emitted 1 diagnostic in total. `types: ["vite/client"]` resolved — from *vize's* root `node_modules`, not the fixture's. |
| 8 | voicevox | unusable | **instrument** | `include: ["**/*.ts", "**/*.vue", …]` replaced by `[]`; 307 of 382 baseline-only diagnostics are `TS2339 Property 'state' does not exist on type 'Store'`. |
| 9 | elk | breach 634 FP / 1506 FN | **instrument** | 1119 FN `TS2304 Cannot find name '<nuxt auto-import>'` + 298 FN `TS2339` + 70 FN `TS7006` = 1487 of 1506 (98.7%): `.nuxt/tsconfig.app.json`'s include (`imports.d.ts`, `components.d.ts`, `nuxt.d.ts`) replaced by `[]`, after `nuxt prepare` had generated them. Residue: 576 FP `TS18046 '$t' is of type 'unknown'`, plausibly a real gap in Vize's i18n `ComponentCustomProperties` augmentation but unmeasurable against this baseline. |
| 10 | misskey | breach 39 FP / 56 FN | **mixed** | Instrument: 25 FN `TS2304 _DEV_` and 8 FN `TS2339 Window.TagCanvas` are the dropped `./@types/**/*.ts` include; 12 FN + 4 FP `TS2307 Cannot find module 'misskey-js'` is `pnpm install --ignore-scripts` leaving the workspace package unbuilt. Real: 22 FP `TS2345` — an `(el: Element) => void` handler not assignable to `(_e: Event) => unknown` across 6 components — and 10 FN `TS7006`. |

Cross-cutting real class: `TS7006` "parameter implicitly has an 'any' type" appears as a false
negative on reka-ui (23), elk (70), voicevox (55) and misskey (10), and as a false positive on
vuestic-admin (16) and element-plus (6). Vize and vue-tsc disagree systematically about
implicit-any on template and handler parameters. That one is worth its own issue once the baseline
is trustworthy.

## What this PR changes

**1. The baseline keeps the fixture's ambient type environment.** `include` becomes
`<fixture>/**/*.d.ts` instead of `[]`. Declaration files are the right thing to add back and the
only thing: they are the type *environment*, never the comparison's subject, so they cannot change
which SFCs are compared, and a diagnostic inside one is already excluded from scoring for being
non-Vue. `exclude` is ours rather than the fixture's for the same reason, and cannot narrow the
compared corpus because `exclude` never applies to `files`.

The source config's own directory is globbed by name as well, because a TypeScript wildcard segment
never descends into a dot-directory — `<fixture>/**/*.d.ts` misses `.nuxt/imports.d.ts`, which is
all of elk's generated environment. Verified against `tsc` 6.0.3 directly.

**Measured, lx-music-desktop at `9c364b48`, vue-tsc 3.3.4 / TypeScript 6.0.3, over the recorded
shard-3 Vize corpus:**

| | before | after |
|---|---|---|
| baseline diagnostics (all) | 1104 | **8** |
| baseline diagnostics over the compared Vue corpus | 25 | **1** |
| authored `.d.ts` in the baseline program | 0 | **37** |
| false negatives / false positives | 24 / 0 | **0 / 0** |
| budget verdict | breached (FN ratio 0.96) | **passed** |

The one diagnostic that survives is `NavBar.vue:17:25 TS2307 Cannot find module '@root/lang'` —
exactly the diagnostic the run recorded as `shared`. The reproduction of the *old* behaviour matches
the artifact exactly: 1104 raw, 1079 excluded as non-Vue, 25 scoreable.

**2. `TS6307` and `TS6059` are configuration diagnostics wherever they are reported.** Both are
attributed to a *source* file while saying the opposite of a type error: that the program could not
be built as asked. `evaluateBaselineConfiguration` only looked at diagnostics with no file or one
against a `tsconfig`, so element-plus's 208 `TS6307` scored as 208 Vize false negatives. #3588's rule
holds — an unusable baseline fails loudly rather than scoring as zero; this widens *what counts as
unusable*, never what counts as passing.

**3. Every failing verdict names its classification**, in the thrown failure, in the
`::warning` of a `record-only` run, and on a new `Classification:` line in the step summary:

```
Typecheck divergence baseline is unusable for element-plus — instrument failure, the vue-tsc
baseline did not measure Vize: vue-tsc could not load the fixture project configuration …

Typecheck divergence budget breached for reka-ui — Vize divergence, the vue-tsc baseline loaded
cleanly over the same 700 Vue files: 77 false positives …
```

That is the durable part. The per-project numbers will keep moving; "which of the two situations is
this" should not have to be inferred from a ratio again.

## What is diagnosed and deliberately not fixed here

No budget was widened and nothing was added to `compat-documented-differences.json` — none of the
below is an *intended* difference.

- **The synthesized tsconfig lives outside the fixture tree** (`real-project-results/shard-N/`), so
  every resolution anchored to the root config's own directory is wrong: the `node_modules` walk for
  `types` (shards 0, 1), and the default `rootDir` (shard 6, 1252 × `TS6059`). Writing it inside the
  fixture would fix all three, but it touches the pinned submodules' working trees and I could not
  demonstrate it on those projects locally, so it is diagnosis only.
- **TypeScript 6.0 deprecations are errors** (shards 1, 5, 6). `ignoreDeprecations: "6.0"` in the
  synthesized config is the fix — the options still function in 6.0 — but it changes the compiler
  options the baseline runs under, which deserves a decision rather than a drive-by.
- **`pnpm install --ignore-scripts` leaves workspace packages unbuilt**, so misskey's `misskey-js`
  is unresolvable on both sides.
- **Genuinely divergent and unfixed**: reka-ui's three classes, misskey's handler-contravariance
  false positives, element-plus's `ariaLabel`, elk's `$t`. The last two only become measurable once
  their baselines load.

After this lands, shard 3 should pass; shards 2 and 9 should turn from "Vize is 87–99% wrong" into
`unusable` with a named cause; 4 and 10 stay breached and are the real work. That is not green, and
I have not tried to make it green.

## Verification

50 pass across `typecheck-baseline-project`, `typecheck-divergence-{baseline,report,budget,
baseline-configuration,ledger}`, `typecheck-divergence` and `real-project-matrix-workflow`. Two of
them are new and both fail before the change:

- **`materialized baseline keeps the fixture's ambient declarations in the program`** builds a
  fixture with one ambient declaration under a plain directory and one under a dot-directory, hands
  it to the **real vue-tsc**, and requires an empty diagnostic list plus both declaration files in
  the program. Without the ambient roots it reports exactly the two shapes that made those shards
  breach: `TS2503 Cannot find namespace 'Authored'` and `TS2304 Cannot find name 'generatedHelper'`.
- **`a file-list error against a Vue file is unusable, not a false negative`** fails before with
  precisely the pathology in the issue: `budget breached … Vize divergence … 1 false negatives`.

The materialized-config assertion and every failure-message assertion are full-equality on the
complete record. `vp check --fix` clean; `tests/tooling/source-file-lengths.test.ts` passes with
nothing allowlisted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Vue type-checking baseline generation to recognize ambient declarations in regular and dot-directories.
  - Excluded nested dependency and build-output directories from generated baseline projects.
  - Improved handling of TypeScript project-configuration and file-list diagnostics.

- **New Features**
  - Divergence reports now identify whether issues are instrumentation failures or Vize divergence.
  - Reports include shared Vue-file coverage and clearer baseline and budget-failure details.

- **Tests**
  - Expanded regression coverage for baseline generation, diagnostics, classifications, and budget reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->