### PR TITLE
fix(jsx): declare destructured props on the generated wrapper

### DIFF
--- a/crates/vize_atelier_jsx/src/compile/render_exports.rs
+++ b/crates/vize_atelier_jsx/src/compile/render_exports.rs
@@ -111,7 +111,9 @@ fn push_component_wrapper(
     module.push_str(name);
     module.push_str(" = _defineComponent({\n  name: \"");
     module.push_str(&escape_js_string(name));
-    module.push_str("\",\n  ");
+    module.push_str("\",\n");
+    push_props_option(module, &setup.destructured_props);
+    module.push_str("  ");
     if setup.is_async {
         // The authored body may `await`, so dropping the modifier would emit a
         // module that does not parse.
@@ -133,6 +135,27 @@ fn push_component_wrapper(
     push_indented_trimmed(module, render, "    ");
 
     module.push_str("    return render\n  }\n});");
+}
+
+/// Declare the destructured prop names so Vue routes caller values to `setup`'s
+/// first argument instead of to `attrs` (#3861).
+///
+/// Defaults stay in the destructuring pattern, mirroring how SFC reactive props
+/// destructure behaves, so only the names belong here.
+fn push_props_option(module: &mut String, props: &[String]) {
+    if props.is_empty() {
+        return;
+    }
+    module.push_str("  props: [");
+    for (index, prop) in props.iter().enumerate() {
+        if index > 0 {
+            module.push_str(", ");
+        }
+        module.push('"');
+        module.push_str(&escape_js_string(prop));
+        module.push('"');
+    }
+    module.push_str("],\n");
 }
 
 /// The component function's own parameter list, reused verbatim as the `setup()`

--- a/crates/vize_atelier_jsx/src/finder.rs
+++ b/crates/vize_atelier_jsx/src/finder.rs
@@ -12,6 +12,8 @@
 //! - the enclosing component function's name (`function App` or
 //!   `const App = () => …`).
 
+mod signature;
+
 use oxc_ast::ast::{
     ArrowFunctionExpression, Expression, FormalParameters, Function, FunctionBody, JSXElement,
     JSXFragment, Program, Statement, TSTypeParameterDeclaration, VariableDeclaration,
@@ -21,6 +23,8 @@ use oxc_ast_visit::{Visit, walk};
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::scope::ScopeFlags;
 use vize_carton::String;
+
+use self::signature::{destructured_prop_names, formal_parameters_range, type_parameters_range};
 
 use crate::diagnostics::JsxDiagnostic;
 use crate::lower::{Lowerer, ScopedStyleExpr};
@@ -137,7 +141,9 @@ impl RootLowerer<'_, '_, '_, '_> {
 
         let (params_start, params_end) = formal_parameters_range(params);
         let (type_params_start, type_params_end) = type_parameters_range(type_parameters);
+        let destructured_props = destructured_prop_names(params);
         Some(ComponentSetupSpan {
+            destructured_props,
             declaration_start: declaration_span.start,
             declaration_end: declaration_span.end,
             params_start,
@@ -199,47 +205,6 @@ impl RootLowerer<'_, '_, '_, '_> {
             }
         }
         resolved
-    }
-}
-
-/// Byte range covering the authored formal parameter list, parentheses excluded.
-///
-/// The range spans from the first parameter to the last one (or to the rest
-/// element when present) so the original text — type annotations, defaults, and
-/// any interleaved comments — is preserved verbatim. An empty parameter list
-/// collapses to an empty range.
-fn formal_parameters_range(params: &FormalParameters<'_>) -> (u32, u32) {
-    let start = params
-        .items
-        .first()
-        .map(GetSpan::span)
-        .or_else(|| params.rest.as_deref().map(GetSpan::span));
-    let end = params
-        .rest
-        .as_deref()
-        .map(GetSpan::span)
-        .or_else(|| params.items.last().map(GetSpan::span));
-    match (start, end) {
-        (Some(start), Some(end)) => (start.start, end.end),
-        _ => (0, 0),
-    }
-}
-
-/// Byte range covering the authored type parameter list, angle brackets excluded.
-///
-/// A generic component (`const List = <T,>(props: Props<T>) => { … }`) annotates
-/// its parameters with type names that are only bound by this declaration, so the
-/// range is re-emitted on the generated `setup<T>()` method. A non-generic
-/// component collapses to an empty range.
-fn type_parameters_range(type_parameters: Option<&TSTypeParameterDeclaration<'_>>) -> (u32, u32) {
-    let Some(declaration) = type_parameters else {
-        return (0, 0);
-    };
-    let start = declaration.params.first().map(GetSpan::span);
-    let end = declaration.params.last().map(GetSpan::span);
-    match (start, end) {
-        (Some(start), Some(end)) => (start.start, end.end),
-        _ => (0, 0),
     }
 }
 

--- a/crates/vize_atelier_jsx/src/finder/signature.rs
+++ b/crates/vize_atelier_jsx/src/finder/signature.rs
@@ -1,0 +1,82 @@
+//! Reading a component function's signature.
+//!
+//! The stateful module renderer rebuilds a block-body component as
+//! `_defineComponent({ …, setup(…) { … } })`, so everything the authored
+//! signature carried — parameters, type parameters, and the prop names a
+//! destructuring pattern names — has to survive the rewrite. These helpers
+//! recover exactly that, as byte ranges into the original source (re-emitted
+//! verbatim) or as plain names.
+
+use oxc_ast::ast::{BindingPattern, FormalParameters, PropertyKey, TSTypeParameterDeclaration};
+use oxc_span::GetSpan;
+use vize_carton::String;
+
+/// Byte range covering the authored formal parameter list, parentheses excluded.
+///
+/// The range spans from the first parameter to the last one (or to the rest
+/// element when present) so the original text — type annotations, defaults, and
+/// any interleaved comments — is preserved verbatim. An empty parameter list
+/// collapses to an empty range.
+pub(super) fn formal_parameters_range(params: &FormalParameters<'_>) -> (u32, u32) {
+    let start = params
+        .items
+        .first()
+        .map(GetSpan::span)
+        .or_else(|| params.rest.as_deref().map(GetSpan::span));
+    let end = params
+        .rest
+        .as_deref()
+        .map(GetSpan::span)
+        .or_else(|| params.items.last().map(GetSpan::span));
+    match (start, end) {
+        (Some(start), Some(end)) => (start.start, end.end),
+        _ => (0, 0),
+    }
+}
+
+/// Byte range covering the authored type parameter list, angle brackets excluded.
+///
+/// A generic component (`const List = <T,>(props: Props<T>) => { … }`) annotates
+/// its parameters with type names that are only bound by this declaration, so the
+/// range is re-emitted on the generated `setup<T>()` method. A non-generic
+/// component collapses to an empty range.
+pub(super) fn type_parameters_range(
+    type_parameters: Option<&TSTypeParameterDeclaration<'_>>,
+) -> (u32, u32) {
+    let Some(declaration) = type_parameters else {
+        return (0, 0);
+    };
+    let start = declaration.params.first().map(GetSpan::span);
+    let end = declaration.params.last().map(GetSpan::span);
+    match (start, end) {
+        (Some(start), Some(end)) => (start.start, end.end),
+        _ => (0, 0),
+    }
+}
+
+/// Prop names declared by the first parameter's object destructuring pattern, in
+/// source order.
+///
+/// Only a pattern whose every name is statically known is usable: the result
+/// becomes the wrapper's `props` option, and declaring a partial list would route
+/// the remaining props to `attrs` while looking authoritative. A rest element or
+/// a computed key therefore yields no names at all rather than a subset, and a
+/// plain `props` parameter carries no names to begin with.
+pub(super) fn destructured_prop_names(params: &FormalParameters<'_>) -> std::vec::Vec<String> {
+    let mut names = std::vec::Vec::new();
+    let Some(BindingPattern::ObjectPattern(object)) =
+        params.items.first().map(|param| &param.pattern)
+    else {
+        return names;
+    };
+    if object.rest.is_some() {
+        return names;
+    }
+    for property in object.properties.iter() {
+        let PropertyKey::StaticIdentifier(key) = &property.key else {
+            return std::vec::Vec::new();
+        };
+        names.push(String::from(key.name.as_str()));
+    }
+    names
+}

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -135,6 +135,15 @@ pub struct ComponentSetupSpan {
     /// `await`, so the generated method has to stay `async setup()` to remain
     /// syntactically valid (#3856).
     pub is_async: bool,
+    /// Prop names read off the first parameter's object destructuring pattern, in
+    /// source order. Vue only fills `setup`'s first argument with *declared*
+    /// props, so these are emitted as the wrapper's `props` option — otherwise a
+    /// value the caller passes lands in `attrs` and the destructured binding
+    /// keeps its default (#3861).
+    ///
+    /// Empty whenever the names cannot be enumerated exactly: a plain `props`
+    /// parameter, a rest element, or a computed key.
+    pub destructured_props: Vec<String>,
     /// Start of setup statements inside the component body.
     pub setup_start: u32,
     /// End of setup statements, immediately before the `return <jsx>` statement.

--- a/crates/vize_atelier_jsx/tests/module_props.rs
+++ b/crates/vize_atelier_jsx/tests/module_props.rs
@@ -1,0 +1,148 @@
+//! Prop declarations on the generated `_defineComponent` wrapper (#3861).
+//!
+//! Vue only fills `setup`'s first argument with *declared* props, so the names a
+//! component destructures have to reach the wrapper's `props` option. The list
+//! is derived from the destructuring pattern alone, and is emitted only when
+//! every name is statically known — a partial list would look authoritative
+//! while silently routing the rest to `attrs`.
+
+use vize_atelier_jsx::{JsxCompileConfig, JsxLang, compile_jsx};
+use vize_carton::Bump;
+
+fn module_code(source: &str, lang: JsxLang) -> std::string::String {
+    let bump = Bump::new();
+    let out = compile_jsx(&bump, source, lang, &JsxCompileConfig::default());
+    assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
+    out.module_code().as_str().to_string()
+}
+
+#[test]
+fn destructured_props_are_declared_so_caller_values_reach_the_binding() {
+    let module = module_code(
+        r#"
+        const Counter = ({ label = "TSX", step }) => {
+          const next = step;
+          return <button>{label}{next}</button>;
+        };
+        "#,
+        JsxLang::Jsx,
+    );
+
+    assert!(module.contains(r#"props: ["label", "step"],"#), "{module}");
+    assert!(
+        module.contains(r#"setup({ label = "TSX", step }) {"#),
+        "the default stays in the pattern rather than moving into props: {module}"
+    );
+}
+
+#[test]
+fn a_renamed_binding_declares_the_prop_name_not_the_local_name() {
+    let module = module_code(
+        r#"
+        const Renamed = ({ label: text }) => {
+          const shown = text;
+          return <span>{shown}</span>;
+        };
+        "#,
+        JsxLang::Jsx,
+    );
+
+    assert!(module.contains(r#"props: ["label"],"#), "{module}");
+    assert!(!module.contains(r#""text""#), "{module}");
+}
+
+#[test]
+fn a_rest_element_declares_nothing_rather_than_a_partial_list() {
+    let module = module_code(
+        r#"
+        const Spread = ({ label, ...rest }) => {
+          const extra = rest;
+          return <div>{label}{extra}</div>;
+        };
+        "#,
+        JsxLang::Jsx,
+    );
+
+    assert!(module.contains("setup({ label, ...rest }) {"), "{module}");
+    assert!(!module.contains("props:"), "{module}");
+}
+
+#[test]
+fn a_computed_key_declares_nothing_rather_than_a_partial_list() {
+    let module = module_code(
+        r#"
+        const Computed = ({ label, [dynamic]: value }) => {
+          const shown = value;
+          return <div>{label}{shown}</div>;
+        };
+        "#,
+        JsxLang::Jsx,
+    );
+
+    assert!(!module.contains("props:"), "{module}");
+}
+
+#[test]
+fn a_plain_props_parameter_declares_nothing() {
+    let module = module_code(
+        r#"
+        const Plain = (props) => {
+          const shown = props.label;
+          return <div>{shown}</div>;
+        };
+        "#,
+        JsxLang::Jsx,
+    );
+
+    assert!(module.contains("setup(props) {"), "{module}");
+    assert!(!module.contains("props:"), "{module}");
+}
+
+#[test]
+fn a_parameterless_component_declares_nothing() {
+    let module = module_code(
+        r#"
+        const Standalone = () => {
+          const label = "hi";
+          return <div>{label}</div>;
+        };
+        "#,
+        JsxLang::Jsx,
+    );
+
+    assert!(module.contains("setup() {"), "{module}");
+    assert!(!module.contains("props:"), "{module}");
+}
+
+#[test]
+fn only_the_first_parameter_contributes_prop_names() {
+    let module = module_code(
+        r#"
+        const WithContext = ({ label }, { emit }) => {
+          const shout = () => emit("shout");
+          return <button onClick={shout}>{label}</button>;
+        };
+        "#,
+        JsxLang::Jsx,
+    );
+
+    assert!(module.contains(r#"props: ["label"],"#), "{module}");
+    assert!(!module.contains(r#""emit""#), "{module}");
+}
+
+#[test]
+fn typed_tsx_components_declare_the_destructured_names() {
+    let module = module_code(
+        r#"
+        type Props = { label?: string };
+
+        const Typed = ({ label = "TSX" }: Props) => {
+          const shown = label;
+          return <div>{shown}</div>;
+        };
+        "#,
+        JsxLang::Tsx,
+    );
+
+    assert!(module.contains(r#"props: ["label"],"#), "{module}");
+}

--- a/crates/vize_atelier_jsx/tests/snapshots/module_code__tsx_component_keeps_destructured_props_signature_bindings.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/module_code__tsx_component_keeps_destructured_props_signature_bindings.snap
@@ -13,6 +13,7 @@ import { defineComponent as _defineComponent } from "vue"
 
         const TsxCounter = _defineComponent({
   name: "TsxCounter",
+  props: ["label"],
   setup({ label = "TSX" }: TsxCounterProps, _ctx: Ctx) {
     const count = ref(0);
               const increment = () => count.value++;


### PR DESCRIPTION
## Summary

Stacked on #3862 (which is stacked on #3859) — review those first; this PR's own diff is the `props` option.

#3859 restored the destructured binding, but not its value. Vue only fills `setup`'s first argument with **declared** props, and the generated `_defineComponent` wrapper declares none — so `<Counter label="Hello" />` left `label` at its destructuring default and leaked the passed value into `attrs`, where it rendered as a stray DOM attribute on the root element. CodeRabbit flagged the same gap on #3859.

This reads the prop names off the first parameter's object pattern and emits them as the wrapper's `props` option:

```js
const Counter = _defineComponent({
  name: "Counter",
  props: ["label", "step"],
  setup({ label = "TSX", step }) { … }
});
```

Defaults stay in the destructuring pattern, mirroring how SFC reactive props destructure already behaves, so only the names belong in `props`.

**The list is all-or-nothing.** A pattern whose names are not all statically known — a rest element (`{ label, ...rest }`) or a computed key (`{ [dynamic]: value }`) — declares *nothing* rather than a partial list. A partial list would look authoritative while quietly routing everything it omits to `attrs`, which is a worse failure than today's uniform behavior. A plain `(props)` parameter carries no names and is likewise left alone.

## Change Class

- [x] Compiler and codegen

## Behavior Reference

- Fix request: #3861
- Prior half of the same contract: #3856 / #3859
- Type-first TSX component contract: #1502

## Verification Evidence

```sh
cargo test -p vize_atelier_jsx                                       # 329 passed
cargo clippy -p vize_atelier_jsx -- -D warnings -D clippy::wildcard_imports
cargo fmt --all -- --check
```

New `crates/vize_atelier_jsx/tests/module_props.rs` covers the decision table rather than just the happy path:

| Pattern | Expected |
| --- | --- |
| `{ label = "TSX", step }` | `props: ["label", "step"]`, default stays in the pattern |
| `{ label: text }` | `props: ["label"]` — the prop name, not the local name |
| `{ label, ...rest }` | no `props` — a rest element cannot be enumerated |
| `{ label, [dynamic]: value }` | no `props` — a computed key cannot be enumerated |
| `(props)` | no `props` |
| `()` | no `props` |
| `({ label }, { emit })` | only the first parameter contributes |
| `({ label = "TSX" }: Props)` (tsx) | `props: ["label"]` |

The `tsx_component_keeps_destructured_props_signature_bindings` snapshot moves by one line (`props: ["label"],`), which is the whole behavior change in the issue's own reproducer.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — one line added to one snapshot
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered — one pattern walk per stateful component
- [x] Fuzzing target or crash-reproducer coverage considered
- [x] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

Declaring props changes attribute fallthrough: a name that previously landed in `attrs` (and rendered onto the root element) now arrives as a prop and no longer renders. That is the intended fix — the previous routing was the bug — but it is a visible output change for any JSX component that destructured props.

`ComponentSetupSpan` gains one public field; it is only constructed inside `vize_atelier_jsx`.

Richer declarations (`type`, `required`, `default`) derived from the TS annotation still need Canon and are not attempted here.

The signature readers moved to `finder/signature.rs` — a pure move, needed to keep `finder.rs` inside the 350-line source budget.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->