### PR TITLE
fix(lsp): map split-script binding definitions

### DIFF
--- a/crates/vize_atelier_sfc/src/croquis.rs
+++ b/crates/vize_atelier_sfc/src/croquis.rs
@@ -5,8 +5,10 @@
 //! merging, generic extraction, and virtual-script offsets.
 
 mod drawer;
+mod source_offsets;
 
 use self::drawer::{analyze_scripts, apply_options_api_mode};
+use self::source_offsets::ScriptOffsetMapper;
 use crate::types::SfcDescriptor;
 use vize_atelier_core::RootNode;
 use vize_carton::{String, ToCompactString, cstr, profile};
@@ -86,13 +88,7 @@ pub struct SfcCroquisAnalysis {
     pub croquis: Croquis,
     pub script_content: Option<String>,
     pub script_offset: u32,
-}
-
-impl SfcCroquisAnalysis {
-    #[inline]
-    pub fn script_content_ref(&self) -> Option<&str> {
-        self.script_content.as_deref()
-    }
+    script_offset_mapper: ScriptOffsetMapper,
 }
 
 /// Analyze an SFC descriptor into a Croquis summary.
@@ -201,10 +197,13 @@ fn analyze_sfc_descriptor_resolved_impl(
     }
 
     let (script_content, script_offset) = script_content_for_descriptor(descriptor, options);
+    let script_offset_mapper =
+        ScriptOffsetMapper::from_descriptor(descriptor, script_offset, options.merge_scripts);
     SfcCroquisAnalysis {
         croquis: drawer.finish(),
         script_content,
         script_offset,
+        script_offset_mapper,
     }
 }
 
@@ -321,6 +320,10 @@ const count = ref(0)
         assert_eq!(
             &script[count_span.0 as usize..count_span.1 as usize],
             "count"
+        );
+        assert_eq!(
+            analysis.script_source_offset(count_span.0),
+            source.find("count").unwrap() as u32,
         );
     }
 }

--- a/crates/vize_atelier_sfc/src/croquis/source_offsets.rs
+++ b/crates/vize_atelier_sfc/src/croquis/source_offsets.rs
@@ -1,0 +1,85 @@
+use crate::types::SfcDescriptor;
+
+/// Maps Croquis' merged script coordinate space back to authored SFC bytes.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct ScriptOffsetMapper {
+    source_start: u32,
+    split_setup: Option<SplitScriptSetupOffset>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SplitScriptSetupOffset {
+    synthetic_start: u32,
+    source_start: u32,
+}
+
+impl ScriptOffsetMapper {
+    pub(super) fn from_descriptor(
+        descriptor: &SfcDescriptor<'_>,
+        source_start: u32,
+        merge_scripts: bool,
+    ) -> Self {
+        let split_setup = if merge_scripts {
+            descriptor
+                .script
+                .as_ref()
+                .zip(descriptor.script_setup.as_ref())
+                .map(|(script, setup)| SplitScriptSetupOffset {
+                    synthetic_start: script.content.len() as u32 + 1,
+                    source_start: setup.loc.start as u32,
+                })
+        } else {
+            None
+        };
+        Self {
+            source_start,
+            split_setup,
+        }
+    }
+
+    #[inline]
+    pub(super) fn to_source_offset(self, offset: u32) -> u32 {
+        if let Some(setup) = self.split_setup
+            && offset >= setup.synthetic_start
+        {
+            return setup
+                .source_start
+                .saturating_add(offset - setup.synthetic_start);
+        }
+        self.source_start.saturating_add(offset)
+    }
+
+    #[inline]
+    pub(super) fn source_len(self, start: u32, end: u32) -> u32 {
+        self.to_source_offset(end)
+            .saturating_sub(self.to_source_offset(start))
+    }
+
+    #[inline]
+    pub(super) fn split_setup_offsets(self) -> Option<(usize, usize)> {
+        self.split_setup
+            .map(|setup| (setup.synthetic_start as usize, setup.source_start as usize))
+    }
+}
+
+impl super::SfcCroquisAnalysis {
+    #[inline]
+    pub fn script_content_ref(&self) -> Option<&str> {
+        self.script_content.as_deref()
+    }
+
+    #[inline]
+    pub fn script_source_offset(&self, offset: u32) -> u32 {
+        self.script_offset_mapper.to_source_offset(offset)
+    }
+
+    #[inline]
+    pub fn script_source_len(&self, start: u32, end: u32) -> u32 {
+        self.script_offset_mapper.source_len(start, end)
+    }
+
+    #[inline]
+    pub fn split_script_setup_offsets(&self) -> Option<(usize, usize)> {
+        self.script_offset_mapper.split_setup_offsets()
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -201,16 +201,10 @@ pub(super) fn generate_vue_virtual_ts(
             analyze_sfc_descriptor_with_context(descriptor, template_ast.as_ref(), croquis_options)
         }
     );
-    let vize_atelier_sfc::croquis::SfcCroquisAnalysis {
-        mut croquis,
-        script_content,
-        script_offset,
-    } = analysis;
-    let split_script_setup_offsets = descriptor
-        .script
-        .as_ref()
-        .zip(descriptor.script_setup.as_ref())
-        .map(|(script, script_setup)| (script.content.len() + 1, script_setup.loc.start));
+    let split_script_setup_offsets = analysis.split_script_setup_offsets();
+    let mut croquis = analysis.croquis;
+    let script_content = analysis.script_content;
+    let script_offset = analysis.script_offset;
     profile!(
         "canon.croquis.augment_type_props",
         augment_type_based_props_from_script_context(&mut croquis, descriptor, path)

--- a/crates/vize_maestro/src/ide/definition/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/definition/corsa_tests.rs
@@ -117,6 +117,110 @@ const msg = 'hello'
     });
 }
 
