### PR TITLE
fix(canon): refresh workspace package vue routes

### DIFF
--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -320,6 +320,8 @@ impl TypeChecker for BatchTypeChecker {
 
         let mut refreshed = self.project.empty_with_same_options()?;
         refreshed.register_paths(&paths)?;
+        refreshed.register_virtual_module_alias_targets()?;
+        refreshed.register_reachable_dependencies()?;
         self.check_registered_project_incremental(&refreshed)
     }
 }

--- a/crates/vize_canon/src/batch/type_checker/paths.rs
+++ b/crates/vize_canon/src/batch/type_checker/paths.rs
@@ -59,11 +59,13 @@ impl IncrementalPaths {
             .paths
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let known_source_paths = project.known_source_paths();
         refresh_paths(
             project.project_root(),
             &mut paths,
             changed,
             self.allow_new_paths,
+            &known_source_paths,
         )?;
         Ok(paths.clone())
     }
@@ -103,6 +105,7 @@ pub(super) fn refresh_paths(
     paths: &mut Vec<PathBuf>,
     changed: &[PathBuf],
     allow_new_paths: bool,
+    known_source_paths: &[PathBuf],
 ) -> CorsaResult<()> {
     let mut refreshed_paths = paths.clone();
     for changed_path in changed {
@@ -116,11 +119,13 @@ pub(super) fn refresh_paths(
         }
 
         let candidate = vize_carton::path::canonicalize_non_verbatim(&candidate);
-        if !candidate.starts_with(project_root) {
+        let already_registered = refreshed_paths.iter().any(|path| path == &candidate);
+        let known_source = known_source_paths.iter().any(|path| path == &candidate);
+        if !candidate.starts_with(project_root) && !already_registered && !known_source {
             return Err(CorsaError::PathError { path: candidate });
         }
         if allow_new_paths
-            && !refreshed_paths.iter().any(|path| path == &candidate)
+            && !already_registered
             && candidate.is_file()
             && is_supported_input(&candidate)
         {
@@ -160,10 +165,38 @@ mod tests {
         let project_root = vize_carton::path::canonicalize_non_verbatim(project.path());
         let existing = vize_carton::path::canonicalize_non_verbatim(&existing);
         let mut paths = vec![existing.clone()];
-        let error = refresh_paths(&project_root, &mut paths, &[added, outside_file], true)
+        let error = refresh_paths(&project_root, &mut paths, &[added, outside_file], true, &[])
             .expect_err("outside path should reject the whole refresh");
 
         assert!(matches!(error, crate::batch::CorsaError::PathError { .. }));
         assert_eq!(paths, vec![existing]);
+    }
+
+    #[test]
+    fn a_registered_out_of_root_dependency_can_refresh() {
+        let project = tempfile::tempdir().expect("project tempdir should exist");
+        let outside = tempfile::tempdir().expect("outside tempdir should exist");
+        let inside_file = project.path().join("inside.ts");
+        let outside_file = outside.path().join("Workspace.vue");
+        std::fs::write(&inside_file, "export {}\n").expect("inside file should write");
+        std::fs::write(&outside_file, "<template />\n").expect("outside file should write");
+
+        let project_root = vize_carton::path::canonicalize_non_verbatim(project.path());
+        let inside_file = vize_carton::path::canonicalize_non_verbatim(&inside_file);
+        let outside_file = vize_carton::path::canonicalize_non_verbatim(&outside_file);
+        let mut paths = vec![inside_file.clone(), outside_file.clone()];
+
+        refresh_paths(
+            &project_root,
+            &mut paths,
+            std::slice::from_ref(&outside_file),
+            true,
+            std::slice::from_ref(&outside_file),
+        )
+        .expect("an already-registered external dependency should refresh");
+        paths.sort();
+        let mut expected = vec![inside_file, outside_file];
+        expected.sort();
+        assert_eq!(paths, expected);
     }
 }

--- a/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
@@ -279,3 +279,143 @@ const outside: number = 'must stay outside the scan'
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn refreshes_workspace_package_vue_routes_in_the_persistent_session() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(
+        "incremental-workspace-package-vue",
+        &[(
+            "src/entry.ts",
+            r#"import Widget from '@scope/workspace-vue'
+type IsAny<T> = 0 extends 1 & T ? true : false
+const componentMustBeTyped: IsAny<typeof Widget> = false
+void componentMustBeTyped
+"#,
+        )],
+    );
+    let package_root = project_root.parent().unwrap().join(
+        vize_carton::cstr!(
+            "{}-package",
+            project_root.file_name().unwrap().to_string_lossy()
+        )
+        .as_str(),
+    );
+    let _ = std::fs::remove_dir_all(&package_root);
+    std::fs::create_dir_all(package_root.join("src")).unwrap();
+    std::fs::write(
+        package_root.join("package.json"),
+        r#"{
+  "name": "@scope/workspace-vue",
+  "exports": {
+    ".": { "types": "./src/Root.vue", "default": "./src/Root.vue" }
+  }
+}"#,
+    )
+    .unwrap();
+    let component_path = package_root.join("src/Root.vue");
+    let clean_source = r#"<script setup lang="ts">
+const count: number = 1
+</script>
+<template>{{ count }}</template>
+"#;
+    std::fs::write(&component_path, clean_source).unwrap();
+
+    let mut checker = BatchTypeChecker::new(&project_root).expect("checker should start");
+    checker.set_virtual_module_aliases([("@scope/workspace-vue".into(), component_path.clone())]);
+    checker.scan_project().expect("initial scan should succeed");
+    let clean = checker.check_project().expect("clean check should succeed");
+    assert!(
+        clean.diagnostics.is_empty(),
+        "workspace package route was not clean: {:#?}",
+        clean.diagnostics
+    );
+
+    std::fs::write(&component_path, clean_source.replace("= 1", "= 'broken'"))
+        .expect("broken external SFC should write");
+    let broken = checker
+        .check_incremental(std::slice::from_ref(&component_path))
+        .expect("external SFC incremental check should complete");
+    let error = broken
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.file == component_path && diagnostic.code == Some(2322))
+        .unwrap_or_else(|| {
+            panic!(
+                "external SFC patch did not report mapped TS2322: {:#?}",
+                broken.diagnostics
+            )
+        });
+    assert_eq!((error.line, error.column), (1, 6));
+    assert!(
+        broken
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != Some(2307)),
+        "persistent route regressed to TS2307: {:#?}",
+        broken.diagnostics
+    );
+
+    std::fs::write(&component_path, clean_source).expect("external SFC repair should write");
+    let repaired = checker
+        .check_incremental(std::slice::from_ref(&component_path))
+        .expect("external SFC repair should complete");
+    assert!(
+        repaired.diagnostics.is_empty(),
+        "external SFC repair retained stale diagnostics: {:#?}",
+        repaired.diagnostics
+    );
+
+    std::fs::remove_file(&component_path).expect("external SFC delete should succeed");
+    let deleted = checker
+        .check_incremental(std::slice::from_ref(&component_path))
+        .expect("external SFC delete should refresh the session");
+    assert!(
+        deleted
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == Some(2307)),
+        "a deleted package target must invalidate its importer: {:#?}",
+        deleted.diagnostics
+    );
+
+    std::fs::write(&component_path, clean_source).expect("external SFC recreate should write");
+    let recreated = checker
+        .check_incremental(std::slice::from_ref(&component_path))
+        .expect("known external SFC recreate should refresh the session");
+    assert!(
+        recreated.diagnostics.is_empty(),
+        "external SFC recreate retained stale diagnostics: {:#?}",
+        recreated.diagnostics
+    );
+
+    let renamed_path = package_root.join("src/Renamed.vue");
+    std::fs::rename(&component_path, &renamed_path).expect("external SFC rename should succeed");
+    std::fs::write(
+        package_root.join("package.json"),
+        r#"{
+  "name": "@scope/workspace-vue",
+  "exports": {
+    ".": { "types": "./src/Renamed.vue", "default": "./src/Renamed.vue" }
+  }
+}"#,
+    )
+    .unwrap();
+    checker.set_virtual_module_aliases([("@scope/workspace-vue".into(), renamed_path.clone())]);
+    let renamed = checker
+        .check_incremental(&[component_path.clone(), renamed_path])
+        .expect("updated external package route should refresh the session");
+    assert!(
+        renamed.diagnostics.is_empty(),
+        "external SFC rename retained stale diagnostics: {:#?}",
+        renamed.diagnostics
+    );
+    assert_eq!(checker.incremental_metrics().session_starts, 1);
+    assert_eq!(checker.incremental_metrics().session_reuses, 4);
+
+    let _ = std::fs::remove_dir_all(&project_root);
+    let _ = std::fs::remove_dir_all(&package_root);
+}

