### PR TITLE
test(e2e): compare VRT within the viewport

### DIFF
--- a/tests/_helpers/visual-parity.ts
+++ b/tests/_helpers/visual-parity.ts
@@ -86,11 +86,17 @@ export async function expectVisualParity(
   fs.writeFileSync(referencePath, referenceBuffer);
   fs.writeFileSync(candidatePath, candidateBuffer);
 
+  const viewportWidths = [
+    referencePage.viewportSize()?.width,
+    candidatePage.viewportSize()?.width,
+  ].filter((width): width is number => width !== undefined);
+  const viewportWidth = viewportWidths.length > 0 ? Math.min(...viewportWidths) : undefined;
   const result = comparePngBuffers(
     referenceBuffer,
     candidateBuffer,
     options.channelThreshold ?? DEFAULT_CHANNEL_THRESHOLD,
     diffPath,
+    viewportWidth,
   );
   const maxDiffRatio = options.maxDiffRatio ?? DEFAULT_MAX_DIFF_RATIO;
   const message = [
@@ -108,10 +114,11 @@ function comparePngBuffers(
   candidateBuffer: Buffer,
   channelThreshold: number,
   diffPath: string,
+  viewportWidth?: number,
 ): PngCompareResult {
   const reference = PNG.sync.read(referenceBuffer);
   const candidate = PNG.sync.read(candidateBuffer);
-  const { height, width } = visualComparisonDimensions(reference, candidate);
+  const { height, width } = visualComparisonDimensions(reference, candidate, viewportWidth);
   const diff = new PNG({ width, height });
   let diffPixels = 0;
 
@@ -158,13 +165,14 @@ function comparePngBuffers(
 export function visualComparisonDimensions(
   reference: ImageDimensions,
   candidate: ImageDimensions,
+  viewportWidth?: number,
 ): ImageDimensions {
   return {
     // Full-page screenshots can include horizontal document overflow beyond the
-    // shared browser viewport. Compare the common visible width while retaining
-    // the full vertical extent so missing page content still fails parity.
+    // shared browser viewport. Cap the common PNG width to the actual viewport
+    // while retaining the full vertical extent so missing page content fails.
     height: Math.max(reference.height, candidate.height),
-    width: Math.min(reference.width, candidate.width),
+    width: Math.min(reference.width, candidate.width, viewportWidth ?? Number.POSITIVE_INFINITY),
   };
 }
 

--- a/tests/tooling/visual-parity.test.ts
+++ b/tests/tooling/visual-parity.test.ts
@@ -13,4 +13,13 @@ test("visual parity compares the shared viewport width and full page height", ()
     visualComparisonDimensions({ height: 720, width: 1_280 }, { height: 900, width: 1_280 }),
     { height: 900, width: 1_280 },
   );
+
+  assert.deepEqual(
+    visualComparisonDimensions(
+      { height: 14_674, width: 1_208 },
+      { height: 14_674, width: 1_208 },
+      390,
+    ),
+    { height: 14_674, width: 390 },
+  );
 });


### PR DESCRIPTION
## Summary

- cap full-page visual comparisons to the actual browser viewport width
- retain the complete vertical document height for missing-content detection
- pin the v0.319.0 Elk failure shape: 1208px PNG overflow from a 390px viewport

## Evidence

The failed v0.319.0 App E2E artifact had 1,539,402 differing pixels over 1208x14674 (8.684%). Restricting the same reference/candidate PNGs to the real 390px viewport yields 17,095 differing pixels over 390x14674 (0.299%), below the existing Elk 4% threshold. The attached 390x844 failure screenshots are visually identical; the counted regression was outside the visible viewport.

## Validation

- node --test tests/tooling/visual-parity.test.ts tests/tooling/source-file-lengths.test.ts (8/8)
- vp check tests/_helpers/visual-parity.ts tests/tooling/visual-parity.test.ts

This repairs the release gate exposed by the failed v0.319.0 release preflight.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->