### PR TITLE
fix(config): synchronize generated config artifacts

### DIFF
--- a/npm/cli/pkl/jsonschema/ConfigArtifactDefinitions.pkl
+++ b/npm/cli/pkl/jsonschema/ConfigArtifactDefinitions.pkl
@@ -1,0 +1,199 @@
+/// Shared definitions used by the secondary JSON Schema compatibility output.
+module vize.jsonschema.ConfigArtifactDefinitions
+
+import "@json_schema/JsonSchema.pkl"
+
+experimentalsConfigDef: JsonSchema = new JsonSchema {
+  type = "object"
+  additionalProperties = new JsonSchema {
+    oneOf = new Listing {
+      new JsonSchema { type = "boolean" }
+      new JsonSchema {
+        type = "object"
+        additionalProperties = true
+      }
+      new JsonSchema { type = "null" }
+    }
+  }
+}
+
+vueVersionDef: JsonSchema = new JsonSchema {
+  type = "string"
+  description = "Host Vue runtime version for opt-in compatibility modes"
+  enum = new Listing { "3"; "2.7"; "2"; "1"; "0.11"; "0.10" }
+}
+
+compilerCompatibilityConfigDef: JsonSchema = new JsonSchema {
+  type = "object"
+  description = "Opt-in compatibility features for unsupported host/runtime combinations"
+  properties {
+    ["vueVersion"] = new JsonSchema {
+      `$ref` = "#/definitions/VueVersion"
+    }
+    ["hostCompiler"] = new JsonSchema {
+      type = "boolean"
+      description = "Delegate .vue compilation to the host Vue compiler for legacy Vue runtimes"
+    }
+    ["scriptSetupInStandalone"] = new JsonSchema {
+      type = "boolean"
+      description = "Enable <script setup> when emitting function-body output for CDN/global Vue usage"
+      default = false
+    }
+    ["optionsApiVapor"] = new JsonSchema {
+      type = "boolean"
+      description = "Allow Vapor output for Options API SFCs when Vapor mode is enabled"
+      default = false
+    }
+    ["nuxtVersion"] = new JsonSchema {
+      type = "integer"
+      description = "Nuxt major line for opt-in Nuxt compatibility behavior"
+      enum = new Listing { 2; 3; 4 }
+    }
+    ["webpackVersion"] = new JsonSchema {
+      type = "integer"
+      description = "webpack major line for opt-in bundler compatibility behavior"
+      enum = new Listing { 4; 5 }
+    }
+  }
+  additionalProperties = false
+}
+
+compilerConfigDef: JsonSchema = new JsonSchema {
+  type = "object"
+  description = "Vue compiler options"
+  properties {
+    ["mode"] = new JsonSchema {
+      type = "string"
+      enum = new Listing { "module"; "function" }
+      description = "Compilation mode"
+      default = "module"
+    }
+    ["vapor"] = new JsonSchema {
+      type = "boolean"
+      description = "Enable Vapor mode compilation"
+      default = false
+    }
+    ["jsxMode"] = new JsonSchema {
+      type = "string"
+      enum = new Listing { "vdom"; "vapor" }
+      description = "Default output mode for .jsx/.tsx components without a \"use vue:*\" directive"
+      default = "vdom"
+    }
+    ["customRenderer"] = new JsonSchema {
+      type = "boolean"
+      description = "Treat lowercase non-HTML tags as custom renderer elements"
+      default = false
+    }
+    ["ssr"] = new JsonSchema {
+      type = "boolean"
+      description = "Enable SSR mode"
+      default = false
+    }
+    ["templateSyntax"] = new JsonSchema {
+      type = "string"
+      enum = new Listing { "standard"; "strict"; "quirks" }
+      description = "Template syntax compatibility mode"
+      default = "standard"
+    }
+    ["sourceMap"] = new JsonSchema {
+      type = "boolean"
+      description = "Enable source map generation"
+    }
+    ["prefixIdentifiers"] = new JsonSchema {
+      type = "boolean"
+      description = "Prefix template identifiers with _ctx"
+      default = false
+    }
+    ["hoistStatic"] = new JsonSchema {
+      type = "boolean"
+      description = "Hoist static nodes"
+      default = true
+    }
+    ["cacheHandlers"] = new JsonSchema {
+      type = "boolean"
+      description = "Cache v-on handlers"
+      default = true
+    }
+    ["isTs"] = new JsonSchema {
+      type = "boolean"
+      description = "Enable TypeScript parsing in <script> blocks"
+      default = true
+    }
+    ["scriptExt"] = new JsonSchema {
+      type = "string"
+      enum = new Listing { "ts"; "js" }
+      description = "Script file extension for generated output"
+      default = "ts"
+    }
+    ["runtimeModuleName"] = new JsonSchema {
+      type = "string"
+      description = "Module name for runtime imports"
+      default = "vue"
+    }
+    ["runtimeGlobalName"] = new JsonSchema {
+      type = "string"
+      description = "Global variable name for runtime (IIFE builds)"
+      default = "Vue"
+    }
+    ["compatibility"] = new JsonSchema {
+      `$ref` = "#/definitions/CompilerCompatibilityConfig"
+    }
+  }
+  additionalProperties = false
+}
+
+restrictedGlobalDef: JsonSchema = new JsonSchema {
+  type = "object"
+  properties {
+    ["name"] = new JsonSchema { type = "string" }
+    ["message"] = new JsonSchema { type = "string" }
+  }
+  required = new Listing { "name" }
+  additionalProperties = false
+}
+
+restrictedMemberDef: JsonSchema = new JsonSchema {
+  type = "object"
+  properties {
+    ["object"] = new JsonSchema { type = "string" }
+    ["property"] = new JsonSchema { type = "string" }
+    ["message"] = new JsonSchema { type = "string" }
+  }
+  required = new Listing { "object"; "property" }
+  additionalProperties = false
+}
+
+noRestrictedGlobalsOptionsDef: JsonSchema = new JsonSchema {
+  type = "object"
+  properties {
+    ["globals"] = new JsonSchema {
+      type = "array"
+      items = new JsonSchema { `$ref` = "#/definitions/RestrictedGlobal" }
+    }
+  }
+  additionalProperties = false
+}
+
+noRestrictedMembersOptionsDef: JsonSchema = new JsonSchema {
+  type = "object"
+  properties {
+    ["members"] = new JsonSchema {
+      type = "array"
+      items = new JsonSchema { `$ref` = "#/definitions/RestrictedMember" }
+    }
+  }
+  additionalProperties = false
+}
+
+lintRuleOptionsDef: JsonSchema = new JsonSchema {
+  type = "object"
+  properties {
+    ["script/no-restricted-globals"] = new JsonSchema {
+      `$ref` = "#/definitions/NoRestrictedGlobalsOptions"
+    }
+    ["script/no-restricted-members"] = new JsonSchema {
+      `$ref` = "#/definitions/NoRestrictedMembersOptions"
+    }
+  }
+  additionalProperties = false
+}

