### PR TITLE
fix(maestro): map cross-sfc rename edits

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -9,6 +9,8 @@ mod canonical;
 #[cfg(all(test, feature = "native"))]
 mod canonical_dependency_tests;
 #[cfg(all(test, feature = "native"))]
+mod canonical_rename_tests;
+#[cfg(all(test, feature = "native"))]
 mod canonical_tests;
 #[cfg(feature = "native")]
 mod html_attribute;

--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -28,8 +28,9 @@ mod workspace_edit;
 #[cfg(feature = "native")]
 pub(crate) use canonical::{
     CanonicalSemanticPosition, CanonicalVirtualDocument, canonical_source_offset_to_position,
-    linked_semantic_position, map_canonical_corsa_locations, map_canonical_lsp_range,
-    open_canonical_virtual_document, open_canonical_virtual_project_document,
+    linked_semantic_position, map_canonical_corsa_locations, map_canonical_corsa_workspace_edit,
+    map_canonical_lsp_range, map_canonical_prepare_rename, merge_canonical_workspace_edits,
+    open_canonical_virtual_document, open_canonical_virtual_project_document, tower_range,
 };
 #[cfg(feature = "native")]
 pub(crate) use html_attribute::{

--- a/crates/vize_maestro/src/ide/corsa_support/canonical.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical.rs
@@ -7,6 +7,7 @@ use crate::ide::diagnostics::VirtualTsResult;
 
 mod open;
 mod project;
+pub(super) mod rename;
 mod semantic_links;
 
 pub(crate) use open::open_canonical_virtual_document;

--- a/crates/vize_maestro/src/ide/corsa_support/canonical.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical.rs
@@ -12,7 +12,11 @@ mod semantic_links;
 
 pub(crate) use open::open_canonical_virtual_document;
 pub(crate) use project::open_canonical_virtual_project_document;
-pub(crate) use semantic_links::{CanonicalSemanticPosition, linked_semantic_position};
+pub(crate) use rename::{
+    map_canonical_corsa_workspace_edit, map_canonical_prepare_rename,
+    merge_canonical_workspace_edits,
+};
+pub(crate) use semantic_links::{CanonicalSemanticPosition, linked_semantic_position, tower_range};
 
 pub(crate) struct CanonicalVirtualDocument {
     pub(crate) request_uri: String,

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/rename.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/rename.rs
@@ -1,0 +1,338 @@
+use std::collections::HashMap;
+
+use tower_lsp::lsp_types::{
+    AnnotatedTextEdit, DocumentChangeOperation, DocumentChanges, OneOf,
+    OptionalVersionedTextDocumentIdentifier, PrepareRenameResponse, ResourceOp, TextDocumentEdit,
+    TextEdit, Url, WorkspaceEdit,
+};
+use vize_canon::{LspLocation, LspPosition, LspRange};
+
+use super::{CanonicalVirtualDocument, is_canonical_vue_virtual_uri};
+use crate::ide::IdeContext;
+
+pub(crate) fn map_canonical_prepare_rename(
+    ctx: &IdeContext<'_>,
+    document: &CanonicalVirtualDocument,
+    response: PrepareRenameResponse,
+) -> Option<PrepareRenameResponse> {
+    match response {
+        PrepareRenameResponse::Range(range)
+        | PrepareRenameResponse::RangeWithPlaceholder { range, .. } => {
+            super::map_canonical_lsp_range(ctx, document, &to_canonical_range(range))
+                .map(PrepareRenameResponse::Range)
+        }
+        PrepareRenameResponse::DefaultBehavior { default_behavior } => {
+            Some(PrepareRenameResponse::DefaultBehavior { default_behavior })
+        }
+    }
+}
+
+pub(crate) fn map_canonical_corsa_workspace_edit(
+    ctx: &IdeContext<'_>,
+    document: &CanonicalVirtualDocument,
+    mut edit: WorkspaceEdit,
+) -> Option<WorkspaceEdit> {
+    if let Some(changes) = edit.changes.take() {
+        let mut mapped = HashMap::new();
+        for (uri, edits) in changes {
+            for edit in edits {
+                if let Some((uri, edit)) = map_text_edit(ctx, document, &uri, edit) {
+                    push_text_edit(&mut mapped, uri, edit);
+                }
+            }
+        }
+        edit.changes = (!mapped.is_empty()).then_some(mapped);
+    }
+
+    if let Some(changes) = edit.document_changes.take() {
+        edit.document_changes = map_document_changes(ctx, document, changes);
+    }
+
+    (!workspace_edit_is_empty(&edit)).then_some(edit)
+}
+
+pub(crate) fn merge_canonical_workspace_edits(
+    edits: impl IntoIterator<Item = WorkspaceEdit>,
+) -> Option<WorkspaceEdit> {
+    let mut changes = HashMap::new();
+    let mut document_changes = None;
+    let mut change_annotations = HashMap::new();
+
+    for mut edit in edits {
+        for (uri, edits) in edit.changes.take().unwrap_or_default() {
+            for edit in edits {
+                push_text_edit(&mut changes, uri.clone(), edit);
+            }
+        }
+        if let Some(incoming) = edit.document_changes.take() {
+            merge_document_change_sets(&mut document_changes, incoming);
+        }
+        for (id, annotation) in edit.change_annotations.take().unwrap_or_default() {
+            if change_annotations
+                .get(&id)
+                .is_some_and(|existing| existing != &annotation)
+            {
+                return None;
+            }
+            change_annotations.insert(id, annotation);
+        }
+    }
+
+    if let Some(document_changes) = document_changes.as_mut() {
+        promote_plain_changes(document_changes, std::mem::take(&mut changes));
+    }
+    let edit = WorkspaceEdit {
+        changes: (!changes.is_empty()).then_some(changes),
+        document_changes,
+        change_annotations: (!change_annotations.is_empty()).then_some(change_annotations),
+    };
+    (!workspace_edit_is_empty(&edit)).then_some(edit)
+}
+
+fn merge_document_change_sets(current: &mut Option<DocumentChanges>, incoming: DocumentChanges) {
+    let Some(current) = current else {
+        *current = Some(incoming);
+        return;
+    };
+    match (current, incoming) {
+        (DocumentChanges::Edits(current), DocumentChanges::Edits(incoming)) => {
+            for edit in incoming {
+                merge_document_edit(current, edit);
+            }
+        }
+        (DocumentChanges::Operations(current), DocumentChanges::Operations(mut incoming)) => {
+            current.append(&mut incoming);
+        }
+        (current @ DocumentChanges::Edits(_), DocumentChanges::Operations(mut incoming)) => {
+            let DocumentChanges::Edits(edits) =
+                std::mem::replace(current, DocumentChanges::Operations(Vec::new()))
+            else {
+                unreachable!();
+            };
+            let DocumentChanges::Operations(current) = current else {
+                unreachable!();
+            };
+            current.extend(edits.into_iter().map(DocumentChangeOperation::Edit));
+            current.append(&mut incoming);
+        }
+        (DocumentChanges::Operations(current), DocumentChanges::Edits(incoming)) => {
+            current.extend(incoming.into_iter().map(DocumentChangeOperation::Edit));
+        }
+    }
+}
+
+fn promote_plain_changes(changes: &mut DocumentChanges, plain: HashMap<Url, Vec<TextEdit>>) {
+    for (uri, edits) in plain {
+        let edit = TextDocumentEdit {
+            text_document: OptionalVersionedTextDocumentIdentifier { uri, version: None },
+            edits: edits.into_iter().map(OneOf::Left).collect(),
+        };
+        match changes {
+            DocumentChanges::Edits(changes) => merge_document_edit(changes, edit),
+            DocumentChanges::Operations(changes) => {
+                changes.push(DocumentChangeOperation::Edit(edit));
+            }
+        }
+    }
+}
+
+fn merge_document_edit(edits: &mut Vec<TextDocumentEdit>, incoming: TextDocumentEdit) {
+    let Some(existing) = edits
+        .iter_mut()
+        .find(|edit| edit.text_document.uri == incoming.text_document.uri)
+    else {
+        edits.push(incoming);
+        return;
+    };
+    for edit in incoming.edits {
+        push_annotatable_edit_to(existing, edit);
+    }
+}
+
+fn push_annotatable_edit_to(
+    document: &mut TextDocumentEdit,
+    edit: OneOf<TextEdit, AnnotatedTextEdit>,
+) {
+    let (range, new_text) = annotatable_identity(&edit);
+    if !document.edits.iter().any(|existing| {
+        let (existing_range, existing_text) = annotatable_identity(existing);
+        existing_range == range && existing_text == new_text
+    }) {
+        document.edits.push(edit);
+    }
+}
+
+fn map_document_changes(
+    ctx: &IdeContext<'_>,
+    document: &CanonicalVirtualDocument,
+    changes: DocumentChanges,
+) -> Option<DocumentChanges> {
+    match changes {
+        DocumentChanges::Edits(edits) => {
+            let mapped = edits
+                .into_iter()
+                .flat_map(|edit| map_document_edit(ctx, document, edit))
+                .collect::<Vec<_>>();
+            (!mapped.is_empty()).then_some(DocumentChanges::Edits(mapped))
+        }
+        DocumentChanges::Operations(operations) => {
+            let mut mapped = Vec::new();
+            for operation in operations {
+                match operation {
+                    DocumentChangeOperation::Edit(edit) => mapped.extend(
+                        map_document_edit(ctx, document, edit)
+                            .into_iter()
+                            .map(DocumentChangeOperation::Edit),
+                    ),
+                    DocumentChangeOperation::Op(operation)
+                        if resource_operation_is_authored(&operation) =>
+                    {
+                        mapped.push(DocumentChangeOperation::Op(operation));
+                    }
+                    DocumentChangeOperation::Op(_) => {}
+                }
+            }
+            (!mapped.is_empty()).then_some(DocumentChanges::Operations(mapped))
+        }
+    }
+}
+
+fn map_document_edit(
+    ctx: &IdeContext<'_>,
+    document: &CanonicalVirtualDocument,
+    edit: TextDocumentEdit,
+) -> Vec<TextDocumentEdit> {
+    let original = edit.text_document;
+    let mut groups: Vec<(Url, Vec<OneOf<TextEdit, AnnotatedTextEdit>>)> = Vec::new();
+
+    for entry in edit.edits {
+        let mapped = match entry {
+            OneOf::Left(edit) => map_text_edit(ctx, document, &original.uri, edit)
+                .map(|(uri, edit)| (uri, OneOf::Left(edit))),
+            OneOf::Right(AnnotatedTextEdit {
+                text_edit,
+                annotation_id,
+            }) => map_text_edit(ctx, document, &original.uri, text_edit).map(|(uri, text_edit)| {
+                (
+                    uri,
+                    OneOf::Right(AnnotatedTextEdit {
+                        text_edit,
+                        annotation_id,
+                    }),
+                )
+            }),
+        };
+        if let Some((uri, entry)) = mapped {
+            push_annotatable_edit(&mut groups, uri, entry);
+        }
+    }
+
+    groups
+        .into_iter()
+        .map(|(uri, edits)| TextDocumentEdit {
+            text_document: OptionalVersionedTextDocumentIdentifier {
+                version: if uri == original.uri {
+                    original.version
+                } else {
+                    None
+                },
+                uri,
+            },
+            edits,
+        })
+        .collect()
+}
+
+fn map_text_edit(
+    ctx: &IdeContext<'_>,
+    document: &CanonicalVirtualDocument,
+    uri: &Url,
+    mut edit: TextEdit,
+) -> Option<(Url, TextEdit)> {
+    let location = super::map_canonical_corsa_location(
+        ctx,
+        document,
+        &LspLocation {
+            uri: uri.to_string(),
+            range: to_canonical_range(edit.range),
+        },
+    )?;
+    edit.range = location.range;
+    Some((location.uri, edit))
+}
+
+fn push_text_edit(changes: &mut HashMap<Url, Vec<TextEdit>>, uri: Url, edit: TextEdit) {
+    let edits = changes.entry(uri).or_default();
+    if !edits
+        .iter()
+        .any(|existing| existing.range == edit.range && existing.new_text == edit.new_text)
+    {
+        edits.push(edit);
+    }
+}
+
+fn push_annotatable_edit(
+    groups: &mut Vec<(Url, Vec<OneOf<TextEdit, AnnotatedTextEdit>>)>,
+    uri: Url,
+    edit: OneOf<TextEdit, AnnotatedTextEdit>,
+) {
+    let edits = if let Some((_, edits)) = groups.iter_mut().find(|(existing, _)| *existing == uri) {
+        edits
+    } else {
+        groups.push((uri, Vec::new()));
+        &mut groups.last_mut().expect("inserted group").1
+    };
+    let (range, new_text) = annotatable_identity(&edit);
+    if !edits.iter().any(|existing| {
+        let (existing_range, existing_text) = annotatable_identity(existing);
+        existing_range == range && existing_text == new_text
+    }) {
+        edits.push(edit);
+    }
+}
+
+fn annotatable_identity(
+    edit: &OneOf<TextEdit, AnnotatedTextEdit>,
+) -> (tower_lsp::lsp_types::Range, &str) {
+    match edit {
+        OneOf::Left(edit) => (edit.range, edit.new_text.as_str()),
+        OneOf::Right(edit) => (edit.text_edit.range, edit.text_edit.new_text.as_str()),
+    }
+}
+
+fn resource_operation_is_authored(operation: &ResourceOp) -> bool {
+    let safe = |uri: &Url| {
+        !is_canonical_vue_virtual_uri(uri) || uri.to_file_path().is_ok_and(|path| path.is_file())
+    };
+    match operation {
+        ResourceOp::Create(operation) => safe(&operation.uri),
+        ResourceOp::Rename(operation) => safe(&operation.old_uri) && safe(&operation.new_uri),
+        ResourceOp::Delete(operation) => safe(&operation.uri),
+    }
+}
+
+fn to_canonical_range(range: tower_lsp::lsp_types::Range) -> LspRange {
+    LspRange {
+        start: LspPosition {
+            line: range.start.line,
+            character: range.start.character,
+        },
+        end: LspPosition {
+            line: range.end.line,
+            character: range.end.character,
+        },
+    }
+}
+
+fn workspace_edit_is_empty(edit: &WorkspaceEdit) -> bool {
+    edit.changes
+        .as_ref()
+        .is_none_or(|changes| changes.values().all(Vec::is_empty))
+        && edit
+            .document_changes
+            .as_ref()
+            .is_none_or(|changes| match changes {
+                DocumentChanges::Edits(edits) => edits.is_empty(),
+                DocumentChanges::Operations(operations) => operations.is_empty(),
+            })
+}

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
@@ -1,4 +1,4 @@
-use vize_canon::LspRange;
+use vize_canon::{LspPosition, LspRange};
 use vize_carton::{String, cstr};
 
 use super::{CanonicalVirtualDocument, location_matches_uri};
@@ -80,6 +80,19 @@ fn virtual_code<'a>(
                 dependency.virtual_result.code.as_str(),
             )
         })
