### PR TITLE
fix(lsp): revalidate importers after file creation

### DIFF
--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -555,7 +555,7 @@ impl LanguageServer for MaestroServer {
     }
 
     async fn did_create_files(&self, params: CreateFilesParams) {
-        super::workspace_files::did_create_files(&self.state, &params);
+        super::workspace_files::did_create_files(self, &params).await;
     }
 
     async fn did_delete_files(&self, params: DeleteFilesParams) {

--- a/crates/vize_maestro/src/server/importers.rs
+++ b/crates/vize_maestro/src/server/importers.rs
@@ -251,6 +251,19 @@ mod tests {
     }
 
     #[test]
+    fn index_keeps_explicit_missing_vue_imports_for_future_create_events() {
+        let dir = tempfile::tempdir().unwrap();
+        let child_uri = Url::from_file_path(dir.path().join("FutureChild.vue")).unwrap();
+        let parent_uri = Url::from_file_path(dir.path().join("Parent.vue")).unwrap();
+        let state = ServerState::new();
+        let source = "<script setup lang=\"ts\">import Child from './FutureChild.vue'</script>";
+
+        state.update_virtual_docs(&parent_uri, source);
+
+        assert_eq!(open_vue_importers(&state, &child_uri), vec![parent_uri]);
+    }
+
+    #[test]
     fn index_resolves_package_export_declaration_variants() {
         let dir = tempfile::tempdir().unwrap();
         let package = dir.path().join("node_modules/vue-router");

--- a/crates/vize_maestro/src/server/workspace_files.rs
+++ b/crates/vize_maestro/src/server/workspace_files.rs
@@ -89,23 +89,10 @@ pub(super) async fn did_change_watched_files(
             params.changes.iter().map(|change| change.uri.as_str()),
         );
 
-        let mut dependents = params
-            .changes
-            .iter()
-            .flat_map(|change| super::importers::open_vue_dependents(&server.state, &change.uri))
-            .collect::<Vec<_>>();
-        dependents.sort();
-        dependents.dedup();
-        let dependents = dependents
-            .into_iter()
-            .filter_map(|uri| {
-                server
-                    .state
-                    .documents
-                    .version(&uri)
-                    .map(|version| (uri, version))
-            })
-            .collect::<Vec<_>>();
+        let dependents = versioned_open_vue_dependents(
+            &server.state,
+            params.changes.iter().map(|change| change.uri.as_str()),
+        );
         let deleted_paths = file_paths(
             params
                 .changes
@@ -129,7 +116,25 @@ pub(super) async fn did_change_watched_files(
     let _ = (server, params);
 }
 
-pub(super) fn did_create_files(state: &ServerState, params: &CreateFilesParams) {
+pub(super) async fn did_create_files(server: &MaestroServer, params: &CreateFilesParams) {
+    #[cfg(feature = "native")]
+    {
+        let dependents = versioned_open_vue_dependents(
+            &server.state,
+            params.files.iter().map(|file| file.uri.as_str()),
+        );
+        record_created_files(&server.state, params);
+        for (dependent, version) in dependents {
+            server
+                .publish_diagnostics_if_version(&dependent, version)
+                .await;
+        }
+    }
+    #[cfg(not(feature = "native"))]
+    let _ = (server, params);
+}
+
+fn record_created_files(state: &ServerState, params: &CreateFilesParams) {
     #[cfg(feature = "native")]
     {
         state.invalidate_global_component_references(
@@ -147,24 +152,10 @@ pub(super) fn did_create_files(state: &ServerState, params: &CreateFilesParams) 
 pub(super) async fn did_delete_files(server: &MaestroServer, params: &DeleteFilesParams) {
     #[cfg(feature = "native")]
     {
-        let mut dependents = params
-            .files
-            .iter()
-            .filter_map(|file| Url::parse(&file.uri).ok())
-            .flat_map(|uri| super::importers::open_vue_dependents(&server.state, &uri))
-            .collect::<Vec<_>>();
-        dependents.sort();
-        dependents.dedup();
-        let dependents = dependents
-            .into_iter()
-            .filter_map(|uri| {
-                server
-                    .state
-                    .documents
-                    .version(&uri)
-                    .map(|version| (uri, version))
-            })
-            .collect::<Vec<_>>();
+        let dependents = versioned_open_vue_dependents(
+            &server.state,
+            params.files.iter().map(|file| file.uri.as_str()),
+        );
         record_deleted_files(&server.state, params);
         let deleted_paths = file_paths(params.files.iter().map(|file| file.uri.as_str()));
         forget_corsa_vue_files(&server.state, &deleted_paths).await;
@@ -243,6 +234,23 @@ fn file_paths<'a>(uris: impl Iterator<Item = &'a str>) -> Vec<PathBuf> {
 }
 
 #[cfg(feature = "native")]
+fn versioned_open_vue_dependents<'a>(
+    state: &ServerState,
+    uris: impl Iterator<Item = &'a str>,
+) -> Vec<(Url, i32)> {
+    let mut dependents = uris
+        .filter_map(|uri| Url::parse(uri).ok())
+        .flat_map(|uri| super::importers::open_vue_dependents(state, &uri))
+        .collect::<Vec<_>>();
+    dependents.sort();
+    dependents.dedup();
+    dependents
+        .into_iter()
+        .filter_map(|uri| state.documents.version(&uri).map(|version| (uri, version)))
+        .collect()
+}
+
+#[cfg(feature = "native")]
 async fn forget_corsa_vue_files(state: &ServerState, deleted: &[PathBuf]) {
     if !state.has_corsa_bridge() {
         return;
@@ -261,8 +269,8 @@ mod tests {
     use tower_lsp::lsp_types::{ClientCapabilities, CreateFilesParams, DeleteFilesParams, Url};
 
     use super::{
-        ServerState, did_create_files, global_component_watcher_registration, record_deleted_files,
-        record_watcher_support,
+        ServerState, global_component_watcher_registration, record_created_files,
+        record_deleted_files, record_watcher_support,
     };
 
     #[test]
@@ -312,7 +320,7 @@ mod tests {
             ]
         }))
         .unwrap();
-        did_create_files(&state, &created);
+        record_created_files(&state, &created);
 
         assert_eq!(state.workspace_vue_file_uris(), vec![vue_uri.clone()]);
 

--- a/tests/tooling/lsp-watched-refresh.test.ts
+++ b/tests/tooling/lsp-watched-refresh.test.ts
@@ -34,10 +34,10 @@ import Child from "./Child.vue";
 
 // A dependency changed outside the editor — a git checkout, a codegen run, a
 // delete — must refresh the open importer's diagnostics without any editor
-// edit (#3918). The lifecycle mirrors the Volar oracle: clean on open, one
-// mismatch after the prop type changes on disk, still broken while the file is
-// gone, clean again once it is restored.
-test("watched dependency changes refresh the open importer", async (t) => {
+// edit (#3918). The lifecycle starts with a missing import, heals on a file
+// operation create, reports a watched prop change, reports TS2307 on watched
+// delete, and heals again on watched recreation.
+test("created and watched dependency changes refresh the open importer", async (t) => {
   const corsaPath = requireTypecheckDependency(
     t,
     resolveCorsaBinary(),
@@ -68,7 +68,6 @@ test("watched dependency changes refresh the open importer", async (t) => {
       "utf8",
     );
     const childPath = path.join(workspaceDir, "Child.vue");
-    fs.writeFileSync(childPath, CHILD_NUMBER, "utf8");
 
     await session.initialize(workspaceDir, {
       editor: true,
@@ -110,9 +109,22 @@ test("watched dependency changes refresh the open importer", async (t) => {
       diagnosticsFor(appUri),
       60000,
     );
-    assert.equal(counted(opened), 0, "the importer opens clean");
+    assert.ok(diagnosticCodes(opened).includes(2307), "the missing dependency starts as TS2307");
 
-    // Phase 1: the dependency's prop narrows on disk, no editor edit.
+    // Phase 1: a file-operation create must heal the already-open importer at
+    // the same document version; requiring an importer edit hides stale state.
+    fs.writeFileSync(childPath, CHILD_NUMBER, "utf8");
+    session.notify("workspace/didCreateFiles", {
+      files: [{ uri: childUri }],
+    });
+    const afterCreate = await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => diagnosticsFor(appUri)(params) && counted(params) === 0,
+      60000,
+    );
+    assert.equal((afterCreate as { version?: number }).version, 1);
+
+    // Phase 2: the dependency's prop narrows on disk, no editor edit.
     fs.writeFileSync(childPath, CHILD_STRING, "utf8");
     session.notify("workspace/didChangeWatchedFiles", {
       changes: [{ uri: childUri, type: 2 }],
@@ -124,7 +136,7 @@ test("watched dependency changes refresh the open importer", async (t) => {
     );
     assert.equal(counted(afterEdit), 1, "the stale binding is reported");
 
-    // Phase 2: the dependency disappears; the importer must stay broken.
+    // Phase 3: the dependency disappears; the importer must stay broken.
     await drainAppDiagnostics();
     fs.rmSync(childPath);
     session.notify("workspace/didChangeWatchedFiles", {
@@ -142,17 +154,17 @@ test("watched dependency changes refresh the open importer", async (t) => {
       )}`,
     );
 
-    // Phase 3: restored with the matching type; the importer recovers.
+    // Phase 4: restored with the matching type; the importer recovers.
     fs.writeFileSync(childPath, CHILD_NUMBER, "utf8");
     session.notify("workspace/didChangeWatchedFiles", {
       changes: [{ uri: childUri, type: 1 }],
     });
-    const afterCreate = await session.waitForNotification(
+    const afterWatchedRestore = await session.waitForNotification(
       "textDocument/publishDiagnostics",
       (params) => diagnosticsFor(appUri)(params) && counted(params) === 0,
       60000,
     );
-    assert.equal(counted(afterCreate), 0, "a restored dependency clears the importer");
+    assert.equal(counted(afterWatchedRestore), 0, "a restored dependency clears the importer");
   } finally {
     await session.shutdown();
     fs.rmSync(workspaceDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- republish diagnostics for open Vue importers affected by `workspace/didCreateFiles`
- preserve explicit missing Vue imports in the reverse-index contract
- share versioned dependent collection across create, delete, and watcher handlers
- prove a version-1 TS2307 heals after file creation without editing the importer

## TDD evidence

Before the fix, the production LSP test timed out for 10 seconds after `didCreateFiles`: no diagnostics were published. After the fix, the same importer version becomes clean, then still passes watched edit/delete/recreate phases.

## Validation

- `cargo build -p vize`
- production `lsp-watched-refresh.test.ts`
- targeted reverse-import and workspace-file Rust tests
- `cargo clippy -p vize_maestro --lib --all-features -- -D warnings`
- strict targeted `tsgo --noEmit` and `vp check`
- source-length gate against the PR base
- `cargo fmt --all --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->