### PR TITLE
fix(check): include allowJs project inputs

### DIFF
--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -82,6 +82,7 @@ fn collect_default_check_files_inner(
             &[],
             FileCollectionOptions {
                 include_hidden: false,
+                include_js: false,
                 include_jsx,
             },
         );
@@ -116,11 +117,18 @@ fn collect_default_check_files_for_tsconfig(
 ) {
     let default_spec = TsconfigInputSpec::default();
     let spec = cache.load(tsconfig_path).unwrap_or(&default_spec);
+    let include_js = spec.allow_js.unwrap_or(false);
 
     for file in &spec.files {
         let resolved = normalize_input_path(&file.resolve());
         if resolved.is_file()
-            && is_supported_check_file_with_options(&resolved, SupportedFileOptions { include_jsx })
+            && is_supported_check_file_with_options(
+                &resolved,
+                SupportedFileOptions {
+                    include_js,
+                    include_jsx,
+                },
+            )
             && !is_nuxt_import_manifest_path(&resolved)
             && !is_generated_codegen_declaration_path(&resolved)
             && seen.insert(resolved.clone())
@@ -154,6 +162,7 @@ fn collect_default_check_files_for_tsconfig(
             excludes,
             FileCollectionOptions {
                 include_hidden: false,
+                include_js,
                 include_jsx,
             },
         );
@@ -178,6 +187,7 @@ fn collect_default_check_files_for_tsconfig(
                 excludes,
                 FileCollectionOptions {
                     include_hidden: true,
+                    include_js,
                     include_jsx,
                 },
             ) {

--- a/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
@@ -41,6 +41,7 @@ pub(super) fn collect_supported_files_with_options(
                     && is_supported_check_file_with_options(
                         path,
                         SupportedFileOptions {
+                            include_js: options.include_js,
                             include_jsx: options.include_jsx,
                         },
                     )
@@ -190,7 +191,13 @@ pub(crate) fn resolve_tsconfig_for_files(
     let files = files
         .iter()
         .filter(|path| {
-            is_supported_check_file_with_options(path, SupportedFileOptions { include_jsx })
+            is_supported_check_file_with_options(
+                path,
+                SupportedFileOptions {
+                    include_js: false,
+                    include_jsx,
+                },
+            )
         })
         .map(|path| normalize_input_path(path))
         .collect::<Vec<_>>();
@@ -301,6 +308,7 @@ impl TsconfigOwnershipMatcher {
             || !is_supported_check_file_with_options(
                 file,
                 SupportedFileOptions {
+                    include_js: false,
                     include_jsx: self.include_jsx,
                 },
             )

--- a/crates/vize/src/commands/check/tsconfig_inputs/loader.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/loader.rs
@@ -119,6 +119,15 @@ fn load_tsconfig_inputs_inner(
             .collect();
     }
 
+    if let Some(allow_js) = value
+        .get("compilerOptions")
+        .and_then(Value::as_object)
+        .and_then(|options| options.get("allowJs"))
+        .and_then(Value::as_bool)
+    {
+        merged.allow_js = Some(allow_js);
+    }
+
     if let Some(out_dir) = compiler_option_dir_exclude(&value, dir, "outDir") {
         merged.out_dir_exclude = Some(out_dir);
     }

--- a/crates/vize/src/commands/check/tsconfig_inputs/matching.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/matching.rs
@@ -10,6 +10,7 @@ use super::{NODE_MODULES_DIR, TARGET_DIR, VIZE_CACHE_DIR};
 
 #[derive(Debug, Clone, Copy, Default)]
 pub(super) struct SupportedFileOptions {
+    pub(super) include_js: bool,
     pub(super) include_jsx: bool,
 }
 
@@ -129,6 +130,11 @@ pub(super) fn is_supported_check_file_with_options(
     options: SupportedFileOptions,
 ) -> bool {
     check_patterns::is_supported_check_file(path, options.include_jsx)
+        || (options.include_js
+            && path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| matches!(extension, "js" | "jsx" | "mjs" | "cjs")))
 }
 
 pub(super) fn glob_match_options() -> MatchOptions {

--- a/crates/vize/src/commands/check/tsconfig_inputs/spec.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/spec.rs
@@ -16,6 +16,8 @@ pub(super) struct TsconfigInputSpec {
     pub(super) has_files: bool,
     pub(super) has_includes: bool,
     pub(super) has_excludes: bool,
+    /// The merged `compilerOptions.allowJs` value for this project.
+    pub(super) allow_js: Option<bool>,
     /// `compilerOptions.outDir`, as a glob over the directory it resolves to.
     pub(super) out_dir_exclude: Option<GlobSpec>,
     /// `compilerOptions.declarationDir`, likewise.
@@ -35,6 +37,9 @@ impl TsconfigInputSpec {
         if extended.has_excludes {
             self.excludes = extended.excludes;
             self.has_excludes = true;
+        }
+        if extended.allow_js.is_some() {
+            self.allow_js = extended.allow_js;
         }
         // Both are ordinary compiler options, so an extending config that does
         // not restate them keeps the base's value.
@@ -155,5 +160,6 @@ impl GlobSpec {
 #[derive(Debug, Clone, Copy, Default)]
 pub(super) struct FileCollectionOptions {
     pub(super) include_hidden: bool,
+    pub(super) include_js: bool,
     pub(super) include_jsx: bool,
 }

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
@@ -769,6 +769,129 @@ fn supported_extensions_cover_ts_family_and_reject_js_family() {
 }
 
 #[test]
+fn allow_js_inherited_from_extended_config_collects_the_js_family() {
+    let case_dir = unique_case_dir("tsconfig-ext-allow-js");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    for name in [
+        "App.vue", "a.ts", "b.tsx", "c.mts", "d.cts", "e.js", "f.jsx", "g.cjs", "h.mjs",
+    ] {
+        fs::write(case_dir.join("src").join(name), "export const value = true").unwrap();
+    }
+    fs::write(
+        case_dir.join("tsconfig.base.json"),
+        r#"{ "compilerOptions": { "allowJs": true } }"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{ "extends": "./tsconfig.base.json", "include": ["src/**/*"] }"#,
+    )
+    .unwrap();
+
+    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+    assert_eq!(
+        relative_paths(&case_dir, &files),
+        vec![
+            "src/App.vue",
+            "src/a.ts",
+            "src/b.tsx",
+            "src/c.mts",
+            "src/d.cts",
+            "src/e.js",
+            "src/f.jsx",
+            "src/g.cjs",
+            "src/h.mjs",
+        ]
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn local_allow_js_false_overrides_an_extended_config() {
+    let case_dir = unique_case_dir("tsconfig-ext-disable-allow-js");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    fs::write(case_dir.join("src/main.ts"), "export const value = true").unwrap();
+    fs::write(case_dir.join("src/skip.js"), "export const skip = true").unwrap();
+    fs::write(
+        case_dir.join("tsconfig.base.json"),
+        r#"{ "compilerOptions": { "allowJs": true } }"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": { "allowJs": false },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+
+    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+    assert_eq!(relative_paths(&case_dir, &files), vec!["src/main.ts"]);
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn referenced_projects_use_their_own_allow_js_setting() {
+    let case_dir = unique_case_dir("tsconfig-references-allow-js");
+    let _ = fs::remove_dir_all(&case_dir);
+    for package in ["allow", "deny"] {
+        fs::create_dir_all(case_dir.join("packages").join(package).join("src")).unwrap();
+        fs::write(
+            case_dir.join("packages").join(package).join("src/index.ts"),
+            "export const typed = true",
+        )
+        .unwrap();
+        fs::write(
+            case_dir.join("packages").join(package).join("src/index.js"),
+            "export const javascript = true",
+        )
+        .unwrap();
+    }
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{
+  "files": [],
+  "references": [
+    { "path": "./packages/allow" },
+    { "path": "./packages/deny" }
+  ]
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("packages/allow/tsconfig.json"),
+        r#"{ "compilerOptions": { "allowJs": true }, "include": ["src/**/*"] }"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("packages/deny/tsconfig.json"),
+        r#"{ "compilerOptions": { "allowJs": false }, "include": ["src/**/*"] }"#,
+    )
+    .unwrap();
+
+    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+    assert_eq!(
+        relative_paths(&case_dir, &files),
+        vec![
+            "packages/allow/src/index.js",
+            "packages/allow/src/index.ts",
+            "packages/deny/src/index.ts",
+        ]
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
 fn jsx_extension_is_collected_only_for_jsx_typecheck() {
     let case_dir = unique_case_dir("tsconfig-ext-jsx");
     let _ = fs::remove_dir_all(&case_dir);

--- a/crates/vize/tests/check_allowjs_imports_cli.rs
+++ b/crates/vize/tests/check_allowjs_imports_cli.rs
@@ -113,11 +113,89 @@ void message;
         output.status.success(),
         "check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
-    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("invalid JSON ({error}):\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
     assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
     assert!(
         !stdout.contains("TS2307"),
         "project-local JS imports should resolve under allowJs:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn default_check_reports_errors_from_allowjs_project_roots() {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
+        return;
+    };
+    let project_root = unique_case_dir("default-root-diagnostic");
+    let _ = std::fs::remove_dir_all(&project_root);
+
+    write(
+        &project_root,
+        "tsconfig.base.json",
+        r#"{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  }
+}"#,
+    );
+    write(
+        &project_root,
+        "tsconfig.json",
+        r#"{ "extends": "./tsconfig.base.json", "include": ["src/**/*"] }"#,
+    );
+    write(
+        &project_root,
+        "src/invalid.js",
+        r#"/** @type {string} */
+export const message = 42;
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("invalid JSON ({error}):\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    assert_eq!(json["errorCount"], serde_json::json!(1), "{stdout}");
+    assert_eq!(
+        json["files"][0]["file"],
+        serde_json::json!("src/invalid.js"),
+        "{stdout}"
+    );
+    assert!(
+        json["files"][0]["diagnostics"][0]
+            .as_str()
+            .is_some_and(|diagnostic| diagnostic.contains("TS2322")),
+        "{stdout}"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -312,8 +312,20 @@ fn virtual_vue_path(
 
 pub(super) fn source_type_for_path(path: &Path) -> Option<SourceType> {
     let file_name = path.file_name()?.to_str()?;
+    if file_name.ends_with(".jsx") {
+        return Some(SourceType::unambiguous().with_jsx(true));
+    }
     if file_name.ends_with(".tsx") {
         return Some(SourceType::tsx());
+    }
+    if file_name.ends_with(".cjs") {
+        return Some(SourceType::cjs());
+    }
+    if file_name.ends_with(".mjs") {
+        return Some(SourceType::mjs());
+    }
+    if file_name.ends_with(".js") {
+        return Some(SourceType::unambiguous());
     }
     if file_name.ends_with(".ts")
         || file_name.ends_with(".d.ts")

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -1034,6 +1034,22 @@ fn test_source_type_for_path() {
         source_type_for_path(Path::new("foo.tsx")),
         Some(oxc_span::SourceType::tsx())
     );
+    assert_eq!(
+        source_type_for_path(Path::new("foo.js")),
+        Some(oxc_span::SourceType::unambiguous())
+    );
+    assert_eq!(
+        source_type_for_path(Path::new("foo.jsx")),
+        Some(oxc_span::SourceType::unambiguous().with_jsx(true))
+    );
+    assert_eq!(
+        source_type_for_path(Path::new("foo.mjs")),
+        Some(oxc_span::SourceType::mjs())
+    );
+    assert_eq!(
+        source_type_for_path(Path::new("foo.cjs")),
+        Some(oxc_span::SourceType::cjs())
+    );
     assert_eq!(source_type_for_path(Path::new("foo.vue")), None);
 }
 


### PR DESCRIPTION
Part of #3984.

## Summary
- inherit `compilerOptions.allowJs` while resolving tsconfig input specs
- collect `.js`, `.jsx`, `.mjs`, and `.cjs` roots per referenced project
- register JavaScript roots in the virtual project with extension-appropriate source kinds
- report `checkJs` diagnostics against the authored JavaScript path

## Tests
- `cargo test -p vize --lib`
- `cargo test -p vize_canon --lib`
- `cargo test -p vize --test check_allowjs_imports_cli`
- `cargo clippy -p vize -p vize_canon --lib --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Scope
This covers default tsconfig-driven project roots. Explicit JavaScript subset inputs and additional transitive-JavaScript reachability are separate follow-up slices.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->