### PR TITLE
fix(canon): support standard tsgo editor sessions

### DIFF
--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -17,7 +17,11 @@ on:
       - "crates/vize_canon/src/batch/virtual_project.rs"
       - "crates/vize_canon/src/batch/virtual_project/content_mapper*"
       - "crates/vize_canon/src/lib.rs"
+      - "crates/vize_canon/src/lsp_client.rs"
+      - "crates/vize_canon/src/lsp_client/**"
+      - "crates/vize_canon/tests/lsp_import_resolution.rs"
       - "crates/vize_canon/src/virtual_ts/**"
+      - "crates/vize_maestro/src/ide/**"
       - "npm/cli/package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
@@ -37,7 +41,11 @@ on:
       - "crates/vize_canon/src/batch/virtual_project.rs"
       - "crates/vize_canon/src/batch/virtual_project/content_mapper*"
       - "crates/vize_canon/src/lib.rs"
+      - "crates/vize_canon/src/lsp_client.rs"
+      - "crates/vize_canon/src/lsp_client/**"
+      - "crates/vize_canon/tests/lsp_import_resolution.rs"
       - "crates/vize_canon/src/virtual_ts/**"
+      - "crates/vize_maestro/src/ide/**"
       - "npm/cli/package.json"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
@@ -102,3 +110,9 @@ jobs:
         env:
           VIZE_TEST_CONTENT_MAPPER_TSGO: ${{ runner.temp }}/tsgo
         run: cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture
+      - name: Run exact editor backend conformance
+        env:
+          TSGO_PATH: ${{ runner.temp }}/tsgo
+        run: |
+          cargo test -p vize_canon --test lsp_import_resolution -- --nocapture
+          cargo test -p vize_maestro

