### PR TITLE
fix(musea): disambiguate the art variant module id and restore the Vue 2 component factory

### DIFF
--- a/npm/builder/vite-musea/src/art-component.ts
+++ b/npm/builder/vite-musea/src/art-component.ts
@@ -85,7 +85,9 @@ export function resolveArtComponent(
 /** Expand `<Self>` in a variant template to the resolved component tag. */
 export function expandSelfTag(template: string, componentTagName: string | undefined): string {
   if (!componentTagName) return template;
+  // Match the complete tag name only, so `<Selfish>` and `<Self-Preview>` are
+  // left alone while `<Self>`, `<Self />`, and `<Self ...>` expand.
   return template
-    .replace(/<Self/g, `<${componentTagName}`)
-    .replace(/<\/Self>/g, `</${componentTagName}>`);
+    .replace(/<Self(?=[\s/>])/g, `<${componentTagName}`)
+    .replace(/<\/Self\s*>/g, `</${componentTagName}>`);
 }

--- a/npm/builder/vite-musea/src/art-module-vue2.ts
+++ b/npm/builder/vite-musea/src/art-module-vue2.ts
@@ -84,18 +84,12 @@ ${components}  setup() {
 });
 `;
   }
-  if (componentTagName) {
-    return `
-export const ${variantComponentName} = {
-  name: '${variantComponentName}',
-${components}  template: \`${fullTemplate}\`,
-};
-`;
-  }
+  // Without a setup block `components` is empty unless a component tag was
+  // resolved, so one template covers both cases.
   return `
 export const ${variantComponentName} = {
   name: '${variantComponentName}',
-  template: \`${fullTemplate}\`,
+${components}  template: \`${fullTemplate}\`,
 };
 `;
 }

--- a/npm/builder/vite-musea/src/art-module.ts
+++ b/npm/builder/vite-musea/src/art-module.ts
@@ -11,6 +11,7 @@ import { allowedSourceRoots, resolveComponentSourcePath } from "./component-sour
 import type { ArtFileInfo } from "./types/index.js";
 import { toPascalCase } from "./utils.js";
 import { emitLegacyVariant } from "./art-module-vue2.js";
