### PR TITLE
fix(check): honor referenced allowJs projects

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -22,7 +22,7 @@ use super::{
     path_cache::CanonicalPathCache,
     patterns::CheckFileOptions,
     reporting::{JsonFileResult, JsonOutput},
-    tsconfig_inputs::{TsconfigInputCache, resolve_tsconfig_for_files, tsconfig_allows_js},
+    tsconfig_inputs::TsconfigInputCache,
 };
 mod collect;
 mod default_imports;
@@ -32,6 +32,7 @@ mod ignores;
 mod input_scope;
 mod invocation;
 mod nuxt_tsconfig;
+mod program_inputs;
 mod resolve;
 #[cfg(unix)]
 mod socket;
@@ -52,10 +53,11 @@ use global_components::{
 };
 use ignores::load_check_ignore_set;
 use input_scope::{exit_if_default_run_leaves_cwd, report_no_inputs};
-use invocation::resolve_invocation_program;
+use invocation::{resolve_invocation_program, resolve_nuxt_project_root};
 use nuxt_tsconfig::resolve_checker_tsconfig_path;
 #[cfg(test)]
 use nuxt_tsconfig::write_nuxt_fallback_tsconfig;
+use program_inputs::{ProgramInputContext, filter_for_program, project_graph_allows_js};
 use resolve::{
     display_path, exit_if_inputs_outside_root, explicit_input_root,
     resolve_declaration_emit_options, resolve_from_config_dir, resolve_project_root,
@@ -153,7 +155,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let mut canonical_paths = CanonicalPathCache::default();
     let check_ignore_set = load_check_ignore_set(args, config_dir);
     let collect_start = Instant::now();
-    let (mut files, explicit_files, reported_files): (
+    let (mut files, mut program_input_files, mut reported_files): (
         Vec<PathBuf>,
         Vec<PathBuf>,
         FxHashSet<PathBuf>,
@@ -174,11 +176,13 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             invocation_tsconfig_path.as_deref(),
             args.quiet,
         );
-        (files, Vec::new(), reported_files)
+        let program_input_files = reported_files.iter().cloned().collect();
+        (files, program_input_files, reported_files)
     } else {
-        let include_js = invocation_tsconfig_path
-            .as_deref()
-            .is_some_and(|path| tsconfig_allows_js(path, &mut tsconfig_input_cache));
+        let include_js = project_graph_allows_js(
+            invocation_tsconfig_path.as_deref(),
+            &mut tsconfig_input_cache,
+        );
         let files = collect_check_files_with_ignores(
             &args.patterns,
             CheckFileOptions {
@@ -187,9 +191,9 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             },
             check_ignore_set.as_ref(),
         );
-        let explicit_files = files.clone();
+        let program_input_files = files.clone();
         let reported_files = canonical_file_set(&files, &mut canonical_paths);
-        (files, explicit_files, reported_files)
+        (files, program_input_files, reported_files)
     };
     let collect_time = collect_start.elapsed();
 
@@ -214,16 +218,20 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &files);
     let discovered_tsconfig_path =
         resolve_tsconfig_path(effective_tsconfig.as_deref(), &cwd, &project_root, &files);
-    let program_tsconfig_path = if args.patterns.is_empty() {
-        invocation_tsconfig_path.clone()
-    } else {
-        resolve_tsconfig_for_files(
-            discovered_tsconfig_path.as_deref(),
-            &explicit_files,
-            jsx_typecheck,
-            &mut tsconfig_input_cache,
-        )
-    };
+    let program_tsconfig_path = filter_for_program(ProgramInputContext {
+        tsconfig_path: discovered_tsconfig_path.as_deref(),
+        explicit: !args.patterns.is_empty(),
+        include_jsx: jsx_typecheck,
+        files: &mut files,
+        inputs: &mut program_input_files,
+        reported: &mut reported_files,
+        cache: &mut tsconfig_input_cache,
+        canonical_paths: &mut canonical_paths,
+    });
+    if !args.patterns.is_empty() && program_input_files.is_empty() {
+        report_no_inputs(args);
+        return;
+    }
     // Explicit subsets need package-local ambient roots and their imported types.
     if !args.patterns.is_empty()
         && let Some(program_tsconfig_path) = program_tsconfig_path.as_deref()
@@ -685,35 +693,4 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         eprintln!("\nToo many warnings ({total_warnings} > max {max_warnings})");
         std::process::exit(1);
     }
