### PR TITLE
test(lsp): consolidate authored lifecycle harness

### DIFF
--- a/tests/tooling/real-project-lsp-authored-oracle.test.ts
+++ b/tests/tooling/real-project-lsp-authored-oracle.test.ts
@@ -5,7 +5,10 @@ import path from "node:path";
 import { test } from "node:test";
 import { pathToFileURL } from "node:url";
 
-import { FakeAuthoredLspSession } from "./support/fake-authored-lsp-session.ts";
+import {
+  assertOrderedEvents,
+  FakeAuthoredLspSession,
+} from "./support/fake-authored-lsp-session.ts";
 import { exerciseAuthoredLspOracle } from "./support/real-project-lsp-authored-oracle.ts";
 import {
   readOracleDocument,
@@ -35,50 +38,18 @@ test("real-project LSP exercises authored binding and component boundary feature
     assert.equal(result.fileLifecycle.deletedDefinition.count, 0);
     assert.equal(result.fileLifecycle.deletedImporterDiagnostics.count, 1);
     assert.equal(result.fileLifecycle.restoredDefinition.count, 1);
-    assert.deepEqual(session.events, [
-      "textDocument/didOpen:1:Binding.vue",
-      "textDocument/publishDiagnostics:1:Binding.vue",
-      "textDocument/hover:Binding.vue",
-      "textDocument/definition:Binding.vue",
-      "textDocument/references:Binding.vue",
-      "textDocument/prepareRename:Binding.vue",
-      "textDocument/rename:Binding.vue",
-      "textDocument/didOpen:1:FeatureChild.vue",
-      "textDocument/publishDiagnostics:1:FeatureChild.vue",
-      "textDocument/didOpen:1:FeatureParent.vue",
-      "textDocument/publishDiagnostics:1:FeatureParent.vue",
-      "textDocument/definition:FeatureParent.vue",
-      "textDocument/completion:FeatureParent.vue",
-      "textDocument/didChange:2:FeatureChild.vue",
-      "textDocument/publishDiagnostics:2:FeatureChild.vue",
-      "textDocument/completion:FeatureParent.vue",
-      "textDocument/didChange:3:FeatureChild.vue",
-      "textDocument/publishDiagnostics:3:FeatureChild.vue",
-      "textDocument/completion:FeatureParent.vue",
-      "workspace/didCreateFiles:__VizeOracleFeatureChild.vue",
-      "workspace/symbol:__vizeFileLifecycleMarker__",
-      "textDocument/didChange:2:FeatureParent.vue",
-      "textDocument/publishDiagnostics:2:FeatureParent.vue",
-      "textDocument/definition:FeatureParent.vue",
-      "workspace/willRenameFiles:__VizeOracleFeatureChild.vue->__VizeOracleRenamedFeatureChild.vue",
-      "workspace/didRenameFiles:__VizeOracleFeatureChild.vue->__VizeOracleRenamedFeatureChild.vue",
-      "textDocument/didChange:3:FeatureParent.vue",
-      "textDocument/publishDiagnostics:3:FeatureParent.vue",
-      "textDocument/definition:FeatureParent.vue",
-      "workspace/symbol:__vizeFileLifecycleMarker__",
-      "textDocument/documentSymbol:__VizeOracleFeatureChild.vue",
-      "workspace/didDeleteFiles:__VizeOracleRenamedFeatureChild.vue",
-      "textDocument/publishDiagnostics:3:FeatureParent.vue",
-      "textDocument/definition:FeatureParent.vue",
-      "workspace/symbol:__vizeFileLifecycleMarker__",
-      "textDocument/documentSymbol:__VizeOracleRenamedFeatureChild.vue",
-      "textDocument/didChange:4:FeatureParent.vue",
-      "textDocument/publishDiagnostics:4:FeatureParent.vue",
-      "textDocument/definition:FeatureParent.vue",
-      "textDocument/didClose:FeatureParent.vue",
-      "textDocument/didClose:FeatureChild.vue",
-      "textDocument/didClose:Binding.vue",
+    assertOrderedEvents(session.events, [
+      ["textDocument/didOpen:1:Binding.vue", "textDocument/publishDiagnostics:1:Binding.vue"],
+      ["textDocument/didOpen:1:FeatureChild.vue", "textDocument/didChange:2:FeatureChild.vue"],
+      ["workspace/didCreateFiles", "workspace/symbol"],
+      ["workspace/willRenameFiles", "workspace/didRenameFiles"],
+      ["workspace/didDeleteFiles", "textDocument/publishDiagnostics:3:FeatureParent.vue"],
+      ["workspace/didDeleteFiles", "textDocument/didChange:4:FeatureParent.vue"],
+      ["textDocument/didChange:4:FeatureParent.vue", "textDocument/didClose:FeatureParent.vue"],
+      ["textDocument/didClose:FeatureParent.vue", "textDocument/didClose:FeatureChild.vue"],
+      ["textDocument/didClose:FeatureChild.vue", "textDocument/didClose:Binding.vue"],
     ]);
+    assert.deepEqual(session.openFiles, []);
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
   }
@@ -107,6 +78,26 @@ test("authored LSP oracle preserves its primary failure when cleanup also fails"
       /hover must resolve the authored title binding/,
     );
     assert.deepEqual(session.openFiles, ["Binding.vue"]);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("fake authored diagnostics cannot match another document at the same version", async () => {
+  const workspace = createFixtureWorkspace("vize-authored-lsp-diagnostic-uri-");
+  const session = new FakeAuthoredLspSession(workspace);
+  try {
+    session.seedDocument("Binding.vue", "<template />\n");
+    session.seedDocument("FeatureChild.vue", "<template />\n");
+    const bindingUri = pathToFileURL(path.join(workspace, "Binding.vue")).href;
+    const diagnostics = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (value) => {
+        const payload = value as { uri?: string; version?: number };
+        return payload.uri === bindingUri && payload.version === 1;
+      },
+    )) as { uri: string };
+    assert.equal(diagnostics.uri, bindingUri);
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
   }

--- a/tests/tooling/real-project-lsp-file-lifecycle.test.ts
+++ b/tests/tooling/real-project-lsp-file-lifecycle.test.ts
@@ -7,6 +7,10 @@ import { pathToFileURL } from "node:url";
 
 import { offsetToPosition } from "./support/lsp/assertions.ts";
 import type { LspRange, PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import {
+  assertOrderedEvents,
+  FakeAuthoredLspSession,
+} from "./support/fake-authored-lsp-session.ts";
 import { exerciseAuthoredFileLifecycle } from "./support/real-project-lsp-file-lifecycle.ts";
 import type { LspAuthoredOracle } from "./support/real-project-lsp-report.ts";
 
@@ -27,8 +31,15 @@ const childValue = 1
   fs.writeFileSync(importerPath, importerSource);
   fs.writeFileSync(dependencyPath, dependencySource);
   const importerUri = pathToFileURL(importerPath).href;
-  const session = new FakeFileLifecycleSession(workspace, importerUri, importerSource);
   const oracle = fixtureOracle();
+  const session = new FakeAuthoredLspSession(workspace, null, false, {
+    copiedFile: oracle.fileLifecycle.copiedFile,
+    copiedImportSpecifier: oracle.fileLifecycle.copiedImportSpecifier,
+    importerFile: oracle.componentBoundary.importerFile,
+    renamedFile: oracle.fileLifecycle.renamedFile,
+    renamedImportSpecifier: oracle.fileLifecycle.renamedImportSpecifier,
+  });
+  session.seedDocument(oracle.componentBoundary.importerFile, importerSource);
   const tagOffset = importerSource.indexOf("Child />");
   const tagRange = rangeAt(importerSource, tagOffset, "Child".length);
   const baselineDiagnostics: PublishDiagnosticsParams = {
@@ -66,134 +77,19 @@ const childValue = 1
     });
     assert.equal(fs.existsSync(path.join(workspace, "__VizeOracleChild.vue")), false);
     assert.equal(fs.existsSync(path.join(workspace, "__VizeOracleRenamedChild.vue")), false);
-    assert.deepEqual(session.events, [
-      "workspace/didCreateFiles:__VizeOracleChild.vue",
-      "workspace/symbol:__vizeFileLifecycleMarker__",
-      "textDocument/didChange:2:Importer.vue",
-      "textDocument/publishDiagnostics:2:Importer.vue",
-      "textDocument/definition:Importer.vue",
-      "workspace/willRenameFiles:__VizeOracleChild.vue->__VizeOracleRenamedChild.vue",
-      "workspace/didRenameFiles:__VizeOracleChild.vue->__VizeOracleRenamedChild.vue",
-      "textDocument/didChange:3:Importer.vue",
-      "textDocument/publishDiagnostics:3:Importer.vue",
-      "textDocument/definition:Importer.vue",
-      "workspace/symbol:__vizeFileLifecycleMarker__",
-      "textDocument/documentSymbol:__VizeOracleChild.vue",
-      "workspace/didDeleteFiles:__VizeOracleRenamedChild.vue",
-      "textDocument/publishDiagnostics:3:Importer.vue",
-      "textDocument/definition:Importer.vue",
-      "workspace/symbol:__vizeFileLifecycleMarker__",
-      "textDocument/documentSymbol:__VizeOracleRenamedChild.vue",
-      "textDocument/didChange:4:Importer.vue",
-      "textDocument/publishDiagnostics:4:Importer.vue",
-      "textDocument/definition:Importer.vue",
+    assertOrderedEvents(session.events, [
+      ["workspace/didCreateFiles", "workspace/symbol"],
+      ["workspace/didCreateFiles", "textDocument/didChange:2"],
+      ["workspace/willRenameFiles", "workspace/didRenameFiles"],
+      ["workspace/didRenameFiles", "textDocument/didChange:3"],
+      ["workspace/didDeleteFiles", "textDocument/publishDiagnostics:3"],
+      ["workspace/didDeleteFiles", "textDocument/definition"],
+      ["workspace/didDeleteFiles", "textDocument/didChange:4"],
     ]);
   } finally {
     fs.rmSync(workspace, { recursive: true, force: true });
   }
 });
-
-class FakeFileLifecycleSession {
-  readonly events: string[] = [];
-  private importerSource: string;
-  private importerVersion = 1;
-  private readonly importerUri: string;
-  private readonly workspace: string;
-  private fileDeleted = false;
-
-  constructor(workspace: string, importerUri: string, importerSource: string) {
-    this.workspace = workspace;
-    this.importerUri = importerUri;
-    this.importerSource = importerSource;
-  }
-
-  notify(method: string, params: unknown): void {
-    if (method === "textDocument/didChange") {
-      const payload = params as {
-        contentChanges: Array<{ text: string }>;
-        textDocument: { uri: string; version: number };
-      };
-      this.importerSource = payload.contentChanges[0]!.text;
-      this.importerVersion = payload.textDocument.version;
-      this.events.push(`${method}:${this.importerVersion}:Importer.vue`);
-      return;
-    }
-    if (method === "workspace/didCreateFiles" || method === "workspace/didDeleteFiles") {
-      const uri = (params as { files: Array<{ uri: string }> }).files[0]!.uri;
-      if (method === "workspace/didDeleteFiles") this.fileDeleted = true;
-      this.events.push(`${method}:${fileName(uri)}`);
-      return;
-    }
-    if (method === "workspace/didRenameFiles") {
-      const file = (params as { files: Array<{ newUri: string; oldUri: string }> }).files[0]!;
-      this.events.push(`${method}:${fileName(file.oldUri)}->${fileName(file.newUri)}`);
-    }
-  }
-
-  async request(method: string, params: unknown): Promise<unknown> {
-    if (method === "workspace/symbol") {
-      const marker = (params as { query: string }).query;
-      this.events.push(`${method}:${marker}`);
-      const target = ["__VizeOracleChild.vue", "__VizeOracleRenamedChild.vue"]
-        .map((file) => path.join(this.workspace, file))
-        .find((file) => fs.existsSync(file));
-      return target == null
-        ? null
-        : [{ name: marker, location: { uri: pathToFileURL(target).href, range: zeroRange() } }];
-    }
-    if (method === "workspace/willRenameFiles") {
-      const file = (params as { files: Array<{ newUri: string; oldUri: string }> }).files[0]!;
-      this.events.push(`${method}:${fileName(file.oldUri)}->${fileName(file.newUri)}`);
-      const specifier = "./__VizeOracleChild.vue";
-      const offset = this.importerSource.indexOf(specifier);
-      assert.notEqual(offset, -1);
-      return {
-        changes: {
-          [this.importerUri]: [
-            {
-              newText: "./__VizeOracleRenamedChild.vue",
-              range: rangeAt(this.importerSource, offset, specifier.length),
-            },
-          ],
-        },
-      };
-    }
-
-    const uri = (params as { textDocument: { uri: string } }).textDocument.uri;
-    this.events.push(`${method}:${fileName(uri)}`);
-    if (method === "textDocument/documentSymbol") return null;
-    assert.equal(method, "textDocument/definition");
-    const specifier = /import Child from "([^"]+)"/.exec(this.importerSource)?.[1];
-    assert.ok(specifier);
-    const target = path.resolve(this.workspace, specifier);
-    return fs.existsSync(target) ? { uri: pathToFileURL(target).href, range: zeroRange() } : null;
-  }
-
-  async waitForNotification(method: string, predicate?: (params: unknown) => boolean) {
-    assert.equal(method, "textDocument/publishDiagnostics");
-    const specifier = "./__VizeOracleRenamedChild.vue";
-    const offset = this.importerSource.indexOf(specifier);
-    const payload: PublishDiagnosticsParams = {
-      diagnostics:
-        this.fileDeleted && offset !== -1
-          ? [
-              {
-                code: 2307,
-                message: `Cannot find module '${specifier}' or its corresponding type declarations.`,
-                range: rangeAt(this.importerSource, offset - 1, specifier.length + 2),
-                severity: 1,
-                source: "vize/types",
-              },
-            ]
-          : [],
-      uri: this.importerUri,
-      version: this.importerVersion,
-    };
-    assert.ok(predicate?.(payload));
-    this.events.push(`${method}:${this.importerVersion}:Importer.vue`);
-    return payload;
-  }
-}
 
 function fixtureOracle(): LspAuthoredOracle {
   return {
@@ -235,15 +131,4 @@ function rangeAt(source: string, offset: number, length: number): LspRange {
     start: offsetToPosition(source, offset),
     end: offsetToPosition(source, offset + length),
   };
-}
-
-function zeroRange(): LspRange {
-  return {
-    start: { line: 0, character: 0 },
-    end: { line: 0, character: 0 },
-  };
-}
-
-function fileName(uri: string): string {
-  return path.basename(new URL(uri).pathname);
 }

--- a/tests/tooling/support/fake-authored-lsp-session.ts
+++ b/tests/tooling/support/fake-authored-lsp-session.ts
@@ -5,19 +5,49 @@ import { pathToFileURL } from "node:url";
 
 import type { PublishDiagnosticsParams } from "./lsp/protocol.ts";
 
+export type FakeAuthoredLspLifecycle = {
+  copiedFile: string;
+  copiedImportSpecifier: string;
+  importerFile: string;
+  renamedFile: string;
+  renamedImportSpecifier: string;
+};
+
+const DEFAULT_LIFECYCLE: FakeAuthoredLspLifecycle = {
+  copiedFile: "__VizeOracleFeatureChild.vue",
+  copiedImportSpecifier: "./__VizeOracleFeatureChild.vue",
+  importerFile: "FeatureParent.vue",
+  renamedFile: "__VizeOracleRenamedFeatureChild.vue",
+  renamedImportSpecifier: "./__VizeOracleRenamedFeatureChild.vue",
+};
+
 export class FakeAuthoredLspSession {
   readonly events: string[] = [];
   readonly openFiles: string[] = [];
   private readonly documents = new Map<string, { text: string; version: number }>();
+  private readonly lifecycle: FakeAuthoredLspLifecycle;
   private readonly nullMethod: string | null;
   private readonly throwOnClose: boolean;
   private readonly workspace: string;
   private fileDeleted = false;
 
-  constructor(workspace: string, nullMethod: string | null = null, throwOnClose = false) {
+  constructor(
+    workspace: string,
+    nullMethod: string | null = null,
+    throwOnClose = false,
+    lifecycle: FakeAuthoredLspLifecycle = DEFAULT_LIFECYCLE,
+  ) {
     this.workspace = workspace;
     this.nullMethod = nullMethod;
     this.throwOnClose = throwOnClose;
+    this.lifecycle = lifecycle;
+  }
+
+  seedDocument(relativeFile: string, text: string, version = 1): void {
+    this.documents.set(pathToFileURL(path.join(this.workspace, relativeFile)).href, {
+      text,
+      version,
+    });
   }
 
   notify(method: string, params: unknown): void {
@@ -107,6 +137,7 @@ export class FakeAuthoredLspSession {
 
   async waitForNotification(method: string, predicate: (params: unknown) => boolean) {
     assert.equal(method, "textDocument/publishDiagnostics");
+    assert.ok(predicate, "fake diagnostics waits require an exact URI/version predicate");
     const notification = [...this.documents.entries()]
       .reverse()
       .map(([uri, document]) => {
@@ -127,7 +158,7 @@ export class FakeAuthoredLspSession {
   private workspaceSymbol(params: unknown): unknown {
     const marker = (params as { query: string }).query;
     this.events.push(`workspace/symbol:${marker}`);
-    const target = ["__VizeOracleFeatureChild.vue", "__VizeOracleRenamedFeatureChild.vue"]
+    const target = [this.lifecycle.copiedFile, this.lifecycle.renamedFile]
       .map((file) => path.join(this.workspace, file))
       .find((file) => fs.existsSync(file));
     return target == null
@@ -140,16 +171,16 @@ export class FakeAuthoredLspSession {
     this.events.push(
       `workspace/willRenameFiles:${fileName(file.oldUri)}->${fileName(file.newUri)}`,
     );
-    const importerUri = pathToFileURL(path.join(this.workspace, "FeatureParent.vue")).href;
+    const importerUri = pathToFileURL(path.join(this.workspace, this.lifecycle.importerFile)).href;
     const source = this.documents.get(importerUri)?.text ?? "";
-    const specifier = "./__VizeOracleFeatureChild.vue";
+    const specifier = this.lifecycle.copiedImportSpecifier;
     const offset = source.indexOf(specifier);
     assert.notEqual(offset, -1);
     return {
       changes: {
         [importerUri]: [
           {
-            newText: "./__VizeOracleRenamedFeatureChild.vue",
+            newText: this.lifecycle.renamedImportSpecifier,
             range: rangeAt(source, offset, specifier.length),
           },
         ],
@@ -159,7 +190,7 @@ export class FakeAuthoredLspSession {
 
   private componentDefinition(uri: string): unknown {
     const source = this.documents.get(uri)?.text ?? "";
-    const specifier = /import FeatureChild from ['"]([^'"]+)['"]/.exec(source)?.[1];
+    const specifier = /import\s+\w+\s+from\s+['"]([^'"]+\.vue)['"]/.exec(source)?.[1];
     assert.ok(specifier);
     const target = path.resolve(this.workspace, specifier);
     return fs.existsSync(target)
@@ -177,7 +208,7 @@ export class FakeAuthoredLspSession {
   }
 
   private deletedDependencyDiagnostics(source: string) {
-    const specifier = "./__VizeOracleRenamedFeatureChild.vue";
+    const specifier = this.lifecycle.renamedImportSpecifier;
     const offset = source.indexOf(specifier);
     if (!this.fileDeleted || offset === -1) return [];
     return [
@@ -189,6 +220,20 @@ export class FakeAuthoredLspSession {
         source: "vize/types",
       },
     ];
+  }
+}
+
+export function assertOrderedEvents(
+  events: readonly string[],
+  expectations: ReadonlyArray<readonly [before: string, after: string]>,
+): void {
+  for (const [before, after] of expectations) {
+    const beforeIndex = events.findIndex((event) => event.startsWith(before));
+    assert.notEqual(beforeIndex, -1, `missing event: ${before}`);
+    const afterIndex = events.findIndex(
+      (event, index) => index > beforeIndex && event.startsWith(after),
+    );
+    assert.notEqual(afterIndex, -1, `${after} must occur after ${before}`);
   }
 }
 


### PR DESCRIPTION
## Summary

- replace the duplicate file-lifecycle protocol fake with the configurable authored-session fake
- assert required lifecycle ordering relationships instead of pinning incidental full request traces
- require exact diagnostics predicates and prove same-version documents cannot cross-match by URI
- record the open-document state when cleanup transport fails

## Validation

- `node --test tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp-file-lifecycle.test.ts`
- strict targeted `tsgo --noEmit`
- `vp check` on all changed files
- source-length gate against the PR base
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->