### PR TITLE
fix(canon): editor sessions resolve aliases under solution-style tsconfigs and mirror in-root barrels

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/dependency_scan.rs
+++ b/crates/vize_canon/src/batch/virtual_project/dependency_scan.rs
@@ -140,9 +140,29 @@ impl VirtualProject {
     /// (pattern, target) pairs. Both come from the flattened chain, so the
     /// anchors match what the generated tsconfig resolves (#3886).
     pub(crate) fn dependency_alias_map(&self) -> Vec<(String, String)> {
-        let Ok(flattened) =
-            self.load_compiler_options_flattened(self.resolved_tsconfig_path().as_deref())
-        else {
+        let anchored = self.resolved_tsconfig_path();
+        let aliases = self.alias_map_of(anchored.as_deref());
+        if !aliases.is_empty() {
+            return aliases;
+        }
+        // A solution-style shell (create-vue's default) declares nothing
+        // itself; the aliases live in the referenced project configs. The
+        // first referenced config that yields paths wins — the standard
+        // app/node split has exactly one (#3915).
+        let Some(anchored) = anchored else {
+            return aliases;
+        };
+        for referenced in super::tsconfig_gen::references::referenced_project_configs(&anchored) {
+            let referenced_aliases = self.alias_map_of(Some(&referenced));
+            if !referenced_aliases.is_empty() {
+                return referenced_aliases;
+            }
+        }
+        aliases
+    }
+
+    fn alias_map_of(&self, tsconfig_path: Option<&Path>) -> Vec<(String, String)> {
+        let Ok(flattened) = self.load_compiler_options_flattened(tsconfig_path) else {
             return Vec::new();
         };
         let Some(paths) = flattened

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -3,6 +3,7 @@ mod compiler_options;
 mod control_alias;
 mod native_options;
 mod path_rebase;
+pub(super) mod references;
 mod vue_alias;
 
 use std::path::{Path, PathBuf};

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen/references.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen/references.rs
@@ -1,0 +1,101 @@
+//! Solution-style tsconfig handling (#3915).
+//!
+//! The create-vue default layout ships a references-only shell —
+//! `{ "files": [], "references": [{ "path": "./tsconfig.app.json" }, …] }` —
+//! with every compiler option, including `paths`, living in the referenced
+//! project configs. An anchor that reads only the shell resolves no aliases,
+//! so consumers that found no `paths` in the anchored chain retry through the
+//! configs the shell references.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use super::super::tsconfig_paths::{normalize_path_lexically, parse_jsonc_value};
+
+/// The project configs referenced by `tsconfig_path`, in declaration order.
+///
+/// A reference `path` may name a config file or a directory (TypeScript
+/// resolves a directory to its `tsconfig.json`); entries that do not resolve
+/// to an existing file are dropped. A config without references — or one that
+/// cannot be read — yields an empty list.
+pub(in super::super) fn referenced_project_configs(tsconfig_path: &Path) -> Vec<PathBuf> {
+    let Ok(content) = std::fs::read_to_string(tsconfig_path) else {
+        return Vec::new();
+    };
+    let Ok(config) = parse_jsonc_value(&content) else {
+        return Vec::new();
+    };
+    let Some(references) = config.get("references").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    let base = tsconfig_path.parent().unwrap_or(Path::new("."));
+    references
+        .iter()
+        .filter_map(|reference| reference.get("path").and_then(Value::as_str))
+        .filter_map(|path| {
+            let joined = normalize_path_lexically(&base.join(path));
+            if joined.is_file() {
+                return Some(joined);
+            }
+            let as_directory = joined.join("tsconfig.json");
+            as_directory.is_file().then_some(as_directory)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    fn write(root: &Path, name: &str, content: &str) {
+        std::fs::write(root.join(name), content).unwrap();
+    }
+
+    #[test]
+    fn file_and_directory_references_resolve_missing_ones_drop() {
+        let root = std::env::temp_dir().join(format!("vize-refs-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("sub")).unwrap();
+        write(
+            &root,
+            "tsconfig.json",
+            r#"{
+  // create-vue style shell
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./sub" },
+    { "path": "./missing.json" }
+  ]
+}"#,
+        );
+        write(&root, "tsconfig.app.json", "{}");
+        write(&root.join("sub"), "tsconfig.json", "{}");
+
+        let configs = super::referenced_project_configs(&root.join("tsconfig.json"));
+        let names: Vec<_> = configs
+            .iter()
+            .map(|config| {
+                config
+                    .strip_prefix(&root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        assert_eq!(names, ["tsconfig.app.json", "sub/tsconfig.json"]);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn a_config_without_references_yields_nothing() {
+        let root = std::env::temp_dir().join(format!("vize-norefs-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        write(&root, "tsconfig.json", r#"{ "compilerOptions": {} }"#);
+        assert!(super::referenced_project_configs(&root.join("tsconfig.json")).is_empty());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}


### PR DESCRIPTION
Fixes #3915 (both measured halves).

**1. Solution-style shells (create-vue default).** The session's alias anchor read the nearest `tsconfig.json`'s own compiler options — empty in a references-only shell, where `paths` live in `tsconfig.app.json`. When the anchored chain yields no aliases, `dependency_alias_map` now retries through the referenced configs (file or directory form, declaration order) and takes the first that declares `paths`. Referenced configs use the same flattened loader, so `extends` chains (including package extends like `@vue/tsconfig/tsconfig.dom.json`, verified) and the baseUrl-anchored rebase apply unchanged; batch is untouched and the Vue Router solution-tsconfig oracle runs byte-identical.

**2. In-root barrels in sessions.** The reachability pass skips in-root non-vue scripts — right for batch, where the generated tsconfig aliases `.vue` imports into the mirror (and pinned by Tier-L, #3898) — but an editor session's only road to a typed alias import is rewriting the specifier to a *mirrored* companion. `import { Primitive } from "@/Primitive"` resolved `src/Primitive/index.ts` on disk, missed the mirror, stayed unrewritten, and every alias-imported symbol degraded to `any`. Sessions now opt into registering reachable in-root scripts (flag defaults off; batch set unchanged).

Real-project result (reka-ui `packages/core`, ComboboxCancel.vue, stdio):

| probe | before | after |
|---|---|---|
| hover `Primitive` tag | `var Primitive: any` | `var Primitive: DefineComponent<ExtractPropTypes<{ asChild: …` |
| hover `handleClick` | — | `function handleClick(): void` |
| hover `./ComboboxRoot.vue` import | `(alias) const injectComboboxRootContext: any` | full generic signature `<T extends ComboboxRootContext<AcceptableValue> …` |
| script completion after `rootContext.` | structural macro list | 53 items incl. `allGroups`, `allItems`, `contentId` |
| minimal create-vue repro, hover `<Tag` | heuristic prose | ```import Tag``` |

Remaining on the issue: definition on the tag through an alias barrel (maestro's `import_target` paths lookup needs the same references-follow), recorded with today's probes.

canon 854/854 (references-resolution unit coverage), workspace CLI test green, `typecheck-errors`/project-references/create-vue/auto-insertion suites 15/15, CI-parity clippy clean, budgets at or under base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)