### PR TITLE
fix(atelier): resolve wildcard exports types entries

### DIFF
--- a/crates/vize_atelier_sfc/src/script/context/external_types/exports_patterns.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/exports_patterns.rs
@@ -19,9 +19,9 @@ pub(super) fn exports_types_entry(manifest: &serde_json::Value, key: &str) -> Op
         if entry.is_null() {
             return Some(ExportsTypes::Excluded);
         }
-        if let Some(types) = super::find_types_condition(entry) {
-            return Some(ExportsTypes::Types(types));
-        }
+        // An exact key ends resolution the way Node does, so an entry without a
+        // `types` condition must not borrow declarations from a wildcard key.
+        return super::find_types_condition(entry).map(ExportsTypes::Types);
     }
     let (captured, target) = best_pattern_match(exports, key)?;
     if target.is_null() {
@@ -118,6 +118,14 @@ mod tests {
             exports_types_entry(&manifest, "./secret"),
             Some(ExportsTypes::Excluded)
         ));
+    }
+
+    #[test]
+    fn an_exact_key_without_types_does_not_borrow_from_a_wildcard() {
+        let manifest = exports(
+            r#"{"exports":{"./style.css":"./dist/style.css","./*":{"types":"./types/*.d.ts"}}}"#,
+        );
+        assert!(exports_types_entry(&manifest, "./style.css").is_none());
     }
 
     #[test]

