### PR TITLE
test(cli): fail closed for declaration Corsa gates

### DIFF
--- a/crates/vize/tests/build_declaration_emit_cli.rs
+++ b/crates/vize/tests/build_declaration_emit_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{path::Path, process::Command};
 
 use vize_carton::{String, ToCompactString, cstr};
@@ -164,7 +167,7 @@ fn collect_declaration_snapshot_recursive(
 
 #[test]
 fn build_dts_emits_declarations_alongside_compiled_js() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_cli_project("build-dts-emit", &[("src/Button.vue", BUTTON_VUE)]);
@@ -205,7 +208,7 @@ fn build_dts_emits_declarations_alongside_compiled_js() {
 
 #[test]
 fn build_declaration_dir_redirects_declaration_outputs() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_cli_project(

--- a/crates/vize/tests/check_declaration_emit_cli.rs
+++ b/crates/vize/tests/check_declaration_emit_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{path::Path, process::Command};
 
 use vize_carton::{String, ToCompactString, cstr};
@@ -80,7 +83,7 @@ fn resolve_test_corsa_path() -> Option<String> {
 
 #[test]
 fn check_declaration_emit_reports_module_declaration_outputs() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_cli_project(
@@ -211,7 +214,7 @@ export const answer = 42;
 
 #[test]
 fn check_declaration_emit_rewrites_declaration_map_sources() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let app_source = r#"<script setup lang="ts">

--- a/crates/vize/tests/check_declaration_emit_vue_floor_cli.rs
+++ b/crates/vize/tests/check_declaration_emit_vue_floor_cli.rs
@@ -20,6 +20,9 @@
 //! workspace's, so the floor is pinned regardless of which `vue` the developer
 //! happens to have installed.
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{path::Path, process::Command};
 
 use vize_carton::{String, ToCompactString, cstr};
@@ -174,7 +177,7 @@ fn create_project(corsa_path: &str) -> std::path::PathBuf {
 
 #[test]
 fn declaration_emit_survives_a_vue_without_native_elements_or_directive() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_project(corsa_path.as_str());

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -152,6 +152,24 @@ test("basic SFC Rust CLI gates use the fail-closed Corsa helper", () => {
   }
 });
 
+test("declaration emit Rust CLI gates use the fail-closed Corsa helper", () => {
+  const files = [
+    ["build_declaration_emit_cli.rs", 2],
+    ["check_declaration_emit_cli.rs", 2],
+    ["check_declaration_emit_vue_floor_cli.rs", 1],
+  ] as const;
+
+  for (const [file, expectedCalls] of files) {
+    const source = readRepoFile("crates", "vize", "tests", file);
+    assert.equal(
+      source.match(/corsa_requirement::required_or_skip\(resolve_test_corsa_path\(\)\)/g)?.length,
+      expectedCalls,
+      `${file} should guard all ${expectedCalls} Corsa resolver calls`,
+    );
+    assert.doesNotMatch(source, /let Some\(corsa_path\) = resolve_test_corsa_path\(\)/);
+  }
+});
+
 test("available dependencies never skip", () => {
   assert.equal(typecheckDependencySkip("/tmp/tsgo", "tsgo", "missing", true), false);
 });


### PR DESCRIPTION
## Summary

- require Corsa in declaration build and check CLI suites under CI fail-closed mode
- keep local dependency-missing skips while preventing silent green CI
- pin the exact declaration emit suites and guarded resolver counts in the tooling oracle

## Validation

- `VIZE_TEST_REQUIRE_TSGO=1` declaration CLI suites: 7 passed
- `node --test tests/tooling/typecheck-dependency-gates.test.ts`: 12 passed
- `cargo fmt --all -- --check`

Refs #3750

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->