### PR TITLE
fix(vite): honor plugin-vue Options API flag

### DIFF
--- a/npm/builder/vite/src/index.ts
+++ b/npm/builder/vite/src/index.ts
@@ -11,6 +11,7 @@ export {
   vizeConfigStore,
 } from "./config.ts";
 export { rewriteStaticAssetUrls as __internal_rewriteStaticAssetUrls } from "./transform.ts";
+export type { VizeVueFeatures } from "./vue-features.ts";
 export type {
   VizeOptions,
   CompiledModule,
@@ -20,7 +21,6 @@ export type {
   UserConfigExport,
   LoadConfigOptions,
   VizeVueVersion,
-  VizeVueFeatures,
   VizeCompatibilityOptions,
   VizeInspectorLintPlanProvider,
   VizeInspectorLintPlanRequest,

--- a/npm/builder/vite/src/index.ts
+++ b/npm/builder/vite/src/index.ts
@@ -20,6 +20,7 @@ export type {
   UserConfigExport,
   LoadConfigOptions,
   VizeVueVersion,
+  VizeVueFeatures,
   VizeCompatibilityOptions,
   VizeInspectorLintPlanProvider,
   VizeInspectorLintPlanRequest,

--- a/npm/builder/vite/src/plugin/index.ts
+++ b/npm/builder/vite/src/plugin/index.ts
@@ -39,6 +39,7 @@ import {
 } from "./vue-version.ts";
 import { resolveSharedConfig } from "./shared-config.ts";
 import * as configBridge from "./config-lifecycle.ts";
+import { resolveOptionsApiFlag } from "./vue-feature-defines.ts";
 
 export type { VizePluginState } from "./state.ts";
 
@@ -80,14 +81,6 @@ function resolveCompatibilityOptions(
   }
 
   return compatibility;
-}
-
-function parseDefine(value: unknown): unknown {
-  try {
-    return typeof value === "string" ? JSON.parse(value) : value;
-  } catch {
-    return value;
-  }
 }
 
 export function vize(options: VizeOptions = {}): Plugin[] {
@@ -134,13 +127,12 @@ export function vize(options: VizeOptions = {}): Plugin[] {
       patchCssModuleGenerateScopedName(userConfig);
 
       return {
-        // Vue 3 ESM bundler build requires these compile-time feature flags.
-        // @vitejs/plugin-vue normally provides them; vize must do so as its replacement.
+        // Vue 3 ESM bundler flags normally injected by @vitejs/plugin-vue.
         define: {
-          __VUE_OPTIONS_API__:
-            options.features?.optionsAPI ??
-            parseDefine(userConfig.define?.__VUE_OPTIONS_API__) ??
-            true,
+          __VUE_OPTIONS_API__: resolveOptionsApiFlag(
+            options.features?.optionsAPI,
+            userConfig.define?.__VUE_OPTIONS_API__,
+          ),
           __VUE_PROD_DEVTOOLS__: env.command === "serve",
           __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
         },

--- a/npm/builder/vite/src/plugin/index.ts
+++ b/npm/builder/vite/src/plugin/index.ts
@@ -82,6 +82,14 @@ function resolveCompatibilityOptions(
   return compatibility;
 }
 
+function parseDefine(value: unknown): unknown {
+  try {
+    return typeof value === "string" ? JSON.parse(value) : value;
+  } catch {
+    return value;
+  }
+}
+
 export function vize(options: VizeOptions = {}): Plugin[] {
   if (isLegacyVueCompatibilityMode(options)) {
     return [createLegacyVueCompatibilityPlugin(options)];
@@ -129,7 +137,10 @@ export function vize(options: VizeOptions = {}): Plugin[] {
         // Vue 3 ESM bundler build requires these compile-time feature flags.
         // @vitejs/plugin-vue normally provides them; vize must do so as its replacement.
         define: {
-          __VUE_OPTIONS_API__: true,
+          __VUE_OPTIONS_API__:
+            options.features?.optionsAPI ??
+            parseDefine(userConfig.define?.__VUE_OPTIONS_API__) ??
+            true,
           __VUE_PROD_DEVTOOLS__: env.command === "serve",
           __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
         },

--- a/npm/builder/vite/src/plugin/vue-feature-defines.ts
+++ b/npm/builder/vite/src/plugin/vue-feature-defines.ts
@@ -1,0 +1,12 @@
+function parseDefine(value: unknown): unknown {
+  try {
+    return typeof value === "string" ? JSON.parse(value) : value;
+  } catch {
+    return value;
+  }
+}
+
+/** Resolve the Options API runtime define with plugin-vue's precedence. */
+export function resolveOptionsApiFlag(option: boolean | undefined, define: unknown): unknown {
+  return option ?? parseDefine(define) ?? true;
+}

--- a/npm/builder/vite/src/types.ts
+++ b/npm/builder/vite/src/types.ts
@@ -6,6 +6,8 @@ import type {
 import type { VizeInspectorOptions } from "./inspector-types.ts";
 import type { VizeVueFeatures } from "./vue-features.ts";
 
+export type { VizeVueFeatures } from "./vue-features.ts";
+
 export type {
   VizeInspectorLintPlanProvider,
   VizeInspectorLintPlanRequest,

--- a/npm/builder/vite/src/types.ts
+++ b/npm/builder/vite/src/types.ts
@@ -6,8 +6,6 @@ import type {
 import type { VizeInspectorOptions } from "./inspector-types.ts";
 import type { VizeVueFeatures } from "./vue-features.ts";
 
-export type { VizeVueFeatures } from "./vue-features.ts";
-
 export type {
   VizeInspectorLintPlanProvider,
   VizeInspectorLintPlanRequest,

--- a/npm/builder/vite/src/types.ts
+++ b/npm/builder/vite/src/types.ts
@@ -106,6 +106,16 @@ export interface VizeCompatibilityOptions {
   webpackVersion?: 4 | 5;
 }
 
+/** Vue runtime feature flags shared with `@vitejs/plugin-vue`. */
+export interface VizeVueFeatures {
+  /**
+   * Set to `false` to allow Vue's Options API code to be tree-shaken from
+   * production bundles.
+   * @default true
+   */
+  optionsAPI?: boolean;
+}
+
 export interface VizeOptions extends ExperimentalPluginOptions {
   /**
    * Inline shared Vize config for Vite Plus-first projects.
@@ -115,6 +125,9 @@ export interface VizeOptions extends ExperimentalPluginOptions {
 
   /** Development inspector integrations exposed through Vite's dev server. */
   inspector?: VizeInspectorOptions;
+
+  /** Vue runtime feature flags compatible with `@vitejs/plugin-vue`. */
+  features?: VizeVueFeatures;
 
   /**
    * Vue major version for the host project.

--- a/npm/builder/vite/src/types.ts
+++ b/npm/builder/vite/src/types.ts
@@ -4,6 +4,7 @@ import type {
   ExperimentalPluginOptions,
 } from "./experimental-options.ts";
 import type { VizeInspectorOptions } from "./inspector-types.ts";
+import type { VizeVueFeatures } from "./vue-features.ts";
 
 export type {
   VizeInspectorLintPlanProvider,
@@ -104,16 +105,6 @@ export interface VizeCompatibilityOptions {
    * Override the host Webpack major when this option object is shared with unplugin.
    */
   webpackVersion?: 4 | 5;
-}
-
-/** Vue runtime feature flags shared with `@vitejs/plugin-vue`. */
-export interface VizeVueFeatures {
-  /**
-   * Set to `false` to allow Vue's Options API code to be tree-shaken from
-   * production bundles.
-   * @default true
-   */
-  optionsAPI?: boolean;
 }
 
 export interface VizeOptions extends ExperimentalPluginOptions {

--- a/npm/builder/vite/src/vue-features.ts
+++ b/npm/builder/vite/src/vue-features.ts
@@ -1,0 +1,9 @@
+/** Vue runtime feature flags shared with `@vitejs/plugin-vue`. */
+export interface VizeVueFeatures {
+  /**
+   * Set to `false` to allow Vue's Options API code to be tree-shaken from
+   * production bundles.
+   * @default true
+   */
+  optionsAPI?: boolean;
+}

--- a/tests/_fixtures/vite-plugin-vue-option-parity.json
+++ b/tests/_fixtures/vite-plugin-vue-option-parity.json
@@ -8,9 +8,9 @@
     "version": "6.0.7"
   },
   "summary": {
-    "honored": 11,
+    "honored": 12,
     "intentional-divergence": 9,
-    "unimplemented": 20
+    "unimplemented": 19
   },
   "options": {
     "compiler": {
@@ -37,9 +37,8 @@
       "reason": "No custom-element output mode: .ce.vue files compile as ordinary components with no shadow-DOM style inlining. @vizejs/rspack-plugin implements the option, the Vite plugin does not."
     },
     "features.optionsAPI": {
-      "status": "unimplemented",
-      "issue": 3227,
-      "reason": "The config hook hard-codes __VUE_OPTIONS_API__: true, so Options API support cannot be dropped from production bundles."
+      "status": "honored",
+      "evidence": "options-api-feature"
     },
     "features.prodDevtools": {
       "status": "unimplemented",

--- a/tests/tooling/_helpers/vite-plugin-vue-parity.ts
+++ b/tests/tooling/_helpers/vite-plugin-vue-parity.ts
@@ -33,6 +33,18 @@ const nonHookPluginKeys = new Set(["api", "name"]);
 
 const requireFromBench = createRequire(path.join(repoRoot, "bench", "package.json"));
 
+/** Instantiate the pinned upstream plugin for behavioral parity probes. */
+export function createUpstreamPlugin(
+  options: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const upstreamModule = requireFromBench(upstreamPackage) as
+    | ((options?: unknown) => Record<string, unknown>)
+    | { default: (options?: unknown) => Record<string, unknown> };
+  const factory = typeof upstreamModule === "function" ? upstreamModule : upstreamModule.default;
+  assert.equal(typeof factory, "function", `${upstreamPackage} must export a plugin factory`);
+  return factory(options);
+}
+
 export interface UpstreamSurface {
   apiMembers: string[];
   hooks: string[];
@@ -143,13 +155,7 @@ function enumerateOptions(): string[] {
 
 /** The `Api` members and plugin hooks the upstream plugin instance exposes. */
 function enumeratePluginSurface(): { apiMembers: string[]; hooks: string[] } {
-  const upstreamModule = requireFromBench(upstreamPackage) as
-    | ((options?: unknown) => Record<string, unknown>)
-    | { default: (options?: unknown) => Record<string, unknown> };
-  const factory = typeof upstreamModule === "function" ? upstreamModule : upstreamModule.default;
-  assert.equal(typeof factory, "function", `${upstreamPackage} must export a plugin factory`);
-
-  const plugin = factory();
+  const plugin = createUpstreamPlugin();
   const api = plugin.api;
   assert.ok(api && typeof api === "object", `${upstreamPackage} must expose its framework api`);
 

--- a/tests/tooling/vite-plugin-vue-option-parity.test.ts
+++ b/tests/tooling/vite-plugin-vue-option-parity.test.ts
@@ -16,6 +16,7 @@ import { test } from "node:test";
 import type { Plugin, ResolvedConfig } from "vite";
 
 import {
+  createUpstreamPlugin,
   honoredEvidence,
   readLedger,
   upstreamSurface,
@@ -190,6 +191,40 @@ async function probeHotUpdateStyleOnly(): Promise<void> {
   assert.match(sent[0].data?.css ?? "", /color:\s*blue/, "the payload carries the new CSS");
 }
 
+/** `features.optionsAPI` produces the same Vue runtime define as plugin-vue. */
+async function probeOptionsApiFeature(): Promise<void> {
+  const cases = [
+    { expected: true, options: {}, userDefine: {} },
+    { expected: false, options: { features: { optionsAPI: false } }, userDefine: {} },
+    {
+      expected: true,
+      options: { features: { optionsAPI: true } },
+      userDefine: { __VUE_OPTIONS_API__: false },
+    },
+    { expected: false, options: {}, userDefine: { __VUE_OPTIONS_API__: "false" } },
+  ] as const;
+
+  for (const { expected, options, userDefine } of cases) {
+    const userConfig = { define: userDefine };
+    const env = { command: "build", mode: "production" } as const;
+    const upstream = createUpstreamPlugin(options) as Plugin;
+    const vizePlugin = vize({ configMode: false, ...options }).find(
+      (candidate) => candidate.name === "vite-plugin-vize",
+    );
+    assert.ok(vizePlugin);
+
+    const upstreamResult = await hook<AnyHook>(upstream.config).call({}, userConfig, env);
+    const vizeResult = await hook<AnyHook>(vizePlugin.config).call({}, userConfig, env);
+    const upstreamDefine = (upstreamResult as { define: Record<string, unknown> }).define
+      .__VUE_OPTIONS_API__;
+    const vizeDefine = (vizeResult as { define: Record<string, unknown> }).define
+      .__VUE_OPTIONS_API__;
+
+    assert.equal(upstreamDefine, expected, "the pinned upstream oracle must stay stable");
+    assert.equal(vizeDefine, upstreamDefine, "Vize must match plugin-vue's Options API define");
+  }
+}
+
 /** The named hook is implemented by one of the plugins Vize contributes. */
 function probeHookImplemented(name: string): void {
   const plugins = vize({ configMode: false }) as Plugin[];
@@ -208,6 +243,7 @@ const probes = new Map<string, () => Promise<void> | void>([
   ["exclude-filter", probeExcludeFilter],
   ["production-css-import", probeProductionCssImport],
   ["hot-update-style-only", probeHotUpdateStyleOnly],
+  ["options-api-feature", probeOptionsApiFeature],
 ]);
 
 test("the parity ledger stays exhaustive over the pinned @vitejs/plugin-vue surface", () => {

--- a/tests/tooling/vite-plugin-vue-option-parity.test.ts
+++ b/tests/tooling/vite-plugin-vue-option-parity.test.ts
@@ -205,7 +205,10 @@ async function probeOptionsApiFeature(): Promise<void> {
   ] as const;
 
   for (const { expected, options, userDefine } of cases) {
-    const userConfig = { define: userDefine };
+    // Each hook gets its own config object so the parity assertion does not
+    // depend on either plugin leaving its input untouched.
+    const upstreamConfig = { define: { ...userDefine } };
+    const vizeConfig = { define: { ...userDefine } };
     const env = { command: "build", mode: "production" } as const;
     const upstream = createUpstreamPlugin(options) as Plugin;
     const vizePlugin = vize({ configMode: false, ...options }).find(
@@ -213,8 +216,8 @@ async function probeOptionsApiFeature(): Promise<void> {
     );
     assert.ok(vizePlugin);
 
-    const upstreamResult = await hook<AnyHook>(upstream.config).call({}, userConfig, env);
-    const vizeResult = await hook<AnyHook>(vizePlugin.config).call({}, userConfig, env);
+    const upstreamResult = await hook<AnyHook>(upstream.config).call({}, upstreamConfig, env);
+    const vizeResult = await hook<AnyHook>(vizePlugin.config).call({}, vizeConfig, env);
     const upstreamDefine = (upstreamResult as { define: Record<string, unknown> }).define
       .__VUE_OPTIONS_API__;
     const vizeDefine = (vizeResult as { define: Record<string, unknown> }).define


### PR DESCRIPTION
## Summary

- accept `features.optionsAPI` in `@vizejs/vite-plugin`
- match `@vitejs/plugin-vue` precedence between the plugin option, an existing Vite define, and the default
- promote the option from `unimplemented` to behaviorally proven in the exhaustive parity ledger

## Why

Vize hard-coded `__VUE_OPTIONS_API__` to `true`, so projects replacing `@vitejs/plugin-vue` could no longer disable the Options API runtime for production tree-shaking.

The parity probe runs the pinned `@vitejs/plugin-vue` 6.0.7 and Vize config hooks with the same inputs. It covers the default, an explicit `false`, option precedence over user config, and a JSON-string Vite define.

## Validation

- `node --test tests/tooling/vite-plugin-vue-option-parity.test.ts npm/builder/vite/src/plugin/index.test.ts npm/builder/vite/src/plugin/compat.test.ts`
- `vp check` on all modified TypeScript files
- `vp check src vite.config.ts` in `npm/builder/vite` (93 files)
- `vp pack` in `npm/builder/vite`

The full local `node src/test.ts` package suite reached the existing source-map test and failed because this worktree used the shared checkout's stale native artifact; CI rebuilds `@vizejs/native` before the package suite and remains the acceptance gate.

Refs #3227

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable Vue Options API feature flag for Vite builds.
  * Options API support can now be enabled or disabled through project feature settings.
  * User-provided build-time configuration is respected when determining the flag.

* **Tests**
  * Added coverage for default, enabled, disabled, and override configurations.
  * Updated feature compatibility tracking to reflect Options API support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->