### PR TITLE
fix(maestro): revalidate watched declaration diagnostics

### DIFF
--- a/crates/vize_maestro/src/document/store.rs
+++ b/crates/vize_maestro/src/document/store.rs
@@ -220,12 +220,19 @@ impl DocumentStore {
         uri: &Url,
         changes: Vec<TextDocumentContentChangeEvent>,
         version: i32,
-    ) {
-        if let Some(mut doc) = self.documents.get_mut(uri) {
-            for change in changes {
-                doc.apply_change(&change, version);
-            }
+    ) -> bool {
+        let Some(mut doc) = self.documents.get_mut(uri) else {
+            return false;
+        };
+        // tower-lsp polls notification handlers concurrently. Preserve the
+        // LSP version order even if a newer didChange reaches the store first.
+        if version <= doc.version {
+            return false;
         }
+        for change in changes {
+            doc.apply_change(&change, version);
+        }
+        true
     }
 
     /// Check if a document exists.
@@ -256,3 +263,5 @@ impl DocumentStore {
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod version_tests;

--- a/crates/vize_maestro/src/document/store/version_tests.rs
+++ b/crates/vize_maestro/src/document/store/version_tests.rs
@@ -1,0 +1,26 @@
+use tower_lsp::lsp_types::{TextDocumentContentChangeEvent, Url};
+
+use super::DocumentStore;
+
+fn full_change(text: &str) -> TextDocumentContentChangeEvent {
+    TextDocumentContentChangeEvent {
+        range: None,
+        range_length: None,
+        text: text.into(),
+    }
+}
+
+#[test]
+fn document_store_rejects_out_of_order_versions() {
+    let store = DocumentStore::new();
+    let uri = Url::parse("file:///version-order.vue").unwrap();
+    store.open(uri.clone(), "initial".into(), 1, "vue".into());
+
+    assert!(store.apply_changes(&uri, vec![full_change("newest")], 3));
+    assert!(!store.apply_changes(&uri, vec![full_change("stale")], 2));
+    assert!(!store.apply_changes(&uri, vec![full_change("duplicate")], 3));
+
+    let doc = store.get(&uri).unwrap();
+    assert_eq!(doc.text(), "newest");
+    assert_eq!(doc.version, 3);
+}

--- a/crates/vize_maestro/src/server.rs
+++ b/crates/vize_maestro/src/server.rs
@@ -14,6 +14,7 @@ use tower_lsp::jsonrpc::{Request, Response};
 mod annotations;
 mod auto_insert;
 mod capabilities;
+mod diagnostic_publishing;
 mod document_structure;
 mod format;
 mod handlers;

--- a/crates/vize_maestro/src/server/diagnostic_publishing.rs
+++ b/crates/vize_maestro/src/server/diagnostic_publishing.rs
@@ -1,0 +1,99 @@
+//! Diagnostic collection and LSP transport publishing.
+
+#[cfg(feature = "native")]
+use tower_lsp::lsp_types::MessageType;
+use tower_lsp::lsp_types::{Diagnostic, Url};
+
+use crate::ide::DiagnosticService;
+
+use super::MaestroServer;
+
+impl MaestroServer {
+    /// Collect diagnostics while the caller owns this document's diagnostic
+    /// lock. Sending the LSP notification is deliberately separate: the
+    /// client channel can apply backpressure, and no document lock should be
+    /// held while waiting for the transport to drain.
+    pub(super) async fn collect_diagnostics_unlocked(
+        &self,
+        uri: &Url,
+    ) -> Option<(i32, Vec<Diagnostic>)> {
+        let version = self
+            .state
+            .documents
+            .get(uri)
+            .map(|document| document.version);
+
+        if !self.state.lsp_features().has_diagnostics() {
+            return version.map(|version| (version, Vec::new()));
+        }
+
+        let Some(version) = version else {
+            tracing::debug!("skipping diagnostics for unopened document: {}", uri);
+            return None;
+        };
+
+        // Use async version when native feature is enabled (includes Corsa diagnostics)
+        #[cfg(feature = "native")]
+        let diagnostics = DiagnosticService::collect_async(&self.state, uri).await;
+
+        #[cfg(not(feature = "native"))]
+        let diagnostics = DiagnosticService::collect(&self.state, uri);
+
+        let current_version = self
+            .state
+            .documents
+            .get(uri)
+            .map(|document| document.version);
+        if current_version != Some(version) {
+            tracing::debug!(
+                "skipping stale diagnostics for {}: collected version {}, current {:?}",
+                uri,
+                version,
+                current_version
+            );
+            return None;
+        }
+
+        Some((version, diagnostics))
+    }
+
+    pub(super) async fn publish_collected_diagnostics(
+        &self,
+        uri: &Url,
+        version: i32,
+        diagnostics: Vec<Diagnostic>,
+    ) {
+        if self.state.documents.version(uri) != Some(version) {
+            tracing::debug!(
+                "skipping superseded diagnostics for {}: collected version {}, current {:?}",
+                uri,
+                version,
+                self.state.documents.version(uri)
+            );
+            return;
+        }
+
+        self.client
+            .publish_diagnostics(uri.clone(), diagnostics, Some(version))
+            .await;
+
+        // Surface a one-shot UI notification when type checking is requested
+        // but Corsa never came up. The hint diagnostic emitted by
+        // collect_async (see #708) shows up in the Problems panel; this
+        // adds a window/showMessage so users with the Problems panel
+        // collapsed also notice. See #681.
+        #[cfg(feature = "native")]
+        if self.state.is_lsp_typecheck_enabled()
+            && !self.state.has_corsa_bridge()
+            && self.state.claim_typecheck_unavailable_notice()
+        {
+            self.client
+                .show_message(
+                    MessageType::WARNING,
+                    "Vize: type checking is unavailable in this workspace. \
+                     Make sure tsconfig.json exists and the Corsa runtime is reachable.",
+                )
+                .await;
+        }
+    }
+}

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -111,14 +111,8 @@ impl LanguageServer for MaestroServer {
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         let uri = params.text_document.uri;
         let version = params.text_document.version;
-
-        self.state
-            .documents
-            .apply_changes(&uri, params.content_changes, version);
-
-        if let Some(content) = self.state.documents.text(&uri) {
-            self.publish_changed_diagnostics(&uri, &content).await;
-        }
+        self.apply_document_changes(&uri, params.content_changes, version)
+            .await;
     }
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
@@ -603,7 +597,7 @@ impl LanguageServer for MaestroServer {
     }
 
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
-        super::workspace_files::did_change_watched_files(&self.state, &params);
+        super::workspace_files::did_change_watched_files(self, &params).await;
     }
 
     async fn did_create_files(&self, params: CreateFilesParams) {

--- a/crates/vize_maestro/src/server/helpers.rs
+++ b/crates/vize_maestro/src/server/helpers.rs
@@ -6,7 +6,7 @@
 
 use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, DiagnosticSeverity, Hover, HoverContents, InsertTextFormat,
-    MarkupContent, MarkupKind, MessageType, NumberOrString, Position, Url,
+    MarkupContent, MarkupKind, NumberOrString, Position, TextDocumentContentChangeEvent, Url,
 };
 
 use crate::ide::DiagnosticService;
@@ -21,17 +21,37 @@ impl MaestroServer {
     /// Publish the changed document first, then refresh open Vue files that
     /// directly import it. Corsa has already received the changed virtual
     /// document by this point, so importer diagnostics observe the new shape.
-    pub(crate) async fn publish_changed_diagnostics(&self, uri: &Url, content: &str) {
-        self.state.update_virtual_docs(uri, content);
-        let version = self.state.documents.version(uri);
-        self.publish_diagnostics(uri).await;
+    pub(crate) async fn apply_document_changes(
+        &self,
+        uri: &Url,
+        changes: Vec<TextDocumentContentChangeEvent>,
+        version: i32,
+    ) {
+        #[cfg(feature = "native")]
+        let diagnostic_lock = self.state.diagnostic_lock(uri);
+        #[cfg(feature = "native")]
+        let diagnostic_guard = diagnostic_lock.lock().await;
+
+        if !self.state.documents.apply_changes(uri, changes, version) {
+            return;
+        }
+        let Some(content) = self.state.documents.text(uri) else {
+            return;
+        };
+        self.state.update_virtual_docs(uri, &content);
+        let diagnostics = self.collect_diagnostics_unlocked(uri).await;
+
+        #[cfg(feature = "native")]
+        drop(diagnostic_guard);
+
+        if let Some((diagnostic_version, diagnostics)) = diagnostics {
+            self.publish_collected_diagnostics(uri, diagnostic_version, diagnostics)
+                .await;
+        }
+
         if !self.state.is_lsp_typecheck_enabled() {
             return;
         }
-
-        let Some(version) = version else {
-            return;
-        };
         self.publish_importer_diagnostics(uri, version).await;
     }
 
@@ -71,66 +91,45 @@ impl MaestroServer {
 
     /// Publish diagnostics for a document.
     pub(crate) async fn publish_diagnostics(&self, uri: &Url) {
-        let version = self
-            .state
-            .documents
-            .get(uri)
-            .map(|document| document.version);
+        // tower-lsp polls notifications concurrently. A watched declaration
+        // change can therefore overlap consecutive didChange passes for the
+        // same Vue file; serialize those passes so their shared Corsa virtual
+        // document and overlay state cannot overtake one another.
+        #[cfg(feature = "native")]
+        let diagnostic_lock = self.state.diagnostic_lock(uri);
+        #[cfg(feature = "native")]
+        let diagnostic_guard = diagnostic_lock.lock().await;
 
-        if !self.state.lsp_features().has_diagnostics() {
-            self.client
-                .publish_diagnostics(uri.clone(), Vec::new(), version)
+        let diagnostics = self.collect_diagnostics_unlocked(uri).await;
+
+        #[cfg(feature = "native")]
+        drop(diagnostic_guard);
+
+        if let Some((version, diagnostics)) = diagnostics {
+            self.publish_collected_diagnostics(uri, version, diagnostics)
                 .await;
-            return;
         }
+    }
 
-        let Some(version) = version else {
-            tracing::debug!("skipping diagnostics for unopened document: {}", uri);
-            return;
+    /// Publish only if the document still has the version that scheduled the
+    /// refresh. Watcher revalidation yields to a newer didChange publish.
+    pub(crate) async fn publish_diagnostics_if_version(&self, uri: &Url, expected: i32) {
+        #[cfg(feature = "native")]
+        let diagnostic_lock = self.state.diagnostic_lock(uri);
+        #[cfg(feature = "native")]
+        let diagnostic_guard = diagnostic_lock.lock().await;
+
+        let diagnostics = if self.state.documents.version(uri) == Some(expected) {
+            self.collect_diagnostics_unlocked(uri).await
+        } else {
+            None
         };
 
-        // Use async version when native feature is enabled (includes Corsa diagnostics)
         #[cfg(feature = "native")]
-        let diagnostics = DiagnosticService::collect_async(&self.state, uri).await;
+        drop(diagnostic_guard);
 
-        #[cfg(not(feature = "native"))]
-        let diagnostics = DiagnosticService::collect(&self.state, uri);
-
-        let current_version = self
-            .state
-            .documents
-            .get(uri)
-            .map(|document| document.version);
-        if current_version != Some(version) {
-            tracing::debug!(
-                "skipping stale diagnostics for {}: collected version {}, current {:?}",
-                uri,
-                version,
-                current_version
-            );
-            return;
-        }
-
-        self.client
-            .publish_diagnostics(uri.clone(), diagnostics, Some(version))
-            .await;
-
-        // Surface a one-shot UI notification when type checking is requested
-        // but Corsa never came up. The hint diagnostic emitted by
-        // collect_async (see #708) shows up in the Problems panel; this
-        // adds a window/showMessage so users with the Problems panel
-        // collapsed also notice. See #681.
-        #[cfg(feature = "native")]
-        if self.state.is_lsp_typecheck_enabled()
-            && !self.state.has_corsa_bridge()
-            && self.state.claim_typecheck_unavailable_notice()
-        {
-            self.client
-                .show_message(
-                    MessageType::WARNING,
-                    "Vize: type checking is unavailable in this workspace. \
-                     Make sure tsconfig.json exists and the Corsa runtime is reachable.",
-                )
+        if let Some((version, diagnostics)) = diagnostics {
+            self.publish_collected_diagnostics(uri, version, diagnostics)
                 .await;
         }
     }

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -111,6 +111,11 @@ pub struct ServerState {
     /// Serializes Corsa bridge initialization without tying us to a runtime.
     #[cfg(feature = "native")]
     corsa_init_lock: AsyncMutex<()>,
+    /// Per-document diagnostic passes. Watcher refreshes and consecutive
+    /// didChange notifications may be polled concurrently by tower-lsp, but
+    /// they must not race the same Corsa virtual document.
+    #[cfg(feature = "native")]
+    diagnostic_locks: DashMap<Url, Arc<AsyncMutex<()>>>,
     /// Flag to track if Corsa initialization has been attempted and failed
     #[cfg(feature = "native")]
     corsa_init_failed: std::sync::atomic::AtomicBool,
@@ -183,6 +188,8 @@ impl ServerState {
             #[cfg(feature = "native")]
             corsa_init_lock: AsyncMutex::new(()),
             #[cfg(feature = "native")]
+            diagnostic_locks: DashMap::new(),
+            #[cfg(feature = "native")]
             corsa_init_failed: std::sync::atomic::AtomicBool::new(false),
             #[cfg(feature = "native")]
             corsa_init_failure_reason: RwLock::new(None),
@@ -217,7 +224,30 @@ impl ServerState {
     pub(crate) fn close_document(&self, uri: &Url) {
         self.documents.close(uri);
         #[cfg(feature = "native")]
-        self.corsa_overlays.remove(uri);
+        {
+            self.corsa_overlays.remove(uri);
+            self.remove_idle_diagnostic_lock(uri);
+        }
+    }
+
+    /// Owned per-document lock for a diagnostic pass. Clone the `Arc` before
+    /// awaiting so no DashMap guard survives across a suspension point.
+    #[cfg(feature = "native")]
+    pub(crate) fn diagnostic_lock(&self, uri: &Url) -> Arc<AsyncMutex<()>> {
+        self.diagnostic_locks
+            .entry(uri.clone())
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone()
+    }
+
+    #[cfg(feature = "native")]
+    fn remove_idle_diagnostic_lock(&self, uri: &Url) {
+        if let dashmap::mapref::entry::Entry::Occupied(entry) =
+            self.diagnostic_locks.entry(uri.clone())
+            && Arc::strong_count(entry.get()) == 1
+        {
+            entry.remove();
+        }
     }
 
     /// Rename a document while dropping the overlay cached under its old URI.

--- a/crates/vize_maestro/src/server/workspace_files.rs
+++ b/crates/vize_maestro/src/server/workspace_files.rs
@@ -70,13 +70,43 @@ fn global_component_watcher_registration() -> Registration {
     }
 }
 
-pub(super) fn did_change_watched_files(state: &ServerState, params: &DidChangeWatchedFilesParams) {
+pub(super) async fn did_change_watched_files(
+    server: &MaestroServer,
+    params: &DidChangeWatchedFilesParams,
+) {
     #[cfg(feature = "native")]
-    state.invalidate_global_component_references(
-        params.changes.iter().map(|change| change.uri.as_str()),
-    );
+    {
+        if !server.state.invalidate_global_component_references(
+            params.changes.iter().map(|change| change.uri.as_str()),
+        ) {
+            return;
+        }
+
+        let mut dependents = params
+            .changes
+            .iter()
+            .flat_map(|change| super::importers::open_vue_dependents(&server.state, &change.uri))
+            .collect::<Vec<_>>();
+        dependents.sort();
+        dependents.dedup();
+        let dependents = dependents
+            .into_iter()
+            .filter_map(|uri| {
+                server
+                    .state
+                    .documents
+                    .version(&uri)
+                    .map(|version| (uri, version))
+            })
+            .collect::<Vec<_>>();
+        for (dependent, version) in dependents {
+            server
+                .publish_diagnostics_if_version(&dependent, version)
+                .await;
+        }
+    }
     #[cfg(not(feature = "native"))]
-    let _ = (state, params);
+    let _ = (server, params);
 }
 
 pub(super) fn did_create_files(state: &ServerState, params: &CreateFilesParams) {

--- a/tests/tooling/lsp-watcher-revalidation.test.ts
+++ b/tests/tooling/lsp-watcher-revalidation.test.ts
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
+
+test("vize lsp revalidates open documents after watched declaration changes", async (t) => {
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTsgoBinary(),
+    "tsgo binary for the LSP watcher revalidation gate",
+    "tsgo binary not found; skipping LSP watcher revalidation test",
+  );
+  if (corsaPath == null) return;
+
+  const testRootDir = path.join(testOutputRoot, "lsp-watcher-revalidation");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+  let primaryError: unknown;
+
+  try {
+    const sourceDir = path.join(workspaceDir, "src");
+    const declarationDir = path.join(workspaceDir, ".nuxt");
+    fs.mkdirSync(sourceDir, { recursive: true });
+    fs.mkdirSync(declarationDir, { recursive: true });
+    const vuePackage = resolveVuePackage();
+    if (vuePackage == null) {
+      writeVueShim(workspaceDir);
+    } else {
+      linkVuePackage(workspaceDir, vuePackage);
+    }
+    fs.writeFileSync(
+      path.join(workspaceDir, "vize.config.json"),
+      JSON.stringify({ lsp: { lint: false, typecheck: true }, typeChecker: { corsaPath } }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src/**/*"],
+      }),
+      "utf8",
+    );
+
+    const declarationPath = path.join(declarationDir, "components.d.ts");
+    const declarationUri = pathToFileURL(declarationPath).href;
+    writeGlobalComponentDeclaration(declarationPath, "string");
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: true,
+    });
+
+    const source = `<script setup lang="ts">
+/// <reference types="vue" />
+const count = 1
+</script>
+
+<template>
+  <NuxtCard :count="count" />
+</template>
+`;
+    const filePath = path.join(sourceDir, "App.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: source },
+    });
+
+    const initial = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) =>
+        isDiagnosticsForUri(params, uri) &&
+        params.version === 1 &&
+        params.diagnostics.some((diagnostic) => diagnostic.message?.includes("string")),
+    )) as PublishDiagnosticsParams;
+    const bindingOffset = source.indexOf(":count");
+    assert.notEqual(bindingOffset, -1);
+    const bindingStart = offsetToPosition(source, bindingOffset + ":".length);
+    assert.deepEqual(initial.diagnostics, [expectedCountDiagnostic(bindingStart, "string")]);
+
+    writeGlobalComponentDeclaration(declarationPath, "boolean");
+    session.notify("workspace/didChangeWatchedFiles", {
+      changes: [{ uri: declarationUri, type: 2 }],
+    });
+
+    const revalidated = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) =>
+        isDiagnosticsForUri(params, uri) &&
+        params.version === 1 &&
+        params.diagnostics.some((diagnostic) => diagnostic.message?.includes("boolean")),
+    )) as PublishDiagnosticsParams;
+    assert.equal(revalidated.version, 1, "the watcher must not require a document edit");
+    assert.deepEqual(revalidated.diagnostics, [expectedCountDiagnostic(bindingStart, "boolean")]);
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    await session.shutdown().catch((error: unknown) => {
+      if (primaryError == null) throw error;
+    });
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+function expectedCountDiagnostic(start: { line: number; character: number }, expectedType: string) {
+  return {
+    code: 2322,
+    message: `Type 'number' is not assignable to type '${expectedType}'.`,
+    range: {
+      start,
+      end: { line: start.line, character: start.character + "count".length },
+    },
+    severity: 1,
+    source: "vize/types",
+  };
+}
+
+function writeGlobalComponentDeclaration(filePath: string, countType: string): void {
+  fs.writeFileSync(
+    filePath,
+    `declare module "vue" {
+  export interface GlobalComponents {
+    NuxtCard: import("vue").DefineComponent<{ count: ${countType} }>;
+  }
+}
+export {};
+`,
+    "utf8",
+  );
+}
+
+function resolveTsgoBinary(): string | undefined {
+  const candidates = [
+    path.join(root, "../corsa-bind/.cache/tsgo"),
+    path.join(root, "node_modules/.bin/tsgo"),
+    path.join(root, "tests/node_modules/.bin/tsgo"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function resolveVuePackage(): string | undefined {
+  const candidates = [
+    path.join(root, "node_modules/vue"),
+    path.join(root, "tests/node_modules/vue"),
+    path.join(root, "playground/node_modules/vue"),
+    path.join(root, "examples/jsx-tsx/node_modules/vue"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function linkVuePackage(workspaceDir: string, vuePackage: string): void {
+  const nodeModules = path.join(workspaceDir, "node_modules");
+  fs.mkdirSync(nodeModules, { recursive: true });
+  symlink(vuePackage, path.join(nodeModules, "vue"));
+
+  const vueNamespace = path.join(path.dirname(vuePackage), "@vue");
+  if (fs.existsSync(vueNamespace)) {
+    symlink(vueNamespace, path.join(nodeModules, "@vue"));
+  }
+}
+
+function symlink(source: string, target: string): void {
+  fs.rmSync(target, { force: true, recursive: true });
+  fs.symlinkSync(source, target, process.platform === "win32" ? "junction" : "dir");
+}
+
+function writeVueShim(workspaceDir: string): void {
+  fs.writeFileSync(
+    path.join(workspaceDir, "src/vue-shim.d.ts"),
+    `declare module "vue" {
+  export interface Ref<T = any> {
+    value: T;
+  }
+
+  export interface ShallowRef<T = any> {
+    value: T;
+  }
+
+  export type DefineComponent<Props = {}> = new () => { $props: Props };
+
+  export interface ComponentPublicInstance {
+    $attrs: Record<string, unknown>;
+    $slots: Record<string, unknown>;
+    $refs: Record<string, unknown>;
+    $emit: (...args: any[]) => void;
+  }
+
+  export interface GlobalComponents {}
+}
+`,
+    "utf8",
+  );
+}

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -33,6 +33,7 @@ test("typecheck and LSP gates do not carry raw dependency skips", () => {
     "lsp-corsa-crash-recovery.test.ts",
     "lsp-file-create-delete.test.ts",
     "lsp-typecheck-template.test.ts",
+    "lsp-watcher-revalidation.test.ts",
     "typecheck-baseline-project.test.ts",
   ];
 


### PR DESCRIPTION
## Summary

- refresh open Vue diagnostics after a watched declaration invalidates global-component discovery
- keep unrelated and out-of-workspace watcher events as no-ops
- add a real stdio LSP oracle that rewrites a `.d.ts` from `string` to `boolean` and requires version-1 diagnostics to update without any document edit
- include the new Corsa-dependent oracle in the fail-closed dependency gate

## Validation

- `cargo test -p vize_maestro --all-features` (692 passed, 2 ignored; 3 integration passed; doctest passed)
- `cargo clippy -p vize_maestro --all-features -- -D warnings`
- `VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/lsp-file-create-delete.test.ts tests/tooling/lsp-watcher-revalidation.test.ts`
- `node --test tests/tooling/typecheck-dependency-gates.test.ts`
- `vp check tests/tooling/lsp-watcher-revalidation.test.ts tests/tooling/typecheck-dependency-gates.test.ts`
- `cargo fmt --all -- --check`
- `git diff --check`

Refs #3742

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->