### PR TITLE
fix(lsp): range fallback template hovers

### DIFF
--- a/crates/vize_maestro/src/ide/hover/corsa.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa.rs
@@ -10,7 +10,7 @@
 
 use std::sync::Arc;
 
-use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Range};
+use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Position, Range};
 use vize_canon::{CorsaBridge, LspHover, LspHoverContents, LspMarkedString};
 
 use super::HoverService;
@@ -163,9 +163,7 @@ impl HoverService {
                 crate::ide::corsa_support::map_canonical_lsp_range(ctx, &doc, range)
             });
             let mut converted = Self::convert_lsp_hover(hover);
-            if mapped_range.is_some() {
-                converted.range = mapped_range;
-            }
+            converted.range = mapped_range.or_else(|| authored_hover_token_range(ctx));
             super::declaration_keyword::align_hover(ctx, &word, &mut converted);
             return Some(converted);
         }
@@ -174,7 +172,12 @@ impl HoverService {
             return None;
         }
 
-        Self::hover_template(ctx)
+        Self::hover_template(ctx).map(|mut hover| {
+            if hover.range.is_none() {
+                hover.range = authored_hover_token_range(ctx);
+            }
+            hover
+        })
     }
 
     /// Get hover for an art variant template with Corsa.
@@ -326,4 +329,15 @@ impl HoverService {
     fn decorate_corsa_hover_markdown(value: &str) -> String {
         value.trim().to_string()
     }
+}
+
+fn authored_hover_token_range(ctx: &IdeContext<'_>) -> Option<Range> {
+    let (start, end) =
+        crate::ide::token_span_at_offset(&ctx.content, ctx.offset, HoverService::is_word_char)?;
+    let (start_line, start_character) = crate::ide::offset_to_position(&ctx.content, start);
+    let (end_line, end_character) = crate::ide::offset_to_position(&ctx.content, end);
+    Some(Range::new(
+        Position::new(start_line, start_character),
+        Position::new(end_line, end_character),
+    ))
 }

--- a/crates/vize_maestro/src/ide/hover/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa_tests.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use tower_lsp::lsp_types::{Hover, HoverContents, MarkedString, Url};
+use tower_lsp::lsp_types::{Hover, HoverContents, MarkedString, Position, Range, Url};
 
 use super::HoverService;
 use crate::{ide::IdeContext, server::ServerState};
@@ -91,6 +91,83 @@ const msg = 'hello'
         let value = hover_markdown(hover);
         assert!(value.contains("message"), "{value}");
         assert!(value.contains("string"), "{value}");
+    });
+}
+
+#[test]
+fn hover_with_corsa_ranges_bare_define_props_template_binding() {
+    crate::runtime::block_on(async {
+        let Some(corsa_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(
+            dir.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .unwrap();
+        fs::write(
+            src.join("vue.d.ts"),
+            r#"declare module "vue" {
+  export type DefineComponent<P = any, _B = any, _D = any> = { new(): { $props: P } };
+}
+"#,
+        )
+        .unwrap();
+
+        let source = r#"<script setup lang="ts">
+defineProps<{ describedBy: string }>()
+</script>
+<template><div :aria-describedby="describedBy" /></template>
+"#;
+        let source_path = src.join("Message.vue");
+        fs::write(&source_path, source).unwrap();
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state.set_workspace_root(dir.path().to_path_buf());
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+        let bridge = std::sync::Arc::new(vize_canon::CorsaBridge::with_config(
+            vize_canon::CorsaBridgeConfig {
+                corsa_path: Some(corsa_path),
+                working_dir: Some(dir.path().to_path_buf()),
+                timeout_ms: 30_000,
+                ..Default::default()
+            },
+        ));
+        bridge.spawn().await.unwrap();
+
+        let start = source.rfind("describedBy").unwrap();
+        let ctx = IdeContext::new(&state, &uri, start).unwrap();
+        let hover = HoverService::hover_with_corsa(&ctx, Some(bridge.clone()))
+            .await
+            .unwrap();
+        let _ = bridge.shutdown().await;
+        let (start_line, start_character) = crate::ide::offset_to_position(source, start);
+        let (end_line, end_character) =
+            crate::ide::offset_to_position(source, start + "describedBy".len());
+
+        assert_eq!(
+            hover.range,
+            Some(Range::new(
+                Position::new(start_line, start_character),
+                Position::new(end_line, end_character),
+            )),
+        );
+        assert!(hover_markdown(hover).contains("_Template binding_"));
     });
 }
 


### PR DESCRIPTION
## Summary

- preserve mapped Corsa/tsgo hover ranges when available
- synthesize the exact authored token range when backend or fallback hover omits it
- pin bare defineProps template bindings at the identifier boundary

## TDD evidence

The focused native test failed before the implementation with an actual null hover range and the exact authored describedBy range as the expectation.

## Validation

- cargo test -p vize_maestro --features native
- cargo clippy -p vize_maestro --features native --lib -- -D warnings
- source-file length comparison against 78f09145f1a7ea9213f6c9010fffd4f97f26da61
- cargo build -p vize

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->