### PR TITLE
fix(maestro): honor in-flight request cancellation

### DIFF
--- a/crates/vize_maestro/src/server.rs
+++ b/crates/vize_maestro/src/server.rs
@@ -23,6 +23,7 @@ mod importers;
 mod state;
 mod workspace_files;
 mod workspace_folder_events;
+mod workspace_symbols;
 
 pub use capabilities::server_capabilities;
 #[cfg(feature = "native")]

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -36,7 +36,7 @@ use super::{MaestroServer, server_capabilities};
 use crate::ide::{
     CodeActionService, CompletionService, DefinitionService, DocumentHighlightService,
     DocumentLinkService, HoverService, IdeContext, ReferencesService, RenameService,
-    SemanticTokensService, WorkspaceSymbolsService, position_to_offset,
+    SemanticTokensService, position_to_offset,
 };
 
 #[tower_lsp::async_trait]
@@ -578,18 +578,7 @@ impl LanguageServer for MaestroServer {
         &self,
         params: WorkspaceSymbolParams,
     ) -> Result<Option<Vec<SymbolInformation>>> {
-        if !self.state.lsp_features().workspace_symbols {
-            return Ok(None);
-        }
-
-        let query = &params.query;
-        let symbols = WorkspaceSymbolsService::search(&self.state, query);
-
-        if symbols.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(symbols))
-        }
+        super::workspace_symbols::search(self, &params).await
     }
 
     async fn will_rename_files(&self, params: RenameFilesParams) -> Result<Option<WorkspaceEdit>> {

--- a/crates/vize_maestro/src/server/workspace_symbols.rs
+++ b/crates/vize_maestro/src/server/workspace_symbols.rs
@@ -1,0 +1,47 @@
+//! Cooperative workspace-symbol request handling.
+
+use std::task::Poll;
+
+use tower_lsp::{
+    jsonrpc::Result,
+    lsp_types::{SymbolInformation, WorkspaceSymbolParams},
+};
+
+use crate::ide::WorkspaceSymbolsService;
+
+use super::MaestroServer;
+
+pub(super) async fn search(
+    server: &MaestroServer,
+    params: &WorkspaceSymbolParams,
+) -> Result<Option<Vec<SymbolInformation>>> {
+    if !server.state.lsp_features().workspace_symbols {
+        return Ok(None);
+    }
+
+    yield_to_pending_cancellation().await;
+    let symbols = WorkspaceSymbolsService::search(&server.state, &params.query);
+
+    if symbols.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(symbols))
+    }
+}
+
+/// Give tower-lsp's cancellation layer a poll boundary before the synchronous
+/// workspace scan. Editors commonly replace symbol queries while typing, so a
+/// queued `$/cancelRequest` should retire the old request before that work.
+async fn yield_to_pending_cancellation() {
+    let mut yielded = false;
+    futures::future::poll_fn(|context| {
+        if yielded {
+            Poll::Ready(())
+        } else {
+            yielded = true;
+            context.waker().wake_by_ref();
+            Poll::Pending
+        }
+    })
+    .await;
+}

--- a/tests/tooling/lsp-request-cancellation.test.ts
+++ b/tests/tooling/lsp-request-cancellation.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isDiagnosticsForUri } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspRequestError, LspSession } from "./support/lsp/session.ts";
+
+const SOURCE = `<script setup lang="ts">
+const cancellableSymbol = 1
+</script>
+<template><p>{{ cancellableSymbol }}</p></template>
+`;
+
+test("vize lsp cancels an in-flight request and remains usable", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-request-cancellation");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const filePath = path.join(workspaceDir, "Cancellable.vue");
+  const uri = pathToFileURL(filePath).href;
+  fs.writeFileSync(filePath, SOURCE, "utf8");
+
+  const session = new LspSession();
+  let primaryError: unknown;
+  try {
+    await session.initialize(workspaceDir, { editor: true, lint: false, typecheck: false });
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: SOURCE },
+    });
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, uri),
+    );
+
+    const requestId = session.nextRequestId;
+    const cancelled = session.request("workspace/symbol", { query: "cancellableSymbol" });
+    session.notify("$/cancelRequest", { id: requestId });
+
+    await assert.rejects(
+      cancelled,
+      (error) =>
+        error instanceof LspRequestError &&
+        error.method === "workspace/symbol" &&
+        error.code === -32800,
+    );
+
+    const retry = (await session.request("workspace/symbol", {
+      query: "cancellableSymbol",
+    })) as Array<{ name: string }> | null;
+    assert.ok(
+      retry?.some((symbol) => symbol.name === "cancellableSymbol"),
+      JSON.stringify(retry),
+    );
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    await session.shutdown().catch((error: unknown) => {
+      if (primaryError == null) throw error;
+    });
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/support/lsp/session.ts
+++ b/tests/tooling/support/lsp/session.ts
@@ -150,6 +150,10 @@ export class LspSession {
     return result;
   }
 
+  get nextRequestId(): number {
+    return this.nextId + 1;
+  }
+
   request(method: string, params: unknown, timeoutMs = 30000): Promise<unknown> {
     const id = ++this.nextId;
 


### PR DESCRIPTION
## Summary

- add a cooperative poll boundary before synchronous workspace-symbol scanning
- let tower-lsp retire queued requests through `$/cancelRequest`
- verify the server remains usable by retrying the cancelled request

## Tests

- regression test fails against the pre-fix binary with `Missing expected rejection`
- `cargo test -p vize_maestro` (694 passed, 2 ignored; integration and doctest passed)
- `cargo clippy -p vize_maestro --lib -- -D warnings`
- `cargo build -p vize`
- cancellation stdio regression repeated 5 times
- cancellation + workspace semantic + protocol resilience stdio tests (12 passed)
- `vp check` (0 errors; 33 pre-existing warnings)

Refs #3742