### PR TITLE
test(cli): fail closed for basic SFC Corsa gates

### DIFF
--- a/crates/vize/tests/check_default_imports_cli.rs
+++ b/crates/vize/tests/check_default_imports_cli.rs
@@ -1,10 +1,13 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{path::Path, process::Command};
 
 use vize_carton::cstr;
 
 #[test]
 fn check_without_patterns_resolves_imports_outside_tsconfig_include_for_types() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project();

--- a/crates/vize/tests/check_define_props_cli.rs
+++ b/crates/vize/tests/check_define_props_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{path::Path, process::Command};
 
 fn workspace_root() -> &'static Path {
@@ -75,7 +78,7 @@ fn resolve_test_corsa_path() -> Option<String> {
 
 #[test]
 fn check_define_props_typeof_setup_binding_resolves_in_setup_scope() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_cli_project(

--- a/crates/vize/tests/check_function_props_cli.rs
+++ b/crates/vize/tests/check_function_props_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -7,7 +10,7 @@ use vize_carton::cstr;
 
 #[test]
 fn check_vue_function_prop_callbacks_and_create_app_chaining() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project();

--- a/crates/vize/tests/check_multistatement_v_on_cli.rs
+++ b/crates/vize/tests/check_multistatement_v_on_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -5,7 +8,7 @@ use std::{
 
 #[test]
 fn check_accepts_asi_separated_v_on_statements() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project = create_project();

--- a/crates/vize/tests/check_sfc_string_blocks_cli.rs
+++ b/crates/vize/tests/check_sfc_string_blocks_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -7,7 +10,7 @@ use vize_carton::cstr;
 
 #[test]
 fn check_ignores_sfc_blocks_inside_script_string_literals() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("sfc-block-string-literal");

--- a/crates/vize/tests/options_api_props_long_comment_cli.rs
+++ b/crates/vize/tests/options_api_props_long_comment_cli.rs
@@ -1,9 +1,12 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[test]
 fn check_options_api_prop_type_long_comments_has_no_ts_parse_errors() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_options_api_long_comment_project();

--- a/crates/vize/tests/options_api_props_spread_cli.rs
+++ b/crates/vize/tests/options_api_props_spread_cli.rs
@@ -1,9 +1,12 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[test]
 fn check_options_api_props_spread_with_instance_members_has_no_ts_parse_errors() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_cli_project();
@@ -52,7 +55,7 @@ fn check_options_api_props_spread_with_instance_members_has_no_ts_parse_errors()
 #[cfg(feature = "legacy")]
 #[test]
 fn check_legacy_vue2_options_api_prop_type_matrix_cli() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_prop_type_matrix_project();

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -130,6 +130,28 @@ test("project-root Rust CLI gates use the fail-closed Corsa helper", () => {
   }
 });
 
+test("basic SFC Rust CLI gates use the fail-closed Corsa helper", () => {
+  const files = [
+    ["check_default_imports_cli.rs", 1],
+    ["check_define_props_cli.rs", 1],
+    ["check_function_props_cli.rs", 1],
+    ["check_multistatement_v_on_cli.rs", 1],
+    ["check_sfc_string_blocks_cli.rs", 1],
+    ["options_api_props_long_comment_cli.rs", 1],
+    ["options_api_props_spread_cli.rs", 2],
+  ] as const;
+
+  for (const [file, expectedCalls] of files) {
+    const source = readRepoFile("crates", "vize", "tests", file);
+    assert.equal(
+      source.match(/corsa_requirement::required_or_skip\(resolve_test_corsa_path\(\)\)/g)?.length,
+      expectedCalls,
+      `${file} should guard all ${expectedCalls} Corsa resolver calls`,
+    );
+    assert.doesNotMatch(source, /let Some\(corsa_path\) = resolve_test_corsa_path\(\)/);
+  }
+});
+
 test("available dependencies never skip", () => {
   assert.equal(typecheckDependencySkip("/tmp/tsgo", "tsgo", "missing", true), false);
 });


### PR DESCRIPTION
## Summary

- apply the shared fail-closed Corsa requirement to seven basic SFC CLI suites
- retain the explicit local opt-out behavior outside required CI
- pin all eight resolver calls with an exact source-level dependency-gate assertion

## Validation

- VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize --test check_default_imports_cli --test check_define_props_cli --test check_function_props_cli --test check_multistatement_v_on_cli --test check_sfc_string_blocks_cli --test options_api_props_long_comment_cli --test options_api_props_spread_cli --test corsa_requirement_cli
- vp exec -- node --test tests/tooling/typecheck-dependency-gates.test.ts
- cargo fmt --all -- --check

Refs #3750