### PR TITLE
fix(canon): preserve scoped event implicit any

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/global_component_callbacks.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/global_component_callbacks.rs
@@ -13,6 +13,7 @@ declare module "vue" {
     MkSuspense: DefineComponent<{
       onResolved?: (result: { file: string }) => void
     }>
+    UnresolvedSuspense: DefineComponent
   }
 }
 "#;
@@ -115,6 +116,40 @@ fn unknown_global_component_array_callbacks_remain_implicit_any() {
             vize_carton::String::from("src/App.vue"),
             Some(7006),
             vize_carton::String::from("2:27:error Parameter 'value' implicitly has an 'any' type.",),
+        )]),
+    );
+}
+
+#[test]
+fn ambient_global_component_unresolved_event_callbacks_remain_implicit_any() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "ambient-global-component-unresolved-event-callback",
+        &[
+            ("src/global-components.d.ts", GLOBAL_COMPONENTS),
+            (
+                "src/App.vue",
+                r#"<template>
+  <UnresolvedSuspense v-slot="{ result }" @resolved="(result) => result.file" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let snapshot = snapshot_project_diagnostics(&project_root);
+    let _ = std::fs::remove_dir_all(&project_root);
+
+    assert_eq!(
+        snapshot,
+        Some(vec![(
+            vize_carton::String::from("src/App.vue"),
+            Some(7006),
+            vize_carton::String::from(
+                "2:55:error Parameter 'result' implicitly has an 'any' type."
+            ),
         )]),
     );
 }

--- a/crates/vize_canon/src/virtual_ts/scope/component_events.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events.rs
@@ -150,20 +150,12 @@ pub(super) fn generate_component_event_types(
             "unknown[] extends {args_type} ? ((...args: any[]) => unknown) : ((...args: {listener_args_type}) => unknown)"
         )
     };
