### PR TITLE
feat(vite-plugin): honor features.prodDevtools

### DIFF
--- a/npm/builder/vite/src/plugin/index.ts
+++ b/npm/builder/vite/src/plugin/index.ts
@@ -124,12 +124,12 @@ export function vize(options: VizeOptions = {}): Plugin[] {
     name: "vite-plugin-vize",
     enforce: "pre",
 
-    config(userConfig, env) {
+    config(userConfig) {
       patchCssModuleGenerateScopedName(userConfig);
 
       return {
         // Vue 3 ESM bundler flags normally injected by @vitejs/plugin-vue.
-        define: resolveVueFeatureDefines(options.features, userConfig.define, env.command),
+        define: resolveVueFeatureDefines(options.features, userConfig.define),
         optimizeDeps: {
           exclude: ["virtual:vize-styles"],
         },

--- a/npm/builder/vite/src/plugin/vue-feature-defines.ts
+++ b/npm/builder/vite/src/plugin/vue-feature-defines.ts
@@ -8,15 +8,22 @@ function parseDefine(value: unknown): unknown {
   }
 }
 
-/** Resolve Vue runtime defines with plugin-vue's precedence and defaults. */
+/**
+ * Resolve Vue runtime defines with plugin-vue's precedence and defaults.
+ *
+ * `__VUE_PROD_DEVTOOLS__` used to be `command === "serve"`, which left no way to
+ * enable devtools for a production build (#3227). It now follows plugin-vue's
+ * OR semantics, and defaults to `false` in dev as upstream does: a development
+ * build enables devtools through Vue's own `__DEV__`, not through this flag.
+ */
 export function resolveVueFeatureDefines(
   features: VizeVueFeatures | undefined,
   define: Record<string, unknown> | undefined,
-  command: "build" | "serve",
 ): Record<string, unknown> {
   return {
     __VUE_OPTIONS_API__: features?.optionsAPI ?? parseDefine(define?.__VUE_OPTIONS_API__) ?? true,
-    __VUE_PROD_DEVTOOLS__: command === "serve",
+    __VUE_PROD_DEVTOOLS__:
+      (features?.prodDevtools || parseDefine(define?.__VUE_PROD_DEVTOOLS__)) ?? false,
     __VUE_PROD_HYDRATION_MISMATCH_DETAILS__:
       (features?.prodHydrationMismatchDetails ||
         parseDefine(define?.__VUE_PROD_HYDRATION_MISMATCH_DETAILS__)) ??

--- a/npm/builder/vite/src/vue-features.ts
+++ b/npm/builder/vite/src/vue-features.ts
@@ -8,6 +8,12 @@ export interface VizeVueFeatures {
   optionsAPI?: boolean;
 
   /**
+   * Enable Vue devtools support in production bundles.
+   * @default false
+   */
+  prodDevtools?: boolean;
+
+  /**
    * Enable detailed hydration mismatch errors in production bundles.
    * @default false
    */

--- a/tests/_fixtures/vite-plugin-vue-option-parity.json
+++ b/tests/_fixtures/vite-plugin-vue-option-parity.json
@@ -8,9 +8,9 @@
     "version": "6.0.7"
   },
   "summary": {
-    "honored": 13,
+    "honored": 14,
     "intentional-divergence": 9,
-    "unimplemented": 18
+    "unimplemented": 17
   },
   "options": {
     "compiler": {
@@ -41,9 +41,8 @@
       "evidence": "options-api-feature"
     },
     "features.prodDevtools": {
-      "status": "unimplemented",
-      "issue": 3227,
-      "reason": "The config hook hard-codes __VUE_PROD_DEVTOOLS__ to `command === \"serve\"`, so devtools cannot be enabled in production builds."
+      "status": "honored",
+      "evidence": "prod-devtools-feature"
     },
     "features.prodHydrationMismatchDetails": {
       "status": "honored",

--- a/tests/tooling/_helpers/vite-plugin-vue-define-probes.ts
+++ b/tests/tooling/_helpers/vite-plugin-vue-define-probes.ts
@@ -1,0 +1,132 @@
+/**
+ * Vue runtime define parity probes for the `@vitejs/plugin-vue` gate (#3227).
+ *
+ * Each `features.*` flag resolves to a `__VUE_*__` define, and the shape of that
+ * resolution — plugin option, then user `define`, then a default — is easy to
+ * get subtly wrong. These probes run the real upstream plugin as the oracle and
+ * compare Vize's `config` hook against it.
+ *
+ * They live beside the parity test rather than inside it to keep that file
+ * within its source-length budget.
+ */
+
+import assert from "node:assert/strict";
+import type { Plugin } from "vite";
+
+import { createUpstreamPlugin } from "./vite-plugin-vue-parity.ts";
+import { vize } from "../../../npm/builder/vite/src/plugin/index.ts";
+
+type AnyHook = (...args: never[]) => unknown;
+
+export type DefineParityCase = {
+  expected: boolean;
+  options: Record<string, unknown>;
+  userDefine: Record<string, unknown>;
+};
+
+function hook<T extends AnyHook>(candidate: unknown): T {
+  const handler =
+    typeof candidate === "function" ? candidate : (candidate as { handler?: T })?.handler;
+  assert.equal(typeof handler, "function", "expected an implemented plugin hook");
+  return handler as T;
+}
+
+/**
+ * A `features.*` flag resolves to the same Vue runtime define as plugin-vue.
+ *
+ * The upstream plugin is the oracle, but each case still pins its own expected
+ * value: a change in upstream semantics then fails as itself, instead of
+ * silently redefining what parity means.
+ */
+export async function probeFeatureDefine(
+  defineName: string,
+  cases: ReadonlyArray<DefineParityCase>,
+): Promise<void> {
+  for (const { expected, options, userDefine } of cases) {
+    // Each hook gets its own config object so the parity assertion does not
+    // depend on either plugin leaving its input untouched.
+    const upstreamConfig = { define: { ...userDefine } };
+    const vizeConfig = { define: { ...userDefine } };
+    const env = { command: "build", mode: "production" } as const;
+    const upstream = createUpstreamPlugin(options) as Plugin;
+    const vizePlugin = vize({ configMode: false, ...options }).find(
+      (candidate) => candidate.name === "vite-plugin-vize",
+    );
+    assert.ok(vizePlugin);
+
+    const upstreamResult = await hook<AnyHook>(upstream.config).call({}, upstreamConfig, env);
+    const vizeResult = await hook<AnyHook>(vizePlugin.config).call({}, vizeConfig, env);
+    const upstreamDefine = (upstreamResult as { define: Record<string, unknown> }).define[
+      defineName
+    ];
+    const vizeDefine = (vizeResult as { define: Record<string, unknown> }).define[defineName];
+
+    assert.equal(upstreamDefine, expected, "the pinned upstream oracle must stay stable");
+    assert.equal(vizeDefine, upstreamDefine, `Vize must match plugin-vue's ${defineName}`);
+  }
+}
+
+/** `features.optionsAPI` produces the same Vue runtime define as plugin-vue. */
+export const probeOptionsApiFeature = (): Promise<void> =>
+  probeFeatureDefine("__VUE_OPTIONS_API__", [
+    { expected: true, options: {}, userDefine: {} },
+    { expected: false, options: { features: { optionsAPI: false } }, userDefine: {} },
+    {
+      expected: true,
+      options: { features: { optionsAPI: true } },
+      userDefine: { __VUE_OPTIONS_API__: false },
+    },
+    { expected: false, options: {}, userDefine: { __VUE_OPTIONS_API__: "false" } },
+  ]);
+
+/**
+ * `features.prodDevtools` matches plugin-vue's OR semantics.
+ *
+ * The define used to be `command === "serve"`, so a production build could not
+ * turn devtools on at all (#3227). Upstream defaults it to `false` even in dev,
+ * where Vue enables devtools through its own `__DEV__` instead.
+ */
+export const probeProdDevtoolsFeature = (): Promise<void> =>
+  probeFeatureDefine("__VUE_PROD_DEVTOOLS__", [
+    { expected: false, options: {}, userDefine: {} },
+    { expected: false, options: { features: { prodDevtools: false } }, userDefine: {} },
+    { expected: true, options: { features: { prodDevtools: true } }, userDefine: {} },
+    {
+      expected: true,
+      options: { features: { prodDevtools: false } },
+      userDefine: { __VUE_PROD_DEVTOOLS__: true },
+    },
+    { expected: true, options: {}, userDefine: { __VUE_PROD_DEVTOOLS__: "true" } },
+    { expected: false, options: {}, userDefine: { __VUE_PROD_DEVTOOLS__: "false" } },
+  ]);
+
+/** `features.prodHydrationMismatchDetails` matches plugin-vue's OR semantics. */
+export const probeProdHydrationMismatchDetailsFeature = (): Promise<void> =>
+  probeFeatureDefine("__VUE_PROD_HYDRATION_MISMATCH_DETAILS__", [
+    { expected: false, options: {}, userDefine: {} },
+    {
+      expected: false,
+      options: { features: { prodHydrationMismatchDetails: false } },
+      userDefine: {},
+    },
+    {
+      expected: true,
+      options: { features: { prodHydrationMismatchDetails: true } },
+      userDefine: { __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false },
+    },
+    {
+      expected: true,
+      options: { features: { prodHydrationMismatchDetails: false } },
+      userDefine: { __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: true },
+    },
+    {
+      expected: true,
+      options: {},
+      userDefine: { __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: "true" },
+    },
+    {
+      expected: false,
+      options: {},
+      userDefine: { __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: "false" },
+    },
+  ]);

--- a/tests/tooling/vite-plugin-vue-option-parity.test.ts
+++ b/tests/tooling/vite-plugin-vue-option-parity.test.ts
@@ -16,12 +16,16 @@ import { test } from "node:test";
 import type { Plugin, ResolvedConfig } from "vite";
 
 import {
-  createUpstreamPlugin,
   honoredEvidence,
   readLedger,
   upstreamSurface,
   validateLedger,
 } from "./_helpers/vite-plugin-vue-parity.ts";
+import {
+  probeOptionsApiFeature,
+  probeProdDevtoolsFeature,
+  probeProdHydrationMismatchDetailsFeature,
+} from "./_helpers/vite-plugin-vue-define-probes.ts";
 import { vize } from "../../npm/builder/vite/src/plugin/index.ts";
 
 type AnyHook = (...args: never[]) => unknown;
@@ -191,100 +195,6 @@ async function probeHotUpdateStyleOnly(): Promise<void> {
   assert.match(sent[0].data?.css ?? "", /color:\s*blue/, "the payload carries the new CSS");
 }
 
-/** `features.optionsAPI` produces the same Vue runtime define as plugin-vue. */
-async function probeOptionsApiFeature(): Promise<void> {
-  const cases = [
-    { expected: true, options: {}, userDefine: {} },
-    { expected: false, options: { features: { optionsAPI: false } }, userDefine: {} },
-    {
-      expected: true,
-      options: { features: { optionsAPI: true } },
-      userDefine: { __VUE_OPTIONS_API__: false },
-    },
-    { expected: false, options: {}, userDefine: { __VUE_OPTIONS_API__: "false" } },
-  ] as const;
-
-  for (const { expected, options, userDefine } of cases) {
-    // Each hook gets its own config object so the parity assertion does not
-    // depend on either plugin leaving its input untouched.
-    const upstreamConfig = { define: { ...userDefine } };
-    const vizeConfig = { define: { ...userDefine } };
-    const env = { command: "build", mode: "production" } as const;
-    const upstream = createUpstreamPlugin(options) as Plugin;
-    const vizePlugin = vize({ configMode: false, ...options }).find(
-      (candidate) => candidate.name === "vite-plugin-vize",
-    );
-    assert.ok(vizePlugin);
-
-    const upstreamResult = await hook<AnyHook>(upstream.config).call({}, upstreamConfig, env);
-    const vizeResult = await hook<AnyHook>(vizePlugin.config).call({}, vizeConfig, env);
-    const upstreamDefine = (upstreamResult as { define: Record<string, unknown> }).define
-      .__VUE_OPTIONS_API__;
-    const vizeDefine = (vizeResult as { define: Record<string, unknown> }).define
-      .__VUE_OPTIONS_API__;
-
-    assert.equal(upstreamDefine, expected, "the pinned upstream oracle must stay stable");
-    assert.equal(vizeDefine, upstreamDefine, "Vize must match plugin-vue's Options API define");
-  }
-}
-
-/** `features.prodHydrationMismatchDetails` matches plugin-vue's OR semantics. */
-async function probeProdHydrationMismatchDetailsFeature(): Promise<void> {
-  const cases: ReadonlyArray<{
-    expected: boolean;
-    options: Record<string, unknown>;
-    userDefine: Record<string, unknown>;
-  }> = [
-    { expected: false, options: {}, userDefine: {} },
-    {
-      expected: false,
-      options: { features: { prodHydrationMismatchDetails: false } },
-      userDefine: {},
-    },
-    {
-      expected: true,
-      options: { features: { prodHydrationMismatchDetails: true } },
-      userDefine: { __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false },
-    },
-    {
-      expected: true,
-      options: { features: { prodHydrationMismatchDetails: false } },
-      userDefine: { __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: true },
-    },
-    {
-      expected: true,
-      options: {},
-      userDefine: { __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: "true" },
-    },
-    {
-      expected: false,
-      options: {},
-      userDefine: { __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: "false" },
-    },
-  ];
-
-  for (const { expected, options, userDefine } of cases) {
-    const upstreamConfig = { define: { ...userDefine } };
-    const vizeConfig = { define: { ...userDefine } };
-    const env = { command: "build", mode: "production" } as const;
-    const upstream = createUpstreamPlugin(options) as Plugin;
-    const vizePlugin = vize({ configMode: false, ...options }).find(
-      (candidate) => candidate.name === "vite-plugin-vize",
-    );
-    assert.ok(vizePlugin);
-
-    const upstreamResult = await hook<AnyHook>(upstream.config).call({}, upstreamConfig, env);
-    const vizeResult = await hook<AnyHook>(vizePlugin.config).call({}, vizeConfig, env);
-    const upstreamDefine = (upstreamResult as { define: Record<string, unknown> }).define
-      .__VUE_PROD_HYDRATION_MISMATCH_DETAILS__;
-    const vizeDefine = (vizeResult as { define: Record<string, unknown> }).define
-      .__VUE_PROD_HYDRATION_MISMATCH_DETAILS__;
-
-    assert.equal(upstreamDefine, expected, "the pinned upstream oracle must stay stable");
-    assert.equal(vizeDefine, upstreamDefine, "Vize must match plugin-vue's hydration define");
-  }
-}
-
 /** The named hook is implemented by one of the plugins Vize contributes. */
 function probeHookImplemented(name: string): void {
   const plugins = vize({ configMode: false }) as Plugin[];
@@ -304,6 +214,7 @@ const probes = new Map<string, () => Promise<void> | void>([
   ["production-css-import", probeProductionCssImport],
   ["hot-update-style-only", probeHotUpdateStyleOnly],
   ["options-api-feature", probeOptionsApiFeature],
+  ["prod-devtools-feature", probeProdDevtoolsFeature],
   ["prod-hydration-mismatch-details-feature", probeProdHydrationMismatchDetailsFeature],
 ]);
 


### PR DESCRIPTION
One option gap closed on #3227's Vite-plugin API parity gate.

## What

`__VUE_PROD_DEVTOOLS__` was hard-coded to `command === "serve"`, so a production build had no way to turn Vue devtools on. It now follows plugin-vue's precedence:

```js
(features?.prodDevtools || parseDefine(define?.__VUE_PROD_DEVTOOLS__)) ?? false
```

## Behavior change in dev

The define now resolves to `false` in dev instead of `true`, which is exactly what upstream does — a development build enables devtools through Vue's own `__DEV__`, not through this flag. Nothing in this repository reads `__VUE_PROD_DEVTOOLS__` outside the Vue runtime, so the change is confined to the flag's documented meaning.

## Tests

The probe runs the real `@vitejs/plugin-vue` as its oracle and compares Vize's `config` hook output against it across six cases, so the assertion is against upstream behavior rather than a transcription of it. Each case still pins its own expected value, so a shift in upstream semantics fails as itself.

Ledger: `features.prodDevtools` moves from `unimplemented` to `honored`, 13 → 14 honored, 18 → 17 unimplemented.

The three define probes moved to `tests/tooling/_helpers/vite-plugin-vue-define-probes.ts` — the parity test was at 345 of its 350-line budget and adding a fourth probe inline would have crossed it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->