### PR TITLE
ci(content-mapper): pin upstream conformance

### DIFF
--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -1,0 +1,97 @@
+name: Content Mapper Conformance
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/content-mapper-conformance.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/vize/Cargo.toml"
+      - "crates/vize/src/commands/content_mapper.rs"
+      - "crates/vize/src/commands/content_mapper/**"
+      - "crates/vize/tests/content_mapper_tsgo_cli.rs"
+      - "crates/vize/tests/fixtures/content_mapper_project/**"
+      - "crates/vize_canon/Cargo.toml"
+      - "crates/vize_canon/src/batch/virtual_project/content_mapper*"
+      - "crates/vize_canon/src/virtual_ts/**"
+      - "npm/cli/package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/content-mapper-conformance.yml"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/vize/Cargo.toml"
+      - "crates/vize/src/commands/content_mapper.rs"
+      - "crates/vize/src/commands/content_mapper/**"
+      - "crates/vize/tests/content_mapper_tsgo_cli.rs"
+      - "crates/vize/tests/fixtures/content_mapper_project/**"
+      - "crates/vize_canon/Cargo.toml"
+      - "crates/vize_canon/src/batch/virtual_project/content_mapper*"
+      - "crates/vize_canon/src/virtual_ts/**"
+      - "npm/cli/package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: content-mapper-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CONTENT_MAPPER_TSGO_SHA: "bddd2162710e50281fa838456a875fd59ee7c91f"
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  exact-tsgo-project:
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 20
+    steps:
+      - name: Checkout Vize
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Checkout exact TypeScript Content Mapper revision
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: microsoft/typescript-go
+          ref: ${{ env.CONTENT_MAPPER_TSGO_SHA }}
+          path: typescript-go-content-mapper
+          persist-credentials: false
+      - name: Setup Go
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+        with:
+          go-version-file: typescript-go-content-mapper/go.mod
+          cache-dependency-path: typescript-go-content-mapper/go.sum
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
+        with:
+          wild-version: "0.9.0"
+      - uses: ./.github/actions/setup-rust-sticky-cache
+        with:
+          key: content-mapper-conformance
+      - name: Setup Vite Plus
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+      - name: Install JavaScript dependencies
+        run: vp install --frozen-lockfile --prefer-offline
+      - name: Build exact upstream tsgo
+        working-directory: typescript-go-content-mapper
+        run: |
+          go build -tags=noembed -trimpath -o "$RUNNER_TEMP/tsgo" ./cmd/tsgo
+          cp internal/bundled/libs/*.d.ts "$RUNNER_TEMP/"
+      - name: Run standard project and declaration conformance
+        env:
+          VIZE_TEST_CONTENT_MAPPER_TSGO: ${{ runner.temp }}/tsgo
+        run: cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
+
+const UPSTREAM_SHA = "bddd2162710e50281fa838456a875fd59ee7c91f";
+
+test("Content Mapper conformance pins and runs the exact upstream project path", () => {
+  const workflow = readRepoFile(
+    ".github",
+    "workflows",
+    "content-mapper-conformance.yml",
+  );
+  const job = workflowJobBody(workflow, "exact-tsgo-project");
+
+  assert.match(workflow, /pull_request:\n\s+branches: \[main\]\n\s+paths:/);
+  for (const relevantPath of [
+    '".github/workflows/content-mapper-conformance.yml"',
+    '"crates/vize/src/commands/content_mapper.rs"',
+    '"crates/vize_canon/src/batch/virtual_project/content_mapper*"',
+    '"crates/vize_canon/src/virtual_ts/**"',
+    '"crates/vize/tests/content_mapper_tsgo_cli.rs"',
+    '"crates/vize/tests/fixtures/content_mapper_project/**"',
+    '"npm/cli/package.json"',
+  ]) {
+    assert.match(
+      workflow,
+      new RegExp(relevantPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    );
+  }
+
+  assert.match(
+    workflow,
+    new RegExp(`CONTENT_MAPPER_TSGO_SHA: "${UPSTREAM_SHA}"`),
+  );
+  assert.match(job, /repository: microsoft\/typescript-go/);
+  assert.match(job, /ref: \$\{\{ env\.CONTENT_MAPPER_TSGO_SHA \}\}/);
+  assert.match(job, /uses: actions\/setup-go@[0-9a-f]{40}\s+# v6\.1\.0/);
+  assert.match(job, /go-version-file: typescript-go-content-mapper\/go\.mod/);
+  assert.match(
+    job,
+    /go build -tags=noembed -trimpath -o "\$RUNNER_TEMP\/tsgo" \.\/cmd\/tsgo/,
+  );
+  assert.match(job, /cp internal\/bundled\/libs\/\*\.d\.ts "\$RUNNER_TEMP\/"/);
+  assert.match(
+    job,
+    /VIZE_TEST_CONTENT_MAPPER_TSGO: \$\{\{ runner\.temp \}\}\/tsgo/,
+  );
+  assert.match(
+    job,
+    /cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture/,
+  );
+});


### PR DESCRIPTION
## Summary
- pin the audited TypeScript Content Mapper revision by immutable commit
- build that exact tsgo and run the standard mixed-project/declaration oracle
- scope the gate to mapper, virtual-code, manifest, fixture, and toolchain changes
- lock the workflow contract with a tooling test

## Verification
- `node --test tests/tooling/content-mapper-workflow.test.ts`
- workflow YAML parse
- Prettier check
- local exact-upstream conformance run

Progresses #3282
Progresses #3984

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->