### PR TITLE
fix(marquette): reject invalid capability manifests

### DIFF
--- a/crates/vize_marquette/src/adapter/compatibility.rs
+++ b/crates/vize_marquette/src/adapter/compatibility.rs
@@ -1,11 +1,27 @@
 use std::collections::BTreeMap;
 
+use serde::{Deserialize, Serialize};
 use vize_carton::{String, ToCompactString};
 
 use crate::{
-    CompatibilityChange, CompatibilityChangeKind, CompatibilityReport,
-    adapter::AdapterCapabilityManifest,
+    CompatibilityChange, CompatibilityChangeKind,
+    adapter::{
+        AdapterCapabilityDiagnostic, AdapterCapabilityManifest,
+        validate_adapter_capability_manifest,
+    },
 };
+
+/// Deterministic compatibility report between two adapter manifests.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AdapterCapabilityCompatibilityReport {
+    /// Validation failures in the previous manifest.
+    pub previous_diagnostics: Vec<AdapterCapabilityDiagnostic>,
+    /// Validation failures in the next manifest.
+    pub next_diagnostics: Vec<AdapterCapabilityDiagnostic>,
+    /// Capability changes, empty when either input is invalid.
+    pub changes: Vec<CompatibilityChange>,
+}
 
 /// Compares adapter capability support from older to newer.
 ///
