### PR TITLE
fix(check): exclude runtime prop options from bindings

### DIFF
--- a/crates/vize/tests/check_allowjs_imports_cli.rs
+++ b/crates/vize/tests/check_allowjs_imports_cli.rs
@@ -35,6 +35,10 @@ fn resolve_test_corsa_path() -> Option<PathBuf> {
     .find(|candidate| candidate.exists())
 }
 
+fn required_corsa_path() -> Option<PathBuf> {
+    corsa_requirement::required_or_skip(resolve_test_corsa_path())
+}
+
 fn write(root: &Path, rel: &str, content: &str) {
     let path = root.join(rel);
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
@@ -43,7 +47,7 @@ fn write(root: &Path, rel: &str, content: &str) {
 
 #[test]
 fn check_allowjs_resolves_project_local_js_imports() {
-    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
+    let Some(corsa_path) = required_corsa_path() else {
         return;
     };
     let project_root = unique_case_dir("local-js");
@@ -127,7 +131,7 @@ void message;
 
 #[test]
 fn default_check_reports_errors_from_allowjs_project_roots() {
-    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
+    let Some(corsa_path) = required_corsa_path() else {
         return;
     };
     let project_root = unique_case_dir("default-root-diagnostic");

--- a/crates/vize_atelier_sfc/src/croquis.rs
+++ b/crates/vize_atelier_sfc/src/croquis.rs
@@ -265,14 +265,6 @@ pub fn merge_resolved_props_into_croquis(
     }
     ctx.analyze();
 
-    for (name, binding_type) in &ctx.bindings.bindings {
-        if matches!(binding_type, BindingType::Props | BindingType::PropsAliased)
-            && !croquis.bindings.contains(name.as_str())
-        {
-            croquis.bindings.add(name.as_str(), *binding_type);
-        }
-    }
-
     let Some(type_args) = croquis
         .macros
         .define_props()
@@ -294,14 +286,18 @@ pub fn merge_resolved_props_into_croquis(
         if !known.insert(prop.name.clone()) {
             continue;
         }
-        croquis.bindings.add(prop.name.as_str(), BindingType::Props);
+        if !croquis.bindings.contains(prop.name.as_str()) {
+            croquis.bindings.add(prop.name.as_str(), BindingType::Props);
+        }
         croquis.macros.add_prop(prop);
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{SfcCroquisOptions, analyze_sfc_descriptor_with_context};
+    use super::{
+        SfcCroquisOptions, analyze_sfc_descriptor_resolved, analyze_sfc_descriptor_with_context,
+    };
     use crate::{SfcParseOptions, parse_sfc};
 
     #[test]
@@ -345,5 +341,42 @@ const count = ref(0)
             analysis.script_source_offset(&descriptor, count_span.0),
             source.find("count").unwrap() as u32,
         );
+    }
+
+    #[test]
+    fn resolved_props_do_not_leak_runtime_option_keys_into_bindings() {
+        let source = r#"<script setup lang="ts">
+const props = defineProps({
+  count: {
+    type: Number,
+    required: true,
+    default: 0,
+    validator: (value: number) => value >= 0,
+  },
+  label: String,
+})
+void props
+</script>
+"#;
+        let descriptor = parse_sfc(source, SfcParseOptions::default()).unwrap();
+
+        let analysis = analyze_sfc_descriptor_resolved(
+            &descriptor,
+            None,
+            SfcCroquisOptions::full(),
+            false,
+            false,
+            "App.vue",
+        );
+
+        assert!(analysis.croquis.bindings.contains("count"));
+        assert!(analysis.croquis.bindings.contains("label"));
+        for option in ["type", "required", "default", "validator"] {
+            assert!(
+                !analysis.croquis.bindings.contains(option),
+                "runtime prop option {option:?} is not a setup binding: {:#?}",
+                analysis.croquis.bindings
+            );
+        }
     }
 }


### PR DESCRIPTION
Part of #3984.

## Summary
- restrict resolved-prop augmentation to type-based `defineProps` metadata
- keep runtime option keys such as `required`, `default`, and `validator` out of setup bindings
- reuse one fail-closed Corsa resolver helper across the allowJs CLI tests

## Regression
The parent Actions run exposed two regressions: Vue parity snapshots gained `void required`, and the dependency-gate test detected duplicate resolver guards. This restores both without updating snapshots or weakening the gate.

## Tests
- `cargo test -p vize_atelier_sfc --lib`
- `cargo test -p vize_canon --lib`
- `cargo test -p vize --test check_allowjs_imports_cli`
- `node --test tests/tooling/typecheck-dependency-gates.test.ts`
- `VIZE_BIN=/absolute/path/to/target/debug/vize node --test --test-concurrency=1 tests/snapshots/check/compiler-macros.ts tests/snapshots/check/typecheck-errors.ts`
- `cargo clippy -p vize_atelier_sfc -p vize_canon -p vize --lib --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->