### PR TITLE
fix(release): reject the nightly fuzz campaign as replay evidence

### DIFF
--- a/tests/tooling/fuzz-setup.test.ts
+++ b/tests/tooling/fuzz-setup.test.ts
@@ -41,6 +41,7 @@ test("fuzz workspace declares libfuzzer-sys and an isolated [workspace]", () => 
 test("fuzz CI workflow gates short PR fuzz and schedules long nightly fuzz", () => {
   const workflow = readRepoFile(".github/workflows/fuzz.yml");
   const parsed = parse(workflow) as {
+    "run-name": string;
     jobs: {
       fuzz: {
         "continue-on-error": string;
@@ -56,10 +57,12 @@ test("fuzz CI workflow gates short PR fuzz and schedules long nightly fuzz", () 
   };
 
   assert.match(workflow, /name:\s*Fuzz/);
-  assert.match(
-    workflow,
-    /^run-name:\s*Fuzz\s+\$\{\{.*inputs\.mode\s*==\s*'replay'.*inputs\.max-total-time.*\}\}\s+@\s+\$\{\{\s*github\.sha\s*\}\}\s*$/m,
-  );
+  // Assert the resolved `run-name` value, not how the YAML wraps it: the
+  // release gate correlates evidence by expanded display title.
+  assert.match(parsed["run-name"], /^Fuzz \$\{\{/);
+  assert.match(parsed["run-name"], /inputs\.mode == 'replay'/);
+  assert.match(parsed["run-name"], /inputs\.max-total-time/);
+  assert.match(parsed["run-name"], /@ \$\{\{ github\.sha \}\}$/);
   assert.match(workflow, /schedule:[\s\S]*?-\s*cron:/);
   assert.match(workflow, /pull_request:[\s\S]*paths:/);
   assert.match(workflow, /"tests\/fuzz\/\*\*"/);
@@ -76,12 +79,6 @@ test("fuzz CI workflow gates short PR fuzz and schedules long nightly fuzz", () 
     );
   }
 
-  assert.match(workflow, /cargo \+nightly fuzz run/);
-  assert.match(workflow, /-max_total_time=/);
-  // Replay is the release gate: `-runs=0` executes each corpus input once and
-  // exits, so the verdict comes from the known corpus rather than a randomized
-  // search that could fail a tag over a brand-new discovery.
-  assert.match(workflow, /-runs=0/);
   const fuzzJob = parsed.jobs.fuzz;
   assert.equal(fuzzJob["continue-on-error"], "${{ github.event_name == 'pull_request' }}");
   const budgetStep = fuzzJob.steps.find((step) => step.id === "budget");
@@ -127,6 +124,11 @@ test("fuzz CI workflow gates short PR fuzz and schedules long nightly fuzz", () 
   );
   assert.match(fuzzStep?.run ?? "", /-rss_limit_mb=4096/);
   assert.match(fuzzStep?.run ?? "", /-malloc_limit_mb=2048/);
+  // Mode selection belongs to this step: replay executes each corpus input once
+  // and exits, campaigns keep their budget. `release-fuzz-gate.test.ts` runs the
+  // script per mode to pin which argument each one actually gets.
+  assert.match(fuzzStep?.run ?? "", /budget="-runs=0"/);
+  assert.match(fuzzStep?.run ?? "", /budget="-max_total_time=\$FUZZ_MAX_TOTAL_TIME"/);
   assert.deepEqual(fuzzStep?.env, {
     FUZZ_MAX_TOTAL_TIME: "${{ steps.budget.outputs.seconds }}",
     FUZZ_TARGET: "${{ matrix.target }}",

--- a/tests/tooling/release-fuzz-gate.test.ts
+++ b/tests/tooling/release-fuzz-gate.test.ts
@@ -1,8 +1,15 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 import { parse } from "yaml";
 
-import { createReleaseGateDispatchPlans } from "../../tools/github/release-preflight-bootstrap.mjs";
+import {
+  createReleaseGateDispatchPlans,
+  releaseGateRunQualifiers,
+} from "../../tools/github/release-preflight-bootstrap.mjs";
 import { readRepoFile } from "./support/github-workflows.ts";
 import { releaseSha } from "./support/release-preflight.ts";
 
@@ -22,6 +29,32 @@ function fuzzWorkflow() {
     on?: { workflow_dispatch?: { inputs?: Record<string, Record<string, unknown>> } };
     jobs?: { fuzz?: { steps?: Array<{ id?: string; run?: string }> } };
   };
+}
+
+// Run the fuzz step's script with a `cargo` stub on PATH so the assertion sees
+// the arguments the workflow actually assembles for a mode, not just tokens
+// present somewhere in the file.
+function fuzzCommand(mode: string): string {
+  const script = fuzzWorkflow().jobs?.fuzz?.steps?.find((step) => step.id === "fuzz")?.run;
+  assert.ok(script, "fuzz workflow must have a step with id: fuzz");
+  const stubDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "vize-fuzz-command-"));
+  fs.writeFileSync(path.join(stubDirectory, "cargo"), '#!/usr/bin/env bash\necho "$@"\n', {
+    mode: 0o755,
+  });
+
+  const result = spawnSync("bash", ["-c", script], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${stubDirectory}${path.delimiter}${process.env.PATH ?? ""}`,
+      FUZZ_MAX_TOTAL_TIME: "120",
+      FUZZ_MODE: mode,
+      FUZZ_TARGET: "sfc_parse",
+    },
+  });
+
+  assert.equal(result.status, 0, `${result.stderr}${result.stdout}`);
+  return result.stdout;
 }
 
 test("release evidence replays the corpus instead of searching for new inputs", () => {
@@ -52,8 +85,22 @@ test("replay mode is an explicit choice the workflow understands", () => {
 });
 
 test("replay runs every corpus input exactly once", () => {
-  const run = fuzzWorkflow().jobs?.fuzz?.steps?.find((step) => step.id === "fuzz")?.run ?? "";
+  const replay = fuzzCommand("replay");
+  assert.match(replay, /-runs=0/, "replay must execute the corpus and exit");
+  assert.doesNotMatch(replay, /-max_total_time/, "replay must not run a timed search");
 
-  assert.match(run, /-runs=0/, "replay must execute the corpus and exit");
-  assert.match(run, /-max_total_time=\$FUZZ_MAX_TOTAL_TIME/, "campaigns keep their budget");
+  const campaign = fuzzCommand("campaign");
+  assert.match(campaign, /-max_total_time=120/, "campaigns keep their budget");
+  assert.doesNotMatch(campaign, /-runs=0/, "campaigns must keep searching for new inputs");
+});
+
+test("the release gate rejects the nightly campaign as replay evidence", () => {
+  const plan = fuzzPlan();
+  const qualify = releaseGateRunQualifiers([plan]).get("Fuzz");
+  assert.ok(qualify);
+
+  // The nightly campaign runs on main, so a tag can share its head SHA. Reusing
+  // it as evidence would put the randomized search back on the release path.
+  assert.equal(qualify({ event: "schedule", display_title: "Fuzz schedule" }), false);
+  assert.equal(qualify({ event: "workflow_dispatch", display_title: plan.expectedRunName }), true);
 });

--- a/tests/tooling/release-preflight-bootstrap.test.ts
+++ b/tests/tooling/release-preflight-bootstrap.test.ts
@@ -214,9 +214,11 @@ test("on-demand gates correlate expanded display titles, never workflow names", 
 test("release gate bootstrap reuses exact-SHA scheduled evidence", async () => {
   const plans = releasePlans();
   const runs = requiredReleaseWorkflows.map((name, index) => successfulReleaseRun(name, index + 1));
-  const benchmarkPlan = findReleasePlan("Benchmark");
-  const benchmark = findEvidenceRun(runs, "Benchmark");
-  benchmark.display_title = benchmarkPlan.expectedRunName;
+  for (const workflowName of ["Benchmark", "Fuzz"]) {
+    const run = findEvidenceRun(runs, workflowName);
+    run.display_title = findReleasePlan(workflowName).expectedRunName;
+    run.event = "workflow_dispatch";
+  }
   const dispatched: string[] = [];
 
   const selected = await bootstrapRequiredWorkflowRuns({
@@ -228,7 +230,7 @@ test("release gate bootstrap reuses exact-SHA scheduled evidence", async () => {
 
   assert.deepEqual(dispatched, []);
   assert.deepEqual([...selected.keys()], requiredReleaseWorkflows);
-  for (const workflowName of ["App E2E", "Native Smoke", "Fuzz"]) {
+  for (const workflowName of ["App E2E", "Native Smoke"]) {
     assert.equal(findEvidenceRun(runs, workflowName).event, "schedule");
   }
 });

--- a/tools/github/release-preflight-bootstrap.mjs
+++ b/tools/github/release-preflight-bootstrap.mjs
@@ -32,6 +32,7 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
       ref,
       inputs: { base_sha: baseSha, head_sha: headSha },
       expectedRunName: `Benchmark ${baseSha}...${headSha}`,
+      acceptsScheduledEvidence: false,
     },
     {
       workflowName: "App E2E",
@@ -39,6 +40,7 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
       ref,
       inputs: { suite: appE2eSuite, target_sha: headSha },
       expectedRunName: `App E2E ${appE2eSuite} @ ${headSha}`,
+      acceptsScheduledEvidence: true,
     },
     {
       workflowName: "Native Smoke",
@@ -46,6 +48,7 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
       ref,
       inputs: {},
       expectedRunName: "Native Smoke",
+      acceptsScheduledEvidence: true,
     },
     {
       workflowName: "Real Project Matrix",
@@ -53,6 +56,7 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
       ref,
       inputs: {},
       expectedRunName: `Real Project Matrix @ ${headSha}`,
+      acceptsScheduledEvidence: true,
     },
     {
       workflowName: "Fuzz",
@@ -60,6 +64,9 @@ export function createReleaseGateDispatchPlans({ ref, headSha, baseSha }) {
       ref,
       inputs: { mode: fuzzMode },
       expectedRunName: `Fuzz ${fuzzMode} @ ${headSha}`,
+      // The nightly schedule runs a campaign, so a scheduled run at the tag SHA
+      // is not replay evidence: it must not stand in for the dispatched replay.
+      acceptsScheduledEvidence: false,
     },
   ];
 }
@@ -68,7 +75,9 @@ export function releaseGateRunQualifiers(dispatchPlans) {
   return new Map(
     dispatchPlans.map((plan) => [
       plan.workflowName,
-      (run) => run.event === "schedule" || run.display_title === plan.expectedRunName,
+      (run) =>
+        (plan.acceptsScheduledEvidence === true && run.event === "schedule") ||
+        run.display_title === plan.expectedRunName,
     ]),
   );
 }


### PR DESCRIPTION
Follow-up to #3878, which was merged while this review feedback was still open.

#3878 made the release gate dispatch `fuzz.yml` in `replay` mode, but `releaseGateRunQualifiers` still accepted *any* scheduled run as evidence for every gate. The nightly fuzz campaign runs on `main`, so a tag can share its head SHA: the gate would then reuse that campaign and the randomized search is back on the release path, which is exactly the failure mode #3878 removed. Scheduled-run eligibility is now per plan, and `false` for Fuzz:

```js
{
  workflowName: "Fuzz",
  inputs: { mode: fuzzMode },
  expectedRunName: `Fuzz ${fuzzMode} @ ${headSha}`,
  // The nightly schedule runs a campaign, so a scheduled run at the tag SHA
  // is not replay evidence: it must not stand in for the dispatched replay.
  acceptsScheduledEvidence: false,
},
```

The qualifier reads that flag with `=== true`, so a plan added without it fails closed to dispatch-only evidence. Benchmark is `false` too (it has no schedule event); App E2E, Native Smoke, and Real Project Matrix keep reusing their nightly runs, so bootstrap dispatch volume is unchanged apart from Fuzz.

The remaining changes tighten test assertions flagged in the same review: `release-fuzz-gate.test.ts` now executes the `id: fuzz` step's script per mode against a `cargo` stub on `PATH`, so replay is proven to get `-runs=0` and no budget while a campaign gets `-max_total_time` and no `-runs=0` (the previous regex pair passed even if the branch were inverted), and `fuzz-setup.test.ts` asserts the parsed `run-name` value and the step-scoped mode branch instead of the raw YAML layout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->