### PR TITLE
fix(maestro): map cross-sfc editor results

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -14,6 +14,7 @@ mod html_attribute_tests;
 mod html_tag;
 #[cfg(feature = "native")]
 mod svg_attribute;
+mod virtual_document;
 #[cfg(feature = "native")]
 mod virtual_mirror;
 mod workspace_edit;
@@ -29,6 +30,9 @@ pub(crate) use html_attribute::{
 };
 #[cfg(feature = "native")]
 pub(crate) use html_tag::{html_tag_request_path, html_tag_virtual_document, native_dom_tag_info};
+use virtual_document::{
+    MatchedVirtualDocument, is_virtual_document_uri, match_virtual_document, virtual_document_path,
+};
 pub(crate) use workspace_edit::map_corsa_workspace_edit;
 
 use vize_canon::LspLocation;
@@ -36,20 +40,6 @@ use vize_carton::{String, cstr};
 
 use super::IdeContext;
 use crate::virtual_code::{SourceRange, VirtualDocument};
-
-enum CurrentVirtualDocument<'a> {
-    Template(&'a VirtualDocument),
-    Script(&'a VirtualDocument),
-    ScriptSetup(&'a VirtualDocument),
-}
-
-impl<'a> CurrentVirtualDocument<'a> {
-    fn document(&self) -> &'a VirtualDocument {
-        match self {
-            Self::Template(doc) | Self::Script(doc) | Self::ScriptSetup(doc) => doc,
-        }
-    }
-}
 
 pub(crate) fn template_request_path(uri: &Url) -> String {
     cstr!("{}.template.ts", uri.path())
@@ -112,10 +102,10 @@ pub(crate) fn map_corsa_locations(
 
 /// Map a single Corsa location back to either the Vue SFC or a real file URI.
 pub(crate) fn map_corsa_location(ctx: &IdeContext<'_>, location: &LspLocation) -> Option<Location> {
-    if let Some(current_doc) = match_current_virtual_document(ctx, &location.uri) {
-        let range = map_virtual_range(
-            ctx,
-            current_doc.document(),
+    if let Some(target) = match_virtual_document(ctx, &location.uri) {
+        let range = map_virtual_range_for_content(
+            target.content(),
+            target.document()?,
             &Range {
                 start: tower_lsp::lsp_types::Position {
                     line: location.range.start.line,
@@ -129,9 +119,12 @@ pub(crate) fn map_corsa_location(ctx: &IdeContext<'_>, location: &LspLocation) -
         )?;
 
         return Some(Location {
-            uri: ctx.uri.clone(),
+            uri: target.uri().clone(),
             range,
         });
+    }
+    if is_virtual_document_uri(&location.uri) {
+        return None;
     }
 
     let uri = Url::parse(&location.uri).ok()?;
@@ -156,14 +149,15 @@ pub(crate) fn map_corsa_prepare_rename(
     request_uri: &str,
     response: PrepareRenameResponse,
 ) -> Option<PrepareRenameResponse> {
-    let current_doc = match_current_virtual_document(ctx, request_uri)?;
+    let target = match_virtual_document(ctx, request_uri)?;
 
     match response {
         PrepareRenameResponse::Range(range) => {
-            map_virtual_range(ctx, current_doc.document(), &range).map(PrepareRenameResponse::Range)
+            map_virtual_range_for_content(target.content(), target.document()?, &range)
+                .map(PrepareRenameResponse::Range)
         }
         PrepareRenameResponse::RangeWithPlaceholder { range, placeholder } => {
-            map_virtual_range(ctx, current_doc.document(), &range)
+            map_virtual_range_for_content(target.content(), target.document()?, &range)
                 .map(|range| PrepareRenameResponse::RangeWithPlaceholder { range, placeholder })
         }
         PrepareRenameResponse::DefaultBehavior { default_behavior } => {
@@ -174,6 +168,14 @@ pub(crate) fn map_corsa_prepare_rename(
 
 pub(crate) fn map_virtual_range(
     ctx: &IdeContext<'_>,
+    document: &VirtualDocument,
+    range: &Range,
+) -> Option<Range> {
+    map_virtual_range_for_content(&ctx.content, document, range)
+}
+
+fn map_virtual_range_for_content(
+    content: &str,
     document: &VirtualDocument,
     range: &Range,
 ) -> Option<Range> {
@@ -195,9 +197,8 @@ pub(crate) fn map_virtual_range(
     };
 
     let (start_line, start_character) =
-        super::offset_to_position(&ctx.content, source_range.start as usize);
-    let (end_line, end_character) =
-        super::offset_to_position(&ctx.content, source_range.end as usize);
+        super::offset_to_position(content, source_range.start as usize);
+    let (end_line, end_character) = super::offset_to_position(content, source_range.end as usize);
 
     Some(Range {
         start: tower_lsp::lsp_types::Position {
@@ -209,53 +210,4 @@ pub(crate) fn map_virtual_range(
             character: end_character,
         },
     })
-}
-
-fn match_current_virtual_document<'a>(
-    ctx: &'a IdeContext<'_>,
-    uri: &str,
-) -> Option<CurrentVirtualDocument<'a>> {
-    let path = virtual_document_path(uri)?;
-    let virtual_docs = ctx.virtual_docs.as_ref()?;
-
-    if path == template_request_path(ctx.uri).as_str() {
-        return virtual_docs
-            .template
-            .as_ref()
-            .map(CurrentVirtualDocument::Template);
-    }
-
-    for (variant_index, template) in virtual_docs.art_templates.iter().enumerate() {
-        if path == art_template_request_path(ctx.uri, variant_index).as_str() {
-            return template.as_ref().map(CurrentVirtualDocument::Template);
-        }
-    }
-
-    if path == script_request_path(ctx.uri, false).as_str() {
-        return virtual_docs
-            .script
-            .as_ref()
-            .map(CurrentVirtualDocument::Script);
-    }
-
-    if path == script_request_path(ctx.uri, true).as_str() {
-        return virtual_docs
-            .script_setup
-            .as_ref()
-            .map(CurrentVirtualDocument::ScriptSetup);
-    }
-
-    None
-}
-
-pub(super) fn virtual_document_path(uri: &str) -> Option<String> {
-    if let Ok(parsed) = Url::parse(uri) {
-        return Some(parsed.path().to_string().into());
-    }
-
-    if let Some(path) = uri.strip_prefix("vize-virtual://") {
-        return Some(path.to_string().into());
-    }
-
-    None
 }

--- a/crates/vize_maestro/src/ide/corsa_support/virtual_document.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/virtual_document.rs
@@ -1,0 +1,186 @@
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::Url;
+use vize_carton::String;
+
+use crate::ide::IdeContext;
+use crate::virtual_code::{VirtualDocument, VirtualDocuments};
+
+#[derive(Clone, Copy)]
+pub(super) enum VirtualDocumentKind {
+    Template,
+    ArtTemplate(usize),
+    Script,
+    ScriptSetup,
+}
+
+enum CurrentVirtualDocument<'a> {
+    Template(&'a VirtualDocument),
+    Script(&'a VirtualDocument),
+    ScriptSetup(&'a VirtualDocument),
+}
+
+impl<'a> CurrentVirtualDocument<'a> {
+    fn document(&self) -> &'a VirtualDocument {
+        match self {
+            Self::Template(doc) | Self::Script(doc) | Self::ScriptSetup(doc) => doc,
+        }
+    }
+}
+
+pub(super) enum MatchedVirtualDocument<'a> {
+    Current {
+        uri: &'a Url,
+        content: &'a str,
+        document: &'a VirtualDocument,
+    },
+    Cached {
+        uri: Url,
+        content: String,
+        documents: Arc<VirtualDocuments>,
+        kind: VirtualDocumentKind,
+    },
+}
+
+impl MatchedVirtualDocument<'_> {
+    pub(super) fn uri(&self) -> &Url {
+        match self {
+            Self::Current { uri, .. } => uri,
+            Self::Cached { uri, .. } => uri,
+        }
+    }
+
+    pub(super) fn content(&self) -> &str {
+        match self {
+            Self::Current { content, .. } => content,
+            Self::Cached { content, .. } => content.as_str(),
+        }
+    }
+
+    pub(super) fn document(&self) -> Option<&VirtualDocument> {
+        match self {
+            Self::Current { document, .. } => Some(document),
+            Self::Cached {
+                documents, kind, ..
+            } => match kind {
+                VirtualDocumentKind::Template => documents.template.as_ref(),
+                VirtualDocumentKind::ArtTemplate(index) => documents.art_template(*index),
+                VirtualDocumentKind::Script => documents.script.as_ref(),
+                VirtualDocumentKind::ScriptSetup => documents.script_setup.as_ref(),
+            },
+        }
+    }
+}
+
+pub(super) fn match_virtual_document<'a>(
+    ctx: &'a IdeContext<'_>,
+    uri: &str,
+) -> Option<MatchedVirtualDocument<'a>> {
+    if let Some(current) = match_current_virtual_document(ctx, uri) {
+        return Some(MatchedVirtualDocument::Current {
+            uri: ctx.uri,
+            content: &ctx.content,
+            document: current.document(),
+        });
+    }
+
+    let (authored_uri, kind) = virtual_document_target(uri)?;
+    let documents = ctx.state.get_virtual_docs(&authored_uri)?;
+    let content = ctx.state.documents.text(&authored_uri).or_else(|| {
+        authored_uri
+            .to_file_path()
+            .ok()
+            .and_then(|path| std::fs::read_to_string(path).ok())
+    })?;
+    let target = MatchedVirtualDocument::Cached {
+        uri: authored_uri,
+        content: content.into(),
+        documents,
+        kind,
+    };
+    target.document()?;
+    Some(target)
+}
+
+pub(super) fn is_virtual_document_uri(uri: &str) -> bool {
+    virtual_document_target(uri).is_some()
+}
+
+fn virtual_document_target(uri: &str) -> Option<(Url, VirtualDocumentKind)> {
+    let mut parsed = Url::parse(uri).ok()?;
+    let path = parsed.path();
+    let (authored_path, kind) = if let Some(without_template) = path.strip_suffix(".template.ts") {
+        if let Some((authored, index)) = without_template.rsplit_once(".art_variant_") {
+            (
+                authored,
+                VirtualDocumentKind::ArtTemplate(index.parse().ok()?),
+            )
+        } else {
+            (without_template, VirtualDocumentKind::Template)
+        }
+    } else if let Some(authored) = path.strip_suffix(".script.ts") {
+        (authored, VirtualDocumentKind::Script)
+    } else if let Some(authored) = path.strip_suffix(".setup.ts") {
+        (authored, VirtualDocumentKind::ScriptSetup)
+    } else {
+        return None;
+    };
+    if !authored_path.ends_with(".vue") {
+        return None;
+    }
+
+    let authored_path = authored_path.to_string();
+    parsed.set_path(&authored_path);
+    parsed.set_query(None);
+    parsed.set_fragment(None);
+    Some((parsed, kind))
+}
+
+fn match_current_virtual_document<'a>(
+    ctx: &'a IdeContext<'_>,
+    uri: &str,
+) -> Option<CurrentVirtualDocument<'a>> {
+    let path = virtual_document_path(uri)?;
+    let virtual_docs = ctx.virtual_docs.as_ref()?;
+
+    if path == super::template_request_path(ctx.uri).as_str() {
+        return virtual_docs
+            .template
+            .as_ref()
+            .map(CurrentVirtualDocument::Template);
+    }
+
+    for (variant_index, template) in virtual_docs.art_templates.iter().enumerate() {
+        if path == super::art_template_request_path(ctx.uri, variant_index).as_str() {
+            return template.as_ref().map(CurrentVirtualDocument::Template);
+        }
+    }
+
+    if path == super::script_request_path(ctx.uri, false).as_str() {
+        return virtual_docs
+            .script
+            .as_ref()
+            .map(CurrentVirtualDocument::Script);
+    }
+
+    if path == super::script_request_path(ctx.uri, true).as_str() {
+        return virtual_docs
+            .script_setup
+            .as_ref()
+            .map(CurrentVirtualDocument::ScriptSetup);
+    }
+
+    None
+}
+
+pub(super) fn virtual_document_path(uri: &str) -> Option<String> {
+    if let Ok(parsed) = Url::parse(uri) {
+        return Some(parsed.path().to_string().into());
+    }
+
+    if let Some(path) = uri.strip_prefix("vize-virtual://") {
+        return Some(path.to_string().into());
+    }
+
+    None
+}

--- a/crates/vize_maestro/src/ide/corsa_support/workspace_edit.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/workspace_edit.rs
@@ -5,7 +5,6 @@ use tower_lsp::lsp_types::{
 };
 
 use crate::ide::IdeContext;
-use crate::virtual_code::VirtualDocument;
 
 pub(crate) fn map_corsa_workspace_edit(
     ctx: &IdeContext<'_>,
@@ -15,16 +14,16 @@ pub(crate) fn map_corsa_workspace_edit(
         let mut mapped_changes = HashMap::with_capacity(changes.len());
 
         for (uri, edits) in changes {
-            if let Some(current_doc) = super::match_current_virtual_document(ctx, uri.as_str()) {
+            if let Some(target) = super::match_virtual_document(ctx, uri.as_str()) {
                 let entry = mapped_changes
-                    .entry(ctx.uri.clone())
+                    .entry(target.uri().clone())
                     .or_insert_with(Vec::new);
                 entry.extend(
                     edits
                         .into_iter()
-                        .filter_map(|edit| map_text_edit(ctx, current_doc.document(), edit)),
+                        .filter_map(|edit| map_text_edit(&target, edit)),
                 );
-            } else {
+            } else if !super::is_virtual_document_uri(uri.as_str()) {
                 mapped_changes.insert(uri, edits);
             }
         }
@@ -106,23 +105,22 @@ fn map_document_edit(
     ctx: &IdeContext<'_>,
     mut edit: tower_lsp::lsp_types::TextDocumentEdit,
 ) -> Option<tower_lsp::lsp_types::TextDocumentEdit> {
-    let current_doc = super::match_current_virtual_document(ctx, edit.text_document.uri.as_str());
+    let target = super::match_virtual_document(ctx, edit.text_document.uri.as_str());
 
-    if let Some(current_doc) = current_doc {
-        edit.text_document.uri = ctx.uri.clone();
+    if let Some(target) = target {
+        edit.text_document.uri = target.uri().clone();
         edit.edits = edit
             .edits
             .into_iter()
             .filter_map(|entry| match entry {
-                OneOf::Left(text_edit) => {
-                    map_text_edit(ctx, current_doc.document(), text_edit).map(OneOf::Left)
-                }
+                OneOf::Left(text_edit) => map_text_edit(&target, text_edit).map(OneOf::Left),
                 OneOf::Right(annotated) => {
-                    map_annotated_text_edit(ctx, current_doc.document(), annotated)
-                        .map(OneOf::Right)
+                    map_annotated_text_edit(&target, annotated).map(OneOf::Right)
                 }
             })
             .collect();
+    } else if super::is_virtual_document_uri(edit.text_document.uri.as_str()) {
+        return None;
     }
 
     if edit.edits.is_empty() {
@@ -133,19 +131,198 @@ fn map_document_edit(
 }
 
 fn map_annotated_text_edit(
-    ctx: &IdeContext<'_>,
-    document: &VirtualDocument,
+    target: &super::MatchedVirtualDocument<'_>,
     mut edit: AnnotatedTextEdit,
 ) -> Option<AnnotatedTextEdit> {
-    edit.text_edit = map_text_edit(ctx, document, edit.text_edit)?;
+    edit.text_edit = map_text_edit(target, edit.text_edit)?;
     Some(edit)
 }
 
 fn map_text_edit(
-    ctx: &IdeContext<'_>,
-    document: &VirtualDocument,
+    target: &super::MatchedVirtualDocument<'_>,
     mut edit: TextEdit,
 ) -> Option<TextEdit> {
-    edit.range = super::map_virtual_range(ctx, document, &edit.range)?;
+    edit.range =
+        super::map_virtual_range_for_content(target.content(), target.document()?, &edit.range)?;
     Some(edit)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use tower_lsp::lsp_types::{
+        DocumentChanges, OneOf, OptionalVersionedTextDocumentIdentifier, Position, Range,
+        TextDocumentEdit, TextEdit, Url, WorkspaceEdit,
+    };
+    use vize_canon::{LspLocation, LspPosition, LspRange};
+
+    use super::map_corsa_workspace_edit;
+    use crate::{
+        ide::{IdeContext, corsa_support, offset_to_position},
+        server::ServerState,
+    };
+
+    #[test]
+    fn maps_cross_sfc_virtual_edits_and_references_to_authored_documents() {
+        let state = ServerState::new();
+        let child_uri = Url::parse("file:///workspace/Child%20View.vue").unwrap();
+        let parent_uri = Url::parse("file:///workspace/Parent%20View.vue").unwrap();
+        let child_source = sfc("child");
+        let parent_source = sfc("parent");
+        for (uri, source) in [
+            (&child_uri, child_source.as_str()),
+            (&parent_uri, parent_source.as_str()),
+        ] {
+            state
+                .documents
+                .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+            state.update_virtual_docs(uri, source);
+        }
+
+        let child_docs = state.get_virtual_docs(&child_uri).unwrap();
+        let parent_docs = state.get_virtual_docs(&parent_uri).unwrap();
+        let child_virtual = child_docs.template.as_ref().unwrap();
+        let parent_virtual = parent_docs.template.as_ref().unwrap();
+        let child_edit = virtual_edit(child_source.as_str(), child_virtual, "renamed");
+        let parent_edit = virtual_edit(parent_source.as_str(), parent_virtual, "renamed");
+        let child_request_uri = request_uri(&child_uri);
+        let parent_request_uri = request_uri(&parent_uri);
+
+        let mut changes = HashMap::new();
+        changes.insert(child_request_uri.clone(), vec![child_edit]);
+        changes.insert(parent_request_uri.clone(), vec![parent_edit.clone()]);
+        let ctx =
+            IdeContext::new(&state, &child_uri, child_source.find("message").unwrap()).unwrap();
+        let mapped = map_corsa_workspace_edit(
+            &ctx,
+            WorkspaceEdit {
+                changes: Some(changes),
+                document_changes: None,
+                change_annotations: None,
+            },
+        )
+        .expect("authored workspace edit");
+        let changes = mapped.changes.expect("authored changes");
+
+        assert_eq!(changes.len(), 2, "synthetic changes leaked: {changes:#?}");
+        for (uri, source) in [(&child_uri, &child_source), (&parent_uri, &parent_source)] {
+            let edits = changes.get(uri).expect("authored SFC edit");
+            assert_eq!(edits.len(), 1);
+            assert_eq!(edits[0].new_text, "renamed");
+            assert_eq!(authored_text(source, edits[0].range), "message");
+        }
+        assert!(!changes.contains_key(&child_request_uri));
+        assert!(!changes.contains_key(&parent_request_uri));
+
+        let mapped_document_changes = map_corsa_workspace_edit(
+            &ctx,
+            WorkspaceEdit {
+                changes: None,
+                document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
+                    text_document: OptionalVersionedTextDocumentIdentifier {
+                        uri: parent_request_uri.clone(),
+                        version: None,
+                    },
+                    edits: vec![OneOf::Left(parent_edit.clone())],
+                }])),
+                change_annotations: None,
+            },
+        )
+        .expect("authored document changes");
+        let Some(DocumentChanges::Edits(document_edits)) = mapped_document_changes.document_changes
+        else {
+            panic!("expected mapped text document edits");
+        };
+        assert_eq!(document_edits.len(), 1);
+        assert_eq!(document_edits[0].text_document.uri, parent_uri);
+        let OneOf::Left(edit) = &document_edits[0].edits[0] else {
+            panic!("expected plain text edit");
+        };
+        assert_eq!(authored_text(&parent_source, edit.range), "message");
+
+        let missing_virtual_uri = Url::parse("file:///workspace/Missing.vue.template.ts").unwrap();
+        assert!(
+            map_corsa_workspace_edit(
+                &ctx,
+                WorkspaceEdit {
+                    changes: Some(HashMap::from([(
+                        missing_virtual_uri.clone(),
+                        vec![parent_edit.clone()],
+                    )])),
+                    document_changes: None,
+                    change_annotations: None,
+                },
+            )
+            .is_none(),
+            "unmappable synthetic edits must not leak to the client"
+        );
+
+        let parent_reference = LspLocation {
+            uri: parent_request_uri.to_string(),
+            range: LspRange {
+                start: LspPosition {
+                    line: parent_edit.range.start.line,
+                    character: parent_edit.range.start.character,
+                },
+                end: LspPosition {
+                    line: parent_edit.range.end.line,
+                    character: parent_edit.range.end.character,
+                },
+            },
+        };
+        let missing_reference = LspLocation {
+            uri: missing_virtual_uri.to_string(),
+            range: parent_reference.range.clone(),
+        };
+        let locations =
+            corsa_support::map_corsa_locations(&ctx, vec![parent_reference, missing_reference]);
+        assert_eq!(locations.len(), 1);
+        assert_eq!(locations[0].uri, parent_uri);
+        assert_eq!(authored_text(&parent_source, locations[0].range), "message");
+    }
+
+    fn sfc(value: &str) -> String {
+        format!(
+            "<script setup lang=\"ts\">\nconst message = '{value}'\n</script>\n<template>😀 {{{{ message }}}}</template>\n"
+        )
+    }
+
+    fn request_uri(uri: &Url) -> Url {
+        Url::parse(
+            corsa_support::request_file_uri(&corsa_support::template_request_path(uri)).as_str(),
+        )
+        .unwrap()
+    }
+
+    fn virtual_edit(
+        source: &str,
+        document: &crate::virtual_code::VirtualDocument,
+        new_text: &str,
+    ) -> TextEdit {
+        let source_start = source.rfind("message").unwrap() as u32;
+        let source_start = source_start.saturating_sub(document.source_map.block_offset);
+        let generated_start = document
+            .source_map
+            .to_generated_for(source_start, |features| features.rename)
+            .expect("generated identifier") as usize;
+        let generated_end = generated_start + "message".len();
+        let (start_line, start_character) = offset_to_position(&document.content, generated_start);
+        let (end_line, end_character) = offset_to_position(&document.content, generated_end);
+        TextEdit {
+            range: Range::new(
+                Position::new(start_line, start_character),
+                Position::new(end_line, end_character),
+            ),
+            new_text: new_text.to_string(),
+        }
+    }
+
+    fn authored_text(source: &str, range: Range) -> &str {
+        let start = crate::ide::position_to_offset(source, range.start.line, range.start.character)
+            .unwrap();
+        let end =
+            crate::ide::position_to_offset(source, range.end.line, range.end.character).unwrap();
+        &source[start..end]
+    }
 }


### PR DESCRIPTION
## Summary

- resolve editor virtual URIs against any cached SFC instead of only the initiating document
- map cross-SFC references and both workspace-edit representations back to authored Vue URIs and ranges
- drop recognized synthetic results when their source snapshot is unavailable, while preserving real TS/TSX results
- cover encoded paths, UTF-16 positions, and missing virtual documents

Progresses #4015 and #3953.

## Verification

- `cargo fmt --all`
- `cargo clippy -p vize_maestro --lib -- -D warnings`
- `cargo test -p vize_maestro`
- `cargo test -p vize_maestro maps_cross_sfc_virtual_edits_and_references_to_authored_documents -- --nocapture`
- `pnpm vp run source:lengths`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->