### PR TITLE
fix(ui): parse SFC authoring sections semantically

### DIFF
--- a/npm/ui/tooling/authoring-gate.test.ts
+++ b/npm/ui/tooling/authoring-gate.test.ts
@@ -142,3 +142,66 @@ void test("rejects SFCs that bypass the explicit authoring contract", async () =
     },
   );
 });
+
+void test("accepts semantic block attributes and a companion script", async () => {
+  const sfc = COMPLIANT_SFC.replace(
+    '<script setup lang="ts">',
+    '<script>export const version = 1;</script>\n<script lang="ts" setup>',
+  ).replace("<style scoped>", '<style lang="css" scoped>');
+  await withFixture(
+    {
+      "TheWidget.vue": sfc,
+      "widget.behavior.md": "TheWidget.vue",
+      "widget.test.ts": 'import TheWidget from "./TheWidget.vue";\nexport default TheWidget;\n',
+    },
+    async (directory) => {
+      assert.deepEqual(await auditComponentAuthoring(directory), []);
+    },
+  );
+});
+
+void test("does not accept canonical section spellings in inert script text", async () => {
+  const sfc = `<script setup lang="ts">
+const fakeSections = "<template></template><style scoped></style>";
+</script>
+`;
+  await withFixture(
+    {
+      "TheWidget.vue": sfc,
+      "widget.behavior.md": "TheWidget.vue",
+      "widget.test.ts": 'import TheWidget from "./TheWidget.vue";\nexport default TheWidget;\n',
+    },
+    async (directory) => {
+      const violations = await auditComponentAuthoring(directory);
+      assert.deepEqual(
+        violations.map((violation) => violation.rule),
+        ["explicit-sfc", "explicit-sfc"],
+      );
+      const report = formatAuthoringViolations(violations);
+      assert.match(report, /Missing <template> block/);
+      assert.match(report, /Missing <style scoped> block/);
+    },
+  );
+});
+
+void test("rejects malformed SFC section structure", async () => {
+  const sfc = COMPLIANT_SFC.replace(
+    "</template>",
+    "</template>\n<template><p>Duplicate</p></template>",
+  );
+  await withFixture(
+    {
+      "TheWidget.vue": sfc,
+      "widget.behavior.md": "TheWidget.vue",
+      "widget.test.ts": 'import TheWidget from "./TheWidget.vue";\nexport default TheWidget;\n',
+    },
+    async (directory) => {
+      const violations = await auditComponentAuthoring(directory);
+      assert.deepEqual(
+        violations.map((violation) => violation.rule),
+        ["explicit-sfc"],
+      );
+      assert.match(formatAuthoringViolations(violations), /SFC source has 1 parse error\(s\)/);
+    },
+  );
+});

--- a/npm/ui/tooling/authoring-gate.ts
+++ b/npm/ui/tooling/authoring-gate.ts
@@ -1,6 +1,8 @@
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
+import { parse } from "@vue/compiler-sfc";
+
 /** Rule identifiers enforced by the component authoring gate. */
 export type AuthoringRule =
   | "behavior-table"
