### PR TITLE
refactor(content-mapper): name span features

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -28,10 +28,60 @@ enum ContentMapperSpanKind {
     Atom = 1,
 }
 
-/// Every protocol-v1 language-service feature from hover (bit 0) through
-/// CodeLens (bit 20). Diagnostics do not have a feature bit and exact text
-/// edits still require verbatim geometry in TypeScript.
-const CONTENT_MAPPER_SPAN_FEATURES_ALL: usize = (1 << 21) - 1;
+/// TypeScript Content Mapper protocol-v1 feature bits.
+///
+/// This is deliberately separate from `crate::source_map::MappingFlags`:
+/// that compact Vize-internal type has different bit positions, includes
+/// diagnostics, and represents only seven capabilities. Protocol diagnostics
+/// do not have a feature bit, and exact edits additionally require verbatim
+/// geometry in TypeScript.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(usize)]
+enum ContentMapperSpanFeature {
+    Hover = 1 << 0,
+    SignatureHelp = 1 << 1,
+    Completion = 1 << 2,
+    Definition = 1 << 3,
+    TypeDefinition = 1 << 4,
+    Implementation = 1 << 5,
+    SourceDefinition = 1 << 6,
+    References = 1 << 7,
+    DocumentHighlights = 1 << 8,
+    Rename = 1 << 9,
+    CallHierarchy = 1 << 10,
+    CodeActions = 1 << 11,
+    Formatting = 1 << 12,
+    InlayHints = 1 << 13,
+    SemanticTokens = 1 << 14,
+    FoldingRanges = 1 << 15,
+    SelectionRanges = 1 << 16,
+    LinkedEditing = 1 << 17,
+    AutoInsert = 1 << 18,
+    DocumentSymbols = 1 << 19,
+    CodeLens = 1 << 20,
+}
+
+const CONTENT_MAPPER_SPAN_FEATURES_ALL: usize = ContentMapperSpanFeature::Hover as usize
+    | ContentMapperSpanFeature::SignatureHelp as usize
+    | ContentMapperSpanFeature::Completion as usize
+    | ContentMapperSpanFeature::Definition as usize
+    | ContentMapperSpanFeature::TypeDefinition as usize
+    | ContentMapperSpanFeature::Implementation as usize
+    | ContentMapperSpanFeature::SourceDefinition as usize
+    | ContentMapperSpanFeature::References as usize
+    | ContentMapperSpanFeature::DocumentHighlights as usize
+    | ContentMapperSpanFeature::Rename as usize
+    | ContentMapperSpanFeature::CallHierarchy as usize
+    | ContentMapperSpanFeature::CodeActions as usize
+    | ContentMapperSpanFeature::Formatting as usize
+    | ContentMapperSpanFeature::InlayHints as usize
+    | ContentMapperSpanFeature::SemanticTokens as usize
+    | ContentMapperSpanFeature::FoldingRanges as usize
+    | ContentMapperSpanFeature::SelectionRanges as usize
+    | ContentMapperSpanFeature::LinkedEditing as usize
+    | ContentMapperSpanFeature::AutoInsert as usize
+    | ContentMapperSpanFeature::DocumentSymbols as usize
+    | ContentMapperSpanFeature::CodeLens as usize;
 
 /// A TypeScript content-mapper transform result.
 #[derive(Debug, Serialize)]

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use super::CONTENT_MAPPER_SPAN_FEATURES_ALL;
 use crate::batch::{
     ContentMapperTransformOptions, generate_vue_content_mapper_transform,
     generate_vue_content_mapper_transform_with_options,
@@ -44,7 +45,7 @@ const message = "hello"
         result
             .mappings
             .iter()
-            .all(|mapping| mapping.0[5] == 2_097_151),
+            .all(|mapping| mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_ALL),
         "protocol v1 spans must participate in every language-service feature"
     );
 }


### PR DESCRIPTION
## Summary
- mirror all 21 protocol-v1 span features by name
- derive the all-feature mask from those named bits
- keep the protocol schema separate from Vize internal mapping flags with different semantics
- remove the duplicated numeric mask from the regression test

## Verification
- `cargo test -p vize_canon content_mapper -- --nocapture`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- exact upstream mixed-project conformance

Progresses #3282

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->