### PR TITLE
fix(core): treat a slash after a type-argument close as division

### DIFF
--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
@@ -138,9 +138,17 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
                 }
                 can_start_regex = true;
             }
+            // A `>` that pays back an open angle closes a type-argument list, and
+            // a `/` after one is division — OXC never starts a regex there. The
+            // arm used to allow a regex after every `>`, so `Props<{ … }>/(((…`
+            // handed `skip_regex` the rest of the line and hid its bracket run
+            // from the depth budget while OXC kept every paren live and recursed
+            // to a stack overflow (#3858). Only a relational `>`, with no angle
+            // outstanding, can precede a regex (`a > /re/.test(b)`).
             b'>' => {
+                let closed_type_angle = angle_depth > 0;
                 angle_depth = angle_depth.saturating_sub(1);
-                can_start_regex = true;
+                can_start_regex = !closed_type_angle;
             }
             b'@' => {
                 decorator_depth += 1;

--- a/crates/vize_atelier_core/tests/expression_nesting_guard.rs
+++ b/crates/vize_atelier_core/tests/expression_nesting_guard.rs
@@ -263,6 +263,41 @@ fn expression_guard_ends_line_comments_at_every_line_terminator() {
 }
 
 #[test]
+fn expression_guard_treats_slash_after_a_type_argument_close_as_division() {
+    // Minimized from the js_ts_expression fuzz reproducer (#3858), whose
+    // `…Props<{pilest c\n}>/(((…` lines repeat for 2.6 KiB. A `>` that pays back
+    // an open angle closes a type-argument list, and a `/` after one is
+    // division — but the guard used to allow a regex after every `>`, so
+    // `skip_regex` swallowed the rest of each line and hid its bracket run from
+    // the depth budget. The guard reported depth 28 on an input carrying 1394
+    // unclosed brackets, so OXC saw it and recursed until the stack overflowed.
+    let hidden = ["Props<{a}>/", &"(".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1)].concat();
+    assert_eq!(
+        expression_nesting_depth(&hidden),
+        MAX_EXPRESSION_NESTING_DEPTH + 1
+    );
+    assert!(expression_exceeds_max_depth(&hidden));
+    assert!(!expression_has_balanced_delimiters(&hidden));
+    assert!(!expression_is_safe_to_parse(&hidden));
+    assert_eq!(
+        prefix_identifiers_in_expression(&hidden).as_str(),
+        hidden.as_str()
+    );
+
+    // Only the angle-closing `>` loses its regex position. A relational `>` with
+    // nothing outstanding still precedes one, so the brackets inside stay hidden.
+    let relational = [
+        "a > /",
+        &"(".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1),
+        "/.test(b)",
+    ]
+    .concat();
+    assert_eq!(expression_nesting_depth(&relational), 1);
+    assert!(!expression_exceeds_max_depth(&relational));
+    assert!(expression_is_safe_to_parse(&relational));
+}
+
+#[test]
 fn expression_guard_ends_regex_at_line_terminator_after_backslash() {
     // A regex literal cannot span a line terminator, and `\` immediately before
     // one is not a valid escape: the lexer ends the regex there. The guard's


### PR DESCRIPTION
## Summary

The `js_ts_expression` reproducer from #3858 is a real hole in our own recursion guard, not an upstream OXC class — replayed locally it does not merely time out, it **overflows the stack**.

The 2.6 KiB input repeats lines shaped like:

```
…mbofneProps<{pilest c
}>/((((((((((((((((((((((((((((((fbodtPqXX(((((…
```

`analyze_expression_nesting` allowed a regex literal after *every* `>`, so each `/` there opened a "regex" that `skip_regex` ran to the end of the line, swallowing the paren run with it. The guard therefore reported:

```
depth=28  balanced=true  safe=true      ← guard
max_depth=1394 unclosed brackets        ← the actual text
```

`expression_is_safe_to_parse` said yes, OXC saw all 1394 live parens, and recursed until the stack overflowed.

A `>` that pays back an open angle closes a type-argument list, and a `/` after one is division — OXC never starts a regex there. Only a relational `>`, with no angle outstanding, can precede a regex (`a > /re/.test(b)`). Tracking that distinction is a two-line change, since the scanner already maintains `angle_depth`:

```rust
b'>' => {
    let closed_type_angle = angle_depth > 0;
    angle_depth = angle_depth.saturating_sub(1);
    can_start_regex = !closed_type_angle;
```

With it the reproducer scans to `depth=1454 balanced=false safe=false`, so the guard rejects it and OXC never sees it.

This also fixes an ordinary mis-scan on the way: `x as Foo<Bar> / 2` previously had everything after the `/` swallowed as regex text.

## Change Class

- [x] Semantic analysis, lint, and cross-file analysis

## Behavior Reference

- Fuzz report: #3858 (artifact `fuzz-reproducers-js_ts_expression`, `timeout-7ab61b1664f497b8d1062ff524b3a3fe0fd7a3cd`, 2615 bytes)
- Same class of guard hole, previously fixed: #3107 (`\` before `/`), #3213 (unterminated string), #3185 (bare CR in a line comment), #3271 / #3274 (quote and backtick swallowing bracket runs)

## Verification Evidence

```sh
cargo test --workspace
cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
cargo fmt --all -- --check
```

Verified directly against the downloaded artifact before and after: guard `safe=true` → stack overflow, then guard `safe=false` → OXC never invoked.

`expression_guard_treats_slash_after_a_type_argument_close_as_division` in `crates/vize_atelier_core/tests/expression_nesting_guard.rs` carries the minimized shape (`Props<{a}>/(((…`), matching how every earlier reproducer in that file is pinned, and asserts both directions:

- the type-argument close now exposes its bracket run to the depth budget
- a relational `>` still precedes a regex, so `a > /(((…/.test(b)` stays at depth 1 and stays parseable

## Risk

The guard now counts brackets it previously skipped, so it can only reject *more*. The reachable false-rejection is an expression that closes a type argument, then opens a regex containing 32+ unbalanced brackets — `a<b > /(((…/` — which needs both an angle-closing `>` and a pathological regex body. Ordinary generic calls (`foo<Bar>(x)`) are unaffected, and the division reading is what OXC already does.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — none
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered — closes a reachable stack overflow on attacker-influenced template expressions
- [x] Performance status or PR benchmark impact considered — one comparison per `>`
- [x] Fuzzing target or crash-reproducer coverage considered — this is that coverage
- [x] Editor/LSP scenario coverage considered — the guard is shared by every expression entry point
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

Closes #3858

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of expressions containing type arguments and division operators.
  * Prevented certain complex expressions from being misinterpreted as regular expressions, improving bracket tracking and parser stability.

* **Tests**
  * Added regression coverage for type-argument closures, division operators, relational operators, and nested brackets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->