### PR TITLE
test(cli): fail closed for template Corsa gates

### DIFF
--- a/crates/vize/tests/check_instance_props_cli.rs
+++ b/crates/vize/tests/check_instance_props_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -93,7 +96,7 @@ fn write(root: &Path, rel: &str, content: &str) {
 
 #[test]
 fn check_instance_type_props_preserves_camel_case_sfc_props() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("camel-props");
@@ -183,7 +186,7 @@ void key;
 
 #[test]
 fn check_template_prop_checks_preserve_camel_case_sfc_props() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("camel-template-prop-mismatch");

--- a/crates/vize/tests/check_ref_enum_template_cli.rs
+++ b/crates/vize/tests/check_ref_enum_template_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -56,7 +59,7 @@ fn link_workspace_node_modules(project_root: &Path) -> std::io::Result<()> {
 
 #[test]
 fn check_template_ref_enum_comparisons_keep_declared_ref_value_type() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("modal-state");

--- a/crates/vize/tests/check_tsx_intrinsic_elements_cli.rs
+++ b/crates/vize/tests/check_tsx_intrinsic_elements_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -87,7 +90,7 @@ fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
 
 #[test]
 fn check_tsx_intrinsic_elements_with_experimental_jsx_vapor() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("jsx-vapor");
@@ -163,7 +166,7 @@ fn check_tsx_intrinsic_elements_with_experimental_jsx_vapor() {
 
 #[test]
 fn check_tsx_vapor_keeps_script_type_errors() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("jsx-vapor-type-error");

--- a/crates/vize/tests/check_tsx_sfc_attrs_cli.rs
+++ b/crates/vize/tests/check_tsx_sfc_attrs_cli.rs
@@ -1,14 +1,14 @@
-use std::{
-    path::{Path, PathBuf},
-    process::Command,
-};
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use vize_carton::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
+        .ancestors()
+        .nth(2)
         .expect("workspace root should exist")
         .to_path_buf()
 }
@@ -87,7 +87,7 @@ fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
 
 #[test]
 fn check_tsx_story_allows_sfc_class_and_style_attrs() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("fallthrough");
@@ -177,7 +177,7 @@ export const Example = () => (
 
 #[test]
 fn check_tsx_story_allows_slot_object_with_kebab_update_handler() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("slot-object-events");
@@ -284,7 +284,7 @@ export const Tabs = () => (
 
 #[test]
 fn check_tsx_sfc_preserves_intrinsic_event_context_without_explicit_types() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("sfc-event-context");

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -170,6 +170,25 @@ test("declaration emit Rust CLI gates use the fail-closed Corsa helper", () => {
   }
 });
 
+test("template and TSX Rust CLI gates use the fail-closed Corsa helper", () => {
+  const files = [
+    ["check_tsx_intrinsic_elements_cli.rs", 2],
+    ["check_tsx_sfc_attrs_cli.rs", 3],
+    ["check_instance_props_cli.rs", 2],
+    ["check_ref_enum_template_cli.rs", 1],
+  ] as const;
+
+  for (const [file, expectedCalls] of files) {
+    const source = readRepoFile("crates", "vize", "tests", file);
+    assert.equal(
+      source.match(/corsa_requirement::required_or_skip\(resolve_test_corsa_path\(\)\)/g)?.length,
+      expectedCalls,
+      `${file} should guard all ${expectedCalls} Corsa resolver calls`,
+    );
+    assert.doesNotMatch(source, /let Some\(corsa_path\) = resolve_test_corsa_path\(\)/);
+  }
+});
+
 test("available dependencies never skip", () => {
   assert.equal(typecheckDependencySkip("/tmp/tsgo", "tsgo", "missing", true), false);
 });


### PR DESCRIPTION
## Summary
- fail closed when the Corsa resolver is unavailable in template and TSX CLI gates
- cover intrinsic elements, SFC attributes, instance props, and ref-enum template cases
- extend the mechanical dependency-gate oracle to keep all guarded calls enforced

## Validation
- `node --import tsx --test tests/tooling/typecheck-dependency-gates.test.ts` (13/13)
- `cargo fmt --check`
- `VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize --test check_tsx_intrinsic_elements_cli --test check_tsx_sfc_attrs_cli --test check_instance_props_cli --test check_ref_enum_template_cli` (8/8)

Refs #3750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved CLI test handling when the Corsa dependency is unavailable by consistently skipping affected tests.
  - Added coverage to verify dependency checks fail safely and reject outdated optional-path handling.
  - Updated template and TSX-related integration tests to use the standardized dependency check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->