### PR TITLE
fix(vite): only rewrite fully static src values into asset imports

### DIFF
--- a/crates/vize_atelier_sfc/src/vite_plugin/transform.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/transform.rs
@@ -400,8 +400,11 @@ fn parse_src_candidate(code: &str, cursor: usize) -> Option<SrcCandidate> {
     let key_end =
         if bytes.get(cursor) == Some(&b's') && bytes.get(cursor..cursor + 3) == Some(&b"src"[..]) {
             // A bare `src` key must start at an identifier boundary, or the
-            // tail of `data_src`/`lazysrc` props would be rewritten too.
-            if cursor > 0 && is_define_tail_byte(bytes[cursor - 1]) {
+            // tail of `data_src`/`lazysrc` props would be rewritten too. Any
+            // non-ASCII byte is part of a multi-byte character that may itself
+            // be an identifier tail (`ésrc`), so reject it as well.
+            let preceding = cursor.checked_sub(1).map(|index| bytes[index]);
+            if preceding.is_some_and(|byte| !byte.is_ascii() || is_define_tail_byte(byte)) {
                 return None;
             }
             cursor + 3
@@ -426,10 +429,25 @@ fn parse_src_candidate(code: &str, cursor: usize) -> Option<SrcCandidate> {
 
     let value_start = quote_index + 1;
     let mut value_end = value_start;
-    while value_end < bytes.len() && bytes[value_end] != quote {
-        value_end += 1;
+    let mut has_escape = false;
+    while value_end < bytes.len() {
+        if bytes[value_end] == b'\\' {
+            // A backslash escapes the next byte, so an escaped quote does not
+            // terminate the literal (`src: '/images/a\', b.jpg'`).
+            has_escape = true;
+            value_end += 2;
+        } else if bytes[value_end] == quote {
+            break;
+        } else {
+            value_end += 1;
+        }
     }
     if value_end >= bytes.len() {
+        return None;
+    }
+    // An escaped literal is not a plain path: its raw slice would be emitted as
+    // an import specifier with the backslash still in it.
+    if has_escape {
         return None;
     }
     // Only a fully static value may become an import. A bound expression like

--- a/crates/vize_atelier_sfc/src/vite_plugin/transform.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/transform.rs
@@ -399,6 +399,11 @@ fn parse_src_candidate(code: &str, cursor: usize) -> Option<SrcCandidate> {
     let bytes = code.as_bytes();
     let key_end =
         if bytes.get(cursor) == Some(&b's') && bytes.get(cursor..cursor + 3) == Some(&b"src"[..]) {
+            // A bare `src` key must start at an identifier boundary, or the
+            // tail of `data_src`/`lazysrc` props would be rewritten too.
+            if cursor > 0 && is_define_tail_byte(bytes[cursor - 1]) {
+                return None;
+            }
             cursor + 3
         } else if bytes.get(cursor) == Some(&b'"')
             && bytes.get(cursor + 1..cursor + 4) == Some(&b"src"[..])
@@ -424,7 +429,22 @@ fn parse_src_candidate(code: &str, cursor: usize) -> Option<SrcCandidate> {
     while value_end < bytes.len() && bytes[value_end] != quote {
         value_end += 1;
     }
-    (value_end < bytes.len()).then_some(SrcCandidate {
+    if value_end >= bytes.len() {
+        return None;
+    }
+    // Only a fully static value may become an import. A bound expression like
+    // `:src="'/images/x-' + suffix"` compiles to a concatenation whose FIRST
+    // string literal would otherwise be hoisted as half a filename (#3945);
+    // the literal is the whole value only when the property ends right after
+    // its closing quote.
+    let after_value = skip_ascii_ws(bytes, value_end + 1);
+    if !matches!(
+        after_value.map(|index| bytes[index]),
+        None | Some(b',') | Some(b'}') | Some(b')')
+    ) {
+        return None;
+    }
+    Some(SrcCandidate {
         prefix_start: cursor,
         value_prefix_end: quote_index,
         value_start,
@@ -553,94 +573,4 @@ fn is_define_tail_byte(byte: u8) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn rewrites_static_asset_src_values() {
-        let rules = [DynamicImportAliasRule {
-            from_prefix: "@/".into(),
-            to_prefix: "/src/".into(),
-        }];
-        let code = r#"const node = { src: "@/assets/logo.svg", other: true };"#;
-
-        insta::assert_snapshot!(rewrite_static_asset_urls(code, &rules), @r###"
-        import __vize_static_0 from "@/assets/logo.svg";
-        const node = { src: __vize_static_0, other: true };
-        "###);
-    }
-
-    #[test]
-    fn skips_script_asset_src_values() {
-        let rules = [DynamicImportAliasRule {
-            from_prefix: "@/".into(),
-            to_prefix: "/src/".into(),
-        }];
-        let code = r#"const node = { src: "@/entry.ts" };"#;
-
-        assert_eq!(rewrite_static_asset_urls(code, &rules), code);
-    }
-
-    #[test]
-    fn rewrites_dynamic_template_imports() {
-        let rules = [DynamicImportAliasRule {
-            from_prefix: "@/".into(),
-            to_prefix: "/src/".into(),
-        }];
-        let code = "const image = import(`@/assets/${name}.svg`);";
-
-        assert_eq!(
-            rewrite_dynamic_template_imports(code, &rules).as_str(),
-            "const image = import(/* @vite-ignore */ `/src/assets/${name}.svg`);"
-        );
-    }
-
-    #[test]
-    fn rewrites_import_meta_glob_relative_patterns() {
-        let code = r#"const modules = import.meta.glob("./demos/*.vue", { eager: true });"#;
-
-        assert_eq!(
-            rewrite_import_meta_glob_base(code, "/project/src/App.vue", "/project").as_str(),
-            r#"const modules = import.meta.glob("/src/demos/*.vue", { eager: true });"#
-        );
-    }
-
-    #[test]
-    fn rewrites_import_meta_glob_array_and_negated_patterns() {
-        let code = r#"const modules = import.meta.glob<{ default: unknown }>(["./demos/*.vue", "!../legacy/*.vue", "/src/stable/*.vue"]);"#;
-
-        assert_eq!(
-            rewrite_import_meta_glob_base(code, "/project/src/App.vue", "/project").as_str(),
-            r#"const modules = import.meta.glob<{ default: unknown }>(["/src/demos/*.vue", "!/legacy/*.vue", "/src/stable/*.vue"]);"#
-        );
-    }
-
-    #[test]
-    fn skips_non_calls_and_non_relative_import_meta_globs() {
-        let code = r#"const text = "import.meta.glob('./demos/*.vue')"; const modules = import.meta.glob("/src/demos/*.vue");"#;
-
-        assert_eq!(
-            rewrite_import_meta_glob_base(code, "/project/src/App.vue", "/project").as_str(),
-            code
-        );
-    }
-
-    #[test]
-    fn applies_define_replacements_longest_first() {
-        let defines = [
-            DefineReplacement {
-                key: "import.meta.env".into(),
-                value: "{}".into(),
-            },
-            DefineReplacement {
-                key: "import.meta.env.MODE".into(),
-                value: "\"test\"".into(),
-            },
-        ];
-
-        assert_eq!(
-            apply_define_replacements("const mode = import.meta.env.MODE;", &defines).as_str(),
-            "const mode = \"test\";"
-        );
-    }
-}
+mod tests;

--- a/crates/vize_atelier_sfc/src/vite_plugin/transform/tests.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/transform/tests.rs
@@ -1,0 +1,123 @@
+use super::*;
+
+#[test]
+fn rewrites_static_asset_src_values() {
+    let rules = [DynamicImportAliasRule {
+        from_prefix: "@/".into(),
+        to_prefix: "/src/".into(),
+    }];
+    let code = r#"const node = { src: "@/assets/logo.svg", other: true };"#;
+
+    insta::assert_snapshot!(rewrite_static_asset_urls(code, &rules), @r###"
+        import __vize_static_0 from "@/assets/logo.svg";
+        const node = { src: __vize_static_0, other: true };
+        "###);
+}
+
+#[test]
+fn skips_script_asset_src_values() {
+    let rules = [DynamicImportAliasRule {
+        from_prefix: "@/".into(),
+        to_prefix: "/src/".into(),
+    }];
+    let code = r#"const node = { src: "@/entry.ts" };"#;
+
+    assert_eq!(rewrite_static_asset_urls(code, &rules), code);
+}
+
+#[test]
+fn rewrites_dynamic_template_imports() {
+    let rules = [DynamicImportAliasRule {
+        from_prefix: "@/".into(),
+        to_prefix: "/src/".into(),
+    }];
+    let code = "const image = import(`@/assets/${name}.svg`);";
+
+    assert_eq!(
+        rewrite_dynamic_template_imports(code, &rules).as_str(),
+        "const image = import(/* @vite-ignore */ `/src/assets/${name}.svg`);"
+    );
+}
+
+#[test]
+fn rewrites_import_meta_glob_relative_patterns() {
+    let code = r#"const modules = import.meta.glob("./demos/*.vue", { eager: true });"#;
+
+    assert_eq!(
+        rewrite_import_meta_glob_base(code, "/project/src/App.vue", "/project").as_str(),
+        r#"const modules = import.meta.glob("/src/demos/*.vue", { eager: true });"#
+    );
+}
+
+#[test]
+fn rewrites_import_meta_glob_array_and_negated_patterns() {
+    let code = r#"const modules = import.meta.glob<{ default: unknown }>(["./demos/*.vue", "!../legacy/*.vue", "/src/stable/*.vue"]);"#;
+
+    assert_eq!(
+        rewrite_import_meta_glob_base(code, "/project/src/App.vue", "/project").as_str(),
+        r#"const modules = import.meta.glob<{ default: unknown }>(["/src/demos/*.vue", "!/legacy/*.vue", "/src/stable/*.vue"]);"#
+    );
+}
+
+#[test]
+fn skips_non_calls_and_non_relative_import_meta_globs() {
+    let code = r#"const text = "import.meta.glob('./demos/*.vue')"; const modules = import.meta.glob("/src/demos/*.vue");"#;
+
+    assert_eq!(
+        rewrite_import_meta_glob_base(code, "/project/src/App.vue", "/project").as_str(),
+        code
+    );
+}
+
+#[test]
+fn applies_define_replacements_longest_first() {
+    let defines = [
+        DefineReplacement {
+            key: "import.meta.env".into(),
+            value: "{}".into(),
+        },
+        DefineReplacement {
+            key: "import.meta.env.MODE".into(),
+            value: "\"test\"".into(),
+        },
+    ];
+
+    assert_eq!(
+        apply_define_replacements("const mode = import.meta.env.MODE;", &defines).as_str(),
+        "const mode = \"test\";"
+    );
+}
+
+#[test]
+fn concatenation_prefixes_and_non_src_keys_never_become_imports() {
+    let rules = [DynamicImportAliasRule {
+        from_prefix: "/images".into(),
+        to_prefix: "/public/images".into(),
+    }];
+
+    // #3945: a bound `:src` compiles to a concatenation; hoisting its first
+    // string literal imports half a filename.
+    let concat =
+        r#"const n = { src: '/images/colors-switch-' + (color ? 'on' : 'off') + '.jpg' };"#;
+    assert_eq!(rewrite_static_asset_urls(concat, &rules), concat);
+
+    // Directory-prefix shape from the same report.
+    let dir = r#"const n = { src: '/images/services/' + locale + '/view-mac.png' };"#;
+    assert_eq!(rewrite_static_asset_urls(dir, &rules), dir);
+
+    // A snake_case prop ending in `src` is not the asset attribute.
+    let other_key = r#"const n = { data_src: '/images/a.jpg' };"#;
+    assert_eq!(rewrite_static_asset_urls(other_key, &rules), other_key);
+
+    // Fully static values still rewrite, whatever ends the property.
+    let static_comma = r#"const n = { src: '/images/a.jpg', other: true };"#;
+    insta::assert_snapshot!(rewrite_static_asset_urls(static_comma, &rules), @r###"
+    import __vize_static_0 from "/images/a.jpg";
+    const n = { src: __vize_static_0, other: true };
+    "###);
+    let static_brace = r#"const n = { src: '/images/a.jpg' };"#;
+    insta::assert_snapshot!(rewrite_static_asset_urls(static_brace, &rules), @r###"
+    import __vize_static_0 from "/images/a.jpg";
+    const n = { src: __vize_static_0 };
+    "###);
+}

--- a/crates/vize_atelier_sfc/src/vite_plugin/transform/tests.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/transform/tests.rs
@@ -109,6 +109,17 @@ fn concatenation_prefixes_and_non_src_keys_never_become_imports() {
     let other_key = r#"const n = { data_src: '/images/a.jpg' };"#;
     assert_eq!(rewrite_static_asset_urls(other_key, &rules), other_key);
 
+    // Neither is a Unicode prop name whose tail happens to be `src`.
+    let unicode_key = r#"const n = { ésrc: '/images/a.jpg' };"#;
+    assert_eq!(rewrite_static_asset_urls(unicode_key, &rules), unicode_key);
+
+    // An escaped quote does not end the literal, so the value is not static.
+    let escaped_quote = r#"const n = { src: '/images/a\', b.jpg' };"#;
+    assert_eq!(
+        rewrite_static_asset_urls(escaped_quote, &rules),
+        escaped_quote
+    );
+
     // Fully static values still rewrite, whatever ends the property.
     let static_comma = r#"const n = { src: '/images/a.jpg', other: true };"#;
     insta::assert_snapshot!(rewrite_static_asset_urls(static_comma, &rules), @r###"


### PR DESCRIPTION
## Summary

External report #3945 (found trialing vize on a 1000-SFC production Laravel+Vite app): with a `resolve.alias` whose key is a URL-path prefix (`/images`), a **bound** `:src` — `'/images/colors-switch-' + (color ? 'on' : 'off') + '.jpg'` — failed the build: the plugin's static-asset rewrite hoisted the concatenation's first string literal into `import __vize_static_0 from "/images/colors-switch-"` — half a filename ([UNLOADABLE_DEPENDENCY]). Same for directory-prefix shapes (`Is a directory`). `@vitejs/plugin-vue` rewrites only static attribute values.

## Fix

`parse_src_candidate` accepts a candidate only when the property ends right after the literal's closing quote (`,`, `}`, `)`, or EOF follows) — a literal that participates in a larger expression is a runtime value and is left untouched. A bare `src` key must also sit at an identifier boundary, so `data_src`-style props no longer match.

## Verification

- New regression tests: both reported shapes (filename-prefix and directory-prefix concatenations) pass through unchanged; `data_src` untouched; fully static values still rewrite with either `,` or `}` terminators (snapshots). **Mutation-checked**: disabling the trailing check flips the concatenation test to the old broken rewrite.
- `cargo test -p vize_atelier_sfc` green outside the 8 pre-existing pkl-environment fixture suites; clippy/fmt clean.
- `transform.rs` tests moved to `transform/tests.rs` (file budget: net −70 on an over-budget file).

Closes #3945

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static asset URL rewriting to avoid incorrectly modifying similarly named properties or incomplete values.
  * Prevented rewrites when source values contain unsupported expressions or concatenated content.
  * Preserved script sources and non-relative dynamic import patterns correctly.
  * Improved handling of relative and negated glob imports, including overlapping replacement definitions.

* **Tests**
  * Added coverage for asset rewriting, dynamic imports, glob patterns, and regression cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->