### PR TITLE
feat(canon): resolve workspace alias components in editor sessions

### DIFF
--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -9,6 +9,7 @@ mod declaration_path;
 mod error;
 mod executor;
 mod import_rewriter;
+mod import_rewriter_alias;
 #[cfg(test)]
 mod import_rewriter_authored_vue_ts_tests;
 #[cfg(test)]

--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -24,7 +24,7 @@ mod materialize_lock;
 mod runtime_deps;
 mod source_map;
 mod type_checker;
-mod virtual_project;
+pub(crate) mod virtual_project;
 mod virtual_specifier_message;
 mod virtual_ts;
 

--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -9,7 +9,7 @@ mod declaration_path;
 mod error;
 mod executor;
 mod import_rewriter;
-mod import_rewriter_alias;
+pub(crate) mod import_rewriter_alias;
 #[cfg(test)]
 mod import_rewriter_authored_vue_ts_tests;
 #[cfg(test)]

--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -30,55 +30,9 @@ use virtual_rewrite::{
 mod dts_rewrite;
 use dts_rewrite::rewrite_relative_dts_specifier;
 
-#[derive(Debug, Clone)]
-pub struct OffsetAdjustment {
-    pub original_offset: u32,
-    pub adjustment: i32,
-}
-
-#[derive(Debug)]
-pub struct RewriteResult {
-    pub code: String,
-    pub source_map: ImportSourceMap,
-}
-
-#[derive(Debug, Default)]
-pub struct ImportSourceMap {
-    adjustments: Vec<OffsetAdjustment>,
-}
-
-impl ImportSourceMap {
-    pub fn new(adjustments: Vec<OffsetAdjustment>) -> Self {
-        Self { adjustments }
-    }
-
-    pub fn empty() -> Self {
-        Self::default()
-    }
-
-    pub fn get_original_offset(&self, virtual_offset: u32) -> u32 {
-        let mut cumulative: i32 = 0;
-        for adj in &self.adjustments {
-            let adjusted = (adj.original_offset as i32 + cumulative) as u32;
-            if virtual_offset < adjusted {
-                break;
-            }
-            cumulative += adj.adjustment;
-        }
-        (virtual_offset as i32 - cumulative) as u32
-    }
-
-    pub fn get_virtual_offset(&self, original_offset: u32) -> u32 {
-        let mut cumulative: i32 = 0;
-        for adj in &self.adjustments {
-            if original_offset < adj.original_offset {
-                break;
-            }
-            cumulative += adj.adjustment;
-        }
-        (original_offset as i32 + cumulative) as u32
-    }
-}
+#[path = "import_rewriter_source_map.rs"]
+mod source_map;
+pub use source_map::{ImportSourceMap, OffsetAdjustment, RewriteResult};
 
 pub struct ImportRewriter;
 

--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -20,9 +20,10 @@ use collect::ModuleSpecifierCollector;
 
 #[path = "import_rewriter_virtual.rs"]
 mod virtual_rewrite;
+pub(super) use virtual_rewrite::rewrite_relative_vue_specifier;
 use virtual_rewrite::{
     absolute_import_needs_virtual_rewrite, is_rewritable_project_specifier,
-    is_rewritable_vue_specifier, rewrite_relative_vue_specifier,
+    is_rewritable_vue_specifier,
 };
 
 #[path = "import_rewriter_dts.rs"]
@@ -151,7 +152,7 @@ impl ImportRewriter {
         })
     }
 
