### PR TITLE
fix(maestro): revalidate runtime workspace folder changes

### DIFF
--- a/crates/vize_maestro/src/server.rs
+++ b/crates/vize_maestro/src/server.rs
@@ -22,6 +22,7 @@ mod helpers;
 mod importers;
 mod state;
 mod workspace_files;
+mod workspace_folder_events;
 
 pub use capabilities::server_capabilities;
 #[cfg(feature = "native")]

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -86,7 +86,7 @@ impl LanguageServer for MaestroServer {
 
     // Keep the per-folder configuration contexts in sync when the editor adds or removes roots mid-session (#3240).
     async fn did_change_workspace_folders(&self, params: DidChangeWorkspaceFoldersParams) {
-        self.state.apply_workspace_folders_change(&params.event);
+        self.reconfigure_workspace_folders(&params.event).await;
     }
 
     async fn shutdown(&self) -> Result<()> {

--- a/crates/vize_maestro/src/server/state/workspace_folders.rs
+++ b/crates/vize_maestro/src/server/state/workspace_folders.rs
@@ -86,9 +86,31 @@ impl ServerState {
         contexts.extend(added.into_iter().map(WorkspaceFolderConfig::load));
     }
 
-    /// Sync the contexts from a `didChangeWorkspaceFolders` event (#3240).
-    pub(crate) fn apply_workspace_folders_change(&self, event: &WorkspaceFoldersChangeEvent) {
-        self.update_workspace_folders(folder_roots(&event.added), &folder_roots(&event.removed));
+    /// Sync the contexts from a `didChangeWorkspaceFolders` event (#3240) and
+    /// return the open documents whose enclosing folder context may have
+    /// changed. The request handler republishes diagnostics for these URIs.
+    pub(crate) fn apply_workspace_folders_change(
+        &self,
+        event: &WorkspaceFoldersChangeEvent,
+    ) -> Vec<Url> {
+        let added = folder_roots(&event.added);
+        let removed = folder_roots(&event.removed);
+        let mut changed_roots = added.clone();
+        changed_roots.extend(removed.iter().cloned());
+
+        self.update_workspace_folders(added, &removed);
+
+        let mut affected = self
+            .documents
+            .uris()
+            .into_iter()
+            .filter(|uri| {
+                uri.to_file_path()
+                    .is_ok_and(|path| changed_roots.iter().any(|root| path.starts_with(root)))
+            })
+            .collect::<Vec<_>>();
+        affected.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        affected
     }
 
     /// Linter settings for a document: its deepest enclosing workspace folder
@@ -124,7 +146,7 @@ fn deepest_enclosing_folder<'a>(
 
 #[cfg(test)]
 mod tests {
-    use tower_lsp::lsp_types::Url;
+    use tower_lsp::lsp_types::{Url, WorkspaceFolder, WorkspaceFoldersChangeEvent};
     use vize_carton::config::LintRuleSeverity;
 
     use crate::server::ServerState;
@@ -209,6 +231,43 @@ mod tests {
         let (config, _) = state.linter_settings_for_uri(&uri);
         assert_eq!(config.rules.get("vue/require-v-for-key"), None);
 
+        let _ = std::fs::remove_dir_all(parent);
+    }
+
+    #[test]
+    fn workspace_folder_changes_select_only_open_documents_under_changed_roots() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let parent = std::env::temp_dir().join(format!(
+            "vize-folder-revalidation-{}-{nonce}",
+            std::process::id()
+        ));
+        let added_root = parent.join("added");
+        let untouched_root = parent.join("untouched");
+        std::fs::create_dir_all(&added_root).unwrap();
+        std::fs::create_dir_all(&untouched_root).unwrap();
+
+        let affected = Url::from_file_path(added_root.join("Affected.vue")).unwrap();
+        let untouched = Url::from_file_path(untouched_root.join("Untouched.vue")).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(affected.clone(), "<template />".into(), 1, "vue".into());
+        state
+            .documents
+            .open(untouched, "<template />".into(), 1, "vue".into());
+
+        let selected = state.apply_workspace_folders_change(&WorkspaceFoldersChangeEvent {
+            added: vec![WorkspaceFolder {
+                uri: Url::from_file_path(&added_root).unwrap(),
+                name: "added".into(),
+            }],
+            removed: Vec::new(),
+        });
+
+        assert_eq!(selected, vec![affected]);
         let _ = std::fs::remove_dir_all(parent);
     }
 }

--- a/crates/vize_maestro/src/server/workspace_folder_events.rs
+++ b/crates/vize_maestro/src/server/workspace_folder_events.rs
@@ -1,0 +1,17 @@
+//! Runtime workspace-folder event handling.
+
+use tower_lsp::lsp_types::WorkspaceFoldersChangeEvent;
+
+use super::MaestroServer;
+
+impl MaestroServer {
+    pub(super) async fn reconfigure_workspace_folders(&self, event: &WorkspaceFoldersChangeEvent) {
+        let affected = self.state.apply_workspace_folders_change(event);
+        for uri in affected {
+            let Some(version) = self.state.documents.version(&uri) else {
+                continue;
+            };
+            self.publish_diagnostics_if_version(&uri, version).await;
+        }
+    }
+}

--- a/tests/tooling/lsp-workspace-folder-changes.test.ts
+++ b/tests/tooling/lsp-workspace-folder-changes.test.ts
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isDiagnosticsForUri } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+const V_FOR_KEY_RULE = "vue/require-v-for-key";
+const SOURCE = `<script setup lang="ts">
+const rows = ['alpha', 'beta']
+</script>
+
+<template>
+  <ul>
+    <li v-for="row in rows">{{ row }}</li>
+  </ul>
+</template>
+`;
+
+test("vize lsp revalidates open documents when workspace folders change", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-workspace-folder-changes");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const parentDir = fs.mkdtempSync(path.join(testRootDir, "roots-"));
+  const rootA = path.join(parentDir, "root-a");
+  const rootB = path.join(parentDir, "root-b");
+  fs.mkdirSync(rootA);
+  fs.mkdirSync(rootB);
+  fs.writeFileSync(
+    path.join(rootB, "vize.config.json"),
+    JSON.stringify({ linter: { rules: { [V_FOR_KEY_RULE]: "off" } } }),
+    "utf8",
+  );
+
+  const filePath = path.join(rootB, "List.vue");
+  const uri = pathToFileURL(filePath).href;
+  const rootBUri = pathToFileURL(rootB).href;
+  fs.writeFileSync(filePath, SOURCE, "utf8");
+  const session = new LspSession();
+  let primaryError: unknown;
+
+  try {
+    await session.initialize(rootA, { editor: true, lint: true, typecheck: false });
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: SOURCE },
+    });
+
+    const initial = await waitForRuleState(session, uri, true);
+    assert.equal(initial.version, 1);
+    assert.equal(ruleDiagnostics(initial).length, 1);
+
+    session.notify("workspace/didChangeWorkspaceFolders", {
+      event: {
+        added: [{ uri: rootBUri, name: "root-b" }],
+        removed: [],
+      },
+    });
+    const afterAdd = await waitForRuleState(session, uri, false);
+    assert.equal(afterAdd.version, 1, "adding a folder must revalidate without a document edit");
+    assert.deepEqual(ruleDiagnostics(afterAdd), []);
+
+    session.notify("workspace/didChangeWorkspaceFolders", {
+      event: {
+        added: [],
+        removed: [{ uri: rootBUri, name: "root-b" }],
+      },
+    });
+    const afterRemove = await waitForRuleState(session, uri, true);
+    assert.equal(
+      afterRemove.version,
+      1,
+      "removing a folder must revalidate without a document edit",
+    );
+    assert.equal(ruleDiagnostics(afterRemove).length, 1);
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    await session.shutdown().catch((error: unknown) => {
+      if (primaryError == null) throw error;
+    });
+    fs.rmSync(parentDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+async function waitForRuleState(
+  session: LspSession,
+  uri: string,
+  present: boolean,
+): Promise<PublishDiagnosticsParams> {
+  return (await session.waitForNotification("textDocument/publishDiagnostics", (params) => {
+    if (!isDiagnosticsForUri(params, uri) || params.version !== 1) return false;
+    return ruleDiagnostics(params).length > 0 === present;
+  })) as PublishDiagnosticsParams;
+}
+
+function ruleDiagnostics(params: PublishDiagnosticsParams) {
+  return params.diagnostics.filter(
+    (diagnostic) => diagnostic.source === "vize/lint" && diagnostic.code === V_FOR_KEY_RULE,
+  );
+}


### PR DESCRIPTION
## Summary
- revalidate open documents under workspace folders added or removed at runtime
- keep folder-triggered diagnostics version-gated against concurrent edits
- cover add and remove transitions through the real stdio LSP server

## Tests
- `cargo test -p vize_maestro workspace_folder_changes_select_only_open_documents_under_changed_roots`
- `cargo clippy -p vize_maestro --lib -- -D warnings`
- `node --test tests/tooling/lsp-workspace-folder-changes.test.ts`

Refs #3742