### PR TITLE
fix(canon): map v-for source diagnostics

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
@@ -17,6 +17,7 @@ mod spread_props;
 mod spread_scope_bindings;
 mod ts_extension_substitution;
 mod unmapped_template_fallback;
+mod v_for_source_callbacks;
 mod vapor_anchors;
 #[test]
 fn issue_2645_infers_generic_sfc_props_in_tsx() {

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/v_for_source_callbacks.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/v_for_source_callbacks.rs
@@ -125,16 +125,28 @@ fn v_for_source_resolves_template_only_props_before_mapping_diagnostics() {
     }
     let project_root = create_project_case(
         "v-for-source-template-prop",
-        &[(
-            "src/App.vue",
-            r#"<script setup lang="ts">
-defineProps<{ messages: string[] }>()
+        &[
+            (
+                "src/contracts.ts",
+                r#"export interface DialogProps {
+  messages: Array<{ text: string }>
+}
+"#,
+            ),
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+import type { DialogProps } from './contracts'
+defineProps<DialogProps>()
 </script>
 <template>
-  <p v-for="message in messages" :key="message">{{ message }}</p>
+  <section v-for="message in messages.slice(0, Math.max(0, messages.length))" :key="message.text">
+    <span v-for="word in message.text.split(' ')" :key="word">{{ word }}</span>
+  </section>
 </template>
 "#,
-        )],
+            ),
+        ],
     );
 
     let snapshot = snapshot_project_diagnostics(&project_root);

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/v_for_source_callbacks.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/v_for_source_callbacks.rs
@@ -1,0 +1,143 @@
+//! Diagnostics inside v-for source expressions must map back to authored bytes (#3756).
+
+use super::super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+
+#[test]
+fn v_for_source_callbacks_report_implicit_any_at_the_authored_parameter() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "v-for-source-callback-diagnostics",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const items: any = []
+</script>
+
+<template>
+  <div v-for="item in items.filter(value => value)" :key="item" />
+</template>
+"#,
+        )],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    assert_eq!(
+        snapshot,
+        // vue-tsc 3.3.4 with TypeScript 6.0.3, on the byte-identical fixture:
+        // src/App.vue(6,36): error TS7006: Parameter 'value' implicitly has an 'any' type.
+        Some(vec![(
+            vize_carton::String::from("src/App.vue"),
+            Some(7006),
+            vize_carton::String::from("6:36:error Parameter 'value' implicitly has an 'any' type."),
+        )]),
+    );
+}
+
+#[test]
+fn component_v_for_source_diagnostics_are_mapped_once() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "component-v-for-source-callback-diagnostics",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts">
+defineProps<{ value: unknown }>()
+</script>
+"#,
+            ),
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+const items: any = []
+</script>
+
+<template>
+  <Child v-for="item in items.filter(value => value)" :key="item" :value="item" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    assert_eq!(
+        snapshot,
+        Some(vec![(
+            vize_carton::String::from("src/App.vue"),
+            Some(7006),
+            vize_carton::String::from("7:38:error Parameter 'value' implicitly has an 'any' type."),
+        )]),
+    );
+}
+
+#[test]
+fn generic_slot_v_for_source_does_not_expose_a_contextual_typing_gap() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "generic-slot-v-for-source-callback",
+        &[
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts" generic="T">
+defineProps<{ items: T[] }>()
+defineSlots<{ default(props: { items: T[] }): unknown }>()
+</script>
+<template><slot :items="items" /></template>
+"#,
+            ),
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+import Child from './Child.vue'
+const items = [{ id: 1 }]
+</script>
+<template>
+  <Child v-slot="{ items: pageItems }" :items="items">
+    <div v-for="item in pageItems.map(value => value)" :key="item.id" />
+  </Child>
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    // vue-tsc 3.3.4 contextually types `value` through the generic slot. Until
+    // Vize resolves those generics, do not surface a Vize-only TS7006 (#3756).
+    assert_eq!(snapshot, Some(Vec::new()));
+}
+
+#[test]
+fn v_for_source_resolves_template_only_props_before_mapping_diagnostics() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "v-for-source-template-prop",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+defineProps<{ messages: string[] }>()
+</script>
+<template>
+  <p v-for="message in messages" :key="message">{{ message }}</p>
+</template>
+"#,
+        )],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+    assert_eq!(snapshot, Some(Vec::new()));
+}

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -12,8 +12,10 @@ use setup_scoped::{props_type_ref, unused_generic_comment};
 use template_bindings::{emit_macro_template_prop_bindings, should_skip_template_prop_binding};
 pub(crate) use template_names::collect_template_prop_names;
 use vize_carton::{FxHashSet, String, append, cstr};