+#[test]
+fn definition_with_corsa_maps_computed_template_binding_to_its_declaration() {
+    crate::runtime::block_on(async {
+        let Some(corsa_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(
+            dir.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .unwrap();
+        fs::write(
+            src.join("vue.d.ts"),
+            r#"declare module "vue" {
+  export interface ComputedRef<T = unknown> { value: T }
+  export function computed<T>(getter: () => T): ComputedRef<T>
+}
+"#,
+        )
+        .unwrap();
+
+        let source = r#"<script lang="ts">
+export interface RadioProps {
+  id?: string
+  value?: string
+}
+</script>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<RadioProps>()
+const { forwardRef, currentElement: triggerElement } = useForwardExpose()
+const isFormControl = useFormControl(triggerElement)
+const ariaLabel = computed(() => props.id && triggerElement.value ? (document.querySelector(`[for="${props.id}"]`) as HTMLLabelElement)?.innerText ?? props.value : undefined)
+</script>
+
+<template>
+  <Primitive
+    :ref="forwardRef"
+    :aria-label="ariaLabel"
+    :data-form-control="isFormControl"
+  />
+</template>
+"#;
+        let source_path = src.join("Radio.vue");
+        fs::write(&source_path, source).unwrap();
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state.set_workspace_root(dir.path().to_path_buf());
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+        let offset = source.rfind("ariaLabel").unwrap();
+        let sync_ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let sync_location = scalar_location(
+            DefinitionService::definition(&sync_ctx).expect("synchronous definition"),
+        );
+        let expected_offset = source.find("const ariaLabel").unwrap() + "const ".len();
+        let (line, character) = crate::ide::offset_to_position(source, expected_offset);
+        assert_eq!(sync_location.range.start.line, line);
+        assert_eq!(sync_location.range.start.character, character);
+
+        let bridge = std::sync::Arc::new(vize_canon::CorsaBridge::with_config(
+            vize_canon::CorsaBridgeConfig {
+                corsa_path: Some(corsa_path),
+                working_dir: Some(dir.path().to_path_buf()),
+                timeout_ms: 30_000,
+                ..Default::default()
+            },
+        ));
+        bridge.spawn().await.unwrap();
+
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let response = DefinitionService::definition_with_corsa(&ctx, Some(bridge.clone()))
+            .await
+            .unwrap();
+        let _ = bridge.shutdown().await;
+        let location = scalar_location(response);
+        assert_eq!(location.uri, uri);
+        assert_eq!(location.range.start.line, line);
+        assert_eq!(location.range.start.character, character);
+        assert_eq!(location.range.end.line, line);
+        assert_eq!(
+            location.range.end.character,
+            character + "ariaLabel".len() as u32
+        );
+    });
+}
+
 fn scalar_location(response: GotoDefinitionResponse) -> Location {
     match response {
         GotoDefinitionResponse::Scalar(location) => location,

--- a/crates/vize_maestro/src/ide/definition/script.rs
+++ b/crates/vize_maestro/src/ide/definition/script.rs
@@ -141,12 +141,9 @@ pub(crate) fn find_analyzed_binding_location(ctx: &IdeContext, word: &str) -> Op
         return None;
     }
 
-    let offset = analysis.script_offset as usize + start as usize;
-    Some(location_from_sfc_offset(
-        ctx,
-        offset,
-        (end - start) as usize,
-    ))
+    let offset = analysis.script_source_offset(start) as usize;
+    let len = analysis.script_source_len(start, end) as usize;
+    Some(location_from_sfc_offset(ctx, offset, len))
 }
 
 pub(crate) fn location_from_sfc_offset(ctx: &IdeContext, offset: usize, len: usize) -> Location {

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -477,7 +477,7 @@ pub(crate) fn find_component_prop_definition(
         if let Some(&(start, end)) = analysis.croquis.binding_spans.get(prop_name.as_str())
             && end > start
         {
-            let sfc_offset = analysis.script_offset + start;
+            let sfc_offset = analysis.script_source_offset(start);
             let (line, character) =
                 helpers::offset_to_position(&component_content, sfc_offset as usize);
 
@@ -488,7 +488,7 @@ pub(crate) fn find_component_prop_definition(
                     start: Position { line, character },
                     end: Position {
                         line,
-                        character: character + (end - start),
+                        character: character + analysis.script_source_len(start, end),
                     },
                 },
             }));


### PR DESCRIPTION
## Summary
- centralize merged-script to authored-SFC offset mapping in Croquis analysis
- reuse the mapper in virtual TS generation and LSP definition ranges
- cover dual script computed bindings through synchronous and tsgo-backed definition paths

## Validation
- cargo test -p vize_maestro --lib
- cargo test -p vize_atelier_sfc --lib
- cargo clippy -p vize_atelier_sfc -p vize_canon -p vize_maestro --lib --all-features -- -D warnings
- SOURCE_LENGTH_BASE_REF=origin/test/real-project-authored-lsp-oracles node --test tests/tooling/source-file-lengths.test.ts
- Reka UI production LSP shard reaches the authored completion oracle after definition validation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->