### PR TITLE
test(fresco): run component tests in workspace CI

### DIFF
--- a/tests/tooling/local-default-tasks.test.ts
+++ b/tests/tooling/local-default-tasks.test.ts
@@ -11,6 +11,7 @@ import { checkTasks } from "../../tools/vite-plus/tasks/check.ts";
 import { testAndBenchmarkTasks } from "../../tools/vite-plus/tasks/test-benchmark.ts";
 import { inTestbox, testboxTasks } from "../../tools/vite-plus/tasks/testbox.ts";
 import { shellQuote } from "../../tools/vite-plus/task-helpers.ts";
+import { testedPackages } from "../../tools/vite-plus/task-inputs.ts";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const pushCurrentBranchCommand = 'git push --set-upstream origin "$(git branch --show-current)"';
@@ -78,6 +79,13 @@ test("workspace build, test, and lint default to their local task graphs", () =>
   assert.equal(ci.cache, false);
   assert.match(ci.command, /vp run --workspace-root test(?:\s|$)/);
   assert.doesNotMatch(ci.command, /blacksmith|test:testbox/);
+});
+
+test("workspace JS tests include the Fresco component suite", () => {
+  assert.ok(testedPackages.includes("./npm/fresco"));
+
+  const jsTests = taskShape(testAndBenchmarkTasks["test:js"]);
+  assert.match(jsTests.command, /--filter '\.\/npm\/fresco'(?:\s|$)/);
 });
 
 test("branch coverage reports every metric before enforcing thresholds", () => {

--- a/tools/vite-plus/task-inputs.ts
+++ b/tools/vite-plus/task-inputs.ts
@@ -75,6 +75,7 @@ export const testedPackages = [
   "./npm/framework/nuxt-lint-config",
   "./npm/framework/nuxt",
   "./npm/mcp-musea",
+  "./npm/fresco",
   "./npm/compose/core",
   "./npm/ui/core",
   "./npm/marquette",


### PR DESCRIPTION
## Summary

- add `@vizejs/fresco` to the workspace JS test package set used by the `test-js-packages` CI job
- pin the generated `test:js` command so the Fresco filter cannot silently disappear again

## Verification

- `vp run --workspace-root test:js`
- `node --test tests/tooling/local-default-tasks.test.ts`
- `pnpm --filter @vizejs/fresco test`
- `pnpm exec vp check tools/vite-plus/task-inputs.ts tests/tooling/local-default-tasks.test.ts`
- `cargo test -p vize_fresco --lib`

Refs #3139
Refs #3113

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->