### PR TITLE
fix(maestro): a component tag hovers as its import, not the machinery

### DIFF
--- a/crates/vize_maestro/src/ide/hover/declaration_keyword.rs
+++ b/crates/vize_maestro/src/ide/hover/declaration_keyword.rs
@@ -46,6 +46,17 @@ pub(super) fn align_hover(ctx: &IdeContext<'_>, word: &str, hover: &mut Hover) {
             markup.value = aligned;
             return;
         }
+        // A component tag resolves to the generated component const, so the
+        // quick info leaks `__vize_component__` and its constructor types.
+        // For an imported SFC the authored fact is the import; present it the
+        // way Volar does (#3912). Anything not imported keeps the checker's
+        // answer until its own shape is measured.
+        if markup.value.contains("__vize_component__")
+            && let Some(aligned) = imported_component_quick_info(&script_setup.content, lang, word)
+        {
+            markup.value = aligned;
+            return;
+        }
     }
     if let Some(template) = descriptor.template.as_ref()
         && ctx.offset >= template.loc.start
@@ -55,6 +66,32 @@ pub(super) fn align_hover(ctx: &IdeContext<'_>, word: &str, hover: &mut Hover) {
     {
         markup.value = aligned;
     }
+}
+
+/// The Volar-shaped quick info for a component imported in `<script setup>`:
+/// ` ```typescript\nimport {word}\n``` `, produced only when an import
+/// declaration actually binds `word` (default, named, aliased, or namespace).
+fn imported_component_quick_info(
+    script_setup: &str,
+    lang: Option<&str>,
+    word: &str,
+) -> Option<String> {
+    if word.is_empty() {
+        return None;
+    }
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script_setup, script_source_type(lang)).parse();
+    let binds_word = parsed.program.body.iter().any(|statement| {
+        let Statement::ImportDeclaration(import) = statement else {
+            return false;
+        };
+        import.specifiers.as_ref().is_some_and(|specifiers| {
+            specifiers
+                .iter()
+                .any(|specifier| specifier.local().name == word)
+        })
+    });
+    binds_word.then(|| format!("```typescript\nimport {word}\n```"))
 }
 
 /// Rewrite a quick-info block opening with `(parameter) {word}` to

--- a/crates/vize_maestro/src/ide/hover/declaration_keyword.rs
+++ b/crates/vize_maestro/src/ide/hover/declaration_keyword.rs
@@ -16,7 +16,9 @@
 )]
 
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{BindingPattern, Declaration, Statement, VariableDeclarationKind};
+use oxc_ast::ast::{
+    BindingPattern, Declaration, ImportDeclarationSpecifier, Statement, VariableDeclarationKind,
+};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use tower_lsp::lsp_types::{Hover, HoverContents};
@@ -85,10 +87,21 @@ fn imported_component_quick_info(
         let Statement::ImportDeclaration(import) = statement else {
             return false;
         };
+        // `import type { Child }` binds a type, not a runtime component, so it
+        // never backs a component tag: keep the checker's answer.
+        if import.import_kind.is_type() {
+            return false;
+        }
         import.specifiers.as_ref().is_some_and(|specifiers| {
-            specifiers
-                .iter()
-                .any(|specifier| specifier.local().name == word)
+            specifiers.iter().any(|specifier| {
+                // Same for a specifier-level `{ type Child }`.
+                if let ImportDeclarationSpecifier::ImportSpecifier(named) = specifier
+                    && named.import_kind.is_type()
+                {
+                    return false;
+                }
+                specifier.local().name == word
+            })
         })
     });
     binds_word.then(|| format!("```typescript\nimport {word}\n```"))

--- a/crates/vize_maestro/src/ide/hover/declaration_keyword/tests.rs
+++ b/crates/vize_maestro/src/ide/hover/declaration_keyword/tests.rs
@@ -138,3 +138,24 @@ fn an_imported_component_presents_its_import_not_the_machinery() {
         None
     );
 }
+
+#[test]
+fn a_type_only_import_keeps_the_checker_answer() {
+    // A declaration-level `import type` binds a type, not a component.
+    let script = "import type Child from \"./Child.vue\";\n";
+    assert_eq!(
+        super::imported_component_quick_info(script, Some("ts"), "Child"),
+        None
+    );
+    // Same for a specifier-level `type` qualifier, while a runtime specifier
+    // in the very same declaration still resolves.
+    let script = "import { type Child, Widget } from \"./kit\";\n";
+    assert_eq!(
+        super::imported_component_quick_info(script, Some("ts"), "Child"),
+        None
+    );
+    assert_eq!(
+        super::imported_component_quick_info(script, Some("ts"), "Widget").as_deref(),
+        Some("```typescript\nimport Widget\n```")
+    );
+}

--- a/crates/vize_maestro/src/ide/hover/declaration_keyword/tests.rs
+++ b/crates/vize_maestro/src/ide/hover/declaration_keyword/tests.rs
@@ -115,3 +115,26 @@ fn a_parameter_named_like_an_alias_keeps_the_checker_answer() {
         Some("```typescript\nconst item: Item\n```")
     );
 }
+
+#[test]
+fn an_imported_component_presents_its_import_not_the_machinery() {
+    let script = "import Child from \"./Child.vue\";\nimport { Widget as W } from \"./kit\";\nconst local = 1;\nvoid local;\n";
+    assert_eq!(
+        super::imported_component_quick_info(script, None, "Child").as_deref(),
+        Some("```typescript\nimport Child\n```")
+    );
+    // Aliased named imports bind their local name.
+    assert_eq!(
+        super::imported_component_quick_info(script, None, "W").as_deref(),
+        Some("```typescript\nimport W\n```")
+    );
+    // A non-imported name keeps the checker's answer.
+    assert_eq!(
+        super::imported_component_quick_info(script, None, "local"),
+        None
+    );
+    assert_eq!(
+        super::imported_component_quick_info(script, None, "Missing"),
+        None
+    );
+}


### PR DESCRIPTION
Fixes #3912.

Hover on a `<Child` tag leaked the generated machinery — `(alias) const __vize_component__: __VizeComponentConstructor & __VizeVueComponentOptions` — on the single most-hovered position in a Vue template. Volar (2.2.10 non-hybrid oracle, real stdio) answers ```import Child```.

The corsa hover path now rewrites the answer when two conditions hold: the quick info carries the `__vize_component__` leak signature, and the hovered word is bound by a `<script setup>` import declaration (default, named, aliased, and namespace specifiers — resolved through oxc like the #3907/#3909 rewrites, not a textual scan). The result is byte-identical to the oracle on the measured fixture:

| | hover on `<Child` |
|---|---|
| Volar | ```import Child``` |
| vize before | `(alias) const __vize_component__: __VizeComponentConstructor & __VizeVueComponentOptions` |
| vize after | **```import Child```** |

Locally defined and globally registered components keep the checker's answer — their Volar shapes need their own oracle capture first, recorded on the issue.

Verified: maestro 706/706 with new unit coverage (default import, aliased named import, non-imported names untouched), the five LSP-driving suites 17/17, CI-parity clippy clean, budgets at base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved component hover information in `<script setup>` files.
  * Imported components now display concise import-style declarations for default, named, aliased, and namespace imports.
  * Mixed import declarations correctly identify runtime component imports.

* **Bug Fixes**
  * Type-only imports no longer appear as runtime component imports.
  * Existing hover information is preserved for unimported components, missing names, and invalid or unsupported import syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->