### PR TITLE
fix(lsp): normalize referenced alias targets

### DIFF
--- a/crates/vize_maestro/src/ide/definition/service/import_target.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target.rs
@@ -10,7 +10,7 @@
 //! target — following `export … from` barrels a bounded number of hops.
 
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Position, Range, Url};
 use vize_carton::cstr;
@@ -201,18 +201,34 @@ fn resolve_import_specifier(uri: &Url, specifier: &str) -> Option<PathBuf> {
 
 fn probe(base: &Path) -> Option<PathBuf> {
     if base.extension().is_some() && base.is_file() {
-        return Some(base.to_path_buf());
+        return Some(normalize_absolute_path(base));
     }
     for extension in ["ts", "tsx", "d.ts", "vue"] {
         let candidate = PathBuf::from(cstr!("{}.{extension}", base.display()).as_str());
         if candidate.is_file() {
-            return Some(candidate);
+            return Some(normalize_absolute_path(&candidate));
         }
     }
-    ["index.ts", "index.tsx"]
+    let candidate = ["index.ts", "index.tsx"]
         .iter()
         .map(|index| base.join(index))
-        .find(|candidate| candidate.is_file())
+        .find(|candidate| candidate.is_file())?;
+    Some(normalize_absolute_path(&candidate))
+}
+
+fn normalize_absolute_path(path: &Path) -> PathBuf {
+    debug_assert!(path.is_absolute());
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
 }
 
 /// The declaration of `word` inside `target`, following re-export barrels.

--- a/crates/vize_maestro/src/ide/definition/service/import_target/tests.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target/tests.rs
@@ -1,3 +1,10 @@
+use std::fs;
+
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Url};
+
+use crate::ide::IdeContext;
+use crate::server::ServerState;
+
 #[test]
 fn the_importing_statement_is_matched_by_offset_and_binding() {
     let content = "import { a } from \"./a\";\nimport { useCounter, type User } from \"../composables/useCounter\";\n";
@@ -76,5 +83,54 @@ fn reexports_cover_named_renames_and_stars() {
     assert_eq!(
         super::reexport_specifier(renaming, "LocalWidget"),
         Some(("./Widget".to_owned(), "Widget".to_owned())),
+    );
+}
+
+#[test]
+fn nuxt_reference_aliases_return_normalized_component_uris() {
+    let workspace = tempfile::tempdir().expect("temporary workspace");
+    let nuxt = workspace.path().join(".nuxt");
+    let pages = workspace.path().join("app/pages");
+    let components = workspace.path().join("app/components");
+    fs::create_dir_all(&nuxt).expect("Nuxt directory");
+    fs::create_dir_all(&pages).expect("pages directory");
+    fs::create_dir_all(&components).expect("components directory");
+    fs::write(
+        workspace.path().join("tsconfig.json"),
+        r#"{"references":[{"path":"./.nuxt/tsconfig.app.json"}],"files":[]}"#,
+    )
+    .expect("solution config");
+    fs::write(
+        nuxt.join("tsconfig.app.json"),
+        r#"{"compilerOptions":{"paths":{"~/*":["../app/*"]}}}"#,
+    )
+    .expect("Nuxt app config");
+
+    let target_path = components.join("AccountSearchResult.vue");
+    fs::write(&target_path, "<template />\n").expect("component");
+    let importer_path = pages.join("accounts.vue");
+    let source = r#"<script setup lang="ts">
+import AccountSearchResult from '~/components/AccountSearchResult.vue'
+</script>
+<template><AccountSearchResult /></template>
+"#;
+    fs::write(&importer_path, source).expect("importer");
+
+    let importer_uri = Url::from_file_path(&importer_path).expect("importer URI");
+    let state = ServerState::new();
+    state
+        .documents
+        .open(importer_uri.clone(), source.to_owned(), 1, "vue".to_owned());
+    state.update_virtual_docs(&importer_uri, source);
+    let offset = source.rfind("AccountSearchResult").expect("component tag");
+    let ctx = IdeContext::new(&state, &importer_uri, offset).expect("IDE context");
+    let definition = super::component_tag_definition(&ctx).expect("component definition");
+    let GotoDefinitionResponse::Scalar(location) = definition else {
+        panic!("component definition must be scalar");
+    };
+
+    assert_eq!(
+        location.uri,
+        Url::from_file_path(target_path).expect("target URI")
     );
 }


### PR DESCRIPTION
## Summary

- normalize `.` and `..` segments in targets resolved from referenced tsconfig path aliases
- preserve workspace and symlink identity by avoiding filesystem canonicalization
- cover the Nuxt solution-config shape where `.nuxt/tsconfig.app.json` maps `~/*` through `../app/*`

Tracks #3952.

## Test plan

- `cargo test -p vize_maestro --features native`
- `cargo clippy -p vize_maestro --features native --lib -- -D warnings`
- `node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/source-file-lengths.test.ts`
- Elk production LSP oracle advanced from component-definition URI validation to component-prop completion validation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->