### PR TITLE
fix(jsx): keep async component functions awaitable in setup()

### DIFF
--- a/crates/vize_atelier_jsx/src/compile/render_exports.rs
+++ b/crates/vize_atelier_jsx/src/compile/render_exports.rs
@@ -111,7 +111,13 @@ fn push_component_wrapper(
     module.push_str(name);
     module.push_str(" = _defineComponent({\n  name: \"");
     module.push_str(&escape_js_string(name));
-    module.push_str("\",\n  setup");
+    module.push_str("\",\n  ");
+    if setup.is_async {
+        // The authored body may `await`, so dropping the modifier would emit a
+        // module that does not parse.
+        module.push_str("async ");
+    }
+    module.push_str("setup");
     let type_params = setup_type_params(source, setup);
     if !type_params.is_empty() {
         module.push('<');

--- a/crates/vize_atelier_jsx/src/finder.rs
+++ b/crates/vize_atelier_jsx/src/finder.rs
@@ -125,6 +125,7 @@ impl RootLowerer<'_, '_, '_, '_> {
         params: &FormalParameters<'_>,
         body: &FunctionBody<'_>,
         declaration_span: Span,
+        is_async: bool,
     ) -> Option<ComponentSetupSpan> {
         let return_stmt = body.statements.iter().find_map(|stmt| {
             let Statement::ReturnStatement(return_stmt) = stmt else {
@@ -143,6 +144,7 @@ impl RootLowerer<'_, '_, '_, '_> {
             params_end,
             type_params_start,
             type_params_end,
+            is_async,
             setup_start: body.span.start.saturating_add(1),
             setup_end: return_stmt.0.start,
             render_start: return_stmt.1.start,
@@ -291,6 +293,7 @@ impl<'ast> Visit<'ast> for RootLowerer<'_, '_, '_, '_> {
                     &it.params,
                     &it.body,
                     span,
+                    it.r#async,
                 )
             })
         };

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -131,6 +131,10 @@ pub struct ComponentSetupSpan {
     /// End of the type parameter list. Equal to [`Self::type_params_start`] when
     /// the component is not generic.
     pub type_params_end: u32,
+    /// Whether the component function was authored `async`. Its body may contain
+    /// `await`, so the generated method has to stay `async setup()` to remain
+    /// syntactically valid (#3856).
+    pub is_async: bool,
     /// Start of setup statements inside the component body.
     pub setup_start: u32,
     /// End of setup statements, immediately before the `return <jsx>` statement.

--- a/crates/vize_atelier_jsx/tests/module_code.rs
+++ b/crates/vize_atelier_jsx/tests/module_code.rs
@@ -138,6 +138,27 @@ fn tsx_generic_component_keeps_its_type_parameters_on_setup() {
 }
 
 #[test]
+fn async_component_keeps_its_async_modifier_on_setup() {
+    let bump = Bump::new();
+    let out = compile_jsx(
+        &bump,
+        r#"
+        const AsyncPanel = async ({ id }) => {
+          const data = await load(id);
+          return <div>{data}</div>;
+        };
+        "#,
+        JsxLang::Jsx,
+        &JsxCompileConfig::default(),
+    );
+    let module = out.module_code();
+
+    // Dropping `async` would leave `await` inside a synchronous method.
+    assert!(module.contains("async setup({ id }) {"), "{module}");
+    assert!(module.contains("const data = await load(id);"), "{module}");
+}
+
+#[test]
 fn module_code_forwards_plain_props_and_context_parameters_to_setup() {
     let bump = Bump::new();
     let out = compile_jsx(

--- a/crates/vize_atelier_jsx/tests/module_code.rs
+++ b/crates/vize_atelier_jsx/tests/module_code.rs
@@ -261,3 +261,23 @@ fn jsx_in_a_parameter_default_falls_back_to_plain_render_exports() {
     assert!(!module.contains("_defineComponent"), "{module}");
     assert!(!module.contains("setup("), "{module}");
 }
+
+#[test]
+fn module_code_leaves_synchronous_components_without_an_async_setup() {
+    let bump = Bump::new();
+    let out = compile_jsx(
+        &bump,
+        r#"
+        const SyncApp = () => {
+          const data = load();
+          return <div>{data}</div>;
+        };
+        "#,
+        JsxLang::Jsx,
+        &JsxCompileConfig::default(),
+    );
+    let module = out.module_code();
+
+    assert!(module.contains("  setup() {"), "{module}");
+    assert!(!module.contains("async setup"), "{module}");
+}


### PR DESCRIPTION
## Summary

An `async` component function lost its modifier when lowered into `_defineComponent`, so a body containing `await` compiled to a synchronous `setup()` and the emitted module failed to parse (#3860). `ComponentSetupSpan` now records whether the authored function was `async`, and the wrapper re-emits the modifier:

```rust
module.push_str("\",\n  ");
if setup.is_async {
    // The authored body may `await`, so dropping the modifier would emit a
    // module that does not parse.
    module.push_str("async ");
}
module.push_str("setup");
```

The modifier is conditional, so synchronous components keep a plain `setup()` and do not start returning a promise (which Vue only resolves under `<Suspense>`). Both directions are pinned by tests: `async_component_keeps_its_async_modifier_on_setup` and `module_code_leaves_synchronous_components_without_an_async_setup`.

Note on scope: this branch previously targeted `fix/jsx-setup-props-signature`, which merged as #3859 (`4010fbb`). That squash carried only the props/generics signature work, not the async fix, so the implementation belongs to this PR again after retargeting onto `main`.

## Change Class

- [x] Bug fix with regression test

## Behavior Reference

- Fix request: #3860
- Signature work already on `main`: #3859 (`4010fbb`)

## Verification Evidence

```sh
cargo test -p vize_atelier_jsx --test module_code   # 11 passed
cargo fmt --all -- --check
```

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — no snapshot changes

## Risk

Low: the extra `async` is emitted only when the source function is `async`, and the negative test guards synchronous components against regressing into promise-returning `setup()`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generated Vue component wrappers now preserve asynchronous setup behavior when components use `async` setup functions.
  * Synchronous components continue to generate standard synchronous setup methods.

* **Tests**
  * Added coverage for both asynchronous and synchronous component setup generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->