### PR TITLE
fix(maestro): file renames re-spell paths-aliased imports

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -1,6 +1,5 @@
-//! IDE features for the LSP server.
-//!
-//! Core IDE functionality; the module list below is the authoritative inventory:
+//! IDE features for the LSP server. The module list below is the
+//! authoritative inventory:
 //! - Correctness: diagnostics, type checking and type information
 //! - Authoring: hover, completion, definition, references, code actions, rename, linked editing
 //! - Structure: document/workspace symbols, selection ranges, semantic tokens, inlay hints
@@ -32,6 +31,7 @@ pub mod semantic_tokens;
 pub(crate) mod sfc_region;
 pub(crate) mod tag_pair;
 mod template_expression;
+pub(crate) mod tsconfig_paths;
 pub mod type_service;
 pub mod workspace_symbols;
 pub use auto_insert::AutoInsertService;

--- a/crates/vize_maestro/src/ide/definition/service/import_target.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target.rs
@@ -109,38 +109,29 @@ fn resolve_import_specifier(uri: &Url, specifier: &str) -> Option<PathBuf> {
     if let Some(path) = module_specifier::resolve_specifier(uri, specifier) {
         return Some(path);
     }
+    // The shared reader anchors like the session does: nearest tsconfig,
+    // following a solution-style shell's references, with string-aware jsonc
+    // stripping — a naive stripper eats every `"@/*"` pattern (#3915, #3917).
     let file = uri.to_file_path().ok()?;
-    let tsconfig_dir = file
-        .ancestors()
-        .skip(1)
-        .find(|dir| dir.join("tsconfig.json").is_file())?;
-    let manifest = fs::read_to_string(tsconfig_dir.join("tsconfig.json")).ok()?;
-    let manifest: serde_json::Value = serde_json::from_str(&manifest)
-        .ok()
-        .or_else(|| serde_json::from_str(&strip_jsonc_comments(&manifest)).ok())?;
-    let paths = manifest.get("compilerOptions")?.get("paths")?.as_object()?;
+    let paths = crate::ide::tsconfig_paths::project_paths(&file)?;
     let mut best: Option<(usize, PathBuf)> = None;
-    for (pattern, targets) in paths {
+    for (pattern, target) in &paths.entries {
         let substituted = if let Some(prefix) = pattern.strip_suffix('*') {
-            specifier.strip_prefix(prefix).and_then(|rest| {
-                targets.as_array()?.iter().find_map(|target| {
-                    let target = target.as_str()?.strip_suffix('*')?;
-                    Some(cstr!("{target}{rest}").to_string())
-                })
-            })
+            match (specifier.strip_prefix(prefix), target.strip_suffix('*')) {
+                (Some(rest), Some(target_prefix)) => {
+                    Some(cstr!("{target_prefix}{rest}").to_string())
+                }
+                _ => None,
+            }
         } else if specifier == pattern {
-            targets
-                .as_array()
-                .and_then(|targets| targets.first())
-                .and_then(|target| target.as_str())
-                .map(str::to_owned)
+            Some(target.clone())
         } else {
             None
         };
         let Some(substituted) = substituted else {
             continue;
         };
-        let base = tsconfig_dir.join(substituted);
+        let base = paths.anchor.join(substituted);
         if let Some(resolved) = probe(&base)
             && best.as_ref().is_none_or(|(len, _)| pattern.len() > *len)
         {
@@ -148,36 +139,6 @@ fn resolve_import_specifier(uri: &Url, specifier: &str) -> Option<PathBuf> {
         }
     }
     best.map(|(_, path)| path)
-}
-
-/// Line and block comments stripped, so real-world tsconfigs parse. Naive
-/// about comment markers inside strings, which tsconfig paths do not contain
-/// in practice; a failed parse simply skips alias resolution.
-fn strip_jsonc_comments(source: &str) -> String {
-    let mut out = String::with_capacity(source.len());
-    let mut chars = source.chars().peekable();
-    while let Some(ch) = chars.next() {
-        if ch == '/' && chars.peek() == Some(&'/') {
-            for skipped in chars.by_ref() {
-                if skipped == '\n' {
-                    out.push('\n');
-                    break;
-                }
-            }
-        } else if ch == '/' && chars.peek() == Some(&'*') {
-            chars.next();
-            let mut previous = ' ';
-            for skipped in chars.by_ref() {
-                if previous == '*' && skipped == '/' {
-                    break;
-                }
-                previous = skipped;
-            }
-        } else {
-            out.push(ch);
-        }
-    }
-    out
 }
 
 fn probe(base: &Path) -> Option<PathBuf> {

--- a/crates/vize_maestro/src/ide/file_rename.rs
+++ b/crates/vize_maestro/src/ide/file_rename.rs
@@ -1,6 +1,9 @@
 //! File rename support for workspace import updates.
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
+mod alias;
+#[cfg(all(test, feature = "native"))]
+mod alias_tests;
 #[cfg(all(test, feature = "native"))]
 mod declaration_index_tests;
 mod manual;

--- a/crates/vize_maestro/src/ide/file_rename/alias.rs
+++ b/crates/vize_maestro/src/ide/file_rename/alias.rs
@@ -1,0 +1,152 @@
+//! Rename-time rewriting of `paths`-aliased import specifiers (#3917).
+//!
+//! The manual scanner rewrote only relative specifiers, so moving a file left
+//! every `@/…`-style import pointing at the old path — exactly the imports
+//! that survive refactors longest. The alias map is anchored the way the
+//! session anchors it (#3915): nearest `tsconfig.json`, following a
+//! solution-style shell's `references` to the first config that declares
+//! `paths`. Style is preserved per specifier: an aliased import stays aliased
+//! when the moved file remains under the alias target, and falls back to a
+//! relative spelling when it leaves the subtree — the oracle's behavior.
+#![allow(clippy::disallowed_types, clippy::disallowed_methods)]
+
+use std::path::{Path, PathBuf};
+
+use super::manual::{
+    RESOLVABLE_SCRIPT_EXTENSIONS, RenameTarget, apply_all_path_renames, candidate_exists,
+    normalize_path_buf, relative_module_path, split_specifier_suffix, strip_extension,
+};
+use crate::server::ServerState;
+
+/// One effective alias: the pattern (`@/*`), and the target's base directory
+/// resolved against its declaring config (`<anchor>/src`).
+struct AliasEntry {
+    pattern_prefix: std::string::String,
+    target_base: PathBuf,
+}
+
+/// Rewrite one specifier for the pending renames: relative specifiers via the
+/// manual scanner's rules, aliased ones via the `paths` map. `None` leaves the
+/// specifier untouched.
+pub(super) fn rewrite_specifier(
+    state: &ServerState,
+    importer_path: &Path,
+    future_importer_dir: &Path,
+    specifier: &str,
+    rename_targets: &[RenameTarget],
+) -> Option<std::string::String> {
+    super::manual::rewrite_relative_specifier(
+        state,
+        importer_path.parent()?,
+        future_importer_dir,
+        specifier,
+        rename_targets,
+    )
+    .or_else(|| {
+        rewrite_alias_specifier(
+            state,
+            importer_path,
+            future_importer_dir,
+            specifier,
+            rename_targets,
+        )
+    })
+}
+
+/// Rewrite one non-relative specifier whose alias-resolved target is being
+/// renamed. `None` leaves the specifier untouched.
+fn rewrite_alias_specifier(
+    state: &ServerState,
+    importer_path: &Path,
+    future_importer_dir: &Path,
+    specifier: &str,
+    rename_targets: &[RenameTarget],
+) -> Option<std::string::String> {
+    let (specifier_path, suffix) = split_specifier_suffix(specifier);
+    if specifier_path.starts_with("./") || specifier_path.starts_with("../") {
+        return None;
+    }
+
+    let mut aliases = project_aliases(importer_path)?;
+    // Longest pattern wins, mirroring TypeScript's `paths` selection.
+    aliases.sort_by_key(|alias| std::cmp::Reverse(alias.pattern_prefix.len()));
+
+    for alias in &aliases {
+        let Some(rest) = specifier_path.strip_prefix(alias.pattern_prefix.as_str()) else {
+            continue;
+        };
+        let base = normalize_path_buf(&alias.target_base.join(rest));
+        let Some((resolved, extensionless)) = probe_alias_target(state, &base, rename_targets)
+        else {
+            continue;
+        };
+        let future = apply_all_path_renames(&resolved, rename_targets)?;
+
+        if let Ok(remainder) = future.strip_prefix(&alias.target_base) {
+            let mut rendered = alias.pattern_prefix.clone();
+            let remainder = if extensionless {
+                strip_extension(remainder)
+            } else {
+                remainder.to_path_buf()
+            };
+            rendered.push_str(&remainder.to_string_lossy().replace('\\', "/"));
+            rendered.push_str(suffix);
+            return Some(rendered);
+        }
+        // The file left the alias subtree: no alias spelling exists any more,
+        // so fall back to a relative path from the importer.
+        let rendered_target = if extensionless {
+            strip_extension(&future)
+        } else {
+            future
+        };
+        let mut rendered = relative_module_path(future_importer_dir, &rendered_target)?;
+        rendered.push_str(suffix);
+        return Some(rendered);
+    }
+    None
+}
+
+/// Resolve the alias-substituted base to a real (or being-renamed) file:
+/// exact when the specifier carries an extension, extension probing otherwise.
+/// The flag reports whether the specifier was extensionless, which decides the
+/// rendered style.
+fn probe_alias_target(
+    state: &ServerState,
+    base: &Path,
+    rename_targets: &[RenameTarget],
+) -> Option<(PathBuf, bool)> {
+    let resolvable = |path: &Path| {
+        candidate_exists(state, path) || apply_all_path_renames(path, rename_targets).is_some()
+    };
+    if base.extension().is_some() {
+        return resolvable(base).then(|| (base.to_path_buf(), false));
+    }
+    for extension in RESOLVABLE_SCRIPT_EXTENSIONS {
+        let candidate = base.with_extension(extension);
+        if resolvable(&candidate) {
+            return Some((candidate, true));
+        }
+    }
+    None
+}
+
+/// The `paths` aliases governing `source_path`, resolved by the shared
+/// reader (nearest tsconfig, references-follow, string-aware jsonc).
+fn project_aliases(source_path: &Path) -> Option<Vec<AliasEntry>> {
+    let paths = crate::ide::tsconfig_paths::project_paths(source_path)?;
+    let mut aliases = Vec::new();
+    for (pattern, target) in &paths.entries {
+        // Exact-match aliases name one module; a rename cannot re-spell them.
+        let (Some(pattern_prefix), Some(target)) =
+            (pattern.strip_suffix('*'), target.strip_suffix('*'))
+        else {
+            continue;
+        };
+        aliases.push(AliasEntry {
+            pattern_prefix: pattern_prefix.to_string(),
+            target_base: normalize_path_buf(&paths.anchor.join(target)),
+        });
+    }
+    (!aliases.is_empty()).then_some(aliases)
+}

--- a/crates/vize_maestro/src/ide/file_rename/alias_tests.rs
+++ b/crates/vize_maestro/src/ide/file_rename/alias_tests.rs
@@ -1,0 +1,121 @@
+#![allow(clippy::disallowed_macros, clippy::disallowed_methods)]
+
+//! Rename edits for `paths`-aliased specifiers (#3917).
+
+use super::manual::collect_import_rename_edits;
+use super::manual_tests::{file_uri, normalize_edit, test_dir};
+use crate::server::ServerState;
+use insta::assert_snapshot;
+use std::fs;
+use tower_lsp::lsp_types::FileRename;
+
+#[test]
+fn aliased_specifiers_follow_the_move_and_leave_the_subtree_relative() {
+    let dir = test_dir();
+    let root = dir.path();
+    fs::create_dir_all(root.join("src/widgets")).unwrap();
+    fs::create_dir_all(root.join("lib")).unwrap();
+    // Solution-style shell: paths live in the referenced app config (#3915).
+    fs::write(
+        root.join("tsconfig.json"),
+        r#"{ "files": [], "references": [{ "path": "./tsconfig.app.json" }] }"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("tsconfig.app.json"),
+        r#"{
+  // aliases govern src only
+  "compilerOptions": { "paths": { "@/*": ["./src/*"] } }
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/App.vue"),
+        r#"<script setup lang="ts">
+import Child from "./Child.vue";
+import AliasChild from "@/Child.vue";
+import { helper } from "@/util";
+</script>
+"#,
+    )
+    .unwrap();
+    fs::write(root.join("src/Child.vue"), "<template><i /></template>").unwrap();
+    fs::write(root.join("src/util.ts"), "export const helper = 1;").unwrap();
+
+    let state = ServerState::new();
+    state.set_workspace_root(root.to_path_buf());
+
+    // Move within the alias subtree: both spellings survive, style preserved.
+    let edit = collect_import_rename_edits(
+        &state,
+        &[FileRename {
+            old_uri: file_uri(&root.join("src/Child.vue")),
+            new_uri: file_uri(&root.join("src/widgets/Kid.vue")),
+        }],
+        true,
+    )
+    .unwrap();
+    assert_snapshot!(serde_json::to_string_pretty(&normalize_edit(root, &edit)).unwrap(), @r###"
+    {
+      "src/App.vue": [
+        {
+          "newText": "./widgets/Kid.vue",
+          "range": {
+            "end": {
+              "character": 30,
+              "line": 1
+            },
+            "start": {
+              "character": 19,
+              "line": 1
+            }
+          }
+        },
+        {
+          "newText": "@/widgets/Kid.vue",
+          "range": {
+            "end": {
+              "character": 35,
+              "line": 2
+            },
+            "start": {
+              "character": 24,
+              "line": 2
+            }
+          }
+        }
+      ]
+    }
+    "###);
+
+    // Move an extensionless script target out of the alias subtree: the alias
+    // has no spelling there, so the specifier falls back to a relative path.
+    let edit = collect_import_rename_edits(
+        &state,
+        &[FileRename {
+            old_uri: file_uri(&root.join("src/util.ts")),
+            new_uri: file_uri(&root.join("lib/util.ts")),
+        }],
+        true,
+    )
+    .unwrap();
+    assert_snapshot!(serde_json::to_string_pretty(&normalize_edit(root, &edit)).unwrap(), @r###"
+    {
+      "src/App.vue": [
+        {
+          "newText": "../lib/util",
+          "range": {
+            "end": {
+              "character": 30,
+              "line": 3
+            },
+            "start": {
+              "character": 24,
+              "line": 3
+            }
+          }
+        }
+      ]
+    }
+    "###);
+}

--- a/crates/vize_maestro/src/ide/file_rename/manual.rs
+++ b/crates/vize_maestro/src/ide/file_rename/manual.rs
@@ -19,7 +19,7 @@ use tower_lsp::lsp_types::{FileRename, Range, TextEdit, Url, WorkspaceEdit};
 use crate::{ide::offset_to_position, server::ServerState};
 
 const SCRIPT_EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"];
-const RESOLVABLE_SCRIPT_EXTENSIONS: &[&str] = &[
+pub(super) const RESOLVABLE_SCRIPT_EXTENSIONS: &[&str] = &[
     "ts", "tsx", "d.ts", "d.mts", "d.cts", "js", "jsx", "mts", "cts", "mjs", "cjs", "vue",
 ];
 #[derive(Clone)]
@@ -403,9 +403,6 @@ fn collect_script_content_edits(
     let mut collector = ModuleSpecifierCollector::default();
     collector.visit_program(&parsed.program);
 
-    let Some(current_dir) = context.current_path.parent() else {
-        return Vec::new();
-    };
     let Some(future_dir) = context.future_path.parent() else {
         return Vec::new();
     };
@@ -414,9 +411,9 @@ fn collect_script_content_edits(
         .specifiers
         .into_iter()
         .filter_map(|specifier| {
-            let new_text = rewrite_relative_specifier(
+            let new_text = super::alias::rewrite_specifier(
                 context.state,
-                current_dir,
+                context.current_path,
                 future_dir,
                 &specifier.specifier,
                 context.rename_targets,
@@ -493,7 +490,7 @@ fn render_module_specifier(
     relative_module_path(importer_dir, &rendered_target)
 }
 
-fn relative_module_path(from_dir: &Path, to_path: &Path) -> Option<std::string::String> {
+pub(super) fn relative_module_path(from_dir: &Path, to_path: &Path) -> Option<std::string::String> {
     let from_dir = normalize_path_buf(from_dir);
     let to_path = normalize_path_buf(to_path);
 
@@ -604,7 +601,7 @@ fn apply_all_uri_renames(uri: &Url, renames: &[RenameTarget]) -> Option<Url> {
     Url::from_file_path(path).ok()
 }
 
-fn apply_all_path_renames(path: &Path, renames: &[RenameTarget]) -> Option<PathBuf> {
+pub(super) fn apply_all_path_renames(path: &Path, renames: &[RenameTarget]) -> Option<PathBuf> {
     let mut updated = normalize_path_buf(path);
     let mut changed = false;
 
@@ -632,7 +629,7 @@ fn apply_path_rename(path: &Path, rename: &RenameTarget) -> Option<PathBuf> {
     }
 }
 
-fn candidate_exists(state: &ServerState, path: &Path) -> bool {
+pub(super) fn candidate_exists(state: &ServerState, path: &Path) -> bool {
     if path.exists() {
         return true;
     }
@@ -671,7 +668,7 @@ fn read_workspace_source(state: &ServerState, path: &Path) -> Option<std::string
     fs::read_to_string(path).ok()
 }
 
-fn split_specifier_suffix(specifier: &str) -> (&str, &str) {
+pub(super) fn split_specifier_suffix(specifier: &str) -> (&str, &str) {
     let split_at = specifier.find(['?', '#']).unwrap_or(specifier.len());
     (&specifier[..split_at], &specifier[split_at..])
 }
@@ -701,7 +698,7 @@ fn script_source_type(lang: Option<&str>) -> SourceType {
     }
 }
 
-fn normalize_path_buf(path: &Path) -> PathBuf {
+pub(super) fn normalize_path_buf(path: &Path) -> PathBuf {
     let mut normalized = PathBuf::new();
 
     for component in path.components() {
@@ -719,7 +716,7 @@ fn normalize_path_buf(path: &Path) -> PathBuf {
     normalized
 }
 
-fn strip_extension(path: &Path) -> PathBuf {
+pub(super) fn strip_extension(path: &Path) -> PathBuf {
     let mut stripped = normalize_path_buf(path);
     let path = stripped.to_string_lossy();
     let extension_depth = 1 + usize::from(

--- a/crates/vize_maestro/src/ide/file_rename/manual_tests.rs
+++ b/crates/vize_maestro/src/ide/file_rename/manual_tests.rs
@@ -8,7 +8,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use tower_lsp::lsp_types::{FileRename, Url, WorkspaceEdit};
 
-fn test_dir() -> tempfile::TempDir {
+pub(super) fn test_dir() -> tempfile::TempDir {
     let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("target")
         .join("vize-tests");
@@ -16,11 +16,11 @@ fn test_dir() -> tempfile::TempDir {
     tempfile::tempdir_in(base).unwrap()
 }
 
-fn file_uri(path: &Path) -> std::string::String {
+pub(super) fn file_uri(path: &Path) -> std::string::String {
     Url::from_file_path(path).unwrap().to_string()
 }
 
-fn normalize_edit(root: &Path, edit: &WorkspaceEdit) -> serde_json::Value {
+pub(super) fn normalize_edit(root: &Path, edit: &WorkspaceEdit) -> serde_json::Value {
     let mut files = BTreeMap::<std::string::String, Vec<serde_json::Value>>::new();
 
     for (uri, edits) in edit.changes.as_ref().unwrap() {

--- a/crates/vize_maestro/src/ide/tsconfig_paths.rs
+++ b/crates/vize_maestro/src/ide/tsconfig_paths.rs
@@ -1,0 +1,143 @@
+//! Shared `tsconfig.json` `paths` reading for editor features (#3915, #3917).
+//!
+//! Anchoring matches the session's rule: the nearest `tsconfig.json` governs;
+//! when it is a solution-style shell that declares no `paths` of its own, the
+//! first referenced project config that does wins (the create-vue app/node
+//! split has exactly one). Comment stripping is string-aware — every `paths`
+//! pattern contains `/*` (`"@/*"`), so a stripper that ignores string state
+//! destroys exactly the value these features need.
+#![allow(clippy::disallowed_types, clippy::disallowed_methods)]
+
+use std::path::{Path, PathBuf};
+
+/// The effective `paths` map for `source_path`: the declaring config's
+/// directory (targets resolve against it) and the (pattern, target) pairs
+/// spelled as written.
+pub(crate) struct ProjectPaths {
+    pub(crate) anchor: PathBuf,
+    pub(crate) entries: Vec<(std::string::String, std::string::String)>,
+}
+
+pub(crate) fn project_paths(source_path: &Path) -> Option<ProjectPaths> {
+    let anchor = source_path
+        .ancestors()
+        .skip(1)
+        .find(|dir| dir.join("tsconfig.json").is_file())?;
+    let shell = anchor.join("tsconfig.json");
+    if let Some(paths) = paths_of(&shell) {
+        return Some(paths);
+    }
+    referenced_configs(&shell)
+        .into_iter()
+        .find_map(|referenced| paths_of(&referenced))
+}
+
+fn paths_of(config_path: &Path) -> Option<ProjectPaths> {
+    let value = read_jsonc(config_path)?;
+    let paths = value.get("compilerOptions")?.get("paths")?.as_object()?;
+    let anchor = config_path.parent()?.to_path_buf();
+    let mut entries = Vec::new();
+    for (pattern, targets) in paths {
+        for target in targets.as_array().into_iter().flatten() {
+            if let Some(target) = target.as_str() {
+                entries.push((pattern.clone(), target.to_owned()));
+            }
+        }
+    }
+    (!entries.is_empty()).then_some(ProjectPaths { anchor, entries })
+}
+
+/// The project configs a solution-style shell references, in declaration
+/// order; a `path` may name a config file or a directory.
+fn referenced_configs(config_path: &Path) -> Vec<PathBuf> {
+    let Some(value) = read_jsonc(config_path) else {
+        return Vec::new();
+    };
+    let Some(references) = value.get("references").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+    let base = config_path.parent().unwrap_or(Path::new("."));
+    references
+        .iter()
+        .filter_map(|reference| reference.get("path").and_then(|p| p.as_str()))
+        .filter_map(|path| {
+            let joined = base.join(path);
+            if joined.is_file() {
+                return Some(joined);
+            }
+            let as_directory = joined.join("tsconfig.json");
+            as_directory.is_file().then_some(as_directory)
+        })
+        .collect()
+}
+
+fn read_jsonc(path: &Path) -> Option<serde_json::Value> {
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content)
+        .ok()
+        .or_else(|| serde_json::from_str(&strip_jsonc_comments(&content)).ok())
+}
+
+fn strip_jsonc_comments(source: &str) -> std::string::String {
+    let mut out = std::string::String::with_capacity(source.len());
+    let mut chars = source.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+    while let Some(c) = chars.next() {
+        if in_string {
+            out.push(c);
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match c {
+            '"' => {
+                in_string = true;
+                out.push(c);
+            }
+            '/' if chars.peek() == Some(&'/') => {
+                for c in chars.by_ref() {
+                    if c == '\n' {
+                        out.push('\n');
+                        break;
+                    }
+                }
+            }
+            '/' if chars.peek() == Some(&'*') => {
+                chars.next();
+                let mut last = ' ';
+                for c in chars.by_ref() {
+                    if last == '*' && c == '/' {
+                        break;
+                    }
+                    last = c;
+                }
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn comments_strip_without_touching_path_patterns() {
+        let source = r#"{
+  // line comment
+  /* block "@/decoy" comment */
+  "compilerOptions": { "paths": { "@/*": ["./src/*"] } }
+}"#;
+        let value: serde_json::Value =
+            serde_json::from_str(&super::strip_jsonc_comments(source)).unwrap();
+        assert_eq!(
+            value["compilerOptions"]["paths"]["@/*"][0],
+            serde_json::json!("./src/*")
+        );
+    }
+}


### PR DESCRIPTION
Fixes #3917; also closes the definition-side residue recorded on #3915.

Moving a file updated only relative specifiers — every `@/…`-style import kept pointing at the old path. Oracle (Volar 2.2.10 non-hybrid, real stdio, same fixture: `App.vue` importing `./Child.vue` **and** `@/Child.vue`, move `src/Child.vue` → `src/widgets/Kid.vue`):

| | `willRenameFiles` edits |
|---|---|
| Volar | `"./widgets/Kid.vue"` + `"@/widgets/Kid.vue"` |
| vize before | `"./widgets/Kid.vue"` only |
| vize after | **both, byte-identical** (verified on the solution-style shell *with jsonc comments*) |

Three layers:

1. **Alias re-spelling** (`file_rename/alias.rs`): every specifier routes through one entry — relative rules first, then the `paths` map. A target that stays under the alias target keeps the alias spelling; a move out of the subtree falls back to a relative path (the oracle's behavior, unit-pinned both ways). Anchoring matches the session (#3915): nearest tsconfig, references-follow for solution-style shells.

2. **String-aware jsonc stripping** (`ide/tsconfig_paths.rs`, shared): both prior strippers treated the `/*` inside every `"@/*"` pattern as a block-comment opener, so **any commented tsconfig silently lost its `paths`** — the very value these features need. Found when the unit fixture's comment made the alias edit vanish while the comment-free E2E passed; reka-ui's real `tsconfig.app.json` is commented, so this was live in the wild.

3. **Definition through alias barrels**: `import_target` now uses the shared reader, gaining the references-follow and the fixed stripper — the remaining measured gap from #3915's real-project probes.

maestro 712/712 (new: alias-move + subtree-exit unit snapshots, stripper unit), CI-parity clippy clean, budgets at or under base (`manual.rs` shrank).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved file renaming for imports that use TypeScript path aliases.
  * Preserved aliases when renamed files remain within the configured alias path.
  * Automatically falls back to relative imports when files move outside an alias path.
  * Added support for path settings from nearby and referenced `tsconfig` files, including JSONC configuration.

* **Bug Fixes**
  * Improved import resolution across project configurations and extensionless imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->