### PR TITLE
fix(patina): gate Pinia store lint on dependency

### DIFF
--- a/crates/vize/src/commands/lint/entry_rules.rs
+++ b/crates/vize/src/commands/lint/entry_rules.rs
@@ -12,9 +12,12 @@ use super::LintArgs;
 use crate::lint_plan::matcher::GlobSequence;
 use crate::lint_plan::matcher::{LintPlanScope, absolute_path};
 
+const PINIA_PREFER_STORE_TO_REFS: &str = "ecosystem/pinia-prefer-store-to-refs";
+
 pub(super) struct ResolvedLinterRuleGroups {
     pub(super) configs: Vec<crate::config::LinterConfig>,
     pub(super) file_config_indices: Vec<usize>,
+    pinia_available: Vec<bool>,
 }
 
 impl ResolvedLinterRuleGroups {
@@ -29,12 +32,13 @@ impl ResolvedLinterRuleGroups {
     ) -> Vec<Linter> {
         self.configs
             .iter()
-            .map(|config| {
+            .zip(&self.pinia_available)
+            .map(|(config, pinia_available)| {
                 let type_aware =
                     args.type_aware || args.strict_reactivity || config.type_aware_lint_enabled();
                 let mut linter = Linter::with_preset(preset)
                     .with_additional_rules(config.enabled_rules())
-                    .with_disabled_rules(config.disabled_rules())
+                    .with_disabled_rules(resolved_disabled_rules(config, *pinia_available))
                     .with_disabled_categories(config.disabled_categories())
                     .with_category_severity_overrides(severity_overrides(
                         config.category_severity_overrides(),
@@ -101,22 +105,22 @@ impl LinterRuleResolver {
 
     /// Resolve each distinct matching-entry signature exactly once for the batch.
     pub(super) fn resolve_files(&self, files: &[PathBuf], cwd: &Path) -> ResolvedLinterRuleGroups {
-        if self.scopes.is_empty() {
-            return ResolvedLinterRuleGroups {
-                configs: vec![self.plan.base.clone()],
-                file_config_indices: vec![0; files.len()],
-            };
-        }
-        let mut signatures = FxHashMap::<Vec<usize>, usize>::default();
+        let mut signatures = FxHashMap::<(Vec<usize>, bool), usize>::default();
+        let mut dependency_cache = FxHashMap::default();
         let mut configs = Vec::new();
+        let mut pinia_available = Vec::new();
         let mut file_config_indices = Vec::with_capacity(files.len());
         for file in files {
-            let signature = self.matching_entries(file, cwd);
+            let signature = (
+                self.matching_entries(file, cwd),
+                package_is_resolvable_from(file, cwd, "pinia", &mut dependency_cache),
+            );
             let index = match signatures.get(&signature) {
                 Some(index) => *index,
                 None => {
                     let index = configs.len();
-                    configs.push(self.plan.resolve_matching_entries(&signature));
+                    configs.push(self.plan.resolve_matching_entries(&signature.0));
+                    pinia_available.push(signature.1);
                     signatures.insert(signature, index);
                     index
                 }
@@ -126,6 +130,7 @@ impl LinterRuleResolver {
         ResolvedLinterRuleGroups {
             configs,
             file_config_indices,
+            pinia_available,
         }
     }
 
@@ -137,6 +142,56 @@ impl LinterRuleResolver {
             .filter_map(|(index, scope)| scope.matches(&file).then_some(index))
             .collect()
     }
+}
+
+fn resolved_disabled_rules(
+    config: &crate::config::LinterConfig,
+    pinia_available: bool,
+) -> Vec<String> {
+    let mut rules = config.disabled_rules();
+    if !pinia_available {
+        rules.push(PINIA_PREFER_STORE_TO_REFS.into());
+    }
+    rules
+}
+
+fn package_is_resolvable_from(
+    file: &Path,
+    cwd: &Path,
+    package_name: &str,
+    cache: &mut FxHashMap<PathBuf, bool>,
+) -> bool {
+    let absolute = absolute_path(file, cwd);
+    let Some(directory) = absolute.parent() else {
+        return false;
+    };
+    let mut current = directory.to_path_buf();
+    let mut visited = Vec::new();
+    let available = loop {
+        if let Some(available) = cache.get(&current) {
+            break *available;
+        }
+        visited.push(current.clone());
+        if current
+            .join("node_modules")
+            .join(package_name)
+            .join("package.json")
+            .is_file()
+        {
+            break true;
+        }
+        let Some(parent) = current.parent() else {
+            break false;
+        };
+        if parent == current {
+            break false;
+        }
+        current = parent.to_path_buf();
+    };
+    for directory in visited {
+        cache.insert(directory, available);
+    }
+    available
 }
 
 #[cfg(test)]

--- a/crates/vize/src/commands/lint/entry_rules_tests.rs
+++ b/crates/vize/src/commands/lint/entry_rules_tests.rs
@@ -1,9 +1,16 @@
-use super::{GlobSequence, LinterRuleResolver};
+use super::{GlobSequence, LinterRuleResolver, resolved_disabled_rules};
 use crate::config::{
     LintRuleSeverity as Severity, LinterConfig, LinterConfigEntry, LinterConfigPlan,
 };
 use std::{collections::BTreeMap, fs, path::PathBuf};
 use vize_carton::FxHashMap;
+use vize_patina::{LintPreset, Linter};
+
+const IMPORTED_STORE_SFC: &str = r#"<script setup lang="ts">
+import { useCounterStore } from "./store"
+const { count, actions } = useCounterStore()
+</script>
+"#;
 
 fn rules(entries: &[(&str, Severity)]) -> FxHashMap<vize_carton::String, Severity> {
     entries
@@ -201,4 +208,102 @@ fn resolves_whole_rule_maps_for_each_distinct_glob_set_once() {
         ]),
     );
     assert_eq!(resolved.configs.len(), 4);
+}
+
+fn lint_imported_store(config: &LinterConfig, filename: &PathBuf, pinia_available: bool) -> usize {
+    Linter::with_preset(LintPreset::Ecosystem)
+        .with_disabled_rules(resolved_disabled_rules(config, pinia_available))
+        .lint_sfc(IMPORTED_STORE_SFC, filename.to_string_lossy().as_ref())
+        .warning_count
+}
+
+#[test]
+fn pinia_rule_requires_a_resolvable_project_dependency() {
+    let project = tempfile::tempdir().unwrap();
+    let imported = project.path().join("src/Imported.vue");
+    fs::create_dir_all(imported.parent().unwrap()).unwrap();
+    fs::write(&imported, IMPORTED_STORE_SFC).unwrap();
+
+    let resolve = || {
+        LinterRuleResolver::new(LinterConfigPlan::default(), project.path(), project.path())
+            .resolve_files(std::slice::from_ref(&imported), project.path())
+    };
+    let without_pinia = resolve();
+    assert_eq!(without_pinia.configs.len(), 1);
+    assert_eq!(
+        lint_imported_store(
+            &without_pinia.configs[0],
+            &imported,
+            without_pinia.pinia_available[0],
+        ),
+        0,
+        "an imported use*Store composable is not Pinia evidence by itself",
+    );
+
+    fs::create_dir_all(project.path().join("node_modules/pinia")).unwrap();
+    fs::write(
+        project.path().join("node_modules/pinia/package.json"),
+        r#"{"name":"pinia","version":"3.0.0"}"#,
+    )
+    .unwrap();
+    let with_pinia = resolve();
+    assert_eq!(with_pinia.configs.len(), 1);
+    assert_eq!(
+        lint_imported_store(
+            &with_pinia.configs[0],
+            &imported,
+            with_pinia.pinia_available[0]
+        ),
+        1,
+        "a resolvable Pinia dependency must preserve the real-store warning",
+    );
+}
+
+#[test]
+fn pinia_availability_isolated_per_monorepo_package() {
+    let project = tempfile::tempdir().unwrap();
+    let plain = project.path().join("packages/plain/src/Imported.vue");
+    let pinia = project.path().join("packages/pinia/src/Imported.vue");
+    for file in [&plain, &pinia] {
+        fs::create_dir_all(file.parent().unwrap()).unwrap();
+        fs::write(file, IMPORTED_STORE_SFC).unwrap();
+    }
+    fs::create_dir_all(project.path().join("packages/pinia/node_modules/pinia")).unwrap();
+    fs::write(
+        project
+            .path()
+            .join("packages/pinia/node_modules/pinia/package.json"),
+        r#"{"name":"pinia","version":"3.0.0"}"#,
+    )
+    .unwrap();
+
+    let files = vec![plain.clone(), pinia.clone()];
+    let resolved =
+        LinterRuleResolver::new(LinterConfigPlan::default(), project.path(), project.path())
+            .resolve_files(&files, project.path());
+    assert_eq!(
+        resolved.configs.len(),
+        2,
+        "dependency availability must participate in linter grouping",
+    );
+    let plain_config = &resolved.configs[resolved.file_config_indices[0]];
+    let pinia_config = &resolved.configs[resolved.file_config_indices[1]];
+    assert_eq!(
+        lint_imported_store(
+            plain_config,
+            &plain,
+            resolved.pinia_available[resolved.file_config_indices[0]],
+        ),
+        0,
+    );
+    assert_eq!(
+        lint_imported_store(
+            pinia_config,
+            &pinia,
+            resolved.pinia_available[resolved.file_config_indices[1]],
+        ),
+        1,
+    );
+    assert!(!resolved.pinia_available[resolved.file_config_indices[0]]);
+    assert!(resolved.pinia_available[resolved.file_config_indices[1]]);
 }

--- a/crates/vize/tests/lint_pinia_dependency_cli.rs
+++ b/crates/vize/tests/lint_pinia_dependency_cli.rs
@@ -1,0 +1,125 @@
+use std::{fs, path::Path, process::Command};
+
+const PINIA_RULE: &str = "ecosystem/pinia-prefer-store-to-refs";
+
+fn write_file(root: &Path, relative: &str, source: &str) {
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, source).unwrap();
+}
+
+fn run_lint(root: &Path, files: &[&str]) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vize"));
+    command
+        .current_dir(root)
+        .arg("lint")
+        .args(files)
+        .args(["--no-config", "--format", "json", "--help-level", "none"])
+        .output()
+        .unwrap()
+}
+
+fn output_details(output: &std::process::Output) -> vize_carton::String {
+    let stdout = std::str::from_utf8(&output.stdout).unwrap_or("<non-UTF-8 stdout>");
+    let stderr = std::str::from_utf8(&output.stderr).unwrap_or("<non-UTF-8 stderr>");
+    vize_carton::cstr!("stdout:\n{stdout}\nstderr:\n{stderr}")
+}
+
+fn pinia_diagnostic_count(output: &std::process::Output) -> usize {
+    let report: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    report
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|file| file.get("messages")?.as_array())
+        .flatten()
+        .filter(|message| {
+            message.get("ruleId").and_then(|value| value.as_str()) == Some(PINIA_RULE)
+        })
+        .count()
+}
+
+#[test]
+fn pinia_store_rule_follows_project_dependency_resolution() {
+    let project = tempfile::tempdir().unwrap();
+    write_file(project.path(), "package.json", r#"{"private":true}"#);
+    write_file(
+        project.path(),
+        "src/store.ts",
+        r#"import { inject, type Ref } from "vue"
+
+export interface CounterStore {
+  count: Ref<number>
+  actions: { inc(): void }
+}
+
+export function useCounterStore(): CounterStore {
+  return inject("counter") as CounterStore
+}
+"#,
+    );
+    write_file(
+        project.path(),
+        "src/SameFile.vue",
+        r#"<script setup lang="ts">
+import { ref } from "vue"
+function useCounterStore() {
+  return { count: ref(0), actions: { inc() {} } }
+}
+const { count, actions } = useCounterStore()
+</script>
+"#,
+    );
+    write_file(
+        project.path(),
+        "src/Imported.vue",
+        r#"<script setup lang="ts">
+import { useCounterStore } from "./store"
+const { count, actions } = useCounterStore()
+</script>
+"#,
+    );
+
+    let without_pinia = run_lint(project.path(), &["src/SameFile.vue", "src/Imported.vue"]);
+    assert!(
+        without_pinia.status.success(),
+        "{}",
+        output_details(&without_pinia),
+    );
+    assert_eq!(
+        pinia_diagnostic_count(&without_pinia),
+        0,
+        "{}",
+        output_details(&without_pinia),
+    );
+
+    write_file(
+        project.path(),
+        "node_modules/pinia/package.json",
+        r#"{"name":"pinia","version":"3.0.0"}"#,
+    );
+    write_file(
+        project.path(),
+        "src/store.ts",
+        r#"import { defineStore } from "pinia"
+
+export const useCounterStore = defineStore("counter", {
+  state: () => ({ count: 0 }),
+  actions: { inc() { this.count += 1 } },
+})
+"#,
+    );
+
+    let with_pinia = run_lint(project.path(), &["src/Imported.vue"]);
+    assert!(
+        with_pinia.status.success(),
+        "{}",
+        output_details(&with_pinia)
+    );
+    assert_eq!(
+        pinia_diagnostic_count(&with_pinia),
+        1,
+        "{}",
+        output_details(&with_pinia),
+    );
+}


### PR DESCRIPTION
## Summary

- disable `ecosystem/pinia-prefer-store-to-refs` when Pinia is not resolvable from the linted file
- keep dependency resolution isolated per monorepo package and cached per lint batch
- cover non-Pinia imports and real Pinia imports through the CLI

Closes #3817

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vize_patina` (2,465 unit tests + 2 integration tests)
- `cargo test -p vize --lib commands::lint::entry_rules::tests` (6/6)
- `cargo test -p vize --test lint_pinia_dependency_cli` (1/1)
- `cargo clippy -p vize -p vize_patina --lib -- -D warnings`
- `cargo clippy -p vize --test lint_pinia_dependency_cli -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->