### PR TITLE
test(content-mapper): cover standard tsgo projects

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_cli.rs
+++ b/crates/vize/tests/content_mapper_tsgo_cli.rs
@@ -1,0 +1,250 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::json;
+use vize_carton::{String as CompactString, cstr};
+
+const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
+const VUE_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_VUE";
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn copy_fixture(source: &Path, destination: &Path) {
+    std::fs::create_dir_all(destination).unwrap();
+    for entry in std::fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_fixture(&source_path, &destination_path);
+        } else {
+            std::fs::copy(source_path, destination_path).unwrap();
+        }
+    }
+}
+
+fn install_mapper_manifest(project_root: &Path) {
+    let package_root = project_root.join("node_modules/vize");
+    std::fs::create_dir_all(&package_root).unwrap();
+    let manifest = json!({
+        "name": "vize",
+        "private": true,
+        "tsContentMapper": {
+            "exec": [env!("CARGO_BIN_EXE_vize"), "content-mapper"],
+        },
+    });
+    std::fs::write(
+        package_root.join("package.json"),
+        serde_json::to_vec_pretty(&manifest).unwrap(),
+    )
+    .unwrap();
+}
+
+fn workspace_vue_package() -> PathBuf {
+    if let Some(path) = std::env::var_os(VUE_ENV).map(PathBuf::from) {
+        assert!(
+            path.join("package.json").is_file(),
+            "{VUE_ENV} does not contain package.json: {}",
+            path.display()
+        );
+        return path;
+    }
+
+    let store = workspace_root().join("node_modules/.pnpm");
+    let mut candidates = std::fs::read_dir(&store)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", store.display()))
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("vue@3."))
+        .map(|entry| entry.path().join("node_modules/vue"))
+        .filter(|path| path.join("package.json").is_file())
+        .collect::<Vec<_>>();
+    candidates.sort();
+    candidates.pop().unwrap_or_else(|| {
+        panic!(
+            "no Vue 3 package found under {}; set {VUE_ENV}",
+            store.display()
+        )
+    })
+}
+
+fn install_vue_package(project_root: &Path) {
+    let source = workspace_vue_package();
+    let target = project_root.join("node_modules/vue");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, target).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, target).unwrap();
+}
+
+fn run_tsgo(tsgo: &Path, project_root: &Path, arguments: &[&str]) -> Output {
+    Command::new(tsgo)
+        .current_dir(project_root)
+        .args(arguments)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run {}: {error}", tsgo.display()))
+}
+
+fn output_text(output: &Output) -> CompactString {
+    let stdout = std::str::from_utf8(&output.stdout).unwrap_or("<non-UTF-8 stdout>");
+    let stderr = std::str::from_utf8(&output.stderr).unwrap_or("<non-UTF-8 stderr>");
+    cstr!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        stdout,
+        stderr,
+    )
+}
+
+fn assert_success(output: &Output) {
+    assert!(output.status.success(), "{}", output_text(output));
+}
+
+fn emitted_vue_declaration(project_root: &Path, name: &str) -> PathBuf {
+    [
+        project_root.join(cstr!("dist/{name}.d.vue.ts").as_str()),
+        project_root.join(cstr!("dist/{name}.vue.d.ts").as_str()),
+    ]
+    .into_iter()
+    .find(|path| path.is_file())
+    .unwrap_or_else(|| panic!("no emitted declaration for {name}.vue"))
+}
+
+#[test]
+fn standard_tsgo_checks_vue_project_and_emits_consumable_declarations() {
+    let Some(tsgo) = std::env::var_os(TSGO_ENV).map(PathBuf::from) else {
+        eprintln!("skipping exact Content Mapper conformance: {TSGO_ENV} is not set");
+        return;
+    };
+    assert!(
+        tsgo.is_file(),
+        "{TSGO_ENV} is not a file: {}",
+        tsgo.display()
+    );
+
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/content_mapper_project");
+    let cases_root = workspace_root().join("target/vize-tests/tests");
+    std::fs::create_dir_all(&cases_root).unwrap();
+    let project = tempfile::Builder::new()
+        .prefix("content-mapper-tsgo-")
+        .tempdir_in(cases_root)
+        .unwrap();
+    copy_fixture(&fixture, project.path());
+    install_mapper_manifest(project.path());
+    install_vue_package(project.path());
+
+    let check = run_tsgo(
+        &tsgo,
+        project.path(),
+        &[
+            "--loadExternalPlugins",
+            "--noEmit",
+            "-p",
+            "tsconfig.json",
+            "--pretty",
+            "false",
+        ],
+    );
+    assert_success(&check);
+
+    let broken = run_tsgo(
+        &tsgo,
+        project.path(),
+        &[
+            "--loadExternalPlugins",
+            "--noEmit",
+            "-p",
+            "tsconfig.error.json",
+            "--pretty",
+            "false",
+        ],
+    );
+    assert!(
+        !broken.status.success(),
+        "broken fixture passed unexpectedly"
+    );
+    let broken_output = output_text(&broken);
+    assert!(
+        broken_output.contains("errors/Broken.vue"),
+        "{broken_output}"
+    );
+    assert!(
+        broken_output.contains("TS2322")
+            && broken_output.contains("not assignable to type 'number'"),
+        "{broken_output}"
+    );
+
+    let emit = run_tsgo(
+        &tsgo,
+        project.path(),
+        &[
+            "--loadExternalPlugins",
+            "-p",
+            "tsconfig.emit.json",
+            "--pretty",
+            "false",
+        ],
+    );
+    assert_success(&emit);
+
+    let app_declaration = emitted_vue_declaration(project.path(), "App");
+    let child_declaration = emitted_vue_declaration(project.path(), "Child");
+    for declaration in [&app_declaration, &child_declaration] {
+        let text = std::fs::read_to_string(declaration).unwrap();
+        assert!(
+            text.contains("$props"),
+            "{}:\n{text}",
+            declaration.display()
+        );
+        assert!(
+            text.contains("count: number"),
+            "{}:\n{text}",
+            declaration.display()
+        );
+    }
+
+    let main_declaration = project.path().join("dist/main.d.ts");
+    let main_text = std::fs::read_to_string(&main_declaration).unwrap();
+    assert!(main_text.contains("./App.vue"), "{main_text}");
+    assert!(main_text.contains("export type AppProps"), "{main_text}");
+
+    std::fs::write(
+        project.path().join("dist/verify.ts"),
+        r#"import type { AppProps } from "./main";
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+const propsMustBeTyped: IsAny<AppProps> = false;
+const valid: AppProps = { count: 1 };
+// @ts-expect-error count must remain a number through declaration emit
+const invalid: AppProps = { count: "wrong" };
+
+void propsMustBeTyped;
+void valid;
+void invalid;
+"#,
+    )
+    .unwrap();
+    let consume = run_tsgo(
+        &tsgo,
+        project.path(),
+        &[
+            "--ignoreConfig",
+            "--noEmit",
+            "--strict",
+            "--module",
+            "preserve",
+            "--moduleResolution",
+            "bundler",
+            "--pretty",
+            "false",
+            "dist/verify.ts",
+        ],
+    );
+    assert_success(&consume);
+}

