### PR TITLE
test(editor): run Helix contract against real server

### DIFF
--- a/.github/actions/vscode-host-smoke/action.yml
+++ b/.github/actions/vscode-host-smoke/action.yml
@@ -1,5 +1,5 @@
 name: Editor real-server end-to-end
-description: Run VS Code, Zed, Neovim, and Vim real-server scenarios plus packaged editor specs
+description: Run VS Code, Zed, Neovim, Vim, and Helix real-server scenarios plus packaged specs
 
 runs:
   using: composite
@@ -63,9 +63,36 @@ runs:
           --scratch-dir "${RUNNER_TEMP}/zed-extension-scratch" \
           --output-dir "${RUNNER_TEMP}/zed-extension-output"
 
+    - name: Install pinned Helix
+      shell: bash
+      env:
+        HELIX_VERSION: 25.07.1
+        HELIX_SHA256: 3f08e63ecd388fff657ad39722f88bb03dcf326f1f2da2700d99e1dc40ab2e8b
+      run: |
+        set -euo pipefail
+        archive="${RUNNER_TEMP}/helix-${HELIX_VERSION}-x86_64-linux.tar.xz"
+        curl -fsSL -o "${archive}" \
+          "https://github.com/helix-editor/helix/releases/download/${HELIX_VERSION}/helix-${HELIX_VERSION}-x86_64-linux.tar.xz"
+        echo "${HELIX_SHA256}  ${archive}" | sha256sum --check --strict
+        mkdir -p "${RUNNER_TEMP}/helix"
+        tar -xJf "${archive}" -C "${RUNNER_TEMP}/helix" --strip-components=1
+        "${RUNNER_TEMP}/helix/hx" --version
+
     - name: Build vize CLI
       shell: bash
       run: cargo build --profile ci -p vize
+
+    - name: Check the Helix package with the official CLI
+      shell: bash
+      env:
+        XDG_CONFIG_HOME: ${{ runner.temp }}/helix-config
+        HELIX_RUNTIME: ${{ runner.temp }}/helix/runtime
+        VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize
+      run: |
+        set -euo pipefail
+        mkdir -p "${XDG_CONFIG_HOME}/helix"
+        cp editors/helix/languages.toml "${XDG_CONFIG_HOME}/helix/languages.toml"
+        node tools/helix-vize/assert-helix-health.mjs "${RUNNER_TEMP}/helix/hx"
 
     - name: Ensure xvfb is available
       shell: bash
@@ -159,3 +186,10 @@ runs:
         NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
         VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize
       run: vp run --workspace-root test:zed-extension:real-server
+
+    - name: Run the Helix scenario against the real server
+      shell: bash
+      env:
+        NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+        VIZE_SERVER_PATH: ${{ github.workspace }}/target/ci/vize
+      run: vp run --workspace-root test:helix-extension:real-server

--- a/editors/helix/README.md
+++ b/editors/helix/README.md
@@ -24,3 +24,8 @@ typecheck = true
 
 The package registers Vize for `vue` and `art-vue`. The `art-vue` language uses a glob so
 `*.art.vue` files do not get swallowed by the generic `.vue` suffix rule.
