### PR TITLE
fix(patina): respect Nuxt 2 config order

### DIFF
--- a/crates/vize_patina/src/linter/tests/nuxt_config_order.rs
+++ b/crates/vize_patina/src/linter/tests/nuxt_config_order.rs
@@ -34,6 +34,20 @@ fn nuxt_preset_reports_fixable_config_order() {
 }
 
 #[test]
+fn nuxt_preset_keeps_explicit_nuxt_two_config_order_quiet() {
+    let source = "export default defineNuxtConfig({ plugins: [], buildModules: [], modules: [], vize: { compatibility: { nuxtVersion: 2 } } })";
+    let result = Linter::with_preset(LintPreset::Nuxt).lint_script(source, "nuxt.config.ts");
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.rule_name != "nuxt/nuxt-config-keys-order"),
+        "{:#?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn nuxt_preset_ignores_unrelated_default_export_configs() {
     let linter = Linter::with_preset(LintPreset::Nuxt);
     for (filename, source) in [

--- a/crates/vize_patina/src/linter/tests/nuxt_config_order.rs
+++ b/crates/vize_patina/src/linter/tests/nuxt_config_order.rs
@@ -48,6 +48,27 @@ fn nuxt_preset_keeps_explicit_nuxt_two_config_order_quiet() {
 }
 
 #[test]
+fn nuxt_preset_fails_closed_for_nested_compatibility_duplicates() {
+    for properties in [
+        "vize: { compatibility: { nuxtVersion: 3 }, compatibility: { nuxtVersion: 2 } }",
+        "vize: { compatibility: { nuxtVersion: 3, nuxtVersion: 2 } }",
+    ] {
+        let source = format!(
+            "export default defineNuxtConfig({{ plugins: [], modules: [], {properties} }})"
+        );
+        let result = Linter::with_preset(LintPreset::Nuxt).lint_script(&source, "nuxt.config.ts");
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.rule_name == "nuxt/nuxt-config-keys-order"),
+            "{source}: {:#?}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
 fn nuxt_preset_ignores_unrelated_default_export_configs() {
     let linter = Linter::with_preset(LintPreset::Nuxt);
     for (filename, source) in [

--- a/crates/vize_patina/src/rules/script/nuxt_config_keys_order.rs
+++ b/crates/vize_patina/src/rules/script/nuxt_config_keys_order.rs
@@ -54,6 +54,14 @@ impl ScriptRule for NuxtConfigKeysOrder {
             let Some(object) = exported_object(&export.declaration) else {
                 continue;
             };
+            // Nuxt 2's official create-nuxt-app template orders `plugins`
+            // before `buildModules` and `modules`, unlike the Nuxt 3 oracle
+            // implemented by this rule. When the project explicitly opts into
+            // Vize's Nuxt 2 compatibility mode, staying quiet is safer than
+            // applying a contradictory Nuxt 3 fix.
+            if declares_nuxt_2_compatibility(object) {
+                continue;
+            }
             report_sort(object, source, offset, result);
             report_environment_sorts(object, source, offset, result);
         }
@@ -91,6 +99,74 @@ fn object_from_expression<'a>(expression: &'a Expression<'a>) -> Option<&'a Obje
         Expression::CallExpression(call) => first_object_argument(call),
         Expression::ParenthesizedExpression(parenthesized) => {
             object_from_expression(&parenthesized.expression)
+        }
+        _ => None,
+    }
+}
+
+fn declares_nuxt_2_compatibility(object: &ObjectExpression<'_>) -> bool {
+    object_property_object(object, "vize")
+        .and_then(|vize| object_property_object(vize, "compatibility"))
+        .and_then(|compatibility| object_property_value(compatibility, "nuxtVersion"))
+        .is_some_and(expression_is_numeric_two)
+}
+
+fn object_property_object<'a>(
+    object: &'a ObjectExpression<'a>,
+    name: &str,
+) -> Option<&'a ObjectExpression<'a>> {
+    object_property_value(object, name).and_then(object_from_expression)
+}
+
+fn object_property_value<'a>(
+    object: &'a ObjectExpression<'a>,
+    name: &str,
+) -> Option<&'a Expression<'a>> {
+    // Read from the end to follow object-literal overwrite semantics. A later
+    // spread or computed key can replace the requested property at runtime, so
+    // it deliberately makes the compatibility value unknown.
+    for entry in object.properties.iter().rev() {
+        let ObjectPropertyKind::ObjectProperty(property) = entry else {
+            return None;
+        };
+        if property.computed {
+            return None;
+        }
+        if static_key_name(&property.key) == Some(name) {
+            return Some(&property.value);
+        }
+    }
+    None
+}
+
+fn expression_is_numeric_two(expression: &Expression<'_>) -> bool {
+    match expression {
+        Expression::NumericLiteral(literal) => literal.value == 2.0,
+        Expression::ParenthesizedExpression(parenthesized) => {
+            expression_is_numeric_two(&parenthesized.expression)
+        }
+        _ => false,
+    }
+}
+
+fn static_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::Identifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::StringLiteral(literal) => Some(literal.value.as_str()),
+        PropertyKey::ParenthesizedExpression(parenthesized) => {
+            static_expression_name(&parenthesized.expression)
+        }
+        _ => None,
+    }
+}
+
+fn static_expression_name<'a>(expression: &'a Expression<'a>) -> Option<&'a str> {
+    match expression {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        Expression::StringLiteral(literal) => Some(literal.value.as_str()),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            static_expression_name(&parenthesized.expression)
         }
         _ => None,
     }

