### PR TITLE
fix(fuzz): skip the upstream unterminated-color-function timeout shape

### DIFF
--- a/tests/fuzz/fuzz_targets/css_parse.rs
+++ b/tests/fuzz/fuzz_targets/css_parse.rs
@@ -6,12 +6,14 @@
 // serialized-AST API. Syntax errors should be returned in CssAstResult; panics
 // are always a bug in the integration layer or upstream parser boundary.
 //
-// Two upstream crash classes are skip-listed below until their fixes land
-// (#3276, #3280; retirement tracked in #3295). Production is protected by the
-// `catch_unwind` boundary in `vize_atelier_sfc::css::parser::engine_boundary`;
-// the skip only exists because libfuzzer-sys aborts inside its panic hook, so
-// a caught-and-reported upstream panic still registers as a fuzz crash. The
-// skip is deliberately broad — it costs fuzz coverage, never product behavior.
+// Three upstream defect classes are skip-listed below until their fixes land
+// (#3276, #3280, #3926; retirement tracked in #3295). Production is protected
+// by the `catch_unwind` boundary in
+// `vize_atelier_sfc::css::parser::engine_boundary`; the skips exist because
+// libfuzzer-sys aborts inside its panic hook (a caught-and-reported upstream
+// panic still registers as a fuzz crash) and counts a slow parse against its
+// timeout budget. Every skip is deliberately broad — it costs fuzz coverage,
+// never product behavior.
 use libfuzzer_sys::fuzz_target;
 use vize_atelier_sfc::{CssCompileOptions, parse_css_ast};
 
@@ -86,14 +88,75 @@ fn has_oversized_numeric_token(lower: &str) -> bool {
     false
 }
 