-    fn rewrite_with<F>(
+    pub(super) fn rewrite_with<F>(
         &self,
         source: &str,
         source_type: SourceType,
@@ -260,7 +261,11 @@ impl ImportRewriter {
         specifiers
     }
 
-    fn rewrite_module_specifier(&self, path: &str, source_dir: Option<&Path>) -> Option<String> {
+    pub(super) fn rewrite_module_specifier(
+        &self,
+        path: &str,
+        source_dir: Option<&Path>,
+    ) -> Option<String> {
         if let Some(collision) = authored_vue_ts_collides_with_sfc(path, source_dir) {
             let marker = match collision {
                 VueTsCollision::Unresolved => AUTHORED_VUE_TS_SENTINEL,

--- a/crates/vize_canon/src/batch/import_rewriter_alias.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_alias.rs
@@ -12,6 +12,10 @@ use oxc_span::SourceType;
 
 use super::import_rewriter::{ImportRewriter, RewriteResult, rewrite_relative_vue_specifier};
 
+/// Resolver consulted for non-relative specifiers.
+#[allow(clippy::disallowed_types)]
+pub type AliasSpecifierResolver<'a> = &'a dyn Fn(&str) -> Option<std::string::String>;
+
 impl ImportRewriter {
     /// Like [`ImportRewriter::rewrite`], additionally consulting
     /// `alias_resolver` for non-relative specifiers.
@@ -20,7 +24,7 @@ impl ImportRewriter {
         source: &str,
         source_type: SourceType,
         source_dir: Option<&Path>,
-        alias_resolver: &dyn Fn(&str) -> Option<std::string::String>,
+        alias_resolver: AliasSpecifierResolver<'_>,
     ) -> RewriteResult {
         self.rewrite_with(source, source_type, |path| {
             self.rewrite_module_specifier(path, source_dir)

--- a/crates/vize_canon/src/batch/import_rewriter_alias.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_alias.rs
@@ -1,0 +1,37 @@
+//! Alias-aware import rewriting for editor dependency documents (#3900).
+//!
+//! Lives beside [`super::import_rewriter`] to keep that file inside its source
+//! budget; the method needs the rewriter's offset-tracking core so downstream
+//! `@vize-map` source maps stay valid — a plain string replacement shifts every
+//! byte offset after the first substitution and silently breaks position
+//! mapping for hover and definition.
+
+use std::path::Path;
+
+use oxc_span::SourceType;
+
+use super::import_rewriter::{ImportRewriter, RewriteResult, rewrite_relative_vue_specifier};
+
+impl ImportRewriter {
+    /// Like [`ImportRewriter::rewrite`], additionally consulting
+    /// `alias_resolver` for non-relative specifiers.
+    pub fn rewrite_with_alias_resolver(
+        &self,
+        source: &str,
+        source_type: SourceType,
+        source_dir: Option<&Path>,
+        alias_resolver: &dyn Fn(&str) -> Option<std::string::String>,
+    ) -> RewriteResult {
+        self.rewrite_with(source, source_type, |path| {
+            self.rewrite_module_specifier(path, source_dir)
+                .or_else(|| source_dir.and_then(|dir| rewrite_relative_vue_specifier(path, dir)))
+                .or_else(|| {
+                    if path.starts_with("./") || path.starts_with("../") {
+                        None
+                    } else {
+                        alias_resolver(path).map(Into::into)
+                    }
+                })
+        })
+    }
+}

--- a/crates/vize_canon/src/batch/import_rewriter_alias.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_alias.rs
@@ -27,15 +27,19 @@ impl ImportRewriter {
         alias_resolver: AliasSpecifierResolver<'_>,
     ) -> RewriteResult {
         self.rewrite_with(source, source_type, |path| {
-            self.rewrite_module_specifier(path, source_dir)
+            if path.starts_with("./") || path.starts_with("../") {
+                return self.rewrite_module_specifier(path, source_dir).or_else(|| {
+                    source_dir.and_then(|dir| rewrite_relative_vue_specifier(path, dir))
+                });
+            }
+            // A resolvable alias wins over the generic `.vue` → `.vue.ts`
+            // rewrite: `is_rewritable_vue_specifier` also matches `@/Foo.vue`
+            // and `~/Foo.vue`, so rewriting first would emit `@/Foo.vue.ts` and
+            // leave the alias prefix unresolved in the generated module.
+            alias_resolver(path)
+                .map(Into::into)
+                .or_else(|| self.rewrite_module_specifier(path, source_dir))
                 .or_else(|| source_dir.and_then(|dir| rewrite_relative_vue_specifier(path, dir)))
-                .or_else(|| {
-                    if path.starts_with("./") || path.starts_with("../") {
-                        None
-                    } else {
-                        alias_resolver(path).map(Into::into)
-                    }
-                })
         })
     }
 }

--- a/crates/vize_canon/src/batch/import_rewriter_source_map.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_source_map.rs
@@ -1,0 +1,53 @@
+//! Offset bookkeeping for rewritten module specifiers.
+
+use vize_carton::String;
+
+#[derive(Debug, Clone)]
+pub struct OffsetAdjustment {
+    pub original_offset: u32,
+    pub adjustment: i32,
+}
+
+#[derive(Debug)]
+pub struct RewriteResult {
+    pub code: String,
+    pub source_map: ImportSourceMap,
+}
+
+#[derive(Debug, Default)]
+pub struct ImportSourceMap {
+    adjustments: Vec<OffsetAdjustment>,
+}
+
+impl ImportSourceMap {
+    pub fn new(adjustments: Vec<OffsetAdjustment>) -> Self {
+        Self { adjustments }
+    }
+
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn get_original_offset(&self, virtual_offset: u32) -> u32 {
+        let mut cumulative: i32 = 0;
+        for adj in &self.adjustments {
+            let adjusted = (adj.original_offset as i32 + cumulative) as u32;
+            if virtual_offset < adjusted {
+                break;
+            }
+            cumulative += adj.adjustment;
+        }
+        (virtual_offset as i32 - cumulative) as u32
+    }
+
+    pub fn get_virtual_offset(&self, original_offset: u32) -> u32 {
+        let mut cumulative: i32 = 0;
+        for adj in &self.adjustments {
+            if original_offset < adj.original_offset {
+                break;
+            }
+            cumulative += adj.adjustment;
+        }
+        (original_offset as i32 + cumulative) as u32
+    }
+}

--- a/crates/vize_canon/src/batch/import_rewriter_virtual.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_virtual.rs
@@ -131,7 +131,7 @@ pub(super) fn is_rewritable_project_specifier(path: &Path) -> bool {
 /// Like that alias candidate, this only ever turns a failing resolution into a
 /// successful one: a specifier TypeScript already resolves through an ordinary
 /// source sibling or directory module keeps its original spelling.
-pub(super) fn rewrite_relative_vue_specifier(specifier: &str, source_dir: &Path) -> Option<String> {
+pub(crate) fn rewrite_relative_vue_specifier(specifier: &str, source_dir: &Path) -> Option<String> {
     // `.`/`..` name a directory module, not a stem an extension can be appended
     // to, so only the `./`-prefixed spellings are candidates here.
     if !(specifier.starts_with("./") || specifier.starts_with("../")) {

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -38,8 +38,10 @@ mod document;
 pub use document::{
     VueDocumentVirtualTs, VueDocumentVirtualTsOptions, generate_vue_document_virtual_ts,
     generate_vue_document_virtual_ts_with_options,
-    generate_vue_document_virtual_ts_with_options_and_alias_resolver,
 };
+// Crate-scoped: the `alias_resolver` parameter names
+// `import_rewriter_alias::AliasSpecifierResolver`, which is `pub(crate)`.
+pub(crate) use document::generate_vue_document_virtual_ts_with_options_and_alias_resolver;
 mod diagnostics;
 mod external_mirror;
 mod javascript_sfc;

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -33,7 +33,7 @@ pub use content_mapper::{
 };
 mod css_var_usage;
 mod declaration_emit;
-mod dependency_scan;
+pub(crate) mod dependency_scan;
 mod document;
 pub use document::{
     VueDocumentVirtualTs, VueDocumentVirtualTsOptions, generate_vue_document_virtual_ts,

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -38,6 +38,7 @@ mod document;
 pub use document::{
     VueDocumentVirtualTs, VueDocumentVirtualTsOptions, generate_vue_document_virtual_ts,
     generate_vue_document_virtual_ts_with_options,
+    generate_vue_document_virtual_ts_with_options_and_alias_resolver,
 };
 mod diagnostics;
 mod external_mirror;

--- a/crates/vize_canon/src/batch/virtual_project/dependency_scan.rs
+++ b/crates/vize_canon/src/batch/virtual_project/dependency_scan.rs
@@ -120,7 +120,7 @@ impl VirtualProject {
     /// The effective `paths` aliases with project-root-relative targets, as
     /// (pattern, target) pairs. Both come from the flattened chain, so the
     /// anchors match what the generated tsconfig resolves (#3886).
-    fn dependency_alias_map(&self) -> Vec<(String, String)> {
+    pub(crate) fn dependency_alias_map(&self) -> Vec<(String, String)> {
         let Ok(flattened) =
             self.load_compiler_options_flattened(self.resolved_tsconfig_path().as_deref())
         else {
@@ -231,7 +231,7 @@ fn may_resolve_a_dependency(content: &str, alias_prefixes: &[CompactString]) -> 
 
 /// Resolve one specifier to a registrable first-party file, or `None`.
 #[allow(clippy::disallowed_types)]
-fn resolve_dependency(
+pub(crate) fn resolve_dependency(
     specifier: &str,
     importer_dir: &Path,
     project_root: &Path,

--- a/crates/vize_canon/src/batch/virtual_project/dependency_scan.rs
+++ b/crates/vize_canon/src/batch/virtual_project/dependency_scan.rs
@@ -24,7 +24,7 @@
 use std::path::{Component, Path, PathBuf};
 
 use oxc_span::SourceType;
-use vize_carton::{FxHashSet, String as CompactString, cstr};
+use vize_carton::{FxHashMap, FxHashSet, String as CompactString, cstr};
 
 use crate::batch::error::CorsaResult;
 
@@ -34,6 +34,21 @@ use super::VirtualProject;
 impl VirtualProject {
     /// Register every reachable first-party dependency, to a fixpoint.
     pub fn register_reachable_dependencies(&mut self) -> CorsaResult<()> {
+        self.register_reachable_dependencies_with_overlays(&FxHashMap::default())
+    }
+
+    /// The same walk, with unsaved editor buffers standing in for their on-disk
+    /// contents.
+    ///
+    /// An editor session must see the buffer the user is typing in: a dependency
+    /// reachable only through an import that exists in an unsaved file is
+    /// invisible to a disk-only walk, so nothing registers it, its mirror
+    /// companion is never generated, and the alias rewrite has no real file to
+    /// point at until the buffer is saved (#3900).
+    pub(crate) fn register_reachable_dependencies_with_overlays(
+        &mut self,
+        overlays: &FxHashMap<PathBuf, &str>,
+    ) -> CorsaResult<()> {
         let aliases = self.dependency_alias_map();
         let alias_prefixes: Vec<CompactString> = aliases
             .iter()
@@ -109,7 +124,11 @@ impl VirtualProject {
                 // abort the check the user actually asked for, so registration
                 // failure degrades to the pre-#3887 ambient stub for that one
                 // import instead of propagating (#3898).
-                if self.register_path(&key).is_ok() {
+                let registered = match overlays.get(&key) {
+                    Some(content) => self.register_path_with_content(&key, content),
+                    None => self.register_path(&key),
+                };
+                if registered.is_ok() {
                     queue.push(key);
                 }
             }

--- a/crates/vize_canon/src/batch/virtual_project/document.rs
+++ b/crates/vize_canon/src/batch/virtual_project/document.rs
@@ -83,7 +83,7 @@ pub fn generate_vue_document_virtual_ts_with_options_and_alias_resolver(
     rewriter: &ImportRewriter,
     hoist_shared_preamble: bool,
     document_options: VueDocumentVirtualTsOptions,
-    alias_resolver: Option<&dyn Fn(&str) -> Option<std::string::String>>,
+    alias_resolver: Option<crate::batch::import_rewriter_alias::AliasSpecifierResolver<'_>>,
 ) -> CorsaResult<VueDocumentVirtualTs> {
     let descriptor = parse_sfc(
         content,

--- a/crates/vize_canon/src/batch/virtual_project/document.rs
+++ b/crates/vize_canon/src/batch/virtual_project/document.rs
@@ -60,10 +60,30 @@ pub fn generate_vue_document_virtual_ts(
 pub fn generate_vue_document_virtual_ts_with_options(
     path: &Path,
     content: &str,
+    virtual_ts_options: &VirtualTsOptions,
+    rewriter: &ImportRewriter,
+    hoist_shared_preamble: bool,
+    options: VueDocumentVirtualTsOptions,
+) -> CorsaResult<VueDocumentVirtualTs> {
+    generate_vue_document_virtual_ts_with_options_and_alias_resolver(
+        path,
+        content,
+        virtual_ts_options,
+        rewriter,
+        hoist_shared_preamble,
+        options,
+        None,
+    )
+}
+
+pub fn generate_vue_document_virtual_ts_with_options_and_alias_resolver(
+    path: &Path,
+    content: &str,
     options: &VirtualTsOptions,
     rewriter: &ImportRewriter,
     hoist_shared_preamble: bool,
     document_options: VueDocumentVirtualTsOptions,
+    alias_resolver: Option<&dyn Fn(&str) -> Option<std::string::String>>,
 ) -> CorsaResult<VueDocumentVirtualTs> {
     let descriptor = parse_sfc(
         content,
@@ -106,7 +126,12 @@ pub fn generate_vue_document_virtual_ts_with_options(
         prepend_vue_jsx_reference(&mut code, &mut mappings);
     }
 
-    let rewritten = rewriter.rewrite(&code, source_type, path.parent());
+    let rewritten = match alias_resolver {
+        Some(resolver) => {
+            rewriter.rewrite_with_alias_resolver(&code, source_type, path.parent(), resolver)
+        }
+        None => rewriter.rewrite(&code, source_type, path.parent()),
+    };
     Ok(VueDocumentVirtualTs {
         code: rewritten.code,
         pre_rewrite_code: code,

--- a/crates/vize_canon/src/batch/virtual_project/document.rs
+++ b/crates/vize_canon/src/batch/virtual_project/document.rs
@@ -76,7 +76,7 @@ pub fn generate_vue_document_virtual_ts_with_options(
     )
 }
 
-pub fn generate_vue_document_virtual_ts_with_options_and_alias_resolver(
+pub(crate) fn generate_vue_document_virtual_ts_with_options_and_alias_resolver(
     path: &Path,
     content: &str,
     options: &VirtualTsOptions,

--- a/crates/vize_canon/src/corsa_bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge.rs
@@ -8,6 +8,7 @@ mod bridge;
 mod session;
 mod types;
 mod vue_dependencies;
+mod vue_dependencies_alias;
 mod vue_dependency_specifiers;
 mod vue_document;
 #[cfg(test)]

--- a/crates/vize_canon/src/corsa_bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge.rs
@@ -13,6 +13,8 @@ mod vue_dependency_paths;
 mod vue_dependency_specifiers;
 mod vue_document;
 #[cfg(test)]
+mod vue_document_alias_tests;
+#[cfg(test)]
 mod vue_document_tests;
 mod worker;
 

--- a/crates/vize_canon/src/corsa_bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge.rs
@@ -9,6 +9,7 @@ mod session;
 mod types;
 mod vue_dependencies;
 mod vue_dependencies_alias;
+mod vue_dependency_paths;
 mod vue_dependency_specifiers;
 mod vue_document;
 #[cfg(test)]

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -22,9 +22,9 @@ pub(super) fn collect_dependency_documents(
     host: &GeneratedVueDocument,
     options: CorsaVueVirtualDocumentOptions,
     rewriter: &ImportRewriter,
+    alias_context: &super::vue_dependencies_alias::AliasContext,
     overlays: &FxHashMap<PathBuf, &str>,
 ) {
-    let alias_context = super::vue_dependencies_alias::AliasContext::for_host(&host.source_path);
     let mut visited_vue = FxHashSet::<PathBuf>::default();
     visited_vue.insert(host.source_path.clone());
     let mut visited_ts = FxHashSet::<PathBuf>::default();
@@ -109,8 +109,23 @@ fn queue_imports(
     code: &str,
     source_type: SourceType,
 ) {
-    queue_vue_imports(&mut imports, options, rewriter, dir, code, source_type);
-    queue_ts_imports(&mut imports, rewriter, dir, code, source_type);
+    queue_vue_imports(
+        &mut imports,
+        options,
+        rewriter,
+        alias_context,
+        dir,
+        code,
+        source_type,
+    );
+    queue_ts_imports(
+        &mut imports,
+        rewriter,
+        alias_context,
+        dir,
+        code,
+        source_type,
+    );
     super::vue_dependencies_alias::queue_alias_imports(
         &mut imports,
         options,
@@ -126,6 +141,7 @@ fn queue_vue_imports(
     imports: &mut ImportQueue<'_>,
     options: CorsaVueVirtualDocumentOptions,
     rewriter: &ImportRewriter,
+    alias_context: &super::vue_dependencies_alias::AliasContext,
     dir: &Path,
     code: &str,
     source_type: SourceType,
@@ -139,7 +155,13 @@ fn queue_vue_imports(
         let Some(content) = dependency_content(&path, imports.overlays) else {
             continue;
         };
-        let generated = match generate_vue_document(&path, &content, options, rewriter) {
+        let generated = match super::vue_document::generate_vue_document_with_alias(
+            &path,
+            &content,
+            options,
+            rewriter,
+            alias_context,
+        ) {
             Ok(generated) => generated,
             Err(_) => {
                 imports.documents.push((
@@ -197,6 +219,7 @@ pub(super) fn tsx_vue_import_shim(path: &Path) -> (String, String) {
 fn queue_ts_imports(
     imports: &mut ImportQueue<'_>,
     rewriter: &ImportRewriter,
+    alias_context: &super::vue_dependencies_alias::AliasContext,
     dir: &Path,
     code: &str,
     source_type: SourceType,
@@ -213,8 +236,11 @@ fn queue_ts_imports(
             continue;
         };
         let dependency_source_type = source_type_for_path(&path);
+        let script_dir = parent_dir(&path);
         let rewritten = rewriter
-            .rewrite(&content, dependency_source_type, path.parent())
+            .rewrite_with_alias_resolver(&content, dependency_source_type, path.parent(), &|spec| {
+                alias_context.resolve_specifier_to_relative(spec, &script_dir)
+            })
             .code;
         let uri = normalize_document_uri(path_to_file_uri(&path).as_str());
         imports.documents.push((uri, rewritten));

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -8,9 +8,7 @@ use vize_carton::{FxHashMap, FxHashSet, String, cstr};
 
 use super::bridge::normalize_document_uri;
 use super::vue_dependency_specifiers::collect_relative_ts_specifiers;
-use super::vue_document::{
-    CorsaVueVirtualDocumentOptions, GeneratedVueDocument, generate_vue_document,
-};
+use super::vue_document::{CorsaVueVirtualDocumentOptions, GeneratedVueDocument};
 use crate::batch::ImportRewriter;
 use crate::file_uri::path_to_file_uri;
 
@@ -51,7 +49,7 @@ pub(super) fn collect_dependency_documents(
                 },
                 options,
                 rewriter,
-                &alias_context,
+                alias_context,
                 &dir,
                 &pre_rewrite_code,
                 source_type,
@@ -70,7 +68,7 @@ pub(super) fn collect_dependency_documents(
                 },
                 options,
                 rewriter,
-                &alias_context,
+                alias_context,
                 &parent_dir(&path),
                 &content,
                 source_type,

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -7,6 +7,7 @@ use oxc_span::SourceType;
 use vize_carton::{FxHashMap, FxHashSet, String, cstr};
 
 use super::bridge::normalize_document_uri;
+use super::vue_dependency_paths::{normalize_path, resolve_relative_script_import};
 use super::vue_dependency_specifiers::collect_relative_ts_specifiers;
 use super::vue_document::{CorsaVueVirtualDocumentOptions, GeneratedVueDocument};
 use crate::batch::ImportRewriter;
@@ -261,56 +262,6 @@ pub(super) fn dependency_content(
         .or_else(|| std::fs::read_to_string(path).ok().map(Into::into))
 }
 
-fn resolve_relative_script_import(dir: &Path, specifier: &str) -> Option<PathBuf> {
-    let base = dir.join(specifier);
-    if base.extension().is_some() {
-        return known_script_path(&base).then(|| normalize_path(&base));
-    }
-
-    for ext in [
-        "ts", "tsx", "mts", "cts", "d.ts", "d.mts", "d.cts", "js", "jsx", "mjs", "cjs",
-    ] {
-        let candidate = base.with_extension(ext);
-        if candidate.exists() {
-            return Some(normalize_path(&candidate));
-        }
-    }
-    for name in [
-        "index.ts",
-        "index.tsx",
-        "index.mts",
-        "index.cts",
-        "index.js",
-        "index.jsx",
-        "index.mjs",
-        "index.cjs",
-        "index.d.ts",
-        "index.d.mts",
-        "index.d.cts",
-    ] {
-        let candidate = base.join(name);
-        if candidate.exists() {
-            return Some(normalize_path(&candidate));
-        }
-    }
-    None
-}
-
-fn known_script_path(path: &Path) -> bool {
-    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-        return false;
-    };
-    path.exists()
-        && (name.ends_with(".ts")
-            || name.ends_with(".tsx")
-            || name.ends_with(".mts")
-            || name.ends_with(".cts")
-            || name.ends_with(".js")
-            || name.ends_with(".jsx")
-            || name.ends_with(".mjs")
-            || name.ends_with(".cjs"))
-}
-
 pub(super) fn source_type_for_path(path: &Path) -> SourceType {
     SourceType::from_path(path).unwrap_or_else(|_| SourceType::ts())
 }
@@ -319,53 +270,4 @@ pub(super) fn parent_dir(path: &Path) -> PathBuf {
     path.parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| path.to_path_buf())
-}
-
-fn normalize_path(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            std::path::Component::CurDir => {}
-            std::path::Component::ParentDir => {
-                if !normalized.pop() {
-                    normalized.push("..");
-                }
-            }
-            other => normalized.push(other.as_os_str()),
-        }
-    }
-    normalized
-}
-
-#[cfg(test)]
-mod tests {
-    use super::resolve_relative_script_import;
-
-    #[test]
-    fn resolves_directory_module_declaration_indices() {
-        let project = tempfile::TempDir::new().expect("temp project");
-        let src = project.path().join("src");
-        std::fs::create_dir_all(src.join("esm")).expect("esm dir");
-        std::fs::create_dir_all(src.join("cjs")).expect("cjs dir");
-
-        let esm = src.join("esm").join("index.d.mts");
-        let cjs = src.join("cjs").join("index.d.cts");
-        let schema = src.join("schema.d.ts");
-        std::fs::write(&esm, "export type Value = string;\n").expect("esm dts");
-        std::fs::write(&cjs, "export type Value = string;\n").expect("cjs dts");
-        std::fs::write(&schema, "export type Schema = { id: string };\n").expect("schema dts");
-
-        assert_eq!(
-            resolve_relative_script_import(&src, "./esm").as_deref(),
-            Some(esm.as_path())
-        );
-        assert_eq!(
-            resolve_relative_script_import(&src, "./cjs").as_deref(),
-            Some(cjs.as_path())
-        );
-        assert_eq!(
-            resolve_relative_script_import(&src, "./schema").as_deref(),
-            Some(schema.as_path())
-        );
-    }
 }

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -24,6 +24,7 @@ pub(super) fn collect_dependency_documents(
     rewriter: &ImportRewriter,
     overlays: &FxHashMap<PathBuf, &str>,
 ) {
+    let alias_context = super::vue_dependencies_alias::AliasContext::for_host(&host.source_path);
     let mut visited_vue = FxHashSet::<PathBuf>::default();
     visited_vue.insert(host.source_path.clone());
     let mut visited_ts = FxHashSet::<PathBuf>::default();
@@ -50,6 +51,7 @@ pub(super) fn collect_dependency_documents(
                 },
                 options,
                 rewriter,
+                &alias_context,
                 &dir,
                 &pre_rewrite_code,
                 source_type,
@@ -68,6 +70,7 @@ pub(super) fn collect_dependency_documents(
                 },
                 options,
                 rewriter,
+                &alias_context,
                 &parent_dir(&path),
                 &content,
                 source_type,
@@ -76,15 +79,15 @@ pub(super) fn collect_dependency_documents(
     }
 }
 
-struct ImportQueue<'a> {
-    documents: &'a mut Vec<(String, String)>,
-    queue: &'a mut VecDeque<DependencyScan>,
-    visited_vue: &'a mut FxHashSet<PathBuf>,
-    visited_ts: &'a mut FxHashSet<PathBuf>,
-    overlays: &'a FxHashMap<PathBuf, &'a str>,
+pub(super) struct ImportQueue<'a> {
+    pub(super) documents: &'a mut Vec<(String, String)>,
+    pub(super) queue: &'a mut VecDeque<DependencyScan>,
+    pub(super) visited_vue: &'a mut FxHashSet<PathBuf>,
+    pub(super) visited_ts: &'a mut FxHashSet<PathBuf>,
+    pub(super) overlays: &'a FxHashMap<PathBuf, &'a str>,
 }
 
-enum DependencyScan {
+pub(super) enum DependencyScan {
     Vue {
         dir: PathBuf,
         source_type: SourceType,
@@ -101,12 +104,22 @@ fn queue_imports(
     mut imports: ImportQueue<'_>,
     options: CorsaVueVirtualDocumentOptions,
     rewriter: &ImportRewriter,
+    alias_context: &super::vue_dependencies_alias::AliasContext,
     dir: &Path,
     code: &str,
     source_type: SourceType,
 ) {
     queue_vue_imports(&mut imports, options, rewriter, dir, code, source_type);
     queue_ts_imports(&mut imports, rewriter, dir, code, source_type);
+    super::vue_dependencies_alias::queue_alias_imports(
+        &mut imports,
+        options,
+        rewriter,
+        alias_context,
+        dir,
+        code,
+        source_type,
+    );
 }
 
 fn queue_vue_imports(
@@ -151,7 +164,7 @@ fn queue_vue_imports(
     }
 }
 
-fn fallback_vue_virtual_uri(path: &Path) -> String {
+pub(super) fn fallback_vue_virtual_uri(path: &Path) -> String {
     let virtual_path = path.with_file_name(cstr!(
         "{}.ts",
         path.file_name()
@@ -213,7 +226,10 @@ fn queue_ts_imports(
     }
 }
 
-fn dependency_content(path: &Path, overlays: &FxHashMap<PathBuf, &str>) -> Option<String> {
+pub(super) fn dependency_content(
+    path: &Path,
+    overlays: &FxHashMap<PathBuf, &str>,
+) -> Option<String> {
     let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
     overlays
         .get(&key)
@@ -271,11 +287,11 @@ fn known_script_path(path: &Path) -> bool {
             || name.ends_with(".cjs"))
 }
 
-fn source_type_for_path(path: &Path) -> SourceType {
+pub(super) fn source_type_for_path(path: &Path) -> SourceType {
     SourceType::from_path(path).unwrap_or_else(|_| SourceType::ts())
 }
 
-fn parent_dir(path: &Path) -> PathBuf {
+pub(super) fn parent_dir(path: &Path) -> PathBuf {
     path.parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| path.to_path_buf())

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -147,42 +147,55 @@ fn queue_vue_imports(
 ) {
     for specifier in rewriter.collect_relative_vue_specifiers(code, source_type, Some(dir)) {
         let path = normalize_path(&dir.join(specifier.as_str()));
-        let key = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
-        if !imports.visited_vue.insert(key) {
-            continue;
-        }
-        let Some(content) = dependency_content(&path, imports.overlays) else {
-            continue;
-        };
-        let generated = match super::vue_document::generate_vue_document_with_alias(
-            &path,
-            &content,
-            options,
-            rewriter,
-            alias_context,
-        ) {
-            Ok(generated) => generated,
-            Err(_) => {
-                imports.documents.push((
-                    fallback_vue_virtual_uri(&path),
-                    VUE_DEPENDENCY_FALLBACK.into(),
-                ));
-                continue;
-            }
-        };
-        imports.documents.push((
-            generated.virtual_uri.clone(),
-            generated.generated.code.clone(),
-        ));
-        if generated.generated.virtual_suffix == ".tsx" {
-            imports.documents.push(tsx_vue_import_shim(&path));
-        }
-        imports.queue.push_back(DependencyScan::Vue {
-            dir: parent_dir(&generated.source_path),
-            source_type: generated.generated.source_type,
-            pre_rewrite_code: generated.generated.pre_rewrite_code,
-        });
+        queue_vue_dependency(imports, options, rewriter, alias_context, &path);
     }
+}
+
+/// Generate one resolved `.vue` dependency, push its document, and queue the
+/// component's own imports. Shared with the alias walk so both spellings of a
+/// dependency produce the same document and the same ambient fallback.
+pub(super) fn queue_vue_dependency(
+    imports: &mut ImportQueue<'_>,
+    options: CorsaVueVirtualDocumentOptions,
+    rewriter: &ImportRewriter,
+    alias_context: &super::vue_dependencies_alias::AliasContext,
+    path: &Path,
+) {
+    let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    if !imports.visited_vue.insert(key) {
+        return;
+    }
+    let Some(content) = dependency_content(path, imports.overlays) else {
+        return;
+    };
+    let generated = match super::vue_document::generate_vue_document_with_alias(
+        path,
+        &content,
+        options,
+        rewriter,
+        alias_context,
+    ) {
+        Ok(generated) => generated,
+        Err(_) => {
+            imports.documents.push((
+                fallback_vue_virtual_uri(path),
+                VUE_DEPENDENCY_FALLBACK.into(),
+            ));
+            return;
+        }
+    };
+    imports.documents.push((
+        generated.virtual_uri.clone(),
+        generated.generated.code.clone(),
+    ));
+    if generated.generated.virtual_suffix == ".tsx" {
+        imports.documents.push(tsx_vue_import_shim(path));
+    }
+    imports.queue.push_back(DependencyScan::Vue {
+        dir: parent_dir(&generated.source_path),
+        source_type: generated.generated.source_type,
+        pre_rewrite_code: generated.generated.pre_rewrite_code,
+    });
 }
 
 pub(super) fn fallback_vue_virtual_uri(path: &Path) -> String {
@@ -238,7 +251,7 @@ fn queue_ts_imports(
         let script_dir = parent_dir(&path);
         let rewritten = rewriter
             .rewrite_with_alias_resolver(&content, dependency_source_type, path.parent(), &|spec| {
-                alias_context.resolve_specifier_to_relative(spec, &script_dir)
+                alias_context.resolve_specifier_to_mirror_path(spec, &script_dir)
             })
             .code;
         let uri = normalize_document_uri(path_to_file_uri(&path).as_str());

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
@@ -1,0 +1,164 @@
+//! Alias-resolved dependencies for Vue editor virtual documents (#3900).
+//!
+//! The relative walk in [`super::vue_dependencies`] covers `./Child.vue`-style
+//! imports; a workspace component imported through a tsconfig `paths` alias
+//! (`import { UiButton } from "#ui"`) never entered the queue, so the editor
+//! session fell back to the ambient stub and the component hovered as `any`
+//! even after the batch pipeline learned to register it (#3887/#3898).
+//!
+//! Resolution reuses the batch pass's resolver — the same baseUrl-anchored
+//! alias map and probing — so `vize check` and the editor can no longer
+//! disagree about which file an alias names. First-party policy matches the
+//! batch narrowing: any `.vue`, plus out-of-root non-declaration scripts (a
+//! workspace barrel); everything in `node_modules` keeps the stub.
+
+use std::path::{Component, Path, PathBuf};
+
+use oxc_span::SourceType;
+
+use super::bridge::normalize_document_uri;
+use super::vue_dependencies::{
+    DependencyScan, ImportQueue, dependency_content, fallback_vue_virtual_uri, parent_dir,
+    source_type_for_path, tsx_vue_import_shim,
+};
+use super::vue_document::{CorsaVueVirtualDocumentOptions, generate_vue_document};
+use crate::batch::ImportRewriter;
+use crate::batch::virtual_project::VirtualProject;
+use crate::batch::virtual_project::dependency_scan::resolve_dependency;
+use crate::file_uri::path_to_file_uri;
+
+/// The alias map for the host document's package, resolved once per open.
+pub(super) struct AliasContext {
+    project_root: PathBuf,
+    aliases: Vec<(std::string::String, std::string::String)>,
+}
+
+impl AliasContext {
+    /// Anchor at the nearest ancestor with a `tsconfig.json` — the same
+    /// package-local config `vize check` treats as authoritative.
+    pub(super) fn for_host(source_path: &Path) -> Self {
+        let root = source_path
+            .ancestors()
+            .skip(1)
+            .find(|dir| dir.join("tsconfig.json").is_file())
+            .map(Path::to_path_buf);
+        let (project_root, aliases) = match root {
+            Some(root) => {
+                let aliases = VirtualProject::new(&root)
+                    .map(|project| project.dependency_alias_map())
+                    .unwrap_or_default();
+                (root, aliases)
+            }
+            None => (
+                source_path.parent().unwrap_or(source_path).to_path_buf(),
+                Vec::new(),
+            ),
+        };
+        Self {
+            project_root,
+            aliases,
+        }
+    }
+}
+
+/// Queue alias-resolved first-party dependencies of one document.
+pub(super) fn queue_alias_imports(
+    imports: &mut ImportQueue<'_>,
+    options: CorsaVueVirtualDocumentOptions,
+    rewriter: &ImportRewriter,
+    context: &AliasContext,
+    dir: &Path,
+    code: &str,
+    source_type: SourceType,
+) {
+    if context.aliases.is_empty() {
+        return;
+    }
+    for specifier in rewriter.collect_all_specifiers(code, source_type) {
+        if specifier.starts_with("./") || specifier.starts_with("../") {
+            continue; // the relative walk owns these
+        }
+        let Some(path) =
+            resolve_dependency(&specifier, dir, &context.project_root, &context.aliases)
+        else {
+            continue;
+        };
+        let key = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+        if inside_node_modules(&key) {
+            continue;
+        }
+        if key.extension().is_some_and(|extension| extension == "vue") {
+            queue_alias_vue(imports, options, rewriter, &key);
+        } else if !key.starts_with(&context.project_root) && !is_declaration(&key) {
+            queue_alias_script(imports, rewriter, &key);
+        }
+    }
+}
+
+fn queue_alias_vue(
+    imports: &mut ImportQueue<'_>,
+    options: CorsaVueVirtualDocumentOptions,
+    rewriter: &ImportRewriter,
+    path: &Path,
+) {
+    if !imports.visited_vue.insert(path.to_path_buf()) {
+        return;
+    }
+    let Some(content) = dependency_content(path, imports.overlays) else {
+        return;
+    };
+    let generated = match generate_vue_document(path, &content, options, rewriter) {
+        Ok(generated) => generated,
+        Err(_) => {
+            imports
+                .documents
+                .push((fallback_vue_virtual_uri(path), FALLBACK.into()));
+            return;
+        }
+    };
+    imports.documents.push((
+        generated.virtual_uri.clone(),
+        generated.generated.code.clone(),
+    ));
+    if generated.generated.virtual_suffix == ".tsx" {
+        imports.documents.push(tsx_vue_import_shim(path));
+    }
+    imports.queue.push_back(DependencyScan::Vue {
+        dir: parent_dir(&generated.source_path),
+        source_type: generated.generated.source_type,
+        pre_rewrite_code: generated.generated.pre_rewrite_code,
+    });
+}
+
+fn queue_alias_script(imports: &mut ImportQueue<'_>, rewriter: &ImportRewriter, path: &Path) {
+    if !imports.visited_ts.insert(path.to_path_buf()) {
+        return;
+    }
+    let Some(content) = dependency_content(path, imports.overlays) else {
+        return;
+    };
+    let dependency_source_type = source_type_for_path(path);
+    let rewritten = rewriter
+        .rewrite(&content, dependency_source_type, path.parent())
+        .code;
+    let uri = normalize_document_uri(path_to_file_uri(path).as_str());
+    imports.documents.push((uri, rewritten));
+    imports.queue.push_back(DependencyScan::Script {
+        path: path.to_path_buf(),
+        source_type: dependency_source_type,
+        content,
+    });
+}
+
+const FALLBACK: &str = "const component: any = undefined;\nexport default component;\n";
+
+fn inside_node_modules(path: &Path) -> bool {
+    path.components()
+        .any(|component| matches!(component, Component::Normal(part) if part == "node_modules"))
+}
+
+fn is_declaration(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".d.ts") || name.ends_with(".d.mts"))
+}

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
@@ -62,6 +62,72 @@ impl AliasContext {
     }
 }
 
+impl AliasContext {
+    /// Resolve one non-relative specifier to a relative path targeting the
+    /// synced overlay identities, for the offset-preserving rewriter.
+    pub(super) fn resolve_specifier_to_relative(
+        &self,
+        specifier: &str,
+        importer_dir: &Path,
+    ) -> Option<std::string::String> {
+        if self.aliases.is_empty() {
+            return None;
+        }
+        let path = resolve_dependency(specifier, importer_dir, &self.project_root, &self.aliases)?;
+        let key = std::fs::canonicalize(&path).unwrap_or(path);
+        if inside_node_modules(&key) || is_declaration(&key) {
+            return None;
+        }
+        let target = if key.extension().is_some_and(|extension| extension == "vue") {
+            let mut spelled = key.as_os_str().to_os_string();
+            spelled.push(".ts");
+            PathBuf::from(spelled)
+        } else if !key.starts_with(&self.project_root) {
+            virtual_script_identity(&key)
+        } else {
+            return None;
+        };
+        relative_specifier(importer_dir, &target)
+    }
+}
+
+/// The non-disk sync identity for an out-of-root script.
+///
+/// A path that exists on disk splits identity inside the checker: the program
+/// loads the disk file while the rewritten overlay sits unused, and the disk
+/// spelling's `.vue` import falls back to the ambient wildcard (`any`). The
+/// appended suffix guarantees a path no real tree contains, giving the barrel
+/// the same clean open-document identity the generated `.vue.ts` docs have.
+pub(super) fn virtual_script_identity(path: &Path) -> PathBuf {
+    let mut spelled = path.as_os_str().to_os_string();
+    spelled.push(".vize.ts");
+    PathBuf::from(spelled)
+}
+
+/// `to` spelled relative to `from_dir`, POSIX separators, always `./`-anchored.
+fn relative_specifier(from_dir: &Path, to: &Path) -> Option<std::string::String> {
+    let from: Vec<_> = from_dir.components().collect();
+    let to_components: Vec<_> = to.components().collect();
+    let common = from
+        .iter()
+        .zip(to_components.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+    let mut parts: Vec<std::string::String> = Vec::new();
+    for _ in common..from.len() {
+        parts.push("..".into());
+    }
+    for component in &to_components[common..] {
+        parts.push(component.as_os_str().to_str()?.to_owned());
+    }
+    let joined = parts.join("/");
+    Some(if joined.starts_with("..") {
+        joined
+    } else {
+        format!("./{joined}")
+    })
+}
+
 /// Queue alias-resolved first-party dependencies of one document.
 pub(super) fn queue_alias_imports(
     imports: &mut ImportQueue<'_>,
@@ -89,9 +155,9 @@ pub(super) fn queue_alias_imports(
             continue;
         }
         if key.extension().is_some_and(|extension| extension == "vue") {
-            queue_alias_vue(imports, options, rewriter, &key);
+            queue_alias_vue(imports, options, rewriter, context, &key);
         } else if !key.starts_with(&context.project_root) && !is_declaration(&key) {
-            queue_alias_script(imports, rewriter, &key);
+            queue_alias_script(imports, rewriter, context, &key);
         }
     }
 }
@@ -100,6 +166,7 @@ fn queue_alias_vue(
     imports: &mut ImportQueue<'_>,
     options: CorsaVueVirtualDocumentOptions,
     rewriter: &ImportRewriter,
+    context: &AliasContext,
     path: &Path,
 ) {
     if !imports.visited_vue.insert(path.to_path_buf()) {
@@ -108,7 +175,9 @@ fn queue_alias_vue(
     let Some(content) = dependency_content(path, imports.overlays) else {
         return;
     };
-    let generated = match generate_vue_document(path, &content, options, rewriter) {
+    let generated = match super::vue_document::generate_vue_document_with_alias(
+        path, &content, options, rewriter, context,
+    ) {
         Ok(generated) => generated,
         Err(_) => {
             imports
@@ -131,7 +200,12 @@ fn queue_alias_vue(
     });
 }
 
-fn queue_alias_script(imports: &mut ImportQueue<'_>, rewriter: &ImportRewriter, path: &Path) {
+fn queue_alias_script(
+    imports: &mut ImportQueue<'_>,
+    rewriter: &ImportRewriter,
+    context: &AliasContext,
+    path: &Path,
+) {
     if !imports.visited_ts.insert(path.to_path_buf()) {
         return;
     }
@@ -139,10 +213,13 @@ fn queue_alias_script(imports: &mut ImportQueue<'_>, rewriter: &ImportRewriter, 
         return;
     };
     let dependency_source_type = source_type_for_path(path);
+    let dir = parent_dir(path);
     let rewritten = rewriter
-        .rewrite(&content, dependency_source_type, path.parent())
+        .rewrite_with_alias_resolver(&content, dependency_source_type, path.parent(), &|spec| {
+            context.resolve_specifier_to_relative(spec, &dir)
+        })
         .code;
-    let uri = normalize_document_uri(path_to_file_uri(path).as_str());
+    let uri = normalize_document_uri(path_to_file_uri(&virtual_script_identity(path)).as_str());
     imports.documents.push((uri, rewritten));
     imports.queue.push_back(DependencyScan::Script {
         path: path.to_path_buf(),

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
@@ -17,8 +17,7 @@ use std::path::{Component, Path, PathBuf};
 use oxc_span::SourceType;
 
 use super::vue_dependencies::{
-    DependencyScan, ImportQueue, dependency_content, fallback_vue_virtual_uri, parent_dir,
-    source_type_for_path, tsx_vue_import_shim,
+    DependencyScan, ImportQueue, dependency_content, queue_vue_dependency, source_type_for_path,
 };
 use super::vue_document::CorsaVueVirtualDocumentOptions;
 use crate::batch::ImportRewriter;
@@ -56,12 +55,14 @@ impl AliasContext {
                     let aliases = project.dependency_alias_map();
                     // Register the host and everything reachable, then put the
                     // companions on disk where the checker can resolve them.
-                    let mirror = (aliases.is_empty()
-                        || (project.register_path(source_path).is_ok()
+                    let mirror = if aliases.is_empty() {
+                        None
+                    } else {
+                        (project.register_path(source_path).is_ok()
                             && project.register_reachable_dependencies().is_ok()
-                            && project.materialize().is_ok()))
-                    .then_some(project)
-                    .filter(|_| !aliases.is_empty());
+                            && project.materialize().is_ok())
+                        .then_some(project)
+                    };
                     (root, aliases, mirror)
                 }
                 Err(_) => (root, Vec::new(), None),
@@ -81,10 +82,10 @@ impl AliasContext {
 }
 
 impl AliasContext {
-    /// Resolve one non-relative specifier to a relative path targeting the
-    /// synced overlay identities, for the offset-preserving rewriter.
+    /// Resolve one non-relative specifier to an absolute mirror path, for the
+    /// offset-preserving rewriter.
     #[allow(clippy::disallowed_types)]
-    pub(super) fn resolve_specifier_to_relative(
+    pub(super) fn resolve_specifier_to_mirror_path(
         &self,
         specifier: &str,
         importer_dir: &Path,
@@ -98,22 +99,18 @@ impl AliasContext {
             return None;
         }
         // Resolution must land on a real file: the mirror's generated
-        // companion for a registered dependency, or nothing. The trailing
-        // `.ts`/`.tsx` is stripped because the governing tsconfig is the
-        // user's, which need not enable `allowImportingTsExtensions`; the
-        // checker then appends the extension itself, so `…/UiButton.vue`
-        // resolves to the on-disk `UiButton.vue.ts` companion exactly the way
-        // extensionless script imports resolve.
+        // companion for a registered dependency, or nothing.
         let mirror = self.mirror.as_ref()?;
         let target = mirror.find_by_original(&key)?.virtual_path.clone();
 
-        // The session client may relocate virtual documents to an overlay
-        // root, so a relative specifier would anchor at the wrong directory.
-        // An absolute specifier resolves identically from anywhere; the
-        // trailing extension is stripped because the governing tsconfig need
-        // not enable `allowImportingTsExtensions`, and the checker then
-        // appends it itself (`…/UiButton.vue` → the on-disk `.vue.ts`
-        // companion).
+        // The path is absolute because the session client may relocate virtual
+        // documents to an overlay root, where a relative specifier would
+        // anchor at the wrong directory; an absolute one resolves identically
+        // from anywhere. The trailing extension is stripped because the
+        // governing tsconfig is the user's, which need not enable
+        // `allowImportingTsExtensions`; the checker appends it itself, so
+        // `…/UiButton.vue` resolves to the on-disk `.vue.ts` companion exactly
+        // the way extensionless script imports resolve.
         let spelled = target.to_string_lossy().replace('\\', "/");
         Some(
             spelled
@@ -138,9 +135,21 @@ pub(super) fn queue_alias_imports(
     if context.aliases.is_empty() {
         return;
     }
+    // Only a specifier under a configured alias prefix can resolve here, so
+    // pre-filter before touching the filesystem: `resolve_dependency` probes up
+    // to seven candidate paths per alias, and this walk runs on the request
+    // thread for every bare package name (`vue`, `pinia`, `@vueuse/core`) in
+    // every scanned document. The batch pass filters the same way (#3898).
     for specifier in rewriter.collect_all_specifiers(code, source_type) {
         if specifier.starts_with("./") || specifier.starts_with("../") {
             continue; // the relative walk owns these
+        }
+        if !context
+            .aliases
+            .iter()
+            .any(|(pattern, _)| specifier.starts_with(pattern.trim_end_matches('*')))
+        {
+            continue;
         }
         let Some(path) =
             resolve_dependency(&specifier, dir, &context.project_root, &context.aliases)
@@ -152,49 +161,11 @@ pub(super) fn queue_alias_imports(
             continue;
         }
         if key.extension().is_some_and(|extension| extension == "vue") {
-            queue_alias_vue(imports, options, rewriter, context, &key);
+            queue_vue_dependency(imports, options, rewriter, context, &key);
         } else if !key.starts_with(&context.project_root) && !is_declaration(&key) {
             queue_alias_script(imports, &key);
         }
     }
-}
-
-fn queue_alias_vue(
-    imports: &mut ImportQueue<'_>,
-    options: CorsaVueVirtualDocumentOptions,
-    rewriter: &ImportRewriter,
-    context: &AliasContext,
-    path: &Path,
-) {
-    if !imports.visited_vue.insert(path.to_path_buf()) {
-        return;
-    }
-    let Some(content) = dependency_content(path, imports.overlays) else {
-        return;
-    };
-    let generated = match super::vue_document::generate_vue_document_with_alias(
-        path, &content, options, rewriter, context,
-    ) {
-        Ok(generated) => generated,
-        Err(_) => {
-            imports
-                .documents
-                .push((fallback_vue_virtual_uri(path), FALLBACK.into()));
-            return;
-        }
-    };
-    imports.documents.push((
-        generated.virtual_uri.clone(),
-        generated.generated.code.clone(),
-    ));
-    if generated.generated.virtual_suffix == ".tsx" {
-        imports.documents.push(tsx_vue_import_shim(path));
-    }
-    imports.queue.push_back(DependencyScan::Vue {
-        dir: parent_dir(&generated.source_path),
-        source_type: generated.generated.source_type,
-        pre_rewrite_code: generated.generated.pre_rewrite_code,
-    });
 }
 
 fn queue_alias_script(imports: &mut ImportQueue<'_>, path: &Path) {
@@ -214,8 +185,6 @@ fn queue_alias_script(imports: &mut ImportQueue<'_>, path: &Path) {
     });
 }
 
-const FALLBACK: &str = "const component: any = undefined;\nexport default component;\n";
-
 fn inside_node_modules(path: &Path) -> bool {
     path.components()
         .any(|component| matches!(component, Component::Normal(part) if part == "node_modules"))
@@ -224,5 +193,7 @@ fn inside_node_modules(path: &Path) -> bool {
 fn is_declaration(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| name.ends_with(".d.ts") || name.ends_with(".d.mts"))
+        .is_some_and(|name| {
+            name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts")
+        })
 }

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
@@ -15,6 +15,7 @@
 use std::path::{Component, Path, PathBuf};
 
 use oxc_span::SourceType;
+use vize_carton::FxHashMap;
 
 use super::vue_dependencies::{
     DependencyScan, ImportQueue, dependency_content, queue_vue_dependency, source_type_for_path,
@@ -43,7 +44,15 @@ pub(super) struct AliasContext {
 impl AliasContext {
     /// Anchor at the nearest ancestor with a `tsconfig.json` — the same
     /// package-local config `vize check` treats as authoritative.
-    pub(super) fn for_host(source_path: &Path) -> Self {
+    ///
+    /// `content` is the host's editor buffer and `overlays` the unsaved
+    /// dependency buffers: the mirror is built from those rather than from disk,
+    /// so an alias import the user just typed still materializes its target.
+    pub(super) fn for_host(
+        source_path: &Path,
+        content: &str,
+        overlays: &FxHashMap<PathBuf, &str>,
+    ) -> Self {
         let root = source_path
             .ancestors()
             .skip(1)
@@ -55,11 +64,17 @@ impl AliasContext {
                     let aliases = project.dependency_alias_map();
                     // Register the host and everything reachable, then put the
                     // companions on disk where the checker can resolve them.
+                    // Buffer text wins over disk on both steps, so the mirror
+                    // describes the session the user is editing.
                     let mirror = if aliases.is_empty() {
                         None
                     } else {
-                        (project.register_path(source_path).is_ok()
-                            && project.register_reachable_dependencies().is_ok()
+                        (project
+                            .register_path_with_content(source_path, content)
+                            .is_ok()
+                            && project
+                                .register_reachable_dependencies_with_overlays(overlays)
+                                .is_ok()
                             && project.materialize().is_ok())
                         .then_some(project)
                     };

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
@@ -16,16 +16,14 @@ use std::path::{Component, Path, PathBuf};
 
 use oxc_span::SourceType;
 
-use super::bridge::normalize_document_uri;
 use super::vue_dependencies::{
     DependencyScan, ImportQueue, dependency_content, fallback_vue_virtual_uri, parent_dir,
     source_type_for_path, tsx_vue_import_shim,
 };
-use super::vue_document::{CorsaVueVirtualDocumentOptions, generate_vue_document};
+use super::vue_document::CorsaVueVirtualDocumentOptions;
 use crate::batch::ImportRewriter;
 use crate::batch::virtual_project::VirtualProject;
 use crate::batch::virtual_project::dependency_scan::resolve_dependency;
-use crate::file_uri::path_to_file_uri;
 
 /// The alias map for the host document's package, resolved once per open,
 /// plus the materialized mirror the resolutions point into.
@@ -85,6 +83,7 @@ impl AliasContext {
 impl AliasContext {
     /// Resolve one non-relative specifier to a relative path targeting the
     /// synced overlay identities, for the offset-preserving rewriter.
+    #[allow(clippy::disallowed_types)]
     pub(super) fn resolve_specifier_to_relative(
         &self,
         specifier: &str,
@@ -107,67 +106,23 @@ impl AliasContext {
         // extensionless script imports resolve.
         let mirror = self.mirror.as_ref()?;
         let target = mirror.find_by_original(&key)?.virtual_path.clone();
-        // A/B probe (#3900): shadow-copy outside node_modules.
-        let target = match target
-            .to_string_lossy()
-            .split_once("node_modules/.vize/canon/")
-        {
-            Some((root, tail)) => {
-                let shadow = Path::new(root).join(".vize-editor").join(tail);
-                if let Some(parent) = shadow.parent() {
-                    let _ = std::fs::create_dir_all(parent);
-                }
-                let _ = std::fs::copy(&target, &shadow);
-                shadow
-            }
-            None => target,
-        };
-        let relative = relative_specifier(importer_dir, &target)?;
+
+        // The session client may relocate virtual documents to an overlay
+        // root, so a relative specifier would anchor at the wrong directory.
+        // An absolute specifier resolves identically from anywhere; the
+        // trailing extension is stripped because the governing tsconfig need
+        // not enable `allowImportingTsExtensions`, and the checker then
+        // appends it itself (`…/UiButton.vue` → the on-disk `.vue.ts`
+        // companion).
+        let spelled = target.to_string_lossy().replace('\\', "/");
         Some(
-            relative
+            spelled
                 .strip_suffix(".tsx")
-                .or_else(|| relative.strip_suffix(".ts"))
-                .unwrap_or(&relative)
+                .or_else(|| spelled.strip_suffix(".ts"))
+                .unwrap_or(&spelled)
                 .to_owned(),
         )
     }
-}
-
-/// The non-disk sync identity for an out-of-root script.
-///
-/// A path that exists on disk splits identity inside the checker: the program
-/// loads the disk file while the rewritten overlay sits unused, and the disk
-/// spelling's `.vue` import falls back to the ambient wildcard (`any`). The
-/// appended suffix guarantees a path no real tree contains, giving the barrel
-/// the same clean open-document identity the generated `.vue.ts` docs have.
-pub(super) fn virtual_script_identity(path: &Path) -> PathBuf {
-    let mut spelled = path.as_os_str().to_os_string();
-    spelled.push(".vize.ts");
-    PathBuf::from(spelled)
-}
-
-/// `to` spelled relative to `from_dir`, POSIX separators, always `./`-anchored.
-fn relative_specifier(from_dir: &Path, to: &Path) -> Option<std::string::String> {
-    let from: Vec<_> = from_dir.components().collect();
-    let to_components: Vec<_> = to.components().collect();
-    let common = from
-        .iter()
-        .zip(to_components.iter())
-        .take_while(|(a, b)| a == b)
-        .count();
-    let mut parts: Vec<std::string::String> = Vec::new();
-    for _ in common..from.len() {
-        parts.push("..".into());
-    }
-    for component in &to_components[common..] {
-        parts.push(component.as_os_str().to_str()?.to_owned());
-    }
-    let joined = parts.join("/");
-    Some(if joined.starts_with("..") {
-        joined
-    } else {
-        format!("./{joined}")
-    })
 }
 
 /// Queue alias-resolved first-party dependencies of one document.
@@ -199,7 +154,7 @@ pub(super) fn queue_alias_imports(
         if key.extension().is_some_and(|extension| extension == "vue") {
             queue_alias_vue(imports, options, rewriter, context, &key);
         } else if !key.starts_with(&context.project_root) && !is_declaration(&key) {
-            queue_alias_script(imports, rewriter, context, &key);
+            queue_alias_script(imports, &key);
         }
     }
 }
@@ -242,27 +197,16 @@ fn queue_alias_vue(
     });
 }
 
-fn queue_alias_script(
-    imports: &mut ImportQueue<'_>,
-    rewriter: &ImportRewriter,
-    context: &AliasContext,
-    path: &Path,
-) {
+fn queue_alias_script(imports: &mut ImportQueue<'_>, path: &Path) {
     if !imports.visited_ts.insert(path.to_path_buf()) {
         return;
     }
     let Some(content) = dependency_content(path, imports.overlays) else {
         return;
     };
+    // No document is synced for the barrel: the mirror's on-disk copy is the
+    // resolution target. Queueing it keeps the walk following its re-exports.
     let dependency_source_type = source_type_for_path(path);
-    let dir = parent_dir(path);
-    let rewritten = rewriter
-        .rewrite_with_alias_resolver(&content, dependency_source_type, path.parent(), &|spec| {
-            context.resolve_specifier_to_relative(spec, &dir)
-        })
-        .code;
-    let uri = normalize_document_uri(path_to_file_uri(&virtual_script_identity(path)).as_str());
-    imports.documents.push((uri, rewritten));
     imports.queue.push_back(DependencyScan::Script {
         path: path.to_path_buf(),
         source_type: dependency_source_type,

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
@@ -27,11 +27,20 @@ use crate::batch::virtual_project::VirtualProject;
 use crate::batch::virtual_project::dependency_scan::resolve_dependency;
 use crate::file_uri::path_to_file_uri;
 
-/// The alias map for the host document's package, resolved once per open.
+/// The alias map for the host document's package, resolved once per open,
+/// plus the materialized mirror the resolutions point into.
+///
+/// The checker resolves modules from the disk only — open in-memory documents
+/// are never resolution targets — so alias imports must land on real files.
+/// The batch pipeline already materializes exactly those (#3898): reachable
+/// `.vue` companions and out-of-root barrels inside `node_modules/.vize/canon`.
+/// Editor sessions reuse that machinery and rewrite their imports to relative
+/// paths into the mirror.
 #[allow(clippy::disallowed_types)]
 pub(super) struct AliasContext {
     project_root: PathBuf,
     aliases: Vec<(std::string::String, std::string::String)>,
+    mirror: Option<VirtualProject>,
 }
 
 impl AliasContext {
@@ -43,21 +52,32 @@ impl AliasContext {
             .skip(1)
             .find(|dir| dir.join("tsconfig.json").is_file())
             .map(Path::to_path_buf);
-        let (project_root, aliases) = match root {
-            Some(root) => {
-                let aliases = VirtualProject::new(&root)
-                    .map(|project| project.dependency_alias_map())
-                    .unwrap_or_default();
-                (root, aliases)
-            }
+        let (project_root, aliases, mirror) = match root {
+            Some(root) => match VirtualProject::new(&root) {
+                Ok(mut project) => {
+                    let aliases = project.dependency_alias_map();
+                    // Register the host and everything reachable, then put the
+                    // companions on disk where the checker can resolve them.
+                    let mirror = (aliases.is_empty()
+                        || (project.register_path(source_path).is_ok()
+                            && project.register_reachable_dependencies().is_ok()
+                            && project.materialize().is_ok()))
+                    .then_some(project)
+                    .filter(|_| !aliases.is_empty());
+                    (root, aliases, mirror)
+                }
+                Err(_) => (root, Vec::new(), None),
+            },
             None => (
                 source_path.parent().unwrap_or(source_path).to_path_buf(),
                 Vec::new(),
+                None,
             ),
         };
         Self {
             project_root,
             aliases,
+            mirror,
         }
     }
 }
@@ -78,16 +98,23 @@ impl AliasContext {
         if inside_node_modules(&key) || is_declaration(&key) {
             return None;
         }
-        let target = if key.extension().is_some_and(|extension| extension == "vue") {
-            let mut spelled = key.as_os_str().to_os_string();
-            spelled.push(".ts");
-            PathBuf::from(spelled)
-        } else if !key.starts_with(&self.project_root) {
-            virtual_script_identity(&key)
-        } else {
-            return None;
-        };
-        relative_specifier(importer_dir, &target)
+        // Resolution must land on a real file: the mirror's generated
+        // companion for a registered dependency, or nothing. The trailing
+        // `.ts`/`.tsx` is stripped because the governing tsconfig is the
+        // user's, which need not enable `allowImportingTsExtensions`; the
+        // checker then appends the extension itself, so `…/UiButton.vue`
+        // resolves to the on-disk `UiButton.vue.ts` companion exactly the way
+        // extensionless script imports resolve.
+        let mirror = self.mirror.as_ref()?;
+        let target = mirror.find_by_original(&key)?.virtual_path.clone();
+        let relative = relative_specifier(importer_dir, &target)?;
+        Some(
+            relative
+                .strip_suffix(".tsx")
+                .or_else(|| relative.strip_suffix(".ts"))
+                .unwrap_or(&relative)
+                .to_owned(),
+        )
     }
 }
 

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
@@ -28,6 +28,7 @@ use crate::batch::virtual_project::dependency_scan::resolve_dependency;
 use crate::file_uri::path_to_file_uri;
 
 /// The alias map for the host document's package, resolved once per open.
+#[allow(clippy::disallowed_types)]
 pub(super) struct AliasContext {
     project_root: PathBuf,
     aliases: Vec<(std::string::String, std::string::String)>,

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
@@ -107,6 +107,21 @@ impl AliasContext {
         // extensionless script imports resolve.
         let mirror = self.mirror.as_ref()?;
         let target = mirror.find_by_original(&key)?.virtual_path.clone();
+        // A/B probe (#3900): shadow-copy outside node_modules.
+        let target = match target
+            .to_string_lossy()
+            .split_once("node_modules/.vize/canon/")
+        {
+            Some((root, tail)) => {
+                let shadow = Path::new(root).join(".vize-editor").join(tail);
+                if let Some(parent) = shadow.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
+                let _ = std::fs::copy(&target, &shadow);
+                shadow
+            }
+            None => target,
+        };
         let relative = relative_specifier(importer_dir, &target)?;
         Some(
             relative

--- a/crates/vize_canon/src/corsa_bridge/vue_dependency_paths.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependency_paths.rs
@@ -1,0 +1,102 @@
+//! Filesystem resolution helpers for the editor dependency walk.
+
+use std::path::{Path, PathBuf};
+
+pub(super) fn resolve_relative_script_import(dir: &Path, specifier: &str) -> Option<PathBuf> {
+    let base = dir.join(specifier);
+    if base.extension().is_some() {
+        return known_script_path(&base).then(|| normalize_path(&base));
+    }
+
+    for ext in [
+        "ts", "tsx", "mts", "cts", "d.ts", "d.mts", "d.cts", "js", "jsx", "mjs", "cjs",
+    ] {
+        let candidate = base.with_extension(ext);
+        if candidate.exists() {
+            return Some(normalize_path(&candidate));
+        }
+    }
+    for name in [
+        "index.ts",
+        "index.tsx",
+        "index.mts",
+        "index.cts",
+        "index.js",
+        "index.jsx",
+        "index.mjs",
+        "index.cjs",
+        "index.d.ts",
+        "index.d.mts",
+        "index.d.cts",
+    ] {
+        let candidate = base.join(name);
+        if candidate.exists() {
+            return Some(normalize_path(&candidate));
+        }
+    }
+    None
+}
+
+fn known_script_path(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    path.exists()
+        && (name.ends_with(".ts")
+            || name.ends_with(".tsx")
+            || name.ends_with(".mts")
+            || name.ends_with(".cts")
+            || name.ends_with(".js")
+            || name.ends_with(".jsx")
+            || name.ends_with(".mjs")
+            || name.ends_with(".cjs"))
+}
+
+pub(super) fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push("..");
+                }
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_relative_script_import;
+
+    #[test]
+    fn resolves_directory_module_declaration_indices() {
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = project.path().join("src");
+        std::fs::create_dir_all(src.join("esm")).expect("esm dir");
+        std::fs::create_dir_all(src.join("cjs")).expect("cjs dir");
+
+        let esm = src.join("esm").join("index.d.mts");
+        let cjs = src.join("cjs").join("index.d.cts");
+        let schema = src.join("schema.d.ts");
+        std::fs::write(&esm, "export type Value = string;\n").expect("esm dts");
+        std::fs::write(&cjs, "export type Value = string;\n").expect("cjs dts");
+        std::fs::write(&schema, "export type Schema = { id: string };\n").expect("schema dts");
+
+        assert_eq!(
+            resolve_relative_script_import(&src, "./esm").as_deref(),
+            Some(esm.as_path())
+        );
+        assert_eq!(
+            resolve_relative_script_import(&src, "./cjs").as_deref(),
+            Some(cjs.as_path())
+        );
+        assert_eq!(
+            resolve_relative_script_import(&src, "./schema").as_deref(),
+            Some(schema.as_path())
+        );
+    }
+}

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -10,7 +10,6 @@ use super::types::CorsaBridgeError;
 use super::vue_dependencies::{collect_dependency_documents, tsx_vue_import_shim};
 use crate::batch::{
     ImportRewriter, ImportSourceMap, VueDocumentVirtualTs, VueDocumentVirtualTsOptions,
-    generate_vue_document_virtual_ts_with_options,
 };
 use crate::file_uri::path_to_file_uri;
 use crate::virtual_ts::{VirtualTsOptions, VizeMapping};
@@ -221,24 +220,7 @@ fn build_vue_virtual_project_with_overlays_and_options(
         documents,
     })
 }
-
-pub(super) fn generate_vue_document(
-    source_path: &Path,
-    content: &str,
-    options: CorsaVueVirtualDocumentOptions,
-    rewriter: &ImportRewriter,
-) -> Result<GeneratedVueDocument, CorsaBridgeError> {
-    generate_vue_document_with_options(
-        source_path,
-        content,
-        options,
-        &VirtualTsOptions::default(),
-        rewriter,
-        None,
-    )
-}
-
-/// [`generate_vue_document`] with alias-aware import rewriting: non-relative
+/// Generate a Vue document with alias-aware import rewriting: non-relative
 /// specifiers the context resolves are pointed at the synced overlay
 /// identities through the offset-preserving rewriter (#3900).
 pub(super) fn generate_vue_document_with_alias(
@@ -282,7 +264,7 @@ fn generate_vue_document_with_options(
         },
         alias_resolver
             .as_ref()
-            .map(|resolver| resolver as &dyn Fn(&str) -> Option<std::string::String>),
+            .map(|resolver| resolver as crate::batch::import_rewriter_alias::AliasSpecifierResolver<'_>),
     )
     .map_err(|error| CorsaBridgeError::CommunicationError(cstr!("{error}")))?;
     let virtual_path = source_path.with_file_name(cstr!(

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -178,12 +178,14 @@ fn build_vue_virtual_project_with_overlays_and_options(
     virtual_ts_options: &VirtualTsOptions,
 ) -> Result<CorsaVueVirtualProject, CorsaBridgeError> {
     let rewriter = ImportRewriter::new();
+    let alias_context = super::vue_dependencies_alias::AliasContext::for_host(source_path);
     let host = generate_vue_document_with_options(
         source_path,
         content,
         options,
         virtual_ts_options,
         &rewriter,
+        Some(&alias_context),
     )?;
     let mut documents = vec![(host.virtual_uri.clone(), host.generated.code.clone())];
     if host.generated.virtual_suffix == ".tsx" {
@@ -196,7 +198,14 @@ fn build_vue_virtual_project_with_overlays_and_options(
             (key, *content)
         })
         .collect::<FxHashMap<_, _>>();
-    collect_dependency_documents(&mut documents, &host, options, &rewriter, &overlays);
+    collect_dependency_documents(
+        &mut documents,
+        &host,
+        options,
+        &rewriter,
+        &alias_context,
+        &overlays,
+    );
 
     let generated = host.generated;
     Ok(CorsaVueVirtualProject {
@@ -225,6 +234,27 @@ pub(super) fn generate_vue_document(
         options,
         &VirtualTsOptions::default(),
         rewriter,
+        None,
+    )
+}
+
+/// [`generate_vue_document`] with alias-aware import rewriting: non-relative
+/// specifiers the context resolves are pointed at the synced overlay
+/// identities through the offset-preserving rewriter (#3900).
+pub(super) fn generate_vue_document_with_alias(
+    source_path: &Path,
+    content: &str,
+    options: CorsaVueVirtualDocumentOptions,
+    rewriter: &ImportRewriter,
+    context: &super::vue_dependencies_alias::AliasContext,
+) -> Result<GeneratedVueDocument, CorsaBridgeError> {
+    generate_vue_document_with_options(
+        source_path,
+        content,
+        options,
+        &VirtualTsOptions::default(),
+        rewriter,
+        Some(context),
     )
 }
 
@@ -234,8 +264,13 @@ fn generate_vue_document_with_options(
     options: CorsaVueVirtualDocumentOptions,
     virtual_ts_options: &VirtualTsOptions,
     rewriter: &ImportRewriter,
+    alias_context: Option<&super::vue_dependencies_alias::AliasContext>,
 ) -> Result<GeneratedVueDocument, CorsaBridgeError> {
-    let generated = generate_vue_document_virtual_ts_with_options(
+    let source_dir = source_path.parent().map(std::path::Path::to_path_buf);
+    let alias_resolver = alias_context.zip(source_dir).map(|(context, dir)| {
+        move |specifier: &str| context.resolve_specifier_to_relative(specifier, &dir)
+    });
+    let generated = crate::batch::virtual_project::generate_vue_document_virtual_ts_with_options_and_alias_resolver(
         source_path,
         content,
         virtual_ts_options,
@@ -245,6 +280,9 @@ fn generate_vue_document_with_options(
             options_api: options.options_api,
             legacy_vue2: options.legacy_vue2,
         },
+        alias_resolver
+            .as_ref()
+            .map(|resolver| resolver as &dyn Fn(&str) -> Option<std::string::String>),
     )
     .map_err(|error| CorsaBridgeError::CommunicationError(cstr!("{error}")))?;
     let virtual_path = source_path.with_file_name(cstr!(

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -250,7 +250,7 @@ fn generate_vue_document_with_options(
 ) -> Result<GeneratedVueDocument, CorsaBridgeError> {
     let source_dir = source_path.parent().map(std::path::Path::to_path_buf);
     let alias_resolver = alias_context.zip(source_dir).map(|(context, dir)| {
-        move |specifier: &str| context.resolve_specifier_to_relative(specifier, &dir)
+        move |specifier: &str| context.resolve_specifier_to_mirror_path(specifier, &dir)
     });
     let generated = crate::batch::virtual_project::generate_vue_document_virtual_ts_with_options_and_alias_resolver(
         source_path,

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -177,7 +177,18 @@ fn build_vue_virtual_project_with_overlays_and_options(
     virtual_ts_options: &VirtualTsOptions,
 ) -> Result<CorsaVueVirtualProject, CorsaBridgeError> {
     let rewriter = ImportRewriter::new();
-    let alias_context = super::vue_dependencies_alias::AliasContext::for_host(source_path);
+    let overlays = overlays
+        .iter()
+        .map(|(path, content)| {
+            let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+            (key, *content)
+        })
+        .collect::<FxHashMap<_, _>>();
+    // The alias mirror is built before generation, and from the same buffers the
+    // dependency walk reads, so a specifier the resolver rewrites always has a
+    // materialized target (#3900).
+    let alias_context =
+        super::vue_dependencies_alias::AliasContext::for_host(source_path, content, &overlays);
     let host = generate_vue_document_with_options(
         source_path,
         content,
@@ -190,13 +201,6 @@ fn build_vue_virtual_project_with_overlays_and_options(
     if host.generated.virtual_suffix == ".tsx" {
         documents.push(tsx_vue_import_shim(&host.source_path));
     }
-    let overlays = overlays
-        .iter()
-        .map(|(path, content)| {
-            let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
-            (key, *content)
-        })
-        .collect::<FxHashMap<_, _>>();
     collect_dependency_documents(
         &mut documents,
         &host,

--- a/crates/vize_canon/src/corsa_bridge/vue_document_alias_tests.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document_alias_tests.rs
@@ -1,0 +1,120 @@
+//! Alias-resolved editor sessions (#3900).
+//!
+//! The mirror an alias rewrite points into is materialized from the *buffers*
+//! the session is holding, not from disk: an import typed into an unsaved file
+//! is reachable to nothing on disk, so a disk-only mirror never generates its
+//! target and the rewritten specifier keeps an unresolvable alias path until
+//! the user saves.
+
+use super::vue_document::{
+    CorsaVueVirtualDocumentOptions, build_vue_virtual_project,
+    build_vue_virtual_project_with_overlays,
+};
+
+const TSCONFIG: &str = "{\n  \"compilerOptions\": {\n    \"baseUrl\": \".\",\n    \"paths\": { \"@/*\": [\"./src/*\"] }\n  }\n}\n";
+
+const UI_BUTTON: &str = "<script setup lang=\"ts\">\ndefineProps<{ variant: \"ghost\" | \"primary\" }>();\n</script>\n<template><button /></template>\n";
+
+/// A temp project with the alias config and the aliased component on disk.
+fn alias_project() -> tempfile::TempDir {
+    let project = tempfile::TempDir::new().expect("temp project");
+    let src = project.path().join("src");
+    std::fs::create_dir_all(&src).expect("src dir");
+    std::fs::write(project.path().join("tsconfig.json"), TSCONFIG).expect("tsconfig");
+    std::fs::write(src.join("UiButton.vue"), UI_BUTTON).expect("component");
+    project
+}
+
+fn mirror_companion(project: &tempfile::TempDir) -> std::path::PathBuf {
+    project
+        .path()
+        .join("node_modules")
+        .join(".vize")
+        .join("canon")
+        .join("src")
+        .join("UiButton.vue.ts")
+}
+
+#[test]
+fn an_alias_import_typed_into_the_host_buffer_resolves_to_the_mirror() {
+    let project = alias_project();
+    let host_path = project.path().join("src").join("Host.vue");
+    // On disk the host imports nothing…
+    std::fs::write(
+        &host_path,
+        "<script setup lang=\"ts\"></script>\n<template><span /></template>\n",
+    )
+    .expect("host");
+    // …the unsaved buffer imports the aliased component.
+    let buffer = "<script setup lang=\"ts\">\nimport UiButton from \"@/UiButton.vue\";\nconst _button = UiButton;\n</script>\n<template><UiButton variant=\"ghost\" /></template>\n";
+
+    let virtual_project = build_vue_virtual_project(
+        &host_path,
+        buffer,
+        CorsaVueVirtualDocumentOptions::default(),
+    )
+    .expect("virtual project");
+
+    assert!(
+        !virtual_project.host.code.contains("@/UiButton"),
+        "an unsaved alias import must not keep its unresolvable alias path:\n{}",
+        virtual_project.host.code,
+    );
+    assert!(
+        virtual_project.host.code.contains("/.vize/canon/"),
+        "an unsaved alias import must resolve into the materialized mirror:\n{}",
+        virtual_project.host.code,
+    );
+    assert!(
+        mirror_companion(&project).is_file(),
+        "the resolution target must exist on disk, where the checker looks",
+    );
+}
+
+#[test]
+fn an_alias_import_typed_into_a_dependency_buffer_resolves_to_the_mirror() {
+    let project = alias_project();
+    let src = project.path().join("src");
+    let host_path = src.join("Host.vue");
+    let child_path = src.join("Child.vue");
+    let host = "<script setup lang=\"ts\">\nimport Child from \"./Child.vue\";\nconst _child = Child;\n</script>\n<template><Child /></template>\n";
+    std::fs::write(&host_path, host).expect("host");
+    // On disk the dependency imports nothing…
+    std::fs::write(
+        &child_path,
+        "<script setup lang=\"ts\"></script>\n<template><span /></template>\n",
+    )
+    .expect("child");
+    // …its unsaved buffer imports the aliased component.
+    let overlays = vec![(
+        child_path.clone(),
+        "<script setup lang=\"ts\">\nimport UiButton from \"@/UiButton.vue\";\nconst _button = UiButton;\n</script>\n<template><UiButton variant=\"ghost\" /></template>\n",
+    )];
+
+    let virtual_project = build_vue_virtual_project_with_overlays(
+        &host_path,
+        host,
+        CorsaVueVirtualDocumentOptions::default(),
+        &overlays,
+    )
+    .expect("virtual project");
+
+    let child = virtual_project
+        .documents
+        .iter()
+        .find(|(uri, _)| uri.ends_with("Child.vue.ts"))
+        .map(|(_, content)| content.as_str())
+        .expect("child virtual document");
+    assert!(
+        !child.contains("@/UiButton"),
+        "an unsaved dependency's alias import must not keep its alias path:\n{child}",
+    );
+    assert!(
+        child.contains("/.vize/canon/"),
+        "an unsaved dependency's alias import must resolve into the mirror:\n{child}",
+    );
+    assert!(
+        mirror_companion(&project).is_file(),
+        "the resolution target must exist on disk, where the checker looks",
+    );
+}


### PR DESCRIPTION
Closes #3900 — the editor half of the monorepo story. A component imported through a tsconfig `paths` alias (`import { UiButton } from "#ui"`) now hovers with its real type; it was silently `any` even after #3898 taught the batch pipeline to check it.

## Acceptance, measured

Protocol-level stdio audit on the monorepo fixture (the oracle this issue was filed with):

| probe | before | after |
|---|---|---|
| hover on `<UiButton>` tag | `var UiButton: any` | `var UiButton: __VizeComponentConstructor & __VizeVueComponentOptions & …` |
| hover on `variant` prop | `any` | `(property) variant: "ghost" \| "primary"` |
| clean-room regression (hover / references=5 / rename=5) | — | unchanged |

## Three pieces, each forced by a measured dead end

1. **Discovery** — the canonical-document walk resolves non-relative specifiers through the batch resolver (#3898's alias map, baseUrl-anchored per #3891) and queues first-party results: `.vue` anywhere, scripts only out-of-root (workspace barrels), the same narrowing the batch uses.
2. **Disk truth** — `AliasContext` runs the batch registration + materialization on creation. Bisection proved the checker resolves modules from disk only (open in-memory documents are never resolution targets), so the mirror the check pipeline already produces is what the editor session reuses.
3. **Absolute, extensionless specifiers** — alias imports rewrite through the offset-preserving rewriter (a plain string replacement shifts every byte offset and broke position mapping — measured), to absolute mirror paths. Relative spellings are wrong *by construction*: the session client relocates virtual documents to an overlay root, so a relative hop anchors at the wrong directory. Extensionless because the governing tsconfig is the user's, which need not enable `allowImportingTsExtensions`; the checker appends the extension itself, resolving `…/UiButton.vue` to the on-disk `.vue.ts` companion.

The full experiment log — five disproven environmental hypotheses and the session-relocation mechanism in `lsp_client/session_paths.rs` that explains every result — is on the issue.

## Verification

- `cargo test -p vize_canon`: 896 passed, 0 failed. Clippy (CI flags) and fmt clean; every touched file inside the source budget (`import_rewriter_alias.rs` and `vue_dependencies_alias.rs` are new siblings for exactly that reason).
- The shared generator change is opt-in (`alias_resolver: Option<…>`, `None` for every batch call site), so `vize check` output is bitwise unchanged — the clean-room and workspace CLI tests still pass.

Follow-up (kept out of scope, noted on the issue): the corollary that canonical cross-document typing through *relative* `.vue` chains has the same relocation hazard — to be measured with a dedicated clean-room scenario now that the mechanism is understood.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for resolving aliased imports in Vue and TypeScript virtual documents.
  * Added support for unsaved editor changes during dependency scanning.
  * Added recursive handling of aliased Vue dependencies and virtual documents.
  * Added script import resolution for extensions, directory indexes, and declaration files.
  * Added source-map tracking for rewritten imports.

* **Bug Fixes**
  * Preserved existing import rewriting when alias configuration is unavailable.
  * Added fallback handling for Vue dependencies that cannot be generated normally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->