--- a/crates/vize/tests/fixtures/content_mapper_project/errors/Broken.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/errors/Broken.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+import Child from "../src/Child.vue";
+</script>
+
+<template>
+  <Child :count="'wrong'" />
+</template>

--- a/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+import Child from "./Child.vue";
+import { increment } from "./model";
+
+defineProps<{ count: number }>();
+</script>
+
+<template>
+  <Child :count="increment(count)" />
+</template>

--- a/crates/vize/tests/fixtures/content_mapper_project/src/Child.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/Child.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+defineProps<{ count: number }>();
+</script>
+
+<template>
+  <output>{{ count.toFixed(0) }}</output>
+</template>

--- a/crates/vize/tests/fixtures/content_mapper_project/src/consumer.tsx
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/consumer.tsx
@@ -1,0 +1,6 @@
+import Child from "./Child.vue";
+
+export type ChildPropsFromTsx = InstanceType<typeof Child>["$props"];
+
+const props: ChildPropsFromTsx = { count: 1 };
+void props;

--- a/crates/vize/tests/fixtures/content_mapper_project/src/main.ts
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/main.ts
@@ -1,0 +1,11 @@
+import App from "./App.vue";
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+const componentMustBeTyped: IsAny<typeof App> = false;
+const props: InstanceType<typeof App>["$props"] = { count: 1 };
+
+export type AppProps = InstanceType<typeof App>["$props"];
+
+void componentMustBeTyped;
+void props;

--- a/crates/vize/tests/fixtures/content_mapper_project/src/model.ts
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/model.ts
@@ -1,0 +1,3 @@
+export function increment(value: number): number {
+  return value + 1;
+}

--- a/crates/vize/tests/fixtures/content_mapper_project/tsconfig.emit.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/tsconfig.emit.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "contentMappers": [
+    { "package": "vize", "extensions": [".vue"] }
+  ],
+  "include": ["src/**/*"]
+}

--- a/crates/vize/tests/fixtures/content_mapper_project/tsconfig.error.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/tsconfig.error.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "contentMappers": [
+    { "package": "vize", "extensions": [".vue"] }
+  ],
+  "include": ["src/**/*", "errors/**/*"]
+}

--- a/crates/vize/tests/fixtures/content_mapper_project/tsconfig.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "contentMappers": [
+    { "package": "vize", "extensions": [".vue"] }
+  ],
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add a mixed TS, TSX, and Vue project fixture for the native Content Mapper path
- prove standard tsgo checks both valid and invalid cross-file template component usage
- prove declaration emit preserves typed Vue imports and remains consumable downstream
- keep the exact upstream binary injectable so a separate gate can pin protocol revisions

## Verification
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/path/to/exact/tsgo cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture`
- `cargo clippy -p vize --test content_mapper_tsgo_cli -- -D warnings`
- `cargo fmt --all -- --check`

Progresses #3282
Progresses #3984

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->