### PR TITLE
fix(check): preserve referenced project options

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -1,52 +1,51 @@
 //! Check command execution logic.
-//! The direct runner delegates to `vize_canon`'s project-backed Corsa type checker so Vue SFCs,
-//! TypeScript sources, ambient declarations, and emitted declarations share one virtual project.
+//! The direct runner materializes one Corsa program per owning tsconfig so
+//! project references retain their own compiler options.
 
 #![allow(clippy::disallowed_macros)]
+
 use std::{
     path::{Path, PathBuf},
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use serde_json::{Map, Value};
-use vize_canon::{
-    BatchTypeChecker, BatchTypeCheckerOptions, batch::TypeChecker as BatchTypeCheckerTrait,
-};
-use vize_carton::{FxHashSet, String, cstr, profiler::global_profiler};
-
-use crate::profile_support;
-use vize_curator::profile::{ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report};
+use vize_carton::{FxHashSet, profiler::global_profiler};
 
 use super::{
     CheckArgs,
     path_cache::CanonicalPathCache,
     patterns::CheckFileOptions,
     reporting::{JsonFileResult, JsonOutput},
-    tsconfig_inputs::TsconfigInputCache,
+    tsconfig_inputs::{TsconfigInputCache, resolve_tsconfig_program_inputs},
 };
+
 mod collect;
 mod default_imports;
 mod diagnostics;
+mod execution;
 mod global_components;
 mod ignores;
 mod input_scope;
 mod invocation;
 mod nuxt_tsconfig;
+mod output;
 mod program_inputs;
 mod resolve;
 #[cfg(unix)]
 mod socket;
 #[cfg(test)]
 mod tests;
+
 use collect::collect_check_files_with_ignores;
 use default_imports::{
     ExplicitAmbientImportContext, canonical_file_set, collect_default_run_files,
-    register_explicit_ambient_imports, register_transitive_local_imports,
+    register_ambient_declaration_files, register_explicit_ambient_imports,
+    register_transitive_local_imports,
 };
-use diagnostics::{
-    emit_json_output, is_reported, is_suppressed_false_positive, render_diagnostics,
-    save_virtual_ts_targets, write_profile_virtual_ts,
-};
+#[cfg(test)]
+use diagnostics::is_suppressed_false_positive;
+use execution::{CheckerSettings, ProgramExecution, ProgramExecutionInput, execute_program};
 use global_components::{
     build_virtual_ts_options, collect_project_global_component_stubs, dialect_from_features,
     template_syntax_mode,
@@ -57,6 +56,7 @@ use invocation::{resolve_invocation_program, resolve_nuxt_project_root};
 use nuxt_tsconfig::resolve_checker_tsconfig_path;
 #[cfg(test)]
 use nuxt_tsconfig::write_nuxt_fallback_tsconfig;
+use output::report_executions;
 use program_inputs::{ProgramInputContext, filter_for_program, project_graph_allows_js};
 use resolve::{
     display_path, exit_if_inputs_outside_root, explicit_input_root,
@@ -71,26 +71,24 @@ pub(crate) use socket::run_with_socket;
 #[allow(clippy::disallowed_types)]
 type JsonObject = Map<std::string::String, Value>;
 
-/// Run type checking directly with a materialized Corsa project.
-pub(crate) fn run_direct(args: &CheckArgs) {
-    use super::nuxt;
+struct ProgramCandidate {
+    files: Vec<PathBuf>,
+    inputs: Vec<PathBuf>,
+    reported: FxHashSet<PathBuf>,
+    tsconfig_path: Option<PathBuf>,
+    rebuild_supporting_files: bool,
+}
 
+/// Run type checking directly with materialized Corsa projects.
+pub(crate) fn run_direct(args: &CheckArgs) {
     let start = Instant::now();
     if args.profile {
         let profiler = global_profiler();
         profiler.clear();
         profiler.enable();
     }
-
     crate::config::write_schema(None);
-
-    if let Some(path) = args.config.as_deref()
-        && !args.no_config
-        && let Err(error) = crate::config::validate_explicit_config_path(path)
-    {
-        eprintln!("\x1b[31mError:\x1b[0m {}", error);
-        std::process::exit(2);
-    }
+    validate_config_arg(args);
 
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let loaded_config = if args.no_config {
@@ -110,14 +108,8 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let options_api = loaded_config.features.type_checker_options_api;
     let jsx_typecheck = loaded_config.features.type_checker_jsx_typecheck;
     let legacy_vue2 = cfg!(feature = "legacy") && loaded_config.features.type_checker_legacy_vue2;
-    #[cfg(not(feature = "legacy"))]
-    if loaded_config.features.type_checker_legacy_vue2 {
-        eprintln!(
-            "\x1b[33mwarning:\x1b[0m a Vue 2 dialect is configured (`typeChecker.legacyVue2` \
-             or `vue.version` 2/2.7) but this `vize` build has no legacy Vue support; rebuild \
-             with `--features legacy` to enable Vue 2 Options API type checking."
-        );
-    }
+    warn_for_disabled_legacy(loaded_config.features.type_checker_legacy_vue2);
+
     let config = loaded_config.config;
     let config_dir = loaded_config
         .source_path
@@ -129,20 +121,24 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         return;
     }
     let effective_tsconfig = args.tsconfig.clone().or_else(|| {
-        let candidate = config.type_checker.tsconfig.as_deref()?;
-        Some(resolve_from_config_dir(config_dir, candidate))
+        config
+            .type_checker
+            .tsconfig
+            .as_deref()
+            .map(|path| resolve_from_config_dir(config_dir, path))
     });
     let effective_corsa_path = args.corsa_path.as_ref().map(PathBuf::from).or_else(|| {
         config
             .type_checker
             .runtime_path()
-            .map(|candidate| resolve_from_config_dir(config_dir, candidate))
+            .map(|path| resolve_from_config_dir(config_dir, path))
     });
     let corsa_servers = args.servers.or(config.type_checker.servers);
     if let Err(error) = validate_corsa_server_count(corsa_servers) {
         eprintln!("\x1b[31mError:\x1b[0m {}", error);
         std::process::exit(2);
     }
+
     let (invocation_project_root, invocation_tsconfig_path) =
         resolve_invocation_program(effective_tsconfig.as_deref(), &cwd);
     let nuxt_project_root = resolve_nuxt_project_root(
@@ -155,542 +151,286 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let mut canonical_paths = CanonicalPathCache::default();
     let check_ignore_set = load_check_ignore_set(args, config_dir);
     let collect_start = Instant::now();
-    let (mut files, mut program_input_files, mut reported_files): (
-        Vec<PathBuf>,
-        Vec<PathBuf>,
-        FxHashSet<PathBuf>,
-    ) = if args.patterns.is_empty() {
-        let (files, reported_files) = collect_default_run_files(
-            &invocation_project_root,
-            &cwd,
-            invocation_tsconfig_path.as_deref(),
-            jsx_typecheck,
-            &mut tsconfig_input_cache,
-            &mut canonical_paths,
-            check_ignore_set.as_ref(),
-        );
-        exit_if_default_run_leaves_cwd(
-            &files,
-            &cwd,
-            &invocation_project_root,
-            invocation_tsconfig_path.as_deref(),
-            args.quiet,
-        );
-        let program_input_files = reported_files.iter().cloned().collect();
-        (files, program_input_files, reported_files)
-    } else {
-        let include_js = project_graph_allows_js(
-            invocation_tsconfig_path.as_deref(),
-            &mut tsconfig_input_cache,
-        );
-        let files = collect_check_files_with_ignores(
-            &args.patterns,
-            CheckFileOptions {
-                include_js,
-                include_jsx: jsx_typecheck,
-            },
-            check_ignore_set.as_ref(),
-        );
-        let program_input_files = files.clone();
-        let reported_files = canonical_file_set(&files, &mut canonical_paths);
-        (files, program_input_files, reported_files)
-    };
+    let (files, inputs, reported) = collect_roots(
+        args,
+        &invocation_project_root,
+        &cwd,
+        invocation_tsconfig_path.as_deref(),
+        jsx_typecheck,
+        &mut tsconfig_input_cache,
+        &mut canonical_paths,
+        check_ignore_set.as_ref(),
+    );
     let collect_time = collect_start.elapsed();
-
     if files.is_empty() {
         report_no_inputs(args);
         return;
     }
 
+    let candidates = split_program_candidates(
+        files,
+        inputs,
+        reported,
+        invocation_tsconfig_path.as_deref(),
+        jsx_typecheck,
+        &mut tsconfig_input_cache,
+        &mut canonical_paths,
+    );
+    let settings = CheckerSettings {
+        virtual_ts_options: build_virtual_ts_options(&config, config_dir),
+        corsa_path: effective_corsa_path,
+        servers: corsa_servers,
+        options_api,
+        legacy_vue2,
+        jsx_typecheck,
+        template_syntax: template_syntax_mode(compiler_template_syntax),
+        experimental_in_tag_comments: loaded_config.features.experimental_in_tag_comments,
+        dialect,
+        check_props: config.type_checker.check_props && !args.no_check_props,
+        check_template_bindings: config.type_checker.check_template_bindings
+            && !args.no_check_template_bindings,
+        check_emits: config.type_checker.check_emits && !args.no_check_emits,
+        quiet: args.quiet,
+    };
     let validate_inputs = !args.patterns.is_empty() && invocation_tsconfig_path.is_some();
-    if !args.patterns.is_empty() {
-        register_transitive_local_imports(
-            &mut files,
+    let mut executions = Vec::new();
+    for candidate in candidates {
+        if let Some(execution) = prepare_and_execute(
+            args,
+            candidate,
             &cwd,
-            invocation_tsconfig_path.as_deref(),
+            &invocation_project_root,
+            &nuxt_project_root,
+            &explicit_input_root,
+            validate_inputs,
             jsx_typecheck,
+            &settings,
+            &mut tsconfig_input_cache,
             &mut canonical_paths,
-            Some(&explicit_input_root),
+        ) {
+            executions.push(execution);
+        }
+    }
+    if executions.is_empty() {
+        report_no_inputs(args);
+        return;
+    }
+    report_executions(
+        args,
+        &cwd,
+        start,
+        collect_time,
+        &executions,
+        &mut canonical_paths,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_roots(
+    args: &CheckArgs,
+    invocation_project_root: &Path,
+    cwd: &Path,
+    invocation_tsconfig_path: Option<&Path>,
+    jsx_typecheck: bool,
+    cache: &mut TsconfigInputCache,
+    canonical_paths: &mut CanonicalPathCache,
+    check_ignore_set: Option<&ignores::CheckIgnoreSet>,
+) -> (Vec<PathBuf>, Vec<PathBuf>, FxHashSet<PathBuf>) {
+    if args.patterns.is_empty() {
+        let (files, reported) = collect_default_run_files(
+            invocation_project_root,
+            cwd,
+            invocation_tsconfig_path,
+            jsx_typecheck,
+            cache,
+            canonical_paths,
+            check_ignore_set,
+        );
+        exit_if_default_run_leaves_cwd(
+            &files,
+            cwd,
+            invocation_project_root,
+            invocation_tsconfig_path,
+            args.quiet,
+        );
+        let inputs = reported.iter().cloned().collect();
+        return (files, inputs, reported);
+    }
+
+    let include_js = project_graph_allows_js(invocation_tsconfig_path, cache);
+    let files = collect_check_files_with_ignores(
+        &args.patterns,
+        CheckFileOptions {
+            include_js,
+            include_jsx: jsx_typecheck,
+        },
+        check_ignore_set,
+    );
+    let reported = canonical_file_set(&files, canonical_paths);
+    (files.clone(), files, reported)
+}
+
+fn split_program_candidates(
+    files: Vec<PathBuf>,
+    inputs: Vec<PathBuf>,
+    reported: FxHashSet<PathBuf>,
+    tsconfig_path: Option<&Path>,
+    include_jsx: bool,
+    cache: &mut TsconfigInputCache,
+    canonical_paths: &mut CanonicalPathCache,
+) -> Vec<ProgramCandidate> {
+    let groups = resolve_tsconfig_program_inputs(tsconfig_path, &inputs, include_jsx, cache);
+    if groups.len() <= 1 {
+        return vec![ProgramCandidate {
+            files,
+            inputs,
+            reported,
+            tsconfig_path: groups
+                .first()
+                .map(|group| group.tsconfig_path.clone())
+                .or_else(|| tsconfig_path.map(Path::to_path_buf)),
+            rebuild_supporting_files: false,
+        }];
+    }
+
+    groups
+        .into_iter()
+        .map(|group| {
+            let reported = canonical_file_set(&group.files, canonical_paths);
+            ProgramCandidate {
+                inputs: group.files.clone(),
+                files: group.files,
+                reported,
+                tsconfig_path: Some(group.tsconfig_path),
+                rebuild_supporting_files: true,
+            }
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn prepare_and_execute(
+    args: &CheckArgs,
+    mut candidate: ProgramCandidate,
+    cwd: &Path,
+    invocation_project_root: &Path,
+    nuxt_project_root: &Path,
+    explicit_input_root: &Path,
+    validate_inputs: bool,
+    jsx_typecheck: bool,
+    settings: &CheckerSettings,
+    cache: &mut TsconfigInputCache,
+    canonical_paths: &mut CanonicalPathCache,
+) -> Option<ProgramExecution> {
+    let initial_root = candidate
+        .tsconfig_path
+        .as_deref()
+        .and_then(Path::parent)
+        .unwrap_or(invocation_project_root);
+    let logical_program_root = if candidate.rebuild_supporting_files {
+        Some(initial_root.to_path_buf())
+    } else if args.patterns.is_empty() {
+        Some(invocation_project_root.to_path_buf())
+    } else {
+        None
+    };
+    if args.patterns.is_empty() && candidate.rebuild_supporting_files {
+        register_ambient_declaration_files(
+            &mut candidate.files,
+            initial_root,
+            candidate.tsconfig_path.as_deref(),
+            cache,
+        );
+    }
+    if !args.patterns.is_empty() || candidate.rebuild_supporting_files {
+        register_transitive_local_imports(
+            &mut candidate.files,
+            cwd,
+            candidate.tsconfig_path.as_deref(),
+            jsx_typecheck,
+            canonical_paths,
+            Some(explicit_input_root),
             validate_inputs,
         );
     }
-    exit_if_inputs_outside_root(&explicit_input_root, &files, validate_inputs);
-    let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &files);
-    let discovered_tsconfig_path =
-        resolve_tsconfig_path(effective_tsconfig.as_deref(), &cwd, &project_root, &files);
+    exit_if_inputs_outside_root(explicit_input_root, &candidate.files, validate_inputs);
+
+    let project_root =
+        resolve_project_root(candidate.tsconfig_path.as_deref(), cwd, &candidate.files);
+    let discovered_tsconfig_path = candidate
+        .tsconfig_path
+        .clone()
+        .or_else(|| resolve_tsconfig_path(None, cwd, &project_root, &candidate.files));
     let program_tsconfig_path = filter_for_program(ProgramInputContext {
         tsconfig_path: discovered_tsconfig_path.as_deref(),
         explicit: !args.patterns.is_empty(),
         include_jsx: jsx_typecheck,
-        files: &mut files,
-        inputs: &mut program_input_files,
-        reported: &mut reported_files,
-        cache: &mut tsconfig_input_cache,
-        canonical_paths: &mut canonical_paths,
+        files: &mut candidate.files,
+        inputs: &mut candidate.inputs,
+        reported: &mut candidate.reported,
+        cache,
+        canonical_paths,
     });
-    if !args.patterns.is_empty() && program_input_files.is_empty() {
-        report_no_inputs(args);
-        return;
+    if !args.patterns.is_empty() && candidate.inputs.is_empty() {
+        return None;
     }
-    // Explicit subsets need package-local ambient roots and their imported types.
     if !args.patterns.is_empty()
         && let Some(program_tsconfig_path) = program_tsconfig_path.as_deref()
     {
         register_explicit_ambient_imports(
-            &mut files,
+            &mut candidate.files,
             ExplicitAmbientImportContext::new(
                 &project_root,
-                &cwd,
+                cwd,
                 program_tsconfig_path,
-                &explicit_input_root,
+                explicit_input_root,
                 jsx_typecheck,
             ),
-            &mut tsconfig_input_cache,
-            &mut canonical_paths,
+            cache,
+            canonical_paths,
         );
     }
-    let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &files);
-    let program_project_root = if args.patterns.is_empty() {
-        &invocation_project_root
-    } else {
-        &project_root
-    };
-    resolve::retain_project_files(&mut files, &project_root);
-    let mut virtual_ts_options = build_virtual_ts_options(&config, config_dir);
-    let nuxt_path_aliases = nuxt::detect(
-        &mut virtual_ts_options,
-        &nuxt_project_root,
-        program_tsconfig_path.as_deref(),
-        legacy_vue2,
-        dialect,
-    );
-    collect_project_global_component_stubs(
-        &mut virtual_ts_options,
-        &files,
-        &project_root,
-        program_tsconfig_path.as_deref(),
-    );
-    let checker_tsconfig_path = match resolve_checker_tsconfig_path(
-        program_tsconfig_path.as_deref(),
-        &project_root,
-        &nuxt_project_root,
-        &nuxt_path_aliases,
-    ) {
-        Ok(path) => path,
-        Err(error) => {
-            eprintln!(
-                "\x1b[31mError:\x1b[0m Failed to prepare type checker tsconfig: {}",
-                error
-            );
-            std::process::exit(1);
-        }
-    };
-
-    if !args.quiet {
-        eprintln!(
-            "Building Corsa virtual project for {} files under {}...",
-            files.len(),
-            program_project_root.display()
-        );
+    let project_root =
+        resolve_project_root(program_tsconfig_path.as_deref(), cwd, &candidate.files);
+    let logical_program_root = logical_program_root.unwrap_or_else(|| project_root.clone());
+    resolve::retain_project_files(&mut candidate.files, &project_root);
+    if candidate.files.is_empty() {
+        return None;
     }
 
-    let gen_start = Instant::now();
-    let mut checker = match BatchTypeChecker::with_options_and_corsa_path(
-        &project_root,
-        BatchTypeCheckerOptions {
-            tsconfig_path: checker_tsconfig_path.clone(),
-            virtual_ts_options,
+    Some(execute_program(
+        ProgramExecutionInput {
+            files: &candidate.files,
+            reported_files: candidate.reported,
+            project_root: &project_root,
+            program_root: logical_program_root,
+            tsconfig_path: program_tsconfig_path,
+            nuxt_project_root,
         },
-        effective_corsa_path.as_deref(),
-    ) {
-        Ok(checker) => checker,
-        Err(error) => {
-            eprintln!("\x1b[31mError:\x1b[0m {}", error);
-            std::process::exit(1);
-        }
-    };
-    checker.set_server_count(corsa_servers);
-    if options_api {
-        checker.enable_options_api();
-    }
-    #[cfg(feature = "legacy")]
-    if legacy_vue2 {
-        checker.enable_legacy_vue2();
-    }
-    if jsx_typecheck {
-        checker.enable_jsx_typecheck();
-    }
-    checker.set_template_syntax(template_syntax_mode(compiler_template_syntax));
-    checker.set_experimental_in_tag_comments(loaded_config.features.experimental_in_tag_comments);
-    checker.set_dialect(dialect);
-    checker.set_virtual_ts_checks(
-        config.type_checker.check_props && !args.no_check_props,
-        config.type_checker.check_template_bindings && !args.no_check_template_bindings,
-        config.type_checker.check_emits && !args.no_check_emits,
-    );
+        settings,
+    ))
+}
 
-    if let Err(error) = checker.scan_paths(&files) {
-        eprintln!("\x1b[31mError:\x1b[0m {}", error);
-        std::process::exit(1);
-    }
-    let gen_time = gen_start.elapsed();
-
-    let virtual_files = checker.virtual_files();
-    if virtual_files.is_empty() {
-        if args.format == "json" {
-            emit_json_output(JsonOutput {
-                files: Vec::new(),
-                error_count: 0,
-                warning_count: 0,
-                file_count: 0,
-                declarations: None,
-            });
-            return;
-        }
-        eprintln!("No files were registered for type checking");
-        return;
-    }
-
-    if args.show_virtual_ts {
-        if let Some(shared_helpers) = checker.shared_helpers_preamble() {
-            eprintln!(
-                "\n=== {} ===",
-                vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME
-            );
-            eprintln!("{shared_helpers}");
-        }
-        for file in &virtual_files {
-            eprintln!("\n=== {} ===", file.original_path.display());
-            eprintln!("{}", file.content);
-        }
-    }
-
-    if !args.save_virtual_ts_for.is_empty() {
-        save_virtual_ts_targets(
-            &args.save_virtual_ts_for,
-            &cwd,
-            || {
-                virtual_files
-                    .iter()
-                    .map(|file| (file.original_path.as_path(), file.content.as_str()))
-            },
-            args.quiet,
-        );
-    }
-
-    let profile_artifact_start = Instant::now();
-    if args.profile {
-        write_profile_virtual_ts(&virtual_files);
-    }
-    let profile_artifact_time = profile_artifact_start.elapsed();
-
-    if !args.quiet {
-        eprintln!(
-            "Running Corsa diagnostics for {} files...",
-            virtual_files.len()
-        );
-    }
-
-    let check_start = Instant::now();
-    let result = match checker.check_project() {
-        Ok(result) => result,
-        Err(error) => {
-            eprintln!("\x1b[31mError:\x1b[0m {}", error);
-            std::process::exit(1);
-        }
-    };
-    let check_time = check_start.elapsed();
-
-    let diagnostics_render_start = Instant::now();
-    let reported_raw = result
-        .diagnostics
-        .iter()
-        .filter(|diagnostic| {
-            if !is_reported(&reported_files, &diagnostic.file, &mut canonical_paths) {
-                return false;
-            }
-            !is_suppressed_false_positive(diagnostic)
-        })
-        .cloned()
-        .collect::<Vec<_>>();
-    let diagnostics = render_diagnostics(&reported_raw);
-    let diagnostics_render_time = diagnostics_render_start.elapsed();
-    let total_errors = reported_raw
-        .iter()
-        .filter(|diagnostic| diagnostic.severity == 1)
-        .count();
-    let total_warnings = reported_raw
-        .iter()
-        .filter(|diagnostic| diagnostic.severity == 2)
-        .count();
-    let emit_start = Instant::now();
-    let emitted_declarations = if args.declaration && total_errors == 0 {
-        let declaration_options = resolve_declaration_emit_options(
-            args.declaration_dir.as_deref(),
-            program_tsconfig_path.as_deref(),
-            program_project_root,
-        );
-        let declaration_dir = declaration_options.out_dir.clone();
-        match checker.emit_declarations(&declaration_options) {
-            Ok(result) => Some((declaration_dir, result)),
-            Err(error) => {
-                eprintln!("\x1b[31mError:\x1b[0m {}", error);
-                std::process::exit(1);
-            }
-        }
-    } else {
-        if args.declaration && total_errors > 0 && !args.quiet {
-            eprintln!("Skipping declaration emit because type errors were reported.");
-        }
-        None
-    };
-    let emit_time = emit_start.elapsed();
-    let total_time = start.elapsed();
-
-    if args.profile {
-        let profiler = global_profiler();
-        let allocation_summary = profile_support::allocation_snapshot();
-        let counter_summary = profiler.counter_summary();
-        let operation_summary = profiler.summary();
-        profiler.disable();
-        let mut phases = vec![
-            ProfilePhase {
-                name: "collect inputs",
-                duration: collect_time,
-                kind: ProfilePhaseKind::Wall,
-                note: "tsconfig or explicit patterns",
-            },
-            ProfilePhase {
-                name: "virtual project",
-                duration: gen_time,
-                kind: ProfilePhaseKind::Wall,
-                note: "scan paths and generate Virtual TS",
-            },
-            ProfilePhase {
-                name: "profile artifacts",
-                duration: profile_artifact_time,
-                kind: ProfilePhaseKind::Wall,
-                note: "write node_modules/.vize/check-profile",
-            },
-            ProfilePhase {
-                name: "corsa diagnostics",
-                duration: check_time,
-                kind: ProfilePhaseKind::Wall,
-                note: "project-session diagnostics",
-            },
-            ProfilePhase {
-                name: "render diagnostics",
-                duration: diagnostics_render_time,
-                kind: ProfilePhaseKind::Wall,
-                note: "group diagnostics by file",
-            },
-        ];
-        if args.declaration {
-            phases.push(ProfilePhase {
-                name: "declaration emit",
-                duration: emit_time,
-                kind: ProfilePhaseKind::Wall,
-                note: "materialized Corsa project",
-            });
-        }
-
-        let virtual_bytes = virtual_files
-            .iter()
-            .fold(0usize, |acc, file| acc + file.content.len());
-        let mut recommendations: Vec<String> = Vec::new();
-        if check_time > gen_time * 2 {
-            recommendations.push(
-                "Corsa diagnostics dominate; keep the generated Virtual TS directory and inspect the largest generated files."
-                    .into(),
-            );
-        } else if gen_time > check_time {
-            recommendations.push(
-                "Virtual TS generation dominates; inspect SFCs with large templates, macros, or cross-file imports."
-                    .into(),
-            );
-        }
-        if let Some(largest) = virtual_files.iter().max_by_key(|file| file.content.len()) {
-            recommendations.push(cstr!(
-                "Largest Virtual TS: {} ({} bytes).",
-                largest.original_path.display(),
-                largest.content.len()
-            ));
-        }
-
-        let summary = cstr!(
-            "{} virtual file(s), {} error(s), project {}",
-            virtual_files.len(),
-            total_errors,
-            program_project_root.display()
-        );
-        let report = ProfileReport {
-            title: "check",
-            summary: summary.as_str(),
-            total: total_time,
-            phases: &phases,
-            files: &[],
-            slow_threshold: Duration::from_millis(0),
-            throughput_bytes: Some(virtual_bytes),
-            operations: Some(&operation_summary),
-            counters: Some(&counter_summary),
-            allocations: allocation_summary,
-            recommendations: &recommendations,
-        };
-        print_profile_report(&report);
-    }
-
-    if args.format == "json" {
-        let mut files_json: Vec<JsonFileResult> = virtual_files
-            .iter()
-            .filter(|file| is_reported(&reported_files, &file.original_path, &mut canonical_paths))
-            .map(|file| {
-                let key = file.original_path.to_string_lossy().into_owned();
-                JsonFileResult {
-                    file: display_path(&cwd, &file.original_path).into(),
-                    virtual_ts: args.show_virtual_ts.then(|| file.content.clone().into()),
-                    diagnostics: diagnostics.get(key.as_str()).cloned().unwrap_or_default(),
-                }
-            })
-            .collect();
-        files_json.sort_by(|left, right| left.file.cmp(&right.file));
-        // `fileCount` counts checked source files; project-level diagnostic
-        // groups (anchored to a tsconfig) are appended to `files` afterwards
-        // so every counted error appears in the output, but they are not
-        // checked files themselves.
-        let reported_file_count = files_json.len();
-
-        let virtual_keys: FxHashSet<String> = virtual_files
-            .iter()
-            .map(|file| String::from(file.original_path.to_string_lossy()))
-            .collect();
-        let mut project_level: Vec<JsonFileResult> = diagnostics
-            .iter()
-            .filter(|(key, file_diagnostics)| {
-                !file_diagnostics.is_empty() && !virtual_keys.contains(key.as_str())
-            })
-            .map(|(key, file_diagnostics)| JsonFileResult {
-                file: display_path(&cwd, Path::new(key)).into(),
-                virtual_ts: None,
-                diagnostics: file_diagnostics.clone(),
-            })
-            .collect();
-        files_json.append(&mut project_level);
-
-        let declarations = emitted_declarations.as_ref().map(|(_, result)| {
-            result
-                .files
-                .iter()
-                .map(|file| display_path(&cwd, &file.path).into())
-                .collect()
-        });
-
-        let json_output = JsonOutput {
-            files: files_json,
-            error_count: total_errors,
-            warning_count: total_warnings,
-            file_count: reported_file_count,
-            declarations,
-        };
-        emit_json_output(json_output);
-        if total_errors > 0 {
-            std::process::exit(1);
-        }
-        return;
-    }
-
-    if !args.quiet {
-        let mut printed_keys: FxHashSet<String> = FxHashSet::default();
-        for file in checker.virtual_files() {
-            let key = file.original_path.to_string_lossy();
-            printed_keys.insert(String::from(key.as_ref()));
-            let Some(file_diagnostics) = diagnostics.get(key.as_ref()) else {
-                continue;
-            };
-            if file_diagnostics.is_empty() {
-                continue;
-            }
-
-            println!("\n\x1b[4m{}\x1b[0m", key);
-            for diagnostic in file_diagnostics {
-                let color = if diagnostic.starts_with("error") {
-                    "\x1b[31m"
-                } else {
-                    "\x1b[33m"
-                };
-                println!("  {}{}\x1b[0m", color, diagnostic);
-            }
-        }
-
-        // Project-level diagnostics (anchored to a tsconfig, not a checked
-        // source file) — print after the per-file groups.
-        for (key, file_diagnostics) in &diagnostics {
-            if file_diagnostics.is_empty() || printed_keys.contains(key.as_str()) {
-                continue;
-            }
-            println!("\n\x1b[4m{}\x1b[0m", key);
-            for diagnostic in file_diagnostics {
-                let color = if diagnostic.starts_with("error") {
-                    "\x1b[31m"
-                } else {
-                    "\x1b[33m"
-                };
-                println!("  {}{}\x1b[0m", color, diagnostic);
-            }
-        }
-    }
-
-    let status = if total_errors > 0 {
-        "\x1b[31m\u{2717}\x1b[0m"
-    } else {
-        "\x1b[32m\u{2713}\x1b[0m"
-    };
-    if emitted_declarations.is_some() {
-        println!(
-            "\n{} Type checked {} files in {:.2?} (collect: {:.2?}, gen: {:.2?}, corsa: {:.2?}, dts: {:.2?})",
-            status,
-            virtual_files.len(),
-            total_time,
-            collect_time,
-            gen_time,
-            check_time,
-            emit_time
-        );
-    } else {
-        println!(
-            "\n{} Type checked {} files in {:.2?} (collect: {:.2?}, gen: {:.2?}, corsa: {:.2?})",
-            status,
-            virtual_files.len(),
-            total_time,
-            collect_time,
-            gen_time,
-            check_time
-        );
-    }
-
-    if total_errors > 0 {
-        println!("  \x1b[31m{} error(s)\x1b[0m", total_errors);
-    } else {
-        println!("  \x1b[32mNo type errors found!\x1b[0m");
-    }
-    if total_warnings > 0 {
-        println!("  \x1b[33m{} warning(s)\x1b[0m", total_warnings);
-    }
-
-    if let Some((declaration_dir, emit_result)) = emitted_declarations {
-        println!(
-            "  \x1b[32mEmitted {} declaration file(s)\x1b[0m to {}",
-            emit_result.files.len(),
-            declaration_dir.display()
-        );
-    }
-
-    if total_errors > 0 {
-        std::process::exit(1);
-    }
-    if let Some(max_warnings) = args.max_warnings
-        && total_warnings > max_warnings
+fn validate_config_arg(args: &CheckArgs) {
+    if let Some(path) = args.config.as_deref()
+        && !args.no_config
+        && let Err(error) = crate::config::validate_explicit_config_path(path)
     {
-        eprintln!("\nToo many warnings ({total_warnings} > max {max_warnings})");
-        std::process::exit(1);
+        eprintln!("\x1b[31mError:\x1b[0m {}", error);
+        std::process::exit(2);
     }
 }
+
+#[cfg(not(feature = "legacy"))]
+fn warn_for_disabled_legacy(requested: bool) {
+    if requested {
+        eprintln!(
+            "\x1b[33mwarning:\x1b[0m a Vue 2 dialect is configured (`typeChecker.legacyVue2` \
+             or `vue.version` 2/2.7) but this `vize` build has no legacy Vue support; rebuild \
+             with `--features legacy` to enable Vue 2 Options API type checking."
+        );
+    }
+}
+
+#[cfg(feature = "legacy")]
+fn warn_for_disabled_legacy(_requested: bool) {}

--- a/crates/vize/src/commands/check/runner/default_imports.rs
+++ b/crates/vize/src/commands/check/runner/default_imports.rs
@@ -78,7 +78,7 @@ pub(super) fn collect_default_run_files(
     (files, reported_files)
 }
 
-fn register_ambient_declaration_files(
+pub(super) fn register_ambient_declaration_files(
     files: &mut Vec<PathBuf>,
     project_root: &Path,
     tsconfig_path: Option<&Path>,

--- a/crates/vize/src/commands/check/runner/execution.rs
+++ b/crates/vize/src/commands/check/runner/execution.rs
@@ -1,0 +1,149 @@
+//! One compiler-options-homogeneous Corsa program within a check invocation.
+
+use std::{path::PathBuf, time::Duration, time::Instant};
+
+use vize_canon::{
+    BatchTypeCheckResult, BatchTypeChecker, BatchTypeCheckerOptions,
+    batch::TypeChecker as BatchTypeCheckerTrait,
+};
+use vize_carton::{FxHashSet, config::VueVersion};
+
+use super::{collect_project_global_component_stubs, resolve_checker_tsconfig_path};
+use crate::commands::check::nuxt;
+
+#[derive(Clone)]
+pub(super) struct CheckerSettings {
+    pub(super) virtual_ts_options: vize_canon::virtual_ts::VirtualTsOptions,
+    pub(super) corsa_path: Option<PathBuf>,
+    pub(super) servers: Option<usize>,
+    pub(super) options_api: bool,
+    pub(super) legacy_vue2: bool,
+    pub(super) jsx_typecheck: bool,
+    pub(super) template_syntax: vize_atelier_core::TemplateSyntaxMode,
+    pub(super) experimental_in_tag_comments: bool,
+    pub(super) dialect: VueVersion,
+    pub(super) check_props: bool,
+    pub(super) check_template_bindings: bool,
+    pub(super) check_emits: bool,
+    pub(super) quiet: bool,
+}
+
+pub(super) struct ProgramExecution {
+    pub(super) checker: BatchTypeChecker,
+    pub(super) result: BatchTypeCheckResult,
+    pub(super) reported_files: FxHashSet<PathBuf>,
+    pub(super) tsconfig_path: Option<PathBuf>,
+    pub(super) program_root: PathBuf,
+    pub(super) gen_time: Duration,
+    pub(super) check_time: Duration,
+}
+
+pub(super) struct ProgramExecutionInput<'a> {
+    pub(super) files: &'a [PathBuf],
+    pub(super) reported_files: FxHashSet<PathBuf>,
+    pub(super) project_root: &'a std::path::Path,
+    pub(super) program_root: PathBuf,
+    pub(super) tsconfig_path: Option<PathBuf>,
+    pub(super) nuxt_project_root: &'a std::path::Path,
+}
+
+pub(super) fn execute_program(
+    input: ProgramExecutionInput<'_>,
+    settings: &CheckerSettings,
+) -> ProgramExecution {
+    let mut virtual_ts_options = settings.virtual_ts_options.clone();
+    let nuxt_path_aliases = nuxt::detect(
+        &mut virtual_ts_options,
+        input.nuxt_project_root,
+        input.tsconfig_path.as_deref(),
+        settings.legacy_vue2,
+        settings.dialect,
+    );
+    collect_project_global_component_stubs(
+        &mut virtual_ts_options,
+        input.files,
+        input.project_root,
+        input.tsconfig_path.as_deref(),
+    );
+    let checker_tsconfig_path = resolve_checker_tsconfig_path(
+        input.tsconfig_path.as_deref(),
+        input.project_root,
+        input.nuxt_project_root,
+        &nuxt_path_aliases,
+    )
+    .unwrap_or_else(|error| {
+        eprintln!(
+            "\x1b[31mError:\x1b[0m Failed to prepare type checker tsconfig: {}",
+            error
+        );
+        std::process::exit(1);
+    });
+
+    if !settings.quiet {
+        eprintln!(
+            "Building Corsa virtual project for {} files under {}...",
+            input.files.len(),
+            input.program_root.display()
+        );
+    }
+
+    let gen_start = Instant::now();
+    let mut checker = BatchTypeChecker::with_options_and_corsa_path(
+        input.project_root,
+        BatchTypeCheckerOptions {
+            tsconfig_path: checker_tsconfig_path,
+            virtual_ts_options,
+        },
+        settings.corsa_path.as_deref(),
+    )
+    .unwrap_or_else(|error| {
+        eprintln!("\x1b[31mError:\x1b[0m {}", error);
+        std::process::exit(1);
+    });
+    checker.set_server_count(settings.servers);
+    if settings.options_api {
+        checker.enable_options_api();
+    }
+    #[cfg(feature = "legacy")]
+    if settings.legacy_vue2 {
+        checker.enable_legacy_vue2();
+    }
+    if settings.jsx_typecheck {
+        checker.enable_jsx_typecheck();
+    }
+    checker.set_template_syntax(settings.template_syntax);
+    checker.set_experimental_in_tag_comments(settings.experimental_in_tag_comments);
+    checker.set_dialect(settings.dialect);
+    checker.set_virtual_ts_checks(
+        settings.check_props,
+        settings.check_template_bindings,
+        settings.check_emits,
+    );
+    checker.scan_paths(input.files).unwrap_or_else(|error| {
+        eprintln!("\x1b[31mError:\x1b[0m {}", error);
+        std::process::exit(1);
+    });
+    let gen_time = gen_start.elapsed();
+
+    if !settings.quiet {
+        eprintln!(
+            "Running Corsa diagnostics for {} files...",
+            checker.virtual_files().len()
+        );
+    }
+    let check_start = Instant::now();
+    let result = checker.check_project().unwrap_or_else(|error| {
+        eprintln!("\x1b[31mError:\x1b[0m {}", error);
+        std::process::exit(1);
+    });
+
+    ProgramExecution {
+        checker,
+        result,
+        reported_files: input.reported_files,
+        tsconfig_path: input.tsconfig_path,
+        program_root: input.program_root,
+        gen_time,
+        check_time: check_start.elapsed(),
+    }
+}

--- a/crates/vize/src/commands/check/runner/output.rs
+++ b/crates/vize/src/commands/check/runner/output.rs
@@ -1,0 +1,465 @@
+//! Aggregates diagnostics and declarations from one or more tsconfig programs.
+
+use std::{collections::BTreeSet, path::Path, time::Duration, time::Instant};
+
+use vize_carton::{FxHashSet, String, cstr, profiler::global_profiler};
+use vize_curator::profile::{ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report};
+
+use super::{
+    CheckArgs, JsonFileResult, JsonOutput, ProgramExecution,
+    diagnostics::{
+        emit_json_output, is_reported, is_suppressed_false_positive, render_diagnostics,
+        save_virtual_ts_targets, write_profile_virtual_ts,
+    },
+    display_path, resolve_declaration_emit_options,
+};
+use crate::{commands::check::path_cache::CanonicalPathCache, profile_support};
+
+#[allow(clippy::disallowed_types)]
+type RenderedDiagnostics =
+    std::collections::BTreeMap<std::string::String, Vec<std::string::String>>;
+
+struct DeclarationSummary {
+    files: BTreeSet<std::path::PathBuf>,
+    directories: BTreeSet<std::path::PathBuf>,
+    elapsed: Duration,
+}
+
+pub(super) fn report_executions(
+    args: &CheckArgs,
+    cwd: &Path,
+    start: Instant,
+    collect_time: Duration,
+    executions: &[ProgramExecution],
+    canonical_paths: &mut CanonicalPathCache,
+) {
+    let virtual_files = executions
+        .iter()
+        .flat_map(|execution| execution.checker.virtual_files())
+        .collect::<Vec<_>>();
+    if virtual_files.is_empty() {
+        if args.format == "json" {
+            emit_json_output(JsonOutput {
+                files: Vec::new(),
+                error_count: 0,
+                warning_count: 0,
+                file_count: 0,
+                declarations: None,
+            });
+        } else {
+            eprintln!("No files were registered for type checking");
+        }
+        return;
+    }
+
+    if args.show_virtual_ts {
+        if executions
+            .iter()
+            .any(|execution| execution.checker.shared_helpers_preamble().is_some())
+        {
+            eprintln!(
+                "\n=== {} ===",
+                vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME
+            );
+            eprintln!("{}", vize_canon::virtual_ts::SHARED_PREAMBLE_DTS);
+        }
+        for file in &virtual_files {
+            eprintln!("\n=== {} ===", file.original_path.display());
+            eprintln!("{}", file.content);
+        }
+    }
+
+    if !args.save_virtual_ts_for.is_empty() {
+        save_virtual_ts_targets(
+            &args.save_virtual_ts_for,
+            cwd,
+            || {
+                virtual_files
+                    .iter()
+                    .map(|file| (file.original_path.as_path(), file.content.as_str()))
+            },
+            args.quiet,
+        );
+    }
+
+    let profile_artifact_start = Instant::now();
+    if args.profile {
+        write_profile_virtual_ts(&virtual_files);
+    }
+    let profile_artifact_time = profile_artifact_start.elapsed();
+
+    let diagnostics_render_start = Instant::now();
+    let mut reported_raw = Vec::new();
+    for execution in executions {
+        for diagnostic in &execution.result.diagnostics {
+            if is_reported(&execution.reported_files, &diagnostic.file, canonical_paths)
+                && !is_suppressed_false_positive(diagnostic)
+            {
+                reported_raw.push(diagnostic.clone());
+            }
+        }
+    }
+    let diagnostics = render_diagnostics(&reported_raw);
+    let diagnostics_render_time = diagnostics_render_start.elapsed();
+    let total_errors = reported_raw
+        .iter()
+        .filter(|diagnostic| diagnostic.severity == 1)
+        .count();
+    let total_warnings = reported_raw
+        .iter()
+        .filter(|diagnostic| diagnostic.severity == 2)
+        .count();
+    let emitted = emit_declarations(args, executions, total_errors);
+    let total_time = start.elapsed();
+    let gen_time = executions.iter().map(|execution| execution.gen_time).sum();
+    let check_time = executions
+        .iter()
+        .map(|execution| execution.check_time)
+        .sum();
+
+    if args.profile {
+        print_profile(
+            executions,
+            &virtual_files,
+            total_errors,
+            total_time,
+            collect_time,
+            gen_time,
+            check_time,
+            profile_artifact_time,
+            diagnostics_render_time,
+            emitted.as_ref(),
+        );
+    }
+
+    if args.format == "json" {
+        emit_json(
+            args,
+            cwd,
+            executions,
+            &virtual_files,
+            &diagnostics,
+            total_errors,
+            total_warnings,
+            emitted.as_ref(),
+            canonical_paths,
+        );
+        if total_errors > 0 {
+            std::process::exit(1);
+        }
+        return;
+    }
+
+    print_text(
+        args,
+        &virtual_files,
+        &diagnostics,
+        total_errors,
+        total_warnings,
+        total_time,
+        collect_time,
+        gen_time,
+        check_time,
+        emitted.as_ref(),
+    );
+}
+
+fn emit_declarations(
+    args: &CheckArgs,
+    executions: &[ProgramExecution],
+    total_errors: usize,
+) -> Option<DeclarationSummary> {
+    if !args.declaration {
+        return None;
+    }
+    if total_errors > 0 {
+        if !args.quiet {
+            eprintln!("Skipping declaration emit because type errors were reported.");
+        }
+        return None;
+    }
+
+    let start = Instant::now();
+    let mut files = BTreeSet::new();
+    let mut directories = BTreeSet::new();
+    for execution in executions {
+        let options = resolve_declaration_emit_options(
+            args.declaration_dir.as_deref(),
+            execution.tsconfig_path.as_deref(),
+            &execution.program_root,
+        );
+        directories.insert(options.out_dir.clone());
+        let result = execution
+            .checker
+            .emit_declarations(&options)
+            .unwrap_or_else(|error| {
+                eprintln!("\x1b[31mError:\x1b[0m {}", error);
+                std::process::exit(1);
+            });
+        files.extend(result.files.into_iter().map(|file| file.path));
+    }
+    Some(DeclarationSummary {
+        files,
+        directories,
+        elapsed: start.elapsed(),
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_json(
+    args: &CheckArgs,
+    cwd: &Path,
+    executions: &[ProgramExecution],
+    virtual_files: &[&vize_canon::VirtualFile],
+    diagnostics: &RenderedDiagnostics,
+    total_errors: usize,
+    total_warnings: usize,
+    emitted: Option<&DeclarationSummary>,
+    canonical_paths: &mut CanonicalPathCache,
+) {
+    let mut files_json = executions
+        .iter()
+        .flat_map(|execution| {
+            execution
+                .checker
+                .virtual_files()
+                .into_iter()
+                .filter(|file| {
+                    is_reported(
+                        &execution.reported_files,
+                        &file.original_path,
+                        canonical_paths,
+                    )
+                })
+                .map(|file| {
+                    let key = file.original_path.to_string_lossy().into_owned();
+                    JsonFileResult {
+                        file: display_path(cwd, &file.original_path).into(),
+                        virtual_ts: args.show_virtual_ts.then(|| file.content.clone().into()),
+                        diagnostics: diagnostics.get(key.as_str()).cloned().unwrap_or_default(),
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    files_json.sort_by(|left, right| left.file.cmp(&right.file));
+    files_json.dedup_by(|left, right| left.file == right.file);
+    let reported_file_count = files_json.len();
+
+    let virtual_keys = virtual_files
+        .iter()
+        .map(|file| String::from(file.original_path.to_string_lossy()))
+        .collect::<FxHashSet<_>>();
+    files_json.extend(
+        diagnostics
+            .iter()
+            .filter(|(key, values)| !values.is_empty() && !virtual_keys.contains(key.as_str()))
+            .map(|(key, values)| JsonFileResult {
+                file: display_path(cwd, Path::new(key)).into(),
+                virtual_ts: None,
+                diagnostics: values.clone(),
+            }),
+    );
+
+    emit_json_output(JsonOutput {
+        files: files_json,
+        error_count: total_errors,
+        warning_count: total_warnings,
+        file_count: reported_file_count,
+        declarations: emitted.map(|summary| {
+            summary
+                .files
+                .iter()
+                .map(|path| display_path(cwd, path).into())
+                .collect()
+        }),
+    });
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_text(
+    args: &CheckArgs,
+    virtual_files: &[&vize_canon::VirtualFile],
+    diagnostics: &RenderedDiagnostics,
+    total_errors: usize,
+    total_warnings: usize,
+    total_time: Duration,
+    collect_time: Duration,
+    gen_time: Duration,
+    check_time: Duration,
+    emitted: Option<&DeclarationSummary>,
+) {
+    if !args.quiet {
+        for (key, file_diagnostics) in diagnostics {
+            if file_diagnostics.is_empty() {
+                continue;
+            }
+            println!("\n\x1b[4m{}\x1b[0m", key);
+            for diagnostic in file_diagnostics {
+                let color = if diagnostic.starts_with("error") {
+                    "\x1b[31m"
+                } else {
+                    "\x1b[33m"
+                };
+                println!("  {}{}\x1b[0m", color, diagnostic);
+            }
+        }
+    }
+
+    let status = if total_errors > 0 {
+        "\x1b[31m\u{2717}\x1b[0m"
+    } else {
+        "\x1b[32m\u{2713}\x1b[0m"
+    };
+    if let Some(summary) = emitted {
+        println!(
+            "\n{} Type checked {} files in {:.2?} (collect: {:.2?}, gen: {:.2?}, corsa: {:.2?}, dts: {:.2?})",
+            status,
+            virtual_files.len(),
+            total_time,
+            collect_time,
+            gen_time,
+            check_time,
+            summary.elapsed
+        );
+    } else {
+        println!(
+            "\n{} Type checked {} files in {:.2?} (collect: {:.2?}, gen: {:.2?}, corsa: {:.2?})",
+            status,
+            virtual_files.len(),
+            total_time,
+            collect_time,
+            gen_time,
+            check_time
+        );
+    }
+    if total_errors > 0 {
+        println!("  \x1b[31m{} error(s)\x1b[0m", total_errors);
+    } else {
+        println!("  \x1b[32mNo type errors found!\x1b[0m");
+    }
+    if total_warnings > 0 {
+        println!("  \x1b[33m{} warning(s)\x1b[0m", total_warnings);
+    }
+    if let Some(summary) = emitted {
+        let destinations = summary
+            .directories
+            .iter()
+            .map(|path| cstr!("{}", path.display()))
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!(
+            "  \x1b[32mEmitted {} declaration file(s)\x1b[0m to {}",
+            summary.files.len(),
+            destinations
+        );
+    }
+
+    if total_errors > 0 {
+        std::process::exit(1);
+    }
+    if let Some(max_warnings) = args.max_warnings
+        && total_warnings > max_warnings
+    {
+        eprintln!("\nToo many warnings ({total_warnings} > max {max_warnings})");
+        std::process::exit(1);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_profile(
+    executions: &[ProgramExecution],
+    virtual_files: &[&vize_canon::VirtualFile],
+    total_errors: usize,
+    total_time: Duration,
+    collect_time: Duration,
+    gen_time: Duration,
+    check_time: Duration,
+    profile_artifact_time: Duration,
+    diagnostics_render_time: Duration,
+    emitted: Option<&DeclarationSummary>,
+) {
+    let profiler = global_profiler();
+    let allocation_summary = profile_support::allocation_snapshot();
+    let counter_summary = profiler.counter_summary();
+    let operation_summary = profiler.summary();
+    profiler.disable();
+    let mut phases = vec![
+        ProfilePhase {
+            name: "collect inputs",
+            duration: collect_time,
+            kind: ProfilePhaseKind::Wall,
+            note: "tsconfig or explicit patterns",
+        },
+        ProfilePhase {
+            name: "virtual project",
+            duration: gen_time,
+            kind: ProfilePhaseKind::Wall,
+            note: "scan paths and generate Virtual TS",
+        },
+        ProfilePhase {
+            name: "profile artifacts",
+            duration: profile_artifact_time,
+            kind: ProfilePhaseKind::Wall,
+            note: "write node_modules/.vize/check-profile",
+        },
+        ProfilePhase {
+            name: "corsa diagnostics",
+            duration: check_time,
+            kind: ProfilePhaseKind::Wall,
+            note: "project-session diagnostics",
+        },
+        ProfilePhase {
+            name: "render diagnostics",
+            duration: diagnostics_render_time,
+            kind: ProfilePhaseKind::Wall,
+            note: "group diagnostics by file",
+        },
+    ];
+    if let Some(summary) = emitted {
+        phases.push(ProfilePhase {
+            name: "declaration emit",
+            duration: summary.elapsed,
+            kind: ProfilePhaseKind::Wall,
+            note: "materialized Corsa project",
+        });
+    }
+    let virtual_bytes = virtual_files.iter().map(|file| file.content.len()).sum();
+    let mut recommendations: Vec<String> = Vec::new();
+    if check_time > gen_time * 2 {
+        recommendations.push(
+            "Corsa diagnostics dominate; inspect the largest generated virtual files.".into(),
+        );
+    } else if gen_time > check_time {
+        recommendations.push(
+            "Virtual TS generation dominates; inspect SFCs with large templates or cross-file imports."
+                .into(),
+        );
+    }
+    if let Some(largest) = virtual_files.iter().max_by_key(|file| file.content.len()) {
+        recommendations.push(cstr!(
+            "Largest Virtual TS: {} ({} bytes).",
+            largest.original_path.display(),
+            largest.content.len()
+        ));
+    }
+    let summary = cstr!(
+        "{} virtual file(s), {} error(s), {} tsconfig program(s)",
+        virtual_files.len(),
+        total_errors,
+        executions.len()
+    );
+    print_profile_report(&ProfileReport {
+        title: "check",
+        summary: summary.as_str(),
+        total: total_time,
+        phases: &phases,
+        files: &[],
+        slow_threshold: Duration::from_millis(0),
+        throughput_bytes: Some(virtual_bytes),
+        operations: Some(&operation_summary),
+        counters: Some(&counter_summary),
+        allocations: allocation_summary,
+        recommendations: &recommendations,
+    });
+}

--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -17,6 +17,7 @@ mod implicit_exclude;
 mod jsonc;
 mod loader;
 mod matching;
+mod ownership;
 mod spec;
 mod type_references;
 
@@ -34,10 +35,10 @@ mod tests;
 pub(crate) use ambient::{
     collect_ambient_declaration_files, collect_hidden_ambient_declaration_files,
 };
-pub(crate) use collect::resolve_tsconfig_for_files;
 pub(super) use jsonc::parse_jsonc_value;
 pub(crate) use loader::{TsconfigInputCache, load_tsconfig_declaration_options};
 pub(super) use loader::{read_extends_entries, resolve_extended_tsconfig};
+pub(crate) use ownership::{resolve_tsconfig_for_files, resolve_tsconfig_program_inputs};
 pub(crate) use spec::TsconfigDeclarationOptions;
 pub(crate) use type_references::{
     collect_tsconfig_type_packages, reference_type_packages, resolve_type_package_declaration_files,

--- a/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
@@ -1,4 +1,4 @@
-//! Filesystem walking, hidden-root expansion, and tsconfig ownership resolution.
+//! Filesystem walking and hidden-root expansion.
 
 use std::path::{Path, PathBuf};
 
@@ -6,7 +6,6 @@ use ignore::WalkBuilder;
 use vize_carton::FxHashSet;
 
 use super::glob::{normalize_input_path, normalize_walked_path};
-use super::loader::TsconfigInputCache;
 use super::matching::{
     SupportedFileOptions, is_generated_codegen_declaration_path, is_generated_path,
     is_hidden_path_segment, is_nuxt_import_manifest_path, is_supported_check_file_with_options,
@@ -174,154 +173,4 @@ fn hidden_pattern_root(base_dir: &Path, pattern: &str) -> Option<PathBuf> {
         }
     }
     None
-}
-
-pub(crate) fn resolve_tsconfig_for_files(
-    tsconfig_path: Option<&Path>,
-    files: &[PathBuf],
-    include_jsx: bool,
-    cache: &mut TsconfigInputCache,
-) -> Option<PathBuf> {
-    let tsconfig_path = tsconfig_path?;
-    let projects = cache.project_paths(tsconfig_path);
-    let root_project = projects
-        .first()
-        .cloned()
-        .unwrap_or_else(|| normalize_input_path(tsconfig_path));
-    let files = files
-        .iter()
-        .filter(|path| {
-            is_supported_check_file_with_options(
-                path,
-                SupportedFileOptions {
-                    // JavaScript candidates must reach the per-project
-                    // ownership matchers below. Each matcher applies its own
-                    // merged allowJs value, so a referenced allowJs project
-                    // cannot leak ownership to a sibling that disables it.
-                    include_js: true,
-                    include_jsx,
-                },
-            )
-        })
-        .map(|path| normalize_input_path(path))
-        .collect::<Vec<_>>();
-    if files.is_empty() {
-        return Some(root_project);
-    }
-
-    // Load each candidate project's input spec exactly once and precompile its
-    // ownership matcher, so the per-file checks below are pure in-memory glob
-    // matches instead of re-reading the tsconfig chain for every file.
-    let matchers = projects
-        .iter()
-        .map(|project| TsconfigOwnershipMatcher::load(project, cache, include_jsx))
-        .collect::<Vec<_>>();
-
-    if let Some((owner, _)) = projects
-        .iter()
-        .zip(&matchers)
-        .find(|(_, matcher)| files.iter().all(|file| matcher.owns(file)))
-    {
-        return Some(owner.clone());
-    }
-
-    let mut shared_owner = None::<&PathBuf>;
-    for file in &files {
-        let Some((owner, _)) = projects
-            .iter()
-            .zip(&matchers)
-            .find(|(_, matcher)| matcher.owns(file))
-        else {
-            return Some(root_project);
-        };
-        match shared_owner {
-            Some(shared) if shared != owner => return Some(root_project),
-            Some(_) => {}
-            None => shared_owner = Some(owner),
-        }
-    }
-
-    shared_owner.cloned().or(Some(root_project))
-}
-
-/// Precompiled ownership matcher for one tsconfig project: the canonicalized
-/// `files` entries plus the effective include/exclude globs (with tsc's
-/// defaults applied), built once per project so matching N files needs no
-/// further I/O or glob compilation.
-struct TsconfigOwnershipMatcher {
-    /// Whether the tsconfig chain loaded; an unreadable tsconfig owns nothing.
-    loaded: bool,
-    files: FxHashSet<PathBuf>,
-    includes: Vec<GlobSpec>,
-    excludes: Vec<GlobSpec>,
-    include_js: bool,
-    include_jsx: bool,
-}
-
-impl TsconfigOwnershipMatcher {
-    fn load(tsconfig_path: &Path, cache: &mut TsconfigInputCache, include_jsx: bool) -> Self {
-        let Some(spec) = cache.load(tsconfig_path) else {
-            return Self {
-                loaded: false,
-                files: FxHashSet::default(),
-                includes: Vec::new(),
-                excludes: Vec::new(),
-                include_js: false,
-                include_jsx,
-            };
-        };
-
-        let files = spec
-            .files
-            .iter()
-            .map(|entry| normalize_input_path(&entry.resolve()))
-            .collect();
-        let default_base_dir = tsconfig_path
-            .parent()
-            .map(Path::to_path_buf)
-            .unwrap_or_default();
-        let includes = if !spec.has_includes && !spec.has_files {
-            GlobSpec::new(&default_base_dir, "**/*")
-                .into_iter()
-                .collect::<Vec<_>>()
-        } else {
-            spec.includes.clone()
-        };
-        let excludes = spec.effective_excludes();
-
-        Self {
-            loaded: true,
-            files,
-            includes,
-            excludes,
-            include_js: spec.allow_js.unwrap_or(false),
-            include_jsx,
-        }
-    }
-
-    /// Whether this project owns `file`, which must already be normalized via
-    /// `normalize_input_path`.
-    fn owns(&self, file: &Path) -> bool {
-        if !self.loaded {
-            return false;
-        }
-        if is_nuxt_import_manifest_path(file) {
-            return false;
-        }
-        if self.files.contains(file) {
-            return true;
-        }
-        if self.includes.is_empty()
-            || !is_supported_check_file_with_options(
-                file,
-                SupportedFileOptions {
-                    include_js: self.include_js,
-                    include_jsx: self.include_jsx,
-                },
-            )
-        {
-            return false;
-        }
-        matches_tsconfig_patterns(file, &self.includes, &self.excludes)
-    }
 }

--- a/crates/vize/src/commands/check/tsconfig_inputs/ownership.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/ownership.rs
@@ -1,0 +1,174 @@
+//! Maps authored source roots to the tsconfig program that owns them.
+
+use std::path::{Path, PathBuf};
+
+use vize_carton::FxHashSet;
+
+use super::{
+    glob::normalize_input_path,
+    loader::TsconfigInputCache,
+    matching::{
+        SupportedFileOptions, is_nuxt_import_manifest_path, is_supported_check_file_with_options,
+        matches_tsconfig_patterns,
+    },
+    spec::GlobSpec,
+};
+
+#[derive(Debug)]
+pub(crate) struct TsconfigProgramInputs {
+    pub(crate) tsconfig_path: PathBuf,
+    pub(crate) files: Vec<PathBuf>,
+}
+
+pub(crate) fn resolve_tsconfig_program_inputs(
+    tsconfig_path: Option<&Path>,
+    files: &[PathBuf],
+    include_jsx: bool,
+    cache: &mut TsconfigInputCache,
+) -> Vec<TsconfigProgramInputs> {
+    let Some(tsconfig_path) = tsconfig_path else {
+        return Vec::new();
+    };
+    let projects = cache.project_paths(tsconfig_path);
+    let root_project = projects
+        .first()
+        .cloned()
+        .unwrap_or_else(|| normalize_input_path(tsconfig_path));
+    let mut matchers = projects
+        .iter()
+        .map(|project| TsconfigOwnershipMatcher::load(project, cache, include_jsx))
+        .collect::<Vec<_>>();
+    if matchers.is_empty() {
+        matchers.push(TsconfigOwnershipMatcher::unloaded(include_jsx));
+    }
+    let projects = if projects.is_empty() {
+        vec![root_project]
+    } else {
+        projects
+    };
+    let mut groups = projects
+        .into_iter()
+        .map(|tsconfig_path| TsconfigProgramInputs {
+            tsconfig_path,
+            files: Vec::new(),
+        })
+        .collect::<Vec<_>>();
+
+    for file in files.iter().filter(|path| {
+        is_supported_check_file_with_options(
+            path,
+            SupportedFileOptions {
+                // JavaScript must reach the ownership matcher so allowJs is
+                // applied by its exact project, never by a sibling.
+                include_js: true,
+                include_jsx,
+            },
+        )
+    }) {
+        let file = normalize_input_path(file);
+        let owner = matchers
+            .iter()
+            .position(|matcher| matcher.owns(&file))
+            .unwrap_or(0);
+        groups[owner].files.push(file);
+    }
+
+    groups.retain(|group| !group.files.is_empty());
+    groups
+}
+
+pub(crate) fn resolve_tsconfig_for_files(
+    tsconfig_path: Option<&Path>,
+    files: &[PathBuf],
+    include_jsx: bool,
+    cache: &mut TsconfigInputCache,
+) -> Option<PathBuf> {
+    let tsconfig_path = tsconfig_path?;
+    let root_project = cache
+        .project_paths(tsconfig_path)
+        .first()
+        .cloned()
+        .unwrap_or_else(|| normalize_input_path(tsconfig_path));
+    let groups = resolve_tsconfig_program_inputs(Some(tsconfig_path), files, include_jsx, cache);
+    match groups.as_slice() {
+        [] => Some(root_project),
+        [group] => Some(group.tsconfig_path.clone()),
+        _ => Some(root_project),
+    }
+}
+
+/// Precompiled ownership matcher for one tsconfig project: canonicalized
+/// `files` plus effective include/exclude globs with tsc defaults applied.
+struct TsconfigOwnershipMatcher {
+    loaded: bool,
+    files: FxHashSet<PathBuf>,
+    includes: Vec<GlobSpec>,
+    excludes: Vec<GlobSpec>,
+    include_js: bool,
+    include_jsx: bool,
+}
+
+impl TsconfigOwnershipMatcher {
+    fn unloaded(include_jsx: bool) -> Self {
+        Self {
+            loaded: false,
+            files: FxHashSet::default(),
+            includes: Vec::new(),
+            excludes: Vec::new(),
+            include_js: false,
+            include_jsx,
+        }
+    }
+
+    fn load(tsconfig_path: &Path, cache: &mut TsconfigInputCache, include_jsx: bool) -> Self {
+        let Some(spec) = cache.load(tsconfig_path) else {
+            return Self::unloaded(include_jsx);
+        };
+        let files = spec
+            .files
+            .iter()
+            .map(|entry| normalize_input_path(&entry.resolve()))
+            .collect();
+        let default_base_dir = tsconfig_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_default();
+        let includes = if !spec.has_includes && !spec.has_files {
+            GlobSpec::new(&default_base_dir, "**/*")
+                .into_iter()
+                .collect()
+        } else {
+            spec.includes.clone()
+        };
+
+        Self {
+            loaded: true,
+            files,
+            includes,
+            excludes: spec.effective_excludes(),
+            include_js: spec.allow_js.unwrap_or(false),
+            include_jsx,
+        }
+    }
+
+    fn owns(&self, file: &Path) -> bool {
+        if !self.loaded || is_nuxt_import_manifest_path(file) {
+            return false;
+        }
+        if self.files.contains(file) {
+            return true;
+        }
+        if self.includes.is_empty()
+            || !is_supported_check_file_with_options(
+                file,
+                SupportedFileOptions {
+                    include_js: self.include_js,
+                    include_jsx: self.include_jsx,
+                },
+            )
+        {
+            return false;
+        }
+        matches_tsconfig_patterns(file, &self.includes, &self.excludes)
+    }
+}

--- a/crates/vize/tests/check_allowjs_imports_cli.rs
+++ b/crates/vize/tests/check_allowjs_imports_cli.rs
@@ -1,5 +1,7 @@
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;
+#[path = "check_allowjs_imports_cli/referenced_compiler_options.rs"]
+mod referenced_compiler_options;
 #[path = "check_allowjs_imports_cli/referenced_projects.rs"]
 mod referenced_projects;
 

--- a/crates/vize/tests/check_allowjs_imports_cli/referenced_compiler_options.rs
+++ b/crates/vize/tests/check_allowjs_imports_cli/referenced_compiler_options.rs
@@ -1,0 +1,213 @@
+use super::*;
+
+#[test]
+fn referenced_projects_preserve_each_child_compiler_options() {
+    let Some(corsa_path) = required_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("referenced-compiler-options");
+    let _ = std::fs::remove_dir_all(&project_root);
+
+    write(
+        &project_root,
+        "tsconfig.json",
+        r#"{
+  "files": [],
+  "references": [
+    { "path": "./packages/strict" },
+    { "path": "./packages/indexed" },
+    { "path": "./packages/loose" }
+  ]
+}"#,
+    );
+    write_child_config(&project_root, "strict", "");
+    write_child_config(
+        &project_root,
+        "indexed",
+        r#"    "noUncheckedIndexedAccess": true,"#,
+    );
+    write_child_config(&project_root, "loose", "");
+    write(
+        &project_root,
+        "packages/strict/src/implicit-any.ts",
+        "export const identity = value => value;\n",
+    );
+    let indexed_source = "const values: string[] = [];\nexport const first: string = values[0];\n";
+    write(
+        &project_root,
+        "packages/indexed/src/unchecked-index.ts",
+        indexed_source,
+    );
+    write(
+        &project_root,
+        "packages/loose/src/allowed-index.ts",
+        indexed_source,
+    );
+
+    assert_program_diagnostics(&project_root, &corsa_path, &[]);
+    assert_program_diagnostics(
+        &project_root,
+        &corsa_path,
+        &[
+            "packages/strict/src/implicit-any.ts",
+            "packages/indexed/src/unchecked-index.ts",
+            "packages/loose/src/allowed-index.ts",
+        ],
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn referenced_projects_emit_declarations_to_each_child_output() {
+    let Some(corsa_path) = required_corsa_path() else {
+        return;
+    };
+    let project_root = unique_case_dir("referenced-declarations");
+    let _ = std::fs::remove_dir_all(&project_root);
+    write(
+        &project_root,
+        "tsconfig.json",
+        r#"{
+  "files": [],
+  "references": [
+    { "path": "./packages/a" },
+    { "path": "./packages/b" }
+  ]
+}"#,
+    );
+    for package in ["a", "b"] {
+        write(
+            &project_root,
+            &format!("packages/{package}/tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationDir": "types"
+  },
+  "include": ["src/**/*.ts"]
+}"#,
+        );
+        write(
+            &project_root,
+            &format!("packages/{package}/src/{package}.ts"),
+            &format!(
+                "export interface {}Value {{ value: string }}\n",
+                package.to_uppercase()
+            ),
+        );
+    }
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", &corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+            "--declaration",
+        ])
+        .output()
+        .unwrap();
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
+    assert_eq!(json["fileCount"], serde_json::json!(2), "{stdout}");
+    assert_eq!(
+        json["declarations"],
+        serde_json::json!(["packages/a/types/a.d.ts", "packages/b/types/b.d.ts"]),
+        "{stdout}"
+    );
+    assert!(project_root.join("packages/a/types/a.d.ts").is_file());
+    assert!(project_root.join("packages/b/types/b.d.ts").is_file());
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+fn write_child_config(project_root: &Path, package: &str, extra_option: &str) {
+    write(
+        project_root,
+        &format!("packages/{package}/tsconfig.json"),
+        &format!(
+            r#"{{
+  "compilerOptions": {{
+    "strict": true,
+{extra_option}
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  }},
+  "include": ["src/**/*.ts"]
+}}"#
+        ),
+    );
+}
+
+fn assert_program_diagnostics(project_root: &Path, corsa_path: &Path, patterns: &[&str]) {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_vize"));
+    command
+        .current_dir(project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", "--no-config", "--tsconfig", "tsconfig.json"])
+        .args(patterns)
+        .args(["--format", "json"]);
+    let output = command.output().unwrap();
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("invalid JSON ({error}):\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    assert_eq!(json["errorCount"], serde_json::json!(2), "{stdout}");
+    assert_eq!(json["fileCount"], serde_json::json!(3), "{stdout}");
+
+    let files = json["files"].as_array().unwrap();
+    assert_file_has_code(files, "implicit-any.ts", "TS7006");
+    assert_file_has_code(files, "unchecked-index.ts", "TS2322");
+    let loose = files
+        .iter()
+        .find(|file| {
+            file["file"]
+                .as_str()
+                .is_some_and(|path| path.ends_with("allowed-index.ts"))
+        })
+        .unwrap();
+    assert_eq!(loose["diagnostics"], serde_json::json!([]), "{stdout}");
+}
+
+fn assert_file_has_code(files: &[serde_json::Value], name: &str, code: &str) {
+    let file = files
+        .iter()
+        .find(|file| {
+            file["file"]
+                .as_str()
+                .is_some_and(|path| path.ends_with(name))
+        })
+        .unwrap_or_else(|| panic!("missing {name}: {files:#?}"));
+    assert!(
+        file["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .any(|diagnostic| diagnostic.contains(code)),
+        "missing {code}: {file:#?}"
+    );
+}


### PR DESCRIPTION
## What
- partition authored roots by their transitive referenced-tsconfig owner
- execute one materialized Corsa program per compiler-options-homogeneous project
- aggregate diagnostics, JSON output, profiles, warning limits, and declaration outputs across programs
- preserve the logical package root separately from widened materialization roots

## Why
A solution tsconfig whose authored files spanned multiple referenced projects fell back to the solution config. Child-only options such as noUncheckedIndexedAccess were silently lost, producing false negatives; merging options into one program would instead create sibling false positives.

## Impact
Default and explicit multi-project checks now retain each child project compiler contract. Pure TS roots, allowJs roots, permissive siblings, and per-child declarationDir outputs are covered. Single-project CLI output and package-local root behavior remain compatible.

## Tests
- VIZE_REQUIRE_CORSA=1 cargo test -p vize --tests
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
- cargo clippy -p vize --lib --all-features -- -D warnings
- node --test tests/tooling/typecheck-dependency-gates.test.ts
- SOURCE_LENGTH_BASE_REF=d5872f277719972dfdec9835fca3bed665bc308a node --test tests/tooling/source-file-lengths.test.ts
- cargo fmt --all -- --check
- git diff --check

Closes part of #3984.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->