### PR TITLE
fix(check): preserve workspace package declarations

### DIFF
--- a/crates/vize/tests/check_declaration_emit_cli.rs
+++ b/crates/vize/tests/check_declaration_emit_cli.rs
@@ -1,5 +1,7 @@
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;
+#[path = "check_declaration_emit_cli/workspace_package_vue_exports.rs"]
+mod workspace_package_vue_exports;
 
 use std::{path::Path, process::Command};
 

--- a/crates/vize/tests/check_declaration_emit_cli/workspace_package_vue_exports.rs
+++ b/crates/vize/tests/check_declaration_emit_cli/workspace_package_vue_exports.rs
@@ -1,0 +1,143 @@
+use super::*;
+
+#[test]
+fn workspace_package_vue_exports_emit_declarations_with_package_identity() {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
+        return;
+    };
+    let case_root = unique_case_dir("declaration-workspace-vue-export");
+    let _ = std::fs::remove_dir_all(&case_root);
+    let app_root = case_root.join("app");
+    let package_root = case_root.join("packages/workspace-vue");
+    std::fs::create_dir_all(app_root.join("src")).unwrap();
+    std::fs::create_dir_all(package_root.join("src")).unwrap();
+    std::fs::write(
+        app_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        app_root.join("src/index.ts"),
+        r#"export { default as WorkspaceWidget } from '@scope/workspace-vue'
+export type { WorkspaceWidgetProps } from '@scope/workspace-vue'
+export type WorkspaceWidgetModule = typeof import('@scope/workspace-vue')
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        package_root.join("package.json"),
+        r#"{
+  "name": "@scope/workspace-vue",
+  "exports": {
+    ".": {
+      "types": "./src/Root.vue",
+      "default": "./src/Root.vue"
+    }
+  }
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        package_root.join("src/Root.vue"),
+        r#"<script setup lang="ts">
+export interface WorkspaceWidgetProps {
+  count: number
+}
+defineProps<WorkspaceWidgetProps>()
+</script>
+<template>{{ count }}</template>
+"#,
+    )
+    .unwrap();
+    link_workspace_package(
+        &package_root,
+        &app_root.join("node_modules/@scope/workspace-vue"),
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&app_root)
+        .env("CORSA_PATH", corsa_path.as_str())
+        .args([
+            "check",
+            ".",
+            "--format",
+            "json",
+            "--declaration",
+            "--declaration-dir",
+            "types",
+        ])
+        .output()
+        .unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
+    let declarations = json["declarations"]
+        .as_array()
+        .expect("declarations should be an array");
+    assert!(
+        declarations
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .all(|path| !path.contains("__vize_external__") && !path.contains(".vize")),
+        "declaration paths leaked the virtual mirror:\n{stdout}\n{stderr}"
+    );
+    let index_declaration_path = declarations
+        .iter()
+        .filter_map(serde_json::Value::as_str)
+        .find(|path| path.ends_with("/types/index.d.ts") || *path == "types/index.d.ts")
+        .unwrap_or_else(|| panic!("missing index declaration:\n{stdout}\n{stderr}"));
+    let index_declaration = std::fs::read_to_string(app_root.join(index_declaration_path)).unwrap();
+    assert!(
+        index_declaration.contains("@scope/workspace-vue"),
+        "declaration must preserve package identity:\n{index_declaration}"
+    );
+    for leaked in ["__vize_external__", ".vize", ".vue.ts"] {
+        assert!(
+            !index_declaration.contains(leaked),
+            "declaration leaked {leaked}:\n{index_declaration}"
+        );
+    }
+    let map_path = app_root.join("types/index.d.ts.map");
+    let map: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&map_path).unwrap()).unwrap();
+    assert_eq!(map["sourceRoot"], "");
+    let source = map["sources"][0].as_str().unwrap();
+    let mapped_source =
+        vize_carton::path::canonicalize_non_verbatim(&map_path.parent().unwrap().join(source));
+    assert_eq!(
+        mapped_source,
+        vize_carton::path::canonicalize_non_verbatim(&app_root.join("src/index.ts")),
+        "declaration map must survive rootDir layout restoration: {map:#?}"
+    );
+    assert!(
+        !app_root.join("types/__vize_external__").exists(),
+        "inferred workspace-package declarations must be pruned"
+    );
+
+    let _ = std::fs::remove_dir_all(case_root);
+}
+
+fn link_workspace_package(source: &Path, target: &Path) {
+    std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, target).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, target).unwrap();
+}

