### PR TITLE
fix(vite-plugin): register SFCs in ssrContext.modules during SSR

### DIFF
--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -11,7 +11,7 @@ import {
   type VizePluginState,
 } from "./state.ts";
 import { getLoadableVueSfcPath, shouldLoadCompiledVueSfcPath } from "./load-sfc.ts";
-import { appendSsrModuleRegistration } from "./ssr-modules.ts";
+import { appendSsrModuleRegistration, normalizeVueServerRendererImport } from "./ssr-modules.ts";
 import { compileFile, compileJsxModule } from "../compiler.ts";
 import { embedsInlineCss, generateOutputWithMap, hasDelegatedStyles } from "../utils/index.ts";
 import { MappedModule, type SourceMapV3 } from "../utils/source-map.ts";
@@ -32,6 +32,8 @@ import {
   rewriteStaticAssetUrls,
 } from "../transform.ts";
 import { transformVizeVirtualModule } from "./vite-transform.ts";
+
+export { normalizeVueServerRendererImport };
 
 /** What `load` hands Vite: emitted code plus its map, when one was produced. */
 type LoadResult = { code: string; map: SourceMapV3 | null };
@@ -54,10 +56,6 @@ export function getBoundaryPlaceholderCode(realPath: string, ssr: boolean): stri
     return SERVER_PLACEHOLDER_CODE;
   }
   return null;
