### PR TITLE
fix(init): scaffold fresh project typechecking

### DIFF
--- a/npm/cli/src/init/args.ts
+++ b/npm/cli/src/init/args.ts
@@ -121,7 +121,7 @@ Options:
       --nuxt                 nuxt module (forces the Nuxt target)
       --bundler/--no-bundler vite plugin or nuxt module, auto-detected
       --fmt / --no-fmt       vize fmt
-      --typecheck            vize check (needs a tsconfig.json)
+      --typecheck            vize check (creates tsconfig.json when missing)
       --no-typecheck
       --editor / --no-editor .vscode/extensions.json recommendation
       --dry-run              Print the plan without writing anything

--- a/npm/cli/src/init/plan-project.ts
+++ b/npm/cli/src/init/plan-project.ts
@@ -5,7 +5,7 @@ import { DEFAULT_SCRIPTS, detectJsonIndent, parsePackageJson } from "../setup/co
 import type { ProjectDetection } from "./detect.js";
 import { skipped, type PlanDraft } from "./plan-types.js";
 import type { FeatureId, FeatureSelection } from "./select.js";
-import { renderVizeConfig } from "./templates.js";
+import { renderTypecheckTsconfig, renderVizeConfig } from "./templates.js";
 
 /** Scripts each feature contributes, reusing the command strings `setup` ships. */
 const FEATURE_SCRIPTS: Readonly<Record<FeatureId, readonly string[]>> = {
@@ -29,29 +29,28 @@ export function planVizeConfig(
   selection: FeatureSelection,
   draft: PlanDraft,
 ): void {
+  if (selection.typecheck && detection.tsconfig === null) {
+    draft.files.push({
+      filename: path.join(detection.root, "tsconfig.json"),
+      source: renderTypecheckTsconfig(detection.typescript),
+    });
+    draft.createdFiles.push("tsconfig.json");
+  }
+
   for (const id of ["fmt", "typecheck"] as const) {
     if (!selection[id]) {
-      draft.features.push(
-        id === "typecheck" && detection.tsconfig === null
-          ? skipped(id, "no tsconfig.json, so vize check has nothing to check")
-          : skipped(id),
-      );
+      draft.features.push(skipped(id));
       continue;
     }
-    if (id === "typecheck" && detection.tsconfig === null) {
-      draft.features.push({
-        id,
-        outcome: "blocked",
-        detail: "vize check needs a tsconfig.json; none was found",
-        snippet: null,
-      });
-      continue;
-    }
+    const scaffoldsTsconfig = id === "typecheck" && detection.tsconfig === null;
     draft.features.push({
       id,
-      outcome: detection.vizeConfig === null ? "configured" : "unchanged",
-      detail:
-        detection.vizeConfig === null
+      outcome: scaffoldsTsconfig || detection.vizeConfig === null ? "configured" : "unchanged",
+      detail: scaffoldsTsconfig
+        ? detection.vizeConfig === null
+          ? "writes tsconfig.json and vize.config.ts"
+          : `writes tsconfig.json; ${detection.vizeConfig} already exists and was left unchanged`
+        : detection.vizeConfig === null
           ? "writes vize.config.ts"
           : `${detection.vizeConfig} already exists and was left unchanged`,
       snippet: null,
@@ -67,7 +66,7 @@ export function planVizeConfig(
     source: renderVizeConfig({
       lint: selection.lint,
       fmt: selection.fmt,
-      typecheck: selection.typecheck && detection.tsconfig !== null,
+      typecheck: selection.typecheck,
       vite: detection.framework === "vite",
     }),
   });
@@ -88,7 +87,7 @@ export function planScripts(
 ): readonly string[] {
   const wanted: string[] = [];
   for (const id of ["lint", "fmt", "typecheck"] as const) {
-    if (!selection[id] || (id === "typecheck" && detection.tsconfig === null)) {
+    if (!selection[id]) {
       continue;
     }
     wanted.push(...FEATURE_SCRIPTS[id]);

--- a/npm/cli/src/init/select.ts
+++ b/npm/cli/src/init/select.ts
@@ -126,18 +126,21 @@ function fmtOffer(detection: ProjectDetection): FeatureOffer {
 }
 
 function typecheckOffer(detection: ProjectDetection): FeatureOffer {
-  const configured = detection.vizeConfig !== null && "vize:check" in detection.scripts;
+  const configured =
+    detection.tsconfig !== null &&
+    detection.vizeConfig !== null &&
+    "vize:check" in detection.scripts;
   return {
     id: "typecheck",
     label: "typecheck (vize check)",
-    available: detection.tsconfig !== null,
+    available: true,
     configured,
     note: configured
       ? "already configured"
       : detection.tsconfig === null
-        ? "needs a tsconfig.json"
+        ? "creates tsconfig.json"
         : "",
-    defaultSelected: detection.tsconfig !== null,
+    defaultSelected: true,
   };
 }
 

--- a/npm/cli/src/init/templates.ts
+++ b/npm/cli/src/init/templates.ts
@@ -50,6 +50,7 @@ export function renderVizeConfig(features: VizeConfigFeatures): string {
     blocks.push(`  typeChecker: {
     enabled: true,
     strict: true,
+    jsxTypecheck: true,
   },`);
   }
   if (features.vite) {
@@ -63,6 +64,24 @@ export default defineConfig({
 ${blocks.join("\n")}
 });
 `;
+}
+
+/** Minimum project config written only when typechecking is selected and no config exists. */
+export function renderTypecheckTsconfig(typescript: boolean): string {
+  const compilerOptions: Record<string, boolean | string> = {
+    strict: true,
+    target: "ES2022",
+    module: "ESNext",
+    moduleResolution: "Bundler",
+    jsx: "preserve",
+  };
+  if (!typescript) {
+    compilerOptions.allowJs = true;
+    compilerOptions.checkJs = true;
+  }
+  compilerOptions.noEmit = true;
+  compilerOptions.skipLibCheck = true;
+  return `${JSON.stringify({ compilerOptions, include: ["src/**/*"] }, null, 2)}\n`;
 }
 
 /**

--- a/npm/cli/src/setup/config.ts
+++ b/npm/cli/src/setup/config.ts
@@ -44,7 +44,7 @@ export const DEFAULT_SCRIPTS = {
   "vize:fmt": "vize fmt --check src",
   "vize:fmt:fix": "vize fmt --write src",
   "vize:lint": "vize lint --preset happy-path --max-warnings 0 src",
-  "vize:check": "vize check src",
+  "vize:check": "vize check",
   "vize:musea": "vize musea",
   "vize:ready": "vize ready src",
 } as const;
@@ -61,6 +61,7 @@ export default defineConfig({
   typeChecker: {
     enabled: true,
     strict: true,
+    jsxTypecheck: true,
   },
   vite: {
     scanPatterns: ["src/**/*.vue"],

--- a/npm/cli/tests/init-frameworks.test.ts
+++ b/npm/cli/tests/init-frameworks.test.ts
@@ -13,6 +13,40 @@ import {
   writeManifest,
 } from "./init-support.ts";
 
+const EXPECTED_JAVASCRIPT_TSCONFIG = `{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "preserve",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*"
+  ]
+}
+`;
+
+const EXPECTED_TYPESCRIPT_TSCONFIG = `{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "preserve",
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*"
+  ]
+}
+`;
+
 test("a Nuxt project is configured through the Nuxt module, not the Vite plugin", async () => {
   const root = temporaryProject("nuxt");
   writeManifest(root, {
@@ -104,7 +138,7 @@ export default defineConfig({
   assert.equal(overridden.output.split("\n")[1], "  framework:       Vite (vite.config.ts)");
 });
 
-test("a JavaScript-only project skips typecheck and still configures the rest", async () => {
+test("a JavaScript-only project scaffolds checkJs typechecking", async () => {
   const root = temporaryProject("javascript");
   writeManifest(root, {
     name: "fixture",
@@ -138,12 +172,17 @@ export default defineConfig({});
       ["lint", "configured"],
       ["bundler", "configured"],
       ["fmt", "configured"],
-      ["typecheck", "blocked"],
+      ["typecheck", "configured"],
       ["editor", "configured"],
     ],
   );
-  assert.deepEqual(result.plan?.addedScripts, ["vize:lint", "vize:fmt", "vize:fmt:fix"]);
-  assert.deepEqual(readAll(root, ["vite.config.js", "vize.config.ts"]), {
+  assert.deepEqual(result.plan?.addedScripts, [
+    "vize:lint",
+    "vize:fmt",
+    "vize:fmt:fix",
+    "vize:check",
+  ]);
+  assert.deepEqual(readAll(root, ["vite.config.js", "vize.config.ts", "tsconfig.json"]), {
     "vite.config.js": `import { defineConfig } from "vite";
 import vize from "@vizejs/vite-plugin";
 
@@ -165,12 +204,94 @@ export default defineConfig({
     singleAttributePerLine: false,
     sortBlocks: true,
   },
+  typeChecker: {
+    enabled: true,
+    strict: true,
+    jsxTypecheck: true,
+  },
   vite: {
     scanPatterns: ["src/**/*.vue"],
   },
 });
 `,
+    "tsconfig.json": EXPECTED_JAVASCRIPT_TSCONFIG,
   });
+
+  const second = await runInit(root, ALL_FEATURES);
+  assert.deepEqual(second.written, []);
+  assert.deepEqual(second.commands, []);
+});
+
+test("a TypeScript project without a config gets a strict minimum scaffold", async () => {
+  const root = temporaryProject("typescript-without-config");
+  writeManifest(root, {
+    name: "fixture",
+    private: true,
+    type: "module",
+    devDependencies: { typescript: "^6.0.0" },
+  });
+
+  const args = [
+    "--yes",
+    "--no-lint",
+    "--no-bundler",
+    "--no-fmt",
+    "--typecheck",
+    "--no-editor",
+    "--no-install",
+  ] as const;
+
+  const dryRun = await runInit(root, [...args, "--dry-run"]);
+  assert.deepEqual(dryRun.written, []);
+  assert.deepEqual(dryRun.plan?.createdFiles, ["tsconfig.json", "vize.config.ts"]);
+  assert.deepEqual(dryRun.plan?.updatedFiles, ["package.json"]);
+  assert.equal(exists(root, "tsconfig.json"), false);
+
+  const result = await runInit(root, args);
+
+  assert.deepEqual(result.written, ["tsconfig.json", "vize.config.ts", "package.json"]);
+  assert.equal(read(root, "tsconfig.json"), EXPECTED_TYPESCRIPT_TSCONFIG);
+  assert.equal(
+    result.plan?.features.find((feature) => feature.id === "typecheck")?.outcome,
+    "configured",
+  );
+  assert.deepEqual(result.plan?.addedScripts, ["vize:check"]);
+});
+
+test("a missing tsconfig is added without rewriting an existing Vize config", async () => {
+  const root = temporaryProject("existing-vize-config-without-tsconfig");
+  writeManifest(root, {
+    name: "fixture",
+    private: true,
+    type: "module",
+    scripts: { "vize:check": "vize check src" },
+    devDependencies: { typescript: "^6.0.0", vize: "^0.306.0" },
+  });
+  const existingConfig = `export default { typeChecker: { strict: false } };\n`;
+  write(root, "vize.config.ts", existingConfig);
+
+  const result = await runInit(root, [
+    "--yes",
+    "--no-lint",
+    "--no-bundler",
+    "--no-fmt",
+    "--typecheck",
+    "--no-editor",
+    "--no-install",
+  ]);
+
+  assert.deepEqual(result.written, ["tsconfig.json"]);
+  assert.equal(read(root, "vize.config.ts"), existingConfig);
+  assert.equal(read(root, "tsconfig.json"), EXPECTED_TYPESCRIPT_TSCONFIG);
+  assert.deepEqual(
+    result.plan?.features.find((feature) => feature.id === "typecheck"),
+    {
+      id: "typecheck",
+      outcome: "configured",
+      detail: "writes tsconfig.json; vize.config.ts already exists and was left unchanged",
+      snippet: null,
+    },
+  );
 });
 
 test("a hand-written lint block is never overwritten and never silently bypassed", async () => {

--- a/npm/cli/tests/init-prompt.test.ts
+++ b/npm/cli/tests/init-prompt.test.ts
@@ -143,7 +143,7 @@ test("an input that ends mid-prompt cancels instead of silently doing nothing", 
   assert.equal(result.output.split("\n").at(-2), "[vize init] cancelled; nothing was written.");
 });
 
-test("an unavailable feature is listed without a number and cannot be toggled", async () => {
+test("an unavailable bundler is listed without a number while typecheck scaffolds", async () => {
   const root = temporaryProject("prompt-unavailable");
   writeManifest(root, { name: "fixture", private: true, type: "module" });
   const prompt = scriptedPrompt(["", "y"]);
@@ -156,8 +156,8 @@ test("an unavailable feature is listed without a number and cannot be toggled", 
   1. [x] oxlint plugin (the oxlint binary reads oxlint.config.ts)
      -  vite plugin or nuxt module (no vite.config or nuxt.config found; the other features work without one)
   2. [x] fmt (vize fmt)
-     -  typecheck (vize check) (needs a tsconfig.json)
-  3. [x] editor extension (.vscode/extensions.json recommendation)
+  3. [x] typecheck (vize check) (creates tsconfig.json)
+  4. [x] editor extension (.vscode/extensions.json recommendation)
 
 `,
   );
@@ -167,7 +167,7 @@ test("an unavailable feature is listed without a number and cannot be toggled", 
       ["lint", "configured"],
       ["bundler", "skipped"],
       ["fmt", "configured"],
-      ["typecheck", "skipped"],
+      ["typecheck", "configured"],
       ["editor", "configured"],
     ],
   );

--- a/npm/cli/tests/init.test.ts
+++ b/npm/cli/tests/init.test.ts
@@ -52,6 +52,7 @@ export default defineConfig({
   typeChecker: {
     enabled: true,
     strict: true,
+    jsxTypecheck: true,
   },
   vite: {
     scanPatterns: ["src/**/*.vue"],
@@ -131,7 +132,7 @@ test("a Vite+ project is configured through the vite.config lint block", async (
           "vize:lint": "vize lint --preset happy-path --max-warnings 0 src",
           "vize:fmt": "vize fmt --check src",
           "vize:fmt:fix": "vize fmt --write src",
-          "vize:check": "vize check src",
+          "vize:check": "vize check",
         },
         devDependencies: {
           "vite-plus": "^0.1.0",

--- a/npm/cli/tests/setup.test.ts
+++ b/npm/cli/tests/setup.test.ts
@@ -111,7 +111,7 @@ export default defineConfig({
     assert.equal(scripts["vize:fmt"], "vize fmt --check src");
     assert.equal(scripts["vize:fmt:fix"], "vize fmt --write src");
     assert.equal(scripts["vize:lint"], "vize lint --preset happy-path --max-warnings 0 src");
-    assert.equal(scripts["vize:check"], "vize check src");
+    assert.equal(scripts["vize:check"], "vize check");
     assert.equal(scripts["vize:build"], "vize build src");
     assert.equal(scripts["vize:musea"], "vize musea");
     assert.equal(scripts["vize:ready"], "vize ready src");


### PR DESCRIPTION
## Summary

- make typechecking selectable in fresh JavaScript and TypeScript projects without an existing tsconfig
- write a deterministic strict tsconfig only when one is missing, with `allowJs` and `checkJs` for JavaScript projects
- generate a project-wide `vize check` script and enable JSX/TSX checking in generated Vize configuration
- preserve existing tsconfig and Vize configuration files byte-for-byte

## Tests

- `pnpm -C npm/cli test`
- `pnpm -C npm/cli check`

The init suite covers JavaScript and TypeScript scaffolds, dry runs, existing configuration preservation, and second-run idempotency. Packed-package clean/broken/repaired source and SFC execution remains tracked by #4037 as a separate end-to-end PR.

Refs #4037
Refs #3956

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->