+
+CI validates this file with the pinned official Helix binary (`hx --health vue` and
+`hx --health art-vue`), then runs the advertised language-server features against one real
+`vize lsp` binary. Formatting is not advertised by this default profile; enable it explicitly
+with `formatting = true` if Helix should use Vize as the document formatter.

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -80,13 +80,14 @@ test("CI runs all real-server editor scenarios from one built server binary", ()
     action.match(/VIZE_SERVER_PATH: \$\{\{ github\.workspace \}\}\/target\/ci\/vize/g) ?? [];
   assert.equal(
     serverPathUses.length,
-    4,
-    "every real-server scenario must consume the one built binary",
+    6,
+    "every real-server scenario and host health check must consume the one built binary",
   );
   assert.match(action, /vp run --workspace-root test:vscode-extension:host-real/);
   assert.match(action, /vp run --workspace-root test:nvim-extension:real-server/);
   assert.match(action, /vp run --workspace-root test:vim-extension:real-server/);
   assert.match(action, /vp run --workspace-root test:zed-extension:real-server/);
+  assert.match(action, /vp run --workspace-root test:helix-extension:real-server/);
 
   // The scenario needs a Neovim with a Lua LSP client, pinned and checksummed.
   assert.match(action, /NVIM_VERSION: v\d+\.\d+\.\d+/);

--- a/tests/tooling/editor-real-server-helix-e2e.test.ts
+++ b/tests/tooling/editor-real-server-helix-e2e.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { testAndBenchmarkTasks } from "../../tools/vite-plus/tasks/test-benchmark.ts";
+import { readRepoFile } from "./support/github-workflows.ts";
+
+function taskCommand(name: string): string {
+  return (testAndBenchmarkTasks[name] as { command: string }).command;
+}
+
+test("the Helix real-server scenario has a task that runs its Node launcher", () => {
+  assert.equal(
+    taskCommand("test:helix-extension:real-server"),
+    "node tools/helix-vize/run-real-server.mjs",
+  );
+});
+
+test("CI checks the package with a pinned official Helix before the server scenario", () => {
+  const action = readRepoFile(".github", "actions", "vscode-host-smoke", "action.yml");
+  const installAt = action.indexOf("- name: Install pinned Helix");
+  const healthAt = action.indexOf("- name: Check the Helix package with the official CLI");
+  const scenarioAt = action.indexOf("- name: Run the Helix scenario against the real server");
+
+  assert.ok(installAt >= 0, "editor host CI must install the official Helix binary");
+  assert.ok(healthAt > installAt, "Helix health checks must use the pinned binary");
+  assert.ok(scenarioAt > healthAt, "the package must pass Helix health before the scenario");
+
+  const install = action.slice(installAt, healthAt);
+  assert.match(install, /HELIX_VERSION: \d+\.\d+\.\d+/);
+  assert.match(install, /HELIX_SHA256: [0-9a-f]{64}/);
+  assert.match(install, /sha256sum --check --strict/);
+  assert.match(install, /helix-\$\{HELIX_VERSION\}-x86_64-linux\.tar\.xz/);
+
+  const health = action.slice(healthAt, scenarioAt);
+  assert.match(health, /XDG_CONFIG_HOME: \$\{\{ runner\.temp \}\}\/helix-config/);
+  assert.match(health, /HELIX_RUNTIME: \$\{\{ runner\.temp \}\}\/helix\/runtime/);
+  assert.match(health, /VIZE_SERVER_PATH: \$\{\{ github\.workspace \}\}\/target\/ci\/vize/);
+  assert.match(health, /node tools\/helix-vize\/assert-helix-health\.mjs/);
+
+  const scenario = action.slice(scenarioAt);
+  assert.match(scenario, /VIZE_SERVER_PATH: \$\{\{ github\.workspace \}\}\/target\/ci\/vize/);
+  assert.match(scenario, /vp run --workspace-root test:helix-extension:real-server/);
+});
+
+test("the official Helix health guard checks both packaged language entries exactly", () => {
+  const health = readRepoFile("tools", "helix-vize", "assert-helix-health.mjs");
+
+  assert.match(health, /\["--health", language\]/);
+  assert.match(health, /for \(const language of \["vue", "art-vue"\]\)/);
+  assert.match(health, /assert\.deepEqual\(\s*configuredServers,\s*\[expectedServer\]/);
+  assert.match(health, /assert\.equal\(result\.status, 0/);
+  assert.doesNotMatch(health, /\.includes\(|\.contains\(/);
+});
+
+test("the Helix scenario pins complete responses for every advertised feature", () => {
+  const scenario = readRepoFile("tools", "helix-vize", "run-real-server.mjs");
+
+  for (const method of [
+    "textDocument/completion",
+    "textDocument/hover",
+    "textDocument/codeAction",
+    "textDocument/semanticTokens/full",
+    "textDocument/rename",
+  ]) {
+    assert.match(scenario, new RegExp(method.replace("/", "\\/")));
+  }
+
+  assert.match(scenario, /assert\.deepEqual\(diagnostics\.diagnostics, expectedDiagnostics\)/);
+  assert.match(scenario, /assert\.deepEqual\(completion, expectedCompletion\)/);
+  assert.match(scenario, /assert\.deepEqual\(hover, expectedHover\)/);
+  assert.match(scenario, /assert\.deepEqual\(codeActions, expectedCodeActions\(uri\)\)/);
+  assert.match(scenario, /assert\.deepEqual\(semanticTokens, expectedSemanticTokens\)/);
+  assert.match(scenario, /assert\.deepEqual\(rename, expectedRename\(uri\)\)/);
+  assert.doesNotMatch(scenario, /textDocument\/formatting/);
+  assert.doesNotMatch(scenario, /\.includes\(|\.contains\(/);
+
+  // This is the exact config Helix sends. Formatting is intentionally absent,
+  // so the scenario verifies only the capabilities the package advertises.
+  assert.match(scenario, /toml\.parse\(fs\.readFileSync\(helixConfigPath, "utf8"\)\)/);
+  assert.match(scenario, /assert\.deepEqual\(helixServer\.config, helixRecommendedOptions\)/);
+  assert.match(scenario, /assert\.equal\(capabilities\.documentFormattingProvider, undefined\)/);
+});

--- a/tools/helix-vize/assert-helix-health.mjs
+++ b/tools/helix-vize/assert-helix-health.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const helixBinary = path.resolve(process.argv[2] ?? "hx");
+const serverPath = path.resolve(
+  process.env.VIZE_SERVER_PATH ?? path.join(root, "target", "ci", "vize"),
+);
+const configHome = process.env.XDG_CONFIG_HOME;
+const runtime = process.env.HELIX_RUNTIME;
+
+assert.ok(fs.existsSync(helixBinary), `Helix binary does not exist: ${helixBinary}`);
+assert.ok(fs.existsSync(serverPath), `Vize server does not exist: ${serverPath}`);
+assert.ok(configHome, "XDG_CONFIG_HOME must point at the isolated Helix config");
+assert.ok(runtime, "HELIX_RUNTIME must point at the pinned Helix runtime");
+assert.ok(fs.existsSync(runtime), `Helix runtime does not exist: ${runtime}`);
+
+const installedConfig = path.join(configHome, "helix", "languages.toml");
+const packagedConfig = path.join(root, "editors", "helix", "languages.toml");
+assert.equal(
+  fs.readFileSync(installedConfig, "utf8"),
+  fs.readFileSync(packagedConfig, "utf8"),
+  "Helix must inspect the exact packaged languages.toml",
+);
+
+const expectedServer = `✓ vize: ${serverPath}`;
+for (const language of ["vue", "art-vue"]) {
+  const result = spawnSync(helixBinary, ["--health", language], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${path.dirname(serverPath)}${path.delimiter}${process.env.PATH ?? ""}`,
+    },
+  });
+  const output = stripAnsi(`${result.stdout ?? ""}${result.stderr ?? ""}`);
+  assert.equal(result.status, 0, `hx --health ${language} failed:\n${output}`);
+
+  const configuredServers = linesBetween(
+    output,
+    "Configured language servers:",
+    "Configured debug adapter:",
+  );
+  assert.deepEqual(
+    configuredServers,
+    [expectedServer],
+    `hx --health ${language} did not resolve exactly the packaged Vize server`,
+  );
+}
+
+console.log("helix package health passed for vue and art-vue");
+
+function stripAnsi(value) {
+  const sequence = new RegExp(`${String.fromCodePoint(27)}\\[[0-?]*[ -/]*[@-~]`, "g");
+  return value.replace(sequence, "");
+}
+
+function linesBetween(value, start, end) {
+  const lines = value.split(/\r?\n/).map((line) => line.trim());
+  const startAt = lines.indexOf(start);
+  const endAt = lines.findIndex((line) => line.startsWith(end));
+  assert.ok(startAt >= 0, `missing ${JSON.stringify(start)} in Helix health output`);
+  assert.ok(endAt > startAt, `missing ${JSON.stringify(end)} in Helix health output`);
+  return lines.slice(startAt + 1, endAt).filter(Boolean);
+}

--- a/tools/helix-vize/run-real-server.mjs
+++ b/tools/helix-vize/run-real-server.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+// Exercise the exact command and initialization profile from the packaged
+// Helix languages.toml against a real `vize lsp` process. Helix 25.07.1 has no
+// supported headless editing API, so the official binary separately validates
+// config loading and command resolution with `hx --health`.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import toml from "@iarna/toml";
+
+import {
+  prepareRealVueWorkspace,
+  resolveRealServerPath,
+} from "../editor-e2e/real-vue-workspace.mjs";
+import { isDiagnosticsForUri } from "../../tests/tooling/support/lsp/assertions.ts";
+import { LspSession } from "../../tests/tooling/support/lsp/session.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const helixConfigPath = path.join(root, "editors", "helix", "languages.toml");
+const parsedConfig = toml.parse(fs.readFileSync(helixConfigPath, "utf8"));
+const helixServer = parsedConfig["language-server"].vize;
+const helixRecommendedOptions = {
+  editor: true,
+  ecosystem: true,
+  lint: true,
+  typecheck: true,
+};
+
+assert.equal(helixServer.command, "vize");
+assert.deepEqual(helixServer.args, ["lsp"]);
+assert.deepEqual(helixServer.config, helixRecommendedOptions);
+
+const expectedAuthoredSource = `<script setup lang="ts">
+import Child from "./Child.vue";
+
+const total = "3";
+</script>
+
+<template>
+<Child  :count="total" />
+</template>
+`;
+
+const expectedDiagnostics = [
+  {
+    code: "vue/no-multi-spaces",
+    codeDescription: { href: "https://eslint.vuejs.org/rules/no-multi-spaces.html" },
+    message: "Multiple consecutive spaces",
+    range: {
+      end: { character: 8, line: 7 },
+      start: { character: 6, line: 7 },
+    },
+    severity: 2,
+    source: "vize/lint",
+  },
+  {
+    code: 2322,
+    message: "Type 'string' is not assignable to type 'number'.",
+    range: {
+      end: { character: 14, line: 7 },
+      start: { character: 9, line: 7 },
+    },
+    severity: 1,
+    source: "vize/types",
+  },
+];
+
+const expectedCompletion = [
+  {
+    detail: " (const)",
+    documentation: {
+      kind: "markdown",
+      value: "**Const**\n\nConstant binding (function, class, or literal).",
+    },
+    kind: 21,
+    label: "Child",
+    labelDetails: { detail: " (const)" },
+    sortText: "0Child",
+  },
+  {
+    detail: " (literal)",
+    documentation: {
+      kind: "markdown",
+      value: "**Literal**\n\nLiteral constant value.",
+    },
+    kind: 21,
+    label: "total",
+    labelDetails: { detail: " (literal)" },
+    sortText: "0total",
+  },
+];
+
+const expectedHover = {
+  contents: {
+    kind: "markdown",
+    value:
+      '**TypeScript quick info**\n\n_Resolved through Vize virtual TypeScript_\n\n```typescript\nconst total: "3"\n```',
+  },
+  range: {
+    end: { character: 11, line: 3 },
+    start: { character: 6, line: 3 },
+  },
+};
+
+function expectedCodeActions(uri) {
+  return [
+    {
+      edit: {
+        changes: {
+          [uri]: [
+            {
+              newText: " ",
+              range: {
+                end: { character: 8, line: 7 },
+                start: { character: 6, line: 7 },
+              },
+            },
+          ],
+        },
+      },
+      isPreferred: true,
+      kind: "quickfix",
+      title: "Fix: Replace multiple spaces with single space",
+    },
+    {
+      edit: {
+        changes: {
+          [uri]: [
+            {
+              newText: "<!-- @vize:forget vue/no-multi-spaces -->\n",
+              range: {
+                end: { character: 0, line: 7 },
+                start: { character: 0, line: 7 },
+              },
+            },
+          ],
+        },
+      },
+      isPreferred: false,
+      kind: "quickfix",
+      title: "Suppress with @vize:forget (vue/no-multi-spaces)",
+    },
+  ];
+}
+
+const expectedSemanticTokens = { data: [7, 8, 6, 9, 0, 0, 8, 5, 8, 0] };
+
+function expectedRename(uri) {
+  return {
+    changes: {
+      [uri]: [
+        {
+          newText: "quantity",
+          range: {
+            end: { character: 11, line: 3 },
+            start: { character: 6, line: 3 },
+          },
+        },
+        {
+          newText: "quantity",
+          range: {
+            end: { character: 21, line: 7 },
+            start: { character: 16, line: 7 },
+          },
+        },
+      ],
+    },
+  };
+}
+
+const sessionRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-helix-e2e-"));
+const workspacePath = path.join(sessionRoot, "real-vue");
+prepareRealVueWorkspace(workspacePath);
+
+process.env.VIZE_LSP_BIN = resolveRealServerPath();
+const session = new LspSession();
+
+try {
+  const initialization = await session.initialize(workspacePath, helixRecommendedOptions);
+  assert.ok(initialization && typeof initialization === "object");
+  const capabilities = initialization.capabilities;
+  assert.equal(capabilities.documentFormattingProvider, undefined);
+
+  const documentPath = path.join(workspacePath, "src", "Scenario.vue");
+  const uri = pathToFileURL(documentPath).href;
+  const source = fs.readFileSync(documentPath, "utf8");
+  assert.equal(source, expectedAuthoredSource, "the shared editor fixture changed");
+
+  session.notify("textDocument/didOpen", {
+    textDocument: { uri, languageId: "vue", version: 1, text: source },
+  });
+
+  const diagnostics = await session.waitForNotification(
+    "textDocument/publishDiagnostics",
+    (params) =>
+      isDiagnosticsForUri(params, uri) && params.diagnostics.length === expectedDiagnostics.length,
+    120_000,
+  );
+  assert.deepEqual(diagnostics.diagnostics, expectedDiagnostics);
+
+  const completion = await session.request(
+    "textDocument/completion",
+    { textDocument: { uri }, position: { character: 16, line: 7 } },
+    120_000,
+  );
+  assert.deepEqual(completion, expectedCompletion);
+
+  const hover = await session.request(
+    "textDocument/hover",
+    { textDocument: { uri }, position: { character: 8, line: 3 } },
+    120_000,
+  );
+  assert.deepEqual(hover, expectedHover);
+
+  const codeActions = await session.request(
+    "textDocument/codeAction",
+    {
+      textDocument: { uri },
+      range: {
+        end: { character: 8, line: 7 },
+        start: { character: 6, line: 7 },
+      },
+      context: { diagnostics: expectedDiagnostics },
+    },
+    120_000,
+  );
+  assert.deepEqual(codeActions, expectedCodeActions(uri));
+
+  const semanticTokens = await session.request(
+    "textDocument/semanticTokens/full",
+    { textDocument: { uri } },
+    120_000,
+  );
+  assert.deepEqual(semanticTokens, expectedSemanticTokens);
+
+  const rename = await session.request(
+    "textDocument/rename",
+    {
+      textDocument: { uri },
+      position: { character: 8, line: 3 },
+      newName: "quantity",
+    },
+    120_000,
+  );
+  assert.deepEqual(rename, expectedRename(uri));
+
+  console.log("helix package-contract real-server scenario passed");
+} finally {
+  await session.shutdown();
+  fs.rmSync(sessionRoot, { force: true, recursive: true });
+}

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -138,6 +138,7 @@ export const testAndBenchmarkTasks = defineTasks({
   "test:vim-extension:real-server": noCacheTask("node tools/vim-vize/run-real-server.mjs"),
   "test:vim-extension:package": noCacheTask("vp run --workspace-root package:vim-extension"),
   "test:helix-extension:package": noCacheTask("vp run --workspace-root package:helix-extension"),
+  "test:helix-extension:real-server": noCacheTask("node tools/helix-vize/run-real-server.mjs"),
   "test:emacs-extension:headless": noCacheTask(
     "emacs -Q --batch -l ert -l editors/emacs/test/vize-test.el -f ert-run-tests-batch-and-exit",
   ),


### PR DESCRIPTION
Closes #3744

## Summary
- install the pinned, checksummed official Helix 25.07.1 binary in the shared editor-host job
- validate the packaged `languages.toml` for both `vue` and `art-vue` with exact `hx --health` command resolution
- exercise the package's exact initialization profile against one real `vize lsp` binary and pin complete diagnostics, completion, hover, code-action, semantic-token, and rename responses
- keep formatting out of the scenario because the default Helix profile does not advertise it

## Validation
- `vp fmt --check`
- `vp lint`
- `vp run --workspace-root test:helix-extension:package`
- related editor tooling tests: 25/25
- official Helix package health: `vue` and `art-vue`
- real-server package contract: passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->