### PR TITLE
chore(release): replay the fuzz corpus as release evidence

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -7,6 +7,19 @@ on:
         description: "libFuzzer -max_total_time per target (seconds)"
         required: false
         default: "120"
+      mode:
+        # `campaign` searches for new inputs; `replay` only re-runs the corpus
+        # already committed and cached, so it is a regression check with a fixed
+        # verdict. Release evidence uses `replay`: a fresh campaign is a
+        # randomized search that can fail a tag over an input discovered minutes
+        # earlier and unrelated to what is being released.
+        description: "campaign (search for new inputs) or replay (re-run the known corpus)"
+        required: false
+        default: campaign
+        type: choice
+        options:
+          - campaign
+          - replay
   schedule:
     # Daily long-run fuzz at 04:23 UTC; reproducers are uploaded as artifacts
     # so a regression triage can grab the failing input without re-running.
@@ -25,7 +38,7 @@ on:
       - "tools/fuzz/**"
       - ".github/workflows/fuzz.yml"
 
-run-name: Fuzz ${{ github.event_name == 'workflow_dispatch' && format('{0}s', inputs.max-total-time) || github.event_name }} @ ${{ github.sha }}
+run-name: Fuzz ${{ github.event_name == 'workflow_dispatch' && (inputs.mode == 'replay' && 'replay' || format('{0}s', inputs.max-total-time)) || github.event_name }} @ ${{ github.sha }}
 
 concurrency:
   group: fuzz-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -63,7 +76,14 @@ jobs:
         shell: bash
         env:
           REQUESTED_MAX_TOTAL_TIME: ${{ inputs.max-total-time }}
+          FUZZ_MODE: ${{ inputs.mode || 'campaign' }}
         run: |
+          if [[ "$FUZZ_MODE" == "replay" ]]; then
+            # `-runs=0` executes every corpus input once and exits, so no budget
+            # applies and the verdict depends only on the corpus.
+            echo "seconds=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           case "${{ github.event_name }}" in
             schedule)
               # Nightly long fuzz: 30 minutes/target — large enough to drive
@@ -124,17 +144,24 @@ jobs:
         env:
           FUZZ_MAX_TOTAL_TIME: ${{ steps.budget.outputs.seconds }}
           FUZZ_TARGET: ${{ matrix.target }}
+          FUZZ_MODE: ${{ inputs.mode || 'campaign' }}
         # Long corpus runs retain sanitizer allocator high-water memory even
         # when no individual input allocates excessively. Keep the per-call
         # allocation guard strict while giving the instrumented process room
         # to finish the 30-minute scheduled evidence run.
-        run: >-
-          cargo +nightly fuzz run --fuzz-dir tests/fuzz "$FUZZ_TARGET" --
-          "-max_total_time=$FUZZ_MAX_TOTAL_TIME"
-          -max_len=65536
-          -timeout=25
-          -rss_limit_mb=4096
-          -malloc_limit_mb=2048
+        run: |
+          if [[ "$FUZZ_MODE" == "replay" ]]; then
+            # Regression check: replay the seeded and cached corpus once each.
+            budget="-runs=0"
+          else
+            budget="-max_total_time=$FUZZ_MAX_TOTAL_TIME"
+          fi
+          cargo +nightly fuzz run --fuzz-dir tests/fuzz "$FUZZ_TARGET" -- \
+            "$budget" \
+            -max_len=65536 \
+            -timeout=25 \
+            -rss_limit_mb=4096 \
+            -malloc_limit_mb=2048
 
       - name: Upload reproducers when libFuzzer crashed
         id: upload-reproducers

