### PR TITLE
fix(fresco): preserve canonical wrap semantics

### DIFF
--- a/crates/vize_fresco/src/napi/render_tests.rs
+++ b/crates/vize_fresco/src/napi/render_tests.rs
@@ -3,7 +3,7 @@ use super::render_payload::{
     RenderNodeKindNapi, parse_render_node_kind, validate_render_node_kinds,
 };
 use super::types::{FlexStyleNapi, InputEventNapi, RenderNodeNapi, StyleNapi};
-use crate::input::{Event, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use crate::input::{Event, Key, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 
 fn render_node(id: i64, node_type: &str) -> RenderNodeNapi {
     RenderNodeNapi {
@@ -89,12 +89,55 @@ fn render_node_kind_accepts_every_public_protocol_literal() {
             RenderNodeKindNapi::Input,
         ]
     );
+
+    assert_eq!(nodes[0].id, 1);
+    assert_eq!(nodes[0].node_type, "root");
+    let root_style = nodes[0].style.as_ref().unwrap();
+    assert_eq!(root_style.width.as_deref(), Some("80"));
+    assert_eq!(root_style.height.as_deref(), Some("24"));
+    assert_eq!(nodes[0].children.as_deref(), Some([2].as_slice()));
+
+    assert_eq!(nodes[1].id, 2);
+    assert_eq!(nodes[1].node_type, "box");
+    let box_style = nodes[1].style.as_ref().unwrap();
+    assert_eq!(box_style.flex_direction.as_deref(), Some("row"));
+    assert_eq!(box_style.padding_left, Some(1.0));
+    let box_appearance = nodes[1].appearance.as_ref().unwrap();
+    assert_eq!(box_appearance.fg.as_deref(), Some("cyan"));
+    assert_eq!(box_appearance.bold, Some(true));
+    assert_eq!(nodes[1].border.as_deref(), Some("rounded"));
+    assert_eq!(nodes[1].children.as_deref(), Some([3, 4].as_slice()));
+
+    assert_eq!(nodes[2].id, 3);
+    assert_eq!(nodes[2].node_type, "text");
+    assert_eq!(nodes[2].text.as_deref(), Some("hello"));
+    assert_eq!(nodes[2].wrap, Some(true));
+    assert_eq!(nodes[2].wrap_mode.as_deref(), Some("truncate-end"));
+
+    assert_eq!(nodes[3].id, 4);
+    assert_eq!(nodes[3].node_type, "input");
+    assert_eq!(nodes[3].value.as_deref(), Some("secret"));
+    assert_eq!(nodes[3].placeholder.as_deref(), Some("type here"));
+    assert_eq!(nodes[3].focused, Some(true));
+    assert_eq!(nodes[3].cursor, Some(6));
+    assert_eq!(nodes[3].mask, Some(true));
+    assert_eq!(nodes[3].mask_char.as_deref(), Some("#"));
 }
 
 #[test]
 fn input_event_conversion_confirms_every_existing_discriminator() {
     let events = [
-        Event::Key(KeyEvent::char('x')),
+        Event::Key(KeyEvent::new(
+            Key::Char('x'),
+            KeyModifiers {
+                ctrl: true,
+                alt: true,
+                shift: true,
+                super_key: true,
+                hyper: true,
+                meta: true,
+            },
+        )),
         Event::Mouse(MouseEvent::new(
             MouseEventKind::Down(MouseButton::Left),
             2,
@@ -107,16 +150,47 @@ fn input_event_conversion_confirms_every_existing_discriminator() {
         Event::Paste("pasted".into()),
     ];
 
-    let discriminators = events
+    let converted = events
         .into_iter()
         .map(InputEventNapi::from)
-        .map(|event| event.event_type)
+        .collect::<Vec<_>>();
+    let discriminators = converted
+        .iter()
+        .map(|event| event.event_type.as_str())
         .collect::<Vec<_>>();
 
     assert_eq!(
         discriminators,
         ["key", "mouse", "resize", "focus", "focus", "paste"]
     );
+
+    let key = &converted[0];
+    assert_eq!(key.key, None);
+    assert_eq!(key.char.as_deref(), Some("x"));
+    assert_eq!(key.key_event_type.as_deref(), Some("press"));
+    let modifiers = key.modifiers.as_ref().unwrap();
+    assert!(modifiers.ctrl);
+    assert!(modifiers.alt);
+    assert!(modifiers.shift);
+    assert!(modifiers.meta);
+    assert!(modifiers.super_key);
+    assert!(modifiers.hyper);
+    assert!(!modifiers.caps_lock);
+    assert!(!modifiers.num_lock);
+
+    let mouse = &converted[1];
+    assert_eq!(mouse.button.as_deref(), Some("left"));
+    assert_eq!(mouse.x, Some(2));
+    assert_eq!(mouse.y, Some(3));
+    assert!(mouse.modifiers.is_none());
+
+    let resize = &converted[2];
+    assert_eq!(resize.width, Some(80));
+    assert_eq!(resize.height, Some(24));
+
+    assert_eq!(converted[3].key.as_deref(), Some("gained"));
+    assert_eq!(converted[4].key.as_deref(), Some("lost"));
+    assert_eq!(converted[5].text.as_deref(), Some("pasted"));
 }
 
 #[test]

--- a/npm/fresco/src/renderPayload.ts
+++ b/npm/fresco/src/renderPayload.ts
@@ -215,9 +215,9 @@ function wrapMode(value: unknown): FrescoTextWrapMode | undefined {
   return enumValue(value, wrapModes);
 }
 
-function wrappingEnabled(value: unknown): boolean {
+function wrappingEnabled(value: unknown, mode: FrescoTextWrapMode | undefined): boolean {
   if (value === undefined || value === false) return false;
-  return !(typeof value === "string" && value.startsWith("truncate"));
+  return !(mode?.startsWith("truncate") ?? false);
 }
 
 export function frescoNodeToRenderNode(node: FrescoNode): FrescoRenderNode {
@@ -233,7 +233,7 @@ export function frescoNodeToRenderNode(node: FrescoNode): FrescoRenderNode {
     const mode = wrapMode(node.props.wrap);
     if (text !== undefined) renderNode.text = text;
     if (node.props.wrap !== undefined) {
-      renderNode.wrap = wrappingEnabled(node.props.wrap);
+      renderNode.wrap = wrappingEnabled(node.props.wrap, mode);
       if (mode) renderNode.wrapMode = mode;
     }
     return renderNode;

--- a/npm/fresco/src/renderer.test.ts
+++ b/npm/fresco/src/renderer.test.ts
@@ -135,7 +135,7 @@ void test("emits all four discriminated render variants with canonical payload f
     id: box.children[0]?.id,
     nodeType: "text",
     text: "hi",
-    wrap: true,
+    wrap: false,
     wrapMode: "truncate-end",
     appearance: { fg: "cyan", bg: "blue", dim: true },
   });
@@ -163,9 +163,13 @@ void test("normalizes wrap props into native wrap modes", () => {
 
   assert.deepEqual(wrapOf(true), { wrap: true, wrapMode: "wrap" });
   assert.deepEqual(wrapOf(false), { wrap: false, wrapMode: "none" });
-  assert.deepEqual(wrapOf("end"), { wrap: true, wrapMode: "truncate-end" });
-  assert.deepEqual(wrapOf("middle"), { wrap: true, wrapMode: "truncate-middle" });
+  assert.deepEqual(wrapOf("end"), wrapOf("truncate-end"));
+  assert.deepEqual(wrapOf("middle"), wrapOf("truncate-middle"));
   assert.deepEqual(wrapOf("truncate-start"), { wrap: false, wrapMode: "truncate-start" });
+  assert.deepEqual(wrapOf("truncate-end"), { wrap: false, wrapMode: "truncate-end" });
+  assert.deepEqual(wrapOf("truncate-middle"), { wrap: false, wrapMode: "truncate-middle" });
+  assert.deepEqual(wrapOf("hard"), { wrap: true, wrapMode: "hard" });
+  assert.deepEqual(wrapOf("invalid"), { wrap: true, wrapMode: undefined });
   assert.deepEqual(wrapOf(undefined), { wrap: undefined, wrapMode: undefined });
 });
 


### PR DESCRIPTION
## Summary

- derive text wrapping from the resolved canonical wrap mode so `end`/`middle` match their `truncate-*` forms
- preserve existing boolean, non-truncation, invalid, and omitted wrap behavior
- assert every Fresco N-API render fixture and input-event payload at field level

Follow-up to #3842 and its late CodeRabbit review.

## Validation

- `pnpm --filter @vizejs/fresco test` (37 passed)
- `pnpm --filter @vizejs/fresco check`
- `pnpm --filter @vizejs/fresco build`
- `cargo test -p vize_fresco --features napi` (132 passed)
- `cargo clippy -p vize_fresco --features napi --all-targets -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->