### PR TITLE
feat(canon): type static CSS module classes

### DIFF
--- a/crates/vize_canon/src/batch/runtime_deps/stubs.rs
+++ b/crates/vize_canon/src/batch/runtime_deps/stubs.rs
@@ -172,6 +172,7 @@ export declare function reactive<T extends object>(target: T): T;
 export declare function shallowRef<T>(value: T): ShallowRef<T>;
 export declare function toRef<T extends object, K extends keyof T>(object: T, key: K): Ref<T[K]>;
 export declare function useTemplateRef<T = unknown>(key: string): ShallowRef<T | null>;
+export declare function useCssModule(name?: string): Record<string, string>;
 export declare function useId(): string;
 export declare function watch<T>(source: T, callback: (...args: any[]) => void, options?: any): void;
 export declare function watchEffect(effect: (onCleanup: (cleanupFn: () => void) => void) => void): void;

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
@@ -1,5 +1,6 @@
 use super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
 mod component_prop_regressions;
+mod css_module_classes;
 mod directive_anchors;
 mod directive_values;
 mod empty_required_props;

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/css_module_classes.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/css_module_classes.rs
@@ -1,0 +1,126 @@
+//! Authored CSS-module classes are closed types when the module is static (#3741).
+
+use super::super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+
+/// `vue-tsc 3.3.4 --noEmit` reports no diagnostics for this byte-identical SFC:
+/// its CSS-module surface remains `Record<string, string>` on both sides. Vize
+/// is intentionally stricter when it can prove a closed inline export shape.
+/// The shared compat ledger cannot encode this as an expected pair because its
+/// comparator deliberately rejects one-sided diagnostics, so the full oracle
+/// is pinned here instead: exact count, code, message, authored line and column.
+#[test]
+fn static_default_and_named_modules_reject_only_misspelled_classes() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "css-module-authored-classes",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+import { useCssModule as cssModule } from "vue";
+const styles = cssModule();
+const tokenStyles = cssModule("tokens");
+void styles.root;
+void styles.typoed;
+void tokenStyles.active;
+void tokenStyles.missing;
+</script>
+
+<template>
+  <div :class="$style.root" />
+  <div :class="$style.typoed" />
+  <div :class="tokens.active" />
+  <div :class="tokens.missing" />
+</template>
+
+<style module>
+.root, .row { display: flex; }
+</style>
+
+<style module="tokens">
+.active { color: green; }
+</style>
+"#,
+        )],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let snapshot = snapshot.expect("type-check CSS-module project");
+
+    assert_eq!(
+        snapshot,
+        vec![
+            (
+                "src/App.vue".into(),
+                Some(2339),
+                "13:23:error Property 'typoed' does not exist on type '{ readonly root: string; readonly row: string; }'.".into(),
+            ),
+            (
+                "src/App.vue".into(),
+                Some(2339),
+                "15:23:error Property 'missing' does not exist on type '{ readonly active: string; }'.".into(),
+            ),
+            (
+                "src/App.vue".into(),
+                Some(2339),
+                "6:13:error Property 'typoed' does not exist on type '{ readonly root: string; readonly row: string; }'.".into(),
+            ),
+            (
+                "src/App.vue".into(),
+                Some(2339),
+                "8:18:error Property 'missing' does not exist on type '{ readonly active: string; }'.".into(),
+            ),
+        ],
+        "correct classes stay clean while script and template typos keep exact authored ranges"
+    );
+}
+
+#[test]
+fn unresolved_modules_keep_the_index_signature_fallback() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "css-module-dynamic-fallback",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+import { useCssModule } from "vue";
+const styles = useCssModule();
+const tokens = useCssModule("tokens");
+const scss = useCssModule("scss");
+void styles.fromExternalFile;
+void tokens.fromImportedCss;
+void scss.generatedByPreprocessor;
+</script>
+
+<template>
+  <div :class="$style.fromExternalFile" />
+  <div :class="tokens.fromImportedCss" />
+  <div :class="scss.generatedByPreprocessor" />
+</template>
+
+<style module src="./external.css"></style>
+<style module="tokens">
+@import "./tokens.css";
+.local { color: green; }
+</style>
+<style module="scss" lang="scss">
+.root { &__child { color: green; } }
+</style>
+"#,
+        )],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    let snapshot = snapshot.expect("type-check unresolved CSS-module project");
+
+    assert_eq!(
+        snapshot,
+        Vec::new(),
+        "external and imported modules must not gain false-positive property errors"
+    );
+}

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -7,7 +7,7 @@ use oxc_span::SourceType;
 use vize_atelier_core::TemplateSyntaxMode;
 use vize_carton::{String as CompactString, ToCompactString, cstr, profile};
 
