### PR TITLE
fix(maestro): anchor tsconfig paths on baseUrl and resolve alias barrels

### DIFF
--- a/crates/vize_maestro/src/ide/file_rename/alias.rs
+++ b/crates/vize_maestro/src/ide/file_rename/alias.rs
@@ -13,8 +13,9 @@
 use std::path::{Path, PathBuf};
 
 use super::manual::{
-    RESOLVABLE_SCRIPT_EXTENSIONS, RenameTarget, apply_all_path_renames, candidate_exists,
-    normalize_path_buf, relative_module_path, split_specifier_suffix, strip_extension,
+    RESOLVABLE_SCRIPT_EXTENSIONS, RenameTarget, RenderStyle, apply_all_path_renames,
+    candidate_exists, is_index_file, normalize_path_buf, render_module_specifier,
+    split_specifier_suffix, strip_extension,
 };
 use crate::server::ServerState;
 
@@ -76,56 +77,70 @@ fn rewrite_alias_specifier(
             continue;
         };
         let base = normalize_path_buf(&alias.target_base.join(rest));
-        let Some((resolved, extensionless)) = probe_alias_target(state, &base, rename_targets)
-        else {
+        let Some((resolved, style)) = probe_alias_target(state, &base, rename_targets) else {
             continue;
         };
         let future = apply_all_path_renames(&resolved, rename_targets)?;
 
         if let Ok(remainder) = future.strip_prefix(&alias.target_base) {
             let mut rendered = alias.pattern_prefix.clone();
-            let remainder = if extensionless {
-                strip_extension(remainder)
-            } else {
-                remainder.to_path_buf()
-            };
-            rendered.push_str(&remainder.to_string_lossy().replace('\\', "/"));
+            rendered.push_str(&render_alias_remainder(remainder, style));
             rendered.push_str(suffix);
             return Some(rendered);
         }
         // The file left the alias subtree: no alias spelling exists any more,
         // so fall back to a relative path from the importer.
-        let rendered_target = if extensionless {
-            strip_extension(&future)
-        } else {
-            future
-        };
-        let mut rendered = relative_module_path(future_importer_dir, &rendered_target)?;
+        let mut rendered = render_module_specifier(future_importer_dir, &future, style)?;
         rendered.push_str(suffix);
         return Some(rendered);
     }
     None
 }
 
-/// Resolve the alias-substituted base to a real (or being-renamed) file:
-/// exact when the specifier carries an extension, extension probing otherwise.
-/// The flag reports whether the specifier was extensionless, which decides the
-/// rendered style.
+/// The alias-relative spelling of a renamed target, in the style the original
+/// specifier used. A directory-index import keeps that spelling as long as the
+/// moved file is still an `index.*`; `@/` alone is not a module, so a target
+/// landing directly on the alias root degrades to the extensionless spelling.
+fn render_alias_remainder(remainder: &Path, style: RenderStyle) -> std::string::String {
+    let rendered = match style {
+        RenderStyle::Explicit => normalize_path_buf(remainder),
+        RenderStyle::Extensionless => strip_extension(remainder),
+        RenderStyle::DirectoryIndex if is_index_file(remainder) => remainder
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .map_or_else(|| strip_extension(remainder), normalize_path_buf),
+        RenderStyle::DirectoryIndex => strip_extension(remainder),
+    };
+    rendered.to_string_lossy().replace('\\', "/")
+}
+
+/// Resolve the alias-substituted base to a real (or being-renamed) file: exact
+/// when the specifier carries an extension, otherwise extension probing and
+/// then directory-index probing, mirroring the relative scanner's candidate
+/// order. The style decides how the rename is re-spelled.
 fn probe_alias_target(
     state: &ServerState,
     base: &Path,
     rename_targets: &[RenameTarget],
-) -> Option<(PathBuf, bool)> {
+) -> Option<(PathBuf, RenderStyle)> {
     let resolvable = |path: &Path| {
         candidate_exists(state, path) || apply_all_path_renames(path, rename_targets).is_some()
     };
     if base.extension().is_some() {
-        return resolvable(base).then(|| (base.to_path_buf(), false));
+        return resolvable(base).then(|| (base.to_path_buf(), RenderStyle::Explicit));
     }
     for extension in RESOLVABLE_SCRIPT_EXTENSIONS {
         let candidate = base.with_extension(extension);
         if resolvable(&candidate) {
-            return Some((candidate, true));
+            return Some((candidate, RenderStyle::Extensionless));
+        }
+    }
+    for extension in RESOLVABLE_SCRIPT_EXTENSIONS {
+        let mut index_name = std::string::String::from("index.");
+        index_name.push_str(extension);
+        let candidate = base.join(index_name);
+        if resolvable(&candidate) {
+            return Some((candidate, RenderStyle::DirectoryIndex));
         }
     }
     None

--- a/crates/vize_maestro/src/ide/file_rename/alias_tests.rs
+++ b/crates/vize_maestro/src/ide/file_rename/alias_tests.rs
@@ -197,3 +197,63 @@ fn nuxt_alias_rename_edits_use_the_open_importer_buffer() {
     }
     "###);
 }