--- a/crates/vize_patina/src/rules/script/nuxt_config_keys_order.rs
+++ b/crates/vize_patina/src/rules/script/nuxt_config_keys_order.rs
@@ -122,21 +122,27 @@ fn object_property_value<'a>(
     object: &'a ObjectExpression<'a>,
     name: &str,
 ) -> Option<&'a Expression<'a>> {
-    // Read from the end to follow object-literal overwrite semantics. A later
-    // spread or computed key can replace the requested property at runtime, so
-    // it deliberately makes the compatibility value unknown.
+    // Read from the end so a later spread or computed key makes the value
+    // unknown. Duplicate static declarations are also treated as ambiguous:
+    // compatibility mode should only suppress this rule for unambiguous input.
+    let mut value = None;
     for entry in object.properties.iter().rev() {
         let ObjectPropertyKind::ObjectProperty(property) = entry else {
-            return None;
+            value?;
+            continue;
         };
         if property.computed {
-            return None;
+            value?;
+            continue;
         }
         if static_key_name(&property.key) == Some(name) {
-            return Some(&property.value);
+            if value.is_some() {
+                return None;
+            }
+            value = Some(&property.value);
         }
     }
-    None
+    value
 }
 
 fn expression_is_numeric_two(expression: &Expression<'_>) -> bool {

--- a/crates/vize_patina/src/rules/script/nuxt_config_keys_order_tests.rs
+++ b/crates/vize_patina/src/rules/script/nuxt_config_keys_order_tests.rs
@@ -190,6 +190,50 @@ fn reports_the_actual_issue_3768_key_pair_at_the_authored_property() {
 }
 
 #[test]
+fn nuxt_two_compatibility_does_not_apply_the_nuxt_three_order() {
+    for source in [
+        "export default defineNuxtConfig({ plugins: [], buildModules: [], modules: [], vize: { compatibility: { nuxtVersion: 2 } } })",
+        "export default { 'plugins': [], modules: [], 'vize': ({ 'compatibility': ({ 'nuxtVersion': (2) }) }) }",
+        "export default { plugins: [], modules: [], ...base, vize: { ...defaults, compatibility: { ...compatibility, nuxtVersion: 2 } } }",
+    ] {
+        let result = lint(source);
+        assert!(result.diagnostics.is_empty(), "{source}: {result:#?}");
+    }
+
+    for version in ["3", "4", "detectedVersion"] {
+        let source = cstr!(
+            "export default defineNuxtConfig({{ plugins: [], modules: [], vize: {{ compatibility: {{ nuxtVersion: {version} }} }} }})"
+        );
+        let result = lint(&source);
+        assert_eq!(result.diagnostics.len(), 1, "{source}");
+        assert_eq!(
+            result.diagnostics[0].message,
+            "Expected config key \"plugins\" to come after \"modules\"",
+            "{source}"
+        );
+        assert!(result.diagnostics[0].fix.is_some(), "{source}");
+    }
+
+    for uncertain_override in [
+        "vize: { compatibility: { nuxtVersion: 2 } }, ...override",
+        "vize: { compatibility: { nuxtVersion: 2 } }, vize: { compatibility: { nuxtVersion: 3 } }",
+        "vize: { compatibility: { nuxtVersion: 2, ...override } }",
+        "vize: { compatibility: { nuxtVersion: 2, [key]: value } }",
+    ] {
+        let source = cstr!(
+            "export default defineNuxtConfig({{ plugins: [], modules: [], {uncertain_override} }})"
+        );
+        let result = lint(&source);
+        assert_eq!(result.diagnostics.len(), 1, "{source}");
+        assert_eq!(
+            result.diagnostics[0].message,
+            "Expected config key \"plugins\" to come after \"modules\"",
+            "{source}"
+        );
+    }
+}
+
+#[test]
 fn unknown_and_literal_keys_follow_upstream_collation() {
     assert_eq!(
         fix_until_stable("export default { zebra: 1, Zebra: 2, alpha: 3, Alpha: 4 }"),

--- a/crates/vize_patina/src/rules/script/nuxt_config_keys_order_tests.rs
+++ b/crates/vize_patina/src/rules/script/nuxt_config_keys_order_tests.rs
@@ -216,7 +216,7 @@ fn nuxt_two_compatibility_does_not_apply_the_nuxt_three_order() {
 
     for uncertain_override in [
         "vize: { compatibility: { nuxtVersion: 2 } }, ...override",
-        "vize: { compatibility: { nuxtVersion: 2 } }, vize: { compatibility: { nuxtVersion: 3 } }",
+        "vize: { compatibility: { nuxtVersion: 3 } }, vize: { compatibility: { nuxtVersion: 2 } }",
         "vize: { compatibility: { nuxtVersion: 2, ...override } }",
         "vize: { compatibility: { nuxtVersion: 2, [key]: value } }",
     ] {

--- a/npm/oxint/src/nuxt-preset.test.ts
+++ b/npm/oxint/src/nuxt-preset.test.ts
@@ -154,6 +154,24 @@ assert.match(
   /nuxt\.config\.ts[\s\S]*2:3[\s\S]*Expected config key "ssr" to come after "modules"[\s\S]*vize\(nuxt\/nuxt-config-keys-order\)/u,
 );
 
+fs.writeFileSync(
+  nuxtConfigPath,
+  `export default defineNuxtConfig({
+  plugins: [],
+  buildModules: [],
+  modules: [],
+  vize: { compatibility: { nuxtVersion: 2 } },
+})
+`,
+);
+const nuxtTwoConfigRun = runOxlint(["-c", ".oxlintrc.json", "-f", "stylish", "nuxt.config.ts"]);
+assert.equal(
+  nuxtTwoConfigRun.exitCode,
+  0,
+  `nuxt preset should not enforce Nuxt 3 ordering in Nuxt 2 compatibility mode:\n${nuxtTwoConfigRun.output}`,
+);
+assert.doesNotMatch(nuxtTwoConfigRun.output, /vize\(nuxt\/nuxt-config-keys-order\)/u);
+
 console.log("oxlint-plugin-vize Nuxt preset tests passed!");
 await import("./type-aware.test.ts");
 


### PR DESCRIPTION
## Summary

- avoid applying the Nuxt 3 config-key oracle when `vize.compatibility.nuxtVersion` is statically set to `2`
- preserve Nuxt 3/4 behavior and fail closed for dynamic, spread-overridden, or duplicate compatibility values
- cover direct Patina, Nuxt preset, and real native-backed Oxlint execution

Nuxt 2's official create-nuxt-app template orders `plugins` before `buildModules` and `modules`; suppressing this Nuxt 3-only rule avoids offering a contradictory fix.

## Verification

- `cargo test -p vize_patina --lib` (2460 passed)
- `cargo clippy -p vize_patina --lib -- -D warnings`
- `vp run build:native:test`
- `pnpm --filter oxlint-plugin-vize test`
- `vp check npm/oxint/src/nuxt-preset.test.ts`

Closes #3768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Nuxt configuration key ordering checks to recognize explicit Nuxt 2 compatibility settings.
  * Prevented incorrect ordering warnings for valid Nuxt 2 configurations.
  * Preserved diagnostics for Nuxt 3 and newer configurations, including ambiguous or unsupported compatibility declarations.
  * Added coverage to verify correct behavior across supported Nuxt versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->