### PR TITLE
fix(lsp): track nested Vue workspace symbols

### DIFF
--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -279,6 +279,14 @@ fn file_event_registration_options(
             },
         });
     }
+    filters.push(FileOperationFilter {
+        scheme: Some("file".to_string()),
+        pattern: FileOperationPattern {
+            glob: "**/*".to_string(),
+            matches: Some(FileOperationPatternKind::Folder),
+            options: None,
+        },
+    });
     FileOperationRegistrationOptions { filters }
 }
 

--- a/crates/vize_maestro/src/server/capabilities/file_operation_tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/file_operation_tests.rs
@@ -15,7 +15,36 @@ fn workspace_symbols_register_vue_file_events_without_typechecking_or_rename() {
         operations.did_rename,
     ] {
         let options = options.expect("every Vue file event must be registered");
-        assert_eq!(options.filters.len(), 1);
+        assert_eq!(options.filters.len(), 2);
         assert_eq!(options.filters[0].pattern.glob, "**/*.vue");
+        assert_eq!(options.filters[1].pattern.glob, "**/*");
+        assert_eq!(
+            options.filters[1].pattern.matches,
+            Some(tower_lsp::lsp_types::FileOperationPatternKind::Folder)
+        );
+    }
+}
+
+#[test]
+fn typechecking_registers_directory_events_without_workspace_symbols() {
+    let mut features = LspFeatureConfig::default();
+    features.typecheck = true;
+    features.workspace_symbols = false;
+    features.file_rename = false;
+
+    let operations = workspace_file_operations(features).expect("typechecking should be tracked");
+    for options in [
+        operations.did_create,
+        operations.did_delete,
+        operations.did_rename,
+    ] {
+        let filters = options.expect("file event registration").filters;
+        assert_eq!(filters.len(), 2);
+        assert_eq!(filters[0].pattern.glob, "**/*.d.{ts,mts,cts}");
+        assert_eq!(filters[1].pattern.glob, "**/*");
+        assert_eq!(
+            filters[1].pattern.matches,
+            Some(tower_lsp::lsp_types::FileOperationPatternKind::Folder)
+        );
     }
 }

--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -339,8 +339,10 @@ fn declaration_file_operations_cover_create_delete_and_rename() {
         operations.did_rename,
     ] {
         let options = options.expect("every declaration event must be registered");
-        assert_eq!(options.filters.len(), 2);
+        assert_eq!(options.filters.len(), 3);
         assert_eq!(options.filters[0].pattern.glob, "**/*.d.{ts,mts,cts}");
         assert_eq!(options.filters[1].pattern.glob, "**/*.vue");
+        assert_eq!(options.filters[2].pattern.glob, "**/*");
+        assert!(options.filters[2].pattern.matches == Some(FileOperationPatternKind::Folder));
     }
 }

--- a/crates/vize_maestro/src/server/state/global_components.rs
+++ b/crates/vize_maestro/src/server/state/global_components.rs
@@ -225,7 +225,7 @@ fn is_discoverable_declaration_uri(root: &Path, uri: &str) -> bool {
         })
 }
 
