### PR TITLE
test(canon): gate Tier-L incremental session reuse

### DIFF
--- a/.github/actions/check-vue-parity/action.yml
+++ b/.github/actions/check-vue-parity/action.yml
@@ -31,6 +31,15 @@ runs:
         VIZE_TEST_BIN: target/ci/vize
       run: vp run --filter './tests' test:check:fixtures
 
+    - name: Check Tier-L batch incremental session reuse
+      shell: bash
+      env:
+        VIZE_TIER_L_FIXTURE: tests/_fixtures/_git/vue-vben-admin
+        VIZE_TIER_L_CORSA_BIN: node_modules/.bin/tsgo
+        VIZE_TIER_L_METRICS_DIR: target/vize-tests/metrics/vben-batch-incremental
+        VIZE_RUNTIME_NODE_MODULES: node_modules
+      run: cargo test --locked --profile ci -p vize_canon --test tier_l_incremental -- --ignored --nocapture
+
     - name: Check glyph formatter corpus properties
       shell: bash
       env:
@@ -57,7 +66,7 @@ runs:
       if: ${{ always() }}
       shell: bash
       run: |
-        for suite in misskey-lsp-incremental vben-lsp-incremental misskey-lsp-churn; do
+        for suite in vben-batch-incremental misskey-lsp-incremental vben-lsp-incremental misskey-lsp-churn; do
           if [ -s "target/vize-tests/metrics/$suite/summary.md" ]; then
             cat "target/vize-tests/metrics/$suite/summary.md" >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -78,6 +87,15 @@ runs:
       with:
         name: vben-lsp-incremental-metrics
         path: target/vize-tests/metrics/vben-lsp-incremental/
+        if-no-files-found: warn
+        retention-days: 14
+
+    - name: Upload Vue Vben Admin batch incremental metrics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: vben-batch-incremental-metrics
+        path: target/vize-tests/metrics/vben-batch-incremental/
         if-no-files-found: warn
         retention-days: 14
 

