### PR TITLE
test(core): cover escaped line terminators in the regex guard

### DIFF
--- a/crates/vize_atelier_core/tests/expression_guard_regex.rs
+++ b/crates/vize_atelier_core/tests/expression_guard_regex.rs
@@ -52,14 +52,61 @@ fn a_regex_closed_only_by_a_line_terminator_does_not_hide_what_it_spans() {
     // "ended" that literal, so the scanner skipped everything between and saw
     // depth 22 instead of 6211. A line terminator does not close a regex — the
     // lexer errors and recovers — so the span has to be scanned.
-    let hidden = ["a</", &"s<".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1), "\n"].concat();
+    //
+    // The trailing `/` matters: without it the scan would run out of input and
+    // report the literal as unterminated anyway, so only a later slash proves
+    // the terminator itself is what stops the skip.
+    for terminator in ["\n", "\r", "\u{2028}", "\u{2029}"] {
+        let hidden = [
+            "a</",
+            &"s<".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1),
+            terminator,
+            "/",
+        ]
+        .concat();
 
-    assert!(
-        expression_nesting_depth(&hidden) > MAX_EXPRESSION_NESTING_DEPTH,
-        "angles spanned by an unclosed regex must reach the budget: {}",
-        expression_nesting_depth(&hidden)
-    );
-    assert!(!expression_is_safe_to_parse(&hidden));
+        assert!(
+            expression_nesting_depth(&hidden) > MAX_EXPRESSION_NESTING_DEPTH,
+            "angles spanned by an unclosed regex must reach the budget: terminator {:?} depth {}",
+            terminator.escape_unicode(),
+            expression_nesting_depth(&hidden)
+        );
+        assert!(
+            !expression_is_safe_to_parse(&hidden),
+            "terminator {:?}",
+            terminator.escape_unicode()
+        );
+    }
+}
+
+#[test]
+fn an_escaped_line_terminator_does_not_extend_a_regex_to_a_later_slash() {
+    // A `\` before a line terminator is not an escape: the lexer still ends the
+    // unterminated literal at the terminator. Consuming the pair as one escape
+    // would step over LF/CR — or over the 0xE2 lead byte of LS/PS — and let a
+    // later `/` "close" the literal, hiding the spanned angles again.
+    for terminator in ["\n", "\r", "\u{2028}", "\u{2029}"] {
+        let hidden = [
+            "a</",
+            &"s<".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1),
+            "\\",
+            terminator,
+            "/",
+        ]
+        .concat();
+
+        assert!(
+            expression_nesting_depth(&hidden) > MAX_EXPRESSION_NESTING_DEPTH,
+            "angles spanned by an escaped terminator must reach the budget: terminator {:?} depth {}",
+            terminator.escape_unicode(),
+            expression_nesting_depth(&hidden)
+        );
+        assert!(
+            !expression_is_safe_to_parse(&hidden),
+            "terminator {:?}",
+            terminator.escape_unicode()
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
Follow-up to review feedback on #3876, which merged before the comment could be addressed there.

`skip_regex` returns `None` on a `\` immediately followed by LF, CR, LS, or PS (`scan.rs:163-170`), a separate arm from the bare-terminator ones, and nothing pinned it. The existing line-terminator test also ended its input at the terminator, so the scan would have reported the literal unterminated on EOF anyway; only a later `/` proves the terminator itself stops the skip. Both tests now carry a trailing slash and run over all four terminators:

```rust
for terminator in ["
", "\r", "\u{2028}", "\u{2029}"] {
    let hidden = [
        "a</",
        &"s<".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1),
        "\\",
        terminator,
        "/",
    ]
    .concat();

    assert!(expression_nesting_depth(&hidden) > MAX_EXPRESSION_NESTING_DEPTH, /* ... */);
    assert!(!expression_is_safe_to_parse(&hidden), /* ... */);
}
```

Tests only; no production code touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of regular expressions containing line terminators.
  * Unterminated regular expressions are now analyzed correctly for nested syntax instead of being skipped incorrectly.
  * Properly terminated regular expression contents continue to be handled as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->