@@ -60,7 +62,7 @@ export async function auditComponentAuthoring(
     const basename = path.basename(sfc);
     const source = await read(sfc);
 
-    for (const message of explicitSfcProblems(source)) report(sfc, "explicit-sfc", message);
+    for (const message of explicitSfcProblems(source, sfc)) report(sfc, "explicit-sfc", message);
 
     if (!behaviorSources.some((table) => table.includes(basename))) {
       report(
@@ -111,15 +113,22 @@ export function formatAuthoringViolations(violations: readonly AuthoringViolatio
     .join("\n");
 }
 
-function explicitSfcProblems(source: string): string[] {
+function explicitSfcProblems(source: string, filename: string): string[] {
+  const { descriptor, errors } = parse(source, { filename });
   const problems: string[] = [];
-  if (!source.includes('<script setup lang="ts">')) {
+  if (errors.length > 0) problems.push(`SFC source has ${errors.length} parse error(s)`);
+  if (descriptor.scriptSetup?.lang !== "ts") {
     problems.push('Missing <script setup lang="ts"> block');
   }
-  if (!source.includes("<template>")) problems.push("Missing <template> block");
-  if (!source.includes("<style scoped>")) problems.push("Missing <style scoped> block");
-  if (/\bh\s*\(/.test(source)) problems.push("Render-function escape hatch h() is not allowed");
-  if (/defineOptions|withDefaults|interface (?:Props|Emits)/.test(source)) {
+  if (descriptor.template === null) problems.push("Missing <template> block");
+  if (!descriptor.styles.some((style) => style.scoped)) {
+    problems.push("Missing <style scoped> block");
+  }
+  const scripts = [descriptor.script?.content, descriptor.scriptSetup?.content]
+    .filter((script): script is string => script !== undefined)
+    .join("\n");
+  if (/\bh\s*\(/.test(scripts)) problems.push("Render-function escape hatch h() is not allowed");
+  if (/defineOptions|withDefaults|interface (?:Props|Emits)/.test(scripts)) {
     problems.push("Use literal defineProps/defineEmits types without helper indirection");
   }
   return problems;

--- a/npm/ui/tooling/package.json
+++ b/npm/ui/tooling/package.json
@@ -14,6 +14,9 @@
     "fmt": "vp fmt --write authoring-gate.ts authoring-gate.test.ts lint-sfc.ts lint-sfc.test.ts",
     "test": "vp exec node --test authoring-gate.test.ts lint-sfc.test.ts"
   },
+  "dependencies": {
+    "@vue/compiler-sfc": "catalog:vue-stable"
+  },
   "devDependencies": {
     "@types/node": "catalog:typescript",
     "vite-plus": "catalog:vite-stack"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,9 @@ catalogs:
     '@vue/compiler-dom':
       specifier: 3.5.35
       version: 3.5.35
+    '@vue/compiler-sfc':
+      specifier: 3.5.35
+      version: 3.5.35
     '@vue/runtime-core':
       specifier: 3.5.35
       version: 3.5.35
@@ -999,6 +1002,10 @@ importers:
         version: 3.5.35(typescript@6.0.3)
 
   npm/ui/tooling:
+    dependencies:
+      '@vue/compiler-sfc':
+        specifier: catalog:vue-stable
+        version: 3.5.35
     devDependencies:
       '@types/node':
         specifier: catalog:typescript

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -98,6 +98,7 @@ catalogs:
   vue-stable:
     vue: "3.5.35"
     "@vue/compiler-dom": "3.5.35"
+    "@vue/compiler-sfc": "3.5.35"
     "@vue/runtime-core": "3.5.35"
     "@vue/test-utils": "2.4.10"
     vue-router: "4.5.1"


### PR DESCRIPTION
## Summary

- parse public SFC sections through the stable Vue SFC descriptor instead of matching exact source spellings
- accept semantic attribute order and companion scripts consistently with the existing Doctor public-SFC gate
- reject required-section spellings hidden inside script text and malformed duplicate sections
- keep render-function and helper-indirection checks scoped to authored script blocks

## Root cause

The UI authoring gate used raw `String.includes` checks for exact opening tags. That rejected valid equivalent syntax such as `<script lang="ts" setup>` while inert strings containing `<template>` and `<style scoped>` could satisfy the gate.

## Verification

- `vp install --frozen-lockfile --prefer-offline`
- `vp run --filter @vizejs/ui-tooling test` (10 tests)
- `vp run --filter @vizejs/ui test` (45 tests plus package and size gates)
- `vp run --filter @vizejs/ui-tooling check`
- `vp run --filter @vizejs/ui check`
- `node --test tests/tooling/package-manifests.test.ts` (17 tests)

Part of #3134

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->