### PR TITLE
test(content-mapper): cover Options API declaration members

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_cli.rs
+++ b/crates/vize/tests/content_mapper_tsgo_cli.rs
@@ -271,13 +271,28 @@ const valid: AppProps = { count: 1 };
 // @ts-expect-error count must remain a number through declaration emit
 const invalid: AppProps = { count: "wrong" };
 const optionsCountMustBeTyped: IsAny<OptionsInstance["count"]> = false;
-const optionsCount: number = (undefined as unknown as OptionsInstance).count;
+const optionsLabelMustBeTyped: IsAny<OptionsInstance["label"]> = false;
+const optionsComputedMustBeTyped: IsAny<OptionsInstance["doubled"]> = false;
+const optionsMethodMustBeTyped: IsAny<OptionsInstance["increment"]> = false;
+const options = undefined as unknown as OptionsInstance;
+const optionsCount: number = options.count;
+const optionsLabel: string = options.label;
+const optionsComputed: number = options.doubled;
+const optionsMethodResult: number = options.increment(1);
+// @ts-expect-error the authored method parameter must remain a number
+options.increment("1");
 
 void propsMustBeTyped;
 void valid;
 void invalid;
 void optionsCountMustBeTyped;
+void optionsLabelMustBeTyped;
+void optionsComputedMustBeTyped;
+void optionsMethodMustBeTyped;
 void optionsCount;
+void optionsLabel;
+void optionsComputed;
+void optionsMethodResult;
 "#,
     )
     .unwrap();

--- a/crates/vize/tests/fixtures/content_mapper_project/src/Options.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/Options.vue
@@ -1,9 +1,32 @@
 <script lang="ts">
 export default {
+  props: {
+    label: {
+      type: String,
+      required: true,
+    },
+    initial: {
+      type: Number,
+      default: 1,
+    },
+  },
   data() {
-    return { count: 1 };
+    return { count: this.initial };
+  },
+  computed: {
+    doubled() {
+      return this.count * 2;
+    },
+  },
+  methods: {
+    increment(step: number) {
+      this.count += step;
+      return this.count;
+    },
   },
 };
 </script>
 
-<template>{{ count.toFixed(0) }}</template>
+<template>
+  {{ label }}:{{ count.toFixed(0) }}:{{ doubled.toFixed(0) }}:{{ increment(1).toFixed(0) }}
+</template>


### PR DESCRIPTION
## Summary

- expand the exact upstream tsgo Options API fixture with required props, computed values, and a typed method
- prove emitted declarations preserve every member without degrading to `any`
- prove an invalid method argument remains rejected by the downstream declaration consumer

## Why

#4012 restored Vue's inferred authored public instance in Content Mapper declarations. This follow-up locks the broader instance surface so the fix cannot regress into preserving only `data()` fields.

Refs #4010
Refs #3282

## Validation

- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-tsgo-content-mapper.VbyU0F/tsgo cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture`
- `cargo clippy -p vize --test content_mapper_tsgo_cli -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->