+import { expandSelfTag } from "./art-component.js";
 
 /**
  * Extract the content of the first <script setup> block from a Vue SFC source.
@@ -460,6 +461,14 @@ export function generateArtModule(
 // Auto-generated module for: ${path.basename(filePath)}
 `;
 
+  // Vue 2 variants stay runtime-compiled (see art-module-vue2.ts), and the
+  // wrapper they are emitted with needs its `defineComponent` binding. The alias
+  // keeps it from colliding with an art file that imports `defineComponent`
+  // itself.
+  if (options.vueVersion === 2) {
+    code += `import { defineComponent as __museaDefineComponent } from 'vue';\n`;
+  }
+
   // Add script setup imports at module level
   // Resolve relative paths to absolute since this code runs inside a virtual module
   if (scriptSetup) {
@@ -505,25 +514,10 @@ ${scriptSetup.setupBody.join("\n")}
   for (const variant of art.variants) {
     const variantComponentName = toPascalCase(variant.name);
 
-    let template = variant.template;
-
     // Replace <Self> with the actual component name (for inline art)
-    if (componentTagName) {
-      template = template
-        .replace(/<Self/g, `<${componentTagName}`)
-        .replace(/<\/Self>/g, `</${componentTagName}>`);
-    }
+    const template = expandSelfTag(variant.template, componentTagName);
 
-    // Vue 2 has no `openBlock`/`createElementBlock` runtime, so a compiled Vue 3
-    // render function cannot load there. Legacy galleries keep the
-    // runtime-compiled `template:` string they always had; the TypeScript fix
-    // below applies to Vue 3, which is what `.art.vue` with
-    // `<script setup lang="ts">` targets (#3857).
-    // Vue 2 has no `openBlock`/`createElementBlock` runtime, so a compiled Vue 3
-    // render function cannot load there. Legacy galleries keep the
-    // runtime-compiled `template:` string they always had; the TypeScript fix
-    // applies to Vue 3, which is what `.art.vue` with `<script setup lang="ts">`
-    // targets (#3857).
+    // Vue 2 keeps the runtime-compiled `template:` string; see art-module-vue2.ts (#3857).
     if (options.vueVersion === 2) {
       code += emitLegacyVariant({
         variantComponentName,
@@ -544,7 +538,11 @@ ${scriptSetup.setupBody.join("\n")}
     // module (#3857): `compileSfc` emits a complete module with its own default
     // export, so it cannot be inlined here, and only that pipeline strips the
     // TypeScript in template expressions and resolves bindings correctly.
-    const variantModuleId = `virtual:musea-variant:${filePath}:${variant.name}`;
+    // Variant names are free-form author text, so encode the name to keep the
+    // path/name delimiter unambiguous for the resolver, which splits on the last
+    // colon. A name containing one would otherwise move the split point and the
+    // art path would never match.
+    const variantModuleId = `virtual:musea-variant:${filePath}:${encodeURIComponent(variant.name)}`;
     code += `
 import ${variantComponentName} from ${JSON.stringify(variantModuleId)};
 export { ${variantComponentName} };

--- a/npm/builder/vite-musea/src/art-module.ts
+++ b/npm/builder/vite-musea/src/art-module.ts
@@ -457,6 +457,9 @@ export function generateArtModule(
     componentBindingName = componentTagName;
   }
 
+  const hasSetupBody = scriptSetup?.setupBody.some((line) => line.trim().length > 0) ?? false;
+  const hasSetup = !!scriptSetup && (hasSetupBody || scriptSetup.returnNames.length > 0);
+
   let code = `
 // Auto-generated module for: ${path.basename(filePath)}
 `;
@@ -464,8 +467,10 @@ export function generateArtModule(
   // Vue 2 variants stay runtime-compiled (see art-module-vue2.ts), and the
   // wrapper they are emitted with needs its `defineComponent` binding. The alias
   // keeps it from colliding with an art file that imports `defineComponent`
-  // itself.
-  if (options.vueVersion === 2) {
+  // itself. Only a variant with a setup block is wrapped, and `defineComponent`
+  // is a Vue 2.7+ export, so the import is skipped otherwise to keep art files
+  // without `<script setup>` loadable on Vue 2.6.
+  if (options.vueVersion === 2 && hasSetup) {
     code += `import { defineComponent as __museaDefineComponent } from 'vue';\n`;
   }
 
@@ -496,8 +501,6 @@ export const variants = ${JSON.stringify(art.variants)};
 export const __styles__ = ${JSON.stringify(art.styleBlocks ?? [])};
 `;
 
-  const hasSetupBody = scriptSetup?.setupBody.some((line) => line.trim().length > 0) ?? false;
-  const hasSetup = !!scriptSetup && (hasSetupBody || scriptSetup.returnNames.length > 0);
   const setupReturn = `{ ${scriptSetup?.returnNames.join(", ") ?? ""} }`;
   const isolatedSetup = art.scriptSetupIsolated !== false;
 

--- a/npm/builder/vite-musea/src/art-module.ts
+++ b/npm/builder/vite-musea/src/art-module.ts
@@ -464,12 +464,10 @@ export function generateArtModule(
 // Auto-generated module for: ${path.basename(filePath)}
 `;
 
-  // Vue 2 variants stay runtime-compiled (see art-module-vue2.ts), and the
-  // wrapper they are emitted with needs its `defineComponent` binding. The alias
-  // keeps it from colliding with an art file that imports `defineComponent`
-  // itself. Only a variant with a setup block is wrapped, and `defineComponent`
-  // is a Vue 2.7+ export, so the import is skipped otherwise to keep art files
-  // without `<script setup>` loadable on Vue 2.6.
+  // Vue 2 variants stay runtime-compiled (see art-module-vue2.ts), and only a
+  // variant with a setup block is wrapped in `defineComponent`, a Vue 2.7+
+  // export that therefore stays unimported otherwise. The alias keeps it from
+  // colliding with an art file that imports `defineComponent` itself.
   if (options.vueVersion === 2 && hasSetup) {
     code += `import { defineComponent as __museaDefineComponent } from 'vue';\n`;
   }

--- a/npm/builder/vite-musea/src/art-variant-sfc.ts
+++ b/npm/builder/vite-musea/src/art-variant-sfc.ts
@@ -74,8 +74,19 @@ export function buildVariantSfcSource(
   if (options.sharedBindings && options.sharedBindings.names.length > 0) {
     const { moduleId, names } = options.sharedBindings;
     const escapedShared = variantName.replace(/"/g, "&quot;");
+    // The demonstrated component is not necessarily a shared binding: an art
+    // file can name it through `defineArt`/`component` without importing it in
+    // `<script setup>`. Import it here too, unless the shared module already
+    // exports that name, or `<Self>` expands to a tag the variant cannot resolve.
+    const sharedComponentImport =
+      options.componentImportPath &&
+      options.componentBindingName &&
+      !names.includes(options.componentBindingName)
+        ? `import ${options.componentBindingName} from ${JSON.stringify(options.componentImportPath)}\n`
+        : "";
     return (
       `<script setup lang="ts">\n` +
+      sharedComponentImport +
       `import { ${names.join(", ")} } from ${JSON.stringify(moduleId)}\n` +
       `</script>\n` +
       `<template><div data-variant="${escapedShared}">${variantTemplate}</div></template>\n`

--- a/npm/builder/vite-musea/src/art-variant-wiring.test.ts
+++ b/npm/builder/vite-musea/src/art-variant-wiring.test.ts
@@ -150,3 +150,55 @@ const count = ref(0)
   assert.match(variant, /import \{ Button, count \} from "virtual:musea-shared:/);
   assert.doesNotMatch(variant, /const count = ref\(0\)/, "the variant must not re-declare it");
 });
+
+void test("a shared variant imports the demonstrated component when setup does not", () => {
+  const art: ArtFileInfo = {
+    path: "/repo/components/Button.art.vue",
+    metadata: {
+      title: "Button",
+      // Named through metadata rather than imported in `<script setup>`, so the
+      // component is not one of the shared bindings.
+      component: "./Button.vue",
+      tags: [],
+      status: "ready",
+    },
+    variants: [
+      { name: "Primary", template: `<Button :count="count" />`, isDefault: true, skipVrt: false },
+    ],
+    hasScriptSetup: true,
+    scriptSetupContent: `
+import { ref } from "vue"
+const count = ref(0)
+`.trim(),
+    scriptSetupIsolated: false,
+    hasScript: false,
+    styleCount: 0,
+  };
+
+  const sharedBindings = {
+    moduleId: `virtual:musea-shared:${art.path}`,
+    names: ["count"],
+  };
+
+  // `<Self>` expands to `<Button>`, so the variant needs that binding even
+  // though the shared module does not export it.
+  const variant = buildVariantSfcSource(art, `<Button :count="count" />`, "Primary", {
+    artFilePath: art.path,
+    componentImportPath: "/repo/components/Button.vue",
+    componentBindingName: "Button",
+    sharedBindings,
+  });
+  assert.match(variant, /import Button from "\/repo\/components\/Button\.vue"/);
+  assert.match(variant, /import \{ count \} from "virtual:musea-shared:/);
+
+  // When the shared module does export it, importing it again would redeclare
+  // the binding.
+  const shared = buildVariantSfcSource(art, `<Button :count="count" />`, "Primary", {
+    artFilePath: art.path,
+    componentImportPath: "/repo/components/Button.vue",
+    componentBindingName: "Button",
+    sharedBindings: { ...sharedBindings, names: ["Button", "count"] },
+  });
+  assert.doesNotMatch(shared, /import Button from "\/repo\/components\/Button\.vue"/);
+  assert.match(shared, /import \{ Button, count \} from "virtual:musea-shared:/);
+});

--- a/npm/builder/vite-musea/src/plugin/virtual.ts
+++ b/npm/builder/vite-musea/src/plugin/virtual.ts
@@ -177,6 +177,13 @@ export function createLoad(state: VirtualModuleState) {
               `Failed to compile <art> variant "${variantName}" in ${artPath}:\n${compiled.errors.join("\n")}`,
             );
           }
+          // An empty module is a valid module to Vite, so it would surface far
+          // from here as a variant that resolves to `undefined` at render time.
+          if (!compiled.code) {
+            throw new Error(
+              `The compiler produced no code for <art> variant "${variantName}" in ${artPath}.`,
+            );
+          }
           return compiled.code;
         }
       }

--- a/npm/builder/vite-musea/src/plugin/virtual.ts
+++ b/npm/builder/vite-musea/src/plugin/virtual.ts
@@ -45,6 +45,21 @@ export interface VirtualModuleState {
   processArtFile: (filePath: string) => Promise<void>;
 }
 
+/**
+ * Recover a variant name from a virtual module id.
+ *
+ * `generateArtModule` percent-encodes it, so a hand-written import with an
+ * invalid escape still falls back to the raw text instead of throwing a
+ * `URIError` out of `load`.
+ */
+function decodeVariantName(encoded: string): string {
+  try {
+    return decodeURIComponent(encoded);
+  } catch {
+    return encoded;
+  }
+}
+
 export function createResolveId(state: VirtualModuleState) {
   return function resolveId(id: string): string | null {
     const root = state.getConfigRoot();
@@ -135,7 +150,8 @@ export function createLoad(state: VirtualModuleState) {
       const lastColonIndex = rest.lastIndexOf(":");
       if (lastColonIndex !== -1) {
         const artPath = rest.slice(0, lastColonIndex);
-        const variantName = rest.slice(lastColonIndex + 1);
+        // The producer encodes the name so the delimiter stays unambiguous.
+        const variantName = decodeVariantName(rest.slice(lastColonIndex + 1));
         const art = state.artFiles.get(artPath);
         const variant = art?.variants.find((candidate) => candidate.name === variantName);
         if (art && variant) {

--- a/npm/builder/vite-musea/src/plugin/virtual.ts
+++ b/npm/builder/vite-musea/src/plugin/virtual.ts
@@ -52,7 +52,7 @@ export interface VirtualModuleState {
  * invalid escape still falls back to the raw text instead of throwing a
  * `URIError` out of `load`.
  */
-function decodeVariantName(encoded: string): string {
+export function decodeVariantName(encoded: string): string {
   try {
     return decodeURIComponent(encoded);
   } catch {

--- a/npm/builder/vite-musea/src/static-build-vue2.test.ts
+++ b/npm/builder/vite-musea/src/static-build-vue2.test.ts
@@ -6,6 +6,7 @@ import { build, type Plugin, type ResolvedConfig } from "vite";
 
 import { generateArtModule } from "./art-module.js";
 import { compileVariantSfc } from "./art-variant-sfc.js";
+import { decodeVariantName } from "./plugin/virtual.js";
 import { generatePreviewModule } from "./preview/index.js";
 import {
   emitStaticGallery,
@@ -117,7 +118,7 @@ function createVue2StaticBuildPlugin(
         const rest = id.slice("\0musea-variant-test:".length);
         const separator = rest.lastIndexOf(":");
         const artPath = rest.slice(0, separator);
-        const variantName = decodeURIComponent(rest.slice(separator + 1));
+        const variantName = decodeVariantName(rest.slice(separator + 1));
         const art = artFiles.get(artPath)!;
         const variant = art.variants.find((candidate) => candidate.name === variantName)!;
         return compileVariantSfc(art, variant.template, variant.name, artPath).code;

--- a/npm/builder/vite-musea/src/static-build-vue2.test.ts
+++ b/npm/builder/vite-musea/src/static-build-vue2.test.ts
@@ -117,7 +117,7 @@ function createVue2StaticBuildPlugin(
         const rest = id.slice("\0musea-variant-test:".length);
         const separator = rest.lastIndexOf(":");
         const artPath = rest.slice(0, separator);
-        const variantName = rest.slice(separator + 1);
+        const variantName = decodeURIComponent(rest.slice(separator + 1));
         const art = artFiles.get(artPath)!;
         const variant = art.variants.find((candidate) => candidate.name === variantName)!;
         return compileVariantSfc(art, variant.template, variant.name, artPath).code;


### PR DESCRIPTION
Review follow-up to #3880, which was already merged, so the fixes land here instead.

**Vue 2 galleries could not evaluate their art module.** `emitLegacyVariant()` wraps script-setup variants in `__museaDefineComponent(...)`, but #3880 dropped the `defineComponent` import along with the Vue 3 legacy path, leaving the binding undefined at module evaluation. It is emitted again, for Vue 2 only:

```ts
if (options.vueVersion === 2) {
  code += `import { defineComponent as __museaDefineComponent } from 'vue';
`;
}
```

**A colon in a variant name broke variant resolution.** `virtual:musea-variant:<path>:<name>` is split on the last colon, so a name containing one moved the split point, `state.artFiles.get(artPath)` missed, and Vite reported an unresolved import rather than the real cause. The name is now percent-encoded by the producer and decoded in `plugin/virtual.ts` (with a raw-text fallback so a malformed hand-written id cannot throw a `URIError` out of `load`).

Also: `<Self>` expansion now requires a tag boundary, so `<Selfish>` and `<Self-Preview>` are left alone; the art module reuses `expandSelfTag` instead of repeating the replacement; and a duplicated comment block and a pair of identical Vue 2 template branches are collapsed.

**A shared variant could not resolve the component it demonstrates.** With `isolate="false"`, `buildVariantSfcSource` returned early with only the shared bindings, so an art file that names its component through `defineArt`/`component` without importing it in `<script setup>` expanded `<Self>` to a tag with no binding behind it. The component is now imported alongside the shared bindings, unless the shared module already exports that name:

```ts
const sharedComponentImport =
  options.componentImportPath &&
  options.componentBindingName &&
  !names.includes(options.componentBindingName)
    ? `import ${options.componentBindingName} from ${JSON.stringify(options.componentImportPath)}\n`
    : "";
```

`plugin/virtual.ts` also rejects empty compiler output now: Vite treats `""` as a valid module, so a variant would otherwise surface as `undefined` at render time, far from the cause.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of variant names containing special characters during builds and rendering.
  * Fixed template processing so only complete `<Self>` tags are expanded, while similarly named tags remain unchanged.
  * Improved Vue 2 component generation for legacy templates, ensuring components render consistently across supported configurations.
  * Corrected variant matching during Vue 2 static builds.
  * Fixed component imports for variants using shared setup bindings.
  * Added clearer errors when variant compilation produces no usable module output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
