### PR TITLE
fix(canon): pin the Corsa checker count so diagnostics stop varying by machine

### DIFF
--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -13,10 +13,12 @@ use crate::batch::executor::diagnostics::{
 use vize_carton::{FxHashMap, profile};
 use vize_carton::{String, cstr};
 
+mod checkers;
 mod diagnostic_paths;
 mod import_resolution;
 mod project_diagnostics;
 
+use checkers::checker_count;
 use diagnostic_paths::normalize_cli_path;
 use import_resolution::resolve_virtual_import;
 
@@ -25,13 +27,7 @@ pub(super) fn check_with_cli(
     project: &VirtualProject,
 ) -> CorsaResult<TypeCheckResult> {
     let config_path = project.virtual_root().join("tsconfig.json");
-    run_cli_for_config(corsa_path, project, &config_path, Some(available_threads()))
-}
-
-fn available_threads() -> usize {
-    std::thread::available_parallelism()
-        .map(std::num::NonZero::get)
-        .unwrap_or(1)
+    run_cli_for_config(corsa_path, project, &config_path, Some(checker_count()))
 }
 
 /// Run the project check sharded across `servers` concurrent Corsa CLI
@@ -63,8 +59,9 @@ pub(super) fn check_with_cli_sharded(
     }
 
     let owners = &plan.owners;
-    // Split the machine's checker budget across the concurrent programs.
-    let checkers = (available_threads() / config_paths.len()).max(4);
+    // Shards already parallelize across processes; each process keeps the
+    // deterministic per-program checker count (see `checker_count`).
+    let checkers = checker_count();
     let results = profile!("canon.corsa.cli.sharded", {
         std::thread::scope(|scope| {
             let handles: Vec<_> = config_paths

--- a/crates/vize_canon/src/batch/executor/cli/checkers.rs
+++ b/crates/vize_canon/src/batch/executor/cli/checkers.rs
@@ -1,0 +1,36 @@
+//! Deterministic Corsa checker sizing (#3905).
+
+/// Checker workers per Corsa process. Corsa's parallel checker partitions the
+/// program and inference diverges across partitions: measured on the bare
+/// npmx.dev fixture against tsc 6.0.3 (315 diagnostics), worker counts of
+/// 4/8/14 each produce a DIFFERENT set and drop 15–18 oracle diagnostics,
+/// while one worker is count-exact (#3905). Machine-derived counts also made
+/// `vize check` report different errors on different machines for the same
+/// commit. Pinned to one until the upstream divergence is fixed;
+/// `VIZE_CHECKERS` opts back into width where throughput matters more than
+/// oracle fidelity.
+pub(super) fn checker_count() -> usize {
+    std::env::var("VIZE_CHECKERS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|&count| count >= 1)
+        .unwrap_or(1)
+}
+
+#[cfg(test)]
+mod tests {
+    /// The default is pinned, not machine-derived — the whole point of #3905.
+    #[test]
+    fn default_is_one_checker_env_overrides() {
+        // Serialized by cargo's per-process test env: mutate and restore.
+        unsafe { std::env::remove_var("VIZE_CHECKERS") };
+        assert_eq!(super::checker_count(), 1);
+        unsafe { std::env::set_var("VIZE_CHECKERS", "6") };
+        assert_eq!(super::checker_count(), 6);
+        unsafe { std::env::set_var("VIZE_CHECKERS", "0") };
+        assert_eq!(super::checker_count(), 1);
+        unsafe { std::env::set_var("VIZE_CHECKERS", "wide") };
+        assert_eq!(super::checker_count(), 1);
+        unsafe { std::env::remove_var("VIZE_CHECKERS") };
+    }
+}

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -423,8 +423,8 @@
         "maxTailToHeadLatencyRatio": 3
       },
       "batchCheckBudget": {
-        "coldMs": 60000,
-        "warmMs": 45000
+        "coldMs": 180000,
+        "warmMs": 150000
       }
     },
     {

--- a/tests/snapshots/check/__snapshots__/npmx.dev-check.snap
+++ b/tests/snapshots/check/__snapshots__/npmx.dev-check.snap
@@ -714,33 +714,51 @@
         "error:5:26 [TS2307] Cannot find module 'perfect-debounce' or its corresponding type declarations.",
         "error:82:30 [TS7006] Parameter 'r' implicitly has an 'any' type.",
         "error:91:38 [TS7006] Parameter 'r' implicitly has an 'any' type.",
-        "error:128:21 [TS7053] Element implicitly has an 'any' type because expression of type 'any' can't be used to index type 'Record<\"algolia\" | \"npm\", Set<SortKey>>'.",
-        "error:168:17 [TS7053] Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{ readonly algolia: 500; readonly npm: 500; }'.",
-        "error:177:21 [TS7053] Element implicitly has an 'any' type because expression of type 'any' can't be used to index type 'Record<\"algolia\" | \"npm\", Set<SortKey>>'.",
+        "error:129:31 [TS7006] Parameter 'k' implicitly has an 'any' type.",
         "error:355:44 [TS7006] Parameter 'r' implicitly has an 'any' type.",
         "error:364:5 [TS7006] Parameter 's' implicitly has an 'any' type.",
-        "error:380:9 [TS7006] Parameter 's' implicitly has an 'any' type."
+        "error:380:9 [TS7006] Parameter 's' implicitly has an 'any' type.",
+        "error:400:12 [TS7006] Parameter 'a' implicitly has an 'any' type.",
+        "error:400:15 [TS7006] Parameter 'b' implicitly has an 'any' type.",
+        "error:408:12 [TS7006] Parameter 'a' implicitly has an 'any' type.",
+        "error:408:15 [TS7006] Parameter 'b' implicitly has an 'any' type.",
+        "error:490:43 [TS7006] Parameter 'el' implicitly has an 'any' type."
       ]
     },
     {
       "file": "app/pages/settings.vue",
-      "diagnostics": []
+      "diagnostics": [
+        "error:39:45 [TS7006] Parameter 'locale' implicitly has an 'any' type.",
+        "error:225:39 [TS7006] Parameter 'loc' implicitly has an 'any' type."
+      ]
     },
     {
       "file": "app/pages/~[username]/index.vue",
       "diagnostics": [
-        "error:2:26 [TS2307] Cannot find module 'perfect-debounce' or its corresponding type declarations."
+        "error:2:26 [TS2307] Cannot find module 'perfect-debounce' or its corresponding type declarations.",
+        "error:74:7 [TS7006] Parameter 'pkg' implicitly has an 'any' type.",
+        "error:83:18 [TS7006] Parameter 'a' implicitly has an 'any' type.",
+        "error:83:21 [TS7006] Parameter 'b' implicitly has an 'any' type.",
+        "error:90:18 [TS7006] Parameter 'a' implicitly has an 'any' type.",
+        "error:90:21 [TS7006] Parameter 'b' implicitly has an 'any' type.",
+        "error:93:18 [TS7006] Parameter 'a' implicitly has an 'any' type.",
+        "error:93:21 [TS7006] Parameter 'b' implicitly has an 'any' type.",
+        "error:97:18 [TS7006] Parameter 'a' implicitly has an 'any' type.",
+        "error:97:21 [TS7006] Parameter 'b' implicitly has an 'any' type.",
+        "error:108:43 [TS7006] Parameter 'sum' implicitly has an 'any' type.",
+        "error:108:48 [TS7006] Parameter 'pkg' implicitly has an 'any' type."
       ]
     },
     {
       "file": "app/pages/~[username]/orgs.vue",
       "diagnostics": [
-        "error:44:7 [TS2322] Type '{} | null' is not assignable to type '\"admin\" | \"developer\" | \"owner\" | null'.\nType '{}' is not assignable to type '\"admin\" | \"developer\" | \"owner\" | null'.",
-        "error:65:32 [TS7006] Parameter 'name' implicitly has an 'any' type."
+        "error:43:50 [TS7031] Binding element 'k' implicitly has an 'any' type.",
+        "error:65:32 [TS7006] Parameter 'name' implicitly has an 'any' type.",
+        "error:73:40 [TS7006] Parameter 'org' implicitly has an 'any' type."
       ]
     }
   ],
-  "errorCount": 154,
+  "errorCount": 171,
   "warningCount": 0,
   "fileCount": 134
 }

--- a/tests/tooling/batch-check-budgets.test.ts
+++ b/tests/tooling/batch-check-budgets.test.ts
@@ -18,9 +18,12 @@ test("Vben and Misskey own complete batch cold and warm budgets", () => {
     coldMs: 15_000,
     warmMs: 10_000,
   });
+  // Raised with the deterministic single-checker pin (#3905): the one-program
+  // misskey check measured 61s cold on an M-series darwin, and CI runners
+  // need headroom above that.
   assert.deepEqual(loadBatchCheckBudget("misskey"), {
-    coldMs: 60_000,
-    warmMs: 45_000,
+    coldMs: 180_000,
+    warmMs: 150_000,
   });
 });
 


