### PR TITLE
test(ci): fail closed when typecheck dependencies are missing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -262,8 +262,8 @@ jobs:
         with:
           key: test-scripts
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
-      - name: Install JS dependencies
-        run: vp install --frozen-lockfile --prefer-offline
+      - name: Hydrate CLI diagnostic fixture and install JS dependencies
+        run: git submodule update --init --depth 1 -- tests/_fixtures/_git/ant-design-vue && vp install --frozen-lockfile --prefer-offline
       - name: Build vize CLI
         run: cargo build --profile ci -p vize
       - name: Install vize CLI

--- a/tests/tooling/check-bench-gate.test.ts
+++ b/tests/tooling/check-bench-gate.test.ts
@@ -11,6 +11,7 @@ import { generateCorpus } from "../../bench/generate.mjs";
 // @ts-expect-error plain-JS bench module without type declarations
 import { evaluateBudget } from "../../bench/check-gate-report.mjs";
 import { resolveVizeCommand } from "../_helpers/realworld-typecheck.ts";
+import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const gateScript = path.join(root, "bench/check-gate.mjs");
@@ -338,10 +339,10 @@ test("check-gate publishes reproducibility metadata for a gated run", (t) => {
 });
 
 function requireTsgoOrSkip(t: { skip(reason: string): void }): void {
-  assert.notEqual(
-    process.env.VIZE_TEST_REQUIRE_TSGO,
-    "1",
-    "tsgo (or a built vize binary) is required but unavailable",
+  requireTypecheckDependency(
+    t,
+    undefined,
+    "tsgo (or a built vize binary) for the check benchmark gate",
+    "tsgo or a built vize binary is unavailable",
   );
-  t.skip("tsgo or a built vize binary is unavailable");
 }

--- a/tests/tooling/cli-check-collection.test.ts
+++ b/tests/tooling/cli-check-collection.test.ts
@@ -6,6 +6,8 @@ import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { typecheckDependencySkip } from "./support/typecheck-dependency.ts";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 /**
@@ -145,9 +147,14 @@ test("unsupported file extensions (.js) collect nothing", () => {
 
 // Kept LAST in the file: this case needs a real, runnable type checker.
 const checkerPath = resolveCheckerPath();
+const checkerSkip = typecheckDependencySkip(
+  checkerPath,
+  "a runnable corsa/tsgo binary for the CLI collection gate",
+  "no runnable corsa/tsgo found",
+);
 test(
   "tsconfig-driven default collection honors include/exclude through the CLI",
-  { skip: checkerPath === null ? "no runnable corsa/tsgo found" : false },
+  { skip: checkerSkip },
   () => {
     withWorkspace((dir) => {
       fs.mkdirSync(path.join(dir, "src/generated"), { recursive: true });

--- a/tests/tooling/cli-check-diagnostics.test.ts
+++ b/tests/tooling/cli-check-diagnostics.test.ts
@@ -6,6 +6,8 @@ import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { typecheckDependencySkip } from "./support/typecheck-dependency.ts";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 /**
@@ -101,7 +103,13 @@ function stripAnsi(input: string): string {
   return input.replace(ANSI, "");
 }
 
-const corsaSkip = CHECKER == null ? { skip: "no corsa/tsgo checker in node_modules/.bin" } : {};
+const corsaSkip = {
+  skip: typecheckDependencySkip(
+    CHECKER,
+    "a corsa/tsgo checker for the CLI diagnostics gates",
+    "no corsa/tsgo checker in node_modules/.bin",
+  ),
+};
 
 const ANT_DESIGN_VUE_FIXTURE = path.join(root, "tests/_fixtures/_git/ant-design-vue");
 const ANT_DESIGN_VUE_COMPONENTS = path.join(ANT_DESIGN_VUE_FIXTURE, "components");
@@ -112,7 +120,13 @@ const antDesignVueSkip =
     ? corsaSkip
     : fs.existsSync(ANT_DESIGN_VUE_COMPONENTS)
       ? {}
-      : { skip: "ant-design-vue fixture checkout unavailable" };
+      : {
+          skip: typecheckDependencySkip(
+            undefined,
+            "the hydrated ant-design-vue fixture for the CLI diagnostics gate",
+            "ant-design-vue fixture checkout unavailable",
+          ),
+        };
 
 test(
   "SFC template parse errors reported with stable 1-based position and message",

--- a/tests/tooling/cli-check-json-shape.test.ts
+++ b/tests/tooling/cli-check-json-shape.test.ts
@@ -6,6 +6,8 @@ import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { typecheckDependencySkip } from "./support/typecheck-dependency.ts";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 /**
@@ -49,6 +51,13 @@ function resolveCheckerPath(): string | null {
 }
 
 const CHECKER = resolveCheckerPath();
+const checkerOptions = {
+  skip: typecheckDependencySkip(
+    CHECKER,
+    "a corsa/tsgo checker for the CLI JSON gates",
+    "no corsa/tsgo checker discoverable",
+  ),
+};
 
 type CheckResult = { status: number | null; stdout: string; stderr: string };
 
@@ -96,9 +105,7 @@ const GOOD_TS = "export const answer = 42 as const;\n";
 
 test(
   "vize check --format json has a stable top-level shape and key names",
-  {
-    skip: CHECKER == null ? "no corsa/tsgo checker discoverable" : false,
-  },
+  checkerOptions,
   () => {
     withWorkspace((dir) => {
       fs.writeFileSync(path.join(dir, "bad.ts"), BAD_TS, "utf8");
@@ -138,9 +145,7 @@ test(
 
 test(
   "vize check --format json exposes declaration outputs when --declaration succeeds",
-  {
-    skip: CHECKER == null ? "no corsa/tsgo checker discoverable" : false,
-  },
+  checkerOptions,
   () => {
     withWorkspace((dir) => {
       fs.writeFileSync(path.join(dir, "good.ts"), GOOD_TS, "utf8");
@@ -172,9 +177,7 @@ test(
 
 test(
   "vize check --format json skips declaration outputs when type errors exist",
-  {
-    skip: CHECKER == null ? "no corsa/tsgo checker discoverable" : false,
-  },
+  checkerOptions,
   () => {
     withWorkspace((dir) => {
       fs.writeFileSync(path.join(dir, "bad.ts"), BAD_TS, "utf8");
@@ -207,9 +210,7 @@ test(
 
 test(
   "vize check --format json reports files cwd-relative, '/'-separated and sorted",
-  {
-    skip: CHECKER == null ? "no corsa/tsgo checker discoverable" : false,
-  },
+  checkerOptions,
   () => {
     withWorkspace((dir) => {
       fs.mkdirSync(path.join(dir, "src"));
@@ -248,9 +249,7 @@ test(
 
 test(
   "vize check --format json reports only the requested subset of files",
-  {
-    skip: CHECKER == null ? "no corsa/tsgo checker discoverable" : false,
-  },
+  checkerOptions,
   () => {
     withWorkspace((dir) => {
       fs.mkdirSync(path.join(dir, "src"));

--- a/tests/tooling/cli-check-json-shape.test.ts
+++ b/tests/tooling/cli-check-json-shape.test.ts
@@ -103,45 +103,38 @@ function parseJson(result: CheckResult): CheckJson {
 const BAD_TS = "export const x: string = 123;";
 const GOOD_TS = "export const answer = 42 as const;\n";
 
-test(
-  "vize check --format json has a stable top-level shape and key names",
-  checkerOptions,
-  () => {
-    withWorkspace((dir) => {
-      fs.writeFileSync(path.join(dir, "bad.ts"), BAD_TS, "utf8");
-      const result = runCheck(
-        ["bad.ts", "--format", "json", "--corsa-path", CHECKER as string],
-        dir,
-      );
-      assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+test("vize check --format json has a stable top-level shape and key names", checkerOptions, () => {
+  withWorkspace((dir) => {
+    fs.writeFileSync(path.join(dir, "bad.ts"), BAD_TS, "utf8");
+    const result = runCheck(["bad.ts", "--format", "json", "--corsa-path", CHECKER as string], dir);
+    assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
 
-      const parsed = parseJson(result);
+    const parsed = parseJson(result);
+    assert.deepEqual(
+      Object.keys(parsed).sort(),
+      ["errorCount", "fileCount", "files", "warningCount"],
+      "top-level keys should be exactly the documented camelCase envelope",
+    );
+    // `--declaration` is absent, so the emitter must not surface a declarations key.
+    assert.equal("declarations" in parsed, false, "no declarations key without --declaration");
+
+    assert.ok(Array.isArray(parsed.files), "files should be an array");
+    for (const entry of parsed.files) {
       assert.deepEqual(
-        Object.keys(parsed).sort(),
-        ["errorCount", "fileCount", "files", "warningCount"],
-        "top-level keys should be exactly the documented camelCase envelope",
+        Object.keys(entry).sort(),
+        ["diagnostics", "file"],
+        "each file entry should expose file/diagnostics without virtualTs by default",
       );
-      // `--declaration` is absent, so the emitter must not surface a declarations key.
-      assert.equal("declarations" in parsed, false, "no declarations key without --declaration");
+      assert.equal(typeof entry.file, "string");
+      assert.equal("virtualTs" in entry, false);
+      assert.ok(Array.isArray(entry.diagnostics));
+    }
 
-      assert.ok(Array.isArray(parsed.files), "files should be an array");
-      for (const entry of parsed.files) {
-        assert.deepEqual(
-          Object.keys(entry).sort(),
-          ["diagnostics", "file"],
-          "each file entry should expose file/diagnostics without virtualTs by default",
-        );
-        assert.equal(typeof entry.file, "string");
-        assert.equal("virtualTs" in entry, false);
-        assert.ok(Array.isArray(entry.diagnostics));
-      }
-
-      assert.equal(typeof parsed.errorCount, "number");
-      assert.equal(typeof parsed.warningCount, "number");
-      assert.equal(typeof parsed.fileCount, "number");
-    });
-  },
-);
+    assert.equal(typeof parsed.errorCount, "number");
+    assert.equal(typeof parsed.warningCount, "number");
+    assert.equal(typeof parsed.fileCount, "number");
+  });
+});
 
 test(
   "vize check --format json exposes declaration outputs when --declaration succeeds",
@@ -247,37 +240,33 @@ test(
   },
 );
 
-test(
-  "vize check --format json reports only the requested subset of files",
-  checkerOptions,
-  () => {
-    withWorkspace((dir) => {
-      fs.mkdirSync(path.join(dir, "src"));
-      fs.writeFileSync(
-        path.join(dir, "src/Good.vue"),
-        '<script setup lang="ts">\nconst x: number = 1\n</script>\n<template><div>{{ x }}</div></template>\n',
-        "utf8",
-      );
-      // Sibling with an unterminated interpolation: it must never appear in the
-      // report when only Good.vue is checked.
-      fs.writeFileSync(
-        path.join(dir, "src/Bad.vue"),
-        '<script setup lang="ts">\nconst x: number = 1\n</script>\n<template><div>{{ unclosed </div></template>\n',
-        "utf8",
-      );
+test("vize check --format json reports only the requested subset of files", checkerOptions, () => {
+  withWorkspace((dir) => {
+    fs.mkdirSync(path.join(dir, "src"));
+    fs.writeFileSync(
+      path.join(dir, "src/Good.vue"),
+      '<script setup lang="ts">\nconst x: number = 1\n</script>\n<template><div>{{ x }}</div></template>\n',
+      "utf8",
+    );
+    // Sibling with an unterminated interpolation: it must never appear in the
+    // report when only Good.vue is checked.
+    fs.writeFileSync(
+      path.join(dir, "src/Bad.vue"),
+      '<script setup lang="ts">\nconst x: number = 1\n</script>\n<template><div>{{ unclosed </div></template>\n',
+      "utf8",
+    );
 
-      const result = runCheck(
-        ["src/Good.vue", "--format", "json", "--corsa-path", CHECKER as string],
-        dir,
-      );
-      const parsed = parseJson(result);
+    const result = runCheck(
+      ["src/Good.vue", "--format", "json", "--corsa-path", CHECKER as string],
+      dir,
+    );
+    const parsed = parseJson(result);
 
-      assert.equal(parsed.files.length, 1, "only the explicitly requested file should be reported");
-      assert.equal(parsed.files[0]?.file, "src/Good.vue");
-      assert.ok(
-        parsed.files.every((f) => f.file !== "src/Bad.vue"),
-        "the unrequested sibling must not appear in the report",
-      );
-    });
-  },
-);
+    assert.equal(parsed.files.length, 1, "only the explicitly requested file should be reported");
+    assert.equal(parsed.files[0]?.file, "src/Good.vue");
+    assert.ok(
+      parsed.files.every((f) => f.file !== "src/Bad.vue"),
+      "the unrequested sibling must not appear in the report",
+    );
+  });
+});

--- a/tests/tooling/cli-check-sub-package-dependency.test.ts
+++ b/tests/tooling/cli-check-sub-package-dependency.test.ts
@@ -24,6 +24,8 @@ import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
+import { typecheckDependencySkip } from "./support/typecheck-dependency.ts";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 function resolveVizeCommand(): { command: string; prefix: string[] } {
@@ -53,7 +55,13 @@ function resolveCheckerPath(): string | null {
 }
 
 const CHECKER = resolveCheckerPath();
-const corsaSkip = CHECKER == null ? { skip: "no corsa/tsgo checker in node_modules/.bin" } : {};
+const corsaSkip = {
+  skip: typecheckDependencySkip(
+    CHECKER,
+    "a corsa/tsgo checker for the sub-package dependency gate",
+    "no corsa/tsgo checker in node_modules/.bin",
+  ),
+};
 
 type ParsedCheck = {
   files: Array<{ file: string; diagnostics: string[] }>;

--- a/tests/tooling/lsp-auto-insertion.test.ts
+++ b/tests/tooling/lsp-auto-insertion.test.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import { root, testOutputRoot } from "./support/lsp/paths.ts";
 import type { AutoInsertParams } from "./support/lsp/protocol.ts";
 import { LspSession } from "./support/lsp/session.ts";
+import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
 
 type OracleCase = {
   name: string;
@@ -98,11 +99,13 @@ test("real stdio server matches the pinned Vue LS auto-insertion responses", asy
 });
 
 test("real stdio server asks Corsa type information before inserting .value", async (t) => {
-  const corsaPath = resolveCorsaBinary();
-  if (!corsaPath) {
-    t.skip("Corsa runtime is unavailable");
-    return;
-  }
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveCorsaBinary(),
+    "Corsa runtime for the auto-insertion gate",
+    "Corsa runtime is unavailable",
+  );
+  if (corsaPath == null) return;
 
   const testRootDir = path.join(testOutputRoot, "lsp-auto-insertion-dot-value");
   fs.mkdirSync(testRootDir, { recursive: true });

--- a/tests/tooling/lsp-concurrent-edit-deadlock.test.ts
+++ b/tests/tooling/lsp-concurrent-edit-deadlock.test.ts
@@ -8,6 +8,7 @@ import { isDiagnosticsForUri } from "./support/lsp/assertions.ts";
 import { root, testOutputRoot } from "./support/lsp/paths.ts";
 import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
 import { LspSession } from "./support/lsp/session.ts";
+import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
 
 // Concurrent-edit publish deadlock (#3315).
 //
@@ -78,11 +79,13 @@ function markersOf(publish: PublishDiagnosticsParams): string[] {
 }
 
 test("vize lsp keeps publishing when edits race an in-flight diagnostics pass", async (t) => {
-  const corsaPath = resolveTsgoBinary();
-  if (corsaPath == null) {
-    t.skip("tsgo binary not found; skipping concurrent-edit deadlock test");
-    return;
-  }
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTsgoBinary(),
+    "tsgo binary for the concurrent-edit deadlock gate",
+    "tsgo binary not found; skipping concurrent-edit deadlock test",
+  );
+  if (corsaPath == null) return;
 
   const testRootDir = path.join(testOutputRoot, "lsp-concurrent-edit-deadlock");
   fs.mkdirSync(testRootDir, { recursive: true });

--- a/tests/tooling/lsp-corsa-crash-recovery.test.ts
+++ b/tests/tooling/lsp-corsa-crash-recovery.test.ts
@@ -8,6 +8,7 @@ import { hoverToText, isDiagnosticsForUri, offsetToPosition } from "./support/ls
 import { root, testOutputRoot } from "./support/lsp/paths.ts";
 import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
 import { LspSession } from "./support/lsp/session.ts";
+import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
 
 // Corsa mid-session crash recovery (#3240, audit item 6 of #2971): the type
 // checker backend (tsgo) is an external child process that can die at any
@@ -143,11 +144,13 @@ function typeErrorFor(publish: PublishDiagnosticsParams, marker: string): boolea
 }
 
 test("vize lsp recovers typecheck diagnostics after the Corsa backend is killed", async (t) => {
-  const corsaPath = resolveTsgoBinary();
-  if (corsaPath == null) {
-    t.skip("tsgo binary not found; skipping Corsa crash-recovery test");
-    return;
-  }
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTsgoBinary(),
+    "tsgo binary for the Corsa crash-recovery gate",
+    "tsgo binary not found; skipping Corsa crash-recovery test",
+  );
+  if (corsaPath == null) return;
 
   const testRootDir = path.join(testOutputRoot, "lsp-corsa-crash-recovery");
   fs.mkdirSync(testRootDir, { recursive: true });

--- a/tests/tooling/lsp-typecheck-template.test.ts
+++ b/tests/tooling/lsp-typecheck-template.test.ts
@@ -7,13 +7,16 @@ import { hoverToText, isDiagnosticsForUri, offsetToPosition } from "./support/ls
 import { root, testOutputRoot } from "./support/lsp/paths.ts";
 import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
 import { LspSession } from "./support/lsp/session.ts";
+import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
 
 test("vize lsp typecheck keeps DOM libs and template diagnostics", async (t) => {
-  const corsaPath = resolveTsgoBinary();
-  if (corsaPath == null) {
-    t.skip("tsgo binary not found; skipping LSP typecheck test");
-    return;
-  }
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTsgoBinary(),
+    "tsgo binary for the LSP typecheck gate",
+    "tsgo binary not found; skipping LSP typecheck test",
+  );
+  if (corsaPath == null) return;
 
   const testRootDir = path.join(testOutputRoot, "lsp-typecheck-template");
   fs.mkdirSync(testRootDir, { recursive: true });
@@ -127,11 +130,13 @@ const button = document.createElement("button")
 });
 
 test("vize lsp publishes and clears exact parent diagnostics after child prop edits", async (t) => {
-  const corsaPath = resolveTsgoBinary();
-  if (corsaPath == null) {
-    t.skip("tsgo binary not found; skipping LSP typecheck test");
-    return;
-  }
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTsgoBinary(),
+    "tsgo binary for the dependent-component LSP gate",
+    "tsgo binary not found; skipping LSP typecheck test",
+  );
+  if (corsaPath == null) return;
 
   const testRootDir = path.join(testOutputRoot, "lsp-typecheck-dependent-component");
   fs.mkdirSync(testRootDir, { recursive: true });

--- a/tests/tooling/support/typecheck-dependency.ts
+++ b/tests/tooling/support/typecheck-dependency.ts
@@ -1,0 +1,34 @@
+type SkippableTest = { skip(reason: string): void };
+
+function dependencyIsAvailable(value: unknown): boolean {
+  return value !== null && value !== undefined && value !== false;
+}
+
+export function typecheckDependencySkip(
+  value: unknown,
+  label: string,
+  skipReason: string,
+  required = process.env.VIZE_TEST_REQUIRE_TSGO === "1",
+): false | string {
+  if (dependencyIsAvailable(value)) return false;
+
+  if (required) {
+    throw new Error(`${label} is required when VIZE_TEST_REQUIRE_TSGO=1`);
+  }
+  return skipReason;
+}
+
+export function requireTypecheckDependency<T>(
+  t: SkippableTest,
+  value: T | null | undefined | false,
+  label: string,
+  skipReason: string,
+  required = process.env.VIZE_TEST_REQUIRE_TSGO === "1",
+): T | undefined {
+  const skip = typecheckDependencySkip(value, label, skipReason, required);
+  if (skip !== false) {
+    t.skip(skip);
+    return undefined;
+  }
+  return value as T;
+}

--- a/tests/tooling/typecheck-baseline-project.test.ts
+++ b/tests/tooling/typecheck-baseline-project.test.ts
@@ -7,15 +7,23 @@ import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 
 import { materializeBaselineProject } from "../../tools/fixtures/typecheck-baseline-project.mjs";
+import { typecheckDependencySkip } from "./support/typecheck-dependency.ts";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const dependencyRoot =
   process.env.VIZE_TEST_WORKSPACE_NODE_MODULES ?? path.join(root, "tests/node_modules");
 const vueTsc = path.join(dependencyRoot, ".bin/vue-tsc");
+const vueTscOptions = {
+  skip: typecheckDependencySkip(
+    fs.existsSync(vueTsc) ? vueTsc : undefined,
+    "vue-tsc for the baseline-project gates",
+    "vue-tsc binary unavailable",
+  ),
+};
 
 test(
   "materialized baseline checks Vue files omitted by a solution-style config",
-  { skip: !fs.existsSync(vueTsc) },
+  vueTscOptions,
   () => {
     const temp = fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-project-"));
     const fixtureRoot = path.join(temp, "fixture");
@@ -81,7 +89,7 @@ test("materialized baseline extends an explicit generated project", () => {
 
 test(
   "materialized baseline keeps the fixture's ambient declarations in the program",
-  { skip: !fs.existsSync(vueTsc) },
+  vueTscOptions,
   () => {
     // #3738. A `files` list seeds the program with those roots and nothing else,
     // so an ambient declaration — never imported, by definition — leaves the

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { testAndBenchmarkTasks } from "../../tools/vite-plus/tasks/test-benchmark.ts";
+import {
+  requireTypecheckDependency,
+  typecheckDependencySkip,
+} from "./support/typecheck-dependency.ts";
+import { readRepoFile } from "./support/github-workflows.ts";
+
+test("test:scripts requires its typecheck dependencies", () => {
+  const command = (testAndBenchmarkTasks["test:scripts"] as { command: string }).command;
+  const workflow = readRepoFile(".github", "workflows", "check.yml");
+  assert.match(
+    command,
+    /&& VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests\/tooling\/\*\.test\.ts$/,
+  );
+  assert.match(
+    workflow,
+    /\n  test-scripts:\n[\s\S]*?git submodule update --init --depth 1 -- tests\/_fixtures\/_git\/ant-design-vue && vp install --frozen-lockfile --prefer-offline[\s\S]*?\n  editor-extensions:\n/,
+  );
+});
+
+test("typecheck and LSP gates do not carry raw dependency skips", () => {
+  const files = [
+    "check-bench-gate.test.ts",
+    "cli-check-collection.test.ts",
+    "cli-check-diagnostics.test.ts",
+    "cli-check-json-shape.test.ts",
+    "cli-check-sub-package-dependency.test.ts",
+    "lsp-auto-insertion.test.ts",
+    "lsp-concurrent-edit-deadlock.test.ts",
+    "lsp-corsa-crash-recovery.test.ts",
+    "lsp-typecheck-template.test.ts",
+    "typecheck-baseline-project.test.ts",
+  ];
+
+  for (const file of files) {
+    const source = readRepoFile("tests", "tooling", file);
+    assert.doesNotMatch(source, /t\.skip\(["'](?:Corsa|tsgo)/);
+    assert.doesNotMatch(source, /skip:\s*(?:CHECKER|checkerPath|!fs\.existsSync\(vueTsc\))/);
+    assert.match(source, /(?:requireTypecheckDependency|typecheckDependencySkip)\(/);
+  }
+});
+
+test("available dependencies never skip", () => {
+  assert.equal(typecheckDependencySkip("/tmp/tsgo", "tsgo", "missing", true), false);
+});
+
+test("an unavailable optional dependency keeps the local skip reason", () => {
+  assert.equal(typecheckDependencySkip(undefined, "tsgo", "local opt-out", false), "local opt-out");
+});
+
+test("an unavailable required dependency fails closed", () => {
+  assert.throws(() => typecheckDependencySkip(undefined, "tsgo binary", "missing", true), {
+    message: "tsgo binary is required when VIZE_TEST_REQUIRE_TSGO=1",
+  });
+});
+
+test("runtime skip gates use the same fail-closed policy", () => {
+  const skipped: string[] = [];
+  const t = { skip: (reason: string) => skipped.push(reason) };
+
+  assert.equal(
+    requireTypecheckDependency(t, undefined, "Corsa runtime", "local opt-out", false),
+    undefined,
+  );
+  assert.deepEqual(skipped, ["local opt-out"]);
+  assert.throws(() => requireTypecheckDependency(t, undefined, "Corsa runtime", "missing", true), {
+    message: "Corsa runtime is required when VIZE_TEST_REQUIRE_TSGO=1",
+  });
+});

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -101,7 +101,7 @@ export const testAndBenchmarkTasks = defineTasks({
   // dev profile (~1m20s). Building once in the CI profile saves both legs.
   "test:js": noCacheTask(`${runTask("build:native:test")} && ${jsPackageTestCommand}`),
   "test:scripts": noCacheTask(
-    `${runTask("build:native:test")} && node --test --test-concurrency=1 tests/tooling/*.test.ts`,
+    `${runTask("build:native:test")} && VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.ts`,
   ),
   "test:vscode-extension:vsix": noCacheTask(
     runInVscodeExtension(


### PR DESCRIPTION
## Summary

- run the required test:scripts task with VIZE_TEST_REQUIRE_TSGO=1
- centralize fail-closed dependency handling for the 15 named LSP, CLI, benchmark, and baseline gates
- hydrate the ant-design-vue fixture in test-scripts so its real diagnostic gate runs instead of skipping
- pin the task environment, fixture hydration, policy behavior, and absence of raw tsgo/Corsa skips

## Reproduction

In a dependency-free worktree, the old suites reported green skips. With required mode enabled, the CLI JSON suite now fails immediately with: a corsa/tsgo checker for the CLI JSON gates is required when VIZE_TEST_REQUIRE_TSGO=1.

## Verification

Using a current-SHA vize 0.319.0 CI-profile binary, the pinned tsgo dependency, and the hydrated ant-design-vue fixture:

- dependency policy and workflow regressions: 6 passed
- CLI JSON and baseline-project gates: 8 passed
- LSP auto-insertion, concurrent edit, crash recovery, and typecheck gates: 6 passed
- CLI collection, diagnostics, and sub-package dependency gates: 14 passed
- git diff check: clean
- check.yml remains 702 lines; touched TypeScript files remain below the 350-line limit

This is the Node test-scripts slice of #3750. Rust CLI test guards and the vue2-elm hydration assertion remain separate small PRs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->