### PR TITLE
test(lsp): ratchet authored coverage with Elk

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 6,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 1,
+    "minimumProjectCount": 2,
     "trackingIssue": 3952
   },
   "projects": [
@@ -343,6 +343,69 @@
         "lsp"
       ],
       "diff": "e2e-vrt",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "app/components/common/CommonErrorMessage.vue",
+          "symbol": "describedBy",
+          "usageAnchor": ":aria-describedby=\"describedBy\"",
+          "declarationAnchor": "defineProps<{ describedBy: string }>()",
+          "hoverContains": ["const describedBy: string"],
+          "renameTo": "__vizeRenamedDescribedBy"
+        },
+        "componentBoundary": {
+          "importerFile": "app/pages/[[server]]/list/[list]/index/accounts.vue",
+          "componentFile": "app/components/list/AccountSearchResult.vue",
+          "tagName": "AccountSearchResult",
+          "tagAnchor": "<AccountSearchResult\n",
+          "completionItemCount": 30,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "result", "rank": 28 },
+            { "label": "active", "rank": 29 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  active: boolean\n",
+            "replacement": "  active: boolean\n  vizeOracleProbe?: boolean\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "app/components/list/__VizeOracleAccountSearchResult.vue",
+          "renamedFile": "app/components/list/__VizeOracleRenamedAccountSearchResult.vue",
+          "originalImportSpecifier": "~/components/list/AccountSearchResult.vue",
+          "copiedImportSpecifier": "~/components/list/__VizeOracleAccountSearchResult.vue",
+          "renamedImportSpecifier": "~/components/list/__VizeOracleRenamedAccountSearchResult.vue",
+          "markerInsertionAnchor": "<script setup lang=\"ts\">\n",
+          "markerSymbol": "__vizeElkFileLifecycleMarker__"
+        }
+      },
       "typecheckPerformance": {
         "enabled": true,
         "compareTo": "vue-tsc",


### PR DESCRIPTION
## Summary

- add a real authored LSP oracle for the Elk Nuxt fixture
- pin exact hover, definition, references, rename, completion order, and unsaved dependency behavior
- exercise component create, rename, delete, stale-symbol cleanup, missing-module diagnostics, and exact repair
- raise the authored real-project coverage ratchet from one project to two

## Why Elk

Elk contributes a materially different production shape from the existing oracle: solution-style Nuxt tsconfig references, `~/*` aliases, bracketed route paths, a larger template, and an authored cross-component completion surface. Building the oracle exposed and drove fixes for value-subspan mapping, normalized alias targets, alias component metadata, percent-encoded open buffers, and aliased dependency refresh.

## Validation

- authored registry/oracle/lifecycle tests — 7 passed
- production Elk authored LSP oracle — 5 tests passed; full lifecycle completed in 10.0s
- `cargo test -p vize_maestro` — 728 passed, 2 ignored; 3 integration tests and 1 doctest passed
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- fixture worktree and lifecycle scratch files are clean after the run
- tsgo crash hardening remains tracked separately in #3975

Closes one project increment from #3952.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->