### PR TITLE
fix(check): preserve component props in JSX

### DIFF
--- a/crates/vize/tests/check_jsx_component_contract_cli.rs
+++ b/crates/vize/tests/check_jsx_component_contract_cli.rs
@@ -1,0 +1,202 @@
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+#[path = "support/jsx_check_project.rs"]
+mod jsx_check_project;
+
+use std::path::{Path, PathBuf};
+
+use jsx_check_project::{CheckOutput, JsxCheckProject};
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn resolve_test_corsa_path() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.parent()?.join("corsa-bind/.cache/tsgo"),
+        root.join("node_modules/.bin/tsgo"),
+        root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn assert_broken(project: &JsxCheckProject, source: &str, expected: &str) -> CheckOutput {
+    project.write("src/Consumer.tsx", source);
+    let output = project.check();
+    assert!(!output.success, "invalid TSX passed:\n{}", output.stdout);
+    assert!(
+        output.stdout.contains("src/Consumer.tsx") && output.stdout.contains(expected),
+        "stdout:\n{}\nstderr:\n{}",
+        output.stdout,
+        output.stderr
+    );
+    output
+}
+
+fn assert_clean(output: CheckOutput) {
+    assert!(
+        output.success && output.stdout.contains(r#""errorCount": 0"#),
+        "stdout:\n{}\nstderr:\n{}",
+        output.stdout,
+        output.stderr
+    );
+}
+
+#[test]
+fn check_tsx_enforces_imported_sfc_and_local_component_contracts() {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
+        return;
+    };
+    let project = JsxCheckProject::new("tsx", corsa_path, false);
+    project.write(
+        "src/Counter.vue",
+        r#"<script setup lang="ts">
+defineProps<{ count: number; isOpened: boolean; 'data-id': number; label?: string }>();
+defineEmits<{ select: [value: number] }>();
+</script>
+<template><span>{{ count }}</span></template>
+"#,
+    );
+    project.write(
+        "src/Generic.vue",
+        r#"<script setup lang="ts" generic="T = string">
+defineProps<{ value: T }>();
+</script>
+"#,
+    );
+
+    let wrong_value = assert_broken(
+        &project,
+        r#"import Counter from './Counter.vue';
+export const view = <Counter count="wrong" is-opened data-id={1} />;
+"#,
+        "not assignable",
+    );
+    assert!(
+        wrong_value.stdout.contains("error:2:30"),
+        "{}",
+        wrong_value.stdout
+    );
+    let missing_prop = assert_broken(
+        &project,
+        r#"import Counter from './Counter.vue';
+export const view = <Counter count={1} data-id={1} />;
+"#,
+        "isOpened",
+    );
+    assert!(
+        missing_prop.stdout.contains("error:2:22"),
+        "{}",
+        missing_prop.stdout
+    );
+    assert_broken(
+        &project,
+        r#"import Counter from './Counter.vue';
+export const view = <Counter count={1} is-opened />;
+"#,
+        "dataId",
+    );
+    assert_broken(
+        &project,
+        r#"import Counter from './Counter.vue';
+export const view = <Counter count={1} is-opened data-id={1} typo />;
+"#,
+        "typo",
+    );
+    assert_broken(
+        &project,
+        r#"import Counter from './Counter.vue';
+const props = { count: 'wrong', isOpened: true, 'data-id': 1 };
+export const view = <Counter {...props} />;
+"#,
+        "not assignable",
+    );
+    assert_broken(
+        &project,
+        r#"import Counter from './Counter.vue';
+export const view = <Counter count={1} is-opened data-id={1} onSelect={(value) => value.toUpperCase()} />;
+"#,
+        "toUpperCase",
+    );
+    assert_broken(
+        &project,
+        r#"import Counter from './Counter.vue';
+const Library = { Counter };
+export const view = <Library.Counter count="wrong" is-opened data-id={1} />;
+"#,
+        "not assignable",
+    );
+    assert_broken(
+        &project,
+        r#"const Local = (_props: { count: number }) => null;
+export const view = <Local count="wrong" />;
+"#,
+        "not assignable",
+    );
+
+    project.write(
+        "src/Consumer.tsx",
+        r#"import Counter from './Counter.vue';
+import Generic from './Generic.vue';
+const Library = { Counter };
+const props = { count: 1, isOpened: true, 'data-id': 1 };
+export const generic = <Generic value={123} />;
+export const view = (
+  <Library.Counter
+    {...props}
+    class="counter"
+    style="color: red"
+    onSelect={(value) => value.toFixed(0)}
+  />
+);
+"#,
+    );
+    assert_clean(project.check());
+}
+
+#[test]
+fn check_jsx_with_check_js_enforces_imported_sfc_props_and_repair() {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
+        return;
+    };
+    let project = JsxCheckProject::new("jsx", corsa_path, true);
+    project.write(
+        "src/Counter.vue",
+        r#"<script setup lang="ts">
+defineProps<{ count: number }>();
+</script>
+<template><span>{{ count }}</span></template>
+"#,
+    );
+    project.write(
+        "src/Consumer.jsx",
+        r#"import Counter from './Counter.vue';
+export const view = <Counter count="wrong" />;
+"#,
+    );
+    let broken = project.check();
+    assert!(!broken.success, "invalid JSX passed:\n{}", broken.stdout);
+    assert!(
+        broken.stdout.contains("src/Consumer.jsx")
+            && broken.stdout.contains("error:2:30")
+            && broken
+                .stdout
+                .contains("Type 'string' is not assignable to type 'number'"),
+        "{}",
+        broken.stdout
+    );
+
+    project.write(
+        "src/Consumer.jsx",
+        r#"import Counter from './Counter.vue';
+export const view = <Counter count={1} />;
+"#,
+    );
+    assert_clean(project.check());
+}

