### PR TITLE
test(lsp): add Reka UI authored oracle

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 6,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 2,
+    "minimumProjectCount": 3,
     "trackingIssue": 3952
   },
   "projects": [
@@ -181,6 +181,70 @@
         "lsp"
       ],
       "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "packages/core/src/RadioGroup/Radio.vue",
+          "symbol": "ariaLabel",
+          "usageAnchor": ":aria-label=\"ariaLabel\"",
+          "declarationAnchor": "const ariaLabel = computed(() => props.id && triggerElement.value ? (document.querySelector(`[for=\"${props.id}\"]`) as HTMLLabelElement)?.innerText ?? props.value : undefined)",
+          "hoverContains": ["const ariaLabel"],
+          "renameTo": "__vizeRenamedAriaLabel"
+        },
+        "componentBoundary": {
+          "importerFile": "packages/core/src/Toolbar/ToolbarToggleItem.vue",
+          "componentFile": "packages/core/src/Toolbar/ToolbarButton.vue",
+          "tagName": "ToolbarButton",
+          "tagAnchor": "<ToolbarButton ",
+          "completionItemCount": 31,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "as-child", "rank": 28 },
+            { "label": "as", "rank": 29 },
+            { "label": "disabled", "rank": 30 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  disabled?: boolean\n",
+            "replacement": "  disabled?: boolean\n  vizeOracleProbe?: boolean\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "packages/core/src/Toolbar/__VizeOracleToolbarButton.vue",
+          "renamedFile": "packages/core/src/Toolbar/__VizeOracleRenamedToolbarButton.vue",
+          "originalImportSpecifier": "./ToolbarButton.vue",
+          "copiedImportSpecifier": "./__VizeOracleToolbarButton.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedToolbarButton.vue",
+          "markerInsertionAnchor": "<script lang=\"ts\">\n",
+          "markerSymbol": "__vizeRekaFileLifecycleMarker__"
+        }
+      },
       "typecheckPerformance": {
         "enabled": true,
         "compareTo": "vue-tsc",


### PR DESCRIPTION
## Summary

- add the third authored real-project LSP oracle using pinned Reka UI sources
- pin template hover/definition/references/rename and exact component completion ranks
- exercise unsaved child prop edits plus component copy, rename, delete, and repair lifecycle
- ratchet authored real-project coverage from two projects to three

## Validation

- `node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts`
- Reka UI production LSP shard with the real server and tsgo

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->