### PR TITLE
fix(core): treat a line-terminated regex as unterminated too

### DIFF
--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting.rs
@@ -84,10 +84,11 @@ fn analyze_expression_nesting(content: &str) -> (usize, bool) {
             // A regex literal that never closes is not one: the lexer reports an
             // unterminated regex and recovers, so the bytes stay live for the
             // parser. Skipping them anyway hid 183 unclosed type angles behind a
-            // single `/` — the guard scored the input at depth 6 while OXC
-            // speculated over every angle until it ran out of memory (#3873).
-            // Falling through scans them as ordinary source instead, which can
-            // only over-count.
+            // single `/` running to EOF — the guard scored that input at depth 6
+            // while OXC speculated over every angle until it ran out of memory
+            // (#3873) — and 6182 more behind a `/` that a line terminator closed
+            // 27 KiB later (#3875). Falling through scans them as ordinary
+            // source instead, which can only over-count.
             b'/' if can_start_regex => {
                 if let Some(next) = skip_regex(bytes, i + 1) {
                     i = next;

--- a/crates/vize_atelier_core/src/transforms/transform_expression/nesting/scan.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/nesting/scan.rs
@@ -144,11 +144,13 @@ pub(super) fn skip_block_comment(bytes: &[u8], mut i: usize) -> usize {
 
 /// Skip a regex literal, returning where it ends.
 ///
-/// `None` means the literal never terminated: no closing `/`, and no line
-/// terminator to end it either, so the scan ran to the end of the input. The
-/// lexer reports that as an unterminated regex and recovers, leaving those
-/// bytes live for the parser, so the caller must scan them rather than treat
-/// them as skipped literal text (#3873).
+/// Only a closing `/` terminates one. `None` means the literal never closed —
+/// the scan hit a line terminator or the end of the input — and the lexer
+/// reports that as an unterminated regex and recovers, leaving those bytes live
+/// for the parser. Treating them as skipped literal text hid the source in
+/// between from the depth budget: an unclosed `/` swallowed to EOF hid 183 type
+/// angles (#3873), and one closed by a line terminator 27 KiB later hid 6182
+/// more (#3875). The caller scans them instead, which can only over-count.
 pub(super) fn skip_regex(bytes: &[u8], mut i: usize) -> Option<usize> {
     let mut in_character_class = false;
     while i < bytes.len() {
@@ -159,12 +161,12 @@ pub(super) fn skip_regex(bytes: &[u8], mut i: usize) -> Option<usize> {
             // its 0xE2 lead byte (LS/PS), hiding the following source from the
             // guard, so bail before consuming it.
             b'\\' => match bytes.get(i + 1) {
-                Some(&b'\n' | &b'\r') => return Some(i),
+                Some(&b'\n' | &b'\r') => return None,
                 Some(&0xe2)
                     if bytes.get(i + 2) == Some(&0x80)
                         && matches!(bytes.get(i + 3), Some(&0xa8) | Some(&0xa9)) =>
                 {
-                    return Some(i);
+                    return None;
                 }
                 _ => i = i.saturating_add(2),
             },
@@ -177,12 +179,12 @@ pub(super) fn skip_regex(bytes: &[u8], mut i: usize) -> Option<usize> {
                 i += 1;
             }
             b'/' if !in_character_class => return Some(skip_identifier(bytes, i + 1)),
-            b'\n' | b'\r' => return Some(i),
+            b'\n' | b'\r' => return None,
             // LS/PS terminate an (unterminated) regex literal like LF/CR.
             0xe2 if bytes.get(i + 1) == Some(&0x80)
                 && matches!(bytes.get(i + 2), Some(&0xa8) | Some(&0xa9)) =>
             {
-                return Some(i);
+                return None;
             }
             _ => i += 1,
         }

--- a/crates/vize_atelier_core/tests/expression_guard_regex.rs
+++ b/crates/vize_atelier_core/tests/expression_guard_regex.rs
@@ -46,9 +46,26 @@ fn a_terminated_regex_still_hides_its_contents() {
 }
 
 #[test]
+fn a_regex_closed_only_by_a_line_terminator_does_not_hide_what_it_spans() {
+    // The `slow-unit` reproducers behind #3875 are ~26 KiB with ~6000 unclosed
+    // type angles and a single `/` at byte 177. A line terminator 27 KiB later
+    // "ended" that literal, so the scanner skipped everything between and saw
+    // depth 22 instead of 6211. A line terminator does not close a regex — the
+    // lexer errors and recovers — so the span has to be scanned.
+    let hidden = ["a</", &"s<".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1), "\n"].concat();
+
+    assert!(
+        expression_nesting_depth(&hidden) > MAX_EXPRESSION_NESTING_DEPTH,
+        "angles spanned by an unclosed regex must reach the budget: {}",
+        expression_nesting_depth(&hidden)
+    );
+    assert!(!expression_is_safe_to_parse(&hidden));
+}
+
+#[test]
 fn a_line_terminator_still_ends_an_unclosed_regex() {
-    // Already handled before #3873 — the scanner resumes at the terminator — so
-    // this pins that the `Option` refactor did not regress it.
+    // Bytes *after* the terminator were always scanned; this pins that they
+    // still are.
     for terminator in ["\n", "\r", "\u{2028}", "\u{2029}"] {
         let hidden = [
             "a = /x",


### PR DESCRIPTION
## Summary

#3874 stopped skipping a regex literal that ran to the end of the input, but left the other unterminated case in place: one ended by a **line terminator**.

The two `slow-unit` reproducers behind #3875 are ~26 KiB each, holding ~6000 unclosed type angles and a single `/` at byte 177. The next line terminator is at byte 27726 — 61 bytes from the end — so `skip_regex` reported the literal as ended there and the scanner skipped 27549 bytes:

```
slash at 177,  next line terminator at 27726 of 27787
angles before the slash: 14
angles hidden in between: 6182
angles after the terminator: 8      →  guard depth 22
```

`expression_is_safe_to_parse` said yes, and OXC speculated over every angle until the fuzz target timed out.

A line terminator does not close a regex — the lexer reports an unterminated literal and recovers, leaving the span live for the parser. Only a closing `/` terminates one now.

| reproducer | before | after |
| --- | ---: | ---: |
| `slow-unit-0dc04a49…` (#3875) | 22 | **6211** |
| `slow-unit-3622ae51…` (#3875) | — | **5621** |
| `oom-4e19bed2…` (#3873) | 6 | 206 |

All rejected against a limit of 31.

## Change Class

- [x] Semantic analysis, lint, and cross-file analysis

## Behavior Reference

- Fuzz report: #3875 (artifacts `slow-unit-0dc04a49cd386bf228814154d5a78596c67c488d`, `slow-unit-3622ae51f093a7e1069d200ab732c417c1869acd`)
- Immediate predecessor: #3873 / #3874 — same divergence, narrower case
- Same class further back: #3107, #3185, #3213, #3271, #3274, #3858

## Verification Evidence

```sh
cargo test --workspace      # 2190 passed; the 8 failures are the pre-existing
                            # vize_atelier_sfc pkl-fixture ones, unrelated
cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
cargo fmt --all -- --check
```

Measured against all three downloaded artifacts before and after.

`expression_guard_regex.rs` gains `a_regex_closed_only_by_a_line_terminator_does_not_hide_what_it_spans`, and the existing `a_line_terminator_still_ends_an_unclosed_regex` keeps pinning the other half — bytes *after* the terminator were always scanned and still are. Terminated literals still skip their contents, so `/[@@@…]+/gu.test(v)` stays at depth 1.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — none
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered — closes a reachable parser DoS on attacker-influenced template expressions
- [x] Performance status or PR benchmark impact considered — the scan is unchanged; only the exit value differs
- [x] Fuzzing target or crash-reproducer coverage considered — this is that coverage
- [x] Editor/LSP scenario coverage considered — the guard is shared by every expression entry point
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

The guard counts bytes it previously skipped, so it can only reject *more*. The reachable false rejection is an expression containing an unclosed `/` whose remainder carries 32+ unbalanced brackets or type angles — already a syntax error.

Closes #3875

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unterminated regular expressions that encounter line breaks.
  * Prevented malformed regex-like text from hiding nested expressions during parsing.
  * Added coverage for line terminators and related recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->