### PR TITLE
test(content-mapper): cover Options API projects

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_cli.rs
+++ b/crates/vize/tests/content_mapper_tsgo_cli.rs
@@ -152,6 +152,44 @@ fn standard_tsgo_checks_vue_project_and_emits_consumable_declarations() {
     );
     assert_success(&check);
 
+    let options_enabled = run_tsgo(
+        &tsgo,
+        project.path(),
+        &[
+            "--loadExternalPlugins",
+            "--noEmit",
+            "-p",
+            "tsconfig.options-api-enabled.json",
+            "--pretty",
+            "false",
+        ],
+    );
+    assert_success(&options_enabled);
+
+    let options_disabled = run_tsgo(
+        &tsgo,
+        project.path(),
+        &[
+            "--loadExternalPlugins",
+            "--noEmit",
+            "-p",
+            "tsconfig.options-api-disabled.json",
+            "--pretty",
+            "false",
+        ],
+    );
+    assert!(
+        !options_disabled.status.success(),
+        "Options API disabled fixture passed unexpectedly"
+    );
+    let options_disabled_output = output_text(&options_disabled);
+    assert!(
+        options_disabled_output.contains("src/Options.vue")
+            && options_disabled_output.contains("TS2304")
+            && options_disabled_output.contains("Cannot find name 'count'"),
+        "{options_disabled_output}"
+    );
+
     let broken = run_tsgo(
         &tsgo,
         project.path(),
@@ -194,6 +232,7 @@ fn standard_tsgo_checks_vue_project_and_emits_consumable_declarations() {
 
     let app_declaration = emitted_vue_declaration(project.path(), "App");
     let child_declaration = emitted_vue_declaration(project.path(), "Child");
+    let options_declaration = emitted_vue_declaration(project.path(), "Options");
     for declaration in [&app_declaration, &child_declaration] {
         let text = std::fs::read_to_string(declaration).unwrap();
         assert!(
@@ -207,6 +246,12 @@ fn standard_tsgo_checks_vue_project_and_emits_consumable_declarations() {
             declaration.display()
         );
     }
+    let options_text = std::fs::read_to_string(&options_declaration).unwrap();
+    assert!(options_text.contains("$props"), "{options_text}");
+    assert!(
+        options_text.contains("export default __vize_component__"),
+        "{options_text}"
+    );
 
     let main_declaration = project.path().join("dist/main.d.ts");
     let main_text = std::fs::read_to_string(&main_declaration).unwrap();

--- a/crates/vize/tests/fixtures/content_mapper_project/src/Options.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/Options.vue
@@ -1,0 +1,9 @@
+<script lang="ts">
+export default {
+  data() {
+    return { count: 1 };
+  },
+};
+</script>
+
+<template>{{ count.toFixed(0) }}</template>

--- a/crates/vize/tests/fixtures/content_mapper_project/tsconfig.options-api-disabled.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/tsconfig.options-api-disabled.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "contentMappers": [
+    {
+      "package": "vize",
+      "extensions": [".vue"],
+      "options": { "optionsApi": false }
+    }
+  ],
+  "files": ["src/Options.vue"]
+}

--- a/crates/vize/tests/fixtures/content_mapper_project/tsconfig.options-api-enabled.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/tsconfig.options-api-enabled.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "contentMappers": [
+    {
+      "package": "vize",
+      "extensions": [".vue"],
+      "options": { "optionsApi": true }
+    }
+  ],
+  "files": ["src/Options.vue"]
+}


### PR DESCRIPTION
## Summary
- add a realistic Options API component to the exact-upstream project fixture
- prove omitted and explicitly enabled Options API template bindings pass
- prove explicit disablement reports the authored missing binding
- include the Options API component in standard declaration emit

The missing public-instance declaration surface is tracked separately in #4010.

## Verification
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/path/to/exact/tsgo cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture`
- `cargo clippy -p vize --test content_mapper_tsgo_cli -- -D warnings`
- `cargo fmt --all -- --check`

Progresses #3282

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->