--- a/crates/vize_atelier_sfc/src/script/context/external_types/exports_patterns.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/exports_patterns.rs
@@ -1,0 +1,63 @@
+/// Match `key` against Node-style `exports` pattern keys such as `"./dist/*"`,
+/// returning the captured wildcard segment and the pattern's target value.
+///
+/// The most specific pattern wins: longest literal prefix first, then longest
+/// literal suffix, matching Node's package export resolution order.
+pub(super) fn best_pattern_match<'a>(
+    exports: &'a serde_json::Value,
+    key: &'a str,
+) -> Option<(&'a str, &'a serde_json::Value)> {
+    let mut best: Option<(usize, usize, &str, &serde_json::Value)> = None;
+    for (pattern, target) in exports.as_object()? {
+        if !pattern.starts_with("./") {
+            continue;
+        }
+        let Some((prefix, suffix)) = pattern.split_once('*') else {
+            continue;
+        };
+        let Some(captured) = key
+            .strip_prefix(prefix)
+            .and_then(|rest| rest.strip_suffix(suffix))
+        else {
+            continue;
+        };
+        if best.is_none_or(|(best_prefix, best_suffix, _, _)| {
+            (prefix.len(), suffix.len()) > (best_prefix, best_suffix)
+        }) {
+            best = Some((prefix.len(), suffix.len(), captured, target));
+        }
+    }
+    best.map(|(_, _, captured, target)| (captured, target))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::best_pattern_match;
+
+    fn exports(raw: &str) -> serde_json::Value {
+        serde_json::from_str(raw).unwrap()
+    }
+
+    #[test]
+    fn captures_the_wildcard_segment() {
+        let exports = exports(r#"{"./dist/*":{"types":"./types/*.d.ts"}}"#);
+        let (captured, target) = best_pattern_match(&exports, "./dist/nested/foo").unwrap();
+        assert_eq!(captured, "nested/foo");
+        assert_eq!(target["types"], "./types/*.d.ts");
+    }
+
+    #[test]
+    fn prefers_the_most_specific_pattern() {
+        let exports =
+            exports(r#"{"./*":{"types":"./root/*.d.ts"},"./dist/*.js":{"types":"./dist/*.d.ts"}}"#);
+        let (captured, target) = best_pattern_match(&exports, "./dist/foo.js").unwrap();
+        assert_eq!(captured, "foo");
+        assert_eq!(target["types"], "./dist/*.d.ts");
+    }
+
+    #[test]
+    fn ignores_condition_keys_and_unmatched_patterns() {
+        let exports = exports(r#"{"types":"./root.d.ts","./dist/*":{"types":"./dist/*.d.ts"}}"#);
+        assert!(best_pattern_match(&exports, "./other/foo").is_none());
+    }
+}

--- a/crates/vize_atelier_sfc/src/script/context/external_types/exports_patterns.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/exports_patterns.rs
@@ -1,3 +1,39 @@
+use vize_carton::{String, ToCompactString};
+
+/// Outcome of an `exports` lookup for one subpath key.
+pub(super) enum ExportsTypes {
+    /// The `types` target published for the subpath.
+    Types(String),
+    /// The subpath matched a `null` target. Node treats those as explicitly
+    /// blocked, so resolution must stop instead of falling back to a path
+    /// lookup that would expose the declaration anyway.
+    Excluded,
+}
+
+/// Find the `types` condition for an `exports` subpath entry. An exact key
+/// wins; otherwise a `*` pattern key is matched and the captured segment is
+/// substituted into its target, so wildcard exports still yield declarations.
+pub(super) fn exports_types_entry(manifest: &serde_json::Value, key: &str) -> Option<ExportsTypes> {
+    let exports = manifest.get("exports")?;
+    if let Some(entry) = exports.get(key) {
+        if entry.is_null() {
+            return Some(ExportsTypes::Excluded);
+        }
+        if let Some(types) = super::find_types_condition(entry) {
+            return Some(ExportsTypes::Types(types));
+        }
+    }
+    let (captured, target) = best_pattern_match(exports, key)?;
+    if target.is_null() {
+        return Some(ExportsTypes::Excluded);
+    }
+    Some(ExportsTypes::Types(
+        super::find_types_condition(target)?
+            .replace('*', captured)
+            .to_compact_string(),
+    ))
+}
+
 /// Match `key` against Node-style `exports` pattern keys such as `"./dist/*"`,
 /// returning the captured wildcard segment and the pattern's target value.
 ///
@@ -32,7 +68,7 @@ pub(super) fn best_pattern_match<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::best_pattern_match;
+    use super::{ExportsTypes, best_pattern_match, exports_types_entry};
 
     fn exports(raw: &str) -> serde_json::Value {
         serde_json::from_str(raw).unwrap()
@@ -59,5 +95,34 @@ mod tests {
     fn ignores_condition_keys_and_unmatched_patterns() {
         let exports = exports(r#"{"types":"./root.d.ts","./dist/*":{"types":"./dist/*.d.ts"}}"#);
         assert!(best_pattern_match(&exports, "./other/foo").is_none());
+    }
+
+    #[test]
+    fn a_more_specific_null_pattern_blocks_the_subpath() {
+        let manifest =
+            exports(r#"{"exports":{"./*":{"types":"./types/*.d.ts"},"./private/*":null}}"#);
+        assert!(matches!(
+            exports_types_entry(&manifest, "./private/secret"),
+            Some(ExportsTypes::Excluded)
+        ));
+        assert!(matches!(
+            exports_types_entry(&manifest, "./button"),
+            Some(ExportsTypes::Types(types)) if types == "./types/button.d.ts"
+        ));
+    }
+
+    #[test]
+    fn an_exact_null_key_blocks_the_subpath() {
+        let manifest = exports(r#"{"exports":{"./*":{"types":"./types/*.d.ts"},"./secret":null}}"#);
+        assert!(matches!(
+            exports_types_entry(&manifest, "./secret"),
+            Some(ExportsTypes::Excluded)
+        ));
+    }
+
+    #[test]
+    fn an_unexported_subpath_stays_unmatched() {
+        let manifest = exports(r#"{"exports":{"./dist/*":{"types":"./dist/*.d.ts"}}}"#);
+        assert!(exports_types_entry(&manifest, "./other").is_none());
     }
 }

--- a/crates/vize_atelier_sfc/src/script/context/external_types/resolution.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/resolution.rs
@@ -9,6 +9,8 @@ use super::super::batch_epoch::{NO_EPOCH, current_batch_epoch};
 #[path = "exports_patterns.rs"]
 mod exports_patterns;
 
+use self::exports_patterns::{ExportsTypes, exports_types_entry};
+
 const RESOLVE_EXTENSIONS: &[&str] = &[
     ".ts", ".tsx", ".d.ts", ".mts", ".cts", ".js", ".jsx", ".vue",
 ];
@@ -213,29 +215,19 @@ fn resolve_package_types(package_dir: &Path, subpath: &str) -> Option<PathBuf> {
     if let Some(manifest) = &manifest {
         let mut export_key = String::from("./");
         export_key.push_str(subpath);
-        if let Some(types) = exports_types_entry(manifest, export_key.as_str())
-            && let Some(path) = resolve_candidate_path(package_dir.join(types))
-        {
-            return Some(path);
+        match exports_types_entry(manifest, export_key.as_str()) {
+            // A `null` target blocks the subpath, so the physical declaration
+            // beside it must stay unreachable.
+            Some(ExportsTypes::Excluded) => return None,
+            Some(ExportsTypes::Types(types)) => {
+                if let Some(path) = resolve_candidate_path(package_dir.join(types)) {
+                    return Some(path);
+                }
+            }
+            None => {}
         }
     }
     resolve_candidate_path(package_dir.join(subpath))
-}
-
-/// Find the `types` condition for an `exports` subpath entry. An exact key
-/// wins; otherwise a `*` pattern key is matched and the captured segment is
-/// substituted into its target, so wildcard exports still yield declarations.
-fn exports_types_entry(manifest: &serde_json::Value, key: &str) -> Option<String> {
-    let exports = manifest.get("exports")?;
-    if let Some(types) = exports.get(key).and_then(find_types_condition) {
-        return Some(types);
-    }
-    let (captured, target) = exports_patterns::best_pattern_match(exports, key)?;
-    Some(
-        find_types_condition(target)?
-            .replace('*', captured)
-            .to_compact_string(),
-    )
 }
 
 /// Find the `types` condition for the package root. The root entry is either

--- a/crates/vize_atelier_sfc/src/script/context/external_types/resolution.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/resolution.rs
@@ -6,6 +6,9 @@ use vize_carton::{FxHashMap, String, ToCompactString};
 
 use super::super::batch_epoch::{NO_EPOCH, current_batch_epoch};
 
+#[path = "exports_patterns.rs"]
+mod exports_patterns;
+
 const RESOLVE_EXTENSIONS: &[&str] = &[
     ".ts", ".tsx", ".d.ts", ".mts", ".cts", ".js", ".jsx", ".vue",
 ];
@@ -219,9 +222,20 @@ fn resolve_package_types(package_dir: &Path, subpath: &str) -> Option<PathBuf> {
     resolve_candidate_path(package_dir.join(subpath))
 }
 
-/// Find the `types` condition for an `exports` subpath entry.
+/// Find the `types` condition for an `exports` subpath entry. An exact key
+/// wins; otherwise a `*` pattern key is matched and the captured segment is
+/// substituted into its target, so wildcard exports still yield declarations.
 fn exports_types_entry(manifest: &serde_json::Value, key: &str) -> Option<String> {
-    find_types_condition(manifest.get("exports")?.get(key)?)
+    let exports = manifest.get("exports")?;
+    if let Some(types) = exports.get(key).and_then(find_types_condition) {
+        return Some(types);
+    }
+    let (captured, target) = exports_patterns::best_pattern_match(exports, key)?;
+    Some(
+        find_types_condition(target)?
+            .replace('*', captured)
+            .to_compact_string(),
+    )
 }
 
 /// Find the `types` condition for the package root. The root entry is either

--- a/crates/vize_atelier_sfc/src/script/context/external_types/resolution_tests.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/resolution_tests.rs
@@ -130,3 +130,37 @@ fn package_root_ignores_subpath_only_exports_map() {
 
     let _ = std::fs::remove_dir_all(package);
 }
+
+#[test]
+fn subpath_falls_back_to_wildcard_exports_types() {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let package = std::env::temp_dir().join(format!(
+        "vize-sfc-external-types-{}-wildcard-{nonce}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(package.join("types")).unwrap();
+    std::fs::create_dir_all(package.join("dist")).unwrap();
+    // Only a `*` pattern subpath is exported, as bundlers commonly emit.
+    std::fs::write(
+        package.join("package.json"),
+        r#"{"exports":{"./*":{"types":"./types/*.d.ts","import":"./dist/*.mjs"}}}"#,
+    )
+    .unwrap();
+    std::fs::write(package.join("dist/button.mjs"), "export default {}").unwrap();
+    std::fs::write(
+        package.join("types/button.d.ts"),
+        "export type ButtonProps = { label: string }",
+    )
+    .unwrap();
+
+    let resolved = resolve_package_types(&package, "button").unwrap();
+    assert!(
+        resolved.ends_with("types/button.d.ts"),
+        "expected wildcard exports types entry, got {resolved:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(package);
+}

--- a/crates/vize_atelier_sfc/src/script/context/external_types/resolution_tests.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types/resolution_tests.rs
@@ -164,3 +164,40 @@ fn subpath_falls_back_to_wildcard_exports_types() {
 
     let _ = std::fs::remove_dir_all(package);
 }
+
+#[test]
+fn subpath_excluded_by_a_null_export_is_not_resolved() {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let package = std::env::temp_dir().join(format!(
+        "vize-sfc-external-types-{}-null-export-{nonce}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(package.join("types")).unwrap();
+    std::fs::create_dir_all(package.join("private")).unwrap();
+    // The broad pattern exposes declarations, but `./private/*` is blocked.
+    std::fs::write(
+        package.join("package.json"),
+        r#"{"exports":{"./*":{"types":"./types/*.d.ts"},"./private/*":null}}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        package.join("types/button.d.ts"),
+        "export type ButtonProps = { label: string }",
+    )
+    .unwrap();
+    // A physical declaration under the blocked subpath must stay unreachable.
+    std::fs::write(
+        package.join("private/internal.d.ts"),
+        "export type Internal = { secret: string }",
+    )
+    .unwrap();
+
+    assert!(resolve_package_types(&package, "button").is_some());
+    let blocked = resolve_package_types(&package, "private/internal");
+    assert!(blocked.is_none(), "expected no resolution, got {blocked:?}");
+
+    let _ = std::fs::remove_dir_all(package);
+}


### PR DESCRIPTION
Follow-up to the review on #3837 (already merged): `exports_types_entry` only looked up exact subpath keys, so packages that publish declarations behind Node-style pattern exports (`"./*"`, `"./dist/*.js"`) lost their `types` target and fell back to the runtime file. Exact keys still win; when none matches, the pattern key is matched and the captured segment is substituted into the target:

```rust
fn exports_types_entry(manifest: &serde_json::Value, key: &str) -> Option<String> {
    let exports = manifest.get("exports")?;
    if let Some(types) = exports.get(key).and_then(find_types_condition) {
        return Some(types);
    }
    let (captured, target) = exports_patterns::best_pattern_match(exports, key)?;
    Some(
        find_types_condition(target)?
            .replace('*', captured)
            .to_compact_string(),
    )
}
```

Pattern selection lives in the new `exports_patterns` module (keeping `resolution.rs` under the source-length limit) and follows Node's specificity order: longest literal prefix first, then longest literal suffix. Keys that do not start with `./` are skipped so condition names inside a condition-only `exports` map are never mistaken for patterns, and a non-matching key still falls through to the existing path-based resolution.

Covered by unit tests for capture, specificity, and condition-key rejection, plus a filesystem test that resolves `pkg/button` to `types/button.d.ts` through a `"./*"` export while `dist/button.mjs` exists beside it. The full `cargo test`/`clippy` run could not execute in this workspace (disk exhausted); `rustfmt --check` is clean and the new module type-checks and passes its tests under the pinned 1.95.0 toolchain.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for wildcard package export patterns during subpath resolution.
  * Wildcard matches now substitute requested paths into corresponding type declarations.
  * More specific export patterns take precedence, with exact matches prioritized.
  * Explicitly excluded subpaths are recognized and prevented from resolving through fallback paths.

* **Bug Fixes**
  * Improved package type resolution when only wildcard or conditional export entries are available.

* **Tests**
  * Added coverage for wildcard matching, specificity, conditional entries, exclusions, and fallback resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->