### PR TITLE
feat(canon): bridge tsgo signature help

### DIFF
--- a/crates/vize_canon/src/corsa_bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge.rs
@@ -22,8 +22,9 @@ pub use bridge::{BatchTypeChecker, CorsaBridge};
 pub use types::{
     CorsaBridgeConfig, CorsaBridgeError, LspCompletionItem, LspCompletionList,
     LspCompletionResponse, LspDefinitionResponse, LspDiagnostic, LspDocumentation, LspHover,
-    LspHoverContents, LspLocation, LspLocationLink, LspMarkedString, LspMarkupContent, LspPosition,
-    LspRange, TypeCheckResult, VIRTUAL_URI_SCHEME,
+    LspHoverContents, LspLocation, LspLocationLink, LspMarkedString, LspMarkupContent,
+    LspParameterInformation, LspParameterLabel, LspPosition, LspRange, LspSignatureHelp,
+    LspSignatureInformation, TypeCheckResult, VIRTUAL_URI_SCHEME,
 };
 pub use vue_document::{CorsaVueVirtualDocument, CorsaVueVirtualDocumentOptions};
 pub(crate) use vue_document::{CorsaVueVirtualProject, build_vue_virtual_project};

--- a/crates/vize_canon/src/corsa_bridge/bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge.rs
@@ -11,7 +11,7 @@ use vize_carton::{String, cstr};
 use super::session::build_client;
 use super::types::{
     CorsaBridgeConfig, CorsaBridgeError, LspCompletionItem, LspCompletionResponse,
-    LspDefinitionResponse, LspDiagnostic, LspHover, LspLocation, TypeCheckResult,
+    LspDefinitionResponse, LspDiagnostic, LspHover, LspLocation, LspSignatureHelp, TypeCheckResult,
     VIRTUAL_URI_SCHEME,
 };
 use super::worker::{BoundedWorker, WorkerError};
@@ -419,6 +419,30 @@ impl CorsaBridge {
         }
 
         Ok(Vec::new())
+    }
+
+    /// Get signature help at a position.
+    pub async fn signature_help(
+        &self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<LspSignatureHelp>, CorsaBridgeError> {
+        let _timer = self.profiler.timer("corsa_signature_help");
+        let uri = uri.to_owned();
+        let result = self
+            .with_client(move |client| {
+                client
+                    .signature_help_raw(uri.as_str(), line, character)
+                    .map_err(CorsaBridgeError::CommunicationError)
+            })
+            .await?;
+
+        if let Some(timer) = _timer {
+            timer.record(&self.profiler);
+        }
+
+        result.map(parse_json_value::<LspSignatureHelp>).transpose()
     }
 
     pub(super) async fn with_client<R, F>(&self, f: F) -> Result<R, CorsaBridgeError>

--- a/crates/vize_canon/src/corsa_bridge/types.rs
+++ b/crates/vize_canon/src/corsa_bridge/types.rs
@@ -182,6 +182,54 @@ pub enum LspDocumentation {
     Markup(LspMarkupContent),
 }
 
+/// LSP signature-help response.
+#[derive(Debug, Clone, Deserialize)]
+#[allow(clippy::disallowed_types)]
+pub struct LspSignatureHelp {
+    /// Candidate call signatures.
+    pub signatures: Vec<LspSignatureInformation>,
+    /// Selected signature, when the server identifies one.
+    #[serde(rename = "activeSignature")]
+    pub active_signature: Option<u32>,
+    /// Selected parameter, when the server identifies one.
+    #[serde(rename = "activeParameter")]
+    pub active_parameter: Option<u32>,
+}
+
+/// One candidate call signature.
+#[derive(Debug, Clone, Deserialize)]
+#[allow(clippy::disallowed_types)]
+pub struct LspSignatureInformation {
+    /// Display label for the complete signature.
+    pub label: std::string::String,
+    /// Documentation attached to the signature.
+    pub documentation: Option<LspDocumentation>,
+    /// Parameters in declaration order.
+    pub parameters: Option<Vec<LspParameterInformation>>,
+    /// Signature-local active parameter.
+    #[serde(rename = "activeParameter")]
+    pub active_parameter: Option<u32>,
+}
+
+/// One parameter in a signature-help response.
+#[derive(Debug, Clone, Deserialize)]
+#[allow(clippy::disallowed_types)]
+pub struct LspParameterInformation {
+    /// Parameter label as text or UTF-16 offsets into the signature label.
+    pub label: LspParameterLabel,
+    /// Documentation attached to the parameter.
+    pub documentation: Option<LspDocumentation>,
+}
+
+/// LSP permits parameter labels as text or a two-offset tuple.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+#[allow(clippy::disallowed_types)]
+pub enum LspParameterLabel {
+    String(std::string::String),
+    Offsets([u32; 2]),
+}
+
 /// LSP completion list.
 #[derive(Debug, Clone, Deserialize)]
 pub struct LspCompletionList {

--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -45,6 +45,14 @@ impl lsp_types::request::Request for RawCompletionRequest {
     const METHOD: &'static str = "textDocument/completion";
 }
 
+struct RawSignatureHelpRequest;
+
+impl lsp_types::request::Request for RawSignatureHelpRequest {
+    type Params = Value;
+    type Result = Option<Value>;
+    const METHOD: &'static str = "textDocument/signatureHelp";
+}
+
 /// A reusable `--lsp --stdio` session used only for editor requests.
 pub(super) struct EditorLspSession {
     client: LspClient,
@@ -142,6 +150,28 @@ impl EditorLspSession {
         )
         .map_err(|error| cstr!("Failed to request editor LSP completion: {error}"))
     }
+
+    fn signature_help(
+        &mut self,
+        document_uri: &str,
+        text: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        let uri = self.mirror(document_uri, text)?;
+        block_on(
+            self.client
+                .request::<RawSignatureHelpRequest>(serde_json::json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": line, "character": character },
+                    "context": {
+                        "triggerKind": 1,
+                        "isRetrigger": false
+                    },
+                })),
+        )
+        .map_err(|error| cstr!("Failed to request editor LSP signature help: {error}"))
+    }
 }
 
 impl Drop for EditorLspSession {
@@ -232,6 +262,29 @@ impl CorsaProjectClient {
             return Ok(None);
         };
         session.completion(document_uri.as_str(), text.as_str(), line, character)
+    }
+
+    pub(super) fn signature_help_via_editor_lsp(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        let document_uri = self.session_document_uri(uri);
+        let Some(text) = self.document_texts.get(uri).cloned() else {
+            return Ok(None);
+        };
+
+        if self.editor_lsp.is_none() {
+            let root = self.editor_lsp_root();
+            let executable = self.executable.clone();
+            let cwd = self.cwd.clone();
+            self.editor_lsp = Some(EditorLspSession::spawn(executable.as_str(), &cwd, &root)?);
+        }
+        let Some(session) = self.editor_lsp.as_mut() else {
+            return Ok(None);
+        };
+        session.signature_help(document_uri.as_str(), text.as_str(), line, character)
     }
 
     /// Drop the editor session so the next request respawns it. Used when the

