### PR TITLE
test(content-mapper): cover project reference builds

### DIFF
--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -11,6 +11,7 @@ on:
       - "crates/vize/src/commands/content_mapper.rs"
       - "crates/vize/src/commands/content_mapper/**"
       - "crates/vize/tests/content_mapper_tsgo_cli.rs"
+      - "crates/vize/tests/content_mapper_tsgo_build.rs"
       - "crates/vize/tests/fixtures/content_mapper_project/**"
       - "crates/vize_canon/Cargo.toml"
       - "crates/vize_canon/src/batch.rs"
@@ -35,6 +36,7 @@ on:
       - "crates/vize/src/commands/content_mapper.rs"
       - "crates/vize/src/commands/content_mapper/**"
       - "crates/vize/tests/content_mapper_tsgo_cli.rs"
+      - "crates/vize/tests/content_mapper_tsgo_build.rs"
       - "crates/vize/tests/fixtures/content_mapper_project/**"
       - "crates/vize_canon/Cargo.toml"
       - "crates/vize_canon/src/batch.rs"
@@ -110,7 +112,9 @@ jobs:
         env:
           VIZE_TEST_CONTENT_MAPPER_TSGO: ${{ runner.temp }}/tsgo
           VIZE_TEST_CONTENT_MAPPER_JAVASCRIPT_TSC: ${{ github.workspace }}/npm/cli/node_modules/.bin/tsc
-        run: cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture
+        run: |
+          cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture
+          cargo test -p vize --test content_mapper_tsgo_build -- --nocapture
       - name: Run exact editor backend conformance
         env:
           TSGO_PATH: ${{ runner.temp }}/tsgo

--- a/crates/vize/tests/content_mapper_tsgo_build.rs
+++ b/crates/vize/tests/content_mapper_tsgo_build.rs
@@ -1,0 +1,164 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::json;
+use vize_carton::{String as CompactString, cstr};
+
+const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
+const VUE_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_VUE";
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn copy_fixture(source: &Path, destination: &Path) {
+    std::fs::create_dir_all(destination).unwrap();
+    for entry in std::fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_fixture(&source_path, &destination_path);
+        } else {
+            std::fs::copy(source_path, destination_path).unwrap();
+        }
+    }
+}
+
+fn install_packages(project_root: &Path) {
+    let mapper_root = project_root.join("node_modules/vize");
+    std::fs::create_dir_all(&mapper_root).unwrap();
+    std::fs::write(
+        mapper_root.join("package.json"),
+        serde_json::to_vec_pretty(&json!({
+            "name": "vize",
+            "private": true,
+            "tsContentMapper": {
+                "exec": [env!("CARGO_BIN_EXE_vize"), "content-mapper"],
+            },
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let vue_source = std::env::var_os(VUE_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let store = workspace_root().join("node_modules/.pnpm");
+            let mut candidates = std::fs::read_dir(&store)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", store.display()))
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_name().to_string_lossy().starts_with("vue@3."))
+                .map(|entry| entry.path().join("node_modules/vue"))
+                .filter(|path| path.join("package.json").is_file())
+                .collect::<Vec<_>>();
+            candidates.sort();
+            candidates.pop().unwrap_or_else(|| {
+                panic!(
+                    "no Vue 3 package found under {}; set {VUE_ENV}",
+                    store.display()
+                )
+            })
+        });
+    assert!(vue_source.join("package.json").is_file());
+    let vue_target = project_root.join("node_modules/vue");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(vue_source, vue_target).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(vue_source, vue_target).unwrap();
+}
+
+fn run_build(tsgo: &Path, project_root: &Path) -> Output {
+    Command::new(tsgo)
+        .current_dir(project_root)
+        .args([
+            "--build",
+            "references/tsconfig.json",
+            "--loadExternalPlugins",
+            "--pretty",
+            "false",
+            "--verbose",
+        ])
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run {}: {error}", tsgo.display()))
+}
+
+fn output_text(output: &Output) -> CompactString {
+    let stdout = std::str::from_utf8(&output.stdout).unwrap_or("<non-UTF-8 stdout>");
+    let stderr = std::str::from_utf8(&output.stderr).unwrap_or("<non-UTF-8 stderr>");
+    cstr!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        stdout,
+        stderr,
+    )
+}
+
+#[test]
+fn standard_tsgo_builds_vue_project_references_incrementally() {
+    let Some(tsgo) = std::env::var_os(TSGO_ENV).map(PathBuf::from) else {
+        eprintln!("skipping exact Content Mapper build conformance: {TSGO_ENV} is not set");
+        return;
+    };
+    assert!(
+        tsgo.is_file(),
+        "{TSGO_ENV} is not a file: {}",
+        tsgo.display()
+    );
+
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/content_mapper_project");
+    let cases_root = workspace_root().join("target/vize-tests/tests");
+    std::fs::create_dir_all(&cases_root).unwrap();
+    let project = tempfile::Builder::new()
+        .prefix("content-mapper-build-")
+        .tempdir_in(cases_root)
+        .unwrap();
+    copy_fixture(&fixture, project.path());
+    install_packages(project.path());
+
+    let initial = run_build(&tsgo, project.path());
+    assert!(initial.status.success(), "{}", output_text(&initial));
+    for declaration in [
+        "references/ui/dist/Counter.d.vue.ts",
+        "references/ui/dist/index.d.ts",
+        "references/app/dist/App.d.vue.ts",
+        "references/app/dist/main.d.ts",
+    ] {
+        assert!(
+            project.path().join(declaration).is_file(),
+            "missing build output {declaration}"
+        );
+    }
+
+    let unchanged = run_build(&tsgo, project.path());
+    assert!(unchanged.status.success(), "{}", output_text(&unchanged));
+    assert!(
+        output_text(&unchanged).contains("up to date"),
+        "no incremental no-op reported: {}",
+        output_text(&unchanged)
+    );
+
+    let counter = project.path().join("references/ui/src/Counter.vue");
+    let valid_counter = std::fs::read_to_string(&counter).unwrap();
+    let invalid_counter = valid_counter.replace("count.toFixed(0)", "count.missing()");
+    assert_ne!(valid_counter, invalid_counter);
+    std::fs::write(&counter, invalid_counter).unwrap();
+
+    let broken = run_build(&tsgo, project.path());
+    assert!(!broken.status.success(), "broken build passed unexpectedly");
+    let broken_text = output_text(&broken);
+    assert!(
+        broken_text.contains("Counter.vue")
+            && broken_text.contains("TS2339")
+            && broken_text.contains("Property 'missing' does not exist on type 'number'"),
+        "{broken_text}"
+    );
+
+    std::fs::write(&counter, valid_counter).unwrap();
+    let repaired = run_build(&tsgo, project.path());
+    assert!(repaired.status.success(), "{}", output_text(&repaired));
+}

--- a/crates/vize/tests/fixtures/content_mapper_project/references/app/src/App.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/references/app/src/App.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { Counter } from "../../ui/src/index";
+
+defineProps<{ initial: number }>();
+</script>
+
+<template>
+  <Counter :count="initial" />
+</template>

--- a/crates/vize/tests/fixtures/content_mapper_project/references/app/src/main.ts
+++ b/crates/vize/tests/fixtures/content_mapper_project/references/app/src/main.ts
@@ -1,0 +1,1 @@
+export { default as App } from "./App.vue";

--- a/crates/vize/tests/fixtures/content_mapper_project/references/app/tsconfig.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/references/app/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "contentMappers": [{ "package": "vize", "extensions": [".vue"] }],
+  "include": ["src/**/*"],
+  "references": [{ "path": "../ui" }]
+}

