### PR TITLE
fix(compose): use the package-owned type checker

### DIFF
--- a/npm/compose/core/package.json
+++ b/npm/compose/core/package.json
@@ -49,7 +49,7 @@
     "check": "vp check src scripts vite.config.ts && pnpm check:types",
     "check:fix": "vp check --fix src scripts vite.config.ts",
     "check:size": "node scripts/check-size.mjs",
-    "check:types": "vp exec tsgo --noEmit -p tsconfig.json",
+    "check:types": "vp exec tsc --noEmit -p tsconfig.json",
     "fmt": "vp fmt --write src scripts vite.config.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- run the composable package type-check script with its own stable `typescript` dependency
- keep TypeScript 7 validation as an explicit workspace-level compatibility check
- avoid dependency and lockfile churn

This follows up on the late [CodeRabbit feedback on #3830](https://github.com/ubugeeei-prod/vize/pull/3830#discussion_r3705201061). `vp exec` resolves package-local binaries, and `@vizejs/composable` already owns `typescript`, so using `tsc` makes the package check self-contained without adding another dependency.

## Validation

- `vp run --filter @vizejs/composable check:types`
- `vp exec tsgo --noEmit -p npm/compose/core/tsconfig.json`
- `vp run --filter @vizejs/composable check`
- `vp run --filter @vizejs/composable test` (98 tests, build, gzip size budgets)
- `node --test tests/tooling/package-manifests.test.ts` (17 tests)
- `vp install --frozen-lockfile --prefer-offline`
- `git diff --check`

Follow-up to #3830. Part of #3136.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TypeScript validation command to use the standard TypeScript compiler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->