### PR TITLE
test(editor): run the Emacs ERT suite in CI

### DIFF
--- a/.github/actions/vscode-host-smoke/action.yml
+++ b/.github/actions/vscode-host-smoke/action.yml
@@ -56,6 +56,10 @@ runs:
       shell: bash
       run: command -v vim || (sudo apt-get update && sudo apt-get install -y vim)
 
+    - name: Ensure Emacs is available
+      shell: bash
+      run: command -v emacs || (sudo apt-get update && sudo apt-get install -y emacs-nox)
+
     - name: Run VS Code host smoke against the real server
       shell: bash
       env:
@@ -74,6 +78,12 @@ runs:
       env:
         NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
       run: vp run --workspace-root test:vim-extension:headless
+
+    - name: Run the packaged Emacs ERT suite
+      shell: bash
+      env:
+        NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+      run: vp run --workspace-root test:emacs-extension:headless
 
     - name: Run the Neovim scenario against the real server
       shell: bash

--- a/editors/emacs/test/vize-test.el
+++ b/editors/emacs/test/vize-test.el
@@ -1,4 +1,5 @@
 (require 'ert)
+(require 'eglot)
 
 (load-file (expand-file-name "../vize.el" (file-name-directory load-file-name)))
 
@@ -81,7 +82,6 @@
   (let ((eglot-server-programs nil)
         (vize-eglot-major-modes '(vize-vue-mode vize-art-vue-mode)))
     (vize-setup-eglot 'lint)
-    (provide 'eglot)
     (should
      (equal eglot-server-programs
             '((vize-art-vue-mode "vize" "lsp" :initializationOptions (:lint t))

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -12,6 +12,19 @@ function taskCommand(name: string): string {
   return (testAndBenchmarkTasks[name] as { command: string }).command;
 }
 
+// Composite-action steps in declaration order, so tests can assert what a step
+// actually runs and that it runs before the step depending on it. Steps written
+// as `run: |` blocks report `|`; the callers below only need single-line steps.
+function actionSteps(action: string): Array<{ name: string; run: string }> {
+  return action
+    .split(/\n {4}- name: /)
+    .slice(1)
+    .map((chunk) => {
+      const [name, ...rest] = chunk.split("\n");
+      return { name, run: /^ {6}run: (.*)$/m.exec(rest.join("\n"))?.[1] ?? "" };
+    });
+}
+
 test("the Neovim real-server scenario has a task that runs its Node launcher", () => {
   assert.equal(
     taskCommand("test:nvim-extension:real-server"),
@@ -50,15 +63,24 @@ test("CI runs both headless editor specs", () => {
 });
 
 test("CI executes the packaged Emacs ERT suite", () => {
-  const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
+  const steps = actionSteps(readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml"));
 
   assert.equal(
     taskCommand("test:emacs-extension:headless"),
     "emacs -Q --batch -l ert -l editors/emacs/test/vize-test.el -f ert-run-tests-batch-and-exit",
   );
-  assert.match(action, /command -v emacs/);
-  assert.match(action, /sudo apt-get install -y emacs-nox/);
-  assert.match(action, /vp run --workspace-root test:emacs-extension:headless/);
+
+  // The interpreter is only guaranteed by the emacs-nox fallback, so the setup
+  // step and its position ahead of the ERT task are one contract.
+  const setupIndex = steps.findIndex((step) => step.name === "Ensure Emacs is available");
+  const runIndex = steps.findIndex((step) => step.name === "Run the packaged Emacs ERT suite");
+
+  assert.equal(
+    steps[setupIndex]?.run,
+    "command -v emacs || (sudo apt-get update && sudo apt-get install -y emacs-nox)",
+  );
+  assert.equal(steps[runIndex]?.run, "vp run --workspace-root test:emacs-extension:headless");
+  assert.ok(setupIndex < runIndex, "Emacs setup must run before the ERT suite");
 });
 
 test("check.yml keeps the editor real-server job in the required set", () => {

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -49,6 +49,18 @@ test("CI runs both headless editor specs", () => {
   assert.match(action, /command -v vim/);
 });
 
+test("CI executes the packaged Emacs ERT suite", () => {
+  const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
+
+  assert.equal(
+    taskCommand("test:emacs-extension:headless"),
+    "emacs -Q --batch -l ert -l editors/emacs/test/vize-test.el -f ert-run-tests-batch-and-exit",
+  );
+  assert.match(action, /command -v emacs/);
+  assert.match(action, /sudo apt-get install -y emacs-nox/);
+  assert.match(action, /vp run --workspace-root test:emacs-extension:headless/);
+});
+
 test("check.yml keeps the editor real-server job in the required set", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
 

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -136,6 +136,9 @@ export const testAndBenchmarkTasks = defineTasks({
   ),
   "test:vim-extension:package": noCacheTask("vp run --workspace-root package:vim-extension"),
   "test:helix-extension:package": noCacheTask("vp run --workspace-root package:helix-extension"),
+  "test:emacs-extension:headless": noCacheTask(
+    "emacs -Q --batch -l ert -l editors/emacs/test/vize-test.el -f ert-run-tests-batch-and-exit",
+  ),
   "test:emacs-extension:package": noCacheTask("vp run --workspace-root package:emacs-extension"),
   "test:playground": task(runInPackages("test:browser", ["./playground"]), {
     input: cacheInputs.jsChecks,


### PR DESCRIPTION
## Summary

- add a dedicated headless Emacs task that executes all 17 existing ERT tests
- install emacs-nox and run that task in the required editor-host-smoke job
- load Eglot deterministically so the previously dead suite is order-independent
- pin the task command and workflow wiring in the editor real-server guardrail

## Reproduction

Running the dormant suite before the test fix produced 15 passes and 2 failures: the off-profile test queued work without loading Eglot, and that queued callback polluted the following registration test. Requiring Eglot in the suite makes each setup assertion execute synchronously and independently.

## Verification

- Node editor integration and CI wiring tests: 13 passed
- Emacs 30.2 ERT suite through emacs-nox: 17 passed, 0 unexpected
- git diff check: clean
- every touched source file remains below 350 lines

This is the first, smallest slice of #3744. Vim, Zed, and Helix real-server scenarios remain separate work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a headless Emacs extension test task for running packaged ERT tests.
  * CI now installs Emacs when needed and runs the packaged Emacs test suite automatically.

* **Tests**
  * Added end-to-end coverage for the Emacs test task, installation fallback, executable availability, and workflow execution.
  * Updated Emacs test setup to load required tooling explicitly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->