### PR TITLE
test(cli): fail closed for project-root Corsa gates

### DIFF
--- a/crates/vize/tests/check_default_run_project_root_cli.rs
+++ b/crates/vize/tests/check_default_run_project_root_cli.rs
@@ -14,6 +14,9 @@
 
 use vize_carton::cstr;
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 #[path = "support/default_run_root.rs"]
 mod default_run_root;
 
@@ -173,7 +176,7 @@ fn default_run_through_a_symlinked_workspace_path_reports_the_wrong_root() {
 /// app's real error, and surfaces the wider scope instead of failing.
 #[test]
 fn default_run_inside_an_owning_ancestor_program_checks_the_app_and_notes_the_scope() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         eprintln!("skipping owning-ancestor case: tsgo not found");
         return;
     };
@@ -238,7 +241,7 @@ fn default_run_inside_an_owning_ancestor_program_checks_the_app_and_notes_the_sc
 /// scope note, and the app's error is reported.
 #[test]
 fn default_run_with_a_local_tsconfig_stays_in_the_app() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         eprintln!("skipping local-tsconfig case: tsgo not found");
         return;
     };

--- a/crates/vize/tests/check_symlinked_node_modules_cli.rs
+++ b/crates/vize/tests/check_symlinked_node_modules_cli.rs
@@ -11,6 +11,9 @@
 //! the file reported as checked with an empty list. Both layouts are pinned
 //! here because the dangerous direction is the *absence* of a diagnostic.
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -62,7 +65,7 @@ enum NodeModulesLayout {
 }
 
 fn run_case(name: &str, layout: NodeModulesLayout) {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         eprintln!("skipping {name}: tsgo not found");
         return;
     };

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -113,6 +113,23 @@ test("Canon Rust CLI gates use the fail-closed Corsa helper", () => {
   }
 });
 
+test("project-root Rust CLI gates use the fail-closed Corsa helper", () => {
+  const files = [
+    ["check_default_run_project_root_cli.rs", 2],
+    ["check_symlinked_node_modules_cli.rs", 1],
+  ] as const;
+
+  for (const [file, expectedCalls] of files) {
+    const source = readRepoFile("crates", "vize", "tests", file);
+    assert.equal(
+      source.match(/corsa_requirement::required_or_skip\(resolve_test_corsa_path\(\)\)/g)?.length,
+      expectedCalls,
+      `${file} should guard all ${expectedCalls} Corsa resolver calls`,
+    );
+    assert.doesNotMatch(source, /let Some\(corsa_path\) = resolve_test_corsa_path\(\)/);
+  }
+});
+
 test("available dependencies never skip", () => {
   assert.equal(typecheckDependencySkip("/tmp/tsgo", "tsgo", "missing", true), false);
 });


### PR DESCRIPTION
## Summary

- apply the shared fail-closed Corsa requirement to project-root discovery tests
- apply it to symlinked node_modules diagnostics tests
- pin every resolver call in these suites with a source-level dependency-gate assertion

## Validation

- VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize --test check_symlinked_node_modules_cli --test check_default_run_project_root_cli --test corsa_requirement_cli
- vp exec -- node --test tests/tooling/typecheck-dependency-gates.test.ts
- cargo fmt --all -- --check

Refs #3750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved CLI test setup to consistently handle unavailable Corsa executables while preserving existing skip behavior.
  * Added coverage to verify required tool resolution uses fail-closed handling.
  * Expanded checks for project-root and symlinked dependency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->