### PR TITLE
fix(maestro): track on-disk Vue file lifecycle

### DIFF
--- a/crates/vize_maestro/src/ide/workspace_symbols.rs
+++ b/crates/vize_maestro/src/ide/workspace_symbols.rs
@@ -1,14 +1,12 @@
-//! Workspace symbols provider.
-//!
-//! Provides workspace-wide symbol search for:
-//! - Vue components (from file names)
-//! - Script bindings (functions, variables, classes)
-//! - CSS classes and IDs
+//! Workspace-wide symbol search for Vue components, script bindings, and styles.
 #![allow(
     clippy::disallowed_types,
     clippy::disallowed_methods,
     clippy::disallowed_macros
 )]
+
+#[cfg(feature = "native")]
+mod disk;
 
 use tower_lsp::lsp_types::{Location, Position, Range, SymbolInformation, SymbolKind, Url};
 
@@ -38,6 +36,9 @@ impl WorkspaceSymbolsService {
             Self::collect_symbols_from_document(uri, &content, &query_lower, &mut symbols);
         }
 
+        #[cfg(feature = "native")]
+        disk::collect(state, &query_lower, &mut symbols);
+
         // Sort by relevance (exact match first, then prefix match, then contains)
         symbols.sort_by(|a, b| {
             let a_name = a.name.to_lowercase();
@@ -60,7 +61,6 @@ impl WorkspaceSymbolsService {
             a_name.cmp(&b_name)
         });
 
-        // Limit results
         symbols.truncate(100);
 
         symbols

--- a/crates/vize_maestro/src/ide/workspace_symbols/disk.rs
+++ b/crates/vize_maestro/src/ide/workspace_symbols/disk.rs
@@ -1,0 +1,23 @@
+//! Workspace-symbol contributions from closed files created mid-session.
+
+use tower_lsp::lsp_types::SymbolInformation;
+
+use super::WorkspaceSymbolsService;
+use crate::server::ServerState;
+
+pub(super) fn collect(state: &ServerState, query: &str, symbols: &mut Vec<SymbolInformation>) {
+    for uri in state.workspace_vue_file_uris() {
+        // Open buffers remain authoritative when their unsaved text differs
+        // from the corresponding file on disk.
+        if state.documents.contains(&uri) {
+            continue;
+        }
+        let Ok(path) = uri.to_file_path() else {
+            continue;
+        };
+        let Ok(content) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        WorkspaceSymbolsService::collect_symbols_from_document(&uri, &content, query, symbols);
+    }
+}

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -237,34 +237,53 @@ fn workspace_file_operations(
     features: LspFeatureConfig,
 ) -> Option<WorkspaceFileOperationsServerCapabilities> {
     let track_declarations = cfg!(feature = "native") && features.typecheck;
-    if !track_declarations && !features.file_rename {
+    let track_vue_symbols = cfg!(feature = "native") && features.workspace_symbols;
+    let track_file_events = track_declarations || track_vue_symbols;
+    if !track_file_events && !features.file_rename {
         return None;
     }
     Some(WorkspaceFileOperationsServerCapabilities {
-        did_create: track_declarations.then(declaration_file_registration_options),
+        did_create: track_file_events
+            .then(|| file_event_registration_options(track_declarations, track_vue_symbols)),
         will_create: None,
         did_rename: Some(if features.file_rename {
             file_rename_registration_options()
         } else {
-            declaration_file_registration_options()
+            file_event_registration_options(track_declarations, track_vue_symbols)
         }),
         will_rename: features.file_rename.then(file_rename_registration_options),
-        did_delete: track_declarations.then(declaration_file_registration_options),
+        did_delete: track_file_events
+            .then(|| file_event_registration_options(track_declarations, track_vue_symbols)),
         will_delete: None,
     })
 }
 
-fn declaration_file_registration_options() -> FileOperationRegistrationOptions {
-    FileOperationRegistrationOptions {
-        filters: vec![FileOperationFilter {
+fn file_event_registration_options(
+    track_declarations: bool,
+    track_vue_symbols: bool,
+) -> FileOperationRegistrationOptions {
+    let mut filters = Vec::with_capacity(2);
+    if track_declarations {
+        filters.push(FileOperationFilter {
             scheme: Some("file".to_string()),
             pattern: FileOperationPattern {
                 glob: "**/*.d.{ts,mts,cts}".to_string(),
                 matches: Some(FileOperationPatternKind::File),
                 options: None,
             },
-        }],
+        });
     }
+    if track_vue_symbols {
+        filters.push(FileOperationFilter {
+            scheme: Some("file".to_string()),
+            pattern: FileOperationPattern {
+                glob: "**/*.vue".to_string(),
+                matches: Some(FileOperationPatternKind::File),
+                options: None,
+            },
+        });
+    }
+    FileOperationRegistrationOptions { filters }
 }
 
 fn file_rename_registration_options() -> FileOperationRegistrationOptions {
@@ -290,5 +309,7 @@ fn file_rename_registration_options() -> FileOperationRegistrationOptions {
     }
 }
 
+#[cfg(test)]
+mod file_operation_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/vize_maestro/src/server/capabilities/file_operation_tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/file_operation_tests.rs
@@ -1,0 +1,21 @@
+use super::{LspFeatureConfig, workspace_file_operations};
+
+#[test]
+fn workspace_symbols_register_vue_file_events_without_typechecking_or_rename() {
+    let mut features = LspFeatureConfig::default();
+    features.typecheck = false;
+    features.workspace_symbols = true;
+    features.file_rename = false;
+
+    let operations = workspace_file_operations(features)
+        .expect("workspace symbol lifecycle should be advertised");
+    for options in [
+        operations.did_create,
+        operations.did_delete,
+        operations.did_rename,
+    ] {
+        let options = options.expect("every Vue file event must be registered");
+        assert_eq!(options.filters.len(), 1);
+        assert_eq!(options.filters[0].pattern.glob, "**/*.vue");
+    }
+}

--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -339,7 +339,8 @@ fn declaration_file_operations_cover_create_delete_and_rename() {
         operations.did_rename,
     ] {
         let options = options.expect("every declaration event must be registered");
-        assert_eq!(options.filters.len(), 1);
+        assert_eq!(options.filters.len(), 2);
         assert_eq!(options.filters[0].pattern.glob, "**/*.d.{ts,mts,cts}");
+        assert_eq!(options.filters[1].pattern.glob, "**/*.vue");
     }
 }

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -14,6 +14,8 @@ mod corsa;
 mod corsa_overlays;
 #[cfg(feature = "native")]
 mod global_components;
+#[cfg(feature = "native")]
+mod workspace_vue_files;
 
 #[cfg(test)]
 mod config_tests;
@@ -72,6 +74,13 @@ pub struct ServerState {
     /// component file's length + modification time.
     component_metadata_cache:
         DashMap<PathBuf, crate::ide::completion::template::CachedComponentMetadata>,
+    /// Closed `.vue` files announced through workspace file-operation events.
+    ///
+    /// These stay separate from [`Self::documents`]: document features must
+    /// only serve editor-open buffers, while workspace symbol search also
+    /// needs to follow files created and deleted on disk mid-session.
+    #[cfg(feature = "native")]
+    workspace_vue_files: DashMap<Url, ()>,
     /// Enabled LSP feature surface.
     lsp_features: RwLock<LspFeatureConfig>,
     /// Fast path for checking whether type-aware features are enabled.
@@ -166,6 +175,8 @@ impl ServerState {
             virtual_docs_cache: DashMap::new(),
             open_vue_imports: super::importers::OpenVueImportIndex::default(),
             component_metadata_cache: DashMap::new(),
+            #[cfg(feature = "native")]
+            workspace_vue_files: DashMap::new(),
             lsp_features: RwLock::new(default_features),
             lsp_typecheck_enabled: AtomicBool::new(default_features.typecheck),
             type_checker_config: RwLock::new(TypeCheckerConfig::default()),

--- a/crates/vize_maestro/src/server/state/workspace_vue_files.rs
+++ b/crates/vize_maestro/src/server/state/workspace_vue_files.rs
@@ -1,0 +1,39 @@
+//! Closed Vue files announced through workspace file-operation events.
+
+use tower_lsp::lsp_types::Url;
+
+use super::ServerState;
+
+impl ServerState {
+    /// Track a newly-created on-disk Vue file without treating it as an open
+    /// editor document. Returns false for non-file, non-Vue, or missing URIs.
+    pub(crate) fn track_workspace_vue_file(&self, uri: &str) -> bool {
+        let Ok(uri) = Url::parse(uri) else {
+            return false;
+        };
+        if !uri.path().ends_with(".vue") || !uri.to_file_path().is_ok_and(|path| path.is_file()) {
+            return false;
+        }
+        self.workspace_vue_files.insert(uri, ()).is_none()
+    }
+
+    /// Forget a deleted or renamed on-disk Vue file.
+    pub(crate) fn forget_workspace_vue_file(&self, uri: &str) -> bool {
+        let Ok(uri) = Url::parse(uri) else {
+            return false;
+        };
+        self.workspace_vue_files.remove(&uri).is_some()
+    }
+
+    /// Stable URI snapshot for workspace-wide searches. The caller performs
+    /// filesystem reads after all DashMap guards have been released.
+    pub(crate) fn workspace_vue_file_uris(&self) -> Vec<Url> {
+        let mut uris = self
+            .workspace_vue_files
+            .iter()
+            .map(|entry| entry.key().clone())
+            .collect::<Vec<_>>();
+        uris.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+        uris
+    }
+}

--- a/crates/vize_maestro/src/server/workspace_files.rs
+++ b/crates/vize_maestro/src/server/workspace_files.rs
@@ -111,14 +111,28 @@ pub(super) async fn did_change_watched_files(
 
 pub(super) fn did_create_files(state: &ServerState, params: &CreateFilesParams) {
     #[cfg(feature = "native")]
-    state.invalidate_global_component_references(params.files.iter().map(|file| file.uri.as_str()));
+    {
+        state.invalidate_global_component_references(
+            params.files.iter().map(|file| file.uri.as_str()),
+        );
+        for file in &params.files {
+            state.track_workspace_vue_file(file.uri.as_str());
+        }
+    }
     #[cfg(not(feature = "native"))]
     let _ = (state, params);
 }
 
 pub(super) fn did_delete_files(state: &ServerState, params: &DeleteFilesParams) {
     #[cfg(feature = "native")]
-    state.invalidate_global_component_references(params.files.iter().map(|file| file.uri.as_str()));
+    {
+        state.invalidate_global_component_references(
+            params.files.iter().map(|file| file.uri.as_str()),
+        );
+        for file in &params.files {
+            state.forget_workspace_vue_file(file.uri.as_str());
+        }
+    }
     #[cfg(not(feature = "native"))]
     let _ = (state, params);
 }
@@ -135,12 +149,20 @@ pub(super) async fn will_rename_files(
 
 pub(super) async fn did_rename_files(server: &MaestroServer, params: &RenameFilesParams) {
     #[cfg(feature = "native")]
-    server.state.invalidate_global_component_references(
-        params
-            .files
-            .iter()
-            .flat_map(|file| [file.old_uri.as_str(), file.new_uri.as_str()]),
-    );
+    {
+        server.state.invalidate_global_component_references(
+            params
+                .files
+                .iter()
+                .flat_map(|file| [file.old_uri.as_str(), file.new_uri.as_str()]),
+        );
+        for file in &params.files {
+            server
+                .state
+                .forget_workspace_vue_file(file.old_uri.as_str());
+            server.state.track_workspace_vue_file(file.new_uri.as_str());
+        }
+    }
     if !server.state.lsp_features().file_rename {
         return;
     }
@@ -157,9 +179,12 @@ pub(super) async fn did_rename_files(server: &MaestroServer, params: &RenameFile
 
 #[cfg(all(test, feature = "native"))]
 mod tests {
-    use tower_lsp::lsp_types::ClientCapabilities;
+    use tower_lsp::lsp_types::{ClientCapabilities, CreateFilesParams, DeleteFilesParams, Url};
 
-    use super::{ServerState, global_component_watcher_registration, record_watcher_support};
+    use super::{
+        ServerState, did_create_files, did_delete_files, global_component_watcher_registration,
+        record_watcher_support,
+    };
 
     #[test]
     fn declaration_watcher_tracks_create_change_and_delete_recursively() {
@@ -186,5 +211,39 @@ mod tests {
         record_watcher_support(&state, &capabilities);
 
         assert!(state.global_component_watcher_supported());
+    }
+
+    #[test]
+    fn vue_file_events_track_only_existing_created_files_and_forget_deletes() {
+        let root = tempfile::tempdir().unwrap();
+        let vue_path = root.path().join("DiskChild.vue");
+        let declaration_path = root.path().join("components.d.ts");
+        std::fs::write(&vue_path, "<template />\n").unwrap();
+        std::fs::write(&declaration_path, "export {};\n").unwrap();
+        let vue_uri = Url::from_file_path(&vue_path).unwrap();
+        let declaration_uri = Url::from_file_path(&declaration_path).unwrap();
+        let missing_uri = Url::from_file_path(root.path().join("Missing.vue")).unwrap();
+        let state = ServerState::new();
+
+        let created: CreateFilesParams = serde_json::from_value(serde_json::json!({
+            "files": [
+                { "uri": vue_uri.as_str() },
+                { "uri": declaration_uri.as_str() },
+                { "uri": missing_uri.as_str() }
+            ]
+        }))
+        .unwrap();
+        did_create_files(&state, &created);
+
+        assert_eq!(state.workspace_vue_file_uris(), vec![vue_uri.clone()]);
+
+        std::fs::remove_file(&vue_path).unwrap();
+        let deleted: DeleteFilesParams = serde_json::from_value(serde_json::json!({
+            "files": [{ "uri": vue_uri.as_str() }]
+        }))
+        .unwrap();
+        did_delete_files(&state, &deleted);
+
+        assert!(state.workspace_vue_file_uris().is_empty());
     }
 }

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -39,9 +39,10 @@ async function withCapabilities(
   }
 }
 
-/** Declaration shims, the only files type checking has to watch itself. */
-const DECLARATION_FILTERS = [
+/** Closed Vue files feed workspace symbols; declarations feed type checking. */
+const FILE_EVENT_FILTERS = [
   { scheme: "file", pattern: { glob: "**/*.d.{ts,mts,cts}", matches: "file" } },
+  { scheme: "file", pattern: { glob: "**/*.vue", matches: "file" } },
 ];
 /** Everything a rename can move, plus folders. */
 const RENAME_FILTERS = [
@@ -165,10 +166,10 @@ const EDITOR_BUNDLE_CAPABILITIES = {
   workspace: {
     workspaceFolders: { supported: true, changeNotifications: true },
     fileOperations: {
-      didCreate: { filters: DECLARATION_FILTERS },
+      didCreate: { filters: FILE_EVENT_FILTERS },
       didRename: { filters: RENAME_FILTERS },
       willRename: { filters: RENAME_FILTERS },
-      didDelete: { filters: DECLARATION_FILTERS },
+      didDelete: { filters: FILE_EVENT_FILTERS },
     },
   },
   // Absent on purpose, and therefore absent from this object: the three

--- a/tests/tooling/lsp-vue-file-lifecycle.test.ts
+++ b/tests/tooling/lsp-vue-file-lifecycle.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+type Location = {
+  uri: string;
+  range: { start: { line: number; character: number } };
+};
+
+type SymbolInformation = {
+  name: string;
+  location: Location;
+};
+
+async function workspaceSymbols(
+  session: LspSession,
+  query: string,
+): Promise<SymbolInformation[] | null> {
+  return (await session.request("workspace/symbol", { query })) as SymbolInformation[] | null;
+}
+
+async function definitionAt(
+  session: LspSession,
+  uri: string,
+  source: string,
+  marker: string,
+): Promise<Location | Location[] | null> {
+  const offset = source.indexOf(marker);
+  assert.notEqual(offset, -1, `missing definition marker ${marker}`);
+  return (await session.request("textDocument/definition", {
+    textDocument: { uri },
+    position: offsetToPosition(source, offset + 1),
+  })) as Location | Location[] | null;
+}
+
+test("vize lsp follows created and deleted on-disk Vue files without opening them", async (t) => {
+  const testRootDir = path.join(testOutputRoot, "lsp-vue-file-lifecycle");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    const sourceDir = path.join(workspaceDir, "src");
+    fs.mkdirSync(sourceDir, { recursive: true });
+
+    const appSource = `<script setup lang="ts">
+import DiskChild from "./DiskChild.vue"
+</script>
+
+<template>
+  <DiskChild :message="'hello'" />
+</template>
+`;
+    const appPath = path.join(sourceDir, "App.vue");
+    const appUri = pathToFileURL(appPath).href;
+    fs.writeFileSync(appPath, appSource, "utf8");
+
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: false,
+    });
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri: appUri, languageId: "vue", version: 1, text: appSource },
+    });
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, appUri),
+    );
+
+    const childSource = `<script setup lang="ts">
+defineProps<{ message: string }>()
+const diskLifecycleMarker = 1
+</script>
+
+<template>
+  <span>{{ message }} {{ diskLifecycleMarker }}</span>
+</template>
+`;
+    const childPath = path.join(sourceDir, "DiskChild.vue");
+    const childUri = pathToFileURL(childPath).href;
+
+    await t.test(
+      "a create event indexes the closed file and resolves its imported props",
+      async () => {
+        assert.equal(await workspaceSymbols(session, "diskLifecycleMarker"), null);
+        assert.equal(await definitionAt(session, appUri, appSource, "message"), null);
+
+        fs.writeFileSync(childPath, childSource, "utf8");
+        session.notify("workspace/didCreateFiles", { files: [{ uri: childUri }] });
+
+        const symbols = await workspaceSymbols(session, "diskLifecycleMarker");
+        assert.equal(symbols?.length, 1, JSON.stringify(symbols));
+        assert.equal(symbols?.[0]?.name, "diskLifecycleMarker");
+        assert.equal(symbols?.[0]?.location.uri, childUri);
+
+        const definition = await definitionAt(session, appUri, appSource, "message");
+        assert.ok(definition != null && !Array.isArray(definition), JSON.stringify(definition));
+        assert.equal(definition.uri, childUri);
+      },
+    );
+
+    await t.test("a delete event removes the closed file from both surfaces", async () => {
+      fs.rmSync(childPath);
+      session.notify("workspace/didDeleteFiles", { files: [{ uri: childUri }] });
+
+      assert.equal(await workspaceSymbols(session, "diskLifecycleMarker"), null);
+      assert.equal(await definitionAt(session, appUri, appSource, "message"), null);
+    });
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #3742

## Summary
- advertise Vue create, delete, and rename file-operation filters when workspace symbols are enabled
- keep closed on-disk Vue files in a separate lifecycle index so open editor buffers remain authoritative
- update workspace symbols from current disk content and let import definitions follow create/delete events
- add an exact real-stdio regression that creates an unopened Vue file, resolves its symbol and imported prop, then deletes it and verifies both disappear

## Regression evidence
- unchanged main returned null for the newly-created file workspace symbol
- the implementation passes the exact create/import/symbol/delete lifecycle contract

## Validation
- cargo test -p vize_maestro --lib: 696 passed, 2 ignored
- full real LSP suite: 2220 passed
- vp check: 0 errors
- cargo clippy -p vize_maestro --lib
- cargo fmt --all -- --check
- source length ratchet: no new or grown files over 350 lines