+
+#[test]
+fn aliased_directory_index_specifiers_keep_the_barrel_spelling() {
+    let dir = test_dir();
+    let root = dir.path();
+    fs::create_dir_all(root.join("src/components/Button")).unwrap();
+    fs::write(
+        root.join("tsconfig.json"),
+        // `baseUrl` anchors the targets, so `@/*` maps to `<root>/src/*`.
+        r#"{ "compilerOptions": { "baseUrl": "./src", "paths": { "@/*": ["*"] } } }"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/components/Button/index.ts"),
+        "export const Button = 1;",
+    )
+    .unwrap();
+    fs::write(
+        root.join("src/App.vue"),
+        r#"<script setup lang="ts">
+import { Button } from "@/components/Button";
+</script>
+"#,
+    )
+    .unwrap();
+
+    let state = ServerState::new();
+    state.set_workspace_root(root.to_path_buf());
+
+    // Moving the barrel directory: the target is still an `index.*`, so the
+    // directory-index spelling survives rather than gaining an `/index` tail.
+    let edit = collect_import_rename_edits(
+        &state,
+        &[FileRename {
+            old_uri: file_uri(&root.join("src/components/Button")),
+            new_uri: file_uri(&root.join("src/widgets/Button")),
+        }],
+        true,
+    )
+    .unwrap();
+    assert_snapshot!(serde_json::to_string_pretty(&normalize_edit(root, &edit)).unwrap(), @r###"
+    {
+      "src/App.vue": [
+        {
+          "newText": "@/widgets/Button",
+          "range": {
+            "end": {
+              "character": 43,
+              "line": 1
+            },
+            "start": {
+              "character": 24,
+              "line": 1
+            }
+          }
+        }
+      ]
+    }
+    "###);
+}

--- a/crates/vize_maestro/src/ide/file_rename/manual.rs
+++ b/crates/vize_maestro/src/ide/file_rename/manual.rs
@@ -16,8 +16,8 @@ use tower_lsp::lsp_types::{FileRename, Range, TextEdit, Url, WorkspaceEdit};
 
 pub(super) use self::path::{
     RESOLVABLE_SCRIPT_EXTENSIONS, RenderStyle, apply_all_path_renames, candidate_exists,
-    is_index_file, normalize_path_buf, relative_module_path, render_module_specifier,
-    rewrite_relative_specifier, split_specifier_suffix, strip_extension,
+    is_index_file, normalize_path_buf, render_module_specifier, rewrite_relative_specifier,
+    split_specifier_suffix, strip_extension,
 };
 use self::script::{collect_script_file_edits, collect_vue_edits};
 use crate::{ide::offset_to_position, server::ServerState};

--- a/crates/vize_maestro/src/ide/file_rename/manual.rs
+++ b/crates/vize_maestro/src/ide/file_rename/manual.rs
@@ -15,8 +15,9 @@ use ignore::{WalkBuilder, WalkState};
 use tower_lsp::lsp_types::{FileRename, Range, TextEdit, Url, WorkspaceEdit};
 
 pub(super) use self::path::{
-    RESOLVABLE_SCRIPT_EXTENSIONS, apply_all_path_renames, candidate_exists, normalize_path_buf,
-    relative_module_path, rewrite_relative_specifier, split_specifier_suffix, strip_extension,
+    RESOLVABLE_SCRIPT_EXTENSIONS, RenderStyle, apply_all_path_renames, candidate_exists,
+    is_index_file, normalize_path_buf, relative_module_path, render_module_specifier,
+    rewrite_relative_specifier, split_specifier_suffix, strip_extension,
 };
 use self::script::{collect_script_file_edits, collect_vue_edits};
 use crate::{ide::offset_to_position, server::ServerState};

--- a/crates/vize_maestro/src/ide/file_rename/manual/path.rs
+++ b/crates/vize_maestro/src/ide/file_rename/manual/path.rs
@@ -12,7 +12,7 @@ pub(in crate::ide::file_rename) const RESOLVABLE_SCRIPT_EXTENSIONS: &[&str] = &[
     "ts", "tsx", "d.ts", "d.mts", "d.cts", "js", "jsx", "mts", "cts", "mjs", "cjs", "vue",
 ];
 #[derive(Clone, Copy)]
-pub(super) enum RenderStyle {
+pub(in crate::ide::file_rename) enum RenderStyle {
     Explicit,
     Extensionless,
     DirectoryIndex,
@@ -62,7 +62,7 @@ pub(in crate::ide::file_rename) fn rewrite_relative_specifier(
     Some(rewritten)
 }
 
-pub(super) fn render_module_specifier(
+pub(in crate::ide::file_rename) fn render_module_specifier(
     importer_dir: &Path,
     target_path: &Path,
     style: RenderStyle,
@@ -253,6 +253,6 @@ pub(in crate::ide::file_rename) fn strip_extension(path: &Path) -> PathBuf {
     stripped
 }
 
-pub(super) fn is_index_file(path: &Path) -> bool {
+pub(in crate::ide::file_rename) fn is_index_file(path: &Path) -> bool {
     strip_extension(path).ends_with("index")
 }

--- a/crates/vize_maestro/src/ide/file_rename/manual/path.rs
+++ b/crates/vize_maestro/src/ide/file_rename/manual/path.rs
@@ -11,9 +11,8 @@ use super::RenameTarget;
 pub(in crate::ide::file_rename) const RESOLVABLE_SCRIPT_EXTENSIONS: &[&str] = &[
     "ts", "tsx", "d.ts", "d.mts", "d.cts", "js", "jsx", "mts", "cts", "mjs", "cjs", "vue",
 ];
-#[derive(Clone)]
-
-enum RenderStyle {
+#[derive(Clone, Copy)]
+pub(super) enum RenderStyle {
     Explicit,
     Extensionless,
     DirectoryIndex,
@@ -63,7 +62,7 @@ pub(in crate::ide::file_rename) fn rewrite_relative_specifier(
     Some(rewritten)
 }
 
-fn render_module_specifier(
+pub(super) fn render_module_specifier(
     importer_dir: &Path,
     target_path: &Path,
     style: RenderStyle,
@@ -254,6 +253,6 @@ pub(in crate::ide::file_rename) fn strip_extension(path: &Path) -> PathBuf {
     stripped
 }
 
-fn is_index_file(path: &Path) -> bool {
+pub(super) fn is_index_file(path: &Path) -> bool {
     strip_extension(path).ends_with("index")
 }

--- a/crates/vize_maestro/src/ide/tsconfig_paths.rs
+++ b/crates/vize_maestro/src/ide/tsconfig_paths.rs
@@ -10,9 +10,9 @@
 
 use std::path::{Path, PathBuf};
 
-/// The effective `paths` map for `source_path`: the declaring config's
-/// directory (targets resolve against it) and the (pattern, target) pairs
-/// spelled as written.
+/// The effective `paths` map for `source_path`: the directory targets resolve
+/// against — `compilerOptions.baseUrl` when set, otherwise the declaring
+/// config's own directory — and the (pattern, target) pairs spelled as written.
 pub(crate) struct ProjectPaths {
     pub(crate) anchor: PathBuf,
     pub(crate) entries: Vec<(std::string::String, std::string::String)>,
@@ -34,8 +34,15 @@ pub(crate) fn project_paths(source_path: &Path) -> Option<ProjectPaths> {
 
 fn paths_of(config_path: &Path) -> Option<ProjectPaths> {
     let value = read_jsonc(config_path)?;
-    let paths = value.get("compilerOptions")?.get("paths")?.as_object()?;
-    let anchor = config_path.parent()?.to_path_buf();
+    let compiler_options = value.get("compilerOptions")?;
+    let paths = compiler_options.get("paths")?.as_object()?;
+    let config_dir = config_path.parent()?;
+    // TypeScript resolves `paths` targets against `baseUrl` when it is set,
+    // falling back to the declaring config's directory otherwise.
+    let anchor = match compiler_options.get("baseUrl").and_then(|v| v.as_str()) {
+        Some(base_url) => config_dir.join(base_url),
+        None => config_dir.to_path_buf(),
+    };
     let mut entries = Vec::new();
     for (pattern, targets) in paths {
         for target in targets.as_array().into_iter().flatten() {
@@ -126,6 +133,50 @@ fn strip_jsonc_comments(source: &str) -> std::string::String {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    fn temp_dir() -> tempfile::TempDir {
+        let base = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("vize-tests");
+        fs::create_dir_all(&base).unwrap();
+        tempfile::tempdir_in(base).unwrap()
+    }
+
+    #[test]
+    fn base_url_anchors_path_targets() {
+        let dir = temp_dir();
+        let root = dir.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(
+            root.join("tsconfig.json"),
+            r#"{ "compilerOptions": { "baseUrl": "./src", "paths": { "@/*": ["*"] } } }"#,
+        )
+        .unwrap();
+        let paths = super::project_paths(&root.join("src/App.vue")).unwrap();
+        // `Path` equality normalizes the `.` away, so `<root>/./src` matches.
+        assert_eq!(paths.anchor, root.join("src"));
+        assert_eq!(
+            paths.entries,
+            vec![("@/*".to_string(), "*".to_string())],
+            "targets stay spelled as written"
+        );
+    }
+
+    #[test]
+    fn config_directory_anchors_path_targets_without_base_url() {
+        let dir = temp_dir();
+        let root = dir.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        fs::write(
+            root.join("tsconfig.json"),
+            r#"{ "compilerOptions": { "paths": { "@/*": ["./src/*"] } } }"#,
+        )
+        .unwrap();
+        let paths = super::project_paths(&root.join("src/App.vue")).unwrap();
+        assert_eq!(paths.anchor, root);
+    }
+
     #[test]
     fn comments_strip_without_touching_path_patterns() {
         let source = r#"{

--- a/crates/vize_maestro/src/ide/tsconfig_paths.rs
+++ b/crates/vize_maestro/src/ide/tsconfig_paths.rs
@@ -11,8 +11,8 @@
 use std::path::{Path, PathBuf};
 
 /// The effective `paths` map for `source_path`: the directory targets resolve
-/// against — `compilerOptions.baseUrl` when set, otherwise the declaring
-/// config's own directory — and the (pattern, target) pairs spelled as written.
+/// against (`compilerOptions.baseUrl` when set, otherwise the declaring
+/// config's own directory), and the (pattern, target) pairs spelled as written.
 pub(crate) struct ProjectPaths {
     pub(crate) anchor: PathBuf,
     pub(crate) entries: Vec<(std::string::String, std::string::String)>,
@@ -82,10 +82,14 @@ fn read_jsonc(path: &Path) -> Option<serde_json::Value> {
     let content = std::fs::read_to_string(path).ok()?;
     serde_json::from_str(&content)
         .ok()
-        .or_else(|| serde_json::from_str(&strip_jsonc_comments(&content)).ok())
+        .or_else(|| serde_json::from_str(&strip_jsonc_sugar(&content)).ok())
 }
 
-fn strip_jsonc_comments(source: &str) -> std::string::String {
+/// Reduce the JSONC that TypeScript accepts to the JSON `serde_json` parses:
+/// comments and trailing commas, both of which `tsc` allows anywhere. String
+/// state is tracked throughout, because every `paths` pattern contains `/*`
+/// (`"@/*"`) and a stripper that ignores it destroys the value we came for.
+fn strip_jsonc_sugar(source: &str) -> std::string::String {
     let mut out = std::string::String::with_capacity(source.len());
     let mut chars = source.chars().peekable();
     let mut in_string = false;
@@ -124,6 +128,17 @@ fn strip_jsonc_comments(source: &str) -> std::string::String {
                     }
                     last = c;
                 }
+            }
+            // A closing brace or bracket retroactively makes any comma that
+            // precedes it (across whitespace and stripped comments) trailing.
+            '}' | ']' => {
+                while out.ends_with(char::is_whitespace) {
+                    out.pop();
+                }
+                if out.ends_with(',') {
+                    out.pop();
+                }
+                out.push(c);
             }
             _ => out.push(c),
         }
@@ -178,6 +193,36 @@ mod tests {
     }
 
     #[test]
+    fn trailing_commas_and_comments_still_yield_paths() {
+        let dir = temp_dir();
+        let root = dir.path();
+        fs::create_dir_all(root.join("src")).unwrap();
+        // Everything `tsc` tolerates at once: comments, and trailing commas in
+        // the target array, the `paths` object, and `compilerOptions`.
+        fs::write(
+            root.join("tsconfig.json"),
+            r#"{
+  // aliases
+  "compilerOptions": {
+    "paths": {
+      "@/*": ["./src/*",], /* block */
+      "~/*": ["./src/*",],
+    },
+  },
+}"#,
+        )
+        .unwrap();
+        let paths = super::project_paths(&root.join("src/App.vue")).unwrap();
+        assert_eq!(
+            paths.entries,
+            vec![
+                ("@/*".to_string(), "./src/*".to_string()),
+                ("~/*".to_string(), "./src/*".to_string()),
+            ]
+        );
+    }
+
+    #[test]
     fn comments_strip_without_touching_path_patterns() {
         let source = r#"{
   // line comment
@@ -185,7 +230,7 @@ mod tests {
   "compilerOptions": { "paths": { "@/*": ["./src/*"] } }
 }"#;
         let value: serde_json::Value =
-            serde_json::from_str(&super::strip_jsonc_comments(source)).unwrap();
+            serde_json::from_str(&super::strip_jsonc_sugar(source)).unwrap();
         assert_eq!(
             value["compilerOptions"]["paths"]["@/*"][0],
             serde_json::json!("./src/*")


### PR DESCRIPTION
Follow-up to #3919 (already merged), addressing three review findings on the alias re-spelling work.

**`paths` targets now anchor on `compilerOptions.baseUrl`.** `project_paths` returned the declaring config's directory unconditionally, but TypeScript resolves `paths` targets against `baseUrl` when it is set. With `baseUrl: "./src"` and `"@/*": ["*"]`, `@/foo` resolved to `<root>/foo` instead of `<root>/src/foo`, so both the definition jump and rename re-spelling missed every alias in that (very common) `create-vue`-shaped config:

```rust
let config_dir = config_path.parent()?;
// TypeScript resolves `paths` targets against `baseUrl` when it is set,
// falling back to the declaring config's directory otherwise.
let anchor = match compiler_options.get("baseUrl").and_then(|v| v.as_str()) {
    Some(base_url) => config_dir.join(base_url),
    None => config_dir.to_path_buf(),
};
```

**Trailing commas no longer void the whole config.** The jsonc reader stripped comments but handed the result to `serde_json`, which rejects the trailing commas `tsc` accepts, so a single stray comma anywhere in `tsconfig.json` silently dropped `paths` entirely: the same failure mode as the comment bug #3919 fixed. The stripper now removes them in the same string-aware pass, treating a closing delimiter as what makes a preceding comma trailing:

```rust
// A closing brace or bracket retroactively makes any comma that
// precedes it (across whitespace and stripped comments) trailing.
'}' | ']' => {
    while out.ends_with(char::is_whitespace) {
        out.pop();
    }
    if out.ends_with(',') {
        out.pop();
    }
    out.push(c);
}
```

**Aliased directory-index imports get rename edits.** `probe_alias_target` probed `base` and `base.<ext>` only, so `@/components/Button` backed by `src/components/Button/index.ts` resolved to nothing and silently received no edit. It now falls through to `base/index.<ext>`, mirroring the relative scanner's candidate order, and carries the relative scanner's `RenderStyle` instead of a bare `extensionless` flag. That lets the barrel spelling survive the move (`@/widgets/Button`, not `@/widgets/Button/index`) while the out-of-subtree fallback reuses `render_module_specifier` verbatim. A target landing directly on the alias root degrades to `@/index`, since `@/` is not a module.

All three are unit-pinned: two anchor tests plus a comments-and-trailing-commas test in `tsconfig_paths.rs`, and a barrel-directory move in `alias_tests.rs`.

Opened as a new PR because #3919 was merged (and its branch deleted) before these comments were addressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - File renaming now preserves explicit, extensionless, and directory-index import styles.
  - Aliased imports retain the correct directory spelling when referenced folders are renamed.
  - Path aliases now resolve relative to the configured base URL when available.

- **Improvements**
  - Improved handling of comments and trailing commas in configuration files.
  - Added coverage for alias-based renaming and configuration path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->