### PR TITLE
fix(content-mapper): preserve Options API declarations

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_cli.rs
+++ b/crates/vize/tests/content_mapper_tsgo_cli.rs
@@ -260,18 +260,24 @@ fn standard_tsgo_checks_vue_project_and_emits_consumable_declarations() {
 
     std::fs::write(
         project.path().join("dist/verify.ts"),
-        r#"import type { AppProps } from "./main";
+        r#"import Options from "./Options.vue";
+import type { AppProps } from "./main";
 
 type IsAny<T> = 0 extends 1 & T ? true : false;
+type OptionsInstance = InstanceType<typeof Options>;
 
 const propsMustBeTyped: IsAny<AppProps> = false;
 const valid: AppProps = { count: 1 };
 // @ts-expect-error count must remain a number through declaration emit
 const invalid: AppProps = { count: "wrong" };
+const optionsCountMustBeTyped: IsAny<OptionsInstance["count"]> = false;
+const optionsCount: number = (undefined as unknown as OptionsInstance).count;
 
 void propsMustBeTyped;
 void valid;
 void invalid;
+void optionsCountMustBeTyped;
+void optionsCount;
 "#,
     )
     .unwrap();
@@ -286,6 +292,7 @@ void invalid;
             "preserve",
             "--moduleResolution",
             "bundler",
+            "--allowArbitraryExtensions",
             "--pretty",
             "false",
             "dist/verify.ts",

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -140,6 +140,7 @@ pub(super) fn build_vue_registered_file(
                 check_options: context.virtual_ts_check_options,
                 preserve_unused_diagnostics: context.preserve_unused_diagnostics,
                 options_api: context.options_api,
+                preserve_authored_component: false,
                 legacy_vue2: context.legacy_vue2,
                 dialect: context.dialect,
                 template_syntax: context.template_syntax,

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -192,6 +192,7 @@ pub fn generate_vue_content_mapper_transform_with_options(
             check_options: VirtualTsCheckOptions::default(),
             preserve_unused_diagnostics: false,
             options_api: transform_options.options_api(),
+            preserve_authored_component: true,
             legacy_vue2: false,
             dialect: VueVersion::default(),
             template_syntax: TemplateSyntaxMode::default(),

--- a/crates/vize_canon/src/batch/virtual_project/document.rs
+++ b/crates/vize_canon/src/batch/virtual_project/document.rs
@@ -114,6 +114,7 @@ pub(crate) fn generate_vue_document_virtual_ts_with_options_and_alias_resolver(
             check_options: VirtualTsCheckOptions::default(),
             preserve_unused_diagnostics: false,
             options_api: document_options.options_api,
+            preserve_authored_component: false,
             legacy_vue2: document_options.legacy_vue2,
             dialect: vize_carton::config::VueVersion::default(),
             template_syntax: TemplateSyntaxMode::default(),

--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -47,6 +47,7 @@ pub(super) struct VueCodegenOptions {
     pub(super) check_options: VirtualTsCheckOptions,
     pub(super) preserve_unused_diagnostics: bool,
     pub(super) options_api: bool,
+    pub(super) preserve_authored_component: bool,
     pub(super) legacy_vue2: bool,
     pub(super) dialect: VueVersion,
     pub(super) template_syntax: TemplateSyntaxMode,
@@ -245,6 +246,7 @@ pub(super) fn generate_vue_virtual_ts(
                 preserve_unused_diagnostics: codegen_options.preserve_unused_diagnostics,
                 extra_template_referenced_names: extra_template_referenced_names.as_ref(),
                 options_api: codegen_options.options_api || vue2_compat,
+                preserve_authored_component: codegen_options.preserve_authored_component,
                 legacy_vue2: vue2_compat,
                 template_syntax_quirks: matches!(
                     codegen_options.template_syntax,

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -842,6 +842,15 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     let mut setup_artifact_return_fields = Vec::new();
     setup_props_plan.push_return_field(&mut setup_artifact_return_fields);
     setup_return_fields.extend(setup_artifact_return_fields.into_iter().map(String::from));
+    let preserve_authored_component =
+        declared_default_alias && generation_options.preserve_authored_component;
+    if preserve_authored_component
+        && !setup_return_fields
+            .iter()
+            .any(|field| field == "__default__")
+    {
+        setup_return_fields.push("__default__".into());
+    }
     if let Some(expose) = summary.macros.define_expose()
         && expose.type_args.is_none()
         && let Some(runtime_args) = expose.runtime_args.as_ref()
@@ -871,6 +880,14 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     setup_type_exports.emit_module_exports(&mut ts);
 
     setup_props_plan.emit_module_export(&mut ts, options_api_props.as_ref());
+    if preserve_authored_component {
+        ts.push_str(
+            "type __VizeAuthoredComponent = Awaited<ReturnType<typeof __setup>>[\"__default__\"];\n",
+        );
+        ts.push_str(
+            "type __VizeAuthoredInstance = __VizeAuthoredComponent extends abstract new (...args: any[]) => infer __I ? __I : {};\n\n",
+        );
+    }
 
     let emits_info = emit_emits_type(
         &mut ts,
@@ -901,6 +918,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             exposed_is_generic,
             has_emits_for_props: emits_info.has_emits_for_props,
             has_exposed_type,
+            has_authored_default: preserve_authored_component,
         },
         legacy_vue2,
         dialect,
@@ -912,6 +930,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         generic_component_params
             .as_ref()
             .map(|(decl, names)| (decl.as_str(), names.as_str())),
+        preserve_authored_component,
     );
     ts.push_str("export default __vize_component__;\n");
 

--- a/crates/vize_canon/src/virtual_ts/generator/component_constructors.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/component_constructors.rs
@@ -22,6 +22,7 @@ pub(super) struct ComponentInstanceAliases<'a> {
     pub(super) exposed_is_generic: bool,
     pub(super) has_emits_for_props: bool,
     pub(super) has_exposed_type: bool,
+    pub(super) has_authored_default: bool,
 }
 
 /// Reference to a module-scope alias inside the generic component constructor:
@@ -48,7 +49,11 @@ pub(super) fn emit_component_constructors(
     if aliases.has_exposed_type {
         ts.push_str(exposed_unwrap_helper(legacy_vue2, dialect));
     }
-    ts.push_str("type __VizeComponentInstance = {\n");
+    if aliases.has_authored_default {
+        ts.push_str("type __VizeComponentInstance = __VizeAuthoredInstance & {\n");
+    } else {
+        ts.push_str("type __VizeComponentInstance = {\n");
+    }
     setup_props_plan.emit_component_props_field(
         ts,
         aliases.has_emits_for_props,
@@ -77,7 +82,14 @@ pub(super) fn emit_component_constructors(
     };
     append!(
         *ts,
-        "type __VizeGenericComponentConstructor = new <{generic_decl}>(...args: any[]) => {{\n  $props: __VizeComponentProps<Props<{generic_names}>>{emit_props_field};\n  readonly __vizeRawProps?: Props<{generic_names}>;\n  $emit: __EmitFn<{emits_ref}>;\n  $slots: {slots_ref};\n"
+        "type __VizeGenericComponentConstructor = new <{generic_decl}>(...args: any[]) => "
+    );
+    if aliases.has_authored_default {
+        ts.push_str("__VizeAuthoredInstance & ");
+    }
+    append!(
+        *ts,
+        "{{\n  $props: __VizeComponentProps<Props<{generic_names}>>{emit_props_field};\n  readonly __vizeRawProps?: Props<{generic_names}>;\n  $emit: __EmitFn<{emits_ref}>;\n  $slots: {slots_ref};\n"
     );
     ts.push_str(&generic_instance_suffix(
         legacy_vue2,

--- a/crates/vize_canon/src/virtual_ts/generator/component_export.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/component_export.rs
@@ -35,8 +35,14 @@ pub(super) fn emit_default_export_declaration(
     ts: &mut String,
     emits_info: &EmitsInfo,
     generic_component_params: Option<(&str, &str)>,
+    has_authored_default: bool,
 ) {
     let emit_props_static = emits_info.static_emit_props_field();
+    let authored_component = if has_authored_default {
+        "__VizeAuthoredComponent & "
+    } else {
+        ""
+    };
     if let Some((generic_decl, generic_names)) = generic_component_params {
         let emit_props_resolver =
             emits_info.generic_emit_props_resolver_field(generic_decl, generic_names);
@@ -47,16 +53,17 @@ pub(super) fn emit_default_export_declaration(
         };
         append!(
             *ts,
-            "declare const __vize_component__: __VizeGenericComponentConstructor & __VizeComponentConstructor & __VizeVueComponentOptions & {{ __vizeCheck: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => void; __vizeResolveProps?: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => Props<{generic_names}>; {emit_props_static}{emit_props_separator}{emit_props_resolver} }};\n",
+            "declare const __vize_component__: {authored_component}__VizeGenericComponentConstructor & __VizeComponentConstructor & __VizeVueComponentOptions & {{ __vizeCheck: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => void; __vizeResolveProps?: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => Props<{generic_names}>; {emit_props_static}{emit_props_separator}{emit_props_resolver} }};\n",
         );
     } else if emits_info.has_emits_for_props {
         append!(
             *ts,
-            "declare const __vize_component__: __VizeComponentConstructor & __VizeVueComponentOptions & {{ {emit_props_static} }};\n",
+            "declare const __vize_component__: {authored_component}__VizeComponentConstructor & __VizeVueComponentOptions & {{ {emit_props_static} }};\n",
         );
     } else {
-        ts.push_str(
-            "declare const __vize_component__: __VizeComponentConstructor & __VizeVueComponentOptions;\n",
+        append!(
+            *ts,
+            "declare const __vize_component__: {authored_component}__VizeComponentConstructor & __VizeVueComponentOptions;\n",
         );
     }
 }

--- a/crates/vize_canon/src/virtual_ts/generator/entry.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/entry.rs
@@ -71,6 +71,7 @@ pub fn generate_virtual_ts_with_offsets_options_api(
         options,
         VirtualTsGenerationOptions {
             options_api: true,
+            preserve_authored_component: true,
             ..Default::default()
         },
     )

--- a/crates/vize_canon/src/virtual_ts/tests/options_api_instance.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/options_api_instance.rs
@@ -60,6 +60,25 @@ fn test_options_api_template_bindings_use_default_instance_type() {
         "template data binding must not be emitted as a fixed any:\n{}",
         output.code
     );
+    assert!(
+        output.code.contains(", __default__ }"),
+        "the typed authored component must escape setup for declaration emit:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains(
+            "type __VizeAuthoredComponent = Awaited<ReturnType<typeof __setup>>[\"__default__\"]"
+        ),
+        "expected a module-scope authored component alias:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("type __VizeComponentInstance = __VizeAuthoredInstance & {"),
+        "the public instance must retain Options API members:\n{}",
+        output.code
+    );
 }
 
 /// A `namespace` the plain script declares stays resolvable from template scope

--- a/crates/vize_canon/src/virtual_ts/types.rs
+++ b/crates/vize_canon/src/virtual_ts/types.rs
@@ -158,6 +158,10 @@ pub(crate) struct VirtualTsGenerationOptions<'a> {
     pub(crate) dialect: VueVersion,
     /// Resolve Vue 3 Options API template bindings (opt-in, standard build).
     pub(crate) options_api: bool,
+    /// Preserve the typed authored default component in the public instance.
+    /// Declaration-producing callers enable this until the batch path can do
+    /// so without changing its committed virtual-code baselines.
+    pub(crate) preserve_authored_component: bool,
     /// Legacy Vue 2.7 / Nuxt 2 (implies `options_api` plus Nuxt 2 globals).
     pub(crate) legacy_vue2: bool,
     /// Preserve Vue parser compatibility semantics when generating template


### PR DESCRIPTION
## Summary

- preserve the authored Options API component constructor in Content Mapper declaration output
- intersect the generated public instance with Vue's inferred instance so `data`, `computed`, and `methods` remain typed
- add a standard upstream tsgo consumer oracle that imports `Options.vue` directly and rejects `any`

## Root cause

The Content Mapper transform retained Options API bindings for template checking, but rebuilt the exported component solely from generated helpers. Declaration emit therefore discarded Vue's inferred public instance, so downstream `InstanceType<typeof Component>` lost authored members such as `data().count`.

## Scope

This enables preservation only for declaration-producing Content Mapper transforms. The batch virtual-project output stays byte-identical; shared enablement and the broader Options API declaration matrix remain tracked in #4010.

Refs #4010
Refs #3282

## Validation

- `cargo test -p vize_canon --lib` (866 passed)
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-tsgo-content-mapper.VbyU0F/tsgo cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo clippy -p vize --test content_mapper_tsgo_cli -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->