### PR TITLE
fix(canon): protect control files from path aliases

### DIFF
--- a/crates/vize/tests/check_canon_path_alias_json_cli.rs
+++ b/crates/vize/tests/check_canon_path_alias_json_cli.rs
@@ -1,0 +1,104 @@
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use std::{path::Path, process::Command};
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(file_path, content).unwrap();
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    let root = workspace_root();
+    let sibling_cache = root.parent()?.join("corsa-bind/.cache/tsgo");
+    if sibling_cache.exists() {
+        return Some(sibling_cache.display().to_string());
+    }
+
+    let workspace_bin = root.join("node_modules/.bin/tsgo");
+    workspace_bin
+        .exists()
+        .then(|| workspace_bin.display().to_string())
+}
+
+#[test]
+fn path_aliases_do_not_resolve_project_json_to_canon_control_files() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+
+    let project_root = workspace_root()
+        .join("target/vize-tests/tests")
+        .join(format!("canon-path-alias-json-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    write_file(
+        &project_root,
+        "package.json",
+        r#"{ "name": "alias-json-app", "version": "1.2.3" }"#,
+    );
+    write_file(
+        &project_root,
+        "tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "strict": true,
+    "noEmit": true,
+    "paths": {
+      "~/*": ["./*"],
+      "@/*": ["./*"]
+    }
+  }
+}"#,
+    );
+    write_file(
+        &project_root,
+        "repro.ts",
+        r#"import { version as tildeVersion } from "~/package.json";
+import { version as atVersion } from "@/package.json";
+
+export const versions: [string, string] = [tildeVersion, atVersion];
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", "repro.ts", "--no-config", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "project JSON aliases resolved to Canon control files:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stdout.contains("node_modules/.vize/canon/package"),
+        "diagnostics must not resolve aliases to Canon's package boundary:\n{stdout}\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 0, "{stdout}\n{stderr}");
+    assert_eq!(json["warningCount"], 0, "{stdout}\n{stderr}");
+    assert_eq!(json["fileCount"], 1, "{stdout}\n{stderr}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -1,4 +1,5 @@
 mod compiler_options;
+mod control_alias;
 mod native_options;
 mod path_rebase;
 mod vue_alias;
@@ -12,6 +13,7 @@ use crate::batch::error::CorsaResult;
 use crate::batch::materialize_fs::write_if_changed;
 
 use super::{SHARED_HELPERS_FILE, VirtualProject};
+use control_alias::protect_control_file_aliases;
 use native_options::normalize_native_removed_options;
 use vue_alias::remap_path_targets;
 
@@ -292,6 +294,7 @@ impl VirtualProject {
                 Value::Array(remap_path_targets(targets, &up)),
             );
         }
+        protect_control_file_aliases(paths, &mut remapped, &up);
         remapped
     }
 

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen/control_alias.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen/control_alias.rs
@@ -1,0 +1,119 @@
+//! Exact path mappings that keep Canon's control files private.
+
+use std::path::Path;
+
+use serde_json::{Map, Value};
+use vize_carton::cstr;
+
+use super::super::{
+    AUTO_IMPORT_STUBS_FILE, MODULE_AUGMENTATION_STUBS_FILE, PACKAGE_BOUNDARY_FILE,
+    SHARED_HELPERS_FILE, VUE_MODULE_STUBS_FILE,
+};
+
+const CONTROL_FILES: &[&str] = &[
+    PACKAGE_BOUNDARY_FILE,
+    "tsconfig.json",
+    "tsconfig.options.json",
+    "tsconfig.declaration.json",
+    AUTO_IMPORT_STUBS_FILE,
+    MODULE_AUGMENTATION_STUBS_FILE,
+    VUE_MODULE_STUBS_FILE,
+    SHARED_HELPERS_FILE,
+];
+
+/// Add exact real-tree mappings wherever a wildcard or exact user target would
+/// otherwise expose a same-named control file at the virtual project root.
+#[allow(clippy::disallowed_types)]
+pub(super) fn protect_control_file_aliases(
+    paths: &Map<std::string::String, Value>,
+    remapped: &mut Map<std::string::String, Value>,
+    project_prefix: &str,
+) {
+    let mut overrides = Vec::new();
+    for (alias, targets) in paths {
+        let Some(targets) = targets.as_array() else {
+            continue;
+        };
+        for target in targets.iter().filter_map(Value::as_str) {
+            for control_file in CONTROL_FILES {
+                let Some(exact_alias) = exact_alias_for_target(alias, target, control_file) else {
+                    continue;
+                };
+                if exact_alias != *alias && paths.contains_key(&exact_alias) {
+                    continue;
+                }
+                overrides.push((exact_alias, *control_file));
+            }
+        }
+    }
+
+    for (alias, control_file) in overrides {
+        remapped.insert(
+            alias,
+            Value::Array(vec![Value::String(
+                cstr!("{project_prefix}{control_file}").into(),
+            )]),
+        );
+    }
+}
+
+#[allow(clippy::disallowed_types)]
+fn exact_alias_for_target(alias: &str, target: &str, control_file: &str) -> Option<String> {
+    if Path::new(target).is_absolute() {
+        return None;
+    }
+    let target = target.strip_prefix("./").unwrap_or(target);
+    let Some((prefix, suffix)) = target.split_once('*') else {
+        return (target == control_file).then(|| alias.to_owned());
+    };
+    let capture = control_file.strip_prefix(prefix)?.strip_suffix(suffix)?;
+    alias.contains('*').then(|| alias.replacen('*', capture, 1))
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Map, Value, json};
+
+    use super::protect_control_file_aliases;
+
+    #[allow(clippy::disallowed_types)]
+    fn protect(paths: Value) -> Map<std::string::String, Value> {
+        let paths = paths.as_object().unwrap();
+        let mut remapped = paths.clone();
+        protect_control_file_aliases(paths, &mut remapped, "../../../");
+        remapped
+    }
+
+    #[test]
+    fn root_wildcards_cannot_resolve_to_canon_control_files() {
+        let protected = protect(json!({ "~/*": ["./*"], "@/*": ["*"] }));
+        assert_eq!(
+            protected["~/package.json"],
+            json!(["../../../package.json"])
+        );
+        assert_eq!(
+            protected["@/tsconfig.json"],
+            json!(["../../../tsconfig.json"])
+        );
+    }
+
+    #[test]
+    fn exact_package_target_uses_the_real_project_file() {
+        let protected = protect(json!({ "manifest": ["./package.json"] }));
+        assert_eq!(protected["manifest"], json!(["../../../package.json"]));
+    }
+
+    #[test]
+    fn explicit_aliases_and_unrelated_targets_are_unchanged() {
+        let protected = protect(json!({
+            "~/*": ["./*"],
+            "~/package.json": ["fixtures/package.json"],
+            "src/*": ["src/*"]
+        }));
+        assert_eq!(
+            protected["~/package.json"],
+            json!(["fixtures/package.json"])
+        );
+        assert_eq!(protected["src/*"], json!(["src/*"]));
+    }
+}


### PR DESCRIPTION
Closes #3771.

## Summary

- add exact real-tree path mappings when a wildcard alias would expose Canon control files
- preserve explicit user aliases and existing Vue mirror candidate ordering
- cover tilde and at-sign package.json aliases through the real vize check CLI

## Verification

- cargo test -p vize_canon --lib (795 passed)
- cargo test -p vize_canon --lib batch::virtual_project (94 passed)
- cargo test -p vize_canon --test relative_extensionless_vue_imports (4 passed)
- cargo test -p vize --test check_canon_path_alias_json_cli
- cargo clippy -p vize_canon --lib -- -D warnings
- cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript path alias handling in virtual projects.
  * Prevented aliases such as `~/*` and `@/*` from incorrectly resolving to internal control files.
  * Preserved explicit aliases while safely remapping conflicting paths to the appropriate project files.
  * Added validation to ensure affected projects complete checks successfully without diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->