### PR TITLE
polish(maestro): present imported component tag hovers with the oracle's keyword

### DIFF
--- a/crates/vize_maestro/src/ide/hover/declaration_keyword.rs
+++ b/crates/vize_maestro/src/ide/hover/declaration_keyword.rs
@@ -25,6 +25,9 @@ use tower_lsp::lsp_types::{Hover, HoverContents};
 
 use crate::ide::IdeContext;
 
+mod imported_tag;
+use imported_tag::imported_tag_property_keyword;
+
 /// Replace a leading synthesized `var` in a Corsa hover with the authored
 /// declaration keyword for the hovered template binding, and a leading
 /// `(parameter)` with `const` when the word is a `v-for` alias: the virtual
@@ -59,6 +62,21 @@ pub(super) fn align_hover(ctx: &IdeContext<'_>, word: &str, hover: &mut Hover) {
             markup.value = aligned;
             return;
         }
+        // A tag whose import carries no marker — a .ts `defineComponent`
+        // export like reka-ui's Primitive — hovers with the synthesized `var`
+        // and a type body that already matches the oracle; Volar opens with
+        // its ctx-property keyword there. Rewrite the keyword only (#3937).
+        if let Some(aligned) = imported_tag_property_keyword(
+            &markup.value,
+            &ctx.content,
+            ctx.offset,
+            &script_setup.content,
+            lang,
+            word,
+        ) {
+            markup.value = aligned;
+            return;
+        }
     }
     if let Some(template) = descriptor.template.as_ref()
         && ctx.offset >= template.loc.start
@@ -78,12 +96,19 @@ fn imported_component_quick_info(
     lang: Option<&str>,
     word: &str,
 ) -> Option<String> {
+    import_binds_word(script_setup, lang, word)
+        .then(|| format!("```typescript\nimport {word}\n```"))
+}
+
+/// Whether a value import declaration in `script_setup` binds `word`
+/// (default, named, aliased, or namespace).
+fn import_binds_word(script_setup: &str, lang: Option<&str>, word: &str) -> bool {
     if word.is_empty() {
-        return None;
+        return false;
     }
     let allocator = Allocator::default();
     let parsed = Parser::new(&allocator, script_setup, script_source_type(lang)).parse();
-    let binds_word = parsed.program.body.iter().any(|statement| {
+    parsed.program.body.iter().any(|statement| {
         let Statement::ImportDeclaration(import) = statement else {
             return false;
         };
@@ -103,8 +128,7 @@ fn imported_component_quick_info(
                 specifier.local().name == word
             })
         })
-    });
-    binds_word.then(|| format!("```typescript\nimport {word}\n```"))
+    })
 }
 
 /// Rewrite a quick-info block opening with `(parameter) {word}` to

--- a/crates/vize_maestro/src/ide/hover/declaration_keyword/imported_tag.rs
+++ b/crates/vize_maestro/src/ide/hover/declaration_keyword/imported_tag.rs
@@ -24,7 +24,7 @@ pub(super) fn imported_tag_property_keyword(
         return None;
     }
     let following = markdown[after_fence + synthesized.len()..].chars().next();
