### PR TITLE
fix(vite-plugin): register SFCs in ssrContext.modules during SSR

### DIFF
--- a/npm/builder/vite/src/plugin/load.ts
+++ b/npm/builder/vite/src/plugin/load.ts
@@ -11,6 +11,7 @@ import {
   type VizePluginState,
 } from "./state.ts";
 import { getLoadableVueSfcPath, shouldLoadCompiledVueSfcPath } from "./load-sfc.ts";
+import { appendSsrModuleRegistration, normalizeVueServerRendererImport } from "./ssr-modules.ts";
 import { compileFile, compileJsxModule } from "../compiler.ts";
 import { embedsInlineCss, generateOutputWithMap, hasDelegatedStyles } from "../utils/index.ts";
 import { MappedModule, type SourceMapV3 } from "../utils/source-map.ts";
@@ -31,6 +32,8 @@ import {
   rewriteStaticAssetUrls,
 } from "../transform.ts";
 import { transformVizeVirtualModule } from "./vite-transform.ts";
+
+export { normalizeVueServerRendererImport };
 
 /** What `load` hands Vite: emitted code plus its map, when one was produced. */
 type LoadResult = { code: string; map: SourceMapV3 | null };
@@ -53,10 +56,6 @@ export function getBoundaryPlaceholderCode(realPath: string, ssr: boolean): stri
     return SERVER_PLACEHOLDER_CODE;
   }
   return null;
