### PR TITLE
perf(canon): budget batch check cold and warm runs

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -54,6 +54,10 @@
           "warmNoopSecondApp": 1500,
           "cancellationConverge": 6000
         }
+      },
+      "batchCheckBudget": {
+        "coldMs": 15000,
+        "warmMs": 10000
       }
     },
     {
@@ -411,6 +415,10 @@
         "maxPeakProcessTreeRssMiB": 384,
         "maxProcessTreeSize": 3,
         "maxTailToHeadLatencyRatio": 3
+      },
+      "batchCheckBudget": {
+        "coldMs": 60000,
+        "warmMs": 45000
       }
     },
     {

--- a/tests/snapshots/_helpers/batch-check-performance.ts
+++ b/tests/snapshots/_helpers/batch-check-performance.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import type { AppConfig } from "../../_helpers/apps.ts";
+import { repoRoot } from "../../_helpers/realworld-patch.ts";
+import { runCrashFreeVizeCheck, type VizeCheckSummary } from "./realworld.ts";
+
+export interface BatchCheckBudget {
+  coldMs: number;
+  warmMs: number;
+}
+
+const registryPath = "tests/_fixtures/vue-ecosystem-fixtures.json";
+
+export function loadBatchCheckBudget(projectId: string): BatchCheckBudget {
+  const registry = JSON.parse(fs.readFileSync(path.join(repoRoot, registryPath), "utf8")) as {
+    projects: Array<{ id: string; batchCheckBudget?: BatchCheckBudget }>;
+  };
+  const owners = registry.projects.filter(
+    (project) => project.id === projectId && project.batchCheckBudget != null,
+  );
+  assert.equal(
+    owners.length,
+    1,
+    `${projectId} must have exactly one batchCheckBudget block in ${registryPath}`,
+  );
+  const budget = owners[0].batchCheckBudget!;
+  for (const [lane, value] of Object.entries(budget)) {
+    assert.ok(
+      Number.isSafeInteger(value) && value > 0 && value <= 300_000,
+      `${projectId} batchCheckBudget.${lane} must be a positive integer at most 300000`,
+    );
+  }
+  assert.ok(budget.warmMs <= budget.coldMs, `${projectId} warm budget must not exceed cold`);
+  return budget;
+}
+
+export function runBudgetedBatchVizeCheck(app: AppConfig): {
+  cold: VizeCheckSummary;
+  warm: VizeCheckSummary;
+} {
+  const budget = loadBatchCheckBudget(app.name);
+  const cold = runCrashFreeVizeCheck(app, { timeoutMs: budget.coldMs });
+  const warm = runCrashFreeVizeCheck(app, { timeoutMs: budget.warmMs });
+
+  assert.deepEqual(
+    warm.result,
+    cold.result,
+    `${app.name} warm batch check must reproduce the complete cold result`,
+  );
+  return { cold, warm };
+}

--- a/tests/snapshots/_helpers/realworld.ts
+++ b/tests/snapshots/_helpers/realworld.ts
@@ -10,6 +10,14 @@ export interface VizeCheckSummary {
   fileCount: number;
   errorCount: number;
   durationMs: number;
+  result: VizeCheckResult;
+}
+
+export interface VizeCheckResult {
+  fileCount?: number;
+  errorCount?: number;
+  warningCount?: number;
+  files?: Array<{ file?: string; diagnostics?: string[] }>;
 }
 
 export interface VizeLintSummary {
@@ -89,22 +97,12 @@ function runVizeCheckJson(
   checkConfig: NonNullable<AppConfig["check"]>,
   patterns: string[],
   timeoutMs: number,
-): {
-  fileCount?: number;
-  errorCount?: number;
-  warningCount?: number;
-  files?: Array<{ file?: string; diagnostics?: string[] }>;
-} {
+): VizeCheckResult {
   const cmd = buildVizeCheckCommand(checkConfig, patterns);
   console.log(`Running: ${cmd}`);
 
   const stdout = readCommandStdout(cmd, checkConfig.cwd, timeoutMs);
-  return JSON.parse(stdout) as {
-    fileCount?: number;
-    errorCount?: number;
-    warningCount?: number;
-    files?: Array<{ file?: string; diagnostics?: string[] }>;
-  };
+  return JSON.parse(stdout) as VizeCheckResult;
 }
 
 export function runCrashFreeVizeCheck(
@@ -125,6 +123,7 @@ export function runCrashFreeVizeCheck(
     fileCount: parsed.fileCount ?? 0,
     errorCount: parsed.errorCount ?? 0,
     durationMs,
+    result: parsed,
   };
 }
 
@@ -240,6 +239,7 @@ const __vizeIntentionalTypeError: number = "not-a-number";
       fileCount: parsed.fileCount ?? 0,
       errorCount: parsed.errorCount ?? 0,
       durationMs,
+      result: parsed,
     };
   } finally {
     fs.rmSync(absoluteFile, { force: true });

--- a/tests/snapshots/check/misskey.ts
+++ b/tests/snapshots/check/misskey.ts
@@ -1,16 +1,9 @@
 import { describe, it, before } from "node:test";
-import assert from "node:assert/strict";
-import { execSync } from "node:child_process";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  misskeyApp,
-  MISSKEY_WORK_DIR,
-  CORSA_BIN,
-  VIZE_BIN,
-  requireVizeAndCorsaBins,
-} from "../../_helpers/apps.ts";
+import { misskeyApp, MISSKEY_WORK_DIR, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
+import { runBudgetedBatchVizeCheck } from "../_helpers/batch-check-performance.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
@@ -22,33 +15,16 @@ describe(`${app.name} check (type checker)`, () => {
     if (app.setup) app.setup();
   });
 
-  it("vize check does not crash and snapshot matches", () => {
+  it("vize check keeps budgeted cold and warm output exact", () => {
     const checkConfig = app.check!;
-    const patterns = checkConfig.patterns.map((p) => `'${p}'`).join(" ");
-    const cmd = `${VIZE_BIN} check ${patterns} --format json --quiet --corsa-path '${CORSA_BIN}'`;
-    console.log(`Running: ${cmd}`);
-
-    let stdout: string;
-    try {
-      stdout = execSync(cmd, {
-        cwd: checkConfig.cwd,
-        timeout: 120_000,
-        maxBuffer: 100 * 1024 * 1024,
-      }).toString();
-    } catch (e: any) {
-      if (e.status === 1 && e.stdout) {
-        stdout = e.stdout.toString();
-      } else {
-        throw new Error(`vize check crashed (exit code ${e.status}): ${e.stderr?.toString()}`);
-      }
-    }
-
-    const parsed = JSON.parse(stdout);
-    console.log(`fileCount=${parsed.fileCount}, errorCount=${parsed.errorCount}`);
-    assert.ok(parsed.fileCount > 0, "fileCount should be > 0");
+    const { cold, warm } = runBudgetedBatchVizeCheck(app);
+    console.log(
+      `fileCount=${cold.fileCount}, errorCount=${cold.errorCount}, ` +
+        `coldMs=${cold.durationMs.toFixed(0)}, warmMs=${warm.durationMs.toFixed(0)}`,
+    );
 
     const prettyOutput =
-      JSON.stringify(parsed, null, 2)
+      JSON.stringify(cold.result, null, 2)
         .replaceAll(checkConfig.cwd, "<cwd>")
         .replaceAll(MISSKEY_WORK_DIR, "<project>") + "\n";
     assertSnapshot(SNAPSHOT_DIR, `${app.name}-check`, prettyOutput);

--- a/tests/snapshots/check/vue-vben-admin.ts
+++ b/tests/snapshots/check/vue-vben-admin.ts
@@ -1,17 +1,18 @@
 import { describe, it, before } from "node:test";
 
 import { requireVizeAndCorsaBins, vueVbenAdminApp } from "../../_helpers/apps.ts";
-import { runCrashFreeVizeCheck } from "../_helpers/realworld.ts";
+import { runBudgetedBatchVizeCheck } from "../_helpers/batch-check-performance.ts";
 
 const app = vueVbenAdminApp;
 
 describe(`${app.name} check (type checker)`, () => {
   before(requireVizeAndCorsaBins);
 
-  it("vize check covers the real-world Vue app without crashing or hanging", () => {
-    const summary = runCrashFreeVizeCheck(app, { timeoutMs: 300_000 });
+  it("vize check covers budgeted cold and warm real-world runs exactly", () => {
+    const { cold, warm } = runBudgetedBatchVizeCheck(app);
     console.log(
-      `fileCount=${summary.fileCount}, errorCount=${summary.errorCount}, durationMs=${summary.durationMs.toFixed(0)}`,
+      `fileCount=${cold.fileCount}, errorCount=${cold.errorCount}, ` +
+        `coldMs=${cold.durationMs.toFixed(0)}, warmMs=${warm.durationMs.toFixed(0)}`,
     );
   });
 });

--- a/tests/tooling/batch-check-budgets.test.ts
+++ b/tests/tooling/batch-check-budgets.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { loadBatchCheckBudget } from "../snapshots/_helpers/batch-check-performance.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const registry = JSON.parse(
+  fs.readFileSync(path.join(root, "tests/_fixtures/vue-ecosystem-fixtures.json"), "utf8"),
+) as { projects: Array<{ id: string; batchCheckBudget?: { coldMs: number; warmMs: number } }> };
+
+test("Vben and Misskey own complete batch cold and warm budgets", () => {
+  const owners = registry.projects.filter((project) => project.batchCheckBudget != null);
+  assert.deepEqual(owners.map((project) => project.id).sort(), ["misskey", "vue-vben-admin"]);
+  assert.deepEqual(loadBatchCheckBudget("vue-vben-admin"), {
+    coldMs: 15_000,
+    warmMs: 10_000,
+  });
+  assert.deepEqual(loadBatchCheckBudget("misskey"), {
+    coldMs: 60_000,
+    warmMs: 45_000,
+  });
+});
+
+test("batch budget consumers run both projects through the fail-closed helper", () => {
+  for (const fixture of ["vue-vben-admin.ts", "misskey.ts"]) {
+    const source = fs.readFileSync(path.join(root, "tests/snapshots/check", fixture), "utf8");
+    assert.match(source, /runBudgetedBatchVizeCheck\(app\)/);
+  }
+  const helper = fs.readFileSync(
+    path.join(root, "tests/snapshots/_helpers/batch-check-performance.ts"),
+    "utf8",
+  );
+  assert.match(helper, /const cold = runCrashFreeVizeCheck/);
+  assert.match(helper, /const warm = runCrashFreeVizeCheck/);
+  assert.match(helper, /warm\.result,[\s\S]*cold\.result/);
+});


### PR DESCRIPTION
## Summary
- give Vben and Misskey checked-in cold and warm batch check budgets
- run both process invocations in one fixture setup and fail closed on either ceiling
- require the complete warm JSON report to equal the cold report exactly

#3762 added the Vben cancellation lane. This PR closes the remaining batch cold and warm gaps.

Closes #3746

## Validation
- Vben real batch oracle: cold 1339ms, warm 1078ms, complete JSON equality
- Misskey prepared real fixture: cold 26241ms, warm 26698ms, complete JSON equality
- node --test tests/tooling/batch-check-budgets.test.ts
- source-file-lengths.test.ts with pinned MoonBit: 7/7
- scoped vp check --fix
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3765"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->