### PR TITLE
fix(marquette): fail closed on invalid compatibility inputs

### DIFF
--- a/crates/vize_marquette/README.md
+++ b/crates/vize_marquette/README.md
@@ -12,7 +12,7 @@ Support and deprecation guarantees are defined in the
 
 - deterministic validation diagnostics with stable machine-readable codes;
 - canonical serialization and fingerprints for cache and provenance keys;
-- compatibility reports for additive and breaking graph changes;
+- fail-closed compatibility reports for validated additive and breaking graph changes;
 - a checked JSON Schema embedded in the crate;
 - shared conformance fixtures for adapters implemented in other languages.
 

--- a/crates/vize_marquette/src/compatibility.rs
+++ b/crates/vize_marquette/src/compatibility.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use vize_carton::{String, ToCompactString};
 
-use crate::ApplicationContract;
+use crate::{ApplicationContract, ContractDiagnostic, DiagnosticSeverity, validate_contract};
 
 /// Compatibility classification for one marquette graph change.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -27,20 +27,61 @@ pub struct CompatibilityChange {
     pub message: String,
 }
 
+/// Owned validation diagnostic retained with a compatibility report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CompatibilityInputDiagnostic {
+    /// Stable machine-readable diagnostic code.
+    pub code: String,
+    /// Validation severity used to decide whether comparison is safe.
+    pub severity: DiagnosticSeverity,
+    /// JSON-style path into the authored contract.
+    pub path: String,
+    /// Human-readable explanation and next action.
+    pub message: String,
+}
+
+impl From<ContractDiagnostic> for CompatibilityInputDiagnostic {
+    fn from(diagnostic: ContractDiagnostic) -> Self {
+        Self {
+            code: diagnostic.code.into(),
+            severity: diagnostic.severity,
+            path: diagnostic.path,
+            message: diagnostic.message,
+        }
+    }
+}
+
 /// Deterministic compatibility report between two contracts.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CompatibilityReport {
     /// All changes in stable path order.
     pub changes: Vec<CompatibilityChange>,
+    /// Validation diagnostics from the older contract.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub previous_diagnostics: Vec<CompatibilityInputDiagnostic>,
+    /// Validation diagnostics from the newer contract.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub next_diagnostics: Vec<CompatibilityInputDiagnostic>,
 }
 
 impl CompatibilityReport {
-    /// Returns `true` when any existing client or adapter may be incompatible.
+    /// Returns `true` when an invalid input or breaking change prevents compatibility.
     pub fn is_breaking(&self) -> bool {
-        self.changes
+        self.has_invalid_inputs()
+            || self
+                .changes
+                .iter()
+                .any(|change| change.kind == CompatibilityChangeKind::Breaking)
+    }
+
+    /// Returns `true` when either contract contains a validation error.
+    pub fn has_invalid_inputs(&self) -> bool {
+        self.previous_diagnostics
             .iter()
-            .any(|change| change.kind == CompatibilityChangeKind::Breaking)
+            .chain(&self.next_diagnostics)
+            .any(|diagnostic| diagnostic.severity == DiagnosticSeverity::Error)
     }
 }
 
@@ -49,6 +90,23 @@ pub fn compare_contracts(
     previous: &ApplicationContract,
     next: &ApplicationContract,
 ) -> CompatibilityReport {
+    let previous_diagnostics = validate_contract(previous)
+        .into_iter()
+        .map(CompatibilityInputDiagnostic::from)
+        .collect::<Vec<_>>();
+    let next_diagnostics = validate_contract(next)
+        .into_iter()
+        .map(CompatibilityInputDiagnostic::from)
+        .collect::<Vec<_>>();
+    let mut report = CompatibilityReport {
+        changes: Vec::new(),
+        previous_diagnostics,
+        next_diagnostics,
+    };
+    if report.has_invalid_inputs() {
+        return report;
+    }
+
     let mut changes = Vec::new();
 
     compare_by_id(
@@ -139,7 +197,8 @@ pub fn compare_contracts(
     }
 
     changes.sort_by(|left, right| (&left.path, left.kind).cmp(&(&right.path, right.kind)));
-    CompatibilityReport { changes }
+    report.changes = changes;
+    report
 }
 
 /// Compares a named collection by stable identifier.
@@ -192,6 +251,9 @@ fn change(
         message: message.into(),
     }
 }
