### PR TITLE
fix(lsp): map template value subspans to tsgo

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support/canonical.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical.rs
@@ -82,12 +82,26 @@ fn mapping_for_source_offset(
 ) -> Option<&vize_canon::virtual_ts::VizeMapping> {
     mappings
         .iter()
-        .filter(|mapping| offset >= mapping.src_range.start && offset <= mapping.src_range.end)
+        .filter(|mapping| {
+            (offset >= mapping.src_range.start && offset <= mapping.src_range.end)
+                || mapping
+                    .sub_spans
+                    .iter()
+                    .any(|span| offset >= span.src_range.start && offset <= span.src_range.end)
+        })
         .min_by_key(|mapping| {
             mapping
-                .src_range
-                .end
-                .saturating_sub(mapping.src_range.start)
+                .sub_spans
+                .iter()
+                .filter(|span| offset >= span.src_range.start && offset <= span.src_range.end)
+                .map(|span| span.src_range.end.saturating_sub(span.src_range.start))
+                .min()
+                .unwrap_or_else(|| {
+                    mapping
+                        .src_range
+                        .end
+                        .saturating_sub(mapping.src_range.start)
+                })
         })
 }
 
@@ -277,4 +291,25 @@ fn location_matches_uri(actual: &str, expected: &str) -> bool {
     actual == expected
         || super::virtual_document_path(actual).as_deref()
             == super::virtual_document_path(expected).as_deref()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{map_source_offset_to_generated, mapping_for_source_offset};
+    use vize_canon::virtual_ts::{VizeMapping, VizeSubSpan};
+
+    #[test]
+    fn source_mapping_selects_a_value_sub_span_outside_the_parent_source_range() {
+        let mappings = [VizeMapping {
+            gen_range: 100..140,
+            src_range: 10..20,
+            sub_spans: vec![VizeSubSpan {
+                gen_range: 124..129,
+                src_range: 30..35,
+            }],
+        }];
+
+        let mapping = mapping_for_source_offset(&mappings, 32).expect("value sub-span mapping");
+        assert_eq!(map_source_offset_to_generated(mapping, 32), 126);
+    }
 }

--- a/crates/vize_maestro/src/ide/hover/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa_tests.rs
@@ -167,7 +167,8 @@ defineProps<{ describedBy: string }>()
                 Position::new(end_line, end_character),
             )),
         );
-        assert!(hover_markdown(hover).contains("_Template binding_"));
+        let value = hover_markdown(hover);
+        assert!(value.contains("const describedBy: string"), "{value}");
     });
 }
 


### PR DESCRIPTION
## Summary

- select canonical mappings when an authored template token is represented by a value sub-span outside the mapping parent range
- preserve the narrowest matching sub-span when projecting source offsets into virtual TypeScript
- require real tsgo hover to expose `const describedBy: string` for a bare `defineProps` binding used in a dynamic native attribute

Tracks #3952.

## Test plan

- `cargo test -p vize_maestro --features native`
- `cargo clippy -p vize_maestro --features native --lib -- -D warnings`
- `node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/source-file-lengths.test.ts`
- Elk production LSP oracle advanced past the typed hover assertion to component-definition URI validation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->