### PR TITLE
fix(core): do not skip an unterminated regex literal

### DIFF
--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
@@ -81,10 +81,20 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
                 i = skip_block_comment(bytes, i + 2);
                 continue;
             }
+            // A regex literal that never closes is not one: the lexer reports an
+            // unterminated regex and recovers, so the bytes stay live for the
+            // parser. Skipping them anyway hid 183 unclosed type angles behind a
+            // single `/` — the guard scored the input at depth 6 while OXC
+            // speculated over every angle until it ran out of memory (#3873).
+            // Falling through scans them as ordinary source instead, which can
+            // only over-count.
             b'/' if can_start_regex => {
-                i = skip_regex(bytes, i + 1);
-                can_start_regex = false;
-                continue;
+                if let Some(next) = skip_regex(bytes, i + 1) {
+                    i = next;
+                    can_start_regex = false;
+                    continue;
+                }
+                can_start_regex = true;
             }
             b'a'..=b'z' | b'A'..=b'Z' | b'_' | b'$' => {
                 let start = i;

--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting/scan.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting/scan.rs
@@ -142,7 +142,14 @@ pub(super) fn skip_block_comment(bytes: &[u8], mut i: usize) -> usize {
     bytes.len()
 }
 
-pub(super) fn skip_regex(bytes: &[u8], mut i: usize) -> usize {
+/// Skip a regex literal, returning where it ends.
+///
+/// `None` means the literal never terminated: no closing `/`, and no line
+/// terminator to end it either, so the scan ran to the end of the input. The
+/// lexer reports that as an unterminated regex and recovers, leaving those
+/// bytes live for the parser, so the caller must scan them rather than treat
+/// them as skipped literal text (#3873).
+pub(super) fn skip_regex(bytes: &[u8], mut i: usize) -> Option<usize> {
     let mut in_character_class = false;
     while i < bytes.len() {
         match bytes[i] {
@@ -152,12 +159,12 @@ pub(super) fn skip_regex(bytes: &[u8], mut i: usize) -> usize {
             // its 0xE2 lead byte (LS/PS), hiding the following source from the
             // guard, so bail before consuming it.
             b'\\' => match bytes.get(i + 1) {
-                Some(&b'\n' | &b'\r') => return i,
+                Some(&b'\n' | &b'\r') => return Some(i),
                 Some(&0xe2)
                     if bytes.get(i + 2) == Some(&0x80)
                         && matches!(bytes.get(i + 3), Some(&0xa8) | Some(&0xa9)) =>
                 {
-                    return i;
+                    return Some(i);
                 }
                 _ => i = i.saturating_add(2),
             },
@@ -169,18 +176,18 @@ pub(super) fn skip_regex(bytes: &[u8], mut i: usize) -> usize {
                 in_character_class = false;
                 i += 1;
             }
-            b'/' if !in_character_class => return skip_identifier(bytes, i + 1),
-            b'\n' | b'\r' => return i,
+            b'/' if !in_character_class => return Some(skip_identifier(bytes, i + 1)),
+            b'\n' | b'\r' => return Some(i),
             // LS/PS terminate an (unterminated) regex literal like LF/CR.
             0xe2 if bytes.get(i + 1) == Some(&0x80)
                 && matches!(bytes.get(i + 2), Some(&0xa8) | Some(&0xa9)) =>
             {
-                return i;
+                return Some(i);
             }
             _ => i += 1,
         }
     }
-    i
+    None
 }
 
 pub(super) fn skip_identifier(bytes: &[u8], mut i: usize) -> usize {

--- a/crates/vize_atelier_core/tests/expression_guard_regex.rs
+++ b/crates/vize_atelier_core/tests/expression_guard_regex.rs
@@ -1,0 +1,80 @@
+//! Regex-literal boundaries in the expression nesting guard.
+//!
+//! The byte scanner has to stop exactly where OXC's lexer stops. Skipping more
+//! than the lexer does hides brackets and type angles from the depth budget
+//! while OXC still recurses over them.
+
+use vize_atelier_core::steps::expression::{
+    MAX_EXPRESSION_NESTING_DEPTH, expression_exceeds_max_depth, expression_is_safe_to_parse,
+    expression_nesting_depth,
+};
+
+#[test]
+fn an_unterminated_regex_does_not_swallow_the_rest_of_the_input() {
+    // Minimized from the js_ts_expression fuzz OOM (#3873). Its 1409 bytes held
+    // 189 unclosed type angles and exactly one `/`, at byte 37 with no line
+    // terminator after it. The `<` before that slash put the scanner in
+    // regex-start position, `skip_regex` found no closing `/` and ran to the end
+    // of the input, and the 183 angles behind it never reached the depth budget:
+    // the guard scored the whole thing at depth 6 and passed it to OXC, which
+    // speculated over every angle until it ran out of memory.
+    let hidden = ["a</", &"s<".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1)].concat();
+
+    assert!(
+        expression_nesting_depth(&hidden) > MAX_EXPRESSION_NESTING_DEPTH,
+        "angles behind an unterminated regex must reach the depth budget: {}",
+        expression_nesting_depth(&hidden)
+    );
+    assert!(expression_exceeds_max_depth(&hidden));
+    assert!(!expression_is_safe_to_parse(&hidden));
+}
+
+#[test]
+fn a_terminated_regex_still_hides_its_contents() {
+    // The other direction: a real literal must stay skipped, or ordinary code
+    // with brackets inside a character class starts failing the guard.
+    let literal = [
+        "a = /[",
+        &"(".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1),
+        "]/.test(b)",
+    ]
+    .concat();
+
+    assert_eq!(expression_nesting_depth(&literal), 1);
+    assert!(!expression_exceeds_max_depth(&literal));
+    assert!(expression_is_safe_to_parse(&literal));
+}
+
+#[test]
+fn a_line_terminator_still_ends_an_unclosed_regex() {
+    // Already handled before #3873 — the scanner resumes at the terminator — so
+    // this pins that the `Option` refactor did not regress it.
+    for terminator in ["\n", "\r", "\u{2028}", "\u{2029}"] {
+        let hidden = [
+            "a = /x",
+            terminator,
+            &"[".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1),
+        ]
+        .concat();
+
+        assert!(
+            expression_exceeds_max_depth(&hidden),
+            "terminator {:?}",
+            terminator.escape_unicode()
+        );
+        assert!(!expression_is_safe_to_parse(&hidden));
+    }
+}
+
+#[test]
+fn an_unterminated_regex_keeps_scanning_its_own_bytes() {
+    // The bytes inside the never-closed literal are ordinary source to the
+    // recovering lexer, so their brackets count too.
+    let hidden = ["a = /", &"(".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1)].concat();
+
+    assert_eq!(
+        expression_nesting_depth(&hidden),
+        MAX_EXPRESSION_NESTING_DEPTH + 1
+    );
+    assert!(!expression_is_safe_to_parse(&hidden));
+}


