### PR TITLE
fix(croquis): rebuild component usage by import target

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/core/deps.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/deps.rs
@@ -32,6 +32,7 @@ impl CrossFileAnalyzer {
             })
             .collect();
         let used_components: Vec<_> = entry.analysis.used_components.iter().cloned().collect();
+        self.clear_component_usage_edges(file_id);
 
         let mut import_bindings = Vec::new();
         for (source, is_type_only, local_bindings) in imports_data {
@@ -119,6 +120,29 @@ impl CrossFileAnalyzer {
 
     pub(super) fn find_component_by_name(&self, name: &str) -> Option<FileId> {
         self.graph.find_by_component(name)
+    }
+
+    fn clear_component_usage_edges(&mut self, file_id: FileId) {
+        let targets = self.graph.get_node(file_id).map_or_else(Vec::new, |node| {
+            node.imports
+                .iter()
+                .filter_map(|(target, edge)| {
+                    (*edge == DependencyEdge::ComponentUsage).then_some(*target)
+                })
+                .collect()
+        });
+
+        if let Some(node) = self.graph.get_node_mut(file_id) {
+            node.imports
+                .retain(|(_, edge)| *edge != DependencyEdge::ComponentUsage);
+        }
+        for target in targets {
+            if let Some(node) = self.graph.get_node_mut(target) {
+                node.importers.retain(|(source, edge)| {
+                    *source != file_id || *edge != DependencyEdge::ComponentUsage
+                });
+            }
+        }
     }
 }
 

--- a/crates/vize_croquis_cf/src/analyzer/core/files.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/files.rs
@@ -1,5 +1,5 @@
 use super::CrossFileAnalyzer;
-use crate::graph::{DependencyEdge, ModuleNode};
+use crate::graph::ModuleNode;
 use crate::registry::FileId;
 use std::path::Path;
 use vize_croquis::{
@@ -106,31 +106,10 @@ impl CrossFileAnalyzer {
 
     /// Rebuild component usage edges.
     ///
-    /// This should be called after all files have been added to ensure
-    /// that ComponentUsage edges are correctly established. When files
-    /// are added one by one, component references might not resolve
-    /// if the target component hasn't been added yet.
+    /// Re-resolve imports after all files have been added so each component
+    /// usage follows the importing file's own binding before name fallback.
     pub fn rebuild_component_edges(&mut self) {
-        // Collect all used_components from all files
-        let component_data: Vec<_> = self
-            .registry
-            .iter()
-            .map(|entry| {
-                let components: Vec<_> = entry.analysis.used_components.iter().cloned().collect();
-                (entry.id, components)
-            })
-            .collect();
-
-        // Add ComponentUsage edges for any that were missed
-        for (file_id, used_components) in component_data {
-            for component in used_components {
-                if let Some(target_id) = self.find_component_by_name(component.as_str()) {
-                    // add_edge checks for duplicates internally
-                    self.graph
-                        .add_edge(file_id, target_id, DependencyEdge::ComponentUsage);
-                }
-            }
-        }
+        self.rebuild_import_edges();
     }
 }
 

--- a/crates/vize_croquis_cf/src/analyzer/tests_props_validation_identity.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_props_validation_identity.rs
@@ -1,25 +1,84 @@
 use super::{CrossFileAnalyzer, CrossFileOptions};
-use crate::PropsValidationIssueKind;
+use crate::{DependencyEdge, FileId, PropsValidationIssueKind};
 use std::path::Path;
 use vize_carton::{CompactString, smallvec};
 use vize_croquis::{AnalyzerOptions, ScopeId, analysis::ComponentUsage};
 
 #[test]
 fn prop_contracts_are_keyed_by_component_identity() {
-    let forward = same_basename_required_props(false);
-    let reversed = same_basename_required_props(true);
+    assert_prop_contracts_follow_import_targets(false);
+}
 
-    assert_eq!(
-        forward,
-        vec![
-            ("AdminParent", CompactString::new("adminId")),
-            ("ShopParent", CompactString::new("shopId")),
-        ]
+#[test]
+fn prop_contracts_follow_identical_local_import_names() {
+    assert_prop_contracts_follow_import_targets(true);
+}
+
+#[test]
+fn rebuilding_edges_replaces_stale_same_name_fallback() {
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_props_validation(true));
+    let admin_parent = analyzer.add_file_with_analysis(
+        Path::new("AdminParent.vue"),
+        "",
+        analyze("import Button from './admin/Button.vue'", Some("Button")),
     );
+    let shop_parent = analyzer.add_file_with_analysis(
+        Path::new("ShopParent.vue"),
+        "",
+        analyze("import Button from './shop/Button.vue'", Some("Button")),
+    );
+    let shop_child = analyzer.add_file_with_analysis(
+        Path::new("shop/Button.vue"),
+        "",
+        analyze("defineProps<{ shopId: string }>()", None),
+    );
+
+    analyzer.rebuild_component_edges();
+    assert!(
+        analyzer
+            .graph()
+            .component_usage()
+            .any(|edge| edge == (admin_parent, shop_child))
+    );
+
+    let admin_child = analyzer.add_file_with_analysis(
+        Path::new("admin/Button.vue"),
+        "",
+        analyze("defineProps<{ adminId: string }>()", None),
+    );
+    analyzer.rebuild_component_edges();
+
+    let edges = analyzer.graph().component_usage().collect::<Vec<_>>();
+    assert_eq!(edges.len(), 2);
+    assert!(edges.contains(&(admin_parent, admin_child)));
+    assert!(edges.contains(&(shop_parent, shop_child)));
+    assert!(
+        !analyzer
+            .graph()
+            .dependents(shop_child)
+            .any(|(source, edge)| {
+                source == admin_parent && edge == DependencyEdge::ComponentUsage
+            })
+    );
+    assert_eq!(
+        missing_props(&mut analyzer, admin_parent, shop_parent),
+        expected_missing_props()
+    );
+}
+
+fn assert_prop_contracts_follow_import_targets(shared_local_name: bool) {
+    let forward = same_basename_required_props(false, shared_local_name);
+    let reversed = same_basename_required_props(true, shared_local_name);
+
+    assert_eq!(forward, expected_missing_props());
     assert_eq!(reversed, forward);
 }
 
-fn same_basename_required_props(reverse_children: bool) -> Vec<(&'static str, CompactString)> {
+fn same_basename_required_props(
+    reverse_children: bool,
+    shared_local_name: bool,
+) -> Vec<(&'static str, CompactString)> {
     let mut analyzer =
         CrossFileAnalyzer::new(CrossFileOptions::default().with_props_validation(true));
     let children = [
@@ -37,24 +96,39 @@ fn same_basename_required_props(reverse_children: bool) -> Vec<(&'static str, Co
         analyzer.add_file_with_analysis(children[index].0, "", analyze(children[index].1, None));
     }
 
+    let admin_import = if shared_local_name {
+        ("import Button from './admin/Button.vue'", "Button")
+    } else {
+        (
+            "import AdminButton from './admin/Button.vue'",
+            "AdminButton",
+        )
+    };
+    let shop_import = if shared_local_name {
+        ("import Button from './shop/Button.vue'", "Button")
+    } else {
+        ("import ShopButton from './shop/Button.vue'", "ShopButton")
+    };
     let admin_parent = analyzer.add_file_with_analysis(
         Path::new("AdminParent.vue"),
         "",
-        analyze(
-            "import AdminButton from './admin/Button.vue'",
-            Some("AdminButton"),
-        ),
+        analyze(admin_import.0, Some(admin_import.1)),
     );
     let shop_parent = analyzer.add_file_with_analysis(
         Path::new("ShopParent.vue"),
         "",
-        analyze(
-            "import ShopButton from './shop/Button.vue'",
-            Some("ShopButton"),
-        ),
+        analyze(shop_import.0, Some(shop_import.1)),
     );
     analyzer.rebuild_component_edges();
 
+    missing_props(&mut analyzer, admin_parent, shop_parent)
+}
+
+fn missing_props(
+    analyzer: &mut CrossFileAnalyzer,
+    admin_parent: FileId,
+    shop_parent: FileId,
+) -> Vec<(&'static str, CompactString)> {
     let result = analyzer.analyze();
     let mut missing = result
         .props_validation_issues
@@ -75,6 +149,13 @@ fn same_basename_required_props(reverse_children: bool) -> Vec<(&'static str, Co
         .collect::<Vec<_>>();
     missing.sort_unstable();
     missing
+}
+
+fn expected_missing_props() -> Vec<(&'static str, CompactString)> {
+    vec![
+        ("AdminParent", CompactString::new("adminId")),
+        ("ShopParent", CompactString::new("shopId")),
+    ]
 }
 
 fn analyze(script: &str, component: Option<&str>) -> vize_croquis::Croquis {


### PR DESCRIPTION
## Summary

- rebuild component usage edges through each parent file's resolved import binding instead of a global same-name fallback
- remove stale outgoing component-usage edges and matching reverse importer edges before recomputing
- cover identical local `Button` names across distinct parent imports, both child-registration orders, and a parents-first stale-fallback sequence

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p vize_croquis_cf prop_contracts_ -- --nocapture`
- `cargo test --locked -p vize_croquis_cf rebuilding_edges_replaces_stale_same_name_fallback -- --nocapture`
- `cargo test --locked -p vize_croquis_cf -- --nocapture`
- `cargo clippy --locked -p vize_croquis_cf --lib -- -D warnings -D clippy::wildcard_imports`
- `moon run --target native tools/moon/cmd/source_file_lengths -- --check --base-ref origin/main --max-lines 350 --limit 20`
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`

Follow-up to #3833. Progresses #3138.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->