### PR TITLE
test(content-mapper): verify portable public declarations

### DIFF
--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -109,6 +109,7 @@ jobs:
       - name: Run standard project and declaration conformance
         env:
           VIZE_TEST_CONTENT_MAPPER_TSGO: ${{ runner.temp }}/tsgo
+          VIZE_TEST_CONTENT_MAPPER_JAVASCRIPT_TSC: ${{ github.workspace }}/npm/cli/node_modules/.bin/tsc
         run: cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture
       - name: Run exact editor backend conformance
         env:

--- a/crates/vize/tests/content_mapper_tsgo_cli.rs
+++ b/crates/vize/tests/content_mapper_tsgo_cli.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 use vize_carton::{String as CompactString, cstr};
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
+const JAVASCRIPT_TSC_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_JAVASCRIPT_TSC";
 const VUE_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_VUE";
 
 fn workspace_root() -> &'static Path {
@@ -125,6 +126,14 @@ fn standard_tsgo_checks_vue_project_and_emits_consumable_declarations() {
         "{TSGO_ENV} is not a file: {}",
         tsgo.display()
     );
+    let javascript_tsc = std::env::var_os(JAVASCRIPT_TSC_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| panic!("{JAVASCRIPT_TSC_ENV} must accompany {TSGO_ENV}"));
+    assert!(
+        javascript_tsc.is_file(),
+        "{JAVASCRIPT_TSC_ENV} is not a file: {}",
+        javascript_tsc.display()
+    );
 
     let fixture =
         Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/content_mapper_project");
