### PR TITLE
test(canon): cover Vben cancellation recovery

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -51,7 +51,8 @@
           "sharedBrokenSecondApp": 3000,
           "sharedRepaired": 3000,
           "sharedRepairedSecondApp": 3000,
-          "warmNoopSecondApp": 1500
+          "warmNoopSecondApp": 1500,
+          "cancellationConverge": 6000
         }
       }
     },

--- a/tests/performance/vben-lsp-incremental.test.ts
+++ b/tests/performance/vben-lsp-incremental.test.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from "node:url";
 import { withPinnedFixtureWorkspace } from "../_helpers/realworld-patch.ts";
 import { completionLabels, hoverToText } from "../tooling/support/lsp/assertions.ts";
 import { LspSession } from "../tooling/support/lsp/session.ts";
+import { assertCancellationWindow, recordPublishes } from "./support/churn-oracle.ts";
 import { countFiles, IncrementalMetrics } from "./support/incremental-metrics.ts";
 import {
   assertSingleInjectedMismatch,
@@ -80,6 +81,7 @@ test(
           id: "vben-lsp-incremental",
           title: "Vue Vben Admin LSP Incremental Oracle",
         });
+        const publishes = recordPublishes(session);
         let baseline: string[] = [];
         let secondBaseline: string[] = [];
         let failure: unknown;
@@ -184,6 +186,7 @@ test(
             expectError: true,
           });
           assertSingleInjectedMismatch(leafBroken.diagnostics, baseline, leafBrokenSource, symbol);
+          const leafBrokenBaseline = normalizeDiagnostics(leafBroken.diagnostics);
 
           const leafRepaired = await changeVue(session, metrics, {
             name: "leafRepaired",
@@ -242,6 +245,42 @@ test(
             source: secondLeafSource,
           });
           assert.deepEqual(normalizeDiagnostics(secondWarm.diagnostics), secondBaseline);
+
+          // Fire four same-document changes without waiting between them. The
+          // server may cancel superseded work, but every publish that escapes
+          // must match the content for its own version and the window must end
+          // on the repaired version. Keeping the second app open makes this a
+          // cancellation oracle inside the real cross-package monorepo session.
+          const cancellationStart = publishes.length;
+          const expectedByVersion = new Map<number, string[]>();
+          let firstLeafVersion = 4;
+          for (const source of [leafBrokenSource, firstLeafSource, leafBrokenSource]) {
+            firstLeafVersion += 1;
+            expectedByVersion.set(
+              firstLeafVersion,
+              source === firstLeafSource ? baseline : leafBrokenBaseline,
+            );
+            session.notify("textDocument/didChange", {
+              textDocument: { uri: firstLeafUri, version: firstLeafVersion },
+              contentChanges: [{ text: source }],
+            });
+          }
+          firstLeafVersion += 1;
+          expectedByVersion.set(firstLeafVersion, baseline);
+          const cancellationConverged = await metrics.measure("cancellationConverge", () => {
+            session.notify("textDocument/didChange", {
+              textDocument: { uri: firstLeafUri, version: firstLeafVersion },
+              contentChanges: [{ text: firstLeafSource }],
+            });
+            return waitForDiagnostics(session, firstLeafUri, firstLeafVersion, false);
+          });
+          assert.deepEqual(normalizeDiagnostics(cancellationConverged.diagnostics), baseline);
+          assertCancellationWindow(
+            publishes.slice(cancellationStart),
+            firstLeafUri,
+            expectedByVersion,
+            firstLeafVersion,
+          );
 
           session.notify("textDocument/didClose", { textDocument: { uri: firstLeafUri } });
           session.notify("textDocument/didClose", { textDocument: { uri: secondLeafUri } });

--- a/tests/tooling/lsp-incremental-budgets.test.ts
+++ b/tests/tooling/lsp-incremental-budgets.test.ts
@@ -286,6 +286,7 @@ test("incremental LSP suites carry complete enforced budget blocks", () => {
       "sharedBrokenSecondApp",
       "sharedRepairedSecondApp",
       "warmNoopSecondApp",
+      "cancellationConverge",
     ],
   };
 


### PR DESCRIPTION
## Summary
- record every Vben diagnostics publish during its existing two-app monorepo session
- fire four rapid same-document edits without waits and require exact per-version payloads
- require the stream to converge on the final repaired version under a checked-in 6s budget

Part of #3746

## Validation
- VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/performance/vben-lsp-incremental.test.ts (1/1)
- node --test tests/tooling/lsp-incremental-budgets.test.ts (13/13)
- scoped vp check --fix
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->