### PR TITLE
perf(canon): cache the editor session's alias context per host

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/materialize.rs
+++ b/crates/vize_canon/src/batch/virtual_project/materialize.rs
@@ -236,6 +236,20 @@ impl VirtualProject {
         tsconfig.exists().then_some(tsconfig)
     }
 
+    /// The configs whose contents govern this project's alias map: the
+    /// anchored tsconfig plus, for a solution-style shell, everything it
+    /// references (#3923 cache invalidation).
+    pub(crate) fn governing_config_paths(&self) -> Vec<PathBuf> {
+        let Some(anchored) = self.resolved_tsconfig_path() else {
+            return Vec::new();
+        };
+        let mut paths = vec![anchored.clone()];
+        paths.extend(super::tsconfig_gen::references::referenced_project_configs(
+            &anchored,
+        ));
+        paths
+    }
+
     /// File that project-level (file-less) diagnostics are attributed to:
     /// the effective tsconfig when one exists, otherwise the project root.
     pub(crate) fn project_diagnostics_anchor(&self) -> PathBuf {

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
@@ -48,6 +48,50 @@ impl AliasContext {
     /// `content` is the host's editor buffer and `overlays` the unsaved
     /// dependency buffers: the mirror is built from those rather than from disk,
     /// so an alias import the user just typed still materializes its target.
+    /// Cached per project root (#3923): the walk + materialize dominate large
+    /// apps, and a collect cycle runs on every keystroke. A cached context is
+    /// reused only while everything it depends on is provably unchanged —
+    /// the host's import lines, every open overlay's content, the governing
+    /// tsconfigs, and the mtime of every file the mirror registered — so the
+    /// watched-refresh contract (#3918) keeps holding: a disk edit to a
+    /// dependency changes its mtime and forces a rebuild.
+    #[allow(clippy::disallowed_types)]
+    pub(super) fn for_host_cached(
+        source_path: &Path,
+        content: &str,
+        overlays: &FxHashMap<PathBuf, &str>,
+    ) -> std::sync::Arc<Self> {
+        let fingerprint = ContextFingerprint::capture(source_path, content, overlays);
+        let cache = session_cache();
+        if let Ok(mut slots) = cache.lock() {
+            if let Some(cached) = slots.get(source_path)
+                && cached.fingerprint == fingerprint
+                && cached.fingerprint.stamps_still_valid()
+            {
+                return std::sync::Arc::clone(&cached.context);
+            }
+            slots.remove(source_path);
+        }
+        let context = std::sync::Arc::new(Self::for_host(source_path, content, overlays));
+        let mut fingerprint = fingerprint;
+        fingerprint.stamp(context.as_ref());
+        if let Ok(mut slots) = cache.lock() {
+            // A handful of concurrently edited packages at most; refuse to
+            // grow without bound rather than manage recency.
+            if slots.len() >= 8 {
+                slots.clear();
+            }
+            slots.insert(
+                source_path.to_path_buf(),
+                CachedContext {
+                    fingerprint,
+                    context: std::sync::Arc::clone(&context),
+                },
+            );
+        }
+        context
+    }
+
     pub(super) fn for_host(
         source_path: &Path,
         content: &str,
@@ -135,6 +179,86 @@ impl AliasContext {
                 .unwrap_or(&spelled)
                 .to_owned(),
         )
+    }
+}
+
+#[allow(clippy::disallowed_types)]
+struct CachedContext {
+    fingerprint: ContextFingerprint,
+    context: std::sync::Arc<AliasContext>,
+}
+
+#[allow(clippy::disallowed_types)]
+fn session_cache() -> &'static std::sync::Mutex<FxHashMap<PathBuf, CachedContext>> {
+    static CACHE: std::sync::OnceLock<std::sync::Mutex<FxHashMap<PathBuf, CachedContext>>> =
+        std::sync::OnceLock::new();
+    CACHE.get_or_init(|| std::sync::Mutex::new(FxHashMap::default()))
+}
+
+/// Everything a cached context's validity depends on. The host is keyed by
+/// its import lines, not its full text: edits that cannot change the
+/// dependency closure (typing in the template, a type tweak) reuse the
+/// mirror, which is the hot path the bridge bound was tripping over.
+#[derive(PartialEq)]
+#[allow(clippy::disallowed_types)]
+struct ContextFingerprint {
+    host_imports: u64,
+    overlays: u64,
+    stamps: Vec<(PathBuf, Option<std::time::SystemTime>)>,
+}
+
+impl ContextFingerprint {
+    #[allow(clippy::disallowed_methods)]
+    fn capture(source_path: &Path, content: &str, overlays: &FxHashMap<PathBuf, &str>) -> Self {
+        use std::hash::{Hash, Hasher};
+        let mut host = std::hash::DefaultHasher::new();
+        source_path.hash(&mut host);
+        for line in content.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.contains("import") || trimmed.contains("require(") {
+                trimmed.hash(&mut host);
+            }
+        }
+        let mut overlay_entries: Vec<_> = overlays.iter().collect();
+        overlay_entries.sort_by(|left, right| left.0.cmp(right.0));
+        let mut overlay_hash = std::hash::DefaultHasher::new();
+        for (path, text) in overlay_entries {
+            path.hash(&mut overlay_hash);
+            text.hash(&mut overlay_hash);
+        }
+        Self {
+            host_imports: host.finish(),
+            overlays: overlay_hash.finish(),
+            stamps: Vec::new(),
+        }
+    }
+
+    /// Record the disk state the freshly built context depends on: governing
+    /// configs and every file the mirror registered.
+    fn stamp(&mut self, context: &AliasContext) {
+        let mut paths = vec![context.project_root.join("tsconfig.json")];
+        if let Some(mirror) = context.mirror.as_ref() {
+            paths.extend(mirror.governing_config_paths());
+            paths.extend(mirror.registered_original_paths_sorted());
+        }
+        self.stamps = paths
+            .into_iter()
+            .map(|path| {
+                let stamp = std::fs::metadata(&path)
+                    .and_then(|metadata| metadata.modified())
+                    .ok();
+                (path, stamp)
+            })
+            .collect();
+    }
+
+    fn stamps_still_valid(&self) -> bool {
+        self.stamps.iter().all(|(path, stamp)| {
+            std::fs::metadata(path)
+                .and_then(|metadata| metadata.modified())
+                .ok()
+                == *stamp
+        })
     }
 }
 

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -187,8 +187,11 @@ fn build_vue_virtual_project_with_overlays_and_options(
     // The alias mirror is built before generation, and from the same buffers the
     // dependency walk reads, so a specifier the resolver rewrites always has a
     // materialized target (#3900).
-    let alias_context =
-        super::vue_dependencies_alias::AliasContext::for_host(source_path, content, &overlays);
+    let alias_context = super::vue_dependencies_alias::AliasContext::for_host_cached(
+        source_path,
+        content,
+        &overlays,
+    );
     let host = generate_vue_document_with_options(
         source_path,
         content,


### PR DESCRIPTION
Fixes #3923.

The alias context — map resolution, the reachability walk, mirror materialization, overlay sync — was rebuilt on **every collect cycle**, so large apps paid the whole cost per keystroke; on 2-core CI runners a single cycle could outrun the 10s corsa bridge bound (the elk Real Project Matrix signature). With #3924's in-root barrel registration restored, the closure grows on real apps, which raises the stakes.

`AliasContext::for_host_cached` reuses the context only while everything it depends on is provably unchanged:

- **the host's import lines** (an import-line digest, not full text — template typing and type tweaks hit the cache, which is exactly the hot path the bound was tripping over);
- **every open overlay's content** (digest);
- **the governing tsconfigs** (anchored + a solution-style shell's references, via `VirtualProject::governing_config_paths`), by mtime;
- **every file the mirror registered**, by mtime — so a disk edit to a dependency forces a rebuild and the watched-refresh contract (#3918) holds.

Verified: the #3918 lifecycle test passes against the cached build (disk edit → stale binding reported → delete → broken → restore → clean), the reka-ui probes stay typed (#3915/#3924), canon 854/854, CI-parity clippy clean, budgets at or under limits. Eviction is a deliberate clear-at-8-roots — a handful of concurrently edited packages at most, and refusing unbounded growth beats managing recency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->