### PR TITLE
test(cli): fail closed for project resolution Corsa gates

### DIFF
--- a/crates/vize/tests/check_entry_ignores_cli.rs
+++ b/crates/vize/tests/check_entry_ignores_cli.rs
@@ -1,10 +1,13 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{path::Path, process::Command};
 
 use vize_carton::cstr;
 
 #[test]
 fn check_config_entry_ignores_explicit_inputs() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_cli_project(
@@ -61,7 +64,7 @@ const count: string = 0;
 
 #[test]
 fn check_config_entry_ignores_default_and_explicit_path_matrix() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = create_cli_project(

--- a/crates/vize/tests/check_package_cwd_cli.rs
+++ b/crates/vize/tests/check_package_cwd_cli.rs
@@ -4,6 +4,9 @@
     clippy::disallowed_types
 )]
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{path::Path, process::Command};
 
 fn workspace_root() -> &'static Path {
@@ -58,7 +61,7 @@ fn resolve_test_corsa_path() -> Option<String> {
 
 #[test]
 fn check_from_package_cwd_uses_package_local_tsconfig_inputs() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
 
@@ -163,7 +166,7 @@ void rootOnly;
 
 #[test]
 fn check_from_workspace_root_accepts_subproject_directory_input() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
 
@@ -250,7 +253,7 @@ const msg: string = rootValue;
 
 #[test]
 fn check_from_package_cwd_resolves_package_local_dependencies() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
 

--- a/crates/vize/tests/check_tsconfig_types_cli.rs
+++ b/crates/vize/tests/check_tsconfig_types_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{
     path::{Path, PathBuf},
     process::Command,
@@ -93,7 +96,7 @@ fn write(root: &Path, rel: &str, content: &str) {
 
 #[test]
 fn check_loads_compiler_options_types_from_tsconfig_ambient_declarations() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let project_root = unique_case_dir("compiler-options-types");
@@ -194,7 +197,7 @@ void label;
 
 #[test]
 fn check_loads_parent_type_packages_without_mirroring_them_as_sources() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
     let workspace = unique_case_dir("parent-types");

--- a/crates/vize/tests/check_vue_reexports_cli.rs
+++ b/crates/vize/tests/check_vue_reexports_cli.rs
@@ -1,3 +1,6 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{path::Path, process::Command};
 
 fn workspace_root() -> &'static Path {
@@ -43,7 +46,7 @@ fn resolve_test_corsa_path() -> Option<String> {
 #[cfg(unix)]
 #[test]
 fn check_preserves_named_exports_from_vue_reexported_through_symlinked_absolute_path() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
 

--- a/crates/vize/tests/check_workspace_package_boundary_cli.rs
+++ b/crates/vize/tests/check_workspace_package_boundary_cli.rs
@@ -4,6 +4,9 @@
     clippy::disallowed_types
 )]
 
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
 use std::{path::Path, process::Command};
 
 fn workspace_root() -> &'static Path {
@@ -48,7 +51,7 @@ fn resolve_test_corsa_path() -> Option<String> {
 
 #[test]
 fn check_filtered_child_workspace_keeps_package_root_for_corsa_resolution() {
-    let Some(corsa_path) = resolve_test_corsa_path() else {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
         return;
     };
 

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -229,6 +229,26 @@ test("plain script and reference Rust CLI gates use the fail-closed Corsa helper
   }
 });
 
+test("project resolution Rust CLI gates use the fail-closed Corsa helper", () => {
+  const files = [
+    ["check_entry_ignores_cli.rs", 2],
+    ["check_package_cwd_cli.rs", 3],
+    ["check_tsconfig_types_cli.rs", 2],
+    ["check_vue_reexports_cli.rs", 1],
+    ["check_workspace_package_boundary_cli.rs", 1],
+  ] as const;
+
+  for (const [file, expectedCalls] of files) {
+    const source = readRepoFile("crates", "vize", "tests", file);
+    assert.equal(
+      source.match(/corsa_requirement::required_or_skip\(resolve_test_corsa_path\(\)\)/g)?.length,
+      expectedCalls,
+      `${file} should guard all ${expectedCalls} Corsa resolver calls`,
+    );
+    assert.doesNotMatch(source, /let Some\(corsa_path\) = resolve_test_corsa_path\(\)/);
+  }
+});
+
 test("available dependencies never skip", () => {
   assert.equal(typecheckDependencySkip("/tmp/tsgo", "tsgo", "missing", true), false);
 });


### PR DESCRIPTION
## Summary

- route the remaining project-resolution CLI test binaries through the shared fail-closed Corsa dependency policy
- reject raw green skips when CI requires `tsgo`
- pin the exact call counts with a mechanical tooling oracle

## Verification

- `node --test tests/tooling/source-file-lengths.test.ts tests/tooling/typecheck-dependency-gates.test.ts` (23/23)
- `cargo fmt --all -- --check`
- `cargo test -p vize --test check_entry_ignores_cli --test check_package_cwd_cli --test check_tsconfig_types_cli --test check_vue_reexports_cli --test check_workspace_package_boundary_cli` with `VIZE_TEST_REQUIRE_TSGO=1` (9/9)

Refs #3750