### PR TITLE
refactor(lsp): keep lifecycle changes within source limits

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge.rs
@@ -2,8 +2,6 @@
 
 use serde_json::Value;
 #[allow(clippy::disallowed_types)]
-use std::path::PathBuf;
-#[allow(clippy::disallowed_types)]
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -261,20 +259,6 @@ impl CorsaBridge {
         });
         self.cache_stats.set_entries(0);
         self.cache_stats.reset();
-    }
-
-    /// Remove virtual TypeScript overlays derived from deleted Vue SFCs.
-    pub async fn forget_vue_virtual_documents(
-        &self,
-        source_paths: &[PathBuf],
-    ) -> Result<(), CorsaBridgeError> {
-        let source_paths = source_paths.to_vec();
-        self.with_client(move |client| {
-            client
-                .forget_vue_virtual_documents(&source_paths)
-                .map_err(CorsaBridgeError::CommunicationError)
-        })
-        .await
     }
 
     /// Get hover information at a position.

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -44,6 +44,20 @@ pub(super) struct GeneratedVueDocument {
 }
 
 impl CorsaBridge {
+    /// Remove virtual TypeScript overlays derived from deleted Vue SFCs.
+    pub async fn forget_vue_virtual_documents(
+        &self,
+        source_paths: &[PathBuf],
+    ) -> Result<(), CorsaBridgeError> {
+        let source_paths = source_paths.to_vec();
+        self.with_client(move |client| {
+            client
+                .forget_vue_virtual_documents(&source_paths)
+                .map_err(CorsaBridgeError::CommunicationError)
+        })
+        .await
+    }
+
     /// Generate, sync, and return the canonical `.vue.{ts,tsx}` document used
     /// for editor diagnostics, hover, definition, references, and rename.
     pub async fn open_vue_virtual_document(

--- a/crates/vize_maestro/src/ide/definition.rs
+++ b/crates/vize_maestro/src/ide/definition.rs
@@ -291,40 +291,6 @@ import MyButton from './MyButton.vue'
     }
 
     #[test]
-    fn component_definition_rejects_deleted_target_but_keeps_open_unsaved_target() {
-        let dir = tempfile::tempdir().unwrap();
-        let component_path = dir.path().join("Deleted.vue");
-        let source_path = dir.path().join("Parent.vue");
-        let source = r#"<script setup lang="ts">
-import Deleted from './Deleted.vue'
-</script>
-<template><Deleted /></template>
-"#;
-        let uri = Url::from_file_path(source_path).unwrap();
-        let component_uri = Url::from_file_path(component_path).unwrap();
-        let state = ServerState::new();
-        state
-            .documents
-            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
-        state.update_virtual_docs(&uri, source);
-        let offset = source.find("Deleted />").unwrap();
-        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-
-        assert!(DefinitionService::definition(&ctx).is_none());
-
-        state.documents.open(
-            component_uri.clone(),
-            "<template />\n".to_string(),
-            1,
-            "vue".to_string(),
-        );
-        assert_eq!(
-            scalar_location(DefinitionService::definition(&ctx).unwrap()).uri,
-            component_uri
-        );
-    }
-
-    #[test]
     fn test_definition_resolves_define_art_source() {
         let dir = tempfile::tempdir().unwrap();
         let component_path = dir.path().join("Button.vue");

--- a/crates/vize_maestro/src/ide/definition/module_specifier_tests.rs
+++ b/crates/vize_maestro/src/ide/definition/module_specifier_tests.rs
@@ -114,6 +114,42 @@ fn resolves_scoped_wildcard_declaration_subpath() {
 }
 
 #[test]
+fn component_definition_rejects_deleted_target_but_keeps_open_unsaved_target() {
+    let dir = tempdir().unwrap();
+    let component_path = dir.path().join("Deleted.vue");
+    let source_path = dir.path().join("Parent.vue");
+    let source = r#"<script setup lang="ts">
+import Deleted from './Deleted.vue'
+</script>
+<template><Deleted /></template>
+"#;
+    let uri = Url::from_file_path(source_path).unwrap();
+    let component_uri = Url::from_file_path(component_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+    let offset = source.find("Deleted />").unwrap();
+    let context = IdeContext::new(&state, &uri, offset).unwrap();
+
+    assert!(DefinitionService::definition(&context).is_none());
+
+    state.documents.open(
+        component_uri.clone(),
+        "<template />\n".to_string(),
+        1,
+        "vue".to_string(),
+    );
+    let GotoDefinitionResponse::Scalar(location) =
+        DefinitionService::definition(&context).expect("open target definition")
+    else {
+        panic!("component definition must be a scalar location");
+    };
+    assert_eq!(location.uri, component_uri);
+}
+
+#[test]
 fn resolves_relative_declarations_and_rejects_package_escape() {
     let workspace = tempdir().unwrap();
     let source = workspace.path().join("src/App.vue");


### PR DESCRIPTION
## Summary

- move Vue overlay eviction next to Vue virtual-document synchronization
- move the deleted/unsaved component definition regression into the existing focused test module
- restore the source-length growth gate without changing behavior

## Validation

- `SOURCE_LENGTH_BASE_REF=d5872f277719972dfdec9835fca3bed665bc308a node --test --test-name-pattern="source length script checks the current checkout" tests/tooling/source-file-lengths.test.ts`
- `cargo test -p vize_maestro component_definition_rejects_deleted_target_but_keeps_open_unsaved_target --all-features`
- `cargo clippy -p vize_canon -p vize_maestro --lib --all-features -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->