--- a/npm/cli/pkl/jsonschema/generate.pkl
+++ b/npm/cli/pkl/jsonschema/generate.pkl
@@ -3,6 +3,7 @@
 /// Usage: pkl eval -f json pkl/jsonschema/generate.pkl
 module vize.jsonschema.generate
 import "@json_schema/JsonSchema.pkl"
+import "ConfigArtifactDefinitions.pkl"
 local ruleSeverityEnum: JsonSchema = new JsonSchema {
   type = "string"
   enum = new Listing { "off"; "warn"; "error" }
@@ -21,81 +22,6 @@ local configExtendsDef: JsonSchema = new JsonSchema {
     new JsonSchema { type = "string" }
     stringListDef
   }
-}
-local compilerConfigDef: JsonSchema = new JsonSchema {
-  type = "object"
-  description = "Vue compiler options"
-  properties {
-    ["mode"] = new JsonSchema {
-      type = "string"
-      enum = new Listing { "module"; "function" }
-      description = "Compilation mode"
-      default = "module"
-    }
-    ["vapor"] = new JsonSchema {
-      type = "boolean"
-      description = "Enable Vapor mode compilation"
-      default = false
-    }
-    ["jsxMode"] = new JsonSchema {
-      type = "string"
-      enum = new Listing { "vdom"; "vapor" }
-      description = "Default output mode for .jsx/.tsx components without a \"use vue:*\" directive"
-      default = "vdom"
-    }
-    ["ssr"] = new JsonSchema {
-      type = "boolean"
-      description = "Enable SSR mode"
-      default = false
-    }
-    ["templateSyntax"] = new JsonSchema {
-      type = "string"
-      enum = new Listing { "standard"; "strict"; "quirks" }
-      description = "Template syntax compatibility mode"
-      default = "standard"
-    }
-    ["sourceMap"] = new JsonSchema {
-      type = "boolean"
-      description = "Enable source map generation"
-    }
-    ["prefixIdentifiers"] = new JsonSchema {
-      type = "boolean"
-      description = "Prefix template identifiers with _ctx"
-      default = false
-    }
-    ["hoistStatic"] = new JsonSchema {
-      type = "boolean"
-      description = "Hoist static nodes"
-      default = true
-    }
-    ["cacheHandlers"] = new JsonSchema {
-      type = "boolean"
-      description = "Cache v-on handlers"
-      default = true
-    }
-    ["isTs"] = new JsonSchema {
-      type = "boolean"
-      description = "Enable TypeScript parsing in <script> blocks"
-      default = true
-    }
-    ["scriptExt"] = new JsonSchema {
-      type = "string"
-      enum = new Listing { "ts"; "js" }
-      description = "Script file extension for generated output"
-      default = "ts"
-    }
-    ["runtimeModuleName"] = new JsonSchema {
-      type = "string"
-      description = "Module name for runtime imports"
-      default = "vue"
-    }
-    ["runtimeGlobalName"] = new JsonSchema {
-      type = "string"
-      description = "Global variable name for runtime (IIFE builds)"
-      default = "Vue"
-    }
-  }
-  additionalProperties = false
 }
 local vitePluginConfigDef: JsonSchema = new JsonSchema {
   type = "object"
@@ -145,7 +71,7 @@ local linterConfigDef: JsonSchema = new JsonSchema {
       type = lintPresetEnum.type
       enum = lintPresetEnum.enum
       description = "Built-in lint preset"
-      default = "happy-path"
+      default = "ecosystem"
     }
     ["typeAware"] = new JsonSchema {
       type = "boolean"
@@ -155,6 +81,9 @@ local linterConfigDef: JsonSchema = new JsonSchema {
       type = "object"
       description = "Rules to enable/disable"
       additionalProperties = ruleSeverityEnum
+    }
+    ["ruleOptions"] = new JsonSchema {
+      `$ref` = "#/definitions/LintRuleOptions"
     }
     ["categories"] = new JsonSchema {
       type = "object"
@@ -219,6 +148,11 @@ local typeCheckerConfigDef: JsonSchema = new JsonSchema {
     ["checkFallthroughAttrs"] = new JsonSchema {
       type = "boolean"
       description = "Check fallthrough attrs on multi-root templates"
+      default = true
+    }
+    ["optionsApi"] = new JsonSchema {
+      type = "boolean"
+      description = "Resolve Vue 3 Options API template bindings during type checking"
       default = true
     }
     ["legacyVue2"] = new JsonSchema {
@@ -644,8 +578,13 @@ local configEntryDef: JsonSchema = new JsonSchema {
       description = "Glob patterns this entry excludes"
     }
     ["extends"] = configExtendsDef
+    ["dialect"] = new JsonSchema {
+      type = "string"
+      enum = new Listing { "vue"; "petite-vue" }
+      description = "Vue dialect profile for standalone HTML documents; when absent the dialect is detected structurally per document"
+    }
     ["compiler"] = new JsonSchema { `$ref` = "#/definitions/CompilerConfig" }
-    ["experimentals"] = new JsonSchema { type = "object" }
+    ["experimentals"] = ConfigArtifactDefinitions.experimentalsConfigDef
     ["vite"] = new JsonSchema { `$ref` = "#/definitions/VitePluginConfig" }
     ["linter"] = new JsonSchema { `$ref` = "#/definitions/LinterConfig" }
     ["typeChecker"] = new JsonSchema { `$ref` = "#/definitions/TypeCheckerConfig" }
@@ -665,9 +604,16 @@ output {
     description = "Configuration file for vize - High-performance Vue.js toolchain"
     type = "object"
     definitions {
-      ["CompilerConfig"] = compilerConfigDef
+      ["VueVersion"] = ConfigArtifactDefinitions.vueVersionDef
+      ["CompilerCompatibilityConfig"] = ConfigArtifactDefinitions.compilerCompatibilityConfigDef
+      ["CompilerConfig"] = ConfigArtifactDefinitions.compilerConfigDef
       ["VitePluginConfig"] = vitePluginConfigDef
       ["LinterConfig"] = linterConfigDef
+      ["RestrictedGlobal"] = ConfigArtifactDefinitions.restrictedGlobalDef
+      ["RestrictedMember"] = ConfigArtifactDefinitions.restrictedMemberDef
+      ["NoRestrictedGlobalsOptions"] = ConfigArtifactDefinitions.noRestrictedGlobalsOptionsDef
+      ["NoRestrictedMembersOptions"] = ConfigArtifactDefinitions.noRestrictedMembersOptionsDef
+      ["LintRuleOptions"] = ConfigArtifactDefinitions.lintRuleOptionsDef
       ["TypeCheckerConfig"] = typeCheckerConfigDef
       ["FormatterConfig"] = formatterConfigDef
       ["LanguageServerConfig"] = languageServerConfigDef
@@ -704,8 +650,13 @@ output {
         description = "Glob patterns this config excludes"
       }
       ["extends"] = configExtendsDef
+      ["dialect"] = new JsonSchema {
+        type = "string"
+        enum = new Listing { "vue"; "petite-vue" }
+        description = "Vue dialect profile for standalone HTML documents; when absent the dialect is detected structurally per document"
+      }
       ["compiler"] = new JsonSchema { `$ref` = "#/definitions/CompilerConfig" }
-      ["experimentals"] = new JsonSchema { type = "object" }
+      ["experimentals"] = ConfigArtifactDefinitions.experimentalsConfigDef
       ["vite"] = new JsonSchema { `$ref` = "#/definitions/VitePluginConfig" }
       ["linter"] = new JsonSchema { `$ref` = "#/definitions/LinterConfig" }
       ["typeChecker"] = new JsonSchema { `$ref` = "#/definitions/TypeCheckerConfig" }

--- a/npm/cli/pkl/vize.pkl
+++ b/npm/cli/pkl/vize.pkl
@@ -19,6 +19,15 @@ typealias FilterPattern = String | Listing<String>
 typealias GlobalTypeValue = String | GlobalTypeDeclaration
 typealias ConfigExtends = String | Listing<String>
 
+class CompilerCompatibilityConfig {
+  vueVersion: ("3" | "2.7" | "2" | "1" | "0.11" | "0.10")? = null
+  hostCompiler: Boolean? = null
+  scriptSetupInStandalone: Boolean? = null
+  optionsApiVapor: Boolean? = null
+  nuxtVersion: Number? = null
+  webpackVersion: Number? = null
+}
+
 class CompilerConfig {
   mode: CompilerMode? = null
   vapor: Boolean? = null
@@ -34,6 +43,7 @@ class CompilerConfig {
   scriptExt: ScriptExt? = null
   runtimeModuleName: String? = null
   runtimeGlobalName: String? = null
+  compatibility: CompilerCompatibilityConfig?
 }
 
 class ExperimentalsConfig {
@@ -97,6 +107,7 @@ class TypeCheckerConfig {
   checkSetupContext: Boolean? = null
   checkInvalidExports: Boolean? = null
   checkFallthroughAttrs: Boolean? = null
+  optionsApi: Boolean? = null
   legacyVue2: Boolean? = null
   jsxTypecheck: Boolean? = null
   tsconfig: String? = null

--- a/npm/cli/schemas/vize.config.schema.json
+++ b/npm/cli/schemas/vize.config.schema.json
@@ -1,6 +1,45 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "VueVersion": {
+      "description": "Host Vue runtime version for opt-in compatibility modes",
+      "type": "string",
+      "enum": ["3", "2.7", "2", "1", "0.11", "0.10"]
+    },
+    "CompilerCompatibilityConfig": {
+      "description": "Opt-in compatibility features for unsupported host/runtime combinations",
+      "type": "object",
+      "properties": {
+        "vueVersion": {
+          "$ref": "#/definitions/VueVersion"
+        },
+        "hostCompiler": {
+          "description": "Delegate .vue compilation to the host Vue compiler for legacy Vue runtimes",
+          "type": "boolean"
+        },
+        "scriptSetupInStandalone": {
+          "description": "Enable <script setup> when emitting function-body output for CDN/global Vue usage",
+          "default": false,
+          "type": "boolean"
+        },
+        "optionsApiVapor": {
+          "description": "Allow Vapor output for Options API SFCs when Vapor mode is enabled",
+          "default": false,
+          "type": "boolean"
+        },
+        "nuxtVersion": {
+          "description": "Nuxt major line for opt-in Nuxt compatibility behavior",
+          "type": "integer",
+          "enum": [2, 3, 4]
+        },
+        "webpackVersion": {
+          "description": "webpack major line for opt-in bundler compatibility behavior",
+          "type": "integer",
+          "enum": [4, 5]
+        }
+      },
+      "additionalProperties": false
+    },
     "CompilerConfig": {
       "description": "Vue compiler options",
       "type": "object",
@@ -84,45 +123,6 @@
       },
       "additionalProperties": false
     },
-    "VueVersion": {
-      "description": "Host Vue runtime version for opt-in compatibility modes",
-      "type": "string",
-      "enum": ["3", "2.7", "2", "1", "0.11", "0.10"]
-    },
-    "CompilerCompatibilityConfig": {
-      "description": "Opt-in compatibility features for unsupported host/runtime combinations",
-      "type": "object",
-      "properties": {
-        "vueVersion": {
-          "$ref": "#/definitions/VueVersion"
-        },
-        "hostCompiler": {
-          "description": "Delegate .vue compilation to the host Vue compiler for legacy Vue runtimes",
-          "type": "boolean"
-        },
-        "scriptSetupInStandalone": {
-          "description": "Enable <script setup> when emitting function-body output for CDN/global Vue usage",
-          "default": false,
-          "type": "boolean"
-        },
-        "optionsApiVapor": {
-          "description": "Allow Vapor output for Options API SFCs when Vapor mode is enabled",
-          "default": false,
-          "type": "boolean"
-        },
-        "nuxtVersion": {
-          "description": "Host Nuxt major version for compatibility bridges",
-          "type": "integer",
-          "enum": [2, 3, 4]
-        },
-        "webpackVersion": {
-          "description": "Host Webpack major version for compatibility bridges",
-          "type": "integer",
-          "enum": [4, 5]
-        }
-      },
-      "additionalProperties": false
-    },
     "VitePluginConfig": {
       "type": "object",
       "properties": {
@@ -172,17 +172,21 @@
       "additionalProperties": false
     },
     "LinterConfig": {
+      "description": "Linter options",
       "type": "object",
       "properties": {
         "enabled": {
+          "description": "Enable linting",
           "type": "boolean"
         },
         "preset": {
+          "description": "Built-in lint preset",
           "default": "ecosystem",
           "type": "string",
           "enum": ["happy-path", "opinionated", "essential", "incremental", "ecosystem", "nuxt"]
         },
         "typeAware": {
+          "description": "Enable native type-aware lint rules from the active lint configuration",
           "type": "boolean"
         },
         "rules": {
@@ -192,6 +196,9 @@
             "type": "string",
             "enum": ["off", "warn", "error"]
           }
+        },
+        "ruleOptions": {
+          "$ref": "#/definitions/LintRuleOptions"
         },
         "categories": {
           "description": "Category-level severity overrides",
@@ -223,6 +230,71 @@
             }
           },
           "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "RestrictedGlobal": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["name"]
+    },
+    "RestrictedMember": {
+      "type": "object",
+      "properties": {
+        "object": {
+          "type": "string"
+        },
+        "property": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["object", "property"]
+    },
+    "NoRestrictedGlobalsOptions": {
+      "type": "object",
+      "properties": {
+        "globals": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RestrictedGlobal"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "NoRestrictedMembersOptions": {
+      "type": "object",
+      "properties": {
+        "members": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RestrictedMember"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "LintRuleOptions": {
+      "type": "object",
+      "properties": {
+        "script/no-restricted-globals": {
+          "$ref": "#/definitions/NoRestrictedGlobalsOptions"
+        },
+        "script/no-restricted-members": {
+          "$ref": "#/definitions/NoRestrictedMembersOptions"
         }
       },
       "additionalProperties": false
@@ -276,7 +348,7 @@
           "type": "boolean"
         },
         "optionsApi": {
-          "description": "Resolve Vue 3 Options API template bindings (data/computed/methods/inject/setup/props) during type checking. Default-on (matches vue-tsc); set to false to opt out. Available in the standard build (not a legacy feature).",
+          "description": "Resolve Vue 3 Options API template bindings during type checking",
           "default": true,
           "type": "boolean"
         },
@@ -739,7 +811,23 @@
         "compiler": {
           "$ref": "#/definitions/CompilerConfig"
         },
-        "experimentals": { "type": "object" },
+        "experimentals": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "object",
+                "additionalProperties": true
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
         "vite": {
           "$ref": "#/definitions/VitePluginConfig"
         },
@@ -820,7 +908,23 @@
     "compiler": {
       "$ref": "#/definitions/CompilerConfig"
     },
-    "experimentals": { "type": "object" },
+    "experimentals": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "object",
+            "additionalProperties": true
+          },
+          {
+            "type": "null"
+          }
+        ]
+      }
+    },
     "vite": {
       "$ref": "#/definitions/VitePluginConfig"
     },

--- a/npm/cli/src/types/generated.ts
+++ b/npm/cli/src/types/generated.ts
@@ -46,8 +46,19 @@ export interface VizeConfig {
    * Base config files or presets to compose
    */
   extends?: string | string[];
+  /**
+   * Vue dialect profile for standalone HTML documents; when absent the dialect is detected structurally per document
+   */
+  dialect?: "vue" | "petite-vue";
   compiler?: CompilerConfig;
-  experimentals?: Record<string, boolean | Record<string, unknown> | null>;
+  experimentals?: {
+    [k: string]:
+      | boolean
+      | {
+          [k: string]: unknown;
+        }
+      | null;
+  };
   vite?: VitePluginConfig;
   linter?: LinterConfig;
   typeChecker?: TypeCheckerConfig;
@@ -141,11 +152,11 @@ export interface CompilerCompatibilityConfig {
    */
   optionsApiVapor?: boolean;
   /**
-   * Host Nuxt major version for compatibility bridges
+   * Nuxt major line for opt-in Nuxt compatibility behavior
    */
   nuxtVersion?: 2 | 3 | 4;
   /**
-   * Host Webpack major version for compatibility bridges
+   * webpack major line for opt-in bundler compatibility behavior
    */
   webpackVersion?: 4 | 5;
 }
@@ -175,9 +186,13 @@ export interface LinterConfig {
    * Enable linting
    */
   enabled?: boolean;
-  /** Built-in lint preset */
+  /**
+   * Built-in lint preset
+   */
   preset?: "happy-path" | "opinionated" | "essential" | "incremental" | "ecosystem" | "nuxt";
-  /** Enable native type-aware lint rules from the active lint configuration */
+  /**
+   * Enable native type-aware lint rules from the active lint configuration
+   */
   typeAware?: boolean;
   /**
    * Rules to enable/disable
@@ -185,6 +200,7 @@ export interface LinterConfig {
   rules?: {
     [k: string]: "off" | "warn" | "error";
   };
+  ruleOptions?: LintRuleOptions;
   /**
    * Category-level severity overrides
    */
@@ -196,6 +212,25 @@ export interface LinterConfig {
     a11y?: "off" | "warn" | "error";
     security?: "off" | "warn" | "error";
   };
+}
+export interface LintRuleOptions {
+  "script/no-restricted-globals"?: NoRestrictedGlobalsOptions;
+  "script/no-restricted-members"?: NoRestrictedMembersOptions;
+}
+export interface NoRestrictedGlobalsOptions {
+  globals?: RestrictedGlobal[];
+}
+export interface RestrictedGlobal {
+  name: string;
+  message?: string;
+}
+export interface NoRestrictedMembersOptions {
+  members?: RestrictedMember[];
+}
+export interface RestrictedMember {
+  object: string;
+  property: string;
+  message?: string;
 }
 export interface TypeCheckerConfig {
   /**
@@ -234,7 +269,9 @@ export interface TypeCheckerConfig {
    * Check fallthrough attrs on multi-root templates
    */
   checkFallthroughAttrs?: boolean;
-  /** Resolve Vue 3 Options API template bindings during type checking. */
+  /**
+   * Resolve Vue 3 Options API template bindings during type checking
+   */
   optionsApi?: boolean;
   /**
    * Enable Vue 2.7 / Nuxt 2 Options API template binding support
@@ -248,7 +285,9 @@ export interface TypeCheckerConfig {
    * Path to tsconfig.json
    */
   tsconfig?: string;
-  /** Path to the Corsa executable. tsgoPath is kept as a compatibility alias. */
+  /**
+   * Path to the Corsa executable. This is the canonical runtime key; tsgoPath is kept as a compatibility alias.
+   */
   corsaPath?: string;
   /**
    * Deprecated alias for typeChecker.corsaPath
@@ -583,8 +622,19 @@ export interface VizeConfigEntry {
    * Base config files or presets to compose
    */
   extends?: string | string[];
+  /**
+   * Vue dialect profile for standalone HTML documents; when absent the dialect is detected structurally per document
+   */
+  dialect?: "vue" | "petite-vue";
   compiler?: CompilerConfig;
-  experimentals?: Record<string, boolean | Record<string, unknown> | null>;
+  experimentals?: {
+    [k: string]:
+      | boolean
+      | {
+          [k: string]: unknown;
+        }
+      | null;
+  };
   vite?: VitePluginConfig;
   linter?: LinterConfig;
   typeChecker?: TypeCheckerConfig;

--- a/tests/tooling/config-json-shape.test.ts
+++ b/tests/tooling/config-json-shape.test.ts
@@ -83,64 +83,56 @@ test("nested null values are stripped from object config", async () => {
   });
 });
 
-test("type-aware lint opt-in is exposed across config artifacts", () => {
+function bracedBody(source: string, declaration: RegExp): string {
+  const match = declaration.exec(source);
+  assert.ok(match, `missing declaration ${declaration}`);
+  const open = source.indexOf("{", match.index);
+  let depth = 0;
+  for (let index = open; index < source.length; index += 1) {
+    if (source[index] === "{") depth += 1;
+    if (source[index] === "}" && --depth === 0) return source.slice(open + 1, index);
+  }
+  throw new Error(`unterminated declaration ${declaration}`);
+}
+
+function pklClassKeys(file: string, className: string): string[] {
+  const body = bracedBody(fs.readFileSync(file, "utf8"), new RegExp(`class ${className}\\b`));
+  return [...body.matchAll(/^\s{2}([\w$]+|`[^`]+`)\s*:/gm)]
+    .map((match) => match[1].replaceAll("`", ""))
+    .sort();
+}
+
+function typescriptInterfaceKeys(source: string, interfaceName: string): string[] {
+  const body = bracedBody(source, new RegExp(`export interface ${interfaceName}\\b`));
+  return [...body.matchAll(/^\s{2}([\w$]+)\??:/gm)].map((match) => match[1]).sort();
+}
+
+const configSections = ["CompilerConfig", "LinterConfig", "TypeCheckerConfig"] as const;
+
+test("public config keys stay identical across generated artifacts", () => {
   const schema = JSON.parse(
     fs.readFileSync(path.join("npm", "cli", "schemas", "vize.config.schema.json"), "utf8"),
   ) as {
-    definitions: {
-      LinterConfig: {
-        properties: Record<string, { type?: string; description?: string }>;
-      };
-    };
+    definitions: Record<string, { properties: Record<string, unknown> }>;
   };
   const generatedTypes = fs.readFileSync(
     path.join("npm", "cli", "src", "types", "generated.ts"),
     "utf8",
   );
-  const pklLinterConfig = fs.readFileSync(
-    path.join("npm", "cli", "pkl", "LinterConfig.pkl"),
-    "utf8",
-  );
-  const pklCompatConfig = fs.readFileSync(path.join("npm", "cli", "pkl", "vize.pkl"), "utf8");
-  const pklSchemaGenerator = fs.readFileSync(
-    path.join("npm", "cli", "pkl", "jsonschema", "generate.pkl"),
-    "utf8",
-  );
+  const compatPkl = path.join("npm", "cli", "pkl", "vize.pkl");
 
-  assert.equal(schema.definitions.LinterConfig.properties.typeAware.type, "boolean");
-  assert.match(generatedTypes, /typeAware\?: boolean;/);
-  assert.match(pklLinterConfig, /typeAware: Boolean = false/);
-  assert.match(pklCompatConfig, /typeAware: Boolean\? = null/);
-  assert.match(pklSchemaGenerator, /\["typeAware"\] = new JsonSchema/);
-});
-
-test("JSX type-check opt-in is exposed across config artifacts", () => {
-  const schema = JSON.parse(
-    fs.readFileSync(path.join("npm", "cli", "schemas", "vize.config.schema.json"), "utf8"),
-  ) as {
-    definitions: {
-      TypeCheckerConfig: {
-        properties: Record<string, { type?: string; description?: string }>;
-      };
+  for (const section of configSections) {
+    const primaryKeys = pklClassKeys(path.join("npm", "cli", "pkl", `${section}.pkl`), section);
+    const artifactKeys = {
+      primaryPkl: primaryKeys,
+      compatPkl: pklClassKeys(compatPkl, section),
+      jsonSchema: Object.keys(schema.definitions[section].properties).sort(),
+      generatedTypes: typescriptInterfaceKeys(generatedTypes, section),
     };
-  };
-  const generatedTypes = fs.readFileSync(
-    path.join("npm", "cli", "src", "types", "generated.ts"),
-    "utf8",
-  );
-  const pklTypeCheckerConfig = fs.readFileSync(
-    path.join("npm", "cli", "pkl", "TypeCheckerConfig.pkl"),
-    "utf8",
-  );
-  const pklCompatConfig = fs.readFileSync(path.join("npm", "cli", "pkl", "vize.pkl"), "utf8");
-  const pklSchemaGenerator = fs.readFileSync(
-    path.join("npm", "cli", "pkl", "jsonschema", "generate.pkl"),
-    "utf8",
-  );
-
-  assert.equal(schema.definitions.TypeCheckerConfig.properties.jsxTypecheck.type, "boolean");
-  assert.match(generatedTypes, /jsxTypecheck\?: boolean;/);
-  assert.match(pklTypeCheckerConfig, /jsxTypecheck: Boolean = false/);
-  assert.match(pklCompatConfig, /jsxTypecheck: Boolean\? = null/);
-  assert.match(pklSchemaGenerator, /\["jsxTypecheck"\] = new JsonSchema/);
+    assert.deepEqual(
+      artifactKeys,
+      Object.fromEntries(Object.keys(artifactKeys).map((name) => [name, primaryKeys])),
+      `${section} public key sets must be identical`,
+    );
+  }
 });

--- a/tools/moon/cmd/source_file_lengths/main.mbt
+++ b/tools/moon/cmd/source_file_lengths/main.mbt
@@ -2,7 +2,6 @@ struct SourceFile {
   path : String
   lines : Int
 }
-
 enum FailureReason {
   NewFileExceededLimit
   CrossedLimit
@@ -58,10 +57,11 @@ fn is_excluded_path(path : String) -> Bool {
   path.has_suffix("Cargo.lock") ||
   path.has_suffix("pnpm-lock.yaml") ||
   path.has_suffix(".lock") ||
-  // Recorded benchmark artifacts are written by bench/compare-tools.mjs and
-  // grow whenever the generator records another derived field; they are not
-  // hand-maintained source and cannot be split up.
-  path.has_prefix("bench/results/") ||
+  // Generated benchmark/config artifacts cannot be split without breaking
+  // producer contracts or their public package paths.
+  (path.has_prefix("bench/results/") ||
+  path == "npm/cli/schemas/vize.config.schema.json" ||
+  path == "npm/cli/src/types/generated.ts") ||
   path.has_prefix("docs/content/ja/") || path.has_prefix("docs/content/zh-CN/") ||
   path.has_prefix("docs/content/pt-BR/") || path.has_prefix("docs/content/fr/") ||
   path.contains(".min.") ||


### PR DESCRIPTION
## Summary

- synchronize the compatibility Pkl model with existing compiler compatibility and type-checker options
- make the JSON Schema generator reproduce existing compiler, linter, type-checker, dialect, and experimental fields
- split shared schema definitions into a focused Pkl module so the hand-maintained generator shrinks below its previous size
- regenerate the JSON Schema and TypeScript types
- replace two per-key smoke checks with exact public key-set parity across primary Pkl, compatibility Pkl, JSON Schema, and generated TypeScript
- keep the source-length ratchet focused on hand-maintained code by excluding only the two deterministic generated config artifacts

## Root cause

The secondary Pkl model and schema generator lagged fields already present in the primary Pkl model and committed generated artifacts. Regenerating from the source therefore dropped or weakened public options, and the existing tests only checked two individual keys.

## Validation

- `cargo test -p vize_carton --test pkl_compat`
- `pkl eval npm/cli/pkl/vize.pkl -f json`
- `NAPI_RS_NATIVE_LIBRARY_PATH=... node --test tests/tooling/config-json-shape.test.ts` (6/6)
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts` (7/7)
- `vp check tests/tooling/config-json-shape.test.ts tests/tooling/source-file-lengths.test.ts`
- `pnpm --dir npm/cli check`
- schema/type regeneration is byte-stable across a second run
