### PR TITLE
fix(lsp): revalidate importers after file rename

### DIFF
--- a/crates/vize_maestro/src/server/workspace_files.rs
+++ b/crates/vize_maestro/src/server/workspace_files.rs
@@ -197,6 +197,13 @@ pub(super) async fn will_rename_files(
 pub(super) async fn did_rename_files(server: &MaestroServer, params: &RenameFilesParams) {
     #[cfg(feature = "native")]
     {
+        let dependents = versioned_open_vue_dependents(
+            &server.state,
+            params
+                .files
+                .iter()
+                .flat_map(|file| [file.old_uri.as_str(), file.new_uri.as_str()]),
+        );
         server.state.invalidate_global_component_references(
             params
                 .files
@@ -212,6 +219,11 @@ pub(super) async fn did_rename_files(server: &MaestroServer, params: &RenameFile
         server.state.invalidate_batch_cache();
         let renamed_paths = file_paths(params.files.iter().map(|file| file.old_uri.as_str()));
         forget_corsa_vue_files(&server.state, &renamed_paths).await;
+        for (dependent, version) in dependents {
+            server
+                .publish_diagnostics_if_version(&dependent, version)
+                .await;
+        }
     }
     if !server.state.lsp_features().file_rename {
         return;

--- a/tests/tooling/lsp-watched-refresh.test.ts
+++ b/tests/tooling/lsp-watched-refresh.test.ts
@@ -68,6 +68,7 @@ test("created and watched dependency changes refresh the open importer", async (
       "utf8",
     );
     const childPath = path.join(workspaceDir, "Child.vue");
+    const renamedChildPath = path.join(workspaceDir, "RenamedChild.vue");
 
     await session.initialize(workspaceDir, {
       editor: true,
@@ -77,6 +78,7 @@ test("created and watched dependency changes refresh the open importer", async (
     });
     const appUri = pathToFileURL(path.join(workspaceDir, "App.vue")).href;
     const childUri = pathToFileURL(childPath).href;
+    const renamedChildUri = pathToFileURL(renamedChildPath).href;
     const diagnosticsFor = (uri: string) => (params: unknown) =>
       (params as { uri: string }).uri === uri;
     const counted = (params: unknown) => (params as { diagnostics: unknown[] }).diagnostics.length;
@@ -124,7 +126,34 @@ test("created and watched dependency changes refresh the open importer", async (
     );
     assert.equal((afterCreate as { version?: number }).version, 1);
 
-    // Phase 2: the dependency's prop narrows on disk, no editor edit.
+    // Phase 2: a rename that removes the imported path must republish TS2307
+    // without relying on the client to apply a willRename workspace edit.
+    await drainAppDiagnostics();
+    fs.renameSync(childPath, renamedChildPath);
+    session.notify("workspace/didRenameFiles", {
+      files: [{ oldUri: childUri, newUri: renamedChildUri }],
+    });
+    const afterRename = await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => diagnosticsFor(appUri)(params) && diagnosticCodes(params).includes(2307),
+      60000,
+    );
+    assert.equal((afterRename as { version?: number }).version, 1);
+
+    // Phase 3: reversing the rename recreates the imported path and must heal
+    // the same importer version without an editor edit.
+    fs.renameSync(renamedChildPath, childPath);
+    session.notify("workspace/didRenameFiles", {
+      files: [{ oldUri: renamedChildUri, newUri: childUri }],
+    });
+    const afterReverseRename = await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => diagnosticsFor(appUri)(params) && counted(params) === 0,
+      60000,
+    );
+    assert.equal((afterReverseRename as { version?: number }).version, 1);
+
+    // Phase 4: the dependency's prop narrows on disk, no editor edit.
     fs.writeFileSync(childPath, CHILD_STRING, "utf8");
     session.notify("workspace/didChangeWatchedFiles", {
       changes: [{ uri: childUri, type: 2 }],
@@ -136,7 +165,7 @@ test("created and watched dependency changes refresh the open importer", async (
     );
     assert.equal(counted(afterEdit), 1, "the stale binding is reported");
 
-    // Phase 3: the dependency disappears; the importer must stay broken.
+    // Phase 5: the dependency disappears; the importer must stay broken.
     await drainAppDiagnostics();
     fs.rmSync(childPath);
     session.notify("workspace/didChangeWatchedFiles", {
@@ -154,7 +183,7 @@ test("created and watched dependency changes refresh the open importer", async (
       )}`,
     );
 
-    // Phase 4: restored with the matching type; the importer recovers.
+    // Phase 6: restored with the matching type; the importer recovers.
     fs.writeFileSync(childPath, CHILD_NUMBER, "utf8");
     session.notify("workspace/didChangeWatchedFiles", {
       changes: [{ uri: childUri, type: 1 }],


### PR DESCRIPTION
## Summary

- collect open importers affected by both sides of `workspace/didRenameFiles`
- republish same-version diagnostics after old overlay eviction
- prove rename-away reports TS2307 without applying a willRename edit
- prove reverse rename heals the unchanged importer

## TDD evidence

Before the fix, on-disk rename plus `didRenameFiles` produced no importer diagnostics within 10 seconds. After the fix, forward rename publishes TS2307 at version 1 and reverse rename publishes clean diagnostics at version 1.

## Validation

- production `lsp-watched-refresh.test.ts`
- `cargo test -p vize_maestro server::workspace_files::tests --all-features`
- `cargo clippy -p vize_maestro --lib --all-features -- -D warnings`
- strict targeted `tsgo --noEmit` and `vp check`
- source-length gate against the PR base
- `cargo fmt --all --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->