### PR TITLE
style(check): use explicit project graph imports

### DIFF
--- a/crates/vize/src/commands/check/tsconfig_inputs/loader/project_graph.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/loader/project_graph.rs
@@ -1,4 +1,7 @@
-use super::*;
+use super::{
+    FxHashSet, Path, PathBuf, Value, normalize_input_path, parse_jsonc_value,
+    push_tsconfig_candidates, tracked_read_to_string,
+};
 
 pub(super) fn collect_tsconfig_project_paths(tsconfig_path: &Path) -> Vec<PathBuf> {
     let mut paths = Vec::new();


### PR DESCRIPTION
## What
- replace the project-graph wildcard import with the exact loader dependencies

## Why
The parent workspace CI denies clippy wildcard imports. The project-graph module introduced by the referenced-project input work was the only violation, which stopped the test job before the suite ran.

## Impact
No runtime behavior changes. This restores the workspace clippy gate.

## Validation
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->