### PR TITLE
perf(canon): expose incremental check metrics

### DIFF
--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -34,7 +34,7 @@ pub use import_rewriter::{ImportRewriter, ImportSourceMap, OffsetAdjustment, Rew
 pub use source_map::{CompositeSourceMap, SfcBlockRange, SfcSourceMap};
 pub use type_checker::{
     BatchTypeChecker, BatchTypeCheckerOptions, DeclarationEmitOptions, DeclarationEmitResult,
-    DeclarationOutput, TypeCheckResult, TypeChecker,
+    DeclarationOutput, IncrementalCheckMetrics, TypeCheckResult, TypeChecker,
 };
 pub use virtual_project::{
     ContentMapperDiagnostic, ContentMapperSpan, ContentMapperTransform, OriginalPosition,

--- a/crates/vize_canon/src/batch/executor.rs
+++ b/crates/vize_canon/src/batch/executor.rs
@@ -12,7 +12,8 @@ use super::error::{CorsaError, CorsaNotFoundError, CorsaResult};
 use super::import_rewriter::ImportRewriter;
 use super::materialize_lock::MaterializeLock;
 use super::type_checker::{
-    DeclarationEmitOptions, DeclarationEmitResult, DeclarationOutput, TypeCheckResult,
+    DeclarationEmitOptions, DeclarationEmitResult, DeclarationOutput, IncrementalCheckMetrics,
+    TypeCheckResult,
 };
 use super::virtual_project::VirtualProject;
 use oxc_span::SourceType;
@@ -74,6 +75,13 @@ impl CorsaExecutor {
 
     pub fn corsa_path(&self) -> &Path {
         &self.corsa_path
+    }
+
+    pub(crate) fn incremental_metrics(&self) -> IncrementalCheckMetrics {
+        self.incremental_session
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .metrics
     }
 
     pub fn check(&self, project: &VirtualProject) -> CorsaResult<TypeCheckResult> {

--- a/crates/vize_canon/src/batch/executor/fallback.rs
+++ b/crates/vize_canon/src/batch/executor/fallback.rs
@@ -98,6 +98,11 @@ pub(super) fn classify_fallback_cause(error: &CorsaError) -> FallbackCause {
 pub(super) static FALLBACK_NOTICE_EMITTED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
+/// Serializes tests that exercise the process-global notice and environment
+/// policy while the Rust test runner executes unrelated checks in parallel.
+#[cfg(test)]
+pub(super) static FALLBACK_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Emit an observable signal that the Corsa integration degraded to a
 /// slower/weaker path. Always records a structured `tracing::warn!` event
 /// (consumed by the LSP and CI which install a subscriber); additionally prints

--- a/crates/vize_canon/src/batch/executor/session.rs
+++ b/crates/vize_canon/src/batch/executor/session.rs
@@ -14,6 +14,7 @@ use super::{
 };
 use crate::batch::error::CorsaResult;
 use crate::batch::executor::diagnostics::map_batch_diagnostics;
+use crate::batch::type_checker::IncrementalCheckMetrics;
 use crate::batch::virtual_project::{
     AUTO_IMPORT_STUBS_FILE, SHARED_HELPERS_FILE, VUE_MODULE_STUBS_FILE,
 };
@@ -21,9 +22,7 @@ use crate::batch::virtual_project::{
 #[derive(Default)]
 pub(super) struct IncrementalSessionState {
     session: Option<IncrementalSession>,
-    starts: usize,
-    reuses: usize,
-    refreshes: usize,
+    pub(super) metrics: IncrementalCheckMetrics,
 }
 
 struct IncrementalSession {
@@ -99,6 +98,8 @@ impl CorsaExecutor {
             let result = state.check(&self.corsa_path, project, snapshot);
             if result.is_err() {
                 state.session = None;
+                state.metrics.session_to_cli_fallbacks += 1;
+                state.metrics.last_session_to_cli_fallback = true;
             }
             result
         };
@@ -111,15 +112,6 @@ impl CorsaExecutor {
             }
         }
     }
-
-    #[cfg(test)]
-    pub(crate) fn incremental_session_counts(&self) -> (usize, usize, usize) {
-        let state = self
-            .incremental_session
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        (state.starts, state.reuses, state.refreshes)
-    }
 }
 
 impl IncrementalSessionState {
@@ -129,9 +121,24 @@ impl IncrementalSessionState {
         project: &VirtualProject,
         snapshot: MaterializedSnapshot,
     ) -> CorsaResult<TypeCheckResult> {
+        self.metrics.checks += 1;
+        self.metrics.last_requested_files = snapshot.uris.len();
+        self.metrics.last_session_started = false;
+        self.metrics.last_session_reused = false;
+        self.metrics.last_session_refreshed = false;
+        self.metrics.last_session_to_cli_fallback = false;
+        self.metrics.last_changed_files = 0;
+        self.metrics.last_created_files = 0;
+        self.metrics.last_deleted_files = 0;
+
         if let Some(session) = &mut self.session {
+            self.metrics.last_session_reused = true;
             let delta = snapshot.diff(&session.snapshot);
+            self.metrics.last_changed_files = delta.changed.len();
+            self.metrics.last_created_files = delta.created.len();
+            self.metrics.last_deleted_files = delta.deleted.len();
             let refreshed = !delta.is_empty();
+            self.metrics.last_session_refreshed = refreshed;
             if refreshed {
                 profile!(
                     "canon.corsa.incremental.refresh",
@@ -144,8 +151,8 @@ impl IncrementalSessionState {
                 .map_err(map_corsa_error)?;
             }
             session.snapshot = snapshot;
-            self.reuses += 1;
-            self.refreshes += usize::from(refreshed);
+            self.metrics.session_reuses += 1;
+            self.metrics.session_refreshes += usize::from(refreshed);
         } else {
             let corsa_path = corsa_path.to_string_lossy();
             let client = profile!(
@@ -157,7 +164,8 @@ impl IncrementalSessionState {
             )
             .map_err(map_corsa_error)?;
             self.session = Some(IncrementalSession { client, snapshot });
-            self.starts += 1;
+            self.metrics.session_starts += 1;
+            self.metrics.last_session_started = true;
         }
 
         let session = self.session.as_mut().expect("session initialized above");

--- a/crates/vize_canon/src/batch/executor/tests.rs
+++ b/crates/vize_canon/src/batch/executor/tests.rs
@@ -197,6 +197,10 @@ fn checks_with_cli_when_project_session_api_is_unavailable() {
     use crate::batch::VirtualProject;
     use std::os::unix::fs::PermissionsExt;
 
+    let _fallback_guard = super::fallback::FALLBACK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
     let case_dir = unique_case_dir("cli-fallback");
     let _ = fs::remove_dir_all(&case_dir);
     let cache_dir = case_dir.join(".cache");

--- a/crates/vize_canon/src/batch/executor/tests.rs
+++ b/crates/vize_canon/src/batch/executor/tests.rs
@@ -224,6 +224,58 @@ fn checks_with_cli_when_project_session_api_is_unavailable() {
     let _ = fs::remove_dir_all(&case_dir);
 }
 
+#[cfg(unix)]
+#[test]
+fn incremental_session_fallback_is_counted_per_check() {
+    use crate::batch::{IncrementalCheckMetrics, VirtualProject};
+    use std::os::unix::fs::PermissionsExt;
+
+    let _fallback_guard = super::fallback::FALLBACK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    let case_dir = unique_case_dir("incremental-session-fallback-metrics");
+    let _ = fs::remove_dir_all(&case_dir);
+    let cache_dir = case_dir.join(".cache");
+    let source = case_dir.join("src").join("main.ts");
+    fs::create_dir_all(&cache_dir).unwrap();
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    fs::write(&source, "const value: number = 1;\n").unwrap();
+
+    // The project-session protocol exits before its handshake. The ordinary
+    // CLI succeeds, making the degradation deterministic without a real Corsa
+    // runtime and letting the metrics prove it was not silently hidden.
+    let tsgo = cache_dir.join("tsgo");
+    fs::write(
+        &tsgo,
+        "#!/bin/sh\nif [ \"$1\" = \"--api\" ]; then printf 'api unavailable'; exit 0; fi\nexit 0\n",
+    )
+    .unwrap();
+    fs::set_permissions(&tsgo, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_path(&source).unwrap();
+    let executor = CorsaExecutor::new(&case_dir).unwrap();
+    let result = executor
+        .check_incremental_session(&project, Some(1))
+        .expect("the CLI fallback should keep the check successful");
+
+    assert!(result.success);
+    assert!(result.diagnostics.is_empty());
+    assert_eq!(
+        executor.incremental_metrics(),
+        IncrementalCheckMetrics {
+            checks: 1,
+            session_to_cli_fallbacks: 1,
+            last_session_to_cli_fallback: true,
+            last_requested_files: 1,
+            ..Default::default()
+        }
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
 #[test]
 fn classifies_spawn_failures() {
     let io = CorsaError::Io(std::io::Error::new(
@@ -266,6 +318,10 @@ fn classifies_check_failures() {
 #[test]
 fn fallback_notice_is_observable_once_and_silenceable() {
     use super::fallback::{FallbackCause, FallbackStep, fallback_stderr_notice};
+
+    let _fallback_guard = super::fallback::FALLBACK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     // Re-arm the once-per-run guard and ensure the notice is not suppressed,
     // regardless of earlier degradations in this process.

--- a/crates/vize_canon/src/batch/executor/tests.rs
+++ b/crates/vize_canon/src/batch/executor/tests.rs
@@ -10,6 +10,10 @@ use vize_carton::cstr;
 
 use tempfile::TempDir;
 
+#[cfg(unix)]
+#[path = "tests/incremental_fallback.rs"]
+mod incremental_fallback;
+
 fn unique_case_dir(name: &str) -> PathBuf {
     static NEXT_CASE_ID: AtomicUsize = AtomicUsize::new(0);
 
@@ -224,58 +228,6 @@ fn checks_with_cli_when_project_session_api_is_unavailable() {
 
     assert!(result.success);
     assert!(result.diagnostics.is_empty());
-
-    let _ = fs::remove_dir_all(&case_dir);
-}
-
-#[cfg(unix)]
-#[test]
-fn incremental_session_fallback_is_counted_per_check() {
-    use crate::batch::{IncrementalCheckMetrics, VirtualProject};
-    use std::os::unix::fs::PermissionsExt;
-
-    let _fallback_guard = super::fallback::FALLBACK_TEST_LOCK
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-
-    let case_dir = unique_case_dir("incremental-session-fallback-metrics");
-    let _ = fs::remove_dir_all(&case_dir);
-    let cache_dir = case_dir.join(".cache");
-    let source = case_dir.join("src").join("main.ts");
-    fs::create_dir_all(&cache_dir).unwrap();
-    fs::create_dir_all(source.parent().unwrap()).unwrap();
-    fs::write(&source, "const value: number = 1;\n").unwrap();
-
-    // The project-session protocol exits before its handshake. The ordinary
-    // CLI succeeds, making the degradation deterministic without a real Corsa
-    // runtime and letting the metrics prove it was not silently hidden.
-    let tsgo = cache_dir.join("tsgo");
-    fs::write(
-        &tsgo,
-        "#!/bin/sh\nif [ \"$1\" = \"--api\" ]; then printf 'api unavailable'; exit 0; fi\nexit 0\n",
-    )
-    .unwrap();
-    fs::set_permissions(&tsgo, fs::Permissions::from_mode(0o755)).unwrap();
-
-    let mut project = VirtualProject::new(&case_dir).unwrap();
-    project.register_path(&source).unwrap();
-    let executor = CorsaExecutor::new(&case_dir).unwrap();
-    let result = executor
-        .check_incremental_session(&project, Some(1))
-        .expect("the CLI fallback should keep the check successful");
-
-    assert!(result.success);
-    assert!(result.diagnostics.is_empty());
-    assert_eq!(
-        executor.incremental_metrics(),
-        IncrementalCheckMetrics {
-            checks: 1,
-            session_to_cli_fallbacks: 1,
-            last_session_to_cli_fallback: true,
-            last_requested_files: 1,
-            ..Default::default()
-        }
-    );
 
     let _ = fs::remove_dir_all(&case_dir);
 }

--- a/crates/vize_canon/src/batch/executor/tests/incremental_fallback.rs
+++ b/crates/vize_canon/src/batch/executor/tests/incremental_fallback.rs
@@ -1,0 +1,51 @@
+use super::{CorsaExecutor, fs, unique_case_dir};
+use crate::batch::{IncrementalCheckMetrics, VirtualProject};
+use std::os::unix::fs::PermissionsExt;
+
+#[test]
+fn incremental_session_fallback_is_counted_per_check() {
+    let _fallback_guard = super::super::fallback::FALLBACK_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    let case_dir = unique_case_dir("incremental-session-fallback-metrics");
+    let _ = fs::remove_dir_all(&case_dir);
+    let cache_dir = case_dir.join(".cache");
+    let source = case_dir.join("src").join("main.ts");
+    fs::create_dir_all(&cache_dir).unwrap();
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    fs::write(&source, "const value: number = 1;\n").unwrap();
+
+    // The project-session protocol exits before its handshake. The ordinary
+    // CLI succeeds, making the degradation deterministic without a real Corsa
+    // runtime and letting the metrics prove it was not silently hidden.
+    let tsgo = cache_dir.join("tsgo");
+    fs::write(
+        &tsgo,
+        "#!/bin/sh\nif [ \"$1\" = \"--api\" ]; then printf 'api unavailable'; exit 0; fi\nexit 0\n",
+    )
+    .unwrap();
+    fs::set_permissions(&tsgo, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_path(&source).unwrap();
+    let executor = CorsaExecutor::new(&case_dir).unwrap();
+    let result = executor
+        .check_incremental_session(&project, Some(1))
+        .expect("the CLI fallback should keep the check successful");
+
+    assert!(result.success);
+    assert!(result.diagnostics.is_empty());
+    assert_eq!(
+        executor.incremental_metrics(),
+        IncrementalCheckMetrics {
+            checks: 1,
+            session_to_cli_fallbacks: 1,
+            last_session_to_cli_fallback: true,
+            last_requested_files: 1,
+            ..Default::default()
+        }
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -23,6 +23,41 @@ pub struct TypeCheckResult {
     pub success: bool,
 }
 
+/// Observable work performed by [`TypeChecker::check_incremental`].
+///
+/// Counts are cumulative for one [`BatchTypeChecker`]. `last_*` fields describe
+/// only the most recent incremental call, so embedders and performance gates can
+/// distinguish a reused Corsa session from a silent full-project CLI fallback.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct IncrementalCheckMetrics {
+    /// Number of incremental checks attempted.
+    pub checks: usize,
+    /// Number of Corsa project sessions started successfully.
+    pub session_starts: usize,
+    /// Number of checks served by an existing Corsa project session.
+    pub session_reuses: usize,
+    /// Number of reused sessions that received a non-empty materialized delta.
+    pub session_refreshes: usize,
+    /// Number of incremental checks that degraded from a session to the CLI.
+    pub session_to_cli_fallbacks: usize,
+    /// Whether the most recent incremental check started a Corsa session.
+    pub last_session_started: bool,
+    /// Whether the most recent incremental check reused a Corsa session.
+    pub last_session_reused: bool,
+    /// Whether the most recent incremental check refreshed a reused session.
+    pub last_session_refreshed: bool,
+    /// Whether the most recent incremental check degraded to the CLI.
+    pub last_session_to_cli_fallback: bool,
+    /// Diagnostic input files requested in the most recent incremental check.
+    pub last_requested_files: usize,
+    /// Materialized files whose content changed in the most recent refresh.
+    pub last_changed_files: usize,
+    /// Materialized files created in the most recent refresh.
+    pub last_created_files: usize,
+    /// Materialized files deleted in the most recent refresh.
+    pub last_deleted_files: usize,
+}
+
 impl TypeCheckResult {
     /// Check if there are any errors.
     pub fn has_errors(&self) -> bool {
@@ -102,6 +137,14 @@ pub trait TypeChecker: Send + Sync {
     ///
     /// The result must observe the latest on-disk contents and include
     /// diagnostics from dependents, not only the changed files themselves.
+    ///
+    /// This is a low-level, Corsa-facing embedding API; it currently has no
+    /// in-tree production consumer. Vize rebuilds the scanned virtual sources
+    /// and sends their materialized delta to the persistent Corsa project
+    /// session. Corsa, rather than a duplicate Vize dependency graph, owns
+    /// dependency-aware invalidation. Use
+    /// [`BatchTypeChecker::incremental_metrics`] to measure session reuse,
+    /// refresh scope, diagnostic requests, and CLI degradation.
     fn check_incremental(&self, changed: &[PathBuf]) -> CorsaResult<TypeCheckResult>;
 }
 
@@ -254,6 +297,15 @@ impl BatchTypeChecker {
         self.project
             .uses_shared_helpers()
             .then_some(crate::virtual_ts::SHARED_PREAMBLE_DTS)
+    }
+
+    /// Return cumulative and most-recent incremental execution metrics.
+    ///
+    /// Reading metrics does not reset them. The cumulative fields remain safe
+    /// under concurrent use; `last_*` fields describe whichever non-empty
+    /// incremental call most recently entered the serialized Corsa session.
+    pub fn incremental_metrics(&self) -> IncrementalCheckMetrics {
+        self.executor.incremental_metrics()
     }
 
     /// Emit declaration files for the scanned project.

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -9,7 +9,10 @@ use super::virtual_project::VirtualProject;
 use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 use vize_carton::String;
 
+mod metrics;
 mod paths;
+mod result;
+pub use metrics::IncrementalCheckMetrics;
 use paths::{IncrementalPaths, collect_project_paths};
 
 /// Result of type checking.
@@ -21,58 +24,6 @@ pub struct TypeCheckResult {
     pub exit_code: i32,
     /// Whether type checking succeeded.
     pub success: bool,
-}
-
-/// Observable work performed by [`TypeChecker::check_incremental`].
-///
-/// Counts are cumulative for one [`BatchTypeChecker`]. `last_*` fields describe
-/// only the most recent incremental call, so embedders and performance gates can
-/// distinguish a reused Corsa session from a silent full-project CLI fallback.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct IncrementalCheckMetrics {
-    /// Number of incremental checks attempted.
-    pub checks: usize,
-    /// Number of Corsa project sessions started successfully.
-    pub session_starts: usize,
-    /// Number of checks served by an existing Corsa project session.
-    pub session_reuses: usize,
-    /// Number of reused sessions that received a non-empty materialized delta.
-    pub session_refreshes: usize,
-    /// Number of incremental checks that degraded from a session to the CLI.
-    pub session_to_cli_fallbacks: usize,
-    /// Whether the most recent incremental check started a Corsa session.
-    pub last_session_started: bool,
-    /// Whether the most recent incremental check reused a Corsa session.
-    pub last_session_reused: bool,
-    /// Whether the most recent incremental check refreshed a reused session.
-    pub last_session_refreshed: bool,
-    /// Whether the most recent incremental check degraded to the CLI.
-    pub last_session_to_cli_fallback: bool,
-    /// Diagnostic input files requested in the most recent incremental check.
-    pub last_requested_files: usize,
-    /// Materialized files whose content changed in the most recent refresh.
-    pub last_changed_files: usize,
-    /// Materialized files created in the most recent refresh.
-    pub last_created_files: usize,
-    /// Materialized files deleted in the most recent refresh.
-    pub last_deleted_files: usize,
-}
-
-impl TypeCheckResult {
-    /// Check if there are any errors.
-    pub fn has_errors(&self) -> bool {
-        self.diagnostics.iter().any(|d| d.severity == 1)
-    }
-
-    /// Get the number of errors.
-    pub fn error_count(&self) -> usize {
-        self.diagnostics.iter().filter(|d| d.severity == 1).count()
-    }
-
-    /// Get the number of warnings.
-    pub fn warning_count(&self) -> usize {
-        self.diagnostics.iter().filter(|d| d.severity == 2).count()
-    }
 }
 
 /// Options for a project-backed batch type checker.
@@ -297,15 +248,6 @@ impl BatchTypeChecker {
         self.project
             .uses_shared_helpers()
             .then_some(crate::virtual_ts::SHARED_PREAMBLE_DTS)
-    }
-
-    /// Return cumulative and most-recent incremental execution metrics.
-    ///
-    /// Reading metrics does not reset them. The cumulative fields remain safe
-    /// under concurrent use; `last_*` fields describe whichever non-empty
-    /// incremental call most recently entered the serialized Corsa session.
-    pub fn incremental_metrics(&self) -> IncrementalCheckMetrics {
-        self.executor.incremental_metrics()
     }
 
     /// Emit declaration files for the scanned project.

--- a/crates/vize_canon/src/batch/type_checker/metrics.rs
+++ b/crates/vize_canon/src/batch/type_checker/metrics.rs
@@ -1,0 +1,47 @@
+use super::BatchTypeChecker;
+
+/// Observable work performed by [`super::TypeChecker::check_incremental`].
+///
+/// Counts are cumulative for one [`BatchTypeChecker`]. `last_*` fields describe
+/// only the most recent incremental call, so embedders and performance gates can
+/// distinguish a reused Corsa session from a silent full-project CLI fallback.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct IncrementalCheckMetrics {
+    /// Number of incremental checks attempted.
+    pub checks: usize,
+    /// Number of Corsa project sessions started successfully.
+    pub session_starts: usize,
+    /// Number of checks served by an existing Corsa project session.
+    pub session_reuses: usize,
+    /// Number of reused sessions that received a non-empty materialized delta.
+    pub session_refreshes: usize,
+    /// Number of incremental checks that degraded from a session to the CLI.
+    pub session_to_cli_fallbacks: usize,
+    /// Whether the most recent incremental check started a Corsa session.
+    pub last_session_started: bool,
+    /// Whether the most recent incremental check reused a Corsa session.
+    pub last_session_reused: bool,
+    /// Whether the most recent incremental check refreshed a reused session.
+    pub last_session_refreshed: bool,
+    /// Whether the most recent incremental check degraded to the CLI.
+    pub last_session_to_cli_fallback: bool,
+    /// Diagnostic input files requested in the most recent incremental check.
+    pub last_requested_files: usize,
+    /// Materialized files whose content changed in the most recent refresh.
+    pub last_changed_files: usize,
+    /// Materialized files created in the most recent refresh.
+    pub last_created_files: usize,
+    /// Materialized files deleted in the most recent refresh.
+    pub last_deleted_files: usize,
+}
+
+impl BatchTypeChecker {
+    /// Return cumulative and most-recent incremental execution metrics.
+    ///
+    /// Reading metrics does not reset them. The cumulative fields remain safe
+    /// under concurrent use; `last_*` fields describe whichever non-empty
+    /// incremental call most recently entered the serialized Corsa session.
+    pub fn incremental_metrics(&self) -> IncrementalCheckMetrics {
+        self.executor.incremental_metrics()
+    }
+}

--- a/crates/vize_canon/src/batch/type_checker/result.rs
+++ b/crates/vize_canon/src/batch/type_checker/result.rs
@@ -1,0 +1,18 @@
+use super::TypeCheckResult;
+
+impl TypeCheckResult {
+    /// Check if there are any errors.
+    pub fn has_errors(&self) -> bool {
+        self.diagnostics.iter().any(|d| d.severity == 1)
+    }
+
+    /// Get the number of errors.
+    pub fn error_count(&self) -> usize {
+        self.diagnostics.iter().filter(|d| d.severity == 1).count()
+    }
+
+    /// Get the number of warnings.
+    pub fn warning_count(&self) -> usize {
+        self.diagnostics.iter().filter(|d| d.severity == 2).count()
+    }
+}

--- a/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
@@ -1,6 +1,9 @@
 use super::super::{BatchTypeChecker, create_project_case, resolve_test_tsgo_binary};
 use crate::batch::TypeChecker;
 
+#[path = "incremental/file_lifecycle.rs"]
+mod file_lifecycle;
+
 #[test]
 fn observes_broken_and_repaired_vue_patch() {
     if resolve_test_tsgo_binary().is_none() {
@@ -272,105 +275,6 @@ const outside: number = 'must stay outside the scan'
             ..Default::default()
         },
         "an unchanged materialized scope should expose reuse without refresh work"
-    );
-
-    let _ = std::fs::remove_dir_all(&project_root);
-}
-
-#[test]
-fn retains_added_files_across_incremental_refreshes() {
-    if resolve_test_tsgo_binary().is_none() {
-        return;
-    }
-
-    let clean_source = r#"<script setup lang="ts">
-const initial: number = 1
-</script>
-"#;
-    let project_root =
-        create_project_case("incremental-added-file", &[("src/App.vue", clean_source)]);
-    let app_path = project_root.join("src/App.vue");
-    let added_path = project_root.join("src/Added.vue");
-    let mut checker = BatchTypeChecker::new(&project_root).expect("checker should start");
-    checker.scan_project().expect("initial scan should succeed");
-
-    std::fs::write(
-        &added_path,
-        r#"<script setup lang="ts">
-const added: number = 'broken added file'
-</script>
-"#,
-    )
-    .expect("added file should write");
-    let after_add = checker
-        .check_incremental(std::slice::from_ref(&added_path))
-        .expect("added-file check should complete");
-    assert!(
-        after_add
-            .diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.file == added_path && diagnostic.code == Some(2322)),
-        "added file did not report TS2322: {:#?}",
-        after_add.diagnostics
-    );
-
-    std::fs::write(&app_path, clean_source.replace("= 1", "= 'broken app'"))
-        .expect("app patch should write");
-    let after_unrelated_edit = checker
-        .check_incremental(std::slice::from_ref(&app_path))
-        .expect("second incremental check should complete");
-    assert!(
-        after_unrelated_edit
-            .diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.file == added_path && diagnostic.code == Some(2322)),
-        "unrelated edit dropped the added file from the project: {:#?}",
-        after_unrelated_edit.diagnostics
-    );
-    assert!(
-        after_unrelated_edit
-            .diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.file == app_path && diagnostic.code == Some(2322)),
-        "second incremental check did not observe the App.vue patch: {:#?}",
-        after_unrelated_edit.diagnostics
-    );
-
-    std::fs::remove_file(&added_path).expect("added file should delete");
-    let after_delete = checker
-        .check_incremental(std::slice::from_ref(&added_path))
-        .expect("deleted-file check should complete");
-    assert!(
-        after_delete
-            .diagnostics
-            .iter()
-            .all(|diagnostic| diagnostic.file != added_path),
-        "deleted file retained stale diagnostics: {:#?}",
-        after_delete.diagnostics
-    );
-    assert!(
-        after_delete
-            .diagnostics
-            .iter()
-            .any(|diagnostic| diagnostic.file == app_path && diagnostic.code == Some(2322)),
-        "deleting the added file dropped the unrelated App.vue diagnostic: {:#?}",
-        after_delete.diagnostics
-    );
-    assert_eq!(
-        checker.incremental_metrics(),
-        crate::batch::IncrementalCheckMetrics {
-            checks: 3,
-            session_starts: 1,
-            session_reuses: 2,
-            session_refreshes: 2,
-            last_session_reused: true,
-            last_session_refreshed: true,
-            last_requested_files: 1,
-            last_changed_files: 1,
-            last_deleted_files: 1,
-            ..Default::default()
-        },
-        "the final delete should expose the deleted file and changed project config"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
@@ -53,6 +53,17 @@ const total: number = 1
         "unexpected TS2322 message: {}",
         type_error.message
     );
+    assert_eq!(
+        checker.incremental_metrics(),
+        crate::batch::IncrementalCheckMetrics {
+            checks: 1,
+            session_starts: 1,
+            last_session_started: true,
+            last_requested_files: 1,
+            ..Default::default()
+        },
+        "the first incremental check should expose its cold session work"
+    );
 
     std::fs::write(&app_path, clean_source).expect("repair patch should write");
     let repaired = checker
@@ -67,9 +78,19 @@ const total: number = 1
         repaired.diagnostics
     );
     assert_eq!(
-        checker.executor.incremental_session_counts(),
-        (1, 1, 1),
-        "broken and repaired patches should reuse one refreshed Corsa session"
+        checker.incremental_metrics(),
+        crate::batch::IncrementalCheckMetrics {
+            checks: 2,
+            session_starts: 1,
+            session_reuses: 1,
+            session_refreshes: 1,
+            last_session_reused: true,
+            last_session_refreshed: true,
+            last_requested_files: 1,
+            last_changed_files: 1,
+            ..Default::default()
+        },
+        "the repair should expose one refreshed-file request on the reused session"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);
@@ -148,9 +169,19 @@ const total: Total = 1
         repaired.diagnostics
     );
     assert_eq!(
-        checker.executor.incremental_session_counts(),
-        (1, 1, 1),
-        "dependency patches should reuse one refreshed Corsa session"
+        checker.incremental_metrics(),
+        crate::batch::IncrementalCheckMetrics {
+            checks: 2,
+            session_starts: 1,
+            session_reuses: 1,
+            session_refreshes: 1,
+            last_session_reused: true,
+            last_session_refreshed: true,
+            last_requested_files: 2,
+            last_changed_files: 1,
+            ..Default::default()
+        },
+        "dependency repair should request both diagnostic inputs after one-file refresh"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);
@@ -231,9 +262,16 @@ const outside: number = 'must stay outside the scan'
         outside_change.diagnostics
     );
     assert_eq!(
-        checker.executor.incremental_session_counts(),
-        (1, 1, 0),
-        "an unchanged materialized scope should reuse without refreshing Corsa"
+        checker.incremental_metrics(),
+        crate::batch::IncrementalCheckMetrics {
+            checks: 2,
+            session_starts: 1,
+            session_reuses: 1,
+            last_session_reused: true,
+            last_requested_files: 1,
+            ..Default::default()
+        },
+        "an unchanged materialized scope should expose reuse without refresh work"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);
@@ -319,9 +357,20 @@ const added: number = 'broken added file'
         after_delete.diagnostics
     );
     assert_eq!(
-        checker.executor.incremental_session_counts(),
-        (1, 2, 2),
-        "create, edit, and delete patches should reuse one refreshed Corsa session"
+        checker.incremental_metrics(),
+        crate::batch::IncrementalCheckMetrics {
+            checks: 3,
+            session_starts: 1,
+            session_reuses: 2,
+            session_refreshes: 2,
+            last_session_reused: true,
+            last_session_refreshed: true,
+            last_requested_files: 1,
+            last_changed_files: 1,
+            last_deleted_files: 1,
+            ..Default::default()
+        },
+        "the final delete should expose the deleted file and changed project config"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize_canon/src/batch/type_checker/tests/incremental/file_lifecycle.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/incremental/file_lifecycle.rs
@@ -1,0 +1,100 @@
+use super::{BatchTypeChecker, TypeChecker, create_project_case, resolve_test_tsgo_binary};
+
+#[test]
+fn retains_added_files_across_incremental_refreshes() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let clean_source = r#"<script setup lang="ts">
+const initial: number = 1
+</script>
+"#;
+    let project_root =
+        create_project_case("incremental-added-file", &[("src/App.vue", clean_source)]);
+    let app_path = project_root.join("src/App.vue");
+    let added_path = project_root.join("src/Added.vue");
+    let mut checker = BatchTypeChecker::new(&project_root).expect("checker should start");
+    checker.scan_project().expect("initial scan should succeed");
+
+    std::fs::write(
+        &added_path,
+        r#"<script setup lang="ts">
+const added: number = 'broken added file'
+</script>
+"#,
+    )
+    .expect("added file should write");
+    let after_add = checker
+        .check_incremental(std::slice::from_ref(&added_path))
+        .expect("added-file check should complete");
+    assert!(
+        after_add
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.file == added_path && diagnostic.code == Some(2322)),
+        "added file did not report TS2322: {:#?}",
+        after_add.diagnostics
+    );
+
+    std::fs::write(&app_path, clean_source.replace("= 1", "= 'broken app'"))
+        .expect("app patch should write");
+    let after_unrelated_edit = checker
+        .check_incremental(std::slice::from_ref(&app_path))
+        .expect("second incremental check should complete");
+    assert!(
+        after_unrelated_edit
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.file == added_path && diagnostic.code == Some(2322)),
+        "unrelated edit dropped the added file from the project: {:#?}",
+        after_unrelated_edit.diagnostics
+    );
+    assert!(
+        after_unrelated_edit
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.file == app_path && diagnostic.code == Some(2322)),
+        "second incremental check did not observe the App.vue patch: {:#?}",
+        after_unrelated_edit.diagnostics
+    );
+
+    std::fs::remove_file(&added_path).expect("added file should delete");
+    let after_delete = checker
+        .check_incremental(std::slice::from_ref(&added_path))
+        .expect("deleted-file check should complete");
+    assert!(
+        after_delete
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.file != added_path),
+        "deleted file retained stale diagnostics: {:#?}",
+        after_delete.diagnostics
+    );
+    assert!(
+        after_delete
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.file == app_path && diagnostic.code == Some(2322)),
+        "deleting the added file dropped the unrelated App.vue diagnostic: {:#?}",
+        after_delete.diagnostics
+    );
+    assert_eq!(
+        checker.incremental_metrics(),
+        crate::batch::IncrementalCheckMetrics {
+            checks: 3,
+            session_starts: 1,
+            session_reuses: 2,
+            session_refreshes: 2,
+            last_session_reused: true,
+            last_session_refreshed: true,
+            last_requested_files: 1,
+            last_changed_files: 1,
+            last_deleted_files: 1,
+            ..Default::default()
+        },
+        "the final delete should expose the deleted file and changed project config"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -122,9 +122,10 @@ pub use batch::{
     BatchTypeChecker, BatchTypeCheckerOptions, ContentMapperDiagnostic, ContentMapperSpan,
     ContentMapperTransform, CorsaError, CorsaExecutor, CorsaNotFoundError, DeclarationEmitOptions,
     DeclarationEmitResult, DeclarationOutput, Diagnostic as BatchDiagnostic, ImportRewriter,
-    ImportSourceMap, PackageManager, SfcBlockType, TypeCheckResult as BatchTypeCheckResult,
-    TypeChecker as BatchTypeCheckerTrait, VirtualFile, VirtualProject, VirtualTsGenerator,
-    generate_vue_content_mapper_transform, sfc_block_fallback_offset,
+    ImportSourceMap, IncrementalCheckMetrics, PackageManager, SfcBlockType,
+    TypeCheckResult as BatchTypeCheckResult, TypeChecker as BatchTypeCheckerTrait, VirtualFile,
+    VirtualProject, VirtualTsGenerator, generate_vue_content_mapper_transform,
+    sfc_block_fallback_offset,
 };
 
 #[cfg(feature = "native")]


### PR DESCRIPTION
## Summary
- expose cumulative and per-check batch incremental work metrics
- document the Corsa-owned dependency invalidation contract and absent in-tree production consumer
- gate session start/reuse/refresh, requested inputs, materialized deltas, and SessionToCli fallback with deterministic tests

## Validation
- VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon
- cargo clippy -p vize_canon --lib -- -D warnings
- cargo fmt --all -- --check
- git diff --check

Refs #3739

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed metrics for incremental type-checking activity, including session reuse, refreshes, fallbacks, requested files, and file changes.
  * Added an API to retrieve cumulative and most-recent incremental check metrics without resetting them.
  * Improved documentation describing incremental checking behavior and metrics.

* **Tests**
  * Expanded coverage for session startup, reuse, refreshes, file changes, deletions, and CLI fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->