### PR TITLE
chore(deps): waive RUSTSEC-2026-0235 while lightningcss pins rkyv 0.7

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,23 @@
+# cargo-audit configuration.
+#
+# `ignore` is a last resort for advisories that have no upgrade path and that
+# Vize provably cannot reach. Every entry must carry a `why:` line explaining
+# why the vulnerable code path is unreachable here and a `tracking:` line
+# pointing at the issue that removes the waiver, so a temporary suppression
+# cannot quietly become permanent. `tests/tooling/cargo-audit-ignores.test.ts`
+# enforces that shape.
+
+[advisories]
+ignore = [
+  # RUSTSEC-2026-0235 — rkyv 0.7 performs insufficient archive validation, so an
+  # archive containing Rc/Arc can cause out-of-bounds reads while deserializing.
+  # why: rkyv is a non-optional dependency of parcel_sourcemap, which lightningcss
+  # pulls in through its default `bundler` feature. Vize uses that bundler only to
+  # build a stylesheet — crates/vize_atelier_sfc/src/css/parser.rs calls
+  # Bundler::new(&fs, None, parser_options) with None for the source map — so no
+  # parcel_sourcemap::SourceMap is ever constructed and no rkyv archive is ever
+  # deserialized. parcel_sourcemap 2.1.1 is the newest release and still requires
+  # rkyv 0.7, so there is no version to upgrade to.
+  # tracking: #3864
+  "RUSTSEC-2026-0235",
+]

