### PR TITLE
fix(check): report base-url authored diagnostics

### DIFF
--- a/crates/vize/src/commands/check/imports_aliases.rs
+++ b/crates/vize/src/commands/check/imports_aliases.rs
@@ -10,6 +10,7 @@ use super::tsconfig_inputs::{parse_jsonc_value, read_extends_entries, resolve_ex
 #[derive(Default)]
 pub(super) struct PathAliasResolver {
     aliases: Vec<PathAlias>,
+    base_url: Option<PathBuf>,
 }
 
 struct PathAlias {
@@ -52,7 +53,9 @@ impl PathAliasResolver {
                 }
             }
         }
-        None
+        self.base_url
+            .as_ref()
+            .and_then(|base_url| resolve_base(&base_url.join(specifier), canonical_paths, options))
     }
 }
 
@@ -92,14 +95,20 @@ fn load_aliases(
     let Some(options) = value.get("compilerOptions").and_then(Value::as_object) else {
         return Ok(resolver);
     };
-    let base_dir = options
+    if let Some(base_url) = options
         .get("baseUrl")
         .and_then(Value::as_str)
         .map(|base| dir.join(base))
-        .unwrap_or_else(|| dir.to_path_buf());
+    {
+        resolver.base_url = Some(base_url);
+    }
     let Some(paths) = options.get("paths").and_then(Value::as_object) else {
         return Ok(resolver);
     };
+    let base_dir = resolver
+        .base_url
+        .clone()
+        .unwrap_or_else(|| dir.to_path_buf());
 
     resolver.aliases.clear();
     for (pattern, targets) in paths {

--- a/crates/vize/tests/check_default_imports_cli.rs
+++ b/crates/vize/tests/check_default_imports_cli.rs
@@ -1,5 +1,7 @@
 #[path = "check_default_imports_cli/aliased_diagnostics.rs"]
 mod aliased_diagnostics;
+#[path = "check_default_imports_cli/base_url_diagnostics.rs"]
+mod base_url_diagnostics;
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;
 

--- a/crates/vize/tests/check_default_imports_cli/base_url_diagnostics.rs
+++ b/crates/vize/tests/check_default_imports_cli/base_url_diagnostics.rs
@@ -1,0 +1,172 @@
+use super::*;
+
+#[derive(Clone, Copy)]
+enum BaseUrlKind {
+    TypeScript,
+    JavaScript,
+    Transitive,
+    Inherited,
+}
+
+impl BaseUrlKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::TypeScript => "ts",
+            Self::JavaScript => "js",
+            Self::Transitive => "transitive",
+            Self::Inherited => "inherited",
+        }
+    }
+}
+
+const KINDS: &[BaseUrlKind] = &[
+    BaseUrlKind::TypeScript,
+    BaseUrlKind::JavaScript,
+    BaseUrlKind::Transitive,
+    BaseUrlKind::Inherited,
+];
+
+#[test]
+fn default_check_reports_base_url_authored_sources() {
+    for &kind in KINDS {
+        assert_base_url_source_is_reported(kind, false);
+    }
+}
+
+#[test]
+fn explicit_check_reports_base_url_authored_sources() {
+    for &kind in KINDS {
+        assert_base_url_source_is_reported(kind, true);
+    }
+}
+
+fn assert_base_url_source_is_reported(kind: BaseUrlKind, explicit: bool) {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
+        return;
+    };
+    let mode = if explicit { "explicit" } else { "default" };
+    let project_root = unique_case_dir(&format!("base-url-{}-{mode}", kind.name()));
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    std::fs::create_dir_all(project_root.join("support")).unwrap();
+    let allow_js = matches!(kind, BaseUrlKind::JavaScript);
+    let extends = matches!(kind, BaseUrlKind::Inherited);
+    if extends {
+        std::fs::create_dir_all(project_root.join("config")).unwrap();
+        std::fs::write(
+            project_root.join("config/tsconfig.base.json"),
+            r#"{
+  "compilerOptions": {
+    "baseUrl": "..",
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  }
+}"#,
+        )
+        .unwrap();
+    }
+    let config = if extends {
+        r#"{
+  "extends": "./config/tsconfig.base.json",
+  "include": ["src/entry.ts"]
+}"#
+        .to_owned()
+    } else {
+        format!(
+            r#"{{
+  "compilerOptions": {{
+    "allowJs": {allow_js},
+    "checkJs": {allow_js},
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "noEmit": true
+  }},
+  "include": ["src/entry.ts"]
+}}"#
+        )
+    };
+    std::fs::write(project_root.join("tsconfig.json"), config).unwrap();
+    let entry_specifier = match kind {
+        BaseUrlKind::JavaScript => "support/invalid.js",
+        BaseUrlKind::Transitive => "support/index",
+        BaseUrlKind::TypeScript | BaseUrlKind::Inherited => "support/invalid",
+    };
+    std::fs::write(
+        project_root.join("src/entry.ts"),
+        format!("import '{entry_specifier}'\nexport const clean = true\n"),
+    )
+    .unwrap();
+    if matches!(kind, BaseUrlKind::Transitive) {
+        std::fs::write(
+            project_root.join("support/index.ts"),
+            "import './invalid'\nexport const support = true\n",
+        )
+        .unwrap();
+    }
+    let invalid_path = if allow_js {
+        project_root.join("support/invalid.js")
+    } else {
+        project_root.join("support/invalid.ts")
+    };
+    let invalid_source = if allow_js {
+        "/** @type {string} */\nconst invalid = 42\nvoid invalid\n"
+    } else {
+        "const invalid: string = 42\nvoid invalid\n"
+    };
+    std::fs::write(&invalid_path, invalid_source).unwrap();
+
+    let mut args = vec!["check", "--format", "json"];
+    if explicit {
+        args.push("src/entry.ts");
+    }
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(args)
+        .output()
+        .unwrap();
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}/{mode}:\n{stdout}\n{stderr}",
+        kind.name()
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let expected_count = if matches!(kind, BaseUrlKind::Transitive) {
+        3
+    } else {
+        2
+    };
+    assert_eq!(json["fileCount"], expected_count, "{stdout}\n{stderr}");
+    assert_eq!(json["errorCount"], 1, "{stdout}\n{stderr}");
+    let invalid_relative = invalid_path
+        .strip_prefix(&project_root)
+        .unwrap()
+        .to_string_lossy();
+    let invalid = json["files"]
+        .as_array()
+        .and_then(|files| {
+            files
+                .iter()
+                .find(|file| file["file"] == invalid_relative.as_ref())
+        })
+        .unwrap_or_else(|| panic!("missing invalid source:\n{stdout}\n{stderr}"));
+    assert!(
+        invalid["diagnostics"]
+            .as_array()
+            .is_some_and(|diagnostics| diagnostics.iter().any(|diagnostic| diagnostic
+                .as_str()
+                .is_some_and(|diagnostic| diagnostic.contains("TS2322")))),
+        "{stdout}\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(project_root);
+}


### PR DESCRIPTION
## Summary
- retain the effective baseUrl anchor while flattening extended tsconfig import resolution
- discover baseUrl-only TypeScript and JavaScript sources without treating them as virtual roots
- cover direct, transitive, inherited, default, and explicit check flows

## Validation
- `VIZE_REQUIRE_CORSA=1 cargo test -p vize --tests --quiet`
- `cargo test -p vize --lib commands::check::imports --quiet`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy -p vize --lib --all-features -- -D warnings`
- typecheck dependency gates
- source length gates
- formatting and diff checks

Tracks #3984.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/3999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->