### PR TITLE
fix(canon): Options API template unknown names resolve on the public instance

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -309,6 +309,12 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     };
 
     namespace_hoist.emit_ambient_captures(&mut ts, &named_value_exports);
+    // Whether the default-export rewrite actually declared the `__default__`
+    // alias. Template-scope generation reads `typeof __default__`, so the fact
+    // has to be tracked as state: the generated text also mentions
+    // `__default__` in helper type positions, and a user script can mention the
+    // name without ever exporting a default.
+    let mut declared_default_alias = false;
     if let Some(script) = script_content {
         profile!("canon.virtual_ts.emit_module_statements", {
             // Emit each module-level statement with source mapping
@@ -371,12 +377,17 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                     };
                     let span_relative_object = default_export_object.and_then(rebase);
                     let span_relative_expr = default_export_expr.and_then(rebase);
-                    let text = rewrite_export_default_for_module_scope(
+                    let rewritten = rewrite_export_default_for_module_scope(
                         text,
                         span_relative_object,
                         span_relative_expr,
                     );
-                    ts.push_str(&text);
+                    // Both rewrite shapes replace the `export default` keyword
+                    // with the `const __default__ =` alias, and a span with no
+                    // rewriteable default export (`export { default } from
+                    // './x'`) comes back untouched.
+                    declared_default_alias |= rewritten.as_str() != text;
+                    ts.push_str(&rewritten);
                     ts.push_str("void __default__;\n");
                 } else {
                     ts.push_str(text);
@@ -567,6 +578,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                     .filter(|rest| options_api_support::follows_default_keyword(rest))
                 {
                     emitted_default_alias = true;
+                    declared_default_alias = true;
                     let leading_ws = &output_line[..output_line.len() - trimmed_line.len()];
                     // A class default export (the class-component shape) stays
                     // a real class declaration so `@Component()` decorators
@@ -802,6 +814,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                             check_unresolved_global_components: global_components.component_check(),
                             legacy_vue2,
                             options_api,
+                            has_default_alias: declared_default_alias,
                             script_content,
                         },
                     )

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -802,6 +802,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                             check_unresolved_global_components: global_components.component_check(),
                             legacy_vue2,
                             options_api,
+                            script_content,
                         },
                     )
                 );

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -3,6 +3,7 @@ mod component_constructors;
 mod component_export;
 mod css_modules;
 mod emits;
+mod entry;
 mod generics;
 mod global_components;
 mod imports;
@@ -23,6 +24,10 @@ use self::component_constructors::{ComponentInstanceAliases, emit_component_cons
 use self::component_export::emit_default_export_declaration;
 use self::css_modules::CssModuleAssertions;
 use self::emits::{emit_emit_props_helper, emit_emits_type, emit_exposed_type, emit_slots_type};
+pub use self::entry::{
+    generate_virtual_ts, generate_virtual_ts_with_offsets,
+    generate_virtual_ts_with_offsets_options_api,
+};
 use self::generics::{HoistedGenericAliases, generic_injection_point, references_any_identifier};
 use self::global_components::GlobalComponentPlan;
 use self::imports::{
@@ -57,71 +62,6 @@ use super::{
 };
 use vize_carton::{FxHashMap, FxHashSet, String, append, cstr, profile};
 use vize_croquis::{Croquis, ScopeData, ScopeKind};
-/// Generate virtual TypeScript from Vue SFC analysis.
-///
-/// This ensures compiler macros like defineProps are ONLY valid in setup scope.
-pub fn generate_virtual_ts(
-    summary: &Croquis,
-    script_content: Option<&str>,
-    template_ast: Option<&vize_relief::RootNode<'_>>,
-    template_offset: u32,
-) -> VirtualTsOutput {
-    generate_virtual_ts_with_offsets(
-        summary,
-        script_content,
-        template_ast,
-        0,
-        template_offset,
-        &VirtualTsOptions::default(),
-    )
-}
-/// Generate virtual TypeScript with explicit script and template offsets.
-///
-/// `script_offset` is the byte offset of the script content within the SFC file.
-/// `template_offset` is the byte offset of the template content within the SFC file.
-/// When these are provided, source mappings point to SFC-absolute positions.
-/// `options` controls template globals and other generation settings.
-pub fn generate_virtual_ts_with_offsets(
-    summary: &Croquis,
-    script_content: Option<&str>,
-    template_ast: Option<&vize_relief::RootNode<'_>>,
-    script_offset: u32,
-    template_offset: u32,
-    options: &VirtualTsOptions,
-) -> VirtualTsOutput {
-    generate_virtual_ts_with_offsets_and_checks(
-        summary,
-        script_content,
-        template_ast,
-        script_offset,
-        template_offset,
-        options,
-        VirtualTsGenerationOptions::default(),
-    )
-}
-/// Generate virtual TypeScript with Vue 3 Options API binding resolution
-/// enabled (opt-in, standard build — no `legacy` feature required).
-pub fn generate_virtual_ts_with_offsets_options_api(
-    summary: &Croquis,
-    script_content: Option<&str>,
-    template_ast: Option<&vize_relief::RootNode<'_>>,
-    script_offset: u32,
-    template_offset: u32,
-    options: &VirtualTsOptions,
-) -> VirtualTsOutput {
-    generate_virtual_ts_with_offsets_and_checks(
-        summary,
-        script_content,
-        template_ast,
-        script_offset,
-        template_offset,
-        options,
-        VirtualTsGenerationOptions {
-            options_api: true,
-            ..Default::default()
-        },
-    )
-}
 
 pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     summary: &Croquis,
@@ -309,11 +249,9 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     };
 
     namespace_hoist.emit_ambient_captures(&mut ts, &named_value_exports);
-    // Whether the default-export rewrite actually declared the `__default__`
-    // alias. Template-scope generation reads `typeof __default__`, so the fact
-    // has to be tracked as state: the generated text also mentions
-    // `__default__` in helper type positions, and a user script can mention the
-    // name without ever exporting a default.
+    // Whether a default-export rewrite declared `__default__`, tracked as
+    // state: grepping the generated text would match helper type positions
+    // and user code that merely mentions the name (#3888).
     let mut declared_default_alias = false;
     if let Some(script) = script_content {
         profile!("canon.virtual_ts.emit_module_statements", {
@@ -382,10 +320,8 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                         span_relative_object,
                         span_relative_expr,
                     );
-                    // Both rewrite shapes replace the `export default` keyword
-                    // with the `const __default__ =` alias, and a span with no
-                    // rewriteable default export (`export { default } from
-                    // './x'`) comes back untouched.
+                    // Every rewrite shape declares the alias; a span with no
+                    // rewriteable default export comes back untouched.
                     declared_default_alias |= rewritten.as_str() != text;
                     ts.push_str(&rewritten);
                     ts.push_str("void __default__;\n");

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -801,6 +801,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                             template_ast,
                             check_unresolved_global_components: global_components.component_check(),
                             legacy_vue2,
+                            options_api,
                         },
                     )
                 );

