### PR TITLE
feat(canon): bridge tsgo rename and references

### DIFF
--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -53,6 +53,30 @@ impl lsp_types::request::Request for RawDefinitionRequest {
     const METHOD: &'static str = "textDocument/definition";
 }
 
+struct RawReferencesRequest;
+
+impl lsp_types::request::Request for RawReferencesRequest {
+    type Params = Value;
+    type Result = Option<Value>;
+    const METHOD: &'static str = "textDocument/references";
+}
+
+struct RawPrepareRenameRequest;
+
+impl lsp_types::request::Request for RawPrepareRenameRequest {
+    type Params = Value;
+    type Result = Option<Value>;
+    const METHOD: &'static str = "textDocument/prepareRename";
+}
+
+struct RawRenameRequest;
+
+impl lsp_types::request::Request for RawRenameRequest {
+    type Params = Value;
+    type Result = Option<Value>;
+    const METHOD: &'static str = "textDocument/rename";
+}
+
 struct RawSignatureHelpRequest;
 
 impl lsp_types::request::Request for RawSignatureHelpRequest {
@@ -207,6 +231,58 @@ impl EditorLspSession {
         .map_err(|error| cstr!("Failed to request editor LSP definition: {error}"))
     }
 
+    fn references(
+        &mut self,
+        document_uri: &str,
+        line: u32,
+        character: u32,
+        include_declaration: bool,
+    ) -> Result<Option<Value>, String> {
+        let uri = self.document_uri(document_uri)?;
+        block_on(
+            self.client
+                .request::<RawReferencesRequest>(serde_json::json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": line, "character": character },
+                    "context": { "includeDeclaration": include_declaration },
+                })),
+        )
+        .map_err(|error| cstr!("Failed to request editor LSP references: {error}"))
+    }
+
+    fn prepare_rename(
+        &mut self,
+        document_uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        let uri = self.document_uri(document_uri)?;
+        block_on(
+            self.client
+                .request::<RawPrepareRenameRequest>(serde_json::json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": line, "character": character },
+                })),
+        )
+        .map_err(|error| cstr!("Failed to request editor LSP prepare rename: {error}"))
+    }
+
+    fn rename(
+        &mut self,
+        document_uri: &str,
+        line: u32,
+        character: u32,
+        new_name: &str,
+    ) -> Result<Option<Value>, String> {
+        let uri = self.document_uri(document_uri)?;
+        block_on(self.client.request::<RawRenameRequest>(serde_json::json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": line, "character": character },
+            "newName": new_name,
+        })))
+        .map_err(|error| cstr!("Failed to request editor LSP rename: {error}"))
+    }
+
     fn signature_help(
         &mut self,
         document_uri: &str,
@@ -356,6 +432,47 @@ impl CorsaProjectClient {
             return Ok(None);
         }
         self.editor_lsp_session()?.definition(uri, line, character)
+    }
+
+    pub(super) fn references_via_editor_lsp(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+        include_declaration: bool,
+    ) -> Result<Option<Value>, String> {
+        if !self.document_texts.contains_key(uri) {
+            return Ok(None);
+        }
+        self.editor_lsp_session()?
+            .references(uri, line, character, include_declaration)
+    }
+
+    pub(super) fn prepare_rename_via_editor_lsp(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        if !self.document_texts.contains_key(uri) {
+            return Ok(None);
+        }
+        self.editor_lsp_session()?
+            .prepare_rename(uri, line, character)
+    }
+
+    pub(super) fn rename_via_editor_lsp(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+        new_name: &str,
+    ) -> Result<Option<Value>, String> {
+        if !self.document_texts.contains_key(uri) {
+            return Ok(None);
+        }
+        self.editor_lsp_session()?
+            .rename(uri, line, character, new_name)
     }
 
     pub(super) fn signature_help_via_editor_lsp(

--- a/crates/vize_canon/src/lsp_client/queries.rs
+++ b/crates/vize_canon/src/lsp_client/queries.rs
@@ -78,31 +78,36 @@ impl CorsaProjectClient {
         uri: &str,
         line: u32,
         character: u32,
-        _include_declaration: bool,
+        include_declaration: bool,
     ) -> Result<Option<Value>, String> {
         let Some(position) =
             self.api_position(uri, line, character, self.supports_references_api())?
         else {
-            return Ok(None);
+            return self.references_via_editor_lsp(uri, line, character, include_declaration);
         };
 
         let document_uri = self.session_document_uri(uri);
-        let response =
-            block_on(self.project_session()?.get_references_at_position(
+        match block_on(
+            self.project_session()?.get_references_at_position(
                 uri_document_identifier(document_uri.as_str()),
                 position,
-            ))
-            .map_err(|error| cstr!("Failed to request references: {error}"))?;
-        self.serialize_with_remapped_uris(Some(response))
+            ),
+        ) {
+            Ok(response) => self.serialize_with_remapped_uris(Some(response)),
+            Err(CorsaError::Unsupported(_)) => {
+                self.references_via_editor_lsp(uri, line, character, include_declaration)
+            }
+            Err(error) => Err(cstr!("Failed to request references: {error}")),
+        }
     }
 
     pub(crate) fn prepare_rename_raw(
         &mut self,
-        _uri: &str,
-        _line: u32,
-        _character: u32,
+        uri: &str,
+        line: u32,
+        character: u32,
     ) -> Result<Option<Value>, String> {
-        Ok(None)
+        self.prepare_rename_via_editor_lsp(uri, line, character)
     }
 
     pub(crate) fn rename_raw(
@@ -114,17 +119,21 @@ impl CorsaProjectClient {
     ) -> Result<Option<Value>, String> {
         let Some(position) = self.api_position(uri, line, character, self.supports_rename_api())?
         else {
-            return Ok(None);
+            return self.rename_via_editor_lsp(uri, line, character, new_name);
         };
 
         let document_uri = self.session_document_uri(uri);
-        let response = block_on(self.project_session()?.get_rename_at_position(
+        match block_on(self.project_session()?.get_rename_at_position(
             uri_document_identifier(document_uri.as_str()),
             position,
             new_name,
-        ))
-        .map_err(|error| cstr!("Failed to request rename: {error}"))?;
-        self.serialize_with_remapped_uris(response)
+        )) {
+            Ok(response) => self.serialize_with_remapped_uris(response),
+            Err(CorsaError::Unsupported(_)) => {
+                self.rename_via_editor_lsp(uri, line, character, new_name)
+            }
+            Err(error) => Err(cstr!("Failed to request rename: {error}")),
+        }
     }
 
     pub(crate) fn will_rename_files_raw(

--- a/crates/vize_canon/tests/lsp_import_resolution.rs
+++ b/crates/vize_canon/tests/lsp_import_resolution.rs
@@ -420,6 +420,126 @@ props.message;
     assert!(!parent_path.exists());
 }
 
+#[test]
+fn bridge_editor_references_and_rename_span_in_memory_virtual_dependencies() {
+    let Some(corsa_path) = resolve_test_tsgo_binary() else {
+        return;
+    };
+
+    let project = tempfile::TempDir::new().unwrap();
+    let project_root = project.path();
+    let src_dir = project_root.join("src");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(src_dir.join("Parent.vue"), "<template />\n").unwrap();
+    std::fs::write(src_dir.join("Child.vue"), "<template />\n").unwrap();
+
+    let child_virtual = "export const message = 'hello';\n";
+    let parent_virtual =
+        "import { message } from './Child.vue.ts';\nexport const displayed = message;\n";
+    let child_path = src_dir.join("Child.vue.ts");
+    let parent_path = src_dir.join("Parent.vue.ts");
+    let bridge = CorsaBridge::with_config(CorsaBridgeConfig {
+        corsa_path: Some(corsa_path),
+        working_dir: Some(project_root.to_path_buf()),
+        timeout_ms: 30_000,
+        ..Default::default()
+    });
+
+    let (child_uri, parent_uri, references, references_with_declaration, prepare, rename) =
+        corsa::runtime::block_on(async {
+            bridge.spawn().await.unwrap();
+            let child_uri = child_path.display().to_compact_string();
+            let child_uri = bridge
+                .open_or_update_virtual_document(child_uri.as_str(), child_virtual)
+                .await
+                .unwrap();
+            let parent_uri = parent_path.display().to_compact_string();
+            let parent_uri = bridge
+                .open_or_update_virtual_document(parent_uri.as_str(), parent_virtual)
+                .await
+                .unwrap();
+            let declaration_character = child_virtual.find("message").unwrap() as u32;
+            let references = bridge
+                .references(child_uri.as_str(), 0, declaration_character, false)
+                .await
+                .unwrap();
+            let references_with_declaration = bridge
+                .references(child_uri.as_str(), 0, declaration_character, true)
+                .await
+                .unwrap();
+            let prepare = bridge
+                .prepare_rename(child_uri.as_str(), 0, declaration_character)
+                .await
+                .unwrap();
+            let rename = bridge
+                .rename(
+                    child_uri.as_str(),
+                    0,
+                    declaration_character,
+                    "renamedMessage",
+                )
+                .await
+                .unwrap();
+            bridge.shutdown().await.unwrap();
+            (
+                child_uri,
+                parent_uri,
+                references,
+                references_with_declaration,
+                prepare,
+                rename,
+            )
+        });
+
+    assert!(
+        references.iter().all(|location| location.uri != child_uri),
+        "declaration must be excluded: {references:#?}"
+    );
+    assert!(
+        references_with_declaration.iter().any(|location| {
+            location.uri == child_uri
+                && location.range.start.line == 0
+                && location.range.start.character == child_virtual.find("message").unwrap() as u32
+        }),
+        "declaration must be included: {references_with_declaration:#?}"
+    );
+    assert!(
+        references_with_declaration
+            .iter()
+            .any(|location| location.uri == parent_uri && location.range.start.line == 0),
+        "import must be included: {references_with_declaration:#?}"
+    );
+    assert!(
+        references_with_declaration
+            .iter()
+            .any(|location| location.uri == parent_uri && location.range.start.line == 1),
+        "usage must be included: {references_with_declaration:#?}"
+    );
+    assert!(prepare.is_some(), "the declaration must be renameable");
+
+    let rename = rename.expect("rename must return a workspace edit");
+    let rename_json = serde_json::to_string(&rename).unwrap();
+    assert!(rename_json.contains(child_uri.as_str()), "{rename_json}");
+    assert!(rename_json.contains(parent_uri.as_str()), "{rename_json}");
+    assert!(rename_json.contains("renamedMessage"), "{rename_json}");
+    assert!(!child_path.exists());
+    assert!(!parent_path.exists());
+}
+
 fn hover_contains(hover: &Option<LspHover>, expected: &str) -> bool {
     hover.as_ref().is_some_and(|hover| match &hover.contents {
         LspHoverContents::Markup(markup) => markup.value.contains(expected),


### PR DESCRIPTION
## Summary

- add reusable standard-LSP requests for references, prepare rename, and rename
- preserve the custom project-session fast path and fall back only when its editor capability is unavailable
- verify declaration filtering and cross-file edits across in-memory Vue virtual dependencies against both supported runtimes

Progresses #4015 and #3953.

## Verification

- `cargo fmt --all`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo test -p vize_canon`
- `TSGO_PATH=/tmp/vize-tsgo-content-mapper.VbyU0F/tsgo cargo test -p vize_canon --test lsp_import_resolution -- --nocapture`
- `cargo test -p vize_canon --test lsp_import_resolution -- --nocapture`
- `pnpm vp run source:lengths`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->