--- a/crates/vize/tests/fixtures/content_mapper_project/references/tsconfig.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/references/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./ui" }, { "path": "./app" }]
+}

--- a/crates/vize/tests/fixtures/content_mapper_project/references/ui/src/Counter.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/references/ui/src/Counter.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+defineProps<{ count: number }>();
+</script>
+
+<template>
+  <button>{{ count.toFixed(0) }}</button>
+</template>

--- a/crates/vize/tests/fixtures/content_mapper_project/references/ui/src/index.ts
+++ b/crates/vize/tests/fixtures/content_mapper_project/references/ui/src/index.ts
@@ -1,0 +1,1 @@
+export { default as Counter } from "./Counter.vue";

--- a/crates/vize/tests/fixtures/content_mapper_project/references/ui/tsconfig.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/references/ui/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "composite": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "contentMappers": [{ "package": "vize", "extensions": [".vue"] }],
+  "include": ["src/**/*"]
+}

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -23,6 +23,7 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
     '"crates/vize_canon/src/virtual_ts/**"',
     '"crates/vize_maestro/src/ide/**"',
     '"crates/vize/tests/content_mapper_tsgo_cli.rs"',
+    '"crates/vize/tests/content_mapper_tsgo_build.rs"',
     '"crates/vize/tests/fixtures/content_mapper_project/**"',
     '"npm/cli/package.json"',
   ]) {
@@ -46,6 +47,7 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
     /VIZE_TEST_CONTENT_MAPPER_JAVASCRIPT_TSC: \$\{\{ github\.workspace \}\}\/npm\/cli\/node_modules\/\.bin\/tsc/,
   );
   assert.match(job, /cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture/);
+  assert.match(job, /cargo test -p vize --test content_mapper_tsgo_build -- --nocapture/);
   assert.match(job, /TSGO_PATH: \$\{\{ runner\.temp \}\}\/tsgo/);
   assert.match(job, /cargo test -p vize_canon --test lsp_import_resolution -- --nocapture/);
   assert.match(job, /cargo test -p vize_maestro/);


### PR DESCRIPTION
## Summary

- exercise the exact upstream tsgo Content Mapper through build mode
- cover Vue declarations across composite project references
- prove no-op incremental builds and broken-to-repaired source invalidation
- run the build conformance in the pinned upstream workflow

## Validation

- exact upstream Content Mapper build conformance: pass
- workflow tooling test: pass
- targeted Rust tests: pass
- target-specific clippy with warnings denied: pass
- format and diff checks: pass

Refs #3282

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->