### PR TITLE
test(editor): run Vim against the real server

### DIFF
--- a/.github/actions/vscode-host-smoke/action.yml
+++ b/.github/actions/vscode-host-smoke/action.yml
@@ -1,5 +1,5 @@
 name: Editor real-server end-to-end
-description: Run VS Code and Neovim real-server scenarios plus Neovim and Vim headless specs
+description: Run VS Code, Neovim, and Vim real-server scenarios plus packaged editor specs
 
 runs:
   using: composite
@@ -61,7 +61,27 @@ runs:
 
     - name: Ensure Vim is available
       shell: bash
-      run: command -v vim || (sudo apt-get update && sudo apt-get install -y vim)
+      run: |
+        set -euo pipefail
+        if ! command -v vim || ! vim --version | grep -F '+timers' >/dev/null; then
+          sudo apt-get update
+          sudo apt-get install -y vim-nox
+        fi
+        vim --version | sed -n '1,2p'
+        vim --version | grep -F '+timers' >/dev/null
+
+    - name: Install pinned vim-lsp
+      shell: bash
+      env:
+        VIM_LSP_COMMIT: 474c656659b5fb51eec6770309e0211c8aa49b5b
+      run: |
+        set -euo pipefail
+        git init "${RUNNER_TEMP}/vim-lsp"
+        git -C "${RUNNER_TEMP}/vim-lsp" remote add origin https://github.com/prabirshrestha/vim-lsp.git
+        git -C "${RUNNER_TEMP}/vim-lsp" fetch --depth 1 origin "${VIM_LSP_COMMIT}"
+        git -C "${RUNNER_TEMP}/vim-lsp" checkout --detach FETCH_HEAD
+        cd "${RUNNER_TEMP}/vim-lsp"
+        test "$(git rev-parse HEAD)" = "${VIM_LSP_COMMIT}"
 
     - name: Ensure Emacs is available
       shell: bash
@@ -98,3 +118,11 @@ runs:
         NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
         VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize
       run: vp run --workspace-root test:nvim-extension:real-server
+
+    - name: Run the Vim scenario against the real server
+      shell: bash
+      env:
+        NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+        VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize
+        VIZE_TEST_VIM_LSP_PATH: ${{ runner.temp }}/vim-lsp
+      run: vp run --workspace-root test:vim-extension:real-server

--- a/editors/vim/autoload/vize.vim
+++ b/editors/vim/autoload/vize.vim
@@ -67,7 +67,10 @@ endfunction
 
 function! vize#setup(...) abort
   let l:config = vize#normalize(a:0 ? a:1 : {})
-  if exists('*lsp#register_server')
+  " vim-lsp defines its public functions through autoload, so checking only
+  " exists('*lsp#register_server') misses the normal startup order where its
+  " plugin commands are loaded before an autoload function is first called.
+  if exists('*lsp#register_server') || exists(':LspStatus') == 2
     call lsp#register_server(vize#vim_lsp_config(l:config))
   else
     echohl WarningMsg

