### PR TITLE
test(cli): fail closed for Canon Corsa gates

### DIFF
--- a/crates/vize/tests/check_canon_boolean_tsx_regressions_cli.rs
+++ b/crates/vize/tests/check_canon_boolean_tsx_regressions_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -146,7 +149,7 @@ fn run_check_json(project_root: &Path, corsa_path: &Path, target: &str) {
 
 #[test]
 fn check_type_based_boolean_props_are_normalized_in_setup() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case(
@@ -175,7 +178,7 @@ useFlag(() => props.modal)
 
 #[test]
 fn check_tsx_setup_refs_are_unwrapped_in_templates() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case(

--- a/crates/vize/tests/check_canon_component_derived_props_cli.rs
+++ b/crates/vize/tests/check_canon_component_derived_props_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -152,7 +155,7 @@ fn run_check_json(project_root: &Path, corsa_path: &Path) {
 
 #[test]
 fn check_component_derived_reserved_prop_shorthand_in_template_scope() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case(

--- a/crates/vize/tests/check_canon_generic_inference_cli.rs
+++ b/crates/vize/tests/check_canon_generic_inference_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -146,7 +149,7 @@ fn run_check_json(project_root: &Path, corsa_path: &Path) {
 
 #[test]
 fn check_generic_sfc_infers_type_from_template_props() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case(
@@ -181,7 +184,7 @@ import Child from "./Child.vue"
 
 #[test]
 fn check_generic_child_infers_model_type_from_v_model() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case(
@@ -220,7 +223,7 @@ const modelValue = shallowRef<T | null>(null)
 
 #[test]
 fn check_generic_model_type_infers_from_value_key_prop() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case(

--- a/crates/vize/tests/check_canon_generic_props_cli.rs
+++ b/crates/vize/tests/check_canon_generic_props_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -140,7 +143,7 @@ fn run_check_json(project_root: &Path, corsa_path: &Path) {
 }
 
 fn run_generic_props_case(name: &str, files: &[(&str, &str)]) {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         skip_case(name, "tsgo not found");
         return;
     };

--- a/crates/vize/tests/check_canon_generic_sfc_mount_cli.rs
+++ b/crates/vize/tests/check_canon_generic_sfc_mount_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -148,7 +151,7 @@ fn run_check_json(project_root: &Path, corsa_path: &Path, target: &str) {
 
 #[test]
 fn check_generic_sfc_props_infer_from_typescript_mount_options() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case_with_files(

--- a/crates/vize/tests/check_canon_graphql_cli.rs
+++ b/crates/vize/tests/check_canon_graphql_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -121,7 +124,7 @@ fn run_check_json(project_root: &Path, corsa_path: &Path) -> String {
 
 #[test]
 fn check_explicit_vue_keeps_generated_graphql_schema_out_of_canon() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project = temp_case_dir("dedupe");
@@ -225,7 +228,7 @@ void childComponents
 /// positives vue-tsc does not raise.
 #[test]
 fn check_barrel_reexport_preserves_generated_graphql_identity() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project = temp_case_dir("barrel");

--- a/crates/vize/tests/check_canon_recent_issues_cli.rs
+++ b/crates/vize/tests/check_canon_recent_issues_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -143,7 +146,7 @@ fn run_check_json(project_root: &Path, corsa_path: &Path, target: &str) -> Strin
 
 #[test]
 fn check_with_defaults_preserves_loose_required_props() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case(
@@ -185,7 +188,7 @@ readModelValue({ props })
 
 #[test]
 fn check_with_defaults_undefined_default_preserves_optional_prop_value() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case(
@@ -228,7 +231,7 @@ useModel({
 
 #[test]
 fn check_v_for_infers_items_from_union_of_arrays() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case(
@@ -263,7 +266,7 @@ const items = computed<ItemA[] | ItemB[]>(() => (
 
 #[test]
 fn check_define_props_return_assignable_to_record_helpers() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case(
@@ -295,7 +298,7 @@ forwardProps(props)
 
 #[test]
 fn check_extended_interface_props_are_available_in_template_scope() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case(

--- a/crates/vize/tests/check_canon_recent_type_regressions_cli.rs
+++ b/crates/vize/tests/check_canon_recent_type_regressions_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -149,7 +152,7 @@ fn run_check_json(project_root: &Path, corsa_path: &Path, target: &str) -> Strin
 
 #[test]
 fn check_imported_base_interface_props_are_available_in_template_scope() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case_with_files(
@@ -179,7 +182,7 @@ const props = withDefaults(defineProps<FooProps>(), { orientation: "horizontal" 
 
 #[test]
 fn check_contextmenu_accepts_pointer_event_handler() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case_with_files(
@@ -201,7 +204,7 @@ async function onPointer(event: PointerEvent) { event.preventDefault(); }
 
 #[test]
 fn check_generic_sfc_value_can_be_specialized_from_typescript() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case_with_files(
@@ -229,7 +232,7 @@ defineProps<{ modelValue?: T }>();
 
 #[test]
 fn check_exposed_template_ref_is_unwrapped_on_component_instance() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case_with_files(
@@ -276,7 +279,7 @@ const child = useTemplateRef<InstanceType<typeof Child>>("child");
 
 #[test]
 fn check_with_defaults_generic_props_do_not_gain_boolean_intersections() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case_with_files(
@@ -312,7 +315,7 @@ getKey(props.value);
 
 #[test]
 fn check_generic_define_props_preserves_local_boolean_keys() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_case_with_files(

--- a/crates/vize/tests/check_canon_remapped_key_cli.rs
+++ b/crates/vize/tests/check_canon_remapped_key_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -34,7 +37,7 @@ fn resolve_test_corsa_path() -> Option<PathBuf> {
 
 #[test]
 fn check_remapped_key_indexed_assignment_matches_typescript() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("indexed-assignment");

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -88,6 +88,30 @@ test("Nuxt Rust CLI gates use the fail-closed Corsa helper", () => {
   }
 });
 
+test("Canon Rust CLI gates use the fail-closed Corsa helper", () => {
+  const files = [
+    ["check_canon_boolean_tsx_regressions_cli.rs", 2],
+    ["check_canon_component_derived_props_cli.rs", 1],
+    ["check_canon_generic_inference_cli.rs", 3],
+    ["check_canon_generic_props_cli.rs", 1],
+    ["check_canon_generic_sfc_mount_cli.rs", 1],
+    ["check_canon_graphql_cli.rs", 2],
+    ["check_canon_recent_issues_cli.rs", 5],
+    ["check_canon_recent_type_regressions_cli.rs", 6],
+    ["check_canon_remapped_key_cli.rs", 1],
+  ] as const;
+
+  for (const [file, expectedCalls] of files) {
+    const source = readRepoFile("crates", "vize", "tests", file);
+    assert.equal(
+      source.match(/corsa_requirement::required_or_skip\(resolve_test_corsa_path\(\)\)/g)?.length,
+      expectedCalls,
+      `${file} should guard all ${expectedCalls} Corsa resolver calls`,
+    );
+    assert.doesNotMatch(source, /let Some\(corsa_path\) = resolve_test_corsa_path\(\)/);
+  }
+});
+
 test("available dependencies never skip", () => {
   assert.equal(typecheckDependencySkip("/tmp/tsgo", "tsgo", "missing", true), false);
 });


### PR DESCRIPTION
## Summary

- route the Canon-focused Rust CLI integration gates through the shared fail-closed Corsa helper
- cover all 22 resolver call sites across nine focused Canon test binaries
- enforce exact per-file helper-call counts so partial reversions cannot stay green

This is the third Rust CLI slice of #3750. The three slices migrate 28 of the 61 original exact-pattern Rust test files; the issue remains open for the remaining families and the two additional non-identical silent-return gates found by the broader audit.

## Validation

- `cargo fmt --all -- --check`
- `node --test tests/tooling/typecheck-dependency-gates.test.ts` (9/9)
- required-Corsa run across all nine Canon binaries (25/25)
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->