-use vize_croquis::Croquis;
+use vize_croquis::builtins::{is_event_local, is_js_global, is_render_local, is_vue_builtin};
+use vize_croquis::drawer::{extract_identifiers_oxc, is_keyword};
 use vize_croquis::macros::{MacroKind, ModelDefinition};
+use vize_croquis::{Croquis, ScopeData};
 use with_defaults::{collect_with_defaults_default_names_from_source, template_props_type_ref};
 
 fn emit_template_prop_binding(
@@ -87,6 +89,36 @@ fn collect_keyed_template_prop_names(
             continue;
         }
         names.insert(name.into());
+    }
+    // A v-for source is emitted as the loop initializer rather than as a
+    // standalone template expression. Include its root references in the
+    // imported/opaque defineProps fallback so template-only props such as
+    // `messages` still receive a local binding. Scope locals and language/
+    // template globals must remain untouched (for example a nested `group`
+    // alias or `Math` in the source expression).
+    for scope in summary.scopes.iter() {
+        let ScopeData::VFor(data) = scope.data() else {
+            continue;
+        };
+        for ident in extract_identifiers_oxc(data.source.as_str()) {
+            let name = ident.as_str();
+            if emitted_names.contains(name)
+                || should_skip_template_prop_binding(summary, name)
+                || !can_emit_keyed_template_prop_binding(name)
+                || summary
+                    .scopes
+                    .iter()
+                    .any(|candidate| candidate.has_binding(name))
+                || is_js_global(name)
+                || is_render_local(name)
+                || is_event_local(name)
+                || is_vue_builtin(name)
+                || is_keyword(name)
+            {
+                continue;
+            }
+            names.insert(name.into());
+        }
     }
     let mut names: Vec<String> = names.into_iter().collect();
     names.sort_unstable();

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -237,7 +237,6 @@ pub(super) fn generate_scope_node(
             if let Some(guard) = enclosing_guard {
                 append!(*ts, "{indent}if ({guard}) {{\n");
             }
-
             append_v_for_comment(
                 ts,
                 &loop_indent,
@@ -245,16 +244,15 @@ pub(super) fn generate_scope_node(
                 data.value_alias.as_str(),
                 data.source.as_str(),
             );
-
             emit_v_for_loop_open(
                 ts,
+                mappings,
+                ctx.template_offset,
+                ctx.summary.scopes.v_for_source_offset(scope.id),
                 &loop_indent,
-                data.value_alias.as_str(),
-                data.key_alias.as_deref(),
-                data.index_alias.as_deref(),
-                data.source.as_str(),
+                data,
+                ctx.template_prop_names,
             );
-
             // A positive narrowing outside a callback is not retained for captured
             // object properties. Recheck those terms so discriminated unions narrow.
             let callback_guard = enclosing_guard.and_then(callback_vif_guard);

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -245,11 +245,12 @@ fn generate_closure_component_props_recursive(
             );
             emit_v_for_loop_open(
                 ts,
+                mappings,
+                ctx.source_context.offset,
+                ctx.summary.scopes.v_for_source_offset(scope.id),
                 &loop_indent,
-                data.value_alias.as_str(),
-                data.key_alias.as_deref(),
-                data.index_alias.as_deref(),
-                data.source.as_str(),
+                data,
+                ctx.template_prop_names,
             );
 
             // Mark v-for variables as used to avoid TS6133

--- a/crates/vize_canon/src/virtual_ts/scope/emit.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/emit.rs
@@ -1,13 +1,13 @@
 //! Shared text-emission helpers for v-for loops and v-slot prop types.
 
-use vize_carton::String;
 use vize_carton::append;
 use vize_carton::cstr;
+use vize_carton::{FxHashSet, String};
 use vize_carton::{camelize, capitalize};
-use vize_croquis::Croquis;
+use vize_croquis::{Croquis, VForScopeData};
 
-use crate::virtual_ts::helpers::to_safe_identifier;
-use crate::virtual_ts::types::VirtualTsOptions;
+use crate::virtual_ts::types::{VirtualTsOptions, VizeMapping};
+use crate::virtual_ts::{expressions::rewrite_reserved_template_prop, helpers::to_safe_identifier};
 
 /// Type annotation for a `v-slot` scope's props. When the slot is on a child
 /// component (`component` is `Some`), the props are inferred from that child's
@@ -155,23 +155,43 @@ pub(super) fn append_v_for_comment(
 /// object source yields `value: T[keyof T]` and `key: keyof T` (matching
 /// vue-tsc) instead of the old array-only `(source).forEach` assumption that
 /// mis-typed objects and raised spurious TS2339/TS2537. The source expression is
-/// passed through verbatim so any `as Type` assertion flows into the helper.
+/// rewritten through the template-prop bridge so a source such as `messages`
+/// resolves to `__props.messages`; all other authored syntax stays verbatim.
 pub(super) fn emit_v_for_loop_open(
     ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    template_offset: u32,
+    source_offset: Option<u32>,
     indent: &str,
-    value_alias: &str,
-    key_alias: Option<&str>,
-    index_alias: Option<&str>,
-    source: &str,
+    data: &VForScopeData,
+    template_prop_names: &FxHashSet<String>,
 ) {
-    append!(*ts, "{indent}__vForList({source}).forEach(([{value_alias}");
-    if let Some(key) = key_alias {
+    append!(*ts, "{indent}__vForList(");
+    let source_gen_start = ts.len();
+    let rewritten_source =
+        rewrite_reserved_template_prop(data.source.as_str(), template_prop_names);
+    ts.push_str(
+        rewritten_source
+            .as_ref()
+            .map_or(data.source.as_str(), |source| source.as_str()),
+    );
+    let source_gen_end = ts.len();
+    if let Some(source_offset) = source_offset {
+        let source_start = (template_offset + source_offset) as usize;
+        mappings.push(VizeMapping {
+            gen_range: source_gen_start..source_gen_end,
+            src_range: source_start..(source_start + data.source.len()),
+            sub_spans: Vec::new(),
+        });
+    }
+    append!(*ts, ").forEach(([{}", data.value_alias);
+    if let Some(key) = data.key_alias.as_deref() {
         append!(*ts, ", {key}");
-    } else if index_alias.is_some() {
+    } else if data.index_alias.is_some() {
         // Keep the index in the third tuple slot even when no key alias is bound.
         ts.push_str(", _key");
     }
-    if let Some(index) = index_alias {
+    if let Some(index) = data.index_alias.as_deref() {
         append!(*ts, ", {index}");
     }
     ts.push_str("]) => {\n");

--- a/crates/vize_croquis/src/drawer/template/directives/control_flow.rs
+++ b/crates/vize_croquis/src/drawer/template/directives/control_flow.rs
@@ -99,7 +99,7 @@ impl Drawer {
                 .cloned()
                 .unwrap_or_else(|| CompactString::const_new("_"));
 
-            self.croquis.scopes.enter_v_for_scope(
+            let scope_id = self.croquis.scopes.enter_v_for_scope(
                 VForScopeData {
                     value_alias: value_alias.clone(),
                     value_bindings: smallvec![value_alias],
@@ -111,6 +111,9 @@ impl Drawer {
                 for_node.loc.start.offset,
                 for_node.loc.end.offset,
             );
+            self.croquis
+                .scopes
+                .set_v_for_source_offset(scope_id, for_node.source.loc().start.offset);
             // Entering a v-for scope: O(1) flag read by `is_in_vfor_scope`.
             self.vfor_depth += 1;
             for var in &vars_added {

--- a/crates/vize_croquis/src/drawer/template/visit_element/first_pass.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element/first_pass.rs
@@ -8,7 +8,7 @@ use vize_relief::{ElementNode, ExpressionNode, PropNode};
 
 use super::bounds::element_subtree_end;
 use super::scopes::ElementDirectiveState;
-use super::v_for_scope::v_for_alias_declaration_offsets;
+use super::v_for_scope::{v_for_alias_declaration_offsets, v_for_source_offset};
 
 impl Drawer {
     pub(super) fn collect_element_directive_state(
@@ -42,9 +42,15 @@ impl Drawer {
                         );
                         if let Some(aliases) = aliases {
                             let alias_offsets = v_for_alias_declaration_offsets(exp, &aliases);
+                            let source_offset = v_for_source_offset(exp, &aliases);
                             let end = *subtree_end.get_or_insert_with(|| element_subtree_end(el));
-                            state.for_scope =
-                                Some((aliases, alias_offsets, el.loc.start.offset, end));
+                            state.for_scope = Some((
+                                aliases,
+                                alias_offsets,
+                                source_offset,
+                                el.loc.start.offset,
+                                end,
+                            ));
                         }
                     }
                 } else if dir.name == "bind" {

--- a/crates/vize_croquis/src/drawer/template/visit_element/scopes.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element/scopes.rs
@@ -1,6 +1,6 @@
 use crate::drawer::Drawer;
 use crate::drawer::helpers::{ConditionalKind, VForScopeAliases, extract_identifiers_oxc};
-use crate::scope::{ParamNames, VForScopeData, VSlotScopeData};
+use crate::scope::{ParamNames, ScopeKind, VForScopeData, VSlotScopeData};
 use vize_carton::{CompactString, SmallVec};
 use vize_relief::ElementNode;
 
@@ -18,6 +18,7 @@ pub(super) type SlotScopeInfo = (
 pub(super) type ForScopeInfo = (
     VForScopeAliases,
     SmallVec<[(CompactString, u32); 4]>,
+    Option<u32>,
     u32,
     u32,
 );
@@ -85,7 +86,7 @@ impl Drawer {
         key_expression: Option<CompactString>,
         scope_vars: &mut Vec<CompactString>,
     ) -> usize {
-        let Some((aliases, alias_offsets, start, end)) = for_scope else {
+        let Some((aliases, alias_offsets, source_offset, start, end)) = for_scope else {
             return 0;
         };
 
@@ -98,8 +99,19 @@ impl Drawer {
         if self.options.detect_undefined {
             self.mark_v_for_source_scope_refs(aliases.source.as_str());
         }
+        // Generic slot props are not yet instantiated from sibling bindings. Mapping a
+        // callback that consumes one would expose a Vize-only implicit-any diagnostic.
+        let source_has_slot_bound_callback = aliases.source.contains("=>")
+            && extract_identifiers_oxc(aliases.source.as_str())
+                .iter()
+                .any(|name| {
+                    self.croquis
+                        .scopes
+                        .lookup(name.as_str())
+                        .is_some_and(|(scope, _)| scope.kind == ScopeKind::VSlot)
+                });
 
-        self.croquis.scopes.enter_v_for_scope(
+        let scope_id = self.croquis.scopes.enter_v_for_scope(
             VForScopeData {
                 value_alias: aliases.value_pattern,
                 value_bindings: aliases.value_bindings,
@@ -111,6 +123,11 @@ impl Drawer {
             start,
             end,
         );
+        if !source_has_slot_bound_callback && let Some(source_offset) = source_offset {
+            self.croquis
+                .scopes
+                .set_v_for_source_offset(scope_id, source_offset);
+        }
         // Entering a v-for scope: O(1) flag read by `is_in_vfor_scope`.
         self.vfor_depth += 1;
 

--- a/crates/vize_croquis/src/drawer/template/visit_element/v_for_scope.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element/v_for_scope.rs
@@ -34,6 +34,20 @@ pub(super) fn v_for_alias_declaration_offsets(
     offsets
 }
 
+pub(super) fn v_for_source_offset(
+    exp: &ExpressionNode<'_>,
+    aliases: &VForScopeAliases,
+) -> Option<u32> {
+    let (content, base_offset) = expression_content_and_offset(exp);
+    source_offset_in_expression(content, base_offset, aliases.source.as_str())
+}
+
+fn source_offset_in_expression(content: &str, base_offset: u32, source: &str) -> Option<u32> {
+    content
+        .rfind(source)
+        .map(|relative| base_offset + relative as u32)
+}
+
 fn expression_content_and_offset<'a>(exp: &'a ExpressionNode<'_>) -> (&'a str, u32) {
     let loc = exp.loc();
     let content = match exp {
@@ -85,4 +99,25 @@ fn find_identifier_token(text: &str, name: &str) -> Option<usize> {
 
 fn is_identifier_continue(byte: u8) -> bool {
     byte == b'_' || byte == b'$' || byte.is_ascii_alphanumeric()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::source_offset_in_expression;
+
+    #[test]
+    fn source_offsets_keep_whitespace_and_choose_the_final_duplicate() {
+        assert_eq!(
+            source_offset_in_expression("  item in item  ", 40, "item"),
+            Some(50)
+        );
+        assert_eq!(
+            source_offset_in_expression(
+                "({ id }, key) of rows.filter(row => row.id)",
+                7,
+                "rows.filter(row => row.id)"
+            ),
+            Some(24)
+        );
+    }
 }

--- a/crates/vize_croquis/src/scope/chain.rs
+++ b/crates/vize_croquis/src/scope/chain.rs
@@ -1,17 +1,15 @@
 //! Scope chain management for Vue templates and scripts.
 //!
-//! This module provides the core scope management functionality:
 //! - [`Scope`] - A single scope in the scope chain
 //! - [`ScopeChain`] - Manages the hierarchical scope chain
 //!
-//! Split into:
 //! - Core types, `Scope`, and `ScopeChain` struct with basic accessors (this file)
 //! - [`builder`]: Methods for entering/creating scopes
 //! - [`resolution`]: Binding lookup, mutation tracking, and depth computation
 
 mod builder;
 mod resolution;
-
+mod v_for_offsets;
 use core::fmt;
 
 use vize_carton::{
@@ -219,10 +217,10 @@ impl Scope {
 pub struct ScopeChain {
     /// All scopes (indexed by ScopeId)
     pub(crate) scopes: Vec<Scope>,
-    /// Current scope ID
     pub(crate) current: ScopeId,
     /// v-slot scopes whose directive argument was dynamic (`v-slot:[name]`).
     dynamic_v_slot_scopes: FxHashSet<ScopeId>,
+    v_for_source_offsets: FxHashMap<ScopeId, u32>,
 }
 
 impl fmt::Debug for ScopeChain {
@@ -326,6 +324,7 @@ impl ScopeChain {
             scopes: vec![root],
             current: ScopeId::ROOT,
             dynamic_v_slot_scopes: FxHashSet::default(),
+            v_for_source_offsets: FxHashMap::default(),
         }
     }
 
@@ -345,6 +344,7 @@ impl ScopeChain {
             scopes,
             current: ScopeId::ROOT,
             dynamic_v_slot_scopes: FxHashSet::default(),
+            v_for_source_offsets: FxHashMap::default(),
         }
     }
 

--- a/crates/vize_croquis/src/scope/chain/v_for_offsets.rs
+++ b/crates/vize_croquis/src/scope/chain/v_for_offsets.rs
@@ -1,0 +1,14 @@
+use super::ScopeChain;
+use crate::scope::ScopeId;
+
+impl ScopeChain {
+    pub(crate) fn set_v_for_source_offset(&mut self, id: ScopeId, offset: u32) {
+        self.v_for_source_offsets.insert(id, offset);
+    }
+
+    /// Authored template offset where a v-for source expression begins.
+    #[inline]
+    pub fn v_for_source_offset(&self, id: ScopeId) -> Option<u32> {
+        self.v_for_source_offsets.get(&id).copied()
+    }
+}

--- a/tests/snapshots/check/__snapshots__/vue2-elm-check.snap
+++ b/tests/snapshots/check/__snapshots__/vue2-elm-check.snap
@@ -369,6 +369,7 @@
         "error:13:101 [TS2552] Cannot find name 'orderDetail'. Did you mean 'orderData'?",
         "error:15:53 [TS2552] Cannot find name 'orderDetail'. Did you mean 'orderData'?",
         "error:16:37 [TS2552] Cannot find name 'orderDetail'. Did you mean 'orderData'?",
+        "error:23:44 [TS2552] Cannot find name 'orderDetail'. Did you mean 'orderData'?",
         "error:33:33 [TS2552] Cannot find name 'orderDetail'. Did you mean 'orderData'?",
         "error:33:65 [TS2552] Cannot find name 'orderDetail'. Did you mean 'orderData'?",
         "error:35:47 [TS2552] Cannot find name 'orderDetail'. Did you mean 'orderData'?",
@@ -412,6 +413,7 @@
     {
       "file": "src/page/profile/children/children/address.vue",
       "diagnostics": [
+        "error:8:38 [TS2304] Cannot find name 'removeAddress'.",
         "error:38:40 [TS2307] Cannot find module 'vuex' or its corresponding type declarations.",
         "error:49:9 [TS2300] Duplicate identifier 'mounted'.",
         "error:53:9 [TS2300] Duplicate identifier 'mounted'.",
@@ -559,6 +561,8 @@
     {
       "file": "src/page/shop/children/shopDetail.vue",
       "diagnostics": [
+        "error:7:36 [TS2304] Cannot find name 'shopDetail'.",
+        "error:13:36 [TS2304] Cannot find name 'shopDetail'.",
         "error:31:52 [TS2304] Cannot find name 'shopDetail'.",
         "error:41:62 [TS2304] Cannot find name 'shopDetail'.",
         "error:46:33 [TS2304] Cannot find name 'shopDetail'.",
@@ -642,7 +646,7 @@
       ]
     }
   ],
-  "errorCount": 373,
+  "errorCount": 377,
   "warningCount": 0,
   "fileCount": 55
 }


### PR DESCRIPTION
## Summary

- retain the authored byte offset for each `v-for` source expression
- map generated `__vForList(...)` source diagnostics back to the Vue template
- deduplicate component-loop diagnostics and cover native/component callback locations exactly

## Verification

- `cargo fmt --all -- --check`
- source-length guard: 7/7
- `cargo test -p vize_croquis`: 269 unit, 3 integration, 7 doc tests
- `VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --lib`: 800/800
- `cargo clippy -p vize_croquis -p vize_canon --lib -- -D warnings`

Refs #3756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript diagnostics for implicit-`any` errors in `v-for` source callbacks across elements, components, slots, and template props.
  * Diagnostic locations now more accurately point to authored template source.
  * Improved source mapping for generated `v-for` code, including whitespace, repeated expressions, and template bindings.
  * Improved detection of template properties referenced in `v-for` source expressions.

* **Tests**
  * Added regression coverage for callback diagnostics, source offsets, and template binding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->