--- a/editors/vim/test/vize_e2e_expected.vim
+++ b/editors/vim/test/vize_e2e_expected.vim
@@ -1,0 +1,138 @@
+" Complete real-server responses for vize_e2e_spec.vim.
+"
+" The fixture and positions match the VS Code and Neovim host scenarios, but
+" this file keeps Vim's native Dictionary/List representation so assert_equal
+" detects added, removed, or moved response fields.
+
+let g:vize_e2e_expected = {
+      \ 'authored_source': [
+      \   '<script setup lang="ts">',
+      \   'import Child from "./Child.vue";',
+      \   '',
+      \   'const total = "3";',
+      \   '</script>',
+      \   '',
+      \   '<template>',
+      \   '<Child  :count="total" />',
+      \   '</template>',
+      \ ],
+      \ 'completion': [
+      \   {
+      \     'detail': ' (const)',
+      \     'documentation': {
+      \       'kind': 'markdown',
+      \       'value': "**Const**\n\nConstant binding (function, class, or literal).",
+      \     },
+      \     'kind': 21,
+      \     'label': 'Child',
+      \     'labelDetails': {'detail': ' (const)'},
+      \     'sortText': '0Child',
+      \   },
+      \   {
+      \     'detail': ' (literal)',
+      \     'documentation': {
+      \       'kind': 'markdown',
+      \       'value': "**Literal**\n\nLiteral constant value.",
+      \     },
+      \     'kind': 21,
+      \     'label': 'total',
+      \     'labelDetails': {'detail': ' (literal)'},
+      \     'sortText': '0total',
+      \   },
+      \ ],
+      \ 'diagnostics': [
+      \   {
+      \     'code': 'vue/no-multi-spaces',
+      \     'codeDescription': {'href': 'https://eslint.vuejs.org/rules/no-multi-spaces.html'},
+      \     'message': 'Multiple consecutive spaces',
+      \     'range': {
+      \       'end': {'character': 8, 'line': 7},
+      \       'start': {'character': 6, 'line': 7},
+      \     },
+      \     'severity': 2,
+      \     'source': 'vize/lint',
+      \   },
+      \   {
+      \     'code': 2322,
+      \     'message': "Type 'string' is not assignable to type 'number'.",
+      \     'range': {
+      \       'end': {'character': 14, 'line': 7},
+      \       'start': {'character': 9, 'line': 7},
+      \     },
+      \     'severity': 1,
+      \     'source': 'vize/types',
+      \   },
+      \ ],
+      \ 'formatting': [
+      \   {
+      \     'newText': "<script setup lang=\"ts\">\nimport Child from \"./Child.vue\";\n\nconst total = \"3\";\n</script>\n\n<template>\n  <Child :count=\"total\" />\n</template>\n",
+      \     'range': {
+      \       'end': {'character': 0, 'line': 9},
+      \       'start': {'character': 0, 'line': 0},
+      \     },
+      \   },
+      \ ],
+      \ 'hover': {
+      \   'contents': {
+      \     'kind': 'markdown',
+      \     'value': "**TypeScript quick info**\n\n_Resolved through Vize virtual TypeScript_\n\n```typescript\nconst total: \"3\"\n```",
+      \   },
+      \   'range': {
+      \     'end': {'character': 11, 'line': 3},
+      \     'start': {'character': 6, 'line': 3},
+      \   },
+      \ },
+      \ 'semantic_tokens': {'data': [7, 8, 6, 9, 0, 0, 8, 5, 8, 0]},
+      \ }
+
+function! VizeE2EExpectedCodeActions(uri) abort
+  return [
+        \ {
+        \   'edit': {'changes': {a:uri: [
+        \     {
+        \       'newText': ' ',
+        \       'range': {
+        \         'end': {'character': 8, 'line': 7},
+        \         'start': {'character': 6, 'line': 7},
+        \       },
+        \     },
+        \   ]}},
+        \   'isPreferred': v:true,
+        \   'kind': 'quickfix',
+        \   'title': 'Fix: Replace multiple spaces with single space',
+        \ },
+        \ {
+        \   'edit': {'changes': {a:uri: [
+        \     {
+        \       'newText': "<!-- @vize:forget vue/no-multi-spaces -->\n",
+        \       'range': {
+        \         'end': {'character': 0, 'line': 7},
+        \         'start': {'character': 0, 'line': 7},
+        \       },
+        \     },
+        \   ]}},
+        \   'isPreferred': v:false,
+        \   'kind': 'quickfix',
+        \   'title': 'Suppress with @vize:forget (vue/no-multi-spaces)',
+        \ },
+        \ ]
+endfunction
+
+function! VizeE2EExpectedRename(uri) abort
+  return {'changes': {a:uri: [
+        \ {
+        \   'newText': 'quantity',
+        \   'range': {
+        \     'end': {'character': 11, 'line': 3},
+        \     'start': {'character': 6, 'line': 3},
+        \   },
+        \ },
+        \ {
+        \   'newText': 'quantity',
+        \   'range': {
+        \     'end': {'character': 21, 'line': 7},
+        \     'start': {'character': 16, 'line': 7},
+        \   },
+        \ },
+        \ ]}}
+endfunction

