### PR TITLE
fix(fresco): reject unknown render node kinds

### DIFF
--- a/crates/vize_fresco/src/napi.rs
+++ b/crates/vize_fresco/src/napi.rs
@@ -21,6 +21,12 @@ mod layout;
     clippy::disallowed_macros
 )]
 mod render;
+#[allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros
+)]
+mod render_payload;
 #[cfg(test)]
 mod render_tests;
 #[allow(

--- a/crates/vize_fresco/src/napi/render.rs
+++ b/crates/vize_fresco/src/napi/render.rs
@@ -5,54 +5,16 @@ use napi_derive::napi;
 use std::cell::RefCell;
 
 use super::input_size::input_intrinsic_size;
+use super::render_payload::{
+    RenderNodeKindNapi, parse_wrap_mode, unsupported_render_node_kind, validate_render_node_kinds,
+};
 use super::terminal::with_backend;
 use super::types::{LayoutResultNapi, RenderNodeNapi, StyleNapi};
 use crate::layout::Rect;
 use crate::terminal::{Color, Style};
-use crate::text::WrapMode;
 
 thread_local! {
     static LAST_RENDER_LAYOUTS: RefCell<Vec<LayoutResultNapi>> = const { RefCell::new(Vec::new()) };
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum RenderNodeKindNapi {
-    Root,
-    Box,
-    Text,
-    Input,
-}
-
-pub(super) fn parse_render_node_kind(value: &str) -> Option<RenderNodeKindNapi> {
-    match value {
-        "root" => Some(RenderNodeKindNapi::Root),
-        "box" => Some(RenderNodeKindNapi::Box),
-        "text" => Some(RenderNodeKindNapi::Text),
-        "input" => Some(RenderNodeKindNapi::Input),
-        _ => None,
-    }
-}
-
-pub(super) fn validate_render_node_kinds(
-    nodes: &[RenderNodeNapi],
-) -> std::result::Result<Vec<RenderNodeKindNapi>, &str> {
-    nodes
-        .iter()
-        .map(|node| parse_render_node_kind(&node.node_type).ok_or(node.node_type.as_str()))
-        .collect()
-}
-
-fn parse_wrap_mode(mode: Option<&str>, wrap: Option<bool>) -> WrapMode {
-    match mode {
-        Some("wrap") => WrapMode::Word,
-        Some("hard") => WrapMode::Char,
-        Some("truncate") | Some("truncate-end") => WrapMode::TruncateEnd,
-        Some("truncate-start") => WrapMode::TruncateStart,
-        Some("truncate-middle") => WrapMode::TruncateMiddle,
-        Some("false") | Some("none") => WrapMode::NoWrap,
-        _ if wrap.unwrap_or(false) => WrapMode::Word,
-        _ => WrapMode::NoWrap,
-    }
 }
 
 /// Get layout results from the most recent renderTree call.
@@ -198,16 +160,7 @@ pub fn render_tree(nodes: Vec<RenderNodeNapi>) -> Result<()> {
         TextContent,
     };
 
-    // Validate the complete payload before borrowing or mutating the terminal
-    // backend so one unknown kind cannot partially render the preceding nodes.
-    let node_kinds = validate_render_node_kinds(&nodes).map_err(|node_type| {
-        Error::new(
-            Status::InvalidArg,
-            format!(
-                "Unsupported render node type `{node_type}`; expected one of: root, box, text, input"
-            ),
-        )
-    })?;
+    let node_kinds = validate_render_node_kinds(&nodes).map_err(unsupported_render_node_kind)?;
 
     with_backend(|backend| {
         let mut tree = RenderTree::new();

--- a/crates/vize_fresco/src/napi/render.rs
+++ b/crates/vize_fresco/src/napi/render.rs
@@ -15,6 +15,33 @@ thread_local! {
     static LAST_RENDER_LAYOUTS: RefCell<Vec<LayoutResultNapi>> = const { RefCell::new(Vec::new()) };
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RenderNodeKindNapi {
+    Root,
+    Box,
+    Text,
+    Input,
+}
+
+pub(super) fn parse_render_node_kind(value: &str) -> Option<RenderNodeKindNapi> {
+    match value {
+        "root" => Some(RenderNodeKindNapi::Root),
+        "box" => Some(RenderNodeKindNapi::Box),
+        "text" => Some(RenderNodeKindNapi::Text),
+        "input" => Some(RenderNodeKindNapi::Input),
+        _ => None,
+    }
+}
+
+pub(super) fn validate_render_node_kinds(
+    nodes: &[RenderNodeNapi],
+) -> std::result::Result<Vec<RenderNodeKindNapi>, &str> {
+    nodes
+        .iter()
+        .map(|node| parse_render_node_kind(&node.node_type).ok_or(node.node_type.as_str()))
+        .collect()
+}
+
 fn parse_wrap_mode(mode: Option<&str>, wrap: Option<bool>) -> WrapMode {
     match mode {
         Some("wrap") => WrapMode::Word,
@@ -171,19 +198,30 @@ pub fn render_tree(nodes: Vec<RenderNodeNapi>) -> Result<()> {
         TextContent,
     };
 
+    // Validate the complete payload before borrowing or mutating the terminal
+    // backend so one unknown kind cannot partially render the preceding nodes.
+    let node_kinds = validate_render_node_kinds(&nodes).map_err(|node_type| {
+        Error::new(
+            Status::InvalidArg,
+            format!(
+                "Unsupported render node type `{node_type}`; expected one of: root, box, text, input"
+            ),
+        )
+    })?;
+
     with_backend(|backend| {
         let mut tree = RenderTree::new();
 
         // Build tree from NAPI nodes
-        for node in &nodes {
+        for (node, node_type) in nodes.iter().zip(&node_kinds) {
             let text_content = node.text.clone().unwrap_or_default();
-            let kind = match node.node_type.as_str() {
-                "text" => NodeKind::Text(TextContent {
+            let kind = match node_type {
+                RenderNodeKindNapi::Text => NodeKind::Text(TextContent {
                     text: text_content.clone().into(),
                     wrap: node.wrap.unwrap_or(false),
                     wrap_mode: parse_wrap_mode(node.wrap_mode.as_deref(), node.wrap),
                 }),
-                "input" => NodeKind::Input(InputContent {
+                RenderNodeKindNapi::Input => NodeKind::Input(InputContent {
                     value: node.value.clone().unwrap_or_default().into(),
                     placeholder: node.placeholder.clone().unwrap_or_default().into(),
                     cursor: node.cursor.unwrap_or(0) as usize,
@@ -195,13 +233,13 @@ pub fn render_tree(nodes: Vec<RenderNodeNapi>) -> Result<()> {
                         .and_then(|s| s.chars().next())
                         .unwrap_or('*'),
                 }),
-                _ => NodeKind::Box,
+                RenderNodeKindNapi::Root | RenderNodeKindNapi::Box => NodeKind::Box,
             };
 
             let mut render_node = RenderNode::new(node.id as u64, kind);
 
             // For text nodes, set the size based on text content
-            if node.node_type == "text" && !text_content.is_empty() {
+            if *node_type == RenderNodeKindNapi::Text && !text_content.is_empty() {
                 use crate::text::TextWidth;
                 let text_width = TextWidth::width(&text_content) as f32;
                 let text_height = text_content.lines().count().max(1) as f32;
@@ -209,7 +247,7 @@ pub fn render_tree(nodes: Vec<RenderNodeNapi>) -> Result<()> {
                 render_node.style.height = Dimension::Points(text_height);
             }
 
-            if node.node_type == "input" {
+            if *node_type == RenderNodeKindNapi::Input {
                 let (input_width, height) = input_intrinsic_size(node);
                 render_node.style.width = Dimension::Points(input_width);
                 render_node.style.height = Dimension::Points(height);
@@ -485,8 +523,8 @@ pub fn render_tree(nodes: Vec<RenderNodeNapi>) -> Result<()> {
 
         // Find focused input and position cursor for IME
         let mut found_focused = false;
-        for node in &nodes {
-            if node.node_type == "input"
+        for (node, node_type) in nodes.iter().zip(&node_kinds) {
+            if *node_type == RenderNodeKindNapi::Input
                 && node.focused.unwrap_or(false)
                 && let Some(render_node) = tree.get(node.id as u64)
                 && let Some(layout) = render_node.layout

--- a/crates/vize_fresco/src/napi/render_payload.rs
+++ b/crates/vize_fresco/src/napi/render_payload.rs
@@ -1,0 +1,57 @@
+//! Render payload parsing for the render NAPI bindings.
+
+use napi::bindgen_prelude::*;
+
+use super::types::RenderNodeNapi;
+use crate::text::WrapMode;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RenderNodeKindNapi {
+    Root,
+    Box,
+    Text,
+    Input,
+}
+
+pub(super) fn parse_render_node_kind(value: &str) -> Option<RenderNodeKindNapi> {
+    match value {
+        "root" => Some(RenderNodeKindNapi::Root),
+        "box" => Some(RenderNodeKindNapi::Box),
+        "text" => Some(RenderNodeKindNapi::Text),
+        "input" => Some(RenderNodeKindNapi::Input),
+        _ => None,
+    }
+}
+
+/// Resolve every node kind in a render payload, reporting the first unsupported
+/// `nodeType` so the batch can be rejected before the backend is borrowed.
+pub(super) fn validate_render_node_kinds(
+    nodes: &[RenderNodeNapi],
+) -> std::result::Result<Vec<RenderNodeKindNapi>, &str> {
+    nodes
+        .iter()
+        .map(|node| parse_render_node_kind(&node.node_type).ok_or(node.node_type.as_str()))
+        .collect()
+}
+
+pub(super) fn unsupported_render_node_kind(node_type: &str) -> Error {
+    Error::new(
+        Status::InvalidArg,
+        format!(
+            "Unsupported render node type `{node_type}`; expected one of: root, box, text, input"
+        ),
+    )
+}
+
+pub(super) fn parse_wrap_mode(mode: Option<&str>, wrap: Option<bool>) -> WrapMode {
+    match mode {
+        Some("wrap") => WrapMode::Word,
+        Some("hard") => WrapMode::Char,
+        Some("truncate") | Some("truncate-end") => WrapMode::TruncateEnd,
+        Some("truncate-start") => WrapMode::TruncateStart,
+        Some("truncate-middle") => WrapMode::TruncateMiddle,
+        Some("false") | Some("none") => WrapMode::NoWrap,
+        _ if wrap.unwrap_or(false) => WrapMode::Word,
+        _ => WrapMode::NoWrap,
+    }
+}

--- a/crates/vize_fresco/src/napi/render_tests.rs
+++ b/crates/vize_fresco/src/napi/render_tests.rs
@@ -1,5 +1,7 @@
 use super::input_size::{input_intrinsic_size, wrapped_line_count};
-use super::render::{RenderNodeKindNapi, parse_render_node_kind, validate_render_node_kinds};
+use super::render_payload::{
+    RenderNodeKindNapi, parse_render_node_kind, validate_render_node_kinds,
+};
 use super::types::{FlexStyleNapi, RenderNodeNapi};
 
 fn render_node(id: i64, node_type: &str) -> RenderNodeNapi {

--- a/crates/vize_fresco/src/napi/render_tests.rs
+++ b/crates/vize_fresco/src/napi/render_tests.rs
@@ -1,27 +1,68 @@
 use super::input_size::{input_intrinsic_size, wrapped_line_count};
+use super::render::{RenderNodeKindNapi, parse_render_node_kind, validate_render_node_kinds};
 use super::types::{FlexStyleNapi, RenderNodeNapi};
 
-fn input_node(value: &str, width: Option<&str>) -> RenderNodeNapi {
+fn render_node(id: i64, node_type: &str) -> RenderNodeNapi {
     RenderNodeNapi {
-        id: 1,
-        node_type: "input".into(),
+        id,
+        node_type: node_type.into(),
         text: None,
         wrap: None,
         wrap_mode: None,
-        value: Some(value.into()),
+        value: None,
         placeholder: None,
         focused: None,
         cursor: None,
         mask: None,
         mask_char: None,
-        style: width.map(|width| FlexStyleNapi {
-            width: Some(width.into()),
-            ..FlexStyleNapi::default()
-        }),
+        style: None,
         appearance: None,
         border: None,
         children: None,
     }
+}
+
+fn input_node(value: &str, width: Option<&str>) -> RenderNodeNapi {
+    RenderNodeNapi {
+        value: Some(value.into()),
+        style: width.map(|width| FlexStyleNapi {
+            width: Some(width.into()),
+            ..FlexStyleNapi::default()
+        }),
+        ..render_node(1, "input")
+    }
+}
+
+#[test]
+fn render_node_kind_accepts_every_public_protocol_literal() {
+    for (literal, expected) in [
+        ("root", RenderNodeKindNapi::Root),
+        ("box", RenderNodeKindNapi::Box),
+        ("text", RenderNodeKindNapi::Text),
+        ("input", RenderNodeKindNapi::Input),
+    ] {
+        assert_eq!(parse_render_node_kind(literal).unwrap(), expected);
+    }
+}
+
+#[test]
+fn render_node_kind_rejects_unknown_protocol_values() {
+    assert_eq!(parse_render_node_kind("grid"), None);
+}
+
+#[test]
+fn render_node_kind_literals_are_exact_and_case_sensitive() {
+    for value in ["", "Box", " box", "box ", "raw"] {
+        assert_eq!(parse_render_node_kind(value), None);
+    }
+}
+
+#[test]
+fn render_tree_payload_validation_fails_the_complete_batch_closed() {
+    let nodes = [render_node(1, "root"), render_node(2, "unknown")];
+    let error = validate_render_node_kinds(&nodes).unwrap_err();
+
+    assert_eq!(error, "unknown");
 }
 
 #[test]

--- a/crates/vize_fresco/src/napi/types.rs
+++ b/crates/vize_fresco/src/napi/types.rs
@@ -106,8 +106,11 @@ pub struct FlexStyleNapi {
 pub struct RenderNodeNapi {
     /// Node ID
     pub id: i64,
-    /// Node type: "box" | "text" | "input"
-    #[napi(js_name = "nodeType")]
+    /// Node type accepted by the native renderer.
+    #[napi(
+        js_name = "nodeType",
+        ts_type = "\"root\" | \"box\" | \"text\" | \"input\""
+    )]
     pub node_type: String,
     /// Text content (for text nodes)
     pub text: Option<String>,

--- a/crates/vize_fresco/src/napi/types.rs
+++ b/crates/vize_fresco/src/napi/types.rs
@@ -107,10 +107,7 @@ pub struct RenderNodeNapi {
     /// Node ID
     pub id: i64,
     /// Node type accepted by the native renderer.
-    #[napi(
-        js_name = "nodeType",
-        ts_type = "\"root\" | \"box\" | \"text\" | \"input\""
-    )]
+    #[napi(ts_type = "\"root\" | \"box\" | \"text\" | \"input\"")]
     pub node_type: String,
     /// Text content (for text nodes)
     pub text: Option<String>,

--- a/docs/fresco/compatibility.md
+++ b/docs/fresco/compatibility.md
@@ -20,7 +20,7 @@ affected rows in the same PR.
 | Surface          | Audited source                                                                                            |
 | ---------------- | --------------------------------------------------------------------------------------------------------- |
 | Fresco Vue layer | `npm/fresco/src` (`index.ts`, `app.ts`, `renderer.ts`, `accessibility.ts`, `components/`, `composables/`) |
-| Native bindings  | `npm/fresco-native/index.d.ts` (hand-written N-API declarations)                                          |
+| Native bindings  | `npm/fresco-native/index.d.ts` (checked-in declarations; node kind mirrors its Rust annotation)           |
 | Rust renderer    | `crates/vize_fresco/src` (`component/`, `input/`, `layout/`, `render/`, `terminal/`, `text/`, `napi/`)    |
 | Ink              | `vadimdemedes/ink` README + v6 type declarations, retrieved 2026-07-19                                    |
 | OpenTUI          | opentui.com core-concepts/renderables documentation, retrieved 2026-07-19                                 |
@@ -159,7 +159,7 @@ parity but are intentional no-ops (see "Intentional differences"). Fresco adds `
 | Accessibility                           | —                                                                           | `aria-role`/`aria-state` props produce screen-reader text frames; `INK_SCREEN_READER`/`FRESCO_SCREEN_READER` env toggles; no semantic output contract or snapshots yet (M2). | Partial     |
 | Testing                                 | —                                                                           | `renderToString` only; no frame snapshots, input injection, or type-contract fixtures (M0).                                                                                  | Planned     |
 | Devtools/diagnostics                    | —                                                                           | `debug` JSON tree dump, `onRender` timing, `getLastRenderLayouts`; no tree inspector or event trace (M4).                                                                    | Partial     |
-| Typed render protocol                   | —                                                                           | `nodeType` is a string, props are `Record<string, unknown>`, and `index.d.ts` is hand-mirrored (M0: discriminated unions + generated declarations).                          | Partial     |
+| Typed render protocol                   | —                                                                           | Native `nodeType` is the closed `root`/`box`/`text`/`input` union; Rust rejects unknown kinds before rendering. Untyped props and the full discriminated M0 protocol remain. | Partial     |
 | SFC / Vite / HMR                        | — (Vue TermUI: SFC + dedicated Vite plugin with HMR)                        | SFC example builds with `@vizejs/vite-plugin`; dev runs re-execute via `vite-node`; no HMR pipeline (M4).                                                                    | Partial     |
 | Rust test/bench coverage                | —                                                                           | Unit tests across `input`/`layout`/`render`/`terminal`/`text`; Criterion `render` bench. No JS test suite yet (M0).                                                          | Partial     |
 

--- a/npm/fresco-native/index.d.ts
+++ b/npm/fresco-native/index.d.ts
@@ -54,7 +54,7 @@ export interface FlexStyleNapi {
 
 export interface RenderNodeNapi {
   id: number;
-  nodeType: string;
+  nodeType: "root" | "box" | "text" | "input";
   text?: string;
   wrap?: boolean;
   wrapMode?: string;

--- a/npm/fresco/src/index.ts
+++ b/npm/fresco/src/index.ts
@@ -29,7 +29,7 @@ export {
   type FocusEvent,
   type CompositionEvent,
 } from "./app.js";
-export { createRenderer } from "./renderer.js";
+export { createRenderer, type FrescoRenderNodeKind } from "./renderer.js";
 export {
   kittyFlags,
   kittyModifiers,

--- a/npm/fresco/src/renderer.ts
+++ b/npm/fresco/src/renderer.ts
@@ -13,9 +13,11 @@ import type { FlexStyleNapi, RenderNodeNapi, StyleNapi } from "@vizejs/fresco-na
 /**
  * Fresco node types
  */
+export type FrescoRenderNodeKind = "root" | "box" | "text" | "input";
+
 export interface FrescoNode extends RendererNode {
   id: number;
-  type: "box" | "text" | "input" | "root";
+  type: FrescoRenderNodeKind;
   props: Record<string, unknown>;
   children: FrescoNode[];
   parent: FrescoNode | null;
@@ -29,7 +31,7 @@ export interface FrescoElement extends FrescoNode, RendererElement {}
 
 let nextId = 0;
 
-function createNode(type: FrescoNode["type"]): FrescoNode {
+function createNode(type: FrescoRenderNodeKind): FrescoNode {
   return {
     id: nextId++,
     type,
@@ -122,7 +124,7 @@ const rendererOptions: RendererOptions<FrescoNode, FrescoElement> = {
 /**
  * Map Vue element types to Fresco node types
  */
-function mapElementType(type: string): FrescoNode["type"] {
+function mapElementType(type: string): FrescoRenderNodeKind {
   switch (type.toLowerCase()) {
     case "box":
     case "div":

--- a/npm/fresco/src/renderer.types.test-d.ts
+++ b/npm/fresco/src/renderer.types.test-d.ts
@@ -1,0 +1,31 @@
+/** Compile-only assertions for the public native render-node kind contract. */
+
+import type { RenderNodeNapi } from "@vizejs/fresco-native";
+
+import type { FrescoRenderNodeKind } from "./index.js";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+type _FrescoKindIsTheClosedProtocol = Expect<
+  Equal<FrescoRenderNodeKind, "root" | "box" | "text" | "input">
+>;
+type _NativeKindMatchesThePublicProtocol = Expect<
+  Equal<RenderNodeNapi["nodeType"], FrescoRenderNodeKind>
+>;
+
+export const rootNode: RenderNodeNapi = { id: -1, nodeType: "root" };
+export const boxNode: RenderNodeNapi = { id: 1, nodeType: "box" };
+export const textNode: RenderNodeNapi = { id: 2, nodeType: "text", text: "hello" };
+export const inputNode: RenderNodeNapi = { id: 3, nodeType: "input", value: "value" };
+
+// @ts-expect-error - unknown node kinds must not cross the native render boundary.
+export const unknownNode: RenderNodeNapi = { id: 4, nodeType: "grid" };
+
+declare const arbitraryKind: string;
+
+// @ts-expect-error - the native contract must not widen back to arbitrary strings.
+export const arbitraryNode: RenderNodeNapi = { id: 5, nodeType: arbitraryKind };


### PR DESCRIPTION
## Summary

- expose the supported `root | box | text | input` render-node kinds through the public Fresco and N-API TypeScript contracts
- validate the complete native render payload before borrowing or mutating the terminal backend
- reject unknown, case-shifted, padded, and empty kinds instead of silently rendering them as boxes
- keep the compatibility matrix at Partial because untyped props and the full discriminated M0 protocol remain

## Root cause

`RenderNodeNapi.nodeType` was an arbitrary string. The Rust conversion matched `text` and `input`, then treated every other value as `NodeKind::Box`, so protocol typos failed open. `root` is a real native payload kind used by normal and screen-reader rendering and remains an explicit supported container kind.

## Validation

- `cargo test -p vize_fresco --features napi` (131 tests)
- `cargo clippy -p vize_fresco --features napi --all-targets -- -D warnings`
- native Node→N-API smoke: all four supported kinds reach the backend; unknown/case/whitespace/empty/batched invalid kinds are rejected before terminal access
- `vp run --filter @vizejs/fresco check`
- `vp run --filter @vizejs/fresco test` (37 tests)
- `vp run --filter @vizejs/fresco build`
- `node --test tests/tooling/package-manifests.test.ts` (17 tests)
- `node --test tests/tooling/docs-stability.test.ts` (2 tests)
- `vp install --frozen-lockfile --prefer-offline`
- `cargo fmt --all -- --check`
- `vp fmt --check docs/fresco/compatibility.md`
- `git diff --check`

Part of #3113.
Part of #3139.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->