+
+#[cfg(test)]
+mod fail_closed_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/vize_marquette/src/compatibility/fail_closed_tests.rs
+++ b/crates/vize_marquette/src/compatibility/fail_closed_tests.rs
@@ -1,0 +1,147 @@
+use std::panic::catch_unwind;
+
+use crate::{
+    ApplicationContract, Backend, BackendFamily, DiagnosticSeverity, Environment,
+    EnvironmentConsumer, RuntimeFamily, Target,
+};
+
+use super::{CompatibilityChangeKind, CompatibilityReport, compare_contracts};
+
+fn valid_contract() -> ApplicationContract {
+    let mut contract = ApplicationContract::new("example");
+    contract.targets.insert(Target::Web);
+    contract.environments.push(Environment::new(
+        "client",
+        Target::Web,
+        EnvironmentConsumer::Client,
+        RuntimeFamily::Browser,
+    ));
+    contract
+}
+
+#[test]
+fn duplicate_identifiers_fail_closed_without_comparing_overwritten_nodes() {
+    let previous = valid_contract();
+    let mut next = previous.clone();
+    next.environments.push(Environment::new(
+        "client",
+        Target::Web,
+        EnvironmentConsumer::Server,
+        RuntimeFamily::Rust,
+    ));
+
+    let report = catch_unwind(|| compare_contracts(&previous, &next))
+        .expect("invalid contracts must produce a report instead of panicking");
+
+    assert!(report.changes.is_empty());
+    assert!(report.has_invalid_inputs());
+    assert!(report.is_breaking());
+    assert!(report.previous_diagnostics.is_empty());
+    assert_eq!(report.next_diagnostics.len(), 1);
+    assert_eq!(report.next_diagnostics[0].code, "VIZE_MARQUETTE_006");
+    assert_eq!(report.next_diagnostics[0].path, "environments.client");
+
+    let json = serde_json::to_value(&report).expect("report must serialize");
+    assert_eq!(json["nextDiagnostics"][0]["code"], "VIZE_MARQUETTE_006");
+    assert_eq!(json["changes"], serde_json::json!([]));
+    let round_trip: CompatibilityReport =
+        serde_json::from_value(json).expect("report must deserialize");
+    assert_eq!(round_trip, report);
+}
+
+#[test]
+fn previous_and_next_validation_diagnostics_keep_their_provenance() {
+    let mut previous = valid_contract();
+    previous.routes.push(crate::Route::new(
+        "home",
+        "/",
+        "missing",
+        crate::RenderingMode::Client,
+    ));
+    let next = valid_contract();
+
+    let report = compare_contracts(&previous, &next);
+
+    assert!(report.changes.is_empty());
+    assert!(report.has_invalid_inputs());
+    assert!(report.is_breaking());
+    assert!(
+        report
+            .previous_diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "VIZE_MARQUETTE_015")
+    );
+    assert!(report.next_diagnostics.is_empty());
+}
+
+#[test]
+fn dangling_references_and_cycles_remain_deterministic_and_do_not_panic() {
+    let previous = valid_contract();
+    let mut next = valid_contract();
+    next.environments[0].depends_on.insert("server".into());
+    let mut server = Environment::new(
+        "server",
+        Target::Web,
+        EnvironmentConsumer::Server,
+        RuntimeFamily::Rust,
+    );
+    server.depends_on.insert("client".into());
+    next.environments.push(server);
+    next.backends
+        .push(Backend::new("api", BackendFamily::Rust).with_environment("missing-environment"));
+
+    let first = catch_unwind(|| compare_contracts(&previous, &next))
+        .expect("cyclic and dangling input must not panic");
+    let second = compare_contracts(&previous, &next);
+
+    assert_eq!(first, second);
+    assert!(first.changes.is_empty());
+    assert!(first.next_diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "VIZE_MARQUETTE_011" && diagnostic.path == "backends.api"
+    }));
+    assert!(first.next_diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "VIZE_MARQUETTE_022" && diagnostic.path.starts_with("environments.")
+    }));
+    assert!(first.next_diagnostics.windows(2).all(|pair| {
+        (&pair[0].path, &pair[0].code, &pair[0].message)
+            <= (&pair[1].path, &pair[1].code, &pair[1].message)
+    }));
+}
+
+#[test]
+fn warnings_do_not_block_compatibility_classification() {
+    let previous = ApplicationContract::new("example");
+    let mut next = previous.clone();
+    next.targets.insert(Target::Web);
+    next.backends.push(Backend::new("api", BackendFamily::Rust));
+
+    let report = compare_contracts(&previous, &next);
+
+    assert!(!report.has_invalid_inputs());
+    assert!(!report.is_breaking());
+    assert!(report.previous_diagnostics.is_empty());
+    assert_eq!(report.next_diagnostics.len(), 1);
+    assert_eq!(
+        report.next_diagnostics[0].severity,
+        DiagnosticSeverity::Warning
+    );
+    assert_eq!(report.changes.len(), 1);
+    assert_eq!(report.changes[0].kind, CompatibilityChangeKind::Additive);
+    assert_eq!(report.changes[0].path, "backends.api");
+}
+
+#[test]
+fn valid_contracts_report_changes_without_validation_diagnostics() {
+    let previous = valid_contract();
+    let mut next = previous.clone();
+    next.environments[0].consumer = EnvironmentConsumer::Server;
+
+    let report = compare_contracts(&previous, &next);
+
+    assert!(!report.has_invalid_inputs());
+    assert!(report.is_breaking());
+    assert!(report.previous_diagnostics.is_empty());
+    assert!(report.next_diagnostics.is_empty());
+    assert_eq!(report.changes.len(), 1);
+    assert_eq!(report.changes[0].kind, CompatibilityChangeKind::Breaking);
+}

