### PR TITLE
fix(maestro): watched dependency changes refresh open importers

### DIFF
--- a/crates/vize_maestro/src/server/workspace_files.rs
+++ b/crates/vize_maestro/src/server/workspace_files.rs
@@ -76,11 +76,13 @@ pub(super) async fn did_change_watched_files(
 ) {
     #[cfg(feature = "native")]
     {
-        if !server.state.invalidate_global_component_references(
+        // A change to a discoverable global-component declaration invalidates
+        // that cache — but any watched change can break open importers (a git
+        // checkout rewriting a child SFC's props, a codegen run, a delete), so
+        // the dependent refresh below is not gated on it (#3918).
+        let global_components_invalidated = server.state.invalidate_global_component_references(
             params.changes.iter().map(|change| change.uri.as_str()),
-        ) {
-            return;
-        }
+        );
 
         let mut dependents = params
             .changes
@@ -99,6 +101,11 @@ pub(super) async fn did_change_watched_files(
                     .map(|version| (uri, version))
             })
             .collect::<Vec<_>>();
+        if dependents.is_empty() && !global_components_invalidated {
+            return;
+        }
+        // Recomputation must read the changed files fresh from disk.
+        server.state.invalidate_batch_cache();
         for (dependent, version) in dependents {
             server
                 .publish_diagnostics_if_version(&dependent, version)

--- a/tests/tooling/lsp-watched-refresh.test.ts
+++ b/tests/tooling/lsp-watched-refresh.test.ts
@@ -81,12 +81,22 @@ test("watched dependency changes refresh the open importer", async (t) => {
     const diagnosticsFor = (uri: string) => (params: unknown) =>
       (params as { uri: string }).uri === uri;
     const counted = (params: unknown) => (params as { diagnostics: unknown[] }).diagnostics.length;
-    // The deleted state is only distinguishable by content: a stale republish of
-    // the phase-1 mismatch also carries `appUri` with a non-zero count.
-    const mentionsChild = (params: unknown) =>
-      (params as { diagnostics: { message?: string }[] }).diagnostics.some((diagnostic) =>
-        (diagnostic.message ?? "").includes("Child.vue"),
-      );
+    // `waitForNotification` resolves out of the backlog, so a stale republish
+    // could satisfy the delete phase without the deletion ever being observed.
+    // Draining to quiescence first forces the next publish to be the delete's.
+    const drainAppDiagnostics = async () => {
+      for (;;) {
+        try {
+          await session.waitForNotification(
+            "textDocument/publishDiagnostics",
+            diagnosticsFor(appUri),
+            1000,
+          );
+        } catch {
+          return;
+        }
+      }
+    };
 
     session.notify("textDocument/didOpen", {
       textDocument: { uri: appUri, languageId: "vue", version: 1, text: APP },
@@ -111,13 +121,14 @@ test("watched dependency changes refresh the open importer", async (t) => {
     assert.equal(counted(afterEdit), 1, "the stale binding is reported");
 
     // Phase 2: the dependency disappears; the importer must stay broken.
+    await drainAppDiagnostics();
     fs.rmSync(childPath);
     session.notify("workspace/didChangeWatchedFiles", {
       changes: [{ uri: childUri, type: 3 }],
     });
     const afterDelete = await session.waitForNotification(
       "textDocument/publishDiagnostics",
-      (params) => diagnosticsFor(appUri)(params) && mentionsChild(params),
+      (params) => diagnosticsFor(appUri)(params) && counted(params) > 0,
       60000,
     );
     assert.ok(counted(afterDelete) > 0, "a deleted dependency keeps the importer broken");

--- a/tests/tooling/lsp-watched-refresh.test.ts
+++ b/tests/tooling/lsp-watched-refresh.test.ts
@@ -34,8 +34,8 @@ import Child from "./Child.vue";
 
 // A dependency changed outside the editor — a git checkout, a codegen run, a
 // delete — must refresh the open importer's diagnostics without any editor
-// edit (#3918). The lifecycle mirrors the Volar oracle: clean on open, two
-// mismatches after the prop narrows on disk, still broken while the file is
+// edit (#3918). The lifecycle mirrors the Volar oracle: clean on open, one
+// mismatch after the prop type changes on disk, still broken while the file is
 // gone, clean again once it is restored.
 test("watched dependency changes refresh the open importer", async (t) => {
   const corsaPath = requireTypecheckDependency(
@@ -81,6 +81,12 @@ test("watched dependency changes refresh the open importer", async (t) => {
     const diagnosticsFor = (uri: string) => (params: unknown) =>
       (params as { uri: string }).uri === uri;
     const counted = (params: unknown) => (params as { diagnostics: unknown[] }).diagnostics.length;
+    // The deleted state is only distinguishable by content: a stale republish of
+    // the phase-1 mismatch also carries `appUri` with a non-zero count.
+    const mentionsChild = (params: unknown) =>
+      (params as { diagnostics: { message?: string }[] }).diagnostics.some((diagnostic) =>
+        (diagnostic.message ?? "").includes("Child.vue"),
+      );
 
     session.notify("textDocument/didOpen", {
       textDocument: { uri: appUri, languageId: "vue", version: 1, text: APP },
@@ -111,7 +117,7 @@ test("watched dependency changes refresh the open importer", async (t) => {
     });
     const afterDelete = await session.waitForNotification(
       "textDocument/publishDiagnostics",
-      diagnosticsFor(appUri),
+      (params) => diagnosticsFor(appUri)(params) && mentionsChild(params),
       60000,
     );
     assert.ok(counted(afterDelete) > 0, "a deleted dependency keeps the importer broken");

--- a/tests/tooling/lsp-watched-refresh.test.ts
+++ b/tests/tooling/lsp-watched-refresh.test.ts
@@ -80,8 +80,7 @@ test("watched dependency changes refresh the open importer", async (t) => {
     const childUri = pathToFileURL(childPath).href;
     const diagnosticsFor = (uri: string) => (params: unknown) =>
       (params as { uri: string }).uri === uri;
-    const counted = (params: unknown) =>
-      (params as { diagnostics: unknown[] }).diagnostics.length;
+    const counted = (params: unknown) => (params as { diagnostics: unknown[] }).diagnostics.length;
 
     session.notify("textDocument/didOpen", {
       textDocument: { uri: appUri, languageId: "vue", version: 1, text: APP },

--- a/tests/tooling/lsp-watched-refresh.test.ts
+++ b/tests/tooling/lsp-watched-refresh.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
+
+function resolveCorsaBinary(): string | undefined {
+  return [
+    path.join(root, "../corsa-bind/.cache/tsgo"),
+    path.join(root, "node_modules/.bin/tsgo"),
+    path.join(root, "tests/node_modules/.bin/tsgo"),
+  ].find((candidate) => fs.existsSync(candidate));
+}
+
+const CHILD_NUMBER = `<script setup lang="ts">
+defineProps<{ count: number }>();
+</script>
+<template><i>{{ count }}</i></template>
+`;
+
+const CHILD_STRING = CHILD_NUMBER.replace("count: number", "count: string");
+
+const APP = `<script setup lang="ts">
+import Child from "./Child.vue";
+</script>
+<template>
+  <Child :count="1" />
+</template>
+`;
+
+// A dependency changed outside the editor — a git checkout, a codegen run, a
+// delete — must refresh the open importer's diagnostics without any editor
+// edit (#3918). The lifecycle mirrors the Volar oracle: clean on open, two
+// mismatches after the prop narrows on disk, still broken while the file is
+// gone, clean again once it is restored.
+test("watched dependency changes refresh the open importer", async (t) => {
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveCorsaBinary(),
+    "Corsa runtime for the watched-refresh gate",
+    "Corsa runtime is unavailable",
+  );
+  if (corsaPath == null) return;
+
+  const testRootDir = path.join(testOutputRoot, "lsp-watched-refresh");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+  try {
+    fs.mkdirSync(path.join(workspaceDir, "node_modules"), { recursive: true });
+    fs.symlinkSync(
+      path.join(root, "tests/node_modules/vue"),
+      path.join(workspaceDir, "node_modules/vue"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "tsconfig.json"),
+      JSON.stringify({ include: ["*.vue"], compilerOptions: { strict: true } }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "vize.config.json"),
+      JSON.stringify({ typeChecker: { corsaPath } }),
+      "utf8",
+    );
+    const childPath = path.join(workspaceDir, "Child.vue");
+    fs.writeFileSync(childPath, CHILD_NUMBER, "utf8");
+
+    await session.initialize(workspaceDir, {
+      editor: true,
+      typecheck: true,
+      lint: false,
+      autoInsert: false,
+    });
+    const appUri = pathToFileURL(path.join(workspaceDir, "App.vue")).href;
+    const childUri = pathToFileURL(childPath).href;
+    const diagnosticsFor = (uri: string) => (params: unknown) =>
+      (params as { uri: string }).uri === uri;
+    const counted = (params: unknown) =>
+      (params as { diagnostics: unknown[] }).diagnostics.length;
+
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri: appUri, languageId: "vue", version: 1, text: APP },
+    });
+    const opened = await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      diagnosticsFor(appUri),
+      60000,
+    );
+    assert.equal(counted(opened), 0, "the importer opens clean");
+
+    // Phase 1: the dependency's prop narrows on disk, no editor edit.
+    fs.writeFileSync(childPath, CHILD_STRING, "utf8");
+    session.notify("workspace/didChangeWatchedFiles", {
+      changes: [{ uri: childUri, type: 2 }],
+    });
+    const afterEdit = await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => diagnosticsFor(appUri)(params) && counted(params) > 0,
+      60000,
+    );
+    assert.equal(counted(afterEdit), 1, "the stale binding is reported");
+
+    // Phase 2: the dependency disappears; the importer must stay broken.
+    fs.rmSync(childPath);
+    session.notify("workspace/didChangeWatchedFiles", {
+      changes: [{ uri: childUri, type: 3 }],
+    });
+    const afterDelete = await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      diagnosticsFor(appUri),
+      60000,
+    );
+    assert.ok(counted(afterDelete) > 0, "a deleted dependency keeps the importer broken");
+
+    // Phase 3: restored with the matching type; the importer recovers.
+    fs.writeFileSync(childPath, CHILD_NUMBER, "utf8");
+    session.notify("workspace/didChangeWatchedFiles", {
+      changes: [{ uri: childUri, type: 1 }],
+    });
+    const afterCreate = await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => diagnosticsFor(appUri)(params) && counted(params) === 0,
+      60000,
+    );
+    assert.equal(counted(afterCreate), 0, "a restored dependency clears the importer");
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #3918.

An out-of-editor change to a dependency (git checkout, codegen, a delete) left every open importer's diagnostics stale until the user edited the importer itself. Root cause: `didChangeWatchedFiles` gated the entire dependent-refresh path on `invalidate_global_component_references` — a check that is true only for discoverable global-component *declaration* files — so a plain `.vue`/`.ts` change early-returned before the republish loop ever ran. The machinery below the gate (`open_vue_dependents` + `publish_diagnostics_if_version`) was correct and never reached.

| phase (fixture: open `App.vue` binding `:count` against `Child.vue`) | Volar | vize before | vize after |
|---|---|---|---|
| open | clean | clean | clean |
| `Child.vue` prop narrows **on disk** + watched change | fresh publish, mismatches reported | **nothing — stale** | fresh publish, mismatches reported |
| `Child.vue` deleted | broken importer | nothing | broken importer |
| restored | clean | nothing | clean |

The gate now only decides the global-components invalidation; any watched change with open dependents also invalidates the batch cache (recomputation must read the changed files fresh) and republishes them. The dependency walk re-reads disk and re-syncs the checker's virtual documents, so the canonical session heals itself.

The full lifecycle is pinned by a new real-stdio tooling test (`tooling/lsp-watched-refresh.test.ts`, auto-discovered by the `tooling/*.test.ts` glob) — **mutation-checked**: it fails against the previous binary at the first phase and passes with the fix. maestro 710/710, CI-parity clippy clean, budgets fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Diagnostics now refresh correctly in open Vue files when watched dependencies are changed, deleted, or restored.
  * Dependent files are rechecked reliably after updates to shared components.

* **Tests**
  * Added end-to-end coverage for diagnostic refresh behavior across dependency changes and restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->