### PR TITLE
test(tooling): settle the document before probing the .value gate

### DIFF
--- a/tests/tooling/lsp-auto-insertion.test.ts
+++ b/tests/tooling/lsp-auto-insertion.test.ts
@@ -40,10 +40,27 @@ function resolveCorsaBinary(): string | undefined {
   ].find((candidate) => fs.existsSync(candidate));
 }
 
-async function request(session: LspSession, uri: string, fixture: OracleCase): Promise<unknown> {
+async function request(
+  session: LspSession,
+  uri: string,
+  fixture: OracleCase,
+  options: { settle?: boolean } = {},
+): Promise<unknown> {
   session.notify("textDocument/didOpen", {
     textDocument: { uri, languageId: "vue", version: 1, text: fixture.source },
   });
+  if (options.settle) {
+    // The `.value` decision asks the type backend; before the opened document
+    // has produced its first diagnostics the backend can answer cold and the
+    // gate degrades to no-insert. A real editing session types after the file
+    // settles, so the probe waits for that signal — the recurring release
+    // flake was exactly this race on slow runners.
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => (params as { uri: string }).uri === uri,
+      60000,
+    );
+  }
   const params: AutoInsertParams = {
     textDocument: { uri },
     selection: fixture.selection,
@@ -136,7 +153,10 @@ test("real stdio server asks Corsa type information before inserting .value", as
       autoInsert: true,
     });
     const uri = pathToFileURL(path.join(workspaceDir, "Ref.vue")).href;
-    assert.deepEqual(await request(session, uri, oracle.dotValue), oracle.dotValue.response);
+    assert.deepEqual(
+      await request(session, uri, oracle.dotValue, { settle: true }),
+      oracle.dotValue.response,
+    );
   } finally {
     await session.shutdown();
     fs.rmSync(workspaceDir, { recursive: true, force: true });


### PR DESCRIPTION
Kills the recurring release-gate flake (three of the last four tag verifications: v0.337.0, v0.339.0, v0.341.0 attempts).

`lsp-auto-insertion`'s dot-value probe fired immediately after `didOpen`; on slow runners the type backend answered cold (the failures complete in ~180ms — a fast wrong answer, not a timeout) and the `.value` gate degraded to no-insert, failing the assertion. Locally the same SHA passes every time.

The probe now waits for the opened document's first `publishDiagnostics` — the readiness signal the other real-server suites already use — before asking. The markup cases keep the immediate path since they never consult the backend. Behavior under test is unchanged; the test now measures the steady-state contract it always meant to.

Both suite tests pass locally; the flake signature is recorded in the release-recovery notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by waiting for diagnostics to settle before validating automatic insertion behavior.
  * Updated `.value` coverage to use the more stable diagnostic-waiting flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->