### PR TITLE
test(editor): run VS Code host on create-vue

### DIFF
--- a/.github/actions/vscode-host-smoke/action.yml
+++ b/.github/actions/vscode-host-smoke/action.yml
@@ -24,6 +24,13 @@ runs:
         key: editor-host-smoke
         cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
 
+    - name: Hydrate pinned create-vue fixture
+      shell: bash
+      run: |
+        git submodule update --init --force --depth 1 -- tests/_fixtures/_git/create-vue
+        test "$(git rev-parse HEAD:tests/_fixtures/_git/create-vue)" = \
+          "$(git -C tests/_fixtures/_git/create-vue rev-parse HEAD)"
+
     - name: Install JS dependencies
       shell: bash
       env:

--- a/editors/vscode/test/pinned-create-vue-host-result.mjs
+++ b/editors/vscode/test/pinned-create-vue-host-result.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+const expectedResult = {
+  brokenDiagnostics: [
+    {
+      code: 2322,
+      message: "Type 'string' is not assignable to type 'number'.",
+      range: [1, 6, 1, 11],
+      severity: 0,
+      source: "vize/types",
+    },
+  ],
+  documentDirty: true,
+  extensionActive: true,
+  fixtureId: "create-vue",
+  repairedDiagnostics: [],
+  schemaVersion: 1,
+};
+
+export function readPinnedCreateVueHostResult(resultPath) {
+  assert.ok(fs.existsSync(resultPath), `packaged host did not write its result: ${resultPath}`);
+  const actual = JSON.parse(fs.readFileSync(resultPath, "utf8"));
+  assert.deepEqual(actual, expectedResult);
+  return actual;
+}

--- a/editors/vscode/test/run-extension-host-real.mjs
+++ b/editors/vscode/test/run-extension-host-real.mjs
@@ -9,11 +9,16 @@ import {
   prepareRealVueWorkspace,
   resolveRealServerPath,
 } from "../../../tools/editor-e2e/real-vue-workspace.mjs";
+import {
+  createVueTypecheckAppPath,
+  materializeCreateVueTypecheckSource,
+} from "../../../tests/_helpers/create-vue-typecheck-patch.ts";
+import { withPinnedFixtureWorkspace } from "../../../tests/_helpers/realworld-patch.ts";
 import { runPackagedExtensionHost } from "./packaged-host-contract.mjs";
+import { readPinnedCreateVueHostResult } from "./pinned-create-vue-host-result.mjs";
 
 const sourceExtensionPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const testDataPath = path.join(sourceExtensionPath, ".vscode-test", "host-smoke-real");
