### PR TITLE
fix(lsp): preserve encoded open buffers during file rename

### DIFF
--- a/crates/vize_maestro/src/ide/file_rename/alias_tests.rs
+++ b/crates/vize_maestro/src/ide/file_rename/alias_tests.rs
@@ -119,3 +119,81 @@ import { helper } from "@/util";
     }
     "###);
 }
+
+#[test]
+fn nuxt_alias_rename_edits_use_the_open_importer_buffer() {
+    let dir = test_dir();
+    let root = dir.path();
+    let nuxt = root.join(".nuxt");
+    let pages = root.join("app/pages/[[server]]/list/[list]/index");
+    let components = root.join("app/components/list");
+    fs::create_dir_all(&nuxt).unwrap();
+    fs::create_dir_all(&pages).unwrap();
+    fs::create_dir_all(&components).unwrap();
+    fs::write(
+        root.join("tsconfig.json"),
+        r#"{"references":[{"path":"./.nuxt/tsconfig.app.json"}],"files":[]}"#,
+    )
+    .unwrap();
+    fs::write(
+        nuxt.join("tsconfig.app.json"),
+        r#"{"compilerOptions":{"paths":{"~/*":["../app/*"]}}}"#,
+    )
+    .unwrap();
+
+    let importer = pages.join("accounts.vue");
+    fs::write(
+        &importer,
+        "<script setup lang=\"ts\">\nimport Result from '~/components/list/Original.vue'\n</script>\n",
+    )
+    .unwrap();
+    let copied = components.join("__VizeOracleResult.vue");
+    let renamed = components.join("__VizeOracleRenamedResult.vue");
+    fs::write(&copied, "<template />\n").unwrap();
+
+    let open_source = "<script setup lang=\"ts\">\nimport Result from '~/components/list/__VizeOracleResult.vue'\n</script>\n";
+    let canonical_uri = tower_lsp::lsp_types::Url::from_file_path(&importer).unwrap();
+    let importer_uri = tower_lsp::lsp_types::Url::parse(
+        &canonical_uri
+            .as_str()
+            .replace('[', "%5B")
+            .replace(']', "%5D"),
+    )
+    .unwrap();
+    assert_ne!(importer_uri, canonical_uri);
+    let state = ServerState::new();
+    state.set_workspace_root(root.to_path_buf());
+    state
+        .documents
+        .open(importer_uri, open_source.to_owned(), 2, "vue".to_owned());
+
+    let edit = collect_import_rename_edits(
+        &state,
+        &[FileRename {
+            old_uri: file_uri(&copied),
+            new_uri: file_uri(&renamed),
+        }],
+        true,
+    )
+    .expect("rename edit for the open authored importer");
+
+    assert_snapshot!(serde_json::to_string_pretty(&normalize_edit(root, &edit)).unwrap(), @r###"
+    {
+      "app/pages/[[server]]/list/[list]/index/accounts.vue": [
+        {
+          "newText": "~/components/list/__VizeOracleRenamedResult.vue",
+          "range": {
+            "end": {
+              "character": 60,
+              "line": 1
+            },
+            "start": {
+              "character": 20,
+              "line": 1
+            }
+          }
+        }
+      ]
+    }
+    "###);
+}

--- a/crates/vize_maestro/src/ide/file_rename/manual.rs
+++ b/crates/vize_maestro/src/ide/file_rename/manual.rs
@@ -54,6 +54,13 @@ struct SpecifierOccurrence {
     specifier: std::string::String,
 }
 
+struct OpenDocumentSnapshot {
+    uri: Url,
+    source: std::string::String,
+}
+
+type OpenDocumentSnapshots = HashMap<PathBuf, OpenDocumentSnapshot>;
+
 struct ScriptEditContext<'a> {
     state: &'a ServerState,
     current_path: &'a Path,
@@ -161,6 +168,7 @@ pub(super) fn collect_import_rename_edits(
     }
 
     let workspace_root = workspace_root(state);
+    let open_documents = snapshot_open_documents(state);
     let changes = Mutex::new(HashMap::new());
     let seen_paths = Mutex::new(HashSet::new());
 
@@ -171,6 +179,7 @@ pub(super) fn collect_import_rename_edits(
         .run(|| {
             let changes = &changes;
             let seen_paths = &seen_paths;
+            let open_documents = &open_documents;
             let rename_targets = &rename_targets;
 
             Box::new(move |entry| {
@@ -184,10 +193,11 @@ pub(super) fn collect_import_rename_edits(
                 };
 
                 if let Ok(mut seen) = seen_paths.lock() {
-                    seen.insert(path.to_path_buf());
+                    seen.insert(normalize_path_buf(path));
                 }
 
-                if let Some((uri, edits)) = process_importer_path(state, path, kind, rename_targets)
+                if let Some((uri, edits)) =
+                    process_importer_path(state, path, kind, rename_targets, open_documents)
                     && let Ok(mut changes) = changes.lock()
                 {
                     changes.insert(uri, edits);
@@ -198,11 +208,7 @@ pub(super) fn collect_import_rename_edits(
         });
 
     let seen_paths = seen_paths.into_inner().unwrap_or_default();
-    for document in state.documents.iter() {
-        let uri = document.key().clone();
-        let Ok(path) = uri.to_file_path() else {
-            continue;
-        };
+    for (path, document) in open_documents {
         let Some(kind) = importer_kind(&path, only_vue_importers) else {
             continue;
         };
@@ -212,9 +218,9 @@ pub(super) fn collect_import_rename_edits(
 
         if let Some((uri, edits)) = process_source(
             state,
-            uri.clone(),
+            document.uri,
             &path,
-            &document.value().text(),
+            &document.source,
             kind,
             &rename_targets,
         ) && let Ok(mut changes) = changes.lock()
@@ -277,10 +283,23 @@ fn process_importer_path(
     path: &Path,
     kind: ImporterKind,
     rename_targets: &[RenameTarget],
+    open_documents: &OpenDocumentSnapshots,
 ) -> Option<(Url, Vec<TextEdit>)> {
-    let uri = Url::from_file_path(path).ok()?;
-    let source = read_workspace_source(state, path)?;
-    process_source(state, uri, path, &source, kind, rename_targets)
+    let normalized_path = normalize_path_buf(path);
+    if let Some(document) = open_documents.get(&normalized_path) {
+        return process_source(
+            state,
+            document.uri.clone(),
+            &normalized_path,
+            &document.source,
+            kind,
+            rename_targets,
+        );
+    }
+
+    let uri = Url::from_file_path(&normalized_path).ok()?;
+    let source = fs::read_to_string(&normalized_path).ok()?;
+    process_source(state, uri, &normalized_path, &source, kind, rename_targets)
 }
 
 fn process_source(
@@ -658,14 +677,21 @@ fn importer_kind(path: &Path, only_vue_importers: bool) -> Option<ImporterKind> 
     }
 }
 
-fn read_workspace_source(state: &ServerState, path: &Path) -> Option<std::string::String> {
-    if let Ok(uri) = Url::from_file_path(path)
-        && let Some(document) = state.documents.get(&uri)
-    {
-        return Some(document.text());
+fn snapshot_open_documents(state: &ServerState) -> OpenDocumentSnapshots {
+    let mut snapshots = HashMap::with_capacity(state.documents.len());
+    for document in state.documents.iter() {
+        let Ok(path) = document.key().to_file_path() else {
+            continue;
+        };
+        snapshots.insert(
+            normalize_path_buf(&path),
+            OpenDocumentSnapshot {
+                uri: document.key().clone(),
+                source: document.value().text(),
+            },
+        );
     }
-
-    fs::read_to_string(path).ok()
+    snapshots
 }
 
 pub(super) fn split_specifier_suffix(specifier: &str) -> (&str, &str) {


### PR DESCRIPTION
## Summary

- snapshot open documents by normalized filesystem path before the parallel workspace scan
- preserve the client-authored URI when producing rename edits
- cover Nuxt aliases and percent-encoded route segments with a regression test

## Root cause

The rename scanner rebuilt each workspace URI from its filesystem path and looked up the open buffer by exact URI equality. A client URI containing percent-encoded Nuxt route segments such as `%5Blist%5D` was not equal to the URI reconstructed from `[list]`. The scanner therefore read the stale on-disk importer and returned no edit.

The path-keyed snapshot also avoids repeated document-store locking and avoids an `O(workspace files × open documents)` fallback scan.

## Validation

- `cargo test -p vize_maestro` — 727 passed, 2 ignored; 3 integration tests and 1 doctest passed
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- Elk authored production oracle advances through `workspace/willRenameFiles` and rename-following diagnostics; the next independent failure is delete-triggered diagnostic refresh
- separate tsgo runtime crash tracked in #3975

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->