### PR TITLE
feat(marquette): negotiate adapter capabilities

### DIFF
--- a/crates/vize_marquette/schema/adapter-capability-manifest.schema.json
+++ b/crates/vize_marquette/schema/adapter-capability-manifest.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vizejs.dev/schemas/marquette/adapter-capability-manifest.schema.json",
+  "title": "Vize Adapter Capability Manifest",
+  "description": "Versioned language-neutral capability ranges offered by one Vize adapter.",
+  "$ref": "#/$defs/manifest",
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]*$"
+    },
+    "support": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "minVersion", "maxVersion"],
+      "properties": {
+        "id": { "$ref": "#/$defs/identifier" },
+        "minVersion": { "type": "integer", "minimum": 1 },
+        "maxVersion": { "type": "integer", "minimum": 1 }
+      }
+    },
+    "manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["adapter"],
+      "properties": {
+        "formatVersion": { "const": 1, "default": 1 },
+        "adapter": { "$ref": "#/$defs/identifier" },
+        "capabilities": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/support" },
+          "default": []
+        }
+      }
+    }
+  }
+}

--- a/crates/vize_marquette/src/adapter/compatibility.rs
+++ b/crates/vize_marquette/src/adapter/compatibility.rs
@@ -1,0 +1,113 @@
+use std::collections::BTreeMap;
+
+use vize_carton::{String, ToCompactString};
+
+use crate::{
+    CompatibilityChange, CompatibilityChangeKind, CompatibilityReport,
+    adapter::AdapterCapabilityManifest,
+};
+
+/// Compares adapter capability support from older to newer.
+///
+/// Adding support or widening an inclusive version range is additive.
+/// Removing support or narrowing either bound is breaking.
+pub fn compare_adapter_capabilities(
+    previous: &AdapterCapabilityManifest,
+    next: &AdapterCapabilityManifest,
+) -> CompatibilityReport {
+    let mut changes = Vec::new();
+    if previous.adapter != next.adapter {
+        changes.push(change(
+            CompatibilityChangeKind::Breaking,
+            "adapter",
+            "adapter identity changed",
+        ));
+    }
+
+    let previous = by_id(previous);
+    let next = by_id(next);
+    for id in previous.keys().filter(|id| !next.contains_key(*id)) {
+        changes.push(capability_change(
+            CompatibilityChangeKind::Breaking,
+            id,
+            "",
+            "capability support was removed",
+        ));
+    }
+    for id in next.keys().filter(|id| !previous.contains_key(*id)) {
+        changes.push(capability_change(
+            CompatibilityChangeKind::Additive,
+            id,
+            "",
+            "capability support was added",
+        ));
+    }
+    for (id, old) in &previous {
+        let Some(new) = next.get(id) else {
+            continue;
+        };
+        if old.min_version != new.min_version {
+            changes.push(capability_change(
+                if new.min_version < old.min_version {
+                    CompatibilityChangeKind::Additive
+                } else {
+                    CompatibilityChangeKind::Breaking
+                },
+                id,
+                ".minVersion",
+                if new.min_version < old.min_version {
+                    "minimum supported version decreased"
+                } else {
+                    "minimum supported version increased"
+                },
+            ));
+        }
+        if old.max_version != new.max_version {
+            changes.push(capability_change(
+                if new.max_version > old.max_version {
+                    CompatibilityChangeKind::Additive
+                } else {
+                    CompatibilityChangeKind::Breaking
+                },
+                id,
+                ".maxVersion",
+                if new.max_version > old.max_version {
+                    "maximum supported version increased"
+                } else {
+                    "maximum supported version decreased"
+                },
+            ));
+        }
+    }
+
+    changes.sort_by(|left, right| (&left.path, left.kind).cmp(&(&right.path, right.kind)));
+    CompatibilityReport { changes }
+}
+
+fn by_id(manifest: &AdapterCapabilityManifest) -> BTreeMap<&str, &super::AdapterCapabilitySupport> {
+    manifest
+        .capabilities
+        .iter()
+        .map(|capability| (capability.id.as_str(), capability))
+        .collect()
+}
+
+fn capability_change(
+    kind: CompatibilityChangeKind,
+    id: &str,
+    suffix: &str,
+    message: &str,
+) -> CompatibilityChange {
+    let mut path = "capabilities.".to_compact_string();
+    path.push_str(id);
+    path.push_str(suffix);
+    change(kind, &path, message)
+}
+
+fn change(kind: CompatibilityChangeKind, path: &str, message: &str) -> CompatibilityChange {
+    CompatibilityChange {
+        kind,
+        path: String::from(path),
+        message: String::from(message),
+    }
+}

--- a/crates/vize_marquette/src/adapter/mod.rs
+++ b/crates/vize_marquette/src/adapter/mod.rs
@@ -1,0 +1,15 @@
+//! Versioned adapter capability manifests and deterministic negotiation.
+
+mod compatibility;
+mod model;
+mod negotiate;
+mod validate;
+
+pub use compatibility::compare_adapter_capabilities;
+pub use model::{
+    ADAPTER_CAPABILITY_FORMAT_VERSION, AdapterCapabilityDiagnostic,
+    AdapterCapabilityDiagnosticCode, AdapterCapabilityManifest, AdapterCapabilityMismatch,
+    AdapterCapabilityMismatchCode, AdapterCapabilityNegotiation, AdapterCapabilitySupport,
+};
+pub use negotiate::negotiate_adapter_capabilities;
+pub use validate::validate_adapter_capability_manifest;

--- a/crates/vize_marquette/src/adapter/model.rs
+++ b/crates/vize_marquette/src/adapter/model.rs
@@ -1,0 +1,116 @@
+use serde::{Deserialize, Serialize};
+use vize_carton::String;
+
+/// Current serialized adapter-capability manifest format.
+pub const ADAPTER_CAPABILITY_FORMAT_VERSION: u32 = 1;
+
+/// Inclusive version range supported for one capability contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AdapterCapabilitySupport {
+    /// Stable capability identifier from an application marquette.
+    pub id: String,
+    /// Oldest supported capability contract version, inclusive.
+    pub min_version: u32,
+    /// Newest supported capability contract version, inclusive.
+    pub max_version: u32,
+}
+
+/// Versioned, language-neutral capabilities offered by one adapter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AdapterCapabilityManifest {
+    /// Serialized manifest format.
+    ///
+    /// Defaults to `1`.
+    #[serde(default = "default_format_version")]
+    pub format_version: u32,
+    /// Stable adapter identifier shown in diagnostics and reports.
+    pub adapter: String,
+    /// Supported capability ranges.
+    ///
+    /// Defaults to an empty list.
+    #[serde(default)]
+    pub capabilities: Vec<AdapterCapabilitySupport>,
+}
+
+const fn default_format_version() -> u32 {
+    ADAPTER_CAPABILITY_FORMAT_VERSION
+}
+
+/// Stable validation code for an adapter capability manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AdapterCapabilityDiagnosticCode {
+    /// The serialized manifest format is unsupported.
+    InvalidFormatVersion,
+    /// The adapter identifier is not portable.
+    InvalidAdapterId,
+    /// A capability identifier is not portable.
+    InvalidCapabilityId,
+    /// A version bound is zero.
+    InvalidVersion,
+    /// The minimum version exceeds the maximum version.
+    InvalidVersionRange,
+    /// A capability identifier occurs more than once.
+    DuplicateCapability,
+}
+
+/// Deterministic validation diagnostic for an adapter capability manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AdapterCapabilityDiagnostic {
+    /// Stable machine-readable diagnostic code.
+    pub code: AdapterCapabilityDiagnosticCode,
+    /// JSON-style path of the invalid value.
+    pub path: String,
+    /// Human-readable explanation.
+    pub message: String,
+}
+
+/// Stable incompatibility code emitted during capability negotiation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AdapterCapabilityMismatchCode {
+    /// The application references an undeclared capability definition.
+    UnknownRequirement,
+    /// The adapter does not offer a required capability.
+    MissingCapability,
+    /// The application requires an older contract than the adapter supports.
+    VersionBelowMinimum,
+    /// The application requires a newer contract than the adapter supports.
+    VersionAboveMaximum,
+}
+
+/// One failed adapter capability requirement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AdapterCapabilityMismatch {
+    /// Stable machine-readable mismatch code.
+    pub code: AdapterCapabilityMismatchCode,
+    /// Required capability identifier.
+    pub capability: String,
+    /// Required contract version when the capability is declared.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required_version: Option<u32>,
+    /// Adapter minimum when support exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_version: Option<u32>,
+    /// Adapter maximum when support exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_version: Option<u32>,
+}
+
+/// Deterministic result of negotiating requirements with one adapter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AdapterCapabilityNegotiation {
+    /// Adapter whose support was inspected.
+    pub adapter: String,
+    /// Whether the manifest is valid and every requirement is supported.
+    pub compatible: bool,
+    /// Manifest validation failures, in stable path order.
+    pub diagnostics: Vec<AdapterCapabilityDiagnostic>,
+    /// Unsupported or unknown requirements, in stable capability order.
+    pub mismatches: Vec<AdapterCapabilityMismatch>,
+}