--- a/crates/vize_marquette/src/lib.rs
+++ b/crates/vize_marquette/src/lib.rs
@@ -61,7 +61,8 @@ pub use adapter::{
 };
 pub use canonical::{CanonicalContractError, canonical_json, contract_fingerprint};
 pub use compatibility::{
-    CompatibilityChange, CompatibilityChangeKind, CompatibilityReport, compare_contracts,
+    CompatibilityChange, CompatibilityChangeKind, CompatibilityInputDiagnostic,
+    CompatibilityReport, compare_contracts,
 };
 pub use model::{
     ApplicationContract, Backend, BackendFamily, CONTRACT_FORMAT_VERSION, CapabilityDefinition,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,7 @@ overrides:
   glob>minimatch: 10.2.5
   h3: 1.15.11
   hono: 4.12.31
+  ip-address: 10.3.1
   launch-editor: 2.14.1
   nanotar: 0.3.0
   nitropack: 2.13.4
@@ -8340,8 +8341,8 @@ packages:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
     engines: {node: '>=12.22.0'}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -17770,7 +17771,7 @@ snapshots:
   express-rate-limit@8.5.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.3.1
 
   express@5.2.1:
     dependencies:
@@ -18299,7 +18300,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ip-address@10.2.0: {}
+  ip-address@10.3.1: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,7 @@ overrides:
   "glob>minimatch": "10.2.5"
   h3: "1.15.11"
   hono: "4.12.31"
+  ip-address: "10.3.1"
   launch-editor: "2.14.1"
   nanotar: "0.3.0"
   nitropack: "2.13.4"


### PR DESCRIPTION
## Summary

- validate both application contracts before compatibility classification
- retain deterministic previous/next diagnostics and fail closed on validation errors
- keep warnings non-blocking while preventing duplicate IDs from being collapsed by map comparison

## Root cause

`compare_contracts` compared unchecked collections through `BTreeMap`, so duplicate identifiers could overwrite one another and produce a misleading compatible report. Validation diagnostics were not retained by the report, leaving callers unable to distinguish invalid inputs from a safe comparison.

## Validation

- regression-first negative control: focused tests failed against the old API/behavior before the implementation
- `cargo test -p vize_marquette --no-fail-fast`
- `cargo clippy -p vize_marquette --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- pinned MoonBit source-length gate against `origin/main`
- strict coverage for duplicate IDs, dangling references, cycles, warning-only and valid contracts, previous/next provenance, deterministic ordering, serialization round-trip, and no-panic behavior

Part of #3135.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Compatibility reports now include validation diagnostics for both the previous and proposed contracts.
  - Diagnostic details can be serialized and accessed through the public compatibility API.

- **Bug Fixes**
  - Invalid contracts now produce deterministic breaking-compatibility results instead of incomplete results or failures.
  - Added handling for duplicate identifiers, dangling references, and cyclic definitions.
  - Warnings continue to allow compatibility classification.

- **Documentation**
  - Updated compatibility guarantees to document fail-closed behavior for invalid additive and breaking changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->