### PR TITLE
docs(compat): record what style.trim actually diverges on

### DIFF
--- a/tests/_fixtures/vite-plugin-vue-option-parity.json
+++ b/tests/_fixtures/vite-plugin-vue-option-parity.json
@@ -100,7 +100,7 @@
     "style.trim": {
       "status": "unimplemented",
       "issue": 3227,
-      "reason": "No style trim toggle is accepted or forwarded to the native style pipeline, and the behavior behind it differs: Vize emits the author's CSS verbatim, which is byte-for-byte plugin-vue's `trim: false`, while plugin-vue defaults to `trim: true` and normalizes the whitespace around every rule and at-rule to a single newline. Vite minifies production CSS, so the difference is confined to unminified output."
+      "reason": "No style trim toggle is accepted or forwarded to the native style pipeline, and the behavior behind it differs: Vize emits the author's CSS verbatim, which is byte-for-byte plugin-vue's `trim: false`, while plugin-vue defaults to `trim: true` and normalizes the whitespace around every rule and at-rule to a single newline. Vite's production CSS minification (`build.cssMinify`, on by default) collapses the difference away, so it is only observable when minification is disabled."
     },
     "template.compiler": {
       "status": "intentional-divergence",

--- a/tests/_fixtures/vite-plugin-vue-option-parity.json
+++ b/tests/_fixtures/vite-plugin-vue-option-parity.json
@@ -100,7 +100,7 @@
     "style.trim": {
       "status": "unimplemented",
       "issue": 3227,
-      "reason": "No style trim toggle is accepted or forwarded to the native style pipeline."
+      "reason": "No style trim toggle is accepted or forwarded to the native style pipeline, and the behavior behind it differs: Vize emits the author's CSS verbatim, which is byte-for-byte plugin-vue's `trim: false`, while plugin-vue defaults to `trim: true` and normalizes the whitespace around every rule and at-rule to a single newline. Vite minifies production CSS, so the difference is confined to unminified output."
     },
     "template.compiler": {
       "status": "intentional-divergence",


### PR DESCRIPTION
A ledger accuracy fix for #3227.

`style.trim`'s entry said only that no trim toggle is accepted or forwarded, which reads as a missing knob with no behavioral consequence. There is one.

Running `compileStyle` from `@vue/compiler-sfc` at both settings against the same source, and comparing with `compileSfc`:

```
source        "\n\n\n.a {\n  color: red;\n}\n\n\n\n.b { color: blue; }\n\n"
trim=false    "\n\n\n.a {\n  color: red;\n}\n\n\n\n.b { color: blue; }\n\n"
trim=true     "\n.a {\n  color: red;\n}\n.b { color: blue;\n}\n\n"
Vize          "\n\n\n.a {\n  color: red;\n}\n\n\n\n.b { color: blue; }\n\n"
```

Vize's output is byte-for-byte plugin-vue's `trim: false`, while plugin-vue **defaults to `trim: true`**. So the gap is not just an unaccepted option — the default behavior differs.

Not implemented here on purpose: upstream's `trim` is a postcss plugin rewriting `raws.before` / `raws.after` on every rule and at-rule, and reproducing that on emitted CSS text without an AST would be fragile around comments, nested at-rules and braces inside strings. Vite minifies production CSS, so the difference is confined to unminified output — not worth that risk. The entry now says so, instead of leaving the next person to rediscover it.

No status change: `style.trim` stays `unimplemented`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how CSS whitespace handling compares with the standard Vue plugin, including differences in unminified output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->