### PR TITLE
test(check): cover JavaScript input notices

### DIFF
--- a/tests/tooling/cli-check-args.test.ts
+++ b/tests/tooling/cli-check-args.test.ts
@@ -96,7 +96,7 @@ test("vize check --no-config bypasses validation of an invalid -c path", () => {
     assert.equal(result.stdout, "");
     assert.equal(
       result.stderr,
-      'No .vue, .ts, .tsx, .mts, .cts, .jsx, .d.ts, .d.mts, or .d.cts files found matching inputs: ["zzz.vue"]\n',
+      'No .vue, .ts, .tsx, .mts, .cts, .js, .jsx, .mjs, .cjs, .d.ts, .d.mts, or .d.cts files found matching inputs: ["zzz.vue"]\n',
     );
   });
 });

--- a/tests/tooling/cli-check-collection.test.ts
+++ b/tests/tooling/cli-check-collection.test.ts
@@ -122,7 +122,7 @@ test("no-match text run prints the notice to stderr, leaves stdout empty, exits 
     assert.equal(result.stdout.trim(), "");
     assert.equal(
       result.stderr,
-      'No .vue, .ts, .tsx, .mts, .cts, .jsx, .d.ts, .d.mts, or .d.cts files found matching inputs: ["zzz.vue"]\n',
+      'No .vue, .ts, .tsx, .mts, .cts, .js, .jsx, .mjs, .cjs, .d.ts, .d.mts, or .d.cts files found matching inputs: ["zzz.vue"]\n',
     );
   });
 });

--- a/tests/tooling/cli-check-contract.test.ts
+++ b/tests/tooling/cli-check-contract.test.ts
@@ -105,7 +105,7 @@ test("vize check exits 0 when explicit inputs match no supported files", () => {
     assert.equal(result.stdout, "");
     assert.equal(
       result.stderr,
-      'No .vue, .ts, .tsx, .mts, .cts, .jsx, .d.ts, .d.mts, or .d.cts files found matching inputs: ["does-not-exist.vue"]\n',
+      'No .vue, .ts, .tsx, .mts, .cts, .js, .jsx, .mjs, .cjs, .d.ts, .d.mts, or .d.cts files found matching inputs: ["does-not-exist.vue"]\n',
     );
   });
 });
@@ -117,7 +117,7 @@ test("vize check exits 0 in an empty project with no inputs", () => {
     assert.equal(result.stdout, "");
     assert.equal(
       result.stderr,
-      "No .vue, .ts, .tsx, .mts, .cts, .jsx, .d.ts, .d.mts, or .d.cts files found matching inputs: []\n",
+      "No .vue, .ts, .tsx, .mts, .cts, .js, .jsx, .mjs, .cjs, .d.ts, .d.mts, or .d.cts files found matching inputs: []\n",
     );
   });
 });


### PR DESCRIPTION
Part of #3984.

## Summary

- update exact CLI notice contracts for `.js`, `.mjs`, and `.cjs`
- cover no-config, no-match, and empty-project output after JavaScript input support landed

## Root cause

The Rust CLI input display was extended with the JavaScript family, while four Node contract assertions still pinned the older extension list. This caused `test-scripts` to fail even though the command behavior was correct.

## Tests

- `VIZE_TEST_BIN=target/debug/vize node --test --test-concurrency=1 tests/tooling/cli-check-args.test.ts tests/tooling/cli-check-collection.test.ts tests/tooling/cli-check-contract.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->