### PR TITLE
fix(lsp): resolve alias component metadata

### DIFF
--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -20,6 +20,8 @@ mod style;
 pub(crate) mod template;
 
 #[cfg(test)]
+mod component_alias_props_tests;
+#[cfg(test)]
 mod component_props_tests;
 #[cfg(test)]
 mod dedup_tests;

--- a/crates/vize_maestro/src/ide/completion/component_alias_props_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/component_alias_props_tests.rs
@@ -1,0 +1,62 @@
+use std::fs;
+
+use tower_lsp::lsp_types::{CompletionResponse, Url};
+
+use super::CompletionService;
+use crate::{ide::IdeContext, server::ServerState};
+
+#[test]
+fn template_component_prop_completion_resolves_nuxt_reference_aliases() {
+    let workspace = tempfile::tempdir().expect("temporary workspace");
+    let nuxt = workspace.path().join(".nuxt");
+    let pages = workspace.path().join("app/pages");
+    let components = workspace.path().join("app/components");
+    fs::create_dir_all(&nuxt).expect("Nuxt directory");
+    fs::create_dir_all(&pages).expect("pages directory");
+    fs::create_dir_all(&components).expect("components directory");
+    fs::write(
+        workspace.path().join("tsconfig.json"),
+        r#"{"references":[{"path":"./.nuxt/tsconfig.app.json"}],"files":[]}"#,
+    )
+    .expect("solution config");
+    fs::write(
+        nuxt.join("tsconfig.app.json"),
+        r#"{"compilerOptions":{"paths":{"~/*":["../app/*"]}}}"#,
+    )
+    .expect("Nuxt app config");
+    fs::write(
+        components.join("AccountSearchResult.vue"),
+        r#"<script setup lang="ts">
+defineProps<{ result: unknown; active: boolean }>()
+</script>
+"#,
+    )
+    .expect("component");
+
+    let source = r#"<script setup lang="ts">
+import AccountSearchResult from '~/components/AccountSearchResult.vue'
+</script>
+<template><AccountSearchResult  /></template>
+"#;
+    let importer_path = pages.join("accounts.vue");
+    fs::write(&importer_path, source).expect("importer");
+    let uri = Url::from_file_path(&importer_path).expect("importer URI");
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_owned(), 1, "vue".to_owned());
+    state.update_virtual_docs(&uri, source);
+
+    let offset = source.find("<AccountSearchResult  />").unwrap() + "<AccountSearchResult ".len();
+    let ctx = IdeContext::new(&state, &uri, offset).expect("IDE context");
+    let labels = match CompletionService::complete(&ctx).expect("completion") {
+        CompletionResponse::Array(items) => items,
+        CompletionResponse::List(list) => list.items,
+    }
+    .into_iter()
+    .map(|item| item.label)
+    .collect::<Vec<_>>();
+
+    assert!(labels.iter().any(|label| label == "result"), "{labels:?}");
+    assert!(labels.iter().any(|label| label == "active"), "{labels:?}");
+}

--- a/crates/vize_maestro/src/ide/definition.rs
+++ b/crates/vize_maestro/src/ide/definition.rs
@@ -6,6 +6,7 @@ pub(crate) mod helpers;
 mod html;
 #[cfg(all(test, feature = "native"))]
 mod html_tests;
+pub(crate) mod import_resolver;
 mod inline_art;
 mod module_specifier;
 pub(crate) mod script;

--- a/crates/vize_maestro/src/ide/definition/helpers.rs
+++ b/crates/vize_maestro/src/ide/definition/helpers.rs
@@ -314,35 +314,7 @@ pub(crate) fn extract_import_path_from_pos(content: &str, pos: usize) -> Option<
     Some(rest[path_start..path_start + path_end].to_string())
 }
 
