### PR TITLE
fix(atelier): prefer package exports types over legacy field

### DIFF
--- a/crates/vize_atelier_sfc/src/script/context/external_types/resolution.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/resolution.rs
@@ -188,15 +188,17 @@ fn resolve_package_types(package_dir: &Path, subpath: &str) -> Option<PathBuf> {
 
     if subpath.is_empty() {
         if let Some(manifest) = &manifest {
-            if let Some(types) = manifest
-                .get("types")
-                .or_else(|| manifest.get("typings"))
-                .and_then(|value| value.as_str())
+            // Modern resolution honours `exports` ahead of the legacy
+            // top-level `types`/`typings` entry points.
+            if let Some(types) = exports_types_entry(manifest, ".")
                 && let Some(path) = resolve_candidate_path(package_dir.join(types))
             {
                 return Some(path);
             }
-            if let Some(types) = exports_types_entry(manifest, ".")
+            if let Some(types) = manifest
+                .get("types")
+                .or_else(|| manifest.get("typings"))
+                .and_then(|value| value.as_str())
                 && let Some(path) = resolve_candidate_path(package_dir.join(types))
             {
                 return Some(path);

--- a/crates/vize_atelier_sfc/src/script/context/external_types/resolution.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/resolution.rs
@@ -190,7 +190,7 @@ fn resolve_package_types(package_dir: &Path, subpath: &str) -> Option<PathBuf> {
         if let Some(manifest) = &manifest {
             // Modern resolution honours `exports` ahead of the legacy
             // top-level `types`/`typings` entry points.
-            if let Some(types) = exports_types_entry(manifest, ".")
+            if let Some(types) = exports_root_types_entry(manifest)
                 && let Some(path) = resolve_candidate_path(package_dir.join(types))
             {
                 return Some(path);
@@ -219,20 +219,37 @@ fn resolve_package_types(package_dir: &Path, subpath: &str) -> Option<PathBuf> {
     resolve_candidate_path(package_dir.join(subpath))
 }
 
-/// Find the `types` condition for an `exports` entry; conditions may nest.
+/// Find the `types` condition for an `exports` subpath entry.
 fn exports_types_entry(manifest: &serde_json::Value, key: &str) -> Option<String> {
-    fn find_types(value: &serde_json::Value) -> Option<String> {
-        match value {
-            serde_json::Value::Object(map) => {
-                if let Some(types) = map.get("types").and_then(|value| value.as_str()) {
-                    return Some(types.to_compact_string());
-                }
-                map.values().find_map(find_types)
-            }
-            _ => None,
-        }
+    find_types_condition(manifest.get("exports")?.get(key)?)
+}
+
+/// Find the `types` condition for the package root. The root entry is either
+/// the explicit `"."` subpath or, when no subpath keys are present, a condition
+/// map placed directly under `exports`.
+fn exports_root_types_entry(manifest: &serde_json::Value) -> Option<String> {
+    let exports = manifest.get("exports")?;
+    if let Some(root) = exports.get(".") {
+        return find_types_condition(root);
     }
-    find_types(manifest.get("exports")?.get(key)?)
+    let conditions = exports.as_object()?;
+    if conditions.keys().any(|key| key.starts_with('.')) {
+        return None;
+    }
+    find_types_condition(exports)
+}
+
+/// Read a `types` condition out of an `exports` value; conditions may nest.
+fn find_types_condition(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::Object(map) => {
+            if let Some(types) = map.get("types").and_then(|value| value.as_str()) {
+                return Some(types.to_compact_string());
+            }
+            map.values().find_map(find_types_condition)
+        }
+        _ => None,
+    }
 }
 
 pub(super) fn resolve_at_src_alias(current_file: &Path, specifier: &str) -> Option<PathBuf> {

--- a/crates/vize_atelier_sfc/src/script/context/external_types/resolution_tests.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/resolution_tests.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::super::super::batch_epoch::NO_EPOCH;
-use super::{CachedPath, cached_path_is_fresh};
+use super::{CachedPath, cached_path_is_fresh, resolve_package_types};
 
 #[test]
 fn cached_path_revalidates_only_once_per_batch() {
@@ -35,4 +35,36 @@ fn cached_path_revalidates_only_once_per_batch() {
     assert_eq!(entry.validated_epoch.load(Ordering::Relaxed), NO_EPOCH);
 
     let _ = std::fs::remove_dir_all(project);
+}
+
+#[test]
+fn package_root_prefers_exports_types_over_top_level_types() {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let package = std::env::temp_dir().join(format!(
+        "vize-sfc-external-types-{}-exports-{nonce}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(package.join("dist")).unwrap();
+    std::fs::write(
+        package.join("package.json"),
+        r#"{"types":"./legacy.d.ts","exports":{".":{"types":"./dist/index.d.ts","import":"./dist/index.mjs"}}}"#,
+    )
+    .unwrap();
+    std::fs::write(package.join("legacy.d.ts"), "export type Legacy = string").unwrap();
+    std::fs::write(
+        package.join("dist/index.d.ts"),
+        "export type Modern = string",
+    )
+    .unwrap();
+
+    let resolved = resolve_package_types(&package, "").unwrap();
+    assert!(
+        resolved.ends_with("dist/index.d.ts"),
+        "expected exports types entry, got {resolved:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(package);
 }

--- a/crates/vize_atelier_sfc/src/script/context/external_types/resolution_tests.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/resolution_tests.rs
@@ -68,3 +68,65 @@ fn package_root_prefers_exports_types_over_top_level_types() {
 
     let _ = std::fs::remove_dir_all(package);
 }
+
+#[test]
+fn package_root_reads_condition_only_exports_map() {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let package = std::env::temp_dir().join(format!(
+        "vize-sfc-external-types-{}-root-conditions-{nonce}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(package.join("dist")).unwrap();
+    // `exports` may omit the `"."` subpath and hold conditions directly.
+    std::fs::write(
+        package.join("package.json"),
+        r#"{"types":"./legacy.d.ts","exports":{"types":"./dist/index.d.ts","default":"./dist/index.js"}}"#,
+    )
+    .unwrap();
+    std::fs::write(package.join("legacy.d.ts"), "export type Legacy = string").unwrap();
+    std::fs::write(
+        package.join("dist/index.d.ts"),
+        "export type Modern = string",
+    )
+    .unwrap();
+
+    let resolved = resolve_package_types(&package, "").unwrap();
+    assert!(
+        resolved.ends_with("dist/index.d.ts"),
+        "expected root condition types entry, got {resolved:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(package);
+}
+
+#[test]
+fn package_root_ignores_subpath_only_exports_map() {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let package = std::env::temp_dir().join(format!(
+        "vize-sfc-external-types-{}-subpath-only-{nonce}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(package.join("dist")).unwrap();
+    // Only a subpath is exported, so its `types` must not answer for the root.
+    std::fs::write(
+        package.join("package.json"),
+        r#"{"types":"./legacy.d.ts","exports":{"./sub":{"types":"./dist/sub.d.ts"}}}"#,
+    )
+    .unwrap();
+    std::fs::write(package.join("legacy.d.ts"), "export type Legacy = string").unwrap();
+    std::fs::write(package.join("dist/sub.d.ts"), "export type Sub = string").unwrap();
+
+    let resolved = resolve_package_types(&package, "").unwrap();
+    assert!(
+        resolved.ends_with("legacy.d.ts"),
+        "expected legacy types fallback, got {resolved:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(package);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,7 +230,7 @@ overrides:
   '@hono/node-server': 2.0.11
   '@unhead/vue': 2.1.15
   brace-expansion@2: 2.1.2
-  brace-expansion@>=5.0.0 <5.0.8: 5.0.8
+  brace-expansion@>=5.0.0 <5.0.9: 5.0.9
   defu: 6.1.7
   devalue: 5.8.1
   dompurify: 3.4.11
@@ -6799,8 +6799,8 @@ packages:
   brace-expansion@2.1.2:
     resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -16615,7 +16615,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -18792,7 +18792,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,7 +243,7 @@ overrides:
   nanotar: 0.3.0
   nitropack: 2.13.4
   node-forge: 1.4.0
-  postcss@>=8.0.0 <8.5.18: 8.5.18
+  postcss@>=8.0.0 <8.5.23: 8.5.23
   nuxt: 4.4.8
   qs: 6.15.2
   readdir-glob>minimatch: 10.2.5
@@ -276,7 +276,7 @@ importers:
         version: 1.16.0(@typescript-eslint/utils@8.65.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(@vue/compiler-sfc@3.6.0-beta.10)(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
       '@tsdown/css':
         specifier: catalog:content
-        version: 0.22.0(jiti@2.7.0)(postcss@8.5.18)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 0.22.0(jiti@2.7.0)(postcss@8.5.23)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
       '@types/node':
         specifier: catalog:typescript
         version: 25.9.2
@@ -444,7 +444,7 @@ importers:
         version: 2.0.3(@swc/helpers@0.5.21)
       '@tsdown/css':
         specifier: catalog:content
-        version: 0.22.0(jiti@2.7.0)(postcss@8.5.18)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 0.22.0(jiti@2.7.0)(postcss@8.5.23)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
       '@types/node':
         specifier: catalog:typescript
         version: 25.9.2
@@ -515,7 +515,7 @@ importers:
         version: 3.6.0-beta.10(typescript@6.0.3)
       webpack:
         specifier: catalog:bundlers
-        version: 5.107.2(esbuild@0.28.1)(postcss@8.5.18)
+        version: 5.107.2(esbuild@0.28.1)(postcss@8.5.23)
 
   npm/builder/vite:
     dependencies:
@@ -565,7 +565,7 @@ importers:
         version: 7.4.47
       '@tsdown/css':
         specifier: catalog:content
-        version: 0.22.0(jiti@2.7.0)(postcss@8.5.18)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 0.22.0(jiti@2.7.0)(postcss@8.5.23)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
       '@types/node':
         specifier: catalog:typescript
         version: 25.9.2
@@ -648,7 +648,7 @@ importers:
         version: 0.30.2
       '@tsdown/css':
         specifier: catalog:content
-        version: 0.22.0(jiti@2.7.0)(postcss@8.5.18)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 0.22.0(jiti@2.7.0)(postcss@8.5.23)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
       '@types/node':
         specifier: catalog:typescript
         version: 25.9.2
@@ -864,7 +864,7 @@ importers:
     devDependencies:
       '@tsdown/css':
         specifier: catalog:content
-        version: 0.22.0(jiti@2.7.0)(postcss@8.5.18)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 0.22.0(jiti@2.7.0)(postcss@8.5.23)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
       '@types/node':
         specifier: catalog:typescript
         version: 25.9.2
@@ -920,7 +920,7 @@ importers:
     devDependencies:
       '@tsdown/css':
         specifier: catalog:content
-        version: 0.22.0(jiti@2.7.0)(postcss@8.5.18)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 0.22.0(jiti@2.7.0)(postcss@8.5.23)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
       '@types/node':
         specifier: catalog:typescript
         version: 25.9.2
@@ -969,7 +969,7 @@ importers:
     devDependencies:
       '@tsdown/css':
         specifier: catalog:content
-        version: 0.22.0(jiti@2.7.0)(postcss@8.5.18)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
+        version: 0.22.0(jiti@2.7.0)(postcss@8.5.23)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
       '@types/node':
         specifier: catalog:typescript
         version: 25.9.2
@@ -5551,7 +5551,7 @@ packages:
     resolution: {integrity: sha512-gpkuNYVwgibCotNlHqgn1TJ9qHcE8Tim1rwaiQR7Ee9Rjb9BDYLypraaGMxqZgR1gr8NGRLGtbIv3eJtt5MHbQ==}
     engines: {node: ^22.18.0 || >=24.0.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-import: ^16.0.0
       postcss-modules: ^6.0.0
       sass: '*'
@@ -6700,7 +6700,7 @@ packages:
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   axe-core@4.11.1:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
@@ -7192,19 +7192,19 @@ packages:
     resolution: {integrity: sha512-OTdKeYMlvQ8KBgyej5ysktnWJoeyo7rGrVnm+bdpIHGvxhbTGPsOkB+7T1EdTuX00dGlQQb2UEbSPB1OpMXULw==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   cssnano-utils@6.0.0:
     resolution: {integrity: sha512-ztS9W/+uaDn+bkYmDhs+GdMveHJ3CL8IPNHpRqDUQXv5GJOTQAJjV1XUOInr9esLXSabQV1pLRZlJpyUwEqDyQ==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   cssnano@8.0.1:
     resolution: {integrity: sha512-oSiOnPQNNYjusTUlYJiE6xvFQG4don3N0QavaoV1BxIsC1zjvxOwikXlR7lG1EVmZNDDaJkHbQx1VRB8kaoMHA==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
@@ -8953,8 +8953,8 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -9386,62 +9386,62 @@ packages:
     resolution: {integrity: sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==}
     engines: {node: ^18.12 || ^20.9 || >=22.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-colormin@8.0.0:
     resolution: {integrity: sha512-KKwMmsSgsmdYXqrjQeqL3tnuIFtctiR1GEMHdjNpDpz/TCRkkkok2mMcreK2zVV3l7POWOmAkR2xYHUpRUK1DA==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-convert-values@8.0.0:
     resolution: {integrity: sha512-Ohtj3rNZWawTRePv5NCHTy8VJSdJ/G/uKuxcxJreOMichuqcT6uEl2TAnopVeJCJ/c13jaSqg7m63yFLM5zBsA==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-discard-comments@8.0.0:
     resolution: {integrity: sha512-zGpvVLj2sbagEp+BTVETvAfkZdGVA6rALNujDK/WTIjdf1/rQOxOG8BBzkI8UQgnw8SkL6xffAfbtGMHFypadw==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-discard-duplicates@8.0.0:
     resolution: {integrity: sha512-zjRyYmNGI3PTipKBBtCgExlmZXQn49KvKoaiNnR2g+iXxeNk7GY5Js2ULtZXPrCYeqjPagrzKIBNcBocvXCR7g==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-discard-empty@8.0.0:
     resolution: {integrity: sha512-kxPJg6EqahbBvm+l7hpYYCtpsv8dlz7Tv6wJXUXZaeuY0WGS61DxfGdZR4uVB/Cx+yi3iOHQVSqpSHKMFaBg6Q==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-discard-overridden@8.0.0:
     resolution: {integrity: sha512-sW2OWH3l9p0FmBSVr228uztFseqroZxwgD7SGF0Ks0dRPDttSo3P8FK5ZBLtWBH2A5+chpB0J2fB/T8heKHLBw==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-js@4.1.0:
     resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: 8.5.18
+      postcss: 8.5.23
       tsx: ^4.8.1
       yaml: 2.9.0
     peerDependenciesMeta:
@@ -9458,115 +9458,115 @@ packages:
     resolution: {integrity: sha512-YDmAmQ8H+ljfomVpSXvr9NA0GP01fraQJqjWBYoMVGg6rOT+PJLwPyeVo2ekn4WB4ZVSH5ddtK3DTRxbz6CFzg==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-merge-rules@8.0.0:
     resolution: {integrity: sha512-bgstL5mpi41dDpnYGDUcI3M814NWkCMcIWpwDqEHXkHg3BT7b4XRAfNEuwJncZOVn/67kVKvWzhfv/7xyrp2uQ==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-minify-font-values@8.0.0:
     resolution: {integrity: sha512-EnOHQEnSt6oH5NrL1DMFAQuwB2IOimFXTCzc9bKfUeH1jREbqIF5MAK4gQJQOC4mPUwJt4sWifAmNZ1qLu6j3Q==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-minify-gradients@8.0.0:
     resolution: {integrity: sha512-43iAnYIGk0ZjNx5X/rkIcHi6dhmu/vEjY0kqfUfxPuJRO+V7jx8uKIdcnL0dpfNoC5J9TSh3EtzLWbq0gpqnWA==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-minify-params@8.0.0:
     resolution: {integrity: sha512-z7w4QO7G55l4vMUK1Lmx03GW7iyRLgf2V5Dz/7ioSPLnXRjeD+b7m0XfAXUGrbBYYrJ6bXPk+3LoX5u4JfAcSg==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-minify-selectors@8.0.1:
     resolution: {integrity: sha512-c31D46811kTkQDxV1KTTow79axX6gj/01AY5G7cGZg3s31KvAwP13jEFXGAzQbJ7NvOFV1pRqEia6nrAdHU7qg==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-nested@6.2.0:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-charset@8.0.0:
     resolution: {integrity: sha512-s88FUNDSUD8m0wBYvTQQcubVts6zhXwBU8zCD4vkRKiecd0v8cOjHVIF9r/i+5xzS/WG3f98qq4XsOM0JqvfLA==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-display-values@8.0.0:
     resolution: {integrity: sha512-gG2nBxD27fiw6Luinb1QYKdM/Co5GornRJgSD+JTwNH4PGKxImP0qyruDDav49aHUPLY3qrL3qN3LvybO7IzxQ==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-positions@8.0.0:
     resolution: {integrity: sha512-t/wGqpehS20Ke7kc4QAsWpH+AJjUdMK/V5qV2RhrXkj8hO/fT1t1MJ8NL7sedWYk7ZqC7eISEJQonW5j0tU1MQ==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-repeat-style@8.0.0:
     resolution: {integrity: sha512-3ebOmGdCYKrBYyGKc1xhj0unEnW7beZpVU7JohVeGl7mTxR+7T6egpaawTWAVsB0pEIhcsbJVOjPKCJSoRO6Zg==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-string@8.0.0:
     resolution: {integrity: sha512-TvWCGZ/e04Tv31uJvOUtbexkfgUnqmQ3M2P5DkAaVzvOj+BvTkG2QjpA5Y71SL1SPxJcj4M23fNh+RDVCmG8kA==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-timing-functions@8.0.0:
     resolution: {integrity: sha512-uEfaXst5Xgqxv7geYUuz6vs9mn88K2NPY2RoIzM3BMmSjsdTSeppV9x2qIgrxsisdbSqF6IVhzI2occcte3hTA==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-unicode@8.0.0:
     resolution: {integrity: sha512-+WYngZaChEeTHZmWhmKtnJ4gTzWdINEaFcgWBnu6WdVu8Ftim8OBTcw768DuCC/3Aax9bZ9WkwrLGHym2Lzf+A==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-url@8.0.0:
     resolution: {integrity: sha512-4Mz9hZHn/QIB+YtFqTXrDmE2193GYxGb3F8uMfLvMicaEXCCUlDIJ658gFFJbqEGl9FYzwPtRiuNgbwlO9kkBg==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-normalize-whitespace@8.0.0:
     resolution: {integrity: sha512-V1f8tYnwIP5tscOXQFTKK8Y5EJ+R2GMpFJ6FjzwoKoQnhbqQy3IeSrDjJJb8JjVos8ut6Osi80Zybpayv/XjIQ==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-ordered-values@8.0.0:
     resolution: {integrity: sha512-Dg9+itb6lmD0bxqhQyHCtXAwYRh0wUrx6Mp4/BNXgkLoJmdYMmWi+V+Pypw79Q6iQhxA8KFMHqLBITQJV2gKMA==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-reduce-initial@8.0.0:
     resolution: {integrity: sha512-DChcE9d528AKrlpCTHjhsAiOsWCk4H9ApHPS1QqRT3praObWTiWyn6W1UddGpc46K9LQnHwUu4YwaPUukGtXVA==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-reduce-transforms@8.0.0:
     resolution: {integrity: sha512-cLZT0som7vvumQT9XQCnSKOSnRinNQZd1Hm+J723Ney13E8CIydDhw6JwzsjPtgnYThTqn9Q45906gz6wxaAsw==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -9580,19 +9580,19 @@ packages:
     resolution: {integrity: sha512-Q2fMSYEiNE1ioDc/3sxvI24NdgA/MJno2XLNpOxgv8aCcJbym8mZY10/lDY5+AWCIc3Aiqzy2Wcp9/zaIXBZgQ==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-unique-selectors@8.0.0:
     resolution: {integrity: sha512-iObuolUX+ITJfMU2QQFQdh31JgSjNLPNjVs6YGAqBHvOvAWXMMNget6donQl83aQaeS32i5XeKZURUW/WBxIUw==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.18:
-    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -10221,7 +10221,7 @@ packages:
     resolution: {integrity: sha512-sWyjaJvBqHoVKYPbQ8JRvrGSPaYWtWrJsU+fGVtwKB1GE1rRPu3rC7T6UCuXLoL00Dwb+tsHe2T904r8Vnsx8w==}
     engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
     peerDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   stylis@4.4.0:
     resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
@@ -13435,9 +13435,9 @@ snapshots:
       '@rollup/plugin-replace': 6.0.3(rollup@4.60.3)
       '@vitejs/plugin-vue': 6.0.7(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
       '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.5(@types/node@25.9.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.35(typescript@6.0.3))
-      autoprefixer: 10.5.0(postcss@8.5.18)
+      autoprefixer: 10.5.0(postcss@8.5.23)
       consola: 3.4.2
-      cssnano: 8.0.1(postcss@8.5.18)
+      cssnano: 8.0.1(postcss@8.5.23)
       defu: 6.1.7
       escape-string-regexp: 5.0.0
       exsolve: 1.0.8
@@ -13451,7 +13451,7 @@ snapshots:
       nypm: 0.6.6
       pathe: 2.0.3
       pkg-types: 2.3.1
-      postcss: 8.5.18
+      postcss: 8.5.23
       seroval: 1.5.4
       std-env: 4.1.0
       ufo: 1.6.4
@@ -14921,7 +14921,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
-      postcss: 8.5.18
+      postcss: 8.5.23
       tailwindcss: 4.3.0
 
   '@tailwindcss/vite@4.3.0(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))':
@@ -15208,28 +15208,28 @@ snapshots:
       three: 0.184.0
       vue: 3.6.0-beta.10(typescript@6.0.3)
 
-  '@tsdown/css@0.22.0(jiti@1.21.7)(postcss@8.5.18)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)':
+  '@tsdown/css@0.22.0(jiti@1.21.7)(postcss@8.5.23)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)':
     dependencies:
       lightningcss: 1.32.0
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.18)(tsx@4.22.4)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.22.4)(yaml@2.9.0)
       rolldown: 1.0.1
       tsdown: 0.22.0(@tsdown/css@0.22.0)(@typescript/native-preview@7.0.0-dev.20260602.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(vue-tsc@3.2.9(typescript@6.0.3))
     optionalDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
     transitivePeerDependencies:
       - jiti
       - tsx
       - yaml
     optional: true
 
-  '@tsdown/css@0.22.0(jiti@2.7.0)(postcss@8.5.18)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)':
+  '@tsdown/css@0.22.0(jiti@2.7.0)(postcss@8.5.23)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)':
     dependencies:
       lightningcss: 1.32.0
-      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.4)(yaml@2.9.0)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.4)(yaml@2.9.0)
       rolldown: 1.0.1
       tsdown: 0.22.0(@tsdown/css@0.22.0)(@typescript/native-preview@7.0.0-dev.20260602.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(vue-tsc@3.2.9(typescript@6.0.3))
     optionalDependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
     transitivePeerDependencies:
       - jiti
       - tsx
@@ -15723,9 +15723,9 @@ snapshots:
       '@oxc-project/runtime': 0.129.0
       '@oxc-project/types': 0.129.0
       lightningcss: 1.32.0
-      postcss: 8.5.18
+      postcss: 8.5.23
     optionalDependencies:
-      '@tsdown/css': 0.22.0(jiti@1.21.7)(postcss@8.5.18)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
+      '@tsdown/css': 0.22.0(jiti@1.21.7)(postcss@8.5.23)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
       '@types/node': 25.9.2
       esbuild: 0.28.1
       fsevents: 2.3.3
@@ -15741,9 +15741,9 @@ snapshots:
       '@oxc-project/runtime': 0.129.0
       '@oxc-project/types': 0.129.0
       lightningcss: 1.32.0
-      postcss: 8.5.18
+      postcss: 8.5.23
     optionalDependencies:
-      '@tsdown/css': 0.22.0(jiti@2.7.0)(postcss@8.5.18)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
+      '@tsdown/css': 0.22.0(jiti@2.7.0)(postcss@8.5.23)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
       '@types/node': 25.9.2
       esbuild: 0.28.1
       fsevents: 2.3.3
@@ -15981,7 +15981,7 @@ snapshots:
       '@vue/shared': 3.5.34
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.18
+      postcss: 8.5.23
       source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.5.35':
@@ -15993,7 +15993,7 @@ snapshots:
       '@vue/shared': 3.5.35
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.18
+      postcss: 8.5.23
       source-map-js: 1.2.1
 
   '@vue/compiler-sfc@3.6.0-beta.10':
@@ -16006,7 +16006,7 @@ snapshots:
       '@vue/shared': 3.6.0-beta.10
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.18
+      postcss: 8.5.23
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.5.34':
@@ -16528,13 +16528,13 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  autoprefixer@10.5.0(postcss@8.5.18):
+  autoprefixer@10.5.0(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001792
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
   axe-core@4.11.1: {}
@@ -17007,48 +17007,48 @@ snapshots:
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-default@8.0.1(postcss@8.5.18):
+  cssnano-preset-default@8.0.1(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.2
-      cssnano-utils: 6.0.0(postcss@8.5.18)
-      postcss: 8.5.18
-      postcss-calc: 10.1.1(postcss@8.5.18)
-      postcss-colormin: 8.0.0(postcss@8.5.18)
-      postcss-convert-values: 8.0.0(postcss@8.5.18)
-      postcss-discard-comments: 8.0.0(postcss@8.5.18)
-      postcss-discard-duplicates: 8.0.0(postcss@8.5.18)
-      postcss-discard-empty: 8.0.0(postcss@8.5.18)
-      postcss-discard-overridden: 8.0.0(postcss@8.5.18)
-      postcss-merge-longhand: 8.0.0(postcss@8.5.18)
-      postcss-merge-rules: 8.0.0(postcss@8.5.18)
-      postcss-minify-font-values: 8.0.0(postcss@8.5.18)
-      postcss-minify-gradients: 8.0.0(postcss@8.5.18)
-      postcss-minify-params: 8.0.0(postcss@8.5.18)
-      postcss-minify-selectors: 8.0.1(postcss@8.5.18)
-      postcss-normalize-charset: 8.0.0(postcss@8.5.18)
-      postcss-normalize-display-values: 8.0.0(postcss@8.5.18)
-      postcss-normalize-positions: 8.0.0(postcss@8.5.18)
-      postcss-normalize-repeat-style: 8.0.0(postcss@8.5.18)
-      postcss-normalize-string: 8.0.0(postcss@8.5.18)
-      postcss-normalize-timing-functions: 8.0.0(postcss@8.5.18)
-      postcss-normalize-unicode: 8.0.0(postcss@8.5.18)
-      postcss-normalize-url: 8.0.0(postcss@8.5.18)
-      postcss-normalize-whitespace: 8.0.0(postcss@8.5.18)
-      postcss-ordered-values: 8.0.0(postcss@8.5.18)
-      postcss-reduce-initial: 8.0.0(postcss@8.5.18)
-      postcss-reduce-transforms: 8.0.0(postcss@8.5.18)
-      postcss-svgo: 8.0.0(postcss@8.5.18)
-      postcss-unique-selectors: 8.0.0(postcss@8.5.18)
+      cssnano-utils: 6.0.0(postcss@8.5.23)
+      postcss: 8.5.23
+      postcss-calc: 10.1.1(postcss@8.5.23)
+      postcss-colormin: 8.0.0(postcss@8.5.23)
+      postcss-convert-values: 8.0.0(postcss@8.5.23)
+      postcss-discard-comments: 8.0.0(postcss@8.5.23)
+      postcss-discard-duplicates: 8.0.0(postcss@8.5.23)
+      postcss-discard-empty: 8.0.0(postcss@8.5.23)
+      postcss-discard-overridden: 8.0.0(postcss@8.5.23)
+      postcss-merge-longhand: 8.0.0(postcss@8.5.23)
+      postcss-merge-rules: 8.0.0(postcss@8.5.23)
+      postcss-minify-font-values: 8.0.0(postcss@8.5.23)
+      postcss-minify-gradients: 8.0.0(postcss@8.5.23)
+      postcss-minify-params: 8.0.0(postcss@8.5.23)
+      postcss-minify-selectors: 8.0.1(postcss@8.5.23)
+      postcss-normalize-charset: 8.0.0(postcss@8.5.23)
+      postcss-normalize-display-values: 8.0.0(postcss@8.5.23)
+      postcss-normalize-positions: 8.0.0(postcss@8.5.23)
+      postcss-normalize-repeat-style: 8.0.0(postcss@8.5.23)
+      postcss-normalize-string: 8.0.0(postcss@8.5.23)
+      postcss-normalize-timing-functions: 8.0.0(postcss@8.5.23)
+      postcss-normalize-unicode: 8.0.0(postcss@8.5.23)
+      postcss-normalize-url: 8.0.0(postcss@8.5.23)
+      postcss-normalize-whitespace: 8.0.0(postcss@8.5.23)
+      postcss-ordered-values: 8.0.0(postcss@8.5.23)
+      postcss-reduce-initial: 8.0.0(postcss@8.5.23)
+      postcss-reduce-transforms: 8.0.0(postcss@8.5.23)
+      postcss-svgo: 8.0.0(postcss@8.5.23)
+      postcss-unique-selectors: 8.0.0(postcss@8.5.23)
 
-  cssnano-utils@6.0.0(postcss@8.5.18):
+  cssnano-utils@6.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  cssnano@8.0.1(postcss@8.5.18):
+  cssnano@8.0.1(postcss@8.5.23):
     dependencies:
-      cssnano-preset-default: 8.0.1(postcss@8.5.18)
+      cssnano-preset-default: 8.0.1(postcss@8.5.23)
       lilconfig: 3.1.3
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   csso@5.0.5:
     dependencies:
@@ -18879,7 +18879,7 @@ snapshots:
       vue: 3.6.0-beta.10(typescript@6.0.3)
       vueuc: 0.4.65(vue@3.6.0-beta.10(typescript@6.0.3))
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   nanopop@2.4.2: {}
 
@@ -19617,179 +19617,179 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss-calc@10.1.1(postcss@8.5.18):
+  postcss-calc@10.1.1(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@8.0.0(postcss@8.5.18):
+  postcss-colormin@8.0.0(postcss@8.5.23):
     dependencies:
       '@colordx/core': 5.4.3
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@8.0.0(postcss@8.5.18):
+  postcss-convert-values@8.0.0(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-discard-comments@8.0.0(postcss@8.5.18):
+  postcss-discard-comments@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.1
 
-  postcss-discard-duplicates@8.0.0(postcss@8.5.18):
+  postcss-discard-duplicates@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-discard-empty@8.0.0(postcss@8.5.18):
+  postcss-discard-empty@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-discard-overridden@8.0.0(postcss@8.5.18):
+  postcss-discard-overridden@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-import@15.1.0(postcss@8.5.18):
+  postcss-import@15.1.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.12
 
-  postcss-js@4.1.0(postcss@8.5.18):
+  postcss-js@4.1.0(postcss@8.5.23):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.18)(tsx@4.22.4)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.18
+      postcss: 8.5.23
       tsx: 4.22.4
       yaml: 2.9.0
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.22.4)(yaml@2.9.0):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.7.0
-      postcss: 8.5.18
+      postcss: 8.5.23
       tsx: 4.22.4
       yaml: 2.9.0
 
-  postcss-merge-longhand@8.0.0(postcss@8.5.18):
+  postcss-merge-longhand@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
-      stylehacks: 8.0.0(postcss@8.5.18)
+      stylehacks: 8.0.0(postcss@8.5.23)
 
-  postcss-merge-rules@8.0.0(postcss@8.5.18):
+  postcss-merge-rules@8.0.0(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      cssnano-utils: 6.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      cssnano-utils: 6.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.1
 
-  postcss-minify-font-values@8.0.0(postcss@8.5.18):
+  postcss-minify-font-values@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@8.0.0(postcss@8.5.18):
+  postcss-minify-gradients@8.0.0(postcss@8.5.23):
     dependencies:
       '@colordx/core': 5.4.3
-      cssnano-utils: 6.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      cssnano-utils: 6.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@8.0.0(postcss@8.5.18):
+  postcss-minify-params@8.0.0(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.2
-      cssnano-utils: 6.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      cssnano-utils: 6.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@8.0.1(postcss@8.5.18):
+  postcss-minify-selectors@8.0.1(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.2
       caniuse-api: 3.0.0
       cssesc: 3.0.0
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.1
 
-  postcss-nested@6.2.0(postcss@8.5.18):
+  postcss-nested@6.2.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.2
 
-  postcss-normalize-charset@8.0.0(postcss@8.5.18):
+  postcss-normalize-charset@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-normalize-display-values@8.0.0(postcss@8.5.18):
+  postcss-normalize-display-values@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@8.0.0(postcss@8.5.18):
+  postcss-normalize-positions@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@8.0.0(postcss@8.5.18):
+  postcss-normalize-repeat-style@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@8.0.0(postcss@8.5.18):
+  postcss-normalize-string@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@8.0.0(postcss@8.5.18):
+  postcss-normalize-timing-functions@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@8.0.0(postcss@8.5.18):
+  postcss-normalize-unicode@8.0.0(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@8.0.0(postcss@8.5.18):
+  postcss-normalize-url@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@8.0.0(postcss@8.5.18):
+  postcss-normalize-whitespace@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-ordered-values@8.0.0(postcss@8.5.18):
+  postcss-ordered-values@8.0.0(postcss@8.5.23):
     dependencies:
-      cssnano-utils: 6.0.0(postcss@8.5.18)
-      postcss: 8.5.18
+      cssnano-utils: 6.0.0(postcss@8.5.23)
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
-  postcss-reduce-initial@8.0.0(postcss@8.5.18):
+  postcss-reduce-initial@8.0.0(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.2
       caniuse-api: 3.0.0
-      postcss: 8.5.18
+      postcss: 8.5.23
 
-  postcss-reduce-transforms@8.0.0(postcss@8.5.18):
+  postcss-reduce-transforms@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
 
   postcss-selector-parser@6.1.2:
@@ -19802,22 +19802,22 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-svgo@8.0.0(postcss@8.5.18):
+  postcss-svgo@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-value-parser: 4.2.0
       svgo: 4.0.2
 
-  postcss-unique-selectors@8.0.0(postcss@8.5.18):
+  postcss-unique-selectors@8.0.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.1
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.18:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -20623,10 +20623,10 @@ snapshots:
 
   structured-clone-es@2.0.0: {}
 
-  stylehacks@8.0.0(postcss@8.5.18):
+  stylehacks@8.0.0(postcss@8.5.23):
     dependencies:
       browserslist: 4.28.2
-      postcss: 8.5.18
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.1
 
   stylis@4.4.0: {}
@@ -20695,11 +20695,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.18
-      postcss-import: 15.1.0(postcss@8.5.18)
-      postcss-js: 4.1.0(postcss@8.5.18)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.18)(tsx@4.22.4)(yaml@2.9.0)
-      postcss-nested: 6.2.0(postcss@8.5.18)
+      postcss: 8.5.23
+      postcss-import: 15.1.0(postcss@8.5.23)
+      postcss-js: 4.1.0(postcss@8.5.23)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.22.4)(yaml@2.9.0)
+      postcss-nested: 6.2.0(postcss@8.5.23)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
       sucrase: 3.35.1
@@ -20739,16 +20739,16 @@ snapshots:
 
   temporal-polyfill-lite@0.4.2: {}
 
-  terser-webpack-plugin@5.6.0(esbuild@0.28.1)(postcss@8.5.18)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.18)):
+  terser-webpack-plugin@5.6.0(esbuild@0.28.1)(postcss@8.5.23)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.23)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.47.1
-      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.18)
+      webpack: 5.107.2(esbuild@0.28.1)(postcss@8.5.23)
     optionalDependencies:
       esbuild: 0.28.1
-      postcss: 8.5.18
+      postcss: 8.5.23
 
   terser@5.47.1:
     dependencies:
@@ -20860,7 +20860,7 @@ snapshots:
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
     optionalDependencies:
-      '@tsdown/css': 0.22.0(jiti@2.7.0)(postcss@8.5.18)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
+      '@tsdown/css': 0.22.0(jiti@2.7.0)(postcss@8.5.23)(tsdown@0.22.0)(tsx@4.22.4)(yaml@2.9.0)
       tsx: 4.22.4
       typescript: 6.0.3
       unrun: 0.2.39
@@ -21458,7 +21458,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       rollup: 4.61.1
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -21475,7 +21475,7 @@ snapshots:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.18
+      postcss: 8.5.23
       rolldown: 1.0.0-rc.9(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -21660,7 +21660,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.18):
+  webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.23):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -21682,7 +21682,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(esbuild@0.28.1)(postcss@8.5.18)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.18))
+      terser-webpack-plugin: 5.6.0(esbuild@0.28.1)(postcss@8.5.23)(webpack@5.107.2(esbuild@0.28.1)(postcss@8.5.23))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,7 @@ overrides:
   "@hono/node-server": "2.0.11"
   "@unhead/vue": "2.1.15"
   "brace-expansion@2": "2.1.2"
-  "brace-expansion@>=5.0.0 <5.0.8": "5.0.8"
+  "brace-expansion@>=5.0.0 <5.0.9": "5.0.9"
   defu: "6.1.7"
   devalue: "5.8.1"
   dompurify: "3.4.11"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,7 @@ overrides:
   nanotar: "0.3.0"
   nitropack: "2.13.4"
   node-forge: "1.4.0"
-  "postcss@>=8.0.0 <8.5.18": "8.5.18"
+  "postcss@>=8.0.0 <8.5.23": "8.5.23"
   nuxt: "4.4.8"
   qs: "6.15.2"
   "readdir-glob>minimatch": "10.2.5"


### PR DESCRIPTION
Follow-up to #3837, which was already merged before this review feedback could land on its branch.

When resolving a bare package specifier's root entry, `resolve_package_types` consulted the legacy top-level `types`/`typings` field before the `exports` map. Modern module resolution (`node16`/`nodenext`/`bundler`, matching Node's behaviour) ignores top-level entry points once `exports` is present, so a package that publishes both would resolve to the stale legacy declaration file. The root branch now checks the `exports` `types` condition first and only falls back to `types`/`typings`, then `index.d.ts`.

Root lookup also has to cover the shorthand Node allows, where `exports` holds condition keys directly instead of an explicit `"."` subpath. A subpath-only map (every key starting with `.`) must not answer for the root, so its `types` is ignored there:

```rust
fn exports_root_types_entry(manifest: &serde_json::Value) -> Option<String> {
    let exports = manifest.get("exports")?;
    if let Some(root) = exports.get(".") {
        return find_types_condition(root);
    }
    let conditions = exports.as_object()?;
    if conditions.keys().any(|key| key.starts_with('.')) {
        return None;
    }
    find_types_condition(exports)
}
```

Subpath resolution is unchanged (it already consulted `exports` first), and packages without an `exports` `types` condition keep the previous behaviour. Unit tests cover legacy-versus-`exports` precedence, the condition-only root map, and a subpath-only map falling back to legacy `types`.

This branch also widens the existing `brace-expansion` pnpm override to `>=5.0.0 <5.0.9` -> `5.0.9`, which the `security-audit` job needed after GHSA-rgw5-rvv9-x895 was published against 5.0.8.

Local `cargo test` cannot finish in the sandbox (the workspace build exhausts the 4 GB disk), so CI is the validation path; `cargo check -p vize_atelier_sfc --lib --tests` passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package type resolution by prioritizing type definitions declared in package exports.
  * Preserved existing behavior for subpath exports and fallback type fields.

* **Tests**
  * Added coverage confirming the correct precedence of exported type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
