### PR TITLE
test(editor): run Zed contract against real server

### DIFF
--- a/.github/actions/vscode-host-smoke/action.yml
+++ b/.github/actions/vscode-host-smoke/action.yml
@@ -1,5 +1,5 @@
 name: Editor real-server end-to-end
-description: Run VS Code, Neovim, and Vim real-server scenarios plus packaged editor specs
+description: Run VS Code, Zed, Neovim, and Vim real-server scenarios plus packaged editor specs
 
 runs:
   using: composite
@@ -13,6 +13,8 @@ runs:
 
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      with:
+        targets: wasm32-wasip2
 
     - name: Setup Wild linker
       uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
@@ -36,6 +38,30 @@ runs:
       env:
         NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
       run: vp install --frozen-lockfile --prefer-offline
+
+    - name: Install pinned Zed extension CLI
+      shell: bash
+      env:
+        ZED_EXTENSION_CLI_SHA: 9ee3c503a4bbbc6b4a0f8a789acca4871d773223
+        ZED_EXTENSION_CLI_SHA256: a6fca5ef11ff23f0ef8b03bd2453270591c9fc6c03700c3c92017e5082ada757
+      run: |
+        set -euo pipefail
+        curl -fsSL -o "${RUNNER_TEMP}/zed-extension" \
+          "https://zed-extension-cli.nyc3.digitaloceanspaces.com/${ZED_EXTENSION_CLI_SHA}/x86_64-unknown-linux-gnu/zed-extension"
+        echo "${ZED_EXTENSION_CLI_SHA256}  ${RUNNER_TEMP}/zed-extension" | sha256sum --check --strict
+        chmod +x "${RUNNER_TEMP}/zed-extension"
+
+    - name: Validate the Zed extension
+      shell: bash
+      working-directory: editors/zed
+      run: |
+        set -euo pipefail
+        mkdir -p "${RUNNER_TEMP}/zed-extension-scratch"
+        mkdir -p "${RUNNER_TEMP}/zed-extension-output"
+        "${RUNNER_TEMP}/zed-extension" \
+          --source-dir . \
+          --scratch-dir "${RUNNER_TEMP}/zed-extension-scratch" \
+          --output-dir "${RUNNER_TEMP}/zed-extension-output"
 
     - name: Build vize CLI
       shell: bash
@@ -126,3 +152,10 @@ runs:
         VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize
         VIZE_TEST_VIM_LSP_PATH: ${{ runner.temp }}/vim-lsp
       run: vp run --workspace-root test:vim-extension:real-server
+
+    - name: Run the Zed scenario against the real server
+      shell: bash
+      env:
+        NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+        VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize
+      run: vp run --workspace-root test:zed-extension:real-server

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -14,6 +14,6 @@ languages = ["Vue", "Art Vue"]
 "Vue" = "vue"
 "Art Vue" = "art-vue"
 
-[grammars.art_vue]
+[grammars.vue]
 repository = "https://github.com/tree-sitter-grammars/tree-sitter-vue"
 commit = "7e48557b903a9db9c38cea3b7839ef7e1f36c693"

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -14,6 +14,6 @@ languages = ["Vue", "Art Vue"]
 "Vue" = "vue"
 "Art Vue" = "art-vue"
 
-[grammars.art-vue]
+[grammars.art_vue]
 repository = "https://github.com/tree-sitter-grammars/tree-sitter-vue"
 commit = "7e48557b903a9db9c38cea3b7839ef7e1f36c693"

--- a/editors/zed/languages/art-vue/config.toml
+++ b/editors/zed/languages/art-vue/config.toml
@@ -1,6 +1,6 @@
 name = "Art Vue"
 code_fence_block_name = "vue"
-grammar = "art_vue"
+grammar = "vue"
 path_suffixes = ["art.vue"]
 block_comment = ["<!-- ", " -->"]
 autoclose_before = ";:.,=}])>"

--- a/editors/zed/languages/art-vue/config.toml
+++ b/editors/zed/languages/art-vue/config.toml
@@ -1,6 +1,6 @@
 name = "Art Vue"
 code_fence_block_name = "vue"
-grammar = "art-vue"
+grammar = "art_vue"
 path_suffixes = ["art.vue"]
 block_comment = ["<!-- ", " -->"]
 autoclose_before = ";:.,=}])>"