-/// Resolve an import path relative to the current file.
+/// Resolve a relative, package, or tsconfig-path import from the current file.
 pub(crate) fn resolve_import_path(current_uri: &Url, import_path: &str) -> Option<PathBuf> {
-    let current_path = PathBuf::from(current_uri.path());
-    let current_dir = current_path.parent()?;
-
-    if import_path.starts_with("./") || import_path.starts_with("../") {
-        let resolved = current_dir.join(import_path);
-
-        if !resolved.exists() {
-            let extensions = [".vue", ".ts", ".tsx", ".js", ".jsx"];
-            for ext in extensions {
-                let with_ext = resolved.with_extension(&ext[1..]);
-                if with_ext.exists() {
-                    return Some(with_ext);
-                }
-            }
-            // Try index files
-            for ext in extensions {
-                #[allow(clippy::disallowed_macros)]
-                let index_name = format!("index{}", ext);
-                let index_file = resolved.join(index_name);
-                if index_file.exists() {
-                    return Some(index_file);
-                }
-            }
-        }
-
-        Some(resolved.canonicalize().unwrap_or(resolved))
-    } else {
-        None
-    }
+    super::import_resolver::resolve_import_specifier(current_uri, import_path)
 }

--- a/crates/vize_maestro/src/ide/definition/import_resolver.rs
+++ b/crates/vize_maestro/src/ide/definition/import_resolver.rs
@@ -1,0 +1,80 @@
+//! Shared resolution for relative, package, and tsconfig-path imports.
+
+use std::path::{Component, Path, PathBuf};
+
+use tower_lsp::lsp_types::Url;
+use vize_carton::cstr;
+
+use super::module_specifier;
+
+pub(crate) fn resolve_import_specifier(uri: &Url, specifier: &str) -> Option<PathBuf> {
+    if let Some(path) = module_specifier::resolve_specifier(uri, specifier) {
+        return Some(path);
+    }
+
+    let file = uri.to_file_path().ok()?;
+    if specifier.starts_with("./") || specifier.starts_with("../") {
+        return Some(normalize_absolute_path(
+            file.parent()?.join(specifier).as_path(),
+        ));
+    }
+
+    let paths = crate::ide::tsconfig_paths::project_paths(&file)?;
+    let mut best: Option<(usize, PathBuf)> = None;
+    for (pattern, target) in &paths.entries {
+        let substituted = if let Some(prefix) = pattern.strip_suffix('*') {
+            match (specifier.strip_prefix(prefix), target.strip_suffix('*')) {
+                (Some(rest), Some(target_prefix)) => {
+                    Some(cstr!("{target_prefix}{rest}").to_string())
+                }
+                _ => None,
+            }
+        } else if specifier == pattern {
+            Some(target.clone())
+        } else {
+            None
+        };
+        let Some(substituted) = substituted else {
+            continue;
+        };
+        let base = paths.anchor.join(substituted);
+        if let Some(resolved) = probe(&base)
+            && best.as_ref().is_none_or(|(len, _)| pattern.len() > *len)
+        {
+            best = Some((pattern.len(), resolved));
+        }
+    }
+    best.map(|(_, path)| path)
+}
+
+fn probe(base: &Path) -> Option<PathBuf> {
+    if base.extension().is_some() && base.is_file() {
+        return Some(normalize_absolute_path(base));
+    }
+    for extension in ["ts", "tsx", "d.ts", "vue"] {
+        let candidate = PathBuf::from(cstr!("{}.{extension}", base.display()).as_str());
+        if candidate.is_file() {
+            return Some(normalize_absolute_path(&candidate));
+        }
+    }
+    let candidate = ["index.ts", "index.tsx"]
+        .iter()
+        .map(|index| base.join(index))
+        .find(|candidate| candidate.is_file())?;
+    Some(normalize_absolute_path(&candidate))
+}
+
+fn normalize_absolute_path(path: &Path) -> PathBuf {
+    debug_assert!(path.is_absolute());
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}

--- a/crates/vize_maestro/src/ide/definition/service/import_target.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target.rs
@@ -10,13 +10,12 @@
 //! target — following `export … from` barrels a bounded number of hops.
 
 use std::fs;
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 
 use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Position, Range, Url};
