### PR TITLE
fix(check): honor allowJs project roots

### DIFF
--- a/crates/vize/src/commands/check/patterns.rs
+++ b/crates/vize/src/commands/check/patterns.rs
@@ -1,17 +1,28 @@
 use std::path::Path;
 
 pub(super) const CHECK_INPUTS_DISPLAY: &str =
-    ".vue, .ts, .tsx, .mts, .cts, .jsx, .d.ts, .d.mts, or .d.cts";
+    ".vue, .ts, .tsx, .mts, .cts, .js, .mjs, .cjs, .jsx, .d.ts, .d.mts, or .d.cts";
 
 const CHECK_EXTENSIONS: &[&str] = &["vue", "ts", "tsx", "mts", "cts"];
 
+#[cfg(test)]
 pub(super) fn is_supported_check_file(path: &Path, include_jsx: bool) -> bool {
+    is_supported_check_file_with_js(path, include_jsx, false)
+}
+
+pub(super) fn is_supported_check_file_with_js(
+    path: &Path,
+    include_jsx: bool,
+    include_js: bool,
+) -> bool {
     is_declaration_path(path)
         || path
             .extension()
             .and_then(|extension| extension.to_str())
             .is_some_and(|extension| {
-                CHECK_EXTENSIONS.contains(&extension) || (include_jsx && extension == "jsx")
+                CHECK_EXTENSIONS.contains(&extension)
+                    || (include_jsx && extension == "jsx")
+                    || (include_js && matches!(extension, "js" | "mjs" | "cjs"))
             })
 }
 
@@ -25,7 +36,7 @@ pub(super) fn is_declaration_path(path: &Path) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{CHECK_INPUTS_DISPLAY, is_supported_check_file};
+    use super::{CHECK_INPUTS_DISPLAY, is_supported_check_file, is_supported_check_file_with_js};
     use std::path::Path;
 
     #[test]
@@ -46,6 +57,17 @@ mod tests {
         assert!(!is_supported_check_file(Path::new("view.jsx"), false));
         assert!(is_supported_check_file(Path::new("view.jsx"), true));
         assert!(!is_supported_check_file(Path::new("main.js"), true));
+        for file in ["main.js", "module.mjs", "module.cjs"] {
+            assert!(
+                is_supported_check_file_with_js(Path::new(file), false, true),
+                "{file}"
+            );
+        }
+        assert!(!is_supported_check_file_with_js(
+            Path::new("view.jsx"),
+            false,
+            true
+        ));
     }
 
     #[test]
