### PR TITLE
fix(check): support explicit allowJs inputs

### DIFF
--- a/crates/vize/src/commands/check/patterns.rs
+++ b/crates/vize/src/commands/check/patterns.rs
@@ -1,17 +1,26 @@
 use std::path::Path;
 
 pub(super) const CHECK_INPUTS_DISPLAY: &str =
-    ".vue, .ts, .tsx, .mts, .cts, .jsx, .d.ts, .d.mts, or .d.cts";
+    ".vue, .ts, .tsx, .mts, .cts, .js, .jsx, .mjs, .cjs, .d.ts, .d.mts, or .d.cts";
 
 const CHECK_EXTENSIONS: &[&str] = &["vue", "ts", "tsx", "mts", "cts"];
+const JAVASCRIPT_EXTENSIONS: &[&str] = &["js", "jsx", "mjs", "cjs"];
 
-pub(super) fn is_supported_check_file(path: &Path, include_jsx: bool) -> bool {
+#[derive(Debug, Clone, Copy, Default)]
+pub(super) struct CheckFileOptions {
+    pub(super) include_js: bool,
+    pub(super) include_jsx: bool,
+}
+
+pub(super) fn is_supported_check_file(path: &Path, options: CheckFileOptions) -> bool {
     is_declaration_path(path)
         || path
             .extension()
             .and_then(|extension| extension.to_str())
             .is_some_and(|extension| {
-                CHECK_EXTENSIONS.contains(&extension) || (include_jsx && extension == "jsx")
+                CHECK_EXTENSIONS.contains(&extension)
+                    || (options.include_js && JAVASCRIPT_EXTENSIONS.contains(&extension))
+                    || (options.include_jsx && extension == "jsx")
             })
 }
 
@@ -25,7 +34,7 @@ pub(super) fn is_declaration_path(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{CHECK_INPUTS_DISPLAY, is_supported_check_file};
+    use super::{CHECK_INPUTS_DISPLAY, CheckFileOptions, is_supported_check_file};
     use std::path::Path;
 
     #[test]
@@ -40,12 +49,35 @@ mod tests {
             "env.d.mts",
             "env.d.cts",
         ] {
-            assert!(is_supported_check_file(Path::new(file), false), "{file}");
+            assert!(
+                is_supported_check_file(Path::new(file), CheckFileOptions::default()),
+                "{file}"
+            );
         }
 
-        assert!(!is_supported_check_file(Path::new("view.jsx"), false));
-        assert!(is_supported_check_file(Path::new("view.jsx"), true));
-        assert!(!is_supported_check_file(Path::new("main.js"), true));
+        assert!(!is_supported_check_file(
+            Path::new("view.jsx"),
+            CheckFileOptions::default()
+        ));
+        assert!(is_supported_check_file(
+            Path::new("view.jsx"),
+            CheckFileOptions {
+                include_jsx: true,
+                ..Default::default()
+            }
+        ));
+        for file in ["main.js", "view.jsx", "module.mjs", "config.cjs"] {
+            assert!(
+                is_supported_check_file(
+                    Path::new(file),
+                    CheckFileOptions {
+                        include_js: true,
+                        ..Default::default()
+                    }
+                ),
+                "{file}"
+            );
+        }
     }
 
     #[test]
@@ -55,7 +87,7 @@ mod tests {
             .filter(|token| !token.is_empty())
             .collect::<Vec<_>>();
 
-        for extension in ["vue", "ts", "tsx", "mts", "cts", "jsx"] {
+        for extension in ["vue", "ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"] {
             assert!(
                 display_tokens.contains(&extension),
                 "missing .{extension} from display text"

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -20,8 +20,9 @@ use vize_curator::profile::{ProfilePhase, ProfilePhaseKind, ProfileReport, print
 use super::{
     CheckArgs,
     path_cache::CanonicalPathCache,
+    patterns::CheckFileOptions,
     reporting::{JsonFileResult, JsonOutput},
-    tsconfig_inputs::{TsconfigInputCache, resolve_tsconfig_for_files},
+    tsconfig_inputs::{TsconfigInputCache, resolve_tsconfig_for_files, tsconfig_allows_js},
 };
 mod collect;
 mod default_imports;
@@ -175,9 +176,15 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         );
         (files, Vec::new(), reported_files)
     } else {
+        let include_js = invocation_tsconfig_path
+            .as_deref()
+            .is_some_and(|path| tsconfig_allows_js(path, &mut tsconfig_input_cache));
         let files = collect_check_files_with_ignores(
             &args.patterns,
-            jsx_typecheck,
+            CheckFileOptions {
+                include_js,
+                include_jsx: jsx_typecheck,
+            },
             check_ignore_set.as_ref(),
         );
         let explicit_files = files.clone();

--- a/crates/vize/src/commands/check/runner/collect.rs
+++ b/crates/vize/src/commands/check/runner/collect.rs
@@ -9,7 +9,7 @@ use glob::{MatchOptions, Pattern};
 use ignore::WalkBuilder;
 use vize_carton::{FxHashSet, String};
 
-use super::super::patterns::is_supported_check_file;
+use super::super::patterns::{CheckFileOptions, is_supported_check_file};
 use super::ignores::CheckIgnoreSet;
 
 const TARGET_DIR: &str = "target";
@@ -22,13 +22,20 @@ pub(super) fn collect_check_files(
     patterns: &[std::string::String],
     include_jsx: bool,
 ) -> Vec<PathBuf> {
-    collect_check_files_with_ignores(patterns, include_jsx, None)
+    collect_check_files_with_ignores(
+        patterns,
+        CheckFileOptions {
+            include_jsx,
+            ..Default::default()
+        },
+        None,
+    )
 }
 
 #[allow(clippy::disallowed_types)]
 pub(super) fn collect_check_files_with_ignores(
     patterns: &[std::string::String],
-    include_jsx: bool,
+    options: CheckFileOptions,
     ignore_set: Option<&CheckIgnoreSet>,
 ) -> Vec<PathBuf> {
     let mut files = Vec::new();
@@ -39,7 +46,7 @@ pub(super) fn collect_check_files_with_ignores(
         if candidate.exists() {
             if candidate.is_file() {
                 let candidate = normalize_input_path(&candidate);
-                if is_supported_check_file(&candidate, include_jsx)
+                if is_supported_check_file(&candidate, options)
                     && !is_ignored(&candidate, ignore_set)
                     && seen.insert(candidate.clone())
                 {
@@ -48,7 +55,7 @@ pub(super) fn collect_check_files_with_ignores(
                 continue;
             }
             if candidate.is_dir() {
-                collect_from_dir(&candidate, &mut files, &mut seen, include_jsx, ignore_set);
+                collect_from_dir(&candidate, &mut files, &mut seen, options, ignore_set);
                 continue;
             }
         }
@@ -59,7 +66,7 @@ pub(super) fn collect_check_files_with_ignores(
             base_dir.as_path(),
             &mut files,
             &mut seen,
-            include_jsx,
+            options,
             matcher.as_ref(),
             ignore_set,
         );
@@ -91,7 +98,13 @@ pub(super) fn collect_vue_files(patterns: &[std::string::String]) -> Vec<PathBuf
             }
             if candidate.is_dir() {
                 collect_from_dir_filtered(
-                    &candidate, &mut files, &mut seen, true, false, None, None,
+                    &candidate,
+                    &mut files,
+                    &mut seen,
+                    true,
+                    CheckFileOptions::default(),
+                    None,
+                    None,
                 );
                 continue;
             }
@@ -104,7 +117,7 @@ pub(super) fn collect_vue_files(patterns: &[std::string::String]) -> Vec<PathBuf
             &mut files,
             &mut seen,
             true,
-            false,
+            CheckFileOptions::default(),
             matcher.as_ref(),
             None,
         );
@@ -118,21 +131,21 @@ fn collect_from_dir(
     dir: &Path,
     files: &mut Vec<PathBuf>,
     seen: &mut FxHashSet<PathBuf>,
-    include_jsx: bool,
+    options: CheckFileOptions,
     ignore_set: Option<&CheckIgnoreSet>,
 ) {
-    collect_from_dir_with_matcher(dir, files, seen, include_jsx, None, ignore_set);
+    collect_from_dir_with_matcher(dir, files, seen, options, None, ignore_set);
 }
 
 fn collect_from_dir_with_matcher(
     dir: &Path,
     files: &mut Vec<PathBuf>,
     seen: &mut FxHashSet<PathBuf>,
-    include_jsx: bool,
+    options: CheckFileOptions,
     matcher: Option<&InputGlob>,
     ignore_set: Option<&CheckIgnoreSet>,
 ) {
-    collect_from_dir_filtered(dir, files, seen, false, include_jsx, matcher, ignore_set);
+    collect_from_dir_filtered(dir, files, seen, false, options, matcher, ignore_set);
 }
 
 fn collect_from_dir_filtered(
@@ -140,7 +153,7 @@ fn collect_from_dir_filtered(
     files: &mut Vec<PathBuf>,
     seen: &mut FxHashSet<PathBuf>,
     vue_only: bool,
-    include_jsx: bool,
+    options: CheckFileOptions,
     matcher: Option<&InputGlob>,
     ignore_set: Option<&CheckIgnoreSet>,
 ) {
@@ -163,7 +176,7 @@ fn collect_from_dir_filtered(
             if let Ok(entry) = entry {
                 let path = entry.path();
                 if path.is_file()
-                    && is_supported_collect_file(path, vue_only, include_jsx)
+                    && is_supported_collect_file(path, vue_only, options)
                     && matcher.is_none_or(|matcher| matcher.matches(path))
                     && (!skip_generated || !is_generated_path(path))
                     && !is_ignored(path, ignore_set)
@@ -309,11 +322,11 @@ fn is_generated_component(previous: Option<&str>, name: &str) -> bool {
     name == TARGET_DIR || (previous == Some(NODE_MODULES_DIR) && name == VIZE_CACHE_DIR)
 }
 
-fn is_supported_collect_file(path: &Path, vue_only: bool, include_jsx: bool) -> bool {
+fn is_supported_collect_file(path: &Path, vue_only: bool, options: CheckFileOptions) -> bool {
     if vue_only {
         return path.extension().and_then(|extension| extension.to_str()) == Some("vue");
     }
-    is_supported_check_file(path, include_jsx)
+    is_supported_check_file(path, options)
 }
 
 fn glob_match_options() -> MatchOptions {

--- a/crates/vize/src/commands/check/runner/collect_tests.rs
+++ b/crates/vize/src/commands/check/runner/collect_tests.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use crate::commands::check::{
     imports::collect_transitive_local_imports, imports_aliases::PathAliasResolver,
-    path_cache::CanonicalPathCache,
+    path_cache::CanonicalPathCache, patterns::CheckFileOptions,
 };
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -86,6 +86,71 @@ fn collect_check_files_includes_jsx_only_when_enabled() {
 }
 
 #[test]
+fn collect_check_files_honors_allowjs_for_files_directories_and_globs() {
+    let case_dir = unique_case_dir("collect-check-allow-js");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src/nested")).unwrap();
+    for name in [
+        "entry.js",
+        "view.jsx",
+        "module.mjs",
+        "config.cjs",
+        "typed.ts",
+    ] {
+        fs::write(case_dir.join("src").join(name), "").unwrap();
+    }
+    fs::write(case_dir.join("src/nested/worker.mjs"), "").unwrap();
+    let options = CheckFileOptions {
+        include_js: true,
+        include_jsx: false,
+    };
+
+    let direct = collect_check_files_with_ignores(
+        &[case_dir.join("src/entry.js").display().to_string()],
+        options,
+        None,
+    );
+    let directory = collect_check_files_with_ignores(
+        &[case_dir.join("src").display().to_string()],
+        options,
+        None,
+    );
+    let glob = collect_check_files_with_ignores(
+        &[case_dir.join("src/**/*.mjs").display().to_string()],
+        options,
+        None,
+    );
+    let disabled = collect_check_files_with_ignores(
+        &[case_dir.join("src/entry.js").display().to_string()],
+        CheckFileOptions::default(),
+        None,
+    );
+
+    assert_eq!(direct, vec![case_dir.join("src/entry.js")]);
+    assert_eq!(
+        directory,
+        vec![
+            case_dir.join("src/config.cjs"),
+            case_dir.join("src/entry.js"),
+            case_dir.join("src/module.mjs"),
+            case_dir.join("src/nested/worker.mjs"),
+            case_dir.join("src/typed.ts"),
+            case_dir.join("src/view.jsx"),
+        ]
+    );
+    assert_eq!(
+        glob,
+        vec![
+            case_dir.join("src/module.mjs"),
+            case_dir.join("src/nested/worker.mjs"),
+        ]
+    );
+    assert!(disabled.is_empty());
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
 fn collect_check_files_filters_quoted_globs() {
     let case_dir = unique_case_dir("collect-check-glob");
     let _ = fs::remove_dir_all(&case_dir);
@@ -138,12 +203,12 @@ fn collect_check_files_applies_entry_ignores() {
 
     let files = collect_check_files_with_ignores(
         &vec![case_dir.display().to_string()],
-        false,
+        CheckFileOptions::default(),
         ignore_set.as_ref(),
     );
     let explicit = collect_check_files_with_ignores(
         &vec![case_dir.join("src/Ignored.vue").display().to_string()],
-        false,
+        CheckFileOptions::default(),
         ignore_set.as_ref(),
     );
 
@@ -214,7 +279,7 @@ fn collect_check_files_normalizes_entry_ignore_paths_and_duplicates() {
                 .display()
                 .to_string(),
         ],
-        false,
+        CheckFileOptions::default(),
         ignore_set.as_ref(),
     );
 

--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -68,6 +68,13 @@ pub(crate) fn collect_default_check_files(
     collect_default_check_files_inner(project_root, tsconfig_path, false, include_jsx, cache)
 }
 
+pub(crate) fn tsconfig_allows_js(tsconfig_path: &Path, cache: &mut TsconfigInputCache) -> bool {
+    cache
+        .load(tsconfig_path)
+        .and_then(|spec| spec.allow_js)
+        .unwrap_or(false)
+}
+
 fn collect_default_check_files_inner(
     project_root: &Path,
     tsconfig_path: Option<&Path>,

--- a/crates/vize/src/commands/check/tsconfig_inputs/matching.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/matching.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use glob::MatchOptions;
 
-use super::super::patterns as check_patterns;
+use super::super::patterns::{self as check_patterns, CheckFileOptions};
 use super::spec::GlobSpec;
 use super::{NODE_MODULES_DIR, TARGET_DIR, VIZE_CACHE_DIR};
 
@@ -129,12 +129,13 @@ pub(super) fn is_supported_check_file_with_options(
     path: &Path,
     options: SupportedFileOptions,
 ) -> bool {
-    check_patterns::is_supported_check_file(path, options.include_jsx)
-        || (options.include_js
-            && path
-                .extension()
-                .and_then(|extension| extension.to_str())
-                .is_some_and(|extension| matches!(extension, "js" | "jsx" | "mjs" | "cjs")))
+    check_patterns::is_supported_check_file(
+        path,
+        CheckFileOptions {
+            include_js: options.include_js,
+            include_jsx: options.include_jsx,
+        },
+    )
 }
 
 pub(super) fn glob_match_options() -> MatchOptions {

--- a/crates/vize/tests/check_allowjs_imports_cli.rs
+++ b/crates/vize/tests/check_allowjs_imports_cli.rs
@@ -204,3 +204,80 @@ export const message = 42;
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn explicit_allowjs_file_reports_authored_diagnostics() {
+    let Some(corsa_path) = required_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("explicit-root-diagnostic");
+    let _ = std::fs::remove_dir_all(&project_root);
+
+    write(
+        &project_root,
+        "tsconfig.base.json",
+        r#"{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  }
+}"#,
+    );
+    write(
+        &project_root,
+        "tsconfig.json",
+        r#"{ "extends": "./tsconfig.base.json", "include": ["src/**/*"] }"#,
+    );
+    write(
+        &project_root,
+        "src/invalid.js",
+        r#"/** @type {string} */
+export const message = 42;
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "src/invalid.js",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("invalid JSON ({error}):\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    assert_eq!(json["errorCount"], serde_json::json!(1), "{stdout}");
+    assert_eq!(
+        json["files"][0]["file"],
+        serde_json::json!("src/invalid.js"),
+        "{stdout}"
+    );
+    assert!(
+        json["files"][0]["diagnostics"][0]
+            .as_str()
+            .is_some_and(|diagnostic| diagnostic.contains("TS2322")),
+        "{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
Part of #3984.

## Summary

- derive JavaScript input support from inherited root `compilerOptions.allowJs`
- collect explicit JS-family files, directories, and globs through one `CheckFileOptions` contract
- report `checkJs` diagnostics against explicitly selected authored `.js` files

## Root cause

Explicit inputs were filtered by an extension-only collector before the merged tsconfig was considered, so valid JavaScript inputs were silently dropped even when `allowJs` and `checkJs` were inherited.

## Tests

- `cargo test -p vize --lib`
- `cargo test -p vize --test check_allowjs_imports_cli`
- `node --test tests/tooling/typecheck-dependency-gates.test.ts`
- `cargo clippy -p vize --lib --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Scope

This covers a root or inherited tsconfig with `allowJs`. Solution-style roots whose referenced child alone enables `allowJs`, plus further transitive-JavaScript reachability, remain separate follow-up slices.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->