--- a/crates/vize_canon/src/batch/virtual_project/mapping.rs
+++ b/crates/vize_canon/src/batch/virtual_project/mapping.rs
@@ -67,6 +67,18 @@ impl VirtualProject {
         paths
     }
 
+    /// Source paths an incremental project is allowed to refresh even when
+    /// they live outside the project root. This includes the initial reachable
+    /// graph (so delete/recreate works) and newly configured package routes (so
+    /// a package-export rename can enter the next snapshot).
+    pub(crate) fn known_source_paths(&self) -> Vec<PathBuf> {
+        let mut paths = self.registered_original_paths_sorted();
+        paths.extend(self.virtual_module_aliases.values().flatten().cloned());
+        paths.sort();
+        paths.dedup();
+        paths
+    }
+
     /// Parser diagnostics collected while registering source files.
     pub fn diagnostics(&self) -> &[Diagnostic] {
         &self.diagnostics


### PR DESCRIPTION
## Summary

- allow persistent checks to refresh already-registered workspace package sources outside the project root
- re-register configured virtual package routes and their reachable graph for every incremental snapshot
- cover edit, repair, delete, recreate, and manifest-driven rename without restarting the Corsa project session
- reject unrelated out-of-root change notifications atomically

## Verification

- `VIZE_REQUIRE_CORSA=1 cargo test -q -p vize_canon --lib`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Advances #4000.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->