### PR TITLE
fix(check): report workspace package diagnostics

### DIFF
--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -14,6 +14,9 @@ use super::path_cache::CanonicalPathCache;
 #[path = "imports_registration.rs"]
 mod registration;
 use registration::non_relative_import_needs_virtual_registration;
+#[path = "imports_packages.rs"]
+mod packages;
+use packages::PackageImportResolver;
 
 /// Source extensions whose imports carry TypeScript types worth pulling into the
 /// virtual project, in module-resolution precedence order.
@@ -40,6 +43,7 @@ pub(super) fn collect_transitive_local_imports(
     let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
     let mut registered: FxHashSet<PathBuf> = FxHashSet::default();
     let mut registration_cache: FxHashMap<PathBuf, bool> = FxHashMap::default();
+    let mut packages = PackageImportResolver::default();
     let mut queue: Vec<(PathBuf, bool)> = Vec::new();
 
     // Seed the visited set with the roots so they are never re-registered.
@@ -73,9 +77,11 @@ pub(super) fn collect_transitive_local_imports(
             } else if absolute_specifier {
                 resolve_import_base(Path::new(specifier.as_str()), canonical_paths, options)
             } else {
-                aliases.and_then(|aliases| {
-                    aliases.resolve(&specifier, canonical_paths, options, resolve_import_base)
-                })
+                aliases
+                    .and_then(|aliases| {
+                        aliases.resolve(&specifier, canonical_paths, options, resolve_import_base)
+                    })
+                    .or_else(|| packages.resolve(dir, &specifier, canonical_paths, options))
             };
             let Some(resolved) = resolved else {
                 continue;

--- a/crates/vize/src/commands/check/imports_options.rs
+++ b/crates/vize/src/commands/check/imports_options.rs
@@ -6,7 +6,7 @@ const JS_RESOLVE_EXTENSIONS: &[&str] = &[
     ".ts", ".tsx", ".vue", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs",
 ];
 
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 pub(in crate::commands::check) struct ImportFileOptions {
     pub(in crate::commands::check) include_js: bool,
     pub(in crate::commands::check) include_jsx: bool,

--- a/crates/vize/src/commands/check/imports_packages.rs
+++ b/crates/vize/src/commands/check/imports_packages.rs
@@ -1,0 +1,281 @@
+//! Resolve bare imports only far enough to identify authored workspace sources.
+//! TypeScript remains the authority for the actual program resolution.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+use vize_carton::{FxHashMap, String, cstr};
+
+use super::{ImportFileOptions, is_node_modules_path, resolve_import_base};
+use crate::commands::check::path_cache::CanonicalPathCache;
+
+type ResolutionKey = (PathBuf, String, ImportFileOptions);
+
+#[derive(Default)]
+pub(super) struct PackageImportResolver {
+    resolutions: FxHashMap<ResolutionKey, Option<PathBuf>>,
+}
+
+impl PackageImportResolver {
+    pub(super) fn resolve(
+        &mut self,
+        importer_dir: &Path,
+        specifier: &str,
+        canonical_paths: &mut CanonicalPathCache,
+        options: ImportFileOptions,
+    ) -> Option<PathBuf> {
+        let key = (
+            canonical_paths.canonicalize(importer_dir),
+            specifier.into(),
+            options,
+        );
+        if let Some(cached) = self.resolutions.get(&key) {
+            return cached.clone();
+        }
+        let resolved = resolve_uncached(importer_dir, specifier, canonical_paths, options);
+        self.resolutions.insert(key, resolved.clone());
+        resolved
+    }
+}
+
+fn resolve_uncached(
+    importer_dir: &Path,
+    specifier: &str,
+    canonical_paths: &mut CanonicalPathCache,
+    options: ImportFileOptions,
+) -> Option<PathBuf> {
+    if specifier.starts_with('#') {
+        return resolve_internal_import(importer_dir, specifier, canonical_paths, options);
+    }
+    let request = PackageRequest::parse(specifier)?;
+    let package_root = find_package_root(importer_dir, request.package)?;
+    let package_root = canonical_paths.canonicalize(&package_root);
+    // Installed dependencies remain TypeScript's responsibility. Only a
+    // symlinked/self-referenced package whose real source lives outside
+    // `node_modules` can contribute authored diagnostics here.
+    if is_node_modules_path(&package_root) {
+        return None;
+    }
+    let package_json = std::fs::read_to_string(package_root.join("package.json"))
+        .ok()
+        .and_then(|content| serde_json::from_str::<Value>(&content).ok());
+    let exports_declared = package_json
+        .as_ref()
+        .is_some_and(|package| package.get("exports").is_some());
+    let mut candidates = Vec::new();
+    if let Some(package_json) = package_json.as_ref() {
+        collect_manifest_candidates(
+            package_json,
+            &package_root,
+            request.subpath,
+            &mut candidates,
+        );
+    }
+    if candidates.is_empty() {
+        if exports_declared {
+            return None;
+        }
+        candidates.push(match request.subpath {
+            Some(subpath) => package_root.join(subpath),
+            None => package_root.join("index"),
+        });
+    }
+    candidates
+        .into_iter()
+        .find_map(|candidate| resolve_import_base(&candidate, canonical_paths, options))
+}
+
+fn resolve_internal_import(
+    importer_dir: &Path,
+    specifier: &str,
+    canonical_paths: &mut CanonicalPathCache,
+    options: ImportFileOptions,
+) -> Option<PathBuf> {
+    let (package_root, package_json) = nearest_package_manifest(importer_dir)?;
+    let imports = package_json.get("imports")?;
+    let mut candidates = Vec::new();
+    collect_map_request_targets(imports, specifier, &package_root, &mut candidates);
+    candidates
+        .into_iter()
+        .find_map(|candidate| resolve_import_base(&candidate, canonical_paths, options))
+}
+
+fn nearest_package_manifest(start: &Path) -> Option<(PathBuf, Value)> {
+    for dir in start.ancestors() {
+        let Ok(manifest) = std::fs::read_to_string(dir.join("package.json")) else {
+            continue;
+        };
+        let Ok(package) = serde_json::from_str::<Value>(&manifest) else {
+            return None;
+        };
+        return Some((dir.to_path_buf(), package));
+    }
+    None
+}
+
+struct PackageRequest<'a> {
+    package: &'a str,
+    subpath: Option<&'a str>,
+}
+
+impl<'a> PackageRequest<'a> {
+    fn parse(specifier: &'a str) -> Option<Self> {
+        if specifier.is_empty()
+            || specifier.starts_with(['.', '/', '#'])
+            || Path::new(specifier).is_absolute()
+        {
+            return None;
+        }
+        let package_end = if let Some(scoped) = specifier.strip_prefix('@') {
+            let slash = scoped.find('/')? + 1;
+            specifier[slash + 1..]
+                .find('/')
+                .map_or(specifier.len(), |end| slash + 1 + end)
+        } else {
+            specifier.find('/').unwrap_or(specifier.len())
+        };
+        let package = specifier.get(..package_end)?;
+        let subpath = specifier
+            .get(package_end + 1..)
+            .filter(|subpath| !subpath.is_empty());
+        Some(Self { package, subpath })
+    }
+}
+
+fn find_package_root(importer_dir: &Path, package: &str) -> Option<PathBuf> {
+    for dir in importer_dir.ancestors() {
+        if package_name_at(dir).as_deref() == Some(package) {
+            return Some(dir.to_path_buf());
+        }
+        let candidate = dir.join("node_modules").join(package);
+        if candidate.is_dir() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+fn package_name_at(dir: &Path) -> Option<String> {
+    let manifest = std::fs::read_to_string(dir.join("package.json")).ok()?;
+    let package = serde_json::from_str::<Value>(&manifest).ok()?;
+    package.get("name")?.as_str().map(String::from)
+}
+
+fn collect_manifest_candidates(
+    package_json: &Value,
+    package_root: &Path,
+    subpath: Option<&str>,
+    candidates: &mut Vec<PathBuf>,
+) {
+    if let Some(exports) = package_json.get("exports") {
+        if let Some(subpath) = subpath {
+            collect_subpath_export_targets(exports, subpath, package_root, candidates);
+        } else if let Some(export) = exports.get(".").or(Some(exports)) {
+            collect_export_targets(export, package_root, None, candidates);
+        }
+        return;
+    }
+    if let Some(subpath) = subpath {
+        candidates.push(package_root.join(subpath));
+        return;
+    }
+    for field in ["types", "typings", "module", "main"] {
+        if let Some(target) = package_json.get(field).and_then(Value::as_str) {
+            candidates.push(package_root.join(target));
+        }
+    }
+    candidates.push(package_root.join("index"));
+}
+
+fn collect_subpath_export_targets(
+    exports: &Value,
+    subpath: &str,
+    root: &Path,
+    candidates: &mut Vec<PathBuf>,
+) {
+    collect_map_request_targets(exports, &cstr!("./{subpath}"), root, candidates);
+}
+
+fn collect_map_request_targets(
+    mappings: &Value,
+    request: &str,
+    root: &Path,
+    candidates: &mut Vec<PathBuf>,
+) {
+    let Some(mappings) = mappings.as_object() else {
+        return;
+    };
+    if let Some(value) = mappings.get(request) {
+        collect_export_targets(value, root, None, candidates);
+        return;
+    }
+    let best = mappings
+        .iter()
+        .filter_map(|(pattern, value)| {
+            let (prefix, suffix) = pattern.split_once('*')?;
+            let capture = request.strip_prefix(prefix)?.strip_suffix(suffix)?;
+            Some(((prefix.len(), suffix.len()), capture, value))
+        })
+        .max_by_key(|(specificity, _, _)| *specificity);
+    if let Some((_, capture, value)) = best {
+        collect_export_targets(value, root, Some(capture), candidates);
+    }
+}
+
+fn collect_export_targets(
+    value: &Value,
+    root: &Path,
+    wildcard: Option<&str>,
+    candidates: &mut Vec<PathBuf>,
+) {
+    match value {
+        Value::String(target) => {
+            let target = match wildcard {
+                Some(wildcard) => target.replace('*', wildcard),
+                None => target.clone(),
+            };
+            let Some(relative) = target.strip_prefix("./") else {
+                return;
+            };
+            let relative = Path::new(relative);
+            if relative.components().any(|component| {
+                matches!(
+                    component,
+                    std::path::Component::ParentDir
+                        | std::path::Component::RootDir
+                        | std::path::Component::Prefix(_)
+                )
+            }) {
+                return;
+            }
+            candidates.push(root.join(relative));
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_export_targets(value, root, wildcard, candidates);
+            }
+        }
+        Value::Object(_) => collect_condition_targets(value, root, wildcard, candidates),
+        _ => {}
+    }
+}
+
+fn collect_condition_targets(
+    value: &Value,
+    root: &Path,
+    wildcard: Option<&str>,
+    candidates: &mut Vec<PathBuf>,
+) {
+    let Some(conditions) = value.as_object() else {
+        return;
+    };
+    for condition in ["types", "import", "module", "default", "require"] {
+        if let Some(value) = conditions.get(condition) {
+            collect_export_targets(value, root, wildcard, candidates);
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "imports_packages_tests.rs"]
+mod tests;

--- a/crates/vize/src/commands/check/imports_packages_tests.rs
+++ b/crates/vize/src/commands/check/imports_packages_tests.rs
@@ -1,0 +1,85 @@
+use super::{
+    PackageImportResolver, PackageRequest, collect_export_targets, collect_map_request_targets,
+};
+use crate::commands::check::{imports::ImportFileOptions, path_cache::CanonicalPathCache};
+use serde_json::json;
+use std::path::Path;
+
+#[test]
+fn parses_scoped_and_unscoped_package_subpaths() {
+    let scoped = PackageRequest::parse("@scope/pkg/feature").unwrap();
+    assert_eq!(scoped.package, "@scope/pkg");
+    assert_eq!(scoped.subpath, Some("feature"));
+    let plain = PackageRequest::parse("pkg/feature").unwrap();
+    assert_eq!(plain.package, "pkg");
+    assert_eq!(plain.subpath, Some("feature"));
+}
+
+#[test]
+fn prefers_the_most_specific_export_pattern() {
+    let mappings = json!({
+        "./*": "./fallback/*.ts",
+        "./features/*": "./specific/*.ts"
+    });
+    let mut candidates = Vec::new();
+    collect_map_request_targets(
+        &mappings,
+        "./features/alpha",
+        Path::new("/pkg"),
+        &mut candidates,
+    );
+    assert_eq!(candidates, vec![Path::new("/pkg/specific/alpha.ts")]);
+}
+
+#[test]
+fn package_exports_do_not_leak_hidden_subpaths() {
+    let root = tempfile::tempdir().unwrap();
+    let package = root.path().join("package");
+    let source = package.join("src");
+    std::fs::create_dir_all(&source).unwrap();
+    std::fs::write(
+        package.join("package.json"),
+        r#"{"name":"@scope/pkg","exports":{".":"./src/index.ts"}}"#,
+    )
+    .unwrap();
+    std::fs::write(source.join("index.ts"), "export {}\n").unwrap();
+    std::fs::write(source.join("hidden.ts"), "export {}\n").unwrap();
+    let resolved = PackageImportResolver::default().resolve(
+        &source,
+        "@scope/pkg/hidden",
+        &mut CanonicalPathCache::default(),
+        ImportFileOptions::default(),
+    );
+    assert_eq!(resolved, None);
+}
+
+#[test]
+fn installed_dependencies_do_not_enter_the_authored_graph() {
+    let root = tempfile::tempdir().unwrap();
+    let source = root.path().join("src");
+    let package = root.path().join("node_modules/package");
+    std::fs::create_dir_all(&source).unwrap();
+    std::fs::create_dir_all(&package).unwrap();
+    std::fs::write(
+        package.join("package.json"),
+        r#"{"name":"package","exports":"./index.ts"}"#,
+    )
+    .unwrap();
+    std::fs::write(package.join("index.ts"), "export {}\n").unwrap();
+    let resolved = PackageImportResolver::default().resolve(
+        &source,
+        "package",
+        &mut CanonicalPathCache::default(),
+        ImportFileOptions::default(),
+    );
+    assert_eq!(resolved, None);
+}
+
+#[test]
+fn package_targets_cannot_escape_or_alias_the_package_root() {
+    for target in ["../outside.ts", "/outside.ts", "external-package"] {
+        let mut candidates = Vec::new();
+        collect_export_targets(&json!(target), Path::new("/pkg"), None, &mut candidates);
+        assert!(candidates.is_empty(), "accepted invalid target {target}");
+    }
+}

--- a/crates/vize/tests/check_default_imports_cli.rs
+++ b/crates/vize/tests/check_default_imports_cli.rs
@@ -4,6 +4,8 @@ mod aliased_diagnostics;
 mod base_url_diagnostics;
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;
+#[path = "check_default_imports_cli/workspace_package_diagnostics.rs"]
+mod workspace_package_diagnostics;
 
 use std::{path::Path, process::Command};
 

--- a/crates/vize/tests/check_default_imports_cli/workspace_package_diagnostics.rs
+++ b/crates/vize/tests/check_default_imports_cli/workspace_package_diagnostics.rs
@@ -1,0 +1,219 @@
+use super::*;
+
+#[derive(Clone, Copy)]
+enum PackageKind {
+    RootExport,
+    SubpathExport,
+    LegacyTypes,
+    JavaScript,
+    Transitive,
+    WildcardExport,
+    SelfReference,
+    ImportsMap,
+}
+
+impl PackageKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::RootExport => "root-export",
+            Self::SubpathExport => "subpath-export",
+            Self::LegacyTypes => "legacy-types",
+            Self::JavaScript => "javascript",
+            Self::Transitive => "transitive",
+            Self::WildcardExport => "wildcard-export",
+            Self::SelfReference => "self-reference",
+            Self::ImportsMap => "imports-map",
+        }
+    }
+}
+
+const KINDS: &[PackageKind] = &[
+    PackageKind::RootExport,
+    PackageKind::SubpathExport,
+    PackageKind::LegacyTypes,
+    PackageKind::JavaScript,
+    PackageKind::Transitive,
+    PackageKind::WildcardExport,
+    PackageKind::SelfReference,
+    PackageKind::ImportsMap,
+];
+
+#[test]
+fn default_check_reports_workspace_package_sources() {
+    for &kind in KINDS {
+        assert_workspace_source_is_reported(kind, false);
+    }
+}
+
+#[test]
+fn explicit_check_reports_workspace_package_sources() {
+    for &kind in KINDS {
+        assert_workspace_source_is_reported(kind, true);
+    }
+}
+
+fn assert_workspace_source_is_reported(kind: PackageKind, explicit: bool) {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
+        return;
+    };
+    let mode = if explicit { "explicit" } else { "default" };
+    let case_root = unique_case_dir(&format!("workspace-package-{}-{mode}", kind.name()));
+    let _ = std::fs::remove_dir_all(&case_root);
+    let app_root = case_root.join("app");
+    let package_root = case_root.join("packages/workspace-source");
+    std::fs::create_dir_all(app_root.join("src")).unwrap();
+    std::fs::create_dir_all(package_root.join("src")).unwrap();
+    let allow_js = matches!(kind, PackageKind::JavaScript);
+    std::fs::write(
+        app_root.join("tsconfig.json"),
+        format!(
+            r##"{{
+  "compilerOptions": {{
+    "allowJs": {allow_js},
+    "checkJs": {allow_js},
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  }},
+  "include": ["src/entry.ts"]
+}}"##
+        ),
+    )
+    .unwrap();
+    let entry = match kind {
+        PackageKind::SubpathExport => "@scope/workspace-source/feature",
+        PackageKind::WildcardExport => "@scope/workspace-source/features/alpha",
+        _ => "@scope/workspace-source",
+    };
+    std::fs::write(
+        app_root.join("src/entry.ts"),
+        format!("import '{entry}'\nexport const clean = true\n"),
+    )
+    .unwrap();
+    let exported_file = match kind {
+        PackageKind::SubpathExport => "src/feature.ts",
+        PackageKind::JavaScript => "src/index.js",
+        PackageKind::WildcardExport => "src/features/alpha.ts",
+        _ => "src/index.ts",
+    };
+    let package_json = if matches!(kind, PackageKind::LegacyTypes) {
+        r#"{
+  "name": "@scope/workspace-source",
+  "types": "./src/index.ts"
+}"#
+        .to_owned()
+    } else {
+        let target = format!("./{exported_file}");
+        format!(
+            r##"{{
+  "name": "@scope/workspace-source",
+  "exports": {{
+    ".": {{ "types": "{target}", "default": "{target}" }},
+    "./feature": {{ "types": "./src/feature.ts", "default": "./src/feature.ts" }},
+    "./features/*": {{ "types": "./src/features/*.ts", "default": "./src/features/*.ts" }},
+    "./internal": {{ "types": "./src/internal.ts", "default": "./src/internal.ts" }}
+  }},
+  "imports": {{
+    "#internal": {{ "types": "./src/internal.ts", "default": "./src/internal.ts" }}
+  }}
+}}"##
+        )
+    };
+    std::fs::write(package_root.join("package.json"), package_json).unwrap();
+    if matches!(kind, PackageKind::Transitive) {
+        std::fs::write(
+            package_root.join("src/index.ts"),
+            "import './invalid'\nexport const support = true\n",
+        )
+        .unwrap();
+    } else if matches!(kind, PackageKind::SelfReference) {
+        std::fs::write(
+            package_root.join("src/index.ts"),
+            "import '@scope/workspace-source/internal'\nexport const support = true\n",
+        )
+        .unwrap();
+    } else if matches!(kind, PackageKind::ImportsMap) {
+        std::fs::write(
+            package_root.join("src/index.ts"),
+            "import '#internal'\nexport const support = true\n",
+        )
+        .unwrap();
+    }
+    let invalid_path = match kind {
+        PackageKind::Transitive => package_root.join("src/invalid.ts"),
+        PackageKind::SelfReference | PackageKind::ImportsMap => {
+            package_root.join("src/internal.ts")
+        }
+        _ => package_root.join(exported_file),
+    };
+    let invalid_source = if allow_js {
+        "/** @type {string} */\nconst invalid = 42\nvoid invalid\n"
+    } else {
+        "const invalid: string = 42\nvoid invalid\n"
+    };
+    std::fs::create_dir_all(invalid_path.parent().unwrap()).unwrap();
+    std::fs::write(&invalid_path, invalid_source).unwrap();
+    link_workspace_package(
+        &package_root,
+        &app_root.join("node_modules/@scope/workspace-source"),
+    );
+
+    let mut args = vec!["check", "--format", "json"];
+    if explicit {
+        args.push("src/entry.ts");
+    }
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&app_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(args)
+        .output()
+        .unwrap();
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}/{mode}:\n{stdout}\n{stderr}",
+        kind.name()
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let expected_count = if matches!(
+        kind,
+        PackageKind::Transitive | PackageKind::SelfReference | PackageKind::ImportsMap
+    ) {
+        3
+    } else {
+        2
+    };
+    assert_eq!(json["fileCount"], expected_count, "{stdout}\n{stderr}");
+    assert_eq!(json["errorCount"], 1, "{stdout}\n{stderr}");
+    let invalid_display = invalid_path.to_string_lossy();
+    let invalid = json["files"]
+        .as_array()
+        .and_then(|files| {
+            files
+                .iter()
+                .find(|file| file["file"] == invalid_display.as_ref())
+        })
+        .unwrap_or_else(|| panic!("missing {invalid_display}:\n{stdout}\n{stderr}"));
+    assert!(
+        invalid["diagnostics"]
+            .as_array()
+            .is_some_and(|diagnostics| diagnostics.iter().any(|diagnostic| diagnostic
+                .as_str()
+                .is_some_and(|diagnostic| diagnostic.contains("TS2322")))),
+        "{stdout}\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(case_root);
+}
+
+fn link_workspace_package(source: &Path, target: &Path) {
+    std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, target).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, target).unwrap();
+}

