### PR TITLE
test(init): verify packed project typechecking

### DIFF
--- a/tests/tooling/release-smoke-install.test.ts
+++ b/tests/tooling/release-smoke-install.test.ts
@@ -174,6 +174,10 @@ test("release install smoke skips libc-incompatible tarballs", () => {
 
 test("release install smoke can run runtime checks for Vize packages", () => {
   const script = fs.readFileSync(smokeScript, "utf8");
+  const initTypecheckScript = fs.readFileSync(
+    path.join(root, "tools/npm/smoke-release-init-typecheck.mjs"),
+    "utf8",
+  );
 
   assert.match(script, /--runtime-checks/);
   // vize declares @typescript/native-preview itself, so the fresh-install smoke
@@ -189,6 +193,20 @@ test("release install smoke can run runtime checks for Vize packages", () => {
   assert.match(script, /vizeBin, "--version"/);
   assert.match(script, /"check"[\s\S]*"src\/App\.vue"/);
   assert.match(script, /"lint"[\s\S]*"src\/App\.vue"/);
+  assert.match(script, /runInitTypecheckChecks\([\s\S]*RUNTIME_PEER_DEPENDENCIES\)/);
+  assert.match(initTypecheckScript, /`init-smoke-\$\{language\}`/);
+  assert.match(initTypecheckScript, /\["typescript", "javascript"\]/);
+  assert.match(initTypecheckScript, /"init"[\s\S]*"--typecheck"[\s\S]*"--no-install"/);
+  assert.match(initTypecheckScript, /"run", "--silent", "vize:check"/);
+  for (const diagnostic of [
+    "standalone source",
+    "SFC script",
+    "SFC template",
+    "component prop",
+    "JSX consumer",
+  ]) {
+    assert.match(initTypecheckScript, new RegExp(diagnostic));
+  }
   // vite is installed as upstream vite 8, one supported
   // `@vizejs/vite-plugin` peer range. Real vite exposes a `vite` bin entry, so
   // the smoke can use the same resolver as vize.

--- a/tools/npm/smoke-release-init-typecheck.mjs
+++ b/tools/npm/smoke-release-init-typecheck.mjs
@@ -1,0 +1,288 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+function runResult(command, args, options = {}) {
+  const isWindowsBatch = process.platform === "win32" && /\.(cmd|bat)$/i.test(command);
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    env: options.env ?? process.env,
+    input: options.input,
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: isWindowsBatch,
+  });
+  if (result.error != null) throw result.error;
+  return result;
+}
+
+function run(command, args, options = {}) {
+  const result = runResult(command, args, options);
+  if (result.status !== 0) {
+    const rendered = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+    throw new Error(
+      [`${command} ${args.join(" ")} failed with exit ${result.status}`, rendered]
+        .filter(Boolean)
+        .join("\n"),
+    );
+  }
+  return result.stdout;
+}
+function writeProjectFile(projectDir, filename, source) {
+  const target = path.join(projectDir, filename);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, source);
+}
+
+function initTypecheckAppSource(language, failure = null) {
+  const scriptLanguage = language === "typescript" ? ' lang="ts"' : "";
+  const countDeclaration =
+    language === "typescript"
+      ? failure === "SFC script"
+        ? 'const count: number = "wrong";'
+        : "const count: number = 1;"
+      : failure === "SFC script"
+        ? '/** @type {number} */\nconst count = "wrong";'
+        : "/** @type {number} */\nconst count = 1;";
+  const labelDeclaration =
+    failure === "SFC template" ? "const label = 1;" : 'const label = "ready";';
+  const component =
+    failure === "component prop" ? '<Counter count="wrong" />' : '<Counter :count="count" />';
+
+  return [
+    "<template>",
+    `  ${component}`,
+    "  <p>{{ label.toUpperCase() }}</p>",
+    "</template>",
+    "",
+    `<script setup${scriptLanguage}>`,
+    'import Counter from "./Counter.vue";',
+    "",
+    countDeclaration,
+    labelDeclaration,
+    "</script>",
+    "",
+  ].join("\n");
+}
+
+function initTypecheckCounterSource(language) {
+  if (language === "typescript") {
+    return [
+      "<template>",
+      "  <span>{{ count.toFixed(0) }}</span>",
+      "</template>",
+      "",
+      '<script setup lang="ts">',
+      "defineProps<{ count: number }>();",
+      "</script>",
+      "",
+    ].join("\n");
+  }
+
+  return [
+    "<template>",
+    "  <span>{{ count.toFixed(0) }}</span>",
+    "</template>",
+    "",
+    "<script setup>",
+    "defineProps({ count: { type: Number, required: true } });",
+    "</script>",
+    "",
+  ].join("\n");
+}
+
+function initTypecheckStandaloneSource(language, broken) {
+  if (language === "typescript") {
+    return broken ? 'export const count: number = "wrong";\n' : "export const count: number = 1;\n";
+  }
+  return broken
+    ? '/** @type {number} */\nexport const count = "wrong";\n'
+    : "/** @type {number} */\nexport const count = 1;\n";
+}
+
+function initTypecheckConsumerSource(broken) {
+  const value = broken ? '"wrong"' : "1";
+  return [
+    'import Counter from "./Counter.vue";',
+    "",
+    `export const view = <Counter count={${value}} />;`,
+    "",
+  ].join("\n");
+}
+
+function createInitTypecheckProject(installDir, language, runtimePeerDependencies) {
+  const projectDir = path.join(installDir, `init-smoke-${language}`);
+  const sourceExtension = language === "typescript" ? "ts" : "js";
+  const consumerExtension = language === "typescript" ? "tsx" : "jsx";
+  writeProjectFile(
+    projectDir,
+    "package.json",
+    `${JSON.stringify(
+      {
+        name: `vize-init-${language}-smoke`,
+        private: true,
+        type: "module",
+        devDependencies:
+          language === "typescript"
+            ? {
+                typescript: runtimePeerDependencies.typescript,
+                vue: runtimePeerDependencies.vue,
+              }
+            : { vue: runtimePeerDependencies.vue },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  writeProjectFile(
+    projectDir,
+    `src/model.${sourceExtension}`,
+    initTypecheckStandaloneSource(language, false),
+  );
+  writeProjectFile(projectDir, "src/Counter.vue", initTypecheckCounterSource(language));
+  writeProjectFile(projectDir, "src/App.vue", initTypecheckAppSource(language));
+  writeProjectFile(
+    projectDir,
+    `src/Consumer.${consumerExtension}`,
+    initTypecheckConsumerSource(false),
+  );
+  return { consumerExtension, projectDir, sourceExtension };
+}
+
+function runGeneratedTypecheck(installDir, projectDir) {
+  const binDir = path.join(installDir, "node_modules", ".bin");
+  const inheritedPath = process.env.PATH ?? "";
+  return runResult(
+    process.env.NPM_BIN || "npm",
+    ["run", "--silent", "vize:check", "--", "--format", "json", "--quiet"],
+    {
+      cwd: projectDir,
+      env: { ...process.env, PATH: `${binDir}${path.delimiter}${inheritedPath}` },
+    },
+  );
+}
+
+function checkOutput(result) {
+  return [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+}
+
+function assertGeneratedTypecheckPass(installDir, projectDir, phase) {
+  const result = runGeneratedTypecheck(installDir, projectDir);
+  const output = checkOutput(result);
+  assert.equal(result.status, 0, `${phase} should pass\n${output}`);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.errorCount, 0, `${phase} reported errors\n${output}`);
+}
+
+function assertGeneratedTypecheckFailure(installDir, projectDir, phase, filename, code) {
+  const result = runGeneratedTypecheck(installDir, projectDir);
+  const output = checkOutput(result);
+  assert.notEqual(result.status, 0, `${phase} unexpectedly passed`);
+  assert.ok(
+    output.includes(filename) || output.includes(path.basename(filename)),
+    `${phase} lost authored filename\n${output}`,
+  );
+  assert.match(output, new RegExp(`TS${code}\\b`), `${phase} lost diagnostic TS${code}`);
+}
+
+function runInitTypecheckCase(installDir, vizeBin, language, runtimePeerDependencies) {
+  const { consumerExtension, projectDir, sourceExtension } = createInitTypecheckProject(
+    installDir,
+    language,
+    runtimePeerDependencies,
+  );
+  const initArgs = [
+    vizeBin,
+    "init",
+    projectDir,
+    "--yes",
+    "--no-lint",
+    "--no-bundler",
+    "--no-fmt",
+    "--typecheck",
+    "--no-editor",
+    "--no-install",
+  ];
+  run(process.execPath, initArgs, { cwd: installDir });
+
+  const packagePath = path.join(projectDir, "package.json");
+  const tsconfigPath = path.join(projectDir, "tsconfig.json");
+  const configPath = path.join(projectDir, "vize.config.ts");
+  const manifest = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+  const tsconfig = JSON.parse(fs.readFileSync(tsconfigPath, "utf8"));
+  assert.equal(manifest.scripts["vize:check"], "vize check");
+  assert.equal(tsconfig.compilerOptions.allowJs, language === "javascript" ? true : undefined);
+  assert.equal(tsconfig.compilerOptions.checkJs, language === "javascript" ? true : undefined);
+
+  const initializedBytes = [packagePath, tsconfigPath, configPath].map((filename) =>
+    fs.readFileSync(filename, "utf8"),
+  );
+  run(process.execPath, initArgs, { cwd: installDir });
+  assert.deepEqual(
+    [packagePath, tsconfigPath, configPath].map((filename) => fs.readFileSync(filename, "utf8")),
+    initializedBytes,
+    `${language} init should be idempotent`,
+  );
+
+  assertGeneratedTypecheckPass(installDir, projectDir, `${language} initial clean project`);
+
+  const standaloneFile = `src/model.${sourceExtension}`;
+  writeProjectFile(projectDir, standaloneFile, initTypecheckStandaloneSource(language, true));
+  assertGeneratedTypecheckFailure(
+    installDir,
+    projectDir,
+    `${language} standalone source`,
+    standaloneFile,
+    2322,
+  );
+  writeProjectFile(projectDir, standaloneFile, initTypecheckStandaloneSource(language, false));
+  assertGeneratedTypecheckPass(installDir, projectDir, `${language} repaired standalone source`);
+
+  for (const [failure, code] of [
+    ["SFC script", 2322],
+    ["SFC template", 2339],
+    ["component prop", 2322],
+  ]) {
+    writeProjectFile(projectDir, "src/App.vue", initTypecheckAppSource(language, failure));
+    assertGeneratedTypecheckFailure(
+      installDir,
+      projectDir,
+      `${language} ${failure}`,
+      "src/App.vue",
+      code,
+    );
+    writeProjectFile(projectDir, "src/App.vue", initTypecheckAppSource(language));
+    assertGeneratedTypecheckPass(installDir, projectDir, `${language} repaired ${failure}`);
+  }
+
+  const consumerFile = `src/Consumer.${consumerExtension}`;
+  writeProjectFile(projectDir, consumerFile, initTypecheckConsumerSource(true));
+  assertGeneratedTypecheckFailure(
+    installDir,
+    projectDir,
+    `${language} JSX consumer`,
+    consumerFile,
+    2322,
+  );
+  writeProjectFile(projectDir, consumerFile, initTypecheckConsumerSource(false));
+  assertGeneratedTypecheckPass(installDir, projectDir, `${language} repaired JSX consumer`);
+}
+
+export function runInitTypecheckChecks(
+  installDir,
+  vizeBin,
+  repositoryRoot,
+  runtimePeerDependencies,
+) {
+  const installedVizeRoot = fs.realpathSync(path.dirname(path.dirname(vizeBin)));
+  const relativeToRepository = path.relative(repositoryRoot, installedVizeRoot);
+  assert.ok(
+    relativeToRepository.startsWith("..") && !path.isAbsolute(relativeToRepository),
+    `runtime resolved repository-local vize package: ${installedVizeRoot}`,
+  );
+  for (const language of ["typescript", "javascript"]) {
+    runInitTypecheckCase(installDir, vizeBin, language, runtimePeerDependencies);
+  }
+  console.log("runtime: packed vize init typecheck clean/broken/repaired matrix");
+}

--- a/tools/npm/smoke-release-install.mjs
+++ b/tools/npm/smoke-release-install.mjs
@@ -8,6 +8,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { preparePublishManifest } from "./prepare-publish-manifest.mjs";
+import { runInitTypecheckChecks } from "./smoke-release-init-typecheck.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const dependencySections = [
@@ -406,14 +407,10 @@ function writeRuntimeSmokeProject(installDir) {
   );
 }
 
-function hasPackage(packages, name) {
-  return packages.some((pkg) => pkg.name === name);
-}
-
 function runRuntimeChecks(installDir, packages) {
   writeRuntimeSmokeProject(installDir);
 
-  if (hasPackage(packages, "@vizejs/native")) {
+  if (packages.some((pkg) => pkg.name === "@vizejs/native")) {
     run(
       process.execPath,
       [
@@ -448,7 +445,7 @@ function runRuntimeChecks(installDir, packages) {
   // drop them mid-run. The single combined install above already settled the
   // dependency tree; re-entering npm here is what previously broke vite/rolldown
   // native bindings on the fresh-install smoke matrix.
-  if (hasPackage(packages, "vize")) {
+  if (packages.some((pkg) => pkg.name === "vize")) {
     const vizeBin = resolveInstalledBin(installDir, "vize", "vize");
     run(process.execPath, [vizeBin, "--version"], { cwd: installDir });
     console.log("runtime: vize --version");
@@ -464,9 +461,10 @@ function runRuntimeChecks(installDir, packages) {
       { cwd: installDir },
     );
     console.log("runtime: vize lint");
+    runInitTypecheckChecks(installDir, vizeBin, root, RUNTIME_PEER_DEPENDENCIES);
   }
 
-  if (hasPackage(packages, "@vizejs/vite-plugin")) {
+  if (packages.some((pkg) => pkg.name === "@vizejs/vite-plugin")) {
     const viteBin = resolveInstalledBin(installDir, "vite", "vite");
     run(process.execPath, [viteBin, "build"], { cwd: installDir });
     console.log("runtime: @vizejs/vite-plugin vite build");


### PR DESCRIPTION
## Summary

- extend the packed release smoke with fresh TypeScript and JavaScript projects created by `vize init`
- invoke the generated `vize:check` npm script with only the packed CLI and installed bins on PATH
- exercise clean, broken, and repaired standalone, SFC script, SFC template, cross-file component, and TSX/JSX consumer phases
- require authored filenames and stable TypeScript diagnostic codes for every planted failure
- assert generated scripts/config, JavaScript `allowJs`/`checkJs`, and second-run idempotency
- keep the release smoke entrypoint below its source-length baseline by isolating the matrix in a 288-line module

## Validation

- actual N-API rebuild from the stack head into an isolated publish tree
- packed native umbrella, host native package, and CLI installation with runtime checks
- complete TypeScript and JavaScript clean/broken/repaired matrix from packed tarballs
- `node --test tests/tooling/release-smoke-install.test.ts` — 6 passed
- `vp check` on all changed tooling files
- source-length ratchet against the stack base

Closes #4041.
Closes #4037.
Refs #3956, #3984, #4042.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->