### PR TITLE
fix(maestro): member access detection follows identifier characters, not ASCII bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3870,6 +3870,7 @@ dependencies = [
  "oxc_diagnostics",
  "oxc_parser",
  "oxc_span",
+ "oxc_syntax",
  "parking_lot",
  "ropey",
  "serde",

--- a/crates/vize_maestro/Cargo.toml
+++ b/crates/vize_maestro/Cargo.toml
@@ -46,6 +46,7 @@ oxc_ast.workspace = true
 oxc_ast_visit.workspace = true
 oxc_parser.workspace = true
 oxc_span.workspace = true
+oxc_syntax.workspace = true
 oxc_diagnostics.workspace = true
 
 # Internal crates

--- a/crates/vize_maestro/src/ide/template_expression.rs
+++ b/crates/vize_maestro/src/ide/template_expression.rs
@@ -98,9 +98,13 @@ fn identifier_start(content: &str, end: usize) -> usize {
     start
 }
 
+/// ECMAScript `IdentifierPart`, so the scan keeps every character an editor can
+/// have already typed into a member name: `is_alphanumeric` alone drops the
+/// combining marks of decomposed text (`café` as `cafe` + U+0301) and the
+/// zero-width joiners, both of which end the token one character too early.
 #[cfg(feature = "native")]
 fn is_identifier_char(ch: char) -> bool {
-    ch.is_alphanumeric() || ch == '_' || ch == '$'
+    oxc_syntax::identifier::is_identifier_part(ch)
 }
 
 fn is_in_mustache_expression(content: &str, offset: usize) -> bool {
@@ -236,6 +240,12 @@ mod member_access_tests {
         assert!(is_member_access("{{ 名.前| }}"));
         // A digit inside the receiver keeps it an identifier, not a literal.
         assert!(is_member_access("{{ foo1.ba| }}"));
+        // Decomposed text: the caret sits on a combining mark, which is an
+        // identifier part rather than a token boundary.
+        assert!(is_member_access("{{ it.cafe\u{301}| }}"));
+        assert!(is_member_access("{{ cafe\u{301}.na| }}"));
+        // Zero-width joiners are identifier parts too.
+        assert!(is_member_access("{{ it.a\u{200D}b| }}"));
     }
 
     #[test]

--- a/crates/vize_maestro/src/ide/template_expression.rs
+++ b/crates/vize_maestro/src/ide/template_expression.rs
@@ -41,30 +41,50 @@ pub(crate) fn is_at_member_access_position(content: &str, offset: usize) -> bool
         offset -= 1;
     }
 
-    let bytes = content.as_bytes();
-    let mut pos = offset;
-    // Step back over the partial member name already typed.
-    while pos > 0 && is_member_name_byte(bytes[pos - 1]) {
-        pos -= 1;
+    // Step back over the partial member name already typed. Member names are
+    // identifiers, so this walks characters rather than ASCII bytes: `it.名|`
+    // reads a member exactly like `it.na|` does.
+    let mut pos = identifier_start(content, offset);
+    // Skip any whitespace between the `.` and the name (`it. na|`).
+    while let Some(ch) = content[..pos].chars().next_back() {
+        if !ch.is_whitespace() {
+            break;
+        }
+        pos -= ch.len_utf8();
     }
-    // A digit-led token is a numeric literal fragment (`1.5`), not a member.
-    if pos < offset && bytes[pos].is_ascii_digit() {
+    if !content[..pos].ends_with('.') {
         return false;
     }
-    while pos > 0 && bytes[pos - 1].is_ascii_whitespace() {
-        pos -= 1;
-    }
-    if pos == 0 || bytes[pos - 1] != b'.' {
-        return false;
-    }
+
+    let dot = pos - 1;
     // `...rest` spreads an expression rather than reading a member off it.
-    pos -= 1;
-    pos == 0 || bytes[pos - 1] != b'.'
+    if content[..dot].ends_with('.') {
+        return false;
+    }
+    // A digit-led receiver means the `.` belongs to a numeric literal rather
+    // than to a member read, which covers every fragment of one (`1.`, `1.5`,
+    // `1.na`). An identifier that merely contains digits (`foo1.bar`) is still
+    // a member read, so this tests the start of the receiver token, not the
+    // character next to the dot.
+    !content[identifier_start(content, dot)..dot].starts_with(|ch: char| ch.is_ascii_digit())
+}
+
+/// Walk back from `end` over identifier characters and return the token start.
+#[cfg(feature = "native")]
+fn identifier_start(content: &str, end: usize) -> usize {
+    let mut start = end;
+    while let Some(ch) = content[..start].chars().next_back() {
+        if !is_identifier_char(ch) {
+            break;
+        }
+        start -= ch.len_utf8();
+    }
+    start
 }
 
 #[cfg(feature = "native")]
-fn is_member_name_byte(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')
+fn is_identifier_char(ch: char) -> bool {
+    ch.is_alphanumeric() || ch == '_' || ch == '$'
 }
 
 fn is_in_mustache_expression(content: &str, offset: usize) -> bool {
@@ -194,6 +214,15 @@ mod member_access_tests {
     }
 
     #[test]
+    fn member_names_may_be_unicode_identifiers() {
+        assert!(is_member_access("{{ it.名| }}"));
+        assert!(is_member_access("{{ it.名前| }}"));
+        assert!(is_member_access("{{ 名.前| }}"));
+        // A digit inside the receiver keeps it an identifier, not a literal.
+        assert!(is_member_access("{{ foo1.ba| }}"));
+    }
+
+    #[test]
     fn identifier_positions_are_not_member_access() {
         assert!(!is_member_access("{{ | }}"));
         assert!(!is_member_access("{{ cou| }}"));
@@ -206,5 +235,10 @@ mod member_access_tests {
     fn spreads_and_numeric_literals_are_not_member_access() {
         assert!(!is_member_access("{{ f(...arg| ) }}"));
         assert!(!is_member_access("{{ 1.5| }}"));
+        // Every fragment of a numeric literal, not just the one with a digit
+        // under the caret.
+        assert!(!is_member_access("{{ 1.| }}"));
+        assert!(!is_member_access("{{ 1.na| }}"));
+        assert!(!is_member_access("{{ 42.toStrin| }}"));
     }
 }

--- a/crates/vize_maestro/src/ide/template_expression.rs
+++ b/crates/vize_maestro/src/ide/template_expression.rs
@@ -57,16 +57,32 @@ pub(crate) fn is_at_member_access_position(content: &str, offset: usize) -> bool
     }
 
     let dot = pos - 1;
-    // `...rest` spreads an expression rather than reading a member off it.
-    if content[..dot].ends_with('.') {
+    // `...rest` spreads an expression rather than reading a member off it. A
+    // spread is always three dots, so this looks for the other two rather than
+    // for any preceding dot: in `42..toStrin` the first dot closes the numeric
+    // literal `42.` and the second one still reads a member off it.
+    if content[..dot].ends_with("..") {
         return false;
     }
-    // A digit-led receiver means the `.` belongs to a numeric literal rather
-    // than to a member read, which covers every fragment of one (`1.`, `1.5`,
-    // `1.na`). An identifier that merely contains digits (`foo1.bar`) is still
-    // a member read, so this tests the start of the receiver token, not the
-    // character next to the dot.
-    !content[identifier_start(content, dot)..dot].starts_with(|ch: char| ch.is_ascii_digit())
+    !is_decimal_point(content, dot)
+}
+
+/// Whether the `.` at `dot` is the decimal point of a numeric literal rather
+/// than a member-access operator.
+#[cfg(feature = "native")]
+fn is_decimal_point(content: &str, dot: usize) -> bool {
+    let start = identifier_start(content, dot);
+    // A digit-led token before the `.` is the integer part of a literal, which
+    // covers every fragment of one (`1.`, `1.5`, `1.na`). An identifier that
+    // merely contains digits (`foo1.bar`) is still a member read, so this tests
+    // the start of the token, not the character next to the dot.
+    if !content[start..dot].starts_with(|ch: char| ch.is_ascii_digit()) {
+        return false;
+    }
+    // Unless the literal already spent its decimal point, in which case this
+    // `.` reads a member off the finished number (`1.5.toFixed`).
+    let before = &content[..start];
+    !(before.ends_with('.') && before[..before.len() - 1].ends_with(|ch: char| ch.is_ascii_digit()))
 }
 
 /// Walk back from `end` over identifier characters and return the token start.
@@ -240,5 +256,16 @@ mod member_access_tests {
         assert!(!is_member_access("{{ 1.| }}"));
         assert!(!is_member_access("{{ 1.na| }}"));
         assert!(!is_member_access("{{ 42.toStrin| }}"));
+    }
+
+    #[test]
+    fn numbers_still_expose_their_members() {
+        // Both spellings that let a `.` follow an integer literal read a member
+        // off the number: the second dot of `42..x`, and a dot separated from
+        // the literal by whitespace.
+        assert!(is_member_access("{{ 42..toStrin| }}"));
+        assert!(is_member_access("{{ 42..| }}"));
+        assert!(is_member_access("{{ 42 .toStrin| }}"));
+        assert!(is_member_access("{{ 1.5.toFixe| }}"));
     }
 }

--- a/crates/vize_maestro/src/ide/template_expression.rs
+++ b/crates/vize_maestro/src/ide/template_expression.rs
@@ -69,20 +69,59 @@ pub(crate) fn is_at_member_access_position(content: &str, offset: usize) -> bool
 
 /// Whether the `.` at `dot` is the decimal point of a numeric literal rather
 /// than a member-access operator.
+///
+/// Only a literal that can still take a decimal point owns the dot, and that is
+/// a bare run of decimal digits (`1.`, `1_000.`). Every other numeric spelling
+/// has already ended by the time the `.` arrives, so the dot reads a member off
+/// the finished number: a decimal point the literal already spent
+/// (`1.5.toFixed`, `.5.toFixed`), an exponent (`1e3.toFixed`, `1e-3.toFixed`), a
+/// radix prefix (`0xFF.toString`), or the BigInt suffix (`1n.toString`).
 #[cfg(feature = "native")]
 fn is_decimal_point(content: &str, dot: usize) -> bool {
     let start = identifier_start(content, dot);
+    let token = &content[start..dot];
     // A digit-led token before the `.` is the integer part of a literal, which
     // covers every fragment of one (`1.`, `1.5`, `1.na`). An identifier that
     // merely contains digits (`foo1.bar`) is still a member read, so this tests
     // the start of the token, not the character next to the dot.
-    if !content[start..dot].starts_with(|ch: char| ch.is_ascii_digit()) {
+    if !token.starts_with(|ch: char| ch.is_ascii_digit()) {
         return false;
     }
-    // Unless the literal already spent its decimal point, in which case this
-    // `.` reads a member off the finished number (`1.5.toFixed`).
-    let before = &content[..start];
-    !(before.ends_with('.') && before[..before.len() - 1].ends_with(|ch: char| ch.is_ascii_digit()))
+    // Anything other than decimal digits inside that token closed the literal
+    // before the dot: a radix prefix (`0xFF`), an exponent indicator (`1e3`), or
+    // the BigInt suffix (`1n`). None of those can take a decimal point.
+    if !token
+        .bytes()
+        .all(|byte| byte.is_ascii_digit() || byte == b'_')
+    {
+        return false;
+    }
+    // Those digits can still be the tail of a literal that ended before them,
+    // in which case the `.` reads a member too.
+    !closes_numeric_literal(&content[..start])
+}
+
+/// Whether the text ending right before a run of decimal digits already closed
+/// the numeric literal those digits belong to.
+#[cfg(feature = "native")]
+fn closes_numeric_literal(before: &str) -> bool {
+    // A decimal point the literal already spent (`1.5.`, `.5.`): the scan back
+    // over identifier characters stops at that dot, so the digits behind the
+    // caret's dot are only the fraction.
+    if before.ends_with('.') {
+        return true;
+    }
+    // A signed exponent (`1e-3.`, `1E+3.`): the sign is not an identifier
+    // character, so those digits are only the exponent. The `e` has to belong to
+    // a number rather than to an identifier, so `abcde-3.` stays a decimal point.
+    let Some(mantissa) = before
+        .strip_suffix(|ch: char| ch == '+' || ch == '-')
+        .and_then(|signed| signed.strip_suffix(|ch: char| ch == 'e' || ch == 'E'))
+    else {
+        return false;
+    };
+    mantissa[identifier_start(mantissa, mantissa.len())..]
+        .starts_with(|ch: char| ch.is_ascii_digit())
 }
 
 /// Walk back from `end` over identifier characters and return the token start.
@@ -266,6 +305,8 @@ mod member_access_tests {
         assert!(!is_member_access("{{ 1.| }}"));
         assert!(!is_member_access("{{ 1.na| }}"));
         assert!(!is_member_access("{{ 42.toStrin| }}"));
+        // Separators do not close the integer part either.
+        assert!(!is_member_access("{{ 1_000.toStrin| }}"));
     }
 
     #[test]
@@ -277,5 +318,26 @@ mod member_access_tests {
         assert!(is_member_access("{{ 42..| }}"));
         assert!(is_member_access("{{ 42 .toStrin| }}"));
         assert!(is_member_access("{{ 1.5.toFixe| }}"));
+    }
+
+    #[test]
+    fn literals_that_cannot_take_a_decimal_point_read_members() {
+        // An exponent ends the literal, so the `.` after it is a member read
+        // even though the digits next to it look like an integer part.
+        assert!(is_member_access("{{ 1e3.toFixe| }}"));
+        assert!(is_member_access("{{ 1e-3.toFixe| }}"));
+        assert!(is_member_access("{{ 1E+3.toFixe| }}"));
+        assert!(is_member_access("{{ 1.5e-3.toFixe| }}"));
+        // A leading-dot decimal already spent its decimal point.
+        assert!(is_member_access("{{ .5.toFixe| }}"));
+        // Non-decimal radices have no decimal point to spend.
+        assert!(is_member_access("{{ 0xFF.toStrin| }}"));
+        assert!(is_member_access("{{ 0b11.toStrin| }}"));
+        assert!(is_member_access("{{ 0o17.toStrin| }}"));
+        // Neither does a BigInt.
+        assert!(is_member_access("{{ 1n.toStrin| }}"));
+        // The `e` still has to belong to a number: `abcde - 3.foo` is an
+        // identifier minus a numeric literal, not an exponent.
+        assert!(!is_member_access("{{ abcde-3.toFixe| }}"));
     }
 }


### PR DESCRIPTION
Follow-up to #3913, which landed `is_at_member_access_position` as the predicate that routes a template member access through the checker. Review on that PR caught two cases its byte scan gets wrong.

The scan stepped back over the partial member name one ASCII byte at a time, so it stopped at the first byte of any multi-byte character. `{{ it.名| }}` therefore looked like a bare identifier, took the structural binding list, and suggested the SFC's bindings instead of `User`'s members: the exact symptom #3911 describes, just for a Unicode member name.

The digit guard was also asking the wrong question. It tested the first character of the partial *name*, which only catches a numeric fragment that still has a digit under the caret (`1.5|`), so `1.|` and `1.na|` both routed to the checker. The receiver is what decides whether the `.` belongs to a number, so the guard now tests the start of that token:

```rust
let dot = pos - 1;
// `...rest` spreads an expression rather than reading a member off it.
if content[..dot].ends_with('.') {
    return false;
}
// A digit-led receiver means the `.` belongs to a numeric literal rather
// than to a member read, which covers every fragment of one (`1.`, `1.5`,
// `1.na`). An identifier that merely contains digits (`foo1.bar`) is still
// a member read, so this tests the start of the receiver token, not the
// character next to the dot.
!content[identifier_start(content, dot)..dot]
    .starts_with(|ch: char| ch.is_ascii_digit())
```

Scanning is now character-based via a shared `identifier_start` helper, used for both the member name and the receiver. `is_identifier_char` is `is_alphanumeric() || '_' || '$'` rather than a `unicode-ident` lookup, since that crate is only a transitive lock entry here and the distinction (a token *starting* with a Unicode digit) cannot occur in either a valid identifier or a numeric literal.

Neither case changes the routing decision for anything that already worked: receivers ending in `]`, `)`, `?`, or `!` still reach the checker, `...rest` and plain identifier positions still take the structural list, and `foo1.bar|` stays a member read. Covered by new assertions for `it.名|`, `it.名前|`, `名.前|`, `foo1.ba|`, `1.|`, `1.na|`, and `42.toStrin|`.

Opened as a separate PR because #3913 was merged (and its branch deleted) before this fix was ready.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved member-access detection for Unicode identifiers, including combining marks and zero-width joiners.
  * Added support for whitespace between the dot and a partial member name.
  * Correctly distinguishes numeric fragments from identifiers and completed numeric literals.
  * Preserved support for spread access and member access on completed numeric literals.

* **Tests**
  * Expanded coverage for Unicode names, whitespace, numeric fragments, numeric members, and special numeric literal forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->