--- a/crates/vize_canon/tests/support/tier_l_incremental_artifact.rs
+++ b/crates/vize_canon/tests/support/tier_l_incremental_artifact.rs
@@ -1,0 +1,122 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use vize_canon::IncrementalCheckMetrics;
+use vize_carton::{String, append, cstr};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct BatchIncrementalBudget {
+    pub(super) cold_ms: u64,
+    pub(super) warm_ms: u64,
+    pub(super) max_requested_files: usize,
+    pub(super) max_changed_files: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct Artifact {
+    pub(super) schema_version: u8,
+    pub(super) fixture: FixtureEvidence,
+    pub(super) budget: BatchIncrementalBudget,
+    pub(super) file_count: usize,
+    pub(super) lanes: Vec<LaneEvidence>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct FixtureEvidence {
+    pub(super) id: &'static str,
+    pub(super) revision: String,
+    pub(super) injected_file: &'static str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct LaneEvidence {
+    name: &'static str,
+    duration_ms: u128,
+    metrics: MetricsEvidence,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MetricsEvidence {
+    checks: usize,
+    session_starts: usize,
+    session_reuses: usize,
+    session_refreshes: usize,
+    session_to_cli_fallbacks: usize,
+    requested_files: usize,
+    changed_files: usize,
+    created_files: usize,
+    deleted_files: usize,
+}
+
+impl From<IncrementalCheckMetrics> for MetricsEvidence {
+    fn from(metrics: IncrementalCheckMetrics) -> Self {
+        Self {
+            checks: metrics.checks,
+            session_starts: metrics.session_starts,
+            session_reuses: metrics.session_reuses,
+            session_refreshes: metrics.session_refreshes,
+            session_to_cli_fallbacks: metrics.session_to_cli_fallbacks,
+            requested_files: metrics.last_requested_files,
+            changed_files: metrics.last_changed_files,
+            created_files: metrics.last_created_files,
+            deleted_files: metrics.last_deleted_files,
+        }
+    }
+}
+
+pub(super) fn lane(
+    name: &'static str,
+    duration_ms: u128,
+    metrics: IncrementalCheckMetrics,
+) -> LaneEvidence {
+    LaneEvidence {
+        name,
+        duration_ms,
+        metrics: metrics.into(),
+    }
+}
+
+pub(super) fn write_artifact(repo_root: &Path, artifact: &Artifact) {
+    let output_dir = output_dir(repo_root);
+    fs::create_dir_all(&output_dir).expect("metrics directory should be created");
+    fs::write(
+        output_dir.join("metrics.json"),
+        serde_json::to_vec_pretty(artifact).expect("metrics should serialize"),
+    )
+    .expect("metrics JSON should write");
+
+    let mut summary = cstr!(
+        "# Vue Vben Admin batch incremental oracle\n\n| lane | duration (ms) | requested | changed | session reuse | fallback |\n| --- | ---: | ---: | ---: | ---: | ---: |\n",
+    );
+    for lane in &artifact.lanes {
+        append!(
+            summary,
+            "| {} | {} | {} | {} | {} | {} |\n",
+            lane.name,
+            lane.duration_ms,
+            lane.metrics.requested_files,
+            lane.metrics.changed_files,
+            lane.metrics.session_reuses,
+            lane.metrics.session_to_cli_fallbacks,
+        );
+    }
+    summary.push_str("\nDeterministic gates require one session start, two reuses, exact one-file warm deltas, and zero CLI fallbacks. Durations are independent hard ceilings.\n");
+    fs::write(output_dir.join("summary.md"), summary).expect("metrics summary should write");
+}
+
+fn output_dir(repo_root: &Path) -> PathBuf {
+    let path = std::env::var_os("VIZE_TIER_L_METRICS_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("target/vize-tests/metrics/vben-batch-incremental"));
+    if path.is_absolute() {
+        path
+    } else {
+        repo_root.join(path)
+    }
+}

--- a/crates/vize_canon/tests/tier_l_incremental.rs
+++ b/crates/vize_canon/tests/tier_l_incremental.rs
@@ -1,0 +1,315 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+use serde::Deserialize;
+use vize_canon::{
+    BatchTypeChecker, BatchTypeCheckerOptions, BatchTypeCheckerTrait, IncrementalCheckMetrics,
+};
+use vize_carton::{String, ToCompactString};
+
+#[path = "support/tier_l_incremental_artifact.rs"]
+mod artifact;
+use artifact::{Artifact, BatchIncrementalBudget, FixtureEvidence, lane, write_artifact};
+
+const FIXTURE_ID: &str = "vue-vben-admin";
+const TIER_L_VUE_FILES: usize = 500;
+const INJECTED_FILE: &str = "apps/web-antd/src/__vize_batch_incremental_oracle__.vue";
+const CLEAN_SOURCE: &str = r#"<script setup lang="ts">
+const __vizeBatchIncrementalOracle: number = 1;
+</script>
+
+<template><span>{{ __vizeBatchIncrementalOracle }}</span></template>
+"#;
+const BROKEN_SOURCE: &str = r#"<script setup lang="ts">
+const __vizeBatchIncrementalOracle: number = 'broken';
+</script>
+
+<template><span>{{ __vizeBatchIncrementalOracle }}</span></template>
+"#;
+
+#[derive(Deserialize)]
+struct Registry {
+    projects: Vec<RegistryProject>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RegistryProject {
+    id: String,
+    revision: String,
+    batch_incremental_budget: Option<BatchIncrementalBudget>,
+}
+
+struct InjectedFixtureFile(PathBuf);
+
+impl InjectedFixtureFile {
+    fn create(path: PathBuf) -> Self {
+        assert!(!path.exists(), "injected fixture path must start absent");
+        fs::write(&path, CLEAN_SOURCE).expect("clean fixture source should write");
+        Self(path)
+    }
+
+    fn write(&self, source: &str) {
+        fs::write(&self.0, source).expect("fixture patch should write");
+    }
+}
+
+impl Drop for InjectedFixtureFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+#[test]
+#[ignore = "runs the pinned Tier-L fixture in the per-PR Vue parity lane"]
+fn vben_batch_incremental_session_reuses_exact_materialized_delta() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let registry_path = repo_root.join("tests/_fixtures/vue-ecosystem-fixtures.json");
+    let registry: Registry = serde_json::from_slice(
+        &fs::read(registry_path).expect("fixture registry should be readable"),
+    )
+    .expect("fixture registry should parse");
+    let project = registry
+        .projects
+        .into_iter()
+        .find(|project| project.id == FIXTURE_ID)
+        .expect("Vben fixture must be registered");
+    let budget = project
+        .batch_incremental_budget
+        .expect("Vben must own a batchIncrementalBudget");
+    assert_budget(&budget);
+
+    let fixture_root = env_path("VIZE_TIER_L_FIXTURE", &repo_root)
+        .unwrap_or_else(|| repo_root.join("tests/_fixtures/_git/vue-vben-admin"))
+        .canonicalize()
+        .expect("Tier-L fixture path should canonicalize");
+    assert_eq!(
+        git_revision(&fixture_root),
+        project.revision,
+        "fixture revision drift"
+    );
+    let corsa_path = env_path("VIZE_TIER_L_CORSA_BIN", &repo_root)
+        .unwrap_or_else(|| repo_root.join("node_modules/.bin/tsgo"));
+    assert!(
+        corsa_path.exists(),
+        "Corsa binary is missing: {}",
+        corsa_path.display()
+    );
+
+    let injected_path = fixture_root.join(INJECTED_FILE);
+    let injected = InjectedFixtureFile::create(injected_path.clone());
+    let options = BatchTypeCheckerOptions {
+        tsconfig_path: Some(fixture_root.join("playground/tsconfig.json")),
+        ..Default::default()
+    };
+    let mut checker =
+        BatchTypeChecker::with_options_and_corsa_path(&fixture_root, options, Some(&corsa_path))
+            .expect("Tier-L checker should start");
+
+    let cold_started = Instant::now();
+    let vue_paths = collect_vue_paths(&fixture_root);
+    checker
+        .scan_paths(&vue_paths)
+        .expect("Tier-L scan should succeed");
+    assert!(
+        checker.file_count() == TIER_L_VUE_FILES,
+        "fixture must remain Tier-L scale"
+    );
+    let cold = checker
+        .check_incremental(std::slice::from_ref(&injected_path))
+        .expect("cold incremental session should complete");
+    let cold_ms = cold_started.elapsed().as_millis();
+    assert_no_injected_diagnostics(&cold);
+    let cold_metrics = checker.incremental_metrics();
+    assert_cold_metrics(cold_metrics, &budget);
+    assert_within_budget("cold", cold_ms, budget.cold_ms);
+
+    injected.write(BROKEN_SOURCE);
+    let broken_started = Instant::now();
+    let broken = checker
+        .check_incremental(std::slice::from_ref(&injected_path))
+        .expect("broken warm check should complete");
+    let broken_ms = broken_started.elapsed().as_millis();
+    let injected_errors = broken
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.file.file_name().and_then(|name| name.to_str())
+                == Some("__vize_batch_incremental_oracle__.vue")
+                && diagnostic.code == Some(2322)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        injected_errors.len(),
+        1,
+        "broken patch must report exactly one injected TS2322"
+    );
+    assert_eq!((injected_errors[0].line, injected_errors[0].column), (1, 6));
+    assert!(
+        injected_errors[0]
+            .message
+            .contains("not assignable to type 'number'"),
+        "unexpected injected TS2322: {}",
+        injected_errors[0].message
+    );
+    let broken_metrics = checker.incremental_metrics();
+    assert_warm_metrics(broken_metrics, 2, 1, &budget);
+    assert_within_budget("broken warm", broken_ms, budget.warm_ms);
+
+    injected.write(CLEAN_SOURCE);
+    let repaired_started = Instant::now();
+    let repaired = checker
+        .check_incremental(std::slice::from_ref(&injected_path))
+        .expect("repaired warm check should complete");
+    let repaired_ms = repaired_started.elapsed().as_millis();
+    assert_no_injected_diagnostics(&repaired);
+    let repaired_metrics = checker.incremental_metrics();
+    assert_warm_metrics(repaired_metrics, 3, 2, &budget);
+    assert_within_budget("repaired warm", repaired_ms, budget.warm_ms);
+
+    let artifact = Artifact {
+        schema_version: 1,
+        fixture: FixtureEvidence {
+            id: FIXTURE_ID,
+            revision: project.revision,
+            injected_file: INJECTED_FILE,
+        },
+        budget,
+        file_count: checker.file_count(),
+        lanes: vec![
+            lane("cold", cold_ms, cold_metrics),
+            lane("brokenWarm", broken_ms, broken_metrics),
+            lane("repairedWarm", repaired_ms, repaired_metrics),
+        ],
+    };
+    write_artifact(&repo_root, &artifact);
+}
+
+fn env_path(name: &str, repo_root: &Path) -> Option<PathBuf> {
+    std::env::var_os(name).map(|value| {
+        let path = PathBuf::from(value);
+        if path.is_absolute() {
+            path
+        } else {
+            repo_root.join(path)
+        }
+    })
+}
+
+fn git_revision(root: &Path) -> String {
+    let output = Command::new("git")
+        .args([
+            "-C",
+            root.to_str().expect("UTF-8 fixture path"),
+            "rev-parse",
+            "HEAD",
+        ])
+        .output()
+        .expect("git should inspect the fixture");
+    assert!(output.status.success(), "fixture revision lookup failed");
+    std::str::from_utf8(&output.stdout)
+        .expect("revision should be UTF-8")
+        .trim()
+        .to_compact_string()
+}
+
+fn collect_vue_paths(fixture_root: &Path) -> Vec<PathBuf> {
+    let mut paths = ["apps", "packages", "playground"]
+        .into_iter()
+        .flat_map(|relative| walkdir::WalkDir::new(fixture_root.join(relative)))
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_file())
+        .map(walkdir::DirEntry::into_path)
+        .filter(|path| path.extension().and_then(|extension| extension.to_str()) == Some("vue"))
+        .collect::<Vec<_>>();
+    paths.sort();
+    assert!(
+        paths.len() > TIER_L_VUE_FILES,
+        "pinned fixture fell below Tier-L scale"
+    );
+    paths.truncate(TIER_L_VUE_FILES);
+    assert!(paths.iter().any(|path| path.ends_with(INJECTED_FILE)));
+    paths
+}
+
+fn assert_budget(budget: &BatchIncrementalBudget) {
+    assert!((1..=300_000).contains(&budget.cold_ms));
+    assert!((1..=budget.cold_ms).contains(&budget.warm_ms));
+    assert!((1..=10_000).contains(&budget.max_requested_files));
+    assert_eq!(
+        budget.max_changed_files, 1,
+        "one edited SFC must remain the delta budget"
+    );
+}
+
+fn assert_no_injected_diagnostics(result: &vize_canon::BatchTypeCheckResult) {
+    assert!(
+        result.diagnostics.iter().all(|diagnostic| {
+            diagnostic.file.file_name().and_then(|name| name.to_str())
+                != Some("__vize_batch_incremental_oracle__.vue")
+        }),
+        "clean source retained injected-file diagnostics"
+    );
+}
+
+fn assert_cold_metrics(metrics: IncrementalCheckMetrics, budget: &BatchIncrementalBudget) {
+    assert_eq!((metrics.checks, metrics.session_starts), (1, 1));
+    assert_eq!((metrics.session_reuses, metrics.session_refreshes), (0, 0));
+    assert_eq!(metrics.session_to_cli_fallbacks, 0);
+    assert!(metrics.last_session_started);
+    assert!(!metrics.last_session_to_cli_fallback);
+    assert_eq!(
+        (
+            metrics.last_changed_files,
+            metrics.last_created_files,
+            metrics.last_deleted_files
+        ),
+        (0, 0, 0)
+    );
+    assert_requested_budget(metrics, budget);
+}
+
+fn assert_warm_metrics(
+    metrics: IncrementalCheckMetrics,
+    checks: usize,
+    reuses: usize,
+    budget: &BatchIncrementalBudget,
+) {
+    assert_eq!((metrics.checks, metrics.session_starts), (checks, 1));
+    assert_eq!(
+        (metrics.session_reuses, metrics.session_refreshes),
+        (reuses, reuses)
+    );
+    assert_eq!(metrics.session_to_cli_fallbacks, 0);
+    assert!(metrics.last_session_reused && metrics.last_session_refreshed);
+    assert!(!metrics.last_session_to_cli_fallback);
+    assert_eq!(metrics.last_changed_files, budget.max_changed_files);
+    assert_eq!(
+        (metrics.last_created_files, metrics.last_deleted_files),
+        (0, 0)
+    );
+    assert_requested_budget(metrics, budget);
+}
+
+fn assert_requested_budget(metrics: IncrementalCheckMetrics, budget: &BatchIncrementalBudget) {
+    assert!(metrics.last_requested_files > 0);
+    assert_eq!(
+        metrics.last_requested_files, budget.max_requested_files,
+        "the pinned Tier-L corpus must request every registered Vue file"
+    );
+    assert!(
+        metrics.last_requested_files <= budget.max_requested_files,
+        "requested {} files, budget is {}",
+        metrics.last_requested_files,
+        budget.max_requested_files
+    );
+}
+
+fn assert_within_budget(lane: &str, elapsed_ms: u128, budget_ms: u64) {
+    assert!(
+        elapsed_ms < u128::from(budget_ms),
+        "{lane} took {elapsed_ms}ms, budget is {budget_ms}ms"
+    );
+}

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -58,6 +58,12 @@
       "batchCheckBudget": {
         "coldMs": 15000,
         "warmMs": 10000
+      },
+      "batchIncrementalBudget": {
+        "coldMs": 15000,
+        "warmMs": 10000,
+        "maxRequestedFiles": 500,
+        "maxChangedFiles": 1
       }
     },
     {

--- a/tests/tooling/batch-incremental-budget.test.ts
+++ b/tests/tooling/batch-incremental-budget.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const registry = JSON.parse(
+  fs.readFileSync(path.join(root, "tests/_fixtures/vue-ecosystem-fixtures.json"), "utf8"),
+) as {
+  projects: Array<{
+    id: string;
+    batchIncrementalBudget?: {
+      coldMs: number;
+      warmMs: number;
+      maxRequestedFiles: number;
+      maxChangedFiles: number;
+    };
+  }>;
+};
+
+test("Vben owns the Tier-L batch incremental work budget", () => {
+  const owners = registry.projects.filter((project) => project.batchIncrementalBudget != null);
+  assert.deepEqual(
+    owners.map((project) => project.id),
+    ["vue-vben-admin"],
+  );
+  assert.deepEqual(owners[0].batchIncrementalBudget, {
+    coldMs: 15_000,
+    warmMs: 10_000,
+    maxRequestedFiles: 500,
+    maxChangedFiles: 1,
+  });
+});
+
+test("the Tier-L oracle gates deterministic incremental work and emits evidence", () => {
+  const source = [
+    "crates/vize_canon/tests/tier_l_incremental.rs",
+    "crates/vize_canon/tests/support/tier_l_incremental_artifact.rs",
+  ]
+    .map((file) => fs.readFileSync(path.join(root, file), "utf8"))
+    .join("\n");
+  assert.match(source, /check_incremental/);
+  assert.match(source, /session_to_cli_fallbacks, 0/);
+  assert.match(source, /last_changed_files, budget\.max_changed_files/);
+  assert.match(source, /last_requested_files <= budget\.max_requested_files/);
+  assert.match(source, /metrics\.json/);
+  assert.match(source, /summary\.md/);
+  assert.doesNotMatch(source, /broken_ms\s*[<>]=?\s*cold_ms/);
+  assert.doesNotMatch(source, /repaired_ms\s*[<>]=?\s*cold_ms/);
+});

--- a/tests/tooling/github-workflows-vue-parity.test.ts
+++ b/tests/tooling/github-workflows-vue-parity.test.ts
@@ -115,6 +115,20 @@ test("Vue parity structurally gates compiler fixtures and incremental LSP behavi
     "the per-PR batch repair oracle must run every registered app",
   );
 
+  const batchIncremental = steps.find(
+    (step) => step.name === "Check Tier-L batch incremental session reuse",
+  );
+  assert.deepEqual(batchIncremental?.env, {
+    VIZE_TIER_L_FIXTURE: "tests/_fixtures/_git/vue-vben-admin",
+    VIZE_TIER_L_CORSA_BIN: "node_modules/.bin/tsgo",
+    VIZE_TIER_L_METRICS_DIR: "target/vize-tests/metrics/vben-batch-incremental",
+    VIZE_RUNTIME_NODE_MODULES: "node_modules",
+  });
+  assert.equal(
+    batchIncremental?.run,
+    "cargo test --locked --profile ci -p vize_canon --test tier_l_incremental -- --ignored --nocapture",
+  );
+
   const glyphProperties = steps.find(
     (step) => step.name === "Check glyph formatter corpus properties",
   );
@@ -141,12 +155,13 @@ test("Vue parity structurally gates compiler fixtures and incremental LSP behavi
   assert.equal(summary?.if, "${{ always() }}");
   assert.match(
     summary?.run ?? "",
-    /misskey-lsp-incremental vben-lsp-incremental misskey-lsp-churn/,
+    /vben-batch-incremental misskey-lsp-incremental vben-lsp-incremental misskey-lsp-churn/,
   );
   assert.match(summary?.run ?? "", /summary\.md/);
   assert.match(summary?.run ?? "", /GITHUB_STEP_SUMMARY/);
 
   const uploads: Array<[stepName: string, suiteDir: string]> = [
+    ["Upload Vue Vben Admin batch incremental metrics", "vben-batch-incremental"],
     ["Upload Misskey incremental LSP metrics", "misskey-lsp-incremental"],
     ["Upload Vue Vben Admin incremental LSP metrics", "vben-lsp-incremental"],
     ["Upload Misskey churn LSP metrics", "misskey-lsp-churn"],


### PR DESCRIPTION
## Summary

- run the Corsa-facing BatchTypeChecker incremental API against a pinned 500-SFC Vue Vben Admin corpus in the per-PR parity lane
- fail closed on exact requested work, one-file warm deltas, session start/reuse/refresh counts, and any Session-to-CLI fallback
- publish JSON and Markdown evidence with independent cold/warm hard ceilings owned by the fixture registry
- cover the CI wiring, budget ownership, deterministic gates, and artifact contract with tooling tests

This completes the issue-body Corsa-facing option after #3819 exposed per-check metrics. It intentionally does not fabricate an in-tree production caller.

## Verification

- VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon
- cargo clippy -p vize_canon --lib -- -D warnings
- cargo clippy -p vize_canon --test tier_l_incremental -- -D warnings
- node --test --test-concurrency=1 tests/tooling/batch-incremental-budget.test.ts tests/tooling/github-workflows-vue-parity.test.ts tests/tooling/batch-check-budgets.test.ts
- CI-profile Tier-L oracle repeated locally: 500 requested files, one-file warm deltas, two session reuses, zero CLI fallbacks

Closes #3739