-    let (handler_type, handler_type_expr) = if !legacy_vue2
-        && requires_unresolved_handler_implicit_any(summary, component_name, data, scope)
-    {
-        (
-            Some(cstr!(
-                "__{component_type_name}_{scope_id}_{safe_event_name}_handler"
-            )),
-            Some(cstr!(
-                "unknown[] extends {args_type} ? unknown : {listener_type}"
-            )),
-        )
-    } else {
-        (None, None)
-    };
+    let handler_type_expr = (!legacy_vue2
+        && requires_unresolved_handler_implicit_any(summary, component_name, data, scope))
+    .then(|| cstr!("unknown[] extends {args_type} ? unknown : {listener_type}"));
+    let handler_type = handler_type_expr
+        .as_ref()
+        .map(|_| cstr!("__{component_type_name}_{scope_id}_{safe_event_name}_handler"));
     Some(ComponentEventTypes {
         event_type,
         handler_type,

--- a/crates/vize_canon/src/virtual_ts/scope/component_events.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events.rs
@@ -1,5 +1,8 @@
 //! Component event listener type generation.
 
+mod handler_context;
+mod reference;
+
 use vize_carton::{FxHashSet, String, append, cstr};
 use vize_croquis::croquis::PassedProp;
 use vize_croquis::{
@@ -11,9 +14,13 @@ use crate::virtual_ts::{
     expressions::rewrite_reserved_template_prop,
     helpers::{to_camel_case, to_safe_identifier, to_safe_identifier_fragment},
 };
+use handler_context::requires_unresolved_handler_implicit_any;
+use reference::component_reference_expression;
 
 pub(super) struct ComponentEventTypes {
     pub(super) event_type: String,
+    pub(super) handler_type: Option<String>,
+    pub(super) handler_type_expr: Option<String>,
     pub(super) listener_type: String,
     pub(super) listener_type_expr: String,
 }
@@ -143,23 +150,27 @@ pub(super) fn generate_component_event_types(
             "unknown[] extends {args_type} ? ((...args: any[]) => unknown) : ((...args: {listener_args_type}) => unknown)"
         )
     };
+    let (handler_type, handler_type_expr) = if !legacy_vue2
+        && requires_unresolved_handler_implicit_any(summary, component_name, data, scope)
+    {
+        (
+            Some(cstr!(
+                "__{component_type_name}_{scope_id}_{safe_event_name}_handler"
+            )),
+            Some(cstr!(
+                "unknown[] extends {args_type} ? unknown : {listener_type}"
+            )),
+        )
+    } else {
+        (None, None)
+    };
     Some(ComponentEventTypes {
         event_type,
+        handler_type,
+        handler_type_expr,
         listener_type,
         listener_type_expr,
     })
-}
-
-fn component_reference_expression(name: &str) -> String {
-    if name.split('.').all(|segment| {
-        let mut bytes = segment.bytes();
-        matches!(bytes.next(), Some(b'_' | b'$' | b'a'..=b'z' | b'A'..=b'Z'))
-            && bytes.all(|byte| byte == b'_' || byte == b'$' || byte.is_ascii_alphanumeric())
-    }) {
-        String::from(name)
-    } else {
-        to_safe_identifier(name)
-    }
 }
 
 struct EmitInferenceContext<'a> {

--- a/crates/vize_canon/src/virtual_ts/scope/component_events/handler_context.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events/handler_context.rs
@@ -1,0 +1,24 @@
+use vize_croquis::{Croquis, EventHandlerScopeData, Scope};
+
+use super::find_component_usage_for_event;
+
+pub(super) fn requires_unresolved_handler_implicit_any(
+    summary: &Croquis,
+    component_name: &str,
+    data: &EventHandlerScopeData,
+    scope: &Scope,
+) -> bool {
+    let Some((_, usage)) = find_component_usage_for_event(summary, component_name, data, scope)
+    else {
+        return false;
+    };
+
+    usage.slots.iter().any(|slot| {
+        slot.has_scope
+            && slot.scope_vars.iter().any(|slot_var| {
+                data.param_names
+                    .iter()
+                    .any(|param| param.as_str() == slot_var.as_str())
+            })
+    })
+}

--- a/crates/vize_canon/src/virtual_ts/scope/component_events/reference.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events/reference.rs
@@ -1,0 +1,15 @@
+use vize_carton::String;
+
+use crate::virtual_ts::helpers::to_safe_identifier;
+
+pub(super) fn component_reference_expression(name: &str) -> String {
+    if name.split('.').all(|segment| {
+        let mut bytes = segment.bytes();
+        matches!(bytes.next(), Some(b'_' | b'$' | b'a'..=b'z' | b'A'..=b'Z'))
+            && bytes.all(|byte| byte == b'_' || byte == b'$' || byte.is_ascii_alphanumeric())
+    }) {
+        String::from(name)
+    } else {
+        to_safe_identifier(name)
+    }
+}

--- a/crates/vize_canon/src/virtual_ts/scope/context.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/context.rs
@@ -75,6 +75,7 @@ pub(super) struct EventHandlerExprContext<'a> {
     /// so template-binding checks remain valid and parseable.
     pub(super) check_emits: bool,
     pub(super) event_type: &'a str,
+    pub(super) event_handler_type: Option<&'a str>,
     /// For component `@event` handlers, the synthesized listener type
     /// (e.g. `__Child_1_test_listener`) that captures the full emit argument
     /// tuple (or the single `$event` fallback when the emit stays unresolved).

--- a/crates/vize_canon/src/virtual_ts/scope/event_handler.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/event_handler.rs
@@ -72,6 +72,28 @@ pub(super) fn generate_event_handler_expressions(
                 let mapped_end = ts.len();
                 ts.push_str(";  // handler expression (emit checks disabled)\n");
                 mapped_start..mapped_end
+            } else if let (Some(handler_type), Some(listener_type)) =
+                (ctx.event_handler_type, ctx.event_listener_type)
+                && (is_implicit_reference || inline_callback_arg.is_some())
+            {
+                let handler_name = cstr!("__vize_handler_{scope_id}_{}", expr.start);
+                let stmt_start = ts.len();
+                append!(*ts, "{indent}const ", indent = handler_indent);
+                let name_start = ts.len();
+                ts.push_str(handler_name.as_str());
+                let name_end = ts.len();
+                append!(*ts, ": {handler_type} | null | undefined = (");
+                let mapped_start = ts.len();
+                ts.push_str(content);
+                let mapped_end = ts.len();
+                ts.push_str(");\n");
+                listener_spans = Some((stmt_start..ts.len(), name_start..name_end));
+                append!(
+                    *ts,
+                    "{indent}if (typeof {handler_name} === \"function\") ({handler_name} as {listener_type})(...__vize_args);  // handler expression\n",
+                    indent = handler_indent,
+                );
+                mapped_start..mapped_end
             } else if let Some(listener_type) = ctx.event_listener_type
                 && (is_implicit_reference || inline_callback_arg.is_some())
             {

--- a/crates/vize_canon/src/virtual_ts/scope/event_scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/event_scope.rs
@@ -39,6 +39,7 @@ pub(super) fn generate_event_handler_scope(
                     data,
                     check_emits: false,
                     event_type: "any",
+                    event_handler_type: None,
                     event_listener_type: None,
                     event_name_src_range: None,
                     template_prop_names: ctx.template_prop_names,
@@ -63,6 +64,8 @@ pub(super) fn generate_event_handler_scope(
         )
         .expect("component event handler should have a target component");
         let event_type = event_types.event_type;
+        let handler_type = event_types.handler_type;
+        let handler_type_expr = event_types.handler_type_expr;
         let listener_type = event_types.listener_type;
         let listener_type_expr = event_types.listener_type_expr;
         // Type the listener against the FULL emit tuple so multi-arg emits
@@ -71,6 +74,9 @@ pub(super) fn generate_event_handler_scope(
             *ts,
             "{indent}type {listener_type} = {listener_type_expr};\n",
         );
+        if let (Some(handler_type), Some(handler_type_expr)) = (&handler_type, &handler_type_expr) {
+            append!(*ts, "{indent}type {handler_type} = {handler_type_expr};\n",);
+        }
         // Receive listener args via a rest parameter typed by
         // `Parameters<listener>` to avoid TS2556; `$event` is element 0.
         append!(
@@ -93,6 +99,7 @@ pub(super) fn generate_event_handler_scope(
                     data,
                     check_emits: true,
                     event_type: event_type.as_str(),
+                    event_handler_type: handler_type.as_deref(),
                     event_listener_type: Some(listener_type.as_str()),
                     event_name_src_range: event_name_source_range(
                         ctx.template_source,
@@ -126,6 +133,7 @@ pub(super) fn generate_event_handler_scope(
                     data,
                     check_emits: true,
                     event_type,
+                    event_handler_type: None,
                     // Native DOM listeners keep the identity-call shape,
                     // so there is no declared name to anchor at.
                     event_listener_type: None,

--- a/tests/snapshots/check/__snapshots__/misskey-check.snap
+++ b/tests/snapshots/check/__snapshots__/misskey-check.snap
@@ -1152,7 +1152,9 @@
     },
     {
       "file": "src/pages/admin-file.vue",
-      "diagnostics": []
+      "diagnostics": [
+        "error:7:58 [TS7006] Parameter 'result' implicitly has an 'any' type."
+      ]
     },
     {
       "file": "src/pages/admin-user.vue",
@@ -2388,7 +2390,7 @@
       "diagnostics": []
     }
   ],
-  "errorCount": 36,
+  "errorCount": 37,
   "warningCount": 0,
   "fileCount": 583
 }


### PR DESCRIPTION
Closes #3756

## Summary
- preserve authored implicit-any diagnostics when an unresolved ambient component event captures a scoped-slot binding
- keep ordinary unresolved component events permissive
- split handler-context and scoped-reference detection into focused helpers

## Validation
- `cargo test -p vize_canon --lib --no-fail-fast` (804 passed)
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --check`
- source-file-length gate (7 passed)
- Misskey: 583 Vue files; TS7006 FP 3 / FN 0 / shared 244; overall FP 34 / FN 4
- Vuestic Admin: 99 Vue files; 19 diagnostics; TS7006 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->