### PR TITLE
fix(musea): compile <art> variants through the SFC pipeline

### DIFF
--- a/npm/builder/vite-musea/src/art-component.ts
+++ b/npm/builder/vite-musea/src/art-component.ts
@@ -1,0 +1,91 @@
+/**
+ * Resolve which component an art file demonstrates, and under what tag.
+ *
+ * Shared by the art module and by the per-variant SFC compiler (#3857) so both
+ * agree on the import path, the tag `<Self>` expands to, and the binding name.
+ * The parsed `<script setup>` is passed in rather than parsed here, so this
+ * module does not have to import back from `art-module.ts`.
+ */
+
+import path from "node:path";
+
+import { allowedSourceRoots, resolveComponentSourcePath } from "./component-source.js";
+import type { ArtFileInfo } from "./types/index.js";
+import { toPascalCase } from "./utils.js";
+
+export type ArtScriptSetupInfo = {
+  defineArtComponentName?: string;
+  defineArtComponentSource?: string;
+} | null;
+
+export type ResolvedArtComponent = {
+  componentImportPath?: string;
+  componentTagName?: string;
+  componentBindingName: string;
+};
+
+export function componentNameFromSource(source: string): string {
+  const withoutQuery = source.split(/[?#]/, 1)[0] || source;
+  const filename = path.basename(withoutQuery);
+  const extension = path.extname(filename);
+  const stem = extension ? filename.slice(0, -extension.length) : filename;
+  const name = toPascalCase(stem);
+  return name === "Variant" ? "MuseaComponent" : name;
+}
+
+export function resolveArtComponent(
+  art: ArtFileInfo,
+  filePath: string,
+  scriptSetup: ArtScriptSetupInfo,
+  options: { root?: string; scanRoots?: string[] } = {},
+): ResolvedArtComponent {
+  let componentImportPath: string | undefined;
+  let componentTagName: string | undefined;
+  let componentBindingName = "__MuseaComponent";
+  const defineArtComponentName = scriptSetup?.defineArtComponentName;
+  const defineArtComponentSource = scriptSetup?.defineArtComponentSource;
+
+  if (art.isInline && art.componentPath) {
+    // Inline art: import the host .vue file itself as the component
+    componentImportPath = options.root
+      ? (resolveComponentSourcePath(
+          art,
+          filePath,
+          allowedSourceRoots(options.root, options.scanRoots ?? []),
+        ) ?? undefined)
+      : art.componentPath;
+    componentTagName = "MuseaComponent";
+  } else if (defineArtComponentSource || art.metadata.component) {
+    // .art.vue: resolve component from defineArt(source, ...) or the legacy component attribute.
+    const componentSource = defineArtComponentSource ?? art.metadata.component;
+    if (componentSource) {
+      const sourceArt =
+        componentSource === art.metadata.component
+          ? art
+          : { ...art, metadata: { ...art.metadata, component: componentSource } };
+      componentImportPath = options.root
+        ? (resolveComponentSourcePath(
+            sourceArt,
+            filePath,
+            allowedSourceRoots(options.root, options.scanRoots ?? []),
+          ) ?? undefined)
+        : path.isAbsolute(componentSource)
+          ? componentSource
+          : path.resolve(path.dirname(filePath), componentSource);
+    }
+    componentTagName =
+      defineArtComponentName ??
+      (art.metadata.component ? componentNameFromSource(art.metadata.component) : "MuseaComponent");
+    componentBindingName = componentTagName;
+  }
+
+  return { componentImportPath, componentTagName, componentBindingName };
+}
+
+/** Expand `<Self>` in a variant template to the resolved component tag. */
+export function expandSelfTag(template: string, componentTagName: string | undefined): string {
+  if (!componentTagName) return template;
+  return template
+    .replace(/<Self/g, `<${componentTagName}`)
+    .replace(/<\/Self>/g, `</${componentTagName}>`);
+}

--- a/npm/builder/vite-musea/src/art-module-helper-collisions.test.ts
+++ b/npm/builder/vite-musea/src/art-module-helper-collisions.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { generateArtModule } from "./art-module.ts";
+import { compileVariantSfc } from "./art-variant-sfc.ts";
 import type { ArtFileInfo } from "./types/art.ts";
 
 void test("generateArtModule avoids Vue helper collisions with script setup imports", () => {
@@ -37,8 +38,17 @@ function renderStoryResult(value) {
 
   const code = generateArtModule(art, art.path);
 
-  assert.match(code, /import \{ defineComponent as __museaDefineComponent \} from 'vue';/);
   assert.match(code, /import \{ computed, h, isVNode, defineComponent \} from "vue";/);
-  assert.doesNotMatch(code, /import \{ defineComponent, h \} from 'vue';/);
-  assert.match(code, /export const Default = __museaDefineComponent\(\{/);
+  assert.match(code, /import Default from "virtual:musea-variant:[^"]*:Default"/);
+
+  // The art file imports `defineComponent` and `h` itself. The variant compiles
+  // through the SFC pipeline, which aliases its own runtime helpers, so the two
+  // sets cannot collide into a redeclaration.
+  const variant = compileVariantSfc(art, art.variants[0].template, "Default", art.path);
+  assert.deepEqual(variant.errors, []);
+  // The art file's own bindings survive, and the compiler's runtime helpers are
+  // aliased (`createVNode as _createVNode`), so the two sets share no name.
+  assert.match(variant.code, /import \{ computed, h, isVNode \} from "vue"/);
+  assert.match(variant.code, /createVNode as _createVNode/);
+  assert.match(variant.code, /isVNode\(value\) \? value : h\(value\)/);
 });

--- a/npm/builder/vite-musea/src/art-module-vue2.ts
+++ b/npm/builder/vite-musea/src/art-module-vue2.ts
@@ -1,0 +1,101 @@
+/**
+ * Legacy Vue 2 variant emission.
+ *
+ * Vue 2 has no `openBlock`/`createElementBlock` runtime, so the compiled Vue 3
+ * render functions the SFC pipeline produces cannot load there. Vue 2 galleries
+ * keep the runtime-compiled `template:` string they always had — the TypeScript
+ * fix in #3857 applies to Vue 3, which is what `.art.vue` with
+ * `<script setup lang="ts">` targets.
+ */
+
+import { escapeHtml } from "./utils.js";
+
+export function escapeTemplateLiteral(str: string): string {
+  return str.replace(/\\/g, "\\\\").replace(/`/g, "\\`").replace(/\$/g, "\\$");
+}
+
+export type LegacyVariantContext = {
+  variantComponentName: string;
+  variantName: string;
+  template: string;
+  componentTagName?: string;
+  componentBindingName: string;
+  scriptSetup: { setupBody: string[]; returnNames: string[]; imports: string[] } | null;
+  hasSetup: boolean;
+  isolatedSetup: boolean;
+  setupReturn: string;
+  importDeclaresName: (statement: string, name: string) => boolean;
+};
+
+export function emitLegacyVariant(context: LegacyVariantContext): string {
+  const {
+    variantComponentName,
+    variantName,
+    template,
+    componentTagName,
+    componentBindingName,
+    scriptSetup,
+    hasSetup,
+    isolatedSetup,
+    setupReturn,
+    importDeclaresName,
+  } = context;
+
+  const escapedTemplate = escapeTemplateLiteral(template);
+  const escapedVariantName = escapeTemplateLiteral(escapeHtml(variantName));
+  const fullTemplate = `<div data-variant="${escapedVariantName}">${escapedTemplate}</div>`;
+
+  // Runtime-compiled templates use resolveComponent(), which checks the
+  // `components` option rather than setup return values.
+  const componentNames = new Map<string, string>();
+  if (componentTagName) componentNames.set(componentTagName, componentBindingName);
+  if (scriptSetup) {
+    for (const name of scriptSetup.returnNames)
+      if (/^[A-Z]/.test(name) && scriptSetup.imports.some((imp) => importDeclaresName(imp, name)))
+        componentNames.set(name, name);
+  }
+  const components =
+    componentNames.size > 0
+      ? `  components: { ${[...componentNames]
+          .map(([name, value]) => `${JSON.stringify(name)}: ${value}`)
+          .join(", ")} },\n`
+      : "";
+
+  if (scriptSetup && hasSetup && isolatedSetup) {
+    return `
+export const ${variantComponentName} = __museaDefineComponent({
+  name: '${variantComponentName}',
+${components}  setup() {
+${scriptSetup.setupBody.join("\n")}
+    return ${setupReturn};
+  },
+  template: \`${fullTemplate}\`,
+});
+`;
+  }
+  if (scriptSetup && hasSetup) {
+    return `
+export const ${variantComponentName} = __museaDefineComponent({
+  name: '${variantComponentName}',
+${components}  setup() {
+    return __museaSharedSetup;
+  },
+  template: \`${fullTemplate}\`,
+});
+`;
+  }
+  if (componentTagName) {
+    return `
+export const ${variantComponentName} = {
+  name: '${variantComponentName}',
+${components}  template: \`${fullTemplate}\`,
+};
+`;
+  }
+  return `
+export const ${variantComponentName} = {
+  name: '${variantComponentName}',
+  template: \`${fullTemplate}\`,
+};
+`;
+}

--- a/npm/builder/vite-musea/src/art-module.test.ts
+++ b/npm/builder/vite-musea/src/art-module.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { generateArtModule, parseScriptSetupForArt } from "./art-module.ts";
+import { buildVariantSfcSource } from "./art-variant-sfc.ts";
 import { generatePreviewModule } from "./preview/index.ts";
 import type { ArtFileInfo } from "./types/art.ts";
 
@@ -62,89 +63,15 @@ import "../generated/tokens.css"
 
   assert.doesNotMatch(code, /import "..\/generated\/tokens\.css"/);
   assert.match(code, /import "\/repo\/generated\/tokens\.css";?/);
-  assert.match(code, /return \{ MfMatesLogo, mfVerticalInkPresets \};/);
   assert.match(code, /export const __styles__ = \["\.logo-preview \{ color: red; \}"\];/);
-});
-
-void test("generateArtModule treats defineArt as a compiler macro and isolates setup by variant", () => {
-  const art: ArtFileInfo = {
-    path: "/repo/components/Button.art.vue",
-    metadata: {
-      title: "Button",
-      component: "./Button.vue",
-      tags: [],
-      status: "ready",
-    },
-    variants: [
-      { name: "Primary", template: `<Button :count="count" />`, isDefault: true, skipVrt: false },
-      {
-        name: "Secondary",
-        template: `<Button :count="count" />`,
-        isDefault: false,
-        skipVrt: false,
-      },
-    ],
-    hasScriptSetup: true,
-    scriptSetupContent: `
-import { ref } from "vue"
-
-defineArt("./Button.vue", {
-  title: "Button",
-})
-
-const count = ref(0)
-`.trim(),
-    scriptSetupIsolated: true,
-    hasScript: false,
-    styleCount: 0,
-  };
-
-  const code = generateArtModule(art, art.path);
-
-  assert.match(code, /import Button from "\/repo\/components\/Button\.vue";/);
-  assert.doesNotMatch(code, /\bdefineArt\s*\(/);
-  assert.match(code, /components: \{ "Button": Button \}/);
-  assert.match(
-    code,
-    /export const Primary = __museaDefineComponent\(\{[\s\S]*const count = ref\(0\)/,
-  );
-  assert.match(
-    code,
-    /export const Secondary = __museaDefineComponent\(\{[\s\S]*const count = ref\(0\)/,
-  );
-  assert.doesNotMatch(code, /return \{ Button,/);
-});
-
-void test("generateArtModule does not register local PascalCase constants as components", () => {
-  const art: ArtFileInfo = {
-    path: "/repo/components/Foo.art.vue",
-    metadata: {
-      title: "Foo",
-      tags: [],
-      status: "ready",
-    },
-    variants: [
-      {
-        name: "Default",
-        template: `<Foo />`,
-        isDefault: true,
-        skipVrt: false,
-      },
-    ],
-    hasScriptSetup: true,
-    scriptSetupContent: `
-defineArt("./Foo.vue", { title: "Foo" });
-const SAMPLE = "hello";
-`.trim(),
-    hasScript: false,
-    styleCount: 0,
-  };
-
-  const code = generateArtModule(art, art.path);
-
-  assert.match(code, /components: \{ "Foo": Foo \}/);
-  assert.doesNotMatch(code, /"SAMPLE": SAMPLE/);
-  assert.match(code, /return \{ SAMPLE \};/);
+  // The bindings moved into the variant's own SFC, which is what compiles the
+  // template now (#3857). Its imports are rebased too: a relative specifier
+  // cannot resolve from a virtual module.
+  const variant = buildVariantSfcSource(art, art.variants[0].template, "default", {
+    artFilePath: art.path,
+  });
+  assert.match(variant, /import MfMatesLogo from "\/repo\/components\/MfMatesLogo\.vue"/);
+  assert.match(variant, /import \{ mfVerticalInkPresets \} from "\/repo\/components\/presets"/);
 });
 
 void test("generateArtModule preserves multiline template literal indentation in script setup", () => {
@@ -175,10 +102,14 @@ void test("generateArtModule preserves multiline template literal indentation in
     styleCount: 0,
   };
 
-  const code = generateArtModule(art, art.path);
+  // The setup body is carried into the variant SFC verbatim, so a multiline
+  // template literal must not gain the indentation of its new surroundings.
+  const variant = buildVariantSfcSource(art, art.variants[0].template, "Default", {
+    artFilePath: art.path,
+  });
 
-  assert.ok(code.includes("const md = `# Title\n\n- a\n- b`;"));
-  assert.doesNotMatch(code, /`# Title\n    \n    - a\n    - b`/);
+  assert.ok(variant.includes("const md = `# Title\n\n- a\n- b`;"), variant);
+  assert.doesNotMatch(variant, /`# Title\n    \n    - a\n    - b`/);
 });
 
 void test("parseScriptSetupForArt infers defineArt component source literals", () => {
@@ -222,43 +153,14 @@ void test("generateArtModule can resolve component only from defineArt source", 
   const code = generateArtModule(art, art.path);
 
   assert.match(code, /import BaseButton from "\/repo\/components\/base-button\.vue";/);
-  assert.match(code, /components: \{ "BaseButton": BaseButton \}/);
-});
-
-void test("generateArtModule shares setup when script setup isolate is false", () => {
-  const art: ArtFileInfo = {
-    path: "/repo/components/Button.art.vue",
-    metadata: {
-      title: "Button",
-      component: "./Button.vue",
-      tags: [],
-      status: "ready",
-    },
-    variants: [
-      { name: "Primary", template: `<Button :count="count" />`, isDefault: true, skipVrt: false },
-      {
-        name: "Secondary",
-        template: `<Button :count="count" />`,
-        isDefault: false,
-        skipVrt: false,
-      },
-    ],
-    hasScriptSetup: true,
-    scriptSetupContent: `
-import { ref } from "vue"
-import Button from "./Button.vue"
-const count = ref(0)
-`.trim(),
-    scriptSetupIsolated: false,
-    hasScript: false,
-    styleCount: 0,
-  };
-
-  const code = generateArtModule(art, art.path);
-
-  assert.match(code, /const __museaSharedSetup = \(\(\) => \{/);
-  assert.match(code, /return __museaSharedSetup;/);
-  assert.equal((code.match(/const count = ref\(0\)/g) ?? []).length, 1);
+  // The variant imports it too, which is what makes `<BaseButton />` resolve in
+  // its own SFC scope.
+  const variant = buildVariantSfcSource(art, `<BaseButton />`, "Default", {
+    artFilePath: art.path,
+    componentImportPath: "/repo/components/base-button.vue",
+    componentBindingName: "BaseButton",
+  });
+  assert.match(variant, /import BaseButton from "\/repo\/components\/base-button\.vue"/);
 });
 
 void test("generatePreviewModule injects art-scoped styles from the virtual art module", () => {

--- a/npm/builder/vite-musea/src/art-module.ts
+++ b/npm/builder/vite-musea/src/art-module.ts
@@ -10,6 +10,7 @@ import path from "node:path";
 import { allowedSourceRoots, resolveComponentSourcePath } from "./component-source.js";
 import type { ArtFileInfo } from "./types/index.js";
 import { toPascalCase } from "./utils.js";
+import { emitLegacyVariant } from "./art-module-vue2.js";
 
 /**
  * Extract the content of the first <script setup> block from a Vue SFC source.
@@ -401,6 +402,8 @@ function isDefineArtLine(trimmed: string): boolean {
 }
 
 interface GenerateArtModuleOptions {
+  /** Legacy galleries keep runtime-compiled templates; see the Vue 2 branch below. */
+  vueVersion?: 2 | 3;
   root?: string;
   scanRoots?: string[];
 }
@@ -455,7 +458,6 @@ export function generateArtModule(
 
   let code = `
 // Auto-generated module for: ${path.basename(filePath)}
-import { defineComponent as __museaDefineComponent } from 'vue';
 `;
 
   // Add script setup imports at module level
@@ -510,6 +512,32 @@ ${scriptSetup.setupBody.join("\n")}
       template = template
         .replace(/<Self/g, `<${componentTagName}`)
         .replace(/<\/Self>/g, `</${componentTagName}>`);
+    }
+
+    // Vue 2 has no `openBlock`/`createElementBlock` runtime, so a compiled Vue 3
+    // render function cannot load there. Legacy galleries keep the
+    // runtime-compiled `template:` string they always had; the TypeScript fix
+    // below applies to Vue 3, which is what `.art.vue` with
+    // `<script setup lang="ts">` targets (#3857).
+    // Vue 2 has no `openBlock`/`createElementBlock` runtime, so a compiled Vue 3
+    // render function cannot load there. Legacy galleries keep the
+    // runtime-compiled `template:` string they always had; the TypeScript fix
+    // applies to Vue 3, which is what `.art.vue` with `<script setup lang="ts">`
+    // targets (#3857).
+    if (options.vueVersion === 2) {
+      code += emitLegacyVariant({
+        variantComponentName,
+        variantName: variant.name,
+        template,
+        componentTagName,
+        componentBindingName,
+        scriptSetup,
+        hasSetup,
+        isolatedSetup,
+        setupReturn,
+        importDeclaresName,
+      });
+      continue;
     }
 
     // Each variant is compiled through the SFC pipeline in its own virtual

--- a/npm/builder/vite-musea/src/art-module.ts
+++ b/npm/builder/vite-musea/src/art-module.ts
@@ -9,7 +9,7 @@ import path from "node:path";
 
 import { allowedSourceRoots, resolveComponentSourcePath } from "./component-source.js";
 import type { ArtFileInfo } from "./types/index.js";
-import { escapeHtml, toPascalCase } from "./utils.js";
+import { toPascalCase } from "./utils.js";
 
 /**
  * Extract the content of the first <script setup> block from a Vue SFC source.
@@ -35,7 +35,7 @@ function resolveRelativeSpecifier(specifier: string, artDir: string): string {
   return path.resolve(artDir, specifier);
 }
 
-function rewriteRelativeImportStatement(statement: string, artDir: string): string {
+export function rewriteRelativeImportStatement(statement: string, artDir: string): string {
   const rewrittenFromImports = statement.replace(
     /\bfrom\s+(['"])([^'"]+)\1/g,
     (_match, quote: string, specifier: string) =>
@@ -47,10 +47,6 @@ function rewriteRelativeImportStatement(statement: string, artDir: string): stri
     (_match, prefix: string, quote: string, specifier: string, suffix: string) =>
       `${prefix}${quote}${resolveRelativeSpecifier(specifier, artDir)}${quote}${suffix}`,
   );
-}
-
-function escapeTemplateLiteral(str: string): string {
-  return str.replace(/\\/g, "\\\\").replace(/`/g, "\\`").replace(/\$/g, "\\$");
 }
 
 function countCharBalance(source: string, openChar: string, closeChar: string): number {
@@ -516,68 +512,15 @@ ${scriptSetup.setupBody.join("\n")}
         .replace(/<\/Self>/g, `</${componentTagName}>`);
     }
 
-    // Escape the template for use in a JS string
-    const escapedTemplate = escapeTemplateLiteral(template);
-    const escapedVariantName = escapeTemplateLiteral(escapeHtml(variant.name));
-
-    // Wrap template with the variant container (no .musea-variant class -- the
-    // outer mount container already carries it; duplicating causes double padding)
-    const fullTemplate = `<div data-variant="${escapedVariantName}">${escapedTemplate}</div>`;
-
-    // Collect component names for the `components` option.
-    // Runtime-compiled templates use resolveComponent() which checks the
-    // `components` option, NOT setup return values.
-    const componentNames = new Map<string, string>();
-    if (componentTagName) componentNames.set(componentTagName, componentBindingName);
-    if (scriptSetup) {
-      for (const name of scriptSetup.returnNames)
-        if (/^[A-Z]/.test(name) && scriptSetup.imports.some((imp) => importDeclaresName(imp, name)))
-          componentNames.set(name, name);
-    }
-    const components =
-      componentNames.size > 0
-        ? `  components: { ${[...componentNames]
-            .map(([name, value]) => `${JSON.stringify(name)}: ${value}`)
-            .join(", ")} },\n`
-        : "";
-
-    if (scriptSetup && hasSetup && isolatedSetup) {
-      // Generate variant with setup function from art file's <script setup>
-      code += `
-export const ${variantComponentName} = __museaDefineComponent({
-  name: '${variantComponentName}',
-${components}  setup() {
-${scriptSetup.setupBody.join("\n")}
-    return ${setupReturn};
-  },
-  template: \`${fullTemplate}\`,
-});
+    // Each variant is compiled through the SFC pipeline in its own virtual
+    // module (#3857): `compileSfc` emits a complete module with its own default
+    // export, so it cannot be inlined here, and only that pipeline strips the
+    // TypeScript in template expressions and resolves bindings correctly.
+    const variantModuleId = `virtual:musea-variant:${filePath}:${variant.name}`;
+    code += `
+import ${variantComponentName} from ${JSON.stringify(variantModuleId)};
+export { ${variantComponentName} };
 `;
-    } else if (scriptSetup && hasSetup) {
-      code += `
-export const ${variantComponentName} = __museaDefineComponent({
-  name: '${variantComponentName}',
-${components}  setup() {
-    return __museaSharedSetup;
-  },
-  template: \`${fullTemplate}\`,
-});
-`;
-    } else if (componentTagName) {
-      code += `
-export const ${variantComponentName} = {
-  name: '${variantComponentName}',
-${components}  template: \`${fullTemplate}\`,
-};
-`;
-    } else {
-      code += `
-export const ${variantComponentName} = {
-  name: '${variantComponentName}',
-  template: \`${fullTemplate}\`,
-};
-`;
-    }
   }
 
   // Default export

--- a/npm/builder/vite-musea/src/art-shared-setup.ts
+++ b/npm/builder/vite-musea/src/art-shared-setup.ts
@@ -1,0 +1,61 @@
+/**
+ * One shared `<script setup>` instance for an art file's variants.
+ *
+ * `scriptSetupIsolated: false` opts an art file out of per-variant isolation:
+ * every variant sees the same setup instance, so state written in one variant is
+ * visible in the next. Compiling each variant as its own SFC (#3857) would give
+ * each one its own setup and silently drop that, so the shared case hoists the
+ * setup into this module and the variants import its bindings instead of
+ * declaring them.
+ *
+ * A dedicated module rather than the art module itself, because the art module
+ * imports the variants — routing the shared state through it would make that a
+ * cycle.
+ */
+
+import path from "node:path";
+
+import { parseScriptSetupForArt, rewriteRelativeImportStatement } from "./art-module.js";
+import type { ArtFileInfo } from "./types/index.js";
+
+type ParsedScriptSetup = {
+  imports: string[];
+  setupBody: string[];
+  returnNames: string[];
+};
+
+/**
+ * The binding names a variant SFC should import from the shared module.
+ *
+ * `<script setup>` resolves template identifiers from its own bindings, and an
+ * import is a binding, so importing each name by hand is what makes the shared
+ * state reachable from the variant's template.
+ */
+export function sharedBindingNames(parsed: ParsedScriptSetup): string[] {
+  return [...new Set(parsed.returnNames)].filter((name) => /^[A-Za-z_$][\w$]*$/.test(name));
+}
+
+export function generateSharedSetupModule(art: ArtFileInfo, filePath: string): string {
+  const parsed = parseSharedScriptSetup(art);
+  if (!parsed) return "export {};\n";
+
+  const artDir = path.dirname(filePath);
+  const imports = parsed.imports
+    .map((statement) => rewriteRelativeImportStatement(statement, artDir))
+    .join("\n");
+  const names = sharedBindingNames(parsed);
+
+  // Evaluated once at module scope, so every variant importing these bindings
+  // observes the same instance.
+  return [
+    imports,
+    parsed.setupBody.join("\n"),
+    names.length > 0 ? `export { ${names.join(", ")} };` : "export {};",
+    "",
+  ].join("\n");
+}
+
+function parseSharedScriptSetup(art: ArtFileInfo): ParsedScriptSetup | null {
+  if (!art.scriptSetupContent) return null;
+  return parseScriptSetupForArt(art.scriptSetupContent);
+}

--- a/npm/builder/vite-musea/src/art-variant-sfc.test.ts
+++ b/npm/builder/vite-musea/src/art-variant-sfc.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildVariantSfcSource, compileVariantSfc } from "./art-variant-sfc.js";
+import type { ArtFileInfo } from "./types/index.js";
+
+const scriptSetup = [
+  "import { ref } from 'vue'",
+  "const file = ref(null)",
+  "const items = ref([{ isValid: false }])",
+].join("\n");
+
+function artFile(overrides: Partial<ArtFileInfo> = {}): ArtFileInfo {
+  return {
+    path: "/p/src/Example.art.vue",
+    metadata: { title: "Example", tags: [], status: "ready" },
+    variants: [],
+    hasScriptSetup: true,
+    hasScript: false,
+    styleCount: 0,
+    styleBlocks: [],
+    isInline: false,
+    scriptSetupContent: scriptSetup,
+    ...overrides,
+  } as ArtFileInfo;
+}
+
+void test("a type annotation in a template expression compiles instead of reaching the browser", () => {
+  // `@update:value="(f: File | null) => …"` used to be handed to Vue's runtime
+  // compiler as a string, where `new Function` threw on the annotation (#3857).
+  const result = compileVariantSfc(
+    artFile(),
+    `<E :value="file" @update:value="(f: File | null) => (file = f)" />`,
+    "TypeAnnotation",
+    "/p/src/Example.art.vue",
+  );
+
+  assert.deepEqual(result.errors, []);
+  assert.doesNotMatch(result.code, /File \| null/, "the annotation must be stripped");
+  assert.match(result.code, /\(f\) =>/, "the handler must survive as plain JavaScript");
+  assert.match(result.code, /file\.value = f/, "the ref must be unwrapped");
+});
+
+void test("a non-null assertion compiles and keeps its identifier resolved", () => {
+  // The template compiler alone leaves `items[0]!.isValid` unprefixed, which is
+  // a ReferenceError at render time; the SFC pipeline resolves it.
+  const result = compileVariantSfc(
+    artFile(),
+    `<E :disabled="items[0]!.isValid" />`,
+    "NonNullAssertion",
+    "/p/src/Example.art.vue",
+  );
+
+  assert.deepEqual(result.errors, []);
+  assert.doesNotMatch(result.code, /!\./, "the assertion must be stripped");
+  assert.match(result.code, /items\.value\[0\]\.isValid/, "the binding must resolve through setup");
+});
+
+void test("plain JavaScript variants keep working", () => {
+  const result = compileVariantSfc(
+    artFile(),
+    `<E :disabled="items[0].isValid" @update:value="f => (file = f)" />`,
+    "PlainJs",
+    "/p/src/Example.art.vue",
+  );
+
+  assert.deepEqual(result.errors, []);
+  assert.match(result.code, /items\.value\[0\]\.isValid/);
+});
+
+void test("the variant wrapper carries the variant name for gallery queries", () => {
+  const source = buildVariantSfcSource(artFile(), `<E />`, 'Some "Quoted" Name');
+
+  assert.match(source, /data-variant="Some &quot;Quoted&quot; Name"/);
+  assert.match(source, /<script setup lang="ts">/);
+});
+
+void test("an art file without a script block still compiles its template", () => {
+  const result = compileVariantSfc(
+    artFile({ scriptSetupContent: undefined, hasScriptSetup: false }),
+    `<span>static</span>`,
+    "Static",
+    "/p/src/Example.art.vue",
+  );
+
+  assert.deepEqual(result.errors, []);
+  assert.match(result.code, /data-variant/);
+  // A template-only SFC compiles to a bare `export function render`, which the
+  // art module cannot import as a component.
+  assert.match(result.code, /export default/, "every variant must export a component");
+});
+
+void test("the demonstrated component is imported so <Self> resolves", () => {
+  const source = buildVariantSfcSource(artFile(), `<MuseaComponent />`, "Default", {
+    componentImportPath: "/p/src/Example.vue",
+    componentBindingName: "MuseaComponent",
+  });
+
+  assert.match(source, /import MuseaComponent from "\/p\/src\/Example\.vue"/);
+});

--- a/npm/builder/vite-musea/src/art-variant-sfc.ts
+++ b/npm/builder/vite-musea/src/art-variant-sfc.ts
@@ -17,9 +17,29 @@
  *     @u="(f: File | null) => …"      ->   onU: (f) => file.value = f
  */
 
+import path from "node:path";
+
 import { loadNative } from "./native-loader.js";
 import { expandSelfTag, resolveArtComponent } from "./art-component.js";
+import { parseScriptSetupForArt, rewriteRelativeImportStatement } from "./art-module.js";
 import type { ArtFileInfo } from "./types/index.js";
+
+/**
+ * Rebase the art file's `<script setup>` for a virtual module.
+ *
+ * A variant compiles into a virtual module, and a relative specifier cannot be
+ * resolved from one — the art module rebases its own imports for exactly this
+ * reason, and the variant needs the same treatment or every relative import in
+ * an art file fails to resolve.
+ */
+function rebaseScriptSetup(scriptSetup: string, artDir: string): string {
+  if (!scriptSetup.trim()) return "";
+  const parsed = parseScriptSetupForArt(scriptSetup);
+  const imports = parsed.imports.map((statement) =>
+    rewriteRelativeImportStatement(statement, artDir),
+  );
+  return [...imports, ...parsed.setupBody].join("\n").trim();
+}
 
 export type VariantSfcResult = {
   code: string;
@@ -41,6 +61,7 @@ export function buildVariantSfcSource(
     scriptSetup?: string | null;
     componentImportPath?: string;
     componentBindingName?: string;
+    artFilePath?: string;
     /**
      * Bindings to import from the art file's shared setup module instead of
      * declaring locally. `scriptSetupIsolated: false` means every variant sees
@@ -60,7 +81,10 @@ export function buildVariantSfcSource(
       `<template><div data-variant="${escapedShared}">${variantTemplate}</div></template>\n`
     );
   }
-  const scriptSetup = options.scriptSetup ?? art.scriptSetupContent ?? "";
+  const scriptSetup = rebaseScriptSetup(
+    options.scriptSetup ?? art.scriptSetupContent ?? "",
+    path.dirname(options.artFilePath ?? art.path),
+  );
   // The demonstrated component is imported into the variant's own setup scope so
   // `<Self>` — and any tag the art file referenced — resolves through the SFC's
   // binding resolution rather than a `components` option.
@@ -111,6 +135,7 @@ export function compileVariantSfc(
       scriptSetup: options.scriptSetup,
       componentImportPath: component.componentImportPath,
       componentBindingName: component.componentBindingName,
+      artFilePath: filename,
       sharedBindings: options.sharedBindings,
     },
   );

--- a/npm/builder/vite-musea/src/art-variant-sfc.ts
+++ b/npm/builder/vite-musea/src/art-variant-sfc.ts
@@ -1,0 +1,126 @@
+/**
+ * Compile an `<art>` variant through the SFC pipeline.
+ *
+ * Variants used to be emitted as `template:` strings for Vue's runtime
+ * compiler, which never sees the SFC pipeline. Any template expression relying
+ * on SFC-time compilation therefore failed at render time — most importantly
+ * TypeScript, even though `.art.vue` files are authored with
+ * `<script setup lang="ts">` (#3857).
+ *
+ * Compiling the raw template with the template compiler is not enough: it
+ * leaves TypeScript in place *and* its identifier prefixer gives up on TS
+ * syntax, so `items[0]!.isValid` stays unprefixed and throws at runtime. Only
+ * the SFC pipeline handles both, which is what the issue asks for — the variant
+ * is compiled the same way the enclosing SFC is:
+ *
+ *     :disabled="items[0]!.isValid"   ->   disabled: items.value[0].isValid
+ *     @u="(f: File | null) => …"      ->   onU: (f) => file.value = f
+ */
+
+import { loadNative } from "./native-loader.js";
+import { expandSelfTag, resolveArtComponent } from "./art-component.js";
+import type { ArtFileInfo } from "./types/index.js";
+
+export type VariantSfcResult = {
+  code: string;
+  errors: string[];
+};
+
+/**
+ * Build the synthetic SFC source for one variant.
+ *
+ * The art file's own `<script setup>` becomes the variant's setup block, so
+ * bindings resolve exactly as they do in the authored file, and `lang="ts"` is
+ * carried over so the pipeline strips TypeScript from template expressions.
+ */
+export function buildVariantSfcSource(
+  art: ArtFileInfo,
+  variantTemplate: string,
+  variantName: string,
+  options: {
+    scriptSetup?: string | null;
+    componentImportPath?: string;
+    componentBindingName?: string;
+    /**
+     * Bindings to import from the art file's shared setup module instead of
+     * declaring locally. `scriptSetupIsolated: false` means every variant sees
+     * one setup instance, which per-variant SFCs would otherwise each
+     * re-evaluate — losing the shared state that opt-in exists for.
+     */
+    sharedBindings?: { moduleId: string; names: string[] };
+  } = {},
+): string {
+  if (options.sharedBindings && options.sharedBindings.names.length > 0) {
+    const { moduleId, names } = options.sharedBindings;
+    const escapedShared = variantName.replace(/"/g, "&quot;");
+    return (
+      `<script setup lang="ts">\n` +
+      `import { ${names.join(", ")} } from ${JSON.stringify(moduleId)}\n` +
+      `</script>\n` +
+      `<template><div data-variant="${escapedShared}">${variantTemplate}</div></template>\n`
+    );
+  }
+  const scriptSetup = options.scriptSetup ?? art.scriptSetupContent ?? "";
+  // The demonstrated component is imported into the variant's own setup scope so
+  // `<Self>` — and any tag the art file referenced — resolves through the SFC's
+  // binding resolution rather than a `components` option.
+  const componentImport =
+    options.componentImportPath && options.componentBindingName
+      ? `import ${options.componentBindingName} from ${JSON.stringify(options.componentImportPath)}\n`
+      : "";
+  // Always emit the block, even empty. Without a script a template-only SFC
+  // compiles to a bare `export function render`, with no default export for the
+  // art module to import — the variant would resolve to `undefined`.
+  const body = `${componentImport}${scriptSetup.trim()}`.trim();
+  const script = `<script setup lang="ts">\n${body}\n</script>\n`;
+  // The wrapper carries the variant name for the gallery's DOM queries. It is
+  // part of the template so the compiler sees a single root.
+  const escapedName = variantName.replace(/"/g, "&quot;");
+  return `${script}<template><div data-variant="${escapedName}">${variantTemplate}</div></template>\n`;
+}
+
+/**
+ * Compile a variant to a self-contained ES module exporting the component.
+ *
+ * Each variant compiles to its own module because `compileSfc` emits a complete
+ * module with its own `export default` and imports; concatenating several into
+ * one art module would redeclare bindings and collide on the default export.
+ */
+export function compileVariantSfc(
+  art: ArtFileInfo,
+  variantTemplate: string,
+  variantName: string,
+  filename: string,
+  options: {
+    scriptSetup?: string | null;
+    parsedScriptSetup?: Parameters<typeof resolveArtComponent>[2];
+    root?: string;
+    scanRoots?: string[];
+    sharedBindings?: { moduleId: string; names: string[] };
+  } = {},
+): VariantSfcResult {
+  const component = resolveArtComponent(art, filename, options.parsedScriptSetup ?? null, {
+    root: options.root,
+    scanRoots: options.scanRoots,
+  });
+  const source = buildVariantSfcSource(
+    art,
+    expandSelfTag(variantTemplate, component.componentTagName),
+    variantName,
+    {
+      scriptSetup: options.scriptSetup,
+      componentImportPath: component.componentImportPath,
+      componentBindingName: component.componentBindingName,
+      sharedBindings: options.sharedBindings,
+    },
+  );
+  const result = loadNative().compileSfc(source, { filename });
+  return {
+    code: result.code ?? "",
+    errors: (result.errors ?? []).map((error) =>
+      typeof error === "string"
+        ? error
+        : ((error as { message?: string }).message ?? JSON.stringify(error)),
+    ),
+  };
+}

--- a/npm/builder/vite-musea/src/art-variant-wiring.test.ts
+++ b/npm/builder/vite-musea/src/art-variant-wiring.test.ts
@@ -1,0 +1,152 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { generateArtModule } from "./art-module.ts";
+import { buildVariantSfcSource } from "./art-variant-sfc.ts";
+import { generateSharedSetupModule } from "./art-shared-setup.ts";
+import type { ArtFileInfo } from "./types/art.ts";
+
+// Behaviour that moved from the art module into the per-variant SFCs (#3857):
+// component resolution, setup isolation, and the shared-setup opt-out.
+
+void test("generateArtModule treats defineArt as a compiler macro and isolates setup by variant", () => {
+  const art: ArtFileInfo = {
+    path: "/repo/components/Button.art.vue",
+    metadata: {
+      title: "Button",
+      component: "./Button.vue",
+      tags: [],
+      status: "ready",
+    },
+    variants: [
+      { name: "Primary", template: `<Button :count="count" />`, isDefault: true, skipVrt: false },
+      {
+        name: "Secondary",
+        template: `<Button :count="count" />`,
+        isDefault: false,
+        skipVrt: false,
+      },
+    ],
+    hasScriptSetup: true,
+    scriptSetupContent: `
+import { ref } from "vue"
+
+defineArt("./Button.vue", {
+  title: "Button",
+})
+
+const count = ref(0)
+`.trim(),
+    scriptSetupIsolated: true,
+    hasScript: false,
+    styleCount: 0,
+  };
+
+  const code = generateArtModule(art, art.path);
+
+  assert.match(code, /import Button from "\/repo\/components\/Button\.vue";/);
+  assert.doesNotMatch(code, /\bdefineArt\s*\(/);
+  // Each variant is its own module, so isolation is structural rather than a
+  // per-variant copy of the setup body.
+  assert.match(code, /import Primary from "virtual:musea-variant:[^"]*:Primary"/);
+  assert.match(code, /import Secondary from "virtual:musea-variant:[^"]*:Secondary"/);
+
+  for (const variantName of ["Primary", "Secondary"]) {
+    const variant = buildVariantSfcSource(art, `<Button :count="count" />`, variantName, {
+      artFilePath: art.path,
+      componentImportPath: "/repo/components/Button.vue",
+      componentBindingName: "Button",
+    });
+    assert.match(variant, /const count = ref\(0\)/, variantName);
+    assert.doesNotMatch(variant, /\bdefineArt\s*\(/, `${variantName} keeps the macro out`);
+    assert.match(variant, /import Button from "\/repo\/components\/Button\.vue"/, variantName);
+  }
+});
+
+void test("generateArtModule does not register local PascalCase constants as components", () => {
+  const art: ArtFileInfo = {
+    path: "/repo/components/Foo.art.vue",
+    metadata: {
+      title: "Foo",
+      tags: [],
+      status: "ready",
+    },
+    variants: [
+      {
+        name: "Default",
+        template: `<Foo />`,
+        isDefault: true,
+        skipVrt: false,
+      },
+    ],
+    hasScriptSetup: true,
+    scriptSetupContent: `
+defineArt("./Foo.vue", { title: "Foo" });
+const SAMPLE = "hello";
+`.trim(),
+    hasScript: false,
+    styleCount: 0,
+  };
+
+  const code = generateArtModule(art, art.path);
+
+  // `<script setup>` resolves `<Foo />` from its imported binding, so a local
+  // PascalCase constant can no longer be mistaken for a component at all.
+  const variant = buildVariantSfcSource(art, `<Foo />`, "Default", {
+    artFilePath: art.path,
+    componentImportPath: "/repo/components/Foo.vue",
+    componentBindingName: "Foo",
+  });
+  assert.match(variant, /import Foo from "\/repo\/components\/Foo\.vue"/);
+  assert.match(variant, /const SAMPLE = "hello"/);
+  assert.doesNotMatch(variant, /"SAMPLE"\s*:/);
+  assert.doesNotMatch(code, /\bdefineArt\s*\(/);
+});
+
+void test("generateArtModule shares setup when script setup isolate is false", () => {
+  const art: ArtFileInfo = {
+    path: "/repo/components/Button.art.vue",
+    metadata: {
+      title: "Button",
+      component: "./Button.vue",
+      tags: [],
+      status: "ready",
+    },
+    variants: [
+      { name: "Primary", template: `<Button :count="count" />`, isDefault: true, skipVrt: false },
+      {
+        name: "Secondary",
+        template: `<Button :count="count" />`,
+        isDefault: false,
+        skipVrt: false,
+      },
+    ],
+    hasScriptSetup: true,
+    scriptSetupContent: `
+import { ref } from "vue"
+import Button from "./Button.vue"
+const count = ref(0)
+`.trim(),
+    scriptSetupIsolated: false,
+    hasScript: false,
+    styleCount: 0,
+  };
+
+  // Opting out of isolation must still mean one setup instance. Variants import
+  // the shared module's bindings instead of each re-declaring them, which would
+  // give every variant its own `count`.
+  const shared = generateSharedSetupModule(art, art.path);
+  assert.match(shared, /const count = ref\(0\)/);
+  assert.match(shared, /export \{[^}]*\bcount\b/);
+  assert.equal((shared.match(/const count = ref\(0\)/g) ?? []).length, 1);
+
+  const variant = buildVariantSfcSource(art, `<Button :count="count" />`, "Primary", {
+    artFilePath: art.path,
+    sharedBindings: {
+      moduleId: `virtual:musea-shared:${art.path}`,
+      names: ["Button", "count"],
+    },
+  });
+  assert.match(variant, /import \{ Button, count \} from "virtual:musea-shared:/);
+  assert.doesNotMatch(variant, /const count = ref\(0\)/, "the variant must not re-declare it");
+});

--- a/npm/builder/vite-musea/src/native-loader.ts
+++ b/npm/builder/vite-musea/src/native-loader.ts
@@ -36,6 +36,14 @@ export interface NativeBinding {
     hasScript: boolean;
     styleCount: number;
   };
+  /** Compile a Vue SFC the same way the enclosing `.art.vue` file is compiled. */
+  compileSfc: (
+    source: string,
+    options?: { filename?: string },
+  ) => {
+    code?: string;
+    errors?: Array<string | { message?: string }>;
+  };
   artToCsf: (
     source: string,
     options?: { filename?: string },

--- a/npm/builder/vite-musea/src/plugin/virtual.ts
+++ b/npm/builder/vite-musea/src/plugin/virtual.ts
@@ -173,6 +173,7 @@ export function createLoad(state: VirtualModuleState) {
         return generateArtModule(art, artPath, {
           root: state.getConfigRoot(),
           scanRoots: state.getScanRoots(),
+          vueVersion: state.getVueVersion(),
         });
       }
     }
@@ -183,6 +184,7 @@ export function createLoad(state: VirtualModuleState) {
         return generateArtModule(art, realPath, {
           root: state.getConfigRoot(),
           scanRoots: state.getScanRoots(),
+          vueVersion: state.getVueVersion(),
         });
       }
     }

--- a/npm/builder/vite-musea/src/plugin/virtual.ts
+++ b/npm/builder/vite-musea/src/plugin/virtual.ts
@@ -15,6 +15,9 @@ import { generateGalleryModule } from "../gallery/module.js";
 import { generatePreviewModule } from "../preview/index.js";
 import { generateManifestModule } from "../manifest.js";
 import { generateArtModule } from "../art-module.js";
+import { compileVariantSfc } from "../art-variant-sfc.js";
+import { generateSharedSetupModule, sharedBindingNames } from "../art-shared-setup.js";
+import { parseScriptSetupForArt } from "../art-module.js";
 import { toPascalCase } from "../utils.js";
 
 // Virtual module prefixes
@@ -55,6 +58,17 @@ export function createResolveId(state: VirtualModuleState) {
     // Handle virtual:musea-preview: prefix for preview modules
     if (id.startsWith("virtual:musea-preview:")) {
       return "\0musea-preview:" + id.slice("virtual:musea-preview:".length);
+    }
+    // One module per variant, compiled through the SFC pipeline (#3857). Each
+    // one is a complete module with its own default export, so they cannot be
+    // concatenated into the art module.
+    if (id.startsWith("virtual:musea-variant:")) {
+      return "\0musea-variant:" + id.slice("virtual:musea-variant:".length) + "?musea-virtual";
+    }
+    // One shared setup instance for art files that opt out of per-variant
+    // isolation, so `scriptSetupIsolated: false` keeps meaning one instance.
+    if (id.startsWith("virtual:musea-shared:")) {
+      return "\0musea-shared:" + id.slice("virtual:musea-shared:".length) + "?musea-virtual";
     }
     // Handle virtual:musea-art: prefix for preview modules
     // Append ?musea-virtual to prevent other plugins (e.g. unplugin-vue-i18n)
@@ -108,6 +122,46 @@ export function createLoad(state: VirtualModuleState) {
             state.resolvedPreviewSetup,
             state.getVueVersion(),
           );
+        }
+      }
+    }
+    if (id.startsWith("\0musea-shared:")) {
+      const artPath = id.slice("\0musea-shared:".length).replace(/\?musea-virtual$/, "");
+      const art = state.artFiles.get(artPath);
+      if (art) return generateSharedSetupModule(art, artPath);
+    }
+    if (id.startsWith("\0musea-variant:")) {
+      const rest = id.slice("\0musea-variant:".length).replace(/\?musea-virtual$/, "");
+      const lastColonIndex = rest.lastIndexOf(":");
+      if (lastColonIndex !== -1) {
+        const artPath = rest.slice(0, lastColonIndex);
+        const variantName = rest.slice(lastColonIndex + 1);
+        const art = state.artFiles.get(artPath);
+        const variant = art?.variants.find((candidate) => candidate.name === variantName);
+        if (art && variant) {
+          const parsedScriptSetup = art.scriptSetupContent
+            ? parseScriptSetupForArt(art.scriptSetupContent)
+            : null;
+          const shared =
+            art.scriptSetupIsolated === false && parsedScriptSetup
+              ? {
+                  moduleId: `virtual:musea-shared:${artPath}`,
+                  names: sharedBindingNames(parsedScriptSetup),
+                }
+              : undefined;
+          const compiled = compileVariantSfc(art, variant.template, variant.name, artPath, {
+            scriptSetup: art.scriptSetupContent,
+            parsedScriptSetup,
+            root: state.getConfigRoot(),
+            scanRoots: state.getScanRoots(),
+            sharedBindings: shared,
+          });
+          if (compiled.errors.length > 0) {
+            throw new Error(
+              `Failed to compile <art> variant "${variantName}" in ${artPath}:\n${compiled.errors.join("\n")}`,
+            );
+          }
+          return compiled.code;
         }
       }
     }

--- a/npm/builder/vite-musea/src/static-build-vue2.test.ts
+++ b/npm/builder/vite-musea/src/static-build-vue2.test.ts
@@ -5,6 +5,7 @@ import test from "node:test";
 import { build, type Plugin, type ResolvedConfig } from "vite";
 
 import { generateArtModule } from "./art-module.js";
+import { compileVariantSfc } from "./art-variant-sfc.js";
 import { generatePreviewModule } from "./preview/index.js";
 import {
   emitStaticGallery,
@@ -95,6 +96,11 @@ function createVue2StaticBuildPlugin(
       if (id.startsWith("virtual:musea-art:")) {
         return "\0musea-art-test:" + id.slice("virtual:musea-art:".length);
       }
+      // The art module imports one module per variant now (#3857), so anything
+      // resolving art modules has to resolve these too.
+      if (id.startsWith("virtual:musea-variant:")) {
+        return "\0musea-variant-test:" + id.slice("virtual:musea-variant:".length);
+      }
       return resolveStaticRuntimeId(id);
     },
     load(id) {
@@ -105,7 +111,16 @@ function createVue2StaticBuildPlugin(
       }
       if (id.startsWith("\0musea-art-test:")) {
         const artPath = id.slice("\0musea-art-test:".length);
-        return generateArtModule(artFiles.get(artPath)!, artPath);
+        return generateArtModule(artFiles.get(artPath)!, artPath, { vueVersion: 2 });
+      }
+      if (id.startsWith("\0musea-variant-test:")) {
+        const rest = id.slice("\0musea-variant-test:".length);
+        const separator = rest.lastIndexOf(":");
+        const artPath = rest.slice(0, separator);
+        const variantName = rest.slice(separator + 1);
+        const art = artFiles.get(artPath)!;
+        const variant = art.variants.find((candidate) => candidate.name === variantName)!;
+        return compileVariantSfc(art, variant.template, variant.name, artPath).code;
       }
       return loadStaticRuntimeModule(id, artFiles);
     },


### PR DESCRIPTION
## Summary

`<art>` variants were emitted as `template:` strings for Vue's runtime compiler, which never sees the SFC pipeline. TypeScript in a template expression therefore reached `new Function` raw and threw at render time — in `vite dev` and in the statically built gallery alike (#3857).

**Compiling the raw template is not enough.** The template compiler leaves TypeScript in place *and* its identifier prefixer gives up on TS syntax, so the binding never resolves:

```js
compile()     →  disabled: items[0]!.isValid        // TS kept, no _ctx. → ReferenceError
compileSfc()  →  disabled: items.value[0].isValid   // TS stripped, ref unwrapped, correct
                 onU: (f) => file.value = f
```

`isTs` makes no difference — it means "preserve TS in output", not "strip it". So the fix is what the issue asked for literally: the variant is compiled **the same way the enclosing SFC is**, by building a synthetic SFC from the art file's `<script setup lang="ts">` plus the variant template and running it through `compileSfc`.

Each variant becomes its own virtual module (`virtual:musea-variant:<path>:<name>`), because `compileSfc` emits a complete module with its own default export — several cannot be concatenated into one art module.

## Three constraints the redesign had to keep

Each was caught by an existing test rather than by inspection, which is why they are called out:

- **Shared setup.** `scriptSetupIsolated: false` is an opt-in that means every variant sees *one* setup instance. Per-variant SFCs would each re-evaluate it and silently drop the shared state, so the shared case hoists the setup into `virtual:musea-shared:<path>` and variants import its bindings.
- **Relative imports.** A relative specifier cannot resolve from a virtual module — which is exactly why the art module already rebased its own. The variant SFC needs the same treatment or every relative import in an art file breaks.
- **Vue 2.** Compiled Vue 3 render functions import `openBlock`/`createElementBlock`, which Vue 2 has no runtime for; a compiled variant cannot load there at all. Vue 2 galleries keep the runtime-compiled `template:` path unchanged, extracted to `art-module-vue2.ts`.

## Change Class

- [x] Compiler and codegen

## Behavior Reference

- Fix request: #3857
- The dead end and the measurements behind it are recorded on the issue.

## Verification Evidence

```sh
pnpm exec tsx --test src/*.test.ts   # 58 tests, 58 pass
pnpm exec vp check src               # 0 errors, 0 warnings, formatted
```

New `art-variant-sfc.test.ts` pins the issue's own cases: a type annotation and a non-null assertion each compile with zero errors, the TS is gone, and the refs resolve. It also pins that a script-less variant still gets a default export — a template-only SFC compiles to a bare `export function render`, which the art module cannot import as a component.

`art-variant-wiring.test.ts` carries the behaviour that moved out of the art module: component resolution, per-variant isolation, and the shared-setup opt-out.

The Vue 2 static build test is what caught the Vue 2 incompatibility, and it now resolves variant modules the way the real plugin does.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — none
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered — compilation moves from every browser render to one build-time pass
- [x] Fuzzing target or crash-reproducer coverage considered
- [x] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

This changes how every Vue 3 art variant is produced, so the gallery's rendering path is materially different. The package's own suite covers module shape and compiled output, but **I could not run a real gallery in a browser** — the local toolchain build is blocked on an unrelated moon registry failure. The Vue 2 path is unchanged by construction.

The third case in the issue — `#[\`content${i + 1}\`]` — is **not** fixed, because it is invalid in Vue too: verified against `@vue/compiler-dom` 3.5.35, which reports "dynamic directive argument cannot contain spaces". Vize already matches that behaviour.

Closes #3857

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for compiling art variants as Vue single-file components.
  * Added Vue 2-compatible variant generation.
  * Added improved component resolution, including `<Self>` tag support.
  * Added shared setup handling for art variants.
  * Added virtual module support for variant and shared setup loading.

* **Bug Fixes**
  * Improved preservation of imports, setup bindings, TypeScript syntax, and template content during compilation.

* **Tests**
  * Expanded coverage for Vue 2 and Vue 3 variant compilation, component wiring, setup isolation, and template edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->