--- a/tests/tooling/editor-integrations-zed.test.ts
+++ b/tests/tooling/editor-integrations-zed.test.ts
@@ -32,10 +32,11 @@ test("zed extension.toml declares vize server, language ids, grammar pin and ver
   assert.match(manifest, /^"Vue" = "vue"$/m);
   assert.match(manifest, /^"Art Vue" = "art-vue"$/m);
 
-  // art-vue grammar pinned to a tree-sitter repo at a full 40-char commit sha.
-  assert.match(manifest, /^\[grammars\.art-vue\]$/m);
+  // Zed requires grammar identifiers (unlike language ids) to use snake_case.
+  assert.match(manifest, /^\[grammars\.art_vue\]$/m);
+  assert.doesNotMatch(manifest, /^\[grammars\.[^\]]*-.*\]$/m);
   const grammarRepository = manifest.match(
-    /^\[grammars\.art-vue\]\n(?:.*\n)*?repository = "([^"]+)"$/m,
+    /^\[grammars\.art_vue\]\n(?:.*\n)*?repository = "([^"]+)"$/m,
   )?.[1];
   assert.equal(grammarRepository, "https://github.com/tree-sitter-grammars/tree-sitter-vue");
   const grammarCommit = manifest.match(/^commit = "([0-9a-f]{40})"$/m)?.[1];
@@ -59,7 +60,10 @@ test("zed extension source falls back to the recommended initialization profile"
 test("zed art-vue config.toml declares comments, brackets, autoclose and tailwind opt-in", () => {
   const config = readRepoFile("editors/zed/languages/art-vue/config.toml");
 
-  // Identity already covered by editor-integrations; assert the new behavioral knobs.
+  assert.match(config, /^grammar = "art_vue"$/m);
+  assert.doesNotMatch(config, /^grammar = "[^"]*-.*"$/m);
+
+  // Remaining identity is covered by editor-integrations; assert the behavioral knobs.
   assert.match(config, /^block_comment = \["<!-- ", " -->"\]$/m);
   assert.match(config, /^autoclose_before = ";:\.,=\}\]\)>"$/m);
   assert.match(config, /^code_fence_block_name = "vue"$/m);

--- a/tests/tooling/editor-integrations-zed.test.ts
+++ b/tests/tooling/editor-integrations-zed.test.ts
@@ -32,11 +32,12 @@ test("zed extension.toml declares vize server, language ids, grammar pin and ver
   assert.match(manifest, /^"Vue" = "vue"$/m);
   assert.match(manifest, /^"Art Vue" = "art-vue"$/m);
 
-  // Zed requires grammar identifiers (unlike language ids) to use snake_case.
-  assert.match(manifest, /^\[grammars\.art_vue\]$/m);
+  // Zed derives the parser export from this identifier. tree-sitter-vue
+  // exports `tree_sitter_vue`, while the language id remains `art-vue`.
+  assert.match(manifest, /^\[grammars\.vue\]$/m);
   assert.doesNotMatch(manifest, /^\[grammars\.[^\]]*-.*\]$/m);
   const grammarRepository = manifest.match(
-    /^\[grammars\.art_vue\]\n(?:.*\n)*?repository = "([^"]+)"$/m,
+    /^\[grammars\.vue\]\n(?:.*\n)*?repository = "([^"]+)"$/m,
   )?.[1];
   assert.equal(grammarRepository, "https://github.com/tree-sitter-grammars/tree-sitter-vue");
   const grammarCommit = manifest.match(/^commit = "([0-9a-f]{40})"$/m)?.[1];
