### PR TITLE
fix(canon): preserve virtual editor project identity

### DIFF
--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -19,7 +19,7 @@ use corsa::{
 use lsp_types::Uri;
 use serde_json::Value;
 use std::{
-    path::{Path, PathBuf},
+    path::Path,
     str::FromStr,
     sync::{
         Arc,
@@ -224,21 +224,11 @@ impl CorsaProjectClient {
         line: u32,
         character: u32,
     ) -> Result<Option<Value>, String> {
-        let document_uri = self.session_document_uri(uri);
         let Some(text) = self.document_texts.get(uri).cloned() else {
             return Ok(None);
         };
-
-        if self.editor_lsp.is_none() {
-            let root = self.editor_lsp_root();
-            let executable = self.executable.clone();
-            let cwd = self.cwd.clone();
-            self.editor_lsp = Some(EditorLspSession::spawn(executable.as_str(), &cwd, &root)?);
-        }
-        let Some(session) = self.editor_lsp.as_mut() else {
-            return Ok(None);
-        };
-        session.hover(document_uri.as_str(), text.as_str(), line, character)
+        self.editor_lsp_session()?
+            .hover(uri, text.as_str(), line, character)
     }
 
     pub(super) fn completion_via_editor_lsp(
@@ -247,21 +237,11 @@ impl CorsaProjectClient {
         line: u32,
         character: u32,
     ) -> Result<Option<Value>, String> {
-        let document_uri = self.session_document_uri(uri);
         let Some(text) = self.document_texts.get(uri).cloned() else {
             return Ok(None);
         };
-
-        if self.editor_lsp.is_none() {
-            let root = self.editor_lsp_root();
-            let executable = self.executable.clone();
-            let cwd = self.cwd.clone();
-            self.editor_lsp = Some(EditorLspSession::spawn(executable.as_str(), &cwd, &root)?);
-        }
-        let Some(session) = self.editor_lsp.as_mut() else {
-            return Ok(None);
-        };
-        session.completion(document_uri.as_str(), text.as_str(), line, character)
+        self.editor_lsp_session()?
+            .completion(uri, text.as_str(), line, character)
     }
 
     pub(super) fn signature_help_via_editor_lsp(
@@ -270,34 +250,29 @@ impl CorsaProjectClient {
         line: u32,
         character: u32,
     ) -> Result<Option<Value>, String> {
-        let document_uri = self.session_document_uri(uri);
         let Some(text) = self.document_texts.get(uri).cloned() else {
             return Ok(None);
         };
-
-        if self.editor_lsp.is_none() {
-            let root = self.editor_lsp_root();
-            let executable = self.executable.clone();
-            let cwd = self.cwd.clone();
-            self.editor_lsp = Some(EditorLspSession::spawn(executable.as_str(), &cwd, &root)?);
-        }
-        let Some(session) = self.editor_lsp.as_mut() else {
-            return Ok(None);
-        };
-        session.signature_help(document_uri.as_str(), text.as_str(), line, character)
+        self.editor_lsp_session()?
+            .signature_help(uri, text.as_str(), line, character)
     }
 
-    /// Drop the editor session so the next request respawns it. Used when the
-    /// overlay root moves under a materialized project session.
+    fn editor_lsp_session(&mut self) -> Result<&mut EditorLspSession, String> {
+        if self.editor_lsp.is_none() {
+            self.editor_lsp = Some(EditorLspSession::spawn(
+                self.executable.as_str(),
+                &self.cwd,
+                &self.project_root,
+            )?);
+        }
+        self.editor_lsp
+            .as_mut()
+            .ok_or_else(|| cstr!("Corsa editor LSP session did not initialize"))
+    }
+
+    /// Drop the editor session so the next request respawns it after a project
+    /// session transition.
     pub(super) fn retire_editor_lsp(&mut self) {
         self.editor_lsp = None;
-    }
-
-    fn editor_lsp_root(&self) -> PathBuf {
-        if self.materialized_project_session {
-            super::session_paths::overlay_root_for_project(&self.project_root)
-        } else {
-            self.project_root.clone()
-        }
     }
 }

--- a/crates/vize_canon/src/lsp_client/virtual_overlay.rs
+++ b/crates/vize_canon/src/lsp_client/virtual_overlay.rs
@@ -8,13 +8,32 @@ pub(super) fn target_exists(external_path: &Path) -> bool {
     let Some(name) = external_path.file_name().and_then(|name| name.to_str()) else {
         return false;
     };
-    let Some(real_name) = name.strip_suffix(".ts") else {
-        return false;
-    };
-    if !real_name.ends_with(".vue") && !real_name.ends_with(".html") {
-        return false;
+
+    for extension in [".vue", ".html", ".htm", ".tsx", ".jsx"] {
+        let mut search_end = name.len();
+        while let Some(extension_start) = name[..search_end].rfind(extension) {
+            let authored_end = extension_start + extension.len();
+            let virtual_suffix = &name[authored_end..];
+            if is_virtual_typescript_suffix(virtual_suffix)
+                && external_path
+                    .with_file_name(&name[..authored_end])
+                    .is_file()
+            {
+                return true;
+            }
+            search_end = extension_start;
+        }
     }
-    external_path.with_file_name(real_name).is_file()
+
+    false
+}
+
+fn is_virtual_typescript_suffix(suffix: &str) -> bool {
+    suffix.starts_with('.')
+        && suffix.ends_with(".ts")
+        && suffix
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_'))
 }
 
 pub(super) fn upsert_file_changes(
@@ -67,6 +86,51 @@ mod tests {
 
     use super::{delete_file_changes, upsert_file_changes};
     use crate::file_uri::path_to_file_uri;
+
+    #[test]
+    fn recognizes_editor_virtual_documents_backed_by_authored_files() {
+        let temp = tempfile::tempdir().unwrap();
+        for authored in [
+            "App.vue",
+            "Page.html",
+            "Legacy.htm",
+            "Widget.tsx",
+            "Legacy.jsx",
+        ] {
+            std::fs::write(temp.path().join(authored), "").unwrap();
+        }
+
+        for virtual_name in [
+            "App.vue.ts",
+            "App.vue.template.ts",
+            "App.vue.script.ts",
+            "App.vue.setup.ts",
+            "App.vue.art_variant_12.template.ts",
+            "App.vue.html_tag.ts",
+            "App.vue.html_attr.ts",
+            "Page.html.template.ts",
+            "Legacy.htm.template.ts",
+            "Widget.tsx.jsx.ts",
+            "Legacy.jsx.jsx.ts",
+        ] {
+            assert!(
+                super::target_exists(&temp.path().join(virtual_name)),
+                "virtual document should retain authored project identity: {virtual_name}"
+            );
+        }
+
+        for virtual_name in [
+            "Missing.vue.template.ts",
+            "App.vue.template.js",
+            "App.vue.template-ts",
+            "App.vue../template.ts",
+        ] {
+            assert!(
+                !super::target_exists(&temp.path().join(virtual_name)),
+                "invalid virtual document should not claim a backing file: {virtual_name}"
+            );
+        }
+    }
 
     #[test]
     fn virtual_vue_overlay_file_changes_do_not_materialize_sibling_files() {

--- a/crates/vize_canon/tests/lsp_import_resolution.rs
+++ b/crates/vize_canon/tests/lsp_import_resolution.rs
@@ -163,6 +163,70 @@ fn bridge_requests_signature_help_from_corsa_tsgo() {
     );
 }
 
+#[test]
+fn bridge_virtual_sfc_editor_queries_resolve_relative_workspace_imports() {
+    let Some(corsa_path) = resolve_test_tsgo_binary() else {
+        return;
+    };
+
+    let project = tempfile::TempDir::new().unwrap();
+    let project_root = project.path();
+    let src_dir = project_root.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::create_dir(project_root.join("node_modules")).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(src_dir.join("App.vue"), "<template><div /></template>\n").unwrap();
+    std::fs::write(
+        src_dir.join("format.ts"),
+        "export function format(value: number, precision: number): string { return value.toFixed(precision) }\n",
+    )
+    .unwrap();
+
+    let virtual_source = "import { format } from './format';\n\nformat(1, );\n";
+    let virtual_path = src_dir.join("App.vue.template.ts");
+    let bridge = CorsaBridge::with_config(CorsaBridgeConfig {
+        corsa_path: Some(corsa_path),
+        working_dir: Some(project_root.to_path_buf()),
+        timeout_ms: 30_000,
+        ..Default::default()
+    });
+
+    let signature = corsa::runtime::block_on(async {
+        bridge.spawn().await.unwrap();
+        let uri = virtual_path.display().to_compact_string();
+        let uri = bridge
+            .open_or_update_virtual_document(uri.as_str(), virtual_source)
+            .await
+            .unwrap();
+        let signature = bridge
+            .signature_help(uri.as_str(), 2, "format(1, ".encode_utf16().count() as u32)
+            .await
+            .unwrap();
+        bridge.shutdown().await.unwrap();
+        signature
+    })
+    .expect("virtual SFC editor query should resolve the relative workspace import");
+
+    assert_eq!(signature.active_parameter, Some(1));
+    assert_eq!(signature.signatures.len(), 1);
+    assert!(signature.signatures[0].label.contains("value: number"));
+    assert!(signature.signatures[0].label.contains("precision: number"));
+    assert!(!virtual_path.exists());
+}
+
 fn resolve_test_tsgo_binary() -> Option<PathBuf> {
     let root = workspace_root();
     if let Some(resolved) = vize_carton::corsa_resolver::discover_corsa_in_ancestors(&root) {


### PR DESCRIPTION
## Summary

- run the reusable editor LSP session against the authored project root and authored virtual URI
- recognize Vue, HTML, JSX, and TSX editor virtual filenames that have a real backing source file
- prove relative workspace imports through a virtual SFC with Corsa-backed tsgo signature help

The checker project session can still materialize overlays for diagnostics. Editor requests no longer inherit that isolated filesystem identity, so relative imports, path aliases, package boundaries, and unopened workspace sources resolve from the original project.

## Verification

- `cargo test -p vize_canon --test lsp_import_resolution -- --nocapture` (3 passed)
- `cargo test -p vize_canon --lib` (867 passed)
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo clippy -p vize_canon --test lsp_import_resolution -- -D warnings`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all -- --check`
- `git diff --check`

Supports #3953 and unblocks #4015.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->