### PR TITLE
test(cli): fail closed for plain script Corsa gates

### DIFF
--- a/crates/vize/tests/check_plain_script_named_exports_cli.rs
+++ b/crates/vize/tests/check_plain_script_named_exports_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{path::Path, process::Command};
 
 fn workspace_root() -> &'static Path {
@@ -106,7 +109,7 @@ fn run_check_json(project_root: &Path, corsa_path: &str) -> std::process::Output
 
 #[test]
 fn check_preserves_named_exports_from_normal_script_vue() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_cli_project(
@@ -200,7 +203,7 @@ const line: number = cursor.line;
 /// diagnostics were dropped.
 #[test]
 fn check_reports_value_only_plain_script_exports_used_as_types() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_cli_project(

--- a/crates/vize/tests/check_plain_script_namespace_cli.rs
+++ b/crates/vize/tests/check_plain_script_namespace_cli.rs
@@ -6,6 +6,9 @@
 //! CLI so the diagnostics come from a type checker rather than from string
 //! inspection of the generated module.
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{path::Path, process::Command};
 
 fn workspace_root() -> &'static Path {
@@ -130,7 +133,7 @@ fn diagnostics(report: &serde_json::Value) -> Vec<String> {
 
 #[test]
 fn check_accepts_plain_script_namespaces_used_as_values_and_types() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_cli_project(
@@ -246,7 +249,7 @@ const capturedValue: number = captured;
 /// consumer's import is a real error.
 #[test]
 fn check_reports_an_import_of_an_unexported_plain_script_namespace() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_cli_project(
@@ -298,7 +301,7 @@ const label: string = Bare.label;
 /// project whose diagnostics were dropped.
 #[test]
 fn check_reports_the_legacy_module_keyword_from_a_plain_script() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_cli_project(

--- a/crates/vize/tests/check_reference_types_cli.rs
+++ b/crates/vize/tests/check_reference_types_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -93,7 +96,7 @@ fn write(root: &Path, rel: &str, content: &str) {
 
 #[test]
 fn check_loads_reference_types_from_tsconfig_ambient_declarations() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("subpath");
@@ -194,7 +197,7 @@ if (import.meta.vitest) {
 
 #[test]
 fn check_provides_define_art_for_standalone_musea_art_files() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("standalone-art");
@@ -272,7 +275,7 @@ defineArt("./MyButton.vue", {
 
 #[test]
 fn check_no_template_bindings_keeps_component_props_helper_in_project() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("no-template-helper");

--- a/crates/vize/tests/check_sfc_import_suppressions_cli.rs
+++ b/crates/vize/tests/check_sfc_import_suppressions_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -94,7 +97,7 @@ fn write(root: &Path, rel: &str, content: &str) {
 
 #[test]
 fn check_preserves_sfc_import_suppressions_and_wildcard_vue_shims() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("vue-shim");

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -210,6 +210,25 @@ test("module import Rust CLI gates use the fail-closed Corsa helper", () => {
   }
 });
 
+test("plain script and reference Rust CLI gates use the fail-closed Corsa helper", () => {
+  const files = [
+    ["check_plain_script_named_exports_cli.rs", 2],
+    ["check_plain_script_namespace_cli.rs", 3],
+    ["check_reference_types_cli.rs", 3],
+    ["check_sfc_import_suppressions_cli.rs", 1],
+  ] as const;
+
+  for (const [file, expectedCalls] of files) {
+    const source = readRepoFile("crates", "vize", "tests", file);
+    assert.equal(
+      source.match(/corsa_requirement::required_or_skip\(resolve_test_corsa_path\(\)\)/g)?.length,
+      expectedCalls,
+      `${file} should guard all ${expectedCalls} Corsa resolver calls`,
+    );
+    assert.doesNotMatch(source, /let Some\(corsa_path\) = resolve_test_corsa_path\(\)/);
+  }
+});
+
 test("available dependencies never skip", () => {
   assert.equal(typecheckDependencySkip("/tmp/tsgo", "tsgo", "missing", true), false);
 });


### PR DESCRIPTION
## Summary
- fail closed when Corsa is missing from plain-script CLI gates
- cover named exports, namespace imports, reference types, and SFC import suppression
- extend the mechanical dependency-gate oracle for all nine guarded calls

## Validation
- `node --import tsx --test tests/tooling/typecheck-dependency-gates.test.ts` (15/15)
- `cargo fmt --check`
- nine Corsa-backed CLI cases with `VIZE_TEST_REQUIRE_TSGO=1` (9/9)
- source-length contracts (7/7)

Refs #3750