### PR TITLE
feat(canon): expose vue dependency mappings

### DIFF
--- a/crates/vize_canon/src/corsa_bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge.rs
@@ -16,6 +16,8 @@ mod vue_document;
 mod vue_document_alias_tests;
 #[cfg(test)]
 mod vue_document_tests;
+#[cfg(test)]
+mod vue_project_mapping_tests;
 mod worker;
 
 pub use bridge::{BatchTypeChecker, CorsaBridge};
@@ -26,7 +28,9 @@ pub use types::{
     LspParameterInformation, LspParameterLabel, LspPosition, LspRange, LspSignatureHelp,
     LspSignatureInformation, TypeCheckResult, VIRTUAL_URI_SCHEME,
 };
-pub use vue_document::{CorsaVueVirtualDocument, CorsaVueVirtualDocumentOptions};
+pub use vue_document::{
+    CorsaVueVirtualDependency, CorsaVueVirtualDocument, CorsaVueVirtualDocumentOptions,
+};
 pub(crate) use vue_document::{CorsaVueVirtualProject, build_vue_virtual_project};
 
 #[cfg(test)]

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -9,7 +9,9 @@ use vize_carton::{FxHashMap, FxHashSet, String, cstr};
 use super::bridge::normalize_document_uri;
 use super::vue_dependency_paths::{normalize_path, resolve_relative_script_import};
 use super::vue_dependency_specifiers::collect_relative_ts_specifiers;
-use super::vue_document::{CorsaVueVirtualDocumentOptions, GeneratedVueDocument};
+use super::vue_document::{
+    CorsaVueVirtualDependency, CorsaVueVirtualDocumentOptions, GeneratedVueDocument,
+};
 use crate::batch::ImportRewriter;
 use crate::file_uri::path_to_file_uri;
 