-/// Known upstream panic shapes (#3276, #3280): skip them so fuzzing keeps
-/// hunting new engine bugs without re-reporting the documented defects.
-fn hits_known_upstream_panic_shape(source: &str) -> bool {
+/// Color-entry functions recognized by the unparsed-value fallback. When one
+/// of these opens a parenthesis group that never closes, the recovering parser
+/// treats the entire remaining input as its arguments, and lightningcss's
+/// `TokenList` → `UnresolvedColor` path re-attempts a color parse per
+/// candidate token with nested `try_parse` rescans of the whole suffix.
+const COLOR_FUNCTIONS: [&str; 12] = [
+    "rgb(",
+    "rgba(",
+    "hsl(",
+    "hsla(",
+    "hwb(",
+    "lab(",
+    "lch(",
+    "oklab(",
+    "oklch(",
+    "color(",
+    "color-mix(",
+    "light-dark(",
+];
+
+/// Returns true when `name` occurs and its parenthesis group is still open at
+/// end of input. Parens inside strings and comments count like the tokenizer's
+/// wouldn't — the same deliberate coarseness as the other skip scanners.
+fn function_group_unterminated(lower: &str, name: &str) -> bool {
+    let bytes = lower.as_bytes();
+    let mut from = 0;
+    while let Some(found) = lower[from..].find(name) {
+        let open = from + found + name.len() - 1;
+        let mut depth = 1usize;
+        let mut i = open + 1;
+        while i < bytes.len() && depth > 0 {
+            match bytes[i] {
+                b'(' => depth += 1,
+                b')' => depth -= 1,
+                _ => {}
+            }
+            i += 1;
+        }
+        if depth > 0 {
+            return true;
+        }
+        from = open + 1;
+    }
+    false
+}
+
+/// Known upstream defect shapes (#3276, #3280 panics; #3926 timeout): skip
+/// them so fuzzing keeps hunting new engine bugs without re-reporting the
+/// documented defects.
+///
+/// The #3926 class is pathological backtracking, not a hang: unterminated
+/// color functions with rule-block braces interleaved into the open groups
+/// made a 2.6 KB input parse in ~18 s (debug) / ~2.3 s (release), which the
+/// instrumented fuzz build converts into a timeout finding. The skip keys on
+/// the simpler superset — any unterminated color-function group — because
+/// valid stylesheets always close them; a future reproducer that backtracks
+/// without a color function widens this filter rather than refuting it.
+fn hits_known_upstream_defect_shape(source: &str) -> bool {
     let lower = source.to_ascii_lowercase();
     if lower.contains('%')
         && PERCENTAGE_MATH_FUNCTIONS
             .iter()
             .any(|name| function_arguments_contain_percent(&lower, name))
+    {
+        return true;
+    }
+    if COLOR_FUNCTIONS
+        .iter()
+        .any(|name| function_group_unterminated(&lower, name))
     {
         return true;
     }
@@ -104,7 +167,7 @@ fuzz_target!(|data: &[u8]| {
     let Ok(source) = std::str::from_utf8(data) else {
         return;
     };
-    if hits_known_upstream_panic_shape(source) {
+    if hits_known_upstream_defect_shape(source) {
         return;
     }
 

--- a/tests/tooling/lsp-auto-insertion.test.ts
+++ b/tests/tooling/lsp-auto-insertion.test.ts
@@ -40,10 +40,27 @@ function resolveCorsaBinary(): string | undefined {
   ].find((candidate) => fs.existsSync(candidate));
 }
 
-async function request(session: LspSession, uri: string, fixture: OracleCase): Promise<unknown> {
+async function request(
+  session: LspSession,
+  uri: string,
+  fixture: OracleCase,
+  options: { settle?: boolean } = {},
+): Promise<unknown> {
   session.notify("textDocument/didOpen", {
     textDocument: { uri, languageId: "vue", version: 1, text: fixture.source },
   });
+  if (options.settle) {
+    // The `.value` decision asks the type backend; before the opened document
+    // has produced its first diagnostics the backend can answer cold and the
+    // gate degrades to no-insert. A real editing session types after the file
+    // settles, so the probe waits for that signal — the recurring release
+    // flake was exactly this race on slow runners.
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => (params as { uri: string }).uri === uri,
+      60000,
+    );
+  }
   const params: AutoInsertParams = {
     textDocument: { uri },
     selection: fixture.selection,
@@ -136,7 +153,10 @@ test("real stdio server asks Corsa type information before inserting .value", as
       autoInsert: true,
     });
     const uri = pathToFileURL(path.join(workspaceDir, "Ref.vue")).href;
-    assert.deepEqual(await request(session, uri, oracle.dotValue), oracle.dotValue.response);
+    assert.deepEqual(
+      await request(session, uri, oracle.dotValue, { settle: true }),
+      oracle.dotValue.response,
+    );
   } finally {
     await session.shutdown();
     fs.rmSync(workspaceDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

The `css_parse` fuzz bot found a **timeout** reproducer (#3926, run 31152029388, commit 014a2912f): a 2.6 KB input that parses in ~18 s (debug) / ~2.3 s (release) — the instrumented fuzz build converts that into a timeout finding.

## Diagnosis (no cargo-fuzz needed)

- Replayed the artifact directly against `vize_atelier_sfc::parse_css_ast`: full input 18 s, first 2600 bytes 4 ms, dropping the first 500 bytes 142 µs — the blowup needs both the head's unterminated `rgb(`/`inse(` groups and the tail.
- `sample` on the hot process attributes the entire budget to upstream lightningcss: `TokenList::parse_into` → `UnresolvedColor::parse` → `parse_rgb`/`parse_relative` with deep `try_parse`/`parse_nested_block` chains — per-candidate color parse attempts rescanning the whole remaining suffix once unterminated color functions swallow rule-block braces.
- Pure nesting of unterminated `rgb(` is linear (30 levels → 1.8 ms); the pathology needs the brace interleavings from the reproducer.

## Fix

lightningcss is pinned upstream (`=1.0.0-alpha.71`), so per the file's documented convention for upstream defects (#3276, #3280; retirement tracked in #3295) the target now skips inputs containing an **unterminated color-function group** (`rgb(`, `hsl(`, `color-mix(`, …). Valid stylesheets always close these groups; the recovering parser is only pathological when they stay open. Verified the new predicate matches the reproducer bytes and none of a valid-CSS panel (closed color functions, relative color syntax, `color-mix`, `light-dark`, nested calc).

Skip-list retirement tracking in #3295 gains this third class.

Closes #3926

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSS parsing safeguards for unterminated color functions and known parser failure conditions.
  * Improved auto-insertion test reliability by waiting for diagnostics to settle before processing requests.

* **Tests**
  * Expanded fuzz testing coverage across multiple color-function formats.
  * Updated integration test behavior to better reflect diagnostic timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->