--- a/editors/vim/test/vize_e2e_spec.vim
+++ b/editors/vim/test/vize_e2e_spec.vim
@@ -1,0 +1,152 @@
+" Headless Vim end-to-end scenario against a real `vize lsp` process through
+" the packaged vim-lsp registration helper.
+
+set nocompatible
+set nomore
+
+let s:plugin_root = $VIZE_E2E_PLUGIN_ROOT
+let s:vim_lsp_root = $VIZE_TEST_VIM_LSP_PATH
+let s:workspace = $VIZE_E2E_WORKSPACE
+let s:server = $VIZE_E2E_SERVER
+
+call assert_notequal('', s:plugin_root, 'VIZE_E2E_PLUGIN_ROOT must be set')
+call assert_notequal('', s:vim_lsp_root, 'VIZE_TEST_VIM_LSP_PATH must be set')
+call assert_notequal('', s:workspace, 'VIZE_E2E_WORKSPACE must be set')
+call assert_notequal('', s:server, 'VIZE_E2E_SERVER must be set')
+
+execute 'set runtimepath^=' . fnameescape(s:vim_lsp_root)
+execute 'set runtimepath^=' . fnameescape(s:plugin_root)
+runtime plugin/lsp.vim
+runtime plugin/vize.vim
+runtime ftdetect/vize.vim
+execute 'source ' . fnameescape(s:plugin_root . '/test/vize_e2e_expected.vim')
+let s:expected = g:vize_e2e_expected
+
+let s:init_options = vize#profile('recommended')
+let s:init_options.formatting = v:true
+let s:resolved = vize#setup({
+      \ 'cmd': [s:server, 'lsp'],
+      \ 'initialization_options': s:init_options,
+      \ })
+call assert_equal(['vue', 'art-vue'], s:resolved.allowlist, 'packaged filetypes')
+call assert_equal(s:init_options, s:resolved.initialization_options, 'packaged init options')
+
+" Register first, then let vim-lsp enable itself. This is the normal vimrc
+" startup order and catches integrations that wrongly require an autoload
+" function to have run before vize#setup().
+call lsp#enable()
+execute 'edit ' . fnameescape(s:workspace . '/src/Scenario.vue')
+call assert_equal('vue', &filetype, 'ftdetect maps the fixture to vue')
+call assert_equal(s:expected.authored_source, getline(1, '$'), 'authored fixture source')
+
+let s:ready = lsp#utils#_wait(
+      \ 120000,
+      \ {-> lsp#get_server_status('vize') ==# 'running'},
+      \ 100,
+      \ )
+call assert_equal(0, s:ready, 'the vize language server did not initialize')
+let s:uri = lsp#utils#get_buffer_uri()
+call assert_equal(
+      \ resolve(s:workspace),
+      \ resolve(lsp#utils#uri_to_path(lsp#get_server_root_uri('vize'))),
+      \ 'workspace root',
+      \ )
+
+function! s:diagnostic_compare(left, right) abort
+  let l:left = a:left.range.start
+  let l:right = a:right.range.start
+  if l:left.line != l:right.line
+    return l:left.line - l:right.line
+  endif
+  return l:left.character - l:right.character
+endfunction
+
+function! s:diagnostics(uri) abort
+  let l:grouped = lsp#internal#diagnostics#state#_get_all_diagnostics_grouped_by_server_for_uri(a:uri)
+  let l:diagnostics = deepcopy(get(get(get(l:grouped, 'vize', {}), 'params', {}), 'diagnostics', []))
+  return sort(l:diagnostics, function('s:diagnostic_compare'))
+endfunction
+
+let s:diagnostics_ready = lsp#utils#_wait(
+      \ 240000,
+      \ {-> s:diagnostics(s:uri) ==# s:expected.diagnostics},
+      \ 200,
+      \ )
+call assert_equal(0, s:diagnostics_ready, 'real server did not publish the scenario diagnostics')
+call assert_equal(s:expected.diagnostics, s:diagnostics(s:uri))
+
+let s:responses = {}
+function! s:on_response(method, data) abort
+  let s:responses[a:method] = a:data
+endfunction
+
+function! s:request(method, params, expected) abort
+  call lsp#send_request('vize', {
+        \ 'method': a:method,
+        \ 'params': a:params,
+        \ 'on_notification': function('s:on_response', [a:method]),
+        \ })
+  let l:settled = lsp#utils#_wait(120000, {-> has_key(s:responses, a:method)}, 100)
+  call assert_equal(0, l:settled, a:method . ' timed out')
+  if l:settled != 0
+    return
+  endif
+
+  let l:data = remove(s:responses, a:method)
+  call assert_true(has_key(l:data, 'response'), a:method . ' produced no response')
+  if !has_key(l:data, 'response')
+    return
+  endif
+  let l:response = l:data.response
+  call assert_false(lsp#client#is_error(l:response), a:method . ' returned an error')
+  call assert_true(has_key(l:response, 'result'), a:method . ' returned no result')
+  if has_key(l:response, 'result')
+    call assert_equal(a:expected, l:response.result, a:method)
+  endif
+endfunction
+
+call s:request('textDocument/completion', {
+      \ 'position': {'character': 16, 'line': 7},
+      \ 'textDocument': {'uri': s:uri},
+      \ }, s:expected.completion)
+call s:request('textDocument/hover', {
+      \ 'position': {'character': 8, 'line': 3},
+      \ 'textDocument': {'uri': s:uri},
+      \ }, s:expected.hover)
+call s:request('textDocument/codeAction', {
+      \ 'context': {'diagnostics': []},
+      \ 'range': {
+      \   'end': {'character': 8, 'line': 7},
+      \   'start': {'character': 6, 'line': 7},
+      \ },
+      \ 'textDocument': {'uri': s:uri},
+      \ }, VizeE2EExpectedCodeActions(s:uri))
+call s:request('textDocument/formatting', {
+      \ 'options': {'insertSpaces': v:true, 'tabSize': 2},
+      \ 'textDocument': {'uri': s:uri},
+      \ }, s:expected.formatting)
+call s:request('textDocument/semanticTokens/full', {
+      \ 'textDocument': {'uri': s:uri},
+      \ }, s:expected.semantic_tokens)
+call s:request('textDocument/rename', {
+      \ 'newName': 'quantity',
+      \ 'position': {'character': 8, 'line': 3},
+      \ 'textDocument': {'uri': s:uri},
+      \ }, VizeE2EExpectedRename(s:uri))
+
+call lsp#stop_server('vize')
+let s:stopped = lsp#utils#_wait(
+      \ 10000,
+      \ {-> lsp#get_server_status('vize') ==# 'exited'},
+      \ 100,
+      \ )
+call assert_equal(0, s:stopped, 'the vize language server did not stop')
+
+if !empty(v:errors)
+  if $VIZE_E2E_ERROR_PATH !=# ''
+    call writefile(v:errors, $VIZE_E2E_ERROR_PATH)
+  endif
+  cquit 1
+endif
+
+quitall!

--- a/editors/vim/test/vize_spec.vim
+++ b/editors/vim/test/vize_spec.vim
@@ -92,6 +92,26 @@ call assert_equal(['/tmp/vize', 'lsp'], s:custom_lsp_config.cmd({}))
 call assert_equal(['art-vue'], s:custom_lsp_config.allowlist)
 call assert_equal({'hover': v:true}, s:custom_lsp_config.initialization_options)
 
+" vim-lsp exposes commands from plugin/lsp.vim before its autoload functions
+" exist. Verify vize#setup() recognizes that ordinary startup order and lets
+" Vim autoload lsp#register_server on demand.
+let s:lsp_stub_root = tempname()
+call mkdir(s:lsp_stub_root . '/autoload', 'p')
+call writefile([
+      \ 'function! lsp#register_server(config) abort',
+      \ '  let g:vize_test_registered_server = a:config',
+      \ 'endfunction',
+      \ ], s:lsp_stub_root . '/autoload/lsp.vim')
+execute 'set runtimepath^=' . fnameescape(s:lsp_stub_root)
+command! LspStatus echo 'stub'
+call vize#setup({'profile': 'lint'})
+call assert_equal('vize', g:vize_test_registered_server.name)
+call assert_equal({'lint': v:true}, g:vize_test_registered_server.initialization_options)
+delcommand LspStatus
+execute 'set runtimepath-=' . fnameescape(s:lsp_stub_root)
+call delete(s:lsp_stub_root, 'rf')
+unlet g:vize_test_registered_server
+
 try
   call vize#profile('missing')
   call assert_report('expected unknown profile to fail')

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -32,20 +32,29 @@ test("the Neovim real-server scenario has a task that runs its Node launcher", (
   );
 });
 
