### PR TITLE
fix(maestro): hover opens with the signature and the authored keyword

### DIFF
--- a/crates/vize_maestro/src/ide/hover.rs
+++ b/crates/vize_maestro/src/ide/hover.rs
@@ -21,6 +21,7 @@ mod component_tag;
 mod corsa;
 #[cfg(all(test, feature = "native"))]
 mod corsa_tests;
+mod declaration_keyword;
 #[cfg(feature = "native")]
 mod html;
 mod petite_vue;
@@ -598,9 +599,8 @@ const message = ref('hello')
         });
         let value = hover_markdown(hover);
 
-        assert!(value.contains("TypeScript quick info"));
-        assert!(value.contains("Resolved through Vize virtual TypeScript"));
-        assert!(value.contains("```typescript"));
+        // The signature is the whole body: no preamble above the fence (#3894).
+        assert!(value.starts_with("```typescript"));
         assert!(value.contains("count: number"));
     }
 

--- a/crates/vize_maestro/src/ide/hover/corsa.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa.rs
@@ -166,6 +166,7 @@ impl HoverService {
             if mapped_range.is_some() {
                 converted.range = mapped_range;
             }
+            super::declaration_keyword::align_hover(ctx, &word, &mut converted);
             return Some(converted);
         }
 
@@ -317,17 +318,12 @@ impl HoverService {
         }
     }
 
+    /// The hover body is the signature itself. The former
+    /// `**TypeScript quick info**` / `_Resolved through Vize virtual
+    /// TypeScript_` preamble named an implementation detail no user acts on
+    /// and pushed the signature below the fold in small popups (#3894);
+    /// Volar and tsserver open with the code block.
     fn decorate_corsa_hover_markdown(value: &str) -> String {
-        let value = value.trim();
-        if value.is_empty() {
-            return String::new();
-        }
-
-        #[allow(clippy::disallowed_macros)]
-        {
-            format!(
-                "**TypeScript quick info**\n\n_Resolved through Vize virtual TypeScript_\n\n{value}"
-            )
-        }
+        value.trim().to_string()
     }
 }

