### PR TITLE
fix(doctor): reject malformed script sources

### DIFF
--- a/crates/vize/src/commands/doctor.rs
+++ b/crates/vize/src/commands/doctor.rs
@@ -76,6 +76,15 @@ enum DoctorError {
         path: PathBuf,
         message: String,
     },
+    ParseScriptModule {
+        path: PathBuf,
+        message: String,
+    },
+    ParseSfcScript {
+        path: PathBuf,
+        block: &'static str,
+        message: String,
+    },
     Analysis(ApplicationAnalysisError),
     Serialize(serde_json::Error),
     Write(io::Error),
@@ -115,6 +124,24 @@ impl fmt::Display for DoctorError {
                 write!(
                     formatter,
                     "cannot parse component {}: {message}",
+                    path.display()
+                )
+            }
+            Self::ParseScriptModule { path, message } => {
+                write!(
+                    formatter,
+                    "cannot parse script module {}: {message}",
+                    path.display()
+                )
+            }
+            Self::ParseSfcScript {
+                path,
+                block,
+                message,
+            } => {
+                write!(
+                    formatter,
+                    "cannot parse component {block} {}: {message}",
                     path.display()
                 )
             }

--- a/crates/vize/src/commands/doctor/analysis.rs
+++ b/crates/vize/src/commands/doctor/analysis.rs
@@ -1,5 +1,8 @@
 //! Whole-project graph construction with authored SFC coordinate recovery.
 
+use oxc_allocator::Allocator as OxcAllocator;
+use oxc_parser::Parser as OxcParser;
+use oxc_span::SourceType;
 use std::path::Path;
 use vize_armature::Parser;
 use vize_atelier_sfc::{
@@ -7,7 +10,7 @@ use vize_atelier_sfc::{
     croquis::{SfcCroquisOptions, analyze_sfc_descriptor_with_context},
     parse_sfc,
 };
-use vize_carton::{Allocator, FxHashMap};
+use vize_carton::{Allocator, FxHashMap, String, ToCompactString};
 use vize_croquis::{EffectGraphScript, build_effect_graph_from_sfc_scripts};
 use vize_croquis_cf::{CrossFileAnalyzer, CrossFileDiagnosticKind, CrossFileOptions, FileId};
 use vize_doctor::{
@@ -55,6 +58,7 @@ pub(super) fn analyze_application(
                 public_sfc,
             )?;
         } else {
+            validate_script_module(source)?;
             analyzer.add_file(&source.path, source.source.as_str());
         }
     }
@@ -95,6 +99,22 @@ fn add_sfc(
         path: source.path.clone(),
         message: error.message,
     })?;
+    if let Some(script) = descriptor.script.as_ref() {
+        validate_sfc_script(
+            source,
+            "script",
+            script.content.as_ref(),
+            script.lang.as_deref(),
+        )?;
+    }
+    if let Some(script) = descriptor.script_setup.as_ref() {
+        validate_sfc_script(
+            source,
+            "script setup",
+            script.content.as_ref(),
+            script.lang.as_deref(),
+        )?;
+    }
     if public_sfc && let Some(finding) = canonical_sfc::finding(&doctor_path, &descriptor) {
         public_sfc_findings.push(finding);
     }
@@ -131,6 +151,53 @@ fn add_sfc(
     );
     source_maps.insert(file_id, SfcSourceMap::from_descriptor(&descriptor));
     Ok(())
