### PR TITLE
fix(oxint): widen Vite+ lint config types

### DIFF
--- a/npm/oxint/src/configs.ts
+++ b/npm/oxint/src/configs.ts
@@ -1,8 +1,9 @@
 import { getPatinaRules } from "./binding.js";
 import type { PatinaPreset, PatinaRuleMeta } from "./model.js";
 
-export type OxlintRuleSeverity = "error" | "warn";
-export type OxlintRuleConfig = Record<string, OxlintRuleSeverity>;
+export type OxlintRuleSeverity = "error" | "warn" | "off";
+export type OxlintRuleEntry = OxlintRuleSeverity | [OxlintRuleSeverity, ...unknown[]];
+export type OxlintRuleConfig = Record<string, OxlintRuleEntry>;
 export type VizeRuleConfigPreset = Exclude<PatinaPreset, "incremental"> | "all";
 
 export interface VizeRuleConfigOptions {

--- a/npm/oxint/src/index.ts
+++ b/npm/oxint/src/index.ts
@@ -1,5 +1,15 @@
 export { default } from "./plugin.js";
 export { configs, createVizeRuleConfig } from "./configs.js";
-export type { OxlintRuleConfig, OxlintRuleSeverity, VizeRuleConfigOptions } from "./configs.js";
+export type {
+  OxlintRuleConfig,
+  OxlintRuleEntry,
+  OxlintRuleSeverity,
+  VizeRuleConfigOptions,
+} from "./configs.js";
 export { createVizeLintConfig, VIZE_JS_PLUGIN_SPECIFIER } from "./vite-plus.js";
-export type { VizeLintConfig, VizeLintConfigOptions, VizeLintPreset } from "./vite-plus.js";
+export type {
+  VitePlusLintPlugin,
+  VizeLintConfig,
+  VizeLintConfigOptions,
+  VizeLintPreset,
+} from "./vite-plus.js";

--- a/npm/oxint/src/test-support/vite-plus-workspace.ts
+++ b/npm/oxint/src/test-support/vite-plus-workspace.ts
@@ -59,6 +59,65 @@ export async function createVizeLintConfigFromDist(): Promise<
   return bundle.createVizeLintConfig;
 }
 