--- a/crates/vize_maestro/src/ide/hover/declaration_keyword.rs
+++ b/crates/vize_maestro/src/ide/hover/declaration_keyword.rs
@@ -39,17 +39,37 @@ pub(super) fn align_hover(ctx: &IdeContext<'_>, word: &str, hover: &mut Hover) {
     let Some(script_setup) = descriptor.script_setup.as_ref() else {
         return;
     };
-    if let Some(aligned) = align_leading_var(&markup.value, &script_setup.content, word) {
+    let lang = script_setup.lang.as_deref();
+    if let Some(aligned) = align_leading_var(&markup.value, &script_setup.content, lang, word) {
         markup.value = aligned;
+    }
+}
+
+/// The oxc source type for a `<script setup lang="…">` block. `tsx`/`jsx` need
+/// the JSX variant, or a JSX initializer derails the parse and the synthesized
+/// `var` survives. Everything else parses as TypeScript, a superset of the
+/// plain-JS default that only has to yield declaration kinds and patterns here.
+fn script_source_type(lang: Option<&str>) -> SourceType {
+    let lang = lang.unwrap_or_default().trim();
+    if lang.eq_ignore_ascii_case("tsx") {
+        SourceType::tsx()
+    } else if lang.eq_ignore_ascii_case("jsx") {
+        SourceType::jsx()
+    } else {
+        SourceType::ts()
     }
 }
 
 /// The authored declaration keyword for `word`, when its top-level
 /// `<script setup>` declaration is a `const` or `let` binding (including
 /// destructuring patterns and default values).
-pub(super) fn authored_keyword(script_setup: &str, word: &str) -> Option<&'static str> {
+pub(super) fn authored_keyword(
+    script_setup: &str,
+    lang: Option<&str>,
+    word: &str,
+) -> Option<&'static str> {
     let allocator = Allocator::default();
-    let parsed = Parser::new(&allocator, script_setup, SourceType::ts()).parse();
+    let parsed = Parser::new(&allocator, script_setup, script_source_type(lang)).parse();
     let mut found: Option<&'static str> = None;
     for statement in &parsed.program.body {
         let declaration = match statement {
@@ -110,7 +130,12 @@ fn pattern_binds(pattern: &BindingPattern<'_>, word: &str) -> bool {
 
 /// Rewrite a quick-info markdown block whose code fence opens with
 /// `var {word}` to the authored keyword. Returns `None` when nothing applies.
-pub(super) fn align_leading_var(markdown: &str, script_setup: &str, word: &str) -> Option<String> {
+pub(super) fn align_leading_var(
+    markdown: &str,
+    script_setup: &str,
+    lang: Option<&str>,
+    word: &str,
+) -> Option<String> {
     if word.is_empty() {
         return None;
     }
@@ -125,7 +150,7 @@ pub(super) fn align_leading_var(markdown: &str, script_setup: &str, word: &str) 
     if following.is_some_and(|c| c == '_' || c == '$' || c.is_ascii_alphanumeric()) {
         return None;
     }
-    let keyword = authored_keyword(script_setup, word)?;
+    let keyword = authored_keyword(script_setup, lang, word)?;
     let mut rewritten = String::with_capacity(markdown.len());
     rewritten.push_str(&markdown[..after_fence]);
     rewritten.push_str(keyword);
@@ -140,12 +165,12 @@ mod tests {
         let script = "const { errors, meta } = useForm()\nlet attempts = 0\n";
         let hover = "```typescript\nvar errors: Ref<string[]>\n```";
         assert_eq!(
-            super::align_leading_var(hover, script, "errors").as_deref(),
+            super::align_leading_var(hover, script, Some("ts"), "errors").as_deref(),
             Some("```typescript\nconst errors: Ref<string[]>\n```")
         );
         let hover = "```typescript\nvar attempts: number\n```";
         assert_eq!(
-            super::align_leading_var(hover, script, "attempts").as_deref(),
+            super::align_leading_var(hover, script, Some("ts"), "attempts").as_deref(),
             Some("```typescript\nlet attempts: number\n```")
         );
     }
@@ -155,11 +180,43 @@ mod tests {
         let script = "const counter = 1\n";
         // Hover text names a longer identifier than the hovered word.
         let hover = "```typescript\nvar counter: number\n```";
-        assert_eq!(super::align_leading_var(hover, script, "count"), None);
+        assert_eq!(
+            super::align_leading_var(hover, script, Some("ts"), "count"),
+            None
+        );
         // The word has no top-level declaration.
-        assert_eq!(super::align_leading_var(hover, script, "missing"), None);
+        assert_eq!(
+            super::align_leading_var(hover, script, Some("ts"), "missing"),
+            None
+        );
         // The quick info does not open with `var`.
         let hover = "```typescript\nconst counter: 1\n```";
-        assert_eq!(super::align_leading_var(hover, script, "counter"), None);
+        assert_eq!(
+            super::align_leading_var(hover, script, Some("ts"), "counter"),
+            None
+        );
+    }
+
+    #[test]
+    fn a_jsx_initializer_resolves_under_tsx_and_jsx_langs() {
+        // `<script setup lang="tsx">`: parsed as TypeScript, `<Badge />` reads as
+        // a type assertion and the declaration never resolves.
+        let script = "const badge = <Badge count={1} />\n";
+        let hover = "```typescript\nvar badge: JSX.Element\n```";
+        assert_eq!(
+            super::align_leading_var(hover, script, Some("tsx"), "badge").as_deref(),
+            Some("```typescript\nconst badge: JSX.Element\n```")
+        );
+        assert_eq!(
+            super::align_leading_var(hover, script, Some("jsx"), "badge").as_deref(),
+            Some("```typescript\nconst badge: JSX.Element\n```")
+        );
+        // A JSX statement ahead of the hovered `let` must not derail the parse.
+        let script = "const badge = <Badge count={1} />\nlet attempts = 0\n";
+        let hover = "```typescript\nvar attempts: number\n```";
+        assert_eq!(
+            super::align_leading_var(hover, script, Some("tsx"), "attempts").as_deref(),
+            Some("```typescript\nlet attempts: number\n```")
+        );
     }
 }

--- a/crates/vize_maestro/src/ide/hover/declaration_keyword.rs
+++ b/crates/vize_maestro/src/ide/hover/declaration_keyword.rs
@@ -1,0 +1,165 @@
+//! Align the leading declaration keyword of a Corsa quick-info hover with the
+//! authored source (#3894).
+//!
+//! Template bindings are synthesized as `var {name}: T = undefined as any` in
+//! the virtual TypeScript, so the checker's quick info opens with `var ` even
+//! when the authored declaration is a `const` destructuring or a `let`. The
+//! keyword is the first thing a hover shows; leaking the synthesis detail
+//! misstates mutability. The rewrite consults the authored `<script setup>`
+//! text and only ever replaces a leading `var {word}` whose word has exactly
+//! one known top-level declaration kind — anything else keeps the checker's
+//! answer.
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros
+)]
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{BindingPattern, Declaration, Statement, VariableDeclarationKind};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use tower_lsp::lsp_types::{Hover, HoverContents};
+
+use crate::ide::IdeContext;
+
+/// Replace a leading synthesized `var` in a Corsa hover with the authored
+/// declaration keyword for the hovered template binding.
+pub(super) fn align_hover(ctx: &IdeContext<'_>, word: &str, hover: &mut Hover) {
+    let HoverContents::Markup(ref mut markup) = hover.contents else {
+        return;
+    };
+    let options = vize_atelier_sfc::SfcParseOptions {
+        filename: ctx.uri.path().to_string().into(),
+        ..Default::default()
+    };
+    let Ok(descriptor) = vize_atelier_sfc::parse_sfc(&ctx.content, options) else {
+        return;
+    };
+    let Some(script_setup) = descriptor.script_setup.as_ref() else {
+        return;
+    };
+    if let Some(aligned) = align_leading_var(&markup.value, &script_setup.content, word) {
+        markup.value = aligned;
+    }
+}
+
+/// The authored declaration keyword for `word`, when its top-level
+/// `<script setup>` declaration is a `const` or `let` binding (including
+/// destructuring patterns and default values).
+pub(super) fn authored_keyword(script_setup: &str, word: &str) -> Option<&'static str> {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script_setup, SourceType::ts()).parse();
+    let mut found: Option<&'static str> = None;
+    for statement in &parsed.program.body {
+        let declaration = match statement {
+            Statement::VariableDeclaration(declaration) => declaration,
+            Statement::ExportNamedDeclaration(export) => match &export.declaration {
+                Some(Declaration::VariableDeclaration(declaration)) => declaration,
+                _ => continue,
+            },
+            _ => continue,
+        };
+        let keyword = match declaration.kind {
+            VariableDeclarationKind::Const => "const",
+            VariableDeclarationKind::Let => "let",
+            _ => continue,
+        };
+        for declarator in &declaration.declarations {
+            if pattern_binds(&declarator.id, word) {
+                match found {
+                    None => found = Some(keyword),
+                    Some(existing) if existing == keyword => {}
+                    // Two top-level declarations of one name is invalid code;
+                    // do not guess which one the checker resolved.
+                    Some(_) => return None,
+                }
+            }
+        }
+    }
+    found
+}
+
+fn pattern_binds(pattern: &BindingPattern<'_>, word: &str) -> bool {
+    match pattern {
+        BindingPattern::BindingIdentifier(identifier) => identifier.name == word,
+        BindingPattern::ObjectPattern(object) => {
+            object
+                .properties
+                .iter()
+                .any(|property| pattern_binds(&property.value, word))
+                || object
+                    .rest
+                    .as_ref()
+                    .is_some_and(|rest| pattern_binds(&rest.argument, word))
+        }
+        BindingPattern::ArrayPattern(array) => {
+            array
+                .elements
+                .iter()
+                .flatten()
+                .any(|element| pattern_binds(element, word))
+                || array
+                    .rest
+                    .as_ref()
+                    .is_some_and(|rest| pattern_binds(&rest.argument, word))
+        }
+        BindingPattern::AssignmentPattern(assignment) => pattern_binds(&assignment.left, word),
+    }
+}
+
+/// Rewrite a quick-info markdown block whose code fence opens with
+/// `var {word}` to the authored keyword. Returns `None` when nothing applies.
+pub(super) fn align_leading_var(markdown: &str, script_setup: &str, word: &str) -> Option<String> {
+    if word.is_empty() {
+        return None;
+    }
+    let fence_start = markdown.find("```")?;
+    let after_fence = markdown[fence_start..].find('\n')? + fence_start + 1;
+    let synthesized = format!("var {word}");
+    if !markdown[after_fence..].starts_with(&synthesized) {
+        return None;
+    }
+    let following = markdown[after_fence + synthesized.len()..].chars().next();
+    // Only the whole identifier: `var counter` must not match hover on `count`.
+    if following.is_some_and(|c| c == '_' || c == '$' || c.is_ascii_alphanumeric()) {
+        return None;
+    }
+    let keyword = authored_keyword(script_setup, word)?;
+    let mut rewritten = String::with_capacity(markdown.len());
+    rewritten.push_str(&markdown[..after_fence]);
+    rewritten.push_str(keyword);
+    rewritten.push_str(&markdown[after_fence + "var".len()..]);
+    Some(rewritten)
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn a_destructured_const_rewrites_the_var_prefix() {
+        let script = "const { errors, meta } = useForm()\nlet attempts = 0\n";
+        let hover = "```typescript\nvar errors: Ref<string[]>\n```";
+        assert_eq!(
+            super::align_leading_var(hover, script, "errors").as_deref(),
+            Some("```typescript\nconst errors: Ref<string[]>\n```")
+        );
+        let hover = "```typescript\nvar attempts: number\n```";
+        assert_eq!(
+            super::align_leading_var(hover, script, "attempts").as_deref(),
+            Some("```typescript\nlet attempts: number\n```")
+        );
+    }
+
+    #[test]
+    fn unknown_names_prefix_words_and_non_var_hovers_stay_untouched() {
+        let script = "const counter = 1\n";
+        // Hover text names a longer identifier than the hovered word.
+        let hover = "```typescript\nvar counter: number\n```";
+        assert_eq!(super::align_leading_var(hover, script, "count"), None);
+        // The word has no top-level declaration.
+        assert_eq!(super::align_leading_var(hover, script, "missing"), None);
+        // The quick info does not open with `var`.
+        let hover = "```typescript\nconst counter: 1\n```";
+        assert_eq!(super::align_leading_var(hover, script, "counter"), None);
+    }
+}

--- a/editors/nvim/test/vize_e2e_expected.lua
+++ b/editors/nvim/test/vize_e2e_expected.lua
@@ -77,7 +77,7 @@ return {
   hover = {
     contents = {
       kind = "markdown",
-      value = '**TypeScript quick info**\n\n_Resolved through Vize virtual TypeScript_\n\n```typescript\nconst total: "3"\n```',
+      value = '```typescript\nconst total: "3"\n```',
     },
     range = {
       ["end"] = { character = 11, line = 3 },

--- a/editors/vim/test/vize_e2e_expected.vim
+++ b/editors/vim/test/vize_e2e_expected.vim
@@ -75,7 +75,7 @@ let g:vize_e2e_expected = {
       \ 'hover': {
       \   'contents': {
       \     'kind': 'markdown',
-      \     'value': "**TypeScript quick info**\n\n_Resolved through Vize virtual TypeScript_\n\n```typescript\nconst total: \"3\"\n```",
+      \     'value': "```typescript\nconst total: \"3\"\n```",
       \   },
       \   'range': {
       \     'end': {'character': 11, 'line': 3},

--- a/editors/vscode/test/suite/extension-host-real.cjs
+++ b/editors/vscode/test/suite/extension-host-real.cjs
@@ -142,14 +142,17 @@ async function runRealHoverSmoke(mismatchDocument) {
   // This profile enables typechecking, so the hover type text comes from the
   // live backend (#3321): the real literal type of the const, not the
   // script-binding heuristic that used to answer here.
-  assert.match(markdown, /\*\*TypeScript quick info\*\*/);
+  //
+  // The hover opens with the signature code block, like Volar and tsserver:
+  // no implementation-detail preamble ahead of it (#3894).
+  assert.match(markdown, /^```typescript\n/);
   assert.ok(
     markdown.includes('const label: "hello from vize"'),
     `hover must report the backend type of the binding: ${JSON.stringify(markdown)}`,
   );
   assert.ok(
-    markdown.includes("Resolved through Vize virtual TypeScript"),
-    `hover must identify the type backend as its source: ${JSON.stringify(markdown)}`,
+    !markdown.includes("TypeScript quick info"),
+    `hover must not restore the removed preamble: ${JSON.stringify(markdown)}`,
   );
   assert.ok(
     !markdown.includes("Template binding from script"),

--- a/tests/snapshots/check/create-vue-editor-range-oracle.ts
+++ b/tests/snapshots/check/create-vue-editor-range-oracle.ts
@@ -97,9 +97,10 @@ test("create-vue editor features answer in authored Vue ranges", async (t) => {
           };
           assert.equal(hover.contents.kind, "markdown");
           // Template scope, so the backend reports the *unwrapped* computed
-          // value rather than the script-side `ComputedRef` wrapper (#3321).
-          assert.equal(fencedBlock(hover.contents.value), "var doubled: number");
-          assert.match(hover.contents.value, /_Resolved through Vize virtual TypeScript_/);
+          // value rather than the script-side `ComputedRef` wrapper (#3321),
+          // and the synthesized `var` yields to the authored `const` (#3894).
+          assert.equal(fencedBlock(hover.contents.value), "const doubled: number");
+          assert.match(hover.contents.value, /^```typescript\n/);
 
           const scriptHover = (await ask("textDocument/hover", {
             position: scriptVisitCount,
@@ -108,7 +109,7 @@ test("create-vue editor features answer in authored Vue ranges", async (t) => {
             fencedBlock(scriptHover.contents.value),
             "const visitCount: Ref<number, number>",
           );
-          assert.match(scriptHover.contents.value, /_Resolved through Vize virtual TypeScript_/);
+          assert.match(scriptHover.contents.value, /^```typescript\n/);
         });
 
         // Closed with #3321: backend-answered hovers carry the range tsgo

--- a/tests/snapshots/check/element-plus-slot-oracle.ts
+++ b/tests/snapshots/check/element-plus-slot-oracle.ts
@@ -111,11 +111,8 @@ test("Element Plus badge slot contracts stay exact across editor revisions", asy
         // Answered by the backend since #3321. The slot scope parameter still
         // widens to `any` in the generated virtual TS — a separate gap, but the
         // provenance is now the type backend rather than a generic fallback.
-        assert.equal(
-          hoverText,
-          "**TypeScript quick info**\n\n_Resolved through Vize virtual TypeScript_\n\n" +
-            "```typescript\n(parameter) value: any\n```",
-        );
+        // Backend-answered: the body opens with the signature fence (#3894).
+        assert.equal(hoverText, "```typescript\n(parameter) value: any\n```");
 
         const brokenSource = fixture.applyExactPatch(appPath, cleanExpression, brokenExpression);
         session.notify("textDocument/didChange", {

--- a/tests/snapshots/check/nuxt-ui-ambient-oracle.ts
+++ b/tests/snapshots/check/nuxt-ui-ambient-oracle.ts
@@ -105,7 +105,9 @@ test("Nuxt UI generated ambient and #imports types stay exact across editor revi
         // Backend-answered since #3321. The `v-model` binding still widens to
         // `any` against the generated ambient component types; the point pinned
         // here is the provenance, not the precision.
-        assert.match(hoverText, /_Resolved through Vize virtual TypeScript_/);
+        // Backend-answered: the body is the signature fence, not the
+        // croquis fallback prose (#3894).
+        assert.match(hoverText, /^```typescript\n/);
         assert.doesNotMatch(hoverText, /Template binding from script/);
 
         const definition = (await session.request("textDocument/definition", {

--- a/tests/snapshots/check/vitepress-theme-oracle.ts
+++ b/tests/snapshots/check/vitepress-theme-oracle.ts
@@ -125,8 +125,7 @@ test("VitePress theme exports refresh exact template diagnostics", async () => {
         // template-expression hover.
         assert.equal(
           hoverText,
-          "**TypeScript quick info**\n\n_Resolved through Vize virtual TypeScript_\n\n" +
-            "```typescript\n(property) DefaultTheme.NotFoundOptions.code?: string | undefined\n```",
+          "```typescript\n(property) DefaultTheme.NotFoundOptions.code?: string | undefined\n```",
         );
 
         const themeUsage = source.indexOf("theme.notFound");

--- a/tests/snapshots/check/vue-benchmarks-lsp-ref-unwrap-oracle.ts
+++ b/tests/snapshots/check/vue-benchmarks-lsp-ref-unwrap-oracle.ts
@@ -143,7 +143,7 @@ test("ref-unwrap probe proves backend liveness and rejects heuristic hovers", as
       cleanSource.indexOf("const message") + "const mes".length,
     );
     assert.match(scriptHover, /const message: Ref<string, string>/);
-    assert.match(scriptHover, /_Resolved through Vize virtual TypeScript_/);
+    assert.match(scriptHover, /^```typescript\n/);
     assert.doesNotMatch(scriptHover, /_Script binding_/);
 
     // Template-side hovers: the backend presents the unwrapped `string` at the
@@ -154,7 +154,7 @@ test("ref-unwrap probe proves backend liveness and rejects heuristic hovers", as
       uri,
       cleanSource.indexOf("{{ message") + "{{ mes".length,
     );
-    assert.match(templateMessageHover, /var message: string/);
+    assert.match(templateMessageHover, /const message: string/);
     assert.doesNotMatch(templateMessageHover, /_Template binding from script_/);
     assert.doesNotMatch(templateMessageHover, /Ref</);
     assert.equal(classifyTemplateHover(templateMessageHover, "message"), "backend-template-type");
@@ -164,7 +164,7 @@ test("ref-unwrap probe proves backend liveness and rejects heuristic hovers", as
       uri,
       cleanSource.lastIndexOf("upper }}") + 2,
     );
-    assert.match(templateUpperHover, /var upper: string/);
+    assert.match(templateUpperHover, /const upper: string/);
     assert.doesNotMatch(templateUpperHover, /MaybeRef<unknown>/);
     assert.equal(classifyTemplateHover(templateUpperHover, "upper"), "backend-template-type");
 
@@ -248,14 +248,14 @@ test("template hover presents the backend-unwrapped string type", async () => {
     );
 
     const message = await hover(session, uri, cleanSource.indexOf("{{ message") + "{{ mes".length);
-    assert.match(hoverToText(message), /var message: string/);
+    assert.match(hoverToText(message), /const message: string/);
     assert.deepEqual(message?.range, {
       start: { line: 7, character: 8 },
       end: { line: 7, character: 15 },
     });
 
     const upper = await hover(session, uri, cleanSource.lastIndexOf("upper }}") + 2);
-    assert.match(hoverToText(upper), /var upper: string/);
+    assert.match(hoverToText(upper), /const upper: string/);
     assert.deepEqual(upper?.range, {
       start: { line: 7, character: 35 },
       end: { line: 7, character: 40 },

--- a/tools/helix-vize/run-real-server.mjs
+++ b/tools/helix-vize/run-real-server.mjs
@@ -95,8 +95,7 @@ const expectedCompletion = [
 const expectedHover = {
   contents: {
     kind: "markdown",
-    value:
-      '**TypeScript quick info**\n\n_Resolved through Vize virtual TypeScript_\n\n```typescript\nconst total: "3"\n```',
+    value: '```typescript\nconst total: "3"\n```',
   },
   range: {
     end: { character: 11, line: 3 },

--- a/tools/zed-vize/run-real-server.mjs
+++ b/tools/zed-vize/run-real-server.mjs
@@ -86,8 +86,7 @@ const expectedCompletion = [
 const expectedHover = {
   contents: {
     kind: "markdown",
-    value:
-      '**TypeScript quick info**\n\n_Resolved through Vize virtual TypeScript_\n\n```typescript\nconst total: "3"\n```',
+    value: '```typescript\nconst total: "3"\n```',
   },
   range: {
     end: { character: 11, line: 3 },


### PR DESCRIPTION
Two of #3894's four findings (items 1 and 2).

**Header noise.** Every Corsa hover carried a `**TypeScript quick info**` / `_Resolved through Vize virtual TypeScript_` preamble. It names an implementation detail no user acts on, and in small popups it pushes the signature — the thing hover exists for — below the fold. Volar and tsserver open with the code block; vize now does too.

**Leaked declaration keyword.** Template bindings are synthesized as `var name: T = undefined as any` in the virtual TS, so quick info opened with `var count` where the source declares a `const`. The corsa hover path now parses the authored `<script setup>` top level with oxc and rewrites a leading `var {word}` to the authored `const`/`let` — destructuring patterns, defaults and rest included — only when the word has exactly one known top-level declaration; anything else keeps the checker's answer verbatim (whole-identifier match, so hovering `count` never rewrites a `var counter` signature).

Verified over real stdio LSP (driver + fixture with a `ref`, a destructured `const`, and a `let`):

| hover | before | after |
|---|---|---|
| `count` (`const count = ref(0)`) | header + `var count: number` | ```` ```typescript\nconst count: number\n``` ```` |
| `label` (`const { label } = …`) | header + `var label: string` | `const label: string` |
| `attempts` (`let attempts = 0`) | header + `var attempts: number` | `let attempts: number` |

The six hover oracles that pinned the old preamble now pin the new shape — the body must *open* with the fence — and the ref-unwrap probes assert `const message: string` / `const upper: string` at the interpolation positions, still rejecting heuristic-provenance markers. All run green locally, plus the create-vue editor-range, vitepress, element-plus and nuxt-ui-ambient oracles on hydrated pinned fixtures.

Items 3 (v-for item display) and 4 (component-tag definition target) stay open on #3894 — both need a Volar-side oracle capture first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hover information for template bindings, including destructured and exported declarations.
  * Corrected declaration keywords so hover results match the selected code.
  * Removed unnecessary explanatory text from TypeScript hover results.
  * Preserved accurate behavior for unsupported, ambiguous, or unrecognized declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->