-use vize_carton::cstr;
 
 use crate::ide::IdeContext;
-use crate::ide::definition::{helpers, module_specifier, script};
+use crate::ide::definition::{helpers, import_resolver::resolve_import_specifier, script};
 
 /// Barrels can chain; three hops covers a package barrel re-exporting a
 /// directory barrel re-exporting the module, without risking a cycle walk.
@@ -158,77 +157,6 @@ fn split_rename(part: &str) -> (&str, &str) {
         Some((source, bound)) => (source.trim(), bound.trim()),
         None => (part, part),
     }
-}
-
-/// Resolve relative and bare specifiers through the shared resolver, and
-/// tsconfig `paths` aliases through the nearest tsconfig — the shapes the
-/// audit measured (`../composables/useCounter`, `#ui`, `@/lib/format`).
-fn resolve_import_specifier(uri: &Url, specifier: &str) -> Option<PathBuf> {
-    if let Some(path) = module_specifier::resolve_specifier(uri, specifier) {
-        return Some(path);
-    }
-    // The shared reader anchors like the session does: nearest tsconfig,
-    // following a solution-style shell's references, with string-aware jsonc
-    // stripping — a naive stripper eats every `"@/*"` pattern (#3915, #3917).
-    let file = uri.to_file_path().ok()?;
-    let paths = crate::ide::tsconfig_paths::project_paths(&file)?;
-    let mut best: Option<(usize, PathBuf)> = None;
-    for (pattern, target) in &paths.entries {
-        let substituted = if let Some(prefix) = pattern.strip_suffix('*') {
-            match (specifier.strip_prefix(prefix), target.strip_suffix('*')) {
-                (Some(rest), Some(target_prefix)) => {
-                    Some(cstr!("{target_prefix}{rest}").to_string())
-                }
-                _ => None,
-            }
-        } else if specifier == pattern {
-            Some(target.clone())
-        } else {
-            None
-        };
-        let Some(substituted) = substituted else {
-            continue;
-        };
-        let base = paths.anchor.join(substituted);
-        if let Some(resolved) = probe(&base)
-            && best.as_ref().is_none_or(|(len, _)| pattern.len() > *len)
-        {
-            best = Some((pattern.len(), resolved));
-        }
-    }
-    best.map(|(_, path)| path)
-}
-
-fn probe(base: &Path) -> Option<PathBuf> {
-    if base.extension().is_some() && base.is_file() {
-        return Some(normalize_absolute_path(base));
-    }
-    for extension in ["ts", "tsx", "d.ts", "vue"] {
-        let candidate = PathBuf::from(cstr!("{}.{extension}", base.display()).as_str());
-        if candidate.is_file() {
-            return Some(normalize_absolute_path(&candidate));
-        }
-    }
-    let candidate = ["index.ts", "index.tsx"]
-        .iter()
-        .map(|index| base.join(index))
-        .find(|candidate| candidate.is_file())?;
-    Some(normalize_absolute_path(&candidate))
-}
-
-fn normalize_absolute_path(path: &Path) -> PathBuf {
-    debug_assert!(path.is_absolute());
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::CurDir => {}
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            component => normalized.push(component.as_os_str()),
-        }
-    }
-    normalized
 }
 
 /// The declaration of `word` inside `target`, following re-export barrels.


### PR DESCRIPTION
## Summary

- share relative, package, and tsconfig-path import resolution across definition, hover, and component metadata
- resolve component prop completions through Nuxt solution-config references and `~/*` aliases
- keep unresolved relative targets available for open unsaved buffers

Tracks #3952.

## Test plan

- `cargo test -p vize_maestro --features native`
- `cargo clippy -p vize_maestro --features native --lib -- -D warnings`
- `node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/source-file-lengths.test.ts`
- Elk production LSP oracle passed typed hover, exact definition URI, baseline prop completion, dependency edit, and repair; it advanced to alias-aware `willRenameFiles` validation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->