### PR TITLE
test(maestro): verify cancellation under revision churn

### DIFF
--- a/tests/tooling/lsp-request-cancellation.test.ts
+++ b/tests/tooling/lsp-request-cancellation.test.ts
@@ -3,15 +3,30 @@ import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { pathToFileURL } from "node:url";
-import { isDiagnosticsForUri } from "./support/lsp/assertions.ts";
+import { hoverToText, isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
 import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { JsonRpcMessage, PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
 import { LspRequestError, LspSession } from "./support/lsp/session.ts";
 
-const SOURCE = `<script setup lang="ts">
+const CLEAN_SOURCE = `<script setup lang="ts">
 const cancellableSymbol = 1
 </script>
 <template><p>{{ cancellableSymbol }}</p></template>
 `;
+
+const BROKEN_SOURCE = `<template>
+  <p>{{ cancellableSymbol }}</p>
+`;
+
+const BROKEN_CODES = ["vize/sfc:Malformed <template> block: the closing tag is missing."];
+
+type PublishRecord = { version: number | null; codes: string[] };
+
+function codesOf(params: PublishDiagnosticsParams): string[] {
+  return params.diagnostics
+    .map((diagnostic) => `${diagnostic.source ?? "?"}:${diagnostic.message}`)
+    .sort();
+}
 
 test("vize lsp cancels an in-flight request and remains usable", async () => {
   const testRootDir = path.join(testOutputRoot, "lsp-request-cancellation");
@@ -19,14 +34,14 @@ test("vize lsp cancels an in-flight request and remains usable", async () => {
   const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
   const filePath = path.join(workspaceDir, "Cancellable.vue");
   const uri = pathToFileURL(filePath).href;
-  fs.writeFileSync(filePath, SOURCE, "utf8");
+  fs.writeFileSync(filePath, CLEAN_SOURCE, "utf8");
 
   const session = new LspSession();
   let primaryError: unknown;
   try {
     await session.initialize(workspaceDir, { editor: true, lint: false, typecheck: false });
     session.notify("textDocument/didOpen", {
-      textDocument: { uri, languageId: "vue", version: 1, text: SOURCE },
+      textDocument: { uri, languageId: "vue", version: 1, text: CLEAN_SOURCE },
     });
     await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
       isDiagnosticsForUri(params, uri),
@@ -54,6 +69,153 @@ test("vize lsp cancels an in-flight request and remains usable", async () => {
       retry?.some((symbol) => symbol.name === "cancellableSymbol"),
       JSON.stringify(retry),
     );
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    await session.shutdown().catch((error: unknown) => {
+      if (primaryError == null) throw error;
+    });
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+test("vize lsp preserves cancellation and diagnostics under revision churn", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-request-cancellation-churn");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const filePath = path.join(workspaceDir, "CancellationChurn.vue");
+  const uri = pathToFileURL(filePath).href;
+  fs.writeFileSync(filePath, CLEAN_SOURCE, "utf8");
+
+  const session = new LspSession();
+  let primaryError: unknown;
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      hover: true,
+      lint: false,
+      typecheck: false,
+    });
+
+    const publishes: PublishRecord[] = [];
+    session.notificationObservers.push((method, params) => {
+      if (method !== "textDocument/publishDiagnostics") return;
+      const publish = params as PublishDiagnosticsParams;
+      if (!isDiagnosticsForUri(publish, uri)) return;
+      publishes.push({ version: publish.version ?? null, codes: codesOf(publish) });
+    });
+
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: CLEAN_SOURCE },
+    });
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri) && params.version === 1,
+    );
+
+    const expectedCodes = new Map<number, string[]>([[1, []]]);
+    const cancelled: Array<{ id: number; method: string; response: Promise<unknown> }> = [];
+    let version = 1;
+
+    const changeMessage = (text: string): JsonRpcMessage => {
+      version += 1;
+      expectedCodes.set(version, text === BROKEN_SOURCE ? BROKEN_CODES : []);
+      return {
+        jsonrpc: "2.0",
+        method: "textDocument/didChange",
+        params: {
+          textDocument: { uri, version },
+          contentChanges: [{ text }],
+        },
+      };
+    };
+
+    const cancelWorkspaceSymbol = (query: string, following: JsonRpcMessage[] = []): void => {
+      const method = "workspace/symbol";
+      let id = -1;
+      const response = session.request(method, { query }, 30_000, (requestId) => {
+        id = requestId;
+        return [
+          { jsonrpc: "2.0", method: "$/cancelRequest", params: { id: requestId } },
+          ...following,
+        ];
+      });
+      assert.ok(id > 0, "request id must be captured before the frame is sent");
+      cancelled.push({ id, method, response });
+    };
+
+    // Each request and its cancellation share one stdio write. The edit is
+    // alternately queued before, inside, and after those frames so three
+    // repeated rounds cover both queue orderings without timing sleeps.
+    for (const round of [1, 2, 3]) {
+      session.notify("textDocument/didChange", changeMessage(BROKEN_SOURCE).params);
+      cancelWorkspaceSymbol(`cancellableSymbol-before-${round}`);
+      cancelWorkspaceSymbol(`cancellableSymbol-batched-${round}`, [changeMessage(CLEAN_SOURCE)]);
+      cancelWorkspaceSymbol(`cancellableSymbol-after-${round}`);
+    }
+
+    const settled = await Promise.allSettled(cancelled.map(({ response }) => response));
+    settled.forEach((result, index) => {
+      const attempt = cancelled[index];
+      assert.equal(
+        result.status,
+        "rejected",
+        `${attempt.method} request ${attempt.id} must cancel`,
+      );
+      if (result.status !== "rejected") return;
+      assert.ok(result.reason instanceof LspRequestError, String(result.reason));
+      assert.equal(result.reason.id, attempt.id);
+      assert.equal(result.reason.method, attempt.method);
+      assert.equal(result.reason.code, -32800);
+    });
+
+    const finalVersion = version;
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri) && params.version === finalVersion,
+    );
+
+    let previousVersion = 0;
+    for (const publish of publishes) {
+      assert.ok(
+        publish.version != null,
+        `unexpected unversioned publish: ${JSON.stringify(publish)}`,
+      );
+      assert.ok(
+        publish.version > previousVersion,
+        `diagnostic versions must advance monotonically: ${JSON.stringify(publishes)}`,
+      );
+      assert.deepEqual(
+        publish.codes,
+        expectedCodes.get(publish.version),
+        `diagnostics must describe revision ${publish.version}`,
+      );
+      previousVersion = publish.version;
+    }
+    assert.deepEqual(publishes.at(-1), { version: finalVersion, codes: [] });
+
+    const symbols = (await session.request("workspace/symbol", {
+      query: "cancellableSymbol",
+    })) as Array<{ name?: string }> | null;
+    assert.ok(symbols?.some((symbol) => symbol.name === "cancellableSymbol"));
+
+    const hover = (await session.request("textDocument/hover", {
+      textDocument: { uri },
+      position: offsetToPosition(
+        CLEAN_SOURCE,
+        CLEAN_SOURCE.lastIndexOf("cancellableSymbol }}</p>") + 3,
+      ),
+    })) as { contents?: unknown } | null;
+    assert.match(hoverToText(hover), /cancellableSymbol/);
+
+    session.notify("textDocument/didClose", { textDocument: { uri } });
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri) && params.version == null,
+    );
+    assert.deepEqual(publishes.at(-1), { version: null, codes: [] });
   } catch (error) {
     primaryError = error;
     throw error;

--- a/tests/tooling/support/lsp/errors.ts
+++ b/tests/tooling/support/lsp/errors.ts
@@ -1,0 +1,21 @@
+import type { JsonRpcId } from "./protocol.ts";
+
+export class LspRequestError extends Error {
+  readonly code: number;
+  readonly data: unknown;
+  readonly id: JsonRpcId;
+  readonly method: string;
+
+  constructor(
+    id: JsonRpcId,
+    method: string,
+    error: { code: number; message: string; data?: unknown },
+  ) {
+    super(`${method}: ${error.message}`);
+    this.name = "LspRequestError";
+    this.code = error.code;
+    this.data = error.data;
+    this.id = id;
+    this.method = method;
+  }
+}

--- a/tests/tooling/support/lsp/session.ts
+++ b/tests/tooling/support/lsp/session.ts
@@ -2,23 +2,12 @@ import assert from "node:assert/strict";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { LspRequestError } from "./errors.ts";
 import { resolveVizeLaunchCommand } from "./launch.ts";
 import { root } from "./paths.ts";
 import type { JsonRpcId, JsonRpcMessage, LspInitializationOptions } from "./protocol.ts";
 
-export class LspRequestError extends Error {
-  readonly code: number;
-  readonly data: unknown;
-  readonly method: string;
-
-  constructor(method: string, error: { code: number; message: string; data?: unknown }) {
-    super(`${method}: ${error.message}`);
-    this.name = "LspRequestError";
-    this.code = error.code;
-    this.data = error.data;
-    this.method = method;
-  }
-}
+export { LspRequestError };
 
 /**
  * Minimal JSON-RPC client for production LSP smoke tests.
@@ -296,7 +285,7 @@ export class LspSession {
       this.pending.delete(message.id);
 
       if (message.error) {
-        pending.reject(new LspRequestError(pending.method, message.error));
+        pending.reject(new LspRequestError(message.id, pending.method, message.error));
         return;
       }
 


### PR DESCRIPTION
## Summary

- add a deterministic real-stdio `vize lsp` regression that interleaves three rounds of monotonic document edits with nine immediately cancelled workspace-symbol requests
- assert each cancellation response matches its JSON-RPC request ID and method with code `-32800`
- prove observed diagnostics never regress or cross revision payloads, then verify the final clean revision, non-cancelled symbol/hover requests, document close, and graceful shutdown
- move the shared request error into a focused support module so request IDs are observable without growing the 350-line session helper

This supplies the strict cancellation-under-churn evidence tracked by #3224.

## Validation

- `cargo build -p vize`
- `node --test tests/tooling/lsp-request-cancellation.test.ts` (initial run plus five repeated runs and final run)
- `node --test --test-concurrency=1 tests/tooling/lsp-*.test.ts` (2,218/2,221 passed before dependency hydration; the 3 dependency-only failures passed in a focused rerun after exposing the checkout's pinned Vue dependencies)
- `node --test tests/tooling/lsp-auto-insertion.test.ts tests/tooling/lsp-symlinked-node-modules.test.ts`
- `cargo test -p vize_maestro` (700 passed, 2 ignored)
- `cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `vp check` on the three changed files
- source-length gate with the CI-pinned MoonBit toolchain (7/7 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded language-server testing for cancelled requests during rapid document revisions.
  * Added validation for request IDs, cancellation errors, ordered diagnostics, symbols, hover results, and close notifications.
  * Added coverage for malformed source diagnostics and shared clean-source fixtures.

* **Refactor**
  * Improved consistency of language-server request error handling and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->