@@ -18,6 +20,7 @@ const VUE_DEPENDENCY_FALLBACK: &str =
 
 pub(super) fn collect_dependency_documents(
     documents: &mut Vec<(String, String)>,
+    dependencies: &mut Vec<CorsaVueVirtualDependency>,
     host: &GeneratedVueDocument,
     options: CorsaVueVirtualDocumentOptions,
     rewriter: &ImportRewriter,
@@ -43,6 +46,7 @@ pub(super) fn collect_dependency_documents(
             } => queue_imports(
                 ImportQueue {
                     documents,
+                    dependencies,
                     queue: &mut queue,
                     visited_vue: &mut visited_vue,
                     visited_ts: &mut visited_ts,
@@ -62,6 +66,7 @@ pub(super) fn collect_dependency_documents(
             } => queue_imports(
                 ImportQueue {
                     documents,
+                    dependencies,
                     queue: &mut queue,
                     visited_vue: &mut visited_vue,
                     visited_ts: &mut visited_ts,
@@ -80,6 +85,7 @@ pub(super) fn collect_dependency_documents(
 
 pub(super) struct ImportQueue<'a> {
     pub(super) documents: &'a mut Vec<(String, String)>,
+    pub(super) dependencies: &'a mut Vec<CorsaVueVirtualDependency>,
     pub(super) queue: &'a mut VecDeque<DependencyScan>,
     pub(super) visited_vue: &'a mut FxHashSet<PathBuf>,
     pub(super) visited_ts: &'a mut FxHashSet<PathBuf>,
@@ -184,17 +190,29 @@ pub(super) fn queue_vue_dependency(
             return;
         }
     };
-    imports.documents.push((
-        generated.virtual_uri.clone(),
-        generated.generated.code.clone(),
-    ));
+    let generated_code = generated.generated.code;
+    imports
+        .documents
+        .push((generated.virtual_uri.clone(), generated_code.clone()));
     if generated.generated.virtual_suffix == ".tsx" {
-        imports.documents.push(tsx_vue_import_shim(path));
+        imports
+            .documents
+            .push(tsx_vue_import_shim(&generated.source_path));
     }
     imports.queue.push_back(DependencyScan::Vue {
         dir: parent_dir(&generated.source_path),
         source_type: generated.generated.source_type,
         pre_rewrite_code: generated.generated.pre_rewrite_code,
+    });
+    imports.dependencies.push(CorsaVueVirtualDependency {
+        source_path: generated.source_path,
+        source: content,
+        request_uri: generated.virtual_uri,
+        code: generated_code,
+        mappings: generated.generated.mappings,
+        import_source_map: generated.generated.import_source_map,
+        source_type: generated.generated.source_type,
+        virtual_suffix: generated.generated.virtual_suffix,
     });
 }
 

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -30,6 +30,24 @@ pub struct CorsaVueVirtualDocument {
     pub import_source_map: ImportSourceMap,
     pub source_type: SourceType,
     pub virtual_suffix: &'static str,
+    /// Reachable Vue dependencies with the exact authored snapshots and
+    /// mappings used to generate the documents synchronized with Corsa.
+    pub dependencies: Vec<CorsaVueVirtualDependency>,
+}
+
+/// One reachable Vue dependency synchronized as part of a canonical project.
+///
+/// Fallback stubs and script/shim documents are deliberately excluded because
+/// they do not have a trustworthy mapping back to authored Vue source.
+pub struct CorsaVueVirtualDependency {
+    pub source_path: PathBuf,
+    pub source: String,
+    pub request_uri: String,
+    pub code: String,
+    pub mappings: Vec<VizeMapping>,
+    pub import_source_map: ImportSourceMap,
+    pub source_type: SourceType,
+    pub virtual_suffix: &'static str,
 }
 
 pub(crate) struct CorsaVueVirtualProject {
@@ -201,11 +219,13 @@ fn build_vue_virtual_project_with_overlays_and_options(
         Some(&alias_context),
     )?;
     let mut documents = vec![(host.virtual_uri.clone(), host.generated.code.clone())];
+    let mut dependencies = Vec::new();
     if host.generated.virtual_suffix == ".tsx" {
         documents.push(tsx_vue_import_shim(&host.source_path));
     }
     collect_dependency_documents(
         &mut documents,
+        &mut dependencies,
         &host,
         options,
         &rewriter,
@@ -223,6 +243,7 @@ fn build_vue_virtual_project_with_overlays_and_options(
             import_source_map: generated.import_source_map,
             source_type: generated.source_type,
             virtual_suffix: generated.virtual_suffix,
+            dependencies,
         },
         documents,
     })

--- a/crates/vize_canon/src/corsa_bridge/vue_project_mapping_tests.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_project_mapping_tests.rs
@@ -1,0 +1,142 @@
+use super::vue_document::{
+    CorsaVueVirtualDocumentOptions, build_vue_virtual_project,
+    build_vue_virtual_project_with_overlays,
+};
+use crate::file_uri::path_to_file_uri;
+
+#[test]
+fn retains_exact_mappings_for_reachable_nested_vue_dependencies() {
+    let project = tempfile::TempDir::new().expect("temp project");
+    let host_path = project.path().join("Host.vue");
+    let child_path = project.path().join("Child.vue");
+    let grandchild_path = project.path().join("Grandchild.vue");
+    let unrelated_path = project.path().join("Unrelated.vue");
+    let host = r#"<script setup lang="ts">import Child from "./Child.vue"</script>
+<template><Child /></template>"#;
+    std::fs::write(&host_path, host).expect("host");
+    std::fs::write(
+        &child_path,
+        r#"<script setup lang="ts">
+import Grandchild from "./Grandchild.vue";
+const childValue = 1;
+</script>
+<template><Grandchild>{{ childValue }}</Grandchild></template>"#,
+    )
+    .expect("child");
+    std::fs::write(
+        &grandchild_path,
+        "<script setup lang=\"ts\">const leaf = true</script>\n<template>{{ leaf }}</template>",
+    )
+    .expect("grandchild");
+    std::fs::write(&unrelated_path, "<template><aside /></template>").expect("unrelated");
+
+    let virtual_project =
+        build_vue_virtual_project(&host_path, host, CorsaVueVirtualDocumentOptions::default())
+            .expect("virtual project");
+    let dependency_paths = virtual_project
+        .host
+        .dependencies
+        .iter()
+        .map(|dependency| dependency.source_path.as_path())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        dependency_paths,
+        vec![child_path.as_path(), grandchild_path.as_path()]
+    );
+    assert!(!dependency_paths.contains(&unrelated_path.as_path()));
+
+    let child = &virtual_project.host.dependencies[0];
+    let authored_offset = child.source.find("childValue").expect("authored token");
+    let mapping = child
+        .mappings
+        .iter()
+        .filter(|mapping| {
+            authored_offset >= mapping.src_range.start && authored_offset < mapping.src_range.end
+        })
+        .min_by_key(|mapping| mapping.src_range.end - mapping.src_range.start)
+        .expect("mapping for dependency token");
+    let generated_pre_rewrite =
+        mapping.gen_range.start + authored_offset.saturating_sub(mapping.src_range.start);
+    let generated_post_rewrite = child
+        .import_source_map
+        .get_virtual_offset(generated_pre_rewrite as u32) as usize;
+    assert_eq!(
+        &child.code[generated_post_rewrite..generated_post_rewrite + "childValue".len()],
+        "childValue",
+        "metadata must map through the exact import rewrite synchronized with Corsa",
+    );
+}
+
+#[test]
+fn retained_dependency_source_is_the_open_overlay_snapshot() {
+    let project = tempfile::TempDir::new().expect("temp project");
+    let host_path = project.path().join("Host.vue");
+    let child_path = project.path().join("Child.vue");
+    let host = "<script setup lang=\"ts\">import Child from \"./Child.vue\"</script>";
+    let disk = "<script setup lang=\"ts\">defineProps<{ count: string }>()</script>";
+    let overlay = "<script setup lang=\"ts\">defineProps<{ count: number }>()</script>";
+    std::fs::write(&host_path, host).expect("host");
+    std::fs::write(&child_path, disk).expect("child");
+
+    let virtual_project = build_vue_virtual_project_with_overlays(
+        &host_path,
+        host,
+        CorsaVueVirtualDocumentOptions::default(),
+        &[(child_path.clone(), overlay)],
+    )
+    .expect("virtual project");
+    let child = virtual_project
+        .host
+        .dependencies
+        .first()
+        .expect("child dependency metadata");
+    assert_eq!(child.source, overlay);
+    assert!(child.code.contains("count: number"));
+    assert!(!child.code.contains("count: string"));
+}
+
+#[test]
+fn retains_tsx_dependency_identity_but_not_its_ts_import_shim() {
+    let project = tempfile::TempDir::new().expect("temp project");
+    let host_path = project.path().join("Host.vue");
+    let child_path = project.path().join("Child.vue");
+    let host = "<script setup lang=\"ts\">import Child from \"./Child.vue\"</script>";
+    std::fs::write(&host_path, host).expect("host");
+    std::fs::write(
+        &child_path,
+        "<script setup lang=\"tsx\">const vnode = <div /></script>",
+    )
+    .expect("child");
+
+    let virtual_project =
+        build_vue_virtual_project(&host_path, host, CorsaVueVirtualDocumentOptions::default())
+            .expect("virtual project");
+    let dependencies = &virtual_project.host.dependencies;
+    assert_eq!(
+        dependencies.len(),
+        1,
+        "the .vue.ts shim is not authored Vue"
+    );
+    assert_eq!(
+        dependencies[0].request_uri,
+        path_to_file_uri(&child_path.with_extension("vue.tsx"))
+    );
+    assert_eq!(dependencies[0].virtual_suffix, ".tsx");
+    assert!(dependencies[0].source_type.is_typescript());
+    assert!(dependencies[0].source_type.is_jsx());
+}
+
+#[test]
+fn does_not_claim_authored_mappings_for_unparseable_fallbacks() {
+    let project = tempfile::TempDir::new().expect("temp project");
+    let host_path = project.path().join("Host.vue");
+    let broken_path = project.path().join("Broken.vue");
+    let host = "<script setup lang=\"ts\">import Broken from \"./Broken.vue\"</script>";
+    std::fs::write(&host_path, host).expect("host");
+    std::fs::write(&broken_path, "<template><div></div>").expect("broken");
+
+    let virtual_project =
+        build_vue_virtual_project(&host_path, host, CorsaVueVirtualDocumentOptions::default())
+            .expect("virtual project");
+    assert!(virtual_project.host.dependencies.is_empty());
+}

--- a/crates/vize_canon/src/corsa_server/diagnostics.rs
+++ b/crates/vize_canon/src/corsa_server/diagnostics.rs
@@ -165,6 +165,7 @@ mod tests {
                 import_source_map: ImportSourceMap::empty(),
                 source_type: SourceType::ts(),
                 virtual_suffix: ".ts",
+                dependencies: Vec::new(),
             },
             documents: Vec::new(),
         }

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -112,12 +112,12 @@ pub use vize_carton::i18n::Locale;
 
 #[cfg(feature = "native")]
 pub use corsa_bridge::{
-    CorsaBridge, CorsaBridgeConfig, CorsaBridgeError, CorsaVueVirtualDocument,
-    CorsaVueVirtualDocumentOptions, LspCompletionItem, LspCompletionList, LspCompletionResponse,
-    LspDefinitionResponse, LspDiagnostic, LspDocumentation, LspHover, LspHoverContents,
-    LspLocation, LspLocationLink, LspMarkedString, LspMarkupContent, LspParameterInformation,
-    LspParameterLabel, LspPosition, LspRange, LspSignatureHelp, LspSignatureInformation,
-    VIRTUAL_URI_SCHEME,
+    CorsaBridge, CorsaBridgeConfig, CorsaBridgeError, CorsaVueVirtualDependency,
+    CorsaVueVirtualDocument, CorsaVueVirtualDocumentOptions, LspCompletionItem, LspCompletionList,
+    LspCompletionResponse, LspDefinitionResponse, LspDiagnostic, LspDocumentation, LspHover,
+    LspHoverContents, LspLocation, LspLocationLink, LspMarkedString, LspMarkupContent,
+    LspParameterInformation, LspParameterLabel, LspPosition, LspRange, LspSignatureHelp,
+    LspSignatureInformation, VIRTUAL_URI_SCHEME,
 };
 
 // Re-export batch type checker


### PR DESCRIPTION
## Summary

- retain the exact authored snapshot and source maps for every reachable Vue dependency synchronized with the TypeScript backend
- preserve canonical `.vue.ts` / `.vue.tsx` request identities without treating TSX shims or parse fallbacks as authored Vue documents
- expose the dependency metadata through the native bridge for cross-SFC editor result mapping

## Tests

- `cargo test -p vize_canon --lib` (874 passed)
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo check -p vize_maestro`
- `cargo fmt --all -- --check`
- `pnpm exec vp run source:lengths --check --base-ref origin/feat/content-mapper-transform-options`

Progresses #4015.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->