### PR TITLE
test(cli): fail closed for legacy Corsa gates

### DIFF
--- a/crates/vize/tests/check_legacy_vue2_class_bindings_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_class_bindings_cli.rs
@@ -7,9 +7,12 @@ use std::{
 
 use vize_carton::cstr;
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 #[test]
 fn legacy_vue2_merges_static_and_dynamic_component_class_bindings() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("legacy-vue2-component-class-bindings");

--- a/crates/vize/tests/check_legacy_vue2_event_alias_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_event_alias_cli.rs
@@ -7,9 +7,12 @@ use std::{
 
 use vize_carton::cstr;
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 #[test]
 fn legacy_vue2_event_alias_stays_in_scope_inside_nested_arrow_closures() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("legacy-vue2-nested-event-alias");

--- a/crates/vize/tests/check_legacy_vue2_event_payload_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_event_payload_cli.rs
@@ -7,9 +7,12 @@ use std::{
 
 use vize_carton::cstr;
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 #[test]
 fn legacy_vue2_component_event_payloads_stay_variadic_when_unresolved() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("legacy-vue2-event-payload-arity");

--- a/crates/vize/tests/check_legacy_vue2_helpers_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_helpers_cli.rs
@@ -4,9 +4,12 @@ use std::{path::Path, process::Command};
 
 use vize_carton::cstr;
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 #[test]
 fn check_legacy_vue2_show_virtual_ts_omits_shared_helpers() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("legacy-vue2-show-virtual-ts-no-shared-helpers");
@@ -56,7 +59,7 @@ fn check_legacy_vue2_show_virtual_ts_omits_shared_helpers() {
 
 #[test]
 fn check_legacy_vue2_targeted_json_keeps_component_props_helper_available() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("legacy-vue2-targeted-json-component-props-helper");
@@ -97,7 +100,7 @@ fn check_legacy_vue2_targeted_json_keeps_component_props_helper_available() {
 
 #[test]
 fn legacy_vue2_full_tsconfig_no_template_bindings_keeps_props_helper() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("legacy-vue2-full-tsconfig-component-props-helper");
@@ -155,7 +158,7 @@ export default {
 
 #[test]
 fn legacy_vue2_accepts_nuxt2_layout_and_head_this_bindings() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("legacy-vue2-nuxt2-layout-head-this");

--- a/crates/vize/tests/check_legacy_vue2_no_unused_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_no_unused_cli.rs
@@ -4,9 +4,12 @@ use std::{path::Path, process::Command};
 
 use vize_carton::cstr;
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 #[test]
 fn legacy_vue2_template_emit_marks_define_emits_result_as_used() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("legacy-vue2-template-emit-result-binding");
@@ -57,7 +60,7 @@ const emit = defineEmits<{
 
 #[test]
 fn legacy_vue2_typed_emits_do_not_report_unused_loose_emit_helper() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("legacy-vue2-no-unused-loose-emit-helper");
@@ -118,7 +121,7 @@ function handleClick(event: MouseEvent) {
 
 #[test]
 fn legacy_vue2_no_unused_locals_still_reports_user_unused_bindings() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("legacy-vue2-no-unused-user-binding");

--- a/crates/vize/tests/check_legacy_vue2_template_scope_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_template_scope_cli.rs
@@ -7,9 +7,12 @@ use std::{
 
 use vize_carton::cstr;
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 #[test]
 fn legacy_vue2_v_for_template_branch_keeps_alias_narrowing_in_scope() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("legacy-vue2-template-branch-scope");

--- a/crates/vize/tests/check_legacy_vue2_vfor_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_vfor_cli.rs
@@ -7,9 +7,12 @@ use std::{
 
 use vize_carton::cstr;
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 #[test]
 fn legacy_vue2_nested_v_for_member_array_aliases_do_not_fall_back_to_object_keys() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("legacy-vue2-nested-vfor-member-array-aliases");

--- a/crates/vize/tests/check_vue2_vuetify_props_cli.rs
+++ b/crates/vize/tests/check_vue2_vuetify_props_cli.rs
@@ -5,9 +5,12 @@ use std::{
 
 use vize_carton::cstr;
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 #[test]
 fn check_vue2_dialect_allows_vuetify_style_prop_aliases() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("vue2-vuetify-prop-aliases");

--- a/crates/vize/tests/corsa_requirement_cli.rs
+++ b/crates/vize/tests/corsa_requirement_cli.rs
@@ -1,0 +1,33 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
+#[test]
+fn available_corsa_never_skips() {
+    let _runtime_entrypoint = corsa_requirement::required_or_skip::<&str>;
+    assert_eq!(
+        corsa_requirement::required_or_skip_with(Some("tsgo"), true, false),
+        Some("tsgo")
+    );
+}
+
+#[test]
+fn missing_optional_corsa_keeps_the_local_skip() {
+    assert_eq!(
+        corsa_requirement::required_or_skip_with::<()>(None, false, false),
+        None
+    );
+}
+
+#[test]
+fn explicit_disable_keeps_the_opt_out() {
+    assert_eq!(
+        corsa_requirement::required_or_skip_with(Some("tsgo"), true, true),
+        None
+    );
+}
+
+#[test]
+#[should_panic(expected = "VIZE_TEST_REQUIRE_TSGO is set, but no tsgo executable was found")]
+fn missing_required_corsa_fails_closed() {
+    let _ = corsa_requirement::required_or_skip_with::<()>(None, true, false);
+}

--- a/crates/vize/tests/support/corsa_requirement.rs
+++ b/crates/vize/tests/support/corsa_requirement.rs
@@ -1,0 +1,25 @@
+const MISSING_REQUIRED_TSGO: &str =
+    "VIZE_TEST_REQUIRE_TSGO is set, but no tsgo executable was found";
+
+/// Keep dependency-free local runs skippable, but make required CI lanes fail
+/// closed. `VIZE_TEST_DISABLE_TSGO` is the explicit opt-out used by the canon
+/// tests and intentionally takes precedence over discovery.
+pub(crate) fn required_or_skip<T>(resolved: Option<T>) -> Option<T> {
+    required_or_skip_with(
+        resolved,
+        std::env::var_os("VIZE_TEST_REQUIRE_TSGO").is_some(),
+        std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some(),
+    )
+}
+
+pub(crate) fn required_or_skip_with<T>(
+    resolved: Option<T>,
+    required: bool,
+    disabled: bool,
+) -> Option<T> {
+    if disabled {
+        return None;
+    }
+    assert!(resolved.is_some() || !required, "{MISSING_REQUIRED_TSGO}");
+    resolved
+}

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -43,6 +43,25 @@ test("typecheck and LSP gates do not carry raw dependency skips", () => {
   }
 });
 
+test("legacy Rust CLI gates use the fail-closed Corsa helper", () => {
+  const files = [
+    "check_legacy_vue2_class_bindings_cli.rs",
+    "check_legacy_vue2_event_alias_cli.rs",
+    "check_legacy_vue2_event_payload_cli.rs",
+    "check_legacy_vue2_helpers_cli.rs",
+    "check_legacy_vue2_no_unused_cli.rs",
+    "check_legacy_vue2_template_scope_cli.rs",
+    "check_legacy_vue2_vfor_cli.rs",
+    "check_vue2_vuetify_props_cli.rs",
+  ];
+
+  for (const file of files) {
+    const source = readRepoFile("crates", "vize", "tests", file);
+    assert.match(source, /corsa_requirement::required_or_skip\(resolve_test_corsa_path\(\)\)/);
+    assert.doesNotMatch(source, /let Some\(corsa_path\) = resolve_test_corsa_path\(\)/);
+  }
+});
+
 test("available dependencies never skip", () => {
   assert.equal(typecheckDependencySkip("/tmp/tsgo", "tsgo", "missing", true), false);
 });


### PR DESCRIPTION
## Summary

- add a shared Rust integration-test guard matching the canon suite's `VIZE_TEST_REQUIRE_TSGO` fail-closed policy
- preserve dependency-free local skips and the explicit `VIZE_TEST_DISABLE_TSGO` opt-out
- migrate all 13 Corsa call sites across the eight legacy Vue 2/Vuetify CLI integration files
- add four direct policy tests, including the exact required-dependency panic, plus a tooling meta-test that bans the raw silent-return shape in the migrated family

Part of #3750. This is the first bounded Rust family: 8 of the 61 locally-resolved Rust integration files are migrated here; 53 remain for follow-up slices, so this PR intentionally does not close the issue.

## Validation

- Corsa policy tests: 4/4, including missing-required panic and explicit opt-out
- required Corsa run across the eight migrated integration binaries: 13/13
- `node --test tests/tooling/typecheck-dependency-gates.test.ts`: 7/7
- `cargo fmt --all -- --check`
- focused `vp check` on the tooling meta-test
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->