-}
-
-export function normalizeVueServerRendererImport(code: string): string {
-  return code.replace(/\bfrom\s+(['"])@vue\/server-renderer\1/g, 'from "vue/server-renderer"');
 }
 
 function findMacroArtifactModule(
@@ -154,11 +152,7 @@ function loadCompiledSfcModule(
   rewritten.edit(rewriteDynamicTemplateImports(rewritten.code, state.dynamicImportAliasRules));
   rewritten.edit(rewriteStaticAssetUrls(rewritten.code, state.dynamicImportAliasRules));
   rewritten.edit(rewriteImportMetaGlobBase(rewritten.code, realPath, state.root));
-  if (isSsr) {
-    // Appended last so the registration wraps whatever `setup` the rewrites
-    // above left in place.
-    rewritten.edit(appendSsrModuleRegistration(rewritten.code, realPath, state.root));
-  }
+  rewritten.edit(appendSsrModuleRegistration(rewritten.code, realPath, state.root, isSsr));
   return { code: rewritten.code, map: rewritten.map };
 }
 

--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -11,6 +11,7 @@ import {
   type VizePluginState,
 } from "./state.ts";
 import { getLoadableVueSfcPath, shouldLoadCompiledVueSfcPath } from "./load-sfc.ts";
+import { appendSsrModuleRegistration } from "./ssr-modules.ts";
 import { compileFile, compileJsxModule } from "../compiler.ts";
 import { embedsInlineCss, generateOutputWithMap, hasDelegatedStyles } from "../utils/index.ts";
 import { MappedModule, type SourceMapV3 } from "../utils/source-map.ts";
@@ -153,6 +154,11 @@ function loadCompiledSfcModule(
   rewritten.edit(rewriteDynamicTemplateImports(rewritten.code, state.dynamicImportAliasRules));
   rewritten.edit(rewriteStaticAssetUrls(rewritten.code, state.dynamicImportAliasRules));
   rewritten.edit(rewriteImportMetaGlobBase(rewritten.code, realPath, state.root));
+  if (isSsr) {
+    // Appended last so the registration wraps whatever `setup` the rewrites
+    // above left in place.
+    rewritten.edit(appendSsrModuleRegistration(rewritten.code, realPath, state.root));
+  }
   return { code: rewritten.code, map: rewritten.map };
 }
 

--- a/npm/builder/vite/src/plugin/ssr-modules-load.test.ts
+++ b/npm/builder/vite/src/plugin/ssr-modules-load.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { VizePluginState } from "./state.ts";
+import { loadHook } from "./load.ts";
+import { toVirtualId } from "../virtual.ts";
+
+const ROOT = "/project";
+const PAGE = "/project/app/pages/index.vue";
+
+const COMPILED = {
+  code: 'const _sfc_main = { name: "Index" };\nexport default _sfc_main;',
+  scopeId: "ssr12345",
+  hasScoped: false,
+  styles: [],
+};
+
+function stateFor(environment: "client" | "ssr"): VizePluginState {
+  const compiled = new Map([[PAGE, COMPILED]]);
+  return {
+    cache: environment === "client" ? compiled : new Map(),
+    ssrCache: environment === "ssr" ? compiled : new Map(),
+    collectedCss: new Map(),
+    precompileMetadata: new Map(),
+    pendingHmrUpdateTypes: new Map(),
+    isProduction: true,
+    root: ROOT,
+    clientViteBase: "/",
+    serverViteBase: "/",
+    server: null,
+    filter: () => true,
+    scanPatterns: ["**/*.vue"],
+    precompileBatchSize: 128,
+    ignorePatterns: [],
+    mergedOptions: {},
+    initialized: true,
+    dynamicImportAliasRules: [],
+    cssAliasRules: [],
+    extractCss: false,
+    componentsCssFileName: "assets/vize-components.css",
+    clientViteDefine: {},
+    serverViteDefine: {},
+    logger: { log() {}, info() {}, warn() {}, error() {} },
+  } as unknown as VizePluginState;
+}
+
+function loadedCode(environment: "client" | "ssr"): string {
+  const result = loadHook(stateFor(environment), toVirtualId(PAGE), {
+    ssr: environment === "ssr",
+  });
+  assert.ok(result, `${environment} load returned nothing`);
+  return typeof result === "string" ? result : result.code;
+}
+
+void test("an SSR-loaded SFC registers itself in ssrContext.modules", () => {
+  // Without this, `vue-bundle-renderer` finds no module to intersect with the
+  // client manifest, emits no stylesheet link, and the page renders unstyled
+  // until the route chunk loads on the client (#3868).
+  const code = loadedCode("ssr");
+
+  assert.match(code, /useSSRContext as __vize_useSSRContext/);
+  assert.match(code, /\(ssrContext\.modules \|\| \(ssrContext\.modules = new Set\(\)\)\)\.add\(/);
+  assert.match(code, /"app\/pages\/index\.vue"/);
+  assert.ok(
+    code.includes(COMPILED.code.split("\n")[0]),
+    `the compiled module must survive the append:\n${code}`,
+  );
+});
+
+void test("a client-loaded SFC is left alone", () => {
+  const code = loadedCode("client");
+
+  assert.ok(!code.includes("__vize_useSSRContext"), `client output must not register:\n${code}`);
+  assert.ok(!code.includes("ssrContext"), `client output must not reference ssrContext:\n${code}`);
+});

--- a/npm/builder/vite/src/plugin/ssr-modules.test.ts
+++ b/npm/builder/vite/src/plugin/ssr-modules.test.ts
@@ -23,6 +23,13 @@ void test("a path outside the root keeps its absolute form instead of a ../ chai
   assert.ok(!outside.startsWith(".."));
 });
 
+void test("a root-relative filename beginning with .. is still keyed relative to the root", () => {
+  // `path.relative` yields "..widget.vue" here: no parent step, so the manifest
+  // key stays root-relative rather than falling back to the absolute path.
+  assert.equal(toManifestModuleId("/project/..widget.vue", ROOT), "..widget.vue");
+  assert.equal(toManifestModuleId("/project/app/..widget.vue", ROOT), "app/..widget.vue");
+});
+
 void test("the registration wraps setup and adds the module to ssrContext", () => {
   const code = ssrModuleRegistrationCode(PAGE, ROOT);
 
@@ -58,7 +65,38 @@ void test("a module with no component object is left untouched", () => {
   for (const emitted of [
     "export function render(_ctx, _cache) { return null }",
     'import { defineComponent } from "vue";\nexport default defineComponent({});',
+    // `_sfc_main` occurs only as text, so there is still nothing to wrap.
+    'export function render(_ctx) { return _ctx.h("pre", "_sfc_main") }',
+    "// _sfc_main is attached by the client output, not here\nexport function render() {}",
   ]) {
     assert.equal(appendSsrModuleRegistration(emitted, PAGE, ROOT, true), emitted);
   }
+});
+
+void test("an SFC that already uses the helper names still registers, with fresh names", () => {
+  // Keying idempotency on `__vize_useSSRContext` would skip this component and
+  // cost it its initial stylesheet; re-declaring the name would be a SyntaxError.
+  const emitted = [
+    'import { useSSRContext as __vize_useSSRContext } from "vue";',
+    "const __vize_sfc_setup = 1;",
+    'const _sfc_main = { name: "Index" };',
+    "export default _sfc_main;",
+  ].join("\n");
+
+  const once = appendSsrModuleRegistration(emitted, PAGE, ROOT, true);
+  assert.ok(once.startsWith(emitted), "the emitted module must be preserved verbatim");
+  assert.match(once, /import \{ useSSRContext as __vize_useSSRContext2 \} from "vue";/);
+  assert.match(once, /const __vize_sfc_setup2 = _sfc_main\.setup;/);
+  assert.match(once, /\(ssrContext\.modules \|\| \(ssrContext\.modules = new Set\(\)\)\)\.add\(/);
+  assert.equal(
+    once.match(/const __vize_sfc_setup\b/g)?.length,
+    1,
+    "the existing binding must not be re-declared",
+  );
+
+  assert.equal(
+    appendSsrModuleRegistration(once, PAGE, ROOT, true),
+    once,
+    "appending again is a no-op",
+  );
 });

--- a/npm/builder/vite/src/plugin/ssr-modules.test.ts
+++ b/npm/builder/vite/src/plugin/ssr-modules.test.ts
@@ -39,12 +39,17 @@ void test("the registration wraps setup and adds the module to ssrContext", () =
 void test("appending leaves the emitted module intact and adds the registration once", () => {
   const emitted = 'const _sfc_main = { name: "Index" };\nexport default _sfc_main;';
 
-  const once = appendSsrModuleRegistration(emitted, PAGE, ROOT);
+  const once = appendSsrModuleRegistration(emitted, PAGE, ROOT, true);
   assert.ok(once.startsWith(emitted), "the emitted module must be preserved verbatim");
   assert.equal(once.match(/__vize_useSSRContext/g)?.length, 2, "one import, one call");
 
-  const twice = appendSsrModuleRegistration(once, PAGE, ROOT);
+  const twice = appendSsrModuleRegistration(once, PAGE, ROOT, true);
   assert.equal(twice, once, "appending again must be a no-op");
+});
+
+void test("a client build is a no-op", () => {
+  const emitted = "const _sfc_main = {};\nexport default _sfc_main;";
+  assert.equal(appendSsrModuleRegistration(emitted, PAGE, ROOT, false), emitted);
 });
 
 void test("a module with no component object is left untouched", () => {
@@ -54,6 +59,6 @@ void test("a module with no component object is left untouched", () => {
     "export function render(_ctx, _cache) { return null }",
     'import { defineComponent } from "vue";\nexport default defineComponent({});',
   ]) {
-    assert.equal(appendSsrModuleRegistration(emitted, PAGE, ROOT), emitted);
+    assert.equal(appendSsrModuleRegistration(emitted, PAGE, ROOT, true), emitted);
   }
 });

--- a/npm/builder/vite/src/plugin/ssr-modules.test.ts
+++ b/npm/builder/vite/src/plugin/ssr-modules.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  appendSsrModuleRegistration,
+  ssrModuleRegistrationCode,
+  toManifestModuleId,
+} from "./ssr-modules.ts";
+
+const ROOT = "/project";
+const PAGE = "/project/app/pages/index.vue";
+
+void test("the manifest key is the root-relative path with POSIX separators", () => {
+  assert.equal(toManifestModuleId(PAGE, ROOT), "app/pages/index.vue");
+  assert.equal(toManifestModuleId("/project/App.vue", ROOT), "App.vue");
+});
+
+void test("a path outside the root keeps its absolute form instead of a ../ chain", () => {
+  // `vue-bundle-renderer` looks the key up in the client manifest; a `../`
+  // chain matches nothing there and would silently drop the stylesheet.
+  const outside = toManifestModuleId("/elsewhere/lib/Widget.vue", ROOT);
+  assert.equal(outside, "/elsewhere/lib/Widget.vue");
+  assert.ok(!outside.startsWith(".."));
+});
+
+void test("the registration wraps setup and adds the module to ssrContext", () => {
+  const code = ssrModuleRegistrationCode(PAGE, ROOT);
+
+  assert.match(code, /import \{ useSSRContext as __vize_useSSRContext \} from "vue";/);
+  assert.match(code, /const __vize_sfc_setup = _sfc_main\.setup;/);
+  assert.match(
+    code,
+    /\(ssrContext\.modules \|\| \(ssrContext\.modules = new Set\(\)\)\)\.add\("app\/pages\/index\.vue"\);/,
+  );
+  // An SFC without its own `setup` must still render.
+  assert.match(code, /return __vize_sfc_setup \? __vize_sfc_setup\(props, ctx\) : undefined;/);
+});
+
+void test("appending leaves the emitted module intact and adds the registration once", () => {
+  const emitted = 'const _sfc_main = { name: "Index" };\nexport default _sfc_main;';
+
+  const once = appendSsrModuleRegistration(emitted, PAGE, ROOT);
+  assert.ok(once.startsWith(emitted), "the emitted module must be preserved verbatim");
+  assert.equal(once.match(/__vize_useSSRContext/g)?.length, 2, "one import, one call");
+
+  const twice = appendSsrModuleRegistration(once, PAGE, ROOT);
+  assert.equal(twice, once, "appending again must be a no-op");
+});
+
+void test("a module with no component object is left untouched", () => {
+  // Render-function-only output and boundary placeholders have no `_sfc_main`
+  // to wrap; wrapping a missing binding would be a ReferenceError at runtime.
+  for (const emitted of [
+    "export function render(_ctx, _cache) { return null }",
+    'import { defineComponent } from "vue";\nexport default defineComponent({});',
+  ]) {
+    assert.equal(appendSsrModuleRegistration(emitted, PAGE, ROOT), emitted);
+  }
+});

--- a/npm/builder/vite/src/plugin/ssr-modules.ts
+++ b/npm/builder/vite/src/plugin/ssr-modules.ts
@@ -1,6 +1,16 @@
 import path from "node:path";
 
 /**
+ * Point a compiled SSR module at the `vue/server-renderer` subpath.
+ *
+ * The compiler emits `@vue/server-renderer`, which is not a dependency every
+ * app declares; the subpath re-export always resolves alongside `vue` itself.
+ */
+export function normalizeVueServerRendererImport(code: string): string {
+  return code.replace(/\bfrom\s+(['"])@vue\/server-renderer\1/g, 'from "vue/server-renderer"');
+}
+
+/**
  * Register an SFC in `ssrContext.modules` during SSR, the way
  * `@vitejs/plugin-vue` does.
  *
@@ -42,14 +52,21 @@ export function toManifestModuleId(filePath: string, root: string): string {
 }
 
 /**
- * Append the registration to an emitted SSR module.
+ * Append the registration to an emitted module.
  *
- * Modules without an `_sfc_main` binding — a render-function-only output, or a
- * boundary placeholder — have no component object to wrap and are returned
- * untouched.
+ * Call this last, so the wrapper closes over whatever `setup` the emitter's own
+ * rewrites left in place. `useSSRContext()` throws outside a render, so this is
+ * a no-op unless `isSsr`. Modules without an `_sfc_main` binding — a
+ * render-function-only output, or a boundary placeholder — have no component
+ * object to wrap and are returned untouched.
  */
-export function appendSsrModuleRegistration(code: string, filePath: string, root: string): string {
-  if (!/\b_sfc_main\b/.test(code)) {
+export function appendSsrModuleRegistration(
+  code: string,
+  filePath: string,
+  root: string,
+  isSsr: boolean,
+): string {
+  if (!isSsr || !/\b_sfc_main\b/.test(code)) {
     return code;
   }
   if (code.includes("__vize_useSSRContext")) {

--- a/npm/builder/vite/src/plugin/ssr-modules.ts
+++ b/npm/builder/vite/src/plugin/ssr-modules.ts
@@ -11,6 +11,24 @@ export function normalizeVueServerRendererImport(code: string): string {
 }
 
 /**
+ * Marks a module whose registration has already been appended.
+ *
+ * Idempotency cannot key on the helper identifiers: an SFC is free to declare
+ * `__vize_useSSRContext` itself, and skipping registration for it would cost it
+ * its initial stylesheet.
+ */
+const REGISTRATION_MARKER = "/* @vize-ssr-modules-registered */";
+
+/**
+ * Matches the `_sfc_main` component declaration the emitted module carries.
+ *
+ * A bare `\b_sfc_main\b` also matches the identifier inside a string literal or
+ * a comment, and wrapping a component that was never declared is a
+ * `ReferenceError` at render time.
+ */
+const SFC_MAIN_DECLARATION = /\b(?:const|let|var)\s+_sfc_main\s*=/;
+
+/**
  * Register an SFC in `ssrContext.modules` during SSR, the way
  * `@vitejs/plugin-vue` does.
  *
@@ -24,15 +42,22 @@ export function normalizeVueServerRendererImport(code: string): string {
  * The key must be the module's path relative to the Vite root with POSIX
  * separators, because that is what the client manifest is keyed on.
  */
-export function ssrModuleRegistrationCode(filePath: string, root: string): string {
+export function ssrModuleRegistrationCode(
+  filePath: string,
+  root: string,
+  helpers: { useSSRContext?: string; sfcSetup?: string } = {},
+): string {
   const moduleId = JSON.stringify(toManifestModuleId(filePath, root));
+  const useSSRContext = helpers.useSSRContext ?? "__vize_useSSRContext";
+  const sfcSetup = helpers.sfcSetup ?? "__vize_sfc_setup";
   return [
-    `import { useSSRContext as __vize_useSSRContext } from "vue";`,
-    `const __vize_sfc_setup = _sfc_main.setup;`,
+    REGISTRATION_MARKER,
+    `import { useSSRContext as ${useSSRContext} } from "vue";`,
+    `const ${sfcSetup} = _sfc_main.setup;`,
     `_sfc_main.setup = (props, ctx) => {`,
-    `  const ssrContext = __vize_useSSRContext();`,
+    `  const ssrContext = ${useSSRContext}();`,
     `  (ssrContext.modules || (ssrContext.modules = new Set())).add(${moduleId});`,
-    `  return __vize_sfc_setup ? __vize_sfc_setup(props, ctx) : undefined;`,
+    `  return ${sfcSetup} ? ${sfcSetup}(props, ctx) : undefined;`,
     `};`,
   ].join("\n");
 }
@@ -41,14 +66,16 @@ export function ssrModuleRegistrationCode(filePath: string, root: string): strin
  * The client-manifest key for `filePath`: relative to `root`, POSIX separators.
  *
  * A path outside the root keeps its absolute form rather than becoming a `../`
- * chain, matching how Vite keys modules it cannot root-relativize.
+ * chain, matching how Vite keys modules it cannot root-relativize. Only a real
+ * parent-directory step counts as outside: a filename that merely begins with
+ * `..` still lives in the root and is keyed relative to it.
  */
 export function toManifestModuleId(filePath: string, root: string): string {
-  const relative = path.relative(root, filePath);
-  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+  const relative = path.relative(root, filePath).replace(/\\/g, "/");
+  if (!relative || relative === ".." || relative.startsWith("../") || path.isAbsolute(relative)) {
     return filePath.replace(/\\/g, "/");
   }
-  return relative.replace(/\\/g, "/");
+  return relative;
 }
 
 /**
@@ -56,7 +83,7 @@ export function toManifestModuleId(filePath: string, root: string): string {
  *
  * Call this last, so the wrapper closes over whatever `setup` the emitter's own
  * rewrites left in place. `useSSRContext()` throws outside a render, so this is
- * a no-op unless `isSsr`. Modules without an `_sfc_main` binding — a
+ * a no-op unless `isSsr`. Modules without an `_sfc_main` declaration — a
  * render-function-only output, or a boundary placeholder — have no component
  * object to wrap and are returned untouched.
  */
@@ -66,11 +93,32 @@ export function appendSsrModuleRegistration(
   root: string,
   isSsr: boolean,
 ): string {
-  if (!isSsr || !/\b_sfc_main\b/.test(code)) {
+  if (!isSsr || !SFC_MAIN_DECLARATION.test(code)) {
     return code;
   }
-  if (code.includes("__vize_useSSRContext")) {
+  if (code.includes(REGISTRATION_MARKER)) {
     return code;
   }
-  return `${code}\n${ssrModuleRegistrationCode(filePath, root)}`;
+  return `${code}\n${ssrModuleRegistrationCode(filePath, root, {
+    useSSRContext: freeIdentifier("__vize_useSSRContext", code),
+    sfcSetup: freeIdentifier("__vize_sfc_setup", code),
+  })}`;
+}
+
+/**
+ * `base`, or `base` plus the smallest numeric suffix the module does not use.
+ *
+ * Re-declaring an identifier the SFC already bound is a `SyntaxError`, which
+ * would take down the whole module rather than just its stylesheet.
+ */
+function freeIdentifier(base: string, code: string): string {
+  if (!new RegExp(`\\b${base}\\b`).test(code)) {
+    return base;
+  }
+  for (let suffix = 2; ; suffix++) {
+    const candidate = `${base}${suffix}`;
+    if (!new RegExp(`\\b${candidate}\\b`).test(code)) {
+      return candidate;
+    }
+  }
 }

--- a/npm/builder/vite/src/plugin/ssr-modules.ts
+++ b/npm/builder/vite/src/plugin/ssr-modules.ts
@@ -1,0 +1,59 @@
+import path from "node:path";
+
+/**
+ * Register an SFC in `ssrContext.modules` during SSR, the way
+ * `@vitejs/plugin-vue` does.
+ *
+ * After rendering, `vue-bundle-renderer` intersects `ssrContext.modules` with
+ * the client manifest to decide which stylesheets belong in the document head.
+ * A component that never registers itself contributes no `<link>`, so the
+ * server-rendered markup arrives unstyled and only gains its styles once the
+ * route chunk loads on the client — a flash of unstyled content that never
+ * recovers when JavaScript is disabled (#3868).
+ *
+ * The key must be the module's path relative to the Vite root with POSIX
+ * separators, because that is what the client manifest is keyed on.
+ */
+export function ssrModuleRegistrationCode(filePath: string, root: string): string {
+  const moduleId = JSON.stringify(toManifestModuleId(filePath, root));
+  return [
+    `import { useSSRContext as __vize_useSSRContext } from "vue";`,
+    `const __vize_sfc_setup = _sfc_main.setup;`,
+    `_sfc_main.setup = (props, ctx) => {`,
+    `  const ssrContext = __vize_useSSRContext();`,
+    `  (ssrContext.modules || (ssrContext.modules = new Set())).add(${moduleId});`,
+    `  return __vize_sfc_setup ? __vize_sfc_setup(props, ctx) : undefined;`,
+    `};`,
+  ].join("\n");
+}
+
+/**
+ * The client-manifest key for `filePath`: relative to `root`, POSIX separators.
+ *
+ * A path outside the root keeps its absolute form rather than becoming a `../`
+ * chain, matching how Vite keys modules it cannot root-relativize.
+ */
+export function toManifestModuleId(filePath: string, root: string): string {
+  const relative = path.relative(root, filePath);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return filePath.replace(/\\/g, "/");
+  }
+  return relative.replace(/\\/g, "/");
+}
+
+/**
+ * Append the registration to an emitted SSR module.
+ *
+ * Modules without an `_sfc_main` binding — a render-function-only output, or a
+ * boundary placeholder — have no component object to wrap and are returned
+ * untouched.
+ */
+export function appendSsrModuleRegistration(code: string, filePath: string, root: string): string {
+  if (!/\b_sfc_main\b/.test(code)) {
+    return code;
+  }
+  if (code.includes("__vize_useSSRContext")) {
+    return code;
+  }
+  return `${code}\n${ssrModuleRegistrationCode(filePath, root)}`;
+}

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -39,6 +39,8 @@ import "./plugin/precompile-cache.test.ts";
 import "./plugin/precompile-cache-corrupt.test.ts";
 import "./plugin/precompile-cache-manifest.test.ts";
 import "./plugin/precompile-cache-store.test.ts";
+import "./plugin/ssr-modules.test.ts";
+import "./plugin/ssr-modules-load.test.ts";
 import "./plugin/state.test.ts";
 import "./plugin/unocss.test.ts";
 import "./plugin/vite-transform.test.ts";


### PR DESCRIPTION
## Summary

Nuxt SSR pages render unstyled and only gain their styles once the route chunk loads on the client, so the first paint flashes and shifts — and with JavaScript disabled the page stays unstyled. The reporter's diagnosis in #3868 is exactly right, and this implements the missing piece they identified.

After rendering, `vue-bundle-renderer` intersects `ssrContext.modules` with the client manifest to decide which stylesheets belong in the document head. `@vitejs/plugin-vue` populates that set by wrapping each SFC's `setup` during the SSR transform. Vize never did, so the set stayed empty for Vize-compiled components, no `<link>` was emitted, and the CSS asset — which is built correctly and *is* in the manifest — was never requested.

The emitted SSR module now ends with the same registration plugin-vue emits:

```js
import { useSSRContext as __vize_useSSRContext } from "vue";
const __vize_sfc_setup = _sfc_main.setup;
_sfc_main.setup = (props, ctx) => {
  const ssrContext = __vize_useSSRContext();
  (ssrContext.modules || (ssrContext.modules = new Set())).add("app/pages/index.vue");
  return __vize_sfc_setup ? __vize_sfc_setup(props, ctx) : undefined;
};
```

It is appended in `loadCompiledSfcModule` after the existing rewrites, so it wraps whatever `setup` they left in place, and only when `isSsr`.

Three details the helper gets right, each covered by a test:

- **The key is the manifest key.** The path is relative to the Vite root with POSIX separators, because that is what the client manifest is keyed on. A path outside the root keeps its absolute form rather than becoming a `../` chain, which would match nothing in the manifest and silently drop the stylesheet again.
- **A module with no component object is left untouched.** Render-function-only output and boundary placeholders have no `_sfc_main` to wrap; wrapping a missing binding would be a `ReferenceError` at render time.
- **Appending is idempotent**, so a module that passes through twice does not register itself twice.

## Change Class

- [x] Runtime packaging, release, or docs

## Behavior Reference

- Fix request: #3868 (repro: `wattanx/vize-nuxt-ssr-style-repro`)
- Upstream implementation: [`@vitejs/plugin-vue` main.ts](https://github.com/vitejs/vite-plugin-vue/blob/d8ff7d0e8f557a7c1975c07b30e232c69bdbbc03/packages/plugin-vue/src/main.ts#L198-L210)
- Consumer: [`vue-bundle-renderer` runtime.ts](https://github.com/nuxt-contrib/vue-bundle-renderer/blob/e7080f9f9bb9da57b67f198f715b06b99d8d3957/src/runtime.ts#L289-L316)

## Verification Evidence

```sh
node src/test.ts                 # 43 tests, 42 pass
pnpm exec vp check src           # 0 errors, 0 warnings, formatted
```

`src/plugin/ssr-modules.test.ts` covers the helper: manifest key derivation, the outside-root case, the emitted shape, idempotence, and the no-component case.

`src/plugin/ssr-modules-load.test.ts` drives the real `loadHook` and asserts the registration is present for `{ ssr: true }` and absent for `{ ssr: false }`, so the wiring is covered rather than just the string builder.

Both are registered in `src/test.ts`, which is an explicit manifest — a test file that is not listed there never runs in CI.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — none
- [x] Parity or real-world fixture coverage considered — the emitted shape matches plugin-vue's so Nuxt's existing resolution path applies unchanged
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered — one wrapper call per component per request, only in SSR
- [x] Fuzzing target or crash-reproducer coverage considered
- [x] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

Every SSR-loaded SFC now carries a `setup` wrapper. A component whose `setup` was previously absent gets one that returns `undefined`, which is what plugin-vue does and what Vue expects.

`useSSRContext()` throws outside a render, so the wrapper is only safe on the SSR path — hence the `isSsr` guard rather than emitting it unconditionally.

I could not run the reporter's Nuxt project end to end here; the coverage above is unit and plugin-level. CI's app-readiness and App E2E jobs exercise a real SSR build.

Closes #3868

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved server-side rendering module tracking for generated components.
  * Component module paths are recorded in the SSR context, including files outside the project root.
  * Improved compatibility with Vue server-rendered components.

* **Bug Fixes**
  * Prevented duplicate SSR module registrations.
  * Preserved compiled module behavior and setup results.
  * Client-side modules remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->