--- a/crates/vize/tests/support/jsx_check_project.rs
+++ b/crates/vize/tests/support/jsx_check_project.rs
@@ -1,0 +1,155 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use vize_carton::{String, cstr};
+
+pub struct CheckOutput {
+    pub success: bool,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub struct JsxCheckProject {
+    root: PathBuf,
+    corsa_path: PathBuf,
+}
+
+impl JsxCheckProject {
+    pub fn new(name: &str, corsa_path: PathBuf, check_js: bool) -> Self {
+        let case_name = cstr!("check-jsx-component-contract-{name}-{}", std::process::id());
+        let root = workspace_root()
+            .join("target/vize-tests/tests")
+            .join(case_name.as_str());
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("src")).unwrap();
+        link_workspace_vue(&root).unwrap();
+        std::fs::write(
+            root.join("vize.config.json"),
+            r#"{ "typeChecker": { "jsxTypecheck": true } }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("tsconfig.json"),
+            if check_js { JS_TSCONFIG } else { TS_TSCONFIG },
+        )
+        .unwrap();
+        Self { root, corsa_path }
+    }
+
+    pub fn write(&self, path: &str, source: &str) {
+        let path = self.root.join(path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, source).unwrap();
+    }
+
+    pub fn check(&self) -> CheckOutput {
+        let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+            .current_dir(&self.root)
+            .env("CORSA_PATH", &self.corsa_path)
+            .args(["check", "--tsconfig", "tsconfig.json", "--format", "json"])
+            .output()
+            .unwrap();
+        CheckOutput {
+            success: output.status.success(),
+            stdout: std::str::from_utf8(&output.stdout).unwrap().into(),
+            stderr: std::str::from_utf8(&output.stderr).unwrap().into(),
+        }
+    }
+}
+
+impl Drop for JsxCheckProject {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn link_workspace_vue(project_root: &Path) -> std::io::Result<()> {
+    let vue_package = workspace_vue_package().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace Vue package missing",
+        )
+    })?;
+    let workspace_node_modules = vue_package.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "workspace Vue package has no node_modules parent",
+        )
+    })?;
+    let target = project_root.join("node_modules");
+    std::fs::create_dir_all(&target)?;
+    symlink_path(&vue_package, &target.join("vue"))?;
+    let vue_namespace = workspace_node_modules.join("@vue");
+    if vue_namespace.exists() {
+        symlink_path(&vue_namespace, &target.join("@vue"))?;
+    }
+    Ok(())
+}
+
+fn workspace_vue_package() -> Option<PathBuf> {
+    let root = workspace_root();
+    [
+        root.join("node_modules/vue"),
+        root.join("tests/node_modules/vue"),
+        root.join("playground/node_modules/vue"),
+        root.join("examples/vite-musea/node_modules/vue"),
+        root.join("examples/jsx-tsx/node_modules/vue"),
+        root.join("npm/framework/nuxt/node_modules/vue"),
+    ]
+    .into_iter()
+    .find(|candidate| candidate.exists())
+}
+
+fn symlink_path(source: &Path, target: &Path) -> std::io::Result<()> {
+    if target.is_symlink() || target.is_file() {
+        std::fs::remove_file(target)?;
+    } else if target.exists() {
+        std::fs::remove_dir_all(target)?;
+    }
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, target)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_dir(source, target)
+    }
+}
+
+const TS_TSCONFIG: &str = r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#;
+
+const JS_TSCONFIG: &str = r#"{
+  "compilerOptions": {
+    "strict": true,
+    "allowJs": true,
+    "checkJs": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#;

--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen.rs
@@ -45,6 +45,10 @@
 //!   re-emitted as real TypeScript at — and source-mapped back to — its original
 //!   byte range, so a wrong type inside a JSX expression is reported at the right
 //!   location;
+//! - **component tags and props** are preserved as type-only calls. Imported
+//!   SFC constructors reuse their generated `$props`/raw-props contract, while
+//!   local functional components reuse their first parameter. This checks
+//!   required, excess, static, bound, kebab-case, listener, and spread props;
 //! - **directive expressions** are checked too (#1497): a `v-model` binding
 //!   target is re-emitted as an assignment to itself, so binding to a `const`,
 //!   a `readonly`/computed value, or a non-lvalue is reported at the binding; a
@@ -80,6 +84,8 @@ use crate::batch::{Diagnostic, SfcBlockType};
 use crate::virtual_ts::VizeMapping;
 
 use super::diagnostics::diagnostic_for_offset;
+
+mod component;
 
 /// The generated plain-`.ts` virtual file for one `.jsx`/`.tsx` source.
 pub(super) struct GeneratedJsxFile {
@@ -143,6 +149,10 @@ enum JsxEmit {
     Expr(JsxExpr),
     /// A `v-model` binding target, re-emitted as `(<lvalue> = <lvalue>)`.
     ModelTarget(JsxExpr),
+    /// A component tag plus its authored JSX attributes. Unlike intrinsic
+    /// elements, these participate in the imported/local component's props
+    /// contract and therefore cannot be reduced to value expressions alone.
+    Component(component::JsxComponent),
     /// A `v-for` scope: the iterated `source` plus the alias patterns and the
     /// body units evaluated with those aliases in scope.
     ForScope {
@@ -228,6 +238,12 @@ fn render_plain_ts(
     // Ambient `Ctx<Emits, Slots>` so the typed second parameter resolves and the
     // `emit`/`slots` usages in the setup body and JSX expressions type-check.
     out.push_str(CTX_HELPER);
+    if roots
+        .iter()
+        .any(|(_, _, emits)| emits.iter().any(emit_contains_component))
+    {
+        out.push_str(component::HELPER);
+    }
 
     let mut cursor = 0usize;
     for (start, end, emits) in roots {
@@ -283,6 +299,7 @@ fn render_emit(out: &mut CompactString, mappings: &mut Vec<VizeMapping>, emit: &
             out.push_str(&expr.content);
             out.push(')');
         }
+        JsxEmit::Component(component) => component::render(out, mappings, component),
         JsxEmit::ForScope {
             source,
             value_alias,
@@ -309,6 +326,14 @@ fn render_emit(out: &mut CompactString, mappings: &mut Vec<VizeMapping>, emit: &
             render_sink_call(out, mappings, body);
             out.push(')');
         }
+    }
+}
+
+fn emit_contains_component(emit: &JsxEmit) -> bool {
+    match emit {
+        JsxEmit::Component(_) => true,
+        JsxEmit::ForScope { body, .. } => body.iter().any(emit_contains_component),
+        JsxEmit::Expr(_) | JsxEmit::ModelTarget(_) => false,
     }
 }
 
@@ -383,8 +408,15 @@ fn collect_style_expressions(style_exprs: &[StyleExprSpan], out: &mut Vec<JsxEmi
 fn collect_child(child: &TemplateChildNode<'_>, out: &mut Vec<JsxEmit>) {
     match child {
         TemplateChildNode::Element(element) => {
+            let semantic_component = component::collect(element);
+            let has_semantic_component = semantic_component.is_some();
+            if let Some(component) = semantic_component {
+                out.push(JsxEmit::Component(component));
+            }
             for prop in &element.props {
-                collect_prop(prop, out);
+                if !has_semantic_component || !component::captures_prop(element, prop) {
+                    collect_prop(prop, out);
+                }
             }
             for child in &element.children {
                 collect_child(child, out);
@@ -560,78 +592,5 @@ fn jsx_expr(content: &str, start: u32, end: u32) -> Option<JsxExpr> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::ops::Range;
-
-    fn generate(source: &str) -> GeneratedJsxFile {
-        generate_jsx_virtual_ts(Path::new("Comp.tsx"), source, JsxLang::Tsx).unwrap()
-    }
-
-    fn assert_generated_snapshot(name: &str, source: &str) {
-        let generated = generate(source);
-        insta::assert_snapshot!(format!("{name}_code"), generated.code.as_str());
-        insta::assert_debug_snapshot!(
-            format!("{name}_mappings"),
-            mapping_summary(source, &generated)
-        );
-        insta::assert_debug_snapshot!(format!("{name}_diagnostics"), generated.diagnostics);
-    }
-
-    fn mapping_summary<'a>(
-        source: &'a str,
-        generated: &'a GeneratedJsxFile,
-    ) -> Vec<MappingSummary<'a>> {
-        generated
-            .mappings
-            .iter()
-            .map(|mapping| MappingSummary {
-                generated: &generated.code[mapping.gen_range.clone()],
-                source: &source[mapping.src_range.clone()],
-                gen_range: mapping.gen_range.clone(),
-                src_range: mapping.src_range.clone(),
-            })
-            .collect()
-    }
-
-    #[allow(dead_code)]
-    #[derive(Debug)]
-    struct MappingSummary<'a> {
-        generated: &'a str,
-        source: &'a str,
-        gen_range: Range<usize>,
-        src_range: Range<usize>,
-    }
-
-    #[test]
-    fn typed_component_with_jsx_control_flow_directives_and_styles_is_exact() {
-        let source = "import { computed, ref } from 'vue';\n\nconst Comp = (\n  { items, ok, tone, gap }: { items: Array<{ id: string; label: string }>; ok: boolean; tone: string; gap: number },\n  { emit, slots }: Ctx<{ select: [id: string] }, { footer: () => unknown }>,\n) => {\n  const selected = ref(items[0]?.id);\n  const activeItem = computed(() => items.find((item) => item.id === selected.value));\n  return (\n    <>\n      <ul class={tone} v-show={ok}>\n        {items.map((item, index) => (\n          <li key={item.id} onClick={() => emit('select', item.id)} data-index={index}>\n            {item.label}{selected.value === item.id ? <strong>Selected</strong> : <em>{index}</em>}\n          </li>\n        ))}\n      </ul>\n      <input v-model={selected.value} v-focus:lazy={tone} />\n      <footer>{activeItem.value?.label}{slots.footer()}</footer>\n      <style scoped>{`.row { gap: ${gap}px; }`}</style>\n    </>\n  );\n};\n";
-
-        assert_generated_snapshot(
-            "typed_component_with_jsx_control_flow_directives_and_styles",
-            source,
-        );
-    }
-
-    #[test]
-    fn multiple_roots_and_static_style_are_exact() {
-        let source = "const First = (props: { msg: string }) => <section>{props.msg}</section>;\nconst Second = () => (\n  <>\n    <div class=\"box\" />\n    <style scoped>{`.box { color: red; }`}</style>\n  </>\n);\n";
-
-        assert_generated_snapshot("multiple_roots_and_static_style", source);
-    }
-
-    #[test]
-    fn jsx_file_mode_is_exact() {
-        let source =
-            "export const Plain = ({ msg }) => <button onClick={() => save(msg)}>{msg}</button>;\n";
-        let generated =
-            generate_jsx_virtual_ts(Path::new("Plain.jsx"), source, JsxLang::Jsx).unwrap();
-
-        insta::assert_snapshot!("jsx_file_mode_code", generated.code.as_str());
-        insta::assert_debug_snapshot!(
-            "jsx_file_mode_mappings",
-            mapping_summary(source, &generated)
-        );
-        insta::assert_debug_snapshot!("jsx_file_mode_diagnostics", generated.diagnostics);
-    }
-}
+#[path = "jsx_codegen_tests.rs"]
+mod tests;

--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen/component.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen/component.rs
@@ -1,0 +1,324 @@
+//! Semantic JSX component calls for the plain-TypeScript check document.
+//!
+//! JSX lowering keeps a rich component/prop tree, but the original check
+//! codegen retained only dynamic expressions. This module turns component
+//! elements into type-only calls whose props parameter comes from the imported
+//! SFC constructor or local function component contract.
+
+use std::vec::Vec;
+
+use vize_carton::{String as CompactString, ToCompactString};
+use vize_relief::{ElementNode, ElementType, ExpressionNode, PropNode};
+
+use crate::virtual_ts::{VizeMapping, VizeSubSpan};
+
+use super::{JsxExpr, push_mapped_expr};
+
+/// Type-only component invocation. The constructor branch consumes the
+/// `$props` contract exported by generated SFC modules; the function branch
+/// covers locally declared functional components. Unknown component shapes
+/// remain a permissive fallback instead of introducing false positives.
+pub(super) const HELPER: &str = "type __VizeJsxKebabCase<S extends string> = S extends `${infer H}${infer T}` ? H extends Lowercase<H> ? `${H}${__VizeJsxKebabCase<T>}` : `-${Lowercase<H>}${__VizeJsxKebabCase<T>}` : S;\n\
+type __VizeJsxCamelCase<S extends string> = S extends `${infer H}-${infer T}` ? `${H}${Capitalize<__VizeJsxCamelCase<T>>}` : S;\n\
+type __VizeJsxRawPropKeys<R> = R extends unknown ? { [K in keyof R]-?: K extends string ? K | __VizeJsxKebabCase<K> : K }[keyof R] : never;\n\
+type __VizeJsxCanonicalRawProps<R> = R extends unknown ? { [K in keyof R as K extends string ? __VizeJsxCamelCase<K> : K]: R[K] } : never;\n\
+type __VizeJsxComponentProps<C> = C extends abstract new (...args: any[]) => infer I ? I extends { $props: infer P } ? I extends { readonly __vizeRawProps?: infer R } ? Omit<P, __VizeJsxRawPropKeys<R>> & __VizeJsxCanonicalRawProps<R> : __VizeJsxCanonicalRawProps<P> : any : C extends (props: infer P, ...args: any[]) => any ? __VizeJsxCanonicalRawProps<P> : any;\n\
+declare function __vize_jsx_component_spread__<O>(value: O): __VizeJsxCanonicalRawProps<Omit<O, 'key' | 'ref'>>;\n\
+declare function __vize_jsx_component__<C>(component: C, props: __VizeJsxComponentProps<C>): any;\n";
+
+pub(super) struct JsxComponent {
+    tag: JsxExpr,
+    props: Vec<JsxComponentProp>,
+}
+
+enum JsxComponentProp {
+    Property {
+        name: PropName,
+        value: PropValue,
+        source_start: u32,
+        source_end: u32,
+    },
+    Spread {
+        value: JsxExpr,
+        source_start: u32,
+        source_end: u32,
+    },
+}
+
+enum PropName {
+    Static {
+        content: CompactString,
+        start: u32,
+        end: u32,
+    },
+    Computed(JsxExpr),
+}
+
+enum PropValue {
+    Boolean,
+    Expression(JsxExpr),
+}
+
+pub(super) fn collect(element: &ElementNode<'_>) -> Option<JsxComponent> {
+    if element.tag_type != ElementType::Component {
+        return None;
+    }
+    let tag = component_tag(element)?;
+    let props = element
+        .props
+        .iter()
+        .filter_map(|prop| component_prop(element, prop))
+        .collect();
+    Some(JsxComponent { tag, props })
+}
+
+/// Whether `component_prop` already preserves this prop. Props that do not
+/// participate in the component contract continue through the general JSX
+/// expression collector so directive/model expressions are never lost.
+pub(super) fn captures_prop(element: &ElementNode<'_>, prop: &PropNode<'_>) -> bool {
+    match prop {
+        PropNode::Attribute(attribute) => !is_reserved_prop(attribute.name.as_str()),
+        PropNode::Directive(directive) if directive.name.as_str() == "bind" => {
+            if directive.exp.is_none() {
+                return false;
+            }
+            match directive.arg.as_ref() {
+                None => true,
+                Some(arg) => match static_name(arg) {
+                    Some(name) => {
+                        is_dynamic_component_tag_prop(element, name) || !is_reserved_prop(name)
+                    }
+                    None => super::expr_of(arg).is_some(),
+                },
+            }
+        }
+        PropNode::Directive(_) => false,
+    }
+}
+
+pub(super) fn render(
+    out: &mut CompactString,
+    mappings: &mut Vec<VizeMapping>,
+    component: &JsxComponent,
+) {
+    out.push_str("__vize_jsx_component__(");
+    push_mapped_expr(out, mappings, &component.tag);
+    out.push_str(", ");
+    let literal_start = out.len();
+    out.push('{');
+    for (index, prop) in component.props.iter().enumerate() {
+        if index > 0 {
+            out.push_str(", ");
+        }
+        render_prop(out, mappings, prop);
+    }
+    out.push('}');
+    let literal_end = out.len();
+    mappings.push(VizeMapping {
+        gen_range: literal_start..literal_end,
+        src_range: component.tag.start as usize..component.tag.end as usize,
+        sub_spans: Vec::new(),
+    });
+    out.push(')');
+}
+
+fn render_prop(out: &mut CompactString, mappings: &mut Vec<VizeMapping>, prop: &JsxComponentProp) {
+    match prop {
+        JsxComponentProp::Property {
+            name,
+            value,
+            source_start,
+            source_end,
+        } => {
+            let entry_start = out.len();
+            let (name_gen_range, name_src_range) = render_name(out, mappings, name);
+            out.push_str(": ");
+            match value {
+                PropValue::Boolean => out.push_str("true"),
+                PropValue::Expression(expression) => {
+                    push_mapped_expr(out, mappings, expression);
+                }
+            }
+            let entry_end = out.len();
+            mappings.push(VizeMapping {
+                gen_range: entry_start..entry_end,
+                src_range: *source_start as usize..*source_end as usize,
+                sub_spans: name_gen_range
+                    .zip(name_src_range)
+                    .map(|(gen_range, src_range)| VizeSubSpan {
+                        gen_range,
+                        src_range,
+                    })
+                    .into_iter()
+                    .collect(),
+            });
+        }
+        JsxComponentProp::Spread {
+            value,
+            source_start,
+            source_end,
+        } => {
+            let entry_start = out.len();
+            out.push_str("...__vize_jsx_component_spread__(");
+            push_mapped_expr(out, mappings, value);
+            out.push(')');
+            let entry_end = out.len();
+            mappings.push(VizeMapping {
+                gen_range: entry_start..entry_end,
+                src_range: *source_start as usize..*source_end as usize,
+                sub_spans: Vec::new(),
+            });
+        }
+    }
+}
+
+fn render_name(
+    out: &mut CompactString,
+    mappings: &mut Vec<VizeMapping>,
+    name: &PropName,
+) -> (
+    Option<std::ops::Range<usize>>,
+    Option<std::ops::Range<usize>>,
+) {
+    match name {
+        PropName::Static {
+            content,
+            start,
+            end,
+        } => {
+            let gen_start = out.len();
+            out.push_str(&json_string(content));
+            let gen_end = out.len();
+            (
+                Some(gen_start..gen_end),
+                Some(*start as usize..*end as usize),
+            )
+        }
+        PropName::Computed(expression) => {
+            out.push('[');
+            push_mapped_expr(out, mappings, expression);
+            out.push(']');
+            (None, None)
+        }
+    }
+}
+
+fn component_tag(element: &ElementNode<'_>) -> Option<JsxExpr> {
+    if element.tag.as_str() == "component" {
+        return element.props.iter().find_map(|prop| {
+            let PropNode::Directive(directive) = prop else {
+                return None;
+            };
+            (directive.name.as_str() == "bind"
+                && directive.arg.as_ref().and_then(static_name) == Some("is"))
+            .then(|| directive.exp.as_ref().and_then(super::expr_of))
+            .flatten()
+        });
+    }
+
+    let start = element.loc.start.offset.saturating_add(1);
+    Some(JsxExpr {
+        content: element.tag.as_str().to_compact_string(),
+        start,
+        end: start.saturating_add(element.tag.len() as u32),
+    })
+}
+
+fn component_prop(element: &ElementNode<'_>, prop: &PropNode<'_>) -> Option<JsxComponentProp> {
+    match prop {
+        PropNode::Attribute(attribute) if !is_reserved_prop(attribute.name.as_str()) => {
+            let value = match attribute.value.as_ref() {
+                Some(value) => PropValue::Expression(JsxExpr {
+                    content: json_string(value.content.as_str()),
+                    start: value.loc.start.offset,
+                    end: value.loc.end.offset,
+                }),
+                None => PropValue::Boolean,
+            };
+            Some(JsxComponentProp::Property {
+                name: PropName::Static {
+                    content: canonical_prop_name(attribute.name.as_str()),
+                    start: attribute.name_loc.start.offset,
+                    end: attribute.name_loc.end.offset,
+                },
+                value,
+                source_start: attribute.loc.start.offset,
+                source_end: attribute.loc.end.offset,
+            })
+        }
+        PropNode::Attribute(_) => None,
+        PropNode::Directive(directive) if directive.name.as_str() == "bind" => {
+            let value = directive.exp.as_ref().and_then(super::expr_of)?;
+            let Some(arg) = directive.arg.as_ref() else {
+                return Some(JsxComponentProp::Spread {
+                    value,
+                    source_start: directive.loc.start.offset,
+                    source_end: directive.loc.end.offset,
+                });
+            };
+            let name = match arg {
+                ExpressionNode::Simple(simple) if simple.is_static => {
+                    if is_dynamic_component_tag_prop(element, simple.content.as_str())
+                        || is_reserved_prop(simple.content.as_str())
+                    {
+                        return None;
+                    }
+                    PropName::Static {
+                        content: canonical_prop_name(simple.content.as_str()),
+                        start: simple.loc.start.offset,
+                        end: simple.loc.end.offset,
+                    }
+                }
+                _ => PropName::Computed(super::expr_of(arg)?),
+            };
+            Some(JsxComponentProp::Property {
+                name,
+                value: PropValue::Expression(value),
+                source_start: directive.loc.start.offset,
+                source_end: directive.loc.end.offset,
+            })
+        }
+        PropNode::Directive(_) => None,
+    }
+}
+
+fn static_name<'e>(expression: &'e ExpressionNode<'_>) -> Option<&'e str> {
+    match expression {
+        ExpressionNode::Simple(simple) if simple.is_static => Some(simple.content.as_str()),
+        ExpressionNode::Simple(_) | ExpressionNode::Compound(_) => None,
+    }
+}
+
+fn is_dynamic_component_tag_prop(element: &ElementNode<'_>, name: &str) -> bool {
+    element.tag.as_str() == "component" && name == "is"
+}
+
+fn is_reserved_prop(name: &str) -> bool {
+    matches!(name, "key" | "ref")
+}
+
+/// JSX accepts Vue's kebab aliases, while the generated SFC exposes its raw
+/// required contract under camelCase keys. Canonicalizing the authored key lets
+/// the helper intersect `$props` with that raw contract without making both
+/// spellings optional (which would silently lose required props).
+fn canonical_prop_name(name: &str) -> CompactString {
+    let mut out = CompactString::default();
+    let mut uppercase_next = false;
+    for ch in name.chars() {
+        if ch == '-' {
+            uppercase_next = true;
+        } else if uppercase_next {
+            out.extend(ch.to_uppercase());
+            uppercase_next = false;
+        } else {
+            out.push(ch);
+        }
+    }
+    out
+}
+
+fn json_string(value: &str) -> CompactString {
+    serde_json::to_string(value)
+        .expect("serializing a Rust string to JSON cannot fail")
+        .to_compact_string()
+}

--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen_tests.rs
@@ -1,0 +1,112 @@
+use std::ops::Range;
+
+use super::*;
+
+fn generate(source: &str) -> GeneratedJsxFile {
+    generate_jsx_virtual_ts(Path::new("Comp.tsx"), source, JsxLang::Tsx).unwrap()
+}
+
+fn assert_generated_snapshot(name: &str, source: &str) {
+    let generated = generate(source);
+    insta::assert_snapshot!(format!("{name}_code"), generated.code.as_str());
+    insta::assert_debug_snapshot!(
+        format!("{name}_mappings"),
+        mapping_summary(source, &generated)
+    );
+    insta::assert_debug_snapshot!(format!("{name}_diagnostics"), generated.diagnostics);
+}
+
+fn mapping_summary<'a>(
+    source: &'a str,
+    generated: &'a GeneratedJsxFile,
+) -> Vec<MappingSummary<'a>> {
+    generated
+        .mappings
+        .iter()
+        .map(|mapping| MappingSummary {
+            generated: &generated.code[mapping.gen_range.clone()],
+            source: &source[mapping.src_range.clone()],
+            gen_range: mapping.gen_range.clone(),
+            src_range: mapping.src_range.clone(),
+        })
+        .collect()
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+struct MappingSummary<'a> {
+    generated: &'a str,
+    source: &'a str,
+    gen_range: Range<usize>,
+    src_range: Range<usize>,
+}
+
+#[test]
+fn typed_component_with_jsx_control_flow_directives_and_styles_is_exact() {
+    let source = "import { computed, ref } from 'vue';\n\nconst Comp = (\n  { items, ok, tone, gap }: { items: Array<{ id: string; label: string }>; ok: boolean; tone: string; gap: number },\n  { emit, slots }: Ctx<{ select: [id: string] }, { footer: () => unknown }>,\n) => {\n  const selected = ref(items[0]?.id);\n  const activeItem = computed(() => items.find((item) => item.id === selected.value));\n  return (\n    <>\n      <ul class={tone} v-show={ok}>\n        {items.map((item, index) => (\n          <li key={item.id} onClick={() => emit('select', item.id)} data-index={index}>\n            {item.label}{selected.value === item.id ? <strong>Selected</strong> : <em>{index}</em>}\n          </li>\n        ))}\n      </ul>\n      <input v-model={selected.value} v-focus:lazy={tone} />\n      <footer>{activeItem.value?.label}{slots.footer()}</footer>\n      <style scoped>{`.row { gap: ${gap}px; }`}</style>\n    </>\n  );\n};\n";
+
+    assert_generated_snapshot(
+        "typed_component_with_jsx_control_flow_directives_and_styles",
+        source,
+    );
+}
+
+#[test]
+fn multiple_roots_and_static_style_are_exact() {
+    let source = "const First = (props: { msg: string }) => <section>{props.msg}</section>;\nconst Second = () => (\n  <>\n    <div class=\"box\" />\n    <style scoped>{`.box { color: red; }`}</style>\n  </>\n);\n";
+
+    assert_generated_snapshot("multiple_roots_and_static_style", source);
+}
+
+#[test]
+fn jsx_file_mode_is_exact() {
+    let source =
+        "export const Plain = ({ msg }) => <button onClick={() => save(msg)}>{msg}</button>;\n";
+    let generated = generate_jsx_virtual_ts(Path::new("Plain.jsx"), source, JsxLang::Jsx).unwrap();
+
+    insta::assert_snapshot!("jsx_file_mode_code", generated.code.as_str());
+    insta::assert_debug_snapshot!(
+        "jsx_file_mode_mappings",
+        mapping_summary(source, &generated)
+    );
+    insta::assert_debug_snapshot!("jsx_file_mode_diagnostics", generated.diagnostics);
+}
+
+#[test]
+fn semantic_component_tags_props_and_spreads_survive_plain_ts_lowering() {
+    let source = "import Counter from './Counter.vue';\nconst Library = { Counter };\nconst count = 'wrong';\nconst bag = { enabled: true };\nexport const first = <Counter count={count} is-opened />;\nexport const second = <Library.Counter {...bag} label=\"hello\" />;\n";
+    let generated = generate(source);
+
+    assert!(generated.code.contains(component::HELPER));
+    assert!(
+        generated
+            .code
+            .contains("__vize_jsx_component__(Counter, {\"count\": count, \"isOpened\": true})")
+    );
+    assert!(
+        generated.code.contains(
+            "__vize_jsx_component__(Library.Counter, {...__vize_jsx_component_spread__(bag), \"label\": \"hello\"})"
+        )
+    );
+
+    for authored in [
+        "Counter",
+        "count",
+        "is-opened",
+        "Library.Counter",
+        "bag",
+        "label",
+    ] {
+        assert!(
+            generated.mappings.iter().any(|mapping| {
+                &source[mapping.src_range.clone()] == authored
+                    || mapping
+                        .sub_spans
+                        .iter()
+                        .any(|span| &source[span.src_range.clone()] == authored)
+            }),
+            "missing authored mapping for {authored}:\n{}",
+            generated.code
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- preserve JSX/TSX component identity and authored props in the plain-TypeScript check document
- reuse generated SFC `$props` and raw props for required, kebab-case, listener, and fallthrough contracts
- check static, bound, spread, member, local functional, generic SFC, and checkJs JSX consumers
- map value failures to authored attributes and missing-prop failures to authored component tags
- keep intrinsic JSX output and existing snapshots byte-identical

## Validation

- `cargo test -p vize_canon --lib` — 875 passed
- focused JSX codegen unit and snapshot tests — 4 passed
- real-tsgo TSX/JSX component-contract CLI tests — 2 passed
- existing TSX false-positive regression tests — 3 passed
- targeted `cargo clippy` with warnings denied
- source-length ratchet against the stack base

## Scope

This fixes the batch-check component-prop false negative. Slot/children contracts and LSP lifecycle coverage remain tracked in #4042 and #3953; the packed fresh-project acceptance remains in #4041.

Refs #4042, #4041, #3954.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->