### PR TITLE
fix(lsp): enforce JSX component prop contracts

### DIFF
--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -43,6 +43,16 @@ pub use helpers::{
 };
 pub(crate) use types::CSS_MODULE_GLOBAL_MARKER;
 pub use types::{TemplateGlobal, VirtualTsOptions, VirtualTsOutput, VizeMapping, VizeSubSpan};
+
+/// Shared type-only component contract for plain-TS JSX lowering in batch and
+/// editor paths. Keep one declaration source so the two consumers cannot drift.
+pub const JSX_COMPONENT_HELPER: &str = "type __VizeJsxKebabCase<S extends string> = S extends `${infer H}${infer T}` ? H extends Lowercase<H> ? `${H}${__VizeJsxKebabCase<T>}` : `-${Lowercase<H>}${__VizeJsxKebabCase<T>}` : S;\n\
+type __VizeJsxCamelCase<S extends string> = S extends `${infer H}-${infer T}` ? `${H}${Capitalize<__VizeJsxCamelCase<T>>}` : S;\n\
+type __VizeJsxRawPropKeys<R> = R extends unknown ? { [K in keyof R]-?: K extends string ? K | __VizeJsxKebabCase<K> : K }[keyof R] : never;\n\
+type __VizeJsxCanonicalRawProps<R> = R extends unknown ? { [K in keyof R as K extends string ? __VizeJsxCamelCase<K> : K]: R[K] } : never;\n\
+type __VizeJsxComponentProps<C> = C extends abstract new (...args: any[]) => infer I ? I extends { $props: infer P } ? I extends { readonly __vizeRawProps?: infer R } ? Omit<P, __VizeJsxRawPropKeys<R>> & __VizeJsxCanonicalRawProps<R> : __VizeJsxCanonicalRawProps<P> : any : C extends (props: infer P, ...args: any[]) => any ? __VizeJsxCanonicalRawProps<P> : any;\n\
+declare function __vize_jsx_component_spread__<O>(value: O): __VizeJsxCanonicalRawProps<Omit<O, 'key' | 'ref'>>;\n\
+declare function __vize_jsx_component__<C>(component: C, props: __VizeJsxComponentProps<C>): any;\n";
 #[cfg(any(test, feature = "native"))]
 pub(crate) use types::{VirtualTsCheckOptions, VirtualTsGenerationOptions};
 

--- a/crates/vize_maestro/src/ide/diagnostics/corsa.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa.rs
@@ -6,6 +6,7 @@
 
 pub(in crate::ide) mod collect;
 mod collect_virtual;
+pub(in crate::ide) use collect_virtual::corsa_diagnostic_code;
 mod mapping;
 mod message;
 mod virtual_ts;

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
@@ -215,7 +215,7 @@ fn is_inferred_implicit_any_suggestion(
         })
 }
 
