### PR TITLE
fix(patina): condense short help output

### DIFF
--- a/crates/vize_patina/src/diagnostic.rs
+++ b/crates/vize_patina/src/diagnostic.rs
@@ -5,6 +5,7 @@
 //! - [`types`]: Core diagnostic data structures
 //! - [`formatting`]: Markdown rendering and help text formatting
 
+mod compact_help;
 pub mod formatting;
 mod types;
 
@@ -13,7 +14,7 @@ pub use types::{Fix, HelpLevel, LintDiagnostic, LintSummary, Severity, TextEdit}
 
 #[cfg(test)]
 mod tests {
-    use super::{HelpLevel, HelpRenderTarget, formatting, render_help};
+    use super::{HelpLevel, HelpRenderTarget, compact_help, formatting, render_help};
     use vize_carton::ToCompactString;
 
     #[test]
@@ -63,9 +64,51 @@ mod tests {
     }
 
     #[test]
-    fn test_strip_markdown_first_line_with_backticks() {
-        let result = formatting::strip_markdown_first_line("Use `v-model` instead of `{{ }}`");
+    fn test_compact_help_text_with_backticks() {
+        let result = compact_help::compact_help_text("Use `v-model` instead of `{{ }}`");
         assert_eq!(result, "Use v-model instead of {{ }}");
+    }
+
+    #[test]
+    fn test_compact_help_text_removes_examples_in_all_locales() {
+        assert_eq!(
+            compact_help::compact_help_text(
+                "Use a method (e.g. @click=\"handler\") or a function (e.g. @click=\"() => run()\").",
+            ),
+            "Use a method or a function."
+        );
+        assert_eq!(
+            compact_help::compact_help_text(
+                "メソッド参照（例: @click=\"handler\"）または関数（例: @click=\"() => run()\"）を使用してください。",
+            ),
+            "メソッド参照または関数を使用してください。"
+        );
+        assert_eq!(
+            compact_help::compact_help_text(
+                "请使用方法引用（例如 @click=\"handler\"）或函数（例如 @click=\"() => run()\"）。",
+            ),
+            "请使用方法引用或函数。"
+        );
+    }
+
+    #[test]
+    fn test_compact_help_text_keeps_only_the_action_sentence() {
+        assert_eq!(
+            compact_help::compact_help_text(
+                "Apply the safe rewrite. Reason: the longer explanation belongs to full help.",
+            ),
+            "Apply the safe rewrite."
+        );
+        assert_eq!(
+            compact_help::compact_help_text(
+                "安全な修正を適用してください。理由：詳細はfullヘルプにあります。"
+            ),
+            "安全な修正を適用してください。"
+        );
+        assert_eq!(
+            compact_help::compact_help_text("Call storeToRefs(store) before destructuring."),
+            "Call storeToRefs(store) before destructuring."
+        );
     }
 
     #[test]

--- a/crates/vize_patina/src/diagnostic/compact_help.rs
+++ b/crates/vize_patina/src/diagnostic/compact_help.rs
@@ -1,0 +1,138 @@
+//! Compact remediation text for terminal and CI output.
+
+use vize_carton::{String, ToCompactString};
+
+/// Return one actionable help sentence without markdown or inline examples.
+pub(super) fn compact_help_text(text: &str) -> String {
+    let mut in_code_block = false;
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_code_block = !in_code_block;
+            continue;
+        }
+        if in_code_block || trimmed.is_empty() {
+            continue;
+        }
+
+        let stripped = trimmed.replace("**", "").replace("__", "").replace('`', "");
+        let stripped = stripped.trim_start_matches('#').trim();
+        if !stripped.is_empty() {
+            return compact_plain_help_line(stripped);
+        }
+    }
+    text.lines().next().unwrap_or(text).to_compact_string()
+}
+
+fn compact_plain_help_line(line: &str) -> String {
+    let without_examples = remove_example_asides(line);
+    let without_reason = truncate_before_reason(&without_examples);
+    let sentence = first_sentence(without_reason.trim());
+    let mut compact = sentence.split_whitespace().collect::<Vec<_>>().join(" ");
+    for (spaced, punctuation) in [
+        (" .", "."),
+        (" ,", ","),
+        (" ;", ";"),
+        (" !", "!"),
+        (" ?", "?"),
+        (" 。", "。"),
+        (" ，", "，"),
+        (" ！", "！"),
+        (" ？", "？"),
+    ] {
+        compact = compact.replace(spaced, punctuation);
+    }
+    compact.into()
+}
+
+fn remove_example_asides(line: &str) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    let mut output = String::with_capacity(line.len());
+    let mut index = 0;
+
+    while index < chars.len() {
+        let Some(close) = matching_parenthesis(chars[index]) else {
+            output.push(chars[index]);
+            index += 1;
+            continue;
+        };
+        let Some(end) = find_matching_parenthesis(&chars, index, chars[index], close) else {
+            output.push(chars[index]);
+            index += 1;
+            continue;
+        };
+        let content: String = chars[index + 1..end].iter().collect();
+        if is_example_aside(content.trim()) {
+            index = end + 1;
+            continue;
+        }
+
+        output.extend(chars[index..=end].iter());
+        index = end + 1;
+    }
+
+    output
+}
+
+fn matching_parenthesis(open: char) -> Option<char> {
+    match open {
+        '(' => Some(')'),
+        '（' => Some('）'),
+        _ => None,
+    }
+}
+
+fn find_matching_parenthesis(
+    chars: &[char],
+    start: usize,
+    open: char,
+    close: char,
+) -> Option<usize> {
+    let mut depth = 0;
+    for (index, &character) in chars.iter().enumerate().skip(start) {
+        if character == open {
+            depth += 1;
+        } else if character == close {
+            depth -= 1;
+            if depth == 0 {
+                return Some(index);
+            }
+        }
+    }
+    None
+}
+
+fn is_example_aside(content: &str) -> bool {
+    let lower = content.to_ascii_lowercase();
+    lower.starts_with("e.g.")
+        || lower.starts_with("eg.")
+        || lower.starts_with("for example")
+        || content.starts_with("例:")
+        || content.starts_with("例：")
+        || content.starts_with("例えば")
+        || content.starts_with("例如")
+}
+
+fn truncate_before_reason(line: &str) -> &str {
+    [" Reason:", " 理由:", " 理由：", " 原因:", " 原因："]
+        .iter()
+        .filter_map(|marker| line.find(marker))
+        .min()
+        .map_or(line, |index| &line[..index])
+}
+
+fn first_sentence(line: &str) -> &str {
+    let ascii_end = line.find(". ").map(|index| index + 1);
+    let localized_end = ['。', '！', '？']
+        .iter()
+        .filter_map(|punctuation| {
+            line.find(*punctuation)
+                .map(|index| index + punctuation.len_utf8())
+        })
+        .min();
+    ascii_end
+        .into_iter()
+        .chain(localized_end)
+        .min()
+        .map_or(line, |end| &line[..end])
+}

