### PR TITLE
fix(content-mapper): enable every span feature

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -20,9 +20,18 @@ use super::vue_codegen::{GeneratedVueFile, VueCodegenOptions, generate_vue_virtu
 
 const SCRIPT_KIND_TS: u8 = 3;
 const SCRIPT_KIND_TSX: u8 = 4;
-const MAPPING_KIND_VERBATIM: usize = 0;
-const MAPPING_KIND_ATOM: usize = 1;
-const MAPPING_PURPOSE_ALL: usize = 3;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(usize)]
+enum ContentMapperSpanKind {
+    Verbatim = 0,
+    Atom = 1,
+}
+
+/// Every protocol-v1 language-service feature from hover (bit 0) through
+/// CodeLens (bit 20). Diagnostics do not have a feature bit and exact text
+/// edits still require verbatim geometry in TypeScript.
+const CONTENT_MAPPER_SPAN_FEATURES_ALL: usize = (1 << 21) - 1;
 
 /// A TypeScript content-mapper transform result.
 #[derive(Debug, Serialize)]
@@ -200,7 +209,7 @@ fn checked_source_span(source: &str, start: usize, end: usize) -> (usize, usize)
 struct SpanCandidate {
     generated: Range<usize>,
     original: Range<usize>,
-    kind: usize,
+    kind: ContentMapperSpanKind,
 }
 
 fn protocol_spans(
@@ -269,8 +278,8 @@ fn protocol_spans(
                 candidate.generated.len(),
                 candidate.original.start,
                 candidate.original.len(),
-                candidate.kind,
-                MAPPING_PURPOSE_ALL,
+                candidate.kind as usize,
+                CONTENT_MAPPER_SPAN_FEATURES_ALL,
             ])
         })
         .collect()
@@ -301,14 +310,14 @@ fn candidate(
         return Some(SpanCandidate {
             generated: start..start + original_text.len(),
             original: original_range,
-            kind: MAPPING_KIND_VERBATIM,
+            kind: ContentMapperSpanKind::Verbatim,
         });
     }
 
     Some(SpanCandidate {
         generated: generated_range,
         original: original_range,
-        kind: MAPPING_KIND_ATOM,
+        kind: ContentMapperSpanKind::Atom,
     })
 }
 

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -40,7 +40,13 @@ const message = "hello"
             );
         }
     }
-    assert!(result.mappings.iter().all(|mapping| mapping.0[5] == 3));
+    assert!(
+        result
+            .mappings
+            .iter()
+            .all(|mapping| mapping.0[5] == 2_097_151),
+        "protocol v1 spans must participate in every language-service feature"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace the stale span feature mask with the full protocol-v1 bitset
- give mapping kinds explicit protocol types instead of numeric folklore
- lock all generated mappings to the 21 language-service features in a regression test

## Verification
- `cargo test -p vize_canon --lib`
- `cargo test -p vize content_mapper`
- `cargo fmt --all -- --check`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- exact upstream tsgo `--loadExternalPlugins --noEmit` mixed TS/Vue fixture
- exact upstream tsgo declaration emit mixed TS/Vue fixture

Progresses #3282

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->