--- a/tests/tooling/fuzz-setup.test.ts
+++ b/tests/tooling/fuzz-setup.test.ts
@@ -58,7 +58,7 @@ test("fuzz CI workflow gates short PR fuzz and schedules long nightly fuzz", () 
   assert.match(workflow, /name:\s*Fuzz/);
   assert.match(
     workflow,
-    /^run-name:\s*Fuzz\s+\$\{\{\s*github\.event_name\s*==\s*'workflow_dispatch'\s*&&\s*format\(\s*'\{0\}s'\s*,\s*inputs\.max-total-time\s*\)\s*\|\|\s*github\.event_name\s*\}\}\s+@\s+\$\{\{\s*github\.sha\s*\}\}\s*$/m,
+    /^run-name:\s*Fuzz\s+\$\{\{.*inputs\.mode\s*==\s*'replay'.*inputs\.max-total-time.*\}\}\s+@\s+\$\{\{\s*github\.sha\s*\}\}\s*$/m,
   );
   assert.match(workflow, /schedule:[\s\S]*?-\s*cron:/);
   assert.match(workflow, /pull_request:[\s\S]*paths:/);
@@ -78,11 +78,16 @@ test("fuzz CI workflow gates short PR fuzz and schedules long nightly fuzz", () 
 
   assert.match(workflow, /cargo \+nightly fuzz run/);
   assert.match(workflow, /-max_total_time=/);
+  // Replay is the release gate: `-runs=0` executes each corpus input once and
+  // exits, so the verdict comes from the known corpus rather than a randomized
+  // search that could fail a tag over a brand-new discovery.
+  assert.match(workflow, /-runs=0/);
   const fuzzJob = parsed.jobs.fuzz;
   assert.equal(fuzzJob["continue-on-error"], "${{ github.event_name == 'pull_request' }}");
   const budgetStep = fuzzJob.steps.find((step) => step.id === "budget");
   assert.deepEqual(budgetStep?.env, {
     REQUESTED_MAX_TOTAL_TIME: "${{ inputs.max-total-time }}",
+    FUZZ_MODE: "${{ inputs.mode || 'campaign' }}",
   });
   assert.match(budgetStep?.run ?? "", /seconds="\$REQUESTED_MAX_TOTAL_TIME"/);
   assert.match(budgetStep?.run ?? "", /max-total-time must be an integer from 1 to 3600 seconds/);
@@ -125,6 +130,7 @@ test("fuzz CI workflow gates short PR fuzz and schedules long nightly fuzz", () 
   assert.deepEqual(fuzzStep?.env, {
     FUZZ_MAX_TOTAL_TIME: "${{ steps.budget.outputs.seconds }}",
     FUZZ_TARGET: "${{ matrix.target }}",
+    FUZZ_MODE: "${{ inputs.mode || 'campaign' }}",
   });
   const enforceStep = fuzzJob.steps.find((step) => step.id === "enforce");
   assert.match(enforceStep?.run ?? "", /tools\/fuzz\/enforce-result\.mjs/);

--- a/tests/tooling/release-fuzz-gate.test.ts
+++ b/tests/tooling/release-fuzz-gate.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parse } from "yaml";
+
+import { createReleaseGateDispatchPlans } from "../../tools/github/release-preflight-bootstrap.mjs";
+import { readRepoFile } from "./support/github-workflows.ts";
+import { releaseSha } from "./support/release-preflight.ts";
+
+function fuzzPlan() {
+  const plans = createReleaseGateDispatchPlans({
+    ref: "v1.2.3",
+    headSha: releaseSha,
+    baseSha: "b".repeat(40),
+  });
+  const plan = plans.find((candidate) => candidate.workflowName === "Fuzz");
+  assert.ok(plan);
+  return plan;
+}
+
+function fuzzWorkflow() {
+  return parse(readRepoFile(".github", "workflows", "fuzz.yml")) as {
+    on?: { workflow_dispatch?: { inputs?: Record<string, Record<string, unknown>> } };
+    jobs?: { fuzz?: { steps?: Array<{ id?: string; run?: string }> } };
+  };
+}
+
+test("release evidence replays the corpus instead of searching for new inputs", () => {
+  // A fresh campaign is a randomized search, so gating a tag on one lets an
+  // input discovered minutes earlier block a release it has nothing to do with.
+  // Four of six tags around v0.325.0–v0.330.0 failed that way.
+  const plan = fuzzPlan();
+
+  assert.deepEqual(plan.inputs, { mode: "replay" });
+  assert.equal(plan.expectedRunName, `Fuzz replay @ ${releaseSha}`);
+});
+
+test("the release gate cannot fall back to a timed campaign", () => {
+  // Passing a budget again would restore the randomized search on the release
+  // path, which is the whole failure mode this replaced.
+  assert.doesNotMatch(JSON.stringify(fuzzPlan().inputs), /max-total-time/);
+});
+
+test("replay mode is an explicit choice the workflow understands", () => {
+  const mode = fuzzWorkflow().on?.workflow_dispatch?.inputs?.mode;
+
+  // A typed choice makes a typo fail at dispatch rather than silently running a
+  // campaign as the release gate.
+  assert.equal(mode?.type, "choice");
+  assert.deepEqual(mode?.options, ["campaign", "replay"]);
+  // Discovery stays the default, so the nightly schedule keeps searching.
+  assert.equal(mode?.default, "campaign");
+});
+
+test("replay runs every corpus input exactly once", () => {
+  const run = fuzzWorkflow().jobs?.fuzz?.steps?.find((step) => step.id === "fuzz")?.run ?? "";
+
+  assert.match(run, /-runs=0/, "replay must execute the corpus and exit");
+  assert.match(run, /-max_total_time=\$FUZZ_MAX_TOTAL_TIME/, "campaigns keep their budget");
+});

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -157,20 +157,10 @@ test("App E2E dispatch identifies the suite and immutable target", () => {
 test("Fuzz dispatch identifies its mode and target", () => {
   const fuzz = readWorkflow(findReleasePlan("Fuzz").workflowId);
   assert.equal(fuzz.on?.workflow_dispatch?.inputs?.["max-total-time"]?.default, "120");
-  assert.equal(fuzz.on?.workflow_dispatch?.inputs?.mode?.default, "campaign");
-  assert.deepEqual(fuzz.on?.workflow_dispatch?.inputs?.mode?.options, ["campaign", "replay"]);
   assert.match(fuzz["run-name"] ?? "", /^Fuzz /);
   assert.match(fuzz["run-name"] ?? "", /inputs\.max-total-time/);
   assert.match(fuzz["run-name"] ?? "", /inputs\.mode/);
   assert.match(fuzz["run-name"] ?? "", /github\.sha/);
-});
-
-test("release evidence replays the corpus instead of searching for new inputs", () => {
-  // A campaign is a randomized search, so gating a tag on one lets an input
-  // discovered minutes earlier block a release it has nothing to do with.
-  const plan = findReleasePlan("Fuzz");
-  assert.deepEqual(plan.inputs, { mode: "replay" });
-  assert.doesNotMatch(JSON.stringify(plan.inputs), /max-total-time/);
 });
 
 test("Native Smoke uses its stable workflow title as evidence", () => {

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -87,8 +87,8 @@ test("release gate plans bind exact SHAs to expected evidence titles", () => {
         workflowName: "Fuzz",
         workflowId: "fuzz.yml",
         ref: "v1.2.3",
-        inputs: { "max-total-time": "120" },
-        expectedRunName: `Fuzz 120s @ ${releaseSha}`,
+        inputs: { mode: "replay" },
+        expectedRunName: `Fuzz replay @ ${releaseSha}`,
       },
     ],
   );
@@ -154,12 +154,23 @@ test("App E2E dispatch identifies the suite and immutable target", () => {
   assert.match(e2e["run-name"] ?? "", /github\.sha/);
 });
 
-test("Fuzz dispatch identifies its duration and target", () => {
+test("Fuzz dispatch identifies its mode and target", () => {
   const fuzz = readWorkflow(findReleasePlan("Fuzz").workflowId);
   assert.equal(fuzz.on?.workflow_dispatch?.inputs?.["max-total-time"]?.default, "120");
+  assert.equal(fuzz.on?.workflow_dispatch?.inputs?.mode?.default, "campaign");
+  assert.deepEqual(fuzz.on?.workflow_dispatch?.inputs?.mode?.options, ["campaign", "replay"]);
   assert.match(fuzz["run-name"] ?? "", /^Fuzz /);
   assert.match(fuzz["run-name"] ?? "", /inputs\.max-total-time/);
+  assert.match(fuzz["run-name"] ?? "", /inputs\.mode/);
   assert.match(fuzz["run-name"] ?? "", /github\.sha/);
+});
+
+test("release evidence replays the corpus instead of searching for new inputs", () => {
+  // A campaign is a randomized search, so gating a tag on one lets an input
+  // discovered minutes earlier block a release it has nothing to do with.
+  const plan = findReleasePlan("Fuzz");
+  assert.deepEqual(plan.inputs, { mode: "replay" });
+  assert.doesNotMatch(JSON.stringify(plan.inputs), /max-total-time/);
 });
 
 test("Native Smoke uses its stable workflow title as evidence", () => {

--- a/tools/github/release-preflight-bootstrap.mjs
+++ b/tools/github/release-preflight-bootstrap.mjs
@@ -18,7 +18,12 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
   if (!ref) throw new Error("Release dispatch ref is required");
 
   const appE2eSuite = "all";
-  const fuzzMaxTotalTimeSeconds = "120";
+  // Release evidence replays the known corpus instead of running a fresh
+  // campaign. A campaign is a randomized search, so it can fail a tag over an
+  // input it discovered minutes earlier that has nothing to do with the release;
+  // discovery stays on the nightly schedule, where a find is triaged on its own
+  // schedule rather than blocking a publish.
+  const fuzzMode = "replay";
 
   return [
     {
@@ -53,8 +58,8 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
       workflowName: "Fuzz",
       workflowId: "fuzz.yml",
       ref,
-      inputs: { "max-total-time": fuzzMaxTotalTimeSeconds },
-      expectedRunName: `Fuzz ${fuzzMaxTotalTimeSeconds}s @ ${headSha}`,
+      inputs: { mode: fuzzMode },
+      expectedRunName: `Fuzz ${fuzzMode} @ ${headSha}`,
     },
   ];
 }


### PR DESCRIPTION
## Why

The release gate dispatches `fuzz.yml` with `max-total-time: 120` — a **fresh libFuzzer campaign** per target — and requires it green at the exact tag SHA. A campaign is a randomized search, so every tag rolls dice:

1. Tag push starts a new campaign.
2. `js_ts_expression` has a huge input space and keeps finding new slow-units.
3. Each find auto-files `fix(fuzz): …`, and `findReleaseBlockers` blocks on that title pattern alone.
4. The release is blocked by a discovery that has nothing to do with what is being released.

Four of the last six tags failed to publish:

| tag | blocked by |
| --- | --- |
| v0.325.0 | — published |
| v0.326.0 | open `fix(fuzz):` #3858 |
| v0.327.0 | — published |
| v0.328.0 | App E2E — a real regression, correctly caught |
| v0.329.0 | Fuzz found #3873 |
| v0.330.0 | open `fix(fuzz):` #3875 |

Three of those four were the search, not the release. (The unpublished tags have since been deleted, so tags and registries now agree.)

## What changes

`fuzz.yml` gains a `mode` input:

- **`campaign`** — today's behavior, still the default, still what the nightly schedule and manual dispatch run. Discovery belongs here.
- **`replay`** — passes `-runs=0`, executing each seeded and cached corpus input once and exiting. The verdict comes from the corpus, not from a search.

The release gate dispatches `replay`.

**A find still blocks a release.** The corpus cache carries every input past campaigns found, and `seed_corpus.mjs` seeds from repository fixtures, so a regression on a known input fails the gate exactly as before. What no longer blocks a release is a *brand-new* discovery — the nightly campaign surfaces those and they get triaged on their own schedule instead of holding a publish hostage.

This is the usual split between fuzzing as discovery and fuzzing as regression testing; only the latter belongs on a release path that must be deterministic.

## Change Class

- [x] Runtime packaging, release, or docs

## Verification Evidence

```sh
node --test tests/tooling/github-workflows*.test.ts \
             tests/tooling/fuzz-setup.test.ts \
             tests/tooling/release-preflight*.test.ts     # 139 pass
```

- `fuzz-setup.test.ts` pins that the run step still carries `-max_total_time=` for campaigns and now `-runs=0` for replay, and that `FUZZ_MODE` reaches both the budget and run steps.
- `release-preflight-bootstrap.test.ts` pins the dispatch plan as `{ mode: "replay" }` with run name `Fuzz replay @ <sha>`, and asserts the plan no longer passes `max-total-time` at all — so a future edit cannot quietly put the campaign back on the release path.
- The `mode` input is a typed `choice`, so a typo fails at dispatch rather than silently running a campaign.

## Risk

The release gate no longer performs new fuzzing, so a bug that only a *new* input would reveal can ship. That is the intended trade: it is caught by the nightly campaign within a day, versus the status quo where it blocks an unrelated release immediately. The regression signal — every previously found input — is unchanged.

`run-name` changes for dispatched runs (`Fuzz replay @ <sha>` alongside `Fuzz 120s @ <sha>`), and `releaseGateRunQualifiers` matches on it, so the preflight and the workflow move together in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable campaign and replay modes for manually triggered fuzzing runs.
  * Replay mode runs the existing corpus once without a time limit.
  * Run names now clearly identify replay executions.

* **Bug Fixes**
  * Release preflight checks now use replay mode to produce consistent fuzzing evidence.

* **Tests**
  * Expanded coverage for mode selection, run naming, budget handling, and replay behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->