### PR TITLE
fix(doctor): report unavailable fixes explicitly

### DIFF
--- a/crates/vize/src/commands/doctor/canonical_sfc.rs
+++ b/crates/vize/src/commands/doctor/canonical_sfc.rs
@@ -4,14 +4,16 @@ use vize_atelier_sfc::{BlockLocation, SfcDescriptor};
 use vize_carton::cstr;
 use vize_doctor::{
     AnalysisProvenance, DoctorCategory, DoctorFinding, EvidenceKind, FindingAssessment,
-    FindingConfidence, FindingEvidence, FindingImpact, FindingSeverity, HealthPenalty, RuleCost,
-    SourceLocation, SuppressionPolicy,
+    FindingConfidence, FindingEvidence, FindingFix, FindingImpact, FindingSeverity, HealthPenalty,
+    RuleCost, SourceLocation, SuppressionPolicy,
 };
 
 pub(super) const RULE_CODE: &str = "VIZE_DOCTOR_SFC_EXPLICIT_SECTIONS";
 
 const CONTRACT_CAPABILITY: &str = "public-sfc-contract";
 const GATE_RULE: &str = "explicit-sfc";
+const UNAVAILABLE_FIX_REASON: &str =
+    "Canonical SFC sections require authored source changes that must be reviewed.";
 
 #[derive(Clone)]
 struct ContractProblem {
@@ -90,6 +92,7 @@ pub(super) fn finding(path: &str, descriptor: &SfcDescriptor<'_>) -> Option<Doct
          editors, and target adapters.",
     )
     .with_documentation("https://github.com/ubugeeei-prod/vize/issues/3134")
+    .with_fix(FindingFix::unavailable(UNAVAILABLE_FIX_REASON))
     .with_suppression(SuppressionPolicy::Forbidden);
 
     for problem in problems {
@@ -162,6 +165,11 @@ mod tests {
             "<script setup>"
         );
         assert_eq!(finding.evidence.len(), 2);
+        let fix = finding.fix.as_ref().unwrap();
+        assert_eq!(fix.safety, vize_doctor::FixSafety::Unavailable);
+        assert_eq!(fix.title, UNAVAILABLE_FIX_REASON);
+        assert!(fix.edits.is_empty());
+        assert!(fix.verification.is_empty());
         assert_eq!(
             finding.evidence[1].location.as_ref().unwrap().start as usize,
             style_start

--- a/crates/vize/src/commands/doctor/output.rs
+++ b/crates/vize/src/commands/doctor/output.rs
@@ -1,7 +1,7 @@
 //! Deterministic terminal and automation output.
 
 use std::io::{self, Write};
-use vize_doctor::{DoctorFinding, DoctorReport, FindingSeverity};
+use vize_doctor::{DoctorFinding, DoctorReport, FindingSeverity, FixSafety};
 
 use super::{DoctorError, DoctorFormat};
 
@@ -61,5 +61,59 @@ fn write_finding(output: &mut impl Write, finding: &DoctorFinding) -> io::Result
     if let Some(scenario) = &finding.failure_scenario {
         writeln!(output, "  Failure scenario: {scenario}")?;
     }
+    if let Some(fix) = &finding.fix {
+        let safety = match fix.safety {
+            FixSafety::Safe => "safe",
+            FixSafety::ReviewRequired => "review required",
+            FixSafety::Unavailable => "unavailable",
+        };
+        writeln!(output, "  Fix ({safety}): {}", fix.title)?;
+    }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vize_doctor::{
+        AnalysisProvenance, DoctorCategory, FindingAssessment, FindingConfidence, FindingImpact,
+        HealthPenalty, RuleCost, SourceLocation,
+    };
+
+    #[test]
+    fn text_output_explains_unavailable_fixes_exactly() {
+        let finding = DoctorFinding::new(
+            "VIZE_DOCTOR_TEST",
+            DoctorCategory::Correctness,
+            FindingAssessment::new(
+                FindingSeverity::Warning,
+                FindingConfidence::High,
+                FindingImpact::Medium,
+                HealthPenalty::new(10, "Test penalty"),
+            ),
+            SourceLocation::new("src/App.vue", 4, 12),
+            "Test finding",
+            "Test message",
+            AnalysisProvenance::new("test-analysis", RuleCost::Low),
+        );
+        let report = DoctorReport::new(".", [finding]);
+        let mut output = Vec::new();
+
+        write_text(&mut output, &report).unwrap();
+
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            concat!(
+                "Vize Doctor\n",
+                "Workspace: .\n",
+                "Health: 98/100\n",
+                "Findings: 0 error(s), 1 warning(s), 0 notice(s)\n",
+                "\n",
+                "[warning] VIZE_DOCTOR_TEST — Test finding\n",
+                "  src/App.vue:4..12\n",
+                "  Test message\n",
+                "  Fix (unavailable): No automatic fix is available for this finding.\n",
+            )
+        );
+    }
 }

--- a/crates/vize_doctor/src/application_analysis.rs
+++ b/crates/vize_doctor/src/application_analysis.rs
@@ -21,6 +21,9 @@ use crate::{
 
 use self::profile::{failure_scenario, profile_for};
 
+const SOURCE_DIAGNOSTIC_UNAVAILABLE_FIX_REASON: &str =
+    "No automatic fix is available because the source diagnostic did not provide a suggestion.";
+
 /// Source-integrity failure discovered while adapting an analysis result.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ApplicationAnalysisError {
@@ -141,12 +144,12 @@ fn adapt_diagnostic(
     finding.provenance = finding
         .provenance
         .with_invalidation_inputs(invalidation_inputs);
-    if let Some(suggestion) = &diagnostic.suggestion {
-        finding = finding.with_fix(FindingFix::new(
-            FixSafety::ReviewRequired,
-            suggestion.clone(),
-        ));
-    }
+    finding = finding.with_fix(match &diagnostic.suggestion {
+        Some(suggestion) if !suggestion.trim().is_empty() => {
+            FindingFix::new(FixSafety::ReviewRequired, suggestion.clone())
+        }
+        _ => FindingFix::unavailable(SOURCE_DIAGNOSTIC_UNAVAILABLE_FIX_REASON),
+    });
     Ok(finding)
 }
 

--- a/crates/vize_doctor/src/lib.rs
+++ b/crates/vize_doctor/src/lib.rs
@@ -56,10 +56,10 @@ mod model;
 mod report;
 
 pub use model::{
-    AnalysisProvenance, DoctorCategory, DoctorFinding, EvidenceKind, FindingAssessment,
-    FindingConfidence, FindingContext, FindingEvidence, FindingFix, FindingImpact, FindingSeverity,
-    FixSafety, HealthPenalty, RelatedLocation, RuleCost, SourceLocation, SuppressionPolicy,
-    TextEdit,
+    AnalysisProvenance, DEFAULT_UNAVAILABLE_FIX_REASON, DoctorCategory, DoctorFinding,
+    EvidenceKind, FindingAssessment, FindingConfidence, FindingContext, FindingEvidence,
+    FindingFix, FindingImpact, FindingSeverity, FixSafety, HealthPenalty, RelatedLocation,
+    RuleCost, SourceLocation, SuppressionPolicy, TextEdit,
 };
 pub use report::{
     CategoryHealth, DOCTOR_REPORT_FORMAT_VERSION, DOCTOR_SCORING_VERSION, DoctorReport,

--- a/crates/vize_doctor/src/model.rs
+++ b/crates/vize_doctor/src/model.rs
@@ -9,4 +9,4 @@ pub use assessment::{
 pub use evidence::{
     AnalysisProvenance, FindingContext, FindingEvidence, RelatedLocation, SourceLocation, TextEdit,
 };
-pub use finding::{DoctorFinding, FindingFix};
+pub use finding::{DEFAULT_UNAVAILABLE_FIX_REASON, DoctorFinding, FindingFix};

--- a/crates/vize_doctor/src/model/finding.rs
+++ b/crates/vize_doctor/src/model/finding.rs
@@ -9,7 +9,10 @@ use super::{
     },
 };
 
-/// Optional source fix and its verification plan.
+/// Stable fallback used when a finding producer cannot provide a source edit.
+pub const DEFAULT_UNAVAILABLE_FIX_REASON: &str = "No automatic fix is available for this finding.";
+
+/// Source fix disposition and its verification plan.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct FindingFix {
@@ -34,6 +37,11 @@ impl FindingFix {
             edits: Vec::new(),
             verification: Vec::new(),
         }
+    }
+
+    /// Creates an explicit no-fix disposition with a user-visible reason.
+    pub fn unavailable(reason: impl Into<String>) -> Self {
+        Self::new(FixSafety::Unavailable, reason)
     }
 
     /// Adds a source edit.
@@ -77,7 +85,10 @@ pub struct DoctorFinding {
     /// Supporting evidence. Defaults to empty.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub evidence: Vec<FindingEvidence>,
-    /// Source fix. Defaults to absent.
+    /// Source fix or explicit reason no automatic fix is available.
+    ///
+    /// The optional wire shape is retained for format-version compatibility;
+    /// constructors and reports always populate this field.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fix: Option<FindingFix>,
     /// Application graph context. Defaults to empty.
@@ -113,7 +124,7 @@ impl DoctorFinding {
             documentation: None,
             related: Vec::new(),
             evidence: Vec::new(),
-            fix: None,
+            fix: Some(FindingFix::unavailable(DEFAULT_UNAVAILABLE_FIX_REASON)),
             context: FindingContext::default(),
             provenance,
             suppression: SuppressionPolicy::ReasonRequired,
@@ -259,5 +270,15 @@ mod tests {
         let decoded: DoctorFinding = serde_json::from_value(value).unwrap();
 
         assert_eq!(decoded.suppression, SuppressionPolicy::ReasonRequired);
+    }
+    #[test]
+    fn new_findings_have_an_explicit_unavailable_fix() {
+        let finding = finding();
+        let fix = finding.fix.as_ref().unwrap();
+
+        assert_eq!(fix.safety, FixSafety::Unavailable);
+        assert_eq!(fix.title, DEFAULT_UNAVAILABLE_FIX_REASON);
+        assert!(fix.edits.is_empty());
+        assert!(fix.verification.is_empty());
     }
 }

--- a/crates/vize_doctor/src/report.rs
+++ b/crates/vize_doctor/src/report.rs
@@ -3,7 +3,10 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Deserializer, Serialize, de};
 use vize_carton::String;
 
-use crate::{DoctorCategory, DoctorFinding, FindingConfidence, FindingSeverity};
+use crate::{
+    DEFAULT_UNAVAILABLE_FIX_REASON, DoctorCategory, DoctorFinding, FindingConfidence, FindingFix,
+    FindingSeverity,
+};
 
 /// Current serialized doctor report format.
 pub const DOCTOR_REPORT_FORMAT_VERSION: u32 = 1;
@@ -144,6 +147,9 @@ impl DoctorReport {
     ) -> Self {
         let mut findings = findings.into_iter().collect::<Vec<_>>();
         for finding in &mut findings {
+            if finding.fix.is_none() {
+                finding.fix = Some(FindingFix::unavailable(DEFAULT_UNAVAILABLE_FIX_REASON));
+            }
             finding.related.sort();
             finding.evidence.sort();
             finding.provenance.invalidation_inputs.sort();

--- a/crates/vize_doctor/tests/application_analysis.rs
+++ b/crates/vize_doctor/tests/application_analysis.rs
@@ -61,7 +61,61 @@ fn preserves_graph_sources_evidence_fixes_and_invalidation() {
         finding.fix.as_ref().unwrap().safety,
         FixSafety::ReviewRequired
     );
+    assert_eq!(
+        finding.fix.as_ref().unwrap().title,
+        "Move shared state behind an acyclic boundary"
+    );
     assert!(report.summary().has_blocking_errors);
+}
+
+#[test]
+fn distinguishes_exact_review_suggestions_from_unavailable_fixes() {
+    let (analyzer, app, _) = analyzer_with_files();
+    let diagnostic = || {
+        CrossFileDiagnostic::new(
+            CrossFileDiagnosticKind::UnregisteredComponent {
+                component_name: "MissingCard".into(),
+                template_offset: 4,
+            },
+            DiagnosticSeverity::Error,
+            app,
+            4,
+            "Component cannot be resolved",
+        )
+    };
+    let review_title = "  Register MissingCard in this component  ";
+    let result = CrossFileResult {
+        diagnostics: vec![
+            diagnostic(),
+            diagnostic().with_suggestion(" \t\n"),
+            diagnostic().with_suggestion(review_title),
+        ],
+        ..CrossFileResult::default()
+    };
+
+    let findings = findings_from_application_graph(&analyzer, &result).unwrap();
+    let unavailable_reason =
+        "No automatic fix is available because the source diagnostic did not provide a suggestion.";
+
+    for finding in &findings[..2] {
+        let fix = finding.fix.as_ref().unwrap();
+        assert_eq!(fix.safety, FixSafety::Unavailable);
+        assert_eq!(fix.title, unavailable_reason);
+        assert!(fix.edits.is_empty());
+        assert!(fix.verification.is_empty());
+        assert_eq!(
+            serde_json::to_value(fix).unwrap(),
+            serde_json::json!({
+                "safety": "unavailable",
+                "title": unavailable_reason,
+            })
+        );
+    }
+
+    let review = findings[2].fix.as_ref().unwrap();
+    assert_eq!(review.safety, FixSafety::ReviewRequired);
+    assert_eq!(review.title, review_title);
+    assert!(review.edits.is_empty());
 }
 
 #[test]

--- a/crates/vize_doctor/tests/report.rs
+++ b/crates/vize_doctor/tests/report.rs
@@ -1,7 +1,8 @@
 use vize_doctor::{
-    AnalysisProvenance, DOCTOR_REPORT_FORMAT_VERSION, DOCTOR_SCORING_VERSION, DoctorCategory,
-    DoctorFinding, DoctorReport, EvidenceKind, FindingAssessment, FindingConfidence,
-    FindingEvidence, FindingImpact, FindingSeverity, HealthPenalty, RuleCost, SourceLocation,
+    AnalysisProvenance, DEFAULT_UNAVAILABLE_FIX_REASON, DOCTOR_REPORT_FORMAT_VERSION,
+    DOCTOR_SCORING_VERSION, DoctorCategory, DoctorFinding, DoctorReport, EvidenceKind,
+    FindingAssessment, FindingConfidence, FindingEvidence, FindingImpact, FindingSeverity,
+    FixSafety, HealthPenalty, RuleCost, SourceLocation,
 };
 
 fn finding(
@@ -173,7 +174,41 @@ fn serializes_language_neutral_versioned_properties() {
     assert_eq!(value["workspace"], "app");
     assert_eq!(value["findings"][0]["category"], "production-readiness");
     assert_eq!(value["findings"][0]["provenance"]["cost"], "low");
+    assert_eq!(value["findings"][0]["fix"]["safety"], "unavailable");
+    assert_eq!(
+        value["findings"][0]["fix"]["title"],
+        DEFAULT_UNAVAILABLE_FIX_REASON
+    );
     assert_eq!(value["summary"]["hasBlockingErrors"], false);
+}
+
+#[test]
+fn normalizes_legacy_missing_fix_to_explicit_unavailable() {
+    let report = DoctorReport::new(
+        "app",
+        [finding(
+            "VIZE_DOCTOR_001",
+            DoctorCategory::Correctness,
+            FindingSeverity::Warning,
+            FindingConfidence::High,
+            FindingImpact::Medium,
+            "src/a.vue",
+            10,
+        )],
+    );
+    let mut legacy_wire = serde_json::to_value(report).unwrap();
+    legacy_wire["findings"][0]
+        .as_object_mut()
+        .unwrap()
+        .remove("fix");
+
+    let report = serde_json::from_value::<DoctorReport>(legacy_wire).unwrap();
+    let fix = report.findings()[0].fix.as_ref().unwrap();
+
+    assert_eq!(fix.safety, FixSafety::Unavailable);
+    assert_eq!(fix.title, DEFAULT_UNAVAILABLE_FIX_REASON);
+    assert!(fix.edits.is_empty());
+    assert!(fix.verification.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- give every newly created or normalized Doctor finding an explicit fix disposition
- classify missing and blank application-diagnostic suggestions as unavailable while preserving nonblank review suggestions exactly
- explain unavailable canonical-SFC fixes in JSON and terminal output

## Root cause

Doctor findings allowed `fix` to be omitted when an upstream diagnostic had no suggestion. That made it impossible for API, CLI, editor, and AI consumers to distinguish an intentionally unavailable fix from missing producer data.

## Validation

- `cargo test -p vize_doctor --all-features`
- `cargo test -p vize --lib commands::doctor`
- `cargo clippy -p vize_doctor --all-features -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy -p vize --lib -- -D warnings -D clippy::wildcard_imports`
- repo-pinned `source_file_lengths --check --base-ref refs/remotes/origin/main`

Part of #3138.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->