--- a/tests/tooling/cargo-audit-ignores.test.ts
+++ b/tests/tooling/cargo-audit-ignores.test.ts
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { readRepoFile } from "./support/github-workflows.ts";
+
+const ADVISORY_ENTRY = /^\s*"(RUSTSEC-\d{4}-\d{4})"\s*,?\s*$/;
+
+type IgnoredAdvisory = { id: string; justification: string[] };
+
+/**
+ * Collect each ignored advisory together with the comment block directly above
+ * it. Any non-comment line resets the block, so a justification cannot be
+ * inherited from an unrelated entry.
+ */
+function ignoredAdvisories(config: string): IgnoredAdvisory[] {
+  const entries: IgnoredAdvisory[] = [];
+  let comments: string[] = [];
+  for (const line of config.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#")) {
+      comments.push(trimmed.slice(1).trim());
+      continue;
+    }
+    const match = ADVISORY_ENTRY.exec(line);
+    if (match) {
+      entries.push({ id: match[1], justification: comments });
+    }
+    comments = [];
+  }
+  return entries;
+}
+
+test("cargo-audit ignore entries parse only from the advisory list", () => {
+  const entries = ignoredAdvisories(
+    [
+      "# why: reason",
+      "# tracking: #1",
+      '  "RUSTSEC-2020-0001",',
+      "",
+      '  "RUSTSEC-2020-0002",',
+    ].join("\n"),
+  );
+
+  assert.deepEqual(
+    entries.map((entry) => entry.id),
+    ["RUSTSEC-2020-0001", "RUSTSEC-2020-0002"],
+  );
+  assert.deepEqual(entries[0].justification, ["why: reason", "tracking: #1"]);
+  assert.deepEqual(entries[1].justification, [], "a blank line resets the comment block");
+});
+
+test("every ignored advisory names why Vize is unaffected and what removes the waiver", () => {
+  const config = readRepoFile(".cargo", "audit.toml");
+  const entries = ignoredAdvisories(config);
+
+  const seen = new Set<string>();
+  for (const { id, justification } of entries) {
+    assert.equal(seen.has(id), false, `${id} is ignored twice`);
+    seen.add(id);
+
+    assert.ok(
+      justification.some((line) => line.startsWith("why:")),
+      `${id} needs a "why:" line stating why the vulnerable path is unreachable in Vize`,
+    );
+    assert.ok(
+      justification.some((line) => /^tracking: #\d+$/.test(line)),
+      `${id} needs a "tracking: #<issue>" line pointing at the issue that removes it`,
+    );
+  }
+});
+
+test("the audit gate itself stays strict while advisories are waived", () => {
+  const workflow = readRepoFile(".github", "workflows", "check.yml");
+
+  assert.match(
+    workflow,
+    /run: cargo audit --deny warnings\n/,
+    "security-audit must keep failing on warnings; waivers belong in .cargo/audit.toml",
+  );
+  assert.doesNotMatch(
+    workflow,
+    /cargo audit[^\n]*--ignore/,
+    "advisories are waived in .cargo/audit.toml, where the justification test can see them",
+  );
+});


### PR DESCRIPTION
## Summary

**RUSTSEC-2026-0235** landed in the RustSec database between main's last green run (06:02Z) and the first PR run after it (11:32Z) today, turning `cargo audit --deny warnings` red on every branch. `security-audit` is a `needs:` of the required `test-report` gate, so nothing can merge until it is resolved.

```
Crate:     rkyv
Version:   0.7.46
Title:     Insufficient archive validation can cause out-of-bounds reads in archives containing Rc/Arc
Solution:  Upgrade to >=0.8.17

rkyv 0.7.46
└── parcel_sourcemap 2.1.1
    └── lightningcss 1.0.0-alpha.71
```

There is no upgrade path, and the vulnerable path is unreachable here:

- `rkyv` is a **non-optional** dependency of `parcel_sourcemap`, which `lightningcss` pulls in through its default `bundler` feature (`default = ["bundler", "nodejs", "sourcemap"]`).
- `parcel_sourcemap` 2.1.1 is the newest release and still requires `rkyv ^0.7.38`; `lightningcss` 1.0.0-alpha.72 does not change that.
- Vize uses the bundler only to build a stylesheet — [css/parser.rs](crates/vize_atelier_sfc/src/css/parser.rs) calls `Bundler::new(&fs, None, parser_options)` with `None` for the source map — so no `parcel_sourcemap::SourceMap` is ever constructed and no rkyv archive is ever deserialized.
- Dropping `lightningcss/bundler` would remove CSS `@import` bundling, which Vize actually uses.

So this waives that one advisory in `.cargo/audit.toml`, with the reasoning inline, and keeps the gate itself at `--deny warnings`. Removal is tracked in #3864.

## Change Class

- [x] Runtime packaging, release, or docs

## Behavior Reference

- Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0235
- Waiver removal: #3864
- Prior upstream-blocked lightningcss work: #3295

## Verification Evidence

```sh
node --test tests/tooling/cargo-audit-ignores.test.ts   # 3 passed
```

`tests/tooling/cargo-audit-ignores.test.ts` is the guard that keeps this from becoming a habit:

- every entry in `ignore` must carry a `why:` line and a `tracking: #<issue>` line in the comment block directly above it (a blank line resets the block, so a justification cannot be inherited from a neighbour)
- no advisory may be listed twice
- `check.yml` must keep `cargo audit --deny warnings` and must **not** grow a `--ignore` flag, so waivers stay where the justification test can see them

The parser itself is unit-tested against a fixture rather than only the live file, so the guard cannot silently pass by matching nothing.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — none
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered — see the reachability argument above; scope is one advisory ID, the gate stays strict
- [x] Performance status or PR benchmark impact considered
- [x] Fuzzing target or crash-reproducer coverage considered
- [x] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

A waived advisory is a real reduction in coverage for `rkyv` specifically: if a future change starts deserializing rkyv archives through `parcel_sourcemap`, this waiver would hide the exposure. The `why:` line names the exact call site the argument rests on, and #3864 lists the three upstream conditions that let the waiver be deleted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Documented and tracked a reviewed security advisory exception for a Rust dependency.
  * Preserved strict security audit checks for future dependency vulnerabilities.

* **Tests**
  * Added validation to ensure advisory exceptions include clear justifications and issue tracking.
  * Added checks to prevent bypassing audit enforcement through inline command options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->