### PR TITLE
test(maestro): pin production completion ranking

### DIFF
--- a/tests/snapshots/check/create-vue-patch-oracle.ts
+++ b/tests/snapshots/check/create-vue-patch-oracle.ts
@@ -318,7 +318,12 @@ test("create-vue clean, broken, and repaired patches agree across check and LSP"
         )}\n`,
       );
 
-      const cleanSource = materializeCreateVueTypecheckSource(fixture);
+      materializeCreateVueTypecheckSource(fixture);
+      const cleanSource = fixture.applyExactPatch(
+        appPath,
+        `${createVueCleanCount}\nconst label = 'ready'`,
+        `${createVueCleanCount}\nconst countActive = 2\nconst countArchived = 3\nconst label = 'ready'`,
+      );
       const appFile = fixture.resolve(appPath);
       const appUri = pathToFileURL(appFile).href;
 
@@ -341,6 +346,35 @@ test("create-vue clean, broken, and repaired patches agree across check and LSP"
           (params) => isDiagnosticsForUri(params, appUri) && params.version === 1,
         )) as PublishDiagnosticsParams;
         assert.deepEqual(cleanPublish.diagnostics, [], JSON.stringify(cleanPublish.diagnostics));
+
+        const requestCompletionRanking = async () => {
+          const completion = (await session.request("textDocument/completion", {
+            textDocument: { uri: appUri },
+            position: offsetToPosition(
+              cleanSource,
+              cleanSource.indexOf("{{ count }}") + "{{ cou".length,
+            ),
+          })) as
+            | Array<{ label: string; sortText?: string }>
+            | { items?: Array<{ label: string; sortText?: string }> }
+            | null;
+          const items = Array.isArray(completion) ? completion : (completion?.items ?? []);
+          return items
+            .filter((item) => item.label.startsWith("count"))
+            .map((item) => ({ label: item.label, sortText: item.sortText ?? null }));
+        };
+
+        // #3224 completion-ranking oracle: these candidates share the exact
+        // prefix at the request position. Pin both response order and the LSP
+        // sortText contract, then repeat the request so map/set iteration or a
+        // warm Corsa session cannot silently reshuffle the production answer.
+        const expectedCompletionRanking = [
+          { label: "count", sortText: "0count" },
+          { label: "countActive", sortText: "0countActive" },
+          { label: "countArchived", sortText: "0countArchived" },
+        ];
+        assert.deepEqual(await requestCompletionRanking(), expectedCompletionRanking);
+        assert.deepEqual(await requestCompletionRanking(), expectedCompletionRanking);
 
         const completion = await session.request("textDocument/completion", {
           textDocument: { uri: appUri },


### PR DESCRIPTION
## Summary

- extend the pinned create-vue production LSP oracle with three candidates sharing the `cou` prefix
- assert the exact label order and `sortText` values returned by the real `vize lsp` binary
- repeat the request in one live Corsa session so warm-session or iteration-order drift is visible

## Why

The #3224 feature matrix already pins completion context with include/exclude checks, but it had no production ranking regression. A live Vue Language Server 3.x comparison requires its client-hosted tsserver bridge, which is too broad for this slice, so this PR narrowly makes Vize's production ranking deterministic and machine-checked.

Refs #3224

## Validation

- red-first expectation proved all three production `sortText` values are observed, not synthesized by the test
- pinned create-vue compiler/linter/formatter/check/LSP oracle: 4/4
- related production, roadmap, and template completion suites: 18/18
- `cargo build --profile ci -p vize`
- `vp fmt tests/snapshots/check/create-vue-patch-oracle.ts --check`
- `vp check --no-fmt tests/snapshots/check/create-vue-patch-oracle.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->