### PR TITLE
fix(vite-plugin): skip SSR module registration without a context

### DIFF
--- a/npm/builder/vite/src/plugin/ssr-modules.test.ts
+++ b/npm/builder/vite/src/plugin/ssr-modules.test.ts
@@ -35,10 +35,17 @@ void test("the registration wraps setup and adds the module to ssrContext", () =
 
   assert.match(code, /import \{ useSSRContext as __vize_useSSRContext \} from "vue";/);
   assert.match(code, /const __vize_sfc_setup = _sfc_main\.setup;/);
+  // `useSSRContext()` returns undefined outside a request render. Dereferencing
+  // it there is a TypeError inside setup, which fails the whole prerender with a
+  // bare 500 rather than just losing a stylesheet link.
+  assert.match(code, /if \(ssrContext\) \{/);
   assert.match(
     code,
     /\(ssrContext\.modules \|\| \(ssrContext\.modules = new Set\(\)\)\)\.add\("app\/pages\/index\.vue"\);/,
   );
+  // `useSSRContext()` is undefined outside a request render; dereferencing it
+  // there is a TypeError that fails the whole prerender.
+  assert.match(code, /if \(ssrContext\) \{/);
   // An SFC without its own `setup` must still render.
   assert.match(code, /return __vize_sfc_setup \? __vize_sfc_setup\(props, ctx\) : undefined;/);
 });

--- a/npm/builder/vite/src/plugin/ssr-modules.ts
+++ b/npm/builder/vite/src/plugin/ssr-modules.ts
@@ -41,6 +41,13 @@ const SFC_MAIN_DECLARATION = /\b(?:const|let|var)\s+_sfc_main\s*=/;
  *
  * The key must be the module's path relative to the Vite root with POSIX
  * separators, because that is what the client manifest is keyed on.
+ *
+ * `useSSRContext()` returns `undefined` when nothing provided a context — a
+ * component rendered outside Nuxt's request render, such as by a prerender-time
+ * module doing its own `renderToString`. Dereferencing that is a `TypeError`
+ * inside `setup`, which surfaces as a bare `[500] Server Error` and fails the
+ * whole prerender, so the registration is skipped instead. Such a render has no
+ * manifest consumer waiting on `modules`, so there is nothing to lose.
  */
 export function ssrModuleRegistrationCode(
   filePath: string,
@@ -56,7 +63,9 @@ export function ssrModuleRegistrationCode(
     `const ${sfcSetup} = _sfc_main.setup;`,
     `_sfc_main.setup = (props, ctx) => {`,
     `  const ssrContext = ${useSSRContext}();`,
-    `  (ssrContext.modules || (ssrContext.modules = new Set())).add(${moduleId});`,
+    `  if (ssrContext) {`,
+    `    (ssrContext.modules || (ssrContext.modules = new Set())).add(${moduleId});`,
+    `  }`,
     `  return ${sfcSetup} ? ${sfcSetup}(props, ctx) : undefined;`,
     `};`,
   ].join("\n");


### PR DESCRIPTION
## Summary

The SSR module registration added in #3870 dereferences `useSSRContext()` unconditionally:

```js
const ssrContext = __vize_useSSRContext();
(ssrContext.modules || (ssrContext.modules = new Set())).add("app/pages/index.vue");
```

Vue returns `undefined` from `useSSRContext()` when nothing provided a context — a component rendered outside the request render, such as a prerender-time Nuxt module doing its own `renderToString`. That makes the write a `TypeError` **inside `setup`**, which surfaces as a bare `[500] Server Error` and fails the entire prerender rather than merely losing a stylesheet link.

`@vitejs/plugin-vue` is unguarded here too, but that is not a reason to copy the hazard: the downside of guarding is nil. A render with no context has no manifest consumer waiting on `modules`.

## Change Class

- [x] Runtime packaging, release, or docs

## Behavior Reference

- Introduced in #3870 / #3868
- `useSSRContext` returning `undefined` without a provided context: `@vue/runtime-core`

## Verification Evidence

```sh
node --test src/plugin/ssr-modules.test.ts src/plugin/ssr-modules-load.test.ts   # 10 pass
pnpm exec vp check src                                                          # 0 errors, 0 warnings
```

The emitted-shape test now asserts the guard is present, so the hazard cannot come back silently.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — none
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered — one truthiness check per component per SSR render
- [x] Fuzzing target or crash-reproducer coverage considered
- [x] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

Strictly narrowing: the only behavior change is that a render without an SSR context no longer throws. Registration is unchanged wherever a context exists, which is every Nuxt request render.

## Note on how this was found

App E2E only runs on tags, not PRs — `app-e2e (\${{ matrix.suite }})` is **skipped** on `pull_request`. So #3870 never exercised a real Nuxt prerender before landing, and the failure first appeared on the v0.328.0 tag, where `vuefes-2025 build` went from ✔ (v0.327.0) to ✖. Nothing was published — the preflight gate blocked every publish job.

I am re-running the tag's App E2E in parallel to confirm the failure is deterministic rather than a flake; this guard is correct either way.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering stability when no SSR context is available.
  * Prevented module registration from attempting to access missing rendering context data.
  * Preserved existing module tracking when an SSR context is present.

* **Tests**
  * Added coverage for rendering scenarios without an SSR context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->