-test("CI runs both real-server editor scenarios from one built server binary", () => {
+test("the Vim real-server scenario has a task that runs its Node launcher", () => {
+  assert.equal(
+    taskCommand("test:vim-extension:real-server"),
+    "node tools/vim-vize/run-real-server.mjs",
+  );
+});
+
+test("CI runs all real-server editor scenarios from one built server binary", () => {
   const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
 
-  // One `cargo build` feeds both scenarios; both must consume that binary.
+  // One `cargo build` feeds all scenarios; each must consume that binary.
   assert.match(action, /run: cargo build --profile ci -p vize/);
   assert.deepEqual(
     action.match(/VIZE_SERVER_PATH: \$\{\{ github\.workspace \}\}\/target\/ci\/vize/g),
     [
       "VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize",
       "VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize",
+      "VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize",
     ],
   );
   assert.match(action, /vp run --workspace-root test:vscode-extension:host-real/);
   assert.match(action, /vp run --workspace-root test:nvim-extension:real-server/);
+  assert.match(action, /vp run --workspace-root test:vim-extension:real-server/);
 
   // The scenario needs a Neovim with a Lua LSP client, pinned and checksummed.
   assert.match(action, /NVIM_VERSION: v\d+\.\d+\.\d+/);
@@ -76,6 +85,30 @@ test("CI runs both headless editor specs", () => {
   assert.match(action, /vp run --workspace-root test:nvim-extension:headless/);
   assert.match(action, /vp run --workspace-root test:vim-extension:headless/);
   assert.match(action, /command -v vim/);
+  assert.match(action, /vim --version \| grep -F '\+timers'/);
+  assert.match(action, /sudo apt-get install -y vim-nox/);
+});
+
+test("CI pins vim-lsp before running the Vim real-server scenario", () => {
+  const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
+  const installAt = action.indexOf("- name: Install pinned vim-lsp");
+  const scenarioAt = action.indexOf("- name: Run the Vim scenario against the real server");
+
+  assert.ok(installAt >= 0, "editor host CI must install vim-lsp");
+  assert.ok(scenarioAt > installAt, "vim-lsp must be pinned before the scenario starts");
+
+  const install = action.slice(installAt, scenarioAt);
+  assert.match(install, /VIM_LSP_COMMIT: [0-9a-f]{40}/);
+  assert.match(
+    install,
+    /git -C "\$\{RUNNER_TEMP\}\/vim-lsp" fetch --depth 1 origin "\$\{VIM_LSP_COMMIT\}"/,
+  );
+  assert.match(install, /test "\$\(git rev-parse HEAD\)" = "\$\{VIM_LSP_COMMIT\}"/);
+
+  const scenario = action.slice(scenarioAt);
+  assert.match(scenario, /VIZE_TEST_VIM_LSP_PATH: \$\{\{ runner\.temp \}\}\/vim-lsp/);
+  assert.match(scenario, /VIZE_SERVER_PATH: \$\{\{ github\.workspace \}\}\/target\/ci\/vize/);
+  assert.match(scenario, /vp run --workspace-root test:vim-extension:real-server/);
 });
 
 test("CI executes the packaged Emacs ERT suite", () => {
@@ -115,6 +148,33 @@ test("the packaged Neovim archive ships the real-server scenario", () => {
   assert.match(assertion, /"nvim\/test\/vize_e2e_expected\.lua"/);
   assert.match(assertion, /"nvim\/test\/vize_e2e_spec\.lua"/);
   assert.match(assertion, /\^nvim\\\/test\\\/vize_e2e_\(\?:expected\|spec\)\\\.lua\$/);
+});
+
+test("the packaged Vim archive ships the real-server scenario", () => {
+  const assertion = readRepoFile("tools", "vim-vize", "assert-vim-package.mjs");
+
+  assert.match(assertion, /"vim\/test\/vize_e2e_expected\.vim"/);
+  assert.match(assertion, /"vim\/test\/vize_e2e_spec\.vim"/);
+  assert.match(assertion, /\^vim\\\/test\\\/vize_e2e_\(\?:expected\|spec\)\\\.vim\$/);
+});
+
+test("the Vim real-server scenario pins complete host responses", () => {
+  const scenario = readRepoFile("editors", "vim", "test", "vize_e2e_spec.vim");
+
+  for (const method of [
+    "textDocument/completion",
+    "textDocument/hover",
+    "textDocument/codeAction",
+    "textDocument/formatting",
+    "textDocument/semanticTokens/full",
+    "textDocument/rename",
+  ]) {
+    assert.match(scenario, new RegExp(method.replace("/", "\\/")));
+  }
+  assert.match(scenario, /assert_equal\(s:expected\.diagnostics, s:diagnostics\(s:uri\)\)/);
+  assert.match(scenario, /assert_equal\(a:expected, l:response\.result, a:method\)/);
+  assert.doesNotMatch(scenario, /\.includes\(|\.contains\(/);
+  assert.doesNotMatch(scenario, /\/dev\/(?:stdout|stderr)/);
 });
 
 test("the Neovim real-server scenario pins completion and hover responses", () => {

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -1,8 +1,12 @@
 import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 
 import { testAndBenchmarkTasks } from "../../tools/vite-plus/tasks/test-benchmark.ts";
-import { readRepoFile } from "./support/github-workflows.ts";
+import { readRepoFile, root } from "./support/github-workflows.ts";
 
 // Guardrails for the #3457 real-server editor scenarios. A scenario nobody
 // executes is not coverage, so these assert the wiring that makes CI run them,
@@ -25,6 +29,34 @@ function actionSteps(action: string): Array<{ name: string; run: string }> {
     });
 }
 
+// Packs `editors/vim` the way `package:vim-extension` does — optionally
+// dropping entries first — and runs the packaging guard over the archive, so
+// tests can assert what the guard accepts and rejects instead of its source.
+function runVimPackageGuard(omit: string[] = []): { status: number; output: string } {
+  const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "vim-vize-package-"));
+  try {
+    const editors = path.join(workdir, "editors");
+    fs.cpSync(path.join(root, "editors", "vim"), path.join(editors, "vim"), { recursive: true });
+    for (const entry of omit) {
+      fs.rmSync(path.join(editors, entry));
+    }
+
+    const archive = path.join(workdir, "vim-vize-extension.tar.gz");
+    execFileSync("tar", ["-czf", archive, "-C", editors, "vim"], {
+      env: { ...process.env, COPYFILE_DISABLE: "1", LC_ALL: "C", LANG: "C" },
+    });
+
+    const guard = spawnSync(
+      process.execPath,
+      [path.join(root, "tools", "vim-vize", "assert-vim-package.mjs"), archive],
+      { encoding: "utf8" },
+    );
+    return { status: guard.status ?? 1, output: `${guard.stdout ?? ""}${guard.stderr ?? ""}` };
+  } finally {
+    fs.rmSync(workdir, { force: true, recursive: true });
+  }
+}
+
 test("the Neovim real-server scenario has a task that runs its Node launcher", () => {
   assert.equal(
     taskCommand("test:nvim-extension:real-server"),
@@ -44,13 +76,12 @@ test("CI runs all real-server editor scenarios from one built server binary", ()
 
   // One `cargo build` feeds all scenarios; each must consume that binary.
   assert.match(action, /run: cargo build --profile ci -p vize/);
-  assert.deepEqual(
-    action.match(/VIZE_SERVER_PATH: \$\{\{ github\.workspace \}\}\/target\/ci\/vize/g),
-    [
-      "VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize",
-      "VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize",
-      "VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize",
-    ],
+  const serverPathUses =
+    action.match(/VIZE_SERVER_PATH: \$\{\{ github\.workspace \}\}\/target\/ci\/vize/g) ?? [];
+  assert.equal(
+    serverPathUses.length,
+    3,
+    "every real-server scenario must consume the one built binary",
   );
   assert.match(action, /vp run --workspace-root test:vscode-extension:host-real/);
   assert.match(action, /vp run --workspace-root test:nvim-extension:real-server/);
@@ -151,11 +182,22 @@ test("the packaged Neovim archive ships the real-server scenario", () => {
 });
 
 test("the packaged Vim archive ships the real-server scenario", () => {
-  const assertion = readRepoFile("tools", "vim-vize", "assert-vim-package.mjs");
+  const packaged = runVimPackageGuard();
+  assert.equal(packaged.status, 0, packaged.output);
 
-  assert.match(assertion, /"vim\/test\/vize_e2e_expected\.vim"/);
-  assert.match(assertion, /"vim\/test\/vize_e2e_spec\.vim"/);
-  assert.match(assertion, /\^vim\\\/test\\\/vize_e2e_\(\?:expected\|spec\)\\\.vim\$/);
+  for (const scenarioFile of ["vim/test/vize_e2e_expected.vim", "vim/test/vize_e2e_spec.vim"]) {
+    const withoutScenario = runVimPackageGuard([scenarioFile]);
+    assert.notEqual(
+      withoutScenario.status,
+      0,
+      `the packaging guard accepted an archive without ${scenarioFile}`,
+    );
+    assert.match(withoutScenario.output, /missing required file/);
+    assert.ok(
+      withoutScenario.output.includes(scenarioFile),
+      `the packaging guard must name the missing ${scenarioFile}`,
+    );
+  }
 });
 
 test("the Vim real-server scenario pins complete host responses", () => {

--- a/tools/vim-vize/assert-vim-package.mjs
+++ b/tools/vim-vize/assert-vim-package.mjs
@@ -37,6 +37,8 @@ const requiredFiles = [
   "vim/autoload/vize.vim",
   "vim/ftdetect/vize.vim",
   "vim/plugin/vize.vim",
+  "vim/test/vize_e2e_expected.vim",
+  "vim/test/vize_e2e_spec.vim",
   "vim/test/vize_spec.vim",
 ];
 
@@ -56,6 +58,7 @@ const allowedEntries = [
   /^vim\/plugin\/$/,
   /^vim\/plugin\/vize\.vim$/,
   /^vim\/test\/$/,
+  /^vim\/test\/vize_e2e_(?:expected|spec)\.vim$/,
   /^vim\/test\/vize_spec\.vim$/,
 ];
 

--- a/tools/vim-vize/run-real-server.mjs
+++ b/tools/vim-vize/run-real-server.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+// Drive the packaged Vim integration through a pinned vim-lsp checkout and a
+// real `vize lsp` process. All response assertions live in the Vim archive's
+// own test directory so downstream users can run the same host scenario.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  prepareRealVueWorkspace,
+  repositoryRoot,
+  resolveRealServerPath,
+} from "../editor-e2e/real-vue-workspace.mjs";
+
+const vimPath = process.env.VIZE_TEST_VIM_PATH?.trim() || "vim";
+const vimLspPath = process.env.VIZE_TEST_VIM_LSP_PATH?.trim();
+if (!vimLspPath) {
+  throw new Error(
+    "VIZE_TEST_VIM_LSP_PATH must point at the pinned vim-lsp checkout used by the host test",
+  );
+}
+
+const vimLspPlugin = path.join(vimLspPath, "plugin", "lsp.vim");
+if (!fs.existsSync(vimLspPlugin)) {
+  throw new Error(`vim-lsp plugin not found: ${vimLspPlugin}`);
+}
+
+const pluginRoot = path.join(repositoryRoot, "editors", "vim");
+const specPath = path.join(pluginRoot, "test", "vize_e2e_spec.vim");
+const serverPath = resolveRealServerPath();
+const sessionPath = fs.mkdtempSync(path.join(os.tmpdir(), "vize-vim-e2e-"));
+const workspacePath = path.join(sessionPath, "real-vue");
+const errorPath = path.join(sessionPath, "vim-errors.log");
+const verbosePath = path.join(sessionPath, "vim-verbose.log");
+
+prepareRealVueWorkspace(workspacePath);
+
+try {
+  const result = spawnSync(
+    vimPath,
+    ["-Nu", "NONE", "-n", "-es", "-i", "NONE", `-V1${verbosePath}`, "-S", specPath],
+    {
+      cwd: workspacePath,
+      encoding: "utf-8",
+      env: {
+        ...process.env,
+        VIZE_E2E_ERROR_PATH: errorPath,
+        VIZE_E2E_PLUGIN_ROOT: pluginRoot,
+        VIZE_E2E_SERVER: serverPath,
+        VIZE_E2E_WORKSPACE: workspacePath,
+      },
+      timeout: 1_200_000,
+    },
+  );
+
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    for (const diagnosticPath of [errorPath, verbosePath]) {
+      if (fs.existsSync(diagnosticPath)) {
+        process.stderr.write(fs.readFileSync(diagnosticPath, "utf-8"));
+      }
+    }
+    throw new Error(`headless Vim scenario failed with exit code ${result.status}`);
+  }
+  console.log("vim real-server scenario passed");
+} finally {
+  fs.rmSync(sessionPath, { force: true, recursive: true });
+}

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -134,6 +134,7 @@ export const testAndBenchmarkTasks = defineTasks({
   "test:vim-extension:headless": noCacheTask(
     "vim -Nu NONE -n -es -S editors/vim/test/vize_spec.vim",
   ),
+  "test:vim-extension:real-server": noCacheTask("node tools/vim-vize/run-real-server.mjs"),
   "test:vim-extension:package": noCacheTask("vp run --workspace-root package:vim-extension"),
   "test:helix-extension:package": noCacheTask("vp run --workspace-root package:helix-extension"),
   "test:emacs-extension:headless": noCacheTask(


### PR DESCRIPTION
## Summary

- run the packaged Vim integration through a pinned vim-lsp checkout and a real `vize lsp` process
- pin complete diagnostics, completion, hover, code action, formatting, semantic-token, and rename responses
- fix `vize#setup()` detection for vim-lsp's ordinary plugin-before-autoload startup order
- ship the scenario in the Vim archive and make the required editor-host job execute it

## Verification

- red-first editor real-server guard: 4 expected failures before implementation
- `node --test tests/tooling/editor-real-server-e2e.test.ts`: 14 passed
- `/usr/bin/vim -Nu NONE -n -es -i NONE -S editors/vim/test/vize_spec.vim`
- pinned vim-lsp checkout + real `vize lsp`: 20/20 consecutive passes
- `vp run --workspace-root package:vim-extension`: archive smoke passed (13 entries)
- targeted `vp check`: clean
- `git diff --check`: clean

This is the Vim slice of #3744. Zed and Helix remain separate lanes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Vim integration startup detection for additional LSP environments.
  * Added comprehensive Vim support for completion, diagnostics, formatting, hover, semantic tokens, code actions, and rename operations.

* **Bug Fixes**
  * Improved reliability when initializing Vim LSP integrations before all functions are available.

* **Tests**
  * Added headless, real-server end-to-end coverage for the packaged Vim extension.
  * Added validation for Vim package contents and workspace behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->