### PR TITLE
fix(canon): surface unknown event callback implicit any

### DIFF
--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_kebab_case_component_names.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_kebab_case_component_names.snap
@@ -116,10 +116,11 @@ function __setup() {
   type __my_widget_7_update_model_value_args = unknown[] extends __my_widget_7_update_model_value_prop_args ? __my_widget_7_update_model_value_emit_args : __my_widget_7_update_model_value_prop_args;
   type __my_widget_7_update_model_value_event = __my_widget_7_update_model_value_args extends [] ? any : unknown[] extends __my_widget_7_update_model_value_args ? any : __my_widget_7_update_model_value_args[0];
   type __my_widget_7_update_model_value_listener = unknown[] extends __my_widget_7_update_model_value_args ? ((...args: any[]) => unknown) : ((...args: __my_widget_7_update_model_value_args) => unknown);
+  type __my_widget_7_update_model_value_handler = unknown[] extends __my_widget_7_update_model_value_args ? unknown : __my_widget_7_update_model_value_listener;
   ((...__vize_args: Parameters<__my_widget_7_update_model_value_listener>) => {
     const $event = __vize_args[0] as __my_widget_7_update_model_value_event; void $event;
-    const __vize_handler_7_47: __my_widget_7_update_model_value_listener | null | undefined = (handleUpdate);
-    if (__vize_handler_7_47) __vize_handler_7_47(...__vize_args);  // handler expression
+    const __vize_handler_7_47: __my_widget_7_update_model_value_handler | null | undefined = (handleUpdate);
+    if (__vize_handler_7_47) (__vize_handler_7_47 as __my_widget_7_update_model_value_listener)(...__vize_args);  // handler expression
     // @vize-map: handler -> 47:59
   })(...({} as Parameters<__my_widget_7_update_model_value_listener>));
 

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues.rs
@@ -16,6 +16,7 @@ mod split_script_diagnostic_anchors;
 mod spread_props;
 mod spread_scope_bindings;
 mod ts_extension_substitution;
+mod unknown_component_event_callbacks;
 mod unmapped_template_fallback;
 mod vapor_anchors;
 #[test]

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/unknown_component_event_callbacks.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/unknown_component_event_callbacks.rs
@@ -1,0 +1,52 @@
+//! Unknown component events must not hide authored implicit-any parameters (#3756).
+
+use super::super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+
+#[test]
+fn unknown_component_event_callbacks_match_vue_tsc_implicit_any() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "unknown-component-event-callback",
+        &[
+            (
+                "src/global-components.d.ts",
+                r#"import type { DefineComponent } from "vue"
+export {}
+
+declare module "vue" {
+  interface GlobalComponents {
+    MkSuspense: DefineComponent<{
+      p?: () => unknown
+    }>
+  }
+}
+"#,
+            ),
+            (
+                "src/App.vue",
+                r#"<template>
+  <MkSuspense @resolved="(result) => void result" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+
+    assert_eq!(
+        snapshot,
+        // vue-tsc 3.3.4 with TypeScript 6.0.3, on the byte-identical fixture:
+        // src/App.vue(2,27): error TS7006: Parameter 'result' implicitly has an 'any' type.
+        Some(vec![(
+            vize_carton::String::from("src/App.vue"),
+            Some(7006),
+            vize_carton::String::from(
+                "2:27:error Parameter 'result' implicitly has an 'any' type.",
+            ),
+        )]),
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/scope/component_events.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events.rs
@@ -16,6 +16,8 @@ pub(super) struct ComponentEventTypes {
     pub(super) event_type: String,
     pub(super) listener_type: String,
     pub(super) listener_type_expr: String,
+    pub(super) handler_type: String,
+    pub(super) handler_type_expr: String,
 }
 
 pub(super) fn generate_component_event_types(
@@ -46,6 +48,7 @@ pub(super) fn generate_component_event_types(
     let args_type = cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_args");
     let event_type = cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_event");
     let listener_type = cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_listener");
+    let handler_type = cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_handler");
 
     append!(
         *ts,
@@ -143,10 +146,22 @@ pub(super) fn generate_component_event_types(
             "unknown[] extends {args_type} ? ((...args: any[]) => unknown) : ((...args: {listener_args_type}) => unknown)"
         )
     };
+    let handler_type_expr = if legacy_vue2 {
+        listener_type.clone()
+    } else {
+        // An unresolved event has no contextual type in vue-tsc. Annotating the
+        // authored inline callback as `(...args: any[]) => unknown` would hide
+        // its noImplicitAny diagnostics (#3756), so only known emit tuples
+        // provide a listener context. The call site casts back to the callable
+        // listener alias after the initializer has been checked.
+        cstr!("unknown[] extends {args_type} ? unknown : {listener_type}")
+    };
     Some(ComponentEventTypes {
         event_type,
         listener_type,
         listener_type_expr,
+        handler_type,
+        handler_type_expr,
     })
 }
 

--- a/crates/vize_canon/src/virtual_ts/scope/context.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/context.rs
@@ -81,6 +81,10 @@ pub(super) struct EventHandlerExprContext<'a> {
     /// Native DOM events leave this `None` and fall back to the single `$event`
     /// parameter typed by `event_type`.
     pub(super) event_listener_type: Option<&'a str>,
+    /// The contextual type applied to an authored component-event callback.
+    /// This becomes `unknown` when the event args remain unresolved, matching
+    /// vue-tsc by preserving noImplicitAny diagnostics in the callback itself.
+    pub(super) event_handler_type: Option<&'a str>,
     /// Authored range of the `@event` / `v-on:event` attribute name, where
     /// vue-tsc anchors a wrongly-shaped handler (#3462). `None` when the
     /// directive text cannot be read back from the template.

--- a/crates/vize_canon/src/virtual_ts/scope/event_handler.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/event_handler.rs
@@ -72,7 +72,8 @@ pub(super) fn generate_event_handler_expressions(
                 let mapped_end = ts.len();
                 ts.push_str(";  // handler expression (emit checks disabled)\n");
                 mapped_start..mapped_end
-            } else if let Some(listener_type) = ctx.event_listener_type
+            } else if let (Some(listener_type), Some(handler_type)) =
+                (ctx.event_listener_type, ctx.event_handler_type)
                 && (is_implicit_reference || inline_callback_arg.is_some())
             {
                 let handler_name = cstr!("__vize_handler_{scope_id}_{}", expr.start);
@@ -81,7 +82,7 @@ pub(super) fn generate_event_handler_expressions(
                 let name_start = ts.len();
                 ts.push_str(handler_name.as_str());
                 let name_end = ts.len();
-                append!(*ts, ": {listener_type} | null | undefined = (");
+                append!(*ts, ": {handler_type} | null | undefined = (");
                 let mapped_start = ts.len();
                 ts.push_str(content);
                 let mapped_end = ts.len();
@@ -89,7 +90,7 @@ pub(super) fn generate_event_handler_expressions(
                 listener_spans = Some((stmt_start..ts.len(), name_start..name_end));
                 append!(
                     *ts,
-                    "{indent}if ({handler_name}) {handler_name}(...__vize_args);  // handler expression\n",
+                    "{indent}if ({handler_name}) ({handler_name} as {listener_type})(...__vize_args);  // handler expression\n",
                     indent = handler_indent,
                 );
                 mapped_start..mapped_end

--- a/crates/vize_canon/src/virtual_ts/scope/event_scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/event_scope.rs
@@ -40,6 +40,7 @@ pub(super) fn generate_event_handler_scope(
                     check_emits: false,
                     event_type: "any",
                     event_listener_type: None,
+                    event_handler_type: None,
                     event_name_src_range: None,
                     template_prop_names: ctx.template_prop_names,
                     template_offset: ctx.template_offset,
@@ -65,12 +66,15 @@ pub(super) fn generate_event_handler_scope(
         let event_type = event_types.event_type;
         let listener_type = event_types.listener_type;
         let listener_type_expr = event_types.listener_type_expr;
+        let handler_type = event_types.handler_type;
+        let handler_type_expr = event_types.handler_type_expr;
         // Type the listener against the FULL emit tuple so multi-arg emits
         // keep every parameter (#1512); unresolved sigs stay variadic.
         append!(
             *ts,
             "{indent}type {listener_type} = {listener_type_expr};\n",
         );
+        append!(*ts, "{indent}type {handler_type} = {handler_type_expr};\n");
         // Receive listener args via a rest parameter typed by
         // `Parameters<listener>` to avoid TS2556; `$event` is element 0.
         append!(
@@ -94,6 +98,7 @@ pub(super) fn generate_event_handler_scope(
                     check_emits: true,
                     event_type: event_type.as_str(),
                     event_listener_type: Some(listener_type.as_str()),
+                    event_handler_type: Some(handler_type.as_str()),
                     event_name_src_range: event_name_source_range(
                         ctx.template_source,
                         ctx.template_offset,
@@ -129,6 +134,7 @@ pub(super) fn generate_event_handler_scope(
                     // Native DOM listeners keep the identity-call shape,
                     // so there is no declared name to anchor at.
                     event_listener_type: None,
+                    event_handler_type: None,
                     event_name_src_range: None,
                     template_prop_names: ctx.template_prop_names,
                     template_offset: ctx.template_offset,

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -2033,13 +2033,17 @@ function handleTest(value1: string, value2: number) {
     // with every argument spread.
     assert!(
         output.code.contains(
-            "const __vize_handler_8_13: __Test_8_test_listener | null | undefined = (handleTest);"
+            "type __Test_8_test_handler = unknown[] extends __Test_8_test_args ? unknown : __Test_8_test_listener;"
+        ) && output.code.contains(
+            "const __vize_handler_8_13: __Test_8_test_handler | null | undefined = (handleTest);"
         ),
         "bare handler reference must be typed against the emit listener type:\n{}",
         output.code
     );
     assert!(
-        output.code.contains("__vize_handler_8_13(...__vize_args);"),
+        output
+            .code
+            .contains("(__vize_handler_8_13 as __Test_8_test_listener)(...__vize_args);"),
         "bare handler reference must be invoked with the full argument spread:\n{}",
         output.code
     );
@@ -2049,13 +2053,17 @@ function handleTest(value1: string, value2: number) {
     // full argument spread, avoiding TS2556 on the fixed-arity arrow.
     assert!(
         output.code.contains(
-            "const __vize_handler_9_40: __Test_9_test_listener | null | undefined = ((value1, value2) => handleTest(value1, value2));"
+            "type __Test_9_test_handler = unknown[] extends __Test_9_test_args ? unknown : __Test_9_test_listener;"
+        ) && output.code.contains(
+            "const __vize_handler_9_40: __Test_9_test_handler | null | undefined = ((value1, value2) => handleTest(value1, value2));"
         ),
         "inline multi-arg arrow must be typed against the emit listener type:\n{}",
         output.code
     );
     assert!(
-        output.code.contains("__vize_handler_9_40(...__vize_args);"),
+        output
+            .code
+            .contains("(__vize_handler_9_40 as __Test_9_test_listener)(...__vize_args);"),
         "inline multi-arg arrow must be invoked with the full argument spread:\n{}",
         output.code
     );


### PR DESCRIPTION
## Summary

- preserve `noImplicitAny` diagnostics for inline callbacks on unresolved component events
- keep known emit tuples contextually typed and Vue 2's permissive legacy fallback unchanged
- add an exact TS7006 regression oracle based on Misskey's `MkSuspense @resolved` case

## Root cause

Unresolved component events used `(...args: any[]) => unknown` as the contextual type for authored inline callbacks. That synthetic `any` context suppressed TS7006 diagnostics that vue-tsc reports.

The generated callback initializer now receives `unknown` when event arguments are unresolved. Known events still receive their inferred listener signature; invocation uses the existing callable fallback after the initializer is checked.

## Validation

- `VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --lib` (800 passed)
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`
- exact vue-tsc 3.3.4 / TypeScript 6.0.3 oracle: `src/App.vue(2,27): error TS7006: Parameter 'result' implicitly has an 'any' type.`

Local `source-file-lengths` could not complete because the installed MoonBit 0.1.20260512 rejects the current `moon.mod` `license` key; CI installs the repository-pinned toolchain and remains the acceptance gate.

Refs #3756
Refs #3222

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->