--- a/crates/vize_marquette/src/adapter/negotiate.rs
+++ b/crates/vize_marquette/src/adapter/negotiate.rs
@@ -1,0 +1,99 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use vize_carton::String;
+
+use crate::ApplicationContract;
+
+use super::{
+    AdapterCapabilityManifest, AdapterCapabilityMismatch, AdapterCapabilityMismatchCode,
+    AdapterCapabilityNegotiation, AdapterCapabilitySupport, validate_adapter_capability_manifest,
+};
+
+/// Negotiates application capability requirements against one adapter.
+///
+/// Requirement identifiers are deduplicated and sorted. Unknown application
+/// capability identifiers fail closed instead of being treated as adapter
+/// omissions. An invalid manifest never produces a compatible result.
+pub fn negotiate_adapter_capabilities<'a>(
+    contract: &ApplicationContract,
+    required_capabilities: impl IntoIterator<Item = &'a str>,
+    manifest: &AdapterCapabilityManifest,
+) -> AdapterCapabilityNegotiation {
+    let diagnostics = validate_adapter_capability_manifest(manifest);
+    let support = manifest
+        .capabilities
+        .iter()
+        .map(|capability| (capability.id.as_str(), capability))
+        .collect::<BTreeMap<_, _>>();
+    let requirements = required_capabilities.into_iter().collect::<BTreeSet<_>>();
+    let mut mismatches = requirements
+        .into_iter()
+        .filter_map(|id| {
+            mismatch(
+                contract,
+                id,
+                support.get(id).copied(),
+                diagnostics.is_empty(),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    mismatches
+        .sort_by(|left, right| (&left.capability, left.code).cmp(&(&right.capability, right.code)));
+    AdapterCapabilityNegotiation {
+        adapter: manifest.adapter.clone(),
+        compatible: diagnostics.is_empty() && mismatches.is_empty(),
+        diagnostics,
+        mismatches,
+    }
+}
+
+fn mismatch(
+    contract: &ApplicationContract,
+    id: &str,
+    support: Option<&AdapterCapabilitySupport>,
+    manifest_is_valid: bool,
+) -> Option<AdapterCapabilityMismatch> {
+    let Some(requirement) = contract.capabilities.get(id) else {
+        return Some(problem(
+            AdapterCapabilityMismatchCode::UnknownRequirement,
+            id,
+            None,
+            None,
+        ));
+    };
+    if !manifest_is_valid {
+        return None;
+    }
+    let Some(support) = support else {
+        return Some(problem(
+            AdapterCapabilityMismatchCode::MissingCapability,
+            id,
+            Some(requirement.version),
+            None,
+        ));
+    };
+    let code = if requirement.version < support.min_version {
+        Some(AdapterCapabilityMismatchCode::VersionBelowMinimum)
+    } else if requirement.version > support.max_version {
+        Some(AdapterCapabilityMismatchCode::VersionAboveMaximum)
+    } else {
+        None
+    };
+    code.map(|code| problem(code, id, Some(requirement.version), Some(support)))
+}
+
+fn problem(
+    code: AdapterCapabilityMismatchCode,
+    capability: &str,
+    required_version: Option<u32>,
+    support: Option<&AdapterCapabilitySupport>,
+) -> AdapterCapabilityMismatch {
+    AdapterCapabilityMismatch {
+        code,
+        capability: String::from(capability),
+        required_version,
+        min_version: support.map(|value| value.min_version),
+        max_version: support.map(|value| value.max_version),
+    }
+}

--- a/crates/vize_marquette/src/adapter/validate.rs
+++ b/crates/vize_marquette/src/adapter/validate.rs
@@ -1,0 +1,106 @@
+use std::collections::BTreeSet;
+
+use vize_carton::{String, ToCompactString};
+
+use super::{
+    ADAPTER_CAPABILITY_FORMAT_VERSION, AdapterCapabilityDiagnostic,
+    AdapterCapabilityDiagnosticCode, AdapterCapabilityManifest,
+};
+
+/// Validates an adapter capability manifest without mutating it.
+pub fn validate_adapter_capability_manifest(
+    manifest: &AdapterCapabilityManifest,
+) -> Vec<AdapterCapabilityDiagnostic> {
+    let mut diagnostics = Vec::new();
+    if manifest.format_version != ADAPTER_CAPABILITY_FORMAT_VERSION {
+        diagnostics.push(diagnostic(
+            AdapterCapabilityDiagnosticCode::InvalidFormatVersion,
+            "formatVersion",
+            "unsupported adapter capability manifest format version",
+        ));
+    }
+    if !is_identifier(&manifest.adapter) {
+        diagnostics.push(diagnostic(
+            AdapterCapabilityDiagnosticCode::InvalidAdapterId,
+            "adapter",
+            "adapter must be a lowercase portable identifier",
+        ));
+    }
+
+    let mut seen = BTreeSet::new();
+    for (index, capability) in manifest.capabilities.iter().enumerate() {
+        let path = capability_path(index);
+        if !is_identifier(&capability.id) {
+            diagnostics.push(diagnostic(
+                AdapterCapabilityDiagnosticCode::InvalidCapabilityId,
+                &format_path(&path, "id"),
+                "capability id must be a lowercase portable identifier",
+            ));
+        }
+        if !seen.insert(capability.id.as_str()) {
+            diagnostics.push(diagnostic(
+                AdapterCapabilityDiagnosticCode::DuplicateCapability,
+                &format_path(&path, "id"),
+                "capability id must be unique within the adapter manifest",
+            ));
+        }
+        if capability.min_version == 0 {
+            diagnostics.push(diagnostic(
+                AdapterCapabilityDiagnosticCode::InvalidVersion,
+                &format_path(&path, "minVersion"),
+                "minimum supported version must be greater than zero",
+            ));
+        }
+        if capability.max_version == 0 {
+            diagnostics.push(diagnostic(
+                AdapterCapabilityDiagnosticCode::InvalidVersion,
+                &format_path(&path, "maxVersion"),
+                "maximum supported version must be greater than zero",
+            ));
+        }
+        if capability.min_version > capability.max_version {
+            diagnostics.push(diagnostic(
+                AdapterCapabilityDiagnosticCode::InvalidVersionRange,
+                &path,
+                "minimum supported version must not exceed maximum supported version",
+            ));
+        }
+    }
+
+    diagnostics.sort_by(|left, right| {
+        (&left.path, left.code, &left.message).cmp(&(&right.path, right.code, &right.message))
+    });
+    diagnostics
+}
+
+fn diagnostic(
+    code: AdapterCapabilityDiagnosticCode,
+    path: &str,
+    message: &str,
+) -> AdapterCapabilityDiagnostic {
+    AdapterCapabilityDiagnostic {
+        code,
+        path: path.into(),
+        message: message.into(),
+    }
+}
+
+fn capability_path(index: usize) -> String {
+    let mut path = "capabilities.".to_compact_string();
+    path.push_str(&index.to_compact_string());
+    path
+}
+
+fn format_path(parent: &str, field: &str) -> String {
+    let mut path = parent.to_compact_string();
+    path.push('.');
+    path.push_str(field);
+    path
+}
+
+fn is_identifier(value: &str) -> bool {
+    let mut characters = value.bytes();
+    matches!(characters.next(), Some(b'a'..=b'z' | b'0'..=b'9'))
+        && characters
+            .all(|character| matches!(character, b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-'))
+}

--- a/crates/vize_marquette/src/lib.rs
+++ b/crates/vize_marquette/src/lib.rs
@@ -42,6 +42,7 @@
 //! assert!(contract.validate().is_empty());
 //! ```
 
+mod adapter;
 mod canonical;
 mod compatibility;
 mod model;
@@ -51,6 +52,13 @@ mod validate;
 #[cfg(test)]
 mod model_tests;
 
+pub use adapter::{
+    ADAPTER_CAPABILITY_FORMAT_VERSION, AdapterCapabilityDiagnostic,
+    AdapterCapabilityDiagnosticCode, AdapterCapabilityManifest, AdapterCapabilityMismatch,
+    AdapterCapabilityMismatchCode, AdapterCapabilityNegotiation, AdapterCapabilitySupport,
+    compare_adapter_capabilities, negotiate_adapter_capabilities,
+    validate_adapter_capability_manifest,
+};
 pub use canonical::{CanonicalContractError, canonical_json, contract_fingerprint};
 pub use compatibility::{
     CompatibilityChange, CompatibilityChangeKind, CompatibilityReport, compare_contracts,
@@ -84,6 +92,10 @@ pub use validate::{ContractDiagnostic, DiagnosticSeverity, validate_contract};
 /// consumers can expose the exact contract without resolving a filesystem path.
 pub const APPLICATION_CONTRACT_JSON_SCHEMA: &str =
     include_str!("../schema/application-contract.schema.json");
+
+/// Canonical JSON Schema for serialized adapter capability manifests.
+pub const ADAPTER_CAPABILITY_MANIFEST_JSON_SCHEMA: &str =
+    include_str!("../schema/adapter-capability-manifest.schema.json");
 
 /// Canonical JSON Schema for serialized test-run evidence records.
 ///
@@ -123,6 +135,16 @@ pub const TEST_RUN_TRANSITION_JSON_SCHEMA: &str =
 
 #[cfg(test)]
 mod schema_tests {
+    #[test]
+    fn embedded_adapter_schema_tracks_the_current_format() {
+        let schema: serde_json::Value =
+            serde_json::from_str(super::ADAPTER_CAPABILITY_MANIFEST_JSON_SCHEMA).unwrap();
+        assert_eq!(
+            schema["$defs"]["manifest"]["properties"]["formatVersion"]["const"],
+            super::ADAPTER_CAPABILITY_FORMAT_VERSION
+        );
+    }
+
     #[test]
     fn embedded_schema_is_valid_json_and_tracks_the_current_format() {
         let schema: serde_json::Value =

--- a/crates/vize_marquette/tests/adapter_conformance.rs
+++ b/crates/vize_marquette/tests/adapter_conformance.rs
@@ -1,0 +1,147 @@
+use std::{fs, path::PathBuf};
+
+use serde::Deserialize;
+use serde_json::Value;
+use vize_carton::{String, ToCompactString};
+use vize_marquette::{
+    ADAPTER_CAPABILITY_MANIFEST_JSON_SCHEMA, AdapterCapabilityManifest, ApplicationContract,
+    compare_adapter_capabilities, contract_fingerprint, negotiate_adapter_capabilities,
+    validate_adapter_capability_manifest,
+};
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../tests/fixtures/marquette")
+        .join(name)
+}
+
+fn read<T: serde::de::DeserializeOwned>(name: &str) -> T {
+    serde_json::from_slice(&fs::read(fixture(name)).unwrap()).unwrap()
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct NegotiationFixture {
+    contract: ApplicationContract,
+    cases: Vec<NegotiationCase>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct NegotiationCase {
+    name: String,
+    required: Vec<String>,
+    manifest: AdapterCapabilityManifest,
+    expected: Value,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CompatibilityCase {
+    name: String,
+    previous: AdapterCapabilityManifest,
+    next: AdapterCapabilityManifest,
+    expected: Value,
+}
+
+#[test]
+fn matches_shared_negotiation_fixtures_and_input_permutations() {
+    let fixture: NegotiationFixture = read("adapter-negotiation.json");
+    let mut results = Vec::new();
+    for case in fixture.cases {
+        let actual = negotiate_adapter_capabilities(
+            &fixture.contract,
+            case.required.iter().map(String::as_str),
+            &case.manifest,
+        );
+        let actual = serde_json::to_value(actual).unwrap();
+        assert_eq!(actual, case.expected, "{}", case.name);
+        results.push(actual);
+    }
+
+    assert_eq!(results[0], results[1], "input order must not affect output");
+    assert_eq!(results[2]["compatible"], true, "inclusive bounds must pass");
+    assert_eq!(
+        results[3]["mismatches"][0]["code"], "unknown-requirement",
+        "undeclared requirements must fail even when the adapter offers them"
+    );
+}
+
+#[test]
+fn matches_shared_semantic_validation_diagnostics() {
+    let manifest: AdapterCapabilityManifest = read("adapter-manifest-invalid.json");
+    let expected: Value = read("adapter-manifest-invalid.expected.json");
+
+    assert_eq!(
+        serde_json::to_value(validate_adapter_capability_manifest(&manifest)).unwrap(),
+        expected
+    );
+}
+
+#[test]
+fn rejects_unknown_fields_before_negotiation() {
+    let error = serde_json::from_slice::<AdapterCapabilityManifest>(
+        &fs::read(fixture("adapter-manifest-unknown-field.json")).unwrap(),
+    )
+    .unwrap_err();
+
+    assert!(
+        error
+            .to_compact_string()
+            .contains("unknown field `unexpected`")
+    );
+}
+
+#[test]
+fn schema_rejects_unknown_fields_and_non_positive_bounds() {
+    let schema: Value = serde_json::from_str(ADAPTER_CAPABILITY_MANIFEST_JSON_SCHEMA).unwrap();
+    let manifest = &schema["$defs"]["manifest"];
+    let support = &schema["$defs"]["support"];
+
+    assert_eq!(manifest["additionalProperties"], false);
+    assert_eq!(support["additionalProperties"], false);
+    assert_eq!(support["properties"]["minVersion"]["minimum"], 1);
+    assert_eq!(support["properties"]["maxVersion"]["minimum"], 1);
+    assert_eq!(
+        support["required"],
+        serde_json::json!(["id", "minVersion", "maxVersion"])
+    );
+}
+
+#[test]
+fn matches_shared_adapter_compatibility_matrix() {
+    let cases: Vec<CompatibilityCase> = read("adapter-compatibility.json");
+    for case in cases {
+        let actual = compare_adapter_capabilities(&case.previous, &case.next);
+        assert_eq!(
+            serde_json::to_value(actual).unwrap(),
+            case.expected,
+            "{}",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn negotiation_does_not_change_the_application_fingerprint() {
+    let contract: ApplicationContract = read("valid.json");
+    let manifest = AdapterCapabilityManifest {
+        format_version: 1,
+        adapter: "fixture.adapter".into(),
+        capabilities: vec![vize_marquette::AdapterCapabilitySupport {
+            id: "auth.session".into(),
+            min_version: 1,
+            max_version: 1,
+        }],
+    };
+    let before = contract_fingerprint(&contract).unwrap();
+
+    let result = negotiate_adapter_capabilities(&contract, ["auth.session"], &manifest);
+
+    assert!(result.compatible);
+    assert_eq!(contract_fingerprint(&contract).unwrap(), before);
+    assert_eq!(
+        before.as_str(),
+        fs::read_to_string(fixture("valid.sha256")).unwrap().trim()
+    );
+}

--- a/npm/marquette/README.md
+++ b/npm/marquette/README.md
@@ -90,6 +90,44 @@ stable codes shared with the native contract implementation. Keeping it in a
 separate entry means authoring-only applications do not include validation
 code.
 
+## Adapter capability negotiation
+
+Adapters publish inclusive capability-version ranges independently from the
+application marquette. Application capability definitions are the authority
+for requirements; an undeclared requirement fails closed even when an adapter
+offers a capability with the same identifier. Adapter-only capabilities are
+allowed and remain additive until an application requires them.
+
+```ts
+import {
+  negotiateAdapterCapabilities,
+  type AdapterCapabilityManifest,
+} from "@vizejs/marquette/adapter";
+
+const adapter = {
+  adapter: "terminal.fresco",
+  capabilities: [{ id: "terminal.color", minVersion: 1, maxVersion: 3 }],
+} satisfies AdapterCapabilityManifest;
+
+const result = negotiateAdapterCapabilities(
+  marquette,
+  marquette.environments?.[0]?.capabilities ?? [],
+  adapter,
+);
+if (!result.compatible) {
+  console.error(result.diagnostics, result.mismatches);
+}
+```
+
+Exact and inclusive-bound matches are compatible. Missing support,
+requirements below an adapter's minimum, and requirements above its maximum
+use the stable `missing-capability`, `version-below-minimum`, and
+`version-above-maximum` codes. Adding a support range or widening either bound
+is additive; removing support or narrowing either bound is breaking. Both
+negotiation and compatibility reports are sorted deterministically and do not
+mutate their inputs. The published manifest schema is available from
+`@vizejs/marquette/adapter/schema`.
+
 ## Test-run evidence
 
 Release-bound test-run evidence records live in their own lazy entries so
@@ -141,6 +179,8 @@ available from `@vizejs/marquette/test-run/schema`, the decision contract from
   normalization.
 - The published application-contract schema is available from
   `@vizejs/marquette/schema`.
+- The published adapter manifest schema is available from
+  `@vizejs/marquette/adapter/schema`.
 - Every optional contract field documents its default in JSDoc.
 - Package builds enforce a 1 KiB gzip budget for authoring entries and 3 KiB
   or 4 KiB budgets for the validation entries.

--- a/npm/marquette/package.json
+++ b/npm/marquette/package.json
@@ -36,6 +36,11 @@
       "import": "./dist/validate.mjs",
       "default": "./dist/validate.mjs"
     },
+    "./adapter": {
+      "types": "./dist/adapter.d.mts",
+      "import": "./dist/adapter.mjs",
+      "default": "./dist/adapter.mjs"
+    },
     "./test-run": {
       "types": "./dist/test-run.d.mts",
       "import": "./dist/test-run.mjs",
@@ -67,6 +72,7 @@
       "default": "./dist/test-run-transition.mjs"
     },
     "./schema": "./dist/application-contract.schema.json",
+    "./adapter/schema": "./dist/adapter-capability-manifest.schema.json",
     "./test-run/schema": "./dist/test-run-evidence.schema.json",
     "./test-run/admission/schema": "./dist/test-run-admission.schema.json",
     "./test-run/check/schema": "./dist/test-run-check.schema.json",

--- a/npm/marquette/scripts/check-size.mjs
+++ b/npm/marquette/scripts/check-size.mjs
@@ -7,6 +7,11 @@ const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "
 const budgets = [
   { entry: "@vizejs/marquette", file: "dist/index.mjs", maximumGzipBytes: 1024 },
   {
+    entry: "@vizejs/marquette/adapter",
+    file: "dist/adapter.mjs",
+    maximumGzipBytes: 4096,
+  },
+  {
     entry: "@vizejs/marquette/validate",
     file: "dist/validate.mjs",
     maximumGzipBytes: 3072,

--- a/npm/marquette/src/adapter-compatibility.ts
+++ b/npm/marquette/src/adapter-compatibility.ts
@@ -1,0 +1,79 @@
+import type {
+  AdapterCapabilityCompatibilityChange,
+  AdapterCapabilityCompatibilityReport,
+  AdapterCapabilityManifest,
+  AdapterCapabilitySupport,
+  CompatibilityChangeKind,
+} from "./adapter-model.js";
+
+/**
+ * Compares adapter capability support from older to newer.
+ *
+ * Adding support or widening an inclusive version range is additive.
+ * Removing support or narrowing either bound is breaking.
+ */
+export function compareAdapterCapabilities(
+  previous: AdapterCapabilityManifest,
+  next: AdapterCapabilityManifest,
+): AdapterCapabilityCompatibilityReport {
+  const changes: AdapterCapabilityCompatibilityChange[] = [];
+  if (previous.adapter !== next.adapter) {
+    changes.push(change("breaking", "adapter", "adapter identity changed"));
+  }
+
+  const oldSupport = byId(previous);
+  const newSupport = byId(next);
+  for (const id of [...oldSupport.keys()].filter((id) => !newSupport.has(id)).sort()) {
+    changes.push(change("breaking", `capabilities.${id}`, "capability support was removed"));
+  }
+  for (const id of [...newSupport.keys()].filter((id) => !oldSupport.has(id)).sort()) {
+    changes.push(change("additive", `capabilities.${id}`, "capability support was added"));
+  }
+  for (const [id, old] of oldSupport) {
+    const current = newSupport.get(id);
+    if (current === undefined) continue;
+    if (old.minVersion !== current.minVersion) {
+      changes.push(
+        change(
+          current.minVersion < old.minVersion ? "additive" : "breaking",
+          `capabilities.${id}.minVersion`,
+          current.minVersion < old.minVersion
+            ? "minimum supported version decreased"
+            : "minimum supported version increased",
+        ),
+      );
+    }
+    if (old.maxVersion !== current.maxVersion) {
+      changes.push(
+        change(
+          current.maxVersion > old.maxVersion ? "additive" : "breaking",
+          `capabilities.${id}.maxVersion`,
+          current.maxVersion > old.maxVersion
+            ? "maximum supported version increased"
+            : "maximum supported version decreased",
+        ),
+      );
+    }
+  }
+
+  changes.sort(
+    (left, right) => compareText(left.path, right.path) || compareText(left.kind, right.kind),
+  );
+  return { changes };
+}
+
+function byId(manifest: AdapterCapabilityManifest): Map<string, AdapterCapabilitySupport> {
+  return new Map((manifest.capabilities ?? []).map((value) => [value.id, value] as const));
+}
+
+function change(
+  kind: CompatibilityChangeKind,
+  path: string,
+  message: string,
+): AdapterCapabilityCompatibilityChange {
+  return { kind, path, message };
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/npm/marquette/src/adapter-model.ts
+++ b/npm/marquette/src/adapter-model.ts
@@ -1,0 +1,101 @@
+/** Current serialized adapter-capability manifest format. */
+export const ADAPTER_CAPABILITY_FORMAT_VERSION = 1 as const;
+
+/** Inclusive version range supported for one capability contract. */
+export interface AdapterCapabilitySupport {
+  /** Stable capability identifier from an application marquette. */
+  readonly id: string;
+  /** Oldest supported capability contract version, inclusive. */
+  readonly minVersion: number;
+  /** Newest supported capability contract version, inclusive. */
+  readonly maxVersion: number;
+}
+
+/** Versioned, language-neutral capabilities offered by one adapter. */
+export interface AdapterCapabilityManifest {
+  /**
+   * Serialized manifest format.
+   *
+   * @default 1
+   */
+  readonly formatVersion?: typeof ADAPTER_CAPABILITY_FORMAT_VERSION;
+  /** Stable adapter identifier shown in diagnostics and reports. */
+  readonly adapter: string;
+  /**
+   * Supported capability ranges.
+   *
+   * @default []
+   */
+  readonly capabilities?: readonly AdapterCapabilitySupport[];
+}
+
+/** Stable validation code for an adapter capability manifest. */
+export type AdapterCapabilityDiagnosticCode =
+  | "invalid-format-version"
+  | "invalid-adapter-id"
+  | "invalid-capability-id"
+  | "invalid-version"
+  | "invalid-version-range"
+  | "duplicate-capability";
+
+/** Deterministic validation diagnostic for an adapter capability manifest. */
+export interface AdapterCapabilityDiagnostic {
+  /** Stable machine-readable diagnostic code. */
+  readonly code: AdapterCapabilityDiagnosticCode;
+  /** JSON-style path of the invalid value. */
+  readonly path: string;
+  /** Human-readable explanation. */
+  readonly message: string;
+}
+
+/** Stable incompatibility code emitted during capability negotiation. */
+export type AdapterCapabilityMismatchCode =
+  | "unknown-requirement"
+  | "missing-capability"
+  | "version-below-minimum"
+  | "version-above-maximum";
+
+/** One failed adapter capability requirement. */
+export interface AdapterCapabilityMismatch {
+  /** Stable machine-readable mismatch code. */
+  readonly code: AdapterCapabilityMismatchCode;
+  /** Required capability identifier. */
+  readonly capability: string;
+  /** Required contract version when the capability is declared. */
+  readonly requiredVersion?: number;
+  /** Adapter minimum when support exists. */
+  readonly minVersion?: number;
+  /** Adapter maximum when support exists. */
+  readonly maxVersion?: number;
+}
+
+/** Deterministic result of negotiating requirements with one adapter. */
+export interface AdapterCapabilityNegotiation {
+  /** Adapter whose support was inspected. */
+  readonly adapter: string;
+  /** Whether the manifest is valid and every requirement is supported. */
+  readonly compatible: boolean;
+  /** Manifest validation failures, in stable path order. */
+  readonly diagnostics: readonly AdapterCapabilityDiagnostic[];
+  /** Unsupported or unknown requirements, in stable capability order. */
+  readonly mismatches: readonly AdapterCapabilityMismatch[];
+}
+
+/** Compatibility classification for one adapter capability change. */
+export type CompatibilityChangeKind = "additive" | "breaking";
+
+/** One stable adapter capability compatibility change. */
+export interface AdapterCapabilityCompatibilityChange {
+  /** Compatibility classification. */
+  readonly kind: CompatibilityChangeKind;
+  /** JSON-style path of the changed capability support. */
+  readonly path: string;
+  /** Human-readable summary. */
+  readonly message: string;
+}
+
+/** Deterministic compatibility report between two adapter manifests. */
+export interface AdapterCapabilityCompatibilityReport {
+  /** All changes in stable path order. */
+  readonly changes: readonly AdapterCapabilityCompatibilityChange[];
+}

--- a/npm/marquette/src/adapter-negotiate.ts
+++ b/npm/marquette/src/adapter-negotiate.ts
@@ -1,0 +1,74 @@
+import type { ApplicationMarquette } from "./model.js";
+import type {
+  AdapterCapabilityManifest,
+  AdapterCapabilityMismatch,
+  AdapterCapabilityMismatchCode,
+  AdapterCapabilityNegotiation,
+  AdapterCapabilitySupport,
+} from "./adapter-model.js";
+import { validateAdapterCapabilityManifest } from "./adapter-validate.js";
+
+/**
+ * Negotiates application capability requirements against one adapter.
+ *
+ * Requirement identifiers are deduplicated and sorted. Unknown application
+ * capability identifiers fail closed instead of being treated as adapter
+ * omissions. An invalid manifest never produces a compatible result.
+ */
+export function negotiateAdapterCapabilities(
+  marquette: ApplicationMarquette,
+  requiredCapabilities: readonly string[],
+  manifest: AdapterCapabilityManifest,
+): AdapterCapabilityNegotiation {
+  const diagnostics = validateAdapterCapabilityManifest(manifest);
+  const support = new Map(
+    (manifest.capabilities ?? []).map((capability) => [capability.id, capability] as const),
+  );
+  const mismatches = [...new Set(requiredCapabilities)]
+    .sort()
+    .flatMap((id) => mismatch(marquette, id, support.get(id), diagnostics.length === 0));
+
+  return {
+    adapter: manifest.adapter,
+    compatible: diagnostics.length === 0 && mismatches.length === 0,
+    diagnostics,
+    mismatches,
+  };
+}
+
+function mismatch(
+  marquette: ApplicationMarquette,
+  id: string,
+  support: AdapterCapabilitySupport | undefined,
+  manifestIsValid: boolean,
+): AdapterCapabilityMismatch[] {
+  const requirement = marquette.capabilities?.[id];
+  if (requirement === undefined) return [problem("unknown-requirement", id)];
+  if (!manifestIsValid) return [];
+
+  const requiredVersion = requirement.version ?? 1;
+  if (support === undefined) return [problem("missing-capability", id, requiredVersion)];
+  if (requiredVersion < support.minVersion) {
+    return [problem("version-below-minimum", id, requiredVersion, support)];
+  }
+  if (requiredVersion > support.maxVersion) {
+    return [problem("version-above-maximum", id, requiredVersion, support)];
+  }
+  return [];
+}
+
+function problem(
+  code: AdapterCapabilityMismatchCode,
+  capability: string,
+  requiredVersion?: number,
+  support?: AdapterCapabilitySupport,
+): AdapterCapabilityMismatch {
+  return {
+    code,
+    capability,
+    ...(requiredVersion === undefined ? {} : { requiredVersion }),
+    ...(support === undefined
+      ? {}
+      : { minVersion: support.minVersion, maxVersion: support.maxVersion }),
+  };
+}

--- a/npm/marquette/src/adapter-treeshake.test.ts
+++ b/npm/marquette/src/adapter-treeshake.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { dirname, resolve } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { build } from "vite-plus";
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url));
+const sourceDirectory = fileURLToPath(new URL(".", import.meta.url));
+const adapterEntry = fileURLToPath(new URL("adapter.ts", import.meta.url));
+const VIRTUAL_ID = "virtual:marquette-adapter-treeshake";
+const RESOLVED_ID = `\0${VIRTUAL_ID}`;
+
+async function bundle(entryCode: string): Promise<string> {
+  const result = await build({
+    configFile: false,
+    logLevel: "error",
+    root: packageRoot,
+    plugins: [
+      {
+        name: "marquette-adapter-treeshake",
+        enforce: "pre",
+        resolveId(id: string, importer: string | undefined) {
+          if (id === VIRTUAL_ID) return RESOLVED_ID;
+          const importedFrom = importer === RESOLVED_ID ? packageRoot : dirname(importer ?? "/");
+          const target = id.startsWith(".") ? resolve(importedFrom, id) : id;
+          if (target.startsWith(sourceDirectory) && target.endsWith(".ts")) {
+            return { id: target, moduleSideEffects: true };
+          }
+          return undefined;
+        },
+        load(id: string) {
+          return id === RESOLVED_ID ? entryCode : undefined;
+        },
+      },
+    ],
+    build: {
+      write: false,
+      minify: false,
+      target: "es2022",
+      reportCompressedSize: false,
+      rollupOptions: {
+        input: VIRTUAL_ID,
+        preserveEntrySignatures: "strict",
+        output: { format: "es" },
+      },
+    },
+  });
+  assert.ok(!Array.isArray(result));
+  assert.ok("output" in result);
+  return result.output.map((item) => (item.type === "chunk" ? item.code : "")).join("\n");
+}
+
+void test("the adapter entry has no retained module-level side effects", async () => {
+  const code = await bundle(`import ${JSON.stringify(adapterEntry)};`);
+  assert.equal(code.replaceAll(/\/\*[^]*?\*\//g, "").trim(), "");
+});
+
+void test("negotiation excludes compatibility-only implementation", async () => {
+  const code = await bundle(
+    `export { negotiateAdapterCapabilities } from ${JSON.stringify(adapterEntry)};`,
+  );
+  assert.match(code, /missing-capability/);
+  assert.doesNotMatch(code, /capability support was added/);
+  assert.doesNotMatch(code, /minimum supported version decreased/);
+});
+
+void test("compatibility excludes negotiation-only implementation", async () => {
+  const code = await bundle(
+    `export { compareAdapterCapabilities } from ${JSON.stringify(adapterEntry)};`,
+  );
+  assert.match(code, /capability support was added/);
+  assert.doesNotMatch(code, /missing-capability/);
+  assert.doesNotMatch(code, /unknown-requirement/);
+});

--- a/npm/marquette/src/adapter-types.test.ts
+++ b/npm/marquette/src/adapter-types.test.ts
@@ -1,0 +1,30 @@
+import type {
+  AdapterCapabilityDiagnosticCode,
+  AdapterCapabilityManifest,
+  AdapterCapabilityMismatchCode,
+  CompatibilityChangeKind,
+} from "./adapter.js";
+
+const manifest = {
+  formatVersion: 1,
+  adapter: "fixture.adapter",
+  capabilities: [{ id: "auth.session", minVersion: 1, maxVersion: 3 }],
+} as const satisfies AdapterCapabilityManifest;
+const diagnostic: AdapterCapabilityDiagnosticCode = "duplicate-capability";
+const mismatch: AdapterCapabilityMismatchCode = "version-above-maximum";
+const compatibility: CompatibilityChangeKind = "breaking";
+
+// @ts-expect-error The serialized format is pinned to version one.
+const future: AdapterCapabilityManifest = { formatVersion: 2, adapter: "future.adapter" };
+const missingMaximum: AdapterCapabilityManifest = {
+  adapter: "broken.adapter",
+  // @ts-expect-error Supported ranges require both inclusive bounds.
+  capabilities: [{ id: "broken", minVersion: 1 }],
+};
+
+void manifest;
+void diagnostic;
+void mismatch;
+void compatibility;
+void future;
+void missingMaximum;

--- a/npm/marquette/src/adapter-validate.ts
+++ b/npm/marquette/src/adapter-validate.ts
@@ -1,0 +1,173 @@
+import {
+  ADAPTER_CAPABILITY_FORMAT_VERSION,
+  type AdapterCapabilityDiagnostic,
+  type AdapterCapabilityDiagnosticCode,
+  type AdapterCapabilityManifest,
+} from "./adapter-model.js";
+
+const IDENTIFIER = /^[a-z0-9][a-z0-9._-]*$/;
+const DIAGNOSTIC_ORDER: Record<AdapterCapabilityDiagnosticCode, number> = {
+  "invalid-format-version": 0,
+  "invalid-adapter-id": 1,
+  "invalid-capability-id": 2,
+  "invalid-version": 3,
+  "invalid-version-range": 4,
+  "duplicate-capability": 5,
+};
+
+/** Validates an adapter capability manifest without mutating it. */
+export function validateAdapterCapabilityManifest(
+  manifest: AdapterCapabilityManifest,
+): AdapterCapabilityDiagnostic[] {
+  const diagnostics: AdapterCapabilityDiagnostic[] = [];
+  if ((manifest.formatVersion ?? 1) !== ADAPTER_CAPABILITY_FORMAT_VERSION) {
+    diagnostics.push(
+      diagnostic(
+        "invalid-format-version",
+        "formatVersion",
+        "unsupported adapter capability manifest format version",
+      ),
+    );
+  }
+  if (!IDENTIFIER.test(manifest.adapter)) {
+    diagnostics.push(
+      diagnostic(
+        "invalid-adapter-id",
+        "adapter",
+        "adapter must be a lowercase portable identifier",
+      ),
+    );
+  }
+
+  const seen = new Set<string>();
+  for (const [index, capability] of (manifest.capabilities ?? []).entries()) {
+    const path = `capabilities.${index}`;
+    if (!IDENTIFIER.test(capability.id)) {
+      diagnostics.push(
+        diagnostic(
+          "invalid-capability-id",
+          `${path}.id`,
+          "capability id must be a lowercase portable identifier",
+        ),
+      );
+    }
+    if (seen.has(capability.id)) {
+      diagnostics.push(
+        diagnostic(
+          "duplicate-capability",
+          `${path}.id`,
+          "capability id must be unique within the adapter manifest",
+        ),
+      );
+    }
+    seen.add(capability.id);
+    if (capability.minVersion <= 0) {
+      diagnostics.push(
+        diagnostic(
+          "invalid-version",
+          `${path}.minVersion`,
+          "minimum supported version must be greater than zero",
+        ),
+      );
+    }
+    if (capability.maxVersion <= 0) {
+      diagnostics.push(
+        diagnostic(
+          "invalid-version",
+          `${path}.maxVersion`,
+          "maximum supported version must be greater than zero",
+        ),
+      );
+    }
+    if (capability.minVersion > capability.maxVersion) {
+      diagnostics.push(
+        diagnostic(
+          "invalid-version-range",
+          path,
+          "minimum supported version must not exceed maximum supported version",
+        ),
+      );
+    }
+  }
+
+  return diagnostics.sort(
+    (left, right) =>
+      compareText(left.path, right.path) ||
+      DIAGNOSTIC_ORDER[left.code] - DIAGNOSTIC_ORDER[right.code] ||
+      compareText(left.message, right.message),
+  );
+}
+
+/**
+ * Parses an untrusted manifest with strict field and primitive checks.
+ *
+ * Unknown fields, missing required fields, and mismatched primitive types
+ * throw before negotiation. Semantic range errors remain available from
+ * {@link validateAdapterCapabilityManifest}.
+ */
+export function parseAdapterCapabilityManifest(value: unknown): AdapterCapabilityManifest {
+  assertRecord(value, "manifest");
+  assertKnownFields(value, ["formatVersion", "adapter", "capabilities"], "manifest");
+  if (value.formatVersion !== undefined && value.formatVersion !== 1) {
+    throw new TypeError("formatVersion must equal 1");
+  }
+  if (typeof value.adapter !== "string") {
+    throw new TypeError("adapter must be a string");
+  }
+  if (value.capabilities !== undefined) {
+    if (!Array.isArray(value.capabilities)) {
+      throw new TypeError("capabilities must be an array");
+    }
+    for (const [index, capability] of value.capabilities.entries()) {
+      const path = `capabilities.${index}`;
+      assertRecord(capability, path);
+      assertKnownFields(capability, ["id", "minVersion", "maxVersion"], path);
+      if (typeof capability.id !== "string") throw new TypeError(`${path}.id must be a string`);
+      if (
+        typeof capability.minVersion !== "number" ||
+        !Number.isSafeInteger(capability.minVersion) ||
+        capability.minVersion < 0
+      ) {
+        throw new TypeError(`${path}.minVersion must be a safe integer`);
+      }
+      if (
+        typeof capability.maxVersion !== "number" ||
+        !Number.isSafeInteger(capability.maxVersion) ||
+        capability.maxVersion < 0
+      ) {
+        throw new TypeError(`${path}.maxVersion must be a safe integer`);
+      }
+    }
+  }
+  return value as unknown as AdapterCapabilityManifest;
+}
+
+function diagnostic(
+  code: AdapterCapabilityDiagnosticCode,
+  path: string,
+  message: string,
+): AdapterCapabilityDiagnostic {
+  return { code, path, message };
+}
+
+function assertRecord(value: unknown, path: string): asserts value is Record<string, unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError(`${path} must be an object`);
+  }
+}
+
+function assertKnownFields(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+  path: string,
+): void {
+  const known = new Set(expected);
+  const unknown = Object.keys(value)
+    .filter((field) => !known.has(field))
+    .sort()[0];
+  if (unknown !== undefined) throw new TypeError(`${path} has unknown field ${unknown}`);
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}

--- a/npm/marquette/src/adapter.test.ts
+++ b/npm/marquette/src/adapter.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+import type { ApplicationMarquette } from "./model.js";
+import {
+  compareAdapterCapabilities,
+  negotiateAdapterCapabilities,
+  parseAdapterCapabilityManifest,
+  validateAdapterCapabilityManifest,
+  type AdapterCapabilityCompatibilityReport,
+  type AdapterCapabilityDiagnostic,
+  type AdapterCapabilityManifest,
+  type AdapterCapabilityNegotiation,
+} from "./adapter.js";
+
+const fixture = (name: string) =>
+  new URL(`../../../tests/fixtures/marquette/${name}`, import.meta.url);
+
+async function read<T>(name: string): Promise<T> {
+  return JSON.parse(await readFile(fixture(name), "utf8")) as T;
+}
+
+interface NegotiationFixture {
+  readonly contract: ApplicationMarquette;
+  readonly cases: readonly {
+    readonly name: string;
+    readonly required: readonly string[];
+    readonly manifest: AdapterCapabilityManifest;
+    readonly expected: AdapterCapabilityNegotiation;
+  }[];
+}
+
+interface CompatibilityCase {
+  readonly name: string;
+  readonly previous: AdapterCapabilityManifest;
+  readonly next: AdapterCapabilityManifest;
+  readonly expected: AdapterCapabilityCompatibilityReport;
+}
+
+void test("matches shared negotiation fixtures and input permutations", async () => {
+  const fixture = await read<NegotiationFixture>("adapter-negotiation.json");
+  const results = fixture.cases.map((case_) => {
+    const contractBefore = structuredClone(fixture.contract);
+    const manifestBefore = structuredClone(case_.manifest);
+    const actual = negotiateAdapterCapabilities(fixture.contract, case_.required, case_.manifest);
+
+    assert.deepEqual(actual, case_.expected, case_.name);
+    assert.deepEqual(fixture.contract, contractBefore, `${case_.name}: contract mutated`);
+    assert.deepEqual(case_.manifest, manifestBefore, `${case_.name}: manifest mutated`);
+    return actual;
+  });
+
+  assert.equal(JSON.stringify(results[0]), JSON.stringify(results[1]));
+  assert.equal(results[2]?.compatible, true, "inclusive bounds must pass");
+  assert.equal(results[3]?.mismatches[0]?.code, "unknown-requirement");
+});
+
+void test("matches shared semantic validation diagnostics", async () => {
+  const manifest = await read<AdapterCapabilityManifest>("adapter-manifest-invalid.json");
+  const expected = await read<readonly AdapterCapabilityDiagnostic[]>(
+    "adapter-manifest-invalid.expected.json",
+  );
+
+  assert.deepEqual(validateAdapterCapabilityManifest(manifest), expected);
+});
+
+void test("strict parsing rejects unknown and malformed fields before negotiation", async () => {
+  const unknown = await read<unknown>("adapter-manifest-unknown-field.json");
+  assert.throws(
+    () => parseAdapterCapabilityManifest(unknown),
+    /capabilities\.0 has unknown field unexpected/,
+  );
+  assert.throws(
+    () =>
+      parseAdapterCapabilityManifest({
+        adapter: "fixture.adapter",
+        capabilities: [{ id: "missing-min", maxVersion: 1 }],
+      }),
+    /capabilities\.0\.minVersion must be a safe integer/,
+  );
+  assert.throws(
+    () =>
+      parseAdapterCapabilityManifest({
+        adapter: "fixture.adapter",
+        capabilities: [{ id: "negative", minVersion: -1, maxVersion: 1 }],
+      }),
+    /capabilities\.0\.minVersion must be a safe integer/,
+  );
+});
+
+void test("matches the shared adapter compatibility matrix", async () => {
+  const cases = await read<readonly CompatibilityCase[]>("adapter-compatibility.json");
+  for (const case_ of cases) {
+    assert.deepEqual(
+      compareAdapterCapabilities(case_.previous, case_.next),
+      case_.expected,
+      case_.name,
+    );
+  }
+});
+
+void test("invalid manifests fail closed without reporting adapter mismatches", () => {
+  const marquette: ApplicationMarquette = {
+    application: "invalid-manifest",
+    capabilities: { known: { id: "known", description: "Known" } },
+  };
+  const result = negotiateAdapterCapabilities(marquette, ["known"], {
+    adapter: "fixture.adapter",
+    capabilities: [
+      { id: "known", minVersion: 2, maxVersion: 1 },
+      { id: "known", minVersion: 1, maxVersion: 2 },
+    ],
+  });
+
+  assert.equal(result.compatible, false);
+  assert.deepEqual(result.mismatches, []);
+  assert.deepEqual(
+    result.diagnostics.map(({ code }) => code),
+    ["invalid-version-range", "duplicate-capability"],
+  );
+});

--- a/npm/marquette/src/adapter.ts
+++ b/npm/marquette/src/adapter.ts
@@ -1,0 +1,19 @@
+export {
+  ADAPTER_CAPABILITY_FORMAT_VERSION,
+  type AdapterCapabilityCompatibilityChange,
+  type AdapterCapabilityCompatibilityReport,
+  type AdapterCapabilityDiagnostic,
+  type AdapterCapabilityDiagnosticCode,
+  type AdapterCapabilityManifest,
+  type AdapterCapabilityMismatch,
+  type AdapterCapabilityMismatchCode,
+  type AdapterCapabilityNegotiation,
+  type AdapterCapabilitySupport,
+  type CompatibilityChangeKind,
+} from "./adapter-model.js";
+export { compareAdapterCapabilities } from "./adapter-compatibility.js";
+export { negotiateAdapterCapabilities } from "./adapter-negotiate.js";
+export {
+  parseAdapterCapabilityManifest,
+  validateAdapterCapabilityManifest,
+} from "./adapter-validate.js";

--- a/npm/marquette/vite.config.ts
+++ b/npm/marquette/vite.config.ts
@@ -8,6 +8,7 @@ import { defineConfig } from "vite-plus";
  * task cache, so a cache hit could restore `dist/` without the schemas.
  */
 const contractSchemas = [
+  "adapter-capability-manifest.schema.json",
   "application-contract.schema.json",
   "test-run-evidence.schema.json",
   "test-run-admission.schema.json",
@@ -28,6 +29,7 @@ export default defineConfig({
   pack: {
     entry: [
       "src/index.ts",
+      "src/adapter.ts",
       "src/validate.ts",
       "src/test-run.ts",
       "src/test-run-validate.ts",

--- a/tests/fixtures/marquette/adapter-compatibility.json
+++ b/tests/fixtures/marquette/adapter-compatibility.json
@@ -1,0 +1,78 @@
+[
+  {
+    "name": "addition-removal-and-widening",
+    "previous": {
+      "adapter": "fixture.adapter",
+      "capabilities": [
+        { "id": "range", "minVersion": 2, "maxVersion": 4 },
+        { "id": "removed", "minVersion": 1, "maxVersion": 1 },
+        { "id": "same", "minVersion": 1, "maxVersion": 1 }
+      ]
+    },
+    "next": {
+      "adapter": "fixture.adapter",
+      "capabilities": [
+        { "id": "added", "minVersion": 1, "maxVersion": 1 },
+        { "id": "same", "minVersion": 1, "maxVersion": 1 },
+        { "id": "range", "minVersion": 1, "maxVersion": 5 }
+      ]
+    },
+    "expected": {
+      "changes": [
+        {
+          "kind": "additive",
+          "path": "capabilities.added",
+          "message": "capability support was added"
+        },
+        {
+          "kind": "additive",
+          "path": "capabilities.range.maxVersion",
+          "message": "maximum supported version increased"
+        },
+        {
+          "kind": "additive",
+          "path": "capabilities.range.minVersion",
+          "message": "minimum supported version decreased"
+        },
+        {
+          "kind": "breaking",
+          "path": "capabilities.removed",
+          "message": "capability support was removed"
+        }
+      ]
+    }
+  },
+  {
+    "name": "narrowing-is-breaking",
+    "previous": {
+      "adapter": "fixture.adapter",
+      "capabilities": [{ "id": "range", "minVersion": 1, "maxVersion": 5 }]
+    },
+    "next": {
+      "adapter": "fixture.adapter",
+      "capabilities": [{ "id": "range", "minVersion": 2, "maxVersion": 4 }]
+    },
+    "expected": {
+      "changes": [
+        {
+          "kind": "breaking",
+          "path": "capabilities.range.maxVersion",
+          "message": "maximum supported version decreased"
+        },
+        {
+          "kind": "breaking",
+          "path": "capabilities.range.minVersion",
+          "message": "minimum supported version increased"
+        }
+      ]
+    }
+  },
+  {
+    "name": "adapter-identity-is-breaking",
+    "previous": { "adapter": "fixture.adapter", "capabilities": [] },
+    "next": { "adapter": "other.adapter", "capabilities": [] },
+    "expected": {
+      "changes": [{ "kind": "breaking", "path": "adapter", "message": "adapter identity changed" }]
+    }
+  }
+]

--- a/tests/fixtures/marquette/adapter-manifest-invalid.expected.json
+++ b/tests/fixtures/marquette/adapter-manifest-invalid.expected.json
@@ -1,0 +1,42 @@
+[
+  {
+    "code": "invalid-adapter-id",
+    "path": "adapter",
+    "message": "adapter must be a lowercase portable identifier"
+  },
+  {
+    "code": "invalid-version",
+    "path": "capabilities.0.maxVersion",
+    "message": "maximum supported version must be greater than zero"
+  },
+  {
+    "code": "invalid-version",
+    "path": "capabilities.0.minVersion",
+    "message": "minimum supported version must be greater than zero"
+  },
+  {
+    "code": "invalid-version-range",
+    "path": "capabilities.1",
+    "message": "minimum supported version must not exceed maximum supported version"
+  },
+  {
+    "code": "invalid-capability-id",
+    "path": "capabilities.1.id",
+    "message": "capability id must be a lowercase portable identifier"
+  },
+  {
+    "code": "invalid-capability-id",
+    "path": "capabilities.2.id",
+    "message": "capability id must be a lowercase portable identifier"
+  },
+  {
+    "code": "duplicate-capability",
+    "path": "capabilities.2.id",
+    "message": "capability id must be unique within the adapter manifest"
+  },
+  {
+    "code": "invalid-format-version",
+    "path": "formatVersion",
+    "message": "unsupported adapter capability manifest format version"
+  }
+]

--- a/tests/fixtures/marquette/adapter-manifest-invalid.json
+++ b/tests/fixtures/marquette/adapter-manifest-invalid.json
@@ -1,0 +1,9 @@
+{
+  "formatVersion": 2,
+  "adapter": "Bad Adapter",
+  "capabilities": [
+    { "id": "zero", "minVersion": 0, "maxVersion": 0 },
+    { "id": "Bad Id", "minVersion": 4, "maxVersion": 2 },
+    { "id": "Bad Id", "minVersion": 1, "maxVersion": 1 }
+  ]
+}

--- a/tests/fixtures/marquette/adapter-manifest-unknown-field.json
+++ b/tests/fixtures/marquette/adapter-manifest-unknown-field.json
@@ -1,0 +1,4 @@
+{
+  "adapter": "fixture.adapter",
+  "capabilities": [{ "id": "known", "minVersion": 1, "maxVersion": 1, "unexpected": true }]
+}

--- a/tests/fixtures/marquette/adapter-negotiation.json
+++ b/tests/fixtures/marquette/adapter-negotiation.json
@@ -1,0 +1,147 @@
+{
+  "contract": {
+    "formatVersion": 1,
+    "application": "adapter-fixture",
+    "capabilities": {
+      "exact": { "id": "exact", "description": "Exact version", "version": 2 },
+      "lower-bound": { "id": "lower-bound", "description": "Inclusive lower bound", "version": 1 },
+      "upper-bound": { "id": "upper-bound", "description": "Inclusive upper bound", "version": 3 },
+      "missing": { "id": "missing", "description": "Missing adapter support", "version": 1 },
+      "old.application": {
+        "id": "old.application",
+        "description": "Older than adapter range",
+        "version": 1
+      },
+      "new.application": {
+        "id": "new.application",
+        "description": "Newer than adapter range",
+        "version": 5
+      }
+    }
+  },
+  "cases": [
+    {
+      "name": "boundaries-missing-and-extra",
+      "required": [
+        "upper-bound",
+        "old.application",
+        "missing",
+        "exact",
+        "new.application",
+        "lower-bound"
+      ],
+      "manifest": {
+        "formatVersion": 1,
+        "adapter": "fixture.adapter",
+        "capabilities": [
+          { "id": "extra.adapter-only", "minVersion": 1, "maxVersion": 1 },
+          { "id": "new.application", "minVersion": 1, "maxVersion": 4 },
+          { "id": "exact", "minVersion": 2, "maxVersion": 2 },
+          { "id": "upper-bound", "minVersion": 1, "maxVersion": 3 },
+          { "id": "old.application", "minVersion": 2, "maxVersion": 4 },
+          { "id": "lower-bound", "minVersion": 1, "maxVersion": 3 }
+        ]
+      },
+      "expected": {
+        "adapter": "fixture.adapter",
+        "compatible": false,
+        "diagnostics": [],
+        "mismatches": [
+          { "code": "missing-capability", "capability": "missing", "requiredVersion": 1 },
+          {
+            "code": "version-above-maximum",
+            "capability": "new.application",
+            "requiredVersion": 5,
+            "minVersion": 1,
+            "maxVersion": 4
+          },
+          {
+            "code": "version-below-minimum",
+            "capability": "old.application",
+            "requiredVersion": 1,
+            "minVersion": 2,
+            "maxVersion": 4
+          }
+        ]
+      }
+    },
+    {
+      "name": "permutation-is-identical",
+      "required": [
+        "lower-bound",
+        "new.application",
+        "exact",
+        "missing",
+        "old.application",
+        "upper-bound",
+        "missing"
+      ],
+      "manifest": {
+        "adapter": "fixture.adapter",
+        "capabilities": [
+          { "id": "lower-bound", "minVersion": 1, "maxVersion": 3 },
+          { "id": "old.application", "minVersion": 2, "maxVersion": 4 },
+          { "id": "upper-bound", "minVersion": 1, "maxVersion": 3 },
+          { "id": "exact", "minVersion": 2, "maxVersion": 2 },
+          { "id": "new.application", "minVersion": 1, "maxVersion": 4 },
+          { "id": "extra.adapter-only", "minVersion": 1, "maxVersion": 1 }
+        ]
+      },
+      "expected": {
+        "adapter": "fixture.adapter",
+        "compatible": false,
+        "diagnostics": [],
+        "mismatches": [
+          { "code": "missing-capability", "capability": "missing", "requiredVersion": 1 },
+          {
+            "code": "version-above-maximum",
+            "capability": "new.application",
+            "requiredVersion": 5,
+            "minVersion": 1,
+            "maxVersion": 4
+          },
+          {
+            "code": "version-below-minimum",
+            "capability": "old.application",
+            "requiredVersion": 1,
+            "minVersion": 2,
+            "maxVersion": 4
+          }
+        ]
+      }
+    },
+    {
+      "name": "supported-boundaries-and-extra",
+      "required": ["exact", "lower-bound", "upper-bound"],
+      "manifest": {
+        "adapter": "fixture.adapter",
+        "capabilities": [
+          { "id": "exact", "minVersion": 2, "maxVersion": 2 },
+          { "id": "lower-bound", "minVersion": 1, "maxVersion": 3 },
+          { "id": "upper-bound", "minVersion": 1, "maxVersion": 3 },
+          { "id": "extra.adapter-only", "minVersion": 1, "maxVersion": 99 }
+        ]
+      },
+      "expected": {
+        "adapter": "fixture.adapter",
+        "compatible": true,
+        "diagnostics": [],
+        "mismatches": []
+      }
+    },
+    {
+      "name": "unknown-requirement-fails-closed",
+      "required": ["unknown.capability", "unknown.capability"],
+      "manifest": {
+        "adapter": "fixture.adapter",
+        "capabilities": [{ "id": "unknown.capability", "minVersion": 1, "maxVersion": 99 }]
+      },
+      "expected": {
+        "adapter": "fixture.adapter",
+        "compatible": false,
+        "diagnostics": [],
+        "mismatches": [{ "code": "unknown-requirement", "capability": "unknown.capability" }]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a versioned, language-neutral adapter capability manifest to Rust and TypeScript
- negotiate existing application capability versions against inclusive adapter ranges with stable, deterministic mismatch codes
- classify added and widened support as additive and removed or narrowed support as breaking
- publish a strict embedded and npm-exported schema with shared Rust/TypeScript conformance fixtures
- preserve the existing application contract schema and fingerprint

Application capability definitions remain the requirement authority: undeclared requirements fail closed, while adapter-only support is allowed and additive.

## Validation

- cargo fmt --all -- --check
- cargo clippy -p vize_marquette --all-targets -- -D warnings
- cargo test -p vize_marquette
- vp run --filter @vizejs/marquette check
- vp run --filter @vizejs/marquette test (44 tests)
- vp run --filter @vizejs/marquette build (adapter: 2359 / 4096 gzip bytes)
- package manifest policy (17 tests)
- source-file length policy with the CI MoonBit toolchain (7 tests)
- packed artifact contains the adapter runtime, declarations, and schema

Part of #3131

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added versioned adapter capability manifests with a published JSON Schema.
  - Added manifest parsing and validation with clear diagnostics for invalid identifiers, versions, ranges, duplicates, and unknown fields.
  - Added capability negotiation to identify missing, unsupported, or unknown requirements.
  - Added compatibility comparisons for capability additions, removals, version changes, and adapter identity changes.
  - Exposed adapter APIs and schema through the Marquette package.

- **Documentation**
  - Documented manifest declaration, negotiation behavior, compatibility rules, mismatch codes, and schema guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->