--- a/crates/vize_canon/src/lsp_client/queries.rs
+++ b/crates/vize_canon/src/lsp_client/queries.rs
@@ -162,6 +162,15 @@ impl CorsaProjectClient {
         }
     }
 
+    pub(crate) fn signature_help_raw(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        self.signature_help_via_editor_lsp(uri, line, character)
+    }
+
     fn api_position(
         &self,
         uri: &str,

--- a/crates/vize_canon/tests/lsp_import_resolution.rs
+++ b/crates/vize_canon/tests/lsp_import_resolution.rs
@@ -95,6 +95,74 @@ fn bridge_materialized_overlay_preserves_workspace_project_options() {
     assert!(!child_virtual_path.exists());
 }
 
+#[test]
+fn bridge_requests_signature_help_from_corsa_tsgo() {
+    let Some(corsa_path) = resolve_test_tsgo_binary() else {
+        return;
+    };
+
+    let project = tempfile::TempDir::new().unwrap();
+    let project_root = project.path();
+    let src_dir = project_root.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::create_dir(project_root.join("node_modules")).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+
+    let source = "function format(value: number, precision: number): string {\n  return value.toFixed(precision);\n}\nformat(1, );\n";
+    let source_path = src_dir.join("main.ts");
+    std::fs::write(&source_path, source).unwrap();
+
+    let bridge = CorsaBridge::with_config(CorsaBridgeConfig {
+        corsa_path: Some(corsa_path),
+        working_dir: Some(project_root.to_path_buf()),
+        timeout_ms: 30_000,
+        ..Default::default()
+    });
+
+    let signature = corsa::runtime::block_on(async {
+        bridge.spawn().await.unwrap();
+        let uri = source_path.display().to_compact_string();
+        let uri = bridge
+            .open_or_update_virtual_document(uri.as_str(), source)
+            .await
+            .unwrap();
+        let signature = bridge
+            .signature_help(uri.as_str(), 3, "format(1, ".encode_utf16().count() as u32)
+            .await
+            .unwrap();
+        bridge.shutdown().await.unwrap();
+        signature
+    })
+    .expect("Corsa-backed tsgo should return signature help");
+
+    assert_eq!(signature.active_signature, Some(0));
+    assert_eq!(signature.active_parameter, Some(1));
+    assert_eq!(signature.signatures.len(), 1);
+    let label = &signature.signatures[0].label;
+    assert!(label.contains("format("), "unexpected signature: {label}");
+    assert!(
+        label.contains("value: number"),
+        "unexpected signature: {label}"
+    );
+    assert!(
+        label.contains("precision: number"),
+        "unexpected signature: {label}"
+    );
+}
+
 fn resolve_test_tsgo_binary() -> Option<PathBuf> {
     let root = workspace_root();
     if let Some(resolved) = vize_carton::corsa_resolver::discover_corsa_in_ancestors(&root) {


### PR DESCRIPTION
## Summary

- add a typed signature-help response to the Corsa bridge
- route signature-help requests through the reusable tsgo LSP fallback
- cover active signature, active parameter, and parameter labels with a real Corsa-backed tsgo project

## Scope

This PR adds the backend bridge only. Maestro does not advertise signature help yet; SFC, template, JSX, and art source mapping will be proven before enabling the server capability.

Standard upstream tsgo CLI and LSP conformance remain separate from the Corsa project-session extension contract.

## Verification

- `cargo test -p vize_canon --test lsp_import_resolution -- --nocapture`
- `cargo test -p vize_canon --lib` (866 passed)
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo clippy -p vize_canon --test lsp_import_resolution -- -D warnings`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all -- --check`
- `git diff --check`

Tracks #3953.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->