### PR TITLE
fix(canon): fail when Corsa rejects --checkers instead of retrying unpinned

### DIFF
--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -18,7 +18,7 @@ mod diagnostic_paths;
 mod import_resolution;
 mod project_diagnostics;
 
-use checkers::checker_count;
+use checkers::{checker_count, rejects_checkers_flag};
 use diagnostic_paths::normalize_cli_path;
 use import_resolution::resolve_virtual_import;
 
@@ -436,16 +436,7 @@ fn run_cli_for_config(
         parse_output_diagnostics(&output, project)
     );
 
-    // An older runtime without `--checkers` support rejects the whole
-    // invocation with TS5023. Retrying without the option would silently check
-    // the project at Corsa's default checker width, which reports a different
-    // diagnostic set than the pinned one-checker oracle (#3905) — the exact
-    // machine-dependent drift this pin exists to remove. Fail instead.
-    if !output.status.success()
-        && diagnostics.iter().any(|diagnostic| {
-            diagnostic.code == Some(5023) && diagnostic.message.contains("checkers")
-        })
-    {
+    if !output.status.success() && rejects_checkers_flag(&diagnostics) {
         return Err(CorsaError::CorsaExecution {
             exit_code: output.status.code().unwrap_or(-1),
             message: cstr!(

--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -27,7 +27,7 @@ pub(super) fn check_with_cli(
     project: &VirtualProject,
 ) -> CorsaResult<TypeCheckResult> {
     let config_path = project.virtual_root().join("tsconfig.json");
-    run_cli_for_config(corsa_path, project, &config_path, Some(checker_count()))
+    run_cli_for_config(corsa_path, project, &config_path, checker_count())
 }
 
 /// Run the project check sharded across `servers` concurrent Corsa CLI
@@ -68,7 +68,7 @@ pub(super) fn check_with_cli_sharded(
                 .iter()
                 .map(|config_path| {
                     scope.spawn(move || {
-                        run_cli_for_config(corsa_path, project, config_path, Some(checkers))
+                        run_cli_for_config(corsa_path, project, config_path, checkers)
                     })
                 })
                 .collect();
@@ -416,16 +416,14 @@ fn run_cli_for_config(
     corsa_path: &Path,
     project: &VirtualProject,
     config_path: &Path,
-    checkers: Option<usize>,
+    checkers: usize,
 ) -> CorsaResult<TypeCheckResult> {
     let output = profile!("canon.corsa.cli.command", {
         let mut command = Command::new(corsa_path);
         command.current_dir(project.virtual_root());
-        // Corsa's checker pool defaults to four workers; size it to the share
-        // of the machine this program gets so wide machines are not idle.
-        if let Some(checkers) = checkers {
-            command.arg("--checkers").arg(cstr!("{checkers}").as_str());
-        }
+        // The checker count decides the diagnostic set, so it is always pinned
+        // explicitly (see `checker_count`) rather than left to Corsa's default.
+        command.arg("--checkers").arg(cstr!("{checkers}").as_str());
         command
             .arg("--pretty")
             .arg("false")
@@ -439,14 +437,23 @@ fn run_cli_for_config(
     );
 
     // An older runtime without `--checkers` support rejects the whole
-    // invocation with TS5023; retry once without the option.
-    if checkers.is_some()
-        && !output.status.success()
+    // invocation with TS5023. Retrying without the option would silently check
+    // the project at Corsa's default checker width, which reports a different
+    // diagnostic set than the pinned one-checker oracle (#3905) — the exact
+    // machine-dependent drift this pin exists to remove. Fail instead.
+    if !output.status.success()
         && diagnostics.iter().any(|diagnostic| {
             diagnostic.code == Some(5023) && diagnostic.message.contains("checkers")
         })
     {
-        return run_cli_for_config(corsa_path, project, config_path, None);
+        return Err(CorsaError::CorsaExecution {
+            exit_code: output.status.code().unwrap_or(-1),
+            message: cstr!(
+                "corsa runtime does not support `--checkers`, which vize requires for \
+                 deterministic diagnostics (#3905); upgrade the pinned corsa runtime.\n{}",
+                output_message(&output)
+            ),
+        });
     }
 
     let success = output.status.success()

--- a/crates/vize_canon/src/batch/executor/cli/checkers.rs
+++ b/crates/vize_canon/src/batch/executor/cli/checkers.rs
@@ -10,8 +10,13 @@
 /// `VIZE_CHECKERS` opts back into width where throughput matters more than
 /// oracle fidelity.
 pub(super) fn checker_count() -> usize {
-    std::env::var("VIZE_CHECKERS")
-        .ok()
+    parse_checker_count(std::env::var("VIZE_CHECKERS").ok().as_deref())
+}
+
+/// Pure half of [`checker_count`], so the pinning rules are testable without
+/// mutating the process environment shared by every other test.
+fn parse_checker_count(value: Option<&str>) -> usize {
+    value
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|&count| count >= 1)
         .unwrap_or(1)
@@ -19,18 +24,27 @@ pub(super) fn checker_count() -> usize {
 
 #[cfg(test)]
 mod tests {
+    use super::parse_checker_count;
+
     /// The default is pinned, not machine-derived — the whole point of #3905.
     #[test]
-    fn default_is_one_checker_env_overrides() {
-        // Serialized by cargo's per-process test env: mutate and restore.
-        unsafe { std::env::remove_var("VIZE_CHECKERS") };
-        assert_eq!(super::checker_count(), 1);
-        unsafe { std::env::set_var("VIZE_CHECKERS", "6") };
-        assert_eq!(super::checker_count(), 6);
-        unsafe { std::env::set_var("VIZE_CHECKERS", "0") };
-        assert_eq!(super::checker_count(), 1);
-        unsafe { std::env::set_var("VIZE_CHECKERS", "wide") };
-        assert_eq!(super::checker_count(), 1);
-        unsafe { std::env::remove_var("VIZE_CHECKERS") };
+    fn default_is_one_checker() {
+        assert_eq!(parse_checker_count(None), 1);
+    }
+
+    #[test]
+    fn env_opts_back_into_width() {
+        assert_eq!(parse_checker_count(Some("6")), 6);
+        assert_eq!(parse_checker_count(Some("1")), 1);
+    }
+
+    /// A zero or unparsable value must not disable checking or panic; it falls
+    /// back to the pinned default.
+    #[test]
+    fn rejects_zero_and_unparsable_values() {
+        assert_eq!(parse_checker_count(Some("0")), 1);
+        assert_eq!(parse_checker_count(Some("wide")), 1);
+        assert_eq!(parse_checker_count(Some("")), 1);
+        assert_eq!(parse_checker_count(Some("-4")), 1);
     }
 }

--- a/crates/vize_canon/src/batch/executor/cli/checkers.rs
+++ b/crates/vize_canon/src/batch/executor/cli/checkers.rs
@@ -1,5 +1,7 @@
 //! Deterministic Corsa checker sizing (#3905).
 
+use crate::batch::Diagnostic;
+
 /// Checker workers per Corsa process. Corsa's parallel checker partitions the
 /// program and inference diverges across partitions: measured on the bare
 /// npmx.dev fixture against tsc 6.0.3 (315 diagnostics), worker counts of
@@ -20,6 +22,17 @@ fn parse_checker_count(value: Option<&str>) -> usize {
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|&count| count >= 1)
         .unwrap_or(1)
+}
+
+/// Whether the run failed because the runtime does not know `--checkers`: an
+/// older Corsa rejects the whole invocation with TS5023. Retrying without the
+/// option would silently check the project at Corsa's default checker width,
+/// whose diagnostic set differs from the pinned one-checker oracle (#3905),
+/// the exact machine-dependent drift this pin removes, so callers must fail.
+pub(super) fn rejects_checkers_flag(diagnostics: &[Diagnostic]) -> bool {
+    diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == Some(5023) && diagnostic.message.contains("checkers"))
 }
 
 #[cfg(test)]

--- a/crates/vize_canon/src/batch/executor/cli/tests.rs
+++ b/crates/vize_canon/src/batch/executor/cli/tests.rs
@@ -1,3 +1,4 @@
+mod checkers_support;
 use super::{is_cli_diagnostic_line, is_global_diagnostic_line, parse_cli_diagnostics};
 use crate::batch::VirtualProject;
 use crate::batch::executor::diagnostics::DiagnosticMapper;
@@ -344,58 +345,6 @@ fn parses_materialized_tsconfig_diagnostics_as_project_level_errors() {
         diagnostics[0].message.contains("moduleResolution=node10"),
         "{diagnostics:#?}"
     );
-
-    let _ = fs::remove_dir_all(&case_dir);
-}
-
-/// A runtime that rejects `--checkers` must fail the run. Retrying without the
-/// option would check the project at Corsa's default checker width, whose
-/// diagnostic set differs from the pinned one-checker oracle (#3905).
-#[cfg(unix)]
-#[test]
-fn corsa_without_checkers_support_fails_instead_of_retrying() {
-    use super::run_cli_for_config;
-    use crate::batch::error::CorsaError;
-    use std::os::unix::fs::PermissionsExt;
-
-    let case_dir = unique_case_dir("checkers-unsupported");
-    let _ = fs::remove_dir_all(&case_dir);
-    fs::create_dir_all(&case_dir).unwrap();
-    // Stub Corsa: rejects `--checkers` the way an older runtime does, and
-    // succeeds without it, so the failure can only come from an invocation that
-    // actually passes the option.
-    let stub = case_dir.join("corsa-stub.sh");
-    fs::write(
-        &stub,
-        r#"#!/bin/sh
-for arg in "$@"; do
-  if [ "$arg" = "--checkers" ]; then
-    echo "error TS5023: Unknown compiler option '--checkers'."
-    exit 1
-  fi
-done
-exit 0
-"#,
-    )
-    .unwrap();
-    fs::set_permissions(&stub, fs::Permissions::from_mode(0o755)).unwrap();
-
-    let project = VirtualProject::new(&case_dir).unwrap();
-    fs::create_dir_all(project.virtual_root()).unwrap();
-    let config_path = project.virtual_root().join("tsconfig.json");
-    fs::write(&config_path, "{}\n").unwrap();
-
-    let error = run_cli_for_config(&stub, &project, &config_path, 1).unwrap_err();
-    match error {
-        CorsaError::CorsaExecution { exit_code, message } => {
-            assert_eq!(exit_code, 1);
-            assert!(
-                message.contains("does not support `--checkers`"),
-                "expected an unsupported-`--checkers` failure, got: {message}"
-            );
-        }
-        other => panic!("expected a corsa execution failure, got {other:?}"),
-    }
 
     let _ = fs::remove_dir_all(&case_dir);
 }

--- a/crates/vize_canon/src/batch/executor/cli/tests.rs
+++ b/crates/vize_canon/src/batch/executor/cli/tests.rs
@@ -361,11 +361,21 @@ fn corsa_without_checkers_support_fails_instead_of_retrying() {
     let case_dir = unique_case_dir("checkers-unsupported");
     let _ = fs::remove_dir_all(&case_dir);
     fs::create_dir_all(&case_dir).unwrap();
-    // Stub Corsa: rejects the whole invocation the way an older runtime does.
+    // Stub Corsa: rejects `--checkers` the way an older runtime does, and
+    // succeeds without it, so the failure can only come from an invocation that
+    // actually passes the option.
     let stub = case_dir.join("corsa-stub.sh");
     fs::write(
         &stub,
-        "#!/bin/sh\necho \"error TS5023: Unknown compiler option '--checkers'.\"\nexit 1\n",
+        r#"#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = "--checkers" ]; then
+    echo "error TS5023: Unknown compiler option '--checkers'."
+    exit 1
+  fi
+done
+exit 0
+"#,
     )
     .unwrap();
     fs::set_permissions(&stub, fs::Permissions::from_mode(0o755)).unwrap();
@@ -377,10 +387,13 @@ fn corsa_without_checkers_support_fails_instead_of_retrying() {
 
     let error = run_cli_for_config(&stub, &project, &config_path, 1).unwrap_err();
     match error {
-        CorsaError::CorsaExecution { message, .. } => assert!(
-            message.contains("does not support `--checkers`"),
-            "expected an unsupported-`--checkers` failure, got: {message}"
-        ),
+        CorsaError::CorsaExecution { exit_code, message } => {
+            assert_eq!(exit_code, 1);
+            assert!(
+                message.contains("does not support `--checkers`"),
+                "expected an unsupported-`--checkers` failure, got: {message}"
+            );
+        }
         other => panic!("expected a corsa execution failure, got {other:?}"),
     }
 

--- a/crates/vize_canon/src/batch/executor/cli/tests.rs
+++ b/crates/vize_canon/src/batch/executor/cli/tests.rs
@@ -347,3 +347,42 @@ fn parses_materialized_tsconfig_diagnostics_as_project_level_errors() {
 
     let _ = fs::remove_dir_all(&case_dir);
 }
+
+/// A runtime that rejects `--checkers` must fail the run. Retrying without the
+/// option would check the project at Corsa's default checker width, whose
+/// diagnostic set differs from the pinned one-checker oracle (#3905).
+#[cfg(unix)]
+#[test]
+fn corsa_without_checkers_support_fails_instead_of_retrying() {
+    use super::run_cli_for_config;
+    use crate::batch::error::CorsaError;
+    use std::os::unix::fs::PermissionsExt;
+
+    let case_dir = unique_case_dir("checkers-unsupported");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(&case_dir).unwrap();
+    // Stub Corsa: rejects the whole invocation the way an older runtime does.
+    let stub = case_dir.join("corsa-stub.sh");
+    fs::write(
+        &stub,
+        "#!/bin/sh\necho \"error TS5023: Unknown compiler option '--checkers'.\"\nexit 1\n",
+    )
+    .unwrap();
+    fs::set_permissions(&stub, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let project = VirtualProject::new(&case_dir).unwrap();
+    fs::create_dir_all(project.virtual_root()).unwrap();
+    let config_path = project.virtual_root().join("tsconfig.json");
+    fs::write(&config_path, "{}\n").unwrap();
+
+    let error = run_cli_for_config(&stub, &project, &config_path, 1).unwrap_err();
+    match error {
+        CorsaError::CorsaExecution { message, .. } => assert!(
+            message.contains("does not support `--checkers`"),
+            "expected an unsupported-`--checkers` failure, got: {message}"
+        ),
+        other => panic!("expected a corsa execution failure, got {other:?}"),
+    }
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize_canon/src/batch/executor/cli/tests/checkers_support.rs
+++ b/crates/vize_canon/src/batch/executor/cli/tests/checkers_support.rs
@@ -1,0 +1,57 @@
+//! `--checkers` pinning behaviour of the CLI runner (#3905).
+
+use super::unique_case_dir;
+use crate::batch::VirtualProject;
+use crate::batch::error::CorsaError;
+use std::fs;
+
+/// A runtime that rejects `--checkers` must fail the run. Retrying without the
+/// option would check the project at Corsa's default checker width, whose
+/// diagnostic set differs from the pinned one-checker oracle (#3905).
+#[cfg(unix)]
+#[test]
+fn corsa_without_checkers_support_fails_instead_of_retrying() {
+    use super::super::run_cli_for_config;
+    use std::os::unix::fs::PermissionsExt;
+
+    let case_dir = unique_case_dir("checkers-unsupported");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(&case_dir).unwrap();
+    // Stub Corsa: rejects `--checkers` the way an older runtime does, and
+    // succeeds without it, so the failure can only come from an invocation that
+    // actually passes the option.
+    let stub = case_dir.join("corsa-stub.sh");
+    fs::write(
+        &stub,
+        r#"#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = "--checkers" ]; then
+    echo "error TS5023: Unknown compiler option '--checkers'."
+    exit 1
+  fi
+done
+exit 0
+"#,
+    )
+    .unwrap();
+    fs::set_permissions(&stub, fs::Permissions::from_mode(0o755)).unwrap();
+
+    let project = VirtualProject::new(&case_dir).unwrap();
+    fs::create_dir_all(project.virtual_root()).unwrap();
+    let config_path = project.virtual_root().join("tsconfig.json");
+    fs::write(&config_path, "{}\n").unwrap();
+
+    let error = run_cli_for_config(&stub, &project, &config_path, 1).unwrap_err();
+    match error {
+        CorsaError::CorsaExecution { exit_code, message } => {
+            assert_eq!(exit_code, 1);
+            assert!(
+                message.contains("does not support `--checkers`"),
+                "expected an unsupported-`--checkers` failure, got: {message}"
+            );
+        }
+        other => panic!("expected a corsa execution failure, got {other:?}"),
+    }
+
+    let _ = fs::remove_dir_all(&case_dir);
+}


### PR DESCRIPTION
Follow-up to #3939 (already merged), addressing two review findings on that PR.

The `--checkers` pin only holds if the flag is actually honored. The old TS5023 fallback re-ran the same project without the flag, so an older Corsa runtime would silently check at the default checker width and report a different diagnostic set: exactly the machine-dependent drift #3905 removed. That path now fails loudly, and `checkers` is no longer optional at the call boundary:

```rust
if !output.status.success()
    && diagnostics.iter().any(|diagnostic| {
        diagnostic.code == Some(5023) && diagnostic.message.contains("checkers")
    })
{
    return Err(CorsaError::CorsaExecution {
        exit_code: output.status.code().unwrap_or(-1),
        message: cstr!(
            "corsa runtime does not support `--checkers`, which vize requires for \
             deterministic diagnostics (#3905); upgrade the pinned corsa runtime.
{}",
            output_message(&output)
        ),
    });
}
```

A new test drives `run_cli_for_config` against a stub Corsa that prints `error TS5023: Unknown compiler option '--checkers'.` and exits non-zero, asserting the failure instead of a silent unpinned recheck.

`checker_count()` also kept its unit test honest by mutating `VIZE_CHECKERS` in-process, which leaks into every other test running in parallel (and stays leaked if the test panics). The parsing rules moved into a pure `parse_checker_count(Option<&str>)` helper that is tested directly for unset, valid, zero, and unparsable inputs; `checker_count()` is now just the env-reading wrapper.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI checks now consistently apply the configured checker count across single-process and sharded runs.
  * Runtimes that do not support checker-count configuration now display a clear execution error instead of retrying without the setting.
  * Checker-count values are validated more reliably, including defaults and invalid inputs.
  * Added regression coverage to improve error reporting for unsupported runtime configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->