### PR TITLE
fix(maestro): resolve component-tag definition through paths aliases and barrels

### DIFF
--- a/crates/vize_maestro/src/ide/definition/service.rs
+++ b/crates/vize_maestro/src/ide/definition/service.rs
@@ -74,6 +74,11 @@ impl super::DefinitionService {
             return Some(def);
         }
 
+        // Tags imported through a `paths` alias or package barrel (#3932).
+        if let Some(def) = import_target::component_tag_definition(ctx) {
+            return Some(def);
+        }
+
         if let Some(def) = template::find_component_prop_definition(ctx) {
             return Some(def);
         }
@@ -153,6 +158,11 @@ impl super::DefinitionService {
             && is_component_tag(&tag_name)
             && let Some(def) = template::find_component_definition(ctx, &tag_name)
         {
+            return Some(def);
+        }
+
+        // Tags imported through a `paths` alias or package barrel (#3932).
+        if let Some(def) = import_target::component_tag_definition(ctx) {
             return Some(def);
         }
 

--- a/crates/vize_maestro/src/ide/definition/service/import_target.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target.rs
@@ -29,6 +29,29 @@ pub(super) fn definition(ctx: &IdeContext<'_>) -> Option<GotoDefinitionResponse>
     locate_export(&target, &word, MAX_REEXPORT_HOPS).map(GotoDefinitionResponse::Scalar)
 }
 
+/// Definition on a component tag whose import the manual finder cannot
+/// resolve (#3932): that path handles only relative specifiers, so a tag
+/// imported through a tsconfig `paths` alias or a package barrel —
+/// `import { Primitive } from '@/Primitive'` resolving through
+/// `src/Primitive/index.ts` — answered null while hover was typed. Follows
+/// the same import-resolution and re-export hops as the imported-name jump.
+pub(super) fn component_tag_definition(ctx: &IdeContext<'_>) -> Option<GotoDefinitionResponse> {
+    let tag_name = helpers::get_tag_at_offset(&ctx.content, ctx.offset)?;
+    if !crate::ide::is_component_tag(&tag_name) {
+        return None;
+    }
+    let pascal = crate::ide::kebab_to_pascal(&tag_name);
+    for name in [tag_name.as_str(), pascal.as_str()] {
+        if let Some(specifier) = helpers::find_import_path(ctx, name)
+            && let Some(target) = resolve_import_specifier(ctx.uri, &specifier)
+            && let Some(location) = locate_export(&target, name, MAX_REEXPORT_HOPS)
+        {
+            return Some(GotoDefinitionResponse::Scalar(location));
+        }
+    }
+    None
+}
+
 /// The module specifier of the import statement that both contains `offset`
 /// and binds `word`. `None` when the cursor is not on an imported name.
 fn importing_specifier(content: &str, offset: usize, word: &str) -> Option<String> {

--- a/tests/tooling/lsp-alias-barrel-definition.test.ts
+++ b/tests/tooling/lsp-alias-barrel-definition.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+const BARREL = `export { WidgetA } from "./WidgetA.vue";
+export { WidgetB } from "./WidgetB";
+`;
+
+const WIDGET_A = `<script setup lang="ts">
+defineProps<{ label: string }>();
+</script>
+<template><b>{{ label }}</b></template>
+`;
+
+const WIDGET_B = `import { defineComponent } from "vue";
+
+export const WidgetB = defineComponent({});
+`;
+
+const APP = `<script setup lang="ts">
+import { WidgetA, WidgetB } from "@/comps";
+</script>
+<template>
+  <WidgetA label="x" />
+  <WidgetB />
+</template>
+`;
+
+// Definition on a component tag imported through a tsconfig `paths` alias and
+// a directory barrel (#3932): the manual finder resolved only relative
+// specifiers, so these tags answered null while hover was typed. reka-ui's
+// `import { Primitive } from '@/Primitive'` is this shape. No type checker is
+// required — the import-follow path is manual.
+test("definition on an alias-barrel component tag reaches the source", async (t) => {
+  const testRootDir = path.join(testOutputRoot, "lsp-alias-barrel-definition");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+  try {
+    const compsDir = path.join(workspaceDir, "src/comps");
+    fs.mkdirSync(compsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(workspaceDir, "tsconfig.json"),
+      JSON.stringify({
+        include: ["src/**/*"],
+        compilerOptions: {
+          strict: true,
+          paths: { "@/*": ["./src/*"] },
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(path.join(compsDir, "index.ts"), BARREL, "utf8");
+    fs.writeFileSync(path.join(compsDir, "WidgetA.vue"), WIDGET_A, "utf8");
+    fs.writeFileSync(path.join(compsDir, "WidgetB.ts"), WIDGET_B, "utf8");
+    const appPath = path.join(workspaceDir, "src/App.vue");
+    fs.writeFileSync(appPath, APP, "utf8");
+
+    await session.initialize(workspaceDir, {
+      editor: true,
+      typecheck: false,
+      lint: false,
+      autoInsert: false,
+    });
+    const appUri = pathToFileURL(appPath).href;
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri: appUri, languageId: "vue", version: 1, text: APP },
+    });
+
+    const definitionAt = async (line: number, character: number) =>
+      (await session.request("textDocument/definition", {
+        textDocument: { uri: appUri },
+        position: { line, character },
+      })) as { uri: string; range: { start: { line: number } } } | null;
+
+    // `<WidgetA` on line 4 resolves through the barrel to the .vue source.
+    const vueTarget = await definitionAt(4, 4);
+    assert.ok(vueTarget, "the .vue barrel tag must answer a definition");
+    assert.ok(
+      vueTarget.uri.endsWith("src/comps/WidgetA.vue"),
+      `expected WidgetA.vue, got ${vueTarget.uri}`,
+    );
+
+    // `<WidgetB` on line 5 follows the extensionless re-export hop to the
+    // defineComponent declaration inside the .ts module (the reka-ui shape).
+    const tsTarget = await definitionAt(5, 4);
+    assert.ok(tsTarget, "the .ts barrel tag must answer a definition");
+    assert.ok(
+      tsTarget.uri.endsWith("src/comps/WidgetB.ts"),
+      `expected WidgetB.ts, got ${tsTarget.uri}`,
+    );
+    assert.equal(
+      tsTarget.range.start.line,
+      2,
+      "the jump lands on the exported declaration, not the file head",
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/lsp-alias-barrel-definition.test.ts
+++ b/tests/tooling/lsp-alias-barrel-definition.test.ts
@@ -36,7 +36,7 @@ import { WidgetA, WidgetB } from "@/comps";
 // specifiers, so these tags answered null while hover was typed. reka-ui's
 // `import { Primitive } from '@/Primitive'` is this shape. No type checker is
 // required — the import-follow path is manual.
-test("definition on an alias-barrel component tag reaches the source", async (t) => {
+test("definition on an alias-barrel component tag reaches the source", async () => {
   const testRootDir = path.join(testOutputRoot, "lsp-alias-barrel-definition");
   fs.mkdirSync(testRootDir, { recursive: true });
   const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));


### PR DESCRIPTION
## Summary

Re-measuring #3915 on reka-ui: definition on the `<Primitive` tag (imported as `import { Primitive } from '@/Primitive'`, a directory barrel re-exporting `./Primitive`) answered **null** while hover through the same import was typed. The clean-room relative control (`./Child.vue`) worked — the manual component finder's import resolution handles only `./`/`../` specifiers.

## Fix

`component_tag_definition` in the definition service routes a tag whose import the manual finder cannot resolve through the imported-name jump machinery from #3893: shared specifier resolution (relative, bare package, tsconfig `paths` with the references-following anchored reader) plus bounded `export … from` hops. Wired into both the template and art-variant paths, after the existing relative-specifier finder so its answers are unchanged.

## Verification

- reka-ui over stdio: `def-Primitive-tag` **null → `src/Primitive/Primitive.ts` 41:13-22** (the `export const Primitive = defineComponent({` declaration, following `index.ts`'s extensionless re-export). Clean-room relative control unchanged (`Child.vue` 0:0).
- New tooling gate `lsp-alias-barrel-definition.test.ts`: alias barrel to a `.vue` re-export (lands on the file) and to an extensionless `.ts` re-export (lands on the exported declaration line). Mutation-checked: fails (pass 0 / fail 1) on the pre-fix binary, passes after.
- `cargo clippy -p vize_maestro --features native` clean.

Closes #3932

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “Go to Definition” for component tags imported through TypeScript path aliases and package barrel files.
  * Component definitions now resolve correctly across Vue and TypeScript sources, including exported declarations.
* **Tests**
  * Added coverage for alias- and barrel-based component definition navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->