+/**
+ * Type-checks a strict Vite+ consumer against the packed declarations.
+ *
+ * Source-level checks miss declaration bundling mistakes and can accidentally
+ * rely on workspace-only resolution. This project imports the package through
+ * its public name from a throwaway `node_modules`, exactly like a consumer.
+ */
+export function typecheckVitePlusConfigConsumer(source: string): void {
+  const root = createTypecheckWorkspace();
+
+  try {
+    fs.writeFileSync(path.join(root, "package.json"), '{"type":"module"}\n');
+    fs.writeFileSync(path.join(root, "vite.config.mts"), source);
+    fs.writeFileSync(
+      path.join(root, "tsconfig.json"),
+      `${JSON.stringify(
+        {
+          compilerOptions: {
+            module: "NodeNext",
+            moduleResolution: "NodeNext",
+            noEmit: true,
+            // Vite+'s declaration graph references optional tooling packages
+            // that consumers do not need for lint config. Consumer source is
+            // still checked strictly, including the @ts-expect-error probes.
+            skipLibCheck: true,
+            strict: true,
+            target: "ES2022",
+          },
+          include: ["vite.config.mts"],
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const nativePreviewDir = path.dirname(
+      packageRequire.resolve("@typescript/native-preview/package.json"),
+    );
+    execFileSync(
+      process.execPath,
+      [
+        path.join(nativePreviewDir, "bin", "tsgo.js"),
+        "--project",
+        "tsconfig.json",
+        "--pretty",
+        "false",
+      ],
+      { cwd: root, encoding: "utf8", stdio: "pipe" },
+    );
+  } catch (error) {
+    const execError = error as { stdout?: string | Buffer; stderr?: string | Buffer };
+    throw new Error(
+      `Strict Vite+ consumer typecheck failed:\n${String(execError.stdout ?? "")}${String(execError.stderr ?? "")}`,
+    );
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+}
+
 export function lintWorkspaceFixture(fixture: {
   config: VizeLintConfig;
   filename: string;
@@ -135,6 +194,24 @@ function createLintWorkspace(): string {
   fs.mkdirSync(nodeModules, { recursive: true });
   fs.symlinkSync(packageDir, path.join(nodeModules, "oxlint-plugin-vize"), "junction");
   return root;
+}
+
+function createTypecheckWorkspace(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "oxint-vite-plus-types-"));
+  const nodeModules = path.join(root, "node_modules");
+  fs.mkdirSync(nodeModules, { recursive: true });
+  fs.symlinkSync(packageDir, path.join(nodeModules, "oxlint-plugin-vize"), "junction");
+  linkPackageFromManifest(nodeModules, "oxlint");
+  linkPackageFromManifest(nodeModules, "vite-plus");
+  linkOxlintPluginsOnly(root);
+  return root;
+}
+
+function linkPackageFromManifest(nodeModules: string, packageName: string): void {
+  const source = path.dirname(packageRequire.resolve(`${packageName}/package.json`));
+  const target = path.join(nodeModules, ...packageName.split("/"));
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.symlinkSync(source, target, "junction");
 }
 
 function linkOxlintPluginsOnly(root: string): void {

--- a/npm/oxint/src/vite-plus-lint.test.ts
+++ b/npm/oxint/src/vite-plus-lint.test.ts
@@ -5,6 +5,7 @@ import {
   createVizeLintConfigFromDist,
   lintWorkspaceFixture,
   runIsolatedPluginLoadProbe,
+  typecheckVitePlusConfigConsumer,
 } from "./test-support/vite-plus-workspace.ts";
 
 const VIOLATING_SFC = `<script setup lang="ts">
@@ -72,6 +73,79 @@ void test("createVizeLintConfig merges built-in Oxlint plugins instead of narrow
     }).plugins,
     ["vue", "eslint", "typescript", "unicorn", "oxc"],
   );
+});
+
+void test("createVizeLintConfig preserves runtime rule forms with options", () => {
+  assert.deepEqual(
+    createVizeLintConfig({
+      preset: "incremental",
+      rules: {
+        "no-console": "off",
+        "typescript/consistent-type-imports": [
+          "error",
+          { disallowTypeAnnotations: false, fixStyle: "inline-type-imports" },
+        ],
+      },
+    }).rules,
+    {
+      "no-console": "off",
+      "typescript/consistent-type-imports": [
+        "error",
+        { disallowTypeAnnotations: false, fixStyle: "inline-type-imports" },
+      ],
+    },
+  );
+});
+
+void test("packed declarations type-check as a strict Vite+ lint consumer", () => {
+  typecheckVitePlusConfigConsumer(`import { createVizeLintConfig } from "oxlint-plugin-vize";
+import type { VitePlusLintPlugin } from "oxlint-plugin-vize";
+import { defineConfig } from "vite-plus";
+import type { OxlintConfig } from "vite-plus/lint";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends
+  (<Value>() => Value extends Right ? 1 : 2) ? true : false;
+type Assert<Condition extends true> = Condition;
+type VitePlusPlugin = NonNullable<OxlintConfig["plugins"]>[number];
+type _PluginNamesStayInSync = Assert<Equal<VitePlusLintPlugin, VitePlusPlugin>>;
+
+export default defineConfig({
+  lint: {
+    ...createVizeLintConfig({
+      plugins: ["typescript"],
+      preset: "incremental",
+      rules: {
+        "no-console": "off",
+        "typescript/consistent-type-imports": [
+          "error",
+          { disallowTypeAnnotations: false, fixStyle: "inline-type-imports" },
+        ],
+      },
+    }),
+    overrides: [
+      {
+        files: ["**/*.ts"],
+        rules: {
+          "typescript/consistent-type-imports": [
+            "warn",
+            { disallowTypeAnnotations: true, fixStyle: "separate-type-imports" },
+          ],
+        },
+      },
+    ],
+  },
+});
+
+createVizeLintConfig({
+  // @ts-expect-error Vite+ keeps built-in plugin names as a closed union.
+  plugins: ["not-a-vite-plus-plugin"],
+  rules: {
+    // @ts-expect-error Unknown severities must not be widened to string or any.
+    "no-console": "verbose",
+  },
+});
+`);
 });
 
 void test('createVizeLintConfig keeps the rule map and settings.vize.preset in lockstep for "all"', () => {

--- a/npm/oxint/src/vite-plus.ts
+++ b/npm/oxint/src/vite-plus.ts
@@ -12,6 +12,24 @@ export const VIZE_JS_PLUGIN_SPECIFIER = "oxlint-plugin-vize";
 
 const VIZE_RULE_PREFIX = "vize/";
 
+/** Built-in plugin names accepted by Vite+'s Oxlint configuration. */
+export type VitePlusLintPlugin =
+  | "eslint"
+  | "import"
+  | "jest"
+  | "jsdoc"
+  | "jsx-a11y"
+  | "nextjs"
+  | "node"
+  | "oxc"
+  | "promise"
+  | "react"
+  | "react-perf"
+  | "typescript"
+  | "unicorn"
+  | "vitest"
+  | "vue";
+
 /**
  * Rule bundles `createVizeLintConfig` accepts.
  *
@@ -35,7 +53,7 @@ export interface VizeLintConfigOptions {
    * here is merged rather than replaced. A `create-vue` project, for example,
    * needs `["eslint", "typescript", "unicorn", "oxc"]` carried over.
    */
-  plugins?: readonly string[];
+  plugins?: readonly VitePlusLintPlugin[];
   /**
    * Rule bundle to enable. Defaults to `"general-recommended"`, the bridge's own
    * default. `"incremental"` emits no preset rules, so only `rules` run.
@@ -57,7 +75,7 @@ export interface VizeLintConfigOptions {
 
 export interface VizeLintConfig {
   jsPlugins: string[];
-  plugins: string[];
+  plugins: VitePlusLintPlugin[];
   rules: OxlintRuleConfig;
   settings: { vize: PatinaSettings };
 }


### PR DESCRIPTION
## Summary

- accept `off` and `[severity, ...options]` rule entries in `createVizeLintConfig`
- return the closed Vite+/Oxlint built-in plugin union without adding a published Vite+ type dependency
- type-check the packed declaration as a strict Vite+ consumer, including top-level and override tuples plus negative plugin/severity probes
- preserve both newly accepted rule forms exactly at runtime

## Regression proof

Before the implementation, the strict packed-package consumer failed with the three issue-specific errors: `plugins: string[]` was not assignable to Vite+ plugins, `"off"` was rejected, and the tuple options object was treated as a string. The same consumer is now green.

## Validation

- `vp run --filter ./npm/oxint test`
- `vp run --filter ./npm/oxint check`
- packed declaration consumer: strict TypeScript, Vite+ `defineConfig`, top-level and `overrides[].rules` tuples

Fixes #3772

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->