### PR TITLE
fix(lsp): evict overlays on watched deletes

### DIFF
--- a/crates/vize_maestro/src/server/workspace_files.rs
+++ b/crates/vize_maestro/src/server/workspace_files.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use tower_lsp::lsp_types::Url;
 use tower_lsp::lsp_types::{
     ClientCapabilities, CreateFilesParams, DeleteFilesParams, DidChangeWatchedFilesParams,
-    MessageType, RenameFilesParams, WorkspaceEdit,
+    FileChangeType, MessageType, RenameFilesParams, WorkspaceEdit,
 };
 
 use super::{MaestroServer, ServerState};
@@ -106,11 +106,19 @@ pub(super) async fn did_change_watched_files(
                     .map(|version| (uri, version))
             })
             .collect::<Vec<_>>();
-        if dependents.is_empty() && !global_components_invalidated {
+        let deleted_paths = file_paths(
+            params
+                .changes
+                .iter()
+                .filter(|change| change.typ == FileChangeType::DELETED)
+                .map(|change| change.uri.as_str()),
+        );
+        if dependents.is_empty() && !global_components_invalidated && deleted_paths.is_empty() {
             return;
         }
         // Recomputation must read the changed files fresh from disk.
         server.state.invalidate_batch_cache();
+        forget_corsa_vue_files(&server.state, &deleted_paths).await;
         for (dependent, version) in dependents {
             server
                 .publish_diagnostics_if_version(&dependent, version)
@@ -228,7 +236,6 @@ pub(super) async fn did_rename_files(server: &MaestroServer, params: &RenameFile
     }
 }
 
-#[cfg(feature = "native")]
 #[cfg(feature = "native")]
 fn file_paths<'a>(uris: impl Iterator<Item = &'a str>) -> Vec<PathBuf> {
     uris.filter_map(|uri| Url::parse(uri).ok()?.to_file_path().ok())

--- a/tests/tooling/lsp-watched-refresh.test.ts
+++ b/tests/tooling/lsp-watched-refresh.test.ts
@@ -81,6 +81,10 @@ test("watched dependency changes refresh the open importer", async (t) => {
     const diagnosticsFor = (uri: string) => (params: unknown) =>
       (params as { uri: string }).uri === uri;
     const counted = (params: unknown) => (params as { diagnostics: unknown[] }).diagnostics.length;
+    const diagnosticCodes = (params: unknown) =>
+      (params as { diagnostics: Array<{ code?: number | string }> }).diagnostics.map(
+        (diagnostic) => diagnostic.code,
+      );
     // `waitForNotification` resolves out of the backlog, so a stale republish
     // could satisfy the delete phase without the deletion ever being observed.
     // Draining to quiescence first forces the next publish to be the delete's.
@@ -131,7 +135,12 @@ test("watched dependency changes refresh the open importer", async (t) => {
       (params) => diagnosticsFor(appUri)(params) && counted(params) > 0,
       60000,
     );
-    assert.ok(counted(afterDelete) > 0, "a deleted dependency keeps the importer broken");
+    assert.ok(
+      diagnosticCodes(afterDelete).includes(2307),
+      `a deleted dependency reports TS2307 instead of a stale overlay diagnostic: ${JSON.stringify(
+        afterDelete,
+      )}`,
+    );
 
     // Phase 3: restored with the matching type; the importer recovers.
     fs.writeFileSync(childPath, CHILD_NUMBER, "utf8");


### PR DESCRIPTION
## Summary

- evict deleted Vue virtual documents for `workspace/didChangeWatchedFiles` delete events
- invalidate caches before republishing diagnostics to open importers
- strengthen the production LSP watcher gate to require TS2307 instead of accepting a stale TS2322

## TDD evidence

Before the fix, `lsp-watched-refresh.test.ts` failed because delete still published TS2322 from the removed child overlay. After the fix it observes TS2307 and then clean diagnostics after recreation.

## Validation

- `cargo build -p vize`
- `node --test tests/tooling/lsp-watched-refresh.test.ts`
- `cargo test -p vize_maestro server::workspace_files::tests --all-features`
- `cargo clippy -p vize_maestro --lib --all-features -- -D warnings`
- source-length gate against PR base
- `cargo fmt --all --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->