-fn corsa_diagnostic_code(code: serde_json::Value) -> NumberOrString {
+pub(in crate::ide) fn corsa_diagnostic_code(code: serde_json::Value) -> NumberOrString {
     match code {
         serde_json::Value::Number(number) => number.as_i64().map_or_else(
             || NumberOrString::String(number.to_string()),

--- a/crates/vize_maestro/src/ide/jsx/position.rs
+++ b/crates/vize_maestro/src/ide/jsx/position.rs
@@ -31,15 +31,7 @@ pub(super) fn source_offset_to_virtual_position(
     source_offset: usize,
 ) -> Option<(u32, u32)> {
     let mapping = mapping_for_source_offset(mappings, source_offset)?;
-    let relative = source_offset.saturating_sub(mapping.src_range.start);
-    let gen_len = mapping
-        .gen_range
-        .end
-        .saturating_sub(mapping.gen_range.start);
-    let gen_offset = mapping
-        .gen_range
-        .start
-        .saturating_add(relative.min(gen_len));
+    let gen_offset = source_offset_to_generated(mapping, source_offset);
     Some(byte_offset_to_position(virtual_ts, gen_offset))
 }
 
@@ -61,9 +53,9 @@ pub(super) fn virtual_range_to_source(
         .unwrap_or_else(|| start_gen.saturating_add(1));
 
     let start_mapping = mapping_for_generated_offset(mappings, start_gen)?;
-    let src_start = generated_offset_to_source(start_mapping, start_gen);
+    let src_start = generated_offset_to_source(start_mapping, start_gen, false);
     let src_end = mapping_for_generated_offset(mappings, end_gen)
-        .map(|mapping| generated_offset_to_source(mapping, end_gen))
+        .map(|mapping| generated_offset_to_source(mapping, end_gen, true))
         .unwrap_or_else(|| {
             let generated_len = end_gen.saturating_sub(start_gen);
             src_start
@@ -95,10 +87,56 @@ fn mapping_for_source_offset(mappings: &[VizeMapping], offset: usize) -> Option<
 fn mapping_for_generated_offset(mappings: &[VizeMapping], offset: usize) -> Option<&VizeMapping> {
     mappings
         .iter()
-        .find(|mapping| offset >= mapping.gen_range.start && offset <= mapping.gen_range.end)
+        .filter(|mapping| offset >= mapping.gen_range.start && offset <= mapping.gen_range.end)
+        .min_by_key(|mapping| {
+            mapping
+                .gen_range
+                .end
+                .saturating_sub(mapping.gen_range.start)
+        })
 }
 
-fn generated_offset_to_source(mapping: &VizeMapping, generated_offset: usize) -> usize {
+fn source_offset_to_generated(mapping: &VizeMapping, source_offset: usize) -> usize {
+    if let Some(span) = mapping
+        .sub_spans
+        .iter()
+        .find(|span| source_offset >= span.src_range.start && source_offset <= span.src_range.end)
+    {
+        let relative = source_offset.saturating_sub(span.src_range.start);
+        return span
+            .gen_range
+            .start
+            .saturating_add(relative.min(span.gen_range.end.saturating_sub(span.gen_range.start)));
+    }
+    let relative = source_offset.saturating_sub(mapping.src_range.start);
+    mapping.gen_range.start.saturating_add(
+        relative.min(
+            mapping
+                .gen_range
+                .end
+                .saturating_sub(mapping.gen_range.start),
+        ),
+    )
+}
+
+fn generated_offset_to_source(
+    mapping: &VizeMapping,
+    generated_offset: usize,
+    prefer_end: bool,
+) -> usize {
+    if let Some(span) = mapping.sub_spans.iter().find(|span| {
+        generated_offset >= span.gen_range.start && generated_offset <= span.gen_range.end
+    }) {
+        let relative = generated_offset.saturating_sub(span.gen_range.start);
+        let source_len = span.src_range.end.saturating_sub(span.src_range.start);
+        return span
+            .src_range
+            .start
+            .saturating_add(relative.min(source_len));
+    }
+    if prefer_end && generated_offset >= mapping.gen_range.end {
+        return mapping.src_range.end;
+    }
     let generated_relative = generated_offset.saturating_sub(mapping.gen_range.start);
     let source_len = mapping
         .src_range
@@ -107,7 +145,7 @@ fn generated_offset_to_source(mapping: &VizeMapping, generated_offset: usize) ->
     mapping
         .src_range
         .start
-        .saturating_add(generated_relative.min(source_len.saturating_sub(1)))
+        .saturating_add(generated_relative.min(source_len))
 }
 
 /// Convert a byte offset into an LSP `(line, character)` in `text`, counting
@@ -179,6 +217,7 @@ pub(super) fn source_offset_to_position(source: &str, offset: usize) -> (u32, u3
 mod tests {
     use super::*;
     use vize_atelier_jsx::JsxLang;
+    use vize_canon::virtual_ts::VizeSubSpan;
 
     fn round_trip(source: &str, marker: &str) {
         let generated = super::super::virtual_ts::generate_jsx_virtual_ts(source, JsxLang::Tsx)
@@ -211,6 +250,25 @@ mod tests {
         round_trip(
             "const C = (props: { msg: string }) => <div>{props.msg}</div>;\n",
             "props.msg",
+        );
+    }
+
+    #[test]
+    fn maps_component_prop_diagnostic_to_authored_name_subspan() {
+        let virtual_ts = "\"count\"";
+        let source = "count";
+        let mappings = [VizeMapping {
+            gen_range: 0..7,
+            src_range: 0..5,
+            sub_spans: vec![VizeSubSpan {
+                gen_range: 0..7,
+                src_range: 0..5,
+            }],
+        }];
+
+        assert_eq!(
+            virtual_range_to_source(virtual_ts, source, &mappings, 0, 0, 0, 7),
+            Some((0, 0, 0, 5))
         );
     }
 

--- a/crates/vize_maestro/src/ide/jsx/service.rs
+++ b/crates/vize_maestro/src/ide/jsx/service.rs
@@ -176,12 +176,8 @@ impl JsxService {
         }
     }
 
-    /// Type diagnostics for a `.jsx`/`.tsx` document, surfaced from its virtual
-    /// TS through Corsa. Returned alongside the JSX compiler diagnostics.
-    ///
-    /// Each Corsa diagnostic is mapped from virtual-TS coordinates back to the
-    /// source via the byte-range mappings; diagnostics that don't map to any
-    /// user range (e.g. ones on the synthesized ambient preamble) are dropped.
+    /// Type diagnostics surfaced from JSX virtual TS through Corsa. Diagnostics
+    /// outside authored mappings (such as the ambient preamble) are dropped.
     pub async fn diagnostics(
         ctx: &IdeContext<'_>,
         corsa_bridge: Option<Arc<CorsaBridge>>,
@@ -246,6 +242,9 @@ impl JsxService {
                         3 => DiagnosticSeverity::INFORMATION,
                         _ => DiagnosticSeverity::HINT,
                     }),
+                    code: diag
+                        .code
+                        .map(crate::ide::diagnostics::corsa::corsa_diagnostic_code),
                     source: Some(sources::TYPE_CHECKER.to_string()),
                     message: diag.message,
                     ..Default::default()

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts.rs
@@ -28,6 +28,8 @@ use vize_relief::{
     expressions::{CompoundExpressionChild, CompoundExpressionNode},
 };
 
+mod component;
+
 /// Name of the synthesized helper that swallows every re-emitted JSX
 /// expression. Declaring it ambient and `any`-returning lets each argument be
 /// type-checked independently while the whole call stays a valid render return.
@@ -74,6 +76,7 @@ pub(in crate::ide) struct JsxExpr {
 enum JsxEmit {
     Expr(JsxExpr),
     ModelTarget(JsxExpr),
+    Component(component::JsxComponent),
     ForScope {
         source: JsxExpr,
         value_alias: Option<JsxExpr>,
@@ -95,7 +98,7 @@ pub(in crate::ide) fn collect_jsx_expressions(source: &str, lang: JsxLang) -> Ve
     let mut exprs = Vec::new();
     for root in &lowered.roots {
         let mut emits = Vec::new();
-        collect_root_expressions(&root.root, &mut emits);
+        collect_root_expressions(&root.root, &mut emits, false);
         collect_style_expressions(&root.scoped_style_exprs, &mut emits);
         flatten_emits(&emits, &mut exprs);
     }
@@ -117,7 +120,7 @@ pub(in crate::ide) fn generate_jsx_virtual_ts(source: &str, lang: JsxLang) -> Op
     let mut roots: Vec<(u32, u32, Vec<JsxEmit>)> = Vec::with_capacity(lowered.roots.len());
     for root in &lowered.roots {
         let mut emits = Vec::new();
-        collect_root_expressions(&root.root, &mut emits);
+        collect_root_expressions(&root.root, &mut emits, true);
         collect_style_expressions(&root.scoped_style_exprs, &mut emits);
         roots.push((root.root.loc.start.offset, root.root.loc.end.offset, emits));
     }
@@ -147,6 +150,12 @@ fn render_plain_ts(source: &str, roots: &[(u32, u32, Vec<JsxEmit>)]) -> (String,
     // `emit`/`slots` usages in the setup body and JSX expressions type-check.
     // Mirrors the canon batch path so the LSP virtual TS matches the checker.
     out.push_str(CTX_HELPER);
+    if roots
+        .iter()
+        .any(|(_, _, emits)| emits.iter().any(emit_contains_component))
+    {
+        out.push_str(component::HELPER);
+    }
 
     let mut cursor = 0usize;
     for (start, end, emits) in roots {
@@ -195,6 +204,7 @@ fn render_emit(out: &mut String, mappings: &mut Vec<VizeMapping>, emit: &JsxEmit
             out.push_str(&expr.content);
             out.push(')');
         }
+        JsxEmit::Component(component) => component::render(out, mappings, component),
         JsxEmit::ForScope {
             source,
             value_alias,
@@ -217,6 +227,14 @@ fn render_emit(out: &mut String, mappings: &mut Vec<VizeMapping>, emit: &JsxEmit
             render_sink_call(out, mappings, body);
             out.push(')');
         }
+    }
+}
+
+fn emit_contains_component(emit: &JsxEmit) -> bool {
+    match emit {
+        JsxEmit::Component(_) => true,
+        JsxEmit::ForScope { body, .. } => body.iter().any(emit_contains_component),
+        JsxEmit::Expr(_) | JsxEmit::ModelTarget(_) => false,
     }
 }
 
@@ -259,9 +277,13 @@ fn push_verbatim(
 // batch jsx_codegen walker.
 // ---------------------------------------------------------------------------
 
-fn collect_root_expressions(root: &RootNode<'_>, out: &mut Vec<JsxEmit>) {
+fn collect_root_expressions(
+    root: &RootNode<'_>,
+    out: &mut Vec<JsxEmit>,
+    preserve_components: bool,
+) {
     for child in &root.children {
-        collect_child(child, out);
+        collect_child(child, out, preserve_components);
     }
 }
 
@@ -273,14 +295,23 @@ fn collect_style_expressions(style_exprs: &[StyleExprSpan], out: &mut Vec<JsxEmi
     }
 }
 
-fn collect_child(child: &TemplateChildNode<'_>, out: &mut Vec<JsxEmit>) {
+fn collect_child(child: &TemplateChildNode<'_>, out: &mut Vec<JsxEmit>, preserve_components: bool) {
     match child {
         TemplateChildNode::Element(element) => {
+            let semantic_component = preserve_components
+                .then(|| component::collect(element))
+                .flatten();
+            let has_semantic_component = semantic_component.is_some();
+            if let Some(component) = semantic_component {
+                out.push(JsxEmit::Component(component));
+            }
             for prop in &element.props {
-                collect_prop(prop, out);
+                if !has_semantic_component || !component::captures_prop(element, prop) {
+                    collect_prop(prop, out);
+                }
             }
             for child in &element.children {
-                collect_child(child, out);
+                collect_child(child, out, preserve_components);
             }
         }
         TemplateChildNode::Interpolation(interpolation) => {
@@ -295,7 +326,7 @@ fn collect_child(child: &TemplateChildNode<'_>, out: &mut Vec<JsxEmit>) {
                     collect_expression(condition, out);
                 }
                 for child in &branch.children {
-                    collect_child(child, out);
+                    collect_child(child, out, preserve_components);
                 }
             }
         }
@@ -304,19 +335,19 @@ fn collect_child(child: &TemplateChildNode<'_>, out: &mut Vec<JsxEmit>) {
                 collect_expression(condition, out);
             }
             for child in &branch.children {
-                collect_child(child, out);
+                collect_child(child, out, preserve_components);
             }
         }
         TemplateChildNode::For(node) => {
             let Some(source) = expr_of(&node.source) else {
                 for child in &node.children {
-                    collect_child(child, out);
+                    collect_child(child, out, preserve_components);
                 }
                 return;
             };
             let mut body = Vec::new();
             for child in &node.children {
-                collect_child(child, &mut body);
+                collect_child(child, &mut body, preserve_components);
             }
             out.push(JsxEmit::ForScope {
                 source,
@@ -472,171 +503,11 @@ fn flatten_emits(emits: &[JsxEmit], out: &mut Vec<JsxExpr>) {
                 }
                 flatten_emits(body, out);
             }
+            JsxEmit::Component(_) => {}
         }
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::ops::Range;
-
-    use crate::ide::jsx::position::source_offset_to_virtual_position;
-
-    fn generate(source: &str) -> JsxVirtualTs {
-        generate_jsx_virtual_ts(source, JsxLang::Tsx).unwrap()
-    }
-
-    fn assert_virtual_ts_snapshot(name: &str, source: &str) {
-        let generated = generate(source);
-        insta::assert_snapshot!(format!("{name}_code"), generated.code.as_str());
-        insta::assert_debug_snapshot!(
-            format!("{name}_mappings"),
-            mapping_summary(source, &generated)
-        );
-    }
-
-    fn mapping_summary<'a>(
-        source: &'a str,
-        generated: &'a JsxVirtualTs,
-    ) -> Vec<MappingSummary<'a>> {
-        generated
-            .mappings
-            .iter()
-            .map(|mapping| MappingSummary {
-                generated: &generated.code[mapping.gen_range.clone()],
-                source: &source[mapping.src_range.clone()],
-                gen_range: mapping.gen_range.clone(),
-                src_range: mapping.src_range.clone(),
-            })
-            .collect()
-    }
-
-    #[allow(dead_code)]
-    #[derive(Debug)]
-    struct MappingSummary<'a> {
-        generated: &'a str,
-        source: &'a str,
-        gen_range: Range<usize>,
-        src_range: Range<usize>,
-    }
-
-    fn virtual_positions_for_markers(
-        source: &str,
-        generated: &JsxVirtualTs,
-        markers: &[&str],
-    ) -> Vec<VirtualPosition> {
-        markers
-            .iter()
-            .map(|marker| {
-                let source_offset = source
-                    .match_indices(marker)
-                    .map(|(offset, _)| offset)
-                    .next()
-                    .expect("marker present");
-                let position = source_offset_to_virtual_position(
-                    &generated.code,
-                    &generated.mappings,
-                    source_offset,
-                )
-                .expect("marker maps into virtual TS");
-
-                VirtualPosition {
-                    marker: (*marker).to_string(),
-                    source_offset,
-                    source: source[source_offset..source_offset + marker.len()].to_string(),
-                    position,
-                }
-            })
-            .collect()
-    }
-
-    #[allow(dead_code)]
-    #[derive(Debug)]
-    struct VirtualPosition {
-        marker: String,
-        source_offset: usize,
-        source: String,
-        position: (u32, u32),
-    }
-
-    #[test]
-    fn typed_component_with_jsx_control_flow_directives_and_styles_is_exact() {
-        let source = "import { computed, ref } from 'vue';\n\nconst Comp = (\n  { items, ok, tone, gap }: { items: Array<{ id: string; label: string }>; ok: boolean; tone: string; gap: number },\n  { emit, slots }: Ctx<{ select: [id: string] }, { footer: () => unknown }>,\n) => {\n  const selected = ref(items[0]?.id);\n  const activeItem = computed(() => items.find((item) => item.id === selected.value));\n  return (\n    <>\n      <ul class={tone} v-show={ok}>\n        {items.map((item, index) => (\n          <li key={item.id} onClick={() => emit('select', item.id)} data-index={index}>\n            {item.label}{selected.value === item.id ? <strong>Selected</strong> : <em>{index}</em>}\n          </li>\n        ))}\n      </ul>\n      <input v-model={selected.value} v-focus:lazy={tone} />\n      <footer>{activeItem.value?.label}{slots.footer()}</footer>\n      <style scoped>{`.row { gap: ${gap}px; }`}</style>\n    </>\n  );\n};\n";
-
-        assert_virtual_ts_snapshot(
-            "typed_component_with_jsx_control_flow_directives_and_styles",
-            source,
-        );
-        let generated = generate(source);
-        insta::assert_debug_snapshot!(
-            "typed_component_with_jsx_control_flow_directives_and_styles_positions",
-            virtual_positions_for_markers(
-                source,
-                &generated,
-                &[
-                    "items.map",
-                    "tone} v-show",
-                    "ok}>",
-                    "item.id",
-                    "emit('select', item.id)",
-                    "item.label",
-                    "selected.value === item.id",
-                    "index",
-                    "selected.value} v-focus",
-                    "activeItem.value?.label",
-                    "slots.footer()",
-                    "gap}px",
-                ],
-            )
-        );
-    }
-
-    #[test]
-    fn multiple_roots_and_static_style_are_exact() {
-        let source = "const First = (props: { msg: string }) => <section>{props.msg}</section>;\nconst Second = () => (\n  <>\n    <div class=\"box\" />\n    <style scoped>{`.box { color: red; }`}</style>\n  </>\n);\n";
-
-        assert_virtual_ts_snapshot("multiple_roots_and_static_style", source);
-    }
-
-    #[test]
-    fn jsx_file_mode_is_exact() {
-        let source =
-            "export const Plain = ({ msg }) => <button onClick={() => save(msg)}>{msg}</button>;\n";
-        let generated = generate_jsx_virtual_ts(source, JsxLang::Jsx).unwrap();
-
-        insta::assert_snapshot!("jsx_file_mode_code", generated.code.as_str());
-        insta::assert_debug_snapshot!(
-            "jsx_file_mode_mappings",
-            mapping_summary(source, &generated)
-        );
-    }
-
-    #[test]
-    fn collect_jsx_expressions_includes_for_body_model_and_style_exprs() {
-        let source = "const Comp = (props: { items: string[]; color: string }) => (\n  <>\n    {props.items.map((item) => <span>{item}</span>)}\n    <input v-model={props.color} />\n    <style scoped>{`.box { color: ${props.color}; }`}</style>\n  </>\n);\n";
-        let exprs = collect_jsx_expressions(source, JsxLang::Tsx)
-            .into_iter()
-            .map(|expr| ExprSummary {
-                content: expr.content,
-                source: source[expr.start as usize..expr.end as usize].to_string(),
-                start: expr.start,
-                end: expr.end,
-            })
-            .collect::<Vec<_>>();
-
-        insta::assert_debug_snapshot!(
-            "collect_jsx_expressions_includes_for_body_model_and_style_exprs",
-            exprs
-        );
-    }
-
-    #[allow(dead_code)]
-    #[derive(Debug)]
-    struct ExprSummary {
-        content: String,
-        source: String,
-        start: u32,
-        end: u32,
-    }
-}
+#[path = "virtual_ts_tests.rs"]
+mod tests;

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts/component.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts/component.rs
@@ -1,24 +1,12 @@
-//! Semantic JSX component calls for the plain-TypeScript check document.
-//!
-//! JSX lowering keeps a rich component/prop tree, but the original check
-//! codegen retained only dynamic expressions. This module turns component
-//! elements into type-only calls whose props parameter comes from the imported
-//! SFC constructor or local function component contract.
+//! Semantic JSX component calls for the editor's plain-TypeScript document.
 
-use std::vec::Vec;
-
-use vize_carton::{String as CompactString, ToCompactString};
 use vize_relief::{ElementNode, ElementType, ExpressionNode, PropNode};
 
-use crate::virtual_ts::{VizeMapping, VizeSubSpan};
+use vize_canon::virtual_ts::{VizeMapping, VizeSubSpan};
 
 use super::{JsxExpr, push_mapped_expr};
 
-/// Type-only component invocation. The constructor branch consumes the
-/// `$props` contract exported by generated SFC modules; the function branch
-/// covers locally declared functional components. Unknown component shapes
-/// remain a permissive fallback instead of introducing false positives.
-pub(super) const HELPER: &str = crate::virtual_ts::JSX_COMPONENT_HELPER;
+pub(super) const HELPER: &str = vize_canon::virtual_ts::JSX_COMPONENT_HELPER;
 
 pub(super) struct JsxComponent {
     tag: JsxExpr,
@@ -41,7 +29,7 @@ enum JsxComponentProp {
 
 enum PropName {
     Static {
-        content: CompactString,
+        content: String,
         start: u32,
         end: u32,
     },
@@ -66,9 +54,8 @@ pub(super) fn collect(element: &ElementNode<'_>) -> Option<JsxComponent> {
     Some(JsxComponent { tag, props })
 }
 
-/// Whether `component_prop` already preserves this prop. Props that do not
-/// participate in the component contract continue through the general JSX
-/// expression collector so directive/model expressions are never lost.
+/// Whether the semantic call already preserves this prop. Other directives
+/// continue through the expression collector so model/lvalue checks survive.
 pub(super) fn captures_prop(element: &ElementNode<'_>, prop: &PropNode<'_>) -> bool {
     match prop {
         PropNode::Attribute(attribute) => !is_reserved_prop(attribute.name.as_str()),
@@ -90,11 +77,7 @@ pub(super) fn captures_prop(element: &ElementNode<'_>, prop: &PropNode<'_>) -> b
     }
 }
 
-pub(super) fn render(
-    out: &mut CompactString,
-    mappings: &mut Vec<VizeMapping>,
-    component: &JsxComponent,
-) {
+pub(super) fn render(out: &mut String, mappings: &mut Vec<VizeMapping>, component: &JsxComponent) {
     out.push_str("__vize_jsx_component__(");
     push_mapped_expr(out, mappings, &component.tag);
     out.push_str(", ");
@@ -116,7 +99,7 @@ pub(super) fn render(
     out.push(')');
 }
 
-fn render_prop(out: &mut CompactString, mappings: &mut Vec<VizeMapping>, prop: &JsxComponentProp) {
+fn render_prop(out: &mut String, mappings: &mut Vec<VizeMapping>, prop: &JsxComponentProp) {
     match prop {
         JsxComponentProp::Property {
             name,
@@ -129,9 +112,7 @@ fn render_prop(out: &mut CompactString, mappings: &mut Vec<VizeMapping>, prop: &
             out.push_str(": ");
             match value {
                 PropValue::Boolean => out.push_str("true"),
-                PropValue::Expression(expression) => {
-                    push_mapped_expr(out, mappings, expression);
-                }
+                PropValue::Expression(expression) => push_mapped_expr(out, mappings, expression),
             }
             let entry_end = out.len();
             mappings.push(VizeMapping {
@@ -167,7 +148,7 @@ fn render_prop(out: &mut CompactString, mappings: &mut Vec<VizeMapping>, prop: &
 }
 
 fn render_name(
-    out: &mut CompactString,
+    out: &mut String,
     mappings: &mut Vec<VizeMapping>,
     name: &PropName,
 ) -> (
@@ -212,7 +193,7 @@ fn component_tag(element: &ElementNode<'_>) -> Option<JsxExpr> {
 
     let start = element.loc.start.offset.saturating_add(1);
     Some(JsxExpr {
-        content: element.tag.as_str().to_compact_string(),
+        content: element.tag.as_str().to_string(),
         start,
         end: start.saturating_add(element.tag.len() as u32),
     })
@@ -291,12 +272,8 @@ fn is_reserved_prop(name: &str) -> bool {
     matches!(name, "key" | "ref")
 }
 
-/// JSX accepts Vue's kebab aliases, while the generated SFC exposes its raw
-/// required contract under camelCase keys. Canonicalizing the authored key lets
-/// the helper intersect `$props` with that raw contract without making both
-/// spellings optional (which would silently lose required props).
-fn canonical_prop_name(name: &str) -> CompactString {
-    let mut out = CompactString::default();
+fn canonical_prop_name(name: &str) -> String {
+    let mut out = String::new();
     let mut uppercase_next = false;
     for ch in name.chars() {
         if ch == '-' {
@@ -311,8 +288,6 @@ fn canonical_prop_name(name: &str) -> CompactString {
     out
 }
 
-fn json_string(value: &str) -> CompactString {
-    serde_json::to_string(value)
-        .expect("serializing a Rust string to JSON cannot fail")
-        .to_compact_string()
+fn json_string(value: &str) -> String {
+    serde_json::to_string(value).expect("serializing a Rust string to JSON cannot fail")
 }

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts_tests.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts_tests.rs
@@ -1,0 +1,178 @@
+use std::ops::Range;
+
+use super::*;
+use crate::ide::jsx::position::source_offset_to_virtual_position;
+
+fn generate(source: &str) -> JsxVirtualTs {
+    generate_jsx_virtual_ts(source, JsxLang::Tsx).unwrap()
+}
+
+fn assert_virtual_ts_snapshot(name: &str, source: &str) {
+    let generated = generate(source);
+    insta::assert_snapshot!(format!("{name}_code"), generated.code.as_str());
+    insta::assert_debug_snapshot!(
+        format!("{name}_mappings"),
+        mapping_summary(source, &generated)
+    );
+}
+
+fn mapping_summary<'a>(source: &'a str, generated: &'a JsxVirtualTs) -> Vec<MappingSummary<'a>> {
+    generated
+        .mappings
+        .iter()
+        .map(|mapping| MappingSummary {
+            generated: &generated.code[mapping.gen_range.clone()],
+            source: &source[mapping.src_range.clone()],
+            gen_range: mapping.gen_range.clone(),
+            src_range: mapping.src_range.clone(),
+        })
+        .collect()
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+struct MappingSummary<'a> {
+    generated: &'a str,
+    source: &'a str,
+    gen_range: Range<usize>,
+    src_range: Range<usize>,
+}
+
+fn virtual_positions_for_markers(
+    source: &str,
+    generated: &JsxVirtualTs,
+    markers: &[&str],
+) -> Vec<VirtualPosition> {
+    markers
+        .iter()
+        .map(|marker| {
+            let source_offset = source
+                .match_indices(marker)
+                .map(|(offset, _)| offset)
+                .next()
+                .expect("marker present");
+            let position = source_offset_to_virtual_position(
+                &generated.code,
+                &generated.mappings,
+                source_offset,
+            )
+            .expect("marker maps into virtual TS");
+
+            VirtualPosition {
+                marker: (*marker).to_string(),
+                source_offset,
+                source: source[source_offset..source_offset + marker.len()].to_string(),
+                position,
+            }
+        })
+        .collect()
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+struct VirtualPosition {
+    marker: String,
+    source_offset: usize,
+    source: String,
+    position: (u32, u32),
+}
+
+#[test]
+fn typed_component_with_jsx_control_flow_directives_and_styles_is_exact() {
+    let source = "import { computed, ref } from 'vue';\n\nconst Comp = (\n  { items, ok, tone, gap }: { items: Array<{ id: string; label: string }>; ok: boolean; tone: string; gap: number },\n  { emit, slots }: Ctx<{ select: [id: string] }, { footer: () => unknown }>,\n) => {\n  const selected = ref(items[0]?.id);\n  const activeItem = computed(() => items.find((item) => item.id === selected.value));\n  return (\n    <>\n      <ul class={tone} v-show={ok}>\n        {items.map((item, index) => (\n          <li key={item.id} onClick={() => emit('select', item.id)} data-index={index}>\n            {item.label}{selected.value === item.id ? <strong>Selected</strong> : <em>{index}</em>}\n          </li>\n        ))}\n      </ul>\n      <input v-model={selected.value} v-focus:lazy={tone} />\n      <footer>{activeItem.value?.label}{slots.footer()}</footer>\n      <style scoped>{`.row { gap: ${gap}px; }`}</style>\n    </>\n  );\n};\n";
+
+    assert_virtual_ts_snapshot(
+        "typed_component_with_jsx_control_flow_directives_and_styles",
+        source,
+    );
+    let generated = generate(source);
+    insta::assert_debug_snapshot!(
+        "typed_component_with_jsx_control_flow_directives_and_styles_positions",
+        virtual_positions_for_markers(
+            source,
+            &generated,
+            &[
+                "items.map",
+                "tone} v-show",
+                "ok}>",
+                "item.id",
+                "emit('select', item.id)",
+                "item.label",
+                "selected.value === item.id",
+                "index",
+                "selected.value} v-focus",
+                "activeItem.value?.label",
+                "slots.footer()",
+                "gap}px",
+            ],
+        )
+    );
+}
+
+#[test]
+fn multiple_roots_and_static_style_are_exact() {
+    let source = "const First = (props: { msg: string }) => <section>{props.msg}</section>;\nconst Second = () => (\n  <>\n    <div class=\"box\" />\n    <style scoped>{`.box { color: red; }`}</style>\n  </>\n);\n";
+
+    assert_virtual_ts_snapshot("multiple_roots_and_static_style", source);
+}
+
+#[test]
+fn jsx_file_mode_is_exact() {
+    let source =
+        "export const Plain = ({ msg }) => <button onClick={() => save(msg)}>{msg}</button>;\n";
+    let generated = generate_jsx_virtual_ts(source, JsxLang::Jsx).unwrap();
+
+    insta::assert_snapshot!("jsx_file_mode_code", generated.code.as_str());
+    insta::assert_debug_snapshot!(
+        "jsx_file_mode_mappings",
+        mapping_summary(source, &generated)
+    );
+}
+
+#[test]
+fn component_tags_props_and_spreads_survive_editor_lowering() {
+    let source = "import Counter from './Counter.vue';\nconst props = { count: 'wrong' };\nexport const view = <Counter {...props} is-opened />;\n";
+    let generated = generate(source);
+
+    assert!(generated.code.contains(component::HELPER));
+    assert!(generated.code.contains(
+        "__vize_jsx_component__(Counter, {...__vize_jsx_component_spread__(props), \"isOpened\": true})"
+    ));
+    for authored in ["Counter", "props", "is-opened"] {
+        assert!(generated.mappings.iter().any(|mapping| {
+            &source[mapping.src_range.clone()] == authored
+                || mapping
+                    .sub_spans
+                    .iter()
+                    .any(|span| &source[span.src_range.clone()] == authored)
+        }));
+    }
+}
+
+#[test]
+fn collect_jsx_expressions_includes_for_body_model_and_style_exprs() {
+    let source = "const Comp = (props: { items: string[]; color: string }) => (\n  <>\n    {props.items.map((item) => <span>{item}</span>)}\n    <input v-model={props.color} />\n    <style scoped>{`.box { color: ${props.color}; }`}</style>\n  </>\n);\n";
+    let exprs = collect_jsx_expressions(source, JsxLang::Tsx)
+        .into_iter()
+        .map(|expr| ExprSummary {
+            content: expr.content,
+            source: source[expr.start as usize..expr.end as usize].to_string(),
+            start: expr.start,
+            end: expr.end,
+        })
+        .collect::<Vec<_>>();
+
+    insta::assert_debug_snapshot!(
+        "collect_jsx_expressions_includes_for_body_model_and_style_exprs",
+        exprs
+    );
+}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+struct ExprSummary {
+    content: String,
+    source: String,
+    start: u32,
+    end: u32,
+}

--- a/tests/tooling/lsp-typecheck-jsx-component.test.ts
+++ b/tests/tooling/lsp-typecheck-jsx-component.test.ts
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
+
+test("vize lsp enforces and repairs imported SFC props in TSX and checkJs JSX", async (t) => {
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTsgoBinary(),
+    "tsgo binary for the TSX component LSP gate",
+    "tsgo binary not found; skipping TSX component LSP test",
+  );
+  if (corsaPath == null) return;
+
+  const testRootDir = path.join(testOutputRoot, "lsp-typecheck-jsx-component");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    const sourceDir = path.join(workspaceDir, "src");
+    fs.mkdirSync(sourceDir, { recursive: true });
+    const vuePackage = resolveVuePackage();
+    if (vuePackage == null) {
+      writeVueShim(workspaceDir);
+    } else {
+      linkVuePackage(workspaceDir, vuePackage);
+    }
+    fs.writeFileSync(
+      path.join(workspaceDir, "vize.config.json"),
+      JSON.stringify({
+        lsp: { lint: false, typecheck: true },
+        typeChecker: { corsaPath, jsxTypecheck: true },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          allowJs: true,
+          checkJs: true,
+          jsx: "preserve",
+          jsxImportSource: "vue",
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src/**/*"],
+      }),
+      "utf8",
+    );
+
+    const counter = `<script setup lang="ts">
+defineProps<{ count: number }>()
+</script>
+`;
+    const broken = `import Counter from "./Counter.vue";
+export const view = <Counter count="wrong" />;
+`;
+    const repaired = broken.replace('count="wrong"', "count={1}");
+    const spreadBroken = `import Counter from "./Counter.vue";
+const props = { count: "wrong" };
+export const view = <Counter {...props} />;
+`;
+    const spreadRepaired = spreadBroken.replace('count: "wrong"', "count: 1");
+    const counterPath = path.join(sourceDir, "Counter.vue");
+    const consumerPath = path.join(sourceDir, "Consumer.tsx");
+    const counterUri = pathToFileURL(counterPath).href;
+    const consumerUri = pathToFileURL(consumerPath).href;
+    fs.writeFileSync(counterPath, counter, "utf8");
+    fs.writeFileSync(consumerPath, broken, "utf8");
+
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: true,
+    });
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri: counterUri, languageId: "vue", version: 1, text: counter },
+    });
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, counterUri),
+    );
+    session.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: consumerUri,
+        languageId: "typescriptreact",
+        version: 1,
+        text: broken,
+      },
+    });
+
+    const invalid = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, consumerUri),
+    )) as PublishDiagnosticsParams;
+    const propOffset = broken.indexOf("count=");
+    assert.notEqual(propOffset, -1);
+    const propStart = offsetToPosition(broken, propOffset);
+    assert.deepEqual(invalid.diagnostics, [
+      {
+        code: 2322,
+        message: "Type 'string' is not assignable to type 'number'.",
+        range: {
+          start: propStart,
+          end: { line: propStart.line, character: propStart.character + "count".length },
+        },
+        severity: 1,
+        source: "vize/types",
+      },
+    ]);
+
+    session.notify("textDocument/didChange", {
+      textDocument: { uri: consumerUri, version: 2 },
+      contentChanges: [{ text: repaired }],
+    });
+    const clean = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) =>
+        isDiagnosticsForUri(params, consumerUri) &&
+        params.version === 2 &&
+        params.diagnostics.length === 0,
+    )) as PublishDiagnosticsParams;
+    assert.deepEqual(clean.diagnostics, []);
+
+    session.notify("textDocument/didChange", {
+      textDocument: { uri: consumerUri, version: 3 },
+      contentChanges: [{ text: spreadBroken }],
+    });
+    const spreadInvalid = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) =>
+        isDiagnosticsForUri(params, consumerUri) &&
+        params.version === 3 &&
+        params.diagnostics.some((diagnostic) => diagnostic.message?.includes("not assignable")),
+    )) as PublishDiagnosticsParams;
+    assert.equal(spreadInvalid.diagnostics.length, 1, JSON.stringify(spreadInvalid));
+    assert.match(
+      spreadInvalid.diagnostics[0]?.message ?? "",
+      /count.*string.*number|not assignable/,
+    );
+    assert.equal(spreadInvalid.diagnostics[0]?.severity, 1);
+    assert.equal(spreadInvalid.diagnostics[0]?.source, "vize/types");
+
+    session.notify("textDocument/didChange", {
+      textDocument: { uri: consumerUri, version: 4 },
+      contentChanges: [{ text: spreadRepaired }],
+    });
+    const spreadClean = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) =>
+        isDiagnosticsForUri(params, consumerUri) &&
+        params.version === 4 &&
+        params.diagnostics.length === 0,
+    )) as PublishDiagnosticsParams;
+    assert.deepEqual(spreadClean.diagnostics, []);
+
+    const jsxBroken = `import Counter from "./Counter.vue";
+export const view = <Counter count="wrong" />;
+`;
+    const jsxRepaired = jsxBroken.replace('count="wrong"', "count={1}");
+    const jsxPath = path.join(sourceDir, "Consumer.jsx");
+    const jsxUri = pathToFileURL(jsxPath).href;
+    fs.writeFileSync(jsxPath, jsxBroken, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: jsxUri,
+        languageId: "javascriptreact",
+        version: 1,
+        text: jsxBroken,
+      },
+    });
+    const invalidJsx = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, jsxUri),
+    )) as PublishDiagnosticsParams;
+    const jsxPropOffset = jsxBroken.indexOf("count=");
+    assert.notEqual(jsxPropOffset, -1);
+    const jsxPropStart = offsetToPosition(jsxBroken, jsxPropOffset);
+    assert.deepEqual(invalidJsx.diagnostics, [
+      {
+        code: 2322,
+        message: "Type 'string' is not assignable to type 'number'.",
+        range: {
+          start: jsxPropStart,
+          end: {
+            line: jsxPropStart.line,
+            character: jsxPropStart.character + "count".length,
+          },
+        },
+        severity: 1,
+        source: "vize/types",
+      },
+    ]);
+
+    session.notify("textDocument/didChange", {
+      textDocument: { uri: jsxUri, version: 2 },
+      contentChanges: [{ text: jsxRepaired }],
+    });
+    const cleanJsx = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) =>
+        isDiagnosticsForUri(params, jsxUri) &&
+        params.version === 2 &&
+        params.diagnostics.length === 0,
+    )) as PublishDiagnosticsParams;
+    assert.deepEqual(cleanJsx.diagnostics, []);
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+function resolveTsgoBinary(): string | undefined {
+  const candidates = [
+    path.join(root, "../corsa-bind/.cache/tsgo"),
+    path.join(root, "node_modules/.bin/tsgo"),
+    path.join(root, "tests/node_modules/.bin/tsgo"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function resolveVuePackage(): string | undefined {
+  const candidates = [
+    path.join(root, "node_modules/vue"),
+    path.join(root, "tests/node_modules/vue"),
+    path.join(root, "playground/node_modules/vue"),
+    path.join(root, "examples/jsx-tsx/node_modules/vue"),
+  ];
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function linkVuePackage(workspaceDir: string, vuePackage: string): void {
+  const nodeModules = path.join(workspaceDir, "node_modules");
+  fs.mkdirSync(nodeModules, { recursive: true });
+  symlink(vuePackage, path.join(nodeModules, "vue"));
+
+  const vueNamespace = path.join(path.dirname(vuePackage), "@vue");
+  if (fs.existsSync(vueNamespace)) {
+    symlink(vueNamespace, path.join(nodeModules, "@vue"));
+  }
+}
+
+function symlink(source: string, target: string): void {
+  fs.rmSync(target, { force: true, recursive: true });
+  fs.symlinkSync(source, target, process.platform === "win32" ? "junction" : "dir");
+}
+
+function writeVueShim(workspaceDir: string): void {
+  fs.writeFileSync(
+    path.join(workspaceDir, "src/vue-shim.d.ts"),
+    `declare module "vue" {
+  export interface Ref<T = any> { value: T }
+  export interface ShallowRef<T = any> { value: T }
+  export type DefineComponent<Props = {}> = new () => { $props: Props }
+  export interface ComponentPublicInstance {
+    $attrs: Record<string, unknown>
+    $slots: Record<string, unknown>
+    $refs: Record<string, unknown>
+    $emit: (...args: any[]) => void
+  }
+  export interface GlobalComponents {}
+}
+`,
+    "utf8",
+  );
+}


### PR DESCRIPTION
## Summary

- preserve component tags plus static, bound, kebab-case, member, local, and spread props in the JSX/TSX plain-TypeScript document used by the LSP
- preserve TypeScript diagnostic codes and authored prop-name sub-span mappings instead of reporting only broad generated ranges
- share the component type helper with the batch checker and keep structural semantic-token extraction unchanged
- cover imported SFC props through the production LSP with TSX and checkJs JSX broken/repair cycles

## Validation

- `cargo test -p vize_maestro --lib` — 749 passed, 2 ignored
- `cargo test -p vize_canon --lib jsx_codegen` — 4 passed
- `cargo clippy -p vize_maestro --lib -- -D warnings`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- source-length ratchet against `5de2f09b1` — 7 passed
- production LSP tests — 5 passed, including TSX/checkJs JSX, dependent SFC edits, and watcher create/delete

## Post-implementation audit

- The original false negative is closed for LSP diagnostics: invalid imported-SFC props now report TS2322 at the authored prop name and clear after repair.
- The render logic still has batch/editor owners. The shared helper removes one drift source, while the shared semantic representation remains tracked by #4033.
- #4042 remains open for children/slot contracts, component v-model semantics, completion/navigation parity, and create/edit/rename/delete revalidation of this import edge.
- The pre-existing non-native Maestro feature build failure discovered by the matrix audit is isolated in #4045.

Refs #4042, #4033, #3953, #3954.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->