-    if following.is_some_and(|c| c == '_' || c == '$' || c.is_ascii_alphanumeric()) {
+    if following.is_some_and(|c| c == '_' || c == '$' || c.is_alphanumeric()) {
         return None;
     }
     if !hover_is_on_tag(content, offset, word) {
@@ -43,14 +43,21 @@ pub(super) fn imported_tag_property_keyword(
 /// Whether `offset` sits inside an occurrence of `word` that is written as a
 /// tag name — immediately preceded by `<`. A hover on the same identifier in
 /// an expression keeps the checker's answer.
+///
+/// The identifier scan is Unicode-aware: a non-ASCII letter such as the `Å` of
+/// `<ÅButton` continues the name rather than ending it, and `index` advances by
+/// the separator's full UTF-8 width so the resulting byte offset stays on a
+/// char boundary.
 fn hover_is_on_tag(content: &str, offset: usize, word: &str) -> bool {
     let clamped = offset.min(content.len());
     let Some(before) = content.get(..clamped) else {
         return false;
     };
     let word_start = before
-        .rfind(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '$' || c == '-'))
-        .map_or(0, |index| index + 1);
+        .char_indices()
+        .rev()
+        .find(|(_, c)| !(c.is_alphanumeric() || *c == '_' || *c == '$' || *c == '-'))
+        .map_or(0, |(index, c)| index + c.len_utf8());
     content
         .get(word_start..)
         .is_some_and(|rest| rest.starts_with(word))

--- a/crates/vize_maestro/src/ide/hover/declaration_keyword/imported_tag.rs
+++ b/crates/vize_maestro/src/ide/hover/declaration_keyword/imported_tag.rs
@@ -1,0 +1,58 @@
+//! Keyword alignment for marker-less imported component tags (#3937).
+
+use super::import_binds_word;
+
+/// Rewrite a quick-info block opening with `var {word}` to `(property) {word}`
+/// when the hover sits on a component tag (`<Word`) and an import binds the
+/// word — the Volar 2.2.10 oracle shape for tags backed by non-.vue modules
+/// (#3937). The type body is left untouched; it already matches.
+pub(super) fn imported_tag_property_keyword(
+    markdown: &str,
+    content: &str,
+    offset: usize,
+    script_setup: &str,
+    lang: Option<&str>,
+    word: &str,
+) -> Option<String> {
+    if word.is_empty() {
+        return None;
+    }
+    let fence_start = markdown.find("```")?;
+    let after_fence = markdown[fence_start..].find('\n')? + fence_start + 1;
+    let synthesized = format!("var {word}");
+    if !markdown[after_fence..].starts_with(&synthesized) {
+        return None;
+    }
+    let following = markdown[after_fence + synthesized.len()..].chars().next();
+    if following.is_some_and(|c| c == '_' || c == '$' || c.is_ascii_alphanumeric()) {
+        return None;
+    }
+    if !hover_is_on_tag(content, offset, word) {
+        return None;
+    }
+    if !import_binds_word(script_setup, lang, word) {
+        return None;
+    }
+    let mut rewritten = String::with_capacity(markdown.len() + "(property)".len());
+    rewritten.push_str(&markdown[..after_fence]);
+    rewritten.push_str("(property)");
+    rewritten.push_str(&markdown[after_fence + "var".len()..]);
+    Some(rewritten)
+}
+
+/// Whether `offset` sits inside an occurrence of `word` that is written as a
+/// tag name — immediately preceded by `<`. A hover on the same identifier in
+/// an expression keeps the checker's answer.
+fn hover_is_on_tag(content: &str, offset: usize, word: &str) -> bool {
+    let clamped = offset.min(content.len());
+    let Some(before) = content.get(..clamped) else {
+        return false;
+    };
+    let word_start = before
+        .rfind(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == '$' || c == '-'))
+        .map_or(0, |index| index + 1);
+    content
+        .get(word_start..)
+        .is_some_and(|rest| rest.starts_with(word))
+        && before[..word_start].ends_with('<')
+}

--- a/crates/vize_maestro/src/ide/hover/declaration_keyword/tests.rs
+++ b/crates/vize_maestro/src/ide/hover/declaration_keyword/tests.rs
@@ -159,3 +159,63 @@ fn a_type_only_import_keeps_the_checker_answer() {
         Some("```typescript\nimport Widget\n```")
     );
 }
+
+#[test]
+fn a_marker_less_imported_tag_hover_rewrites_var_to_property() {
+    let script = "import { Primitive } from '@/Primitive'\nconst n = 1\n";
+    let content = "<script setup lang=\"ts\">\nimport { Primitive } from '@/Primitive'\nconst n = 1\n</script>\n<template>\n  <Primitive as=\"button\" />\n  {{ Primitive }}\n</template>\n";
+    let hover = "```typescript\nvar Primitive: DefineComponent<{ as: string }>\n```";
+    let on_tag = content.find("<Primitive").unwrap() + 4;
+    assert_eq!(
+        super::imported_tag::imported_tag_property_keyword(
+            hover,
+            content,
+            on_tag,
+            script,
+            Some("ts"),
+            "Primitive"
+        )
+        .as_deref(),
+        Some("```typescript\n(property) Primitive: DefineComponent<{ as: string }>\n```"),
+    );
+
+    // The same identifier in an interpolation keeps the checker's answer.
+    let in_expression = content.find("{{ Primitive").unwrap() + 5;
+    assert_eq!(
+        super::imported_tag::imported_tag_property_keyword(
+            hover,
+            content,
+            in_expression,
+            script,
+            Some("ts"),
+            "Primitive"
+        ),
+        None,
+    );
+
+    // Not import-bound: keep the checker's answer.
+    assert_eq!(
+        super::imported_tag::imported_tag_property_keyword(
+            hover,
+            content,
+            on_tag,
+            "const x = 1\n",
+            Some("ts"),
+            "Primitive"
+        ),
+        None,
+    );
+
+    // A type-only import never backs a runtime tag.
+    assert_eq!(
+        super::imported_tag::imported_tag_property_keyword(
+            hover,
+            content,
+            on_tag,
+            "import type { Primitive } from '@/Primitive'\n",
+            Some("ts"),
+            "Primitive"
+        ),
+        None,
+    );
+}

--- a/crates/vize_maestro/src/ide/hover/declaration_keyword/tests.rs
+++ b/crates/vize_maestro/src/ide/hover/declaration_keyword/tests.rs
@@ -219,3 +219,39 @@ fn a_marker_less_imported_tag_hover_rewrites_var_to_property() {
         None,
     );
 }