@@ -14,7 +30,17 @@ use crate::{
 pub fn compare_adapter_capabilities(
     previous: &AdapterCapabilityManifest,
     next: &AdapterCapabilityManifest,
-) -> CompatibilityReport {
+) -> AdapterCapabilityCompatibilityReport {
+    let previous_diagnostics = validate_adapter_capability_manifest(previous);
+    let next_diagnostics = validate_adapter_capability_manifest(next);
+    if !previous_diagnostics.is_empty() || !next_diagnostics.is_empty() {
+        return AdapterCapabilityCompatibilityReport {
+            previous_diagnostics,
+            next_diagnostics,
+            changes: Vec::new(),
+        };
+    }
+
     let mut changes = Vec::new();
     if previous.adapter != next.adapter {
         changes.push(change(
@@ -81,7 +107,11 @@ pub fn compare_adapter_capabilities(
     }
 
     changes.sort_by(|left, right| (&left.path, left.kind).cmp(&(&right.path, right.kind)));
-    CompatibilityReport { changes }
+    AdapterCapabilityCompatibilityReport {
+        previous_diagnostics,
+        next_diagnostics,
+        changes,
+    }
 }
 
 fn by_id(manifest: &AdapterCapabilityManifest) -> BTreeMap<&str, &super::AdapterCapabilitySupport> {

--- a/crates/vize_marquette/src/adapter/mod.rs
+++ b/crates/vize_marquette/src/adapter/mod.rs
@@ -5,7 +5,7 @@ mod model;
 mod negotiate;
 mod validate;
 
-pub use compatibility::compare_adapter_capabilities;
+pub use compatibility::{AdapterCapabilityCompatibilityReport, compare_adapter_capabilities};
 pub use model::{
     ADAPTER_CAPABILITY_FORMAT_VERSION, AdapterCapabilityDiagnostic,
     AdapterCapabilityDiagnosticCode, AdapterCapabilityManifest, AdapterCapabilityMismatch,

--- a/crates/vize_marquette/src/lib.rs
+++ b/crates/vize_marquette/src/lib.rs
@@ -53,10 +53,10 @@ mod validate;
 mod model_tests;
 
 pub use adapter::{
-    ADAPTER_CAPABILITY_FORMAT_VERSION, AdapterCapabilityDiagnostic,
-    AdapterCapabilityDiagnosticCode, AdapterCapabilityManifest, AdapterCapabilityMismatch,
-    AdapterCapabilityMismatchCode, AdapterCapabilityNegotiation, AdapterCapabilitySupport,
-    compare_adapter_capabilities, negotiate_adapter_capabilities,
+    ADAPTER_CAPABILITY_FORMAT_VERSION, AdapterCapabilityCompatibilityReport,
+    AdapterCapabilityDiagnostic, AdapterCapabilityDiagnosticCode, AdapterCapabilityManifest,
+    AdapterCapabilityMismatch, AdapterCapabilityMismatchCode, AdapterCapabilityNegotiation,
+    AdapterCapabilitySupport, compare_adapter_capabilities, negotiate_adapter_capabilities,
     validate_adapter_capability_manifest,
 };
 pub use canonical::{CanonicalContractError, canonical_json, contract_fingerprint};

--- a/crates/vize_marquette/tests/adapter_conformance.rs
+++ b/crates/vize_marquette/tests/adapter_conformance.rs
@@ -88,7 +88,7 @@ fn rejects_unknown_fields_before_negotiation() {
     assert!(
         error
             .to_compact_string()
-            .contains("unknown field `unexpected`")
+            .contains("unknown field `zUnexpected`")
     );
 }
 

--- a/npm/marquette/README.md
+++ b/npm/marquette/README.md
@@ -125,7 +125,8 @@ use the stable `missing-capability`, `version-below-minimum`, and
 `version-above-maximum` codes. Adding a support range or widening either bound
 is additive; removing support or narrowing either bound is breaking. Both
 negotiation and compatibility reports are sorted deterministically and do not
-mutate their inputs. The published manifest schema is available from
+mutate their inputs. Compatibility reports expose validation diagnostics for
+both manifests and omit changes when either input is invalid. The published manifest schema is available from
 `@vizejs/marquette/adapter/schema`.
 
 ## Test-run evidence

--- a/npm/marquette/src/adapter-compatibility.ts
+++ b/npm/marquette/src/adapter-compatibility.ts
@@ -5,6 +5,7 @@ import type {
   AdapterCapabilitySupport,
   CompatibilityChangeKind,
 } from "./adapter-model.js";
+import { validateAdapterCapabilityManifest } from "./adapter-validate.js";
 
 /**
  * Compares adapter capability support from older to newer.
@@ -16,6 +17,12 @@ export function compareAdapterCapabilities(
   previous: AdapterCapabilityManifest,
   next: AdapterCapabilityManifest,
 ): AdapterCapabilityCompatibilityReport {
+  const previousDiagnostics = validateAdapterCapabilityManifest(previous);
+  const nextDiagnostics = validateAdapterCapabilityManifest(next);
+  if (previousDiagnostics.length > 0 || nextDiagnostics.length > 0) {
+    return { previousDiagnostics, nextDiagnostics, changes: [] };
+  }
+
   const changes: AdapterCapabilityCompatibilityChange[] = [];
   if (previous.adapter !== next.adapter) {
     changes.push(change("breaking", "adapter", "adapter identity changed"));
@@ -59,7 +66,7 @@ export function compareAdapterCapabilities(
   changes.sort(
     (left, right) => compareText(left.path, right.path) || compareText(left.kind, right.kind),
   );
-  return { changes };
+  return { previousDiagnostics, nextDiagnostics, changes };
 }
 
 function byId(manifest: AdapterCapabilityManifest): Map<string, AdapterCapabilitySupport> {

--- a/npm/marquette/src/adapter-model.ts
+++ b/npm/marquette/src/adapter-model.ts
@@ -96,6 +96,10 @@ export interface AdapterCapabilityCompatibilityChange {
 
 /** Deterministic compatibility report between two adapter manifests. */
 export interface AdapterCapabilityCompatibilityReport {
+  /** Validation failures in the previous manifest. */
+  readonly previousDiagnostics: readonly AdapterCapabilityDiagnostic[];
+  /** Validation failures in the next manifest. */
+  readonly nextDiagnostics: readonly AdapterCapabilityDiagnostic[];
   /** All changes in stable path order. */
   readonly changes: readonly AdapterCapabilityCompatibilityChange[];
 }

--- a/npm/marquette/src/adapter-validate.ts
+++ b/npm/marquette/src/adapter-validate.ts
@@ -108,8 +108,8 @@ export function validateAdapterCapabilityManifest(
 export function parseAdapterCapabilityManifest(value: unknown): AdapterCapabilityManifest {
   assertRecord(value, "manifest");
   assertKnownFields(value, ["formatVersion", "adapter", "capabilities"], "manifest");
-  if (value.formatVersion !== undefined && value.formatVersion !== 1) {
-    throw new TypeError("formatVersion must equal 1");
+  if (value.formatVersion !== undefined && typeof value.formatVersion !== "number") {
+    throw new TypeError("formatVersion must be a number");
   }
   if (typeof value.adapter !== "string") {
     throw new TypeError("adapter must be a string");
@@ -162,9 +162,7 @@ function assertKnownFields(
   path: string,
 ): void {
   const known = new Set(expected);
-  const unknown = Object.keys(value)
-    .filter((field) => !known.has(field))
-    .sort()[0];
+  const unknown = Object.keys(value).find((field) => !known.has(field));
   if (unknown !== undefined) throw new TypeError(`${path} has unknown field ${unknown}`);
 }
 

--- a/npm/marquette/src/adapter.test.ts
+++ b/npm/marquette/src/adapter.test.ts
@@ -57,10 +57,11 @@ void test("matches shared negotiation fixtures and input permutations", async ()
 });
 
 void test("matches shared semantic validation diagnostics", async () => {
-  const manifest = await read<AdapterCapabilityManifest>("adapter-manifest-invalid.json");
+  const input = await read<unknown>("adapter-manifest-invalid.json");
   const expected = await read<readonly AdapterCapabilityDiagnostic[]>(
     "adapter-manifest-invalid.expected.json",
   );
+  const manifest = parseAdapterCapabilityManifest(input);
 
   assert.deepEqual(validateAdapterCapabilityManifest(manifest), expected);
 });
@@ -69,7 +70,11 @@ void test("strict parsing rejects unknown and malformed fields before negotiatio
   const unknown = await read<unknown>("adapter-manifest-unknown-field.json");
   assert.throws(
     () => parseAdapterCapabilityManifest(unknown),
-    /capabilities\.0 has unknown field unexpected/,
+    /capabilities\.0 has unknown field zUnexpected/,
+  );
+  assert.throws(
+    () => parseAdapterCapabilityManifest({ formatVersion: "1", adapter: "fixture.adapter" }),
+    /formatVersion must be a number/,
   );
   assert.throws(
     () =>

--- a/tests/fixtures/marquette/adapter-compatibility.json
+++ b/tests/fixtures/marquette/adapter-compatibility.json
@@ -18,6 +18,8 @@
       ]
     },
     "expected": {
+      "previousDiagnostics": [],
+      "nextDiagnostics": [],
       "changes": [
         {
           "kind": "additive",
@@ -53,6 +55,8 @@
       "capabilities": [{ "id": "range", "minVersion": 2, "maxVersion": 4 }]
     },
     "expected": {
+      "previousDiagnostics": [],
+      "nextDiagnostics": [],
       "changes": [
         {
           "kind": "breaking",
@@ -72,7 +76,43 @@
     "previous": { "adapter": "fixture.adapter", "capabilities": [] },
     "next": { "adapter": "other.adapter", "capabilities": [] },
     "expected": {
+      "previousDiagnostics": [],
+      "nextDiagnostics": [],
       "changes": [{ "kind": "breaking", "path": "adapter", "message": "adapter identity changed" }]
+    }
+  },
+  {
+    "name": "duplicate-capabilities-make-both-inputs-invalid",
+    "previous": {
+      "adapter": "fixture.adapter",
+      "capabilities": [
+        { "id": "duplicate", "minVersion": 1, "maxVersion": 2 },
+        { "id": "duplicate", "minVersion": 2, "maxVersion": 3 }
+      ]
+    },
+    "next": {
+      "adapter": "fixture.adapter",
+      "capabilities": [
+        { "id": "duplicate", "minVersion": 1, "maxVersion": 3 },
+        { "id": "duplicate", "minVersion": 1, "maxVersion": 4 }
+      ]
+    },
+    "expected": {
+      "previousDiagnostics": [
+        {
+          "code": "duplicate-capability",
+          "path": "capabilities.1.id",
+          "message": "capability id must be unique within the adapter manifest"
+        }
+      ],
+      "nextDiagnostics": [
+        {
+          "code": "duplicate-capability",
+          "path": "capabilities.1.id",
+          "message": "capability id must be unique within the adapter manifest"
+        }
+      ],
+      "changes": []
     }
   }
 ]

--- a/tests/fixtures/marquette/adapter-manifest-unknown-field.json
+++ b/tests/fixtures/marquette/adapter-manifest-unknown-field.json
@@ -1,4 +1,12 @@
 {
   "adapter": "fixture.adapter",
-  "capabilities": [{ "id": "known", "minVersion": 1, "maxVersion": 1, "unexpected": true }]
+  "capabilities": [
+    {
+      "id": "known",
+      "minVersion": 1,
+      "maxVersion": 1,
+      "zUnexpected": true,
+      "aUnexpected": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- fail closed when either adapter compatibility input is invalid, preserving Rust and TypeScript parity
- parse numeric unsupported format versions into stable semantic diagnostics while rejecting primitive type mismatches
- report the first unknown field in document order across Rust and TypeScript
- pin duplicate, format-version, and unknown-field behavior with shared fixtures

## Verification

- cargo fmt --all -- --check
- cargo clippy -p vize_marquette --all-targets -- -D warnings
- cargo test -p vize_marquette
- vp run --filter @vizejs/marquette check
- vp run --filter @vizejs/marquette test
- vp run --filter @vizejs/marquette build
- vp run --workspace-root source:lengths
- vp run --workspace-root check:ci
- node --test tests/tooling/package-manifests.test.ts

Follow-up to #3841.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->