### PR TITLE
fix(maestro): follow semantic template references

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -25,7 +25,8 @@ mod workspace_edit;
 
 #[cfg(feature = "native")]
 pub(crate) use canonical::{
-    canonical_source_offset_to_position, map_canonical_corsa_locations, map_canonical_lsp_range,
+    CanonicalSemanticPosition, CanonicalVirtualDocument, canonical_source_offset_to_position,
+    linked_semantic_position, map_canonical_corsa_locations, map_canonical_lsp_range,
     open_canonical_virtual_document, open_canonical_virtual_project_document,
 };
 #[cfg(feature = "native")]

--- a/crates/vize_maestro/src/ide/corsa_support/canonical.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical.rs
@@ -7,9 +7,11 @@ use crate::ide::diagnostics::VirtualTsResult;
 
 mod open;
 mod project;
+mod semantic_links;
 
 pub(crate) use open::open_canonical_virtual_document;
 pub(crate) use project::open_canonical_virtual_project_document;
+pub(crate) use semantic_links::{CanonicalSemanticPosition, linked_semantic_position};
 
 pub(crate) struct CanonicalVirtualDocument {
     pub(crate) request_uri: String,

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
@@ -1,0 +1,106 @@
+use vize_canon::LspRange;
+use vize_carton::{String, cstr};
+
+use super::{CanonicalVirtualDocument, location_matches_uri};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct CanonicalSemanticPosition {
+    pub(crate) request_uri: String,
+    pub(crate) line: u32,
+    pub(crate) character: u32,
+}
+
+/// Resolve the synthetic link that joins an authored setup binding to the
+/// template-scope shadow used for Vue ref unwrapping.
+///
+/// TypeScript correctly keeps a template `v-for` local separate from the
+/// setup binding, but the two generated declarations representing the setup
+/// binding are intentionally connected through a type alias rather than the
+/// same TS symbol. Following that generated edge lets a second semantic query
+/// recover template references without a same-spelling source sweep.
+pub(crate) fn linked_semantic_position(
+    document: &CanonicalVirtualDocument,
+    uri: &str,
+    range: &LspRange,
+) -> Option<CanonicalSemanticPosition> {
+    let (request_uri, code) = virtual_code(document, uri)?;
+    let start = crate::ide::position_to_offset(code, range.start.line, range.start.character)?;
+    let end = crate::ide::position_to_offset(code, range.end.line, range.end.character)?;
+    let linked_offset = linked_offset(code, start, end)?;
+    let (line, character) = crate::ide::offset_to_position(code, linked_offset);
+    Some(CanonicalSemanticPosition {
+        request_uri: request_uri.clone(),
+        line,
+        character,
+    })
+}
+
+fn linked_offset(code: &str, start: usize, end: usize) -> Option<usize> {
+    let name = code.get(start..end)?;
+    if name.is_empty() || name.bytes().any(|byte| byte.is_ascii_whitespace()) {
+        return None;
+    }
+
+    let anchor = cstr!("type __R_{name} = typeof {name};");
+    let anchor_name_in_pattern = anchor.rfind(name)?;
+    let anchors = code
+        .match_indices(anchor.as_str())
+        .map(|(offset, _)| offset + anchor_name_in_pattern)
+        .collect::<Vec<_>>();
+    let shadow = cstr!("var {name}: __U<__R_{name}> =");
+    let shadows = code
+        .match_indices(shadow.as_str())
+        .map(|(offset, _)| offset + "var ".len())
+        .collect::<Vec<_>>();
+
+    let linked_offset = if anchors.contains(&start) {
+        shadows.into_iter().filter(|offset| *offset > start).min()?
+    } else if shadows.contains(&start) {
+        anchors.into_iter().filter(|offset| *offset < start).max()?
+    } else {
+        return None;
+    };
+    Some(linked_offset)
+}
+
+fn virtual_code<'a>(
+    document: &'a CanonicalVirtualDocument,
+    uri: &str,
+) -> Option<(&'a String, &'a str)> {
+    if location_matches_uri(uri, document.request_uri.as_str()) {
+        return Some((&document.request_uri, &document.virtual_result.code));
+    }
+    document
+        .dependencies
+        .iter()
+        .find(|dependency| location_matches_uri(uri, dependency.request_uri.as_str()))
+        .map(|dependency| {
+            (
+                &dependency.request_uri,
+                dependency.virtual_result.code.as_str(),
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::linked_offset;
+
+    #[test]
+    fn links_the_matching_generated_pair_when_authored_text_collides() {
+        let pair =
+            "type __R_shared = typeof shared;\nvar shared: __U<__R_shared> = undefined as any;\n";
+        let code = format!("{pair}// generated pair\n{pair}");
+        let generated_start = code.rfind("typeof shared").unwrap() + "typeof ".len();
+        let generated_shadow = code.rfind("var shared").unwrap() + "var ".len();
+
+        assert_eq!(
+            linked_offset(&code, generated_start, generated_start + "shared".len(),),
+            Some(generated_shadow),
+        );
+        assert_eq!(
+            linked_offset(&code, generated_shadow, generated_shadow + "shared".len(),),
+            Some(generated_start),
+        );
+    }
+}

--- a/crates/vize_maestro/src/ide/references.rs
+++ b/crates/vize_maestro/src/ide/references.rs
@@ -237,11 +237,6 @@ impl ReferencesService {
     fn is_identifier_char(c: u8) -> bool {
         c.is_ascii_alphanumeric() || c == b'_' || c == b'$'
     }
-
-    /// Convert offset to (line, character).
-    pub(crate) fn offset_to_position(content: &str, offset: usize) -> (u32, u32) {
-        crate::ide::offset_to_position(content, offset)
-    }
 }
 
 #[cfg(test)]

--- a/crates/vize_maestro/src/ide/references.rs
+++ b/crates/vize_maestro/src/ide/references.rs
@@ -86,6 +86,9 @@ impl ReferencesService {
     ) -> Option<Vec<Location>> {
         let canonical_locations =
             canonical::references(ctx, include_declaration, corsa_bridge.as_deref()).await;
+        if canonical_locations.is_some() {
+            return canonical_locations;
+        }
         let Some(block_type) = ctx.block_type else {
             return canonical_locations;
         };

--- a/crates/vize_maestro/src/ide/references/canonical.rs
+++ b/crates/vize_maestro/src/ide/references/canonical.rs
@@ -1,6 +1,8 @@
 use tower_lsp::lsp_types::Location;
 use vize_canon::CorsaBridge;
+use vize_carton::FxHashSet;
 
+use super::ReferencesService;
 use crate::ide::{IdeContext, corsa_support};
 
 /// Query the project-aware canonical Vue document before the block-local
@@ -17,10 +19,102 @@ pub(super) async fn references(
     let document = corsa_support::open_canonical_virtual_project_document(ctx, bridge).await?;
     let (line, character) =
         corsa_support::canonical_source_offset_to_position(&document, ctx.offset)?;
-    let locations = bridge
+    let mut locations = bridge
         .references(&document.request_uri, line, character, include_declaration)
         .await
         .ok()?;
-    let locations = corsa_support::map_canonical_corsa_locations(ctx, &document, locations);
-    Some(locations)
+    let mut linked = linked_positions(&document, &locations);
+    if linked.is_empty() && !include_declaration {
+        let discovery = bridge
+            .references(&document.request_uri, line, character, true)
+            .await
+            .ok()?;
+        linked.extend(linked_positions(&document, &discovery));
+    }
+    for position in linked {
+        let extra = bridge
+            .references(
+                &position.request_uri,
+                position.line,
+                position.character,
+                include_declaration,
+            )
+            .await
+            .ok()?;
+        locations.extend(extra);
+    }
+
+    let mut mapped = corsa_support::map_canonical_corsa_locations(ctx, &document, locations);
+    mapped.extend(style_locations(ctx, &mapped));
+    mapped.sort_by(|left, right| {
+        left.uri
+            .as_str()
+            .cmp(right.uri.as_str())
+            .then(left.range.start.line.cmp(&right.range.start.line))
+            .then(left.range.start.character.cmp(&right.range.start.character))
+            .then(left.range.end.line.cmp(&right.range.end.line))
+            .then(left.range.end.character.cmp(&right.range.end.character))
+    });
+    mapped.dedup_by(|left, right| left.uri == right.uri && left.range == right.range);
+    Some(mapped)
+}
+
+fn style_locations(ctx: &IdeContext<'_>, semantic: &[Location]) -> Vec<Location> {
+    let mut seeds = FxHashSet::default();
+    let mut styles = Vec::new();
+    collect_style_locations(ctx, ctx.uri, ctx.offset, &mut seeds, &mut styles);
+
+    for location in semantic {
+        if !location.uri.path().ends_with(".vue") {
+            continue;
+        }
+        let Some(source) = ctx.state.documents.text(&location.uri) else {
+            continue;
+        };
+        let Some(offset) = crate::ide::position_to_offset(
+            &source,
+            location.range.start.line,
+            location.range.start.character,
+        ) else {
+            continue;
+        };
+        collect_style_locations(ctx, &location.uri, offset, &mut seeds, &mut styles);
+    }
+    styles
+}
+
+fn collect_style_locations(
+    query: &IdeContext<'_>,
+    uri: &tower_lsp::lsp_types::Url,
+    offset: usize,
+    seeds: &mut FxHashSet<(tower_lsp::lsp_types::Url, vize_carton::String)>,
+    locations: &mut Vec<Location>,
+) {
+    let Some(source) = query.state.documents.text(uri) else {
+        return;
+    };
+    let Some(word) = crate::ide::token_at_offset(&source, offset, |byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')
+    }) else {
+        return;
+    };
+    if !seeds.insert((uri.clone(), word.clone().into())) {
+        return;
+    }
+    let Some(ctx) = IdeContext::new(query.state, uri, offset) else {
+        return;
+    };
+    locations.extend(ReferencesService::find_references_in_style(&ctx, &word));
+}
+
+fn linked_positions(
+    document: &corsa_support::CanonicalVirtualDocument,
+    locations: &[vize_canon::LspLocation],
+) -> FxHashSet<corsa_support::CanonicalSemanticPosition> {
+    locations
+        .iter()
+        .filter_map(|location| {
+            corsa_support::linked_semantic_position(document, &location.uri, &location.range)
+        })
+        .collect()
 }

--- a/crates/vize_maestro/src/ide/references/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/references/corsa_tests.rs
@@ -62,8 +62,10 @@ export default {}
         let parent_source = r#"<script setup lang="ts">
 import { shared } from './Child View.vue'
 const local = shared
+function unrelated() { const shared = 0; return shared }
 </script>
-<template>💥 {{ shared }} {{ local }}</template>
+<template>💥 {{ shared }} {{ local }} <i v-for="shared in [1]">{{ shared }}</i></template>
+<style>.root { color: v-bind(shared) }</style>
 "#;
         let parent_path = src.join("Parent View.vue");
         fs::write(&parent_path, parent_source).expect("parent");
@@ -121,6 +123,16 @@ const local = shared
         )
         .await
         .expect("an empty canonical result is authoritative");
+        let template_offset = parent_source.find("{{ shared }}").expect("template use") + 3;
+        let template_ctx =
+            IdeContext::new(&state, &parent_uri, template_offset).expect("template context");
+        let from_template = ReferencesService::references_with_corsa(
+            &template_ctx,
+            false,
+            Some(Arc::clone(&bridge)),
+        )
+        .await
+        .expect("template references");
         bridge.shutdown().await.expect("shutdown");
 
         assert!(
@@ -139,6 +151,18 @@ const local = shared
                 .any(|location| location.uri == parent_uri),
             "references must use the unsaved child overlay across an encoded importer URI: {without_declaration:#?}",
         );
+        let parent_without_declaration = without_declaration
+            .iter()
+            .filter(|location| location.uri == parent_uri)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            parent_without_declaration.len(),
+            3,
+            "the script, template, and style uses must survive while the import declaration stays excluded: {without_declaration:#?}",
+        );
+        for location in parent_without_declaration {
+            assert_eq!(authored_text(parent_source, location), "shared");
+        }
         let child_declaration = with_declaration
             .iter()
             .find(|location| location.uri == child_uri)
@@ -150,6 +174,14 @@ const local = shared
                 .any(|location| location.uri == parent_uri),
             "references must cross into the open importer: {with_declaration:#?}",
         );
