### PR TITLE
test(maestro): make cancellation oracle deterministic

### DIFF
--- a/tests/tooling/lsp-request-cancellation.test.ts
+++ b/tests/tooling/lsp-request-cancellation.test.ts
@@ -32,9 +32,12 @@ test("vize lsp cancels an in-flight request and remains usable", async () => {
       isDiagnosticsForUri(params, uri),
     );
 
-    const requestId = session.nextRequestId;
-    const cancelled = session.request("workspace/symbol", { query: "cancellableSymbol" });
-    session.notify("$/cancelRequest", { id: requestId });
+    const cancelled = session.request(
+      "workspace/symbol",
+      { query: "cancellableSymbol" },
+      30000,
+      (id) => [{ jsonrpc: "2.0", method: "$/cancelRequest", params: { id } }],
+    );
 
     await assert.rejects(
       cancelled,

--- a/tests/tooling/support/lsp/session.ts
+++ b/tests/tooling/support/lsp/session.ts
@@ -47,12 +47,7 @@ export class LspSession {
     reject: (error: Error) => void;
     timeout: NodeJS.Timeout;
   }> = [];
-  /**
-   * Passive observers invoked for every server notification before waiter
-   * matching and backlog storage. Stream audits (for example the churn-stress
-   * suite's publish ordering oracle) record from here without consuming the
-   * notifications that `waitForNotification` callers race for.
-   */
+  /** Passive notification observers that do not consume waiter/backlog entries. */
   readonly notificationObservers: Array<(method: string, params: unknown) => void> = [];
   private buffer = Buffer.alloc(0);
   private nextId = 0;
@@ -150,11 +145,12 @@ export class LspSession {
     return result;
   }
 
-  get nextRequestId(): number {
-    return this.nextId + 1;
-  }
-
-  request(method: string, params: unknown, timeoutMs = 30000): Promise<unknown> {
+  request(
+    method: string,
+    params: unknown,
+    timeoutMs = 30000,
+    following: (id: number) => JsonRpcMessage[] = () => [],
+  ): Promise<unknown> {
     const id = ++this.nextId;
 
     return new Promise((resolve, reject) => {
@@ -164,7 +160,7 @@ export class LspSession {
       }, timeoutMs);
 
       this.pending.set(id, { resolve, reject, method, timeout });
-      this.send({ jsonrpc: "2.0", id, method, params });
+      this.send({ jsonrpc: "2.0", id, method, params }, ...following(id));
     });
   }
 
@@ -259,9 +255,8 @@ export class LspSession {
     });
   }
 
-  private send(message: JsonRpcMessage): void {
-    const payload = JSON.stringify(message);
-    const frame = `Content-Length: ${Buffer.byteLength(payload, "utf8")}\r\n\r\n${payload}`;
+  private send(...messages: JsonRpcMessage[]): void {
+    const frame = messages.map((message) => frameMessage(message)).join("");
     this.process.stdin.write(frame, "utf8");
   }
 
@@ -347,4 +342,9 @@ export class LspSession {
     clearTimeout(notification.timeout);
     notification.resolve(message.params);
   }
+}
+
+function frameMessage(message: JsonRpcMessage): string {
+  const payload = JSON.stringify(message);
+  return `Content-Length: ${Buffer.byteLength(payload, "utf8")}\r\n\r\n${payload}`;
 }


### PR DESCRIPTION
## Summary

- batch the workspace-symbol request and its `$/cancelRequest` notification into one stdio write
- keep the production cancellation implementation unchanged
- remove the racy `nextRequestId` observation from the real-LSP harness

## Regression evidence

On unmodified `main`, the post-#3809 oracle reproduced `Missing expected rejection` at fresh-process iteration 189/500. The two separate pipe writes let the short request finish before the reader delivered the cancellation frame. Framing both JSON-RPC messages in one write makes the transport queue cancellation before the handler resumes from its cooperative yield.

## Validation

- old oracle: failed at iteration 189/500
- fixed oracle: 1,000/1,000 fresh-process repetitions passed
- after rebasing: 500/500 fresh-process repetitions passed
- final main rebase: 200/200 fresh-process repetitions passed
- real LSP suite: 2,217 passed, 0 failed
- `vp check`: 0 errors (33 existing warnings)

Refs #3742
Context: #3809, #3806

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->