### PR TITLE
fix(maestro): keep Vue API and macro extras out of member-access completion

### DIFF
--- a/crates/vize_maestro/src/ide/completion/script.rs
+++ b/crates/vize_maestro/src/ide/completion/script.rs
@@ -56,8 +56,10 @@ pub(crate) fn script_extras(ctx: &IdeContext, is_setup: bool) -> Vec<CompletionI
 /// Whether the cursor completes a member name: right after a `.` (the shared
 /// detector's shape) or inside the partial identifier following one
 /// (`rootContext.fil|`), which `CursorContext` classifies as a plain
-/// identifier. The scan is ASCII-conservative — an exotic identifier falls
-/// back to including the extras, today's behavior.
+/// identifier. The receiver is classified like `complete_script` does, so an
+/// in-progress decimal literal (`1.`) is not a member position. The scan is
+/// ASCII-conservative — an exotic identifier falls back to including the
+/// extras, today's behavior.
 fn completes_a_member(content: &str, offset: usize) -> bool {
     let clamped = offset.min(content.len());
     let Some(before_cursor) = content.get(..clamped) else {
@@ -66,7 +68,19 @@ fn completes_a_member(content: &str, offset: usize) -> bool {
     let prefix_start = before_cursor
         .rfind(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '$'))
         .map_or(0, |index| index + 1);
-    before_cursor[..prefix_start].trim_end().ends_with('.')
+    let Some(before_dot) = before_cursor[..prefix_start].trim_end().strip_suffix('.') else {
+        return false;
+    };
+    // `?.` can only be optional chaining, never a numeric literal.
+    if before_dot.ends_with('?') {
+        return true;
+    }
+    let receiver_start = before_dot
+        .rfind(|c: char| {
+            !(c.is_ascii_alphanumeric() || c == '_' || c == '$' || c == '.' || c == ']')
+        })
+        .map_or(0, |index| index + 1);
+    receiver_is_member_chain(&before_dot[receiver_start..])
 }
 
 /// Get completions for script context.

--- a/crates/vize_maestro/src/ide/completion/script.rs
+++ b/crates/vize_maestro/src/ide/completion/script.rs
@@ -38,6 +38,37 @@ use crate::ide::cursor_context::CursorContext;
 pub(crate) use self::lists::{composition_api_completions, macro_completions};
 pub(crate) use self::reactive_infer::infer_reactive_value_type;
 
+/// Extras merged after the checker's answer in script positions — the Vue
+/// composition APIs, plus compiler macros in `<script setup>`. After `.` or
+/// `?.` only the accessed type's members belong, the list tsserver and Volar
+/// show, so member-access positions get none (#3933).
+pub(crate) fn script_extras(ctx: &IdeContext, is_setup: bool) -> Vec<CompletionItem> {
+    if completes_a_member(&ctx.content, ctx.offset) {
+        return Vec::new();
+    }
+    let mut extras = composition_api_completions();
+    if is_setup {
+        extras.extend(macro_completions());
+    }
+    extras
+}
+
+/// Whether the cursor completes a member name: right after a `.` (the shared
+/// detector's shape) or inside the partial identifier following one
+/// (`rootContext.fil|`), which `CursorContext` classifies as a plain
+/// identifier. The scan is ASCII-conservative — an exotic identifier falls
+/// back to including the extras, today's behavior.
+fn completes_a_member(content: &str, offset: usize) -> bool {
+    let clamped = offset.min(content.len());
+    let Some(before_cursor) = content.get(..clamped) else {
+        return false;
+    };
+    let prefix_start = before_cursor
+        .rfind(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '$'))
+        .map_or(0, |index| index + 1);
+    before_cursor[..prefix_start].trim_end().ends_with('.')
+}
+
 /// Get completions for script context.
 pub(crate) fn complete_script(ctx: &IdeContext, is_setup: bool) -> Vec<CompletionItem> {
     if is_setup

--- a/crates/vize_maestro/src/ide/completion/script/tests.rs
+++ b/crates/vize_maestro/src/ide/completion/script/tests.rs
@@ -116,6 +116,10 @@ fn member_positions_suppress_extras_identifier_positions_keep_them() {
         ("const x = fil", 13, false),
         ("", 0, false),
         ("rootContext", 11, false),
+        // An in-progress decimal literal is not member access, matching
+        // `complete_script`'s receiver classification.
+        ("1.", 2, false),
+        ("const n = 42.", 13, false),
     ];
     for (content, offset, expected) in cases {
         assert_eq!(

--- a/crates/vize_maestro/src/ide/completion/script/tests.rs
+++ b/crates/vize_maestro/src/ide/completion/script/tests.rs
@@ -102,3 +102,26 @@ fn pins_negative_and_non_inferrable_cases() {
     // A space between callee and `<` defeats the heuristic (preserved).
     assert_eq!(infer("const s = ref <Foo>()", "s", ReactiveKind::Ref), None);
 }
+
+#[test]
+fn member_positions_suppress_extras_identifier_positions_keep_them() {
+    // Bare dot, dot with a typed prefix, optional chaining, and whitespace
+    // after the dot are member positions (#3933).
+    let cases = [
+        ("rootContext.", 12, true),
+        ("rootContext.fil", 15, true),
+        ("rootContext?.fil", 16, true),
+        ("rootContext.  ", 14, true),
+        // Identifier positions keep the extras.
+        ("const x = fil", 13, false),
+        ("", 0, false),
+        ("rootContext", 11, false),
+    ];
+    for (content, offset, expected) in cases {
+        assert_eq!(
+            super::completes_a_member(content, offset),
+            expected,
+            "content={content:?} offset={offset}"
+        );
+    }
+}

--- a/crates/vize_maestro/src/ide/completion/service.rs
+++ b/crates/vize_maestro/src/ide/completion/service.rs
@@ -115,9 +115,7 @@ impl super::CompletionService {
                         let items = Self::complete_script_with_corsa(ctx, true, bridge).await;
                         if !items.is_empty() {
                             let mut all = items;
-                            let mut v = script::composition_api_completions();
-                            v.extend(script::macro_completions());
-                            all.extend(v);
+                            all.extend(script::script_extras(ctx, true));
                             return Some(CompletionResponse::Array(all));
                         }
                     }
@@ -128,7 +126,7 @@ impl super::CompletionService {
                         let items = Self::complete_script_with_corsa(ctx, false, bridge).await;
                         if !items.is_empty() {
                             let mut all = items;
-                            all.extend(script::composition_api_completions());
+                            all.extend(script::script_extras(ctx, false));
                             return Some(CompletionResponse::Array(all));
                         }
                     }
@@ -186,12 +184,8 @@ impl super::CompletionService {
                         vec![]
                     }
                     BlockType::Template => template::corsa_template_completions(ctx),
-                    BlockType::Script => script::composition_api_completions(),
-                    BlockType::ScriptSetup => {
-                        let mut v = script::composition_api_completions();
-                        v.extend(script::macro_completions());
-                        v
-                    }
+                    BlockType::Script => script::script_extras(ctx, false),
+                    BlockType::ScriptSetup => script::script_extras(ctx, true),
                     BlockType::Style(_) => style::vue_css_completions(),
                     BlockType::Art(_) => vec![],
                 });


### PR DESCRIPTION
## Summary

Re-measuring #3915 on reka-ui: completion after `rootContext.` in `<script setup>` answered the 24 real context members from corsa, then appended the identifier-position extras — `ref`/`reactive`/`computed`/`watch`, lifecycle hooks, and `define*` macro snippets (invalid in member position). tsserver/Volar list only the accessed type's members after a dot.

## Fix

`script_extras()` (completion/script.rs) now owns the extras merge for the plain and art script paths, and returns nothing when the cursor completes a member name — right after `.`/`?.` (the shared `CursorContext` shape) or inside the partial identifier following one (`rootContext.fil|`), which the shared detector classifies as a plain identifier. Identifier positions keep the extras. The service arms dedupe into the helper (service.rs shrinks by 6 lines; it is over the file budget and must not grow).

## Verification

- reka-ui over stdio: `rootContext.` completion **53 → 24 items**, extras NONE, first items `modelValue/multiple/disabled/open` — the oracle's member list.
- Identifier-position probe on the same file keeps `ref`/`computed`/`defineProps`.
- New unit cases for `completes_a_member` (bare dot, typed prefix, `?.`, whitespace-after-dot, identifier/empty/no-dot negatives).
- `cargo test -p vize_maestro --features native` green; clippy clean.

Closes #3933

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved script editor completions for Composition API features and optional `<script setup>` macros.
  * Suggestions are now context-aware and hidden when completing object members after dots, optional chaining, or partial member names.

* **Bug Fixes**
  * Prevented unrelated completion suggestions from appearing during member-access completion.
  * Preserved relevant suggestions at ordinary identifier positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->