### PR TITLE
feat(marquette): define native engine capability profile

### DIFF
--- a/crates/vize_marquette/src/adapter/mod.rs
+++ b/crates/vize_marquette/src/adapter/mod.rs
@@ -2,6 +2,7 @@
 
 mod compatibility;
 mod model;
+mod native_profile;
 mod negotiate;
 mod validate;
 
@@ -10,6 +11,10 @@ pub use model::{
     ADAPTER_CAPABILITY_FORMAT_VERSION, AdapterCapabilityDiagnostic,
     AdapterCapabilityDiagnosticCode, AdapterCapabilityManifest, AdapterCapabilityMismatch,
     AdapterCapabilityMismatchCode, AdapterCapabilityNegotiation, AdapterCapabilitySupport,
+};
+pub use native_profile::{
+    NATIVE_ENGINE_CAPABILITY_IDS, NATIVE_ENGINE_CAPABILITY_VERSION,
+    native_engine_capability_profile,
 };
 pub use negotiate::negotiate_adapter_capabilities;
 pub use validate::validate_adapter_capability_manifest;

--- a/crates/vize_marquette/src/adapter/native_profile.rs
+++ b/crates/vize_marquette/src/adapter/native_profile.rs
@@ -1,0 +1,33 @@
+use super::AdapterCapabilitySupport;
+
+/// Current contract version shared by the native-engine capability profile.
+pub const NATIVE_ENGINE_CAPABILITY_VERSION: u32 = 1;
+
+/// Closed set of capability identifiers required from a native rendering engine.
+///
+/// The order is part of the language-neutral profile and follows the execution
+/// boundary from rendering through lifecycle management.
+pub const NATIVE_ENGINE_CAPABILITY_IDS: [&str; 8] = [
+    "native.rendering",
+    "native.events",
+    "native.layout",
+    "native.text",
+    "native.images",
+    "native.animation",
+    "native.accessibility",
+    "native.lifecycle",
+];
+
+/// Creates the canonical version-one native-engine capability profile.
+///
+/// A fresh list is returned so an adapter can extend its manifest without
+/// mutating the shared profile seen by another consumer.
+pub fn native_engine_capability_profile() -> Vec<AdapterCapabilitySupport> {
+    NATIVE_ENGINE_CAPABILITY_IDS
+        .map(|id| AdapterCapabilitySupport {
+            id: id.into(),
+            min_version: NATIVE_ENGINE_CAPABILITY_VERSION,
+            max_version: NATIVE_ENGINE_CAPABILITY_VERSION,
+        })
+        .to_vec()
+}

--- a/crates/vize_marquette/src/lib.rs
+++ b/crates/vize_marquette/src/lib.rs
@@ -56,7 +56,8 @@ pub use adapter::{
     ADAPTER_CAPABILITY_FORMAT_VERSION, AdapterCapabilityCompatibilityReport,
     AdapterCapabilityDiagnostic, AdapterCapabilityDiagnosticCode, AdapterCapabilityManifest,
     AdapterCapabilityMismatch, AdapterCapabilityMismatchCode, AdapterCapabilityNegotiation,
-    AdapterCapabilitySupport, compare_adapter_capabilities, negotiate_adapter_capabilities,
+    AdapterCapabilitySupport, NATIVE_ENGINE_CAPABILITY_IDS, NATIVE_ENGINE_CAPABILITY_VERSION,
+    compare_adapter_capabilities, native_engine_capability_profile, negotiate_adapter_capabilities,
     validate_adapter_capability_manifest,
 };
 pub use canonical::{CanonicalContractError, canonical_json, contract_fingerprint};

