### PR TITLE
fix(canon): synchronize editor virtual dependencies

### DIFF
--- a/crates/vize_canon/src/lsp_client.rs
+++ b/crates/vize_canon/src/lsp_client.rs
@@ -54,6 +54,8 @@ pub struct CorsaProjectClient {
     /// Lazily spawned `--lsp --stdio` session answering editor requests the
     /// project-session API rejects as unsupported (corsa-bind#409).
     editor_lsp: Option<editor_lsp::EditorLspSession>,
+    /// Whether the reusable editor LSP needs the latest virtual project mirror.
+    editor_lsp_documents_dirty: bool,
     closed: bool,
 }
 

--- a/crates/vize_canon/src/lsp_client/bootstrap.rs
+++ b/crates/vize_canon/src/lsp_client/bootstrap.rs
@@ -56,6 +56,7 @@ impl CorsaProjectClient {
             external_document_uris: Default::default(),
             temp_dir,
             editor_lsp: None,
+            editor_lsp_documents_dirty: true,
             closed: false,
         })
     }

--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -117,14 +117,46 @@ impl EditorLspSession {
         Ok(uri)
     }
 
+    /// Bring the reusable editor transport to the same virtual-project view as
+    /// the project-session transport, including dependency removals.
+    fn synchronize(&mut self, documents: &FxHashMap<String, String>) -> Result<(), String> {
+        let removed = self
+            .documents
+            .keys()
+            .filter(|uri| !documents.contains_key(uri.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        for document_uri in removed {
+            let uri = Uri::from_str(document_uri.as_str())
+                .map_err(|error| cstr!("Invalid LSP document URI {document_uri}: {error}"))?;
+            self.overlay.close(&uri).map_err(|error| {
+                cstr!("Failed to close editor LSP overlay for {document_uri}: {error}")
+            })?;
+            self.documents.remove(document_uri.as_str());
+        }
+        for (document_uri, text) in documents {
+            self.mirror(document_uri, text)?;
+        }
+        Ok(())
+    }
+
+    fn document_uri(&self, document_uri: &str) -> Result<Uri, String> {
+        if !self.documents.contains_key(document_uri) {
+            return Err(cstr!(
+                "Editor LSP virtual project does not contain {document_uri}"
+            ));
+        }
+        Uri::from_str(document_uri)
+            .map_err(|error| cstr!("Invalid LSP document URI {document_uri}: {error}"))
+    }
+
     fn hover(
         &mut self,
         document_uri: &str,
-        text: &str,
         line: u32,
         character: u32,
     ) -> Result<Option<Value>, String> {
-        let uri = self.mirror(document_uri, text)?;
+        let uri = self.document_uri(document_uri)?;
         block_on(self.client.request::<RawHoverRequest>(serde_json::json!({
             "textDocument": { "uri": uri },
             "position": { "line": line, "character": character },
@@ -135,11 +167,10 @@ impl EditorLspSession {
     fn completion(
         &mut self,
         document_uri: &str,
-        text: &str,
         line: u32,
         character: u32,
     ) -> Result<Option<Value>, String> {
-        let uri = self.mirror(document_uri, text)?;
+        let uri = self.document_uri(document_uri)?;
         block_on(
             self.client
                 .request::<RawCompletionRequest>(serde_json::json!({
@@ -154,11 +185,10 @@ impl EditorLspSession {
     fn signature_help(
         &mut self,
         document_uri: &str,
-        text: &str,
         line: u32,
         character: u32,
     ) -> Result<Option<Value>, String> {
-        let uri = self.mirror(document_uri, text)?;
+        let uri = self.document_uri(document_uri)?;
         block_on(
             self.client
                 .request::<RawSignatureHelpRequest>(serde_json::json!({
@@ -224,11 +254,10 @@ impl CorsaProjectClient {
         line: u32,
         character: u32,
     ) -> Result<Option<Value>, String> {
-        let Some(text) = self.document_texts.get(uri).cloned() else {
+        if !self.document_texts.contains_key(uri) {
             return Ok(None);
-        };
-        self.editor_lsp_session()?
-            .hover(uri, text.as_str(), line, character)
+        }
+        self.editor_lsp_session()?.hover(uri, line, character)
     }
 
     pub(super) fn completion_via_editor_lsp(
@@ -237,11 +266,10 @@ impl CorsaProjectClient {
         line: u32,
         character: u32,
     ) -> Result<Option<Value>, String> {
-        let Some(text) = self.document_texts.get(uri).cloned() else {
+        if !self.document_texts.contains_key(uri) {
             return Ok(None);
-        };
-        self.editor_lsp_session()?
-            .completion(uri, text.as_str(), line, character)
+        }
+        self.editor_lsp_session()?.completion(uri, line, character)
     }
 
     pub(super) fn signature_help_via_editor_lsp(
@@ -250,11 +278,11 @@ impl CorsaProjectClient {
         line: u32,
         character: u32,
     ) -> Result<Option<Value>, String> {
-        let Some(text) = self.document_texts.get(uri).cloned() else {
+        if !self.document_texts.contains_key(uri) {
             return Ok(None);
-        };
+        }
         self.editor_lsp_session()?
-            .signature_help(uri, text.as_str(), line, character)
+            .signature_help(uri, line, character)
     }
 
     fn editor_lsp_session(&mut self) -> Result<&mut EditorLspSession, String> {
@@ -264,6 +292,15 @@ impl CorsaProjectClient {
                 &self.cwd,
                 &self.project_root,
             )?);
+            self.editor_lsp_documents_dirty = true;
+        }
+        if self.editor_lsp_documents_dirty {
+            let session = self
+                .editor_lsp
+                .as_mut()
+                .ok_or_else(|| cstr!("Corsa editor LSP session did not initialize"))?;
+            session.synchronize(&self.document_texts)?;
+            self.editor_lsp_documents_dirty = false;
         }
         self.editor_lsp
             .as_mut()
@@ -274,5 +311,6 @@ impl CorsaProjectClient {
     /// session transition.
     pub(super) fn retire_editor_lsp(&mut self) {
         self.editor_lsp = None;
+        self.editor_lsp_documents_dirty = true;
     }
 }

--- a/crates/vize_canon/src/lsp_client/lifecycle.rs
+++ b/crates/vize_canon/src/lsp_client/lifecycle.rs
@@ -131,6 +131,7 @@ impl CorsaProjectClient {
             if previous.as_deref() == Some(*content) {
                 continue;
             }
+            self.editor_lsp_documents_dirty = true;
             changed = true;
             merge_materialized_file_changes(
                 &mut summary,

--- a/crates/vize_canon/src/lsp_client/session.rs
+++ b/crates/vize_canon/src/lsp_client/session.rs
@@ -175,6 +175,9 @@ impl CorsaProjectClient {
 
     pub(super) fn sync_overlay_document(&mut self, uri: &str, content: &str) -> Result<(), String> {
         let previous = self.document_texts.insert(uri.into(), content.into());
+        if previous.as_deref() != Some(content) {
+            self.editor_lsp_documents_dirty = true;
+        }
 
         if self.materialized_project_session {
             return self.sync_materialized_overlay_document(uri, content);
@@ -235,7 +238,9 @@ impl CorsaProjectClient {
     }
 
     pub(super) fn delete_overlay_document(&mut self, uri: &str) -> Result<(), String> {
-        self.document_texts.remove(uri);
+        if self.document_texts.remove(uri).is_some() {
+            self.editor_lsp_documents_dirty = true;
+        }
         self.overlay_versions.remove(uri);
         let document_uri = self
             .session_document_uris

--- a/crates/vize_canon/tests/lsp_import_resolution.rs
+++ b/crates/vize_canon/tests/lsp_import_resolution.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use vize_canon::{CorsaBridge, CorsaBridgeConfig};
+use vize_canon::{CorsaBridge, CorsaBridgeConfig, LspHover, LspHoverContents, LspMarkedString};
 use vize_carton::ToCompactString;
 
 #[test]
@@ -225,6 +225,108 @@ fn bridge_virtual_sfc_editor_queries_resolve_relative_workspace_imports() {
     assert!(signature.signatures[0].label.contains("value: number"));
     assert!(signature.signatures[0].label.contains("precision: number"));
     assert!(!virtual_path.exists());
+}
+
+#[test]
+fn bridge_editor_queries_resolve_in_memory_virtual_dependencies() {
+    let Some(corsa_path) = resolve_test_tsgo_binary() else {
+        return;
+    };
+
+    let project = tempfile::TempDir::new().unwrap();
+    let project_root = project.path();
+    let src_dir = project_root.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(src_dir.join("Parent.vue"), "<template />\n").unwrap();
+    std::fs::write(src_dir.join("Child.vue"), "<template />\n").unwrap();
+
+    let child_virtual = r#"declare const Child: new () => {
+  $props: { message: string };
+};
+export default Child;
+"#;
+    let changed_child_virtual = child_virtual.replace("message: string", "message: number");
+    let parent_virtual = r#"import Child from './Child.vue.ts';
+type Props = InstanceType<typeof Child>['$props'];
+const props = {} as Props;
+props.message;
+"#;
+    let child_path = src_dir.join("Child.vue.ts");
+    let parent_path = src_dir.join("Parent.vue.ts");
+    let bridge = CorsaBridge::with_config(CorsaBridgeConfig {
+        corsa_path: Some(corsa_path),
+        working_dir: Some(project_root.to_path_buf()),
+        timeout_ms: 30_000,
+        ..Default::default()
+    });
+
+    let (initial_hover, changed_hover, closed_hover) = corsa::runtime::block_on(async {
+        bridge.spawn().await.unwrap();
+        let child_uri = child_path.display().to_compact_string();
+        let child_uri = bridge
+            .open_or_update_virtual_document(child_uri.as_str(), child_virtual)
+            .await
+            .unwrap();
+        let parent_uri = parent_path.display().to_compact_string();
+        let parent_uri = bridge
+            .open_or_update_virtual_document(parent_uri.as_str(), parent_virtual)
+            .await
+            .unwrap();
+        let initial_hover = bridge.hover(parent_uri.as_str(), 3, 7).await.unwrap();
+        bridge
+            .update_virtual_document(child_uri.as_str(), changed_child_virtual.as_str(), 2)
+            .await
+            .unwrap();
+        let changed_hover = bridge.hover(parent_uri.as_str(), 3, 7).await.unwrap();
+        bridge
+            .close_virtual_document(child_uri.as_str())
+            .await
+            .unwrap();
+        let closed_hover = bridge.hover(parent_uri.as_str(), 3, 7).await.unwrap();
+        bridge.shutdown().await.unwrap();
+        (initial_hover, changed_hover, closed_hover)
+    });
+
+    assert!(
+        hover_contains(&initial_hover, "message") && hover_contains(&initial_hover, "string"),
+        "editor LSP should see every in-memory virtual dependency: {initial_hover:?}"
+    );
+    assert!(
+        hover_contains(&changed_hover, "message") && hover_contains(&changed_hover, "number"),
+        "editor LSP should refresh changed virtual dependencies: {changed_hover:?}"
+    );
+    assert!(
+        !hover_contains(&closed_hover, "string") && !hover_contains(&closed_hover, "number"),
+        "editor LSP should close removed virtual dependencies: {closed_hover:?}"
+    );
+    assert!(!child_path.exists());
+    assert!(!parent_path.exists());
+}
+
+fn hover_contains(hover: &Option<LspHover>, expected: &str) -> bool {
+    hover.as_ref().is_some_and(|hover| match &hover.contents {
+        LspHoverContents::Markup(markup) => markup.value.contains(expected),
+        LspHoverContents::String(value) => value.contains(expected),
+        LspHoverContents::Array(items) => items.iter().any(|item| match item {
+            LspMarkedString::String(value) | LspMarkedString::LanguageString { value, .. } => {
+                value.contains(expected)
+            }
+        }),
+    })
 }
 
 fn resolve_test_tsgo_binary() -> Option<PathBuf> {


### PR DESCRIPTION
## Summary

- synchronize the reusable editor LSP with every in-memory virtual dependency before an editor request
- propagate changed and removed dependency documents without rescanning unchanged projects on every request
- preserve authored workspace URIs and project-root resolution introduced by #4016
- cover initial dependency typing, live dependency edits, dependency close, ordinary TS imports, and Vue component-prop hover

## Root cause

#4016 correctly moved editor requests back to authored workspace URIs, but the editor transport only mirrored the requested host document. Vue dependency virtual documents existed in the project-session transport but were invisible to the reusable editor LSP, so imported component props degraded to `any`.

The editor transport now uses a dirty bit: document mutations mark it stale, and the next editor request applies one project-wide overlay diff before serving the request. Unchanged requests remain O(1) at the synchronization gate and no longer clone the host source text.

## Verification

- `cargo test -p vize_canon --lib -q` — 867 passed
- `cargo test -p vize_canon --test lsp_import_resolution -q` — 4 passed
- `cargo test -p vize_maestro --features native -q` — 716 passed, 2 ignored; integration and doctests passed
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo clippy -p vize_canon --test lsp_import_resolution -- -D warnings`
- `cargo fmt --all -- --check`
- `node --test tests/tooling/source-file-lengths.test.ts`

Progresses #3953.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->