### PR TITLE
fix(atelier): resolve declaration barrel prop types

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/tests/define_props_regressions.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests/define_props_regressions.rs
@@ -1,8 +1,11 @@
 use super::super::compile_sfc;
+use super::temp_compile_project_dir;
 use crate::types::{
     BindingType, ScriptCompileOptions, SfcCompileOptions, SfcCompileResult, TemplateCompileOptions,
 };
 use crate::{SfcParseOptions, parse_sfc};
+use std::fs;
+use vize_carton::ToCompactString;
 
 #[test]
 fn test_define_emits_quoted_update_event_in_sfc() {
@@ -166,6 +169,89 @@ withDefaults(defineProps<{
     assert_eq!(&source[loc.start..loc.end], "items");
     assert_eq!((loc.start_line, loc.start_column), (6, 9));
     assert_eq!((loc.end_line, loc.end_column), (6, 14));
+}
+
+#[test]
+fn test_define_props_extends_value_imported_declaration_barrel_interface() {
+    let project = temp_compile_project_dir("value-import-declaration-barrel-props");
+    let package = project.join("node_modules/some-ui");
+    let dist = package.join("dist");
+    let src = project.join("src");
+    fs::create_dir_all(&dist).unwrap();
+    fs::create_dir_all(&src).unwrap();
+
+    fs::write(
+        package.join("package.json"),
+        r#"{ "name": "some-ui", "types": "./dist/index.d.ts" }"#,
+    )
+    .unwrap();
+    fs::write(
+        dist.join("index.d.ts"),
+        "import { PrimitiveProps } from './index4.js'\nexport { PrimitiveProps }\n",
+    )
+    .unwrap();
+    fs::write(dist.join("index4.js"), "export {};\n").unwrap();
+    fs::write(
+        dist.join("index4.d.ts"),
+        r#"type AsTag = 'a' | 'button' | 'div' | ({} & string)
+interface PrimitiveProps {
+  asChild?: boolean
+  as?: AsTag
+}
+export { PrimitiveProps, AsTag }
+"#,
+    )
+    .unwrap();
+
+    let button_path = src.join("Button.vue");
+    let source = r#"<script setup lang="ts">
+import type { PrimitiveProps } from "some-ui"
+
+interface Props extends PrimitiveProps {
+  variant?: string
+}
+
+const props = withDefaults(defineProps<Props>(), { as: "button" })
+</script>
+
+<template>
+  <div :data-as="as" :data-as-child="asChild" :data-variant="variant" />
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let mut opts = SfcCompileOptions::default();
+    opts.script.id = Some(button_path.to_string_lossy().as_ref().to_compact_string());
+
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains("asChild: {\n      type: Boolean"),
+        "inherited Boolean prop must reach runtime props:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains(
+            "as: {\n      type: [String, Object],\n      required: false,\n      default: \"button\""
+        ),
+        "withDefaults must retain the inherited prop default:\n{}",
+        result.code
+    );
+    assert!(
+        result
+            .code
+            .contains("variant: {\n      type: String,\n      required: false"),
+        "local props must remain present:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("\"data-as\": __props.as")
+            && result.code.contains("\"data-as-child\": __props.asChild")
+            && !result.code.contains("_ctx.as"),
+        "inherited props must not fall back to instance context:\n{}",
+        result.code
+    );
+
+    let _ = fs::remove_dir_all(project);
 }
 
 fn compile_vapor_ts_sfc(source: &str) -> SfcCompileResult {

--- a/crates/vize_atelier_sfc/src/script/context/external_types.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types.rs
@@ -17,6 +17,9 @@ use super::ScriptCompileContext;
 use super::batch_epoch::{NO_EPOCH, current_batch_epoch};
 use super::helpers::is_import_type_only;
 
+mod resolution;
+use resolution::{canonical_base_file, path_key, resolve_import_path};
+
 /// Type declarations and outgoing type-bearing specifiers extracted from one
 /// file on disk.
 #[derive(Default)]
@@ -81,27 +84,43 @@ fn file_stamp(path: &Path) -> FileStamp {
 fn build_file_summary(path: &Path) -> Option<FileTypeSummary> {
     let content = std::fs::read_to_string(path).ok()?;
     let is_vue = path.extension().is_some_and(|ext| ext == "vue");
-    Some(extract_file_summary(&content, is_vue))
+    let follows_value_imports = path.file_name().is_some_and(|name| {
+        let name = name.to_string_lossy();
+        name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts")
+    });
+    Some(extract_file_summary(
+        &content,
+        is_vue,
+        follows_value_imports,
+    ))
 }
 
-fn extract_file_summary(content: &str, is_vue: bool) -> FileTypeSummary {
+fn extract_file_summary(
+    content: &str,
+    is_vue: bool,
+    follows_value_imports: bool,
+) -> FileTypeSummary {
     let mut summary = FileTypeSummary::default();
     if is_vue {
         if let Ok(descriptor) = parse_sfc(content, SfcParseOptions::default()) {
             if let Some(ref script) = descriptor.script {
-                extract_script_summary(&script.content, &mut summary);
+                extract_script_summary(&script.content, &mut summary, false);
             }
             if let Some(ref script_setup) = descriptor.script_setup {
-                extract_script_summary(&script_setup.content, &mut summary);
+                extract_script_summary(&script_setup.content, &mut summary, false);
             }
         }
     } else {
-        extract_script_summary(content, &mut summary);
+        extract_script_summary(content, &mut summary, follows_value_imports);
     }
     summary
 }
 
-fn extract_script_summary(source: &str, summary: &mut FileTypeSummary) {
+fn extract_script_summary(
+    source: &str,
+    summary: &mut FileTypeSummary,
+    follows_value_imports: bool,
+) {
     let allocator = Allocator::default();
     let source_type = SourceType::from_path("script.ts").unwrap_or_default();
     let ret = Parser::new(&allocator, source, source_type).parse();
@@ -131,17 +150,22 @@ fn extract_script_summary(source: &str, summary: &mut FileTypeSummary) {
                 ));
             }
             Statement::ImportDeclaration(import_decl) => {
-                if !import_decl.import_kind.is_type()
-                    && !is_import_type_only(import_decl, source)
-                    && !import_decl.specifiers.as_ref().is_some_and(|specifiers| {
+                let type_import = import_decl.import_kind.is_type()
+                    || is_import_type_only(import_decl, source)
+                    || import_decl.specifiers.as_ref().is_some_and(|specifiers| {
                         specifiers.iter().any(|specifier| match specifier {
                             ImportDeclarationSpecifier::ImportSpecifier(spec) => {
                                 spec.import_kind.is_type()
                             }
                             _ => false,
                         })
-                    })
-                {
+                    });
+                let declaration_value_import = follows_value_imports
+                    && import_decl
+                        .specifiers
+                        .as_ref()
+                        .is_some_and(|specifiers| !specifiers.is_empty());
+                if !type_import && !declaration_value_import {
                     continue;
                 }
                 summary
@@ -195,20 +219,6 @@ fn extract_script_summary(source: &str, summary: &mut FileTypeSummary) {
     }
 }
 
-const RESOLVE_EXTENSIONS: &[&str] = &[
-    ".ts", ".tsx", ".d.ts", ".mts", ".cts", ".js", ".jsx", ".vue",
-];
-const INDEX_CANDIDATES: &[&str] = &[
-    "index.ts",
-    "index.tsx",
-    "index.d.ts",
-    "index.mts",
-    "index.cts",
-    "index.js",
-    "index.jsx",
-    "index.vue",
-];
-
 impl ScriptCompileContext {
     /// Walk the script's type-bearing imports/re-exports on disk and merge the
     /// interfaces/type aliases they declare into this context.
@@ -232,7 +242,7 @@ impl ScriptCompileContext {
         // follow?" signal — strictly tighter than the old substring guard, so
         // no separate text pre-check is needed.
         let mut root = FileTypeSummary::default();
-        extract_script_summary(source, &mut root);
+        extract_script_summary(source, &mut root, false);
         if root.specifiers.is_empty() {
             // Nothing to resolve — skip base-file canonicalization entirely
             // (the common case: scripts with only runtime imports).
@@ -333,311 +343,10 @@ impl ScriptCompileContext {
     }
 }
 
-/// A resolved path plus the [`BATCH_EPOCH`] in which its existence was last
-/// confirmed. As with [`CachedFileSummary`], a read hit can stamp the epoch
-/// forward under the shared read guard.
-struct CachedPath {
-    path: PathBuf,
-    validated_epoch: AtomicU64,
-}
-
-/// Decide whether a cached resolved path is still usable, paying the `is_file`
-/// `stat` only when the entry has not already been confirmed this batch. The
-/// epoch is stamped forward on a successful revalidation so later hits in the
-/// same batch skip the syscall. Outside a batch (`NO_EPOCH`) every hit re-stats.
-fn cached_path_is_fresh(entry: &CachedPath, epoch: u64) -> bool {
-    if epoch != NO_EPOCH && entry.validated_epoch.load(Ordering::Relaxed) == epoch {
-        return true;
-    }
-    if entry.path.is_file() {
-        entry.validated_epoch.store(epoch, Ordering::Relaxed);
-        true
-    } else {
-        false
-    }
-}
-
-/// Base-file canonicalization cache: `(cwd, filename) -> canonical path`.
-/// The same SFC filename is canonicalized by several passes per compile
-/// (script setup + normal script, croquis prop merge, inline compile) and
-/// `canonicalize` walks every path component; outside a batch a hit is
-/// revalidated with a single `is_file` check so a deleted file falls back to a
-/// fresh canonicalization, within a batch the first hit revalidates and the
-/// rest reuse it, and failures are never cached so files created later are
-/// picked up.
-static BASE_CANON_CACHE: LazyLock<RwLock<FxHashMap<(PathBuf, String), CachedPath>>> =
-    LazyLock::new(|| RwLock::new(FxHashMap::default()));
-
-/// Canonicalize the compiled file's own path, falling back to the original
-/// path for virtual filenames (in-memory compiles) that don't exist on disk.
-fn canonical_base_file(filename: &str) -> PathBuf {
-    let path = PathBuf::from(filename);
-    // The canonical form of a relative path depends on the process cwd, so
-    // the cache key includes it; absolute paths (the batch-compile case) use
-    // an empty component and never pay the `getcwd` call.
-    let cwd = if path.is_absolute() {
-        PathBuf::new()
-    } else {
-        std::env::current_dir().unwrap_or_default()
-    };
-    let key = (cwd, filename.to_compact_string());
-    let epoch = current_batch_epoch();
-    if let Ok(cache) = BASE_CANON_CACHE.read()
-        && let Some(entry) = cache.get(&key)
-        && cached_path_is_fresh(entry, epoch)
-    {
-        return entry.path.clone();
-    }
-
-    match path.canonicalize() {
-        Ok(canonical) => {
-            if let Ok(mut cache) = BASE_CANON_CACHE.write() {
-                cache.insert(
-                    key,
-                    CachedPath {
-                        path: canonical.clone(),
-                        validated_epoch: AtomicU64::new(epoch),
-                    },
-                );
-            }
-            canonical
-        }
-        Err(_) => path,
-    }
-}
-
-/// Positive resolution cache: `(importing dir, specifier) -> resolved path`.
-/// Resolution probes many extension/index candidates (each a `stat`); outside
-/// a batch a hit is revalidated with a single `is_file` check so deleted files
-/// fall back to a full re-resolution, within a batch the first hit revalidates
-/// and the rest reuse it, and misses are never cached so newly created files
-/// are picked up.
-static RESOLVE_CACHE: LazyLock<RwLock<FxHashMap<(PathBuf, String), CachedPath>>> =
-    LazyLock::new(|| RwLock::new(FxHashMap::default()));
-
-fn resolve_import_path(current_file: &Path, specifier: &str) -> Option<PathBuf> {
-    let dir = current_file.parent()?.to_path_buf();
-    let key = (dir, specifier.to_compact_string());
-    let epoch = current_batch_epoch();
-    if let Ok(cache) = RESOLVE_CACHE.read()
-        && let Some(entry) = cache.get(&key)
-        && cached_path_is_fresh(entry, epoch)
-    {
-        return Some(entry.path.clone());
-    }
-
-    let resolved = resolve_import_path_uncached(current_file, specifier)?;
-    if let Ok(mut cache) = RESOLVE_CACHE.write() {
-        cache.insert(
-            key,
-            CachedPath {
-                path: resolved.clone(),
-                validated_epoch: AtomicU64::new(epoch),
-            },
-        );
-    }
-    Some(resolved)
-}
-
-fn resolve_import_path_uncached(current_file: &Path, specifier: &str) -> Option<PathBuf> {
-    if let Some(alias_path) = resolve_at_src_alias(current_file, specifier) {
-        return Some(alias_path);
-    }
-
-    if !specifier.starts_with('.') && !specifier.starts_with('/') {
-        return resolve_bare_specifier(current_file, specifier);
-    }
-
-    let base_dir = current_file.parent()?;
-    let candidate = if specifier.starts_with('/') {
-        PathBuf::from(specifier)
-    } else {
-        base_dir.join(specifier)
-    };
-
-    resolve_candidate_path(candidate)
-}
-
-/// Resolve a bare specifier (`reka-ui`, `@scope/pkg/sub`) to a package's type
-/// declarations through `node_modules`. Only first-party sources step into
-/// packages: bare imports *between* packages (every library imports `vue`)
-/// would pull huge, mostly `@vue-ignore`d type graphs, so files already
-/// inside `node_modules` only follow their relative imports.
-fn resolve_bare_specifier(current_file: &Path, specifier: &str) -> Option<PathBuf> {
-    if specifier.starts_with('#') || specifier.starts_with("node:") {
-        return None;
-    }
-    if current_file
-        .components()
-        .any(|component| component.as_os_str() == "node_modules")
-    {
-        return None;
-    }
-
-    let (package, subpath) = split_package_specifier(specifier)?;
-    for dir in current_file.ancestors().skip(1) {
-        let package_dir = dir.join("node_modules").join(&package);
-        if package_dir.is_dir() {
-            return resolve_package_types(&package_dir, &subpath);
-        }
-    }
-    None
-}
-
-/// Split `@scope/name/sub/path` / `name/sub/path` into package name and
-/// subpath.
-fn split_package_specifier(specifier: &str) -> Option<(String, String)> {
-    let segment_count = if specifier.starts_with('@') { 2 } else { 1 };
-    let mut split_at = 0;
-    let mut seen = 0;
-    for (index, byte) in specifier.bytes().enumerate() {
-        if byte == b'/' {
-            seen += 1;
-            if seen == segment_count {
-                split_at = index;
-                break;
-            }
-        }
-    }
-    if seen < segment_count {
-        split_at = specifier.len();
-    }
-    let package = &specifier[..split_at];
-    if package.is_empty() {
-        return None;
-    }
-    let subpath = specifier[split_at..].trim_start_matches('/');
-    Some((package.to_compact_string(), subpath.to_compact_string()))
-}
-
-fn resolve_package_types(package_dir: &Path, subpath: &str) -> Option<PathBuf> {
-    let manifest = std::fs::read_to_string(package_dir.join("package.json")).ok();
-    let manifest: Option<serde_json::Value> =
-        manifest.and_then(|raw| serde_json::from_str(&raw).ok());
-
-    if subpath.is_empty() {
-        if let Some(manifest) = &manifest {
-            if let Some(types) = manifest
-                .get("types")
-                .or_else(|| manifest.get("typings"))
-                .and_then(|value| value.as_str())
-                && let Some(path) = resolve_candidate_path(package_dir.join(types))
-            {
-                return Some(path);
-            }
-            if let Some(types) = exports_types_entry(manifest, ".")
-                && let Some(path) = resolve_candidate_path(package_dir.join(types))
-            {
-                return Some(path);
-            }
-        }
-        return resolve_candidate_path(package_dir.join("index.d.ts"));
-    }
-
-    if let Some(manifest) = &manifest {
-        let mut export_key = String::from("./");
-        export_key.push_str(subpath);
-        if let Some(types) = exports_types_entry(manifest, export_key.as_str())
-            && let Some(path) = resolve_candidate_path(package_dir.join(types))
-        {
-            return Some(path);
-        }
-    }
-    resolve_candidate_path(package_dir.join(subpath))
-}
-
-/// Find the `types` condition for an `exports` entry; conditions may nest
-/// (`{ "import": { "types": "./x.d.mts", "default": "./x.mjs" } }`).
-fn exports_types_entry(manifest: &serde_json::Value, key: &str) -> Option<String> {
-    fn find_types(value: &serde_json::Value) -> Option<String> {
-        match value {
-            serde_json::Value::Object(map) => {
-                if let Some(types) = map.get("types").and_then(|value| value.as_str()) {
-                    return Some(types.to_compact_string());
-                }
-                map.values().find_map(find_types)
-            }
-            _ => None,
-        }
-    }
-    find_types(manifest.get("exports")?.get(key)?)
-}
-
-fn resolve_at_src_alias(current_file: &Path, specifier: &str) -> Option<PathBuf> {
-    let rest = specifier.strip_prefix("@/")?;
-    let src_dir = current_file
-        .parent()?
-        .ancestors()
-        .find(|path| path.file_name().is_some_and(|name| name == "src"))?;
-
-    resolve_candidate_path(src_dir.join(rest))
-}
-
-fn resolve_candidate_path(candidate: PathBuf) -> Option<PathBuf> {
-    if candidate.is_file() {
-        return canonicalize_or_original(candidate);
-    }
-
-    if let Some(ts_source_path) = resolve_ts_source_path_for_js_specifier(&candidate) {
-        return Some(ts_source_path);
-    }
-
-    for ext in RESOLVE_EXTENSIONS {
-        let mut with_ext = candidate.clone().into_os_string();
-        with_ext.push(ext);
-        let path = PathBuf::from(with_ext);
-        if path.is_file() {
-            return canonicalize_or_original(path);
-        }
-    }
-
-    if candidate.is_dir() {
-        for index_name in INDEX_CANDIDATES {
-            let path = candidate.join(index_name);
-            if path.is_file() {
-                return canonicalize_or_original(path);
-            }
-        }
-    }
-
-    None
-}
-
-fn resolve_ts_source_path_for_js_specifier(candidate: &Path) -> Option<PathBuf> {
-    let extension = candidate.extension()?.to_str()?;
-    let source_extensions: &[&str] = match extension {
-        "js" => &["ts", "tsx"],
-        "jsx" => &["tsx", "ts"],
-        "mjs" => &["mts", "ts"],
-        "cjs" => &["cts", "ts"],
-        _ => return None,
-    };
-
-    for source_extension in source_extensions {
-        let source_candidate = candidate.with_extension(source_extension);
-        if source_candidate.is_file() {
-            return canonicalize_or_original(source_candidate);
-        }
-    }
-
-    None
-}
-
-fn canonicalize_or_original(path: PathBuf) -> Option<PathBuf> {
-    match path.canonicalize() {
-        Ok(canonical) => Some(canonical),
-        Err(_) if path.exists() => Some(path),
-        Err(_) => None,
-    }
-}
-
-fn path_key(path: &Path) -> String {
-    path.to_string_lossy().as_ref().to_compact_string()
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{resolve_at_src_alias, resolve_import_path};
+    use super::build_file_summary;
+    use super::resolution::{resolve_at_src_alias, resolve_import_path};
     use std::path::{Path, PathBuf};
 
     fn temp_project_dir(test_name: &str) -> PathBuf {
@@ -812,6 +521,59 @@ const props = defineProps<SelectProps>();
         let target = target.canonicalize().unwrap();
 
         assert_eq!(resolved.as_deref(), Some(target.as_path()));
+
+        let _ = std::fs::remove_dir_all(project);
+    }
+
+    #[test]
+    fn resolves_javascript_specifiers_to_declaration_sources() {
+        let project = temp_project_dir("javascript-to-declaration-imports");
+        let dist = project.join("dist");
+        std::fs::create_dir_all(&dist).unwrap();
+        let current = dist.join("index.d.ts");
+
+        for (specifier, declaration) in [
+            ("./index4.js", "index4.d.ts"),
+            ("./index4.jsx", "index4.d.ts"),
+            ("./index4.mjs", "index4.d.mts"),
+            ("./index4.cjs", "index4.d.cts"),
+        ] {
+            std::fs::write(dist.join(&specifier[2..]), "export {};\n").unwrap();
+            let target = dist.join(declaration);
+            std::fs::write(&target, "export interface PrimitiveProps {}").unwrap();
+
+            let resolved = resolve_import_path(&current, specifier);
+            let target = target.canonicalize().unwrap();
+            assert_eq!(resolved.as_deref(), Some(target.as_path()), "{specifier}");
+        }
+
+        let _ = std::fs::remove_dir_all(project);
+    }
+
+    #[test]
+    fn follows_plain_value_imports_only_in_declaration_summaries() {
+        let project = temp_project_dir("declaration-value-import-scope");
+        std::fs::create_dir_all(&project).unwrap();
+        let source = "import './side-effect.js'\nimport { PrimitiveProps } from './chunk.js'\nexport { PrimitiveProps }\n";
+        let module = project.join("index.ts");
+        std::fs::write(&module, source).unwrap();
+
+        for declaration_name in ["index.d.ts", "index.d.mts", "index.d.cts"] {
+            let declaration = project.join(declaration_name);
+            std::fs::write(&declaration, source).unwrap();
+            let declaration_summary = build_file_summary(&declaration).unwrap();
+            assert_eq!(
+                declaration_summary.specifiers.as_slice(),
+                ["./chunk.js"],
+                "{declaration_name}"
+            );
+        }
+
+        let module_summary = build_file_summary(&module).unwrap();
+        assert!(
+            module_summary.specifiers.is_empty(),
+            "ordinary TS runtime imports must not widen the type graph"
+        );
 
         let _ = std::fs::remove_dir_all(project);
     }
@@ -1004,47 +766,6 @@ const props = defineProps<ButtonProps>();
             Some(&crate::types::BindingType::Props)
         );
         assert_eq!(ctx.bindings.bindings.get("raw"), None);
-
-        let _ = std::fs::remove_dir_all(project);
-    }
-
-    #[test]
-    fn cached_path_revalidates_only_once_per_batch() {
-        use super::{CachedPath, NO_EPOCH, cached_path_is_fresh};
-        use std::sync::atomic::{AtomicU64, Ordering};
-
-        let project = temp_project_dir("cached-path-freshness");
-        std::fs::create_dir_all(&project).unwrap();
-        let file = project.join("present.ts");
-        std::fs::write(&file, "export type T = string").unwrap();
-
-        // Pretend this entry was validated in batch epoch 7.
-        let entry = CachedPath {
-            path: file.clone(),
-            validated_epoch: AtomicU64::new(7),
-        };
-
-        // A later hit in the *same* batch trusts the entry without touching the
-        // filesystem — proven by deleting the file first: a re-stat would fail,
-        // but the same-epoch fast path returns `true` anyway.
-        std::fs::remove_file(&file).unwrap();
-        assert!(
-            cached_path_is_fresh(&entry, 7),
-            "same-epoch hit must skip the is_file stat"
-        );
-
-        // A new batch (epoch 8) forces revalidation, which now fails because the
-        // file is gone — so a fresh resolution would run.
-        assert!(
-            !cached_path_is_fresh(&entry, 8),
-            "a new batch must re-stat and observe the deletion"
-        );
-
-        // Outside any batch (NO_EPOCH) every call re-stats; recreate the file
-        // and confirm it revalidates and stamps the epoch forward.
-        std::fs::write(&file, "export type T = number").unwrap();
-        assert!(cached_path_is_fresh(&entry, NO_EPOCH));
-        assert_eq!(entry.validated_epoch.load(Ordering::Relaxed), NO_EPOCH);
 
         let _ = std::fs::remove_dir_all(project);
     }

--- a/crates/vize_atelier_sfc/src/script/context/external_types/resolution.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/resolution.rs
@@ -1,0 +1,313 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{LazyLock, RwLock};
+
+use vize_carton::{FxHashMap, String, ToCompactString};
+
+use super::super::batch_epoch::{NO_EPOCH, current_batch_epoch};
+
+const RESOLVE_EXTENSIONS: &[&str] = &[
+    ".ts", ".tsx", ".d.ts", ".mts", ".cts", ".js", ".jsx", ".vue",
+];
+const INDEX_CANDIDATES: &[&str] = &[
+    "index.ts",
+    "index.tsx",
+    "index.d.ts",
+    "index.mts",
+    "index.cts",
+    "index.js",
+    "index.jsx",
+    "index.vue",
+];
+
+/// A resolved path plus the batch epoch in which its existence was last
+/// confirmed. A read hit can stamp the epoch forward under the shared guard.
+struct CachedPath {
+    path: PathBuf,
+    validated_epoch: AtomicU64,
+}
+
+/// Decide whether a cached resolved path is still usable, paying the `is_file`
+/// `stat` only when the entry has not already been confirmed this batch.
+fn cached_path_is_fresh(entry: &CachedPath, epoch: u64) -> bool {
+    if epoch != NO_EPOCH && entry.validated_epoch.load(Ordering::Relaxed) == epoch {
+        return true;
+    }
+    if entry.path.is_file() {
+        entry.validated_epoch.store(epoch, Ordering::Relaxed);
+        true
+    } else {
+        false
+    }
+}
+
+/// Base-file canonicalization cache: `(cwd, filename) -> canonical path`.
+/// Outside a batch a hit is revalidated with one `is_file` check; within a
+/// batch the first hit revalidates and later hits reuse it. Failures are never
+/// cached, so files created later are picked up.
+static BASE_CANON_CACHE: LazyLock<RwLock<FxHashMap<(PathBuf, String), CachedPath>>> =
+    LazyLock::new(|| RwLock::new(FxHashMap::default()));
+
+/// Canonicalize the compiled file's own path, falling back to the original
+/// path for virtual filenames that do not exist on disk.
+pub(super) fn canonical_base_file(filename: &str) -> PathBuf {
+    let path = PathBuf::from(filename);
+    let cwd = if path.is_absolute() {
+        PathBuf::new()
+    } else {
+        std::env::current_dir().unwrap_or_default()
+    };
+    let key = (cwd, filename.to_compact_string());
+    let epoch = current_batch_epoch();
+    if let Ok(cache) = BASE_CANON_CACHE.read()
+        && let Some(entry) = cache.get(&key)
+        && cached_path_is_fresh(entry, epoch)
+    {
+        return entry.path.clone();
+    }
+
+    match path.canonicalize() {
+        Ok(canonical) => {
+            if let Ok(mut cache) = BASE_CANON_CACHE.write() {
+                cache.insert(
+                    key,
+                    CachedPath {
+                        path: canonical.clone(),
+                        validated_epoch: AtomicU64::new(epoch),
+                    },
+                );
+            }
+            canonical
+        }
+        Err(_) => path,
+    }
+}
+
+/// Positive resolution cache: `(importing dir, specifier) -> resolved path`.
+/// Misses are not cached so newly created files remain discoverable.
+static RESOLVE_CACHE: LazyLock<RwLock<FxHashMap<(PathBuf, String), CachedPath>>> =
+    LazyLock::new(|| RwLock::new(FxHashMap::default()));
+
+pub(super) fn resolve_import_path(current_file: &Path, specifier: &str) -> Option<PathBuf> {
+    let dir = current_file.parent()?.to_path_buf();
+    let key = (dir, specifier.to_compact_string());
+    let epoch = current_batch_epoch();
+    if let Ok(cache) = RESOLVE_CACHE.read()
+        && let Some(entry) = cache.get(&key)
+        && cached_path_is_fresh(entry, epoch)
+    {
+        return Some(entry.path.clone());
+    }
+
+    let resolved = resolve_import_path_uncached(current_file, specifier)?;
+    if let Ok(mut cache) = RESOLVE_CACHE.write() {
+        cache.insert(
+            key,
+            CachedPath {
+                path: resolved.clone(),
+                validated_epoch: AtomicU64::new(epoch),
+            },
+        );
+    }
+    Some(resolved)
+}
+
+fn resolve_import_path_uncached(current_file: &Path, specifier: &str) -> Option<PathBuf> {
+    if let Some(alias_path) = resolve_at_src_alias(current_file, specifier) {
+        return Some(alias_path);
+    }
+
+    if !specifier.starts_with('.') && !specifier.starts_with('/') {
+        return resolve_bare_specifier(current_file, specifier);
+    }
+
+    let base_dir = current_file.parent()?;
+    let candidate = if specifier.starts_with('/') {
+        PathBuf::from(specifier)
+    } else {
+        base_dir.join(specifier)
+    };
+
+    resolve_candidate_path(candidate)
+}
+
+/// Resolve a bare specifier to package type declarations through
+/// `node_modules`. Files already inside `node_modules` follow only relative
+/// imports, avoiding unrelated dependency type graphs.
+fn resolve_bare_specifier(current_file: &Path, specifier: &str) -> Option<PathBuf> {
+    if specifier.starts_with('#') || specifier.starts_with("node:") {
+        return None;
+    }
+    if current_file
+        .components()
+        .any(|component| component.as_os_str() == "node_modules")
+    {
+        return None;
+    }
+
+    let (package, subpath) = split_package_specifier(specifier)?;
+    for dir in current_file.ancestors().skip(1) {
+        let package_dir = dir.join("node_modules").join(&package);
+        if package_dir.is_dir() {
+            return resolve_package_types(&package_dir, &subpath);
+        }
+    }
+    None
+}
+
+/// Split `@scope/name/sub/path` / `name/sub/path` into package name and
+/// subpath.
+fn split_package_specifier(specifier: &str) -> Option<(String, String)> {
+    let segment_count = if specifier.starts_with('@') { 2 } else { 1 };
+    let mut split_at = 0;
+    let mut seen = 0;
+    for (index, byte) in specifier.bytes().enumerate() {
+        if byte == b'/' {
+            seen += 1;
+            if seen == segment_count {
+                split_at = index;
+                break;
+            }
+        }
+    }
+    if seen < segment_count {
+        split_at = specifier.len();
+    }
+    let package = &specifier[..split_at];
+    if package.is_empty() {
+        return None;
+    }
+    let subpath = specifier[split_at..].trim_start_matches('/');
+    Some((package.to_compact_string(), subpath.to_compact_string()))
+}
+
+fn resolve_package_types(package_dir: &Path, subpath: &str) -> Option<PathBuf> {
+    let manifest = std::fs::read_to_string(package_dir.join("package.json")).ok();
+    let manifest: Option<serde_json::Value> =
+        manifest.and_then(|raw| serde_json::from_str(&raw).ok());
+
+    if subpath.is_empty() {
+        if let Some(manifest) = &manifest {
+            if let Some(types) = manifest
+                .get("types")
+                .or_else(|| manifest.get("typings"))
+                .and_then(|value| value.as_str())
+                && let Some(path) = resolve_candidate_path(package_dir.join(types))
+            {
+                return Some(path);
+            }
+            if let Some(types) = exports_types_entry(manifest, ".")
+                && let Some(path) = resolve_candidate_path(package_dir.join(types))
+            {
+                return Some(path);
+            }
+        }
+        return resolve_candidate_path(package_dir.join("index.d.ts"));
+    }
+
+    if let Some(manifest) = &manifest {
+        let mut export_key = String::from("./");
+        export_key.push_str(subpath);
+        if let Some(types) = exports_types_entry(manifest, export_key.as_str())
+            && let Some(path) = resolve_candidate_path(package_dir.join(types))
+        {
+            return Some(path);
+        }
+    }
+    resolve_candidate_path(package_dir.join(subpath))
+}
+
+/// Find the `types` condition for an `exports` entry; conditions may nest.
+fn exports_types_entry(manifest: &serde_json::Value, key: &str) -> Option<String> {
+    fn find_types(value: &serde_json::Value) -> Option<String> {
+        match value {
+            serde_json::Value::Object(map) => {
+                if let Some(types) = map.get("types").and_then(|value| value.as_str()) {
+                    return Some(types.to_compact_string());
+                }
+                map.values().find_map(find_types)
+            }
+            _ => None,
+        }
+    }
+    find_types(manifest.get("exports")?.get(key)?)
+}
+
+pub(super) fn resolve_at_src_alias(current_file: &Path, specifier: &str) -> Option<PathBuf> {
+    let rest = specifier.strip_prefix("@/")?;
+    let src_dir = current_file
+        .parent()?
+        .ancestors()
+        .find(|path| path.file_name().is_some_and(|name| name == "src"))?;
+
+    resolve_candidate_path(src_dir.join(rest))
+}
+
+fn resolve_candidate_path(candidate: PathBuf) -> Option<PathBuf> {
+    // This resolver only serves type-bearing imports. For JS-shaped
+    // specifiers, prefer the TypeScript/declaration counterpart even when the
+    // published runtime file exists beside it.
+    if let Some(ts_source_path) = resolve_ts_source_path_for_js_specifier(&candidate) {
+        return Some(ts_source_path);
+    }
+
+    if candidate.is_file() {
+        return canonicalize_or_original(candidate);
+    }
+
+    for ext in RESOLVE_EXTENSIONS {
+        let mut with_ext = candidate.clone().into_os_string();
+        with_ext.push(ext);
+        let path = PathBuf::from(with_ext);
+        if path.is_file() {
+            return canonicalize_or_original(path);
+        }
+    }
+
+    if candidate.is_dir() {
+        for index_name in INDEX_CANDIDATES {
+            let path = candidate.join(index_name);
+            if path.is_file() {
+                return canonicalize_or_original(path);
+            }
+        }
+    }
+
+    None
+}
+
+fn resolve_ts_source_path_for_js_specifier(candidate: &Path) -> Option<PathBuf> {
+    let extension = candidate.extension()?.to_str()?;
+    let source_extensions: &[&str] = match extension {
+        "js" => &["ts", "tsx", "d.ts"],
+        "jsx" => &["tsx", "ts", "d.ts"],
+        "mjs" => &["mts", "d.mts", "ts", "d.ts"],
+        "cjs" => &["cts", "d.cts", "ts", "d.ts"],
+        _ => return None,
+    };
+
+    for source_extension in source_extensions {
+        let source_candidate = candidate.with_extension(source_extension);
+        if source_candidate.is_file() {
+            return canonicalize_or_original(source_candidate);
+        }
+    }
+
+    None
+}
+
+fn canonicalize_or_original(path: PathBuf) -> Option<PathBuf> {
+    match path.canonicalize() {
+        Ok(canonical) => Some(canonical),
+        Err(_) if path.exists() => Some(path),
+        Err(_) => None,
+    }
+}
+
+pub(super) fn path_key(path: &Path) -> String {
+    path.to_string_lossy().as_ref().to_compact_string()
+}
+
+#[cfg(test)]
+#[path = "resolution_tests.rs"]
+mod tests;

--- a/crates/vize_atelier_sfc/src/script/context/external_types/resolution_tests.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/resolution_tests.rs
@@ -1,0 +1,38 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::super::super::batch_epoch::NO_EPOCH;
+use super::{CachedPath, cached_path_is_fresh};
+
+#[test]
+fn cached_path_revalidates_only_once_per_batch() {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let project = std::env::temp_dir().join(format!(
+        "vize-sfc-external-types-{}-cached-path-{nonce}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&project).unwrap();
+    let file = project.join("present.ts");
+    std::fs::write(&file, "export type T = string").unwrap();
+
+    let entry = CachedPath {
+        path: file.clone(),
+        validated_epoch: AtomicU64::new(7),
+    };
+
+    // The same batch trusts the cached path without touching the filesystem.
+    std::fs::remove_file(&file).unwrap();
+    assert!(cached_path_is_fresh(&entry, 7));
+
+    // A new batch re-stats and observes the deletion.
+    assert!(!cached_path_is_fresh(&entry, 8));
+
+    // Outside a batch every call re-stats and stamps NO_EPOCH.
+    std::fs::write(&file, "export type T = number").unwrap();
+    assert!(cached_path_is_fresh(&entry, NO_EPOCH));
+    assert_eq!(entry.validated_epoch.load(Ordering::Relaxed), NO_EPOCH);
+
+    let _ = std::fs::remove_dir_all(project);
+}


### PR DESCRIPTION
Closes #3835

## Summary

- follow bound value imports only while walking declaration files
- resolve JS-shaped type specifiers to co-located TypeScript declarations before runtime files
- preserve inherited runtime props, defaults, and template bindings through bundled declaration barrels
- split external type resolution into a source-length-safe module

## Tests

- `cargo test -p vize_atelier_sfc` (612 unit tests plus integration/doc tests)
- `cargo clippy -p vize_atelier_sfc -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `node --test tests/tooling/package-manifests.test.ts` (17/17)
- focused `.js`/`.jsx`/`.mjs`/`.cjs`, `.d.ts`/`.d.mts`/`.d.cts`, runtime-file coexistence, side-effect-import, and compiler-output regressions
- source-length growth check against `origin/main`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of TypeScript, JavaScript, Vue, declaration, aliased, relative, absolute, and package imports.
  * Enhanced support for package export conditions, type declarations, index files, and source resolution.
  * Fixed `defineProps` inheritance through value-imported interfaces re-exported from package barrels.
  * Improved detection of changes to imported files during repeated compilation.
  * Added support for correctly emitting inherited Boolean and typed props, defaults, local props, and template access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->