### PR TITLE
fix(maestro): resolve cross-sfc references

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -856,7 +856,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
 
     // Invoke setup to keep diagnostics inside the generated setup body.
     ts.push_str("// Invoke setup to verify types\n");
-    self::script_module::emit_setup_invocation_and_exports(&mut ts, &named_value_exports);
+    script_module::emit_exports(&mut ts, &mut mappings, &named_value_exports, script_offset);
     setup_type_exports.emit_module_exports(&mut ts);
 
     setup_props_plan.emit_module_export(&mut ts, options_api_props.as_ref());

--- a/crates/vize_canon/src/virtual_ts/generator/script_module.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module.rs
@@ -12,8 +12,8 @@ use vize_carton::{CompactString, FxHashSet, String as VizeString};
 
 pub(super) use namespace_hoist::NamespaceHoistPlan;
 pub(super) use plain_exports::{
-    collect_normal_script_named_value_exports, emit_setup_invocation_and_exports,
-    push_setup_return_fields,
+    collect_normal_script_named_value_exports,
+    emit_setup_invocation_and_exports_with_mappings as emit_exports, push_setup_return_fields,
 };
 
 pub(super) fn collect_line_module_spans(script: &str) -> Vec<(u32, u32)> {

--- a/crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist/tests.rs
@@ -18,6 +18,7 @@ fn export(name: &str, kind: PlainScriptExportKind) -> PlainScriptExport {
     PlainScriptExport {
         name: CompactString::new(name),
         kind,
+        source_range: 0..name.len(),
         bridged_value: true,
     }
 }
@@ -89,6 +90,7 @@ fn captured_setup_bindings_become_ambient_aliases_of_the_setup_return() {
         vec![PlainScriptExport {
             name: CompactString::new("shared"),
             kind: PlainScriptExportKind::Value,
+            source_range: 0.."shared".len(),
             bridged_value: false,
         }]
     );

--- a/crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports.rs
@@ -18,8 +18,10 @@
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{BindingPattern, Declaration, Statement};
 use oxc_parser::Parser;
-use oxc_span::SourceType;
+use oxc_span::{GetSpan, SourceType};
 use vize_carton::{CompactString, FxHashSet, String as VizeString, append};
+
+use crate::virtual_ts::VizeMapping;
 
 /// Which declaration spaces a plain-`<script>` export has to reach.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -52,6 +54,8 @@ impl PlainScriptExportKind {
 pub(crate) struct PlainScriptExport {
     pub(crate) name: CompactString,
     pub(crate) kind: PlainScriptExportKind,
+    /// Script-relative byte range of the exported identifier.
+    pub(crate) source_range: std::ops::Range<usize>,
     /// Whether the bridge declares the value side. Cleared for a name a hoisted
     /// namespace body captures: that name is declared earlier at module scope as
     /// an ambient alias instead (see `super::namespace_hoist`), and declaring it
@@ -77,6 +81,7 @@ pub(crate) fn push_setup_return_fields(
     fields.extend(exports.iter().map(|export| export.name.clone()));
 }
 
+#[cfg(test)]
 pub(crate) fn emit_setup_invocation_and_exports(
     ts: &mut VizeString,
     exports: &[PlainScriptExport],
@@ -99,6 +104,40 @@ pub(crate) fn emit_setup_invocation_and_exports(
         // A value+type declaration loses its type meaning when the bridge only
         // re-exports the value. The alias restores it in the type space, which
         // is disjoint from the `const` above, so both names can coexist.
+        if let Some(body) = export.kind.type_alias_body(name) {
+            append!(*ts, "export type {name} = {body};\n");
+        }
+    }
+    ts.push('\n');
+}
+
+pub(crate) fn emit_setup_invocation_and_exports_with_mappings(
+    ts: &mut VizeString,
+    mappings: &mut Vec<VizeMapping>,
+    exports: &[PlainScriptExport],
+    script_offset: u32,
+) {
+    if exports.iter().any(|export| export.bridged_value) {
+        ts.push_str("const __vize_plain_script_exports = __setup();\n");
+    } else {
+        ts.push_str("__setup();\n");
+    }
+    for export in exports {
+        let name = &export.name;
+        if export.bridged_value {
+            ts.push_str("export const ");
+            let generated_start = ts.len();
+            ts.push_str(name);
+            let generated_end = ts.len();
+            append!(*ts, " = __vize_plain_script_exports.{name};\n");
+            let source_base = script_offset as usize;
+            mappings.push(VizeMapping {
+                gen_range: generated_start..generated_end,
+                src_range: source_base.saturating_add(export.source_range.start)
+                    ..source_base.saturating_add(export.source_range.end),
+                sub_spans: Vec::new(),
+            });
+        }
         if let Some(body) = export.kind.type_alias_body(name) {
             append!(*ts, "export type {name} = {body};\n");
         }
@@ -159,6 +198,7 @@ pub(super) fn collect_declaration_exports(
                 push_export(
                     id.name.as_str(),
                     PlainScriptExportKind::Value,
+                    id.span(),
                     seen,
                     exports,
                 );
@@ -169,6 +209,7 @@ pub(super) fn collect_declaration_exports(
                 push_export(
                     id.name.as_str(),
                     PlainScriptExportKind::Class,
+                    id.span(),
                     seen,
                     exports,
                 );
@@ -180,6 +221,7 @@ pub(super) fn collect_declaration_exports(
             push_export(
                 enumeration.id.name.as_str(),
                 PlainScriptExportKind::Enum,
+                enumeration.id.span(),
                 seen,
                 exports,
             );
@@ -198,6 +240,7 @@ fn collect_binding_names(
             push_export(
                 id.name.as_str(),
                 PlainScriptExportKind::Value,
+                id.span(),
                 seen,
                 exports,
             );
@@ -227,6 +270,7 @@ fn collect_binding_names(
 fn push_export(
     name: &str,
     kind: PlainScriptExportKind,
+    span: oxc_span::Span,
     seen: &mut FxHashSet<CompactString>,
     exports: &mut Vec<PlainScriptExport>,
 ) {
@@ -238,109 +282,11 @@ fn push_export(
         exports.push(PlainScriptExport {
             name,
             kind,
+            source_range: span.start as usize..span.end as usize,
             bridged_value: true,
         });
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{
-        CompactString, PlainScriptExport, PlainScriptExportKind, collect_named_value_exports,
-        emit_setup_invocation_and_exports,
-    };
-
-    fn export(name: &str, kind: PlainScriptExportKind) -> PlainScriptExport {
-        PlainScriptExport {
-            name: CompactString::new(name),
-            kind,
-            bridged_value: true,
-        }
-    }
-
-    #[test]
-    fn collect_named_value_exports_includes_ts_enums() {
-        let exports = collect_named_value_exports(
-            "export enum DiffDisplayMode { Hidden = 'hidden' }\nexport type Props = {}\n",
-        );
-
-        assert_eq!(
-            exports,
-            vec![export("DiffDisplayMode", PlainScriptExportKind::Enum)]
-        );
-    }
-
-    #[test]
-    fn declaration_kinds_are_classified_by_declaration_space() {
-        let exports = collect_named_value_exports(
-            "export const plain = 1;\nexport function helper() {}\nexport class Widget {}\nexport enum Mode { A = 'a' }\nexport const enum ConstMode { B = 'b' }\n",
-        );
-
-        assert_eq!(
-            exports,
-            vec![
-                export("plain", PlainScriptExportKind::Value),
-                export("helper", PlainScriptExportKind::Value),
-                export("Widget", PlainScriptExportKind::Class),
-                export("Mode", PlainScriptExportKind::Enum),
-                export("ConstMode", PlainScriptExportKind::Enum),
-            ]
-        );
-    }
-
-    #[test]
-    fn value_and_type_declarations_are_bridged_in_both_declaration_spaces() {
-        let mut ts = vize_carton::String::default();
-        emit_setup_invocation_and_exports(
-            &mut ts,
-            &[
-                export("Mode", PlainScriptExportKind::Enum),
-                export("Widget", PlainScriptExportKind::Class),
-            ],
-        );
-
-        assert!(ts.contains("export const Mode = __vize_plain_script_exports.Mode;\n"));
-        assert!(ts.contains("export type Mode = (typeof Mode)[keyof typeof Mode];\n"));
-        assert!(ts.contains("export const Widget = __vize_plain_script_exports.Widget;\n"));
-        assert!(ts.contains("export type Widget = InstanceType<typeof Widget>;\n"));
-    }
-
-    #[test]
-    fn value_only_declarations_never_gain_a_type_export() {
-        let mut ts = vize_carton::String::default();
-        emit_setup_invocation_and_exports(
-            &mut ts,
-            &[
-                export("plain", PlainScriptExportKind::Value),
-                export("helper", PlainScriptExportKind::Value),
-            ],
-        );
-
-        assert!(ts.contains("export const plain = __vize_plain_script_exports.plain;\n"));
-        assert!(ts.contains("export const helper = __vize_plain_script_exports.helper;\n"));
-        assert!(
-            !ts.contains("export type "),
-            "value-only exports must not invent a type meaning:\n{ts}"
-        );
-    }
-
-    #[test]
-    fn merged_enum_declarations_are_bridged_once() {
-        let exports = collect_named_value_exports(
-            "export enum Mode { A = 'a' }\nexport enum Mode { B = 'b' }\n",
-        );
-        assert_eq!(exports, vec![export("Mode", PlainScriptExportKind::Enum)]);
-
-        let mut ts = vize_carton::String::default();
-        emit_setup_invocation_and_exports(&mut ts, &exports);
-        assert_eq!(ts.matches("export const Mode =").count(), 1);
-        assert_eq!(ts.matches("export type Mode =").count(), 1);
-    }
-
-    #[test]
-    fn no_exports_keeps_the_bare_setup_invocation() {
-        let mut ts = vize_carton::String::default();
-        emit_setup_invocation_and_exports(&mut ts, &[]);
-        assert_eq!(ts.as_str(), "__setup();\n\n");
-    }
-}
+mod tests;

--- a/crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports/tests.rs
@@ -1,0 +1,112 @@
+use super::{
+    CompactString, PlainScriptExport, PlainScriptExportKind, collect_named_value_exports,
+    emit_setup_invocation_and_exports,
+};
+
+fn export(name: &str, kind: PlainScriptExportKind) -> PlainScriptExport {
+    PlainScriptExport {
+        name: CompactString::new(name),
+        kind,
+        source_range: 0..name.len(),
+        bridged_value: true,
+    }
+}
+
+fn assert_exports(
+    source: &str,
+    exports: &[PlainScriptExport],
+    expected: &[(&str, PlainScriptExportKind)],
+) {
+    assert_eq!(exports.len(), expected.len());
+    for (export, &(name, kind)) in exports.iter().zip(expected) {
+        assert_eq!(export.name, name);
+        assert_eq!(export.kind, kind);
+        assert!(export.bridged_value);
+        assert_eq!(&source[export.source_range.clone()], name);
+    }
+}
+
+#[test]
+fn collect_named_value_exports_includes_ts_enums() {
+    let source = "export enum DiffDisplayMode { Hidden = 'hidden' }\nexport type Props = {}\n";
+    let exports = collect_named_value_exports(source);
+
+    assert_exports(
+        source,
+        &exports,
+        &[("DiffDisplayMode", PlainScriptExportKind::Enum)],
+    );
+}
+
+#[test]
+fn declaration_kinds_are_classified_by_declaration_space() {
+    let source = "export const plain = 1;\nexport function helper() {}\nexport class Widget {}\nexport enum Mode { A = 'a' }\nexport const enum ConstMode { B = 'b' }\n";
+    let exports = collect_named_value_exports(source);
+
+    assert_exports(
+        source,
+        &exports,
+        &[
+            ("plain", PlainScriptExportKind::Value),
+            ("helper", PlainScriptExportKind::Value),
+            ("Widget", PlainScriptExportKind::Class),
+            ("Mode", PlainScriptExportKind::Enum),
+            ("ConstMode", PlainScriptExportKind::Enum),
+        ],
+    );
+}
+
+#[test]
+fn value_and_type_declarations_are_bridged_in_both_declaration_spaces() {
+    let mut ts = vize_carton::String::default();
+    emit_setup_invocation_and_exports(
+        &mut ts,
+        &[
+            export("Mode", PlainScriptExportKind::Enum),
+            export("Widget", PlainScriptExportKind::Class),
+        ],
+    );
+
+    assert!(ts.contains("export const Mode = __vize_plain_script_exports.Mode;\n"));
+    assert!(ts.contains("export type Mode = (typeof Mode)[keyof typeof Mode];\n"));
+    assert!(ts.contains("export const Widget = __vize_plain_script_exports.Widget;\n"));
+    assert!(ts.contains("export type Widget = InstanceType<typeof Widget>;\n"));
+}
+
+#[test]
+fn value_only_declarations_never_gain_a_type_export() {
+    let mut ts = vize_carton::String::default();
+    emit_setup_invocation_and_exports(
+        &mut ts,
+        &[
+            export("plain", PlainScriptExportKind::Value),
+            export("helper", PlainScriptExportKind::Value),
+        ],
+    );
+
+    assert!(ts.contains("export const plain = __vize_plain_script_exports.plain;\n"));
+    assert!(ts.contains("export const helper = __vize_plain_script_exports.helper;\n"));
+    assert!(
+        !ts.contains("export type "),
+        "value-only exports must not invent a type meaning:\n{ts}"
+    );
+}
+
+#[test]
+fn merged_enum_declarations_are_bridged_once() {
+    let source = "export enum Mode { A = 'a' }\nexport enum Mode { B = 'b' }\n";
+    let exports = collect_named_value_exports(source);
+    assert_exports(source, &exports, &[("Mode", PlainScriptExportKind::Enum)]);
+
+    let mut ts = vize_carton::String::default();
+    emit_setup_invocation_and_exports(&mut ts, &exports);
+    assert_eq!(ts.matches("export const Mode =").count(), 1);
+    assert_eq!(ts.matches("export type Mode =").count(), 1);
+}
+
+#[test]
+fn no_exports_keeps_the_bare_setup_invocation() {
+    let mut ts = vize_carton::String::default();
+    emit_setup_invocation_and_exports(&mut ts, &[]);
+    assert_eq!(ts.as_str(), "__setup();\n\n");
+}

--- a/crates/vize_canon/tests/lsp_vue_references.rs
+++ b/crates/vize_canon/tests/lsp_vue_references.rs
@@ -1,0 +1,125 @@
+use vize_canon::{
+    CorsaBridge, CorsaBridgeConfig, ImportRewriter, batch::generate_vue_document_virtual_ts,
+    virtual_ts::VirtualTsOptions,
+};
+
+#[test]
+fn editor_references_link_generated_vue_module_exports_to_importers() {
+    let Some(tsgo_path) = resolve_tsgo_binary() else {
+        return;
+    };
+    let project = tempfile::TempDir::new().expect("temp project");
+    let src = project.path().join("src");
+    std::fs::create_dir_all(&src).expect("src");
+    std::fs::write(
+        project.path().join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .expect("tsconfig");
+    let child_path = src.join("Child.vue");
+    let parent_path = src.join("Parent.vue");
+    let child_source = r#"<script lang="ts">
+export const shared = 1
+export default {}
+</script>"#;
+    let parent_source = r#"<script setup lang="ts">
+import { shared } from './Child.vue'
+const local = shared
+</script>"#;
+    std::fs::write(&child_path, child_source).expect("child");
+    std::fs::write(&parent_path, parent_source).expect("parent");
+    let rewriter = ImportRewriter::new();
+    let child = generate_vue_document_virtual_ts(
+        &child_path,
+        child_source,
+        &VirtualTsOptions::default(),
+        &rewriter,
+        false,
+    )
+    .expect("child virtual ts");
+    let parent = generate_vue_document_virtual_ts(
+        &parent_path,
+        parent_source,
+        &VirtualTsOptions::default(),
+        &rewriter,
+        false,
+    )
+    .expect("parent virtual ts");
+    let child_virtual_path = child_path.with_extension("vue.ts");
+    let parent_virtual_path = parent_path.with_extension("vue.ts");
+    let child_export = child
+        .code
+        .rfind("export const shared")
+        .expect("module export")
+        + "export const ".len();
+    let (line, character) = position(&child.code, child_export);
+    let bridge = CorsaBridge::with_config(CorsaBridgeConfig {
+        corsa_path: Some(tsgo_path),
+        working_dir: Some(project.path().to_path_buf()),
+        timeout_ms: 30_000,
+        ..Default::default()
+    });
+
+    let (child_uri, parent_uri, references) = corsa::runtime::block_on(async {
+        bridge.spawn().await.expect("tsgo session");
+        let child_uri = bridge
+            .open_or_update_virtual_document(&child_virtual_path.to_string_lossy(), &child.code)
+            .await
+            .expect("child open");
+        let parent_uri = bridge
+            .open_or_update_virtual_document(&parent_virtual_path.to_string_lossy(), &parent.code)
+            .await
+            .expect("parent open");
+        let references = bridge
+            .references(&child_uri, line, character, true)
+            .await
+            .expect("references");
+        bridge.shutdown().await.expect("shutdown");
+        (child_uri, parent_uri, references)
+    });
+
+    assert!(
+        references.iter().any(|location| location.uri == child_uri),
+        "declaration missing: {references:#?}",
+    );
+    assert!(
+        references.iter().any(|location| location.uri == parent_uri),
+        "importer missing: {references:#?}",
+    );
+    assert!(!child_virtual_path.exists());
+    assert!(!parent_virtual_path.exists());
+}
+
+fn position(source: &str, offset: usize) -> (u32, u32) {
+    let prefix = &source[..offset];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u32;
+    let line_start = prefix.rfind('\n').map_or(0, |index| index + 1);
+    let character = prefix[line_start..].encode_utf16().count() as u32;
+    (line, character)
+}
+
+fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return None;
+    }
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)?;
+    vize_carton::corsa_resolver::resolve_corsa_executable(
+        vize_carton::corsa_resolver::CorsaResolveRequest {
+            project_root: Some(workspace_root),
+            ..Default::default()
+        },
+    )
+    .ok()
+}

--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -22,7 +22,7 @@ mod workspace_edit;
 #[cfg(feature = "native")]
 pub(crate) use canonical::{
     canonical_source_offset_to_position, map_canonical_corsa_locations, map_canonical_lsp_range,
-    open_canonical_virtual_document,
+    open_canonical_virtual_document, open_canonical_virtual_project_document,
 };
 #[cfg(feature = "native")]
 pub(crate) use html_attribute::{

--- a/crates/vize_maestro/src/ide/corsa_support/canonical.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical.rs
@@ -1,11 +1,15 @@
-use std::sync::Arc;
-
 use tower_lsp::lsp_types::{Location, Range, Url};
-use vize_canon::{CorsaBridge, CorsaVueVirtualDocumentOptions, LspLocation};
+use vize_canon::LspLocation;
 use vize_carton::{String, cstr};
 
 use crate::ide::IdeContext;
 use crate::ide::diagnostics::VirtualTsResult;
+
+mod open;
+mod project;
+
+pub(crate) use open::open_canonical_virtual_document;
+pub(crate) use project::open_canonical_virtual_project_document;
 
 pub(crate) struct CanonicalVirtualDocument {
     pub(crate) request_uri: String,
@@ -22,66 +26,6 @@ pub(crate) struct CanonicalDependencyDocument {
 
 pub(crate) fn canonical_request_path(uri: &Url) -> String {
     cstr!("{}.ts", uri.path())
-}
-
-pub(crate) async fn open_canonical_virtual_document(
-    ctx: &IdeContext<'_>,
-    bridge: &Arc<CorsaBridge>,
-) -> Option<CanonicalVirtualDocument> {
-    if !ctx.uri.path().ends_with(".vue") || ctx.uri.path().ends_with(".art.vue") {
-        return None;
-    }
-
-    let source_path = ctx.uri.to_file_path().ok()?;
-    let opened = bridge
-        .open_vue_virtual_document(
-            &source_path,
-            &ctx.content,
-            CorsaVueVirtualDocumentOptions {
-                options_api: ctx.state.options_api_enabled(),
-                legacy_vue2: ctx.state.legacy_vue2_enabled(),
-            },
-        )
-        .await
-        .ok()?;
-
-    let dependencies = opened
-        .dependencies
-        .into_iter()
-        .filter_map(|dependency| {
-            let source_uri = Url::from_file_path(&dependency.source_path).ok()?;
-            Some(CanonicalDependencyDocument {
-                source_uri,
-                source: dependency.source,
-                request_uri: dependency.request_uri,
-                virtual_result: VirtualTsResult {
-                    code: dependency.code.to_string(),
-                    source_mappings: dependency.mappings,
-                    import_source_map: dependency.import_source_map,
-                    user_code_start_line: 0,
-                    sfc_script_start_line: 0,
-                    template_scope_start_line: 0,
-                    line_mappings: Vec::new(),
-                    skipped_import_lines: 0,
-                },
-            })
-        })
-        .collect();
-
-    Some(CanonicalVirtualDocument {
-        request_uri: opened.request_uri,
-        virtual_result: VirtualTsResult {
-            code: opened.code.to_string(),
-            source_mappings: opened.mappings,
-            import_source_map: opened.import_source_map,
-            user_code_start_line: 0,
-            sfc_script_start_line: 0,
-            template_scope_start_line: 0,
-            line_mappings: Vec::new(),
-            skipped_import_lines: 0,
-        },
-        dependencies,
-    })
 }
 
 pub(crate) fn canonical_source_offset_to_position(

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/open.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/open.rs
@@ -1,0 +1,83 @@
+use std::path::PathBuf;
+
+use tower_lsp::lsp_types::Url;
+use vize_canon::{CorsaBridge, CorsaVueVirtualDocumentOptions};
+
+use super::{CanonicalDependencyDocument, CanonicalVirtualDocument};
+use crate::ide::IdeContext;
+use crate::ide::diagnostics::VirtualTsResult;
+
+pub(crate) async fn open_canonical_virtual_document(
+    ctx: &IdeContext<'_>,
+    bridge: &CorsaBridge,
+) -> Option<CanonicalVirtualDocument> {
+    let cached_overlays = ctx.state.corsa_overlays();
+    let overlays = cached_overlays
+        .iter()
+        .map(|(path, content)| (path.clone(), &**content))
+        .collect::<Vec<_>>();
+    open_canonical_virtual_document_with_overlays(ctx, bridge, &overlays).await
+}
+
+pub(super) async fn open_canonical_virtual_document_with_overlays(
+    ctx: &IdeContext<'_>,
+    bridge: &CorsaBridge,
+    overlays: &[(PathBuf, &str)],
+) -> Option<CanonicalVirtualDocument> {
+    if !ctx.uri.path().ends_with(".vue") || ctx.uri.path().ends_with(".art.vue") {
+        return None;
+    }
+
+    let source_path = ctx.uri.to_file_path().ok()?;
+    let opened = bridge
+        .open_vue_virtual_document_with_borrowed_overlays_and_options(
+            &source_path,
+            &ctx.content,
+            CorsaVueVirtualDocumentOptions {
+                options_api: ctx.state.options_api_enabled(),
+                legacy_vue2: ctx.state.legacy_vue2_enabled(),
+            },
+            overlays,
+            &vize_canon::virtual_ts::VirtualTsOptions::default(),
+        )
+        .await
+        .ok()?;
+
+    let dependencies = opened
+        .dependencies
+        .into_iter()
+        .filter_map(|dependency| {
+            let source_uri = Url::from_file_path(&dependency.source_path).ok()?;
+            Some(CanonicalDependencyDocument {
+                source_uri,
+                source: dependency.source,
+                request_uri: dependency.request_uri,
+                virtual_result: VirtualTsResult {
+                    code: dependency.code.to_string(),
+                    source_mappings: dependency.mappings,
+                    import_source_map: dependency.import_source_map,
+                    user_code_start_line: 0,
+                    sfc_script_start_line: 0,
+                    template_scope_start_line: 0,
+                    line_mappings: Vec::new(),
+                    skipped_import_lines: 0,
+                },
+            })
+        })
+        .collect();
+
+    Some(CanonicalVirtualDocument {
+        request_uri: opened.request_uri,
+        virtual_result: VirtualTsResult {
+            code: opened.code.to_string(),
+            source_mappings: opened.mappings,
+            import_source_map: opened.import_source_map,
+            user_code_start_line: 0,
+            sfc_script_start_line: 0,
+            template_scope_start_line: 0,
+            line_mappings: Vec::new(),
+            skipped_import_lines: 0,
+        },
+        dependencies,
+    })
+}

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/project.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/project.rs
@@ -1,0 +1,73 @@
+use std::collections::VecDeque;
+
+use tower_lsp::lsp_types::Url;
+use vize_canon::CorsaBridge;
+use vize_carton::{FxHashSet, String};
+
+use super::{
+    CanonicalDependencyDocument, CanonicalVirtualDocument, location_matches_uri,
+    open::open_canonical_virtual_document_with_overlays,
+};
+use crate::ide::IdeContext;
+
+impl CanonicalVirtualDocument {
+    fn include_opened_document(&mut self, source_uri: Url, source: String, mut opened: Self) {
+        self.include_dependency(CanonicalDependencyDocument {
+            source_uri,
+            source,
+            request_uri: opened.request_uri,
+            virtual_result: opened.virtual_result,
+        });
+        for dependency in opened.dependencies.drain(..) {
+            self.include_dependency(dependency);
+        }
+    }
+
+    fn include_dependency(&mut self, dependency: CanonicalDependencyDocument) {
+        if location_matches_uri(&dependency.request_uri, &self.request_uri)
+            || self.dependencies.iter().any(|existing| {
+                location_matches_uri(&existing.request_uri, &dependency.request_uri)
+            })
+        {
+            return;
+        }
+        self.dependencies.push(dependency);
+    }
+}
+
+/// Open the query document and every currently-open reverse importer in one
+/// canonical project session. This is intentionally separate from the hot
+/// hover/definition path: project-wide operations need the fan-out, local
+/// operations should not pay for it.
+pub(crate) async fn open_canonical_virtual_project_document(
+    ctx: &IdeContext<'_>,
+    bridge: &CorsaBridge,
+) -> Option<CanonicalVirtualDocument> {
+    let cached_overlays = ctx.state.corsa_overlays();
+    let overlays = cached_overlays
+        .iter()
+        .map(|(path, content)| (path.clone(), &**content))
+        .collect::<Vec<_>>();
+    let mut document =
+        open_canonical_virtual_document_with_overlays(ctx, bridge, &overlays).await?;
+    let mut visited = FxHashSet::default();
+    visited.insert(ctx.uri.clone());
+    let mut queue = VecDeque::from(ctx.state.open_vue_importers(ctx.uri));
+
+    while let Some(uri) = queue.pop_front() {
+        if !visited.insert(uri.clone()) {
+            continue;
+        }
+        queue.extend(ctx.state.open_vue_importers(&uri));
+        let Some(importer_ctx) = IdeContext::new(ctx.state, &uri, 0) else {
+            continue;
+        };
+        if let Some(opened) =
+            open_canonical_virtual_document_with_overlays(&importer_ctx, bridge, &overlays).await
+        {
+            document.include_opened_document(uri.clone(), importer_ctx.content.into(), opened);
+        }
+    }
+
+    Some(document)
+}

--- a/crates/vize_maestro/src/ide/references.rs
+++ b/crates/vize_maestro/src/ide/references.rs
@@ -6,6 +6,10 @@
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 //! - Script bindings used in style v-bind()
 
+#[cfg(feature = "native")]
+mod canonical;
+#[cfg(all(test, feature = "native"))]
+mod corsa_tests;
 mod script;
 mod template;
 
@@ -80,6 +84,11 @@ impl ReferencesService {
         include_declaration: bool,
         corsa_bridge: Option<Arc<CorsaBridge>>,
     ) -> Option<Vec<Location>> {
+        if let Some(locations) =
+            canonical::references(ctx, include_declaration, corsa_bridge.as_deref()).await
+        {
+            return Some(locations);
+        }
         let block_type = ctx.block_type?;
 
         let corsa_locations = match block_type {

--- a/crates/vize_maestro/src/ide/references/canonical.rs
+++ b/crates/vize_maestro/src/ide/references/canonical.rs
@@ -1,0 +1,26 @@
+use tower_lsp::lsp_types::Location;
+use vize_canon::CorsaBridge;
+
+use crate::ide::{IdeContext, corsa_support};
+
+/// Query the project-aware canonical Vue document before the block-local
+/// virtual documents so references can cross SFC boundaries.
+pub(super) async fn references(
+    ctx: &IdeContext<'_>,
+    include_declaration: bool,
+    bridge: Option<&CorsaBridge>,
+) -> Option<Vec<Location>> {
+    let bridge = bridge?;
+    if !bridge.is_initialized() {
+        return None;
+    }
+    let document = corsa_support::open_canonical_virtual_project_document(ctx, bridge).await?;
+    let (line, character) =
+        corsa_support::canonical_source_offset_to_position(&document, ctx.offset)?;
+    let locations = bridge
+        .references(&document.request_uri, line, character, include_declaration)
+        .await
+        .ok()?;
+    let locations = corsa_support::map_canonical_corsa_locations(ctx, &document, locations);
+    Some(locations)
+}

--- a/crates/vize_maestro/src/ide/references/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/references/corsa_tests.rs
@@ -1,0 +1,196 @@
+use std::fs;
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::{Location, Url};
+use vize_canon::{CorsaBridge, CorsaBridgeConfig};
+
+use super::super::ReferencesService;
+use crate::ide::IdeContext;
+use crate::server::ServerState;
+
+#[test]
+fn canonical_references_cross_vue_files_and_honor_include_declaration() {
+    crate::runtime::block_on(async {
+        let Some(tsgo_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = project.path().join("src");
+        fs::create_dir_all(&src).expect("src");
+        fs::write(
+            project.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .expect("tsconfig");
+        fs::write(
+            src.join("vue.d.ts"),
+            r#"declare module "vue" {
+  export type DefineComponent<P = any, _B = any, _D = any> = { new(): { $props: P } };
+  export function defineComponent<T>(component: T): T;
+}
+"#,
+        )
+        .expect("vue types");
+
+        let child_source = r#"<script lang="ts">
+export const shared = 1
+export const isolated = 2
+export default {}
+</script>
+<template><span /></template>
+"#;
+        let child_path = src.join("Child View.vue");
+        fs::write(
+            &child_path,
+            r#"<script lang="ts">
+export const diskOnly = 0
+export default {}
+</script>
+"#,
+        )
+        .expect("stale child on disk");
+        let parent_source = r#"<script setup lang="ts">
+import { shared } from './Child View.vue'
+const local = shared
+</script>
+<template>💥 {{ shared }} {{ local }}</template>
+"#;
+        let parent_path = src.join("Parent View.vue");
+        fs::write(&parent_path, parent_source).expect("parent");
+
+        let parent_uri = Url::from_file_path(&parent_path).expect("parent uri");
+        let child_uri = Url::from_file_path(&child_path).expect("child uri");
+        let state = ServerState::new();
+        state.set_workspace_root(project.path().to_path_buf());
+        state.documents.open(
+            parent_uri.clone(),
+            parent_source.to_string(),
+            1,
+            "vue".to_string(),
+        );
+        state.update_virtual_docs(&parent_uri, parent_source);
+        state.documents.open(
+            child_uri.clone(),
+            child_source.to_string(),
+            1,
+            "vue".to_string(),
+        );
+        state.update_virtual_docs(&child_uri, child_source);
+        assert_eq!(
+            state.open_vue_importers(&child_uri),
+            vec![parent_uri.clone()]
+        );
+        let bridge = Arc::new(CorsaBridge::with_config(CorsaBridgeConfig {
+            corsa_path: Some(tsgo_path),
+            working_dir: Some(project.path().to_path_buf()),
+            timeout_ms: 30_000,
+            ..Default::default()
+        }));
+        bridge.spawn().await.expect("tsgo session");
+
+        let query_offset = child_source.find("shared =").expect("export declaration") + 1;
+        let ctx = IdeContext::new(&state, &child_uri, query_offset).expect("context");
+        let without_declaration =
+            ReferencesService::references_with_corsa(&ctx, false, Some(Arc::clone(&bridge)))
+                .await
+                .unwrap_or_default();
+        let with_declaration =
+            ReferencesService::references_with_corsa(&ctx, true, Some(Arc::clone(&bridge)))
+                .await
+                .expect("references with declaration");
+        let isolated_offset = child_source
+            .find("isolated =")
+            .expect("isolated declaration")
+            + 1;
+        let isolated_ctx =
+            IdeContext::new(&state, &child_uri, isolated_offset).expect("isolated context");
+        let isolated_without_declaration = ReferencesService::references_with_corsa(
+            &isolated_ctx,
+            false,
+            Some(Arc::clone(&bridge)),
+        )
+        .await
+        .expect("an empty canonical result is authoritative");
+        bridge.shutdown().await.expect("shutdown");
+
+        assert!(
+            with_declaration.len() > without_declaration.len(),
+            "includeDeclaration must add the exported declaration: {with_declaration:#?}",
+        );
+        assert!(
+            !without_declaration
+                .iter()
+                .any(|location| location.uri == child_uri),
+            "the child contains only the excluded declaration: {without_declaration:#?}",
+        );
+        assert!(
+            without_declaration
+                .iter()
+                .any(|location| location.uri == parent_uri),
+            "references must use the unsaved child overlay across an encoded importer URI: {without_declaration:#?}",
+        );
+        let child_declaration = with_declaration
+            .iter()
+            .find(|location| location.uri == child_uri)
+            .unwrap_or_else(|| panic!("authored child declaration: {with_declaration:#?}"));
+        assert_eq!(authored_text(child_source, child_declaration), "shared");
+        assert!(
+            with_declaration
+                .iter()
+                .any(|location| location.uri == parent_uri),
+            "references must cross into the open importer: {with_declaration:#?}",
+        );
+        assert!(
+            with_declaration
+                .iter()
+                .all(|location| !location.uri.path().ends_with(".vue.ts")),
+            "canonical mirror URIs must never leak: {with_declaration:#?}",
+        );
+        assert!(
+            isolated_without_declaration.is_empty(),
+            "an isolated declaration has no references when declarations are excluded: {isolated_without_declaration:#?}",
+        );
+    });
+}
+
+fn authored_text<'a>(source: &'a str, location: &Location) -> &'a str {
+    let start = crate::ide::position_to_offset(
+        source,
+        location.range.start.line,
+        location.range.start.character,
+    )
+    .expect("source start");
+    let end = crate::ide::position_to_offset(
+        source,
+        location.range.end.line,
+        location.range.end.character,
+    )
+    .expect("source end");
+    &source[start..end]
+}
+
+fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return None;
+    }
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)?;
+    vize_carton::corsa_resolver::resolve_corsa_executable(
+        vize_carton::corsa_resolver::CorsaResolveRequest {
+            project_root: Some(workspace_root),
+            ..Default::default()
+        },
+    )
+    .ok()
+}

--- a/crates/vize_maestro/src/server/importers.rs
+++ b/crates/vize_maestro/src/server/importers.rs
@@ -93,6 +93,12 @@ pub(super) fn open_vue_importers(state: &ServerState, dependency: &Url) -> Vec<U
         .unwrap_or_default()
 }
 
+impl ServerState {
+    pub(crate) fn open_vue_importers(&self, dependency: &Url) -> Vec<Url> {
+        open_vue_importers(self, dependency)
+    }
+}
+
 fn collect_dependencies(importer: &Path, source: &str) -> Vec<PathBuf> {
     let options = vize_atelier_sfc::SfcParseOptions {
         filename: importer.to_string_lossy().into_owned().into(),


### PR DESCRIPTION
## Summary

- map generated normal-script named exports back to their exact authored identifiers
- build one canonical project view from the query document, its open reverse importers, and one shared unsaved-overlay snapshot
- return cross-SFC references through authored Vue URIs while preserving `includeDeclaration` and authoritative empty results

## Regression coverage

- exact standard tsgo project-session references link generated Vue module exports to importers without materialized mirror files
- LSP references cross an encoded importer URI using an unsaved dependency overlay and UTF-16 template content
- declaration inclusion/exclusion, isolated symbols, and virtual-URI leak prevention are asserted

## Validation

- `cargo test -p vize_canon --lib`
- standard tsgo `cargo test -p vize_canon --test lsp_vue_references`
- standard tsgo canonical Maestro references E2E
- `cargo test -p vize_maestro`
- lib clippy with warnings denied for Canon and Maestro
- source-length policy against the parent branch

Advances #4015.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->