--- a/crates/vize_patina/src/diagnostic/formatting.rs
+++ b/crates/vize_patina/src/diagnostic/formatting.rs
@@ -41,36 +41,6 @@ pub fn render_help(markdown: &str, target: HelpRenderTarget) -> String {
     }
 }
 
-/// Strip markdown formatting and return the first meaningful line.
-pub(crate) fn strip_markdown_first_line(text: &str) -> String {
-    let mut in_code_block = false;
-    for line in text.lines() {
-        let trimmed = line.trim();
-        // Track code fence blocks
-        if trimmed.starts_with("```") {
-            in_code_block = !in_code_block;
-            continue;
-        }
-        // Skip lines inside code blocks
-        if in_code_block {
-            continue;
-        }
-        // Skip empty lines
-        if trimmed.is_empty() {
-            continue;
-        }
-        // Strip markdown bold/italic
-        let stripped = trimmed.replace("**", "").replace("__", "").replace('`', "");
-        // Skip lines that are just markdown headers
-        let stripped = stripped.trim_start_matches('#').trim();
-        if stripped.is_empty() {
-            continue;
-        }
-        return stripped.to_compact_string();
-    }
-    text.lines().next().unwrap_or(text).to_compact_string()
-}
-
 /// Convert markdown text to ANSI-formatted text for TUI display.
 ///
 /// Supports:

