### PR TITLE
test(canon): verify injected errors clear after repair

### DIFF
--- a/tests/snapshots/_helpers/realworld.ts
+++ b/tests/snapshots/_helpers/realworld.ts
@@ -20,6 +20,8 @@ export interface VizeLintSummary {
 export interface InjectedTypeErrorSummary extends VizeCheckSummary {
   file: string;
   diagnostics: string[];
+  repairedDiagnostics: string[];
+  repairDurationMs: number;
 }
 
 interface InjectedTypeErrorOptions {
@@ -90,6 +92,7 @@ function runVizeCheckJson(
 ): {
   fileCount?: number;
   errorCount?: number;
+  warningCount?: number;
   files?: Array<{ file?: string; diagnostics?: string[] }>;
 } {
   const cmd = buildVizeCheckCommand(checkConfig, patterns);
@@ -99,6 +102,7 @@ function runVizeCheckJson(
   return JSON.parse(stdout) as {
     fileCount?: number;
     errorCount?: number;
+    warningCount?: number;
     files?: Array<{ file?: string; diagnostics?: string[] }>;
   };
 }
@@ -159,31 +163,47 @@ export function runVizeCheckWithInjectedTypeError(
   const absoluteTempTsconfig = tempTsconfig
     ? path.join(checkConfig.cwd, tempTsconfig.relativePath)
     : null;
+  const effectiveCheckConfig = tempTsconfig
+    ? { ...checkConfig, tsconfig: tempTsconfig.relativePath }
+    : checkConfig;
+  const cleanSource = `<script setup lang="ts">
+const __vizeIntentionalTypeError: number = 1;
+</script>
 
-  fs.writeFileSync(
-    absoluteFile,
-    `<script setup lang="ts">
+<template>
+  <div>{{ __vizeIntentionalTypeError }}</div>
+</template>
+`;
+  const brokenSource = `<script setup lang="ts">
 const __vizeIntentionalTypeError: number = "not-a-number";
 </script>
 
 <template>
   <div>{{ __vizeIntentionalTypeError }}</div>
 </template>
-`,
-    "utf-8",
-  );
+`;
+  const expectedDiagnostic = "error:2:7 [TS2322] Type 'string' is not assignable to type 'number'.";
+
+  fs.writeFileSync(absoluteFile, cleanSource, "utf-8");
   if (tempTsconfig && absoluteTempTsconfig) {
     fs.mkdirSync(path.dirname(absoluteTempTsconfig), { recursive: true });
     fs.writeFileSync(absoluteTempTsconfig, tempTsconfig.content, "utf-8");
   }
 
   try {
-    const startedAt = performance.now();
-    const parsed = runVizeCheckJson(
-      tempTsconfig ? { ...checkConfig, tsconfig: tempTsconfig.relativePath } : checkConfig,
-      [relativeFile],
-      timeoutMs,
+    const clean = runVizeCheckJson(effectiveCheckConfig, [relativeFile], timeoutMs);
+    const cleanFile = (clean.files ?? []).find(
+      (file) => file.file?.replaceAll("\\", "/") === relativeFile,
     );
+    assert.deepEqual(
+      cleanFile?.diagnostics,
+      [],
+      `clean injected oracle should have no diagnostics in ${relativeFile}`,
+    );
+
+    fs.writeFileSync(absoluteFile, brokenSource, "utf-8");
+    const startedAt = performance.now();
+    const parsed = runVizeCheckJson(effectiveCheckConfig, [relativeFile], timeoutMs);
     const durationMs = performance.now() - startedAt;
     const files = parsed.files ?? [];
     const injected = files.find((file) => file.file?.replaceAll("\\", "/") === relativeFile);
@@ -191,15 +211,32 @@ const __vizeIntentionalTypeError: number = "not-a-number";
 
     assert.ok((parsed.fileCount ?? 0) > 0, "injected check fileCount should be > 0");
     assert.ok((parsed.errorCount ?? 0) > 0, "injected check should report at least one error");
-    assert.ok(
-      diagnostics.some((diagnostic) => /\[TS2322\]/.test(diagnostic)),
+    assert.deepEqual(
+      diagnostics,
+      [expectedDiagnostic],
       `expected injected TS2322 diagnostic in ${relativeFile}, got ${JSON.stringify(files)}`,
     );
     assert.ok(durationMs < timeoutMs, `injected check should finish before ${timeoutMs}ms`);
 
+    fs.writeFileSync(absoluteFile, cleanSource, "utf-8");
+    const repairStartedAt = performance.now();
+    const repaired = runVizeCheckJson(effectiveCheckConfig, [relativeFile], timeoutMs);
+    const repairDurationMs = performance.now() - repairStartedAt;
+    assert.deepEqual(
+      repaired,
+      clean,
+      `repaired check report should equal the clean baseline for ${relativeFile}`,
+    );
+    assert.ok(repairDurationMs < timeoutMs, `repaired check should finish before ${timeoutMs}ms`);
+    const repairedFile = (repaired.files ?? []).find(
+      (file) => file.file?.replaceAll("\\", "/") === relativeFile,
+    );
+
     return {
       file: relativeFile,
       diagnostics,
+      repairedDiagnostics: repairedFile?.diagnostics ?? [],
+      repairDurationMs,
       fileCount: parsed.fileCount ?? 0,
       errorCount: parsed.errorCount ?? 0,
       durationMs,

--- a/tests/snapshots/check/zz-intentional-errors-fixtures.ts
+++ b/tests/snapshots/check/zz-intentional-errors-fixtures.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
 
 import {
@@ -9,6 +10,7 @@ import {
   requireVizeAndCorsaBins,
   stylePreprocessorsApp,
   typecheckErrorsApp,
+  vueVbenAdminApp,
 } from "../../_helpers/apps.ts";
 import { genericBuildApp, typecheckVueImportsApp } from "../../_helpers/fixture-apps.ts";
 import { runVizeCheckWithInjectedTypeError } from "../_helpers/realworld.ts";
@@ -23,16 +25,19 @@ const fixtureApps = [
   nuxtParityApp,
   optionsApiApp,
   classComponentApp,
+  // #3747: keep one Tier-L batch broken -> repaired oracle on every PR.
+  vueVbenAdminApp,
 ] as const;
 
 describe("fixture vize check injected type errors", () => {
   before(requireVizeAndCorsaBins);
 
   for (const app of fixtureApps) {
-    it(`${app.name} catches an injected TS2322`, () => {
+    it(`${app.name} catches and repairs an injected TS2322`, () => {
       const summary = runVizeCheckWithInjectedTypeError(app, { timeoutMs: 120_000 });
+      assert.deepEqual(summary.repairedDiagnostics, []);
       console.log(
-        `${app.name}: file=${summary.file}, fileCount=${summary.fileCount}, errorCount=${summary.errorCount}, durationMs=${summary.durationMs.toFixed(0)}`,
+        `${app.name}: file=${summary.file}, fileCount=${summary.fileCount}, errorCount=${summary.errorCount}, durationMs=${summary.durationMs.toFixed(0)}, repairDurationMs=${summary.repairDurationMs.toFixed(0)}`,
       );
     });
   }

--- a/tests/snapshots/check/zz-intentional-errors-realworld.ts
+++ b/tests/snapshots/check/zz-intentional-errors-realworld.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { before, describe, it } from "node:test";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -88,7 +89,7 @@ describe("real-world vize check injected type errors", () => {
   it("ant-design-vue injected semantic diagnostics are tracked in #1727", { skip: true }, () => {});
 
   for (const app of realWorldApps) {
-    it(`${app.name} catches an injected TS2322`, () => {
+    it(`${app.name} catches and repairs an injected TS2322`, () => {
       const summary = runVizeCheckWithInjectedTypeError(app, {
         timeoutMs: 300_000,
         tsconfig:
@@ -98,8 +99,9 @@ describe("real-world vize check injected type errors", () => {
               ? naiveUiInjectedTsconfig
               : undefined,
       });
+      assert.deepEqual(summary.repairedDiagnostics, []);
       console.log(
-        `${app.name}: file=${summary.file}, fileCount=${summary.fileCount}, errorCount=${summary.errorCount}, durationMs=${summary.durationMs.toFixed(0)}`,
+        `${app.name}: file=${summary.file}, fileCount=${summary.fileCount}, errorCount=${summary.errorCount}, durationMs=${summary.durationMs.toFixed(0)}, repairDurationMs=${summary.repairDurationMs.toFixed(0)}`,
       );
     });
   }

--- a/tests/tooling/github-workflows-vue-parity.test.ts
+++ b/tests/tooling/github-workflows-vue-parity.test.ts
@@ -80,6 +80,16 @@ test("Vue parity structurally gates compiler fixtures and incremental LSP behavi
     /snapshots\/check\/vue-benchmarks-correctness-plants\.ts/,
     "typecheck parity must run the upstream correctness plants",
   );
+  assert.match(
+    testsPackage.scripts["test:check:fixtures"],
+    /snapshots\/check\/zz-intentional-errors-fixtures\.ts/,
+    "typecheck parity must run the batch broken-to-repaired oracle",
+  );
+  assert.match(
+    readRepoFile("tests", "snapshots", "check", "zz-intentional-errors-fixtures.ts"),
+    /vueVbenAdminApp/,
+    "the per-PR batch repair oracle must retain a Tier-L project",
+  );
 
   const glyphProperties = steps.find(
     (step) => step.name === "Check glyph formatter corpus properties",

--- a/tests/tooling/github-workflows-vue-parity.test.ts
+++ b/tests/tooling/github-workflows-vue-parity.test.ts
@@ -85,10 +85,34 @@ test("Vue parity structurally gates compiler fixtures and incremental LSP behavi
     /snapshots\/check\/zz-intentional-errors-fixtures\.ts/,
     "typecheck parity must run the batch broken-to-repaired oracle",
   );
-  assert.match(
-    readRepoFile("tests", "snapshots", "check", "zz-intentional-errors-fixtures.ts"),
-    /vueVbenAdminApp/,
+  // A bare text match would also pass on a mention in a comment or a leftover
+  // import, so pin the two facts that make the Tier-L project actually run:
+  // vueVbenAdminApp is the real app config from _helpers/apps.ts, and it is a
+  // member of the array the suite iterates.
+  const batchOracle = readRepoFile(
+    "tests",
+    "snapshots",
+    "check",
+    "zz-intentional-errors-fixtures.ts",
+  ).replace(/\/\/[^\n]*/g, "");
+  const identifiers = (list: string | undefined) =>
+    (list ?? "").split(",").map((entry) => entry.trim());
+  const appsImport = /import \{([\s\S]*?)\} from "\.\.\/\.\.\/_helpers\/apps\.ts";/.exec(
+    batchOracle,
+  );
+  assert.ok(
+    identifiers(appsImport?.[1]).includes("vueVbenAdminApp"),
+    "the per-PR batch repair oracle must import the Tier-L app config from _helpers/apps.ts",
+  );
+  const fixtureAppList = /const fixtureApps = \[([\s\S]*?)\]/.exec(batchOracle);
+  assert.ok(
+    identifiers(fixtureAppList?.[1]).includes("vueVbenAdminApp"),
     "the per-PR batch repair oracle must retain a Tier-L project",
+  );
+  assert.match(
+    batchOracle,
+    /for \(const app of fixtureApps\)/,
+    "the per-PR batch repair oracle must run every registered app",
   );
 
   const glyphProperties = steps.find(

--- a/tests/tooling/snapshot-baselines.test.ts
+++ b/tests/tooling/snapshot-baselines.test.ts
@@ -77,8 +77,10 @@ const assertionOnlyCheckTests = {
   voicevox: "real-world smoke lane is too large for a deterministic complete baseline",
   "vue-vben-admin": "real-world smoke lane is too large for a deterministic complete baseline",
   vuetify: "real-world smoke lane is too large for a deterministic complete baseline",
-  "zz-intentional-errors-fixtures": "intentional-error aggregate asserts diagnostic presence",
-  "zz-intentional-errors-realworld": "intentional-error aggregate asserts diagnostic presence",
+  "zz-intentional-errors-fixtures":
+    "intentional-error aggregate asserts exact broken diagnostics and complete clean repair",
+  "zz-intentional-errors-realworld":
+    "intentional-error aggregate asserts exact broken diagnostics and complete clean repair",
 } satisfies Record<string, string>;
 
 function snapshotFiles(...segments: string[]): string[] {


### PR DESCRIPTION
## Summary

- run the injected batch typecheck oracle through clean, broken, and repaired source states
- require the exact authored `error:2:7 [TS2322]` diagnostic instead of partial matching
- compare the complete repaired JSON report to the clean baseline
- keep Vue Vben Admin as a Tier-L broken-to-repaired gate on every PR

## Verification

- `vp check tests/snapshots/_helpers/realworld.ts tests/snapshots/check/zz-intentional-errors-fixtures.ts tests/snapshots/check/zz-intentional-errors-realworld.ts tests/tooling/snapshot-baselines.test.ts tests/tooling/github-workflows-vue-parity.test.ts`
- `node --test --test-concurrency=1 tests/snapshots/check/zz-intentional-errors-fixtures.ts tests/tooling/snapshot-baselines.test.ts tests/tooling/github-workflows-vue-parity.test.ts` with Vize and Corsa binaries
- `git diff --check`

Closes #3747

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced workflow validation for Vue parity fixtures, including batch broken-to-repaired scenarios.
  * Updated snapshot checks to verify exact diagnostics and confirm fully clean repairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->