### PR TITLE
fix(maestro): honor requested code action kinds

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -263,7 +263,7 @@ jobs:
           key: test-scripts
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
       - name: Hydrate CLI diagnostic fixture and install JS dependencies
-        run: git submodule update --init --depth 1 -- tests/_fixtures/_git/ant-design-vue && vp install --frozen-lockfile --prefer-offline
+        run: git submodule update --init --force --depth 1 -- tests/_fixtures/_git/ant-design-vue tests/_fixtures/_git/create-vue && vp install --frozen-lockfile --prefer-offline
       - name: Build vize CLI
         run: cargo build --profile ci -p vize
       - name: Install vize CLI

--- a/crates/vize_maestro/src/server.rs
+++ b/crates/vize_maestro/src/server.rs
@@ -14,6 +14,7 @@ use tower_lsp::jsonrpc::{Request, Response};
 mod annotations;
 mod auto_insert;
 mod capabilities;
+mod code_actions;
 mod diagnostic_publishing;
 mod document_structure;
 mod format;

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -65,11 +65,7 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
         // Code actions (quick fixes, refactoring)
         code_action_provider: (features.lint && features.code_actions).then_some(
             CodeActionProviderCapability::Options(CodeActionOptions {
-                code_action_kinds: Some(vec![
-                    CodeActionKind::QUICKFIX,
-                    CodeActionKind::REFACTOR,
-                    CodeActionKind::SOURCE,
-                ]),
+                code_action_kinds: Some(vec![CodeActionKind::QUICKFIX]),
                 work_done_progress_options: WorkDoneProgressOptions::default(),
                 resolve_provider: Some(false),
             }),
@@ -309,6 +305,8 @@ fn file_rename_registration_options() -> FileOperationRegistrationOptions {
     }
 }
 
+#[cfg(test)]
+mod code_action_tests;
 #[cfg(test)]
 mod file_operation_tests;
 #[cfg(test)]

--- a/crates/vize_maestro/src/server/capabilities/code_action_tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/code_action_tests.rs
@@ -1,0 +1,18 @@
+use super::*;
+
+#[test]
+fn advertises_only_the_kind_the_handler_emits() {
+    let capabilities = server_capabilities(LspFeatureConfig {
+        lint: true,
+        code_actions: true,
+        ..LspFeatureConfig::default()
+    });
+    let Some(CodeActionProviderCapability::Options(options)) = capabilities.code_action_provider
+    else {
+        panic!("code action options should be advertised");
+    };
+    assert_eq!(
+        options.code_action_kinds,
+        Some(vec![CodeActionKind::QUICKFIX])
+    );
+}

