### PR TITLE
fix(check): typecheck workspace package vue exports

### DIFF
--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -44,7 +44,7 @@ pub(super) fn collect_transitive_local_imports(
     let mut registered: FxHashSet<PathBuf> = FxHashSet::default();
     let mut registration_cache: FxHashMap<PathBuf, bool> = FxHashMap::default();
     let mut packages = PackageImportResolver::default();
-    let mut queue: Vec<(PathBuf, bool)> = Vec::new();
+    let mut queue: Vec<(PathBuf, bool, bool)> = Vec::new();
 
     // Seed the visited set with the roots so they are never re-registered.
     for root in roots {
@@ -52,14 +52,15 @@ pub(super) fn collect_transitive_local_imports(
             && visited.insert(absolute.clone())
         {
             registered.insert(absolute.clone());
-            queue.push((absolute, true));
+            queue.push((absolute, true, false));
         }
     }
 
     let mut registrations: Vec<PathBuf> = Vec::new();
     let mut authored: Vec<PathBuf> = Vec::new();
+    let mut virtual_module_aliases: FxHashSet<(String, PathBuf)> = FxHashSet::default();
 
-    while let Some((file, materialized_parent)) = queue.pop() {
+    while let Some((file, materialized_parent, package_graph)) = queue.pop() {
         let Some(dir) = file.parent() else {
             continue;
         };
@@ -72,16 +73,23 @@ pub(super) fn collect_transitive_local_imports(
         for specifier in extract_import_specifiers(&source) {
             let relative_specifier = is_relative_specifier(&specifier);
             let absolute_specifier = Path::new(specifier.as_str()).is_absolute();
+            let mut package_resolution = false;
             let resolved = if relative_specifier {
                 resolve_relative_import(dir, &specifier, canonical_paths, options)
             } else if absolute_specifier {
                 resolve_import_base(Path::new(specifier.as_str()), canonical_paths, options)
             } else {
-                aliases
-                    .and_then(|aliases| {
-                        aliases.resolve(&specifier, canonical_paths, options, resolve_import_base)
-                    })
-                    .or_else(|| packages.resolve(dir, &specifier, canonical_paths, options))
+                let aliased = aliases.and_then(|aliases| {
+                    aliases.resolve(&specifier, canonical_paths, options, resolve_import_base)
+                });
+                match aliased {
+                    Some(resolved) => Some(resolved),
+                    None => {
+                        let resolved = packages.resolve(dir, &specifier, canonical_paths, options);
+                        package_resolution = resolved.is_some();
+                        resolved
+                    }
+                }
             };
             let Some(resolved) = resolved else {
                 continue;
@@ -102,23 +110,34 @@ pub(super) fn collect_transitive_local_imports(
                     &mut registration_cache,
                 )
             };
+            let in_package_graph = package_graph || package_resolution;
+            if package_resolution && needs_registration {
+                virtual_module_aliases.insert((specifier.clone(), resolved.clone()));
+            }
             let first_visit = visited.insert(resolved.clone());
             let first_registration = needs_registration && registered.insert(resolved.clone());
             if first_visit {
                 authored.push(resolved.clone());
             }
-            if first_registration {
+            // A bare package route is registered by Canon after the project
+            // root is fixed. Adding it (or its relative descendants) to the
+            // user's roots here would widen the project to the workspace and
+            // defeat the external mirror.
+            if first_registration && !in_package_graph {
                 registrations.push(resolved.clone());
             }
             if first_visit || first_registration {
-                queue.push((resolved, needs_registration));
+                queue.push((resolved, needs_registration, in_package_graph));
             }
         }
     }
 
+    let mut virtual_module_aliases = virtual_module_aliases.into_iter().collect::<Vec<_>>();
+    virtual_module_aliases.sort();
     TransitiveLocalImports {
         registrations,
         authored,
+        virtual_module_aliases,
     }
 }
 

--- a/crates/vize/src/commands/check/imports_options.rs
+++ b/crates/vize/src/commands/check/imports_options.rs
@@ -43,6 +43,11 @@ impl ImportFileOptions {
 pub(in crate::commands::check) struct TransitiveLocalImports {
     pub(in crate::commands::check) registrations: Vec<PathBuf>,
     pub(in crate::commands::check) authored: Vec<PathBuf>,
+    /// Bare workspace-package specifiers whose source target must resolve to
+    /// Vize's virtual mirror instead of the package manifest's real `.vue`.
+    /// Keeping the original specifier in authored code lets declaration emit
+    /// preserve package identity.
+    pub(in crate::commands::check) virtual_module_aliases: Vec<(vize_carton::String, PathBuf)>,
 }
 
 impl From<bool> for ImportFileOptions {

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -76,8 +76,16 @@ struct ProgramCandidate {
     files: Vec<PathBuf>,
     inputs: Vec<PathBuf>,
     reported: FxHashSet<PathBuf>,
+    virtual_module_aliases: Vec<(vize_carton::String, PathBuf)>,
     tsconfig_path: Option<PathBuf>,
     rebuild_supporting_files: bool,
+}
+
+struct CollectedRoots {
+    files: Vec<PathBuf>,
+    inputs: Vec<PathBuf>,
+    reported: FxHashSet<PathBuf>,
+    virtual_module_aliases: Vec<(vize_carton::String, PathBuf)>,
 }
 
 /// Run type checking directly with materialized Corsa projects.
@@ -152,7 +160,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let mut canonical_paths = CanonicalPathCache::default();
     let check_ignore_set = load_check_ignore_set(args, config_dir);
     let collect_start = Instant::now();
-    let (files, inputs, reported) = collect_roots(
+    let collected = collect_roots(
         args,
         &invocation_project_root,
         &cwd,
@@ -163,15 +171,13 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         check_ignore_set.as_ref(),
     );
     let collect_time = collect_start.elapsed();
-    if files.is_empty() {
+    if collected.files.is_empty() {
         report_no_inputs(args);
         return;
     }
 
     let candidates = split_program_candidates(
-        files,
-        inputs,
-        reported,
+        collected,
         invocation_tsconfig_path.as_deref(),
         jsx_typecheck,
         &mut tsconfig_input_cache,
@@ -236,14 +242,14 @@ fn collect_roots(
     cache: &mut TsconfigInputCache,
     canonical_paths: &mut CanonicalPathCache,
     check_ignore_set: Option<&ignores::CheckIgnoreSet>,
-) -> (Vec<PathBuf>, Vec<PathBuf>, FxHashSet<PathBuf>) {
+) -> CollectedRoots {
     let include_js = project_graph_allows_js(invocation_tsconfig_path, cache);
     let import_options = ImportFileOptions {
         include_js,
         include_jsx: jsx_typecheck,
     };
     if args.patterns.is_empty() {
-        let (files, inputs, reported) = collect_default_run_files(
+        let collected = collect_default_run_files(
             invocation_project_root,
             cwd,
             invocation_tsconfig_path,
@@ -253,13 +259,13 @@ fn collect_roots(
             check_ignore_set,
         );
         exit_if_default_run_leaves_cwd(
-            &files,
+            &collected.files,
             cwd,
             invocation_project_root,
             invocation_tsconfig_path,
             args.quiet,
         );
-        return (files, inputs, reported);
+        return collected;
     }
 
     let files = collect_check_files_with_ignores(
@@ -271,18 +277,27 @@ fn collect_roots(
         check_ignore_set,
     );
     let reported = canonical_file_set(&files, canonical_paths);
-    (files.clone(), files, reported)
+    CollectedRoots {
+        files: files.clone(),
+        inputs: files,
+        reported,
+        virtual_module_aliases: Vec::new(),
+    }
 }
 
 fn split_program_candidates(
-    files: Vec<PathBuf>,
-    inputs: Vec<PathBuf>,
-    reported: FxHashSet<PathBuf>,
+    collected: CollectedRoots,
     tsconfig_path: Option<&Path>,
     include_jsx: bool,
     cache: &mut TsconfigInputCache,
     canonical_paths: &mut CanonicalPathCache,
 ) -> Vec<ProgramCandidate> {
+    let CollectedRoots {
+        files,
+        inputs,
+        reported,
+        virtual_module_aliases,
+    } = collected;
     let groups = resolve_tsconfig_program_inputs(tsconfig_path, &inputs, include_jsx, cache);
     let single_group_uses_invocation_config = groups.first().is_none_or(|group| {
         tsconfig_path.is_none_or(|path| {
@@ -294,6 +309,7 @@ fn split_program_candidates(
             files,
             inputs,
             reported,
+            virtual_module_aliases,
             tsconfig_path: groups
                 .first()
                 .map(|group| group.tsconfig_path.clone())
@@ -302,6 +318,9 @@ fn split_program_candidates(
         }];
     }
 
+    // Each referenced program rebuilds its own reachable graph below; routes
+    // collected from the solution shell must not leak across program scopes.
+    drop(virtual_module_aliases);
     groups
         .into_iter()
         .map(|group| {
@@ -310,6 +329,7 @@ fn split_program_candidates(
                 inputs: group.files.clone(),
                 files: group.files,
                 reported,
+                virtual_module_aliases: Vec::new(),
                 tsconfig_path: Some(group.tsconfig_path),
                 rebuild_supporting_files: true,
             }
@@ -351,8 +371,9 @@ fn prepare_and_execute(
         include_jsx: jsx_typecheck,
     };
     let mut authored_imports = Vec::new();
+    let mut virtual_module_aliases = std::mem::take(&mut candidate.virtual_module_aliases);
     if !args.patterns.is_empty() || candidate.rebuild_supporting_files {
-        authored_imports = register_transitive_local_imports(
+        let discovered = register_transitive_local_imports(
             &mut candidate.files,
             cwd,
             candidate.tsconfig_path.as_deref(),
@@ -361,6 +382,8 @@ fn prepare_and_execute(
             Some(explicit_input_root),
             validate_inputs,
         );
+        authored_imports = discovered.authored;
+        virtual_module_aliases.extend(discovered.virtual_module_aliases);
     }
     if args.patterns.is_empty() && candidate.rebuild_supporting_files {
         register_ambient_declaration_files(
@@ -369,7 +392,7 @@ fn prepare_and_execute(
             candidate.tsconfig_path.as_deref(),
             cache,
         );
-        let _ = register_transitive_local_imports(
+        let discovered = register_transitive_local_imports(
             &mut candidate.files,
             cwd,
             candidate.tsconfig_path.as_deref(),
@@ -378,6 +401,7 @@ fn prepare_and_execute(
             Some(explicit_input_root),
             validate_inputs,
         );
+        virtual_module_aliases.extend(discovered.virtual_module_aliases);
     }
     exit_if_inputs_outside_root(explicit_input_root, &candidate.files, validate_inputs);
 
@@ -429,10 +453,13 @@ fn prepare_and_execute(
         return None;
     }
 
+    virtual_module_aliases.sort();
+    virtual_module_aliases.dedup();
     Some(execute_program(
         ProgramExecutionInput {
             files: &candidate.files,
             reported_files: candidate.reported,
+            virtual_module_aliases: &virtual_module_aliases,
             project_root: &project_root,
             program_root: logical_program_root,
             tsconfig_path: program_tsconfig_path,

--- a/crates/vize/src/commands/check/runner/default_imports.rs
+++ b/crates/vize/src/commands/check/runner/default_imports.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use vize_carton::FxHashSet;
 
 use super::{
+    CollectedRoots,
     collect::path_is_inside_root,
     ignores::{CheckIgnoreSet, retain_unignored},
 };
@@ -22,6 +23,11 @@ pub(super) struct ExplicitAmbientImportContext<'a> {
     tsconfig_path: &'a Path,
     explicit_input_root: &'a Path,
     import_options: ImportFileOptions,
+}
+
+pub(super) struct RegisteredLocalImports {
+    pub(super) authored: Vec<PathBuf>,
+    pub(super) virtual_module_aliases: Vec<(vize_carton::String, PathBuf)>,
 }
 
 impl<'a> ExplicitAmbientImportContext<'a> {
@@ -50,7 +56,7 @@ pub(super) fn collect_default_run_files(
     tsconfig_input_cache: &mut TsconfigInputCache,
     canonical_paths: &mut CanonicalPathCache,
     check_ignore_set: Option<&CheckIgnoreSet>,
-) -> (Vec<PathBuf>, Vec<PathBuf>, FxHashSet<PathBuf>) {
+) -> CollectedRoots {
     let mut files = collect_default_check_files(
         project_root,
         tsconfig_path,
@@ -60,7 +66,7 @@ pub(super) fn collect_default_run_files(
     retain_unignored(&mut files, check_ignore_set);
     let inputs = files.clone();
     let mut reported_files = canonical_file_set(&files, canonical_paths);
-    let authored_imports = register_transitive_local_imports(
+    let discovered = register_transitive_local_imports(
         &mut files,
         cwd,
         tsconfig_path,
@@ -69,7 +75,8 @@ pub(super) fn collect_default_run_files(
         None,
         false,
     );
-    reported_files.extend(canonical_file_set(&authored_imports, canonical_paths));
+    reported_files.extend(canonical_file_set(&discovered.authored, canonical_paths));
+    let mut virtual_module_aliases = discovered.virtual_module_aliases;
     register_ambient_declaration_files(
         &mut files,
         project_root,
@@ -78,7 +85,7 @@ pub(super) fn collect_default_run_files(
     );
     // Imports reached only through hidden ambient declarations provide type
     // context, but are not authored members of the checked program.
-    let _ = register_transitive_local_imports(
+    let hidden_discovered = register_transitive_local_imports(
         &mut files,
         cwd,
         tsconfig_path,
@@ -87,8 +94,16 @@ pub(super) fn collect_default_run_files(
         None,
         false,
     );
+    virtual_module_aliases.extend(hidden_discovered.virtual_module_aliases);
+    virtual_module_aliases.sort();
+    virtual_module_aliases.dedup();
 
-    (files, inputs, reported_files)
+    CollectedRoots {
+        files,
+        inputs,
+        reported: reported_files,
+        virtual_module_aliases,
+    }
 }
 
 pub(super) fn register_ambient_declaration_files(
@@ -154,20 +169,22 @@ pub(super) fn register_transitive_local_imports(
     canonical_paths: &mut CanonicalPathCache,
     explicit_input_root: Option<&Path>,
     validate_inputs: bool,
-) -> Vec<PathBuf> {
+) -> RegisteredLocalImports {
     let discovered =
         collect_local_imports(files, cwd, tsconfig_path, import_options, canonical_paths);
     // The explicit-root boundary constrains user-selected roots and files that
     // enter Vize's mirror. It must not hide authored modules that TypeScript
     // legitimately resolves in place outside that boundary.
-    let authored = discovered.authored;
-    append_local_imports(
-        files,
-        discovered.registrations,
-        explicit_input_root,
-        validate_inputs,
-    );
-    authored
+    let TransitiveLocalImports {
+        registrations,
+        authored,
+        virtual_module_aliases,
+    } = discovered;
+    append_local_imports(files, registrations, explicit_input_root, validate_inputs);
+    RegisteredLocalImports {
+        authored,
+        virtual_module_aliases,
+    }
 }
 
 pub(super) fn collect_transitive_local_imports_from(

--- a/crates/vize/src/commands/check/runner/default_imports_tests.rs
+++ b/crates/vize/src/commands/check/runner/default_imports_tests.rs
@@ -50,7 +50,7 @@ export const r = ITEMS.map(({ code, name }) => `${code}:${name}`)
 
     let mut tsconfig_input_cache = super::TsconfigInputCache::default();
     let mut canonical_paths = super::CanonicalPathCache::default();
-    let (files, inputs, reported_files) = super::collect_default_run_files(
+    let collected = super::collect_default_run_files(
         &project_root,
         &project_root,
         Some(&project_root.join("tsconfig.json")),
@@ -59,6 +59,10 @@ export const r = ITEMS.map(({ code, name }) => `${code}:${name}`)
         &mut canonical_paths,
         None,
     );
+    let files = collected.files;
+    let inputs = collected.inputs;
+    let reported_files = collected.reported;
+    let virtual_module_aliases = collected.virtual_module_aliases;
 
     let included_file = canonicalize_non_verbatim(&project_root.join("inside/use.ts"));
     let transitive_file = canonicalize_non_verbatim(&project_root.join("outside/lib.ts"));
@@ -72,6 +76,7 @@ export const r = ITEMS.map(({ code, name }) => `${code}:${name}`)
         reported_files.contains(&transitive_file),
         "authored imports outside include remain part of the checked program"
     );
+    assert!(virtual_module_aliases.is_empty());
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
@@ -114,7 +119,7 @@ fn default_tsconfig_run_registers_hidden_ambient_declarations_for_type_resolutio
 
     let mut tsconfig_input_cache = super::TsconfigInputCache::default();
     let mut canonical_paths = super::CanonicalPathCache::default();
-    let (files, inputs, reported_files) = super::collect_default_run_files(
+    let collected = super::collect_default_run_files(
         &project_root,
         &project_root,
         Some(&project_root.join("tsconfig.json")),
@@ -123,6 +128,10 @@ fn default_tsconfig_run_registers_hidden_ambient_declarations_for_type_resolutio
         &mut canonical_paths,
         None,
     );
+    let files = collected.files;
+    let inputs = collected.inputs;
+    let reported_files = collected.reported;
+    let virtual_module_aliases = collected.virtual_module_aliases;
 
     let app_file = canonicalize_non_verbatim(&project_root.join("app/plugins/auth.ts"));
     let ambient_file =
@@ -137,6 +146,7 @@ fn default_tsconfig_run_registers_hidden_ambient_declarations_for_type_resolutio
         !reported_files.contains(&ambient_file),
         "hidden ambient declarations are registered for types, not reported"
     );
+    assert!(virtual_module_aliases.is_empty());
 
     let _ = std::fs::remove_dir_all(&project_root);
 }

--- a/crates/vize/src/commands/check/runner/execution.rs
+++ b/crates/vize/src/commands/check/runner/execution.rs
@@ -41,6 +41,7 @@ pub(super) struct ProgramExecution {
 pub(super) struct ProgramExecutionInput<'a> {
     pub(super) files: &'a [PathBuf],
     pub(super) reported_files: FxHashSet<PathBuf>,
+    pub(super) virtual_module_aliases: &'a [(vize_carton::String, PathBuf)],
     pub(super) project_root: &'a std::path::Path,
     pub(super) program_root: PathBuf,
     pub(super) tsconfig_path: Option<PathBuf>,
@@ -119,6 +120,7 @@ pub(super) fn execute_program(
         settings.check_template_bindings,
         settings.check_emits,
     );
+    checker.set_virtual_module_aliases(input.virtual_module_aliases.iter().cloned());
     checker.scan_paths(input.files).unwrap_or_else(|error| {
         eprintln!("\x1b[31mError:\x1b[0m {}", error);
         std::process::exit(1);

--- a/crates/vize/tests/check_default_imports_cli.rs
+++ b/crates/vize/tests/check_default_imports_cli.rs
@@ -6,6 +6,8 @@ mod base_url_diagnostics;
 mod corsa_requirement;
 #[path = "check_default_imports_cli/workspace_package_diagnostics.rs"]
 mod workspace_package_diagnostics;
+#[path = "check_default_imports_cli/workspace_package_vue_exports.rs"]
+mod workspace_package_vue_exports;
 
 use std::{path::Path, process::Command};
 

--- a/crates/vize/tests/check_default_imports_cli/workspace_package_vue_exports.rs
+++ b/crates/vize/tests/check_default_imports_cli/workspace_package_vue_exports.rs
@@ -1,0 +1,292 @@
+use super::*;
+
+#[derive(Clone, Copy)]
+enum VueExportKind {
+    Root,
+    Barrel,
+    Subpath,
+    Wildcard,
+    SelfReference,
+    ImportsMap,
+}
+
+impl VueExportKind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Root => "root",
+            Self::Barrel => "barrel",
+            Self::Subpath => "subpath",
+            Self::Wildcard => "wildcard",
+            Self::SelfReference => "self-reference",
+            Self::ImportsMap => "imports-map",
+        }
+    }
+
+    fn entry_specifier(self) -> &'static str {
+        match self {
+            Self::Subpath => "@scope/workspace-vue/feature",
+            Self::Barrel => "@scope/workspace-vue/barrel",
+            Self::Wildcard => "@scope/workspace-vue/features/alpha",
+            Self::Root | Self::SelfReference | Self::ImportsMap => "@scope/workspace-vue",
+        }
+    }
+
+    fn entry_file(self) -> &'static str {
+        match self {
+            Self::Wildcard => "src/entry.tsx",
+            Self::Root | Self::Barrel | Self::Subpath | Self::SelfReference | Self::ImportsMap => {
+                "src/entry.ts"
+            }
+        }
+    }
+
+    fn diagnosed_file(self) -> &'static str {
+        match self {
+            Self::Barrel | Self::Subpath | Self::SelfReference | Self::ImportsMap => {
+                "src/Feature.vue"
+            }
+            Self::Wildcard => "src/features/alpha.vue",
+            Self::Root => "src/Root.vue",
+        }
+    }
+
+    fn expected_file_count(self) -> u64 {
+        match self {
+            Self::Barrel | Self::SelfReference | Self::ImportsMap => 3,
+            Self::Root | Self::Subpath | Self::Wildcard => 2,
+        }
+    }
+}
+
+const KINDS: &[VueExportKind] = &[
+    VueExportKind::Root,
+    VueExportKind::Barrel,
+    VueExportKind::Subpath,
+    VueExportKind::Wildcard,
+    VueExportKind::SelfReference,
+    VueExportKind::ImportsMap,
+];
+
+#[test]
+fn default_check_typechecks_workspace_package_vue_exports() {
+    for &kind in KINDS {
+        assert_workspace_vue_export_is_typechecked(kind, false);
+    }
+}
+
+#[test]
+fn explicit_check_typechecks_workspace_package_vue_exports() {
+    for &kind in KINDS {
+        assert_workspace_vue_export_is_typechecked(kind, true);
+    }
+}
+
+fn assert_workspace_vue_export_is_typechecked(kind: VueExportKind, explicit: bool) {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
+        return;
+    };
+    let mode = if explicit { "explicit" } else { "default" };
+    let case_name = cstr!("workspace-vue-{}-{mode}", kind.name());
+    let case_root = unique_case_dir(case_name.as_str());
+    let _ = std::fs::remove_dir_all(&case_root);
+    let app_root = case_root.join("app");
+    let package_root = case_root.join("packages/workspace-vue");
+    std::fs::create_dir_all(app_root.join("src")).unwrap();
+    std::fs::create_dir_all(package_root.join("src/features")).unwrap();
+
+    std::fs::write(
+        app_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/entry.ts", "src/entry.tsx"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        app_root.join(kind.entry_file()),
+        cstr!(
+            r#"import Widget from '{}'
+
+type IsAny<T> = 0 extends 1 & T ? true : false
+const componentMustBeTyped: IsAny<typeof Widget> = false
+const props: InstanceType<typeof Widget>['$props'] = {{ count: 1 }}
+void componentMustBeTyped
+void props
+"#,
+            kind.entry_specifier()
+        )
+        .as_str(),
+    )
+    .unwrap();
+    std::fs::write(
+        package_root.join("package.json"),
+        r##"{
+  "name": "@scope/workspace-vue",
+  "exports": {
+    ".": { "types": "./src/Root.vue", "default": "./src/Root.vue" },
+    "./barrel": { "types": "./src/index.ts", "default": "./src/index.ts" },
+    "./feature": { "types": "./src/Feature.vue", "default": "./src/Feature.vue" },
+    "./features/*": { "types": "./src/features/*.vue", "default": "./src/features/*.vue" }
+  },
+  "imports": {
+    "#feature": { "types": "./src/Feature.vue", "default": "./src/Feature.vue" }
+  }
+}"##,
+    )
+    .unwrap();
+
+    let root_source = match kind {
+        VueExportKind::SelfReference => {
+            component_source(Some("@scope/workspace-vue/feature"), false)
+        }
+        VueExportKind::ImportsMap => component_source(Some("#feature"), false),
+        VueExportKind::Root => component_source(None, true),
+        VueExportKind::Barrel | VueExportKind::Subpath | VueExportKind::Wildcard => {
+            component_source(None, false)
+        }
+    };
+    std::fs::write(package_root.join("src/Root.vue"), root_source).unwrap();
+    std::fs::write(
+        package_root.join("src/index.ts"),
+        "export { default } from './Feature.vue'\n",
+    )
+    .unwrap();
+    std::fs::write(
+        package_root.join("src/Feature.vue"),
+        component_source(
+            None,
+            matches!(
+                kind,
+                VueExportKind::Barrel
+                    | VueExportKind::Subpath
+                    | VueExportKind::SelfReference
+                    | VueExportKind::ImportsMap
+            ),
+        ),
+    )
+    .unwrap();
+    std::fs::write(
+        package_root.join("src/features/alpha.vue"),
+        component_source(None, matches!(kind, VueExportKind::Wildcard)),
+    )
+    .unwrap();
+    link_workspace_vue_package(
+        &package_root,
+        &app_root.join("node_modules/@scope/workspace-vue"),
+    );
+
+    let mut args = vec!["check", "--format", "json"];
+    if explicit {
+        args.push(kind.entry_file());
+    }
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&app_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(args)
+        .output()
+        .unwrap();
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "{}/{mode}:\n{stdout}\n{stderr}",
+        kind.name()
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        json["fileCount"].as_u64(),
+        Some(kind.expected_file_count()),
+        "{}/{mode}:\n{stdout}\n{stderr}",
+        kind.name()
+    );
+    assert_eq!(json["errorCount"], 2, "{stdout}\n{stderr}");
+
+    let entry = file_result(&json, &app_root.join(kind.entry_file()), &stdout, &stderr);
+    assert_eq!(
+        entry["diagnostics"],
+        serde_json::json!([]),
+        "the package import must resolve to a typed component:\n{stdout}\n{stderr}"
+    );
+
+    let diagnosed_path = package_root.join(kind.diagnosed_file());
+    let diagnosed = file_result(&json, &diagnosed_path, &stdout, &stderr);
+    let diagnostics = diagnosed["diagnostics"].as_array().unwrap();
+    assert!(
+        diagnostics.iter().any(|diagnostic| diagnostic
+            .as_str()
+            .is_some_and(|message| message.contains("error:3:7 [TS2322]"))),
+        "script diagnostic must map to the original SFC:\n{stdout}\n{stderr}"
+    );
+    assert!(
+        diagnostics.iter().any(|diagnostic| diagnostic
+            .as_str()
+            .is_some_and(|message| message.contains("error:6:")
+                && message.contains("[TS2339]")
+                && message.contains("toUpperCase"))),
+        "template diagnostic must map to the original SFC:\n{stdout}\n{stderr}"
+    );
+    assert!(
+        all_diagnostics(&json)
+            .all(|message| !message.contains("TS2307") && !message.contains("TS2882")),
+        "workspace package .vue exports must not produce module-resolution errors:\n{stdout}\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(case_root);
+}
+
+fn component_source(import: Option<&str>, invalid: bool) -> vize_carton::String {
+    let import = import
+        .map(|specifier| cstr!("import Nested from '{specifier}'\nvoid Nested\n"))
+        .unwrap_or_default();
+    let invalid = if invalid {
+        "const invalid: string = 42\nconst templateValue = 1\n"
+    } else {
+        "const invalid: string = 'valid'\nconst templateValue = 'valid'\n"
+    };
+    cstr!(
+        "<script setup lang=\"ts\">\ndefineProps<{{ count: number }}>()\n{invalid}{import}</script>\n<template>{{{{ templateValue.toUpperCase() }}}}</template>\n"
+    )
+}
+
+fn file_result<'a>(
+    json: &'a serde_json::Value,
+    path: &Path,
+    stdout: &str,
+    stderr: &str,
+) -> &'a serde_json::Value {
+    let path = canonicalize_non_verbatim(path).display().to_string();
+    json["files"]
+        .as_array()
+        .and_then(|files| {
+            files.iter().find(|file| {
+                file["file"].as_str().is_some_and(|reported| {
+                    reported == path || Path::new(path.as_str()).ends_with(reported)
+                })
+            })
+        })
+        .unwrap_or_else(|| panic!("missing {path}:\n{stdout}\n{stderr}"))
+}
+
+fn all_diagnostics(json: &serde_json::Value) -> impl Iterator<Item = &str> {
+    json["files"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .flat_map(|file| file["diagnostics"].as_array().into_iter().flatten())
+        .filter_map(serde_json::Value::as_str)
+}
+
+fn link_workspace_vue_package(source: &Path, target: &Path) {
+    std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, target).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, target).unwrap();
+}

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -192,6 +192,16 @@ impl BatchTypeChecker {
             });
     }
 
+    /// Route exact bare workspace-package specifiers to registered source
+    /// modules in the virtual mirror. Authored imports keep their package
+    /// spelling, so declaration emit does not expose internal mirror paths.
+    pub fn set_virtual_module_aliases(
+        &mut self,
+        aliases: impl IntoIterator<Item = (String, PathBuf)>,
+    ) {
+        self.project.set_virtual_module_aliases(aliases);
+    }
+
     /// Configure template syntax compatibility for Vue template parsing.
     pub fn set_template_syntax(&mut self, template_syntax: vize_atelier_core::TemplateSyntaxMode) {
         self.project.set_template_syntax(template_syntax);
@@ -220,6 +230,7 @@ impl BatchTypeChecker {
     /// the batch checker.
     pub fn scan_paths(&mut self, paths: &[PathBuf]) -> CorsaResult<()> {
         self.project.register_paths(paths)?;
+        self.project.register_virtual_module_alias_targets()?;
         // Out-of-root workspace files reachable through imports register too,
         // so their consumers keep real types instead of the ambient stub
         // (#3887).
@@ -233,6 +244,7 @@ impl BatchTypeChecker {
     pub fn scan_project(&mut self) -> CorsaResult<()> {
         let paths = collect_project_paths(self.project.project_root())?;
         self.project.register_paths(&paths)?;
+        self.project.register_virtual_module_alias_targets()?;
         // Same reachability pass as `scan_paths`: imports that leave the
         // project root register instead of falling back to the stub (#3887).
         self.project.register_reachable_dependencies()?;

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -125,6 +125,11 @@ pub struct VirtualProject {
     /// Internal check generation settings applied to every Vue file.
     virtual_ts_check_options: VirtualTsCheckOptions,
 
+    /// Exact bare specifiers that TypeScript must route to registered virtual
+    /// modules. Values are source paths; tsconfig generation translates them
+    /// to their materialized counterparts after registration.
+    virtual_module_aliases: FxHashMap<CompactString, Vec<PathBuf>>,
+
     /// Enable Vue 2.7 / Nuxt 2 Options API compatibility for virtual files.
     options_api: bool,
 

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -46,6 +46,7 @@ impl VirtualProject {
             virtual_ts_options: VirtualTsOptions::default(),
             diagnostic_paths: FxHashSet::default(),
             virtual_ts_check_options: VirtualTsCheckOptions::default(),
+            virtual_module_aliases: FxHashMap::default(),
             options_api: false,
             session_scripts: false,
             legacy_vue2: false,
@@ -76,6 +77,7 @@ impl VirtualProject {
         project.virtual_ts_options = self.virtual_ts_options.clone();
         project.diagnostic_paths = self.diagnostic_paths.clone();
         project.virtual_ts_check_options = self.virtual_ts_check_options;
+        project.virtual_module_aliases = self.virtual_module_aliases.clone();
         project.options_api = self.options_api;
         project.legacy_vue2 = self.legacy_vue2;
         project.jsx_typecheck = self.jsx_typecheck;
@@ -106,6 +108,35 @@ impl VirtualProject {
 
     pub(crate) fn set_virtual_ts_check_options(&mut self, options: VirtualTsCheckOptions) {
         self.virtual_ts_check_options = options;
+    }
+
+    pub(crate) fn set_virtual_module_aliases(
+        &mut self,
+        aliases: impl IntoIterator<Item = (vize_carton::String, PathBuf)>,
+    ) {
+        self.virtual_module_aliases.clear();
+        for (specifier, source_path) in aliases {
+            let source_path = vize_carton::path::canonicalize_non_verbatim(&source_path);
+            let targets = self.virtual_module_aliases.entry(specifier).or_default();
+            if !targets.contains(&source_path) {
+                targets.push(source_path);
+            }
+        }
+        for targets in self.virtual_module_aliases.values_mut() {
+            targets.sort();
+        }
+    }
+
+    pub(crate) fn register_virtual_module_alias_targets(&mut self) -> CorsaResult<()> {
+        let mut targets: Vec<PathBuf> = self
+            .virtual_module_aliases
+            .values()
+            .flatten()
+            .cloned()
+            .collect();
+        targets.sort();
+        targets.dedup();
+        self.register_paths(&targets)
     }
 
     pub(crate) fn set_options_api(&mut self, enabled: bool) {

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -15,6 +15,7 @@ mod source_types;
 mod tsconfig_extends;
 mod tsconfig_native_options;
 mod windows_paths;
+mod workspace_package_routes;
 fn unique_case_dir(name: &str) -> PathBuf {
     static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/crates/vize_canon/src/batch/virtual_project/tests/workspace_package_routes.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/workspace_package_routes.rs
@@ -1,0 +1,73 @@
+use std::fs;
+
+use super::{VirtualProject, unique_case_dir};
+
+#[test]
+fn a_workspace_package_route_precedes_real_tree_path_fallbacks() {
+    let project_root = unique_case_dir("workspace-package-route");
+    let package_root = project_root.parent().unwrap().join(
+        vize_carton::cstr!(
+            "{}-package",
+            project_root.file_name().unwrap().to_string_lossy()
+        )
+        .as_str(),
+    );
+    let _ = fs::remove_dir_all(&project_root);
+    let _ = fs::remove_dir_all(&package_root);
+    fs::create_dir_all(project_root.join("src")).unwrap();
+    fs::create_dir_all(package_root.join("src")).unwrap();
+    fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "paths": {
+      "@scope/workspace-vue": ["./missing"]
+    }
+  }
+}"#,
+    )
+    .unwrap();
+    let entry_path = project_root.join("src/entry.ts");
+    fs::write(
+        &entry_path,
+        "import Widget from '@scope/workspace-vue'\nvoid Widget\n",
+    )
+    .unwrap();
+    let component_path = package_root.join("src/Root.vue");
+    fs::write(
+        &component_path,
+        "<script setup lang=\"ts\">defineProps<{ count: number }>()</script>\n",
+    )
+    .unwrap();
+
+    let mut project = VirtualProject::new(&project_root).unwrap();
+    project.set_virtual_module_aliases([("@scope/workspace-vue".into(), component_path.clone())]);
+    project.register_path(&entry_path).unwrap();
+    project.register_virtual_module_alias_targets().unwrap();
+    project.materialize().unwrap();
+
+    let config: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(project.virtual_root().join("tsconfig.json")).unwrap(),
+    )
+    .unwrap();
+    let targets = config["compilerOptions"]["paths"]["@scope/workspace-vue"]
+        .as_array()
+        .unwrap();
+    let routed = targets[0].as_str().unwrap();
+    assert!(routed.starts_with("./__vize_external__/"), "{targets:#?}");
+    assert!(routed.ends_with("/Root.vue.ts"), "{targets:#?}");
+    assert!(
+        targets
+            .iter()
+            .skip(1)
+            .filter_map(serde_json::Value::as_str)
+            .any(|target| target.contains("missing")),
+        "the user's fallback must remain after the virtual route: {targets:#?}"
+    );
+    let entry = project.find_by_original(&entry_path).unwrap();
+    assert!(entry.content.contains("'@scope/workspace-vue'"));
+    assert!(!entry.content.contains("__vize_external__"));
+
+    let _ = fs::remove_dir_all(&project_root);
+    let _ = fs::remove_dir_all(&package_root);
+}

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -175,11 +175,14 @@ impl VirtualProject {
         // target gets a mirror candidate first (so the generated `.vue.ts`
         // modules win) and the real-tree path as a fallback (so aliases to files
         // outside the checked set keep resolving).
-        if !original_paths.is_empty() {
-            compiler_options.insert(
-                "paths".into(),
-                Value::Object(self.remap_paths(&original_paths)),
-            );
+        let mut remapped_paths = if original_paths.is_empty() {
+            Map::new()
+        } else {
+            self.remap_paths(&original_paths)
+        };
+        self.insert_virtual_module_alias_paths(&mut remapped_paths);
+        if !remapped_paths.is_empty() {
+            compiler_options.insert("paths".into(), Value::Object(remapped_paths));
         }
 
         // Re-anchor custom `typeRoots` the same way: list the mirror copy and
@@ -302,6 +305,35 @@ impl VirtualProject {
         }
         protect_control_file_aliases(paths, &mut remapped, &up);
         remapped
+    }
+
+    /// Add exact bare-specifier routes for workspace package sources whose
+    /// manifests point at `.vue` (or at a barrel that reaches one). The target
+    /// is already inside the virtual tree, so it must be added after ordinary
+    /// project-relative `paths` rebasing. Authored source keeps the bare
+    /// package spelling, which is also the spelling declaration emit retains.
+    #[allow(clippy::disallowed_types)]
+    fn insert_virtual_module_alias_paths(&self, paths: &mut Map<std::string::String, Value>) {
+        let mut aliases: Vec<_> = self.virtual_module_aliases.iter().collect();
+        aliases.sort_by_key(|(specifier, _)| specifier.as_str());
+        for (specifier, source_paths) in aliases {
+            let mut targets = source_paths
+                .iter()
+                .filter_map(|source_path| self.find_by_original(source_path))
+                .filter_map(|file| file.virtual_path.strip_prefix(&self.virtual_root).ok())
+                .map(|relative| Value::String(cstr!("./{}", relative.display()).into()))
+                .collect::<Vec<_>>();
+            if let Some(existing) = paths.get(specifier.as_str()).and_then(Value::as_array) {
+                for target in existing {
+                    if !targets.contains(target) {
+                        targets.push(target.clone());
+                    }
+                }
+            }
+            if !targets.is_empty() {
+                paths.insert(specifier.as_str().into(), Value::Array(targets));
+            }
+        }
     }
 
     /// Re-anchor a list of project-root-relative directories (e.g. `typeRoots`)


### PR DESCRIPTION
## Summary

- discover workspace package exports/imports that resolve to Vue sources without widening the checked project root
- route exact authored package specifiers to Canon's registered virtual modules while preserving user path fallbacks
- cover root, subpath, wildcard, self-reference, private imports, TS barrels, TS and TSX consumers in default and explicit checks
- keep package source diagnostics mapped to authored script/template positions

## Verification

- `VIZE_REQUIRE_CORSA=1 cargo test -q -p vize_canon --lib`
- `VIZE_REQUIRE_CORSA=1 cargo test -q -p vize --lib --test check_default_imports_cli`
- `cargo clippy -p vize_canon -p vize --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Advances #4000. Importer-scoped package identity remains tracked in #4002.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->