+}
+
+fn validate_script_module(source: &DoctorSource) -> Result<(), DoctorError> {
+    let source_type = SourceType::from_path(&source.path).unwrap_or_else(|_| SourceType::ts());
+    if let Some(message) = script_parse_error(source.source.as_str(), source_type) {
+        return Err(DoctorError::ParseScriptModule {
+            path: source.path.clone(),
+            message,
+        });
+    }
+    Ok(())
+}
+
+fn validate_sfc_script(
+    source: &DoctorSource,
+    block: &'static str,
+    script: &str,
+    lang: Option<&str>,
+) -> Result<(), DoctorError> {
+    let source_type = match lang.map(str::trim) {
+        Some(lang) if lang.eq_ignore_ascii_case("jsx") => SourceType::jsx(),
+        Some(lang) if lang.eq_ignore_ascii_case("tsx") => SourceType::tsx(),
+        Some(lang) if lang.eq_ignore_ascii_case("ts") => SourceType::ts(),
+        _ => SourceType::from_path("script.js").unwrap_or_default(),
+    };
+    if let Some(message) = script_parse_error(script, source_type) {
+        return Err(DoctorError::ParseSfcScript {
+            path: source.path.clone(),
+            block,
+            message,
+        });
+    }
+    Ok(())
+}
+
+fn script_parse_error(source: &str, source_type: SourceType) -> Option<String> {
+    let allocator = OxcAllocator::default();
+    let parsed = OxcParser::new(&allocator, source, source_type).parse();
+    parsed
+        .diagnostics
+        .first()
+        .map(ToCompactString::to_compact_string)
+        .or_else(|| {
+            parsed
+                .panicked
+                .then(|| "parser panicked while parsing source".into())
+        })
 }
 
 impl SfcSourceMap {

--- a/crates/vize/tests/doctor_cli.rs
+++ b/crates/vize/tests/doctor_cli.rs
@@ -88,6 +88,69 @@ fn malformed_components_cannot_produce_a_healthy_report() {
 }
 
 #[test]
+fn malformed_script_modules_cannot_produce_a_healthy_report() {
+    let directory = tempfile::tempdir().unwrap();
+    write(
+        directory.path(),
+        "src/broken.ts",
+        "export const answer: number =",
+    );
+
+    let output = doctor(directory.path(), &["src", "--format", "json"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("cannot parse script module"));
+    assert!(output.stdout.is_empty());
+}
+
+#[test]
+fn malformed_sfc_scripts_cannot_produce_a_healthy_report() {
+    let directory = tempfile::tempdir().unwrap();
+    write(
+        directory.path(),
+        "src/Broken.vue",
+        "<script setup lang=\"ts\">const answer: number =</script>\n<template><p /></template>",
+    );
+
+    let output = doctor(directory.path(), &["src", "--format", "json"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("cannot parse component script"));
+    assert!(output.stdout.is_empty());
+}
+
+#[test]
+fn valid_script_module_dialects_remain_supported() {
+    let directory = tempfile::tempdir().unwrap();
+    for (path, source) in [
+        ("src/value.js", "export const value = 1"),
+        ("src/component.jsx", "export const View = () => <div />"),
+        ("src/value.ts", "export const value: number = 1"),
+        (
+            "src/component.tsx",
+            "export const View = () => <div data-value={1} />",
+        ),
+        ("src/value.mjs", "export const value = 1"),
+        ("src/value.cjs", "module.exports = { value: 1 }"),
+        ("src/value.mts", "export const value: number = 1"),
+        ("src/value.cts", "module.exports = { value: 1 as number }"),
+    ] {
+        write(directory.path(), path, source);
+    }
+    write(
+        directory.path(),
+        "src/TsxComponent.vue",
+        "<script setup lang=\"tsx\">const View = () => <div /></script>\n<template><View /></template>",
+    );
+
+    let output = doctor(directory.path(), &["src", "--format", "json"]);
+    let report: DoctorReport = serde_json::from_slice(&output.stdout).unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(report.summary().counts.total(), 0);
+}
+
+#[test]
 fn public_sfc_contract_is_explicit_and_source_accurate() {
     let directory = tempfile::tempdir().unwrap();
     let source = "<script setup>const label = 'Save'</script>\n\

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -240,8 +240,8 @@ initial analyzers cover dependency injection, unique element IDs, server/client 
 reactivity flow, asynchronous mutation risks, setup-context ownership, and circular imports; Vue
 diagnostics map back to byte offsets in the authored `.vue` file, including components with both
 `<script>` and `<script setup>`. Discovery follows source-control ignore files, rejects inputs
-outside the declared workspace, fails closed when a component cannot be parsed, and never writes
-source files.
+outside the declared workspace, fails closed when a component or script module cannot be parsed,
+and never writes source files.
 
 Key options:
 


### PR DESCRIPTION
## Summary

- fail closed when standalone JavaScript or TypeScript modules contain parser diagnostics
- validate both `<script>` and `<script setup>` blocks before building Doctor findings
- preserve all supported JS, JSX, TS, TSX, MJS, CJS, MTS, and CTS dialects

Refs #3138

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p vize --test doctor_cli -- --nocapture`
- `cargo test -p vize doctor -- --nocapture`
- `cargo clippy -p vize --lib --bin vize -- -D warnings`
- `cargo test -p vize_doctor --features application-analysis`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added parsing validation for JavaScript and TypeScript modules, including SFC script blocks.
  * Reports clear errors with the affected file and script block when parsing fails.
  * Supports JS, JSX, TS, TSX, MJS, CJS, MTS, and CTS files.

* **Bug Fixes**
  * Prevents analysis from continuing when source files cannot be parsed.

* **Documentation**
  * Clarified `vize doctor` discovery and failure behavior for unparseable files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->