### PR TITLE
fix(compose): prevent scoped listener resurrection

### DIFF
--- a/npm/compose/core/src/event-listener.test.ts
+++ b/npm/compose/core/src/event-listener.test.ts
@@ -4,7 +4,7 @@ import { effectScope, ref } from "vue";
 
 import { useEventListener } from "./event-listener.ts";
 
-void test("moves a listener between reactive targets and disposes it with the scope", () => {
+void test("moves a listener between targets and cannot restart after scope disposal", () => {
   const first = new EventTarget();
   const second = new EventTarget();
   const target = ref<EventTarget | null>(first);
@@ -26,6 +26,30 @@ void test("moves a listener between reactive targets and disposes it with the sc
   second.dispatchEvent(new Event("change"));
   assert.equal(controls.isListening.value, false);
   assert.equal(calls, 2);
+  assert.equal(controls.start(), false);
+  second.dispatchEvent(new Event("change"));
+  assert.equal(controls.isListening.value, false);
+  assert.equal(calls, 2);
+});
+
+void test("cannot start an immediate-false listener after its scope is disposed", () => {
+  const target = new EventTarget();
+  const scope = effectScope();
+  let calls = 0;
+  const controls = scope.run(() =>
+    useEventListener(target, "change", () => (calls += 1), {
+      flush: "sync",
+      immediate: false,
+    }),
+  );
+
+  assert.ok(controls);
+  assert.equal(controls.isListening.value, false);
+  scope.stop();
+  assert.equal(controls.start(), false);
+  target.dispatchEvent(new Event("change"));
+  assert.equal(controls.isListening.value, false);
+  assert.equal(calls, 0);
 });
 
 void test("supports idempotent manual and one-shot listener controls", () => {
@@ -45,6 +69,9 @@ void test("supports idempotent manual and one-shot listener controls", () => {
   assert.equal(calls, 0);
   assert.equal(controls.start(), true);
   assert.equal(controls.start(), false);
+  controls.stop();
+  assert.equal(controls.isListening.value, false);
+  assert.equal(controls.start(), true);
   target.dispatchEvent(new Event("submit"));
   assert.equal(calls, 1);
   assert.equal(controls.isListening.value, false);
@@ -55,6 +82,26 @@ void test("supports idempotent manual and one-shot listener controls", () => {
   controls.stop();
   controls.stop();
   scope.stop();
+});
+
+void test("keeps caller-owned controls restartable outside a scope", () => {
+  const target = new EventTarget();
+  let calls = 0;
+  const controls = useEventListener(target, "change", () => (calls += 1), {
+    flush: "sync",
+    immediate: false,
+  });
+
+  assert.equal(controls.start(), true);
+  target.dispatchEvent(new Event("change"));
+  controls.stop();
+  target.dispatchEvent(new Event("change"));
+  assert.equal(calls, 1);
+
+  assert.equal(controls.start(), true);
+  target.dispatchEvent(new Event("change"));
+  assert.equal(calls, 2);
+  controls.stop();
 });
 
 void test("stops when the supplied signal aborts", () => {

--- a/npm/compose/core/src/event-listener.ts
+++ b/npm/compose/core/src/event-listener.ts
@@ -59,7 +59,8 @@ export interface EventListenerControls {
    *
    * @returns Whether a new reactive watcher was started. `false` while the
    * watcher is already active (including a null-target watcher with no
-   * listener attached) and after the abort signal has fired.
+   * listener attached), after the abort signal has fired, and after the
+   * owning reactive scope has been disposed.
    */
   readonly start: () => boolean;
 
@@ -131,6 +132,7 @@ export function useEventListener(
     passive,
     ...(signal ? { signal } : {}),
   };
+  let disposed = false;
   let stopWatch: WatchHandle | undefined;
 
   const stop = (): void => {
@@ -139,7 +141,7 @@ export function useEventListener(
     isListening.value = false;
   };
   const start = (): boolean => {
-    if (stopWatch || signal?.aborted) return false;
+    if (disposed || stopWatch || signal?.aborted) return false;
 
     stopWatch = watch(
       () => toValue(target),
@@ -167,7 +169,10 @@ export function useEventListener(
     return true;
   };
 
-  tryOnScopeDispose(stop);
+  tryOnScopeDispose(() => {
+    disposed = true;
+    stop();
+  });
   if (immediate) start();
 
   return { isListening: readonly(isListening), start, stop };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,7 +235,7 @@ overrides:
   devalue: 5.8.1
   dompurify: 3.4.11
   esbuild: 0.28.1
-  fast-uri: 3.1.4
+  fast-uri: 3.1.5
   glob>minimatch: 10.2.5
   h3: 1.15.11
   hono: 4.12.31
@@ -7941,8 +7941,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -16408,7 +16408,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -17839,7 +17839,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,7 @@ overrides:
   devalue: "5.8.1"
   dompurify: "3.4.11"
   esbuild: "0.28.1"
-  fast-uri: "3.1.4"
+  fast-uri: "3.1.5"
   "glob>minimatch": "10.2.5"
   h3: "1.15.11"
   hono: "4.12.31"


### PR DESCRIPTION
## Summary

- make scope disposal permanently close scoped `useEventListener` controls
- keep manual stop/restart and one-shot restart behavior while the owner remains alive
- keep caller-owned listeners restartable when no reactive scope owns them

## Root cause

Scope disposal called `stop()`, but the returned `start()` control had no record that its owner was gone. Calling it after disposal created a new watcher outside the disposed scope, resurrecting a listener that no lifecycle could clean up.

## Validation

- `pnpm --filter @vizejs/composable exec node --test src/event-listener.test.ts`
- `pnpm --filter @vizejs/composable test` (100 tests)
- `pnpm --filter @vizejs/composable check`
- pinned MoonBit `pnpm exec vp run source:lengths`
- negative control: both scope-disposal regressions failed before the production guard was added

Part of #3136.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->