### PR TITLE
fix(atelier): hoist literal consts by top-level span, not by line-matched name

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__script_setup_multiline_type_annotation_hoists_intact.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__script_setup_multiline_type_annotation_hoists_intact.snap
@@ -4,13 +4,14 @@ expression: result.code.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
 
+const _: SomeType<
+  false
+> = true;
+
 export default /*@__PURE__*/_defineComponent({
   __name: 'anonymous',
   setup(__props) {
 
-const _: SomeType<
-  false
-> = true;
 
 return (_ctx: any,_cache: any) => {
   return null

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -610,7 +610,7 @@ const { color: bannerColor } = defineProps<{
 }
 
 #[test]
-fn test_script_setup_multiline_type_annotation_is_not_hoisted() {
+fn test_script_setup_multiline_type_annotation_hoists_intact() {
     let source = r#"<script setup lang="ts">
 const _: SomeType<
   false
@@ -627,7 +627,7 @@ const _: SomeType<
     let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
 
     insta::assert_snapshot!(
-        "script_setup_multiline_type_annotation_is_not_hoisted",
+        "script_setup_multiline_type_annotation_hoists_intact",
         result.code.as_str()
     );
 }

--- a/crates/vize_atelier_sfc/src/compile_script/inline.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline.rs
@@ -5,6 +5,8 @@
 
 mod compiler;
 #[cfg(test)]
+mod const_hoist_tests;
+#[cfg(test)]
 mod define_model_tests;
 pub(crate) mod helpers;
 #[cfg(test)]

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/hoist.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/hoist.rs
@@ -37,8 +37,11 @@ pub(super) fn separate_hoisted_consts(
     // TS parses a superset of the transformed setup in either lang.
     let source_type = SourceType::ts();
     let parsed = Parser::new(&allocator, transformed_setup, source_type).parse();
-    if parsed.panicked {
-        // Unparseable setup: hoist nothing rather than guess textually.
+    // `panicked` alone only covers an unrecoverable abort: oxc also returns a
+    // recovered program with diagnostics attached, and the statements it
+    // salvaged around a syntax error are not a trustworthy basis for moving
+    // declarations between scopes. Either way, hoist nothing rather than guess.
+    if parsed.panicked || !parsed.diagnostics.is_empty() {
         return keep_everything();
     }
 

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/hoist.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/hoist.rs
@@ -1,93 +1,105 @@
+//! Module-scope hoisting of template-referenced literal consts.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{BindingPattern, Expression, Statement, VariableDeclarationKind};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
 use vize_carton::{String, ToCompactString};
 
 use crate::script::ScriptCompileContext;
 
-use super::super::helpers::extract_const_name;
-
-/// Separate hoisted consts (literal consts that can be module-level) from setup code.
+/// Separate hoisted consts (literal consts that can be module-level) from
+/// setup code. Returns (hoisted_segments, setup_body_segments); a segment may
+/// span multiple lines.
 ///
-/// Returns (hoisted_lines, setup_body_lines).
+/// Selection is span-based on the parsed setup program: only a TOP-LEVEL
+/// single-declarator `const` with an identifier binding, a literal
+/// initializer, and a croquis `LiteralConst` binding of that name hoists. The
+/// previous line-by-line scan matched by name alone, so a function-local
+/// `const max = …` shadowing a hoistable top-level `const max = 7` was ripped
+/// out of its function into module scope — a duplicate declaration referencing
+/// setup bindings that do not exist there (#3944).
 pub(super) fn separate_hoisted_consts(
     transformed_setup: &str,
     ctx: &ScriptCompileContext,
 ) -> (Vec<String>, Vec<String>) {
-    let mut hoisted_lines: Vec<String> = Vec::new();
-    let mut setup_body_lines: Vec<String> = Vec::new();
-    let mut in_multiline_value = false;
+    let keep_everything = || {
+        (
+            Vec::new(),
+            transformed_setup
+                .lines()
+                .map(|line| line.to_compact_string())
+                .collect(),
+        )
+    };
 
-    for line in transformed_setup.lines() {
-        let trimmed = line.trim();
-        // Track multi-line template literals / strings - don't hoist individual lines
-        if in_multiline_value {
-            setup_body_lines.push(line.to_compact_string());
-            // Count unescaped backticks to detect end of template literal
-            let backticks = trimmed
-                .chars()
-                .fold((0usize, false), |(count, escaped), c| {
-                    if escaped {
-                        (count, false)
-                    } else if c == '\\' {
-                        (count, true)
-                    } else if c == '`' {
-                        (count + 1, false)
-                    } else {
-                        (count, false)
-                    }
-                })
-                .0;
-            if backticks % 2 == 1 {
-                in_multiline_value = false;
-            }
-            continue;
-        }
-        // Check if this is a literal const that should be hoisted
-        if trimmed.starts_with("const ") && !trimmed.starts_with("const {") {
-            // Check for multi-line const where value is on the next line (e.g., `const x =\n  'value'`)
-            if let Some(eq_pos) = trimmed.find('=') {
-                let value_part = trimmed[eq_pos + 1..].trim();
-                // If value part is empty, the value is on the next line - don't hoist
-                if value_part.is_empty() {
-                    setup_body_lines.push(line.to_compact_string());
-                    continue;
-                }
-                // Check for multi-line template literal (unclosed backtick)
-                let backticks = value_part
-                    .chars()
-                    .fold((0usize, false), |(count, escaped), c| {
-                        if escaped {
-                            (count, false)
-                        } else if c == '\\' {
-                            (count, true)
-                        } else if c == '`' {
-                            (count + 1, false)
-                        } else {
-                            (count, false)
-                        }
-                    })
-                    .0;
-                if backticks % 2 == 1 {
-                    // Unclosed template literal - don't hoist, mark as multi-line
-                    in_multiline_value = true;
-                    setup_body_lines.push(line.to_compact_string());
-                    continue;
-                }
-            } else {
-                setup_body_lines.push(line.to_compact_string());
-                continue;
-            }
-            // Extract variable name and check if it's LiteralConst
-            if let Some(name) = extract_const_name(trimmed)
-                && matches!(
-                    ctx.bindings.bindings.get(name.as_str()),
-                    Some(crate::types::BindingType::LiteralConst)
-                )
-            {
-                hoisted_lines.push(line.to_compact_string());
-                continue;
-            }
-        }
-        setup_body_lines.push(line.to_compact_string());
+    let allocator = Allocator::default();
+    // TS parses a superset of the transformed setup in either lang.
+    let source_type = SourceType::ts();
+    let parsed = Parser::new(&allocator, transformed_setup, source_type).parse();
+    if parsed.panicked {
+        // Unparseable setup: hoist nothing rather than guess textually.
+        return keep_everything();
     }
 
-    (hoisted_lines, setup_body_lines)
+    let mut hoisted: Vec<String> = Vec::new();
+    let mut body: Vec<String> = Vec::new();
+    let mut prev_end = 0usize;
+
+    for statement in &parsed.program.body {
+        let span = statement.span();
+        let (start, end) = (span.start as usize, span.end as usize);
+        if start < prev_end || end > transformed_setup.len() || start > end {
+            return keep_everything();
+        }
+        // Gaps (blank lines, comments) stay with the setup body in order.
+        let gap = &transformed_setup[prev_end..start];
+        if !gap.trim().is_empty() {
+            body.push(gap.trim_matches('\n').into());
+        }
+        let slice: String = transformed_setup[start..end].into();
+        if is_hoistable_literal_const(statement, ctx) {
+            hoisted.push(slice);
+        } else {
+            body.push(slice);
+        }
+        prev_end = end;
+    }
+    let tail = &transformed_setup[prev_end..];
+    if !tail.trim().is_empty() {
+        body.push(tail.trim_matches('\n').into());
+    }
+
+    (hoisted, body)
+}
+
+/// A top-level `const <ident> = <literal>` whose name croquis classified as
+/// `LiteralConst`. The initializer check keeps rewritten or computed values in
+/// setup scope even when the analysis says the binding is literal-like.
+fn is_hoistable_literal_const(statement: &Statement<'_>, ctx: &ScriptCompileContext) -> bool {
+    let Statement::VariableDeclaration(declaration) = statement else {
+        return false;
+    };
+    if declaration.kind != VariableDeclarationKind::Const || declaration.declarations.len() != 1 {
+        return false;
+    }
+    let declarator = &declaration.declarations[0];
+    let BindingPattern::BindingIdentifier(identifier) = &declarator.id else {
+        return false;
+    };
+    let initializer_is_literal = matches!(
+        declarator.init,
+        Some(
+            Expression::NumericLiteral(_)
+                | Expression::StringLiteral(_)
+                | Expression::BooleanLiteral(_)
+                | Expression::BigIntLiteral(_)
+                | Expression::NullLiteral(_)
+        )
+    );
+    initializer_is_literal
+        && matches!(
+            ctx.bindings.bindings.get(identifier.name.as_str()),
+            Some(crate::types::BindingType::LiteralConst)
+        )
 }

--- a/crates/vize_atelier_sfc/src/compile_script/inline/const_hoist_tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/const_hoist_tests.rs
@@ -1,0 +1,98 @@
+//! Scope discipline of literal-const hoisting (#3944).
+
+use super::compile_script_setup_inline;
+use crate::compile_script::TemplateParts;
+
+fn compile(source: &str) -> vize_carton::String {
+    compile_script_setup_inline(
+        source,
+        "ConstScope",
+        false,
+        true,
+        false,
+        TemplateParts {
+            imports: "",
+            hoisted: "",
+            render_fn: "",
+            render_fn_name: "",
+            preamble: "",
+            render_body: "null",
+            render_is_block: false,
+        },
+        None,
+        &[],
+        "",
+        None,
+    )
+    .map(|result| result.code)
+    .unwrap()
+}
+
+#[test]
+fn a_function_local_shadow_of_a_hoisted_const_stays_in_its_function() {
+    // The #3944 reproducer: the top-level literal `const max = 7` hoists to
+    // module scope, but the line-matched scan also ripped the function-local
+    // `const max = …` out of `hover()` — a duplicate module-scope declaration
+    // referencing setup bindings that do not exist there.
+    let source = r#"
+import { ref } from 'vue'
+
+const fetched = ref({ width: 5 })
+
+function hover() {
+    const max = fetched.value.width
+    return max
+}
+
+const max = 7
+"#;
+    let output = compile(source);
+    let component = output.find("export default").expect("component wrapper");
+
+    // Exactly one `const max` before the component: the top-level literal.
+    let hoisted_region = &output[..component];
+    assert_eq!(
+        hoisted_region.matches("const max").count(),
+        1,
+        "only the top-level literal hoists:\n{output}"
+    );
+    assert!(
+        hoisted_region.contains("const max = 7"),
+        "the hoisted one is the literal:\n{output}"
+    );
+    assert!(
+        !hoisted_region.contains("fetched.value"),
+        "no setup-scope reference may leak to module scope:\n{output}"
+    );
+
+    // The local declaration is still inside the function body.
+    let body_region = &output[component..];
+    assert!(
+        body_region.contains("const max = fetched.value.width"),
+        "the function keeps its local declaration:\n{output}"
+    );
+}
+
+#[test]
+fn non_literal_and_multi_declarator_consts_stay_in_setup() {
+    let source = r#"
+const label = 'plain'
+const computed_like = label + '!'
+const a = 1, b = 2
+"#;
+    let output = compile(source);
+    let component = output.find("export default").expect("component wrapper");
+    let hoisted_region = &output[..component];
+    assert!(
+        hoisted_region.contains("const label") && hoisted_region.contains("plain"),
+        "the string literal hoists (quotes may normalize):\n{output}"
+    );
+    assert!(
+        !hoisted_region.contains("computed_like"),
+        "computed initializers stay in setup:\n{output}"
+    );
+    assert!(
+        !hoisted_region.contains("const a"),
+        "multi-declarator statements stay in setup:\n{output}"
+    );
+}

--- a/crates/vize_atelier_sfc/src/compile_script/inline/const_hoist_tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/const_hoist_tests.rs
@@ -74,6 +74,24 @@ const max = 7
 }
 
 #[test]
+fn a_setup_that_only_parses_with_recovery_hoists_nothing() {
+    // oxc reports a syntax error either by setting `panicked` or by returning a
+    // recovered program with diagnostics attached. In the recovered case the
+    // statements it salvaged around the error are not a trustworthy basis for
+    // moving a declaration out of setup scope, so nothing hoists.
+    let source = r#"
+const label = 'plain'
+function () {}
+"#;
+    let output = compile(source);
+    let component = output.find("export default").expect("component wrapper");
+    assert!(
+        !output[..component].contains("const label"),
+        "a setup with a syntax error hoists nothing:\n{output}"
+    );
+}
+
+#[test]
 fn non_literal_and_multi_declarator_consts_stay_in_setup() {
     let source = r#"
 const label = 'plain'
@@ -94,5 +112,17 @@ const a = 1, b = 2
     assert!(
         !hoisted_region.contains("const a"),
         "multi-declarator statements stay in setup:\n{output}"
+    );
+
+    // Not hoisting is only half the contract: the declarations must still be
+    // emitted inside setup rather than dropped.
+    let body_region = &output[component..];
+    assert!(
+        body_region.contains("computed_like"),
+        "computed initializers remain in setup:\n{output}"
+    );
+    assert!(
+        body_region.contains("const a"),
+        "multi-declarator statements remain in setup:\n{output}"
     );
 }

--- a/crates/vize_atelier_sfc/src/compile_script/inline/helpers.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/helpers.rs
@@ -3,7 +3,7 @@
 //! Provides utility functions for comment stripping and const name extraction
 //! used during script parsing.
 
-use vize_carton::{String, ToCompactString};
+use vize_carton::String;
 /// Strip comments from a line for bracket/paren counting.
 /// Removes `// ...` line comments and `/* ... */` block comments while preserving string content.
 pub(crate) fn strip_comments_for_counting(line: &str) -> String {
@@ -51,23 +51,4 @@ pub(crate) fn strip_comments_for_counting(line: &str) -> String {
         }
     }
     result
-}
-
-/// Extract the variable name from a const declaration line.
-/// e.g., "const msg = 'hello'" -> Some("msg")
-/// e.g., "const count = ref(0)" -> Some("count")
-/// e.g., "const { a, b } = obj" -> None (destructure)
-pub(crate) fn extract_const_name(line: &str) -> Option<String> {
-    let rest = line.trim().strip_prefix("const ")?;
-    // Skip destructuring patterns
-    if rest.starts_with('{') || rest.starts_with('[') {
-        return None;
-    }
-    // Extract identifier before = or : (type annotation)
-    let name_end = rest.find(|c: char| c == '=' || c == ':' || c.is_whitespace())?;
-    let name = rest[..name_end].trim();
-    if name.is_empty() {
-        return None;
-    }
-    Some(name.to_compact_string())
 }


### PR DESCRIPTION
## Summary

External report #3944: with a top-level literal `const max = 7` (template-referenced) and a *function-local* `const max = fetched.value.width` in the same `<script setup>`, **both** declarations were hoisted to module scope — the local one deleted from its function — producing a duplicate `const max` that references setup bindings that do not exist at module scope, with `vize build` exiting 0.

## Root cause

`separate_hoisted_consts` scanned the transformed setup **line by line** and hoisted any `const <name>` line whose name croquis classified `LiteralConst`. Croquis bindings are keyed by top-level name, so the function-local shadow matched too.

## Fix

The pass parses the transformed setup (oxc, spans) and selects per top-level statement: only a single-declarator `const` with an identifier binding, a **literal initializer** (numeric/string/boolean/bigint/null — checked in the AST, stronger than the name lookup alone), and a `LiteralConst` croquis binding hoists. Gaps and comments stay with the setup body in order; unparseable setup hoists nothing instead of guessing textually. Multi-line statements ride along as whole segments, so a multiline type annotation no longer blocks hoisting — the snapshot that pinned that old scanner limitation flips to the const hoisting intact (test renamed `…_hoists_intact`). The line-scanning `extract_const_name` helper is removed with its only caller.

## Verification

- Reproducer now emits: top-level `const max = 7` at module scope once; `hover()` keeps its local declaration; `node --check` passes (previously duplicate-declaration invalid JS).
- New `const_hoist_tests`: the #3944 shadow shape (mutation-checked — both cases fail on the old scanner), plus non-literal and multi-declarator consts staying in setup.
- `cargo test -p vize_atelier_sfc`: 618 passed; the only failures are the 8 pre-existing `pkl`-binary fixture suites this machine cannot run (identical on clean main — CI has pkl).
- clippy/fmt clean.

Closes #3944

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compilation of inline scripts by more accurately identifying which top-level literal constants can be safely hoisted.
  * Prevented local variables, non-literal constants, and multi-declaration statements from being moved incorrectly.
  * Preserved setup code ordering, comments, and spacing during compilation.
  * Improved failure handling so code remains intact when analysis cannot be completed.

* **Tests**
  * Added regression coverage for constant hoisting, shadowed variables, and multiline TypeScript annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->