### PR TITLE
fix(lsp): follow component barrels before direct targets

### DIFF
--- a/crates/vize_maestro/src/ide/definition/service.rs
+++ b/crates/vize_maestro/src/ide/definition/service.rs
@@ -28,13 +28,15 @@ impl super::DefinitionService {
     /// Get definition for the symbol at the current position.
     pub fn definition(ctx: &IdeContext) -> Option<GotoDefinitionResponse> {
         match ctx.block_type? {
-            BlockType::Template => Self::definition_in_template_sync(ctx),
+            BlockType::Template => import_target::component_tag_definition(ctx)
+                .or_else(|| Self::definition_in_template_sync(ctx)),
             BlockType::Script | BlockType::ScriptSetup => {
                 module_specifier::definition(ctx).or_else(|| script::definition_in_script(ctx))
             }
             BlockType::Style(_) => script::definition_in_style(ctx),
             BlockType::Art(ArtCursorPosition::VariantTemplate(_)) => {
-                Self::definition_in_template_sync(ctx)
+                import_target::component_tag_definition(ctx)
+                    .or_else(|| Self::definition_in_template_sync(ctx))
             }
             BlockType::Art(_) => None,
         }
@@ -66,16 +68,17 @@ impl super::DefinitionService {
         info: &crate::virtual_code::ArtVariantInfo,
         corsa_bridge: Option<Arc<CorsaBridge>>,
     ) -> Option<GotoDefinitionResponse> {
+        // Follow imported component aliases and re-export barrels before the
+        // direct-file finder can stop at the barrel itself.
+        if let Some(def) = import_target::component_tag_definition(ctx) {
+            return Some(def);
+        }
+
         // Check if this is a component tag
         if let Some(tag_name) = helpers::get_tag_at_offset(&ctx.content, ctx.offset)
             && is_component_tag(&tag_name)
             && let Some(def) = template::find_component_definition(ctx, &tag_name)
         {
-            return Some(def);
-        }
-
-        // Tags imported through a `paths` alias or package barrel (#3932).
-        if let Some(def) = import_target::component_tag_definition(ctx) {
             return Some(def);
         }
 
@@ -129,6 +132,12 @@ impl super::DefinitionService {
         ctx: &IdeContext<'_>,
         corsa_bridge: Option<Arc<CorsaBridge>>,
     ) -> Option<GotoDefinitionResponse> {
+        // A successful manual import walk is deterministic and follows barrel
+        // re-exports to their source instead of returning the barrel module.
+        if let Some(def) = import_target::component_tag_definition(ctx) {
+            return Some(def);
+        }
+
         if let Some(tag_name) = helpers::get_tag_at_offset(&ctx.content, ctx.offset)
             && tag_name == "Self"
             && let Some(def) = template::find_component_definition(ctx, &tag_name)
@@ -158,11 +167,6 @@ impl super::DefinitionService {
             && is_component_tag(&tag_name)
             && let Some(def) = template::find_component_definition(ctx, &tag_name)
         {
-            return Some(def);
-        }
-
-        // Tags imported through a `paths` alias or package barrel (#3932).
-        if let Some(def) = import_target::component_tag_definition(ctx) {
             return Some(def);
         }
 

--- a/crates/vize_maestro/src/ide/definition/service/import_target.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target.rs
@@ -25,15 +25,14 @@ pub(super) fn definition(ctx: &IdeContext<'_>) -> Option<GotoDefinitionResponse>
     let word = helpers::get_word_at_offset(&ctx.content, ctx.offset)?;
     let (specifier, exported) = importing_specifier(&ctx.content, ctx.offset, &word)?;
     let target = resolve_import_specifier(ctx.uri, &specifier)?;
-    locate_export(&target, &exported, MAX_REEXPORT_HOPS).map(GotoDefinitionResponse::Scalar)
+    locate_export(ctx, &target, &exported, MAX_REEXPORT_HOPS).map(GotoDefinitionResponse::Scalar)
 }
 
-/// Definition on a component tag whose import the manual finder cannot
-/// resolve (#3932): that path handles only relative specifiers, so a tag
-/// imported through a tsconfig `paths` alias or a package barrel —
-/// `import { Primitive } from '@/Primitive'` resolving through
-/// `src/Primitive/index.ts` — answered null while hover was typed. Follows
-/// the same import-resolution and re-export hops as the imported-name jump.
+/// Definition on an imported component tag, following tsconfig `paths`
+/// aliases and re-export barrels (#3932). This must run before the direct-file
+/// finder: `import { Primitive } from '@/Primitive'` can resolve first to
+/// `src/Primitive/index.ts`, but the editor jump belongs at the source that
+/// the barrel re-exports. Uses the same bounded walk as the imported-name jump.
 pub(super) fn component_tag_definition(ctx: &IdeContext<'_>) -> Option<GotoDefinitionResponse> {
     let tag_name = helpers::get_tag_at_offset(&ctx.content, ctx.offset)?;
     if !crate::ide::is_component_tag(&tag_name) {
@@ -47,7 +46,7 @@ pub(super) fn component_tag_definition(ctx: &IdeContext<'_>) -> Option<GotoDefin
             .map_or_else(|| name.to_owned(), |(_, exported)| exported);
         if let Some(specifier) = helpers::find_import_path(ctx, name)
             && let Some(target) = resolve_import_specifier(ctx.uri, &specifier)
-            && let Some(location) = locate_export(&target, &exported, MAX_REEXPORT_HOPS)
+            && let Some(location) = locate_export(ctx, &target, &exported, MAX_REEXPORT_HOPS)
         {
             return Some(GotoDefinitionResponse::Scalar(location));
         }
@@ -160,34 +159,41 @@ fn split_rename(part: &str) -> (&str, &str) {
 }
 
 /// The declaration of `word` inside `target`, following re-export barrels.
-fn locate_export(target: &Path, word: &str, hops: usize) -> Option<Location> {
+fn locate_export(ctx: &IdeContext<'_>, target: &Path, word: &str, hops: usize) -> Option<Location> {
+    let uri = Url::from_file_path(target).ok()?;
     if target
         .extension()
         .is_some_and(|extension| extension == "vue")
     {
         // A `.vue` module's meaningful position is the file itself, matching
-        // how component-tag definition resolves today.
+        // how component-tag definition resolves today. Deleted targets are
+        // invalid, while an editor-open unsaved target remains navigable.
+        if !target.is_file() && !ctx.state.documents.contains(&uri) {
+            return None;
+        }
         return Some(Location {
-            uri: Url::from_file_path(target).ok()?,
+            uri,
             range: Range::new(Position::new(0, 0), Position::new(0, 0)),
         });
     }
-    let content = fs::read_to_string(target).ok()?;
+    let content = ctx
+        .state
+        .documents
+        .text(&uri)
+        .or_else(|| fs::read_to_string(target).ok())?;
 
     // A barrel both names the word and points elsewhere; the re-export hop
     // comes first so the jump lands on the real declaration, not the alias.
     if hops > 0
         && let Some((specifier, exported)) = reexport_specifier(&content, word)
-        && let Some(uri) = Url::from_file_path(target).ok()
         && let Some(next) = resolve_import_specifier(&uri, &specifier)
-        && let Some(location) = locate_export(&next, &exported, hops - 1)
+        && let Some(location) = locate_export(ctx, &next, &exported, hops - 1)
     {
         return Some(location);
     }
 
     if let Some(binding) = script::find_binding_location_raw(&content, word) {
         let (line, character) = helpers::offset_to_position(&content, binding.offset);
-        let uri = Url::from_file_path(target).ok()?;
         let position = Position::new(line, character);
         // The end must be a UTF-16 position too: `word.len()` is bytes, so a
         // non-ASCII identifier would overshoot the column.

--- a/crates/vize_maestro/src/ide/definition/service/import_target/tests.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target/tests.rs
@@ -3,6 +3,7 @@ use std::fs;
 use tower_lsp::lsp_types::{GotoDefinitionResponse, Url};
 
 use crate::ide::IdeContext;
+use crate::ide::definition::DefinitionService;
 use crate::server::ServerState;
 
 #[test]
@@ -132,5 +133,57 @@ import AccountSearchResult from '~/components/AccountSearchResult.vue'
     assert_eq!(
         location.uri,
         Url::from_file_path(target_path).expect("target URI")
+    );
+}
+
+#[test]
+fn definition_service_follows_an_alias_barrel_to_the_component_source() {
+    let workspace = tempfile::tempdir().expect("temporary workspace");
+    let source_dir = workspace.path().join("src");
+    let components = source_dir.join("components");
+    fs::create_dir_all(&components).expect("components directory");
+    fs::write(
+        workspace.path().join("tsconfig.json"),
+        r#"{"compilerOptions":{"paths":{"@/*":["./src/*"]}}}"#,
+    )
+    .expect("TypeScript config");
+    fs::write(
+        components.join("index.ts"),
+        "export { Widget } from \"./Widget.vue\";\n",
+    )
+    .expect("component barrel");
+    let target_path = components.join("Widget.vue");
+    fs::write(&target_path, "<template><button /></template>\n").expect("component");
+
+    let importer_path = source_dir.join("App.vue");
+    let source = r#"<script setup lang="ts">
+import { Widget } from "@/components";
+</script>
+<template><Widget /></template>
+"#;
+    fs::write(&importer_path, source).expect("importer");
+
+    let importer_uri = Url::from_file_path(&importer_path).expect("importer URI");
+    let state = ServerState::new();
+    state.set_workspace_root(workspace.path().to_path_buf());
+    state
+        .documents
+        .open(importer_uri.clone(), source.to_owned(), 1, "vue".to_owned());
+    state.update_virtual_docs(&importer_uri, source);
+    let offset = source.rfind("Widget").expect("component tag");
+    let ctx = IdeContext::new(&state, &importer_uri, offset).expect("IDE context");
+    let definition = DefinitionService::definition(&ctx).expect("component definition");
+    let GotoDefinitionResponse::Scalar(location) = definition else {
+        panic!("component definition must be scalar");
+    };
+
+    assert_eq!(
+        location
+            .uri
+            .to_file_path()
+            .expect("definition path")
+            .canonicalize()
+            .expect("canonical definition path"),
+        target_path.canonicalize().expect("canonical target path")
     );
 }


### PR DESCRIPTION
## Summary
- prefer the barrel-aware import walk before direct component-file resolution
- preserve deleted-target rejection and open unsaved-buffer navigation
- cover the public definition service path that previously stopped at `index.ts`

## Tests
- `cargo test -p vize_maestro`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `VIZE_LSP_BIN=$PWD/target/debug/vize node --test tests/tooling/lsp-alias-barrel-definition.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->