-const workspacePath = path.join(testDataPath, "workspaces", "real-vue");
 const extensionTestsPath = path.join(
   sourceExtensionPath,
   "test",
@@ -25,38 +30,67 @@ const vsixPath = path.join(sourceExtensionPath, "dist", "vize.vsix");
 const serverPath = resolveRealServerPath();
 
 fs.rmSync(testDataPath, { force: true, recursive: true });
-prepareRealVueWorkspace(workspacePath);
+await withPinnedFixtureWorkspace(
+  {
+    fixtureId: "create-vue",
+    includePaths: [createVueTypecheckAppPath],
+    outsideRepository: true,
+  },
+  async (fixture) => {
+    materializeCreateVueTypecheckSource(fixture);
+    prepareRealVueWorkspace(fixture.workspaceDir, { preserveExisting: true });
+    fixture.write(
+      "tsconfig.json",
+      `${JSON.stringify(
+        {
+          compilerOptions: {
+            module: "ESNext",
+            moduleResolution: "bundler",
+            noEmit: true,
+            strict: true,
+            target: "ES2022",
+          },
+          include: ["src/**/*", "template/bare/typescript/src/**/*.vue"],
+        },
+        null,
+        2,
+      )}\n`,
+    );
 
-// macOS caps AF_UNIX socket paths at 104 bytes, and VS Code creates its
-// singleton socket inside the user-data directory. Deep checkouts overflow the
-// default `.vscode-test/user-data` location, so keep user data in a short
-// temporary directory instead.
-const profilePath = fs.mkdtempSync(path.join(os.tmpdir(), "vize-host-real-"));
-const extensionsPath = path.join(profilePath, "extensions");
-const userDataPath = path.join(profilePath, "user-data");
+    // macOS caps AF_UNIX socket paths at 104 bytes, and VS Code creates its
+    // singleton socket inside the user-data directory. Deep checkouts overflow
+    // the default location, so keep user data in a short temporary directory.
+    const profilePath = fs.mkdtempSync(path.join(os.tmpdir(), "vize-host-real-"));
+    const extensionsPath = path.join(profilePath, "extensions");
+    const resultPath = path.join(profilePath, "pinned-create-vue-host-result.json");
+    const userDataPath = path.join(profilePath, "user-data");
 
-try {
-  await runPackagedExtensionHost(runVSCodeCommand, {
-    extensionId: "ubugeeei.vize",
-    extensionsPath,
-    extensionTestsPath,
-    hostEnvironment: {
-      ...process.env,
-      VIZE_TEST_PACKAGED_EXTENSIONS_DIR: extensionsPath,
-      VIZE_TEST_SERVER_PATH: serverPath,
-      VIZE_TEST_SOURCE_EXTENSION_PATH: sourceExtensionPath,
-    },
-    hostTimeoutMs: 300_000,
-    installEnvironment: process.env,
-    installTimeoutMs: 120_000,
-    onOutput: writeCommandOutput,
-    userDataPath,
-    vsixPath,
-    workspacePath,
-  });
-} finally {
-  fs.rmSync(profilePath, { force: true, recursive: true });
-}
+    try {
+      await runPackagedExtensionHost(runVSCodeCommand, {
+        extensionId: "ubugeeei.vize",
+        extensionsPath,
+        extensionTestsPath,
+        hostEnvironment: {
+          ...process.env,
+          VIZE_TEST_PACKAGED_EXTENSIONS_DIR: extensionsPath,
+          VIZE_TEST_PINNED_CREATE_VUE_RESULT_PATH: resultPath,
+          VIZE_TEST_SERVER_PATH: serverPath,
+          VIZE_TEST_SOURCE_EXTENSION_PATH: sourceExtensionPath,
+        },
+        hostTimeoutMs: 300_000,
+        installEnvironment: process.env,
+        installTimeoutMs: 120_000,
+        onOutput: writeCommandOutput,
+        userDataPath,
+        vsixPath,
+        workspacePath: fixture.workspaceDir,
+      });
+      readPinnedCreateVueHostResult(resultPath);
+    } finally {
+      fs.rmSync(profilePath, { force: true, recursive: true });
+    }
+  },
+);
 
 function writeCommandOutput({ stderr, stdout }) {
   if (stdout) process.stdout.write(stdout);

--- a/editors/vscode/test/suite/extension-host-real.cjs
+++ b/editors/vscode/test/suite/extension-host-real.cjs
@@ -1,10 +1,12 @@
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
 const vscode = require("vscode");
 
 const { runRealServerScenario } = require("./real-scenario.cjs");
 const {
   assertPackagedExtension,
   assertStaysDiagnosticFree,
+  describeDiagnostic,
   getRealServer,
   openWorkspaceDocument,
   positionAfter,
@@ -67,6 +69,7 @@ exports.run = async function run() {
   await runRealCompletionSmoke(mismatchDocument);
   await runRealHoverSmoke(mismatchDocument);
   await runRealDidChangeRepairSmoke(mismatchDocument, extension);
+  await runPinnedCreateVuePatchOracle(extension);
 
   await runRealServerScenario();
 
@@ -175,4 +178,79 @@ async function runRealDidChangeRepairSmoke(mismatchDocument, extension) {
   // still dirty (never saved) and the same extension host instance is active.
   assert.equal(mismatchDocument.isDirty, true);
   assert.equal(extension.isActive, true);
+}
+
+async function runPinnedCreateVuePatchOracle(extension) {
+  const document = await openWorkspaceDocument("template", "bare", "typescript", "src", "App.vue");
+  await vscode.window.showTextDocument(document);
+  await assertStaysDiagnosticFree(document.uri, "clean pinned create-vue SFC");
+
+  const cleanSource = document.getText();
+  const cleanCount = "const count: number = 1";
+  const brokenCount = "const count: number = 'broken'";
+  const repairedCount = "const count: number = 2";
+  const editor = await vscode.window.showTextDocument(document);
+  const broke = await editor.edit((editBuilder) => {
+    editBuilder.replace(rangeForExactText(document, cleanCount), brokenCount);
+  });
+  assert.equal(broke, true, "expected the pinned create-vue break edit to apply");
+
+  const brokenDiagnostics = await waitForDiagnostics(
+    document.uri,
+    (diagnostics) => diagnostics.length > 0,
+    "pinned create-vue broken type diagnostic",
+    60_000,
+  );
+  assert.deepEqual(brokenDiagnostics.map(describeDiagnostic), [
+    {
+      code: 2322,
+      message: "Type 'string' is not assignable to type 'number'.",
+      range: [1, 6, 1, 11],
+      relatedInformation: undefined,
+      severity: vscode.DiagnosticSeverity.Error,
+      source: "vize/types",
+      tags: undefined,
+    },
+  ]);
+
+  const repaired = await editor.edit((editBuilder) => {
+    editBuilder.replace(rangeForExactText(document, brokenCount), repairedCount);
+  });
+  assert.equal(repaired, true, "expected the pinned create-vue repair edit to apply");
+  const repairedDiagnostics = await waitForDiagnostics(
+    document.uri,
+    (diagnostics) => diagnostics.length === 0,
+    "pinned create-vue repair clearing the type diagnostic",
+    60_000,
+  );
+  assert.deepEqual(repairedDiagnostics, []);
+  assert.equal(document.getText(), cleanSource.replace(cleanCount, repairedCount));
+  assert.equal(document.isDirty, true);
+  assert.equal(extension.isActive, true);
+
+  const resultPath = process.env.VIZE_TEST_PINNED_CREATE_VUE_RESULT_PATH;
+  assert.ok(resultPath, "missing pinned create-vue host result path");
+  fs.writeFileSync(
+    resultPath,
+    `${JSON.stringify({
+      brokenDiagnostics: brokenDiagnostics.map(describeDiagnostic),
+      documentDirty: document.isDirty,
+      extensionActive: extension.isActive,
+      fixtureId: "create-vue",
+      repairedDiagnostics: repairedDiagnostics.map(describeDiagnostic),
+      schemaVersion: 1,
+    })}\n`,
+  );
+}
+
+function rangeForExactText(document, needle) {
+  const source = document.getText();
+  const start = source.indexOf(needle);
+  assert.notEqual(start, -1, `fixture must contain ${JSON.stringify(needle)}`);
+  assert.equal(
+    source.indexOf(needle, start + needle.length),
+    -1,
+    `fixture anchor must be unique: ${JSON.stringify(needle)}`,
+  );
+  return new vscode.Range(document.positionAt(start), document.positionAt(start + needle.length));
 }

--- a/tests/_helpers/create-vue-typecheck-patch.ts
+++ b/tests/_helpers/create-vue-typecheck-patch.ts
@@ -1,0 +1,20 @@
+import type { PinnedFixtureWorkspace } from "./realworld-patch.ts";
+
+export const createVueTypecheckAppPath = "template/bare/typescript/src/App.vue";
+export const createVueCleanCount = "const count: number = 1";
+export const createVueBrokenCount = "const count: number = 'broken'";
+export const createVueRepairedCount = "const count: number = 2";
+
+/** Materialize the clean side shared by check, LSP, and packaged-editor oracles. */
+export function materializeCreateVueTypecheckSource(fixture: PinnedFixtureWorkspace): string {
+  fixture.applyExactPatch(
+    createVueTypecheckAppPath,
+    '<script setup lang="ts"></script>',
+    `<script setup lang="ts">\n${createVueCleanCount}\nconst label = 'ready'\n</script>`,
+  );
+  return fixture.applyExactPatch(
+    createVueTypecheckAppPath,
+    "  <h1>You did it!</h1>",
+    "  <h1>{{ label }}</h1>\n  <p>{{ count }}</p>",
+  );
+}

--- a/tests/snapshots/check/create-vue-patch-oracle.ts
+++ b/tests/snapshots/check/create-vue-patch-oracle.ts
@@ -7,6 +7,13 @@ import { test } from "node:test";
 import { pathToFileURL } from "node:url";
 import { assertParsesAsModule } from "../../_helpers/assertions.ts";
 import {
+  createVueBrokenCount,
+  createVueCleanCount,
+  createVueRepairedCount,
+  createVueTypecheckAppPath,
+  materializeCreateVueTypecheckSource,
+} from "../../_helpers/create-vue-typecheck-patch.ts";
+import {
   repoRoot,
   symlinkDirectory,
   withPinnedFixtureWorkspace,
@@ -20,7 +27,7 @@ import {
 import type { PublishDiagnosticsParams } from "../../tooling/support/lsp/protocol.ts";
 import { LspSession } from "../../tooling/support/lsp/session.ts";
 
-const appPath = "template/bare/typescript/src/App.vue";
+const appPath = createVueTypecheckAppPath;
 const sourceSha256 = "bdafe70baf73a040d432b574108ce0e11823a3c1c1cc8bdfe01d118d6ff7d35a";
 const compiledCodeSha256 = "1216a548943fe8a09ab349a913c627d4115f93935b75ec89922415511475eff7";
 const formattedSourceSha256 = "c76449690404ce5538a17786fa17b812ceab69fe947dc5f29b408fc9354b4b53";
@@ -311,16 +318,7 @@ test("create-vue clean, broken, and repaired patches agree across check and LSP"
         )}\n`,
       );
 
-      fixture.applyExactPatch(
-        appPath,
-        '<script setup lang="ts"></script>',
-        `<script setup lang="ts">\nconst count: number = 1\nconst label = 'ready'\n</script>`,
-      );
-      const cleanSource = fixture.applyExactPatch(
-        appPath,
-        "  <h1>You did it!</h1>",
-        "  <h1>{{ label }}</h1>\n  <p>{{ count }}</p>",
-      );
+      const cleanSource = materializeCreateVueTypecheckSource(fixture);
       const appFile = fixture.resolve(appPath);
       const appUri = pathToFileURL(appFile).href;
 
@@ -368,8 +366,8 @@ test("create-vue clean, broken, and repaired patches agree across check and LSP"
 
         const brokenSource = fixture.applyExactPatch(
           appPath,
-          "const count: number = 1",
-          "const count: number = 'broken'",
+          createVueCleanCount,
+          createVueBrokenCount,
         );
         session.notify("textDocument/didChange", {
           textDocument: { uri: appUri, version: 2 },
@@ -405,8 +403,8 @@ test("create-vue clean, broken, and repaired patches agree across check and LSP"
 
         const repairedSource = fixture.applyExactPatch(
           appPath,
-          "const count: number = 'broken'",
-          "const count: number = 2",
+          createVueBrokenCount,
+          createVueRepairedCount,
         );
         session.notify("textDocument/didChange", {
           textDocument: { uri: appUri, version: 3 },

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -53,6 +53,22 @@ test("CI runs both real-server editor scenarios from one built server binary", (
   assert.match(action, /sha256sum --check --strict/);
 });
 
+test("CI hydrates the exact pinned create-vue revision before the packaged host", () => {
+  const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
+  const hydrateAt = action.indexOf("- name: Hydrate pinned create-vue fixture");
+  const hostAt = action.indexOf("- name: Run VS Code host smoke against the real server");
+
+  assert.ok(hydrateAt >= 0, "editor host CI must hydrate create-vue");
+  assert.ok(hostAt > hydrateAt, "create-vue must be pinned before the host starts");
+  const hydration = action.slice(hydrateAt, hostAt);
+  assert.match(
+    hydration,
+    /git submodule update --init --force --depth 1 -- tests\/_fixtures\/_git\/create-vue/,
+  );
+  assert.match(hydration, /git rev-parse HEAD:tests\/_fixtures\/_git\/create-vue/);
+  assert.match(hydration, /git -C tests\/_fixtures\/_git\/create-vue rev-parse HEAD/);
+});
+
 test("CI runs both headless editor specs", () => {
   const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
 

--- a/tests/tooling/vscode-packaged-host-smoke.test.ts
+++ b/tests/tooling/vscode-packaged-host-smoke.test.ts
@@ -11,6 +11,8 @@ import {
   runPackagedExtensionHost,
   runVSCodeCommandWithTimeout,
 } from "../../editors/vscode/test/packaged-host-contract.mjs";
+import { readPinnedCreateVueHostResult } from "../../editors/vscode/test/pinned-create-vue-host-result.mjs";
+import { prepareRealVueWorkspace } from "../../tools/editor-e2e/real-vue-workspace.mjs";
 import { testAndBenchmarkTasks } from "../../tools/vite-plus/tasks/test-benchmark.ts";
 import { readRepoFile, root } from "./support/github-workflows.ts";
 
@@ -75,6 +77,25 @@ test("the real-server fixture workspace turns off the built-in AI code actions",
   );
 
   assert.deepEqual(settings, { "chat.disableAIFeatures": true, "vize.enable": false });
+});
+
+test("the real-server fixture can preserve a pinned oracle while adding its harness", () => {
+  const workspacePath = fs.mkdtempSync(path.join(os.tmpdir(), "vize-preserved-oracle-"));
+  const pinnedPath = path.join(workspacePath, "pinned", "App.vue");
+  fs.mkdirSync(path.dirname(pinnedPath), { recursive: true });
+  fs.writeFileSync(pinnedPath, "<template>pinned</template>\n");
+
+  try {
+    prepareRealVueWorkspace(workspacePath, { preserveExisting: true });
+
+    assert.equal(fs.readFileSync(pinnedPath, "utf8"), "<template>pinned</template>\n");
+    assert.ok(fs.existsSync(path.join(workspacePath, "src", "App.vue")));
+    assert.ok(fs.existsSync(path.join(workspacePath, ".vscode", "settings.json")));
+    assert.ok(fs.existsSync(path.join(workspacePath, "vize.config.json")));
+    assert.ok(fs.lstatSync(path.join(workspacePath, "node_modules", "vue")).isSymbolicLink());
+  } finally {
+    fs.rmSync(workspacePath, { force: true, recursive: true });
+  }
 });
 
 test("packaged host resolves exactly one installed Vize extension", () => {
@@ -218,6 +239,55 @@ test("real host runner refuses to launch without a packaged VSIX", async () => {
     assert.equal(launched, false);
   } finally {
     fs.rmSync(profilePath, { force: true, recursive: true });
+  }
+});
+
+test("packaged host result proves the pinned create-vue diagnostic transition", () => {
+  const resultDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "vize-create-vue-host-result-"));
+  const resultPath = path.join(resultDirectory, "result.json");
+  const passingResult = {
+    brokenDiagnostics: [
+      {
+        code: 2322,
+        message: "Type 'string' is not assignable to type 'number'.",
+        range: [1, 6, 1, 11],
+        severity: 0,
+        source: "vize/types",
+      },
+    ],
+    documentDirty: true,
+    extensionActive: true,
+    fixtureId: "create-vue",
+    repairedDiagnostics: [],
+    schemaVersion: 1,
+  };
+
+  try {
+    fs.writeFileSync(resultPath, JSON.stringify(passingResult));
+    assert.deepEqual(readPinnedCreateVueHostResult(resultPath), passingResult);
+
+    fs.writeFileSync(
+      resultPath,
+      JSON.stringify({ ...passingResult, documentDirty: false, extensionActive: false }),
+    );
+    assert.throws(
+      () => readPinnedCreateVueHostResult(resultPath),
+      /Expected values to be strictly/,
+    );
+
+    fs.writeFileSync(
+      resultPath,
+      JSON.stringify({
+        ...passingResult,
+        brokenDiagnostics: [{ ...passingResult.brokenDiagnostics[0], range: [1, 7, 1, 12] }],
+      }),
+    );
+    assert.throws(
+      () => readPinnedCreateVueHostResult(resultPath),
+      /Expected values to be strictly/,
+    );
+  } finally {
+    fs.rmSync(resultDirectory, { force: true, recursive: true });
   }
 });
 

--- a/tools/editor-e2e/real-vue-workspace.mjs
+++ b/tools/editor-e2e/real-vue-workspace.mjs
@@ -27,10 +27,17 @@ export const realVueFixturePath = path.join(
  * Materialize the `real-vue` fixture at `workspacePath` and wire it up for the
  * real server. Returns the workspace path so callers can chain.
  */
-export function prepareRealVueWorkspace(workspacePath) {
-  fs.rmSync(workspacePath, { force: true, recursive: true });
+export function prepareRealVueWorkspace(workspacePath, { preserveExisting = false } = {}) {
+  if (!preserveExisting) {
+    fs.rmSync(workspacePath, { force: true, recursive: true });
+  }
   fs.mkdirSync(path.dirname(workspacePath), { recursive: true });
-  fs.cpSync(realVueFixturePath, workspacePath, { recursive: true });
+  fs.mkdirSync(workspacePath, { recursive: true });
+  for (const entry of fs.readdirSync(realVueFixturePath)) {
+    fs.cpSync(path.join(realVueFixturePath, entry), path.join(workspacePath, entry), {
+      recursive: true,
+    });
+  }
   fs.mkdirSync(path.join(workspacePath, "node_modules"), { recursive: true });
   fs.symlinkSync(
     resolveVuePackagePath(),


### PR DESCRIPTION
## Summary
- materialize the pinned create-vue App.vue patch oracle in the packaged VS Code host workspace
- assert the complete TS2322 diagnostic for an unsaved break, then prove repair clears it in the same extension session
- preserve the existing synthetic real-server scorecard and guard the shared workspace wiring with runtime and static tests

## Validation
- create-vue compiler/lint/format/check/LSP oracle: 4/4
- editor/tooling/source-length tests after rebase: 28/28
- packaged VSIX validation and isolated install: passed
- stable VS Code 1.131.0 extension host: exit 0
- scoped vp check: clean

Closes #3743

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded VS Code integration coverage for Vue projects and TypeScript diagnostics.
  * Verified that invalid code produces actionable diagnostics, while corrections clear them as expected.
  * Confirmed diagnostics update correctly while unsaved documents remain open and the extension stays active.
  * Added packaged-host checks for realistic Vue workspaces, configuration, fixture files, and workspace preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->