### PR TITLE
fix(release): avoid redundant preflight fetch

### DIFF
--- a/tests/tooling/release-preflight-runner.test.ts
+++ b/tests/tooling/release-preflight-runner.test.ts
@@ -23,7 +23,7 @@ test("release preflight CLI fails closed on unknown or ambiguous modes", () => {
   assert.throws(() => parseReleasePreflightMode(["--verify-only", "--target-only"]), /Usage:/);
 });
 
-test("target-only mode verifies HEAD, main first-parent history, and the peeled remote tag", () => {
+test("target-only mode verifies the hydrated main ref, HEAD, and the peeled remote tag", () => {
   const tempDir = fs.mkdtempSync(path.join(tmpdir(), "vize-release-target-"));
   const binDir = path.join(tempDir, "bin");
   const version = workspaceVersionFromCargoToml(
@@ -43,7 +43,6 @@ test("target-only mode verifies HEAD, main first-parent history, and the peeled 
       "const command = args.join(' ');",
       "if (command === 'rev-parse HEAD') console.log(process.env.TEST_HEAD_SHA);",
       "else if (command === 'rev-parse refs/remotes/origin/main') console.log(process.env.TEST_MAIN_SHA);",
-      "else if (args[0] === 'fetch') process.exit(0);",
       "else if (args[0] === 'ls-files') process.stdout.write(JSON.parse(process.env.TEST_PACKAGE_MANIFESTS).join('\\0') + '\\0');",
       "else if (args[0] === 'ls-remote') {",
       "  console.log(`${process.env.TEST_TAG_OBJECT}\\trefs/tags/${process.env.TEST_TAG}`);",

--- a/tools/github/release-preflight.mjs
+++ b/tools/github/release-preflight.mjs
@@ -56,7 +56,9 @@ function verifyGitReleaseTarget(tag, sha, version) {
   if (head !== sha) {
     throw new Error(`Checked out HEAD ${head} does not match release event SHA ${sha}`);
   }
-  runGit(["fetch", "--quiet", "--no-tags", "origin", "+refs/heads/main:refs/remotes/origin/main"]);
+  // The reusable workflow checks out the tag with fetch-depth: 0, which also
+  // hydrates origin/main. A second fetch here only repeats the large repository
+  // negotiation and can exceed the command timeout before any gate is checked.
   const mainSha = runGit(["rev-parse", "refs/remotes/origin/main"]).stdout.trim();
   // The local release guard requires an exact main tip before creating the
   // immutable tag. Once the tag exists, later main commits must not invalidate


### PR DESCRIPTION
## Summary

- trust the full-depth release checkout to hydrate `origin/main`
- remove the immediately repeated main fetch that timed out twice on v0.320.0
- make the runner oracle reject any unexpected git fetch

## Validation

- release preflight and publish contract tests: 50 passed
- `vp check`: 0 errors (existing warnings only)

The immutable v0.320.0 workflow cannot pick up this change, so the next minor release will verify the fix end to end.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release preflight validation by using the already available main branch reference.
  * Removed a redundant repository fetch during release checks.
* **Tests**
  * Updated release verification tests to reflect validation of the hydrated main reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->