### PR TITLE
fix(check): report aliased authored diagnostics

### DIFF
--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -1,9 +1,8 @@
 //! Transitive resolution of source imports for `vize check` virtual projects.
 //!
 //! A check run may intentionally report diagnostics for only a subset of
-//! sources, but imported local sources still need to be registered so
-//! cross-file types resolve like tsc/vue-tsc. This module walks the reachable
-//! graph and returns on-disk source files to register.
+//! sources. This module separates authored files that TypeScript can resolve
+//! in place from files that must enter Vize's mirror for Vue import rewriting.
 
 use std::path::{Path, PathBuf};
 
@@ -23,43 +22,40 @@ use registration::non_relative_import_needs_virtual_registration;
 /// `shims.d.ts` with a top-level `declare module "vue"`) shadow the real module
 /// when registered as program roots, so pulling them in would break `vue`
 /// resolution for every file. TypeScript still loads reachable `.d.ts` on demand.
-const RESOLVE_EXTENSIONS: &[&str] = &[".ts", ".tsx", ".vue", ".mts", ".cts"];
-const JSX_RESOLVE_EXTENSIONS: &[&str] = &[".ts", ".tsx", ".jsx", ".vue", ".mts", ".cts"];
-const JS_RESOLVE_EXTENSIONS: &[&str] = &[
-    ".ts", ".tsx", ".vue", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs",
-];
-
 #[path = "imports_options.rs"]
 mod options;
-pub(super) use options::ImportFileOptions;
+pub(super) use options::{ImportFileOptions, TransitiveLocalImports};
 