### PR DESCRIPTION
## Summary

#3905's "darwin check-surface drift" was never platform types: **Corsa's parallel checker mode (`--checkers N`) changes the diagnostic set with the worker count**, and `vize check` passed machine-derived counts, so every machine shape got its own baseline.

## Measurements (bare npmx.dev fixture, tsgo 7.0.0-dev.20260602.1, same materialized project)

Ground truth **tsc 6.0.3 = 315 diagnostics**:

| `--checkers` | raw diagnostics | vs tsc |
|---|---|---|
| 1 | **315** (count-exact) | 19/19 symmetric — the known elaboration differences only |
| 4 / 8 / default | 300 (identical hashes) | drops 15+ real rows |
| 14 | 297 | drops 18+ |

The committed npmx snapshot's 154 maps from the 297-shape (wide CI machine); darwin's 8 threads produced the 300-shape → 157. The `TS7053 ↔ TS7006` swaps in `app/pages/search.vue` are cross-partition inference divergence.

Controls: snapshot-era binary (a0c4bee37) on darwin reproduces today's 157 (not code drift); `tsgo -p` directly on vize's materialized project reproduces the CI shape on darwin (not platform types); per-count runs are stable.

## Fix

- `checker_count()` (new `executor/cli/checkers.rs`, unit-tested): every Corsa process gets **one checker**; `VIZE_CHECKERS` env opts back into width. Both the single-program and sharded paths use it — shards still parallelize across import-graph components, and sharded vs unsharded output is hash-identical under the pin (verified on npmx: 171 both ways, same row hash).
- npmx baseline regenerated: **154 → 171** — the previously dropped oracle rows surface. All 15 other realworld check snapshots are byte-identical under the pin (regenerated with `UPDATE_SNAPSHOTS=1`, only npmx diffs).
- misskey budget 60s/45s → **180s/150s**: the one-program misskey check measured 61s cold / 61s warm on an M-series darwin with the pin; CI runners need headroom. (`batch-check-budgets.test.ts` updated to match.)

Any machine now reproduces the committed baselines, and `vize check` reports the same errors for the same commit everywhere.

Closes #3905

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Batch checking now uses a deterministic checker count across parallel processes.
  * Checker count can be configured with the `VIZE_CHECKERS` environment variable.
  * Invalid, zero, or unset values default to one checker.
  * Updated Misskey batch-check performance thresholds to improve reliability in CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->