--- a/crates/vize_canon/src/batch/executor.rs
+++ b/crates/vize_canon/src/batch/executor.rs
@@ -191,6 +191,7 @@ impl CorsaExecutor {
             "canon.dts.rewrite_outputs",
             rewrite_declaration_outputs(options.out_dir.as_path())
         )?;
+        project.finalize_declaration_outputs(options.out_dir.as_path(), &config_path)?;
         declaration_maps::rewrite_declaration_map_outputs(options.out_dir.as_path(), project)?;
 
         Ok(DeclarationEmitResult {

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -229,6 +229,7 @@ impl BatchTypeChecker {
     /// and virtual-TS generation CPU-bound instead of serializing every file on
     /// the batch checker.
     pub fn scan_paths(&mut self, paths: &[PathBuf]) -> CorsaResult<()> {
+        self.project.set_declaration_roots(paths);
         self.project.register_paths(paths)?;
         self.project.register_virtual_module_alias_targets()?;
         // Out-of-root workspace files reachable through imports register too,
@@ -243,6 +244,7 @@ impl BatchTypeChecker {
     /// Scan the project for source files.
     pub fn scan_project(&mut self) -> CorsaResult<()> {
         let paths = collect_project_paths(self.project.project_root())?;
+        self.project.set_declaration_roots(&paths);
         self.project.register_paths(&paths)?;
         self.project.register_virtual_module_alias_targets()?;
         // Same reachability pass as `scan_paths`: imports that leave the

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -122,6 +122,11 @@ pub struct VirtualProject {
     /// Authored program files diagnosed in place instead of materialized.
     diagnostic_paths: FxHashSet<PathBuf>,
 
+    /// Caller-selected source roots eligible for declaration output. Inferred
+    /// package dependencies participate in checking but must not be published
+    /// under the virtual external-mirror layout.
+    declaration_roots: Option<FxHashSet<PathBuf>>,
+
     /// Internal check generation settings applied to every Vue file.
     virtual_ts_check_options: VirtualTsCheckOptions,
 

--- a/crates/vize_canon/src/batch/virtual_project/declaration_emit.rs
+++ b/crates/vize_canon/src/batch/virtual_project/declaration_emit.rs
@@ -1,4 +1,5 @@
-use std::path::Path;
+use std::ffi::OsString;
+use std::path::{Component, Path, PathBuf};
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
@@ -58,6 +59,207 @@ impl VirtualProject {
             .with_file_name(cstr!("{file_name}x").as_str());
         self.virtual_files.contains_key(&tsx_path)
     }
+
+    /// Restore the caller's configured declaration layout after a widened
+    /// workspace-package emit, then remove outputs for inferred dependencies.
+    /// Authored declarations retain bare package specifiers; the external
+    /// mirror and its implementation paths never become publishable output.
+    pub(crate) fn finalize_declaration_outputs(
+        &self,
+        out_dir: &Path,
+        config_path: &Path,
+    ) -> CorsaResult<()> {
+        let config: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(config_path)?)?;
+        let Some(root_dir) = config["compilerOptions"]["rootDir"].as_str() else {
+            return Ok(());
+        };
+        let emit_root_dir = Path::new(root_dir);
+        let layout_root_dir = self
+            .configured_declaration_root_dir()?
+            .unwrap_or_else(|| emit_root_dir.to_path_buf());
+        for file in self.virtual_files.values() {
+            if self.is_tsx_vue_import_shim(file) {
+                continue;
+            }
+            let Ok(emit_relative) = file.virtual_path.strip_prefix(emit_root_dir) else {
+                continue;
+            };
+            let emitted = declaration_output_path(out_dir, emit_relative);
+            let original = vize_carton::path::canonicalize_non_verbatim(&file.original_path);
+            if self.is_declaration_root(&original) {
+                let Ok(layout_relative) = file.virtual_path.strip_prefix(&layout_root_dir) else {
+                    continue;
+                };
+                let destination = declaration_output_path(out_dir, layout_relative);
+                relocate_declaration_output(&emitted, &destination, out_dir)?;
+                continue;
+            }
+            remove_file_if_present(&emitted)?;
+            remove_file_if_present(&declaration_map_path(&emitted))?;
+            remove_empty_ancestors(emitted.parent(), out_dir)?;
+        }
+        Ok(())
+    }
+}
+
+fn declaration_output_path(out_dir: &Path, relative_input: &Path) -> PathBuf {
+    let mut output = out_dir.join(relative_input);
+    let extension = match relative_input
+        .extension()
+        .and_then(|extension| extension.to_str())
+    {
+        Some("mts") => "d.mts",
+        Some("cts") => "d.cts",
+        _ => "d.ts",
+    };
+    output.set_extension(extension);
+    output
+}
+
+fn declaration_map_path(declaration: &Path) -> PathBuf {
+    let mut map = declaration.as_os_str().to_os_string();
+    map.push(".map");
+    PathBuf::from(map)
+}
+
+fn relocate_declaration_output(
+    source: &Path,
+    destination: &Path,
+    boundary: &Path,
+) -> CorsaResult<()> {
+    if source == destination || !source.exists() {
+        return Ok(());
+    }
+    if let Some(parent) = destination.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    remove_file_if_present(destination)?;
+    std::fs::rename(source, destination)?;
+
+    let source_map = declaration_map_path(source);
+    let destination_map = declaration_map_path(destination);
+    if source_map.exists() {
+        rebase_map_sources_for_move(&source_map, &destination_map)?;
+        remove_file_if_present(&destination_map)?;
+        std::fs::rename(&source_map, &destination_map)?;
+    }
+    remove_empty_ancestors(source.parent(), boundary)?;
+    Ok(())
+}
+
+fn rebase_map_sources_for_move(source: &Path, destination: &Path) -> CorsaResult<()> {
+    let mut map: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(source)?)?;
+    let source_root = map
+        .get("sourceRoot")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_owned();
+    let source_dir = source.parent().unwrap_or_else(|| Path::new("."));
+    let destination_dir = destination.parent().unwrap_or_else(|| Path::new("."));
+    if let Some(sources) = map
+        .get_mut("sources")
+        .and_then(serde_json::Value::as_array_mut)
+    {
+        for source in sources {
+            let Some(raw_source) = source.as_str() else {
+                continue;
+            };
+            let raw_source = Path::new(raw_source);
+            let resolved = if raw_source.is_absolute() {
+                raw_source.to_path_buf()
+            } else if Path::new(&source_root).is_absolute() {
+                Path::new(&source_root).join(raw_source)
+            } else {
+                source_dir.join(&source_root).join(raw_source)
+            };
+            *source = serde_json::Value::String(
+                relative_path_from(destination_dir, &normalize_path_lexically(&resolved))
+                    .to_string_lossy()
+                    .replace('\\', "/"),
+            );
+        }
+    }
+    if let Some(object) = map.as_object_mut() {
+        object.insert("sourceRoot".into(), serde_json::Value::String("".into()));
+    }
+    std::fs::write(source, serde_json::to_string(&map)?)?;
+    Ok(())
+}
+
+fn normalize_path_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push("..");
+                }
+            }
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+fn relative_path_from(from_dir: &Path, target: &Path) -> PathBuf {
+    let from = path_components(from_dir);
+    let to = path_components(target);
+    let mut common = 0usize;
+    while common < from.len() && common < to.len() && from[common] == to[common] {
+        common += 1;
+    }
+    if common == 0 {
+        return target.to_path_buf();
+    }
+
+    let mut relative = PathBuf::new();
+    for _ in common..from.len() {
+        relative.push("..");
+    }
+    for component in to.iter().skip(common) {
+        relative.push(component);
+    }
+    relative
+}
+
+fn path_components(path: &Path) -> Vec<OsString> {
+    path.components()
+        .filter_map(|component| match component {
+            Component::CurDir => None,
+            component => Some(component.as_os_str().to_os_string()),
+        })
+        .collect()
+}
+
+fn remove_file_if_present(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn remove_empty_ancestors(mut directory: Option<&Path>, boundary: &Path) -> std::io::Result<()> {
+    while let Some(path) = directory {
+        if path == boundary || !path.starts_with(boundary) {
+            break;
+        }
+        match std::fs::remove_dir(path) {
+            Ok(()) => directory = path.parent(),
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::NotFound | std::io::ErrorKind::DirectoryNotEmpty
+                ) =>
+            {
+                break;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
 }
 
 fn is_script_path(path: &Path) -> bool {

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -45,6 +45,7 @@ impl VirtualProject {
             check_js: false,
             virtual_ts_options: VirtualTsOptions::default(),
             diagnostic_paths: FxHashSet::default(),
+            declaration_roots: None,
             virtual_ts_check_options: VirtualTsCheckOptions::default(),
             virtual_module_aliases: FxHashMap::default(),
             options_api: false,
@@ -76,6 +77,7 @@ impl VirtualProject {
         project.set_tsconfig_path(self.tsconfig_path.clone());
         project.virtual_ts_options = self.virtual_ts_options.clone();
         project.diagnostic_paths = self.diagnostic_paths.clone();
+        project.declaration_roots = self.declaration_roots.clone();
         project.virtual_ts_check_options = self.virtual_ts_check_options;
         project.virtual_module_aliases = self.virtual_module_aliases.clone();
         project.options_api = self.options_api;
@@ -125,6 +127,22 @@ impl VirtualProject {
         for targets in self.virtual_module_aliases.values_mut() {
             targets.sort();
         }
+    }
+
+    pub(crate) fn set_declaration_roots(&mut self, paths: &[PathBuf]) {
+        self.declaration_roots = Some(
+            paths
+                .iter()
+                .filter(|path| path.is_file())
+                .map(|path| vize_carton::path::canonicalize_non_verbatim(path))
+                .collect(),
+        );
+    }
+
+    pub(super) fn is_declaration_root(&self, original_path: &Path) -> bool {
+        self.declaration_roots
+            .as_ref()
+            .is_none_or(|roots| roots.contains(original_path))
     }
 
     pub(crate) fn register_virtual_module_alias_targets(&mut self) -> CorsaResult<()> {

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -204,12 +204,29 @@ impl VirtualProject {
             compiler_options.insert("declarationMap".into(), Value::Bool(declaration_map));
             // Honor a configured `rootDir` (see [`path_rebase`]) and fall back
             // to inference when nothing is configured.
-            let root_dir = path_rebase::root_dir_into_mirror(
+            let desired_root_dir = path_rebase::root_dir_into_mirror(
                 &self.project_root,
                 &self.virtual_root,
                 original_root_dir.as_deref(),
             )
             .unwrap_or_else(|| self.common_virtual_source_dir());
+            // A workspace-package source is part of the declaration program so
+            // its public type can flow into the caller's output, but it is not
+            // one of the caller-selected declaration roots. TypeScript still
+            // applies TS6059 to imported files, so temporarily widen rootDir
+            // when such an inferred source sits outside the configured root.
+            // The output finalizer restores the configured layout and removes
+            // declarations for those inferred dependencies after emit.
+            let has_inferred_source_outside_root = self.virtual_files.values().any(|file| {
+                let original = vize_carton::path::canonicalize_non_verbatim(&file.original_path);
+                !self.is_declaration_root(&original)
+                    && !file.virtual_path.starts_with(&desired_root_dir)
+            });
+            let root_dir = if has_inferred_source_outside_root {
+                self.common_virtual_source_dir()
+            } else {
+                desired_root_dir
+            };
             compiler_options.insert(
                 "rootDir".into(),
                 Value::String(root_dir.to_string_lossy().into_owned()),
@@ -240,6 +257,16 @@ impl VirtualProject {
         config.insert("exclude".into(), Value::Array(Vec::new()));
 
         Ok(Value::Object(config))
+    }
+
+    pub(super) fn configured_declaration_root_dir(&self) -> CorsaResult<Option<PathBuf>> {
+        let original_tsconfig = self.resolved_tsconfig_path();
+        let flattened = self.load_compiler_options_flattened(original_tsconfig.as_deref())?;
+        Ok(path_rebase::root_dir_into_mirror(
+            &self.project_root,
+            &self.virtual_root,
+            flattened.options.get("rootDir").and_then(Value::as_str),
+        ))
     }
 
     pub(super) fn needs_vue_jsx_compiler_options(&self) -> bool {


### PR DESCRIPTION
## Summary

- widen declaration-only rootDir just enough to type imported workspace package sources without TS6059
- restore the consumer's configured declaration layout after emit and remove inferred external package outputs
- preserve authored bare package specifiers and named Vue exports in generated declarations
- rebase declaration-map sources when outputs move so maps resolve to the original TS source

## Verification

- `VIZE_REQUIRE_CORSA=1 cargo test -q -p vize_canon --lib`
- `VIZE_REQUIRE_CORSA=1 cargo test -q -p vize --test check_declaration_emit_cli`
- `cargo test -q -p vize --lib`
- `cargo clippy -p vize_canon -p vize --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Advances #3984 and #4000.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->