### PR TITLE
fix(compose): enforce package type checking

### DIFF
--- a/npm/compose/core/package.json
+++ b/npm/compose/core/package.json
@@ -46,9 +46,10 @@
     "dev": "vp pack --watch",
     "pretest": "vp pack && pnpm check:size",
     "test": "vp exec node --test 'src/**/*.test.ts'",
-    "check": "vp check src scripts vite.config.ts",
+    "check": "vp check src scripts vite.config.ts && pnpm check:types",
     "check:fix": "vp check --fix src scripts vite.config.ts",
     "check:size": "node scripts/check-size.mjs",
+    "check:types": "vp exec tsgo --noEmit -p tsconfig.json",
     "fmt": "vp fmt --write src scripts vite.config.ts"
   },
   "dependencies": {

--- a/npm/compose/core/src/async-resource.ts
+++ b/npm/compose/core/src/async-resource.ts
@@ -127,7 +127,9 @@ export function useAsyncResource<Data, Arguments extends readonly unknown[], Fai
     return true;
   };
 
-  const execute = async (...arguments_: Arguments) => {
+  const execute = async (
+    ...arguments_: Arguments
+  ): Promise<AsyncResourceExecution<Data, Failure>> => {
     if ((options.cancelPrevious ?? true) && active !== undefined) {
       active.superseded = true;
       active.controller.abort(createAbortReason("A newer execution started."));

--- a/npm/compose/core/src/locale.ts
+++ b/npm/compose/core/src/locale.ts
@@ -87,7 +87,7 @@ export function useLocale(
       : new Intl.Locale(candidate).toString();
   });
   const details = computed(() => new Intl.Locale(locale.value));
-  const direction = computed<TextDirection>(() => details.value.getTextInfo().direction);
+  const direction = computed<TextDirection>(() => details.value.getTextInfo().direction ?? "ltr");
 
   const number = createFormatterCache<Intl.NumberFormatOptions, Intl.NumberFormat>(
     (activeLocale, formatOptions) => new Intl.NumberFormat(activeLocale, formatOptions),

--- a/npm/compose/core/src/temporal.test.ts
+++ b/npm/compose/core/src/temporal.test.ts
@@ -149,7 +149,7 @@ void test("publishes an importable ESM distribution with declarations", async ()
   assert.equal(packageJson.exports["./temporal"].import, "./dist/temporal.mjs");
   assert.equal(packageJson.exports["./temporal"].types, "./dist/temporal.d.mts");
 
-  const distribution = await import("../dist/temporal.mjs");
+  const distribution = await import(new URL("../dist/temporal.mjs", import.meta.url).href);
   assert.equal(typeof distribution.useTemporalNow, "function");
   assert.equal(typeof distribution.Temporal.Instant.from, "function");
 });

--- a/npm/compose/core/src/types.test-d.ts
+++ b/npm/compose/core/src/types.test-d.ts
@@ -1,0 +1,52 @@
+/** Compile-only assertions for public composable type contracts. */
+
+import type { ShallowRef } from "vue";
+
+import { type AsyncResourceExecution, useAsyncResource } from "./async-resource.js";
+import { type TextDirection, useLocale } from "./locale.js";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+const resource = useAsyncResource(async (_context, id: 1 | 2) => ({ id }) as const);
+
+interface LoadFailure {
+  readonly code: "load-failed";
+}
+
+const failureTypedResource = useAsyncResource<{ readonly id: 1 | 2 }, [id: 1 | 2], LoadFailure>(
+  async (_context, id) => ({ id }),
+);
+
+type _ExecuteArgumentsStayExact = Expect<Equal<Parameters<typeof resource.execute>, [id: 1 | 2]>>;
+type _ExecutionPreservesDataAndFailure = Expect<
+  Equal<
+    Awaited<ReturnType<typeof resource.execute>>,
+    AsyncResourceExecution<{ readonly id: 1 | 2 }, unknown>
+  >
+>;
+type _DataRefPreservesTheLoaderResult = Expect<
+  Equal<typeof resource.data, Readonly<ShallowRef<{ readonly id: 1 | 2 } | undefined>>>
+>;
+type _ExecutionPreservesAnExplicitFailure = Expect<
+  Equal<
+    Awaited<ReturnType<typeof failureTypedResource.execute>>,
+    AsyncResourceExecution<{ readonly id: 1 | 2 }, LoadFailure>
+  >
+>;
+
+// @ts-expect-error execute keeps the loader's argument tuple.
+void resource.execute("1");
+
+const locale = useLocale("en");
+
+type _TextDirectionStaysClosed = Expect<Equal<TextDirection, "ltr" | "rtl">>;
+type _LocaleDirectionNeverWidensToUndefined = Expect<
+  Equal<typeof locale.direction.value, TextDirection>
+>;
+
+// @ts-expect-error the public direction ref never exposes capability absence.
+const _undefinedDirection: undefined = locale.direction.value;


### PR DESCRIPTION
## Summary

- add a package-local TypeScript Go check and chain it from the normal compose `check` task
- preserve `Data` and `Failure` through asynchronous resource invalidation results
- keep locale direction closed to `"ltr" | "rtl"` when the platform declaration marks it optional
- make the built Temporal distribution probe runtime-only so type checking works from a clean install before build
- add compile-only exact and negative tests for loader arguments, result/error types, and locale direction

## Root cause

The compose package enabled type-aware linting but never ran a standalone TypeScript check. Enabling it exposed two existing source errors: the generic invalidation helper inferred `unknown` result parameters, and `Intl.TextInfo.direction` is optional in the TypeScript library even though the public API intentionally exposes a closed direction type.

## Validation

- `vp run --filter @vizejs/composable check:types`
- `npm/compose/core/node_modules/.bin/tsc --noEmit -p npm/compose/core/tsconfig.json`
- `vp run --filter @vizejs/composable check`
- `vp run --filter @vizejs/composable test` (98/98; includes build and gzip size budgets)
- `node --test tests/tooling/package-manifests.test.ts` (17/17)
- `vp install --frozen-lockfile --prefer-offline`
- `git diff --check`

Part of #3136

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved locale handling by defaulting text direction to left-to-right when direction metadata is unavailable.
  * Preserved existing asynchronous resource behavior while improving type safety.

* **Tests**
  * Added coverage for locale direction values, asynchronous resource typing, and invalid arguments.
  * Improved distribution import testing for more reliable validation.

* **Chores**
  * Added a dedicated type-checking validation step to the standard checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->