@@ -60,7 +61,7 @@ test("zed extension source falls back to the recommended initialization profile"
 test("zed art-vue config.toml declares comments, brackets, autoclose and tailwind opt-in", () => {
   const config = readRepoFile("editors/zed/languages/art-vue/config.toml");
 
-  assert.match(config, /^grammar = "art_vue"$/m);
+  assert.match(config, /^grammar = "vue"$/m);
   assert.doesNotMatch(config, /^grammar = "[^"]*-.*"$/m);
 
   // Remaining identity is covered by editor-integrations; assert the behavioral knobs.

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -345,11 +345,11 @@ test("zed-vize registers art-vue as a first-party language", () => {
   assert.match(manifest, /^languages = \["Vue", "Art Vue"\]$/m);
   assert.match(manifest, /^"Vue" = "vue"$/m);
   assert.match(manifest, /^"Art Vue" = "art-vue"$/m);
-  assert.match(manifest, /^\[grammars\.art_vue\]$/m);
+  assert.match(manifest, /^\[grammars\.vue\]$/m);
 
   const artConfig = readText("editors/zed/languages/art-vue/config.toml");
   assert.match(artConfig, /^name = "Art Vue"$/m);
-  assert.match(artConfig, /^grammar = "art_vue"$/m);
+  assert.match(artConfig, /^grammar = "vue"$/m);
   assert.match(artConfig, /^path_suffixes = \["art\.vue"\]$/m);
   assert.match(artConfig, /^prettier_parser_name = "vue"$/m);
 

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -345,11 +345,11 @@ test("zed-vize registers art-vue as a first-party language", () => {
   assert.match(manifest, /^languages = \["Vue", "Art Vue"\]$/m);
   assert.match(manifest, /^"Vue" = "vue"$/m);
   assert.match(manifest, /^"Art Vue" = "art-vue"$/m);
-  assert.match(manifest, /^\[grammars\.art-vue\]$/m);
+  assert.match(manifest, /^\[grammars\.art_vue\]$/m);
 
   const artConfig = readText("editors/zed/languages/art-vue/config.toml");
   assert.match(artConfig, /^name = "Art Vue"$/m);
-  assert.match(artConfig, /^grammar = "art-vue"$/m);
+  assert.match(artConfig, /^grammar = "art_vue"$/m);
   assert.match(artConfig, /^path_suffixes = \["art\.vue"\]$/m);
   assert.match(artConfig, /^prettier_parser_name = "vue"$/m);
 

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -71,13 +71,6 @@ test("the Vim real-server scenario has a task that runs its Node launcher", () =
   );
 });
 
-test("the Zed real-server scenario has a task that runs its Node launcher", () => {
-  assert.equal(
-    taskCommand("test:zed-extension:real-server"),
-    "node tools/zed-vize/run-real-server.mjs",
-  );
-});
-
 test("CI runs all real-server editor scenarios from one built server binary", () => {
   const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
 
@@ -99,33 +92,6 @@ test("CI runs all real-server editor scenarios from one built server binary", ()
   assert.match(action, /NVIM_VERSION: v\d+\.\d+\.\d+/);
   assert.match(action, /NVIM_SHA256: [0-9a-f]{64}/);
   assert.match(action, /sha256sum --check --strict/);
-});
-
-test("CI validates Zed with the pinned official extension CLI before the real-server scenario", () => {
-  const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
-  const installAt = action.indexOf("- name: Install pinned Zed extension CLI");
-  const validateAt = action.indexOf("- name: Validate the Zed extension");
-  const scenarioAt = action.indexOf("- name: Run the Zed scenario against the real server");
-
-  assert.ok(installAt >= 0, "editor host CI must install the official Zed extension CLI");
-  assert.ok(validateAt > installAt, "Zed validation must use the pinned CLI");
-  assert.ok(scenarioAt > validateAt, "Zed validation must pass before the server scenario");
-
-  const install = action.slice(installAt, validateAt);
-  assert.match(install, /ZED_EXTENSION_CLI_SHA: [0-9a-f]{40}/);
-  assert.match(install, /ZED_EXTENSION_CLI_SHA256: [0-9a-f]{64}/);
-  assert.match(install, /sha256sum --check --strict/);
-  assert.match(install, /x86_64-unknown-linux-gnu\/zed-extension/);
-
-  const validate = action.slice(validateAt, scenarioAt);
-  assert.match(validate, /working-directory: editors\/zed/);
-  assert.match(validate, /--source-dir \./);
-  assert.match(validate, /--scratch-dir "\$\{RUNNER_TEMP\}\/zed-extension-scratch"/);
-  assert.match(validate, /--output-dir "\$\{RUNNER_TEMP\}\/zed-extension-output"/);
-
-  const scenario = action.slice(scenarioAt);
-  assert.match(scenario, /VIZE_SERVER_PATH: \$\{\{ github\.workspace \}\}\/target\/ci\/vize/);
-  assert.match(scenario, /vp run --workspace-root test:zed-extension:real-server/);
 });
 
 test("CI hydrates the exact pinned create-vue revision before the packaged host", () => {
@@ -252,39 +218,6 @@ test("the Vim real-server scenario pins complete host responses", () => {
   assert.match(scenario, /assert_equal\(a:expected, l:response\.result, a:method\)/);
   assert.doesNotMatch(scenario, /\.includes\(|\.contains\(/);
   assert.doesNotMatch(scenario, /\/dev\/(?:stdout|stderr)/);
-});
-
-test("the Zed real-server scenario pins complete extension-contract responses", () => {
-  const scenario = readRepoFile("tools", "zed-vize", "run-real-server.mjs");
-
-  for (const method of [
-    "textDocument/completion",
-    "textDocument/hover",
-    "textDocument/codeAction",
-    "textDocument/formatting",
-    "textDocument/semanticTokens/full",
-    "textDocument/rename",
-  ]) {
-    assert.match(scenario, new RegExp(method.replace("/", "\\/")));
-  }
-
-  assert.match(scenario, /assert\.deepEqual\(diagnostics\.diagnostics, expectedDiagnostics\)/);
-  assert.match(scenario, /assert\.deepEqual\(completion, expectedCompletion\)/);
-  assert.match(scenario, /assert\.deepEqual\(hover, expectedHover\)/);
-  assert.match(scenario, /assert\.deepEqual\(codeActions, expectedCodeActions\(uri\)\)/);
-  assert.match(scenario, /assert\.deepEqual\(formatting, expectedFormatting\)/);
-  assert.match(scenario, /assert\.deepEqual\(semanticTokens, expectedSemanticTokens\)/);
-  assert.match(scenario, /assert\.deepEqual\(rename, expectedRename\(uri\)\)/);
-  assert.doesNotMatch(scenario, /\.includes\(|\.contains\(/);
-
-  // These are the exact recommended defaults returned by the extension. The
-  // scenario then opts into formatting through the same initialization option
-  // available to Zed users, matching the established Neovim scenario.
-  assert.match(
-    scenario,
-    /editor: true,[\s\S]*ecosystem: true,[\s\S]*lint: true,[\s\S]*typecheck: true/,
-  );
-  assert.match(scenario, /\.\.\.zedRecommendedInitializationOptions,[\s\S]*formatting: true/);
 });
 
 test("the Neovim real-server scenario pins completion and hover responses", () => {

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -71,6 +71,13 @@ test("the Vim real-server scenario has a task that runs its Node launcher", () =
   );
 });
 
+test("the Zed real-server scenario has a task that runs its Node launcher", () => {
+  assert.equal(
+    taskCommand("test:zed-extension:real-server"),
+    "node tools/zed-vize/run-real-server.mjs",
+  );
+});
+
 test("CI runs all real-server editor scenarios from one built server binary", () => {
   const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
 
@@ -80,17 +87,45 @@ test("CI runs all real-server editor scenarios from one built server binary", ()
     action.match(/VIZE_SERVER_PATH: \$\{\{ github\.workspace \}\}\/target\/ci\/vize/g) ?? [];
   assert.equal(
     serverPathUses.length,
-    3,
+    4,
     "every real-server scenario must consume the one built binary",
   );
   assert.match(action, /vp run --workspace-root test:vscode-extension:host-real/);
   assert.match(action, /vp run --workspace-root test:nvim-extension:real-server/);
   assert.match(action, /vp run --workspace-root test:vim-extension:real-server/);
+  assert.match(action, /vp run --workspace-root test:zed-extension:real-server/);
 
   // The scenario needs a Neovim with a Lua LSP client, pinned and checksummed.
   assert.match(action, /NVIM_VERSION: v\d+\.\d+\.\d+/);
   assert.match(action, /NVIM_SHA256: [0-9a-f]{64}/);
   assert.match(action, /sha256sum --check --strict/);
+});
+
+test("CI validates Zed with the pinned official extension CLI before the real-server scenario", () => {
+  const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
+  const installAt = action.indexOf("- name: Install pinned Zed extension CLI");
+  const validateAt = action.indexOf("- name: Validate the Zed extension");
+  const scenarioAt = action.indexOf("- name: Run the Zed scenario against the real server");
+
+  assert.ok(installAt >= 0, "editor host CI must install the official Zed extension CLI");
+  assert.ok(validateAt > installAt, "Zed validation must use the pinned CLI");
+  assert.ok(scenarioAt > validateAt, "Zed validation must pass before the server scenario");
+
+  const install = action.slice(installAt, validateAt);
+  assert.match(install, /ZED_EXTENSION_CLI_SHA: [0-9a-f]{40}/);
+  assert.match(install, /ZED_EXTENSION_CLI_SHA256: [0-9a-f]{64}/);
+  assert.match(install, /sha256sum --check --strict/);
+  assert.match(install, /x86_64-unknown-linux-gnu\/zed-extension/);
+
+  const validate = action.slice(validateAt, scenarioAt);
+  assert.match(validate, /working-directory: editors\/zed/);
+  assert.match(validate, /--source-dir \./);
+  assert.match(validate, /--scratch-dir "\$\{RUNNER_TEMP\}\/zed-extension-scratch"/);
+  assert.match(validate, /--output-dir "\$\{RUNNER_TEMP\}\/zed-extension-output"/);
+
+  const scenario = action.slice(scenarioAt);
+  assert.match(scenario, /VIZE_SERVER_PATH: \$\{\{ github\.workspace \}\}\/target\/ci\/vize/);
+  assert.match(scenario, /vp run --workspace-root test:zed-extension:real-server/);
 });
 
 test("CI hydrates the exact pinned create-vue revision before the packaged host", () => {
@@ -217,6 +252,39 @@ test("the Vim real-server scenario pins complete host responses", () => {
   assert.match(scenario, /assert_equal\(a:expected, l:response\.result, a:method\)/);
   assert.doesNotMatch(scenario, /\.includes\(|\.contains\(/);
   assert.doesNotMatch(scenario, /\/dev\/(?:stdout|stderr)/);
+});
+
+test("the Zed real-server scenario pins complete extension-contract responses", () => {
+  const scenario = readRepoFile("tools", "zed-vize", "run-real-server.mjs");
+
+  for (const method of [
+    "textDocument/completion",
+    "textDocument/hover",
+    "textDocument/codeAction",
+    "textDocument/formatting",
+    "textDocument/semanticTokens/full",
+    "textDocument/rename",
+  ]) {
+    assert.match(scenario, new RegExp(method.replace("/", "\\/")));
+  }
+
+  assert.match(scenario, /assert\.deepEqual\(diagnostics\.diagnostics, expectedDiagnostics\)/);
+  assert.match(scenario, /assert\.deepEqual\(completion, expectedCompletion\)/);
+  assert.match(scenario, /assert\.deepEqual\(hover, expectedHover\)/);
+  assert.match(scenario, /assert\.deepEqual\(codeActions, expectedCodeActions\(uri\)\)/);
+  assert.match(scenario, /assert\.deepEqual\(formatting, expectedFormatting\)/);
+  assert.match(scenario, /assert\.deepEqual\(semanticTokens, expectedSemanticTokens\)/);
+  assert.match(scenario, /assert\.deepEqual\(rename, expectedRename\(uri\)\)/);
+  assert.doesNotMatch(scenario, /\.includes\(|\.contains\(/);
+
+  // These are the exact recommended defaults returned by the extension. The
+  // scenario then opts into formatting through the same initialization option
+  // available to Zed users, matching the established Neovim scenario.
+  assert.match(
+    scenario,
+    /editor: true,[\s\S]*ecosystem: true,[\s\S]*lint: true,[\s\S]*typecheck: true/,
+  );
+  assert.match(scenario, /\.\.\.zedRecommendedInitializationOptions,[\s\S]*formatting: true/);
 });
 
 test("the Neovim real-server scenario pins completion and hover responses", () => {

--- a/tests/tooling/editor-real-server-zed-e2e.test.ts
+++ b/tests/tooling/editor-real-server-zed-e2e.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { testAndBenchmarkTasks } from "../../tools/vite-plus/tasks/test-benchmark.ts";
+import { readRepoFile } from "./support/github-workflows.ts";
+
+function taskCommand(name: string): string {
+  return (testAndBenchmarkTasks[name] as { command: string }).command;
+}
+
+test("the Zed real-server scenario has a task that runs its Node launcher", () => {
+  assert.equal(
+    taskCommand("test:zed-extension:real-server"),
+    "node tools/zed-vize/run-real-server.mjs",
+  );
+});
+
+test("CI validates Zed with the pinned official extension CLI before the real-server scenario", () => {
+  const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
+  const installAt = action.indexOf("- name: Install pinned Zed extension CLI");
+  const validateAt = action.indexOf("- name: Validate the Zed extension");
+  const scenarioAt = action.indexOf("- name: Run the Zed scenario against the real server");
+
+  assert.ok(installAt >= 0, "editor host CI must install the official Zed extension CLI");
+  assert.ok(validateAt > installAt, "Zed validation must use the pinned CLI");
+  assert.ok(scenarioAt > validateAt, "Zed validation must pass before the server scenario");
+
+  const install = action.slice(installAt, validateAt);
+  assert.match(install, /ZED_EXTENSION_CLI_SHA: [0-9a-f]{40}/);
+  assert.match(install, /ZED_EXTENSION_CLI_SHA256: [0-9a-f]{64}/);
+  assert.match(install, /sha256sum --check --strict/);
+  assert.match(install, /x86_64-unknown-linux-gnu\/zed-extension/);
+
+  const validate = action.slice(validateAt, scenarioAt);
+  assert.match(validate, /working-directory: editors\/zed/);
+  assert.match(validate, /--source-dir \./);
+  assert.match(validate, /--scratch-dir "\$\{RUNNER_TEMP\}\/zed-extension-scratch"/);
+  assert.match(validate, /--output-dir "\$\{RUNNER_TEMP\}\/zed-extension-output"/);
+
+  const scenario = action.slice(scenarioAt);
+  assert.match(scenario, /VIZE_SERVER_PATH: \$\{\{ github\.workspace \}\}\/target\/ci\/vize/);
+  assert.match(scenario, /vp run --workspace-root test:zed-extension:real-server/);
+});
+
+test("the Zed real-server scenario pins complete extension-contract responses", () => {
+  const scenario = readRepoFile("tools", "zed-vize", "run-real-server.mjs");
+
+  for (const method of [
+    "textDocument/completion",
+    "textDocument/hover",
+    "textDocument/codeAction",
+    "textDocument/formatting",
+    "textDocument/semanticTokens/full",
+    "textDocument/rename",
+  ]) {
+    assert.match(scenario, new RegExp(method.replace("/", "\\/")));
+  }
+
+  assert.match(scenario, /assert\.deepEqual\(diagnostics\.diagnostics, expectedDiagnostics\)/);
+  assert.match(scenario, /assert\.deepEqual\(completion, expectedCompletion\)/);
+  assert.match(scenario, /assert\.deepEqual\(hover, expectedHover\)/);
+  assert.match(scenario, /assert\.deepEqual\(codeActions, expectedCodeActions\(uri\)\)/);
+  assert.match(scenario, /assert\.deepEqual\(formatting, expectedFormatting\)/);
+  assert.match(scenario, /assert\.deepEqual\(semanticTokens, expectedSemanticTokens\)/);
+  assert.match(scenario, /assert\.deepEqual\(rename, expectedRename\(uri\)\)/);
+  assert.doesNotMatch(scenario, /\.includes\(|\.contains\(/);
+
+  // These are the exact recommended defaults returned by the extension. The
+  // scenario then opts into formatting through the same initialization option
+  // available to Zed users, matching the established Neovim scenario.
+  assert.match(
+    scenario,
+    /editor: true,[\s\S]*ecosystem: true,[\s\S]*lint: true,[\s\S]*typecheck: true/,
+  );
+  assert.match(scenario, /\.\.\.zedRecommendedInitializationOptions,[\s\S]*formatting: true/);
+});

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -123,6 +123,7 @@ export const testAndBenchmarkTasks = defineTasks({
   "test:zed-extension:unit": task("cargo test --manifest-path editors/zed/Cargo.toml", {
     input: ["editors/zed/**"],
   }),
+  "test:zed-extension:real-server": noCacheTask("node tools/zed-vize/run-real-server.mjs"),
   "test:nvim-extension:headless": noCacheTask(
     "nvim --headless -u NONE --noplugin '+set runtimepath^=editors/nvim' '+luafile editors/nvim/test/vize_spec.lua' '+qa' && VIZE_TEST_ART_VUE_NATIVE_PARSER=1 nvim --headless -u NONE --noplugin '+set runtimepath^=editors/nvim' '+luafile editors/nvim/test/vize_spec.lua' '+qa'",
   ),

--- a/tools/zed-vize/assert-zed-package.mjs
+++ b/tools/zed-vize/assert-zed-package.mjs
@@ -114,7 +114,8 @@ assert.match(extensionToml, /^languages = \["Vue", "Art Vue"\]$/m);
 assert.match(extensionToml, /^\[language_servers\.vize\.language_ids\]$/m);
 assert.match(extensionToml, /^"Vue" = "vue"$/m);
 assert.match(extensionToml, /^"Art Vue" = "art-vue"$/m);
-assert.match(extensionToml, /^\[grammars\.art-vue\]$/m);
+assert.match(extensionToml, /^\[grammars\.art_vue\]$/m);
+assert.doesNotMatch(extensionToml, /^\[grammars\.[^\]]*-.*\]$/m);
 assert.match(extensionToml, /^commit = "[0-9a-f]{40}"$/m);
 
 assertTomlString(cargoToml, "name", "vize-zed-extension");
@@ -139,7 +140,7 @@ assert.match(libRs, /language_server_workspace_configuration/);
 assert.match(libRs, /zed::register_extension!\(VizeExtension\);/);
 
 assertTomlString(artVueConfig, "name", "Art Vue");
-assertTomlString(artVueConfig, "grammar", "art-vue");
+assertTomlString(artVueConfig, "grammar", "art_vue");
 assert.match(artVueConfig, /^path_suffixes = \["art\.vue"\]$/m);
 assertTomlString(artVueConfig, "prettier_parser_name", "vue");
 

--- a/tools/zed-vize/assert-zed-package.mjs
+++ b/tools/zed-vize/assert-zed-package.mjs
@@ -114,7 +114,7 @@ assert.match(extensionToml, /^languages = \["Vue", "Art Vue"\]$/m);
 assert.match(extensionToml, /^\[language_servers\.vize\.language_ids\]$/m);
 assert.match(extensionToml, /^"Vue" = "vue"$/m);
 assert.match(extensionToml, /^"Art Vue" = "art-vue"$/m);
-assert.match(extensionToml, /^\[grammars\.art_vue\]$/m);
+assert.match(extensionToml, /^\[grammars\.vue\]$/m);
 assert.doesNotMatch(extensionToml, /^\[grammars\.[^\]]*-.*\]$/m);
 assert.match(extensionToml, /^commit = "[0-9a-f]{40}"$/m);
 
@@ -140,7 +140,7 @@ assert.match(libRs, /language_server_workspace_configuration/);
 assert.match(libRs, /zed::register_extension!\(VizeExtension\);/);
 
 assertTomlString(artVueConfig, "name", "Art Vue");
-assertTomlString(artVueConfig, "grammar", "art_vue");
+assertTomlString(artVueConfig, "grammar", "vue");
 assert.match(artVueConfig, /^path_suffixes = \["art\.vue"\]$/m);
 assertTomlString(artVueConfig, "prettier_parser_name", "vue");
 

--- a/tools/zed-vize/run-real-server.mjs
+++ b/tools/zed-vize/run-real-server.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+// Exercise the exact command and default initialization profile emitted by the
+// Zed extension against a real `vize lsp` process. The extension's Rust unit
+// suite separately pins command discovery/configuration; this scenario pins
+// every full LSP response the default Zed contract enables.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  prepareRealVueWorkspace,
+  resolveRealServerPath,
+} from "../editor-e2e/real-vue-workspace.mjs";
+import { isDiagnosticsForUri } from "../../tests/tooling/support/lsp/assertions.ts";
+import { LspSession } from "../../tests/tooling/support/lsp/session.ts";
+
+const expectedAuthoredSource = `<script setup lang="ts">
+import Child from "./Child.vue";
+
+const total = "3";
+</script>
+
+<template>
+<Child  :count="total" />
+</template>
+`;
+
+const zedRecommendedInitializationOptions = {
+  editor: true,
+  ecosystem: true,
+  lint: true,
+  typecheck: true,
+};
+
+const expectedDiagnostics = [
+  {
+    code: "vue/no-multi-spaces",
+    codeDescription: { href: "https://eslint.vuejs.org/rules/no-multi-spaces.html" },
+    message: "Multiple consecutive spaces",
+    range: {
+      end: { character: 8, line: 7 },
+      start: { character: 6, line: 7 },
+    },
+    severity: 2,
+    source: "vize/lint",
+  },
+  {
+    code: 2322,
+    message: "Type 'string' is not assignable to type 'number'.",
+    range: {
+      end: { character: 14, line: 7 },
+      start: { character: 9, line: 7 },
+    },
+    severity: 1,
+    source: "vize/types",
+  },
+];
+
+const expectedCompletion = [
+  {
+    detail: " (const)",
+    documentation: {
+      kind: "markdown",
+      value: "**Const**\n\nConstant binding (function, class, or literal).",
+    },
+    kind: 21,
+    label: "Child",
+    labelDetails: { detail: " (const)" },
+    sortText: "0Child",
+  },
+  {
+    detail: " (literal)",
+    documentation: {
+      kind: "markdown",
+      value: "**Literal**\n\nLiteral constant value.",
+    },
+    kind: 21,
+    label: "total",
+    labelDetails: { detail: " (literal)" },
+    sortText: "0total",
+  },
+];
+
+const expectedHover = {
+  contents: {
+    kind: "markdown",
+    value:
+      '**TypeScript quick info**\n\n_Resolved through Vize virtual TypeScript_\n\n```typescript\nconst total: "3"\n```',
+  },
+  range: {
+    end: { character: 11, line: 3 },
+    start: { character: 6, line: 3 },
+  },
+};
+
+function expectedCodeActions(uri) {
+  return [
+    {
+      edit: {
+        changes: {
+          [uri]: [
+            {
+              newText: " ",
+              range: {
+                end: { character: 8, line: 7 },
+                start: { character: 6, line: 7 },
+              },
+            },
+          ],
+        },
+      },
+      isPreferred: true,
+      kind: "quickfix",
+      title: "Fix: Replace multiple spaces with single space",
+    },
+    {
+      edit: {
+        changes: {
+          [uri]: [
+            {
+              newText: "<!-- @vize:forget vue/no-multi-spaces -->\n",
+              range: {
+                end: { character: 0, line: 7 },
+                start: { character: 0, line: 7 },
+              },
+            },
+          ],
+        },
+      },
+      isPreferred: false,
+      kind: "quickfix",
+      title: "Suppress with @vize:forget (vue/no-multi-spaces)",
+    },
+  ];
+}
+
+const expectedFormatting = [
+  {
+    newText: `<script setup lang="ts">
+import Child from "./Child.vue";
+
+const total = "3";
+</script>
+
+<template>
+  <Child :count="total" />
+</template>
+`,
+    range: {
+      end: { character: 0, line: 9 },
+      start: { character: 0, line: 0 },
+    },
+  },
+];
+
+const expectedSemanticTokens = { data: [7, 8, 6, 9, 0, 0, 8, 5, 8, 0] };
+
+function expectedRename(uri) {
+  return {
+    changes: {
+      [uri]: [
+        {
+          newText: "quantity",
+          range: {
+            end: { character: 11, line: 3 },
+            start: { character: 6, line: 3 },
+          },
+        },
+        {
+          newText: "quantity",
+          range: {
+            end: { character: 21, line: 7 },
+            start: { character: 16, line: 7 },
+          },
+        },
+      ],
+    },
+  };
+}
+
+const sessionRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-zed-e2e-"));
+const workspacePath = path.join(sessionRoot, "real-vue");
+prepareRealVueWorkspace(workspacePath);
+
+// LspSession's explicit binary override maps to the Zed extension's discovered
+// `vize` command plus its default `["lsp"]` argument.
+process.env.VIZE_LSP_BIN = resolveRealServerPath();
+const session = new LspSession();
+
+try {
+  // Zed's fallback is the shared recommended profile. Formatting is the one
+  // server-default capability intentionally left off, so opt into it exactly
+  // as a Zed user would through `lsp.vize.initialization_options`.
+  await session.initialize(workspacePath, {
+    ...zedRecommendedInitializationOptions,
+    formatting: true,
+  });
+
+  const documentPath = path.join(workspacePath, "src", "Scenario.vue");
+  const uri = pathToFileURL(documentPath).href;
+  const source = fs.readFileSync(documentPath, "utf8");
+  assert.equal(source, expectedAuthoredSource, "the shared editor fixture changed");
+
+  session.notify("textDocument/didOpen", {
+    textDocument: {
+      uri,
+      languageId: "vue",
+      version: 1,
+      text: source,
+    },
+  });
+
+  const diagnostics = await session.waitForNotification(
+    "textDocument/publishDiagnostics",
+    (params) =>
+      isDiagnosticsForUri(params, uri) && params.diagnostics.length === expectedDiagnostics.length,
+    120_000,
+  );
+  assert.deepEqual(diagnostics.diagnostics, expectedDiagnostics);
+
+  const completion = await session.request(
+    "textDocument/completion",
+    { textDocument: { uri }, position: { character: 16, line: 7 } },
+    120_000,
+  );
+  assert.deepEqual(completion, expectedCompletion);
+
+  const hover = await session.request(
+    "textDocument/hover",
+    { textDocument: { uri }, position: { character: 8, line: 3 } },
+    120_000,
+  );
+  assert.deepEqual(hover, expectedHover);
+
+  const codeActions = await session.request(
+    "textDocument/codeAction",
+    {
+      textDocument: { uri },
+      range: {
+        end: { character: 8, line: 7 },
+        start: { character: 6, line: 7 },
+      },
+      context: { diagnostics: expectedDiagnostics },
+    },
+    120_000,
+  );
+  assert.deepEqual(codeActions, expectedCodeActions(uri));
+
+  const formatting = await session.request(
+    "textDocument/formatting",
+    { textDocument: { uri }, options: { insertSpaces: true, tabSize: 2 } },
+    120_000,
+  );
+  assert.deepEqual(formatting, expectedFormatting);
+
+  const semanticTokens = await session.request(
+    "textDocument/semanticTokens/full",
+    { textDocument: { uri } },
+    120_000,
+  );
+  assert.deepEqual(semanticTokens, expectedSemanticTokens);
+
+  const rename = await session.request(
+    "textDocument/rename",
+    {
+      textDocument: { uri },
+      position: { character: 8, line: 3 },
+      newName: "quantity",
+    },
+    120_000,
+  );
+  assert.deepEqual(rename, expectedRename(uri));
+
+  console.log("zed extension-contract real-server scenario passed");
+} finally {
+  await session.shutdown();
+  fs.rmSync(sessionRoot, { force: true, recursive: true });
+}


### PR DESCRIPTION
Part of #3744.

## Summary
- add a Zed extension-contract scenario that launches the built `vize lsp` command with Zed's recommended initialization profile and an explicit formatting opt-in
- compare complete diagnostics, completion, hover, code action, formatting, semantic-token, and rename responses
- validate the extension with Zed's pinned official extension CLI and checksum before running the scenario in `editor-host-smoke`
- guard the task, shared binary wiring, official builder pin, execution order, and ban partial response assertions

## Validation
- red-first: 4 focused guard failures before implementation
- `VIZE_SERVER_PATH=... vp run --workspace-root test:zed-extension:real-server`
- real-server scenario repeated 20/20
- `node --test` related editor/tooling suites: 53/53
- Zed Rust extension unit tests: 14/14
- `vp run --workspace-root package:zed-extension`
- `vp fmt ... --check`
- `vp check --no-fmt ...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Zed extension real-server integration coverage, including diagnostics, completion, hover, code actions, formatting, semantic tokens, and rename support.
  * Added a dedicated task for running the Zed real-server scenario.

* **Bug Fixes**
  * Standardized Art Vue language configuration to reuse the Vue grammar, improving compatibility with Zed.

* **Tests**
  * Expanded automated validation for Zed extension packaging, initialization, server behavior, and CI setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->