### PR TITLE
fix(canon): fall back to editor definition

### DIFF
--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -45,6 +45,14 @@ impl lsp_types::request::Request for RawCompletionRequest {
     const METHOD: &'static str = "textDocument/completion";
 }
 
+struct RawDefinitionRequest;
+
+impl lsp_types::request::Request for RawDefinitionRequest {
+    type Params = Value;
+    type Result = Option<Value>;
+    const METHOD: &'static str = "textDocument/definition";
+}
+
 struct RawSignatureHelpRequest;
 
 impl lsp_types::request::Request for RawSignatureHelpRequest {
@@ -180,6 +188,23 @@ impl EditorLspSession {
                 })),
         )
         .map_err(|error| cstr!("Failed to request editor LSP completion: {error}"))
+    }
+
+    fn definition(
+        &mut self,
+        document_uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        let uri = self.document_uri(document_uri)?;
+        block_on(
+            self.client
+                .request::<RawDefinitionRequest>(serde_json::json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": line, "character": character },
+                })),
+        )
+        .map_err(|error| cstr!("Failed to request editor LSP definition: {error}"))
     }
 
     fn signature_help(
@@ -319,6 +344,18 @@ impl CorsaProjectClient {
             return Ok(None);
         }
         self.editor_lsp_session()?.completion(uri, line, character)
+    }
+
+    pub(super) fn definition_via_editor_lsp(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        if !self.document_texts.contains_key(uri) {
+            return Ok(None);
+        }
+        self.editor_lsp_session()?.definition(uri, line, character)
     }
 
     pub(super) fn signature_help_via_editor_lsp(

--- a/crates/vize_canon/src/lsp_client/queries.rs
+++ b/crates/vize_canon/src/lsp_client/queries.rs
@@ -57,17 +57,20 @@ impl CorsaProjectClient {
         let Some(position) =
             self.api_position(uri, line, character, self.supports_definition_api())?
         else {
-            return Ok(None);
+            return self.definition_via_editor_lsp(uri, line, character);
         };
 
         let document_uri = self.session_document_uri(uri);
-        let response =
-            block_on(self.session.get_definition_at_position(
+        match block_on(
+            self.session.get_definition_at_position(
                 uri_document_identifier(document_uri.as_str()),
                 position,
-            ))
-            .map_err(|error| cstr!("Failed to request definition: {error}"))?;
-        self.serialize_with_remapped_uris(response)
+            ),
+        ) {
+            Ok(response) => self.serialize_with_remapped_uris(response),
+            Err(CorsaError::Unsupported(_)) => self.definition_via_editor_lsp(uri, line, character),
+            Err(error) => Err(cstr!("Failed to request definition: {error}")),
+        }
     }
 
     pub(crate) fn references_raw(

--- a/crates/vize_canon/tests/lsp_import_resolution.rs
+++ b/crates/vize_canon/tests/lsp_import_resolution.rs
@@ -228,6 +228,74 @@ fn bridge_virtual_sfc_editor_queries_resolve_relative_workspace_imports() {
 }
 
 #[test]
+fn bridge_virtual_sfc_definition_resolves_relative_workspace_import() {
+    let Some(corsa_path) = resolve_test_tsgo_binary() else {
+        return;
+    };
+
+    let project = tempfile::TempDir::new().unwrap();
+    let project_root = project.path();
+    let src_dir = project_root.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(src_dir.join("App.vue"), "<template><div /></template>\n").unwrap();
+    let dependency = "export function format(value: number): string { return value.toFixed(2) }\n";
+    std::fs::write(src_dir.join("format.ts"), dependency).unwrap();
+
+    let virtual_source = "import { format } from './format';\n\nformat(1);\n";
+    let virtual_path = src_dir.join("App.vue.template.ts");
+    let bridge = CorsaBridge::with_config(CorsaBridgeConfig {
+        corsa_path: Some(corsa_path),
+        working_dir: Some(project_root.to_path_buf()),
+        timeout_ms: 30_000,
+        ..Default::default()
+    });
+
+    let definitions = corsa::runtime::block_on(async {
+        bridge.spawn().await.unwrap();
+        let uri = virtual_path.display().to_compact_string();
+        let uri = bridge
+            .open_or_update_virtual_document(uri.as_str(), virtual_source)
+            .await
+            .unwrap();
+        let definitions = bridge.definition(uri.as_str(), 2, 1).await.unwrap();
+        bridge.shutdown().await.unwrap();
+        definitions
+    });
+
+    assert_eq!(
+        definitions.len(),
+        1,
+        "unexpected definitions: {definitions:#?}"
+    );
+    let definition = &definitions[0];
+    assert!(
+        definition.uri.ends_with("/src/format.ts"),
+        "unexpected definition URI: {}",
+        definition.uri
+    );
+    assert_eq!(definition.range.start.line, 0);
+    assert_eq!(
+        definition.range.start.character,
+        dependency.find("format").unwrap() as u32
+    );
+    assert!(!virtual_path.exists());
+}
+
+#[test]
 fn bridge_editor_queries_resolve_in_memory_virtual_dependencies() {
     let Some(corsa_path) = resolve_test_tsgo_binary() else {
         return;
@@ -274,7 +342,14 @@ props.message;
         ..Default::default()
     });
 
-    let (initial_hover, changed_hover, closed_hover) = corsa::runtime::block_on(async {
+    let (
+        initial_hover,
+        initial_definition,
+        changed_hover,
+        changed_definition,
+        closed_hover,
+        closed_definition,
+    ) = corsa::runtime::block_on(async {
         bridge.spawn().await.unwrap();
         let child_uri = child_path.display().to_compact_string();
         let child_uri = bridge
@@ -287,18 +362,28 @@ props.message;
             .await
             .unwrap();
         let initial_hover = bridge.hover(parent_uri.as_str(), 3, 7).await.unwrap();
+        let initial_definition = bridge.definition(parent_uri.as_str(), 3, 7).await.unwrap();
         bridge
             .update_virtual_document(child_uri.as_str(), changed_child_virtual.as_str(), 2)
             .await
             .unwrap();
         let changed_hover = bridge.hover(parent_uri.as_str(), 3, 7).await.unwrap();
+        let changed_definition = bridge.definition(parent_uri.as_str(), 3, 7).await.unwrap();
         bridge
             .close_virtual_document(child_uri.as_str())
             .await
             .unwrap();
         let closed_hover = bridge.hover(parent_uri.as_str(), 3, 7).await.unwrap();
+        let closed_definition = bridge.definition(parent_uri.as_str(), 3, 7).await.unwrap();
         bridge.shutdown().await.unwrap();
-        (initial_hover, changed_hover, closed_hover)
+        (
+            initial_hover,
+            initial_definition,
+            changed_hover,
+            changed_definition,
+            closed_hover,
+            closed_definition,
+        )
     });
 
     assert!(
@@ -309,9 +394,25 @@ props.message;
         hover_contains(&changed_hover, "message") && hover_contains(&changed_hover, "number"),
         "editor LSP should refresh changed virtual dependencies: {changed_hover:?}"
     );
+    for definitions in [&initial_definition, &changed_definition] {
+        assert_eq!(
+            definitions.len(),
+            1,
+            "unexpected definitions: {definitions:#?}"
+        );
+        assert!(
+            definitions[0].uri.ends_with("/src/Child.vue.ts"),
+            "definition should target the in-memory Vue dependency: {definitions:#?}"
+        );
+        assert_eq!(definitions[0].range.start.line, 1);
+    }
     assert!(
         !hover_contains(&closed_hover, "string") && !hover_contains(&closed_hover, "number"),
         "editor LSP should close removed virtual dependencies: {closed_hover:?}"
+    );
+    assert!(
+        closed_definition.is_empty(),
+        "definition should disappear with the closed virtual dependency: {closed_definition:#?}"
     );
     assert!(!child_path.exists());
     assert!(!parent_path.exists());
@@ -331,17 +432,13 @@ fn hover_contains(hover: &Option<LspHover>, expected: &str) -> bool {
 
 fn resolve_test_tsgo_binary() -> Option<PathBuf> {
     let root = workspace_root();
-    if let Some(resolved) = vize_carton::corsa_resolver::discover_corsa_in_ancestors(&root) {
-        return Some(resolved);
-    }
-    [
-        root.parent()?.join("corsa-bind/.cache/tsgo"),
-        root.parent()?
-            .join("corsa-bind/ref/corsa-upstream/.cache/tsgo"),
-        root.join("node_modules/.bin/tsgo"),
-    ]
-    .into_iter()
-    .find(|candidate| candidate.exists())
+    vize_carton::corsa_resolver::resolve_corsa_executable(
+        vize_carton::corsa_resolver::CorsaResolveRequest {
+            project_root: Some(&root),
+            ..Default::default()
+        },
+    )
+    .ok()
 }
 
 fn workspace_root() -> PathBuf {

--- a/crates/vize_maestro/src/ide/definition/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/definition/corsa_tests.rs
@@ -117,6 +117,165 @@ const msg = 'hello'
     });
 }
 
+#[test]
+fn definition_with_corsa_resolves_template_call_to_imported_typescript() {
+    crate::runtime::block_on(async {
+        let Some(corsa_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(
+            dir.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .unwrap();
+        let dependency =
+            "export function format(value: string): string { return value.toUpperCase() }\n";
+        let dependency_path = src.join("format.ts");
+        fs::write(&dependency_path, dependency).unwrap();
+        let source = r#"<script setup lang="ts">
+import { format } from './format'
+import * as formatter from './format'
+const values = ['local']
+</script>
+
+<template>
+  {{ format('hello') }} {{ formatter.format('world') }}
+  <span v-for="format in values">{{ format }}</span>
+</template>
+"#;
+        let path = src.join("App.vue");
+        fs::write(&path, source).unwrap();
+
+        let uri = Url::from_file_path(&path).unwrap();
+        let state = ServerState::new();
+        state.set_workspace_root(dir.path().to_path_buf());
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        let bridge = std::sync::Arc::new(vize_canon::CorsaBridge::with_config(
+            vize_canon::CorsaBridgeConfig {
+                corsa_path: Some(corsa_path),
+                working_dir: Some(dir.path().to_path_buf()),
+                timeout_ms: 30_000,
+                ..Default::default()
+            },
+        ));
+        bridge.spawn().await.unwrap();
+
+        let named_offset = source.find("format('hello')").unwrap() + 1;
+        let namespace_offset =
+            source.find("formatter.format('world')").unwrap() + "formatter.".len() + 1;
+        let mut responses = Vec::new();
+        for offset in [named_offset, namespace_offset] {
+            let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+            responses.push(
+                DefinitionService::definition_with_corsa(&ctx, Some(bridge.clone()))
+                    .await
+                    .expect("definition for imported template callable"),
+            );
+        }
+        let expected = dependency.find("format").unwrap();
+        let (line, character) = crate::ide::offset_to_position(dependency, expected);
+        for (index, response) in responses.into_iter().enumerate() {
+            let location = scalar_location(response);
+            assert_eq!(
+                location.uri.to_file_path().unwrap().canonicalize().unwrap(),
+                dependency_path.canonicalize().unwrap(),
+                "template import case {index}: {location:#?}"
+            );
+            assert_eq!(
+                location.range.start,
+                tower_lsp::lsp_types::Position::new(line, character)
+            );
+        }
+
+        let shadowed_offset = source.rfind("{{ format }}").unwrap() + "{{ ".len() + 1;
+        let shadowed_ctx = IdeContext::new(&state, &uri, shadowed_offset).unwrap();
+        let shadowed =
+            DefinitionService::definition_with_corsa(&shadowed_ctx, Some(bridge.clone()))
+                .await
+                .expect("definition for shadowing template binding");
+        let shadowed_location = scalar_location(shadowed);
+        assert_eq!(shadowed_location.uri, uri);
+        let shadowed_expected = source.find("v-for=\"format").unwrap() + "v-for=\"".len();
+        let (line, character) = crate::ide::offset_to_position(source, shadowed_expected);
+        assert_eq!(
+            shadowed_location.range.start,
+            tower_lsp::lsp_types::Position::new(line, character)
+        );
+
+        let art_source = r#"<script setup lang="ts">
+import { format } from './format'
+function decorate(value: string): string { return `[${value}]` }
+</script>
+
+<art title="Definition">
+  <variant name="Secondary">
+    <p>{{ decorate('art') }} {{ format('world') }}</p>
+  </variant>
+</art>
+"#;
+        let art_path = src.join("Definition.art.vue");
+        fs::write(&art_path, art_source).unwrap();
+        let art_uri = Url::from_file_path(&art_path).unwrap();
+        state.documents.open(
+            art_uri.clone(),
+            art_source.to_string(),
+            1,
+            "art-vue".to_string(),
+        );
+        state.update_virtual_docs(&art_uri, art_source);
+
+        for (marker, expected_uri, expected_offset) in [
+            (
+                "decorate('art')",
+                art_uri.clone(),
+                art_source.find("function decorate").unwrap() + "function ".len(),
+            ),
+            (
+                "format('world')",
+                Url::from_file_path(&dependency_path).unwrap(),
+                dependency.find("format").unwrap(),
+            ),
+        ] {
+            let offset = art_source.rfind(marker).unwrap() + 1;
+            let ctx = IdeContext::new(&state, &art_uri, offset).unwrap();
+            let response = DefinitionService::definition_with_corsa(&ctx, Some(bridge.clone()))
+                .await
+                .expect("definition for art variant callable");
+            let location = scalar_location(response);
+            assert_eq!(location.uri, expected_uri);
+            let (line, character) = crate::ide::offset_to_position(
+                if expected_uri == art_uri {
+                    art_source
+                } else {
+                    dependency
+                },
+                expected_offset,
+            );
+            assert_eq!(
+                location.range.start,
+                tower_lsp::lsp_types::Position::new(line, character)
+            );
+        }
+        bridge.shutdown().await.unwrap();
+    });
+}
+
 fn scalar_location(response: GotoDefinitionResponse) -> Location {
     match response {
         GotoDefinitionResponse::Scalar(location) => location,
@@ -136,17 +295,11 @@ fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
     let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(std::path::Path::parent)?;
-    for candidate in [
-        workspace_root.parent()?.join("corsa-bind/.cache/tsgo"),
-        workspace_root
-            .parent()?
-            .join("corsa-bind/ref/corsa-upstream/.cache/tsgo"),
-        workspace_root.join("node_modules/.bin/tsgo"),
-    ] {
-        if candidate.exists() {
-            return Some(candidate);
-        }
-    }
-
-    vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
+    vize_carton::corsa_resolver::resolve_corsa_executable(
+        vize_carton::corsa_resolver::CorsaResolveRequest {
+            project_root: Some(workspace_root),
+            ..Default::default()
+        },
+    )
+    .ok()
 }

--- a/crates/vize_maestro/src/ide/definition/service.rs
+++ b/crates/vize_maestro/src/ide/definition/service.rs
@@ -103,19 +103,29 @@ impl super::DefinitionService {
                     .open_or_update_virtual_document(&vdoc_uri, &tmpl.content)
                     .await
                 else {
-                    return Self::definition_in_template_sync(ctx);
+                    let definition = Self::definition_in_template_sync(ctx)?;
+                    return Some(
+                        import_target::unwrap_bound_name_definition(ctx, &definition)
+                            .unwrap_or(definition),
+                    );
                 };
 
                 if let Ok(locations) = bridge.definition(&uri, line, character).await
                     && !locations.is_empty()
+                    && let Some(definition) = Self::convert_lsp_locations(locations, ctx)
                 {
-                    return Self::convert_lsp_locations(locations, ctx);
+                    return Some(
+                        import_target::unwrap_bound_name_definition(ctx, &definition)
+                            .unwrap_or(definition),
+                    );
                 }
             }
         }
 
-        // Fall back to synchronous definition
-        Self::definition_in_template_sync(ctx)
+        // Fall back to synchronous definition, unwrapping only an actual
+        // import-alias answer so template-local shadowing remains intact.
+        let definition = Self::definition_in_template_sync(ctx)?;
+        Some(import_target::unwrap_bound_name_definition(ctx, &definition).unwrap_or(definition))
     }
 
     /// Find definition in template with Corsa and component jump support.
@@ -129,12 +139,6 @@ impl super::DefinitionService {
             && let Some(def) = template::find_component_definition(ctx, &tag_name)
         {
             return Some(def);
-        }
-
-        if let Some(definition) =
-            Self::definition_via_canonical_corsa(ctx, corsa_bridge.as_ref()).await
-        {
-            return Some(definition);
         }
 
         if let Some(definition) =
@@ -165,6 +169,14 @@ impl super::DefinitionService {
             return Some(def);
         }
 
+        if let Some(definition) =
+            Self::definition_via_canonical_corsa(ctx, corsa_bridge.as_ref()).await
+        {
+            return Some(
+                import_target::unwrap_bound_name_definition(ctx, &definition).unwrap_or(definition),
+            );
+        }
+
         let word = helpers::get_word_at_offset(&ctx.content, ctx.offset)?;
 
         if word.is_empty() {
@@ -193,8 +205,10 @@ impl super::DefinitionService {
             }
         }
 
-        // Fall back to synchronous definition
-        Self::definition_in_template_sync(ctx)
+        // Fall back to synchronous definition, unwrapping only an actual
+        // import-alias answer so template-local shadowing remains intact.
+        let definition = Self::definition_in_template_sync(ctx)?;
+        Some(import_target::unwrap_bound_name_definition(ctx, &definition).unwrap_or(definition))
     }
 
     /// Find definition in script with Corsa support.

--- a/crates/vize_maestro/src/ide/definition/service/import_target.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target.rs
@@ -18,6 +18,10 @@ use vize_carton::cstr;
 use crate::ide::IdeContext;
 use crate::ide::definition::{helpers, module_specifier, script};
 
+mod alias;
+
+pub(super) use alias::unwrap_bound_name_definition;
+
 /// Barrels can chain; three hops covers a package barrel re-exporting a
 /// directory barrel re-exporting the module, without risking a cycle walk.
 const MAX_REEXPORT_HOPS: usize = 3;
@@ -68,8 +72,8 @@ fn importing_specifier(content: &str, offset: usize, word: &str) -> Option<(Stri
 }
 
 /// The specifier and exported name for local binding `word`, scanning every
-/// import statement — the component-tag path has no cursor offset on the
-/// import statement to anchor on.
+/// import statement — template and component-tag paths have no cursor offset
+/// on the import statement to anchor on.
 fn bound_import(content: &str, word: &str) -> Option<(String, String)> {
     import_statements(content)
         .into_iter()

--- a/crates/vize_maestro/src/ide/definition/service/import_target/alias.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target/alias.rs
@@ -1,0 +1,80 @@
+//! Conditional unwrapping for checker answers that stop at an import alias.
+
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Url};
+
+use super::{
+    MAX_REEXPORT_HOPS, bound_import, bound_source_name, import_statements, locate_export,
+    resolve_import_specifier,
+};
+use crate::ide::IdeContext;
+use crate::ide::definition::helpers;
+
+/// Follow an imported binding only when the checker answered with that
+/// binding's authored import alias. This preserves lexical shadowing in
+/// template expressions while avoiding an import self-jump.
+pub(in crate::ide::definition::service) fn unwrap_bound_name_definition(
+    ctx: &IdeContext<'_>,
+    response: &GotoDefinitionResponse,
+) -> Option<GotoDefinitionResponse> {
+    let word = helpers::get_word_at_offset(&ctx.content, ctx.offset)?;
+    let word_start = word_start_at_offset(&ctx.content, ctx.offset)?;
+    if word_start
+        .checked_sub(1)
+        .and_then(|index| ctx.content.as_bytes().get(index))
+        == Some(&b'.')
+    {
+        return None;
+    }
+    let location = match response {
+        GotoDefinitionResponse::Scalar(location) => location,
+        GotoDefinitionResponse::Array(locations) if locations.len() == 1 => &locations[0],
+        GotoDefinitionResponse::Array(_) | GotoDefinitionResponse::Link(_) => return None,
+    };
+    if !same_document_uri(&location.uri, ctx.uri) {
+        return None;
+    }
+    let definition_offset = crate::ide::position_to_offset(
+        &ctx.content,
+        location.range.start.line,
+        location.range.start.character,
+    )?;
+    let (specifier, exported) = bound_import(&ctx.content, &word)?;
+    let points_to_import_alias =
+        import_statements(&ctx.content)
+            .into_iter()
+            .any(|(start, end, clause, _)| {
+                definition_offset >= start
+                    && definition_offset <= end
+                    && bound_source_name(clause, &word).is_some()
+            });
+    if !points_to_import_alias {
+        return None;
+    }
+    let target = resolve_import_specifier(ctx.uri, &specifier)?;
+    locate_export(&target, &exported, MAX_REEXPORT_HOPS).map(GotoDefinitionResponse::Scalar)
+}
+
+fn word_start_at_offset(content: &str, offset: usize) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut start = offset.min(bytes.len());
+    while start > 0 && helpers::is_word_char(bytes[start - 1]) {
+        start -= 1;
+    }
+    let has_word = bytes
+        .get(start)
+        .is_some_and(|byte| helpers::is_word_char(*byte));
+    has_word.then_some(start)
+}
+
+fn same_document_uri(left: &Url, right: &Url) -> bool {
+    if left == right {
+        return true;
+    }
+    let (Ok(left), Ok(right)) = (left.to_file_path(), right.to_file_path()) else {
+        return false;
+    };
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => false,
+    }
+}


### PR DESCRIPTION
## Summary

- route definition requests through the reusable tsgo editor LSP when the project-session endpoint is unavailable
- preserve the project-session fast path and fall back only for unsupported capabilities or typed unsupported responses
- keep component attribute/tag resolution ahead of the generic query and unwrap named-import self-jumps only when the returned range is the authored import alias
- cover cross-file TypeScript targets, namespace imports, template lexical shadowing, non-default art variants, and in-memory Vue dependency open/update/close lifecycle
- make the integration runtime resolver honor the standard tsgo environment overrides

## Validation

- `cargo test -p vize_canon` — 869 unit tests plus integration/doc tests passed; one pre-existing test-helper lifetime warning remains
- `cargo test -p vize_maestro` — 725 passed, 2 ignored; 3 integration tests and 1 doctest passed
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo clippy -p vize_maestro --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `pnpm vp run source:lengths`

## Follow-up found by the audit

The exact upstream Content Mappers tsgo 7.1 build exposes a bootstrap blocker before this fallback can run: the client currently requires a custom project session. The editor-only startup work and exact-upstream CI gate are tracked as P0 in #4022. Test-only lint debt found while tightening validation is tracked separately in #4021.

Relates to #3953 and #4015.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->