-}
-
-fn resolve_nuxt_project_root(
-    explicit_tsconfig: Option<&Path>,
-    cwd: &Path,
-    fallback: &Path,
-) -> PathBuf {
-    let Some(tsconfig) = explicit_tsconfig else {
-        return fallback.to_path_buf();
-    };
-    let tsconfig_path = if tsconfig.is_absolute() {
-        tsconfig.to_path_buf()
-    } else {
-        cwd.join(tsconfig)
-    };
-    let tsconfig_dir = vize_carton::path::canonicalize_non_verbatim(&tsconfig_path)
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| fallback.to_path_buf());
-    if super::nuxt::is_nuxt_project_root(&tsconfig_dir) {
-        return tsconfig_dir;
-    }
-    if tsconfig_dir.join("package.json").exists() {
-        return tsconfig_dir;
-    }
-    if let Some(parent) = tsconfig_dir.parent()
-        && super::nuxt::is_nuxt_project_root(parent)
-    {
-        return parent.to_path_buf();
-    }
-    tsconfig_dir
 }

--- a/crates/vize/src/commands/check/runner/invocation.rs
+++ b/crates/vize/src/commands/check/runner/invocation.rs
@@ -14,3 +14,34 @@ pub(super) fn resolve_invocation_program(
     let tsconfig_path = resolve_tsconfig_path(effective_tsconfig, cwd, &project_root, &[]);
     (project_root, tsconfig_path)
 }
+
+pub(super) fn resolve_nuxt_project_root(
+    explicit_tsconfig: Option<&Path>,
+    cwd: &Path,
+    fallback: &Path,
+) -> PathBuf {
+    let Some(tsconfig) = explicit_tsconfig else {
+        return fallback.to_path_buf();
+    };
+    let tsconfig_path = if tsconfig.is_absolute() {
+        tsconfig.to_path_buf()
+    } else {
+        cwd.join(tsconfig)
+    };
+    let tsconfig_dir = vize_carton::path::canonicalize_non_verbatim(&tsconfig_path)
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| fallback.to_path_buf());
+    if super::super::nuxt::is_nuxt_project_root(&tsconfig_dir) {
+        return tsconfig_dir;
+    }
+    if tsconfig_dir.join("package.json").exists() {
+        return tsconfig_dir;
+    }
+    if let Some(parent) = tsconfig_dir.parent()
+        && super::super::nuxt::is_nuxt_project_root(parent)
+    {
+        return parent.to_path_buf();
+    }
+    tsconfig_dir
+}

--- a/crates/vize/src/commands/check/runner/program_inputs.rs
+++ b/crates/vize/src/commands/check/runner/program_inputs.rs
@@ -1,0 +1,62 @@
+use std::path::{Path, PathBuf};
+
+use vize_carton::FxHashSet;
+
+use super::default_imports::canonical_file_set;
+use crate::commands::check::{
+    path_cache::CanonicalPathCache,
+    patterns::{CheckFileOptions, is_supported_check_file},
+    tsconfig_inputs::{
+        TsconfigInputCache, resolve_tsconfig_for_files, tsconfig_allows_js,
+        tsconfig_project_graph_allows_js,
+    },
+};
+
+pub(super) fn project_graph_allows_js(
+    tsconfig_path: Option<&Path>,
+    cache: &mut TsconfigInputCache,
+) -> bool {
+    tsconfig_path.is_some_and(|path| tsconfig_project_graph_allows_js(path, cache))
+}
+
+pub(super) struct ProgramInputContext<'a> {
+    pub(super) tsconfig_path: Option<&'a Path>,
+    pub(super) explicit: bool,
+    pub(super) include_jsx: bool,
+    pub(super) files: &'a mut Vec<PathBuf>,
+    pub(super) inputs: &'a mut Vec<PathBuf>,
+    pub(super) reported: &'a mut FxHashSet<PathBuf>,
+    pub(super) cache: &'a mut TsconfigInputCache,
+    pub(super) canonical_paths: &'a mut CanonicalPathCache,
+}
+
+pub(super) fn filter_for_program(context: ProgramInputContext<'_>) -> Option<PathBuf> {
+    let program_tsconfig_path = resolve_tsconfig_for_files(
+        context.tsconfig_path,
+        context.inputs,
+        context.include_jsx,
+        context.cache,
+    );
+    if !context.explicit {
+        return program_tsconfig_path;
+    }
+
+    // Candidate collection admits JavaScript when any referenced project
+    // enables allowJs. Once ownership selects the program, apply that exact
+    // config so an allowJs child cannot make a deny sibling eligible.
+    let file_options = CheckFileOptions {
+        include_js: program_tsconfig_path
+            .as_deref()
+            .is_some_and(|path| tsconfig_allows_js(path, context.cache)),
+        include_jsx: context.include_jsx,
+    };
+    context
+        .files
+        .retain(|path| is_supported_check_file(path, file_options));
+    context
+        .inputs
+        .retain(|path| is_supported_check_file(path, file_options));
+    *context.reported = canonical_file_set(context.inputs, context.canonical_paths);
+
+    program_tsconfig_path
+}