--- a/crates/vize_maestro/src/server/code_actions.rs
+++ b/crates/vize_maestro/src/server/code_actions.rs
@@ -1,0 +1,97 @@
+//! Code-action request dispatch and kind filtering.
+
+use tower_lsp::lsp_types::{
+    CodeActionKind, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
+};
+
+use super::MaestroServer;
+use crate::ide::{CodeActionService, IdeContext, position_to_offset};
+
+pub(super) fn code_actions(
+    server: &MaestroServer,
+    params: &CodeActionParams,
+) -> Option<CodeActionResponse> {
+    let features = server.state.lsp_features();
+    if !features.lint || !features.code_actions {
+        return None;
+    }
+
+    let uri = &params.text_document.uri;
+    let range = params.range;
+    let content = server.state.documents.text(uri)?;
+
+    let actions = if crate::utils::is_jsx_path(uri.path()) {
+        // `.jsx`/`.tsx`: surface the fixable Patina/JSX-compiler diagnostics.
+        // Lint-based (parse-only), so not gated on `typeChecker.jsxTypecheck`.
+        crate::ide::JsxCodeActionService::code_actions(&content, uri, range)
+    } else {
+        let offset = position_to_offset(&content, range.start.line, range.start.character)?;
+        let ctx = IdeContext::new(&server.state, uri, offset)?;
+        CodeActionService::code_actions(&ctx, range)
+    };
+
+    filter_requested_code_actions(actions, params.context.only.as_deref())
+}
+
+/// Apply the LSP code-action kind hierarchy to one handler response.
+///
+/// A requested parent kind contains its descendants (`refactor` contains
+/// `refactor.extract`), while requesting a descendant must not include its
+/// parent. Commands and untyped actions cannot satisfy an `only` request
+/// because the client cannot establish which kind they belong to.
+fn filter_requested_code_actions(
+    mut actions: CodeActionResponse,
+    only: Option<&[CodeActionKind]>,
+) -> Option<CodeActionResponse> {
+    if let Some(requested_kinds) = only {
+        actions.retain(|action| match action {
+            CodeActionOrCommand::CodeAction(action) => action
+                .kind
+                .as_ref()
+                .is_some_and(|kind| code_action_kind_is_requested(kind, requested_kinds)),
+            CodeActionOrCommand::Command(_) => false,
+        });
+    }
+    (!actions.is_empty()).then_some(actions)
+}
+
+fn code_action_kind_is_requested(kind: &CodeActionKind, requested: &[CodeActionKind]) -> bool {
+    requested.iter().any(|requested_kind| {
+        let requested = requested_kind.as_str();
+        requested.is_empty()
+            || kind == requested_kind
+            || kind
+                .as_str()
+                .strip_prefix(requested)
+                .is_some_and(|suffix| suffix.starts_with('.'))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn requested_kinds_follow_the_lsp_hierarchy() {
+        assert!(code_action_kind_is_requested(
+            &CodeActionKind::QUICKFIX,
+            &[CodeActionKind::EMPTY]
+        ));
+        assert!(code_action_kind_is_requested(
+            &CodeActionKind::REFACTOR_EXTRACT,
+            &[CodeActionKind::REFACTOR]
+        ));
+        assert!(!code_action_kind_is_requested(
+            &CodeActionKind::REFACTOR,
+            &[CodeActionKind::REFACTOR_EXTRACT]
+        ));
+        assert!(!code_action_kind_is_requested(
+            &CodeActionKind::QUICKFIX,
+            &[CodeActionKind::SOURCE]
+        ));
+        assert!(!code_action_kind_is_requested(
+            &CodeActionKind::QUICKFIX,
+            &[]
+        ));
+    }
+}

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -34,9 +34,9 @@ use tower_lsp::lsp_types::{Position, Range};
 
 use super::{MaestroServer, server_capabilities};
 use crate::ide::{
-    CodeActionService, CompletionService, DefinitionService, DocumentHighlightService,
-    DocumentLinkService, HoverService, IdeContext, ReferencesService, RenameService,
-    SemanticTokensService, position_to_offset,
+    CompletionService, DefinitionService, DocumentHighlightService, DocumentLinkService,
+    HoverService, IdeContext, ReferencesService, RenameService, SemanticTokensService,
+    position_to_offset,
 };
 
 #[tower_lsp::async_trait]
@@ -393,42 +393,7 @@ impl LanguageServer for MaestroServer {
     }
 
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
-        let features = self.state.lsp_features();
-        if !features.lint || !features.code_actions {
-            return Ok(None);
-        }
-
-        let uri = &params.text_document.uri;
-        let range = params.range;
-
-        let Some(content) = self.state.documents.text(uri) else {
-            return Ok(None);
-        };
-
-        // `.jsx`/`.tsx`: surface the fixable Patina/JSX-compiler diagnostics as
-        // quickfix code actions. Lint-based (parse-only), so not gated on
-        // `typeChecker.jsxTypecheck`.
-        if crate::utils::is_jsx_path(uri.path()) {
-            let actions = crate::ide::JsxCodeActionService::code_actions(&content, uri, range);
-            if actions.is_empty() {
-                return Ok(None);
-            }
-            return Ok(Some(actions));
-        }
-
-        let Some(offset) = position_to_offset(&content, range.start.line, range.start.character)
-        else {
-            return Ok(None);
-        };
-
-        if let Some(ctx) = IdeContext::new(&self.state, uri, offset) {
-            let actions = CodeActionService::code_actions(&ctx, range);
-            if !actions.is_empty() {
-                return Ok(Some(actions));
-            }
-        }
-
-        Ok(None)
+        Ok(super::code_actions::code_actions(self, &params))
     }
 
     async fn prepare_rename(

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -106,7 +106,7 @@ const EDITOR_BUNDLE_CAPABILITIES = {
   documentSymbolProvider: true,
   workspaceSymbolProvider: true,
   codeActionProvider: {
-    codeActionKinds: ["quickfix", "refactor", "source"],
+    codeActionKinds: ["quickfix"],
     resolveProvider: false,
   },
   codeLensProvider: { resolveProvider: false },
@@ -229,11 +229,7 @@ test("vize lsp editor:false strips editor providers but keeps lint-driven codeAc
 
       // Lint code actions survive without the editor bundle.
       assert.ok(capabilities.codeActionProvider, "codeActionProvider should remain present");
-      assert.deepEqual(capabilities.codeActionProvider?.codeActionKinds, [
-        "quickfix",
-        "refactor",
-        "source",
-      ]);
+      assert.deepEqual(capabilities.codeActionProvider?.codeActionKinds, ["quickfix"]);
     },
   );
 });

--- a/tests/tooling/lsp-code-action-kinds.test.ts
+++ b/tests/tooling/lsp-code-action-kinds.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import { test } from "node:test";
 import { pathToFileURL } from "node:url";
