### PR TITLE
fix(lsp): revalidate importers after directory changes

### DIFF
--- a/crates/vize_maestro/src/server/importers.rs
+++ b/crates/vize_maestro/src/server/importers.rs
@@ -1,89 +1,22 @@
 //! Reverse dependency index for open Vue documents.
 mod dependents;
+mod index;
 use std::path::{Component, Path, PathBuf};
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::Statement;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use parking_lot::RwLock;
 use tower_lsp::lsp_types::Url;
-use vize_carton::{FxHashMap, FxHashSet};
+use vize_carton::FxHashSet;
 
 use self::package::resolve_package_import;
 use super::ServerState;
 pub(super) use dependents::open_vue_dependents;
+pub(in crate::server) use index::OpenVueImportIndex;
 mod package;
 
 const SCRIPT_EXTENSIONS: &[&str] = &["vue", "ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"];
-
-#[derive(Default)]
-pub(super) struct OpenVueImportIndex {
-    inner: RwLock<ImportIndexData>,
-}
-
-#[derive(Default)]
-struct ImportIndexData {
-    by_dependency: FxHashMap<PathBuf, FxHashSet<Url>>,
-    by_importer: FxHashMap<Url, Vec<PathBuf>>,
-}
-
-impl OpenVueImportIndex {
-    pub(super) fn update(&self, importer: &Url, source: &str) {
-        let dependencies = importer
-            .to_file_path()
-            .ok()
-            .filter(|path| path.extension().is_some_and(|extension| extension == "vue"))
-            .map(|path| collect_dependencies(&path, source))
-            .unwrap_or_default();
-        let mut index = self.inner.write();
-        remove_importer(&mut index, importer);
-
-        for dependency in &dependencies {
-            index
-                .by_dependency
-                .entry(dependency.clone())
-                .or_default()
-                .insert(importer.clone());
-        }
-        if !dependencies.is_empty() {
-            index.by_importer.insert(importer.clone(), dependencies);
-        }
-    }
-
-    pub(super) fn remove(&self, importer: &Url) {
-        remove_importer(&mut self.inner.write(), importer);
-    }
-
-    pub(super) fn clear(&self) {
-        let mut index = self.inner.write();
-        index.by_dependency.clear();
-        index.by_importer.clear();
-    }
-
-    fn importers(&self, dependency: &Path) -> Vec<Url> {
-        self.inner
-            .read()
-            .by_dependency
-            .get(&comparable_path(dependency))
-            .map(|importers| importers.iter().cloned().collect())
-            .unwrap_or_default()
-    }
-}
-
-fn remove_importer(index: &mut ImportIndexData, importer: &Url) {
-    let Some(dependencies) = index.by_importer.remove(importer) else {
-        return;
-    };
-    for dependency in dependencies {
-        if let Some(importers) = index.by_dependency.get_mut(&dependency) {
-            importers.remove(importer);
-            if importers.is_empty() {
-                index.by_dependency.remove(&dependency);
-            }
-        }
-    }
-}
 
 pub(super) fn open_vue_importers(state: &ServerState, dependency: &Url) -> Vec<Url> {
     dependency
@@ -91,6 +24,10 @@ pub(super) fn open_vue_importers(state: &ServerState, dependency: &Url) -> Vec<U
         .ok()
         .map(|path| state.open_vue_imports.importers(&path))
         .unwrap_or_default()
+}
+
+pub(super) fn indexed_dependency_paths(state: &ServerState, dependency: &Path) -> Vec<PathBuf> {
+    state.open_vue_imports.dependency_paths(dependency)
 }
 
 fn collect_dependencies(importer: &Path, source: &str) -> Vec<PathBuf> {
@@ -208,30 +145,79 @@ fn source_type(lang: Option<&str>) -> SourceType {
 mod tests {
     #![allow(clippy::disallowed_methods)]
 
-    use super::{open_vue_importers, resolve_import};
+    use super::{indexed_dependency_paths, open_vue_importers, resolve_import};
     use crate::server::ServerState;
     use tower_lsp::lsp_types::Url;
 
     #[test]
     fn index_tracks_and_removes_open_vue_imports() {
         let dir = tempfile::tempdir().unwrap();
-        let child = dir.path().join("Child.vue");
+        let components = dir.path().join("components");
+        let other_components = dir.path().join("components-old");
+        let child = components.join("Child.vue");
+        let sibling = components.join("Sibling.vue");
+        let outside = other_components.join("Outside.vue");
         let parent = dir.path().join("Parent.vue");
+        std::fs::create_dir(&components).unwrap();
+        std::fs::create_dir(&other_components).unwrap();
         std::fs::write(&child, "<template />").unwrap();
+        std::fs::write(&sibling, "<template />").unwrap();
+        std::fs::write(&outside, "<template />").unwrap();
         std::fs::write(&parent, "<template />").unwrap();
         let child_uri = Url::from_file_path(&child).unwrap();
+        let components_uri = Url::from_file_path(&components).unwrap();
         let parent_uri = Url::from_file_path(&parent).unwrap();
         let state = ServerState::new();
-        let source = "<script setup lang=\"ts\">import Child from './Child'</script>";
+        let source = "<script setup lang=\"ts\">import Child from './components/Child'; import Sibling from './components/Sibling.vue'; import Outside from './components-old/Outside.vue'</script>";
 
         state.update_virtual_docs(&parent_uri, source);
         assert_eq!(
             open_vue_importers(&state, &child_uri),
             vec![parent_uri.clone()]
         );
+        assert_eq!(
+            open_vue_importers(&state, &components_uri),
+            vec![parent_uri.clone()],
+            "directory events return an importer once even with several nested imports"
+        );
+        assert_eq!(
+            indexed_dependency_paths(&state, &components),
+            vec![
+                std::fs::canonicalize(&child).unwrap(),
+                std::fs::canonicalize(&sibling).unwrap(),
+            ],
+            "a sibling whose name only shares the string prefix is excluded"
+        );
 
         state.update_virtual_docs(&parent_uri, "<script setup>const local = 1</script>");
         assert!(open_vue_importers(&state, &child_uri).is_empty());
+    }
+
+    #[test]
+    fn directory_lookup_keeps_exact_and_nested_dependency_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundle = dir.path().join("bundle.vue");
+        let nested = bundle.join("Nested.vue");
+        std::fs::create_dir(&bundle).unwrap();
+        std::fs::write(&nested, "<template />").unwrap();
+        let direct_uri = Url::from_file_path(dir.path().join("Direct.vue")).unwrap();
+        let nested_uri = Url::from_file_path(dir.path().join("NestedImporter.vue")).unwrap();
+        let bundle_uri = Url::from_file_path(&bundle).unwrap();
+        let state = ServerState::new();
+
+        state.update_virtual_docs(
+            &direct_uri,
+            "<script setup>import Bundle from './bundle.vue'</script>",
+        );
+        state.update_virtual_docs(
+            &nested_uri,
+            "<script setup>import Nested from './bundle.vue/Nested.vue'</script>",
+        );
+
+        assert_eq!(
+            open_vue_importers(&state, &bundle_uri),
+            vec![direct_uri, nested_uri]
+        );
     }
 
     #[test]

--- a/crates/vize_maestro/src/server/importers/index.rs
+++ b/crates/vize_maestro/src/server/importers/index.rs
@@ -1,0 +1,100 @@
+//! Reverse dependency storage for open Vue importers.
+
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+use parking_lot::RwLock;
+use tower_lsp::lsp_types::Url;
+use vize_carton::{FxHashMap, FxHashSet};
+
+use super::{collect_dependencies, comparable_path};
+
+#[derive(Default)]
+pub(in crate::server) struct OpenVueImportIndex {
+    inner: RwLock<ImportIndexData>,
+}
+
+#[derive(Default)]
+struct ImportIndexData {
+    by_dependency: BTreeMap<PathBuf, FxHashSet<Url>>,
+    by_importer: FxHashMap<Url, Vec<PathBuf>>,
+}
+
+impl OpenVueImportIndex {
+    pub(in crate::server) fn update(&self, importer: &Url, source: &str) {
+        let dependencies = importer
+            .to_file_path()
+            .ok()
+            .filter(|path| path.extension().is_some_and(|extension| extension == "vue"))
+            .map(|path| collect_dependencies(&path, source))
+            .unwrap_or_default();
+        let mut index = self.inner.write();
+        remove_importer(&mut index, importer);
+
+        for dependency in &dependencies {
+            index
+                .by_dependency
+                .entry(dependency.clone())
+                .or_default()
+                .insert(importer.clone());
+        }
+        if !dependencies.is_empty() {
+            index.by_importer.insert(importer.clone(), dependencies);
+        }
+    }
+
+    pub(in crate::server) fn remove(&self, importer: &Url) {
+        remove_importer(&mut self.inner.write(), importer);
+    }
+
+    pub(in crate::server) fn clear(&self) {
+        let mut index = self.inner.write();
+        index.by_dependency.clear();
+        index.by_importer.clear();
+    }
+
+    pub(super) fn importers(&self, dependency: &Path) -> Vec<Url> {
+        let dependency = comparable_path(dependency);
+        let index = self.inner.read();
+        let mut importers = index
+            .by_dependency
+            .range(dependency.clone()..)
+            .take_while(|(path, _)| path.starts_with(&dependency))
+            .flat_map(|(_, importers)| importers.iter().cloned())
+            .collect::<FxHashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        importers.sort();
+        importers
+    }
+
+    pub(super) fn dependency_paths(&self, dependency: &Path) -> Vec<PathBuf> {
+        let dependency = comparable_path(dependency);
+        let index = self.inner.read();
+        let mut paths = index
+            .by_dependency
+            .range(dependency.clone()..)
+            .take_while(|(path, _)| path.starts_with(&dependency))
+            .map(|(path, _)| path)
+            .cloned()
+            .collect::<Vec<_>>();
+        paths.sort();
+        paths
+    }
+}
+
+fn remove_importer(index: &mut ImportIndexData, importer: &Url) {
+    let Some(dependencies) = index.by_importer.remove(importer) else {
+        return;
+    };
+    for dependency in dependencies {
+        if let Some(importers) = index.by_dependency.get_mut(&dependency) {
+            importers.remove(importer);
+            if importers.is_empty() {
+                index.by_dependency.remove(&dependency);
+            }
+        }
+    }
+}

--- a/crates/vize_maestro/src/server/workspace_files.rs
+++ b/crates/vize_maestro/src/server/workspace_files.rs
@@ -1,10 +1,5 @@
 //! Workspace file-event handling used by LSP diagnostics and rename support.
 
-#[cfg(feature = "native")]
-use std::path::PathBuf;
-
-#[cfg(feature = "native")]
-use tower_lsp::lsp_types::Url;
 use tower_lsp::lsp_types::{
     ClientCapabilities, CreateFilesParams, DeleteFilesParams, DidChangeWatchedFilesParams,
     FileChangeType, MessageType, RenameFilesParams, WorkspaceEdit,
@@ -12,6 +7,13 @@ use tower_lsp::lsp_types::{
 
 use super::{MaestroServer, ServerState};
 use crate::ide::FileRenameService;
+
+#[cfg(feature = "native")]
+mod dependents;
+#[cfg(feature = "native")]
+use dependents::{
+    affected_vue_source_paths, forget_corsa_vue_files, versioned_open_vue_dependents,
+};
 
 #[cfg(feature = "native")]
 use tower_lsp::lsp_types::{
@@ -93,7 +95,8 @@ pub(super) async fn did_change_watched_files(
             &server.state,
             params.changes.iter().map(|change| change.uri.as_str()),
         );
-        let deleted_paths = file_paths(
+        let deleted_paths = affected_vue_source_paths(
+            &server.state,
             params
                 .changes
                 .iter()
@@ -157,7 +160,10 @@ pub(super) async fn did_delete_files(server: &MaestroServer, params: &DeleteFile
             params.files.iter().map(|file| file.uri.as_str()),
         );
         record_deleted_files(&server.state, params);
-        let deleted_paths = file_paths(params.files.iter().map(|file| file.uri.as_str()));
+        let deleted_paths = affected_vue_source_paths(
+            &server.state,
+            params.files.iter().map(|file| file.uri.as_str()),
+        );
         forget_corsa_vue_files(&server.state, &deleted_paths).await;
         for (dependent, version) in dependents {
             server
@@ -217,7 +223,10 @@ pub(super) async fn did_rename_files(server: &MaestroServer, params: &RenameFile
             server.state.track_workspace_vue_file(file.new_uri.as_str());
         }
         server.state.invalidate_batch_cache();
-        let renamed_paths = file_paths(params.files.iter().map(|file| file.old_uri.as_str()));
+        let renamed_paths = affected_vue_source_paths(
+            &server.state,
+            params.files.iter().map(|file| file.old_uri.as_str()),
+        );
         forget_corsa_vue_files(&server.state, &renamed_paths).await;
         for (dependent, version) in dependents {
             server
@@ -236,43 +245,6 @@ pub(super) async fn did_rename_files(server: &MaestroServer, params: &RenameFile
             .publish_diagnostics(old_uri, vec![], None)
             .await;
         server.publish_diagnostics(&new_uri).await;
-    }
-}
-
-#[cfg(feature = "native")]
-fn file_paths<'a>(uris: impl Iterator<Item = &'a str>) -> Vec<PathBuf> {
-    uris.filter_map(|uri| Url::parse(uri).ok()?.to_file_path().ok())
-        .collect()
-}
-
-#[cfg(feature = "native")]
-fn versioned_open_vue_dependents<'a>(
-    state: &ServerState,
-    uris: impl Iterator<Item = &'a str>,
-) -> Vec<(Url, i32)> {
-    let mut dependents = uris
-        .filter_map(|uri| Url::parse(uri).ok())
-        .flat_map(|uri| super::importers::open_vue_dependents(state, &uri))
-        .collect::<Vec<_>>();
-    dependents.sort();
-    dependents.dedup();
-    dependents
-        .into_iter()
-        .filter_map(|uri| state.documents.version(&uri).map(|version| (uri, version)))
-        .collect()
-}
-
-#[cfg(feature = "native")]
-async fn forget_corsa_vue_files(state: &ServerState, deleted: &[PathBuf]) {
-    if !state.has_corsa_bridge() {
-        return;
-    }
-    let Some(bridge) = state.get_corsa_bridge().await else {
-        return;
-    };
-    if let Err(error) = bridge.forget_vue_virtual_documents(deleted).await {
-        tracing::warn!("failed to forget deleted Corsa Vue documents: {error}");
-        state.retire_corsa_bridge(&bridge);
     }
 }
 

--- a/crates/vize_maestro/src/server/workspace_files/dependents.rs
+++ b/crates/vize_maestro/src/server/workspace_files/dependents.rs
@@ -1,0 +1,64 @@
+//! Open-importer refresh and Corsa overlay eviction for workspace file events.
+
+use std::path::{Path, PathBuf};
+
+use tower_lsp::lsp_types::Url;
+
+use super::super::{ServerState, importers};
+
+pub(super) fn versioned_open_vue_dependents<'a>(
+    state: &ServerState,
+    uris: impl Iterator<Item = &'a str>,
+) -> Vec<(Url, i32)> {
+    let mut dependents = uris
+        .filter_map(|uri| Url::parse(uri).ok())
+        .flat_map(|uri| importers::open_vue_dependents(state, &uri))
+        .collect::<Vec<_>>();
+    dependents.sort();
+    dependents.dedup();
+    dependents
+        .into_iter()
+        .filter_map(|uri| state.documents.version(&uri).map(|version| (uri, version)))
+        .collect()
+}
+
+pub(super) fn affected_vue_source_paths<'a>(
+    state: &ServerState,
+    uris: impl Iterator<Item = &'a str>,
+) -> Vec<PathBuf> {
+    let mut sources = Vec::new();
+    for path in uris.filter_map(file_path) {
+        if is_vue_file(&path) {
+            sources.push(path.clone());
+        }
+        sources.extend(
+            importers::indexed_dependency_paths(state, &path)
+                .into_iter()
+                .filter(|dependency| is_vue_file(dependency)),
+        );
+    }
+    sources.sort();
+    sources.dedup();
+    sources
+}
+
+pub(super) async fn forget_corsa_vue_files(state: &ServerState, deleted: &[PathBuf]) {
+    if !state.has_corsa_bridge() {
+        return;
+    }
+    let Some(bridge) = state.get_corsa_bridge().await else {
+        return;
+    };
+    if let Err(error) = bridge.forget_vue_virtual_documents(deleted).await {
+        tracing::warn!("failed to forget deleted Corsa Vue documents: {error}");
+        state.retire_corsa_bridge(&bridge);
+    }
+}
+
+fn file_path(uri: &str) -> Option<PathBuf> {
+    Url::parse(uri).ok()?.to_file_path().ok()
+}
+
+fn is_vue_file(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| extension == "vue")
+}

--- a/tests/tooling/lsp-watched-refresh.test.ts
+++ b/tests/tooling/lsp-watched-refresh.test.ts
@@ -25,7 +25,7 @@ defineProps<{ count: number }>();
 const CHILD_STRING = CHILD_NUMBER.replace("count: number", "count: string");
 
 const APP = `<script setup lang="ts">
-import Child from "./Child.vue";
+import Child from "./components/Child.vue";
 </script>
 <template>
   <Child :count="1" />
@@ -67,8 +67,10 @@ test("created and watched dependency changes refresh the open importer", async (
       JSON.stringify({ typeChecker: { corsaPath } }),
       "utf8",
     );
-    const childPath = path.join(workspaceDir, "Child.vue");
-    const renamedChildPath = path.join(workspaceDir, "RenamedChild.vue");
+    const componentsDir = path.join(workspaceDir, "components");
+    const movedComponentsDir = path.join(workspaceDir, "moved-components");
+    const childPath = path.join(componentsDir, "Child.vue");
+    const renamedChildPath = path.join(componentsDir, "RenamedChild.vue");
 
     await session.initialize(workspaceDir, {
       editor: true,
@@ -79,6 +81,8 @@ test("created and watched dependency changes refresh the open importer", async (
     const appUri = pathToFileURL(path.join(workspaceDir, "App.vue")).href;
     const childUri = pathToFileURL(childPath).href;
     const renamedChildUri = pathToFileURL(renamedChildPath).href;
+    const componentsUri = pathToFileURL(componentsDir).href;
+    const movedComponentsUri = pathToFileURL(movedComponentsDir).href;
     const diagnosticsFor = (uri: string) => (params: unknown) =>
       (params as { uri: string }).uri === uri;
     const counted = (params: unknown) => (params as { diagnostics: unknown[] }).diagnostics.length;
@@ -115,6 +119,7 @@ test("created and watched dependency changes refresh the open importer", async (
 
     // Phase 1: a file-operation create must heal the already-open importer at
     // the same document version; requiring an importer edit hides stale state.
+    fs.mkdirSync(componentsDir);
     fs.writeFileSync(childPath, CHILD_NUMBER, "utf8");
     session.notify("workspace/didCreateFiles", {
       files: [{ uri: childUri }],
@@ -153,7 +158,33 @@ test("created and watched dependency changes refresh the open importer", async (
     );
     assert.equal((afterReverseRename as { version?: number }).version, 1);
 
-    // Phase 4: the dependency's prop narrows on disk, no editor edit.
+    // Phase 4: a directory rename must invalidate nested dependencies, not
+    // only files whose URI exactly matches an indexed import.
+    await drainAppDiagnostics();
+    fs.renameSync(componentsDir, movedComponentsDir);
+    session.notify("workspace/didRenameFiles", {
+      files: [{ oldUri: componentsUri, newUri: movedComponentsUri }],
+    });
+    const afterDirectoryRename = await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => diagnosticsFor(appUri)(params) && diagnosticCodes(params).includes(2307),
+      60000,
+    );
+    assert.equal((afterDirectoryRename as { version?: number }).version, 1);
+
+    // Phase 5: restoring the directory must heal the same importer version.
+    fs.renameSync(movedComponentsDir, componentsDir);
+    session.notify("workspace/didRenameFiles", {
+      files: [{ oldUri: movedComponentsUri, newUri: componentsUri }],
+    });
+    const afterReverseDirectoryRename = await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => diagnosticsFor(appUri)(params) && counted(params) === 0,
+      60000,
+    );
+    assert.equal((afterReverseDirectoryRename as { version?: number }).version, 1);
+
+    // Phase 6: the dependency's prop narrows on disk, no editor edit.
     fs.writeFileSync(childPath, CHILD_STRING, "utf8");
     session.notify("workspace/didChangeWatchedFiles", {
       changes: [{ uri: childUri, type: 2 }],
@@ -165,7 +196,7 @@ test("created and watched dependency changes refresh the open importer", async (
     );
     assert.equal(counted(afterEdit), 1, "the stale binding is reported");
 
-    // Phase 5: the dependency disappears; the importer must stay broken.
+    // Phase 7: the dependency disappears; the importer must stay broken.
     await drainAppDiagnostics();
     fs.rmSync(childPath);
     session.notify("workspace/didChangeWatchedFiles", {
@@ -183,7 +214,7 @@ test("created and watched dependency changes refresh the open importer", async (
       )}`,
     );
 
-    // Phase 6: restored with the matching type; the importer recovers.
+    // Phase 8: restored with the matching type; the importer recovers.
     fs.writeFileSync(childPath, CHILD_NUMBER, "utf8");
     session.notify("workspace/didChangeWatchedFiles", {
       changes: [{ uri: childUri, type: 1 }],
@@ -194,6 +225,34 @@ test("created and watched dependency changes refresh the open importer", async (
       60000,
     );
     assert.equal(counted(afterWatchedRestore), 0, "a restored dependency clears the importer");
+
+    // Phase 9: a directory file-operation delete must evict every nested Vue
+    // overlay and republish the open importer at the same document version.
+    await drainAppDiagnostics();
+    fs.rmSync(componentsDir, { recursive: true });
+    session.notify("workspace/didDeleteFiles", {
+      files: [{ uri: componentsUri }],
+    });
+    const afterDirectoryDelete = await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => diagnosticsFor(appUri)(params) && diagnosticCodes(params).includes(2307),
+      60000,
+    );
+    assert.equal((afterDirectoryDelete as { version?: number }).version, 1);
+
+    // Phase 10: recreating the directory and nested dependency heals without
+    // requiring a file-level event or an importer edit.
+    fs.mkdirSync(componentsDir);
+    fs.writeFileSync(childPath, CHILD_NUMBER, "utf8");
+    session.notify("workspace/didCreateFiles", {
+      files: [{ uri: componentsUri }],
+    });
+    const afterDirectoryCreate = await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => diagnosticsFor(appUri)(params) && counted(params) === 0,
+      60000,
+    );
+    assert.equal((afterDirectoryCreate as { version?: number }).version, 1);
   } finally {
     await session.shutdown();
     fs.rmSync(workspaceDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- make the open Vue reverse-import index component-prefix aware for directory file-operation events
- evict every indexed nested Vue overlay before rechecking importers after directory rename or deletion
- pin same-version diagnostics across file and directory create, rename, delete, and restoration in the production LSP process

## Validation
- cargo test -p vize_maestro --features native
- cargo clippy -p vize_maestro --features native --lib -- -D warnings
- node --test tests/tooling/lsp-watched-refresh.test.ts
- strict tsgo on the changed TypeScript oracle
- vp check tests/tooling/lsp-watched-refresh.test.ts
- source-file-length gate against the parent base

Related to #3952

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->