--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -48,7 +48,6 @@ use collect::{
     explicit_hidden_include_roots, explicit_hidden_pattern_roots,
 };
 use glob::normalize_input_path;
-use loader::collect_tsconfig_project_paths;
 use matching::{
     SupportedFileOptions, is_declaration_path, is_generated_codegen_declaration_path,
     is_nuxt_import_manifest_path, is_supported_check_file_with_options,
@@ -75,6 +74,20 @@ pub(crate) fn tsconfig_allows_js(tsconfig_path: &Path, cache: &mut TsconfigInput
         .unwrap_or(false)
 }
 
+/// Whether the root project or any transitively referenced project accepts
+/// JavaScript inputs. Explicit path collection uses this only as a broad
+/// extension gate; ownership resolution later selects the exact project and
+/// applies that project's own `allowJs` value.
+pub(crate) fn tsconfig_project_graph_allows_js(
+    tsconfig_path: &Path,
+    cache: &mut TsconfigInputCache,
+) -> bool {
+    cache
+        .project_paths(tsconfig_path)
+        .iter()
+        .any(|project| tsconfig_allows_js(project, cache))
+}
+
 fn collect_default_check_files_inner(
     project_root: &Path,
     tsconfig_path: Option<&Path>,
@@ -97,7 +110,7 @@ fn collect_default_check_files_inner(
 
     let mut files = Vec::new();
     let mut seen = FxHashSet::default();
-    for tsconfig_path in collect_tsconfig_project_paths(tsconfig_path) {
+    for tsconfig_path in cache.project_paths(tsconfig_path) {
         collect_default_check_files_for_tsconfig(
             project_root,
             &tsconfig_path,

--- a/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
@@ -6,7 +6,7 @@ use ignore::WalkBuilder;
 use vize_carton::FxHashSet;
 
 use super::glob::{normalize_input_path, normalize_walked_path};
-use super::loader::{TsconfigInputCache, collect_tsconfig_project_paths};
+use super::loader::TsconfigInputCache;
 use super::matching::{
     SupportedFileOptions, is_generated_codegen_declaration_path, is_generated_path,
     is_hidden_path_segment, is_nuxt_import_manifest_path, is_supported_check_file_with_options,
@@ -183,7 +183,7 @@ pub(crate) fn resolve_tsconfig_for_files(
     cache: &mut TsconfigInputCache,
 ) -> Option<PathBuf> {
     let tsconfig_path = tsconfig_path?;
-    let projects = collect_tsconfig_project_paths(tsconfig_path);
+    let projects = cache.project_paths(tsconfig_path);
     let root_project = projects
         .first()
         .cloned()
@@ -194,7 +194,11 @@ pub(crate) fn resolve_tsconfig_for_files(
             is_supported_check_file_with_options(
                 path,
                 SupportedFileOptions {
-                    include_js: false,
+                    // JavaScript candidates must reach the per-project
+                    // ownership matchers below. Each matcher applies its own
+                    // merged allowJs value, so a referenced allowJs project
+                    // cannot leak ownership to a sibling that disables it.
+                    include_js: true,
                     include_jsx,
                 },
             )
@@ -250,6 +254,7 @@ struct TsconfigOwnershipMatcher {
     files: FxHashSet<PathBuf>,
     includes: Vec<GlobSpec>,
     excludes: Vec<GlobSpec>,
+    include_js: bool,
     include_jsx: bool,
 }
 
@@ -261,6 +266,7 @@ impl TsconfigOwnershipMatcher {
                 files: FxHashSet::default(),
                 includes: Vec::new(),
                 excludes: Vec::new(),
+                include_js: false,
                 include_jsx,
             };
         };
@@ -288,6 +294,7 @@ impl TsconfigOwnershipMatcher {
             files,
             includes,
             excludes,
+            include_js: spec.allow_js.unwrap_or(false),
             include_jsx,
         }
     }
@@ -308,7 +315,7 @@ impl TsconfigOwnershipMatcher {
             || !is_supported_check_file_with_options(
                 file,
                 SupportedFileOptions {
-                    include_js: false,
+                    include_js: self.include_js,
                     include_jsx: self.include_jsx,
                 },
             )

--- a/crates/vize/src/commands/check/tsconfig_inputs/loader.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/loader.rs
@@ -12,35 +12,8 @@ use super::glob::{compiler_option_dir_exclude, normalize_input_path};
 use super::jsonc::parse_jsonc_value;
 use super::spec::{GlobSpec, RelativePathSpec, TsconfigDeclarationOptions, TsconfigInputSpec};
 
-pub(super) fn collect_tsconfig_project_paths(tsconfig_path: &Path) -> Vec<PathBuf> {
-    let mut paths = Vec::new();
-    let mut seen = FxHashSet::default();
-    collect_tsconfig_project_paths_inner(tsconfig_path, &mut seen, &mut paths);
-    paths
-}
-
-fn collect_tsconfig_project_paths_inner(
-    tsconfig_path: &Path,
-    seen: &mut FxHashSet<PathBuf>,
-    paths: &mut Vec<PathBuf>,
-) {
-    let resolved = normalize_input_path(tsconfig_path);
-    if !seen.insert(resolved.clone()) {
-        return;
-    }
-    paths.push(resolved.clone());
-
-    let Ok(content) = tracked_read_to_string(&resolved) else {
-        return;
-    };
-    let value = parse_jsonc_value(&content).unwrap_or(Value::Null);
-    for reference in read_reference_entries(&value) {
-        let Some(reference_path) = resolve_referenced_tsconfig(&resolved, &reference) else {
-            continue;
-        };
-        collect_tsconfig_project_paths_inner(&reference_path, seen, paths);
-    }
-}
+mod project_graph;
+use project_graph::collect_tsconfig_project_paths;
 
 /// Run-scoped memo for merged tsconfig input specs, keyed by canonical
 /// tsconfig path.
@@ -53,9 +26,21 @@ fn collect_tsconfig_project_paths_inner(
 #[derive(Default)]
 pub(crate) struct TsconfigInputCache {
     specs: FxHashMap<PathBuf, Option<TsconfigInputSpec>>,
+    project_paths: FxHashMap<PathBuf, Vec<PathBuf>>,
 }
 
 impl TsconfigInputCache {
+    /// Resolve a solution-style project's transitive reference graph once per
+    /// check run. Callers receive an owned list so they can continue loading
+    /// specs through this same mutable cache without overlapping borrows.
+    pub(super) fn project_paths(&mut self, tsconfig_path: &Path) -> Vec<PathBuf> {
+        let resolved = normalize_input_path(tsconfig_path);
+        self.project_paths
+            .entry(resolved)
+            .or_insert_with_key(|resolved| collect_tsconfig_project_paths(resolved))
+            .clone()
+    }
+
     /// Load (or reuse) the merged input spec for `tsconfig_path`. Returns
     /// `None` when the tsconfig chain cannot be read, exactly like an uncached
     /// `load_tsconfig_inputs` call.
@@ -210,19 +195,6 @@ pub(crate) fn resolve_extended_tsconfig(tsconfig_path: &Path, extends: &str) -> 
     candidates.into_iter().find(|candidate| candidate.is_file())
 }
 
-fn resolve_referenced_tsconfig(tsconfig_path: &Path, reference: &str) -> Option<PathBuf> {
-    let base_dir = tsconfig_path.parent().unwrap_or(Path::new("."));
-    let reference_path = Path::new(reference);
-    let base = if reference_path.is_absolute() {
-        reference_path.to_path_buf()
-    } else {
-        base_dir.join(reference_path)
-    };
-    let mut candidates = Vec::new();
-    push_tsconfig_candidates(&mut candidates, base);
-    candidates.into_iter().find(|candidate| candidate.is_file())
-}
-
 fn resolve_tsconfig_path_option(base_dir: &Path, value: &str) -> PathBuf {
     let path = Path::new(value);
     if path.is_absolute() {
@@ -337,15 +309,4 @@ pub(crate) fn read_extends_entries(value: &Value) -> Vec<std::string::String> {
             .collect(),
         _ => Vec::new(),
     }
-}
-
-fn read_reference_entries(value: &Value) -> Vec<std::string::String> {
-    value
-        .get("references")
-        .and_then(Value::as_array)
-        .into_iter()
-        .flatten()
-        .filter_map(|item| item.get("path").and_then(Value::as_str))
-        .map(std::string::String::from)
-        .collect()
 }

--- a/crates/vize/src/commands/check/tsconfig_inputs/loader/project_graph.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/loader/project_graph.rs
@@ -1,0 +1,55 @@
+use super::*;
+
+pub(super) fn collect_tsconfig_project_paths(tsconfig_path: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let mut seen = FxHashSet::default();
+    collect_tsconfig_project_paths_inner(tsconfig_path, &mut seen, &mut paths);
+    paths
+}
+
+fn collect_tsconfig_project_paths_inner(
+    tsconfig_path: &Path,
+    seen: &mut FxHashSet<PathBuf>,
+    paths: &mut Vec<PathBuf>,
+) {
+    let resolved = normalize_input_path(tsconfig_path);
+    if !seen.insert(resolved.clone()) {
+        return;
+    }
+    paths.push(resolved.clone());
+
+    let Ok(content) = tracked_read_to_string(&resolved) else {
+        return;
+    };
+    let value = parse_jsonc_value(&content).unwrap_or(Value::Null);
+    for reference in read_reference_entries(&value) {
+        let Some(reference_path) = resolve_referenced_tsconfig(&resolved, &reference) else {
+            continue;
+        };
+        collect_tsconfig_project_paths_inner(&reference_path, seen, paths);
+    }
+}
+
+fn resolve_referenced_tsconfig(tsconfig_path: &Path, reference: &str) -> Option<PathBuf> {
+    let base_dir = tsconfig_path.parent().unwrap_or(Path::new("."));
+    let reference_path = Path::new(reference);
+    let base = if reference_path.is_absolute() {
+        reference_path.to_path_buf()
+    } else {
+        base_dir.join(reference_path)
+    };
+    let mut candidates = Vec::new();
+    push_tsconfig_candidates(&mut candidates, base);
+    candidates.into_iter().find(|candidate| candidate.is_file())
+}
+
+fn read_reference_entries(value: &Value) -> Vec<std::string::String> {
+    value
+        .get("references")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|item| item.get("path").and_then(Value::as_str))
+        .map(std::string::String::from)
+        .collect()
+}

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
@@ -6,6 +6,7 @@ use super::{TsconfigInputCache, load_tsconfig_declaration_options, resolve_exten
 use std::fs;
 use std::path::{Path, PathBuf};
 use vize_carton::{cstr, path::canonicalize_non_verbatim};
+mod allow_js;
 mod codegen;
 mod tsx_owner;
 // Each call uses a fresh run-scoped cache, mirroring how an actual `vize
@@ -737,161 +738,6 @@ fn declaration_files_are_always_supported() {
 }
 
 #[test]
-fn supported_extensions_cover_ts_family_and_reject_js_family() {
-    let case_dir = unique_case_dir("tsconfig-ext-family");
-    let _ = fs::remove_dir_all(&case_dir);
-    fs::create_dir_all(case_dir.join("src")).unwrap();
-    let supported = ["App.vue", "a.ts", "b.tsx", "c.mts", "d.cts"];
-    let unsupported = ["e.js", "f.jsx", "g.cjs", "h.mjs", "data.json"];
-    for name in supported.iter().chain(unsupported.iter()) {
-        fs::write(case_dir.join("src").join(name), "x").unwrap();
-    }
-    fs::write(
-        case_dir.join("tsconfig.json"),
-        r#"{ "include": ["src/**/*"] }"#,
-    )
-    .unwrap();
-
-    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
-
-    assert_eq!(
-        files,
-        vec![
-            case_dir.join("src/App.vue"),
-            case_dir.join("src/a.ts"),
-            case_dir.join("src/b.tsx"),
-            case_dir.join("src/c.mts"),
-            case_dir.join("src/d.cts"),
-        ]
-    );
-
-    let _ = fs::remove_dir_all(&case_dir);
-}
-
-#[test]
-fn allow_js_inherited_from_extended_config_collects_the_js_family() {
-    let case_dir = unique_case_dir("tsconfig-ext-allow-js");
-    let _ = fs::remove_dir_all(&case_dir);
-    fs::create_dir_all(case_dir.join("src")).unwrap();
-    for name in [
-        "App.vue", "a.ts", "b.tsx", "c.mts", "d.cts", "e.js", "f.jsx", "g.cjs", "h.mjs",
-    ] {
-        fs::write(case_dir.join("src").join(name), "export const value = true").unwrap();
-    }
-    fs::write(
-        case_dir.join("tsconfig.base.json"),
-        r#"{ "compilerOptions": { "allowJs": true } }"#,
-    )
-    .unwrap();
-    fs::write(
-        case_dir.join("tsconfig.json"),
-        r#"{ "extends": "./tsconfig.base.json", "include": ["src/**/*"] }"#,
-    )
-    .unwrap();
-
-    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
-
-    assert_eq!(
-        relative_paths(&case_dir, &files),
-        vec![
-            "src/App.vue",
-            "src/a.ts",
-            "src/b.tsx",
-            "src/c.mts",
-            "src/d.cts",
-            "src/e.js",
-            "src/f.jsx",
-            "src/g.cjs",
-            "src/h.mjs",
-        ]
-    );
-
-    let _ = fs::remove_dir_all(&case_dir);
-}
-
-#[test]
-fn local_allow_js_false_overrides_an_extended_config() {
-    let case_dir = unique_case_dir("tsconfig-ext-disable-allow-js");
-    let _ = fs::remove_dir_all(&case_dir);
-    fs::create_dir_all(case_dir.join("src")).unwrap();
-    fs::write(case_dir.join("src/main.ts"), "export const value = true").unwrap();
-    fs::write(case_dir.join("src/skip.js"), "export const skip = true").unwrap();
-    fs::write(
-        case_dir.join("tsconfig.base.json"),
-        r#"{ "compilerOptions": { "allowJs": true } }"#,
-    )
-    .unwrap();
-    fs::write(
-        case_dir.join("tsconfig.json"),
-        r#"{
-  "extends": "./tsconfig.base.json",
-  "compilerOptions": { "allowJs": false },
-  "include": ["src/**/*"]
-}"#,
-    )
-    .unwrap();
-
-    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
-
-    assert_eq!(relative_paths(&case_dir, &files), vec!["src/main.ts"]);
-
-    let _ = fs::remove_dir_all(&case_dir);
-}
-
-#[test]
-fn referenced_projects_use_their_own_allow_js_setting() {
-    let case_dir = unique_case_dir("tsconfig-references-allow-js");
-    let _ = fs::remove_dir_all(&case_dir);
-    for package in ["allow", "deny"] {
-        fs::create_dir_all(case_dir.join("packages").join(package).join("src")).unwrap();
-        fs::write(
-            case_dir.join("packages").join(package).join("src/index.ts"),
-            "export const typed = true",
-        )
-        .unwrap();
-        fs::write(
-            case_dir.join("packages").join(package).join("src/index.js"),
-            "export const javascript = true",
-        )
-        .unwrap();
-    }
-    fs::write(
-        case_dir.join("tsconfig.json"),
-        r#"{
-  "files": [],
-  "references": [
-    { "path": "./packages/allow" },
-    { "path": "./packages/deny" }
-  ]
-}"#,
-    )
-    .unwrap();
-    fs::write(
-        case_dir.join("packages/allow/tsconfig.json"),
-        r#"{ "compilerOptions": { "allowJs": true }, "include": ["src/**/*"] }"#,
-    )
-    .unwrap();
-    fs::write(
-        case_dir.join("packages/deny/tsconfig.json"),
-        r#"{ "compilerOptions": { "allowJs": false }, "include": ["src/**/*"] }"#,
-    )
-    .unwrap();
-
-    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
-
-    assert_eq!(
-        relative_paths(&case_dir, &files),
-        vec![
-            "packages/allow/src/index.js",
-            "packages/allow/src/index.ts",
-            "packages/deny/src/index.ts",
-        ]
-    );
-
-    let _ = fs::remove_dir_all(&case_dir);
-}
-
-#[test]
 fn jsx_extension_is_collected_only_for_jsx_typecheck() {
     let case_dir = unique_case_dir("tsconfig-ext-jsx");
     let _ = fs::remove_dir_all(&case_dir);
@@ -1184,7 +1030,7 @@ fn owner_resolution_returns_root_for_no_supported_files() {
         Some(normalized_root.clone())
     );
 
-    // Unsupported-only file list -> root (the .js is filtered out first).
+    // A JavaScript file that no project owns under allowJs -> root fallback.
     assert_eq!(
         resolve_tsconfig_for_files(Some(&root), &[case_dir.join("src/app.js")]),
         Some(normalized_root)

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests/allow_js.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests/allow_js.rs
@@ -1,0 +1,204 @@
+use super::*;
+
+#[test]
+fn supported_extensions_cover_ts_family_and_reject_js_family() {
+    let case_dir = unique_case_dir("tsconfig-ext-family");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    let supported = ["App.vue", "a.ts", "b.tsx", "c.mts", "d.cts"];
+    let unsupported = ["e.js", "f.jsx", "g.cjs", "h.mjs", "data.json"];
+    for name in supported.iter().chain(unsupported.iter()) {
+        fs::write(case_dir.join("src").join(name), "x").unwrap();
+    }
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{ "include": ["src/**/*"] }"#,
+    )
+    .unwrap();
+
+    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+    assert_eq!(
+        files,
+        vec![
+            case_dir.join("src/App.vue"),
+            case_dir.join("src/a.ts"),
+            case_dir.join("src/b.tsx"),
+            case_dir.join("src/c.mts"),
+            case_dir.join("src/d.cts"),
+        ]
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn allow_js_inherited_from_extended_config_collects_the_js_family() {
+    let case_dir = unique_case_dir("tsconfig-ext-allow-js");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    for name in [
+        "App.vue", "a.ts", "b.tsx", "c.mts", "d.cts", "e.js", "f.jsx", "g.cjs", "h.mjs",
+    ] {
+        fs::write(case_dir.join("src").join(name), "export const value = true").unwrap();
+    }
+    fs::write(
+        case_dir.join("tsconfig.base.json"),
+        r#"{ "compilerOptions": { "allowJs": true } }"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{ "extends": "./tsconfig.base.json", "include": ["src/**/*"] }"#,
+    )
+    .unwrap();
+
+    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+    assert_eq!(
+        relative_paths(&case_dir, &files),
+        vec![
+            "src/App.vue",
+            "src/a.ts",
+            "src/b.tsx",
+            "src/c.mts",
+            "src/d.cts",
+            "src/e.js",
+            "src/f.jsx",
+            "src/g.cjs",
+            "src/h.mjs",
+        ]
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn local_allow_js_false_overrides_an_extended_config() {
+    let case_dir = unique_case_dir("tsconfig-ext-disable-allow-js");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    fs::write(case_dir.join("src/main.ts"), "export const value = true").unwrap();
+    fs::write(case_dir.join("src/skip.js"), "export const skip = true").unwrap();
+    fs::write(
+        case_dir.join("tsconfig.base.json"),
+        r#"{ "compilerOptions": { "allowJs": true } }"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": { "allowJs": false },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+
+    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+    assert_eq!(relative_paths(&case_dir, &files), vec!["src/main.ts"]);
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn referenced_projects_use_their_own_allow_js_setting() {
+    let case_dir = unique_case_dir("tsconfig-references-allow-js");
+    let _ = fs::remove_dir_all(&case_dir);
+    for package in ["allow", "deny"] {
+        fs::create_dir_all(case_dir.join("packages").join(package).join("src")).unwrap();
+        fs::write(
+            case_dir.join("packages").join(package).join("src/index.ts"),
+            "export const typed = true",
+        )
+        .unwrap();
+        fs::write(
+            case_dir.join("packages").join(package).join("src/index.js"),
+            "export const javascript = true",
+        )
+        .unwrap();
+    }
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{
+  "files": [],
+  "references": [
+    { "path": "./packages/allow" },
+    { "path": "./packages/deny" }
+  ]
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("packages/allow/tsconfig.json"),
+        r#"{ "compilerOptions": { "allowJs": true }, "include": ["src/**/*"] }"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("packages/deny/tsconfig.json"),
+        r#"{ "compilerOptions": { "allowJs": false }, "include": ["src/**/*"] }"#,
+    )
+    .unwrap();
+
+    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+    assert_eq!(
+        relative_paths(&case_dir, &files),
+        vec![
+            "packages/allow/src/index.js",
+            "packages/allow/src/index.ts",
+            "packages/deny/src/index.ts",
+        ]
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn referenced_allowjs_project_owns_its_explicit_javascript_file_only() {
+    let case_dir = unique_case_dir("tsconfig-owner-referenced-allow-js");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("allow/src")).unwrap();
+    fs::create_dir_all(case_dir.join("deny/src")).unwrap();
+    let allow_file = case_dir.join("allow/src/app.js");
+    let deny_file = case_dir.join("deny/src/app.js");
+    fs::write(&allow_file, "export const allow = true").unwrap();
+    fs::write(&deny_file, "export const deny = true").unwrap();
+    let root = case_dir.join("tsconfig.json");
+    fs::write(
+        &root,
+        r#"{
+  "files": [],
+  "references": [{ "path": "./allow" }, { "path": "./deny" }]
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("allow/tsconfig.json"),
+        r#"{ "compilerOptions": { "allowJs": true }, "include": ["src/**/*"] }"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("deny/tsconfig.json"),
+        r#"{ "compilerOptions": { "allowJs": false }, "include": ["src/**/*"] }"#,
+    )
+    .unwrap();
+
+    let mut cache = TsconfigInputCache::default();
+    assert!(super::super::tsconfig_project_graph_allows_js(
+        &root, &mut cache
+    ));
+    assert_eq!(
+        super::super::resolve_tsconfig_for_files(Some(&root), &[allow_file], false, &mut cache),
+        Some(canonicalize_non_verbatim(
+            &case_dir.join("allow/tsconfig.json")
+        ))
+    );
+    assert_eq!(
+        super::super::resolve_tsconfig_for_files(Some(&root), &[deny_file], false, &mut cache),
+        Some(canonicalize_non_verbatim(&root))
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize/tests/check_allowjs_imports_cli.rs
+++ b/crates/vize/tests/check_allowjs_imports_cli.rs
@@ -1,5 +1,7 @@
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;
+#[path = "check_allowjs_imports_cli/referenced_projects.rs"]
+mod referenced_projects;
 
 use std::{
     path::{Path, PathBuf},

--- a/crates/vize/tests/check_allowjs_imports_cli/referenced_projects.rs
+++ b/crates/vize/tests/check_allowjs_imports_cli/referenced_projects.rs
@@ -1,0 +1,173 @@
+use super::*;
+
+#[test]
+fn referenced_projects_apply_allowjs_to_explicit_and_default_checks() {
+    let Some(corsa_path) = required_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("explicit-referenced-project");
+    let _ = std::fs::remove_dir_all(&project_root);
+
+    write(
+        &project_root,
+        "tsconfig.json",
+        r#"{
+  "files": [],
+  "references": [
+    { "path": "./packages/allow" },
+    { "path": "./packages/deny" }
+  ]
+}"#,
+    );
+    write(
+        &project_root,
+        "packages/allow/tsconfig.json",
+        r#"{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write(
+        &project_root,
+        "packages/deny/tsconfig.json",
+        r#"{
+  "compilerOptions": { "allowJs": false },
+  "include": ["src/**/*"]
+}"#,
+    );
+    write(
+        &project_root,
+        "packages/allow/src/invalid.js",
+        r#"/** @type {string} */
+export const message = 42;
+"#,
+    );
+    write(
+        &project_root,
+        "packages/deny/src/ignored.js",
+        r#"/** @type {string} */
+export const ignored = 42;
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "packages/allow/src/invalid.js",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("invalid JSON ({error}):\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    assert_eq!(json["errorCount"], serde_json::json!(1), "{stdout}");
+    assert_eq!(json["fileCount"], serde_json::json!(1), "{stdout}");
+    assert_eq!(
+        json["files"][0]["file"],
+        serde_json::json!("packages/allow/src/invalid.js"),
+        "{stdout}"
+    );
+    assert!(
+        json["files"][0]["diagnostics"][0]
+            .as_str()
+            .is_some_and(|diagnostic| diagnostic.contains("TS2322")),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("ignored.js"), "{stdout}");
+
+    let denied_output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "packages/deny/src/ignored.js",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    let denied_stdout = std::string::String::from_utf8(denied_output.stdout).unwrap();
+    let denied_stderr = std::string::String::from_utf8(denied_output.stderr).unwrap();
+    assert!(
+        denied_output.status.success(),
+        "stdout:\n{denied_stdout}\nstderr:\n{denied_stderr}"
+    );
+    let denied_json: serde_json::Value =
+        serde_json::from_str(&denied_stdout).unwrap_or_else(|error| {
+            panic!("invalid JSON ({error}):\nstdout:\n{denied_stdout}\nstderr:\n{denied_stderr}")
+        });
+    assert_eq!(
+        denied_json["fileCount"],
+        serde_json::json!(0),
+        "{denied_stdout}"
+    );
+
+    let default_output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    let default_stdout = std::string::String::from_utf8(default_output.stdout).unwrap();
+    let default_stderr = std::string::String::from_utf8(default_output.stderr).unwrap();
+    assert_eq!(
+        default_output.status.code(),
+        Some(1),
+        "stdout:\n{default_stdout}\nstderr:\n{default_stderr}"
+    );
+    let default_json: serde_json::Value =
+        serde_json::from_str(&default_stdout).unwrap_or_else(|error| {
+            panic!("invalid JSON ({error}):\nstdout:\n{default_stdout}\nstderr:\n{default_stderr}")
+        });
+    assert_eq!(
+        default_json["errorCount"],
+        serde_json::json!(1),
+        "{default_stdout}"
+    );
+    assert_eq!(
+        default_json["fileCount"],
+        serde_json::json!(1),
+        "{default_stdout}"
+    );
+    assert_eq!(
+        default_json["files"][0]["file"],
+        serde_json::json!("packages/allow/src/invalid.js"),
+        "{default_stdout}"
+    );
+    assert!(!default_stdout.contains("ignored.js"), "{default_stdout}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
Part of #3984.

## Summary

- let explicit JavaScript candidates reach per-project ownership matching across transitive tsconfig references
- select a single referenced child tsconfig for default and explicit runs when all authored roots belong to that child
- apply the selected child project’s own `allowJs` so an allow sibling cannot leak JavaScript eligibility to a deny sibling
- cache the transitive project-reference graph once per check run
- split program-input selection, project graph traversal, allowJs tests, and referenced-project CLI oracles into focused modules

## Root cause

Default collection already followed referenced tsconfigs, but explicit collection consulted only the solution root and ownership discarded JavaScript before evaluating child compiler options. Default runs then started Corsa with the solution config even when every authored root belonged to one child, producing an empty diagnostic list for invalid `checkJs` sources.

## TDD evidence

Before the fix, `packages/allow/src/invalid.js` returned exit 0 with `files: []` for an explicit run. A project-wide run counted the file but returned no diagnostics. The new oracle requires TS2322 in both modes and verifies that a sibling with `allowJs: false` remains excluded.

## Tests

- `cargo test -p vize --lib` (417 passed)
- `cargo test -p vize --test check_allowjs_imports_cli` (4 passed)
- `node --test tests/tooling/typecheck-dependency-gates.test.ts` (17 passed)
- exact compiler-macros and typecheck-errors snapshots
- `cargo clippy -p vize --lib --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Follow-up boundary

Runs whose authored roots span multiple referenced child projects still fall back to the solution config. Correct multi-program execution, rather than option flattening, remains the next P0 slice. The parent source-length gate also still identifies three pre-existing files not touched by this PR; those will be split independently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->