-import { withPinnedFixtureWorkspace } from "../_helpers/realworld-patch.ts";
+import { repoRoot, withPinnedFixtureWorkspace } from "../_helpers/realworld-patch.ts";
 import { isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
 import type { LspDiagnostic, LspRange, PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
 import { LspSession } from "./support/lsp/session.ts";
@@ -10,6 +10,14 @@ import { LspSession } from "./support/lsp/session.ts";
 const CREATE_VUE_APP = "template/code/typescript-default/src/App.vue";
 const CLEAN_ATTRIBUTE = 'alt="Vue logo" class="logo"';
 const BROKEN_ATTRIBUTE = 'alt="Vue logo"  class="logo"';
+
+test("release-script CI hydrates the pinned create-vue code-action oracle", () => {
+  const workflow = fs.readFileSync(`${repoRoot}/.github/workflows/check.yml`, "utf8");
+  assert.match(
+    workflow,
+    /git submodule update --init --force --depth 1 --[^\n]*tests\/_fixtures\/_git\/create-vue/,
+  );
+});
 
 type CodeAction = {
   title: string;

--- a/tests/tooling/lsp-code-action-kinds.test.ts
+++ b/tests/tooling/lsp-code-action-kinds.test.ts
@@ -1,0 +1,189 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { withPinnedFixtureWorkspace } from "../_helpers/realworld-patch.ts";
+import { isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
+import type { LspDiagnostic, LspRange, PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+const CREATE_VUE_APP = "template/code/typescript-default/src/App.vue";
+const CLEAN_ATTRIBUTE = 'alt="Vue logo" class="logo"';
+const BROKEN_ATTRIBUTE = 'alt="Vue logo"  class="logo"';
+
+type CodeAction = {
+  title: string;
+  kind?: string;
+  isPreferred?: boolean;
+  edit?: {
+    changes?: Record<string, Array<{ range: LspRange; newText: string }>>;
+  };
+};
+
+type ExpectedAction = {
+  title: string;
+  kind?: string;
+  isPreferred?: boolean;
+  edits: Array<{ range: LspRange; newText: string }>;
+};
+
+function openDocument(
+  session: LspSession,
+  filePath: string,
+  languageId: string,
+  source: string,
+): { uri: string; diagnostics: Promise<PublishDiagnosticsParams> } {
+  const uri = pathToFileURL(filePath).href;
+  const diagnostics = session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+    isDiagnosticsForUri(params, uri),
+  ) as Promise<PublishDiagnosticsParams>;
+  session.notify("textDocument/didOpen", {
+    textDocument: { uri, languageId, version: 1, text: source },
+  });
+  return { uri, diagnostics };
+}
+
+async function requestActions(
+  session: LspSession,
+  uri: string,
+  range: LspRange,
+  diagnostic: LspDiagnostic,
+  only?: string[],
+): Promise<CodeAction[] | null> {
+  return (await session.request("textDocument/codeAction", {
+    textDocument: { uri },
+    range,
+    context: { diagnostics: [diagnostic], ...(only == null ? {} : { only }) },
+  })) as CodeAction[] | null;
+}
+
+function normalize(actions: CodeAction[] | null, uri: string): ExpectedAction[] | null {
+  return (
+    actions?.map((action) => ({
+      title: action.title,
+      kind: action.kind,
+      isPreferred: action.isPreferred,
+      edits: action.edit?.changes?.[uri] ?? [],
+    })) ?? null
+  );
+}
+
+function lintDiagnostic(publish: PublishDiagnosticsParams): LspDiagnostic {
+  const diagnostic = publish.diagnostics.find(
+    (item) => item.source === "vize/lint" && item.code === "vue/no-multi-spaces",
+  );
+  assert.ok(diagnostic, JSON.stringify(publish.diagnostics));
+  return diagnostic;
+}
+
+test("vize lsp honors requested quickfix kinds for pinned create-vue SFC and TSX", async () => {
+  await withPinnedFixtureWorkspace(
+    { fixtureId: "create-vue", includePaths: [CREATE_VUE_APP] },
+    async (fixture) => {
+      const source = fixture.applyExactPatch(CREATE_VUE_APP, CLEAN_ATTRIBUTE, BROKEN_ATTRIBUTE);
+      const session = new LspSession();
+
+      try {
+        await session.initialize(fixture.workspaceDir, {
+          lint: true,
+          codeActions: true,
+          typecheck: false,
+        });
+
+        const sfc = openDocument(session, fixture.resolve(CREATE_VUE_APP), "vue", source);
+        const sfcDiagnostic = lintDiagnostic(await sfc.diagnostics);
+        const gapStart = source.indexOf("  class=");
+        assert.notEqual(gapStart, -1);
+        const sfcRange = {
+          start: offsetToPosition(source, gapStart),
+          end: offsetToPosition(source, gapStart + 2),
+        };
+        assert.deepEqual(sfcDiagnostic.range, sfcRange);
+
+        const expectedSfcActions: ExpectedAction[] = [
+          {
+            title: "Fix: Replace multiple spaces with single space",
+            kind: "quickfix",
+            isPreferred: true,
+            edits: [{ range: sfcRange, newText: " " }],
+          },
+          {
+            title: "Suppress with @vize:forget (vue/no-multi-spaces)",
+            kind: "quickfix",
+            isPreferred: false,
+            edits: [
+              {
+                range: {
+                  start: { line: sfcRange.start.line, character: 0 },
+                  end: { line: sfcRange.start.line, character: 0 },
+                },
+                newText: "    <!-- @vize:forget vue/no-multi-spaces -->\n",
+              },
+            ],
+          },
+        ];
+        assert.deepEqual(
+          normalize(
+            await requestActions(session, sfc.uri, sfcRange, sfcDiagnostic, ["quickfix"]),
+            sfc.uri,
+          ),
+          expectedSfcActions,
+        );
+        assert.deepEqual(
+          normalize(await requestActions(session, sfc.uri, sfcRange, sfcDiagnostic, [""]), sfc.uri),
+          expectedSfcActions,
+          "the empty root kind contains every concrete code action kind",
+        );
+        assert.equal(
+          await requestActions(session, sfc.uri, sfcRange, sfcDiagnostic, ["refactor", "source"]),
+          null,
+        );
+        assert.equal(
+          await requestActions(session, sfc.uri, sfcRange, sfcDiagnostic, ["quickfix.fixAll"]),
+          null,
+          "a child-only request must not include its quickfix parent",
+        );
+
+        const jsxSource = 'const C = () => <div    class="a">x</div>;\n';
+        const jsxPath = fixture.resolve("src/CodeAction.tsx");
+        fs.mkdirSync(new URL(".", pathToFileURL(jsxPath)), { recursive: true });
+        fs.writeFileSync(jsxPath, jsxSource, "utf8");
+        const jsx = openDocument(session, jsxPath, "typescriptreact", jsxSource);
+        await jsx.diagnostics;
+        const jsxGapStart = jsxSource.indexOf("    class=");
+        assert.notEqual(jsxGapStart, -1);
+        const jsxRange = {
+          start: offsetToPosition(jsxSource, jsxGapStart),
+          end: offsetToPosition(jsxSource, jsxGapStart + 4),
+        };
+        const jsxDiagnostic: LspDiagnostic = {
+          source: "vize/lint",
+          code: "vue/no-multi-spaces",
+          message: "Replace multiple spaces with single space",
+          range: jsxRange,
+        };
+        assert.deepEqual(
+          normalize(
+            await requestActions(session, jsx.uri, jsxRange, jsxDiagnostic, ["quickfix"]),
+            jsx.uri,
+          ),
+          [
+            {
+              title: "Fix: Replace multiple spaces with single space",
+              kind: "quickfix",
+              isPreferred: true,
+              edits: [{ range: jsxRange, newText: " " }],
+            },
+          ],
+        );
+        assert.equal(
+          await requestActions(session, jsx.uri, jsxRange, jsxDiagnostic, ["source"]),
+          null,
+          "JSX must apply the same requested-kind filter as SFC",
+        );
+      } finally {
+        await session.shutdown();
+      }
+    },
+  );
+});

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -17,7 +17,7 @@ test("test:scripts requires its typecheck dependencies", () => {
   );
   assert.match(
     workflow,
-    /\n  test-scripts:\n[\s\S]*?git submodule update --init --depth 1 -- tests\/_fixtures\/_git\/ant-design-vue && vp install --frozen-lockfile --prefer-offline[\s\S]*?\n  editor-extensions:\n/,
+    /\n  test-scripts:\n[\s\S]*?git submodule update --init --force --depth 1 -- tests\/_fixtures\/_git\/ant-design-vue tests\/_fixtures\/_git\/create-vue && vp install --frozen-lockfile --prefer-offline[\s\S]*?\n  editor-extensions:\n/,
   );
 });
 


### PR DESCRIPTION
## Summary

- advertise only the quickfix code-action kind that Maestro actually emits
- apply LSP hierarchical context.only filtering to both SFC and JSX requests
- pin exact create-vue SFC/JSX action titles, kinds, ranges, and edits in a live LSP oracle

## Tests

- cargo test -p vize_maestro (698 passed, 2 ignored; 3 integration tests; 1 doctest)
- cargo clippy -p vize_maestro -- -D warnings -D clippy::wildcard_imports
- live LSP tooling tests (5 passed)
- vp check on changed tooling tests
- cargo fmt --all --check
- source-length check against origin/main with CI MoonBit setup
- pnpm production audit at moderate level and cargo audit --deny warnings

Refs #3224

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->