@@ -233,6 +242,7 @@ fn standard_tsgo_checks_vue_project_and_emits_consumable_declarations() {
     let app_declaration = emitted_vue_declaration(project.path(), "App");
     let child_declaration = emitted_vue_declaration(project.path(), "Child");
     let options_declaration = emitted_vue_declaration(project.path(), "Options");
+    let public_declaration = emitted_vue_declaration(project.path(), "Public");
     for declaration in [&app_declaration, &child_declaration] {
         let text = std::fs::read_to_string(declaration).unwrap();
         assert!(
@@ -252,52 +262,46 @@ fn standard_tsgo_checks_vue_project_and_emits_consumable_declarations() {
         options_text.contains("export default __vize_component__"),
         "{options_text}"
     );
+    let public_text = std::fs::read_to_string(&public_declaration).unwrap();
+    for public_surface in ["$props", "$emit", "$slots", "focus", "modelValue"] {
+        assert!(
+            public_text.contains(public_surface),
+            "missing {public_surface} in {}:\n{public_text}",
+            public_declaration.display()
+        );
+    }
 
     let main_declaration = project.path().join("dist/main.d.ts");
     let main_text = std::fs::read_to_string(&main_declaration).unwrap();
     assert!(main_text.contains("./App.vue"), "{main_text}");
     assert!(main_text.contains("export type AppProps"), "{main_text}");
 
-    std::fs::write(
+    std::fs::copy(
+        project.path().join("consumer/verify.ts"),
         project.path().join("dist/verify.ts"),
-        r#"import Options from "./Options.vue";
-import type { AppProps } from "./main";
-
-type IsAny<T> = 0 extends 1 & T ? true : false;
-type OptionsInstance = InstanceType<typeof Options>;
-
-const propsMustBeTyped: IsAny<AppProps> = false;
-const valid: AppProps = { count: 1 };
-// @ts-expect-error count must remain a number through declaration emit
-const invalid: AppProps = { count: "wrong" };
-const optionsCountMustBeTyped: IsAny<OptionsInstance["count"]> = false;
-const optionsLabelMustBeTyped: IsAny<OptionsInstance["label"]> = false;
-const optionsComputedMustBeTyped: IsAny<OptionsInstance["doubled"]> = false;
-const optionsMethodMustBeTyped: IsAny<OptionsInstance["increment"]> = false;
-const options = undefined as unknown as OptionsInstance;
-const optionsCount: number = options.count;
-const optionsLabel: string = options.label;
-const optionsComputed: number = options.doubled;
-const optionsMethodResult: number = options.increment(1);
-// @ts-expect-error the authored method parameter must remain a number
-options.increment("1");
-
-void propsMustBeTyped;
-void valid;
-void invalid;
-void optionsCountMustBeTyped;
-void optionsLabelMustBeTyped;
-void optionsComputedMustBeTyped;
-void optionsMethodMustBeTyped;
-void optionsCount;
-void optionsLabel;
-void optionsComputed;
-void optionsMethodResult;
-"#,
     )
     .unwrap();
     let consume = run_tsgo(
         &tsgo,
+        project.path(),
+        &[
+            "--ignoreConfig",
+            "--noEmit",
+            "--strict",
+            "--module",
+            "preserve",
+            "--moduleResolution",
+            "bundler",
+            "--allowArbitraryExtensions",
+            "--pretty",
+            "false",
+            "dist/verify.ts",
+        ],
+    );
+    assert_success(&consume);
+
+    let consume = run_tsgo(
+        &javascript_tsc,
         project.path(),
         &[
             "--ignoreConfig",

--- a/crates/vize/tests/fixtures/content_mapper_project/consumer/verify.ts
+++ b/crates/vize/tests/fixtures/content_mapper_project/consumer/verify.ts
@@ -1,0 +1,51 @@
+import Options from "./Options.vue";
+import type { AppProps, PublicInstance } from "./main";
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+type OptionsInstance = InstanceType<typeof Options>;
+
+const propsMustBeTyped: IsAny<AppProps> = false;
+const publicInstanceMustBeTyped: IsAny<PublicInstance> = false;
+const publicSlotMustBeTyped: IsAny<PublicInstance["$slots"]["default"]> = false;
+const publicExposeMustBeTyped: IsAny<PublicInstance["focus"]> = false;
+const valid: AppProps = { count: 1 };
+// @ts-expect-error count must remain a number through declaration emit
+const invalid: AppProps = { count: "wrong" };
+const optionsCountMustBeTyped: IsAny<OptionsInstance["count"]> = false;
+const optionsLabelMustBeTyped: IsAny<OptionsInstance["label"]> = false;
+const optionsComputedMustBeTyped: IsAny<OptionsInstance["doubled"]> = false;
+const optionsMethodMustBeTyped: IsAny<OptionsInstance["increment"]> = false;
+const options = undefined as unknown as OptionsInstance;
+const optionsCount: number = options.count;
+const optionsLabel: string = options.label;
+const optionsComputed: number = options.doubled;
+const optionsMethodResult: number = options.increment(1);
+// @ts-expect-error the authored method parameter must remain a number
+options.increment("1");
+
+declare const publicComponent: PublicInstance;
+const publicValue: string = publicComponent.$props.value;
+const publicModel: number | undefined = publicComponent.$props.modelValue;
+publicComponent.$emit("select", "value");
+publicComponent.$emit("update:modelValue", 1);
+publicComponent.$slots.default?.({ value: "slot" });
+// @ts-expect-error default slot value must remain a string
+publicComponent.$slots.default?.({ value: 1 });
+publicComponent.focus();
+
+void propsMustBeTyped;
+void publicInstanceMustBeTyped;
+void publicSlotMustBeTyped;
+void publicExposeMustBeTyped;
+void valid;
+void invalid;
+void optionsCountMustBeTyped;
+void optionsLabelMustBeTyped;
+void optionsComputedMustBeTyped;
+void optionsMethodMustBeTyped;
+void optionsCount;
+void optionsLabel;
+void optionsComputed;
+void optionsMethodResult;
+void publicValue;
+void publicModel;

--- a/crates/vize/tests/fixtures/content_mapper_project/src/Public.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/Public.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+defineProps<{ value: string }>();
+defineEmits<{ select: [value: string] }>();
+defineSlots<{ default(props: { value: string }): unknown }>();
+defineExpose<{ focus(): void }>();
+defineModel<number>({ required: true });
+</script>
+
+<template>
+  <button @click="$emit('select', value)">
+    <slot :value="value" />
+  </button>
+</template>

--- a/crates/vize/tests/fixtures/content_mapper_project/src/main.ts
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/main.ts
@@ -1,4 +1,5 @@
 import App from "./App.vue";
+import Public from "./Public.vue";
 
 type IsAny<T> = 0 extends 1 & T ? true : false;
 
@@ -6,6 +7,7 @@ const componentMustBeTyped: IsAny<typeof App> = false;
 const props: InstanceType<typeof App>["$props"] = { count: 1 };
 
 export type AppProps = InstanceType<typeof App>["$props"];
+export type PublicInstance = InstanceType<typeof Public>;
 
 void componentMustBeTyped;
 void props;

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -41,6 +41,10 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
   assert.match(job, /go build -tags=noembed -trimpath -o "\$RUNNER_TEMP\/tsgo" \.\/cmd\/tsgo/);
   assert.match(job, /cp internal\/bundled\/libs\/\*\.d\.ts "\$RUNNER_TEMP\/"/);
   assert.match(job, /VIZE_TEST_CONTENT_MAPPER_TSGO: \$\{\{ runner\.temp \}\}\/tsgo/);
+  assert.match(
+    job,
+    /VIZE_TEST_CONTENT_MAPPER_JAVASCRIPT_TSC: \$\{\{ github\.workspace \}\}\/npm\/cli\/node_modules\/\.bin\/tsc/,
+  );
   assert.match(job, /cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture/);
   assert.match(job, /TSGO_PATH: \$\{\{ runner\.temp \}\}\/tsgo/);
   assert.match(job, /cargo test -p vize_canon --test lsp_import_resolution -- --nocapture/);


### PR DESCRIPTION
## Summary

- add an exact Content Mapper declaration fixture covering props, emits, slots, models, expose, and Options API public instances
- consume the emitted package with both the pinned upstream tsgo and JavaScript TypeScript `tsc`
- fail closed when the JavaScript compiler oracle is missing from the conformance workflow

The RED audit also found declaration false negatives for required camel-case model props and `$emit` after typed expose. Those production fixes are tracked separately in #4034; this PR does not hide them or update declaration baselines.

## Validation

- `cargo fmt --check`
- exact upstream Content Mapper conformance with `bddd2162710e50281fa838456a875fd59ee7c91f`
- emitted declaration consumption with TypeScript 6.0.3 `tsc`
- Content Mapper workflow and package-manifest tooling tests
- focused Canon Content Mapper unit tests: 9 passed
- `git diff --check`

Refs #3282, #3984, #4034.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->