### PR TITLE
fix(atelier): clamp skip_quoted's cursor before slicing in the comment rewriter

### DIFF
--- a/crates/vize_atelier_core/src/codegen/expression/comment_rewrite.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/comment_rewrite.rs
@@ -34,7 +34,10 @@ pub(crate) fn convert_line_comments_to_block(content: &str) -> String {
         let b = bytes[i];
         match b {
             b'\'' | b'"' | b'`' => {
-                let end = skip_quoted(bytes, i + 1, b);
+                // `skip_quoted` is a cursor, not a slice bound: an unterminated
+                // literal whose last byte is `\` overshoots to len+1 (the
+                // nesting guard only ever compares it). Clamp before slicing.
+                let end = skip_quoted(bytes, i + 1, b).min(bytes.len());
                 result.push_str(&content[i..end]);
                 i = end;
                 can_start_regex = false;
@@ -206,6 +209,17 @@ mod tests {
             convert_line_comments_to_block("value // */ + sideEffect() /*"),
             "value /*  * / + sideEffect() /* */"
         );
+    }
+
+    #[test]
+    fn an_unterminated_string_ending_in_a_backslash_does_not_slice_past_the_end() {
+        // The template_compile fuzz corpus caught the ported scanner slicing
+        // with skip_quoted's cursor, which overshoots to len+1 when the last
+        // byte is an escape lead (crash-43ea1164, v0.344.0 release gate).
+        for source in ["'\\", "\"unterminated \\", "'//p+\\\\\\\\:\\"] {
+            let converted = convert_line_comments_to_block(source);
+            assert_eq!(converted, source);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The v0.344.0 release gate's `template_compile` corpus replay caught a panic in the #3947 comment rewriter: `end byte index 19 is out of bounds for string of length 18` (`crash-43ea1164…`). `skip_quoted` is a scan **cursor**, not a slice bound — on an unterminated string ending in `\` its escape skip saturates to `len+1` (or `len+2` through the CRLF-continuation path). The nesting guard only ever compares the cursor; the rewriter sliced with it.

## Fix

`.min(bytes.len())` before slicing; an unterminated literal is copied through to end of input (same recovery as before the #3947 port). Regression test covers the distilled shape (`'\\`) and the crash artifact's escape run; the full artifact replayed clean against `compile_template` after the fix.

v0.344.0 stays tagged-unpublished (its SHA legitimately fails the gate); the next release tag carries this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where malformed quoted strings ending with a backslash could cause processing to exceed the available input.
  * Added regression coverage to improve handling of unterminated string literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->