### PR TITLE
fix(init): check the complete tsconfig project

### DIFF
--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -71,7 +71,7 @@ Add scripts to your project and run Vize through your package manager:
     "vize:build": "vize build src",
     "vize:fmt": "vize fmt --write src",
     "vize:lint": "vize lint --preset happy-path src",
-    "vize:check": "vize check src",
+    "vize:check": "vize check",
     "vize:ready": "vize ready src",
     "vize:upgrade": "vize upgrade"
   }

--- a/npm/cli/src/setup/config.ts
+++ b/npm/cli/src/setup/config.ts
@@ -44,7 +44,9 @@ export const DEFAULT_SCRIPTS = {
   "vize:fmt": "vize fmt --check src",
   "vize:fmt:fix": "vize fmt --write src",
   "vize:lint": "vize lint --preset happy-path --max-warnings 0 src",
-  "vize:check": "vize check src",
+  // No positional input: the default command must check the complete tsconfig
+  // project graph, including root files and referenced projects outside src.
+  "vize:check": "vize check",
   "vize:musea": "vize musea",
   "vize:ready": "vize ready src",
 } as const;

--- a/npm/cli/tests/init.test.ts
+++ b/npm/cli/tests/init.test.ts
@@ -131,7 +131,7 @@ test("a Vite+ project is configured through the vite.config lint block", async (
           "vize:lint": "vize lint --preset happy-path --max-warnings 0 src",
           "vize:fmt": "vize fmt --check src",
           "vize:fmt:fix": "vize fmt --write src",
-          "vize:check": "vize check src",
+          "vize:check": "vize check",
         },
         devDependencies: {
           "vite-plus": "^0.1.0",

--- a/npm/cli/tests/setup.test.ts
+++ b/npm/cli/tests/setup.test.ts
@@ -111,7 +111,7 @@ export default defineConfig({
     assert.equal(scripts["vize:fmt"], "vize fmt --check src");
     assert.equal(scripts["vize:fmt:fix"], "vize fmt --write src");
     assert.equal(scripts["vize:lint"], "vize lint --preset happy-path --max-warnings 0 src");
-    assert.equal(scripts["vize:check"], "vize check src");
+    assert.equal(scripts["vize:check"], "vize check");
     assert.equal(scripts["vize:build"], "vize build src");
     assert.equal(scripts["vize:musea"], "vize musea");
     assert.equal(scripts["vize:ready"], "vize ready src");


### PR DESCRIPTION
## Summary

- generate `vize:check` as `vize check` so default input discovery follows the complete tsconfig graph
- avoid forcing fresh projects into explicit `src` subset mode
- keep existing user-defined check scripts unchanged
- align the CLI package documentation with generated setup

## Validation

- targeted init/setup tests: 14 passed
- CLI package test suite: 32 passed
- CLI package format and lint: 37 files passed

Refs #3984.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->