### PR TITLE
fix(maestro): map authored reference ranges

### DIFF
--- a/crates/vize_maestro/src/ide/references.rs
+++ b/crates/vize_maestro/src/ide/references.rs
@@ -237,11 +237,6 @@ impl ReferencesService {
     fn is_identifier_char(c: u8) -> bool {
         c.is_ascii_alphanumeric() || c == b'_' || c == b'$'
     }
-
-    /// Convert offset to (line, character).
-    pub(crate) fn offset_to_position(content: &str, offset: usize) -> (u32, u32) {
-        crate::ide::offset_to_position(content, offset)
-    }
 }
 
 #[cfg(test)]

--- a/crates/vize_maestro/src/ide/references/script.rs
+++ b/crates/vize_maestro/src/ide/references/script.rs
@@ -44,7 +44,11 @@ impl ReferencesService {
         None
     }
 
-    fn location_from_sfc_offset(ctx: &IdeContext, offset: usize, word: &str) -> Location {
+    pub(super) fn location_from_sfc_offset(
+        ctx: &IdeContext,
+        offset: usize,
+        word: &str,
+    ) -> Location {
         let (line, character) = crate::ide::offset_to_position(&ctx.content, offset);
 
         Location {
@@ -145,6 +149,9 @@ impl ReferencesService {
 
     /// Find a binding definition in script content.
     pub(super) fn find_binding_in_script(content: &str, name: &str) -> Option<usize> {
+        if let Some(offset) = Self::find_import_binding(content, name) {
+            return Some(offset);
+        }
         let content_start = Self::skip_virtual_header(content);
         let search_content = &content[content_start..];
 
@@ -183,6 +190,49 @@ impl ReferencesService {
         }
 
         None
+    }
+
+    fn find_import_binding(content: &str, name: &str) -> Option<usize> {
+        use oxc_ast::ast::{ImportDeclarationSpecifier, Statement};
+
+        let allocator = oxc_allocator::Allocator::default();
+        let parsed = oxc_parser::Parser::new(
+            &allocator,
+            content,
+            oxc_span::SourceType::ts().with_module(true),
+        )
+        .parse();
+        let parsed = if parsed.panicked {
+            oxc_parser::Parser::new(
+                &allocator,
+                content,
+                oxc_span::SourceType::tsx().with_module(true),
+            )
+            .parse()
+        } else {
+            parsed
+        };
+        if parsed.panicked {
+            return None;
+        }
+
+        parsed.program.body.iter().find_map(|statement| {
+            let Statement::ImportDeclaration(import) = statement else {
+                return None;
+            };
+            import.specifiers.as_ref()?.iter().find_map(|specifier| {
+                let local = match specifier {
+                    ImportDeclarationSpecifier::ImportSpecifier(specifier) => &specifier.local,
+                    ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => {
+                        &specifier.local
+                    }
+                    ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => {
+                        &specifier.local
+                    }
+                };
+                (local.name == name).then_some(local.span.start as usize)
+            })
+        })
     }
 
     /// Skip virtual code header.
@@ -266,6 +316,16 @@ const doubled = computed(() => visitCount.value * 2)
         assert_eq!(
             spans(SOURCE, "visitCount = ref", false),
             [(4, 31, 41), (8, 18, 28)],
+        );
+    }
+
+    #[test]
+    fn excluding_declarations_recognizes_imported_local_bindings() {
+        let source = "<script setup>\nimport { shared } from './Child.vue'\nconst local = shared\n</script>\n<template>{{ shared }}</template>\n";
+
+        assert_eq!(
+            spans(source, "shared } from", false),
+            [(2, 14, 20), (4, 13, 19)],
         );
     }
 

--- a/crates/vize_maestro/src/ide/references/template.rs
+++ b/crates/vize_maestro/src/ide/references/template.rs
@@ -4,7 +4,7 @@
 //! including mustache interpolations and directive bindings.
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
-use tower_lsp::lsp_types::{Location, Position, Range};
+use tower_lsp::lsp_types::Location;
 
 use super::{IdeContext, ReferencesService};
 
@@ -23,8 +23,6 @@ impl ReferencesService {
         };
 
         let template_content = template.content.as_ref();
-        let template_start_line = template.loc.start_line as u32;
-
         // Find all occurrences of the word in template
         // This includes:
         // - Interpolations: {{ word }}
@@ -42,31 +40,21 @@ impl ReferencesService {
             let word_positions = Self::find_word_occurrences(&expr_text, word);
 
             for word_offset_in_expr in word_positions {
-                let absolute_offset = expr_offset + word_offset_in_expr;
-                let (line, character) = Self::offset_to_position(template_content, absolute_offset);
-
-                locations.push(Location {
-                    uri: ctx.uri.clone(),
-                    range: Range {
-                        start: Position {
-                            line: template_start_line + line - 1,
-                            character,
-                        },
-                        end: Position {
-                            line: template_start_line + line - 1,
-                            character: character + word.len() as u32,
-                        },
-                    },
-                });
+                locations.push(Self::location_from_sfc_offset(
+                    ctx,
+                    template.loc.start + expr_offset + word_offset_in_expr,
+                    word,
+                ));
             }
         }
 
         // Also do a simple text search for the word in template
         // This catches cases the AST might miss
         let simple_refs = Self::find_simple_references_in_content(
+            ctx,
             template_content,
             word,
-            template_start_line - 1,
+            template.loc.start,
         );
 
         for loc in simple_refs {
@@ -195,35 +183,29 @@ impl ReferencesService {
 
     /// Find simple text references in content.
     fn find_simple_references_in_content(
+        ctx: &IdeContext<'_>,
         content: &str,
         word: &str,
-        base_line: u32,
+        base_offset: usize,
     ) -> Vec<Location> {
         let mut locations = Vec::new();
+        let mut line_offset = 0;
 
-        for (line_idx, line) in content.lines().enumerate() {
+        for line in content.split_inclusive('\n') {
             let line_positions = Self::find_word_occurrences(line, word);
 
             for pos in line_positions {
                 // Check if this is in a binding context
                 // (inside {{ }}, after v-*, after :, after @, etc.)
                 if Self::is_in_binding_context(line, pos) {
-                    let character = crate::ide::offset_to_position(line, pos).1;
-                    locations.push(Location {
-                        uri: tower_lsp::lsp_types::Url::parse("file:///dummy").unwrap(),
-                        range: Range {
-                            start: Position {
-                                line: base_line + line_idx as u32,
-                                character,
-                            },
-                            end: Position {
-                                line: base_line + line_idx as u32,
-                                character: character + word.encode_utf16().count() as u32,
-                            },
-                        },
-                    });
+                    locations.push(Self::location_from_sfc_offset(
+                        ctx,
+                        base_offset + line_offset + pos,
+                        word,
+                    ));
                 }
             }
+            line_offset += line.len();
         }
 
         locations
@@ -252,5 +234,48 @@ impl ReferencesService {
         }
 
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tower_lsp::lsp_types::Url;
+
+    use crate::ide::{IdeContext, ReferencesService};
+    use crate::server::ServerState;
+
+    #[test]
+    fn inline_template_references_include_the_tag_column_and_utf16_prefix() {
+        let source =
+            "<script setup>\nconst shared = 1\n</script>\n<template>💥 {{ shared }}</template>\n";
+        let uri = Url::parse("file:///Inline.vue").unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+        let ctx = IdeContext::new(&state, &uri, source.find("shared =").unwrap()).unwrap();
+
+        let references = ReferencesService::references(&ctx, true).unwrap();
+        assert_eq!(
+            references.len(),
+            2,
+            "duplicate or missing hits: {references:#?}"
+        );
+        for location in references {
+            let start = crate::ide::position_to_offset(
+                source,
+                location.range.start.line,
+                location.range.start.character,
+            )
+            .unwrap();
+            let end = crate::ide::position_to_offset(
+                source,
+                location.range.end.line,
+                location.range.end.character,
+            )
+            .unwrap();
+            assert_eq!(&source[start..end], "shared");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- map template references from absolute SFC byte offsets instead of block-relative lines
- preserve inline opening-tag columns and UTF-16 positions
- recognize named, default, and namespace import bindings when excluding declarations

## Verification

- `cargo test -p vize_maestro inline_template_references_include_the_tag_column_and_utf16_prefix --lib`
- `cargo test -p vize_maestro excluding_declarations_recognizes_imported_local_bindings --lib`
- `cargo clippy -p vize_maestro --lib -- -D warnings`

Part of #3953.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->