-/// Walk the relative-import graph reachable from `roots` and return the extra
-/// on-disk source files that should be registered alongside them. The roots
-/// themselves are excluded from the result; every returned path is absolute.
+/// Walk the local import graph reachable from `roots`. The returned sets keep
+/// virtual registrations separate from authored in-place diagnostic sources;
+/// roots are excluded from both and every returned path is absolute.
 pub(super) fn collect_transitive_local_imports(
     roots: &[PathBuf],
     cwd: &Path,
     canonical_paths: &mut CanonicalPathCache,
     options: impl Into<ImportFileOptions>,
     aliases: Option<&PathAliasResolver>,
-) -> Vec<PathBuf> {
+) -> TransitiveLocalImports {
     let options = options.into();
     let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
+    let mut registered: FxHashSet<PathBuf> = FxHashSet::default();
     let mut registration_cache: FxHashMap<PathBuf, bool> = FxHashMap::default();
-    let mut queue: Vec<PathBuf> = Vec::new();
+    let mut queue: Vec<(PathBuf, bool)> = Vec::new();
 
     // Seed the visited set with the roots so they are never re-registered.
     for root in roots {
         if let Some(absolute) = absolutize(root, cwd, canonical_paths)
             && visited.insert(absolute.clone())
         {
-            queue.push(absolute);
+            registered.insert(absolute.clone());
+            queue.push((absolute, true));
         }
     }
 
-    let mut discovered: Vec<PathBuf> = Vec::new();
+    let mut registrations: Vec<PathBuf> = Vec::new();
+    let mut authored: Vec<PathBuf> = Vec::new();
 
-    while let Some(file) = queue.pop() {
+    while let Some((file, materialized_parent)) = queue.pop() {
         let Some(dir) = file.parent() else {
             continue;
         };
@@ -89,25 +85,35 @@ pub(super) fn collect_transitive_local_imports(
             if is_declaration_file(&resolved) || is_node_modules_path(&resolved) {
                 continue;
             }
-            if !relative_specifier
-                && !non_relative_import_needs_virtual_registration(
+            let needs_registration = if relative_specifier {
+                materialized_parent
+            } else {
+                non_relative_import_needs_virtual_registration(
                     &resolved,
                     canonical_paths,
                     options,
                     aliases,
                     &mut registration_cache,
                 )
-            {
-                continue;
+            };
+            let first_visit = visited.insert(resolved.clone());
+            let first_registration = needs_registration && registered.insert(resolved.clone());
+            if first_visit {
+                authored.push(resolved.clone());
             }
-            if visited.insert(resolved.clone()) {
-                discovered.push(resolved.clone());
-                queue.push(resolved);
+            if first_registration {
+                registrations.push(resolved.clone());
+            }
+            if first_visit || first_registration {
+                queue.push((resolved, needs_registration));
             }
         }
     }
 
-    discovered
+    TransitiveLocalImports {
+        registrations,
+        authored,
+    }
 }
 
 /// Resolve `path` against `cwd` and canonicalize it so duplicate registrations
@@ -218,7 +224,7 @@ pub(super) fn resolve_import_base(
     options: ImportFileOptions,
 ) -> Option<PathBuf> {
     // 1. The specifier already points at an existing TS/Vue source file.
-    if has_typescript_source_extension(base) && base.is_file() {
+    if ImportFileOptions::path_has_typescript_source_extension(base) && base.is_file() {
         return Some(canonical_paths.canonicalize(base));
     }
 
@@ -228,12 +234,12 @@ pub(super) fn resolve_import_base(
     }
 
     // 3. Under allowJs (or the JSX feature), keep an existing JS-family file.
-    if has_enabled_javascript_extension(base, options) && base.is_file() {
+    if options.javascript_extension_is_enabled(base) && base.is_file() {
         return Some(canonical_paths.canonicalize(base));
     }
 
     // 4. Append a source extension: `./types` → `./types.ts`.
-    for ext in resolve_extensions(options) {
+    for ext in options.resolve_extensions() {
         let candidate = append_extension(base, ext);
         if candidate.is_file() {
             return Some(canonical_paths.canonicalize(&candidate));
@@ -241,7 +247,7 @@ pub(super) fn resolve_import_base(
     }
 
     // 5. Directory index: `./feature` → `./feature/index.ts`.
-    for ext in resolve_extensions(options) {
+    for ext in options.resolve_extensions() {
         let candidate = base.join(cstr_index(ext));
         if candidate.is_file() {
             return Some(canonical_paths.canonicalize(&candidate));
@@ -295,31 +301,6 @@ fn is_declaration_file(path: &Path) -> bool {
 fn is_node_modules_path(path: &Path) -> bool {
     path.components()
         .any(|component| component.as_os_str() == std::ffi::OsStr::new("node_modules"))
-}
-
-fn has_typescript_source_extension(path: &Path) -> bool {
-    let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
-        return false;
-    };
-    RESOLVE_EXTENSIONS
-        .iter()
-        .any(|ext| name.ends_with(ext) && name.len() > ext.len())
-}
-
-fn has_enabled_javascript_extension(path: &Path, options: ImportFileOptions) -> bool {
-    let extension = path.extension().and_then(|extension| extension.to_str());
-    options.include_js && matches!(extension, Some("js" | "jsx" | "mjs" | "cjs"))
-        || options.include_jsx && extension == Some("jsx")
-}
-
-fn resolve_extensions(options: ImportFileOptions) -> &'static [&'static str] {
-    if options.include_js {
-        JS_RESOLVE_EXTENSIONS
-    } else if options.include_jsx {
-        JSX_RESOLVE_EXTENSIONS
-    } else {
-        RESOLVE_EXTENSIONS
-    }
 }
 
 /// Append a full extension (e.g. `.d.ts`) to a path's file name without

--- a/crates/vize/src/commands/check/imports_aliases.rs
+++ b/crates/vize/src/commands/check/imports_aliases.rs
@@ -259,6 +259,9 @@ void EnglishKeyboard;
             Some(&resolver),
         );
 
-        assert_eq!(discovered, vec![keyboard.canonicalize().unwrap()]);
+        assert_eq!(
+            discovered.registrations,
+            vec![keyboard.canonicalize().unwrap()]
+        );
     }
 }

--- a/crates/vize/src/commands/check/imports_generated_tests.rs
+++ b/crates/vize/src/commands/check/imports_generated_tests.rs
@@ -42,8 +42,12 @@ fn skips_plain_absolute_generated_graphql_imports() {
     );
 
     assert!(
-        discovered.is_empty(),
+        discovered.registrations.is_empty(),
         "plain absolute generated type modules should resolve from their real path, not be copied into .vize/canon: {discovered:#?}"
+    );
+    assert_eq!(
+        discovered.authored,
+        vec![canonicalize_non_verbatim(&schema)]
     );
 
     let _ = std::fs::remove_dir_all(&root);
@@ -67,7 +71,7 @@ fn skips_plain_aliased_generated_graphql_imports() {
 }"#,
     )
     .unwrap();
-    write(
+    let schema = write(
         &root,
         "types/codegen/schema.ts",
         "// Generated GraphQL schema types.\nexport enum AimQuestionDisplayKind { Text = 'TEXT' }\n",
@@ -88,8 +92,12 @@ fn skips_plain_aliased_generated_graphql_imports() {
     );
 
     assert!(
-        discovered.is_empty(),
+        discovered.registrations.is_empty(),
         "plain aliased generated type modules should use the real tsconfig path fallback, not be copied into .vize/canon: {discovered:#?}"
+    );
+    assert_eq!(
+        discovered.authored,
+        vec![canonicalize_non_verbatim(&schema)]
     );
 
     let _ = std::fs::remove_dir_all(&root);
@@ -135,7 +143,7 @@ fn collects_absolute_project_imports_that_need_vue_rewrites() {
     );
 
     assert_eq!(
-        discovered,
+        discovered.registrations,
         vec![
             canonicalize_non_verbatim(&feature),
             canonicalize_non_verbatim(&nested),

--- a/crates/vize/src/commands/check/imports_js_tests.rs
+++ b/crates/vize/src/commands/check/imports_js_tests.rs
@@ -45,8 +45,8 @@ fn allow_js_collects_the_imported_javascript_family() {
         None,
     );
 
-    assert!(disabled.is_empty());
-    assert_eq!(enabled, expected);
+    assert!(disabled.registrations.is_empty());
+    assert_eq!(enabled.registrations, expected);
     let _ = std::fs::remove_dir_all(root);
 }
 
@@ -70,6 +70,9 @@ fn allow_js_keeps_typescript_substitution_ahead_of_javascript() {
         None,
     );
 
-    assert_eq!(discovered, vec![canonicalize_non_verbatim(&typescript)]);
+    assert_eq!(
+        discovered.registrations,
+        vec![canonicalize_non_verbatim(&typescript)]
+    );
     let _ = std::fs::remove_dir_all(root);
 }

--- a/crates/vize/src/commands/check/imports_options.rs
+++ b/crates/vize/src/commands/check/imports_options.rs
@@ -1,7 +1,48 @@
+use std::path::{Path, PathBuf};
+
+const RESOLVE_EXTENSIONS: &[&str] = &[".ts", ".tsx", ".vue", ".mts", ".cts"];
+const JSX_RESOLVE_EXTENSIONS: &[&str] = &[".ts", ".tsx", ".jsx", ".vue", ".mts", ".cts"];
+const JS_RESOLVE_EXTENSIONS: &[&str] = &[
+    ".ts", ".tsx", ".vue", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs",
+];
+
 #[derive(Clone, Copy, Debug, Default)]
 pub(in crate::commands::check) struct ImportFileOptions {
     pub(in crate::commands::check) include_js: bool,
     pub(in crate::commands::check) include_jsx: bool,
+}
+
+impl ImportFileOptions {
+    pub(super) fn path_has_typescript_source_extension(path: &Path) -> bool {
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            return false;
+        };
+        RESOLVE_EXTENSIONS
+            .iter()
+            .any(|ext| name.ends_with(ext) && name.len() > ext.len())
+    }
+
+    pub(super) fn javascript_extension_is_enabled(self, path: &Path) -> bool {
+        let extension = path.extension().and_then(|extension| extension.to_str());
+        self.include_js && matches!(extension, Some("js" | "jsx" | "mjs" | "cjs"))
+            || self.include_jsx && extension == Some("jsx")
+    }
+
+    pub(super) fn resolve_extensions(self) -> &'static [&'static str] {
+        if self.include_js {
+            JS_RESOLVE_EXTENSIONS
+        } else if self.include_jsx {
+            JSX_RESOLVE_EXTENSIONS
+        } else {
+            RESOLVE_EXTENSIONS
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(in crate::commands::check) struct TransitiveLocalImports {
+    pub(in crate::commands::check) registrations: Vec<PathBuf>,
+    pub(in crate::commands::check) authored: Vec<PathBuf>,
 }
 
 impl From<bool> for ImportFileOptions {

--- a/crates/vize/src/commands/check/imports_tests.rs
+++ b/crates/vize/src/commands/check/imports_tests.rs
@@ -42,7 +42,10 @@ fn collects_relative_ts_and_vue_imports_transitively() {
     );
 
     let canon = canonicalize_non_verbatim;
-    assert_eq!(discovered, vec![canon(&types), canon(&child), canon(&util)]);
+    assert_eq!(
+        discovered.registrations,
+        vec![canon(&types), canon(&child), canon(&util)]
+    );
 
     let _ = std::fs::remove_dir_all(&root);
 }
@@ -66,7 +69,7 @@ fn ignores_bare_and_missing_specifiers() {
         false,
         None,
     );
-    assert!(discovered.is_empty());
+    assert!(discovered.registrations.is_empty());
 
     let _ = std::fs::remove_dir_all(&root);
 }
@@ -102,7 +105,10 @@ void percent
         None,
     );
 
-    assert_eq!(discovered, vec![canonicalize_non_verbatim(&index)]);
+    assert_eq!(
+        discovered.registrations,
+        vec![canonicalize_non_verbatim(&index)]
+    );
 
     let _ = std::fs::remove_dir_all(&root);
 }
@@ -131,8 +137,11 @@ fn jsx_imports_are_resolved_only_when_jsx_typecheck_is_enabled() {
         None,
     );
 
-    assert_eq!(disabled, Vec::<PathBuf>::new());
-    assert_eq!(enabled, vec![canonicalize_non_verbatim(&panel)]);
+    assert_eq!(disabled.registrations, Vec::<PathBuf>::new());
+    assert_eq!(
+        enabled.registrations,
+        vec![canonicalize_non_verbatim(&panel)]
+    );
 
     let _ = std::fs::remove_dir_all(&root);
 }
@@ -162,7 +171,7 @@ fn module_js_specifiers_prefer_module_source_extensions() {
     );
 
     assert_eq!(
-        discovered,
+        discovered.registrations,
         vec![
             canonicalize_non_verbatim(&esm_mts),
             canonicalize_non_verbatim(&common_cts),
@@ -204,8 +213,11 @@ fn js_specifiers_can_follow_tsx_when_jsx_typecheck_is_enabled() {
         None,
     );
 
-    assert_eq!(disabled, Vec::<PathBuf>::new());
-    assert_eq!(enabled, vec![canonicalize_non_verbatim(&panel)]);
+    assert_eq!(disabled.registrations, Vec::<PathBuf>::new());
+    assert_eq!(
+        enabled.registrations,
+        vec![canonicalize_non_verbatim(&panel)]
+    );
 
     let _ = std::fs::remove_dir_all(&root);
 }
@@ -310,7 +322,10 @@ export const cycleB = cycleA;
         Some(&aliases),
     );
 
-    assert_eq!(discovered, vec![canonicalize_non_verbatim(&panel)]);
+    assert_eq!(
+        discovered.registrations,
+        vec![canonicalize_non_verbatim(&panel)]
+    );
 
     let _ = std::fs::remove_dir_all(&root);
 }

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -400,12 +400,10 @@ fn prepare_and_execute(
     if !args.patterns.is_empty() && candidate.inputs.is_empty() {
         return None;
     }
-    let registered_files = canonical_file_set(&candidate.files, canonical_paths);
     candidate.reported.extend(
         authored_imports
             .into_iter()
-            .map(|path| canonical_paths.canonicalize(&path))
-            .filter(|path| registered_files.contains(path)),
+            .map(|path| canonical_paths.canonicalize(&path)),
     );
     if !args.patterns.is_empty()
         && let Some(program_tsconfig_path) = program_tsconfig_path.as_deref()

--- a/crates/vize/src/commands/check/runner/collect_tests.rs
+++ b/crates/vize/src/commands/check/runner/collect_tests.rs
@@ -278,7 +278,7 @@ void rootOnly;
     );
 
     assert!(
-        discovered.is_empty(),
+        discovered.registrations.is_empty(),
         "root app import leaked into package inputs: {discovered:#?}"
     );
 

--- a/crates/vize/src/commands/check/runner/default_imports.rs
+++ b/crates/vize/src/commands/check/runner/default_imports.rs
@@ -7,7 +7,7 @@ use super::{
     ignores::{CheckIgnoreSet, retain_unignored},
 };
 use crate::commands::check::{
-    imports::{ImportFileOptions, collect_transitive_local_imports},
+    imports::{ImportFileOptions, TransitiveLocalImports, collect_transitive_local_imports},
     imports_aliases::PathAliasResolver,
     path_cache::CanonicalPathCache,
     tsconfig_inputs::{
@@ -157,7 +157,17 @@ pub(super) fn register_transitive_local_imports(
 ) -> Vec<PathBuf> {
     let discovered =
         collect_local_imports(files, cwd, tsconfig_path, import_options, canonical_paths);
-    append_local_imports(files, discovered, explicit_input_root, validate_inputs)
+    // The explicit-root boundary constrains user-selected roots and files that
+    // enter Vize's mirror. It must not hide authored modules that TypeScript
+    // legitimately resolves in place outside that boundary.
+    let authored = discovered.authored;
+    append_local_imports(
+        files,
+        discovered.registrations,
+        explicit_input_root,
+        validate_inputs,
+    );
+    authored
 }
 
 pub(super) fn collect_transitive_local_imports_from(
@@ -170,6 +180,7 @@ pub(super) fn collect_transitive_local_imports_from(
     validate_inputs: bool,
 ) -> Vec<PathBuf> {
     collect_local_imports(roots, cwd, tsconfig_path, import_options, canonical_paths)
+        .registrations
         .into_iter()
         .filter(|path| local_import_is_allowed(path, explicit_input_root, validate_inputs))
         .collect()
@@ -181,7 +192,7 @@ fn collect_local_imports(
     tsconfig_path: Option<&Path>,
     import_options: ImportFileOptions,
     canonical_paths: &mut CanonicalPathCache,
-) -> Vec<PathBuf> {
+) -> TransitiveLocalImports {
     let aliases = PathAliasResolver::from_tsconfig(tsconfig_path);
     collect_transitive_local_imports(roots, cwd, canonical_paths, import_options, Some(&aliases))
 }

--- a/crates/vize/src/commands/check/runner/execution.rs
+++ b/crates/vize/src/commands/check/runner/execution.rs
@@ -123,6 +123,7 @@ pub(super) fn execute_program(
         eprintln!("\x1b[31mError:\x1b[0m {}", error);
         std::process::exit(1);
     });
+    checker.set_diagnostic_paths(input.reported_files.iter().map(PathBuf::as_path));
     let gen_time = gen_start.elapsed();
 
     if !settings.quiet {

--- a/crates/vize/src/commands/check/runner/output.rs
+++ b/crates/vize/src/commands/check/runner/output.rs
@@ -2,23 +2,25 @@
 
 use std::{collections::BTreeSet, path::Path, time::Duration, time::Instant};
 
-use vize_carton::{FxHashSet, String, cstr};
+use vize_carton::cstr;
 
 use super::{
-    CheckArgs, JsonFileResult, JsonOutput, ProgramExecution,
+    CheckArgs, JsonOutput, ProgramExecution,
     diagnostics::{
         emit_json_output, is_reported, is_suppressed_false_positive, render_diagnostics,
         save_virtual_ts_targets, write_profile_virtual_ts,
     },
-    display_path,
 };
 use crate::commands::check::path_cache::CanonicalPathCache;
 
 #[path = "output_declarations.rs"]
 mod declarations;
+#[path = "output_json.rs"]
+mod json;
 #[path = "output_profile.rs"]
 mod profile;
 use declarations::emit_declarations;
+use json::emit_json;
 use profile::print_profile;
 
 #[allow(clippy::disallowed_types)]
@@ -143,7 +145,6 @@ pub(super) fn report_executions(
             args,
             cwd,
             executions,
-            &virtual_files,
             &diagnostics,
             total_errors,
             total_warnings,
@@ -168,77 +169,6 @@ pub(super) fn report_executions(
         check_time,
         emitted.as_ref(),
     );
-}
-
-#[allow(clippy::too_many_arguments)]
-fn emit_json(
-    args: &CheckArgs,
-    cwd: &Path,
-    executions: &[ProgramExecution],
-    virtual_files: &[&vize_canon::VirtualFile],
-    diagnostics: &RenderedDiagnostics,
-    total_errors: usize,
-    total_warnings: usize,
-    emitted: Option<&DeclarationSummary>,
-    canonical_paths: &mut CanonicalPathCache,
-) {
-    let mut files_json = executions
-        .iter()
-        .flat_map(|execution| {
-            execution
-                .checker
-                .virtual_files()
-                .into_iter()
-                .filter(|file| {
-                    is_reported(
-                        &execution.reported_files,
-                        &file.original_path,
-                        canonical_paths,
-                    )
-                })
-                .map(|file| {
-                    let key = file.original_path.to_string_lossy().into_owned();
-                    JsonFileResult {
-                        file: display_path(cwd, &file.original_path).into(),
-                        virtual_ts: args.show_virtual_ts.then(|| file.content.clone().into()),
-                        diagnostics: diagnostics.get(key.as_str()).cloned().unwrap_or_default(),
-                    }
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
-    files_json.sort_by(|left, right| left.file.cmp(&right.file));
-    files_json.dedup_by(|left, right| left.file == right.file);
-    let reported_file_count = files_json.len();
-
-    let virtual_keys = virtual_files
-        .iter()
-        .map(|file| String::from(file.original_path.to_string_lossy()))
-        .collect::<FxHashSet<_>>();
-    files_json.extend(
-        diagnostics
-            .iter()
-            .filter(|(key, values)| !values.is_empty() && !virtual_keys.contains(key.as_str()))
-            .map(|(key, values)| JsonFileResult {
-                file: display_path(cwd, Path::new(key)).into(),
-                virtual_ts: None,
-                diagnostics: values.clone(),
-            }),
-    );
-
-    emit_json_output(JsonOutput {
-        files: files_json,
-        error_count: total_errors,
-        warning_count: total_warnings,
-        file_count: reported_file_count,
-        declarations: emitted.map(|summary| {
-            summary
-                .files
-                .iter()
-                .map(|path| display_path(cwd, path).into())
-                .collect()
-        }),
-    });
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/vize/src/commands/check/runner/output_json.rs
+++ b/crates/vize/src/commands/check/runner/output_json.rs
@@ -1,0 +1,92 @@
+use std::path::Path;
+
+use vize_carton::{FxHashSet, String};
+
+use super::super::{
+    CheckArgs, JsonFileResult, JsonOutput, ProgramExecution,
+    diagnostics::{emit_json_output, is_reported},
+    display_path,
+};
+use super::{DeclarationSummary, RenderedDiagnostics};
+use crate::commands::check::path_cache::CanonicalPathCache;
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn emit_json(
+    args: &CheckArgs,
+    cwd: &Path,
+    executions: &[ProgramExecution],
+    diagnostics: &RenderedDiagnostics,
+    total_errors: usize,
+    total_warnings: usize,
+    emitted: Option<&DeclarationSummary>,
+    canonical_paths: &mut CanonicalPathCache,
+) {
+    let mut files_json = executions
+        .iter()
+        .flat_map(|execution| {
+            execution
+                .checker
+                .virtual_files()
+                .into_iter()
+                .filter(|file| {
+                    is_reported(
+                        &execution.reported_files,
+                        &file.original_path,
+                        canonical_paths,
+                    )
+                })
+                .map(|file| {
+                    let key = file.original_path.to_string_lossy().into_owned();
+                    JsonFileResult {
+                        file: display_path(cwd, &file.original_path).into(),
+                        virtual_ts: args.show_virtual_ts.then(|| file.content.clone().into()),
+                        diagnostics: diagnostics.get(key.as_str()).cloned().unwrap_or_default(),
+                    }
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    files_json.extend(executions.iter().flat_map(|execution| {
+        execution.reported_files.iter().map(|path| {
+            let key = path.to_string_lossy();
+            JsonFileResult {
+                file: display_path(cwd, path).into(),
+                virtual_ts: None,
+                diagnostics: diagnostics.get(key.as_ref()).cloned().unwrap_or_default(),
+            }
+        })
+    }));
+    files_json.sort_by(|left, right| left.file.cmp(&right.file));
+    files_json.dedup_by(|left, right| left.file == right.file);
+    let reported_file_count = files_json.len();
+
+    let reported_keys = executions
+        .iter()
+        .flat_map(|execution| execution.reported_files.iter())
+        .map(|path| String::from(path.to_string_lossy()))
+        .collect::<FxHashSet<_>>();
+    files_json.extend(
+        diagnostics
+            .iter()
+            .filter(|(key, values)| !values.is_empty() && !reported_keys.contains(key.as_str()))
+            .map(|(key, values)| JsonFileResult {
+                file: display_path(cwd, Path::new(key)).into(),
+                virtual_ts: None,
+                diagnostics: values.clone(),
+            }),
+    );
+
+    emit_json_output(JsonOutput {
+        files: files_json,
+        error_count: total_errors,
+        warning_count: total_warnings,
+        file_count: reported_file_count,
+        declarations: emitted.map(|summary| {
+            summary
+                .files
+                .iter()
+                .map(|path| display_path(cwd, path).into())
+                .collect()
+        }),
+    });
+}

--- a/crates/vize/tests/check_default_imports_cli.rs
+++ b/crates/vize/tests/check_default_imports_cli.rs
@@ -1,3 +1,5 @@
+#[path = "check_default_imports_cli/aliased_diagnostics.rs"]
+mod aliased_diagnostics;
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;
 

--- a/crates/vize/tests/check_default_imports_cli/aliased_diagnostics.rs
+++ b/crates/vize/tests/check_default_imports_cli/aliased_diagnostics.rs
@@ -1,0 +1,231 @@
+use super::*;
+
+#[derive(Clone, Copy)]
+enum ImportKind {
+    AliasTypeScript,
+    AliasJavaScript,
+    AliasTransitive,
+    AbsoluteTypeScript,
+}
+
+impl ImportKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::AliasTypeScript => "alias-ts",
+            Self::AliasJavaScript => "alias-js",
+            Self::AliasTransitive => "alias-transitive",
+            Self::AbsoluteTypeScript => "absolute-ts",
+        }
+    }
+
+    fn imported_file(self) -> &'static str {
+        match self {
+            Self::AliasJavaScript => "support/invalid.js",
+            _ => "support/invalid.ts",
+        }
+    }
+}
+
+const IMPORT_KINDS: &[ImportKind] = &[
+    ImportKind::AliasTypeScript,
+    ImportKind::AliasJavaScript,
+    ImportKind::AliasTransitive,
+    ImportKind::AbsoluteTypeScript,
+];
+
+#[test]
+fn default_check_reports_aliased_and_absolute_authored_sources() {
+    for &kind in IMPORT_KINDS {
+        assert_authored_import_is_reported(kind, false);
+    }
+}
+
+#[test]
+fn explicit_check_reports_aliased_and_absolute_authored_sources() {
+    for &kind in IMPORT_KINDS {
+        assert_authored_import_is_reported(kind, true);
+    }
+}
+
+#[test]
+fn sharded_check_reports_an_aliased_source_owned_by_a_nonzero_shard() {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
+        return;
+    };
+    let project_root = unique_case_dir("alias-sharded-nonzero-owner");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    std::fs::create_dir_all(project_root.join("support")).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": { "@/*": ["*"] },
+    "noEmit": true
+  },
+  "include": ["src/*.ts"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/heavy.ts"),
+        format!("export const payload = '{}'\n", "x".repeat(16_384)),
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/alias.ts"),
+        format!(
+            "import '@/support/invalid'\n/* {} */\nexport const alias = true\n",
+            "y".repeat(12_000)
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("support/invalid.ts"),
+        "const invalid: string = 42\nvoid invalid\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", "--format", "json", "--servers", "2"])
+        .output()
+        .unwrap();
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert_eq!(output.status.code(), Some(1), "{stdout}\n{stderr}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["fileCount"], 3, "{stdout}\n{stderr}");
+    assert_eq!(json["errorCount"], 1, "{stdout}\n{stderr}");
+
+    let _ = std::fs::remove_dir_all(project_root);
+}
+
+fn assert_authored_import_is_reported(kind: ImportKind, explicit: bool) {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
+        return;
+    };
+    let mode = if explicit { "explicit" } else { "default" };
+    let project_root = unique_case_dir(&format!("{}-{mode}", kind.name()));
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    std::fs::create_dir_all(project_root.join("support")).unwrap();
+    let allow_js = matches!(kind, ImportKind::AliasJavaScript);
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        format!(
+            r#"{{
+  "compilerOptions": {{
+    "allowJs": {allow_js},
+    "checkJs": {allow_js},
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {{ "@/*": ["*"] }},
+    "noEmit": true
+  }},
+  "include": ["src/entry.ts"]
+}}"#
+        ),
+    )
+    .unwrap();
+    let imported_path = if matches!(kind, ImportKind::AbsoluteTypeScript) {
+        project_root.with_file_name(format!(
+            "{}-external.ts",
+            project_root.file_name().unwrap().to_string_lossy()
+        ))
+    } else {
+        project_root.join(kind.imported_file())
+    };
+    let specifier = match kind {
+        ImportKind::AbsoluteTypeScript => imported_path.to_string_lossy().into_owned(),
+        ImportKind::AliasTransitive => "@/support/index".into(),
+        ImportKind::AliasJavaScript => "@/support/invalid.js".into(),
+        ImportKind::AliasTypeScript => "@/support/invalid".into(),
+    };
+    std::fs::write(
+        project_root.join("src/entry.ts"),
+        format!("import '{specifier}'\nexport const clean = true\n"),
+    )
+    .unwrap();
+    if matches!(kind, ImportKind::AliasTransitive) {
+        std::fs::write(
+            project_root.join("support/index.ts"),
+            "import './invalid'\nexport const support = true\n",
+        )
+        .unwrap();
+    }
+    let invalid_source = if allow_js {
+        "/** @type {string} */\nconst invalid = 42\nvoid invalid\n"
+    } else {
+        "const invalid: string = 42\nvoid invalid\n"
+    };
+    std::fs::write(&imported_path, invalid_source).unwrap();
+
+    let mut args = vec!["check", "--format", "json"];
+    if explicit {
+        args.push("src/entry.ts");
+    }
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(args)
+        .output()
+        .unwrap();
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}/{mode}:\n{stdout}\n{stderr}",
+        kind.name()
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let expected_count = if matches!(kind, ImportKind::AliasTransitive) {
+        3
+    } else {
+        2
+    };
+    assert_eq!(
+        json["fileCount"],
+        expected_count,
+        "{}/{mode}:\n{stdout}\n{stderr}",
+        kind.name()
+    );
+    assert_eq!(
+        json["errorCount"],
+        1,
+        "{}/{mode}:\n{stdout}\n{stderr}",
+        kind.name()
+    );
+    let expected_file = imported_path
+        .strip_prefix(&project_root)
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| imported_path.to_string_lossy().into_owned());
+    let imported = json["files"]
+        .as_array()
+        .and_then(|files| files.iter().find(|file| file["file"] == expected_file))
+        .unwrap_or_else(|| panic!("missing {expected_file}:\n{stdout}\n{stderr}"));
+    assert!(
+        imported["diagnostics"]
+            .as_array()
+            .is_some_and(|diagnostics| diagnostics.iter().any(|diagnostic| diagnostic
+                .as_str()
+                .is_some_and(|diagnostic| diagnostic.contains("TS2322")))),
+        "{}/{mode}:\n{stdout}\n{stderr}",
+        kind.name()
+    );
+
+    let _ = std::fs::remove_dir_all(project_root);
+    if matches!(kind, ImportKind::AbsoluteTypeScript) {
+        let _ = std::fs::remove_file(imported_path);
+    }
+}

--- a/crates/vize/tests/check_package_cwd_cli.rs
+++ b/crates/vize/tests/check_package_cwd_cli.rs
@@ -90,7 +90,7 @@ fn check_from_package_cwd_uses_package_local_tsconfig_inputs() {
     write_file(
         &workspace,
         "src/generated/tecack/custom.ts",
-        "export const rootOnly: string = 'root';\n",
+        "export const rootOnly: string = 42;\n",
     );
 
     let package_root = workspace.join("devtools");
@@ -140,25 +140,32 @@ void rootOnly;
 
     let stdout = std::string::String::from_utf8(output.stdout).unwrap();
     let stderr = std::string::String::from_utf8(output.stderr).unwrap();
-    assert!(
-        output.status.success(),
-        "package-local check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
-    );
+    assert_eq!(output.status.code(), Some(1), "{stdout}\n{stderr}");
 
     let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    assert_eq!(
-        json["errorCount"], 0,
-        "unexpected diagnostics:\nstdout:\n{stdout}\nstderr:\n{stderr}"
-    );
+    assert_eq!(json["errorCount"], 1, "{stdout}\n{stderr}");
     assert_eq!(json["warningCount"], 0, "{stdout}\n{stderr}");
-    assert_eq!(json["fileCount"], 1, "{stdout}\n{stderr}");
+    assert_eq!(json["fileCount"], 2, "{stdout}\n{stderr}");
     let files = json["files"].as_array().unwrap();
-    assert_eq!(files.len(), 1, "{stdout}\n{stderr}");
-    assert_eq!(files[0]["file"], "src/App.vue", "{stdout}\n{stderr}");
-    assert_eq!(
-        files[0]["diagnostics"],
-        serde_json::json!([]),
-        "{stdout}\n{stderr}"
+    assert_eq!(files.len(), 2, "{stdout}\n{stderr}");
+    let app = files
+        .iter()
+        .find(|file| file["file"] == "src/App.vue")
+        .expect("App.vue result");
+    assert!(app["diagnostics"].as_array().is_some_and(Vec::is_empty));
+    let workspace_source = workspace.join("src/generated/tecack/custom.ts");
+    let workspace_source = workspace_source.to_string_lossy();
+    let imported = files
+        .iter()
+        .find(|file| file["file"] == workspace_source.as_ref())
+        .expect("workspace alias result");
+    assert!(
+        imported["diagnostics"]
+            .as_array()
+            .is_some_and(|diagnostics| diagnostics.iter().any(|diagnostic| diagnostic
+                .as_str()
+                .is_some_and(|diagnostic| diagnostic.contains("TS2322")))),
+        "missing TS2322:\n{stdout}\n{stderr}"
     );
 
     let _ = std::fs::remove_dir_all(&workspace);

--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -97,12 +97,11 @@ pub(super) fn check_with_cli_sharded(
         let result = result?;
         merged.exit_code = merged.exit_code.max(result.exit_code);
         merged.success = merged.success && result.success;
-        merged.diagnostics.extend(
-            result
-                .diagnostics
-                .into_iter()
-                .filter(|diagnostic| owners.get(&diagnostic.file).copied().unwrap_or(0) == index),
-        );
+        merged
+            .diagnostics
+            .extend(result.diagnostics.into_iter().filter(
+            |diagnostic| !matches!(owners.get(&diagnostic.file), Some(owner) if *owner != index),
+        ));
     }
     Ok(merged)
 }
@@ -124,8 +123,8 @@ struct ShardPlan<'a> {
     /// Virtual paths to include per shard (owned Vue files plus every shared
     /// file).
     shards: Vec<Vec<&'a Path>>,
-    /// Original path -> owning shard for partitioned Vue files; files absent
-    /// from the map (shared sources, project-level anchors) belong to shard 0.
+    /// Registered-file ownership. Absent shared or real-tree diagnostics are
+    /// accepted from every shard, then deduplicated in the merged result.
     owners: FxHashMap<PathBuf, usize>,
 }
 

--- a/crates/vize_canon/src/batch/executor/diagnostics.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics.rs
@@ -159,12 +159,9 @@ impl<'a> DiagnosticMapper<'a> {
         None
     }
 
-    /// Map a virtual position back to the authored source, or `None` when the
-    /// diagnostic has no reportable origin. Both diagnostic paths (LSP and the
-    /// Corsa CLI text output) funnel through here, so this is also where the
-    /// `checkJs` gate lives: a diagnostic landing in a JavaScript SFC has no
-    /// reportable origin unless the project asked for JavaScript to be checked,
-    /// exactly as `tsc`/`vue-tsc` leave a `lang="js"` block alone (#3322).
+    /// Map a Corsa position to a virtual source-map origin or to an explicitly
+    /// authored, in-place diagnostic path. The `checkJs` gate for JavaScript
+    /// SFCs also lives here (#3322).
     pub(super) fn map_to_original(
         &mut self,
         virtual_path: &Path,
@@ -174,7 +171,9 @@ impl<'a> DiagnosticMapper<'a> {
         if self.project.skips_typescript_diagnostics(virtual_path) {
             return None;
         }
-        let file = self.project.find_by_virtual(virtual_path)?;
+        let Some(file) = self.project.find_by_virtual(virtual_path) else {
+            return self.project.diagnostic_position(virtual_path, line, column);
+        };
         let virtual_offset = self.virtual_offset(file, line, column)?;
         let (original_offset, _, block_type) =
             file.source_map.get_original_position(virtual_offset)?;

--- a/crates/vize_canon/src/batch/executor/session.rs
+++ b/crates/vize_canon/src/batch/executor/session.rs
@@ -19,6 +19,10 @@ use crate::batch::virtual_project::{
     AUTO_IMPORT_STUBS_FILE, SHARED_HELPERS_FILE, VUE_MODULE_STUBS_FILE,
 };
 
+mod diagnostic_paths;
+
+use diagnostic_paths::{extend_diagnostic_path_uris, is_authored_diagnostic_input};
+
 #[derive(Default)]
 pub(super) struct IncrementalSessionState {
     session: Option<IncrementalSession>,
@@ -69,10 +73,11 @@ impl CorsaExecutor {
             }
             Err(error) => return Err(map_corsa_error(error)),
         };
-        let uris = profile!(
+        let mut uris = profile!(
             "canon.corsa.collect_uris",
             collect_virtual_file_uris(project.virtual_root())
         )?;
+        extend_diagnostic_path_uris(project, &mut uris);
         check_session_client(&mut client, project, &uris)
     }
 
@@ -87,10 +92,11 @@ impl CorsaExecutor {
                 "canon.executor.materialize_incremental",
                 project.materialize()
             )?;
-            let snapshot = profile!(
+            let mut snapshot = profile!(
                 "canon.corsa.incremental.snapshot",
                 MaterializedSnapshot::capture(project.virtual_root())
             )?;
+            snapshot.extend_diagnostic_paths(project)?;
             let mut state = self
                 .incremental_session
                 .lock()
@@ -232,6 +238,20 @@ impl MaterializedSnapshot {
         }
         delta.sort();
         delta
+    }
+
+    fn extend_diagnostic_paths(&mut self, project: &VirtualProject) -> CorsaResult<()> {
+        for path in project.diagnostic_paths_sorted() {
+            if !path.is_file() || !is_authored_diagnostic_input(&path) {
+                continue;
+            }
+            let content = std::fs::read(&path)?;
+            self.revisions.insert(path.clone(), hash_bytes(&content));
+            self.uris.push(path_to_file_uri(&path));
+        }
+        self.uris.sort();
+        self.uris.dedup();
+        Ok(())
     }
 }
 

--- a/crates/vize_canon/src/batch/executor/session/diagnostic_paths.rs
+++ b/crates/vize_canon/src/batch/executor/session/diagnostic_paths.rs
@@ -1,0 +1,49 @@
+use super::VirtualProject;
+use crate::file_uri::path_to_file_uri;
+use std::path::Path;
+use vize_carton::String;
+
+pub(super) fn extend_diagnostic_path_uris(project: &VirtualProject, uris: &mut Vec<String>) {
+    uris.extend(
+        project
+            .diagnostic_paths_sorted()
+            .into_iter()
+            .filter(|path| path.is_file() && is_authored_diagnostic_input(path))
+            .map(|path| path_to_file_uri(&path)),
+    );
+    uris.sort();
+    uris.dedup();
+}
+
+pub(super) fn is_authored_diagnostic_input(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|extension| extension.to_str()),
+        Some("ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extend_diagnostic_path_uris;
+    use crate::{batch::VirtualProject, file_uri::path_to_file_uri};
+
+    #[test]
+    fn adds_only_existing_authored_source_uris() {
+        let root = tempfile::tempdir().unwrap();
+        let source = root.path().join("source.js");
+        let ignored = root.path().join("notes.txt");
+        let missing = root.path().join("missing.ts");
+        std::fs::write(&source, "export const value = 1\n").unwrap();
+        std::fs::write(&ignored, "notes\n").unwrap();
+        let mut project = VirtualProject::new(root.path()).unwrap();
+        project.set_diagnostic_paths([source.as_path(), ignored.as_path(), missing.as_path()]);
+        let mut uris = Vec::new();
+
+        extend_diagnostic_path_uris(&project, &mut uris);
+
+        assert_eq!(
+            uris,
+            vec![path_to_file_uri(&source.canonicalize().unwrap())]
+        );
+    }
+}

--- a/crates/vize_canon/src/batch/executor/session/tests.rs
+++ b/crates/vize_canon/src/batch/executor/session/tests.rs
@@ -1,4 +1,4 @@
-use super::{MaterializedDelta, MaterializedSnapshot};
+use super::{MaterializedDelta, MaterializedSnapshot, VirtualProject};
 use std::path::PathBuf;
 use vize_carton::FxHashMap;
 
@@ -40,6 +40,28 @@ fn snapshot_keeps_symlinked_typescript_files_as_diagnostic_inputs() {
     assert!(after.revisions.contains_key(&linked));
     assert_eq!(after.uris, vec![path_to_file_uri(&linked)]);
     assert_eq!(after.diff(&before).changed, vec![linked]);
+}
+
+#[test]
+fn snapshot_tracks_in_place_diagnostic_source_changes() {
+    use crate::file_uri::path_to_file_uri;
+
+    let temp = tempfile::tempdir().unwrap();
+    let source = temp.path().join("aliased.ts");
+    std::fs::write(&source, "export const value = 1\n").unwrap();
+    let mut project = VirtualProject::new(temp.path()).unwrap();
+    std::fs::create_dir_all(project.virtual_root()).unwrap();
+    project.set_diagnostic_paths([source.as_path()]);
+    let mut before = MaterializedSnapshot::capture(project.virtual_root()).unwrap();
+    before.extend_diagnostic_paths(&project).unwrap();
+
+    std::fs::write(&source, "export const value = 2\n").unwrap();
+    let mut after = MaterializedSnapshot::capture(project.virtual_root()).unwrap();
+    after.extend_diagnostic_paths(&project).unwrap();
+
+    let source = source.canonicalize().unwrap();
+    assert_eq!(after.uris, vec![path_to_file_uri(&source)]);
+    assert_eq!(after.diff(&before).changed, vec![source]);
 }
 
 fn snapshot(entries: &[(&str, u64)]) -> MaterializedSnapshot {

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -9,6 +9,7 @@ use super::virtual_project::VirtualProject;
 use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 use vize_carton::String;
 
+mod diagnostic_paths;
 mod metrics;
 mod paths;
 mod result;

--- a/crates/vize_canon/src/batch/type_checker/diagnostic_paths.rs
+++ b/crates/vize_canon/src/batch/type_checker/diagnostic_paths.rs
@@ -1,0 +1,15 @@
+//! Authored files that stay in the real TypeScript program instead of being
+//! copied into Vize's virtual mirror.
+
+use std::path::Path;
+
+use super::BatchTypeChecker;
+
+impl BatchTypeChecker {
+    /// Diagnose authored program files in place without registering them as
+    /// virtual roots. This preserves module identity for generated sources and
+    /// lets TypeScript own alias and absolute-import resolution.
+    pub fn set_diagnostic_paths<'a>(&mut self, paths: impl IntoIterator<Item = &'a Path>) {
+        self.project.set_diagnostic_paths(paths);
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -119,6 +119,9 @@ pub struct VirtualProject {
     /// Global virtual TS options applied to every Vue file.
     virtual_ts_options: VirtualTsOptions,
 
+    /// Authored program files diagnosed in place instead of materialized.
+    diagnostic_paths: FxHashSet<PathBuf>,
+
     /// Internal check generation settings applied to every Vue file.
     virtual_ts_check_options: VirtualTsCheckOptions,
 

--- a/crates/vize_canon/src/batch/virtual_project/mapping.rs
+++ b/crates/vize_canon/src/batch/virtual_project/mapping.rs
@@ -9,6 +9,39 @@ use crate::batch::SfcBlockType;
 use super::{Diagnostic, OriginalPosition, VirtualFile, VirtualProject};
 
 impl VirtualProject {
+    pub(crate) fn set_diagnostic_paths<'a>(&mut self, paths: impl IntoIterator<Item = &'a Path>) {
+        self.diagnostic_paths = paths
+            .into_iter()
+            .filter(|path| path.is_file())
+            .map(vize_carton::path::canonicalize_non_verbatim)
+            .collect();
+    }
+
+    pub(crate) fn diagnostic_path(&self, path: &Path) -> Option<&Path> {
+        let normalized = vize_carton::path::canonicalize_non_verbatim(path);
+        self.diagnostic_paths.get(&normalized).map(PathBuf::as_path)
+    }
+
+    pub(crate) fn diagnostic_position(
+        &self,
+        path: &Path,
+        line: u32,
+        column: u32,
+    ) -> Option<OriginalPosition> {
+        Some(OriginalPosition {
+            path: self.diagnostic_path(path)?.to_path_buf(),
+            line,
+            column,
+            block_type: None,
+        })
+    }
+
+    pub(crate) fn diagnostic_paths_sorted(&self) -> Vec<PathBuf> {
+        let mut paths: Vec<_> = self.diagnostic_paths.iter().cloned().collect();
+        paths.sort();
+        paths
+    }
+
     /// Find a virtual file by its original path.
     pub fn find_by_original(&self, original_path: &Path) -> Option<&VirtualFile> {
         let virtual_path = self.original_index.get(original_path)?;

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -22,7 +22,6 @@ use super::build::{
 
 const MUSEA_DEFINE_ART_STUB: &str =
     "declare function defineArt(source: string, options?: Record<string, any>): void;";
-
 fn is_musea_art_vue_path(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
@@ -45,6 +44,7 @@ impl VirtualProject {
             preserve_unused_diagnostics: false,
             check_js: false,
             virtual_ts_options: VirtualTsOptions::default(),
+            diagnostic_paths: FxHashSet::default(),
             virtual_ts_check_options: VirtualTsCheckOptions::default(),
             options_api: false,
             session_scripts: false,
@@ -74,6 +74,7 @@ impl VirtualProject {
         let mut project = Self::new(&self.project_root)?;
         project.set_tsconfig_path(self.tsconfig_path.clone());
         project.virtual_ts_options = self.virtual_ts_options.clone();
+        project.diagnostic_paths = self.diagnostic_paths.clone();
         project.virtual_ts_check_options = self.virtual_ts_check_options;
         project.options_api = self.options_api;
         project.legacy_vue2 = self.legacy_vue2;


### PR DESCRIPTION
## Summary
- distinguish authored in-place sources from files that require virtual registration
- preserve diagnostics for path aliases, absolute imports, JavaScript, transitive imports, project-external sources, and multi-server shards
- expose in-place diagnostic paths to CLI and persistent project sessions without changing generated-module identity
- report every authored program file in JSON output

## Validation
- `VIZE_REQUIRE_CORSA=1 cargo test -p vize --tests --quiet`
- `cargo test -p vize_canon --lib --quiet`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy -p vize --lib --all-features -- -D warnings`
- typecheck dependency gates
- source length gates
- formatting and diff checks

Tracks #3984.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->