+        assert_eq!(
+            with_declaration
+                .iter()
+                .filter(|location| location.uri == parent_uri)
+                .count(),
+            4,
+            "including declarations must retain the import plus script, template, and style uses: {with_declaration:#?}",
+        );
         assert!(
             with_declaration
                 .iter()
@@ -159,6 +191,18 @@ const local = shared
         assert!(
             isolated_without_declaration.is_empty(),
             "an isolated declaration has no references when declarations are excluded: {isolated_without_declaration:#?}",
+        );
+        assert_eq!(
+            from_template.len(),
+            3,
+            "a template-local query must return only its script, template, and style uses: {from_template:#?}",
+        );
+        assert!(
+            from_template
+                .iter()
+                .all(|location| location.uri == parent_uri
+                    && authored_text(parent_source, location) == "shared"),
+            "the linked query must not jump to the exported symbol or a shadowed spelling: {from_template:#?}",
         );
     });
 }

--- a/crates/vize_maestro/src/ide/references/script.rs
+++ b/crates/vize_maestro/src/ide/references/script.rs
@@ -44,7 +44,11 @@ impl ReferencesService {
         None
     }
 
-    fn location_from_sfc_offset(ctx: &IdeContext, offset: usize, word: &str) -> Location {
+    pub(super) fn location_from_sfc_offset(
+        ctx: &IdeContext,
+        offset: usize,
+        word: &str,
+    ) -> Location {
         let (line, character) = crate::ide::offset_to_position(&ctx.content, offset);
 
         Location {
@@ -145,6 +149,9 @@ impl ReferencesService {
 
     /// Find a binding definition in script content.
     pub(super) fn find_binding_in_script(content: &str, name: &str) -> Option<usize> {
+        if let Some(offset) = Self::find_import_binding(content, name) {
+            return Some(offset);
+        }
         let content_start = Self::skip_virtual_header(content);
         let search_content = &content[content_start..];
 
@@ -183,6 +190,49 @@ impl ReferencesService {
         }
 
         None
+    }
+
+    fn find_import_binding(content: &str, name: &str) -> Option<usize> {
+        use oxc_ast::ast::{ImportDeclarationSpecifier, Statement};
+
+        let allocator = oxc_allocator::Allocator::default();
+        let parsed = oxc_parser::Parser::new(
+            &allocator,
+            content,
+            oxc_span::SourceType::ts().with_module(true),
+        )
+        .parse();
+        let parsed = if parsed.panicked {
+            oxc_parser::Parser::new(
+                &allocator,
+                content,
+                oxc_span::SourceType::tsx().with_module(true),
+            )
+            .parse()
+        } else {
+            parsed
+        };
+        if parsed.panicked {
+            return None;
+        }
+
+        parsed.program.body.iter().find_map(|statement| {
+            let Statement::ImportDeclaration(import) = statement else {
+                return None;
+            };
+            import.specifiers.as_ref()?.iter().find_map(|specifier| {
+                let local = match specifier {
+                    ImportDeclarationSpecifier::ImportSpecifier(specifier) => &specifier.local,
+                    ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => {
+                        &specifier.local
+                    }
+                    ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => {
+                        &specifier.local
+                    }
+                };
+                (local.name == name).then_some(local.span.start as usize)
+            })
+        })
     }
 
     /// Skip virtual code header.
@@ -266,6 +316,16 @@ const doubled = computed(() => visitCount.value * 2)
         assert_eq!(
             spans(SOURCE, "visitCount = ref", false),
             [(4, 31, 41), (8, 18, 28)],
+        );
+    }
+
+    #[test]
+    fn excluding_declarations_recognizes_imported_local_bindings() {
+        let source = "<script setup>\nimport { shared } from './Child.vue'\nconst local = shared\n</script>\n<template>{{ shared }}</template>\n";
+
+        assert_eq!(
+            spans(source, "shared } from", false),
+            [(2, 14, 20), (4, 13, 19)],
         );
     }
 

--- a/crates/vize_maestro/src/ide/references/template.rs
+++ b/crates/vize_maestro/src/ide/references/template.rs
@@ -4,7 +4,7 @@
 //! including mustache interpolations and directive bindings.
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
-use tower_lsp::lsp_types::{Location, Position, Range};
+use tower_lsp::lsp_types::Location;
 
 use super::{IdeContext, ReferencesService};
 
@@ -23,8 +23,6 @@ impl ReferencesService {
         };
 
         let template_content = template.content.as_ref();
-        let template_start_line = template.loc.start_line as u32;
-
         // Find all occurrences of the word in template
         // This includes:
         // - Interpolations: {{ word }}
@@ -42,31 +40,21 @@ impl ReferencesService {
             let word_positions = Self::find_word_occurrences(&expr_text, word);
 
             for word_offset_in_expr in word_positions {
-                let absolute_offset = expr_offset + word_offset_in_expr;
-                let (line, character) = Self::offset_to_position(template_content, absolute_offset);
-
-                locations.push(Location {
-                    uri: ctx.uri.clone(),
-                    range: Range {
-                        start: Position {
-                            line: template_start_line + line - 1,
-                            character,
-                        },
-                        end: Position {
-                            line: template_start_line + line - 1,
-                            character: character + word.len() as u32,
-                        },
-                    },
-                });
+                locations.push(Self::location_from_sfc_offset(
+                    ctx,
+                    template.loc.start + expr_offset + word_offset_in_expr,
+                    word,
+                ));
             }
         }
 
         // Also do a simple text search for the word in template
         // This catches cases the AST might miss
         let simple_refs = Self::find_simple_references_in_content(
+            ctx,
             template_content,
             word,
-            template_start_line - 1,
+            template.loc.start,
         );
 
         for loc in simple_refs {
@@ -195,35 +183,29 @@ impl ReferencesService {
 
     /// Find simple text references in content.
     fn find_simple_references_in_content(
+        ctx: &IdeContext<'_>,
         content: &str,
         word: &str,
-        base_line: u32,
+        base_offset: usize,
     ) -> Vec<Location> {
         let mut locations = Vec::new();
+        let mut line_offset = 0;
 
-        for (line_idx, line) in content.lines().enumerate() {
+        for line in content.split_inclusive('\n') {
             let line_positions = Self::find_word_occurrences(line, word);
 
             for pos in line_positions {
                 // Check if this is in a binding context
                 // (inside {{ }}, after v-*, after :, after @, etc.)
                 if Self::is_in_binding_context(line, pos) {
-                    let character = crate::ide::offset_to_position(line, pos).1;
-                    locations.push(Location {
-                        uri: tower_lsp::lsp_types::Url::parse("file:///dummy").unwrap(),
-                        range: Range {
-                            start: Position {
-                                line: base_line + line_idx as u32,
-                                character,
-                            },
-                            end: Position {
-                                line: base_line + line_idx as u32,
-                                character: character + word.encode_utf16().count() as u32,
-                            },
-                        },
-                    });
+                    locations.push(Self::location_from_sfc_offset(
+                        ctx,
+                        base_offset + line_offset + pos,
+                        word,
+                    ));
                 }
             }
+            line_offset += line.len();
         }
 
         locations
@@ -252,5 +234,48 @@ impl ReferencesService {
         }
 
         false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tower_lsp::lsp_types::Url;
+
+    use crate::ide::{IdeContext, ReferencesService};
+    use crate::server::ServerState;
+
+    #[test]
+    fn inline_template_references_include_the_tag_column_and_utf16_prefix() {
+        let source =
+            "<script setup>\nconst shared = 1\n</script>\n<template>💥 {{ shared }}</template>\n";
+        let uri = Url::parse("file:///Inline.vue").unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+        let ctx = IdeContext::new(&state, &uri, source.find("shared =").unwrap()).unwrap();
+
+        let references = ReferencesService::references(&ctx, true).unwrap();
+        assert_eq!(
+            references.len(),
+            2,
+            "duplicate or missing hits: {references:#?}"
+        );
+        for location in references {
+            let start = crate::ide::position_to_offset(
+                source,
+                location.range.start.line,
+                location.range.start.character,
+            )
+            .unwrap();
+            let end = crate::ide::position_to_offset(
+                source,
+                location.range.end.line,
+                location.range.end.character,
+            )
+            .unwrap();
+            assert_eq!(&source[start..end], "shared");
+        }
     }
 }


### PR DESCRIPTION
## Summary

- follow the generated setup-binding/template-shadow type link with a second tsgo semantic query
- reject same-spelling script scopes and template locals instead of merging an authored word sweep
- recover exact style `v-bind()` references only from semantic authored symbol seeds
- preserve authoritative empty reference answers

## Verification

- exact standard tsgo cross-SFC E2E covers source and template entry points
- E2E covers unsaved overlays, percent-encoded paths, UTF-16, declarations, style bindings, script shadows, and `v-for` shadows
- `cargo clippy -p vize_maestro --lib -- -D warnings`

Part of #3953 and #3282.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->