--- a/crates/vize_canon/src/virtual_ts/generator/entry.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/entry.rs
@@ -1,0 +1,77 @@
+//! Public entry points for virtual TypeScript generation: thin wrappers that
+//! fix offsets and generation flags before delegating to
+//! [`super::generate_virtual_ts_with_offsets_and_checks`].
+
+use vize_croquis::Croquis;
+
+use crate::virtual_ts::types::{VirtualTsGenerationOptions, VirtualTsOptions, VirtualTsOutput};
+
+use super::generate_virtual_ts_with_offsets_and_checks;
+
+/// Generate virtual TypeScript from Vue SFC analysis.
+///
+/// This ensures compiler macros like defineProps are ONLY valid in setup scope.
+pub fn generate_virtual_ts(
+    summary: &Croquis,
+    script_content: Option<&str>,
+    template_ast: Option<&vize_relief::RootNode<'_>>,
+    template_offset: u32,
+) -> VirtualTsOutput {
+    generate_virtual_ts_with_offsets(
+        summary,
+        script_content,
+        template_ast,
+        0,
+        template_offset,
+        &VirtualTsOptions::default(),
+    )
+}
+
+/// Generate virtual TypeScript with explicit script and template offsets.
+///
+/// `script_offset` is the byte offset of the script content within the SFC file.
+/// `template_offset` is the byte offset of the template content within the SFC file.
+/// When these are provided, source mappings point to SFC-absolute positions.
+/// `options` controls template globals and other generation settings.
+pub fn generate_virtual_ts_with_offsets(
+    summary: &Croquis,
+    script_content: Option<&str>,
+    template_ast: Option<&vize_relief::RootNode<'_>>,
+    script_offset: u32,
+    template_offset: u32,
+    options: &VirtualTsOptions,
+) -> VirtualTsOutput {
+    generate_virtual_ts_with_offsets_and_checks(
+        summary,
+        script_content,
+        template_ast,
+        script_offset,
+        template_offset,
+        options,
+        VirtualTsGenerationOptions::default(),
+    )
+}
+
+/// Generate virtual TypeScript with Vue 3 Options API binding resolution
+/// enabled (opt-in, standard build — no `legacy` feature required).
+pub fn generate_virtual_ts_with_offsets_options_api(
+    summary: &Croquis,
+    script_content: Option<&str>,
+    template_ast: Option<&vize_relief::RootNode<'_>>,
+    script_offset: u32,
+    template_offset: u32,
+    options: &VirtualTsOptions,
+) -> VirtualTsOutput {
+    generate_virtual_ts_with_offsets_and_checks(
+        summary,
+        script_content,
+        template_ast,
+        script_offset,
+        template_offset,
+        options,
+        VirtualTsGenerationOptions {
+            options_api: true,
+            ..Default::default()
+        },
+    )
+}

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -186,7 +186,7 @@ pub(crate) fn generate_scope_closures(
                 mappings,
                 summary,
                 template_offset,
-                options.options_api,
+                options.options_api && options.has_default_alias,
                 options.script_content,
             )
         );

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -181,14 +181,7 @@ pub(crate) fn generate_scope_closures(
     if check_options.check_template_bindings {
         profile!(
             "canon.virtual_ts.undefined_refs",
-            generate_undefined_refs(
-                ts,
-                mappings,
-                summary,
-                template_offset,
-                options.options_api && options.has_default_alias,
-                options.script_content,
-            )
+            generate_undefined_refs(ts, mappings, summary, template_offset, &options)
         );
     }
     if check_options.check_props {

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -181,7 +181,14 @@ pub(crate) fn generate_scope_closures(
     if check_options.check_template_bindings {
         profile!(
             "canon.virtual_ts.undefined_refs",
-            generate_undefined_refs(ts, mappings, summary, template_offset, options.options_api)
+            generate_undefined_refs(
+                ts,
+                mappings,
+                summary,
+                template_offset,
+                options.options_api,
+                options.script_content,
+            )
         );
     }
     if check_options.check_props {

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -181,7 +181,7 @@ pub(crate) fn generate_scope_closures(
     if check_options.check_template_bindings {
         profile!(
             "canon.virtual_ts.undefined_refs",
-            generate_undefined_refs(ts, mappings, summary, template_offset)
+            generate_undefined_refs(ts, mappings, summary, template_offset, options.options_api)
         );
     }
     if check_options.check_props {

--- a/crates/vize_canon/src/virtual_ts/scope/context.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/context.rs
@@ -57,6 +57,11 @@ pub(crate) struct ScopeGenerationOptions<'a, 'template> {
     /// Options API generation declares `__default__`; template names outside
     /// the known bindings then resolve on the public instance (#3888).
     pub(crate) options_api: bool,
+    /// Whether the default-export rewrite declared the `__default__` alias. The
+    /// public-instance form reads `typeof __default__`, so it stays off for a
+    /// shape that never produced one (a re-exported default, no default export
+    /// at all).
+    pub(crate) has_default_alias: bool,
     /// Plain `<script>` content, when the component has one. Names it declares
     /// stay resolvable from template scope (a relocated `namespace`, a class, a
     /// plain binding), so those keep the free-name emission instead of the

--- a/crates/vize_canon/src/virtual_ts/scope/context.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/context.rs
@@ -57,6 +57,11 @@ pub(crate) struct ScopeGenerationOptions<'a, 'template> {
     /// Options API generation declares `__default__`; template names outside
     /// the known bindings then resolve on the public instance (#3888).
     pub(crate) options_api: bool,
+    /// Plain `<script>` content, when the component has one. Names it declares
+    /// stay resolvable from template scope (a relocated `namespace`, a class, a
+    /// plain binding), so those keep the free-name emission instead of the
+    /// public-instance property access.
+    pub(crate) script_content: Option<&'a str>,
 }
 
 /// Context for recursive component prop checks inside v-for scopes.

--- a/crates/vize_canon/src/virtual_ts/scope/context.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/context.rs
@@ -54,6 +54,9 @@ pub(crate) struct ScopeGenerationOptions<'a, 'template> {
     pub(crate) template_ast: Option<&'a vize_relief::RootNode<'template>>,
     pub(crate) check_unresolved_global_components: GlobalComponentCheck,
     pub(crate) legacy_vue2: bool,
+    /// Options API generation declares `__default__`; template names outside
+    /// the known bindings then resolve on the public instance (#3888).
+    pub(crate) options_api: bool,
 }
 
 /// Context for recursive component prop checks inside v-for scopes.

--- a/crates/vize_canon/src/virtual_ts/scope/globals.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/globals.rs
@@ -16,27 +16,28 @@ use crate::virtual_ts::types::{VirtualTsOptions, VizeMapping};
 use super::context::ScopeGenerationOptions;
 
 /// Handle undefined references from template.
+///
+/// `resolve_on_instance` is the Options API opt-in: it is set only when the
+/// script rewrite actually declared the `__default__` alias the instance form
+/// reads, so a shape without one keeps the free-name emission rather than
+/// referencing an alias that was never generated.
 pub(super) fn generate_undefined_refs(
     ts: &mut String,
     mappings: &mut Vec<VizeMapping>,
     summary: &Croquis,
     template_offset: u32,
-    options_api: bool,
+    resolve_on_instance: bool,
     script_content: Option<&str>,
 ) {
     if summary.undefined_refs.is_empty() {
         return;
     }
-    // The instance form leans on the `__default__` alias the script rewrite
-    // declares; an Options API shape without one (no plain default export)
-    // keeps the free-name emission rather than minting an unresolved alias.
-    let options_api = options_api && ts.contains("__default__");
     // Names the plain script declares itself resolve from an enclosing scope of
     // the template closure even when the analyzer never tracked them as
     // bindings (a `namespace` is the measured case). Those are not unknown
     // template names, so they keep the free-name emission: a property access on
     // the instance would invent a `TS2339` `vue-tsc` does not report.
-    let script_scope_names = if options_api {
+    let script_scope_names = if resolve_on_instance {
         script_content.map_or_else(FxHashSet::default, script_top_level_binding_names)
     } else {
         FxHashSet::default()
@@ -66,7 +67,7 @@ pub(super) fn generate_undefined_refs(
 
         let src_start = (template_offset + undef.offset) as usize;
         let src_end = src_start + undef.name.len();
-        let on_instance = options_api && !script_scope_names.contains(undef.name.as_str());
+        let on_instance = resolve_on_instance && !script_scope_names.contains(undef.name.as_str());
 
         if !emitted_header {
             ts.push_str("\n  // Undefined references from template:\n");

--- a/crates/vize_canon/src/virtual_ts/scope/globals.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/globals.rs
@@ -17,10 +17,15 @@ pub(super) fn generate_undefined_refs(
     mappings: &mut Vec<VizeMapping>,
     summary: &Croquis,
     template_offset: u32,
+    options_api: bool,
 ) {
     if summary.undefined_refs.is_empty() {
         return;
     }
+    // The instance form leans on the `__default__` alias the script rewrite
+    // declares; an Options API shape without one (no plain default export)
+    // keeps the free-name emission rather than minting an unresolved alias.
+    let options_api = options_api && ts.contains("__default__");
 
     // Collect type export names to exclude from undefined refs
     let type_export_names: FxHashSet<&str> = summary
@@ -48,13 +53,37 @@ pub(super) fn generate_undefined_refs(
 
         if !emitted_header {
             ts.push_str("\n  // Undefined references from template:\n");
+            if options_api {
+                // A declaration typed as an indexed access on the public
+                // instance: the missing key reports `TS2339` naming the
+                // instance type — the code and shape `vue-tsc` emits for
+                // Options API templates — while the declared binding lets the
+                // interpolation expression itself resolve, so the bare
+                // `TS2304` disappears instead of doubling up (#3888).
+                ts.push_str(
+                    "  const __vize_template_instance = undefined as unknown as (typeof __default__ extends abstract new (...args: any) => infer __I ? __I : {});\n  void __vize_template_instance;\n",
+                );
+            }
             emitted_header = true;
         }
 
         let gen_start = ts.len();
         // Use void expression to reference the name without creating an unused variable
-        let expr_code = cstr!("  void ({});\n", undef.name);
-        let name_offset = expr_code.find(undef.name.as_str()).unwrap_or(0);
+        let expr_code = if options_api {
+            cstr!(
+                "  var {}: any = undefined; void ({});\n  void (__vize_template_instance.{});\n",
+                undef.name,
+                undef.name,
+                undef.name
+            )
+        } else {
+            cstr!("  void ({});\n", undef.name)
+        };
+        let name_offset = if options_api {
+            expr_code.rfind(undef.name.as_str()).unwrap_or(0)
+        } else {
+            expr_code.find(undef.name.as_str()).unwrap_or(0)
+        };
         let gen_name_start = gen_start + name_offset;
         let gen_name_end = gen_name_start + undef.name.len();
 

--- a/crates/vize_canon/src/virtual_ts/scope/globals.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/globals.rs
@@ -41,10 +41,17 @@ pub(super) fn generate_undefined_refs(
     // bindings (a `namespace` is the measured case). Those are not unknown
     // template names, so they keep the free-name emission: a property access on
     // the instance would invent a `TS2339` `vue-tsc` does not report.
+    //
+    // `None` turns the form off for the whole template: either this shape never
+    // resolves one, or the script did not parse, in which case which names it
+    // declares is unknown and the free-name emission is the only safe one.
     let script_scope_names = if resolve_on_instance {
-        script_content.map_or_else(FxHashSet::default, script_top_level_binding_names)
+        match script_content {
+            Some(script) => script_top_level_binding_names(script),
+            None => Some(FxHashSet::default()),
+        }
     } else {
-        FxHashSet::default()
+        None
     };
 
     // Collect type export names to exclude from undefined refs
@@ -71,7 +78,16 @@ pub(super) fn generate_undefined_refs(
 
         let src_start = (template_offset + undef.offset) as usize;
         let src_end = src_start + undef.name.len();
-        let on_instance = resolve_on_instance && !script_scope_names.contains(undef.name.as_str());
+        // A name a configured `globalTypes` entry or a CSS module already
+        // declares in this scope keeps the free-name emission too: the `var` the
+        // instance form hoists would redeclare it (`TS2451`).
+        let on_instance = script_scope_names.as_ref().is_some_and(|names| {
+            !names.contains(undef.name.as_str())
+                && !is_declared_template_context_name(
+                    undef.name.as_str(),
+                    options.virtual_ts_options,
+                )
+        });
 
         if !emitted_header {
             ts.push_str("\n  // Undefined references from template:\n");
@@ -127,19 +143,27 @@ pub(super) fn generate_undefined_refs(
 /// `interface`, `type`). The generated module keeps the script verbatim in a
 /// scope that encloses the template closure, so every one of these stays
 /// resolvable from a template expression.
-fn script_top_level_binding_names(script: &str) -> FxHashSet<String> {
-    let allocator = Allocator::default();
-    let parsed = Parser::new(&allocator, script, SourceType::ts().with_module(true)).parse();
-    if parsed.panicked {
-        return FxHashSet::default();
+///
+/// `<script lang="ts">` may hold JSX, which only the TSX dialect parses, so the
+/// plain source type is tried first and TSX second. `None` means neither parsed
+/// the script cleanly: its top-level names are then unknown, and no template
+/// name may be classified against the public instance on a partial program.
+fn script_top_level_binding_names(script: &str) -> Option<FxHashSet<String>> {
+    for source_type in [SourceType::ts(), SourceType::tsx()] {
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, script, source_type.with_module(true)).parse();
+        if parsed.panicked || !parsed.diagnostics.is_empty() {
+            continue;
+        }
+        let semantic = SemanticBuilder::new().build(&parsed.program).semantic;
+        let scoping = semantic.scoping();
+        let mut names = FxHashSet::default();
+        for (name, _) in scoping.get_bindings(scoping.root_scope_id()) {
+            names.insert(String::from(name.as_str()));
+        }
+        return Some(names);
     }
-    let semantic = SemanticBuilder::new().build(&parsed.program).semantic;
-    let scoping = semantic.scoping();
-    let mut names = FxHashSet::default();
-    for (name, _) in scoping.get_bindings(scoping.root_scope_id()) {
-        names.insert(String::from(name.as_str()));
-    }
-    names
+    None
 }
 
 pub(super) fn generate_instance_global_refs(

--- a/crates/vize_canon/src/virtual_ts/scope/globals.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/globals.rs
@@ -9,7 +9,7 @@ use vize_carton::String;
 use vize_carton::append;
 use vize_carton::cstr;
 
-use vize_croquis::{BindingMetadata, Croquis, analyzer::extract_identifiers_oxc};
+use vize_croquis::{BindingMetadata, Croquis, ScopeKind, analyzer::extract_identifiers_oxc};
 
 use crate::virtual_ts::types::{VirtualTsOptions, VizeMapping};
 
@@ -23,6 +23,11 @@ use super::context::ScopeGenerationOptions;
 /// export is a plain options object — not a constructor — so the conditional
 /// would degrade to `{}` and turn every filter or runtime-resolved name into
 /// a `TS2339` the pinned Vue 2 parity surfaces do not contain.
+///
+/// A `<script setup>` block alongside the plain script keeps the form off too:
+/// there the plain script's default export is a partial options object
+/// (`inheritAttrs`, `name`, ...) whose instance type describes none of the
+/// template's real bindings, which live in the setup scope.
 pub(super) fn generate_undefined_refs(
     ts: &mut String,
     mappings: &mut Vec<VizeMapping>,
@@ -33,8 +38,10 @@ pub(super) fn generate_undefined_refs(
     if summary.undefined_refs.is_empty() {
         return;
     }
-    let resolve_on_instance =
-        options.options_api && options.has_default_alias && !options.legacy_vue2;
+    let resolve_on_instance = options.options_api
+        && options.has_default_alias
+        && !options.legacy_vue2
+        && !has_script_setup(summary);
     let script_content = options.script_content;
     // Names the plain script declares itself resolve from an enclosing scope of
     // the template closure even when the analyzer never tracked them as
@@ -136,6 +143,16 @@ pub(super) fn generate_undefined_refs(
             "  // @vize-map: {gen_name_start}:{gen_name_end} -> {src_start}:{src_end}\n",
         );
     }
+}
+
+/// Whether the SFC authored a `<script setup>` block: its bindings are the
+/// template's real surface, and the plain script's default export next to it
+/// carries only the options the setup form cannot express.
+fn has_script_setup(summary: &Croquis) -> bool {
+    summary
+        .scopes
+        .iter()
+        .any(|scope| matches!(scope.kind, ScopeKind::ScriptSetup))
 }
 
 /// Names bound at the plain script's own top level, including the TypeScript-only

--- a/crates/vize_canon/src/virtual_ts/scope/globals.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/globals.rs
@@ -17,21 +17,25 @@ use super::context::ScopeGenerationOptions;
 
 /// Handle undefined references from template.
 ///
-/// `resolve_on_instance` is the Options API opt-in: it is set only when the
-/// script rewrite actually declared the `__default__` alias the instance form
-/// reads, so a shape without one keeps the free-name emission rather than
-/// referencing an alias that was never generated.
+/// The public-instance form is the Vue 3 Options API opt-in: it requires the
+/// script rewrite to have actually declared the `__default__` alias the
+/// instance conditional reads, and stays off for legacy Vue 2, whose default
+/// export is a plain options object — not a constructor — so the conditional
+/// would degrade to `{}` and turn every filter or runtime-resolved name into
+/// a `TS2339` the pinned Vue 2 parity surfaces do not contain.
 pub(super) fn generate_undefined_refs(
     ts: &mut String,
     mappings: &mut Vec<VizeMapping>,
     summary: &Croquis,
     template_offset: u32,
-    resolve_on_instance: bool,
-    script_content: Option<&str>,
+    options: &ScopeGenerationOptions<'_, '_>,
 ) {
     if summary.undefined_refs.is_empty() {
         return;
     }
+    let resolve_on_instance =
+        options.options_api && options.has_default_alias && !options.legacy_vue2;
+    let script_content = options.script_content;
     // Names the plain script declares itself resolve from an enclosing scope of
     // the template closure even when the analyzer never tracked them as
     // bindings (a `namespace` is the measured case). Those are not unknown

--- a/crates/vize_canon/src/virtual_ts/scope/globals.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/globals.rs
@@ -1,5 +1,9 @@
 //! Generation of undefined-reference checks and instance-global declarations.
 
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
+use oxc_span::SourceType;
 use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::append;
@@ -18,6 +22,7 @@ pub(super) fn generate_undefined_refs(
     summary: &Croquis,
     template_offset: u32,
     options_api: bool,
+    script_content: Option<&str>,
 ) {
     if summary.undefined_refs.is_empty() {
         return;
@@ -26,6 +31,16 @@ pub(super) fn generate_undefined_refs(
     // declares; an Options API shape without one (no plain default export)
     // keeps the free-name emission rather than minting an unresolved alias.
     let options_api = options_api && ts.contains("__default__");
+    // Names the plain script declares itself resolve from an enclosing scope of
+    // the template closure even when the analyzer never tracked them as
+    // bindings (a `namespace` is the measured case). Those are not unknown
+    // template names, so they keep the free-name emission: a property access on
+    // the instance would invent a `TS2339` `vue-tsc` does not report.
+    let script_scope_names = if options_api {
+        script_content.map_or_else(FxHashSet::default, script_top_level_binding_names)
+    } else {
+        FxHashSet::default()
+    };
 
     // Collect type export names to exclude from undefined refs
     let type_export_names: FxHashSet<&str> = summary
@@ -36,6 +51,7 @@ pub(super) fn generate_undefined_refs(
 
     let mut seen_names: FxHashSet<&str> = FxHashSet::default();
     let mut emitted_header = false;
+    let mut emitted_instance = false;
     for undef in &summary.undefined_refs {
         if !seen_names.insert(undef.name.as_str()) {
             continue;
@@ -50,26 +66,27 @@ pub(super) fn generate_undefined_refs(
 
         let src_start = (template_offset + undef.offset) as usize;
         let src_end = src_start + undef.name.len();
+        let on_instance = options_api && !script_scope_names.contains(undef.name.as_str());
 
         if !emitted_header {
             ts.push_str("\n  // Undefined references from template:\n");
-            if options_api {
-                // A declaration typed as an indexed access on the public
-                // instance: the missing key reports `TS2339` naming the
-                // instance type — the code and shape `vue-tsc` emits for
-                // Options API templates — while the declared binding lets the
-                // interpolation expression itself resolve, so the bare
-                // `TS2304` disappears instead of doubling up (#3888).
-                ts.push_str(
-                    "  const __vize_template_instance = undefined as unknown as (typeof __default__ extends abstract new (...args: any) => infer __I ? __I : {});\n  void __vize_template_instance;\n",
-                );
-            }
             emitted_header = true;
+        }
+        if on_instance && !emitted_instance {
+            // A value typed as the public instance: the missing key reports
+            // `TS2339` naming the instance type (the code and shape `vue-tsc`
+            // emits for Options API templates), while the declared binding lets
+            // the interpolation expression itself resolve, so the bare `TS2304`
+            // disappears instead of doubling up (#3888).
+            ts.push_str(
+                "  const __vize_template_instance = undefined as unknown as (typeof __default__ extends abstract new (...args: any) => infer __I ? __I : {});\n  void __vize_template_instance;\n",
+            );
+            emitted_instance = true;
         }
 
         let gen_start = ts.len();
         // Use void expression to reference the name without creating an unused variable
-        let expr_code = if options_api {
+        let expr_code = if on_instance {
             cstr!(
                 "  var {}: any = undefined; void ({});\n  void (__vize_template_instance.{});\n",
                 undef.name,
@@ -79,7 +96,7 @@ pub(super) fn generate_undefined_refs(
         } else {
             cstr!("  void ({});\n", undef.name)
         };
-        let name_offset = if options_api {
+        let name_offset = if on_instance {
             expr_code.rfind(undef.name.as_str()).unwrap_or(0)
         } else {
             expr_code.find(undef.name.as_str()).unwrap_or(0)
@@ -98,6 +115,26 @@ pub(super) fn generate_undefined_refs(
             "  // @vize-map: {gen_name_start}:{gen_name_end} -> {src_start}:{src_end}\n",
         );
     }
+}
+
+/// Names bound at the plain script's own top level, including the TypeScript-only
+/// declaration forms the analyzer does not model (`namespace`, `enum`,
+/// `interface`, `type`). The generated module keeps the script verbatim in a
+/// scope that encloses the template closure, so every one of these stays
+/// resolvable from a template expression.
+fn script_top_level_binding_names(script: &str) -> FxHashSet<String> {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script, SourceType::ts().with_module(true)).parse();
+    if parsed.panicked {
+        return FxHashSet::default();
+    }
+    let semantic = SemanticBuilder::new().build(&parsed.program).semantic;
+    let scoping = semantic.scoping();
+    let mut names = FxHashSet::default();
+    for (name, _) in scoping.get_bindings(scoping.root_scope_id()) {
+        names.insert(String::from(name.as_str()));
+    }
+    names
 }
 
 pub(super) fn generate_instance_global_refs(

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -216,6 +216,52 @@ fn test_options_api_template_bindings_use_default_instance_type() {
     );
 }
 
+/// A `namespace` the plain script declares stays resolvable from template scope
+/// (the generated module keeps the declaration in a scope that encloses the
+/// template closure), so it is not an unknown template name: a public-instance
+/// property access for it would invent a `TS2339` vue-tsc never reports. A name
+/// the script does not declare still resolves on the instance.
+#[test]
+fn test_options_api_script_declared_namespace_is_not_checked_on_the_instance() {
+    let script = r#"namespace Bare {
+  export const label = 'bare'
+}
+
+export default {
+    name: 'Namespaces',
+}
+"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) =
+        vize_armature::parse(&allocator, "<div>{{ Bare.label }} {{ missingThing }}</div>");
+    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full())
+        .with_options_api();
+    analyzer.analyze_script_plain(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        !output.code.contains("__vize_template_instance.Bare"),
+        "a script-declared namespace must not be checked against the public instance:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("__vize_template_instance.missingThing"),
+        "a name the script never declares still resolves on the public instance:\n{}",
+        output.code
+    );
+}
+
 #[test]
 fn test_options_api_emits_real_props_type_from_object_option() {
     // Runtime props are values, so keep the object in setup scope and derive a

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -13,6 +13,7 @@ mod define_props_scope;
 mod generic_module_type_exports;
 mod legacy_nuxt2_page_context;
 mod no_check_template_bindings;
+mod options_api_instance;
 mod options_api_props_spread;
 mod options_api_setup_spread;
 mod options_api_this_bridge;
@@ -158,108 +159,6 @@ export default {
             output.code
         );
     }
-}
-
-#[test]
-fn test_options_api_template_bindings_use_default_instance_type() {
-    let script = r#"export default {
-    props: {
-        initial: Number,
-    },
-    data() {
-        return { count: 0 }
-    },
-    computed: {
-        doubled() {
-            return this.count * 2
-        },
-    },
-    methods: {
-        bump() {
-            return this.count + 1
-        },
-    },
-}
-"#;
-    let allocator = vize_carton::Bump::new();
-    let (root, _) = vize_armature::parse(&allocator, "<div>{{ count }}</div>");
-    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full())
-        .with_options_api();
-    analyzer.analyze_script_plain(script);
-    analyzer.analyze_template(&root);
-    let summary = analyzer.finish();
-    let output = generate_virtual_ts_with_offsets_options_api(
-        &summary,
-        Some(script),
-        Some(&root),
-        0,
-        0,
-        &Default::default(),
-    );
-
-    assert!(
-        output.code.contains("type __VizeOptionsInstance<T>"),
-        "expected Options API instance helper:\n{}",
-        output.code
-    );
-    assert!(
-        output
-            .code
-            .contains("const count: __VizeOptionsBinding<typeof __default__, \"count\">"),
-        "expected data binding to reference the default component instance:\n{}",
-        output.code
-    );
-    assert!(
-        !output.code.contains("const count: any = undefined as any;"),
-        "template data binding must not be emitted as a fixed any:\n{}",
-        output.code
-    );
-}
-
-/// A `namespace` the plain script declares stays resolvable from template scope
-/// (the generated module keeps the declaration in a scope that encloses the
-/// template closure), so it is not an unknown template name: a public-instance
-/// property access for it would invent a `TS2339` vue-tsc never reports. A name
-/// the script does not declare still resolves on the instance.
-#[test]
-fn test_options_api_script_declared_namespace_is_not_checked_on_the_instance() {
-    let script = r#"namespace Bare {
-  export const label = 'bare'
-}
-
-export default {
-    name: 'Namespaces',
-}
-"#;
-    let allocator = vize_carton::Bump::new();
-    let (root, _) =
-        vize_armature::parse(&allocator, "<div>{{ Bare.label }} {{ missingThing }}</div>");
-    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full())
-        .with_options_api();
-    analyzer.analyze_script_plain(script);
-    analyzer.analyze_template(&root);
-    let summary = analyzer.finish();
-    let output = generate_virtual_ts_with_offsets_options_api(
-        &summary,
-        Some(script),
-        Some(&root),
-        0,
-        0,
-        &Default::default(),
-    );
-
-    assert!(
-        !output.code.contains("__vize_template_instance.Bare"),
-        "a script-declared namespace must not be checked against the public instance:\n{}",
-        output.code
-    );
-    assert!(
-        output
-            .code
-            .contains("__vize_template_instance.missingThing"),
-        "a name the script never declares still resolves on the public instance:\n{}",
-        output.code
-    );
 }
 
 #[test]

--- a/crates/vize_canon/src/virtual_ts/tests/options_api_instance.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/options_api_instance.rs
@@ -1,0 +1,107 @@
+//! The Options API public-instance form for unknown template names (#3888):
+//! opted in only for a Vue 3 plain default export, and never for names the
+//! script itself declares.
+
+use crate::virtual_ts::generate_virtual_ts_with_offsets_options_api;
+
+#[test]
+fn test_options_api_template_bindings_use_default_instance_type() {
+    let script = r#"export default {
+    props: {
+        initial: Number,
+    },
+    data() {
+        return { count: 0 }
+    },
+    computed: {
+        doubled() {
+            return this.count * 2
+        },
+    },
+    methods: {
+        bump() {
+            return this.count + 1
+        },
+    },
+}
+"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, "<div>{{ count }}</div>");
+    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full())
+        .with_options_api();
+    analyzer.analyze_script_plain(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        output.code.contains("type __VizeOptionsInstance<T>"),
+        "expected Options API instance helper:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("const count: __VizeOptionsBinding<typeof __default__, \"count\">"),
+        "expected data binding to reference the default component instance:\n{}",
+        output.code
+    );
+    assert!(
+        !output.code.contains("const count: any = undefined as any;"),
+        "template data binding must not be emitted as a fixed any:\n{}",
+        output.code
+    );
+}
+
+/// A `namespace` the plain script declares stays resolvable from template scope
+/// (the generated module keeps the declaration in a scope that encloses the
+/// template closure), so it is not an unknown template name: a public-instance
+/// property access for it would invent a `TS2339` vue-tsc never reports. A name
+/// the script does not declare still resolves on the instance.
+#[test]
+fn test_options_api_script_declared_namespace_is_not_checked_on_the_instance() {
+    let script = r#"namespace Bare {
+  export const label = 'bare'
+}
+
+export default {
+    name: 'Namespaces',
+}
+"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) =
+        vize_armature::parse(&allocator, "<div>{{ Bare.label }} {{ missingThing }}</div>");
+    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full())
+        .with_options_api();
+    analyzer.analyze_script_plain(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        !output.code.contains("__vize_template_instance.Bare"),
+        "a script-declared namespace must not be checked against the public instance:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("__vize_template_instance.missingThing"),
+        "a name the script never declares still resolves on the public instance:\n{}",
+        output.code
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/tests/options_api_instance.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/options_api_instance.rs
@@ -2,7 +2,9 @@
 //! opted in only for a Vue 3 plain default export, and never for names the
 //! script itself declares.
 
-use crate::virtual_ts::generate_virtual_ts_with_offsets_options_api;
+use crate::virtual_ts::{
+    TemplateGlobal, VirtualTsOptions, generate_virtual_ts_with_offsets_options_api,
+};
 
 #[test]
 fn test_options_api_template_bindings_use_default_instance_type() {
@@ -102,6 +104,128 @@ export default {
             .code
             .contains("__vize_template_instance.missingThing"),
         "a name the script never declares still resolves on the public instance:\n{}",
+        output.code
+    );
+}
+
+/// `<script lang="ts">` may hold JSX, which only the TSX dialect parses: the
+/// script's top-level names must still be found so they are not checked on the
+/// public instance.
+#[test]
+fn test_options_api_tsx_script_names_are_not_checked_on_the_instance() {
+    let script = r#"const icon = () => <span>ok</span>
+
+export default {
+    name: 'Tsx',
+}
+"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, "<div>{{ icon }} {{ missingThing }}</div>");
+    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full())
+        .with_options_api();
+    analyzer.analyze_script_plain(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        !output.code.contains("__vize_template_instance.icon"),
+        "a name a TSX script declares must not be checked against the public instance:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("__vize_template_instance.missingThing"),
+        "a name the script never declares still resolves on the public instance:\n{}",
+        output.code
+    );
+}
+
+/// A script the parser cannot read leaves its top-level names unknown, so no
+/// template name may be classified against the public instance: a name the
+/// broken script does declare would otherwise gain an invented `TS2339`.
+#[test]
+fn test_options_api_unparseable_script_disables_the_instance_form() {
+    let script = r#"const broken = (
+
+export default {
+    name: 'Broken',
+}
+"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, "<div>{{ missingThing }}</div>");
+    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full())
+        .with_options_api();
+    analyzer.analyze_script_plain(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        !output.code.contains("__vize_template_instance"),
+        "an unparseable script must keep the public-instance form off:\n{}",
+        output.code
+    );
+}
+
+/// A configured `globalTypes` entry already declares the name in the template
+/// closure, so the `var` the instance form hoists would redeclare it
+/// (`TS2451 Cannot redeclare block-scoped variable`).
+#[test]
+fn test_options_api_configured_globals_are_not_redeclared_by_the_instance_form() {
+    let script = r#"export default {
+    name: 'Globals',
+}
+"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, "<div>{{ toThousandFilter(1) }}</div>");
+    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full())
+        .with_options_api();
+    analyzer.analyze_script_plain(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let options = VirtualTsOptions {
+        template_globals: vec![TemplateGlobal {
+            name: "toThousandFilter".into(),
+            type_annotation: "any".into(),
+            default_value: "undefined as any".into(),
+        }],
+        ..Default::default()
+    };
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &options,
+    );
+
+    assert!(
+        !output
+            .code
+            .contains("__vize_template_instance.toThousandFilter"),
+        "a configured template global must not be checked against the public instance:\n{}",
+        output.code
+    );
+    assert!(
+        !output.code.contains("var toThousandFilter"),
+        "a configured template global must not be redeclared by the instance form:\n{}",
         output.code
     );
 }

--- a/crates/vize_canon/src/virtual_ts/tests/options_api_instance.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/options_api_instance.rs
@@ -183,6 +183,50 @@ export default {
     );
 }
 
+/// A `<script setup>` block next to the plain script keeps the form off: there
+/// the plain default export carries only the options the setup form cannot
+/// express (`inheritAttrs`, `name`, ...), so its instance type describes none of
+/// the template's real bindings, and every setup binding or auto-imported name
+/// would gain an invented `TS2339` (measured on the Elk and Nuxt UI surfaces).
+#[test]
+fn test_options_api_script_setup_next_to_plain_script_disables_the_instance_form() {
+    let setup = r#"const props = defineProps<{ toaster: boolean }>()
+"#;
+    let script = r#"export default {
+    inheritAttrs: false,
+}
+"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, "<div>{{ toaster }} {{ missingThing }}</div>");
+    // The split-script shape the SFC pipeline builds: the setup summary is the
+    // base, the plain script is merged into it, then the template is drawn.
+    let options = vize_croquis::AnalyzerOptions::full();
+    let mut setup_analyzer = vize_croquis::Analyzer::with_options(options).with_options_api();
+    setup_analyzer.analyze_script_setup(setup);
+    let mut summary = setup_analyzer.finish();
+    let mut plain_analyzer = vize_croquis::Analyzer::with_options(options).with_options_api();
+    plain_analyzer.analyze_script_plain(script);
+    summary.merge_plain_script(plain_analyzer.finish());
+    let mut analyzer =
+        vize_croquis::Analyzer::with_summary(options, summary, true).with_options_api();
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        !output.code.contains("__vize_template_instance"),
+        "a `<script setup>` block must keep the public-instance form off:\n{}",
+        output.code
+    );
+}
+
 /// A configured `globalTypes` entry already declares the name in the template
 /// closure, so the `var` the instance form hoists would redeclare it
 /// (`TS2451 Cannot redeclare block-scoped variable`).


### PR DESCRIPTION
Closes #3888 — the last measured typecheck-code divergence from the clean-room audit.

## What

An undeclared name in an Options API template reported `TS2304 Cannot find name 'missingThing'` where vue-tsc reports **TS2339 on the instance type** — the message that tells the user which component surface was searched, and the code editors key quick-fixes on.

After this change, the audit fixture's diagnostic is **byte-identical to vue-tsc 3.3.4**, down to the type display:

```
error:30:14 [TS2339] Property 'missingThing' does not exist on type 'CreateComponentPublicInstanceWithMixins<ToResolvedProps<ExtractPropTypes<{ size: { type: NumberConstructor; required: true; }; }>, {}>, {}, { text: string; }, { shout(): string; }, ... 21 more ..., {}>'.
```

## The form, shaped by two measured dead ends

Unknown names emit two cooperating statements: a hoisted `var` declaration so the interpolation expression itself resolves (the old TS2304 disappears instead of doubling up), and a property access on a public-instance value derived from the `__default__` alias, mapped to the template span, which reports the one TS2339.

- A `const` declaration trips `TS2448` — the undefined-refs block emits after the interpolation statements, so only `var` hoisting works.
- An indexed-access *type* on the instance (`(typeof instance)["missingThing"]`) does not error at all under the checker — only the property access does. Both attempts are in the branch history.

Scope guards: Options API shapes without a plain `export default` (no `__default__` alias) keep the free-name emission — the guard tests the alias actually existing in the generated module. The `<script setup>` path is untouched: its unknown-name behavior needs its own vue-tsc oracle before changing (noted on the issue).

## Verification

- `cargo test -p vize_canon`: 898 passed, 0 failed.
- Clean-room full run: total unchanged at 23 diagnostics, with E17's code moving from divergent to parity.
- Clippy (CI flags) and fmt clean; `closures.rs` held at its base line count, `globals.rs` +29 well under budget.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reference resolution for Options API templates, including names declared in plain `<script>`.
  - Prevented script-declared namespaces from being misclassified as component instance properties.
  - Corrected routing of template names between component-instance and standard expressions.
  - Improved handling of default exports during template scope generation.
  - Disabled instance resolution when scripts cannot be safely analyzed or when mixed scripts make resolution ambiguous.
  - Avoided unnecessary component-instance access for configured template globals.

- **Tests**
  - Added regression coverage for Options API template bindings and script declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->