@@ -55,7 +77,7 @@ mod tests {
             .filter(|token| !token.is_empty())
             .collect::<Vec<_>>();
 
-        for extension in ["vue", "ts", "tsx", "mts", "cts", "jsx"] {
+        for extension in ["vue", "ts", "tsx", "mts", "cts", "js", "mjs", "cjs", "jsx"] {
             assert!(
                 display_tokens.contains(&extension),
                 "missing .{extension} from display text"

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -149,6 +149,8 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     );
     let explicit_input_root = explicit_input_root(&invocation_project_root, &cwd);
     let mut tsconfig_input_cache = TsconfigInputCache::default();
+    let include_js =
+        tsconfig_input_cache.project_graph_allows_javascript(invocation_tsconfig_path.as_deref());
     let mut canonical_paths = CanonicalPathCache::default();
     let check_ignore_set = load_check_ignore_set(args, config_dir);
     let collect_start = Instant::now();
@@ -178,6 +180,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         let files = collect_check_files_with_ignores(
             &args.patterns,
             jsx_typecheck,
+            include_js,
             check_ignore_set.as_ref(),
         );
         let explicit_files = files.clone();

--- a/crates/vize/src/commands/check/runner/collect.rs
+++ b/crates/vize/src/commands/check/runner/collect.rs
@@ -9,12 +9,19 @@ use glob::{MatchOptions, Pattern};
 use ignore::WalkBuilder;
 use vize_carton::{FxHashSet, String};
 
-use super::super::patterns::is_supported_check_file;
+use super::super::patterns::is_supported_check_file_with_js;
 use super::ignores::CheckIgnoreSet;
 
 const TARGET_DIR: &str = "target";
 const NODE_MODULES_DIR: &str = "node_modules";
 const VIZE_CACHE_DIR: &str = ".vize";
+
+#[derive(Clone, Copy)]
+struct CollectionFileOptions {
+    vue_only: bool,
+    include_jsx: bool,
+    include_js: bool,
+}
 
 #[cfg(test)]
 #[allow(clippy::disallowed_types)]
@@ -22,13 +29,14 @@ pub(super) fn collect_check_files(
     patterns: &[std::string::String],
     include_jsx: bool,
 ) -> Vec<PathBuf> {
-    collect_check_files_with_ignores(patterns, include_jsx, None)
+    collect_check_files_with_ignores(patterns, include_jsx, false, None)
 }
 
 #[allow(clippy::disallowed_types)]
 pub(super) fn collect_check_files_with_ignores(
     patterns: &[std::string::String],
     include_jsx: bool,
+    include_js: bool,
     ignore_set: Option<&CheckIgnoreSet>,
 ) -> Vec<PathBuf> {
     let mut files = Vec::new();
@@ -39,7 +47,7 @@ pub(super) fn collect_check_files_with_ignores(
         if candidate.exists() {
             if candidate.is_file() {
                 let candidate = normalize_input_path(&candidate);
-                if is_supported_check_file(&candidate, include_jsx)
+                if is_supported_check_file_with_js(&candidate, include_jsx, include_js)
                     && !is_ignored(&candidate, ignore_set)
                     && seen.insert(candidate.clone())
                 {
@@ -48,7 +56,14 @@ pub(super) fn collect_check_files_with_ignores(
                 continue;
             }
             if candidate.is_dir() {
-                collect_from_dir(&candidate, &mut files, &mut seen, include_jsx, ignore_set);
+                collect_from_dir(
+                    &candidate,
+                    &mut files,
+                    &mut seen,
+                    include_jsx,
+                    include_js,
+                    ignore_set,
+                );
                 continue;
             }
         }
@@ -60,6 +75,7 @@ pub(super) fn collect_check_files_with_ignores(
             &mut files,
             &mut seen,
             include_jsx,
+            include_js,
             matcher.as_ref(),
             ignore_set,
         );
@@ -91,7 +107,16 @@ pub(super) fn collect_vue_files(patterns: &[std::string::String]) -> Vec<PathBuf
             }
             if candidate.is_dir() {
                 collect_from_dir_filtered(
-                    &candidate, &mut files, &mut seen, true, false, None, None,
+                    &candidate,
+                    &mut files,
+                    &mut seen,
+                    CollectionFileOptions {
+                        vue_only: true,
+                        include_jsx: false,
+                        include_js: false,
+                    },
+                    None,
+                    None,
                 );
                 continue;
             }
@@ -103,8 +128,11 @@ pub(super) fn collect_vue_files(patterns: &[std::string::String]) -> Vec<PathBuf
             &base_dir,
             &mut files,
             &mut seen,
-            true,
-            false,
+            CollectionFileOptions {
+                vue_only: true,
+                include_jsx: false,
+                include_js: false,
+            },
             matcher.as_ref(),
             None,
         );
@@ -119,9 +147,10 @@ fn collect_from_dir(
     files: &mut Vec<PathBuf>,
     seen: &mut FxHashSet<PathBuf>,
     include_jsx: bool,
+    include_js: bool,
     ignore_set: Option<&CheckIgnoreSet>,
 ) {
-    collect_from_dir_with_matcher(dir, files, seen, include_jsx, None, ignore_set);
+    collect_from_dir_with_matcher(dir, files, seen, include_jsx, include_js, None, ignore_set);
 }
 
 fn collect_from_dir_with_matcher(
@@ -129,18 +158,29 @@ fn collect_from_dir_with_matcher(
     files: &mut Vec<PathBuf>,
     seen: &mut FxHashSet<PathBuf>,
     include_jsx: bool,
+    include_js: bool,
     matcher: Option<&InputGlob>,
     ignore_set: Option<&CheckIgnoreSet>,
 ) {
-    collect_from_dir_filtered(dir, files, seen, false, include_jsx, matcher, ignore_set);
+    collect_from_dir_filtered(
+        dir,
+        files,
+        seen,
+        CollectionFileOptions {
+            vue_only: false,
+            include_jsx,
+            include_js,
+        },
+        matcher,
+        ignore_set,
+    );
 }
 
 fn collect_from_dir_filtered(
     dir: &Path,
     files: &mut Vec<PathBuf>,
     seen: &mut FxHashSet<PathBuf>,
-    vue_only: bool,
-    include_jsx: bool,
+    file_options: CollectionFileOptions,
     matcher: Option<&InputGlob>,
     ignore_set: Option<&CheckIgnoreSet>,
 ) {
@@ -163,7 +203,7 @@ fn collect_from_dir_filtered(
             if let Ok(entry) = entry {
                 let path = entry.path();
                 if path.is_file()
-                    && is_supported_collect_file(path, vue_only, include_jsx)
+                    && is_supported_collect_file(path, file_options)
                     && matcher.is_none_or(|matcher| matcher.matches(path))
                     && (!skip_generated || !is_generated_path(path))
                     && !is_ignored(path, ignore_set)
@@ -309,11 +349,11 @@ fn is_generated_component(previous: Option<&str>, name: &str) -> bool {
     name == TARGET_DIR || (previous == Some(NODE_MODULES_DIR) && name == VIZE_CACHE_DIR)
 }
 
-fn is_supported_collect_file(path: &Path, vue_only: bool, include_jsx: bool) -> bool {
-    if vue_only {
+fn is_supported_collect_file(path: &Path, options: CollectionFileOptions) -> bool {
+    if options.vue_only {
         return path.extension().and_then(|extension| extension.to_str()) == Some("vue");
     }
-    is_supported_check_file(path, include_jsx)
+    is_supported_check_file_with_js(path, options.include_jsx, options.include_js)
 }
 
 fn glob_match_options() -> MatchOptions {

--- a/crates/vize/src/commands/check/runner/collect_tests.rs
+++ b/crates/vize/src/commands/check/runner/collect_tests.rs
@@ -86,6 +86,32 @@ fn collect_check_files_includes_jsx_only_when_enabled() {
 }
 
 #[test]
+fn collect_check_files_includes_javascript_only_when_enabled() {
+    let case_dir = unique_case_dir("collect-check-javascript");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    for file in ["main.js", "module.mjs", "module.cjs", "view.jsx"] {
+        fs::write(case_dir.join("src").join(file), "").unwrap();
+    }
+
+    let patterns = vec![case_dir.display().to_string()];
+    let excluded = collect_check_files_with_ignores(&patterns, false, false, None);
+    let included = collect_check_files_with_ignores(&patterns, false, true, None);
+
+    assert!(excluded.is_empty());
+    assert_eq!(
+        included,
+        vec![
+            case_dir.join("src/main.js"),
+            case_dir.join("src/module.cjs"),
+            case_dir.join("src/module.mjs"),
+        ]
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
 fn collect_check_files_filters_quoted_globs() {
     let case_dir = unique_case_dir("collect-check-glob");
     let _ = fs::remove_dir_all(&case_dir);
@@ -139,10 +165,12 @@ fn collect_check_files_applies_entry_ignores() {
     let files = collect_check_files_with_ignores(
         &vec![case_dir.display().to_string()],
         false,
+        false,
         ignore_set.as_ref(),
     );
     let explicit = collect_check_files_with_ignores(
         &vec![case_dir.join("src/Ignored.vue").display().to_string()],
+        false,
         false,
         ignore_set.as_ref(),
     );
@@ -214,6 +242,7 @@ fn collect_check_files_normalizes_entry_ignore_paths_and_duplicates() {
                 .display()
                 .to_string(),
         ],
+        false,
         false,
         ignore_set.as_ref(),
     );

--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -83,6 +83,7 @@ fn collect_default_check_files_inner(
             FileCollectionOptions {
                 include_hidden: false,
                 include_jsx,
+                include_js: false,
             },
         );
     };
@@ -116,11 +117,18 @@ fn collect_default_check_files_for_tsconfig(
 ) {
     let default_spec = TsconfigInputSpec::default();
     let spec = cache.load(tsconfig_path).unwrap_or(&default_spec);
+    let include_js = spec.allow_js.unwrap_or(false);
 
     for file in &spec.files {
         let resolved = normalize_input_path(&file.resolve());
         if resolved.is_file()
-            && is_supported_check_file_with_options(&resolved, SupportedFileOptions { include_jsx })
+            && is_supported_check_file_with_options(
+                &resolved,
+                SupportedFileOptions {
+                    include_jsx,
+                    include_js,
+                },
+            )
             && !is_nuxt_import_manifest_path(&resolved)
             && !is_generated_codegen_declaration_path(&resolved)
             && seen.insert(resolved.clone())
@@ -155,6 +163,7 @@ fn collect_default_check_files_for_tsconfig(
             FileCollectionOptions {
                 include_hidden: false,
                 include_jsx,
+                include_js,
             },
         );
         for path in collected {
@@ -179,6 +188,7 @@ fn collect_default_check_files_for_tsconfig(
                 FileCollectionOptions {
                     include_hidden: true,
                     include_jsx,
+                    include_js,
                 },
             ) {
                 // Declaration files under a hidden root are ambient program

--- a/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
@@ -42,6 +42,7 @@ pub(super) fn collect_supported_files_with_options(
                         path,
                         SupportedFileOptions {
                             include_jsx: options.include_jsx,
+                            include_js: options.include_js,
                         },
                     )
                     && (!skip_generated || !is_generated_path(path))
@@ -190,7 +191,13 @@ pub(crate) fn resolve_tsconfig_for_files(
     let files = files
         .iter()
         .filter(|path| {
-            is_supported_check_file_with_options(path, SupportedFileOptions { include_jsx })
+            is_supported_check_file_with_options(
+                path,
+                SupportedFileOptions {
+                    include_jsx,
+                    include_js: true,
+                },
+            )
         })
         .map(|path| normalize_input_path(path))
         .collect::<Vec<_>>();
@@ -244,6 +251,7 @@ struct TsconfigOwnershipMatcher {
     includes: Vec<GlobSpec>,
     excludes: Vec<GlobSpec>,
     include_jsx: bool,
+    include_js: bool,
 }
 
 impl TsconfigOwnershipMatcher {
@@ -255,6 +263,7 @@ impl TsconfigOwnershipMatcher {
                 includes: Vec::new(),
                 excludes: Vec::new(),
                 include_jsx,
+                include_js: false,
             };
         };
 
@@ -282,6 +291,7 @@ impl TsconfigOwnershipMatcher {
             includes,
             excludes,
             include_jsx,
+            include_js: spec.allow_js.unwrap_or(false),
         }
     }
 
@@ -302,6 +312,7 @@ impl TsconfigOwnershipMatcher {
                 file,
                 SupportedFileOptions {
                     include_jsx: self.include_jsx,
+                    include_js: self.include_js,
                 },
             )
         {

--- a/crates/vize/src/commands/check/tsconfig_inputs/loader.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/loader.rs
@@ -66,6 +66,20 @@ impl TsconfigInputCache {
             .or_insert_with_key(|resolved| load_tsconfig_inputs(resolved))
             .as_ref()
     }
+
+    /// Whether the selected solution or any referenced project enables
+    /// JavaScript inputs. Explicit directory/glob collection needs this before
+    /// individual files are available for project ownership resolution.
+    pub(crate) fn project_graph_allows_javascript(&mut self, tsconfig_path: Option<&Path>) -> bool {
+        tsconfig_path.is_some_and(|tsconfig_path| {
+            collect_tsconfig_project_paths(tsconfig_path)
+                .iter()
+                .any(|project| {
+                    self.load(project)
+                        .is_some_and(|spec| spec.allow_js.unwrap_or(false))
+                })
+        })
+    }
 }
 
 fn load_tsconfig_inputs(tsconfig_path: &Path) -> Option<TsconfigInputSpec> {
@@ -124,6 +138,14 @@ fn load_tsconfig_inputs_inner(
     }
     if let Some(declaration_dir) = compiler_option_dir_exclude(&value, dir, "declarationDir") {
         merged.declaration_dir_exclude = Some(declaration_dir);
+    }
+    if let Some(allow_js) = value
+        .get("compilerOptions")
+        .and_then(Value::as_object)
+        .and_then(|options| options.get("allowJs"))
+        .and_then(Value::as_bool)
+    {
+        merged.allow_js = Some(allow_js);
     }
 
     Ok(merged)

--- a/crates/vize/src/commands/check/tsconfig_inputs/matching.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/matching.rs
@@ -11,6 +11,7 @@ use super::{NODE_MODULES_DIR, TARGET_DIR, VIZE_CACHE_DIR};
 #[derive(Debug, Clone, Copy, Default)]
 pub(super) struct SupportedFileOptions {
     pub(super) include_jsx: bool,
+    pub(super) include_js: bool,
 }
 
 pub(super) fn path_has_component(path: &Path, component_name: &str) -> bool {
@@ -128,7 +129,7 @@ pub(super) fn is_supported_check_file_with_options(
     path: &Path,
     options: SupportedFileOptions,
 ) -> bool {
-    check_patterns::is_supported_check_file(path, options.include_jsx)
+    check_patterns::is_supported_check_file_with_js(path, options.include_jsx, options.include_js)
 }
 
 pub(super) fn glob_match_options() -> MatchOptions {

--- a/crates/vize/src/commands/check/tsconfig_inputs/spec.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/spec.rs
@@ -20,6 +20,8 @@ pub(super) struct TsconfigInputSpec {
     pub(super) out_dir_exclude: Option<GlobSpec>,
     /// `compilerOptions.declarationDir`, likewise.
     pub(super) declaration_dir_exclude: Option<GlobSpec>,
+    /// Effective `compilerOptions.allowJs` value across the extends chain.
+    pub(super) allow_js: Option<bool>,
 }
 
 impl TsconfigInputSpec {
@@ -43,6 +45,9 @@ impl TsconfigInputSpec {
         }
         if extended.declaration_dir_exclude.is_some() {
             self.declaration_dir_exclude = extended.declaration_dir_exclude;
+        }
+        if extended.allow_js.is_some() {
+            self.allow_js = extended.allow_js;
         }
     }
 
@@ -156,4 +161,5 @@ impl GlobSpec {
 pub(super) struct FileCollectionOptions {
     pub(super) include_hidden: bool,
     pub(super) include_jsx: bool,
+    pub(super) include_js: bool,
 }

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
@@ -6,6 +6,7 @@ use super::{TsconfigInputCache, load_tsconfig_declaration_options, resolve_exten
 use std::fs;
 use std::path::{Path, PathBuf};
 use vize_carton::{cstr, path::canonicalize_non_verbatim};
+mod allow_js;
 mod codegen;
 mod tsx_owner;
 // Each call uses a fresh run-scoped cache, mirroring how an actual `vize
@@ -737,7 +738,7 @@ fn declaration_files_are_always_supported() {
 }
 
 #[test]
-fn supported_extensions_cover_ts_family_and_reject_js_family() {
+fn supported_extensions_follow_allow_js() {
     let case_dir = unique_case_dir("tsconfig-ext-family");
     let _ = fs::remove_dir_all(&case_dir);
     fs::create_dir_all(case_dir.join("src")).unwrap();
@@ -762,6 +763,29 @@ fn supported_extensions_cover_ts_family_and_reject_js_family() {
             case_dir.join("src/b.tsx"),
             case_dir.join("src/c.mts"),
             case_dir.join("src/d.cts"),
+        ]
+    );
+
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": { "allowJs": true },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+    assert_eq!(
+        files,
+        vec![
+            case_dir.join("src/App.vue"),
+            case_dir.join("src/a.ts"),
+            case_dir.join("src/b.tsx"),
+            case_dir.join("src/c.mts"),
+            case_dir.join("src/d.cts"),
+            case_dir.join("src/e.js"),
+            case_dir.join("src/g.cjs"),
+            case_dir.join("src/h.mjs"),
         ]
     );
 
@@ -911,23 +935,20 @@ fn files_present_suppresses_the_implicit_wildcard_scan() {
 }
 
 #[test]
-fn files_entry_with_unsupported_extension_is_dropped() {
+fn files_entry_accepts_javascript_when_allow_js_is_enabled() {
     let case_dir = unique_case_dir("tsconfig-files-bad-ext");
     let _ = fs::remove_dir_all(&case_dir);
     fs::create_dir_all(case_dir.join("src")).unwrap();
     fs::write(case_dir.join("src/x.js"), "module.exports = {}").unwrap();
     fs::write(
         case_dir.join("tsconfig.json"),
-        r#"{ "files": ["src/x.js"] }"#,
+        r#"{ "compilerOptions": { "allowJs": true }, "files": ["src/x.js"] }"#,
     )
     .unwrap();
 
     let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
 
-    assert!(
-        files.is_empty(),
-        "unsupported files entry should drop: {files:?}"
-    );
+    assert_eq!(files, vec![case_dir.join("src/x.js")]);
 
     let _ = fs::remove_dir_all(&case_dir);
 }

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests/allow_js.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests/allow_js.rs
@@ -1,0 +1,64 @@
+use std::fs;
+
+use super::{TsconfigInputCache, collect_default_check_files, unique_case_dir};
+
+#[test]
+fn allow_js_is_inherited_and_can_be_disabled_by_a_child_config() {
+    let case_dir = unique_case_dir("tsconfig-allow-js-extends");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    fs::write(case_dir.join("src/main.js"), "export const value = 1;").unwrap();
+    fs::write(
+        case_dir.join("tsconfig.base.json"),
+        r#"{ "compilerOptions": { "allowJs": true } }"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{ "extends": "./tsconfig.base.json", "include": ["src/**/*"] }"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json"))),
+        vec![case_dir.join("src/main.js")]
+    );
+
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": { "allowJs": false },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    assert!(
+        collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json"))).is_empty()
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn explicit_collection_detects_allow_js_in_referenced_projects() {
+    let case_dir = unique_case_dir("tsconfig-allow-js-reference");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("packages/app")).unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{ "files": [], "references": [{ "path": "packages/app" }] }"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("packages/app/tsconfig.json"),
+        r#"{ "compilerOptions": { "allowJs": true }, "include": ["src/**/*"] }"#,
+    )
+    .unwrap();
+
+    let mut cache = TsconfigInputCache::default();
+    assert!(cache.project_graph_allows_javascript(Some(&case_dir.join("tsconfig.json"))));
+    assert!(!cache.project_graph_allows_javascript(None));
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize/tests/check_allowjs_imports_cli.rs
+++ b/crates/vize/tests/check_allowjs_imports_cli.rs
@@ -41,6 +41,27 @@ fn write(root: &Path, rel: &str, content: &str) {
     std::fs::write(path, content).unwrap();
 }
 
+fn run_project_check(project_root: &Path, corsa_path: &Path) -> std::process::Output {
+    run_check(project_root, corsa_path, &[])
+}
+
+fn run_check(project_root: &Path, corsa_path: &Path, patterns: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .args(patterns)
+        .output()
+        .unwrap()
+}
+
 #[test]
 fn check_allowjs_resolves_project_local_js_imports() {
     let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
@@ -107,17 +128,97 @@ void message;
         .output()
         .unwrap();
 
-    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
-    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let stdout = std::str::from_utf8(&output.stdout).unwrap();
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
     assert!(
         output.status.success(),
         "check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
-    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
     assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
     assert!(
         !stdout.contains("TS2307"),
         "project-local JS imports should resolve under allowJs:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn check_allowjs_checks_javascript_roots_only_when_checkjs_is_enabled() {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
+        return;
+    };
+    let project_root = unique_case_dir("javascript-roots");
+    let _ = std::fs::remove_dir_all(&project_root);
+    const CHECK_JS_OFF: &str = r#"{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#;
+    const CHECK_JS_ON: &str = r#"{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#;
+    const BROKEN: &str = "/** @type {number} */\nexport const value = \"wrong\";\n";
+    const REPAIRED: &str = "/** @type {number} */\nexport const value = 1;\n";
+    write(&project_root, "tsconfig.json", CHECK_JS_OFF);
+    write(&project_root, "src/main.js", BROKEN);
+
+    let unchecked = run_project_check(&project_root, &corsa_path);
+    let unchecked_stdout = std::str::from_utf8(&unchecked.stdout).unwrap();
+    assert!(unchecked.status.success(), "{unchecked_stdout}");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(unchecked_stdout).unwrap()["errorCount"],
+        0
+    );
+
+    write(&project_root, "tsconfig.json", CHECK_JS_ON);
+    let broken = run_project_check(&project_root, &corsa_path);
+    let broken_stdout = std::str::from_utf8(&broken.stdout).unwrap();
+    assert!(!broken.status.success(), "broken JavaScript root passed");
+    let broken_json: serde_json::Value = serde_json::from_str(broken_stdout).unwrap();
+    assert_eq!(broken_json["errorCount"], 1, "{broken_stdout}");
+    assert!(
+        broken_stdout.contains("src/main.js")
+            && broken_stdout.contains("TS2322")
+            && broken_stdout.contains("Type 'string' is not assignable to type 'number'"),
+        "{broken_stdout}"
+    );
+
+    write(&project_root, "src/main.js", REPAIRED);
+    let repaired = run_project_check(&project_root, &corsa_path);
+    let repaired_stdout = std::str::from_utf8(&repaired.stdout).unwrap();
+    assert!(repaired.status.success(), "{repaired_stdout}");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(repaired_stdout).unwrap()["errorCount"],
+        0
+    );
+
+    write(&project_root, "src/main.js", BROKEN);
+    let explicit = run_check(&project_root, &corsa_path, &["src"]);
+    let explicit_stdout = std::str::from_utf8(&explicit.stdout).unwrap();
+    assert!(
+        !explicit.status.success()
+            && explicit_stdout.contains("src/main.js")
+            && explicit_stdout.contains("TS2322"),
+        "explicit allowJs input was not checked:\nstdout:\n{explicit_stdout}\nstderr:\n{}",
+        std::str::from_utf8(&explicit.stderr).unwrap()
     );
 
     let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -323,5 +323,8 @@ pub(super) fn source_type_for_path(path: &Path) -> Option<SourceType> {
     {
         return Some(SourceType::ts());
     }
+    if file_name.ends_with(".js") || file_name.ends_with(".mjs") || file_name.ends_with(".cjs") {
+        return SourceType::from_path(path).ok();
+    }
     None
 }

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -1034,6 +1034,13 @@ fn test_source_type_for_path() {
         source_type_for_path(Path::new("foo.tsx")),
         Some(oxc_span::SourceType::tsx())
     );
+    for path in ["foo.js", "foo.mjs", "foo.cjs"] {
+        assert!(
+            source_type_for_path(Path::new(path))
+                .is_some_and(|source_type| !source_type.is_typescript()),
+            "{path} should retain a JavaScript source kind"
+        );
+    }
     assert_eq!(source_type_for_path(Path::new("foo.vue")), None);
 }
 


### PR DESCRIPTION
## Summary

- honor the effective `compilerOptions.allowJs` value across `extends` chains and referenced projects
- collect `.js`, `.mjs`, and `.cjs` project roots for both default and explicit `vize check` inputs
- preserve JavaScript source kinds in the virtual project instead of dropping those roots

## Tests

- `cargo test -p vize --lib`
- `cargo test -p vize_canon --lib test_source_type_for_path`
- `VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize --test check_allowjs_imports_cli`
- `cargo clippy -p vize --lib -- -D warnings`
- `cargo clippy -p vize --test check_allowjs_imports_cli -- -D warnings`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo fmt --all -- --check`

Closes #4038
Refs #3984

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->