-}
-
-export function normalizeVueServerRendererImport(code: string): string {
-  return code.replace(/\bfrom\s+(['"])@vue\/server-renderer\1/g, 'from "vue/server-renderer"');
 }
 
 function findMacroArtifactModule(
@@ -153,6 +152,7 @@ function loadCompiledSfcModule(
   rewritten.edit(rewriteDynamicTemplateImports(rewritten.code, state.dynamicImportAliasRules));
   rewritten.edit(rewriteStaticAssetUrls(rewritten.code, state.dynamicImportAliasRules));
   rewritten.edit(rewriteImportMetaGlobBase(rewritten.code, realPath, state.root));
+  rewritten.edit(appendSsrModuleRegistration(rewritten.code, realPath, state.root, isSsr));
   return { code: rewritten.code, map: rewritten.map };
 }
 

--- a/npm/builder/vite/src/plugin/ssr-modules-load.test.ts
+++ b/npm/builder/vite/src/plugin/ssr-modules-load.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { VizePluginState } from "./state.ts";
+import { loadHook } from "./load.ts";
+import { toVirtualId } from "../virtual.ts";
+
+const ROOT = "/project";
+const PAGE = "/project/app/pages/index.vue";
+
+const COMPILED = {
+  code: 'const _sfc_main = { name: "Index" };\nexport default _sfc_main;',
+  scopeId: "ssr12345",
+  hasScoped: false,
+  styles: [],
+};
+
+function stateFor(environment: "client" | "ssr"): VizePluginState {
+  const compiled = new Map([[PAGE, COMPILED]]);
+  return {
+    cache: environment === "client" ? compiled : new Map(),
+    ssrCache: environment === "ssr" ? compiled : new Map(),
+    collectedCss: new Map(),
+    precompileMetadata: new Map(),
+    pendingHmrUpdateTypes: new Map(),
+    isProduction: true,
+    root: ROOT,
+    clientViteBase: "/",
+    serverViteBase: "/",
+    server: null,
+    filter: () => true,
+    scanPatterns: ["**/*.vue"],
+    precompileBatchSize: 128,
+    ignorePatterns: [],
+    mergedOptions: {},
+    initialized: true,
+    dynamicImportAliasRules: [],
+    cssAliasRules: [],
+    extractCss: false,
+    componentsCssFileName: "assets/vize-components.css",
+    clientViteDefine: {},
+    serverViteDefine: {},
+    logger: { log() {}, info() {}, warn() {}, error() {} },
+  } as unknown as VizePluginState;
+}
+
+function loadedCode(environment: "client" | "ssr"): string {
+  const result = loadHook(stateFor(environment), toVirtualId(PAGE), {
+    ssr: environment === "ssr",
+  });
+  assert.ok(result, `${environment} load returned nothing`);
+  return typeof result === "string" ? result : result.code;
+}
+
+void test("an SSR-loaded SFC registers itself in ssrContext.modules", () => {
+  // Without this, `vue-bundle-renderer` finds no module to intersect with the
+  // client manifest, emits no stylesheet link, and the page renders unstyled
+  // until the route chunk loads on the client (#3868).
+  const code = loadedCode("ssr");
+
+  assert.match(code, /useSSRContext as __vize_useSSRContext/);
+  assert.match(code, /\(ssrContext\.modules \|\| \(ssrContext\.modules = new Set\(\)\)\)\.add\(/);
+  assert.match(code, /"app\/pages\/index\.vue"/);
+  assert.ok(
+    code.includes(COMPILED.code.split("\n")[0]),
+    `the compiled module must survive the append:\n${code}`,
+  );
+});
+
+void test("a client-loaded SFC is left alone", () => {
+  const code = loadedCode("client");
+
+  assert.ok(!code.includes("__vize_useSSRContext"), `client output must not register:\n${code}`);
+  assert.ok(!code.includes("ssrContext"), `client output must not reference ssrContext:\n${code}`);
+});

--- a/npm/builder/vite/src/plugin/ssr-modules.test.ts
+++ b/npm/builder/vite/src/plugin/ssr-modules.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  appendSsrModuleRegistration,
+  ssrModuleRegistrationCode,
+  toManifestModuleId,
+} from "./ssr-modules.ts";
+
+const ROOT = "/project";
+const PAGE = "/project/app/pages/index.vue";
+
+void test("the manifest key is the root-relative path with POSIX separators", () => {
+  assert.equal(toManifestModuleId(PAGE, ROOT), "app/pages/index.vue");
+  assert.equal(toManifestModuleId("/project/App.vue", ROOT), "App.vue");
+});
+
+void test("a path outside the root keeps its absolute form instead of a ../ chain", () => {
+  // `vue-bundle-renderer` looks the key up in the client manifest; a `../`
+  // chain matches nothing there and would silently drop the stylesheet.
+  const outside = toManifestModuleId("/elsewhere/lib/Widget.vue", ROOT);
+  assert.equal(outside, "/elsewhere/lib/Widget.vue");
+  assert.ok(!outside.startsWith(".."));
+});
+
+void test("a root-relative filename beginning with .. is still keyed relative to the root", () => {
+  // `path.relative` yields "..widget.vue" here: no parent step, so the manifest
+  // key stays root-relative rather than falling back to the absolute path.
+  assert.equal(toManifestModuleId("/project/..widget.vue", ROOT), "..widget.vue");
+  assert.equal(toManifestModuleId("/project/app/..widget.vue", ROOT), "app/..widget.vue");
+});
+
+void test("the registration wraps setup and adds the module to ssrContext", () => {
+  const { prologue, epilogue } = ssrModuleRegistrationCode(PAGE, ROOT);
+
+  assert.match(prologue, /import \{ useSSRContext as __vize_useSSRContext \} from "vue";/);
+  assert.match(epilogue, /const __vize_sfc_setup = _sfc_main\.setup;/);
+  assert.match(
+    epilogue,
+    /\(ssrContext\.modules \|\| \(ssrContext\.modules = new Set\(\)\)\)\.add\("app\/pages\/index\.vue"\);/,
+  );
+  // An SFC without its own `setup` must still render.
+  assert.match(epilogue, /return __vize_sfc_setup \? __vize_sfc_setup\(props, ctx\) : undefined;/);
+});
+
+void test("the import leads the module so auto-import injection still applies", () => {
+  // A trailing `import` makes the module's last import its last line, and Nuxt
+  // injects its auto-imports relative to that — a component using an
+  // auto-imported composable then throws `ReferenceError` at render (#3868).
+  const { prologue, epilogue } = ssrModuleRegistrationCode(PAGE, ROOT);
+
+  assert.doesNotMatch(epilogue, /\bimport\b/, "the appended half must declare no import");
+  const wrapped = appendSsrModuleRegistration(
+    'const _sfc_main = { name: "Index" };\nexport default _sfc_main;',
+    PAGE,
+    ROOT,
+    true,
+  );
+  assert.ok(wrapped.startsWith(prologue), "the import must be the module's first statement");
+  const lastImport = wrapped.lastIndexOf("import ");
+  assert.ok(
+    lastImport < wrapped.indexOf("const _sfc_main"),
+    "no import may follow the emitted module body",
+  );
+});
+
+void test("appending leaves the emitted module intact and adds the registration once", () => {
+  const emitted = 'const _sfc_main = { name: "Index" };\nexport default _sfc_main;';
+
+  const once = appendSsrModuleRegistration(emitted, PAGE, ROOT, true);
+  assert.ok(once.includes(emitted), "the emitted module must be preserved verbatim");
+  assert.equal(once.match(/__vize_useSSRContext/g)?.length, 2, "one import, one call");
+
+  const twice = appendSsrModuleRegistration(once, PAGE, ROOT, true);
+  assert.equal(twice, once, "appending again must be a no-op");
+});
+
+void test("a client build is a no-op", () => {
+  const emitted = "const _sfc_main = {};\nexport default _sfc_main;";
+  assert.equal(appendSsrModuleRegistration(emitted, PAGE, ROOT, false), emitted);
+});
+
+void test("a module with no component object is left untouched", () => {
+  // Render-function-only output and boundary placeholders have no `_sfc_main`
+  // to wrap; wrapping a missing binding would be a ReferenceError at runtime.
+  for (const emitted of [
+    "export function render(_ctx, _cache) { return null }",
+    'import { defineComponent } from "vue";\nexport default defineComponent({});',
+    // `_sfc_main` occurs only as text, so there is still nothing to wrap.
+    'export function render(_ctx) { return _ctx.h("pre", "_sfc_main") }',
+    "// _sfc_main is attached by the client output, not here\nexport function render() {}",
+  ]) {
+    assert.equal(appendSsrModuleRegistration(emitted, PAGE, ROOT, true), emitted);
+  }
+});
+
+void test("an SFC that already uses the helper names still registers, with fresh names", () => {
+  // Keying idempotency on `__vize_useSSRContext` would skip this component and
+  // cost it its initial stylesheet; re-declaring the name would be a SyntaxError.
+  const emitted = [
+    'import { useSSRContext as __vize_useSSRContext } from "vue";',
+    "const __vize_sfc_setup = 1;",
+    'const _sfc_main = { name: "Index" };',
+    "export default _sfc_main;",
+  ].join("\n");
+
+  const once = appendSsrModuleRegistration(emitted, PAGE, ROOT, true);
+  assert.ok(once.includes(emitted), "the emitted module must be preserved verbatim");
+  assert.match(once, /import \{ useSSRContext as __vize_useSSRContext2 \} from "vue";/);
+  assert.match(once, /const __vize_sfc_setup2 = _sfc_main\.setup;/);
+  assert.match(once, /\(ssrContext\.modules \|\| \(ssrContext\.modules = new Set\(\)\)\)\.add\(/);
+  assert.equal(
+    once.match(/const __vize_sfc_setup\b/g)?.length,
+    1,
+    "the existing binding must not be re-declared",
+  );
+
+  assert.equal(
+    appendSsrModuleRegistration(once, PAGE, ROOT, true),
+    once,
+    "appending again is a no-op",
+  );
+});

--- a/npm/builder/vite/src/plugin/ssr-modules.ts
+++ b/npm/builder/vite/src/plugin/ssr-modules.ts
@@ -1,0 +1,133 @@
+import path from "node:path";
+
+/**
+ * Point a compiled SSR module at the `vue/server-renderer` subpath.
+ *
+ * The compiler emits `@vue/server-renderer`, which is not a dependency every
+ * app declares; the subpath re-export always resolves alongside `vue` itself.
+ */
+export function normalizeVueServerRendererImport(code: string): string {
+  return code.replace(/\bfrom\s+(['"])@vue\/server-renderer\1/g, 'from "vue/server-renderer"');
+}
+
+/**
+ * Marks a module whose registration has already been appended.
+ *
+ * Idempotency cannot key on the helper identifiers: an SFC is free to declare
+ * `__vize_useSSRContext` itself, and skipping registration for it would cost it
+ * its initial stylesheet.
+ */
+const REGISTRATION_MARKER = "/* @vize-ssr-modules-registered */";
+
+/**
+ * Matches the `_sfc_main` component declaration the emitted module carries.
+ *
+ * A bare `\b_sfc_main\b` also matches the identifier inside a string literal or
+ * a comment, and wrapping a component that was never declared is a
+ * `ReferenceError` at render time.
+ */
+const SFC_MAIN_DECLARATION = /\b(?:const|let|var)\s+_sfc_main\s*=/;
+
+/**
+ * Register an SFC in `ssrContext.modules` during SSR, the way
+ * `@vitejs/plugin-vue` does.
+ *
+ * After rendering, `vue-bundle-renderer` intersects `ssrContext.modules` with
+ * the client manifest to decide which stylesheets belong in the document head.
+ * A component that never registers itself contributes no `<link>`, so the
+ * server-rendered markup arrives unstyled and only gains its styles once the
+ * route chunk loads on the client — a flash of unstyled content that never
+ * recovers when JavaScript is disabled (#3868).
+ *
+ * The key must be the module's path relative to the Vite root with POSIX
+ * separators, because that is what the client manifest is keyed on.
+ */
+export function ssrModuleRegistrationCode(
+  filePath: string,
+  root: string,
+  helpers: { useSSRContext?: string; sfcSetup?: string } = {},
+): { prologue: string; epilogue: string } {
+  const moduleId = JSON.stringify(toManifestModuleId(filePath, root));
+  const useSSRContext = helpers.useSSRContext ?? "__vize_useSSRContext";
+  const sfcSetup = helpers.sfcSetup ?? "__vize_sfc_setup";
+  return {
+    prologue: `${REGISTRATION_MARKER}\nimport { useSSRContext as ${useSSRContext} } from "vue";`,
+    epilogue: [
+      `const ${sfcSetup} = _sfc_main.setup;`,
+      `_sfc_main.setup = (props, ctx) => {`,
+      `  const ssrContext = ${useSSRContext}();`,
+      `  (ssrContext.modules || (ssrContext.modules = new Set())).add(${moduleId});`,
+      `  return ${sfcSetup} ? ${sfcSetup}(props, ctx) : undefined;`,
+      `};`,
+    ].join("\n"),
+  };
+}
+
+/**
+ * The client-manifest key for `filePath`: relative to `root`, POSIX separators.
+ *
+ * A path outside the root keeps its absolute form rather than becoming a `../`
+ * chain, matching how Vite keys modules it cannot root-relativize. Only a real
+ * parent-directory step counts as outside: a filename that merely begins with
+ * `..` still lives in the root and is keyed relative to it.
+ */
+export function toManifestModuleId(filePath: string, root: string): string {
+  const relative = path.relative(root, filePath).replace(/\\/g, "/");
+  if (!relative || relative === ".." || relative.startsWith("../") || path.isAbsolute(relative)) {
+    return filePath.replace(/\\/g, "/");
+  }
+  return relative;
+}
+
+/**
+ * Wrap an emitted module with the registration.
+ *
+ * The wrapper is appended, so it closes over whatever `setup` the emitter's own
+ * rewrites left in place, but its `import` is *prepended*. A trailing `import`
+ * is legal ESM, yet it makes the module's last import statement its last line,
+ * and Nuxt's auto-import injection then inserts nothing — a component relying on
+ * an auto-imported composable loses that binding and throws `ReferenceError` at
+ * render time (#3868). Leading the module with the import keeps the import
+ * section where every downstream transform expects to find it.
+ *
+ * `useSSRContext()` throws outside a render, so this is a no-op unless `isSsr`.
+ * Modules without an `_sfc_main` declaration — a render-function-only output, or
+ * a boundary placeholder — have no component object to wrap and are returned
+ * untouched.
+ */
+export function appendSsrModuleRegistration(
+  code: string,
+  filePath: string,
+  root: string,
+  isSsr: boolean,
+): string {
+  if (!isSsr || !SFC_MAIN_DECLARATION.test(code)) {
+    return code;
+  }
+  if (code.includes(REGISTRATION_MARKER)) {
+    return code;
+  }
+  const { prologue, epilogue } = ssrModuleRegistrationCode(filePath, root, {
+    useSSRContext: freeIdentifier("__vize_useSSRContext", code),
+    sfcSetup: freeIdentifier("__vize_sfc_setup", code),
+  });
+  return `${prologue}\n${code}\n${epilogue}`;
+}
+
+/**
+ * `base`, or `base` plus the smallest numeric suffix the module does not use.
+ *
+ * Re-declaring an identifier the SFC already bound is a `SyntaxError`, which
+ * would take down the whole module rather than just its stylesheet.
+ */
+function freeIdentifier(base: string, code: string): string {
+  if (!new RegExp(`\\b${base}\\b`).test(code)) {
+    return base;
+  }
+  for (let suffix = 2; ; suffix++) {
+    const candidate = `${base}${suffix}`;
+    if (!new RegExp(`\\b${candidate}\\b`).test(code)) {
+      return candidate;
+    }
+  }
+}

--- a/npm/builder/vite/src/test.ts
+++ b/npm/builder/vite/src/test.ts
@@ -39,6 +39,8 @@ import "./plugin/precompile-cache.test.ts";
 import "./plugin/precompile-cache-corrupt.test.ts";
 import "./plugin/precompile-cache-manifest.test.ts";
 import "./plugin/precompile-cache-store.test.ts";
+import "./plugin/ssr-modules.test.ts";
+import "./plugin/ssr-modules-load.test.ts";
 import "./plugin/state.test.ts";
 import "./plugin/unocss.test.ts";
 import "./plugin/vite-transform.test.ts";


### PR DESCRIPTION
Closes #3868.

## What

`vue-bundle-renderer` intersects `ssrContext.modules` with the client manifest to decide which stylesheets belong in the document head. Vize never registered its SFCs there, so server-rendered markup arrived unstyled and only gained its styles once the route chunk loaded — a flash that never recovers with JavaScript disabled.

## Why this is a second attempt

#3870 shipped the same registration and had to be reverted in #3872: it broke Nuxt prerendering of the vuefes-2025 app.

The cause, found by bisecting a local reproduction of that app's build: the registration appended its `import` at the **end** of the module. That is legal ESM — imports hoist — but it makes the module's last import statement its last line, and Nuxt's auto-import injection then adds nothing. `SectionStaff.vue` lost its auto-imported `useI18n`, and prerendering `/` failed with

```
ReferenceError: useI18n is not defined
    at setup (SectionStaff.vue-Cc1UHvCP.mjs:336:17)
```

while every sibling route still built — which is why the failure read as route-specific rather than as a transform bug.

This PR splits the emitted snippet: the `import` is prepended, the wrapper is still appended so it closes over whatever `setup` the emitter's own rewrites left in place.

## Verification

Against the real `vuefes-2025` fixture, built locally three times:

| build | result |
| --- | --- |
| without the change (control) | green, no registrations |
| #3870 as merged | **`[500]` prerendering `/`**, `useI18n` import dropped from 1 chunk |
| this PR | green, no dropped imports, **40 modules carry the registration** |

`node src/test.ts` in `npm/builder/vite`: 47/47 pass, including a new test asserting no import may follow the emitted module body.

Note that `app-e2e` — which covers this app — is skipped on `pull_request` and only runs on tags, schedule, or dispatch, so this PR's own checks do not exercise it. That is what let #3870 through.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->