### PR TITLE
fix(patina): ignore local non-Pinia store composables

### DIFF
--- a/crates/vize_patina/src/rules/script/pinia_prefer_store_to_refs.rs
+++ b/crates/vize_patina/src/rules/script/pinia_prefer_store_to_refs.rs
@@ -9,7 +9,10 @@
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
 use memchr::memmem;
-use oxc_ast::ast::{BindingPattern, CallExpression, Expression, Program, VariableDeclarator};
+use oxc_ast::ast::{
+    BindingPattern, CallExpression, Declaration, Expression, Program, Statement,
+    VariableDeclaration, VariableDeclarator,
+};
 use oxc_ast_visit::{Visit, walk::walk_variable_declarator};
 use oxc_span::{GetSpan, Span};
 use vize_carton::{CompactString, FxHashSet};
@@ -43,7 +46,10 @@ impl ScriptRule for PiniaPreferStoreToRefs {
             return;
         }
 
+        let local_callables = collect_local_callables(program);
+
         let mut visitor = PiniaVisitor {
+            local_callables: &local_callables,
             offset,
             result,
             store_bindings: FxHashSet::default(),
@@ -53,6 +59,7 @@ impl ScriptRule for PiniaPreferStoreToRefs {
 }
 
 struct PiniaVisitor<'result> {
+    local_callables: &'result FxHashSet<CompactString>,
     offset: usize,
     result: &'result mut ScriptLintResult,
     store_bindings: FxHashSet<CompactString>,
@@ -66,7 +73,9 @@ impl<'a> Visit<'a> for PiniaVisitor<'_> {
         };
 
         match &it.id {
-            BindingPattern::BindingIdentifier(identifier) if is_pinia_store_expression(init) => {
+            BindingPattern::BindingIdentifier(identifier)
+                if is_pinia_store_expression(init, self.local_callables) =>
+            {
                 self.store_bindings
                     .insert(CompactString::new(identifier.name.as_str()));
             }
@@ -82,7 +91,7 @@ impl<'a> Visit<'a> for PiniaVisitor<'_> {
 
 impl PiniaVisitor<'_> {
     fn is_store_destructure(&self, expression: &Expression<'_>) -> bool {
-        if is_pinia_store_expression(expression) {
+        if is_pinia_store_expression(expression, self.local_callables) {
             return true;
         }
 
@@ -105,24 +114,94 @@ impl PiniaVisitor<'_> {
     }
 }
 
-fn is_pinia_store_expression(expression: &Expression<'_>) -> bool {
+fn collect_local_callables(program: &Program<'_>) -> FxHashSet<CompactString> {
+    let mut names = FxHashSet::default();
+    for statement in &program.body {
+        match statement {
+            Statement::FunctionDeclaration(function) => {
+                if let Some(identifier) = &function.id {
+                    names.insert(CompactString::new(identifier.name.as_str()));
+                }
+            }
+            Statement::VariableDeclaration(declaration) => {
+                collect_callable_variables(declaration, &mut names);
+            }
+            Statement::ExportNamedDeclaration(export) => match &export.declaration {
+                Some(Declaration::FunctionDeclaration(function)) => {
+                    if let Some(identifier) = &function.id {
+                        names.insert(CompactString::new(identifier.name.as_str()));
+                    }
+                }
+                Some(Declaration::VariableDeclaration(declaration)) => {
+                    collect_callable_variables(declaration, &mut names);
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+    names
+}
+
+fn collect_callable_variables(
+    declaration: &VariableDeclaration<'_>,
+    names: &mut FxHashSet<CompactString>,
+) {
+    for declarator in &declaration.declarations {
+        if let BindingPattern::BindingIdentifier(identifier) = &declarator.id
+            && declarator.init.as_ref().is_some_and(is_function_expression)
+        {
+            names.insert(CompactString::new(identifier.name.as_str()));
+        }
+    }
+}
+
+fn is_function_expression(expression: &Expression<'_>) -> bool {
     match expression {
-        Expression::CallExpression(call) => is_pinia_store_call(call),
-        Expression::ParenthesizedExpression(paren) => is_pinia_store_expression(&paren.expression),
-        Expression::TSAsExpression(ts_as) => is_pinia_store_expression(&ts_as.expression),
+        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_) => true,
+        Expression::ParenthesizedExpression(paren) => is_function_expression(&paren.expression),
+        Expression::TSAsExpression(ts_as) => is_function_expression(&ts_as.expression),
         Expression::TSSatisfiesExpression(ts_satisfies) => {
-            is_pinia_store_expression(&ts_satisfies.expression)
+            is_function_expression(&ts_satisfies.expression)
         }
         Expression::TSNonNullExpression(ts_non_null) => {
-            is_pinia_store_expression(&ts_non_null.expression)
+            is_function_expression(&ts_non_null.expression)
         }
         _ => false,
     }
 }
 
-fn is_pinia_store_call(call: &CallExpression<'_>) -> bool {
+fn is_pinia_store_expression(
+    expression: &Expression<'_>,
+    local_callables: &FxHashSet<CompactString>,
+) -> bool {
+    match expression {
+        Expression::CallExpression(call) => is_pinia_store_call(call, local_callables),
+        Expression::ParenthesizedExpression(paren) => {
+            is_pinia_store_expression(&paren.expression, local_callables)
+        }
+        Expression::TSAsExpression(ts_as) => {
+            is_pinia_store_expression(&ts_as.expression, local_callables)
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            is_pinia_store_expression(&ts_satisfies.expression, local_callables)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            is_pinia_store_expression(&ts_non_null.expression, local_callables)
+        }
+        _ => false,
+    }
+}
+
+fn is_pinia_store_call(
+    call: &CallExpression<'_>,
+    local_callables: &FxHashSet<CompactString>,
+) -> bool {
     match &call.callee {
-        Expression::Identifier(identifier) => is_store_composable_name(identifier.name.as_str()),
+        Expression::Identifier(identifier) => {
+            let name = identifier.name.as_str();
+            is_store_composable_name(name) && !local_callables.contains(name)
+        }
         expression if expression.is_member_expression() => expression
             .as_member_expression()
             .and_then(|member| member.static_property_name())
@@ -180,6 +259,42 @@ const { name } = storeToRefs(store)
         let source = r#"
 const store = useUserStore()
 const { name } = store
+"#;
+        let mut result = ScriptLintResult::default();
+        PiniaPreferStoreToRefs.check(source, 0, &mut result);
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn accepts_same_file_function_named_like_a_store() {
+        let source = r#"
+export function useCounterStore() {
+    return { count: ref(0), inc: () => {} }
+}
+const { count, inc } = useCounterStore()
+"#;
+        let mut result = ScriptLintResult::default();
+        PiniaPreferStoreToRefs.check(source, 0, &mut result);
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn accepts_same_file_function_expression_named_like_a_store() {
+        let source = r#"
+const useCounterStore = () => ({ count: ref(0) })
+const counter = useCounterStore()
+const { count } = counter
+"#;
+        let mut result = ScriptLintResult::default();
+        PiniaPreferStoreToRefs.check(source, 0, &mut result);
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn reports_actual_define_store_factory_declared_in_the_same_file() {
+        let source = r#"
+const useUserStore = defineStore('user', { state: () => ({ name: '' }) })
+const { name } = useUserStore()
 "#;
         let mut result = ScriptLintResult::default();
         PiniaPreferStoreToRefs.check(source, 0, &mut result);


### PR DESCRIPTION
## Summary

- distinguish same-file functions from unresolved use*Store calls before reporting Pinia destructuring
- preserve diagnostics for real defineStore factories and unresolved external store composables
- cover exported function declarations, arrow functions, direct calls, and intermediate bindings

Closes #3782

## Validation

- cargo test -p vize_patina (2460 unit + 2 integration)
- cargo test -p vize_patina pinia_prefer_store_to_refs (6/6)
- cargo clippy -p vize_patina --lib -- -D warnings
- exact issue SFC through rebuilt vize lint: No problems found in 1 file

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->