--- a/crates/vize_patina/src/diagnostic/types.rs
+++ b/crates/vize_patina/src/diagnostic/types.rs
@@ -32,7 +32,7 @@ pub enum Severity {
 pub enum HelpLevel {
     /// No help text.
     None,
-    /// Short help text (first line only, markdown stripped).
+    /// Short help text (first actionable sentence, markdown and examples stripped).
     Short,
     /// Full help text with markdown formatting.
     #[default]
@@ -44,7 +44,7 @@ impl HelpLevel {
     pub fn process(&self, help: &str) -> Option<String> {
         match self {
             HelpLevel::None => None,
-            HelpLevel::Short => Some(super::formatting::strip_markdown_first_line(help)),
+            HelpLevel::Short => Some(super::compact_help::compact_help_text(help)),
             HelpLevel::Full => Some(help.to_compact_string()),
         }
     }

--- a/crates/vize_patina/src/rules/opinionated/vue/v_on_handler_style.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/v_on_handler_style.rs
@@ -142,6 +142,7 @@ mod tests {
     use super::VOnHandlerStyle;
     use crate::linter::Linter;
     use crate::rule::RuleRegistry;
+    use crate::{HelpLevel, Locale};
 
     fn create_linter() -> Linter {
         let mut registry = RuleRegistry::new();
@@ -194,6 +195,31 @@ mod tests {
         let result = linter.lint_template(r#"<button @click="count++"></button>"#, "App.vue");
         assert_eq!(result.warning_count, 1);
         insta::assert_debug_snapshot!(result.diagnostics);
+    }
+
+    #[test]
+    fn short_help_is_distinct_and_actionable_in_every_locale() {
+        for (locale, expected) in [
+            (
+                Locale::En,
+                "Write the handler as a method reference or an inline function instead of an inline statement.",
+            ),
+            (
+                Locale::Ja,
+                "ハンドラをインライン文ではなく、メソッド参照またはインライン関数として記述してください。",
+            ),
+            (
+                Locale::Zh,
+                "请将处理函数写成方法引用或内联函数，而不是内联语句。",
+            ),
+        ] {
+            let result = create_linter()
+                .with_locale(locale)
+                .with_help_level(HelpLevel::Short)
+                .lint_template(r#"<button @click="count++"></button>"#, "App.vue");
+
+            assert_eq!(result.diagnostics[0].help.as_deref(), Some(expected));
+        }
     }
 
     #[test]

--- a/npm/oxint/README.md
+++ b/npm/oxint/README.md
@@ -169,7 +169,7 @@ You can pass Patina settings through `settings.vize`:
 - `"ecosystem"` enables Vize's Vue Router, Vue I18n, Pinia, Vue Test Utils, Nuxt, and Void Vue rules without taking on the full opinionated preset.
 - `"opinionated"` is the preset that enables Vize's built-in script rules such as `vize/script/no-options-api`.
 - Legacy aliases such as `"GeneralRecommended"`, `"Essential"`, `"Ecosystem"`, `"Incremental"`, `"Opinionated"`, `"Nuxt"`, and `"happy-path"` are still accepted for compatibility.
-- `helpLevel` accepts `"full"`, `"short"`, or `"none"`.
+- `helpLevel` accepts `"full"`, `"short"`, or `"none"`. Short help keeps one actionable sentence and removes inline examples and trailing rationale.
 - `helpLevel: "full"` only expands the Patina remediation text. It does not restore original-SFC formatter anchors or machine-readable range fidelity.
 - `typeAware: true` enables Corsa-backed `vize/type/*` rules during shared Patina passes.
 - `corsaPath` selects the Corsa or `tsgo` executable for type-aware linting. Omit it to use Vize's normal resolver.


### PR DESCRIPTION
## Summary
- make short help keep the first actionable sentence instead of merely the first line
- remove inline example asides in English, Japanese, and Chinese while preserving non-example call syntax
- document the compact help contract and pin real v-on handler output in all three locales

## Validation
- cargo test -p vize_patina --lib: 2457/2457
- cargo clippy -p vize_patina --lib -- -D warnings: passed
- cargo fmt --check: passed
- source-file-length tests: 7/7
- rebuilt native binding: short and full v-on help differ exactly in en/ja/zh

Closes #3770

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->