### PR TITLE
fix(canon): editor sessions mirror reachable in-root barrels

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -124,6 +124,13 @@ pub struct VirtualProject {
 
     /// Enable Vue 2.7 / Nuxt 2 Options API compatibility for virtual files.
     options_api: bool,
+
+    /// Editor sessions register reachable in-root scripts too: they have no
+    /// generated tsconfig aliasing `.vue` imports into the mirror, so a barrel
+    /// like `src/Primitive/index.ts` must be mirrored for its `.vue`
+    /// re-exports to rewrite (#3915). Batch keeps the narrow set that
+    /// incremental sessions and Tier-L pin (#3898).
+    session_scripts: bool,
     legacy_vue2: bool,
 
     /// Opt-in type-checking of `.jsx`/`.tsx` Vue components (#1497). Default-off:

--- a/crates/vize_canon/src/batch/virtual_project/dependency_scan.rs
+++ b/crates/vize_canon/src/batch/virtual_project/dependency_scan.rs
@@ -110,7 +110,7 @@ impl VirtualProject {
                 // and force-registering them would change the scanned set that
                 // incremental sessions and Tier-L pin (#3898).
                 let is_vue = key.extension().is_some_and(|extension| extension == "vue");
-                if !is_vue && key.starts_with(&self.project_root) {
+                if !is_vue && !self.session_scripts && key.starts_with(&self.project_root) {
                     continue;
                 }
                 if !visited.insert(key.clone()) {
@@ -139,6 +139,11 @@ impl VirtualProject {
     /// The effective `paths` aliases with project-root-relative targets, as
     /// (pattern, target) pairs. Both come from the flattened chain, so the
     /// anchors match what the generated tsconfig resolves (#3886).
+    /// Opt an editor session into registering reachable in-root scripts (#3915).
+    pub(crate) fn set_session_script_registration(&mut self, enabled: bool) {
+        self.session_scripts = enabled;
+    }
+
     pub(crate) fn dependency_alias_map(&self) -> Vec<(String, String)> {
         let anchored = self.resolved_tsconfig_path();
         let aliases = self.alias_map_of(anchored.as_deref());
@@ -146,9 +151,8 @@ impl VirtualProject {
             return aliases;
         }
         // A solution-style shell (create-vue's default) declares nothing
-        // itself; the aliases live in the referenced project configs. The
-        // first referenced config that yields paths wins — the standard
-        // app/node split has exactly one (#3915).
+        // itself; the first referenced config that yields paths wins — the
+        // standard app/node split has exactly one (#3915).
         let Some(anchored) = anchored else {
             return aliases;
         };

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -47,6 +47,7 @@ impl VirtualProject {
             virtual_ts_options: VirtualTsOptions::default(),
             virtual_ts_check_options: VirtualTsCheckOptions::default(),
             options_api: false,
+            session_scripts: false,
             legacy_vue2: false,
             jsx_typecheck: false,
             dialect: vize_carton::config::VueVersion::default(),
@@ -66,11 +67,9 @@ impl VirtualProject {
         Ok(project)
     }
 
-    /// Create an empty project snapshot with the same generation settings.
-    ///
-    /// This is used by correctness-safe refreshes: source files are registered
-    /// again from disk, while every caller-configured Vue dialect and virtual
-    /// TypeScript option remains identical to the original scan.
+    /// Create an empty project snapshot with the same generation settings:
+    /// correctness-safe refreshes register source files again from disk while
+    /// every caller-configured dialect and virtual TS option stays identical.
     pub(crate) fn empty_with_same_options(&self) -> CorsaResult<Self> {
         let mut project = Self::new(&self.project_root)?;
         project.set_tsconfig_path(self.tsconfig_path.clone());

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
@@ -61,6 +61,7 @@ impl AliasContext {
         let (project_root, aliases, mirror) = match root {
             Some(root) => match VirtualProject::new(&root) {
                 Ok(mut project) => {
+                    project.set_session_script_registration(true);
                     let aliases = project.dependency_alias_map();
                     // Register the host and everything reachable, then put the
                     // companions on disk where the checker can resolve them.


### PR DESCRIPTION
Restores the second half of #3915's fix, which was lost in the #3916 squash: auto-merge fired on the branch's first commit just before the second landed, so the merged PR carries only the solution-style references fallback. Main today still degrades real-project sessions (reka-ui probes answer `any`) even though the PR that claimed to fix them is merged — re-verified on a clean main build before this cherry-pick, and re-verified typed with it.

Original rationale (unchanged, cherry-picked verbatim): the reachability pass skips in-root non-vue scripts — right for batch, where the generated tsconfig aliases `.vue` imports into the mirror, and pinned by Tier-L (#3898) — but an editor session's only road to a typed alias import is rewriting the specifier to a *mirrored* companion. `import { Primitive } from "@/Primitive"` resolved the barrel on disk, missed the mirror, stayed unrewritten, and every alias-imported symbol degraded to `any`. Sessions opt into registering reachable in-root scripts; the flag defaults off, so the batch set (and Tier-L) is untouched.

canon 854/854, CI-parity clippy clean, budgets at or under limits, reka-ui probes re-measured typed (`DefineComponent<…>` tag hover, full generic `injectComboboxRootContext` signature, 53 real members after `rootContext.`).

Process note: the auto-merge race that dropped this commit is why the release-tag verification (#3923's elk investigation) initially mis-attributed a CI flake to this change — the change had never shipped. Corrected on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->