--- a/crates/vize/tests/check_hoisted_workspace_cli.rs
+++ b/crates/vize/tests/check_hoisted_workspace_cli.rs
@@ -70,7 +70,7 @@ fn check_resolves_hoisted_workspace_package_with_explicit_types() {
     write_file(
         &workspace,
         "packages/lib/src/index.ts",
-        "export const answer: number = 42;\n",
+        "export const answer: number = 'forty-two';\n",
     );
     write_file(
         &workspace,
@@ -140,14 +140,29 @@ fn check_resolves_hoisted_workspace_package_with_explicit_types() {
 
     let stdout = std::string::String::from_utf8(output.stdout).unwrap();
     let stderr = std::string::String::from_utf8(output.stderr).unwrap();
-    assert!(
-        output.status.success(),
-        "hoisted workspace check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
-    );
+    assert_eq!(output.status.code(), Some(1), "{stdout}\n{stderr}");
     let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    assert_eq!(json["errorCount"], 0, "{stdout}\n{stderr}");
+    assert_eq!(json["errorCount"], 1, "{stdout}\n{stderr}");
     assert_eq!(json["warningCount"], 0, "{stdout}\n{stderr}");
-    assert_eq!(json["fileCount"], 1, "{stdout}\n{stderr}");
+    assert_eq!(json["fileCount"], 2, "{stdout}\n{stderr}");
+    let package_source = workspace.join("packages/lib/src/index.ts");
+    let package_source = package_source.to_string_lossy();
+    let imported = json["files"]
+        .as_array()
+        .and_then(|files| {
+            files
+                .iter()
+                .find(|file| file["file"] == package_source.as_ref())
+        })
+        .expect("workspace package source result");
+    assert!(
+        imported["diagnostics"]
+            .as_array()
+            .is_some_and(|diagnostics| diagnostics.iter().any(|diagnostic| diagnostic
+                .as_str()
+                .is_some_and(|diagnostic| diagnostic.contains("TS2322")))),
+        "{stdout}\n{stderr}"
+    );
     assert!(
         !stdout.contains("Cannot find module '@repro/lib'"),
         "workspace package should resolve through app/node_modules:\n{stdout}\n{stderr}"


### PR DESCRIPTION
## Summary
- resolve authored TS/JS sources exposed by symlinked workspace packages
- support root, subpath, wildcard, legacy types, self-reference, and relative package imports mappings
- keep installed dependencies outside the authored diagnostic graph and cache package resolutions per run
- report external workspace diagnostics in both default and explicit check modes

## Validation
- `VIZE_REQUIRE_CORSA=1 cargo test -p vize --tests --quiet`
- `cargo test -p vize_canon --quiet`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy -p vize --lib --all-features -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- source-length and fail-closed typecheck dependency gates

Tracks #3984. External workspace package `.vue` exports remain isolated in #4000.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->