--- a/crates/vize_canon/src/lsp_client.rs
+++ b/crates/vize_canon/src/lsp_client.rs
@@ -34,7 +34,9 @@ mod tests;
 pub struct CorsaProjectClient {
     executable: String,
     cwd: PathBuf,
-    session: ProjectSession,
+    /// Optional custom project-session transport. Standard tsgo builds expose
+    /// the editor LSP without this API, so the client can run editor-only.
+    session: Option<ProjectSession>,
     capabilities: Arc<CapabilitiesResponse>,
     overlay_api_disabled: bool,
     materialized_project_session: bool,

--- a/crates/vize_canon/src/lsp_client/bootstrap.rs
+++ b/crates/vize_canon/src/lsp_client/bootstrap.rs
@@ -1,12 +1,15 @@
 use super::{
     CorsaProjectClient,
     lifecycle_setup::{workspace_config_path, write_materialized_project_tsconfig},
-    session::{materialize_session_document, spawn_project_session},
+    session::{ProjectSessionSpawnError, materialize_session_document, spawn_project_session},
     session_paths::build_materialized_session_document_uri,
 };
 use crate::file_uri::file_uri_to_path;
 use corsa::runtime::block_on;
-use std::path::{Path, PathBuf};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use vize_carton::{
     String,
     corsa_resolver::{CorsaResolveError, CorsaResolveRequest},
@@ -40,7 +43,17 @@ impl CorsaProjectClient {
     ) -> Result<Self, String> {
         let project_root = root_path.as_deref().unwrap_or(&cwd);
         let config_path = workspace_config_path(project_root);
-        let (session, capabilities) = spawn_project_session(executable, &cwd, &config_path)?;
+        let (session, capabilities) = match spawn_project_session(executable, &cwd, &config_path) {
+            Ok((session, capabilities)) => (Some(session), capabilities),
+            Err(ProjectSessionSpawnError::Unavailable(reason)) => {
+                tracing::debug!(
+                    reason = reason.as_str(),
+                    "using standard tsgo editor-only session"
+                );
+                (None, Arc::new(Default::default()))
+            }
+            Err(ProjectSessionSpawnError::Failed(error)) => return Err(error),
+        };
         Ok(Self {
             executable: executable.into(),
             cwd: cwd.clone(),
@@ -95,11 +108,19 @@ impl CorsaProjectClient {
             }
             mappings.push((uri.clone(), document_uri));
         }
-        let (session, capabilities) =
-            spawn_project_session(self.executable.as_str(), &self.cwd, &config_path)?;
-        let previous = std::mem::replace(&mut self.session, session);
-        let _ = block_on(previous.close());
-        self.capabilities = capabilities;
+        if self.has_project_session() {
+            let (session, capabilities) =
+                match spawn_project_session(self.executable.as_str(), &self.cwd, &config_path) {
+                    Ok(result) => result,
+                    Err(ProjectSessionSpawnError::Unavailable(error))
+                    | Err(ProjectSessionSpawnError::Failed(error)) => return Err(error),
+                };
+            let previous = self.session.replace(session);
+            if let Some(previous) = previous {
+                let _ = block_on(previous.close());
+            }
+            self.capabilities = capabilities;
+        }
         self.session_document_uris.clear();
         self.external_document_uris.clear();
         for (uri, document_uri) in mappings {

--- a/crates/vize_canon/src/lsp_client/diagnostics.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics.rs
@@ -111,7 +111,7 @@ impl CorsaProjectClient {
         &mut self,
         uris: &[String],
     ) -> Result<Option<DiagnosticBatch>, String> {
-        let report = match block_on(self.session.get_diagnostics_for_project()) {
+        let report = match block_on(self.project_session()?.get_diagnostics_for_project()) {
             Ok(report) => report,
             Err(error) if corsa_diagnostics_error_is_unsupported(&error) => return Ok(None),
             Err(error) => {
@@ -141,7 +141,7 @@ impl CorsaProjectClient {
         }
 
         let response = block_on(
-            self.session
+            self.project_session()?
                 .get_diagnostics_for_file(uri_document_identifier(document_uri.as_str())),
         );
         let response = match response {
@@ -159,7 +159,7 @@ impl CorsaProjectClient {
         &mut self,
         uri: &str,
     ) -> Result<Option<Result<DiagnosticFetch, String>>, String> {
-        let report = match block_on(self.session.get_diagnostics_for_project()) {
+        let report = match block_on(self.project_session()?.get_diagnostics_for_project()) {
             Ok(report) => report,
             Err(error) if corsa_diagnostics_error_is_unsupported(&error) => return Ok(None),
             Err(error) => {
@@ -249,7 +249,7 @@ impl CorsaProjectClient {
     ) -> Result<Option<Vec<Diagnostic>>, String> {
         if self.supports_file_diagnostics_api() {
             let response = block_on(
-                self.session
+                self.project_session()?
                     .get_diagnostics_for_file(uri_document_identifier(document_uri)),
             );
             let response = match response {
@@ -260,17 +260,18 @@ impl CorsaProjectClient {
                     let _ = error;
                     // Proceed to the project-diagnostics branch below.
                     return if self.supports_project_diagnostics_api() {
-                        let report = match block_on(self.session.get_diagnostics_for_project()) {
-                            Ok(report) => report,
-                            Err(error) if diagnostics_api_error_is_unsupported(&error) => {
-                                return Ok(None);
-                            }
-                            Err(error) => {
-                                return Err(cstr!(
-                                    "Failed to request Corsa project diagnostics: {error}"
-                                ));
-                            }
-                        };
+                        let report =
+                            match block_on(self.project_session()?.get_diagnostics_for_project()) {
+                                Ok(report) => report,
+                                Err(error) if diagnostics_api_error_is_unsupported(&error) => {
+                                    return Ok(None);
+                                }
+                                Err(error) => {
+                                    return Err(cstr!(
+                                        "Failed to request Corsa project diagnostics: {error}"
+                                    ));
+                                }
+                            };
                         let diagnostics = report
                             .files
                             .iter()
@@ -292,7 +293,7 @@ impl CorsaProjectClient {
         }
 
         if self.supports_project_diagnostics_api() {
-            let report = match block_on(self.session.get_diagnostics_for_project()) {
+            let report = match block_on(self.project_session()?.get_diagnostics_for_project()) {
                 Ok(report) => report,
                 Err(error) if diagnostics_api_error_is_unsupported(&error) => {
                     return Ok(None);
@@ -319,7 +320,7 @@ impl CorsaProjectClient {
         &mut self,
         pairs: &[(String, String)],
     ) -> Result<Option<DiagnosticBatch>, String> {
-        let report = match block_on(self.session.get_diagnostics_for_project()) {
+        let report = match block_on(self.project_session()?.get_diagnostics_for_project()) {
             Ok(report) => report,
             Err(error) if corsa_diagnostics_error_is_unsupported(&error) => return Ok(None),
             Err(error) => {

--- a/crates/vize_canon/src/lsp_client/lifecycle.rs
+++ b/crates/vize_canon/src/lsp_client/lifecycle.rs
@@ -82,7 +82,9 @@ impl CorsaProjectClient {
             return Ok(());
         }
 
-        let _ = corsa::runtime::block_on(self.session.close());
+        if let Some(session) = self.session.take() {
+            let _ = corsa::runtime::block_on(session.close());
+        }
         self.retire_editor_lsp();
         self.document_texts.clear();
         self.diagnostics.clear();
@@ -105,6 +107,21 @@ impl CorsaProjectClient {
     /// Open many virtual document overlays with a single snapshot refresh when possible.
     pub fn did_open_batch_fast(&mut self, documents: &[(&str, &str)]) -> Result<(), String> {
         if documents.is_empty() {
+            return Ok(());
+        }
+
+        if !self.has_project_session() {
+            for (uri, content) in documents {
+                self.clear_document_state(uri);
+                if self.materialized_project_session {
+                    self.sync_overlay_document(uri, content)?;
+                } else {
+                    let previous = self.document_texts.insert((*uri).into(), (*content).into());
+                    if previous.as_deref() != Some(*content) {
+                        self.editor_lsp_documents_dirty = true;
+                    }
+                }
+            }
             return Ok(());
         }
 
@@ -175,11 +192,11 @@ impl CorsaProjectClient {
         };
 
         if overlay_upserts.is_empty() {
-            return block_on(self.session.refresh(file_changes))
+            return block_on(self.project_session_mut()?.refresh(file_changes))
                 .map_err(|error| cstr!("Failed to refresh Corsa snapshot: {error}"));
         }
 
-        match block_on(self.session.refresh_with_overlay_changes(
+        match block_on(self.project_session_mut()?.refresh_with_overlay_changes(
             file_changes,
             Some(OverlayChanges {
                 upsert: overlay_upserts,

--- a/crates/vize_canon/src/lsp_client/materialized_refresh.rs
+++ b/crates/vize_canon/src/lsp_client/materialized_refresh.rs
@@ -22,7 +22,11 @@ impl CorsaProjectClient {
         };
 
         self.clear_diagnostics_cache();
-        block_on(self.session.refresh(Some(file_changes)))
+        if !self.has_project_session() {
+            self.retire_editor_lsp();
+            return Ok(());
+        }
+        block_on(self.project_session_mut()?.refresh(Some(file_changes)))
             .map_err(|error| cstr!("Failed to refresh materialized Corsa files: {error}"))
     }
 }

--- a/crates/vize_canon/src/lsp_client/queries.rs
+++ b/crates/vize_canon/src/lsp_client/queries.rs
@@ -39,7 +39,7 @@ impl CorsaProjectClient {
 
         let document_uri = self.session_document_uri(uri);
         match block_on(
-            self.session
+            self.project_session()?
                 .get_hover_at_position(uri_document_identifier(document_uri.as_str()), position),
         ) {
             Ok(response) => response.map(value_to_json).transpose(),
@@ -62,7 +62,7 @@ impl CorsaProjectClient {
 
         let document_uri = self.session_document_uri(uri);
         match block_on(
-            self.session.get_definition_at_position(
+            self.project_session()?.get_definition_at_position(
                 uri_document_identifier(document_uri.as_str()),
                 position,
             ),
@@ -88,7 +88,7 @@ impl CorsaProjectClient {
 
         let document_uri = self.session_document_uri(uri);
         let response =
-            block_on(self.session.get_references_at_position(
+            block_on(self.project_session()?.get_references_at_position(
                 uri_document_identifier(document_uri.as_str()),
                 position,
             ))
@@ -118,7 +118,7 @@ impl CorsaProjectClient {
         };
 
         let document_uri = self.session_document_uri(uri);
-        let response = block_on(self.session.get_rename_at_position(
+        let response = block_on(self.project_session()?.get_rename_at_position(
             uri_document_identifier(document_uri.as_str()),
             position,
             new_name,
@@ -154,7 +154,7 @@ impl CorsaProjectClient {
             trigger_character: None,
         };
         let document_uri = self.session_document_uri(uri);
-        match block_on(self.session.get_completion_at_position(
+        match block_on(self.project_session()?.get_completion_at_position(
             uri_document_identifier(document_uri.as_str()),
             position,
             Some(context),

--- a/crates/vize_canon/src/lsp_client/session.rs
+++ b/crates/vize_canon/src/lsp_client/session.rs
@@ -25,7 +25,7 @@ pub(super) fn spawn_project_session(
     executable: &str,
     cwd: &Path,
     config_path: &Path,
-) -> Result<(ProjectSession, Arc<CapabilitiesResponse>), String> {
+) -> Result<(ProjectSession, Arc<CapabilitiesResponse>), ProjectSessionSpawnError> {
     let config_path_wire = config_path.to_string_lossy();
     let mode = api_mode_for_executable(executable);
     let session = match block_on(spawn_project_session_with_mode(
@@ -35,24 +35,52 @@ pub(super) fn spawn_project_session(
         mode,
     )) {
         Ok(session) => session,
-        Err(error) if should_retry_json_rpc(mode, &error) => block_on(
-            spawn_project_session_with_mode(
+        Err(error) if should_retry_json_rpc(mode, &error) => {
+            match block_on(spawn_project_session_with_mode(
                 executable,
                 cwd,
                 config_path_wire.as_ref(),
                 ApiMode::AsyncJsonRpcStdio,
-            ),
-        )
-        .map_err(|fallback| {
-            cstr!("Failed to start Corsa API session: {fallback} (after msgpack error: {error})")
-        })?,
-        Err(error) => {
-            return Err(cstr!("Failed to start Corsa API session: {error}"));
+            )) {
+                Ok(session) => session,
+                Err(fallback) => {
+                    return Err(classify_project_session_error(
+                        fallback,
+                        Some(cstr!("after msgpack error: {error}")),
+                    ));
+                }
+            }
         }
+        Err(error) => return Err(classify_project_session_error(error, None)),
     };
     let capabilities = block_on(session.describe_capabilities())
         .unwrap_or_else(|_| Arc::new(CapabilitiesResponse::default()));
     Ok((session, capabilities))
+}
+
+#[derive(Debug)]
+pub(super) enum ProjectSessionSpawnError {
+    Unavailable(String),
+    Failed(String),
+}
+
+fn classify_project_session_error(
+    error: CorsaError,
+    context: Option<String>,
+) -> ProjectSessionSpawnError {
+    let message = context.map_or_else(
+        || cstr!("Failed to start Corsa API session: {error}"),
+        |context| cstr!("Failed to start Corsa API session: {error} ({context})"),
+    );
+    if matches!(
+        &error,
+        CorsaError::Protocol(detail)
+            if detail.contains("project session did not resolve a project")
+    ) {
+        ProjectSessionSpawnError::Unavailable(message)
+    } else {
+        ProjectSessionSpawnError::Failed(message)
+    }
 }
 
 async fn spawn_project_session_with_mode(
@@ -131,42 +159,68 @@ pub(super) fn uri_document_identifier(uri: &str) -> DocumentIdentifier {
 }
 
 impl CorsaProjectClient {
+    pub(super) fn has_project_session(&self) -> bool {
+        self.session.is_some()
+    }
+
+    pub(super) fn project_session(&self) -> Result<&ProjectSession, String> {
+        self.session
+            .as_ref()
+            .ok_or_else(|| cstr!("Corsa project-session API is unavailable"))
+    }
+
+    pub(super) fn project_session_mut(&mut self) -> Result<&mut ProjectSession, String> {
+        self.session
+            .as_mut()
+            .ok_or_else(|| cstr!("Corsa project-session API is unavailable"))
+    }
+
     fn trusts_capabilities(&self) -> bool {
         self.capabilities.runtime.capability_endpoint
     }
 
     pub(super) fn supports_overlay_api(&self) -> bool {
+        if !self.has_project_session() {
+            return true;
+        }
         !self.overlay_api_disabled
             && (!self.trusts_capabilities()
                 || self.capabilities.overlay.update_snapshot_overlay_changes)
     }
 
     pub(super) fn supports_project_diagnostics_api(&self) -> bool {
-        !self.trusts_capabilities() || self.capabilities.diagnostics.project
+        self.has_project_session()
+            && (!self.trusts_capabilities() || self.capabilities.diagnostics.project)
     }
 
     pub(super) fn supports_file_diagnostics_api(&self) -> bool {
-        !self.trusts_capabilities() || self.capabilities.diagnostics.file
+        self.has_project_session()
+            && (!self.trusts_capabilities() || self.capabilities.diagnostics.file)
     }
 
     pub(super) fn supports_hover_api(&self) -> bool {
-        !self.trusts_capabilities() || self.capabilities.editor.hover
+        self.has_project_session()
+            && (!self.trusts_capabilities() || self.capabilities.editor.hover)
     }
 
     pub(super) fn supports_definition_api(&self) -> bool {
-        !self.trusts_capabilities() || self.capabilities.editor.definition
+        self.has_project_session()
+            && (!self.trusts_capabilities() || self.capabilities.editor.definition)
     }
 
     pub(super) fn supports_references_api(&self) -> bool {
-        !self.trusts_capabilities() || self.capabilities.editor.references
+        self.has_project_session()
+            && (!self.trusts_capabilities() || self.capabilities.editor.references)
     }
 
     pub(super) fn supports_rename_api(&self) -> bool {
-        !self.trusts_capabilities() || self.capabilities.editor.rename
+        self.has_project_session()
+            && (!self.trusts_capabilities() || self.capabilities.editor.rename)
     }
 
     pub(super) fn supports_completion_api(&self) -> bool {
-        !self.trusts_capabilities() || self.capabilities.editor.completion
+        self.has_project_session()
+            && (!self.trusts_capabilities() || self.capabilities.editor.completion)
     }
 
     pub(super) fn can_use_api_for_uri(&self, uri: &str) -> bool {
@@ -181,6 +235,10 @@ impl CorsaProjectClient {
 
         if self.materialized_project_session {
             return self.sync_materialized_overlay_document(uri, content);
+        }
+
+        if !self.has_project_session() {
+            return Ok(());
         }
 
         let document_uri = self.session_document_uri(uri);
@@ -202,7 +260,7 @@ impl CorsaProjectClient {
                 )
             });
         let version = next_overlay_version(&mut self.overlay_versions, uri);
-        match block_on(self.session.refresh_with_overlay_changes(
+        match block_on(self.project_session_mut()?.refresh_with_overlay_changes(
             file_changes,
             Some(OverlayChanges {
                 upsert: vec![OverlayUpdate {
@@ -233,7 +291,10 @@ impl CorsaProjectClient {
             .materialized_session_document_uri(uri)
             .ok_or_else(|| cstr!("Failed to derive materialized Corsa overlay path for {uri}"))?;
         let file_changes = materialize_session_document(uri, document_uri.as_str(), content);
-        block_on(self.session.refresh(file_changes))
+        if !self.has_project_session() {
+            return Ok(());
+        }
+        block_on(self.project_session_mut()?.refresh(file_changes))
             .map_err(|error| cstr!("Failed to refresh Corsa snapshot: {error}"))
     }
 
@@ -250,8 +311,11 @@ impl CorsaProjectClient {
         let file_changes = remove_session_document(uri, document_uri.as_str()).or_else(|| {
             virtual_overlay::delete_file_changes(uri, document_uri.as_str(), &self.project_root)
         });
+        if !self.has_project_session() {
+            return Ok(());
+        }
         if document_uri != uri {
-            return block_on(self.session.refresh(file_changes))
+            return block_on(self.project_session_mut()?.refresh(file_changes))
                 .map_err(|error| cstr!("Failed to refresh Corsa snapshot: {error}"));
         }
 
@@ -259,7 +323,7 @@ impl CorsaProjectClient {
             return Ok(());
         }
 
-        block_on(self.session.refresh_with_overlay_changes(
+        block_on(self.project_session_mut()?.refresh_with_overlay_changes(
             file_changes,
             Some(OverlayChanges {
                 upsert: Vec::new(),
@@ -410,7 +474,8 @@ pub(super) fn line_character_to_utf16_offset(text: &str, line: u32, character: u
 #[cfg(test)]
 mod tests {
     use super::{
-        api_mode_for_executable, build_session_document_uri, line_character_to_utf16_offset,
+        ProjectSessionSpawnError, api_mode_for_executable, build_session_document_uri,
+        classify_project_session_error, line_character_to_utf16_offset,
         overlay_changes_error_is_unsupported, should_retry_json_rpc, uri_document_identifier,
     };
     use crate::file_uri::path_to_file_uri;
@@ -529,5 +594,27 @@ mod tests {
             uri_document_identifier("corsa://overlay/App.vue.ts"),
             DocumentIdentifier::Uri { .. }
         ));
+    }
+
+    #[test]
+    fn recognizes_only_the_standard_runtime_project_session_gap() {
+        let unavailable = classify_project_session_error(
+            CorsaError::Protocol("project session did not resolve a project".into()),
+            None,
+        );
+        assert!(matches!(
+            unavailable,
+            ProjectSessionSpawnError::Unavailable(_)
+        ));
+
+        for error in [
+            CorsaError::Protocol("EOF while parsing project response".into()),
+            CorsaError::Protocol("project session crashed".into()),
+        ] {
+            assert!(matches!(
+                classify_project_session_error(error, None),
+                ProjectSessionSpawnError::Failed(_)
+            ));
+        }
     }
 }

--- a/crates/vize_canon/tests/lsp_import_resolution.rs
+++ b/crates/vize_canon/tests/lsp_import_resolution.rs
@@ -4,7 +4,7 @@ use vize_canon::{CorsaBridge, CorsaBridgeConfig, LspHover, LspHoverContents, Lsp
 use vize_carton::ToCompactString;
 
 #[test]
-fn bridge_materialized_overlay_preserves_workspace_project_options() {
+fn bridge_virtual_overlay_preserves_workspace_project_options() {
     let Some(corsa_path) = resolve_test_tsgo_binary() else {
         return;
     };
@@ -61,12 +61,6 @@ fn bridge_materialized_overlay_preserves_workspace_project_options() {
         diagnostics
     });
 
-    assert!(
-        project_root
-            .join("node_modules/.vize/corsa-overlay/tsconfig.json")
-            .is_file(),
-        "virtual overlays must activate the materialized project"
-    );
     assert_eq!(
         diagnostics.len(),
         1,
@@ -82,15 +76,23 @@ fn bridge_materialized_overlay_preserves_workspace_project_options() {
         std::fs::read_to_string(project_root.join("tsconfig.json")).unwrap(),
         tsconfig
     );
-    let overlay_src = project_root.join("node_modules/.vize/corsa-overlay/src");
-    assert_eq!(
-        std::fs::read_to_string(overlay_src.join("App.vue.ts")).unwrap(),
-        app_virtual
-    );
-    assert_eq!(
-        std::fs::read_to_string(overlay_src.join("Child.vue.ts")).unwrap(),
-        child_virtual
-    );
+    let overlay_root = project_root.join("node_modules/.vize/corsa-overlay");
+    if overlay_root.join("tsconfig.json").is_file() {
+        let overlay_src = overlay_root.join("src");
+        assert_eq!(
+            std::fs::read_to_string(overlay_src.join("App.vue.ts")).unwrap(),
+            app_virtual
+        );
+        assert_eq!(
+            std::fs::read_to_string(overlay_src.join("Child.vue.ts")).unwrap(),
+            child_virtual
+        );
+    } else {
+        assert!(
+            !overlay_root.exists(),
+            "editor-only mode must not partially materialize an overlay"
+        );
+    }
     assert!(!app_virtual_path.exists());
     assert!(!child_virtual_path.exists());
 }

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -17,7 +17,11 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
     '"crates/vize_canon/src/batch/virtual_project.rs"',
     '"crates/vize_canon/src/batch/virtual_project/content_mapper*"',
     '"crates/vize_canon/src/lib.rs"',
+    '"crates/vize_canon/src/lsp_client.rs"',
+    '"crates/vize_canon/src/lsp_client/**"',
+    '"crates/vize_canon/tests/lsp_import_resolution.rs"',
     '"crates/vize_canon/src/virtual_ts/**"',
+    '"crates/vize_maestro/src/ide/**"',
     '"crates/vize/tests/content_mapper_tsgo_cli.rs"',
     '"crates/vize/tests/fixtures/content_mapper_project/**"',
     '"npm/cli/package.json"',
@@ -38,4 +42,10 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
   assert.match(job, /cp internal\/bundled\/libs\/\*\.d\.ts "\$RUNNER_TEMP\/"/);
   assert.match(job, /VIZE_TEST_CONTENT_MAPPER_TSGO: \$\{\{ runner\.temp \}\}\/tsgo/);
   assert.match(job, /cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture/);
+  assert.match(job, /TSGO_PATH: \$\{\{ runner\.temp \}\}\/tsgo/);
+  assert.match(
+    job,
+    /cargo test -p vize_canon --test lsp_import_resolution -- --nocapture/,
+  );
+  assert.match(job, /cargo test -p vize_maestro/);
 });


### PR DESCRIPTION
## Summary

- recognize the exact standard tsgo project-session capability gap and keep arbitrary startup failures fail-closed
- route diagnostics, hover, definition, completion, and signature help through the standard editor LSP while preserving workspace project options and virtual dependency identity
- pin the exact upstream tsgo editor backend in the Content Mapper conformance workflow

Closes #4022.

## Verification

- `cargo fmt --all`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo test -p vize_canon`
- `TSGO_PATH=/tmp/vize-tsgo-content-mapper.VbyU0F/tsgo cargo test -p vize_canon --test lsp_import_resolution -- --nocapture`
- `TSGO_PATH=/tmp/vize-tsgo-content-mapper.VbyU0F/tsgo cargo test -p vize_maestro`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-tsgo-content-mapper.VbyU0F/tsgo cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture`
- `node --test tests/tooling/content-mapper-workflow.test.ts`
- `pnpm vp run source:lengths`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->