### PR TITLE
test(cli): fail closed for Nuxt Corsa gates

### DIFF
--- a/crates/vize/tests/check_nuxt2_classic_plugin_bindings_cli.rs
+++ b/crates/vize/tests/check_nuxt2_classic_plugin_bindings_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -6,7 +9,7 @@ use vize_carton::cstr;
 
 #[test]
 fn check_nuxt2_use_context_sees_classic_plugin_binding_injections() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project();

--- a/crates/vize/tests/check_nuxt2_fallback_guidance_cli.rs
+++ b/crates/vize/tests/check_nuxt2_fallback_guidance_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -7,7 +10,7 @@ use vize_carton::cstr;
 
 #[test]
 fn check_nuxt2_compiler_compat_warning_does_not_suggest_nuxi_prepare() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("nuxt2-fallback-guidance");

--- a/crates/vize/tests/check_nuxt2_plugin_injections_cli.rs
+++ b/crates/vize/tests/check_nuxt2_plugin_injections_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -5,7 +8,7 @@ use std::{
 
 #[test]
 fn check_nuxt2_use_context_sees_plugin_injections() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("nuxt2-plugin-injections");
@@ -106,7 +109,7 @@ context.app.$logger.info(context.app.i18n.t("ready"));
 #[cfg(feature = "legacy")]
 #[test]
 fn check_nuxt2_false_positive_fixture_matrix() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("nuxt2-false-positive-matrix");

--- a/crates/vize/tests/check_nuxt2_template_globals_cli.rs
+++ b/crates/vize/tests/check_nuxt2_template_globals_cli.rs
@@ -1,5 +1,8 @@
 #![cfg(feature = "legacy")]
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -9,7 +12,7 @@ use vize_carton::cstr;
 
 #[test]
 fn check_legacy_nuxt2_template_fetch_state_and_route_globals() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("legacy-nuxt2-template-globals");

--- a/crates/vize/tests/check_nuxt_ambient_cli.rs
+++ b/crates/vize/tests/check_nuxt_ambient_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -40,7 +43,7 @@ fn write(root: &Path, rel: &str, content: &str) {
 
 #[test]
 fn check_tsconfig_default_run_loads_nuxt_ambient_declarations() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("import-meta");
@@ -115,7 +118,7 @@ fn check_tsconfig_default_run_loads_nuxt_ambient_declarations() {
 
 #[test]
 fn check_explicit_nuxt_build_dir_loads_generated_context_types() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("custom-build-dir-context");

--- a/crates/vize/tests/check_nuxt_bridge_shims_cli.rs
+++ b/crates/vize/tests/check_nuxt_bridge_shims_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -41,7 +44,7 @@ fn write(root: &Path, rel: &str, content: &str) {
 
 #[test]
 fn check_suppresses_legacy_vue_shim_and_nuxt_bridge_global_duplicates() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("gtag");

--- a/crates/vize/tests/check_nuxt_composition_api_cli.rs
+++ b/crates/vize/tests/check_nuxt_composition_api_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -92,7 +95,7 @@ export declare function useRoute(): { value: { path: string } };
 
 #[test]
 fn check_resolves_nuxt2_composition_api_named_exports_in_sfc() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("exports");
@@ -173,7 +176,7 @@ export default defineComponent({
 
 #[test]
 fn check_deduplicates_nuxt_global_with_setup_return_spread() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("global-spread");

--- a/crates/vize/tests/check_nuxt_composition_api_plugin_augmentation_cli.rs
+++ b/crates/vize/tests/check_nuxt_composition_api_plugin_augmentation_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -46,7 +49,7 @@ fn write(root: &Path, rel: &str, content: &str) {
 
 #[test]
 fn check_resolves_latest_nuxt2_composition_api_exports_with_plugin_augmentation() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("exports");

--- a/crates/vize/tests/check_nuxt_legacy_tsconfig_cli.rs
+++ b/crates/vize/tests/check_nuxt_legacy_tsconfig_cli.rs
@@ -7,6 +7,9 @@
     clippy::disallowed_types
 )]
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::{Command, Output},
@@ -114,7 +117,7 @@ fn output_text(output: &Output) -> (String, String) {
 
 #[test]
 fn check_accepts_a_nuxt_fallback_over_a_ts5_era_config() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let root = project("clean", "const count: number = 1;\nvoid count;");
@@ -135,7 +138,7 @@ fn check_accepts_a_nuxt_fallback_over_a_ts5_era_config() {
 
 #[test]
 fn check_still_reports_source_errors_with_the_nuxt_fallback() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let root = project(
@@ -163,7 +166,7 @@ fn check_still_reports_source_errors_with_the_nuxt_fallback() {
 
 #[test]
 fn check_still_reports_unrelated_config_errors_with_the_nuxt_fallback() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let root = project("config-error", "const count: number = 1;\nvoid count;");

--- a/crates/vize/tests/check_nuxt_monorepo_cli.rs
+++ b/crates/vize/tests/check_nuxt_monorepo_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -5,7 +8,7 @@ use std::{
 
 #[test]
 fn check_explicit_nuxt_app_tsconfig_in_monorepo_keeps_app_root_detection() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("monorepo-nuxt-app-tsconfig");
@@ -116,7 +119,7 @@ declare global {
 
 #[test]
 fn check_non_nuxt_child_package_does_not_warn_about_root_nuxt_generated_types() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("monorepo-non-nuxt-child");

--- a/crates/vize/tests/check_nuxt_tsconfig_paths_cli.rs
+++ b/crates/vize/tests/check_nuxt_tsconfig_paths_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -5,7 +8,7 @@ use std::{
 
 #[test]
 fn check_nuxt_sfc_virtual_ts_prefers_explicit_tsconfig_paths_over_fallback_modules() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("nuxt-explicit-alias-shims");
@@ -162,7 +165,7 @@ export function useRouter(): {
 
 #[test]
 fn check_nuxt2_options_api_component_event_payloads_resolve_through_aliases() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project("nuxt2-options-api-emits-alias");

--- a/crates/vize/tests/corsa_requirement_cli.rs
+++ b/crates/vize/tests/corsa_requirement_cli.rs
@@ -19,9 +19,13 @@ fn missing_optional_corsa_keeps_the_local_skip() {
 }
 
 #[test]
-fn explicit_disable_keeps_the_opt_out() {
+fn explicit_disable_keeps_the_opt_out_with_or_without_corsa() {
     assert_eq!(
         corsa_requirement::required_or_skip_with(Some("tsgo"), true, true),
+        None
+    );
+    assert_eq!(
+        corsa_requirement::required_or_skip_with::<()>(None, true, true),
         None
     );
 }

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -62,6 +62,32 @@ test("legacy Rust CLI gates use the fail-closed Corsa helper", () => {
   }
 });
 
+test("Nuxt Rust CLI gates use the fail-closed Corsa helper", () => {
+  const files = [
+    ["check_nuxt2_classic_plugin_bindings_cli.rs", 1],
+    ["check_nuxt2_fallback_guidance_cli.rs", 1],
+    ["check_nuxt2_plugin_injections_cli.rs", 2],
+    ["check_nuxt2_template_globals_cli.rs", 1],
+    ["check_nuxt_ambient_cli.rs", 2],
+    ["check_nuxt_bridge_shims_cli.rs", 1],
+    ["check_nuxt_composition_api_cli.rs", 2],
+    ["check_nuxt_composition_api_plugin_augmentation_cli.rs", 1],
+    ["check_nuxt_legacy_tsconfig_cli.rs", 3],
+    ["check_nuxt_monorepo_cli.rs", 2],
+    ["check_nuxt_tsconfig_paths_cli.rs", 2],
+  ] as const;
+
+  for (const [file, expectedCalls] of files) {
+    const source = readRepoFile("crates", "vize", "tests", file);
+    assert.equal(
+      source.match(/corsa_requirement::required_or_skip\(resolve_test_corsa_path\(\)\)/g)?.length,
+      expectedCalls,
+      `${file} should guard all ${expectedCalls} Corsa resolver calls`,
+    );
+    assert.doesNotMatch(source, /let Some\(corsa_path\) = resolve_test_corsa_path\(\)/);
+  }
+});
+
 test("available dependencies never skip", () => {
   assert.equal(typecheckDependencySkip("/tmp/tsgo", "tsgo", "missing", true), false);
 });


### PR DESCRIPTION
## Summary

- route the Nuxt and Nuxt 2 Rust CLI integration gates through the shared fail-closed Corsa helper
- cover all 18 resolver call sites across 11 focused Nuxt test binaries
- enforce exact per-file helper-call counts so a partially reverted file cannot stay green
- strengthen the shared behavior oracle for required, disabled, optional, and available Corsa modes

This is the second Rust CLI slice of #3750. Together with #3774, 19 of the 61 original Rust test files are migrated; 42 remain in those two slices, so this PR intentionally does not close the issue.

## Validation

- `cargo fmt --all -- --check`
- `node --test tests/tooling/typecheck-dependency-gates.test.ts` (8/8)
- `cargo test -p vize --test corsa_requirement_cli` (4/4)
- required-Corsa default-feature run across all 11 Nuxt binaries (16/16)
- required-Corsa legacy run for `check_nuxt2_template_globals_cli` (1/1)

An `--all-features` probe also reaches the newly guarded tests, but the existing `check_nuxt2_false_positive_fixture_matrix` test currently reports nine diagnostics. The same failure reproduces unchanged on `main`; this PR does not alter that fixture or its assertions.