+}
+
+pub(crate) fn tower_range(range: tower_lsp::lsp_types::Range) -> LspRange {
+    LspRange {
+        start: LspPosition {
+            line: range.start.line,
+            character: range.start.character,
+        },
+        end: LspPosition {
+            line: range.end.line,
+            character: range.end.character,
+        },
+    }
 }
 
 #[cfg(test)]

--- a/crates/vize_maestro/src/ide/corsa_support/canonical_dependency_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical_dependency_tests.rs
@@ -9,7 +9,7 @@ use super::request_file_uri;
 use crate::ide::{DiagnosticService, IdeContext, offset_to_position, position_to_offset};
 use crate::server::ServerState;
 
-fn mapped_document(uri: &Url, source: &str) -> CanonicalDependencyDocument {
+pub(super) fn mapped_document(uri: &Url, source: &str) -> CanonicalDependencyDocument {
     CanonicalDependencyDocument {
         source_uri: uri.clone(),
         source: source.into(),
@@ -19,7 +19,7 @@ fn mapped_document(uri: &Url, source: &str) -> CanonicalDependencyDocument {
     }
 }
 
-fn host_document(uri: &Url, source: &str) -> CanonicalVirtualDocument {
+pub(super) fn host_document(uri: &Url, source: &str) -> CanonicalVirtualDocument {
     CanonicalVirtualDocument {
         request_uri: request_file_uri(canonical_request_path(uri).as_str()),
         virtual_result: DiagnosticService::generate_virtual_ts(uri, source, false, false)
@@ -162,7 +162,7 @@ fn path_uri(path: &std::path::Path) -> String {
     Url::from_file_path(path).expect("file uri").to_string()
 }
 
-fn generated_offset_for_source(
+pub(super) fn generated_offset_for_source(
     document: &CanonicalDependencyDocument,
     source_offset: usize,
 ) -> usize {

--- a/crates/vize_maestro/src/ide/corsa_support/canonical_rename_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical_rename_tests.rs
@@ -1,0 +1,170 @@
+use tower_lsp::lsp_types::{
+    AnnotatedTextEdit, CreateFile, DocumentChangeOperation, DocumentChanges, OneOf,
+    OptionalVersionedTextDocumentIdentifier, Position, Range, ResourceOp, TextDocumentEdit,
+    TextEdit, Url, WorkspaceEdit,
+};
+
+use super::canonical::rename::{
+    map_canonical_corsa_workspace_edit, merge_canonical_workspace_edits,
+};
+use super::canonical_dependency_tests::{
+    generated_offset_for_source, host_document, mapped_document,
+};
+use crate::ide::{IdeContext, offset_to_position, position_to_offset};
+use crate::server::ServerState;
+
+#[test]
+fn maps_annotated_document_edits_and_drops_synthetic_resource_operations() {
+    let project = tempfile::TempDir::new().expect("temp project");
+    let host_path = project.path().join("Host.vue");
+    let child_path = project.path().join("Child View.vue");
+    let host_uri = Url::from_file_path(&host_path).expect("host uri");
+    let child_uri = Url::from_file_path(&child_path).expect("child uri");
+    let host_source = "<template><main /></template>";
+    let child_source = "<script setup>const emoji = '💥'; const shared = 1</script>";
+    std::fs::write(&host_path, host_source).expect("host");
+    std::fs::write(&child_path, child_source).expect("child");
+
+    let state = ServerState::new();
+    state.documents.open(
+        host_uri.clone(),
+        host_source.to_string(),
+        1,
+        "vue".to_string(),
+    );
+    let ctx = IdeContext::new(&state, &host_uri, 1).expect("host context");
+    let dependency = mapped_document(&child_uri, child_source);
+    let source_start = child_source.find("shared").expect("source token");
+    let generated_start = generated_offset_for_source(&dependency, source_start);
+    let generated_end = generated_offset_for_source(&dependency, source_start + "shared".len());
+    let (start_line, start_character) =
+        offset_to_position(&dependency.virtual_result.code, generated_start);
+    let (end_line, end_character) =
+        offset_to_position(&dependency.virtual_result.code, generated_end);
+    let request_uri = Url::parse(&dependency.request_uri).expect("request uri");
+    let annotated = AnnotatedTextEdit {
+        text_edit: TextEdit {
+            range: Range::new(
+                Position::new(start_line, start_character),
+                Position::new(end_line, end_character),
+            ),
+            new_text: "renamed".to_string(),
+        },
+        annotation_id: "rename-symbol".to_string(),
+    };
+    let mut host = host_document(&host_uri, host_source);
+    host.dependencies.push(dependency);
+
+    let mapped = map_canonical_corsa_workspace_edit(
+        &ctx,
+        &host,
+        WorkspaceEdit {
+            changes: None,
+            document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
+                text_document: OptionalVersionedTextDocumentIdentifier {
+                    uri: request_uri,
+                    version: Some(9),
+                },
+                edits: vec![OneOf::Right(annotated)],
+            }])),
+            change_annotations: None,
+        },
+    )
+    .expect("mapped workspace edit");
+    let Some(DocumentChanges::Edits(edits)) = mapped.document_changes else {
+        panic!("expected document edits");
+    };
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].text_document.uri, child_uri);
+    assert_eq!(edits[0].text_document.version, None);
+    let OneOf::Right(edit) = &edits[0].edits[0] else {
+        panic!("expected annotated edit");
+    };
+    assert_eq!(edit.annotation_id, "rename-symbol");
+    let mapped_start = position_to_offset(
+        child_source,
+        edit.text_edit.range.start.line,
+        edit.text_edit.range.start.character,
+    )
+    .unwrap();
+    let mapped_end = position_to_offset(
+        child_source,
+        edit.text_edit.range.end.line,
+        edit.text_edit.range.end.character,
+    )
+    .unwrap();
+    assert_eq!(&child_source[mapped_start..mapped_end], "shared");
+
+    let synthetic_uri = Url::from_file_path(child_path.with_extension("vue.ts")).unwrap();
+    assert!(
+        map_canonical_corsa_workspace_edit(
+            &ctx,
+            &host,
+            WorkspaceEdit {
+                changes: None,
+                document_changes: Some(DocumentChanges::Operations(vec![
+                    DocumentChangeOperation::Op(ResourceOp::Create(CreateFile {
+                        uri: synthetic_uri,
+                        options: None,
+                        annotation_id: None,
+                    })),
+                ])),
+                change_annotations: None,
+            },
+        )
+        .is_none(),
+        "synthetic resource operations must fail closed",
+    );
+}
+
+#[test]
+fn merges_plain_and_annotated_canonical_rename_edits_without_forking_containers() {
+    let uri = Url::parse("file:///workspace/App.vue").unwrap();
+    let plain = TextEdit {
+        range: Range::new(Position::new(1, 2), Position::new(1, 8)),
+        new_text: "renamed".to_string(),
+    };
+    let annotated = AnnotatedTextEdit {
+        text_edit: TextEdit {
+            range: Range::new(Position::new(3, 4), Position::new(3, 10)),
+            new_text: "renamed".to_string(),
+        },
+        annotation_id: "template-use".to_string(),
+    };
+
+    let merged = merge_canonical_workspace_edits([
+        WorkspaceEdit {
+            changes: Some(std::collections::HashMap::from([(
+                uri.clone(),
+                vec![plain.clone()],
+            )])),
+            document_changes: None,
+            change_annotations: None,
+        },
+        WorkspaceEdit {
+            changes: None,
+            document_changes: Some(DocumentChanges::Edits(vec![TextDocumentEdit {
+                text_document: OptionalVersionedTextDocumentIdentifier {
+                    uri: uri.clone(),
+                    version: None,
+                },
+                edits: vec![OneOf::Right(annotated.clone())],
+            }])),
+            change_annotations: None,
+        },
+    ])
+    .expect("merged edit");
+
+    assert!(
+        merged.changes.is_none(),
+        "clients must see one edit container"
+    );
+    let Some(DocumentChanges::Edits(edits)) = merged.document_changes else {
+        panic!("expected document edits");
+    };
+    assert_eq!(edits.len(), 1);
+    assert_eq!(
+        edits[0].edits,
+        [OneOf::Right(annotated), OneOf::Left(plain)],
+    );
+}

--- a/crates/vize_maestro/src/ide/references/script.rs
+++ b/crates/vize_maestro/src/ide/references/script.rs
@@ -93,7 +93,7 @@ impl ReferencesService {
     }
 
     /// Find references to a symbol in style blocks (v-bind).
-    pub(super) fn find_references_in_style(ctx: &IdeContext, word: &str) -> Vec<Location> {
+    pub(in crate::ide) fn find_references_in_style(ctx: &IdeContext, word: &str) -> Vec<Location> {
         let mut locations = Vec::new();
 
         let options = vize_atelier_sfc::SfcParseOptions::default();

--- a/crates/vize_maestro/src/ide/rename.rs
+++ b/crates/vize_maestro/src/ide/rename.rs
@@ -6,6 +6,11 @@
 //! - CSS variables in v-bind()
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
+#[cfg(feature = "native")]
+mod canonical;
+#[cfg(all(test, feature = "native"))]
+mod corsa_tests;
+
 use std::collections::HashMap;
 
 #[cfg(feature = "native")]
@@ -89,6 +94,10 @@ impl RenameService {
         ctx: &IdeContext<'_>,
         corsa_bridge: Option<Arc<CorsaBridge>>,
     ) -> Option<PrepareRenameResponse> {
+        match canonical::prepare(ctx, corsa_bridge.as_deref()).await {
+            canonical::Answer::Available(response) => return response,
+            canonical::Answer::Unavailable => {}
+        }
         let corsa_result = match ctx.block_type? {
             BlockType::Template => {
                 Self::prepare_template_rename_with_corsa(ctx, corsa_bridge.as_deref()).await
@@ -122,6 +131,11 @@ impl RenameService {
             return None;
         }
 
+        if let canonical::Answer::Available(edit) =
+            canonical::rename(ctx, new_name, corsa_bridge.as_deref()).await
+        {
+            return edit;
+        }
         let corsa_result = match ctx.block_type? {
             BlockType::Template => {
                 Self::rename_template_with_corsa(ctx, new_name, corsa_bridge.as_deref()).await
@@ -473,116 +487,4 @@ impl RenameService {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::RenameService;
-
-    /// Renaming a local binding must not rewrite a same-named prop
-    /// *attribute name* on a component usage — that token belongs to the
-    /// child's own prop symbol, and rewriting it silently breaks the call
-    /// site (#3892). Building rename from the references provider makes the
-    /// invariant structural: every edit is a reference (or the declaration).
-    #[test]
-    fn rename_leaves_same_named_prop_attribute_names_alone() {
-        let content = r#"<script setup lang="ts">
-import Child from './Child.vue'
-const count = 1
-</script>
-
-<template>
-  <Child :count="count" />
-</template>
-"#;
-        let uri = tower_lsp::lsp_types::Url::parse("file:///ws/Parent.vue").unwrap();
-        let state = crate::server::ServerState::new();
-        state
-            .documents
-            .open(uri.clone(), content.to_string(), 1, "vue".to_string());
-        state.update_virtual_docs(&uri, content);
-        let offset = content.find("const count").unwrap() + "const ".len();
-        let ctx = crate::ide::IdeContext::new(&state, &uri, offset).unwrap();
-
-        let edit = RenameService::rename(&ctx, "tally").unwrap();
-        let edits = &edit.changes.unwrap()[&uri];
-
-        let attr_name_line = content[..content.find(":count=").unwrap()]
-            .matches('\n')
-            .count() as u32;
-        for edit in edits {
-            let touches_attr_name = edit.range.start.line == attr_name_line
-                && edit.range.start.character
-                    == content
-                        .lines()
-                        .nth(attr_name_line as usize)
-                        .unwrap()
-                        .find(":count")
-                        .unwrap() as u32
-                        + 1;
-            assert!(
-                !touches_attr_name,
-                "the :count attribute name must not be renamed: {edits:?}"
-            );
-        }
-
-        // The invariant that pins the providers together: every rename edit is
-        // one of the reference locations.
-        let references = crate::ide::references::ReferencesService::references(&ctx, true).unwrap();
-        for edit in edits {
-            assert!(
-                references
-                    .iter()
-                    .any(|reference| reference.range == edit.range),
-                "rename edit {edit:?} is not a reference: {references:?}"
-            );
-        }
-        assert!(
-            edits.len() >= 2,
-            "the declaration and the binding value must still rename: {edits:?}"
-        );
-    }
-
-    #[test]
-    fn test_get_word_at_offset() {
-        let content = "const count = ref(0)";
-        assert_eq!(
-            RenameService::get_word_at_offset(content, 6),
-            Some("count".to_string())
-        );
-        assert_eq!(
-            RenameService::get_word_at_offset(content, 14),
-            Some("ref".to_string())
-        );
-        assert_eq!(
-            RenameService::get_word_at_offset(content, 11),
-            Some("count".to_string())
-        );
-        assert_eq!(RenameService::get_word_at_offset(content, 12), None);
-    }
-
-    #[test]
-    fn test_is_valid_identifier() {
-        assert!(RenameService::is_valid_identifier("count"));
-        assert!(RenameService::is_valid_identifier("_private"));
-        assert!(RenameService::is_valid_identifier("$refs"));
-        assert!(!RenameService::is_valid_identifier("123abc"));
-        assert!(!RenameService::is_valid_identifier(""));
-    }
-
-    #[test]
-    fn test_is_keyword() {
-        assert!(RenameService::is_keyword("const"));
-        assert!(RenameService::is_keyword("function"));
-        assert!(!RenameService::is_keyword("count"));
-    }
-
-    #[test]
-    fn test_offset_range_to_lsp_counts_utf16_code_units() {
-        let content = "const emoji = \"😀\"; const message = ref(emoji)";
-        let start = content.find("message").unwrap();
-        let end = start + "message".len();
-        let range = RenameService::offset_range_to_lsp(content, start, end);
-
-        assert_eq!(range.start.line, 0);
-        assert_eq!(range.start.character, 26);
-        assert_eq!(range.end.character, 33);
-    }
-}
+mod tests;

--- a/crates/vize_maestro/src/ide/rename/canonical.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical.rs
@@ -1,0 +1,265 @@
+use std::collections::HashMap;
+
+use tower_lsp::lsp_types::{
+    DocumentChangeOperation, DocumentChanges, OneOf, PrepareRenameResponse, Range, TextEdit, Url,
+    WorkspaceEdit,
+};
+use vize_canon::CorsaBridge;
+use vize_carton::{FxHashSet, String};
+
+use crate::ide::{IdeContext, ReferencesService, corsa_support};
+
+pub(super) enum Answer<T> {
+    Unavailable,
+    Available(Option<T>),
+}
+
+pub(super) async fn prepare(
+    ctx: &IdeContext<'_>,
+    bridge: Option<&CorsaBridge>,
+) -> Answer<PrepareRenameResponse> {
+    let Some(bridge) = initialized_bridge(bridge) else {
+        return Answer::Unavailable;
+    };
+    let Some(document) = corsa_support::open_canonical_virtual_document(ctx, bridge).await else {
+        return Answer::Unavailable;
+    };
+    let Some((line, character)) =
+        corsa_support::canonical_source_offset_to_position(&document, ctx.offset)
+    else {
+        return Answer::Unavailable;
+    };
+    let response = match bridge
+        .prepare_rename(&document.request_uri, line, character)
+        .await
+    {
+        Ok(response) => response,
+        Err(_) => return Answer::Unavailable,
+    };
+    let response = response.and_then(|response| serde_json::from_value(response).ok());
+    Answer::Available(
+        response.and_then(|response| {
+            corsa_support::map_canonical_prepare_rename(ctx, &document, response)
+        }),
+    )
+}
+
+pub(super) async fn rename(
+    ctx: &IdeContext<'_>,
+    new_name: &str,
+    bridge: Option<&CorsaBridge>,
+) -> Answer<WorkspaceEdit> {
+    let Some(bridge) = initialized_bridge(bridge) else {
+        return Answer::Unavailable;
+    };
+    let Some(document) = corsa_support::open_canonical_virtual_project_document(ctx, bridge).await
+    else {
+        return Answer::Unavailable;
+    };
+    let Some((line, character)) =
+        corsa_support::canonical_source_offset_to_position(&document, ctx.offset)
+    else {
+        return Answer::Unavailable;
+    };
+    let response = match bridge
+        .rename(&document.request_uri, line, character, new_name)
+        .await
+    {
+        Ok(response) => response,
+        Err(_) => return Answer::Unavailable,
+    };
+    let Some(response) = response else {
+        return Answer::Available(None);
+    };
+    let Ok(response) = serde_json::from_value::<WorkspaceEdit>(response) else {
+        return Answer::Available(None);
+    };
+    let linked = linked_positions(&document, &response);
+    let mut mapped = corsa_support::map_canonical_corsa_workspace_edit(ctx, &document, response)
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    for position in linked {
+        let Ok(Some(extra)) = bridge
+            .rename(
+                &position.request_uri,
+                position.line,
+                position.character,
+                new_name,
+            )
+            .await
+        else {
+            return Answer::Available(None);
+        };
+        let Ok(extra) = serde_json::from_value(extra) else {
+            return Answer::Available(None);
+        };
+        let Some(extra) = corsa_support::map_canonical_corsa_workspace_edit(ctx, &document, extra)
+        else {
+            return Answer::Available(None);
+        };
+        mapped.push(extra);
+    }
+    if let Some(styles) = style_workspace_edit(ctx, &mapped, new_name) {
+        mapped.push(styles);
+    }
+
+    Answer::Available(corsa_support::merge_canonical_workspace_edits(mapped))
+}
+
+fn style_workspace_edit(
+    query: &IdeContext<'_>,
+    semantic: &[WorkspaceEdit],
+    new_name: &str,
+) -> Option<WorkspaceEdit> {
+    let mut seeds = FxHashSet::default();
+    let mut changes = HashMap::new();
+    collect_style_edits(
+        query,
+        query.uri,
+        query.offset,
+        new_name,
+        &mut seeds,
+        &mut changes,
+    );
+    for edit in semantic {
+        for (uri, range) in authored_edit_ranges(edit) {
+            let Some(source) = query.state.documents.text(&uri) else {
+                continue;
+            };
+            let Some(offset) =
+                crate::ide::position_to_offset(&source, range.start.line, range.start.character)
+            else {
+                continue;
+            };
+            collect_style_edits(query, &uri, offset, new_name, &mut seeds, &mut changes);
+        }
+    }
+    (!changes.is_empty()).then_some(WorkspaceEdit {
+        changes: Some(changes),
+        document_changes: None,
+        change_annotations: None,
+    })
+}
+
+fn collect_style_edits(
+    query: &IdeContext<'_>,
+    uri: &Url,
+    offset: usize,
+    new_name: &str,
+    seeds: &mut FxHashSet<(Url, String)>,
+    changes: &mut HashMap<Url, Vec<TextEdit>>,
+) {
+    let Some(source) = query.state.documents.text(uri) else {
+        return;
+    };
+    let Some(word) = crate::ide::token_at_offset(&source, offset, |byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')
+    }) else {
+        return;
+    };
+    if !seeds.insert((uri.clone(), word.clone().into())) {
+        return;
+    }
+    let Some(ctx) = IdeContext::new(query.state, uri, offset) else {
+        return;
+    };
+    for location in ReferencesService::find_references_in_style(&ctx, &word) {
+        let edits = changes.entry(location.uri).or_default();
+        if !edits.iter().any(|edit| edit.range == location.range) {
+            edits.push(TextEdit {
+                range: location.range,
+                new_text: new_name.to_string(),
+            });
+        }
+    }
+}
+
+fn authored_edit_ranges(edit: &WorkspaceEdit) -> Vec<(Url, Range)> {
+    let mut ranges = Vec::new();
+    if let Some(changes) = &edit.changes {
+        for (uri, edits) in changes {
+            ranges.extend(edits.iter().map(|edit| (uri.clone(), edit.range)));
+        }
+    }
+    if let Some(changes) = &edit.document_changes {
+        match changes {
+            DocumentChanges::Edits(edits) => {
+                for edit in edits {
+                    ranges.extend(
+                        edit.edits.iter().map(|entry| {
+                            (edit.text_document.uri.clone(), annotatable_range(entry))
+                        }),
+                    );
+                }
+            }
+            DocumentChanges::Operations(operations) => {
+                for operation in operations {
+                    if let DocumentChangeOperation::Edit(edit) = operation {
+                        ranges.extend(edit.edits.iter().map(|entry| {
+                            (edit.text_document.uri.clone(), annotatable_range(entry))
+                        }));
+                    }
+                }
+            }
+        }
+    }
+    ranges
+}
+
+fn linked_positions(
+    document: &corsa_support::CanonicalVirtualDocument,
+    edit: &WorkspaceEdit,
+) -> Vec<corsa_support::CanonicalSemanticPosition> {
+    let mut positions = FxHashSet::default();
+    let mut push = |uri: &Url, range: Range| {
+        if let Some(position) = corsa_support::linked_semantic_position(
+            document,
+            uri.as_str(),
+            &corsa_support::tower_range(range),
+        ) {
+            positions.insert(position);
+        }
+    };
+    if let Some(changes) = &edit.changes {
+        for (uri, edits) in changes {
+            for edit in edits {
+                push(uri, edit.range);
+            }
+        }
+    }
+    if let Some(changes) = &edit.document_changes {
+        match changes {
+            DocumentChanges::Edits(edits) => {
+                for edit in edits {
+                    for entry in &edit.edits {
+                        push(&edit.text_document.uri, annotatable_range(entry));
+                    }
+                }
+            }
+            DocumentChanges::Operations(operations) => {
+                for operation in operations {
+                    if let DocumentChangeOperation::Edit(edit) = operation {
+                        for entry in &edit.edits {
+                            push(&edit.text_document.uri, annotatable_range(entry));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    positions.into_iter().collect()
+}
+
+fn annotatable_range(
+    edit: &OneOf<tower_lsp::lsp_types::TextEdit, tower_lsp::lsp_types::AnnotatedTextEdit>,
+) -> Range {
+    match edit {
+        OneOf::Left(edit) => edit.range,
+        OneOf::Right(edit) => edit.text_edit.range,
+    }
+}
+
+fn initialized_bridge(bridge: Option<&CorsaBridge>) -> Option<&CorsaBridge> {
+    bridge.filter(|bridge| bridge.is_initialized())
+}

--- a/crates/vize_maestro/src/ide/rename/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_tests.rs
@@ -1,0 +1,205 @@
+use std::fs;
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::{PrepareRenameResponse, Range, TextEdit, Url};
+use vize_canon::{CorsaBridge, CorsaBridgeConfig};
+
+use super::RenameService;
+use crate::ide::IdeContext;
+use crate::server::ServerState;
+
+#[test]
+fn canonical_rename_edits_authored_cross_vue_files() {
+    crate::runtime::block_on(async {
+        let Some(tsgo_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = project.path().join("src");
+        fs::create_dir_all(&src).expect("src");
+        fs::write(
+            project.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .expect("tsconfig");
+
+        let child_source = r#"<script lang="ts">
+export const shared = 1
+export default {}
+</script>
+<template><span /></template>
+"#;
+        let child_path = src.join("Child View.vue");
+        fs::write(
+            &child_path,
+            r#"<script lang="ts">
+export const diskOnly = 0
+export default {}
+</script>
+"#,
+        )
+        .expect("stale child on disk");
+        let parent_source = r#"<script setup lang="ts">
+import { shared } from './Child View.vue'
+const local = shared
+function unrelated() { const shared = 0; return shared }
+</script>
+<template>💥 {{ shared }} {{ local }} <i v-for="shared in [1]">{{ shared }}</i></template>
+<style>.root { color: v-bind(shared) }</style>
+"#;
+        let parent_path = src.join("Parent View.vue");
+        fs::write(&parent_path, parent_source).expect("parent");
+
+        let parent_uri = Url::from_file_path(&parent_path).expect("parent uri");
+        let child_uri = Url::from_file_path(&child_path).expect("child uri");
+        let state = ServerState::new();
+        state.set_workspace_root(project.path().to_path_buf());
+        for (uri, source) in [(&parent_uri, parent_source), (&child_uri, child_source)] {
+            state
+                .documents
+                .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+            state.update_virtual_docs(uri, source);
+        }
+        let bridge = Arc::new(CorsaBridge::with_config(CorsaBridgeConfig {
+            corsa_path: Some(tsgo_path),
+            working_dir: Some(project.path().to_path_buf()),
+            timeout_ms: 30_000,
+            ..Default::default()
+        }));
+        bridge.spawn().await.expect("tsgo session");
+
+        let query_offset = child_source.find("shared =").expect("declaration") + 1;
+        let ctx = IdeContext::new(&state, &child_uri, query_offset).expect("context");
+        let prepare = RenameService::prepare_rename_with_corsa(&ctx, Some(Arc::clone(&bridge)))
+            .await
+            .expect("prepare rename");
+        assert_eq!(
+            authored_text(child_source, prepare_range(prepare)),
+            "shared"
+        );
+
+        let edit = RenameService::rename_with_corsa(&ctx, "renamed", Some(Arc::clone(&bridge)))
+            .await
+            .expect("rename");
+        let template_offset = parent_source.find("{{ shared }}").expect("template use") + 3;
+        let template_ctx =
+            IdeContext::new(&state, &parent_uri, template_offset).expect("template context");
+        let template_prepare =
+            RenameService::prepare_rename_with_corsa(&template_ctx, Some(Arc::clone(&bridge)))
+                .await
+                .expect("template prepare rename");
+        assert_eq!(
+            authored_text(parent_source, prepare_range(template_prepare)),
+            "shared",
+        );
+        let local_edit = RenameService::rename_with_corsa(
+            &template_ctx,
+            "renamedLocal",
+            Some(Arc::clone(&bridge)),
+        )
+        .await
+        .expect("template rename");
+        bridge.shutdown().await.expect("shutdown");
+
+        let changes = edit.changes.expect("plain workspace changes");
+        assert_eq!(changes.len(), 2, "only authored Vue files: {changes:#?}");
+        assert_authored_edits(
+            child_source,
+            changes.get(&child_uri).expect("child edits"),
+            1,
+        );
+        assert_authored_edits(
+            parent_source,
+            changes.get(&parent_uri).expect("parent edits"),
+            4,
+        );
+        assert!(
+            changes.keys().all(|uri| !uri.path().ends_with(".vue.ts")),
+            "canonical mirror URIs must never leak: {changes:#?}",
+        );
+
+        let local_changes = local_edit.changes.expect("local workspace changes");
+        assert_eq!(
+            local_changes.keys().collect::<Vec<_>>(),
+            [&parent_uri],
+            "renaming the imported local from template must not rename the child export: {local_changes:#?}",
+        );
+        let local_edits = local_changes.get(&parent_uri).expect("parent local edits");
+        assert_eq!(
+            local_edits.len(),
+            4,
+            "import, script, template, and style edits",
+        );
+        assert!(
+            local_edits
+                .iter()
+                .all(|edit| authored_text(parent_source, edit.range) == "shared"),
+            "shadowed same-spelling bindings must remain untouched: {local_edits:#?}",
+        );
+        let mut replacements = local_edits
+            .iter()
+            .map(|edit| edit.new_text.as_str())
+            .collect::<Vec<_>>();
+        replacements.sort_unstable();
+        assert_eq!(
+            replacements,
+            [
+                "renamedLocal",
+                "renamedLocal",
+                "renamedLocal",
+                "shared as renamedLocal",
+            ],
+            "the import edit must preserve the exported name while changing the local alias",
+        );
+    });
+}
+
+fn prepare_range(response: PrepareRenameResponse) -> Range {
+    match response {
+        PrepareRenameResponse::Range(range)
+        | PrepareRenameResponse::RangeWithPlaceholder { range, .. } => range,
+        PrepareRenameResponse::DefaultBehavior { .. } => panic!("expected an authored range"),
+    }
+}
+
+fn assert_authored_edits(source: &str, edits: &[TextEdit], expected: usize) {
+    assert_eq!(edits.len(), expected, "unexpected edits: {edits:#?}");
+    for edit in edits {
+        assert_eq!(edit.new_text, "renamed");
+        assert_eq!(authored_text(source, edit.range), "shared");
+    }
+}
+
+fn authored_text(source: &str, range: Range) -> &str {
+    let start = crate::ide::position_to_offset(source, range.start.line, range.start.character)
+        .expect("source start");
+    let end = crate::ide::position_to_offset(source, range.end.line, range.end.character)
+        .expect("source end");
+    &source[start..end]
+}
+
+fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return None;
+    }
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)?;
+    vize_carton::corsa_resolver::resolve_corsa_executable(
+        vize_carton::corsa_resolver::CorsaResolveRequest {
+            project_root: Some(workspace_root),
+            ..Default::default()
+        },
+    )
+    .ok()
+}

--- a/crates/vize_maestro/src/ide/rename/tests.rs
+++ b/crates/vize_maestro/src/ide/rename/tests.rs
@@ -1,0 +1,111 @@
+use super::RenameService;
+
+/// Renaming a local binding must not rewrite a same-named prop
+/// *attribute name* on a component usage — that token belongs to the
+/// child's own prop symbol, and rewriting it silently breaks the call
+/// site (#3892). Building rename from the references provider makes the
+/// invariant structural: every edit is a reference (or the declaration).
+#[test]
+fn rename_leaves_same_named_prop_attribute_names_alone() {
+    let content = r#"<script setup lang="ts">
+import Child from './Child.vue'
+const count = 1
+</script>
+
+<template>
+  <Child :count="count" />
+</template>
+"#;
+    let uri = tower_lsp::lsp_types::Url::parse("file:///ws/Parent.vue").unwrap();
+    let state = crate::server::ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), content.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, content);
+    let offset = content.find("const count").unwrap() + "const ".len();
+    let ctx = crate::ide::IdeContext::new(&state, &uri, offset).unwrap();
+
+    let edit = RenameService::rename(&ctx, "tally").unwrap();
+    let edits = &edit.changes.unwrap()[&uri];
+
+    let attr_name_line = content[..content.find(":count=").unwrap()]
+        .matches('\n')
+        .count() as u32;
+    for edit in edits {
+        let touches_attr_name = edit.range.start.line == attr_name_line
+            && edit.range.start.character
+                == content
+                    .lines()
+                    .nth(attr_name_line as usize)
+                    .unwrap()
+                    .find(":count")
+                    .unwrap() as u32
+                    + 1;
+        assert!(
+            !touches_attr_name,
+            "the :count attribute name must not be renamed: {edits:?}"
+        );
+    }
+
+    // The invariant that pins the providers together: every rename edit is
+    // one of the reference locations.
+    let references = crate::ide::references::ReferencesService::references(&ctx, true).unwrap();
+    for edit in edits {
+        assert!(
+            references
+                .iter()
+                .any(|reference| reference.range == edit.range),
+            "rename edit {edit:?} is not a reference: {references:?}"
+        );
+    }
+    assert!(
+        edits.len() >= 2,
+        "the declaration and the binding value must still rename: {edits:?}"
+    );
+}
+
+#[test]
+fn test_get_word_at_offset() {
+    let content = "const count = ref(0)";
+    assert_eq!(
+        RenameService::get_word_at_offset(content, 6),
+        Some("count".to_string())
+    );
+    assert_eq!(
+        RenameService::get_word_at_offset(content, 14),
+        Some("ref".to_string())
+    );
+    assert_eq!(
+        RenameService::get_word_at_offset(content, 11),
+        Some("count".to_string())
+    );
+    assert_eq!(RenameService::get_word_at_offset(content, 12), None);
+}
+
+#[test]
+fn test_is_valid_identifier() {
+    assert!(RenameService::is_valid_identifier("count"));
+    assert!(RenameService::is_valid_identifier("_private"));
+    assert!(RenameService::is_valid_identifier("$refs"));
+    assert!(!RenameService::is_valid_identifier("123abc"));
+    assert!(!RenameService::is_valid_identifier(""));
+}
+
+#[test]
+fn test_is_keyword() {
+    assert!(RenameService::is_keyword("const"));
+    assert!(RenameService::is_keyword("function"));
+    assert!(!RenameService::is_keyword("count"));
+}
+
+#[test]
+fn test_offset_range_to_lsp_counts_utf16_code_units() {
+    let content = "const emoji = \"😀\"; const message = ref(emoji)";
+    let start = content.find("message").unwrap();
+    let end = start + "message".len();
+    let range = RenameService::offset_range_to_lsp(content, start, end);
+
+    assert_eq!(range.start.line, 0);
+    assert_eq!(range.start.character, 26);
+    assert_eq!(range.end.character, 33);
+}


### PR DESCRIPTION
## Summary

- map canonical prepare-rename and WorkspaceEdit responses back to authored Vue files
- preserve `changes`, `documentChanges`, annotated edits, and safe resource operations without virtual URI leaks
- follow semantic template links for cross-SFC rename and preserve TypeScript alias edits
- add exact style `v-bind()` edits from semantic authored symbol seeds
- fail closed when a linked rename response cannot be mapped atomically

## Verification

- exact standard tsgo cross-SFC prepare/rename E2E from script and template positions
- E2E covers unsaved overlays, percent-encoded paths, UTF-16, style bindings, alias-preserving imports, script shadows, and `v-for` shadows
- 745 unit tests passed, 2 ignored; 3 integration tests and 1 doctest passed
- `cargo clippy -p vize_maestro --lib -- -D warnings`
- source-length, formatting, and diff checks passed

Part of #3953, #4015, and #3282.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->