### PR TITLE
fix(patina): report actual Nuxt config inversions

### DIFF
--- a/crates/vize_patina/src/linter/tests/nuxt_config_order.rs
+++ b/crates/vize_patina/src/linter/tests/nuxt_config_order.rs
@@ -24,8 +24,9 @@ fn nuxt_preset_reports_fixable_config_order() {
         .unwrap();
     assert_eq!(
         diagnostic.message,
-        "Expected config key \"modules\" to come before \"ssr\""
+        "Expected config key \"ssr\" to come after \"modules\""
     );
+    assert_eq!((diagnostic.start, diagnostic.end), (17, 26));
     assert_eq!(
         diagnostic.fix.as_ref().unwrap().apply(source),
         "export default { modules: [], ssr: true, }"

--- a/crates/vize_patina/src/rules/script/nuxt_config_keys_order.rs
+++ b/crates/vize_patina/src/rules/script/nuxt_config_keys_order.rs
@@ -1,8 +1,9 @@
 //! nuxt/nuxt-config-keys-order
 //!
-//! Reproduce `@nuxt/eslint-plugin` 1.16.0's config ordering, including its
-//! official-module positions, `$environment` group, unknown-key collation,
-//! comment-preserving text edits, and nested environment objects.
+//! Reproduce `@nuxt/eslint-plugin` 1.16.0's config ordering and fixes, while
+//! reporting the first authored inversion instead of the whole config object.
+//! This includes official-module positions, the `$environment` group,
+//! unknown-key collation, comment-preserving edits, and nested environments.
 
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{Fix, LintDiagnostic, Severity, TextEdit};
@@ -10,11 +11,15 @@ use oxc_ast::ast::{
     Argument, ExportDefaultDeclarationKind, Expression, ObjectExpression, ObjectPropertyKind,
     Program, PropertyKey, Statement,
 };
+use oxc_span::GetSpan;
 use vize_carton::{String, cstr};
 
 #[path = "nuxt_config_keys_order_support.rs"]
 mod support;
-use support::{property_name, property_text_ranges, sort_named_segments};
+use support::{
+    first_order_inversion, property_display_name, property_name, property_text_ranges,
+    sort_named_segments,
+};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "nuxt/nuxt-config-keys-order",
@@ -127,32 +132,30 @@ fn report_sort(
         .iter()
         .map(|property| property_name(property, source))
         .collect::<Vec<_>>();
+    let Some((misplaced_index, expected_after_index)) = first_order_inversion(&names) else {
+        return;
+    };
     let mut reordered = (0..object.properties.len()).collect::<Vec<_>>();
     sort_named_segments(&mut reordered, &names);
-    if reordered
-        .iter()
-        .enumerate()
-        .all(|(index, item)| index == *item)
-    {
-        return;
-    }
 
     let (range_start, range_end, pieces) = property_text_ranges(object, source);
     let mut replacement = String::new("");
     for index in &reordered {
         replacement.push_str(&pieces[*index]);
     }
-    let mut visible = reordered
-        .iter()
-        .filter_map(|index| names[*index].as_deref());
-    let first = visible.next().unwrap_or("unknown");
-    let second = visible.next().unwrap_or(first);
-    let start = offset as u32 + object.span.start;
-    let end = offset as u32 + object.span.end;
+    let misplaced = property_display_name(&object.properties[misplaced_index], source)
+        .or_else(|| names[misplaced_index].clone())
+        .unwrap_or_else(|| "unknown".into());
+    let expected_after = property_display_name(&object.properties[expected_after_index], source)
+        .or_else(|| names[expected_after_index].clone())
+        .unwrap_or_else(|| "unknown".into());
+    let misplaced_span = object.properties[misplaced_index].span();
+    let start = offset as u32 + misplaced_span.start;
+    let end = offset as u32 + misplaced_span.end;
     result.add_diagnostic(
         LintDiagnostic::error(
             META.name,
-            cstr!("Expected config key \"{first}\" to come before \"{second}\""),
+            cstr!("Expected config key \"{misplaced}\" to come after \"{expected_after}\""),
             start,
             end,
         )

--- a/crates/vize_patina/src/rules/script/nuxt_config_keys_order_support.rs
+++ b/crates/vize_patina/src/rules/script/nuxt_config_keys_order_support.rs
@@ -91,6 +91,27 @@ pub(super) fn sort_named_segments(reordered: &mut [usize], names: &[Option<Strin
     }
 }
 
+/// Return the first adjacent pair whose authored order contradicts the Nuxt
+/// comparator. Unnamed properties (notably spreads) remain sorting boundaries,
+/// matching `sort_named_segments` and the fix that the diagnostic accompanies.
+pub(super) fn first_order_inversion(names: &[Option<String>]) -> Option<(usize, usize)> {
+    let mut previous: Option<usize> = None;
+    for (index, name) in names.iter().enumerate() {
+        let Some(name) = name.as_deref() else {
+            previous = None;
+            continue;
+        };
+        if let Some(previous_index) = previous {
+            let previous_name = names[previous_index].as_deref()?;
+            if compare_names(previous_name, name).is_gt() {
+                return Some((previous_index, index));
+            }
+        }
+        previous = Some(index);
+    }
+    None
+}
+
 fn sort_segment(segment: &mut [usize], names: &[Option<String>]) {
     segment.sort_by(|left, right| {
         compare_names(
@@ -157,6 +178,39 @@ pub(super) fn property_name(property: &ObjectPropertyKind<'_>, source: &str) -> 
         return None;
     };
     key_name(&property.key, source)
+}
+
+pub(super) fn property_display_name(
+    property: &ObjectPropertyKind<'_>,
+    source: &str,
+) -> Option<String> {
+    let ObjectPropertyKind::ObjectProperty(property) = property else {
+        return None;
+    };
+    display_key_name(&property.key, source)
+}
+
+fn display_key_name(key: &PropertyKey<'_>, source: &str) -> Option<String> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.to_compact_string()),
+        PropertyKey::Identifier(identifier) => Some(identifier.name.to_compact_string()),
+        PropertyKey::StringLiteral(literal) => Some(literal.value.to_compact_string()),
+        PropertyKey::ParenthesizedExpression(parenthesized) => {
+            display_expression_key_name(&parenthesized.expression, source)
+        }
+        _ => Some(span_text(key.span(), source)),
+    }
+}
+
+fn display_expression_key_name(expression: &Expression<'_>, source: &str) -> Option<String> {
+    match expression {
+        Expression::Identifier(identifier) => Some(identifier.name.to_compact_string()),
+        Expression::StringLiteral(literal) => Some(literal.value.to_compact_string()),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            display_expression_key_name(&parenthesized.expression, source)
+        }
+        _ => Some(span_text(expression.span(), source)),
+    }
 }
 
 fn key_name(key: &PropertyKey<'_>, source: &str) -> Option<String> {

--- a/crates/vize_patina/src/rules/script/nuxt_config_keys_order_tests.rs
+++ b/crates/vize_patina/src/rules/script/nuxt_config_keys_order_tests.rs
@@ -2,7 +2,7 @@ use super::{META, NuxtConfigKeysOrder};
 use crate::diagnostic::Severity;
 use crate::rules::script::{ScriptLintResult, ScriptLinter, ScriptRule};
 use serde_json::Value;
-use vize_carton::{String, ToCompactString};
+use vize_carton::{String, ToCompactString, cstr};
 
 const CORPUS: &str = include_str!(
     "../../../../../npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/fixtures/corpus.json"
@@ -56,20 +56,6 @@ fn fix_until_stable(source: &str) -> String {
     panic!("Nuxt config order fix did not converge");
 }
 
-fn line_column(source: &str, offset: usize) -> (u64, u64) {
-    let prefix = &source[..offset];
-    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u64 + 1;
-    // ESLint columns count UTF-16 code units, not bytes.
-    let column = prefix
-        .rsplit_once('\n')
-        .map_or(prefix, |(_, tail)| tail)
-        .chars()
-        .map(char::len_utf16)
-        .sum::<usize>() as u64
-        + 1;
-    (line, column)
-}
-
 #[test]
 fn metadata_matches_the_nuxt_rule_contract() {
     let meta = NuxtConfigKeysOrder.meta();
@@ -91,9 +77,9 @@ fn exact_single_line_diagnostic_and_fix_contract() {
     assert_eq!(diagnostic.severity, Severity::Error);
     assert_eq!(
         diagnostic.message,
-        "Expected config key \"modules\" to come before \"ssr\""
+        "Expected config key \"ssr\" to come after \"modules\""
     );
-    assert_eq!((diagnostic.start, diagnostic.end), (32, 58));
+    assert_eq!((diagnostic.start, diagnostic.end), (34, 43));
     assert!(diagnostic.help.is_none());
 
     let edit = &diagnostic.fix.as_ref().unwrap().edits[0];
@@ -127,9 +113,9 @@ fn sorts_top_level_and_environment_objects_to_convergence() {
             .map(|diagnostic| diagnostic.message.as_str())
             .collect::<Vec<_>>(),
         [
-            "Expected config key \"modules\" to come before \"$production\"",
-            "Expected config key \"modules\" to come before \"ssr\"",
-            "Expected config key \"app\" to come before \"build\"",
+            "Expected config key \"ssr\" to come after \"$test\"",
+            "Expected config key \"ssr\" to come after \"modules\"",
+            "Expected config key \"build\" to come after \"app\"",
         ]
     );
     let fixed = fix_until_stable(source);
@@ -143,10 +129,64 @@ fn sorts_top_level_and_environment_objects_to_convergence() {
 #[test]
 fn spreads_are_boundaries_between_sortable_segments() {
     let source = "export default { modules: [], ssr: true, ...base, css: [], app: {}, ...tail, vite: {}, build: {} }";
+    let result = lint(source);
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(
+        result.diagnostics[0].message,
+        "Expected config key \"css\" to come after \"app\""
+    );
+    assert_eq!(
+        (result.diagnostics[0].start, result.diagnostics[0].end),
+        (50, 57)
+    );
     assert_eq!(
         fix_until_stable(source),
         "export default { modules: [], ssr: true, ...base, app: {}, css: [], ...tail, build: {}, vite: {}, }"
     );
+}
+
+#[test]
+fn reports_the_actual_issue_3768_key_pair_at_the_authored_property() {
+    for (properties, message, property) in [
+        (
+            "modules: [], css: [], plugins: []",
+            "Expected config key \"css\" to come after \"plugins\"",
+            "css: []",
+        ),
+        (
+            "css: [], modules: [], plugins: []",
+            "Expected config key \"css\" to come after \"modules\"",
+            "css: []",
+        ),
+        (
+            "ssr: false, modules: [], plugins: []",
+            "Expected config key \"ssr\" to come after \"modules\"",
+            "ssr: false",
+        ),
+        (
+            "modules: [], router: {}, plugins: []",
+            "Expected config key \"router\" to come after \"plugins\"",
+            "router: {}",
+        ),
+        (
+            "modules: [], components: {}, plugins: []",
+            "Expected config key \"components\" to come after \"plugins\"",
+            "components: {}",
+        ),
+    ] {
+        let source = cstr!("export default defineNuxtConfig({{ {properties} }})");
+        let result = lint(&source);
+        assert_eq!(result.diagnostics.len(), 1, "{properties}");
+        let diagnostic = &result.diagnostics[0];
+        assert_eq!(diagnostic.message, message, "{properties}");
+        let start = source.find(property).unwrap() as u32;
+        assert_eq!(
+            (diagnostic.start, diagnostic.end),
+            (start, start + property.len() as u32),
+            "{properties}"
+        );
+        assert!(diagnostic.fix.is_some(), "{properties}");
+    }
 }
 
 #[test]
@@ -155,6 +195,18 @@ fn unknown_and_literal_keys_follow_upstream_collation() {
         fix_until_stable("export default { zebra: 1, Zebra: 2, alpha: 3, Alpha: 4 }"),
         "export default { alpha: 3, Alpha: 4, zebra: 1, Zebra: 2, }"
     );
+    let literal_source =
+        "export default { zebra: 1, \"ssr\": true, modules: [], 'app': {}, css: [] }";
+    let literal_diagnostic = &lint(literal_source).diagnostics[0];
+    assert_eq!(
+        literal_diagnostic.message,
+        "Expected config key \"zebra\" to come after \"ssr\""
+    );
+    assert_eq!((literal_diagnostic.start, literal_diagnostic.end), (17, 25));
+    assert_eq!(
+        fix_until_stable(literal_source),
+        "export default { modules: [], css: [], 'app': {}, \"ssr\": true, zebra: 1, }"
+    );
     assert_eq!(
         fix_until_stable("export default { \"ssr\": true, modules: [], 'app': {}, css: [] }"),
         "export default { modules: [], css: [], 'app': {}, \"ssr\": true, }"
@@ -162,7 +214,7 @@ fn unknown_and_literal_keys_follow_upstream_collation() {
 }
 
 #[test]
-fn matches_the_recorded_nuxt_eslint_plugin_oracle() {
+fn keeps_the_recorded_nuxt_eslint_plugin_fix_oracle() {
     let corpus: Value = serde_json::from_str(CORPUS).unwrap();
     let recording: Value = serde_json::from_str(RECORDING).unwrap();
     let cases = corpus["nuxtConfigKeysOrderCases"].as_array().unwrap();
@@ -176,32 +228,24 @@ fn matches_the_recorded_nuxt_eslint_plugin_oracle() {
         let result = lint(source);
         assert_eq!(result.diagnostics.len(), expected_messages.len(), "{id}");
 
+        // #3768 intentionally narrows the upstream whole-object range and
+        // rewrites its sorted-prefix message. Focused tests above pin those
+        // fields; this corpus continues to pin the upstream sorting fix.
         for (diagnostic, expected) in result.diagnostics.iter().zip(expected_messages) {
             assert_eq!(diagnostic.rule_name, "nuxt/nuxt-config-keys-order", "{id}");
             assert_eq!(diagnostic.severity, Severity::Error, "{id}");
-            assert_eq!(
-                diagnostic.message,
-                expected["message"].as_str().unwrap(),
-                "{id}"
-            );
-
             let range = expected["range"].as_array().unwrap();
             let start = range[0].as_u64().unwrap();
             let end = range[1].as_u64().unwrap();
-            assert_eq!(
-                (u64::from(diagnostic.start), u64::from(diagnostic.end)),
-                (start, end),
-                "diagnostic range for {id}"
-            );
-            assert_eq!(
-                line_column(source, start as usize),
-                (
-                    expected["line"].as_u64().unwrap(),
-                    expected["column"].as_u64().unwrap()
-                ),
+            assert!(
+                u64::from(diagnostic.start) >= start,
                 "diagnostic start for {id}"
             );
-
+            assert!(u64::from(diagnostic.end) <= end, "diagnostic end for {id}");
+            assert!(
+                diagnostic.start < diagnostic.end,
+                "diagnostic range for {id}"
+            );
             let fix = diagnostic.fix.as_ref().unwrap();
             assert_eq!(fix.edits.len(), 1, "{id}");
             let expected_fix = &expected["fix"];
@@ -256,7 +300,7 @@ fn diagnostic_and_fix_offsets_include_the_sfc_block_offset() {
     let source = "export default { ssr: true, modules: [] }";
     let result = lint_at(source, 41);
     let diagnostic = &result.diagnostics[0];
-    assert_eq!((diagnostic.start, diagnostic.end), (56, 82));
+    assert_eq!((diagnostic.start, diagnostic.end), (58, 67));
     let edit = &diagnostic.fix.as_ref().unwrap().edits[0];
     assert_eq!((edit.start, edit.end), (57, 80));
 }

--- a/npm/oxint/src/nuxt-preset.test.ts
+++ b/npm/oxint/src/nuxt-preset.test.ts
@@ -151,7 +151,7 @@ assert.match(
 );
 assert.match(
   nuxtConfigRun.output,
-  /nuxt\.config\.ts[\s\S]*Expected config key "modules" to come before "ssr"[\s\S]*vize\(nuxt\/nuxt-config-keys-order\)/u,
+  /nuxt\.config\.ts[\s\S]*2:3[\s\S]*Expected config key "ssr" to come after "modules"[\s\S]*vize\(nuxt\/nuxt-config-keys-order\)/u,
 );
 
 console.log("oxlint-plugin-vize Nuxt preset tests passed!");


### PR DESCRIPTION
## Summary

- report the first actual adjacent Nuxt 3 config inversion instead of the sorted prefix
- point diagnostics at the authored misplaced property while retaining the atomic full-sort fix
- cover issue reproduction cases, nested environments, spread boundaries, literal keys, SFC offsets, and native Oxlint line/column output

Nuxt 2 ordering remains a separate compatibility decision.

## Verification

- `cargo test -p vize_patina --lib`
- `cargo clippy -p vize_patina --lib -- -D warnings`
- `vp run build:native:test`
- `pnpm --filter oxlint-plugin-vize test`
- `vp check npm/oxint/src/nuxt-preset.test.ts`

Refs #3768

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->