--- a/crates/vize_marquette/tests/adapter_conformance.rs
+++ b/crates/vize_marquette/tests/adapter_conformance.rs
@@ -5,8 +5,9 @@ use serde_json::Value;
 use vize_carton::{String, ToCompactString};
 use vize_marquette::{
     ADAPTER_CAPABILITY_MANIFEST_JSON_SCHEMA, AdapterCapabilityManifest, ApplicationContract,
-    compare_adapter_capabilities, contract_fingerprint, negotiate_adapter_capabilities,
-    validate_adapter_capability_manifest,
+    CapabilityDefinition, NATIVE_ENGINE_CAPABILITY_IDS, NATIVE_ENGINE_CAPABILITY_VERSION,
+    compare_adapter_capabilities, contract_fingerprint, native_engine_capability_profile,
+    negotiate_adapter_capabilities, validate_adapter_capability_manifest,
 };
 
 fn fixture(name: &str) -> PathBuf {
@@ -42,6 +43,46 @@ struct CompatibilityCase {
     previous: AdapterCapabilityManifest,
     next: AdapterCapabilityManifest,
     expected: Value,
+}
+
+#[test]
+fn native_engine_profile_matches_the_shared_contract_and_negotiates_fail_closed() {
+    let expected: AdapterCapabilityManifest = read("native-engine-capability-profile.json");
+    let profile = native_engine_capability_profile();
+    let actual = AdapterCapabilityManifest {
+        format_version: 1,
+        adapter: "fixture.native".into(),
+        capabilities: profile.clone(),
+    };
+
+    assert_eq!(actual, expected);
+    assert!(validate_adapter_capability_manifest(&actual).is_empty());
+    assert_eq!(profile.len(), NATIVE_ENGINE_CAPABILITY_IDS.len());
+    assert!(profile.iter().all(|support| {
+        support.min_version == NATIVE_ENGINE_CAPABILITY_VERSION
+            && support.max_version == NATIVE_ENGINE_CAPABILITY_VERSION
+    }));
+
+    let mut contract = ApplicationContract::new("native-profile");
+    for id in NATIVE_ENGINE_CAPABILITY_IDS {
+        contract.capabilities.insert(
+            id.into(),
+            CapabilityDefinition::new(id, "Native engine contract"),
+        );
+    }
+    let compatible =
+        negotiate_adapter_capabilities(&contract, NATIVE_ENGINE_CAPABILITY_IDS, &actual);
+    assert!(compatible.compatible);
+
+    let mut missing_animation = actual;
+    missing_animation
+        .capabilities
+        .retain(|support| support.id.as_str() != "native.animation");
+    let incompatible =
+        negotiate_adapter_capabilities(&contract, NATIVE_ENGINE_CAPABILITY_IDS, &missing_animation);
+    assert!(!incompatible.compatible);
+    assert_eq!(incompatible.mismatches.len(), 1);
+    assert_eq!(incompatible.mismatches[0].capability, "native.animation");
 }
 
 #[test]

--- a/npm/marquette/README.md
+++ b/npm/marquette/README.md
@@ -129,6 +129,22 @@ mutate their inputs. Compatibility reports expose validation diagnostics for
 both manifests and omit changes when either input is invalid. The published manifest schema is available from
 `@vizejs/marquette/adapter/schema`.
 
+Native rendering adapters share one closed version-one baseline for rendering,
+events, layout, text, images, animation, accessibility, and lifecycle:
+
+```ts
+import { nativeEngineCapabilityProfile } from "@vizejs/marquette/adapter";
+
+const nativeAdapter = {
+  adapter: "native.example",
+  capabilities: nativeEngineCapabilityProfile(),
+};
+```
+
+The canonical identifiers use the `native.*` namespace and are emitted in a
+stable order. The helper returns fresh values so an adapter may add private
+capabilities without changing the baseline used by another consumer.
+
 ## Test-run evidence
 
 Release-bound test-run evidence records live in their own lazy entries so

--- a/npm/marquette/src/adapter-native-profile.ts
+++ b/npm/marquette/src/adapter-native-profile.ts
@@ -1,0 +1,33 @@
+import type { AdapterCapabilitySupport } from "./adapter-model.js";
+
+/** Current contract version shared by the native-engine capability profile. */
+export const NATIVE_ENGINE_CAPABILITY_VERSION = 1 as const;
+
+/** Closed set of capability identifiers required from a native rendering engine. */
+export const NATIVE_ENGINE_CAPABILITY_IDS = [
+  "native.rendering",
+  "native.events",
+  "native.layout",
+  "native.text",
+  "native.images",
+  "native.animation",
+  "native.accessibility",
+  "native.lifecycle",
+] as const;
+
+/** One identifier from the canonical native-engine capability profile. */
+export type NativeEngineCapabilityId = (typeof NATIVE_ENGINE_CAPABILITY_IDS)[number];
+
+/**
+ * Creates the canonical version-one native-engine capability profile.
+ *
+ * A fresh list is returned so an adapter can extend its manifest without
+ * mutating the shared profile seen by another consumer.
+ */
+export function nativeEngineCapabilityProfile(): readonly AdapterCapabilitySupport[] {
+  return NATIVE_ENGINE_CAPABILITY_IDS.map((id) => ({
+    id,
+    minVersion: NATIVE_ENGINE_CAPABILITY_VERSION,
+    maxVersion: NATIVE_ENGINE_CAPABILITY_VERSION,
+  }));
+}

--- a/npm/marquette/src/adapter-types.test.ts
+++ b/npm/marquette/src/adapter-types.test.ts
@@ -3,6 +3,7 @@ import type {
   AdapterCapabilityManifest,
   AdapterCapabilityMismatchCode,
   CompatibilityChangeKind,
+  NativeEngineCapabilityId,
 } from "./adapter.js";
 
 const manifest = {
@@ -13,6 +14,7 @@ const manifest = {
 const diagnostic: AdapterCapabilityDiagnosticCode = "duplicate-capability";
 const mismatch: AdapterCapabilityMismatchCode = "version-above-maximum";
 const compatibility: CompatibilityChangeKind = "breaking";
+const nativeCapability: NativeEngineCapabilityId = "native.accessibility";
 
 // @ts-expect-error The serialized format is pinned to version one.
 const future: AdapterCapabilityManifest = { formatVersion: 2, adapter: "future.adapter" };
@@ -21,10 +23,14 @@ const missingMaximum: AdapterCapabilityManifest = {
   // @ts-expect-error Supported ranges require both inclusive bounds.
   capabilities: [{ id: "broken", minVersion: 1 }],
 };
+// @ts-expect-error Native engine capability identifiers are a closed contract.
+const unknownNativeCapability: NativeEngineCapabilityId = "native.unknown";
 
 void manifest;
 void diagnostic;
 void mismatch;
 void compatibility;
+void nativeCapability;
 void future;
 void missingMaximum;
+void unknownNativeCapability;

--- a/npm/marquette/src/adapter.test.ts
+++ b/npm/marquette/src/adapter.test.ts
@@ -4,7 +4,10 @@ import { test } from "node:test";
 
 import type { ApplicationMarquette } from "./model.js";
 import {
+  NATIVE_ENGINE_CAPABILITY_IDS,
+  NATIVE_ENGINE_CAPABILITY_VERSION,
   compareAdapterCapabilities,
+  nativeEngineCapabilityProfile,
   negotiateAdapterCapabilities,
   parseAdapterCapabilityManifest,
   validateAdapterCapabilityManifest,
@@ -37,6 +40,58 @@ interface CompatibilityCase {
   readonly next: AdapterCapabilityManifest;
   readonly expected: AdapterCapabilityCompatibilityReport;
 }
+
+void test("native engine profile matches the shared contract and returns fresh values", async () => {
+  const expected = await read<AdapterCapabilityManifest>("native-engine-capability-profile.json");
+  const first = nativeEngineCapabilityProfile();
+  const manifest = {
+    formatVersion: 1,
+    adapter: "fixture.native",
+    capabilities: first,
+  } as const satisfies AdapterCapabilityManifest;
+
+  assert.deepEqual(manifest, expected);
+  assert.deepEqual(
+    first.map(({ id }) => id),
+    NATIVE_ENGINE_CAPABILITY_IDS,
+  );
+  assert.equal(first.length, 8);
+  assert.ok(
+    first.every(
+      ({ minVersion, maxVersion }) =>
+        minVersion === NATIVE_ENGINE_CAPABILITY_VERSION &&
+        maxVersion === NATIVE_ENGINE_CAPABILITY_VERSION,
+    ),
+  );
+  assert.deepEqual(validateAdapterCapabilityManifest(manifest), []);
+
+  const contract: ApplicationMarquette = {
+    application: "native-profile",
+    capabilities: Object.fromEntries(
+      NATIVE_ENGINE_CAPABILITY_IDS.map((id) => [
+        id,
+        { id, description: "Native engine contract", version: 1 },
+      ]),
+    ),
+  };
+  assert.equal(
+    negotiateAdapterCapabilities(contract, NATIVE_ENGINE_CAPABILITY_IDS, manifest).compatible,
+    true,
+  );
+
+  const missingAnimation = {
+    ...manifest,
+    capabilities: manifest.capabilities.filter(({ id }) => id !== "native.animation"),
+  };
+  assert.deepEqual(
+    negotiateAdapterCapabilities(contract, NATIVE_ENGINE_CAPABILITY_IDS, missingAnimation)
+      .mismatches,
+    [{ code: "missing-capability", capability: "native.animation", requiredVersion: 1 }],
+  );
+
+  (first[0] as { id: string }).id = "mutated";
+  assert.equal(nativeEngineCapabilityProfile()[0]?.id, "native.rendering");
+});
 
 void test("matches shared negotiation fixtures and input permutations", async () => {
   const fixture = await read<NegotiationFixture>("adapter-negotiation.json");

--- a/npm/marquette/src/adapter.ts
+++ b/npm/marquette/src/adapter.ts
@@ -11,6 +11,12 @@ export {
   type AdapterCapabilitySupport,
   type CompatibilityChangeKind,
 } from "./adapter-model.js";
+export {
+  NATIVE_ENGINE_CAPABILITY_IDS,
+  NATIVE_ENGINE_CAPABILITY_VERSION,
+  nativeEngineCapabilityProfile,
+  type NativeEngineCapabilityId,
+} from "./adapter-native-profile.js";
 export { compareAdapterCapabilities } from "./adapter-compatibility.js";
 export { negotiateAdapterCapabilities } from "./adapter-negotiate.js";
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,7 +238,7 @@ overrides:
   fast-uri: 3.1.5
   glob>minimatch: 10.2.5
   h3: 1.15.11
-  hono: 4.12.31
+  hono: 4.12.34
   ip-address: 10.3.1
   launch-editor: 2.14.1
   nanotar: 0.3.0
@@ -2059,7 +2059,7 @@ packages:
     resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: 4.12.31
+      hono: 4.12.34
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -8224,8 +8224,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.31:
-    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
@@ -12234,9 +12234,9 @@ snapshots:
     dependencies:
       tailwindcss: 3.4.19(tsx@4.22.4)(yaml@2.9.0)
 
-  '@hono/node-server@2.0.11(hono@4.12.31)':
+  '@hono/node-server@2.0.11(hono@4.12.34)':
     dependencies:
-      hono: 4.12.31
+      hono: 4.12.34
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -12558,7 +12558,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 2.0.11(hono@4.12.31)
+      '@hono/node-server': 2.0.11(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -12568,7 +12568,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.1(express@5.2.1)
-      hono: 4.12.31
+      hono: 4.12.34
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -18193,7 +18193,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.31: {}
+  hono@4.12.34: {}
 
   hookable@5.5.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,6 +18,9 @@ packages:
   - "tests"
   - "bench"
 
+minimumReleaseAgeExclude:
+  - "hono@4.12.34"
+
 overrides:
   "@azure/msal-node>uuid": "11.1.1"
   "@hono/node-server": "2.0.11"
@@ -31,7 +34,7 @@ overrides:
   fast-uri: "3.1.5"
   "glob>minimatch": "10.2.5"
   h3: "1.15.11"
-  hono: "4.12.31"
+  hono: "4.12.34"
   ip-address: "10.3.1"
   launch-editor: "2.14.1"
   nanotar: "0.3.0"

--- a/tests/fixtures/marquette/native-engine-capability-profile.json
+++ b/tests/fixtures/marquette/native-engine-capability-profile.json
@@ -1,0 +1,14 @@
+{
+  "formatVersion": 1,
+  "adapter": "fixture.native",
+  "capabilities": [
+    { "id": "native.rendering", "minVersion": 1, "maxVersion": 1 },
+    { "id": "native.events", "minVersion": 1, "maxVersion": 1 },
+    { "id": "native.layout", "minVersion": 1, "maxVersion": 1 },
+    { "id": "native.text", "minVersion": 1, "maxVersion": 1 },
+    { "id": "native.images", "minVersion": 1, "maxVersion": 1 },
+    { "id": "native.animation", "minVersion": 1, "maxVersion": 1 },
+    { "id": "native.accessibility", "minVersion": 1, "maxVersion": 1 },
+    { "id": "native.lifecycle", "minVersion": 1, "maxVersion": 1 }
+  ]
+}


### PR DESCRIPTION
## Summary

- define the closed native-engine capability baseline for rendering, events, layout, text, images, animation, accessibility, and lifecycle
- expose identical Rust and TypeScript profile helpers with stable identifiers and version ranges
- pin the cross-language contract with shared positive, missing-capability, type, mutation-isolation, and validation coverage
- clear a newly published moderate advisory that began blocking the required security gate, with a minimal override and lockfile-only diff

Part of #3132.

## Validation

- `cargo test -p vize_marquette`
- `cargo clippy -p vize_marquette --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `pnpm --filter @vizejs/marquette test`
- `pnpm --filter @vizejs/marquette check`
- `pnpm --filter @vizejs/marquette build`
- `vp install --frozen-lockfile --prefer-offline`
- `vp exec pnpm audit --prod --audit-level moderate`
- `pnpm --filter @vizejs/musea-mcp-server check`
- pinned MoonBit source-length gate against `origin/main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared version-one native rendering capability profile.
  * Exposed standardized capability identifiers covering rendering, events, layout, text, images, animation, accessibility, and lifecycle.
  * Added capability negotiation support with clear mismatch reporting.
  * Added type-safe native capability identifiers and fresh profile values for each request.

* **Documentation**
  * Documented the native capability profile, stable ordering, and usage examples.

* **Tests**
  * Added coverage for validation, negotiation, type safety, and missing-capability diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->