+
+#[test]
+fn a_non_ascii_imported_tag_name_still_rewrites_var_to_property() {
+    let script = "import { ÅButton } from '@/ÅButton'\n";
+    let content = "<script setup lang=\"ts\">\nimport { ÅButton } from '@/ÅButton'\n</script>\n<template>\n  <ÅButton as=\"button\" />\n</template>\n";
+    let hover = "```typescript\nvar ÅButton: DefineComponent<{ as: string }>\n```";
+    // Land inside the name past the two-byte leading letter.
+    let on_tag = content.find("<ÅButton").unwrap() + "<Å".len() + 1;
+    assert_eq!(
+        super::imported_tag::imported_tag_property_keyword(
+            hover,
+            content,
+            on_tag,
+            script,
+            Some("ts"),
+            "ÅButton"
+        )
+        .as_deref(),
+        Some("```typescript\n(property) ÅButton: DefineComponent<{ as: string }>\n```"),
+    );
+
+    // A non-ASCII letter directly after the word means the quick info names a
+    // longer identifier — decline rather than rewrite someone else's keyword.
+    let longer = "```typescript\nvar ÅButtonÅ: DefineComponent<{ as: string }>\n```";
+    assert_eq!(
+        super::imported_tag::imported_tag_property_keyword(
+            longer,
+            content,
+            on_tag,
+            script,
+            Some("ts"),
+            "ÅButton"
+        ),
+        None,
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up from #3894's real-project addendum. Hover on `<Primitive` in reka-ui (imported from `@/Primitive`, a `.ts` `defineComponent` export) printed `var Primitive: DefineComponent<…>` — the template-scope synthesis leaking — where Volar 2.2.10 answers `(property) Primitive: DefineComponent<…>`. The `.vue`-import case already aligns to ```import Child``` via the `__vize_component__` marker; marker-less imports kept the leak.

## Fix

`imported_tag_property_keyword` (new `declaration_keyword/imported_tag.rs`) rewrites the leading keyword only — the type body already matches the oracle — and only when all three authored facts hold: the quick info opens with `var {word}`, the hover position sits on a tag occurrence of the word (immediately preceded by `<`), and a value import binds the word. Interpolation positions, non-imported names, and `import type` keep the checker's answer.

## Verification

- reka-ui over stdio: tag hover now `(property) Primitive: DefineComponent<ExtractPropTypes<{asChild…, as…}>, …>` — keyword byte-identical to the captured Volar answer.
- Clean-room regressions unchanged: ```import Child``` (marker path), `const users: User[]`, `const it: User` at both v-for positions.
- New unit cases: tag position rewrites; interpolation position, non-imported, and type-only import all decline.
- `cargo test -p vize_maestro --features native` green; clippy clean.

Closes #3937

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hover information for imported component tags by displaying matching properties instead of generic variable labels.
  * Prevented incorrect hover updates in interpolations, non-imported bindings, type-only imports, and similarly prefixed identifiers.
  * Preserved existing type details and handled invalid or incomplete hover locations safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->