-use vize_atelier_sfc::{SfcDescriptor, SfcParseOptions, parse_sfc};
+use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
 
 use crate::batch::Diagnostic;
 use crate::batch::declaration_path::is_declaration_file;
@@ -15,6 +15,9 @@ use crate::batch::error::{CorsaError, CorsaResult};
 use crate::batch::import_rewriter::ImportRewriter;
 use crate::batch::source_map::{CompositeSourceMap, SfcSourceMap};
 use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions, VizeMapping};
+
+mod css_modules;
+pub(super) use css_modules::virtual_ts_options_for_descriptor;
 
 use super::VirtualFile;
 use super::diagnostics::collect_sfc_block_ranges;
@@ -225,41 +228,6 @@ pub(super) fn build_script_registered_file(
         diagnostics: Vec::new(),
         unchecked_javascript: false,
     })
-}
-
-pub(super) fn virtual_ts_options_for_descriptor(
-    base: &VirtualTsOptions,
-    descriptor: &SfcDescriptor,
-) -> VirtualTsOptions {
-    // Per-file generation never re-emits the global auto-import stubs inline:
-    // they are written once to a shared ambient `.d.ts` (see
-    // `write_auto_import_stubs`). Build the per-file options with an empty
-    // `auto_import_stubs` instead of deep-cloning the (potentially large,
-    // Nuxt/auto-import) global Vec only to clear it again at the call site.
-    let css_modules: Vec<CompactString> = descriptor
-        .styles
-        .iter()
-        .filter_map(|style| {
-            style
-                .module
-                .as_ref()
-                .map(|module| module.to_compact_string())
-        })
-        .collect();
-    let css_modules = if css_modules.is_empty() {
-        // No `<style module>` blocks: reuse the global css_modules.
-        base.css_modules.clone()
-    } else {
-        css_modules
-    };
-
-    VirtualTsOptions {
-        template_globals: base.template_globals.clone(),
-        css_modules,
-        auto_import_stubs: Vec::new(),
-        external_template_bindings: base.external_template_bindings.clone(),
-        reference_paths: base.reference_paths.clone(),
-    }
 }
 
 pub(super) fn prepend_vue_jsx_reference(code: &mut CompactString, mappings: &mut [VizeMapping]) {

--- a/crates/vize_canon/src/batch/virtual_project/build/css_modules.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build/css_modules.rs
@@ -1,0 +1,239 @@
+//! CSS-module metadata for per-SFC virtual TypeScript options.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use vize_atelier_sfc::SfcDescriptor;
+use vize_carton::{String as CompactString, ToCompactString};
+
+use crate::virtual_ts::{CSS_MODULE_GLOBAL_MARKER, TemplateGlobal, VirtualTsOptions};
+
+pub(crate) fn virtual_ts_options_for_descriptor(
+    base: &VirtualTsOptions,
+    descriptor: &SfcDescriptor,
+) -> VirtualTsOptions {
+    // Per-file generation never re-emits the global auto-import stubs inline:
+    // they are written once to a shared ambient `.d.ts`.
+    let module_types = css_module_types(descriptor);
+    let has_css_modules = !module_types.is_empty();
+    let mut template_globals = base.template_globals.clone();
+    let mut css_modules = Vec::new();
+    for (module_name, classes) in module_types {
+        template_globals.retain(|global| global.name != module_name);
+        if let Some(classes) = classes {
+            template_globals.push(TemplateGlobal {
+                name: module_name,
+                type_annotation: css_module_type_annotation(&classes),
+                default_value: CSS_MODULE_GLOBAL_MARKER.into(),
+            });
+        } else {
+            css_modules.push(module_name);
+        }
+    }
+    let css_modules = if !has_css_modules {
+        base.css_modules.clone()
+    } else {
+        css_modules
+    };
+
+    VirtualTsOptions {
+        template_globals,
+        css_modules,
+        auto_import_stubs: Vec::new(),
+        external_template_bindings: base.external_template_bindings.clone(),
+        reference_paths: base.reference_paths.clone(),
+    }
+}
+
+/// Collect the classes that are statically exported by each CSS module.
+///
+/// A module falls back to `Record<string, string>` when another file or CSS
+/// Modules composition can contribute names. That deliberately trades typo
+/// detection for soundness rather than inventing a closed shape.
+fn css_module_types(
+    descriptor: &SfcDescriptor<'_>,
+) -> BTreeMap<CompactString, Option<BTreeSet<CompactString>>> {
+    let mut modules = BTreeMap::new();
+    for style in descriptor.styles.iter() {
+        let Some(module_name) = style.module.as_ref() else {
+            continue;
+        };
+        let module_name = module_name.to_compact_string();
+        let is_plain_css = style
+            .lang
+            .as_deref()
+            .is_none_or(|language| language.eq_ignore_ascii_case("css"));
+        let authored_classes = (style.src.is_none()
+            && is_plain_css
+            && !contains_dynamic_css_module_exports(&style.content))
+        .then(|| extract_authored_css_classes(&style.content))
+        .flatten();
+
+        let entry = modules
+            .entry(module_name)
+            .or_insert_with(|| Some(BTreeSet::new()));
+        let Some(authored_classes) = authored_classes else {
+            *entry = None;
+            continue;
+        };
+        if let Some(existing) = entry.as_mut() {
+            existing.extend(authored_classes);
+        }
+    }
+    modules
+}
+
+fn contains_dynamic_css_module_exports(css: &str) -> bool {
+    let lower = css.to_ascii_lowercase();
+    ["@import", "@value", "composes", ":export", ":global", "#{"]
+        .iter()
+        .any(|marker| lower.contains(marker))
+}
+
+/// Extract simple authored class selectors from selector preludes. Declarations
+/// are never scanned, so values such as `url(./asset.png)` cannot become fake
+/// module keys. Comments and string contents are blanked before inspection.
+fn extract_authored_css_classes(css: &str) -> Option<BTreeSet<CompactString>> {
+    let bytes = css.as_bytes();
+    let mut classes = BTreeSet::new();
+    let mut prelude = Vec::new();
+    let mut index = 0usize;
+    let mut quote = None;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if let Some(open_quote) = quote {
+            if byte == b'\\' {
+                index = (index + 2).min(bytes.len());
+                continue;
+            }
+            if byte == open_quote {
+                quote = None;
+            }
+            index += 1;
+            continue;
+        }
+        if byte == b'/' && bytes.get(index + 1) == Some(&b'*') {
+            let relative_end = css[index + 2..].find("*/")?;
+            index += relative_end + 4;
+            continue;
+        }
+        if matches!(byte, b'\'' | b'"') {
+            quote = Some(byte);
+            index += 1;
+            continue;
+        }
+        match byte {
+            b'{' => {
+                collect_classes_from_selector_prelude(&prelude, &mut classes)?;
+                prelude.clear();
+            }
+            b';' | b'}' => prelude.clear(),
+            _ => prelude.push(byte),
+        }
+        index += 1;
+    }
+    quote.is_none().then_some(classes)
+}
+
+fn collect_classes_from_selector_prelude(
+    prelude: &[u8],
+    classes: &mut BTreeSet<CompactString>,
+) -> Option<()> {
+    let trimmed = prelude
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .map_or(&[][..], |start| &prelude[start..]);
+    if trimmed.starts_with(b"@") {
+        return Some(());
+    }
+    if trimmed.contains(&b'\\') || !trimmed.is_ascii() {
+        return None;
+    }
+
+    let mut index = 0usize;
+    while index + 1 < trimmed.len() {
+        if trimmed[index] != b'.' || !is_css_class_start(trimmed[index + 1]) {
+            index += 1;
+            continue;
+        }
+        let start = index + 1;
+        let mut end = start + 1;
+        while end < trimmed.len() && is_css_class_continue(trimmed[end]) {
+            end += 1;
+        }
+        let class_name = std::str::from_utf8(&trimmed[start..end]).ok()?;
+        classes.insert(class_name.to_compact_string());
+        index = end;
+    }
+    Some(())
+}
+
+fn is_css_class_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || matches!(byte, b'_' | b'-')
+}
+
+fn is_css_class_continue(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-')
+}
+
+fn css_module_type_annotation(classes: &BTreeSet<CompactString>) -> CompactString {
+    let mut annotation = CompactString::from("{ ");
+    for class_name in classes {
+        annotation.push_str("readonly ");
+        annotation.push_str(
+            serde_json::to_string(class_name.as_str())
+                .expect("CSS class name should serialize")
+                .as_str(),
+        );
+        annotation.push_str(": string; ");
+    }
+    annotation.push('}');
+    annotation
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        contains_dynamic_css_module_exports, css_module_type_annotation,
+        extract_authored_css_classes,
+    };
+
+    #[test]
+    fn extracts_only_classes_from_selector_preludes() {
+        let classes = extract_authored_css_classes(
+            r#"
+/* .commented-out {} */
+.root, .row:hover {
+  background: url(./asset.png);
+  content: ".not-a-class";
+}
+@media (width > 20rem) {
+  .nested-item { color: green; }
+}
+"#,
+        )
+        .expect("plain CSS selectors should resolve");
+        assert_eq!(
+            classes.iter().map(|name| name.as_str()).collect::<Vec<_>>(),
+            ["nested-item", "root", "row"]
+        );
+        assert_eq!(
+            css_module_type_annotation(&classes).as_str(),
+            r#"{ readonly "nested-item": string; readonly "root": string; readonly "row": string; }"#
+        );
+    }
+
+    #[test]
+    fn rejects_selectors_that_cannot_form_a_closed_export_shape() {
+        for source in [
+            r#"@import "./base.css"; .root {}"#,
+            r#".root { composes : shared from "./base.css"; }"#,
+            r#":global(.external) .root {}"#,
+            r#".#{dynamic} {}"#,
+        ] {
+            assert!(contains_dynamic_css_module_exports(source), "{source}");
+        }
+        assert!(extract_authored_css_classes(r#".café {}"#).is_none());
+        assert!(extract_authored_css_classes(r#".escaped\:name {}"#).is_none());
+    }
+}

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -38,6 +38,7 @@ pub use generator::{
     generate_virtual_ts_with_offsets_legacy_vue2, generate_virtual_ts_with_offsets_options_api,
 };
 pub use helpers::{DECLARATION_HELPERS_DTS, SHARED_PREAMBLE_DTS, SHARED_PREAMBLE_FILE_NAME};
+pub(crate) use types::CSS_MODULE_GLOBAL_MARKER;
 pub use types::{TemplateGlobal, VirtualTsOptions, VirtualTsOutput, VizeMapping, VizeSubSpan};
 #[cfg(any(test, feature = "native"))]
 pub(crate) use types::{VirtualTsCheckOptions, VirtualTsGenerationOptions};

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -1,6 +1,7 @@
 mod anchors;
 mod component_constructors;
 mod component_export;
+mod css_modules;
 mod emits;
 mod generics;
 mod global_components;
@@ -20,6 +21,7 @@ mod template_refs;
 use self::anchors::emit_setup_binding_anchors;
 use self::component_constructors::{ComponentInstanceAliases, emit_component_constructors};
 use self::component_export::emit_default_export_declaration;
+use self::css_modules::CssModuleAssertions;
 use self::emits::{emit_emit_props_helper, emit_emits_type, emit_exposed_type, emit_slots_type};
 use self::generics::{HoistedGenericAliases, generic_injection_point, references_any_identifier};
 use self::global_components::GlobalComponentPlan;
@@ -493,20 +495,17 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         profile!("canon.virtual_ts.emit_script_body", {
             ts.push_str("  // User setup code\n");
             let script_gen_start = ts.len();
-            // Use split('\n') to correctly track byte offsets for CRLF files.
-            // Rust's lines() strips \r from CRLF but +1 for \n undercounts,
-            // causing src_byte_offset drift that incorrectly skips user code.
+            // `split('\n')` preserves byte offsets for CRLF; `lines()` strips `\r`.
             let mut src_byte_offset: usize = 0; // offset within script content
             let mut module_span_index = 0usize;
             let named_value_export_starts =
                 self::script_module::collect_named_value_export_starts(script);
             let mut props_const_assertions = PropsConstAssertions::new(script, options_api);
-            // Script-absolute offset right after the wrapped options object.
+            let mut css_module_assertions = CssModuleAssertions::new(script, options);
             let mut pending_wrap_close: Option<usize> = None;
             // Deferred class-component alias: `(class_end, name)`.
             let mut pending_class_alias: Option<(usize, &str)> = None;
             let mut emitted_default_alias = false;
-
             let uses_import_meta = self::script_module::emit_import_meta_polyfill(&mut ts, script);
 
             for raw_line in script.split('\n') {
@@ -557,6 +556,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                     pending_wrap_close = None;
                 }
 
+                css_module_assertions.splice_output_line(&mut output_line, line_start);
                 props_const_assertions.splice_output_line(&mut output_line, line_start);
 
                 // Strip `export` from non-import lines inside setup scope

--- a/crates/vize_canon/src/virtual_ts/generator/css_modules.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/css_modules.rs
@@ -1,0 +1,132 @@
+//! Script-side CSS-module typing for `useCssModule()`.
+
+use std::collections::BTreeMap;
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Argument, Expression, ImportDeclarationSpecifier, Statement};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{FxHashSet, String, cstr};
+
+use crate::virtual_ts::types::{CSS_MODULE_GLOBAL_MARKER, VirtualTsOptions};
+
+/// Inserts a type assertion immediately after a top-level `useCssModule()`
+/// initializer. Vue's public return type is intentionally open-ended, while an
+/// SFC's authored inline module can be narrower. Calls with a dynamic name and
+/// modules that require the index-signature fallback are left untouched.
+pub(super) struct CssModuleAssertions {
+    insertions: Vec<(usize, String)>,
+    index: usize,
+}
+
+impl CssModuleAssertions {
+    pub(super) fn new(script: &str, options: &VirtualTsOptions) -> Self {
+        let module_types: BTreeMap<&str, &str> = options
+            .template_globals
+            .iter()
+            .filter(|global| global.default_value == CSS_MODULE_GLOBAL_MARKER)
+            .map(|global| (global.name.as_str(), global.type_annotation.as_str()))
+            .collect();
+        if module_types.is_empty() {
+            return Self {
+                insertions: Vec::new(),
+                index: 0,
+            };
+        }
+
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, script, SourceType::tsx()).parse();
+        if parsed.panicked {
+            return Self {
+                insertions: Vec::new(),
+                index: 0,
+            };
+        }
+
+        let mut local_names = FxHashSet::default();
+        for statement in parsed.program.body.iter() {
+            let Statement::ImportDeclaration(import) = statement else {
+                continue;
+            };
+            if import.source.value.as_str() != "vue" {
+                continue;
+            }
+            for specifier in import.specifiers.iter().flatten() {
+                let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier else {
+                    continue;
+                };
+                if specifier.imported.name().as_str() == "useCssModule" {
+                    local_names.insert(specifier.local.name.as_str());
+                }
+            }
+        }
+
+        let mut insertions = Vec::new();
+        if !local_names.is_empty() {
+            for statement in parsed.program.body.iter() {
+                let Statement::VariableDeclaration(declaration) = statement else {
+                    continue;
+                };
+                for declarator in declaration.declarations.iter() {
+                    let Some(Expression::CallExpression(call)) = declarator.init.as_ref() else {
+                        continue;
+                    };
+                    let Expression::Identifier(callee) = &call.callee else {
+                        continue;
+                    };
+                    if !local_names.contains(callee.name.as_str()) {
+                        continue;
+                    }
+                    let module_name = match call.arguments.as_slice() {
+                        [] => "$style",
+                        [Argument::StringLiteral(name)] => name.value.as_str(),
+                        _ => continue,
+                    };
+                    let Some(type_annotation) = module_types.get(module_name) else {
+                        continue;
+                    };
+                    insertions.push((call.span.end as usize, cstr!(" as {type_annotation}")));
+                }
+            }
+        }
+        insertions.sort_by_key(|(offset, _)| *offset);
+        Self {
+            insertions,
+            index: 0,
+        }
+    }
+
+    pub(super) fn splice_output_line<'a>(
+        &mut self,
+        output_line: &mut std::borrow::Cow<'a, str>,
+        line_start: usize,
+    ) {
+        while self.index < self.insertions.len() && self.insertions[self.index].0 <= line_start {
+            self.index += 1;
+        }
+        let line_end = line_start + output_line.len();
+        if self.index >= self.insertions.len() || self.insertions[self.index].0 > line_end {
+            return;
+        }
+
+        let mut rewritten = String::default();
+        let mut copied_until = 0usize;
+        while self.index < self.insertions.len() {
+            let (offset, assertion) = &self.insertions[self.index];
+            if *offset > line_end {
+                break;
+            }
+            let column = *offset - line_start;
+            if output_line.is_char_boundary(column) {
+                rewritten.push_str(&output_line[copied_until..column]);
+                rewritten.push_str(assertion);
+                copied_until = column;
+            }
+            self.index += 1;
+        }
+        if copied_until != 0 {
+            rewritten.push_str(&output_line[copied_until..]);
+            *output_line = std::borrow::Cow::Owned(rewritten.into());
+        }
+    }
+}

--- a/crates/vize_canon/src/virtual_ts/helpers.rs
+++ b/crates/vize_canon/src/virtual_ts/helpers.rs
@@ -6,9 +6,8 @@
 use std::ops::Range;
 
 use super::types::VirtualTsOptions;
-use vize_carton::String;
-use vize_carton::append;
 use vize_carton::config::VueVersion;
+use vize_carton::{String, append};
 use vize_croquis::macros::{
     DEFINE_EMITS, DEFINE_EXPOSE, DEFINE_MODEL, DEFINE_PROPS, DEFINE_SLOTS, WITH_DEFAULTS,
 };
@@ -286,12 +285,12 @@ pub(crate) fn generate_template_context(
     if !options.template_globals.is_empty() {
         ctx.push_str("    // Plugin globals (via ComponentCustomProperties)\n");
         for global in &options.template_globals {
+            let type_annotation = global.context_type_annotation();
             append!(
                 ctx,
-                "    const {}: __Global<'{}', {}> = undefined as any;\n",
+                "    const {}: {} = undefined as any;\n",
                 global.name,
-                global.name,
-                global.type_annotation
+                type_annotation
             );
         }
     }

--- a/crates/vize_canon/src/virtual_ts/types.rs
+++ b/crates/vize_canon/src/virtual_ts/types.rs
@@ -1,7 +1,7 @@
 //! Type definitions for virtual TypeScript generation.
 
 use std::ops::Range;
-use vize_carton::{FxHashSet, String, config::VueVersion};
+use vize_carton::{FxHashSet, String, config::VueVersion, cstr};
 
 /// A mapping from generated virtual TS position to SFC source position.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -48,6 +48,22 @@ pub struct TemplateGlobal {
     pub type_annotation: String,
     /// Default value expression (e.g., "(() => '') as any")
     pub default_value: String,
+}
+
+/// Marks a [`TemplateGlobal`] synthesized from an authored `<style module>`
+/// block. The marker stays in the otherwise-unused fallback-value field so
+/// per-SFC CSS-module metadata does not expand the public `VirtualTsOptions`
+/// struct (which downstream users construct directly).
+pub(crate) const CSS_MODULE_GLOBAL_MARKER: &str = "__vize_css_module_global";
+
+impl TemplateGlobal {
+    pub(crate) fn context_type_annotation(&self) -> String {
+        if self.default_value == CSS_MODULE_GLOBAL_MARKER {
+            self.type_annotation.clone()
+        } else {
+            cstr!("__Global<'{}', {}>", self.name, self.type_annotation)
+        }
+    }
 }
 
 /// Options for virtual TypeScript generation.


### PR DESCRIPTION
## Summary

- infer closed readonly class maps for inline plain-CSS default and named modules
- apply those maps to template globals and imported or aliased useCssModule calls
- retain the existing index-signature fallback for external, imported, composed, global, preprocessed, and unresolved styles

## Compatibility

vue-tsc 3.3.4 reports zero diagnostics for the byte-identical strictness fixture. Vize intentionally reports authored-range errors when a static inline module proves a closed export shape. The current documented-difference comparator rejects one-sided diagnostics, so this is pinned as an exact Vize oracle instead of adding a misleading pair to the compat ledger.

This is the safe static slice of the issue; it does not close dynamic or preprocessor-backed module inference.

Refs #3741

## Tests

- cargo test -p vize_canon
- cargo test -p vize_canon css_module -- --nocapture
- cargo clippy -p vize_canon --lib --no-deps
- cargo fmt --all -- --check
- vp check
- vue-tsc 3.3.4 byte-identical oracle: 0 diagnostics

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->