### PR DESCRIPTION
## Summary

The `js_ts_expression` fuzzer found an OOM (#3873). The 1409-byte reproducer holds **189 unclosed type angles** and exactly **one** `/`, at byte 37, with no line terminator after it.

The `<` before that slash puts the scanner in regex-start position. `skip_regex` then finds no closing `/` and no terminator, so it runs to the end of the input and the 183 angles behind it never reach the depth budget:

```
guard:  depth=6   balanced=true   safe=true      ← 6 angles, all before the slash
actual: 189 unclosed type angles
```

`expression_is_safe_to_parse` said yes, and OXC speculated over every angle until it ran out of memory.

A regex literal that never closes is not one — the lexer reports an unterminated regex and recovers, leaving those bytes live for the parser. `skip_regex` now returns `Option<usize>`, `None` meaning it reached the end without terminating, and the caller scans those bytes as ordinary source instead of skipping them.

With the fix the reproducer scans to **depth 206** and is rejected before OXC sees it.

This is the same class as #3107, #3271/#3274 and #3858: the byte scanner skipping more than OXC's lexer does. The scanner now only skips a regex it can prove terminated.

## Change Class

- [x] Semantic analysis, lint, and cross-file analysis

## Behavior Reference

- Fuzz report: #3873 (artifact `oom-4e19bed28552bfe2a62d7d2bf2ef834ea50b443d`, 1409 bytes)
- Prior guard holes of the same shape: #3107, #3185, #3213, #3271, #3274, #3858

## Verification Evidence

```sh
cargo test --workspace      # 2189 passed; the 8 failures are the pre-existing
                            # vize_atelier_sfc pkl-fixture ones, unrelated
cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
cargo fmt --all -- --check
```

Measured directly against the downloaded artifact before and after: `safe=true` at depth 6, then `safe=false` at depth 206.

New `crates/vize_atelier_core/tests/expression_guard_regex.rs` pins all four directions, in its own file because `expression_nesting_guard.rs` sits at 324 lines and would cross the 350-line budget:

| case | expectation |
| --- | --- |
| `a</` + angle run | angles reach the budget — the reproducer's shape |
| `a = /[(((…]/.test(b)` | a terminated literal still hides its contents |
| `a = /x<LF>[[[…` and LS/PS/CR | a line terminator still ends an unclosed regex |
| `a = /(((…` | the unterminated literal's own bytes are scanned too |

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — none
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered — closes a reachable OOM on attacker-influenced template expressions
- [x] Performance status or PR benchmark impact considered — one `Option` discriminant per regex literal
- [x] Fuzzing target or crash-reproducer coverage considered — this is that coverage
- [x] Editor/LSP scenario coverage considered — the guard is shared by every expression entry point
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

The guard now counts bytes it previously skipped, so it can only reject *more*. The reachable false rejection is an expression ending in an unterminated regex whose tail carries 32+ unbalanced brackets or type angles — which is already a syntax error.

Closes #3873

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expression parsing when regular expressions are unterminated.
  * Brackets and type-angle syntax following incomplete regular expressions are now handled correctly.
  * Line breaks properly end incomplete regular-expression scanning.
  * Completed regular expressions continue to be ignored during nesting analysis.

* **Tests**
  * Added regression coverage for incomplete and completed regular-expression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->