### PR TITLE
test(cli): fail closed for module import Corsa gates

### DIFF
--- a/crates/vize/tests/check_allowjs_imports_cli.rs
+++ b/crates/vize/tests/check_allowjs_imports_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -40,7 +43,7 @@ fn write(root: &Path, rel: &str, content: &str) {
 
 #[test]
 fn check_allowjs_resolves_project_local_js_imports() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("local-js");

--- a/crates/vize/tests/check_ambient_export_assignment_cli.rs
+++ b/crates/vize/tests/check_ambient_export_assignment_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -43,7 +46,7 @@ fn write(root: &Path, rel: &str, content: &str) {
 
 #[test]
 fn check_allows_export_assignment_inside_ambient_module_declaration() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("cjs-module");

--- a/crates/vize/tests/check_ambient_imports_cli.rs
+++ b/crates/vize/tests/check_ambient_imports_cli.rs
@@ -4,6 +4,9 @@
     clippy::disallowed_types
 )]
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{path::Path, process::Command};
 
 #[path = "support/vue_stub.rs"]
@@ -41,7 +44,7 @@ fn resolve_test_corsa_path() -> Option<std::path::PathBuf> {
 
 #[test]
 fn explicit_check_registers_types_imported_by_ambient_declarations() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir();

--- a/crates/vize/tests/check_directory_self_imports_cli.rs
+++ b/crates/vize/tests/check_directory_self_imports_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{path::Path, process::Command};
 
 fn workspace_root() -> &'static Path {
@@ -52,7 +55,7 @@ fn resolve_test_corsa_path() -> Option<String> {
 
 #[test]
 fn check_resolves_current_directory_imports_from_vue_inputs() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
 

--- a/crates/vize/tests/check_hoisted_workspace_cli.rs
+++ b/crates/vize/tests/check_hoisted_workspace_cli.rs
@@ -4,6 +4,9 @@
     clippy::disallowed_types
 )]
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{path::Path, process::Command};
 
 fn workspace_root() -> &'static Path {
@@ -46,7 +49,7 @@ fn resolve_test_corsa_path() -> Option<std::path::PathBuf> {
 
 #[test]
 fn check_resolves_hoisted_workspace_package_with_explicit_types() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
 

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -189,6 +189,26 @@ test("template and TSX Rust CLI gates use the fail-closed Corsa helper", () => {
   }
 });
 
+test("module import Rust CLI gates use the fail-closed Corsa helper", () => {
+  const files = [
+    "check_allowjs_imports_cli.rs",
+    "check_ambient_export_assignment_cli.rs",
+    "check_ambient_imports_cli.rs",
+    "check_directory_self_imports_cli.rs",
+    "check_hoisted_workspace_cli.rs",
+  ];
+
+  for (const file of files) {
+    const source = readRepoFile("crates", "vize", "tests", file);
+    assert.equal(
+      source.match(/corsa_requirement::required_or_skip\(resolve_test_corsa_path\(\)\)/g)?.length,
+      1,
+      `${file} should guard its Corsa resolver call`,
+    );
+    assert.doesNotMatch(source, /let Some\(corsa_path\) = resolve_test_corsa_path\(\)/);
+  }
+});
+
 test("available dependencies never skip", () => {
   assert.equal(typecheckDependencySkip("/tmp/tsgo", "tsgo", "missing", true), false);
 });


### PR DESCRIPTION
## Summary
- fail closed when Corsa is missing from module-import CLI gates
- cover allowJs, ambient export/import, directory self-import, and hoisted workspace resolution
- extend the mechanical dependency-gate oracle for all five guarded calls

## Validation
- `node --import tsx --test tests/tooling/typecheck-dependency-gates.test.ts` (14/14)
- `cargo fmt --check`
- five Corsa-backed CLI cases with `VIZE_TEST_REQUIRE_TSGO=1` (5/5)
- source-length contracts (7/7)

Refs #3750

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->