-fn is_excluded_directory(name: &OsStr) -> bool {
+pub(super) fn is_excluded_directory(name: &OsStr) -> bool {
     matches!(
         name.to_str(),
         Some(".git" | "node_modules" | "target" | "coverage" | "dist")

--- a/crates/vize_maestro/src/server/state/workspace_vue_files.rs
+++ b/crates/vize_maestro/src/server/state/workspace_vue_files.rs
@@ -1,28 +1,55 @@
 //! Closed Vue files announced through workspace file-operation events.
 
+use std::path::Path;
+
+use ignore::{DirEntry, WalkBuilder};
 use tower_lsp::lsp_types::Url;
 
 use super::ServerState;
+use super::global_components::is_excluded_directory;
 
 impl ServerState {
-    /// Track a newly-created on-disk Vue file without treating it as an open
-    /// editor document. Returns false for non-file, non-Vue, or missing URIs.
-    pub(crate) fn track_workspace_vue_file(&self, uri: &str) -> bool {
+    /// Track newly-created on-disk Vue files without treating them as open
+    /// editor documents. Folder events recursively discover nested SFCs.
+    pub(crate) fn track_workspace_vue_files(&self, uri: &str) -> bool {
         let Ok(uri) = Url::parse(uri) else {
             return false;
         };
-        if !uri.path().ends_with(".vue") || !uri.to_file_path().is_ok_and(|path| path.is_file()) {
+        let Ok(path) = uri.to_file_path() else {
+            return false;
+        };
+        if path.is_file() {
+            return is_vue_file(&path) && self.workspace_vue_files.insert(uri, ()).is_none();
+        }
+        if !path.is_dir() {
             return false;
         }
-        self.workspace_vue_files.insert(uri, ()).is_none()
+
+        let mut changed = false;
+        for entry in vue_files_below(&path) {
+            let Ok(uri) = Url::from_file_path(entry.path()) else {
+                continue;
+            };
+            changed |= self.workspace_vue_files.insert(uri, ()).is_none();
+        }
+        changed
     }
 
-    /// Forget a deleted or renamed on-disk Vue file.
-    pub(crate) fn forget_workspace_vue_file(&self, uri: &str) -> bool {
+    /// Forget a deleted or renamed on-disk Vue file or directory subtree.
+    pub(crate) fn forget_workspace_vue_files(&self, uri: &str) -> bool {
         let Ok(uri) = Url::parse(uri) else {
             return false;
         };
-        self.workspace_vue_files.remove(&uri).is_some()
+        let Ok(prefix) = uri.to_file_path() else {
+            return false;
+        };
+        let before = self.workspace_vue_files.len();
+        self.workspace_vue_files.retain(|candidate, _| {
+            candidate
+                .to_file_path()
+                .map_or(true, |path| !path.starts_with(&prefix))
+        });
+        self.workspace_vue_files.len() != before
     }
 
     /// Stable URI snapshot for workspace-wide searches. The caller performs
@@ -35,5 +62,67 @@ impl ServerState {
             .collect::<Vec<_>>();
         uris.sort_by(|left, right| left.as_str().cmp(right.as_str()));
         uris
+    }
+}
+
+fn vue_files_below(root: &Path) -> impl Iterator<Item = DirEntry> {
+    let mut builder = WalkBuilder::new(root);
+    builder
+        .hidden(false)
+        .ignore(false)
+        .git_global(false)
+        .git_ignore(false)
+        .git_exclude(false)
+        .parents(false)
+        .follow_links(false)
+        .filter_entry(|entry| {
+            !entry.file_type().is_some_and(|kind| kind.is_dir())
+                || !is_excluded_directory(entry.file_name())
+        });
+    builder
+        .build()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_type().is_some_and(|kind| kind.is_file()))
+        .filter(|entry| is_vue_file(entry.path()))
+}
+
+fn is_vue_file(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| extension == "vue")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ServerState, Url};
+
+    #[test]
+    fn directory_events_track_nested_vue_files_and_forget_only_that_subtree() {
+        let root = tempfile::tempdir().unwrap();
+        let components = root.path().join("components");
+        let sibling_dir = root.path().join("components-old");
+        let child = components.join("nested/Child.vue");
+        let ignored = components.join("node_modules/pkg/Ignored.vue");
+        let sibling = sibling_dir.join("Sibling.vue");
+        std::fs::create_dir_all(child.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(ignored.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(&sibling_dir).unwrap();
+        std::fs::write(&child, "<template />").unwrap();
+        std::fs::write(&ignored, "<template />").unwrap();
+        std::fs::write(&sibling, "<template />").unwrap();
+        let components_uri = Url::from_file_path(&components).unwrap();
+        let sibling_dir_uri = Url::from_file_path(&sibling_dir).unwrap();
+        let child_uri = Url::from_file_path(&child).unwrap();
+        let sibling_uri = Url::from_file_path(&sibling).unwrap();
+        let state = ServerState::new();
+
+        assert!(state.track_workspace_vue_files(components_uri.as_str()));
+        assert!(state.track_workspace_vue_files(sibling_dir_uri.as_str()));
+        assert_eq!(
+            state.workspace_vue_file_uris(),
+            vec![sibling_uri.clone(), child_uri]
+        );
+
+        std::fs::remove_dir_all(&components).unwrap();
+        assert!(state.forget_workspace_vue_files(components_uri.as_str()));
+        assert_eq!(state.workspace_vue_file_uris(), vec![sibling_uri]);
     }
 }

--- a/crates/vize_maestro/src/server/workspace_files.rs
+++ b/crates/vize_maestro/src/server/workspace_files.rs
@@ -144,7 +144,7 @@ fn record_created_files(state: &ServerState, params: &CreateFilesParams) {
             params.files.iter().map(|file| file.uri.as_str()),
         );
         for file in &params.files {
-            state.track_workspace_vue_file(file.uri.as_str());
+            state.track_workspace_vue_files(file.uri.as_str());
         }
         state.invalidate_batch_cache();
     }
@@ -182,7 +182,7 @@ fn record_deleted_files(state: &ServerState, params: &DeleteFilesParams) {
             params.files.iter().map(|file| file.uri.as_str()),
         );
         for file in &params.files {
-            state.forget_workspace_vue_file(file.uri.as_str());
+            state.forget_workspace_vue_files(file.uri.as_str());
         }
         state.invalidate_batch_cache();
     }
@@ -219,8 +219,10 @@ pub(super) async fn did_rename_files(server: &MaestroServer, params: &RenameFile
         for file in &params.files {
             server
                 .state
-                .forget_workspace_vue_file(file.old_uri.as_str());
-            server.state.track_workspace_vue_file(file.new_uri.as_str());
+                .forget_workspace_vue_files(file.old_uri.as_str());
+            server
+                .state
+                .track_workspace_vue_files(file.new_uri.as_str());
         }
         server.state.invalidate_batch_cache();
         let renamed_paths = affected_vue_source_paths(

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -43,6 +43,7 @@ async function withCapabilities(
 const FILE_EVENT_FILTERS = [
   { scheme: "file", pattern: { glob: "**/*.d.{ts,mts,cts}", matches: "file" } },
   { scheme: "file", pattern: { glob: "**/*.vue", matches: "file" } },
+  { scheme: "file", pattern: { glob: "**/*", matches: "folder" } },
 ];
 /** Everything a rename can move, plus folders. */
 const RENAME_FILTERS = [

--- a/tests/tooling/lsp-vue-file-lifecycle.test.ts
+++ b/tests/tooling/lsp-vue-file-lifecycle.test.ts
@@ -38,7 +38,7 @@ async function definitionAt(
   })) as Location | Location[] | null;
 }
 
-test("vize lsp follows created and deleted on-disk Vue files without opening them", async (t) => {
+test("vize lsp follows directory lifecycle for closed on-disk Vue files", async (t) => {
   const testRootDir = path.join(testOutputRoot, "lsp-vue-file-lifecycle");
   fs.mkdirSync(testRootDir, { recursive: true });
   const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
@@ -49,7 +49,7 @@ test("vize lsp follows created and deleted on-disk Vue files without opening the
     fs.mkdirSync(sourceDir, { recursive: true });
 
     const appSource = `<script setup lang="ts">
-import DiskChild from "./DiskChild.vue"
+import DiskChild from "./components/DiskChild.vue"
 </script>
 
 <template>
@@ -81,17 +81,24 @@ const diskLifecycleMarker = 1
   <span>{{ message }} {{ diskLifecycleMarker }}</span>
 </template>
 `;
-    const childPath = path.join(sourceDir, "DiskChild.vue");
+    const componentsDir = path.join(sourceDir, "components");
+    const movedComponentsDir = path.join(sourceDir, "moved-components");
+    const childPath = path.join(componentsDir, "DiskChild.vue");
+    const movedChildPath = path.join(movedComponentsDir, "DiskChild.vue");
     const childUri = pathToFileURL(childPath).href;
+    const movedChildUri = pathToFileURL(movedChildPath).href;
+    const componentsUri = pathToFileURL(componentsDir).href;
+    const movedComponentsUri = pathToFileURL(movedComponentsDir).href;
 
     await t.test(
-      "a create event indexes the closed file and resolves its imported props",
+      "a directory create indexes nested closed files and resolves imported props",
       async () => {
         assert.equal(await workspaceSymbols(session, "diskLifecycleMarker"), null);
         assert.equal(await definitionAt(session, appUri, appSource, "message"), null);
 
+        fs.mkdirSync(componentsDir);
         fs.writeFileSync(childPath, childSource, "utf8");
-        session.notify("workspace/didCreateFiles", { files: [{ uri: childUri }] });
+        session.notify("workspace/didCreateFiles", { files: [{ uri: componentsUri }] });
 
         const symbols = await workspaceSymbols(session, "diskLifecycleMarker");
         assert.equal(symbols?.length, 1, JSON.stringify(symbols));
@@ -104,9 +111,37 @@ const diskLifecycleMarker = 1
       },
     );
 
-    await t.test("a delete event removes the closed file from both surfaces", async () => {
-      fs.rmSync(childPath);
-      session.notify("workspace/didDeleteFiles", { files: [{ uri: childUri }] });
+    await t.test("directory renames relocate every nested closed-file symbol", async () => {
+      fs.renameSync(componentsDir, movedComponentsDir);
+      session.notify("workspace/didRenameFiles", {
+        files: [{ oldUri: componentsUri, newUri: movedComponentsUri }],
+      });
+
+      const movedSymbols = await workspaceSymbols(session, "diskLifecycleMarker");
+      assert.deepEqual(
+        movedSymbols?.map((symbol) => symbol.location.uri),
+        [movedChildUri],
+      );
+      assert.equal(await definitionAt(session, appUri, appSource, "message"), null);
+
+      fs.renameSync(movedComponentsDir, componentsDir);
+      session.notify("workspace/didRenameFiles", {
+        files: [{ oldUri: movedComponentsUri, newUri: componentsUri }],
+      });
+
+      const restoredSymbols = await workspaceSymbols(session, "diskLifecycleMarker");
+      assert.deepEqual(
+        restoredSymbols?.map((symbol) => symbol.location.uri),
+        [childUri],
+      );
+      const definition = await definitionAt(session, appUri, appSource, "message");
+      assert.ok(definition != null && !Array.isArray(definition), JSON.stringify(definition));
+      assert.equal(definition.uri, childUri);
+    });
+
+    await t.test("a directory delete removes nested closed files from both surfaces", async () => {
+      fs.rmSync(componentsDir, { recursive: true });
+      session.notify("workspace/didDeleteFiles", { files: [{ uri: componentsUri }] });
 
       assert.equal(await workspaceSymbols(session, "diskLifecycleMarker"), null);
       assert.equal(await definitionAt(session, appUri, appSource, "message"), null);


### PR DESCRIPTION
## Summary
- advertise folder create, delete, and rename events for typechecking and workspace-symbol configurations
- recursively index nested closed Vue files while excluding dependency and build trees
- relocate and remove nested workspace symbols across directory rename and deletion

## Validation
- cargo test -p vize_maestro --features native
- cargo clippy -p vize_maestro --features native --lib -- -D warnings
- production LSP lifecycle and capability tests
- strict tsgo and Vite+ checks for changed TypeScript tests
- source-file-length gate against the parent base

Related to #3952

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->