### PR TITLE
test(canon): pin Vapor and TSX diagnostic ranges

### DIFF
--- a/crates/vize/tests/check_tsx_intrinsic_elements_cli.rs
+++ b/crates/vize/tests/check_tsx_intrinsic_elements_cli.rs
@@ -236,11 +236,12 @@ fn check_tsx_vapor_keeps_script_type_errors() {
         "stdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert_eq!(json["errorCount"], serde_json::json!(1), "{diagnostics:#?}");
-    assert!(
-        diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.contains("[TS2322]")),
-        "JSX Vapor typecheck should keep TSX script errors: {diagnostics:#?}"
+    // vue-tsc 3.3.4 on this byte-identical Standalone.tsx reports:
+    // `src/Standalone.tsx(2,9): error TS2322: Type 'string' is not assignable to type 'number'.`
+    assert_eq!(
+        diagnostics,
+        vec!["error:2:9 [TS2322] Type 'string' is not assignable to type 'number'."],
+        "JSX Vapor typecheck should keep the exact authored TSX diagnostic"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
@@ -13,6 +13,7 @@ mod spread_props;
 mod spread_scope_bindings;
 mod ts_extension_substitution;
 mod unmapped_template_fallback;
+mod vapor_anchors;
 #[test]
 fn issue_2645_infers_generic_sfc_props_in_tsx() {
     if resolve_test_tsgo_binary().is_none() {

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/vapor_anchors.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/vapor_anchors.rs
@@ -1,0 +1,42 @@
+//! Vapor SFC typecheck diagnostic anchors (#3740).
+
+use super::super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+
+/// vue-tsc 3.3.4 reports the same complete diagnostic at `title`, line 3,
+/// column 7. The bad value comes from a declared component prop and is used as
+/// a template binding, while the explicit `Readonly` annotation avoids relying
+/// on vue-tsc's incomplete inference for Vapor-mode `defineProps`.
+#[test]
+fn vapor_component_prop_type_error_keeps_its_authored_range() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "vapor-script-setup-type-error-anchor",
+        &[(
+            "src/VaporError.vue",
+            r#"<script setup lang="ts" vapor>
+const props: Readonly<{ count: number }> = defineProps<{ count: number }>()
+const title: string = props.count
+</script>
+
+<template>
+  <div :title="title" />
+</template>
+"#,
+        )],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let snapshot = snapshot.expect("type-check Vapor SFC project");
+
+    assert_eq!(
+        snapshot,
+        vec![(
+            "src/VaporError.vue".into(),
+            Some(2322),
+            "3:7:error Type 'number' is not assignable to type 'string'.".into(),
+        )]
+    );
+}


### PR DESCRIPTION
## Summary

- add a Vapor SFC prop-to-binding type-error oracle with the exact authored `3:7` TS2322 diagnostic
- replace the TSX Vapor test partial code match with full diagnostic equality at authored `2:9`
- record the byte-identical vue-tsc 3.3.4 expectations alongside both oracles

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p vize --test check_tsx_intrinsic_elements_cli`
- `cargo test -p vize_canon vapor_component_prop_type_error_keeps_its_authored_range`
- byte-identical manual `vue-tsc --pretty false` oracle runs: Vapor `3:7`, TSX `2:9`
- `git diff --check`

Closes #3740

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->