### PR TITLE
fix(lsp): synchronize JSX Vue dependency graphs

### DIFF
--- a/crates/vize_canon/src/corsa_bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge.rs
@@ -5,6 +5,9 @@
 //! behind the bridge surface.
 
 mod bridge;
+mod script_document;
+#[cfg(test)]
+mod script_document_tests;
 mod session;
 mod types;
 mod vue_dependencies;

--- a/crates/vize_canon/src/corsa_bridge/script_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/script_document.rs
@@ -1,0 +1,70 @@
+//! Script-host synchronization for editor Corsa sessions.
+
+use std::path::{Path, PathBuf};
+
+use oxc_span::SourceType;
+use vize_carton::{FxHashMap, String};
+
+use super::bridge::{CorsaBridge, normalize_document_uri};
+use super::types::CorsaBridgeError;
+use super::vue_dependencies::collect_script_dependency_documents;
+use super::vue_document::CorsaVueVirtualDocumentOptions;
+use crate::batch::ImportRewriter;
+
+impl CorsaBridge {
+    /// Open a generated TS/JS host together with every reachable Vue virtual
+    /// document, using the same graph materialization as an SFC host.
+    pub async fn open_script_virtual_document_with_vue_dependencies(
+        &self,
+        source_path: &Path,
+        request_path: &str,
+        code: &str,
+        source_type: SourceType,
+        options: CorsaVueVirtualDocumentOptions,
+        overlays: &[(PathBuf, &str)],
+    ) -> Result<String, CorsaBridgeError> {
+        let (request_uri, documents) = build_script_virtual_project(
+            source_path,
+            request_path,
+            code,
+            source_type,
+            options,
+            overlays,
+        );
+        self.open_virtual_documents_batch(&documents).await?;
+        Ok(request_uri)
+    }
+}
+
+pub(super) fn build_script_virtual_project(
+    source_path: &Path,
+    request_path: &str,
+    code: &str,
+    source_type: SourceType,
+    options: CorsaVueVirtualDocumentOptions,
+    overlays: &[(PathBuf, &str)],
+) -> (String, Vec<(String, String)>) {
+    let rewriter = ImportRewriter::new();
+    let overlays = overlays
+        .iter()
+        .map(|(path, content)| {
+            let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+            (key, *content)
+        })
+        .collect::<FxHashMap<_, _>>();
+    let alias_context =
+        super::vue_dependencies_alias::AliasContext::for_host_cached(source_path, code, &overlays);
+    let request_uri = normalize_document_uri(request_path);
+    let mut documents = vec![(request_uri.clone(), code.into())];
+    collect_script_dependency_documents(
+        &mut documents,
+        source_path,
+        code,
+        source_type,
+        options,
+        &rewriter,
+        &alias_context,
+        &overlays,
+    );
+    (request_uri, documents)
+}

--- a/crates/vize_canon/src/corsa_bridge/script_document_tests.rs
+++ b/crates/vize_canon/src/corsa_bridge/script_document_tests.rs
@@ -1,0 +1,42 @@
+use oxc_span::SourceType;
+
+use super::script_document::build_script_virtual_project;
+use super::vue_document::CorsaVueVirtualDocumentOptions;
+use crate::file_uri::path_to_file_uri;
+
+#[test]
+fn script_virtual_project_syncs_vue_dependencies_without_opening_the_sfc() {
+    let project = tempfile::TempDir::new().expect("temp project");
+    let host_path = project.path().join("Consumer.tsx");
+    let child_path = project.path().join("Counter.vue");
+    let source = "import Counter from './Counter.vue';\nexport const view = Counter;\n";
+    std::fs::write(&host_path, source).expect("host");
+    std::fs::write(
+        &child_path,
+        "<script setup lang=\"ts\">defineProps<{ count: number }>()</script>",
+    )
+    .expect("child");
+
+    let (request_uri, documents) = build_script_virtual_project(
+        &host_path,
+        host_path.with_extension("tsx.jsx.ts").to_str().unwrap(),
+        source,
+        SourceType::ts(),
+        CorsaVueVirtualDocumentOptions::default(),
+        &[],
+    );
+    let uris = documents
+        .iter()
+        .map(|(uri, _)| uri.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        request_uri,
+        path_to_file_uri(&host_path.with_extension("tsx.jsx.ts"))
+    );
+    assert!(uris.contains(&request_uri.as_str()), "{uris:?}");
+    assert!(
+        uris.contains(&path_to_file_uri(&child_path.with_extension("vue.ts")).as_str()),
+        "script hosts must materialize unopened Vue dependencies: {uris:?}",
+    );
+}

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -15,6 +15,9 @@ use super::vue_document::{
 use crate::batch::ImportRewriter;
 use crate::file_uri::path_to_file_uri;
 
+#[path = "vue_dependencies_walk.rs"]
+mod walk;
+
 const VUE_DEPENDENCY_FALLBACK: &str =
     "const component: any = undefined;\nexport default component;\n";
 
@@ -37,55 +40,55 @@ pub(super) fn collect_dependency_documents(
         pre_rewrite_code: host.generated.pre_rewrite_code.clone(),
     });
 
-    while let Some(scan) = queue.pop_front() {
-        match scan {
-            DependencyScan::Vue {
-                dir,
-                source_type,
-                pre_rewrite_code,
-            } => queue_imports(
-                ImportQueue {
-                    documents,
-                    dependencies,
-                    queue: &mut queue,
-                    visited_vue: &mut visited_vue,
-                    visited_ts: &mut visited_ts,
-                    overlays,
-                },
-                options,
-                rewriter,
-                alias_context,
-                &dir,
-                &pre_rewrite_code,
-                source_type,
-            ),
-            DependencyScan::Script {
-                path,
-                source_type,
-                content,
-            } => queue_imports(
-                ImportQueue {
-                    documents,
-                    dependencies,
-                    queue: &mut queue,
-                    visited_vue: &mut visited_vue,
-                    visited_ts: &mut visited_ts,
-                    overlays,
-                },
-                options,
-                rewriter,
-                alias_context,
-                &parent_dir(&path),
-                &content,
-                source_type,
-            ),
-        }
-    }
+    walk::collect_queued_documents(
+        documents,
+        Some(dependencies),
+        options,
+        rewriter,
+        alias_context,
+        overlays,
+        &mut visited_vue,
+        &mut visited_ts,
+        queue,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn collect_script_dependency_documents(
+    documents: &mut Vec<(String, String)>,
+    source_path: &Path,
+    code: &str,
+    source_type: SourceType,
+    options: CorsaVueVirtualDocumentOptions,
+    rewriter: &ImportRewriter,
+    alias_context: &super::vue_dependencies_alias::AliasContext,
+    overlays: &FxHashMap<PathBuf, &str>,
+) {
+    let mut visited_vue = FxHashSet::<PathBuf>::default();
+    let mut visited_ts = FxHashSet::<PathBuf>::default();
+    visited_ts.insert(source_path.to_path_buf());
+    let mut queue = VecDeque::new();
+    queue.push_back(DependencyScan::Script {
+        path: source_path.to_path_buf(),
+        source_type,
+        content: code.into(),
+    });
+    walk::collect_queued_documents(
+        documents,
+        None,
+        options,
+        rewriter,
+        alias_context,
+        overlays,
+        &mut visited_vue,
+        &mut visited_ts,
+        queue,
+    );
 }
 
 pub(super) struct ImportQueue<'a> {
     pub(super) documents: &'a mut Vec<(String, String)>,
-    pub(super) dependencies: &'a mut Vec<CorsaVueVirtualDependency>,
+    pub(super) dependencies: Option<&'a mut Vec<CorsaVueVirtualDependency>>,
     pub(super) queue: &'a mut VecDeque<DependencyScan>,
     pub(super) visited_vue: &'a mut FxHashSet<PathBuf>,
     pub(super) visited_ts: &'a mut FxHashSet<PathBuf>,
@@ -204,16 +207,18 @@ pub(super) fn queue_vue_dependency(
         source_type: generated.generated.source_type,
         pre_rewrite_code: generated.generated.pre_rewrite_code,
     });
-    imports.dependencies.push(CorsaVueVirtualDependency {
-        source_path: generated.source_path,
-        source: content,
-        request_uri: generated.virtual_uri,
-        code: generated_code,
-        mappings: generated.generated.mappings,
-        import_source_map: generated.generated.import_source_map,
-        source_type: generated.generated.source_type,
-        virtual_suffix: generated.generated.virtual_suffix,
-    });
+    if let Some(dependencies) = imports.dependencies.as_mut() {
+        dependencies.push(CorsaVueVirtualDependency {
+            source_path: generated.source_path,
+            source: content,
+            request_uri: generated.virtual_uri,
+            code: generated_code,
+            mappings: generated.generated.mappings,
+            import_source_map: generated.generated.import_source_map,
+            source_type: generated.generated.source_type,
+            virtual_suffix: generated.generated.virtual_suffix,
+        });
+    }
 }
 
 pub(super) fn fallback_vue_virtual_uri(path: &Path) -> String {

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_walk.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_walk.rs
@@ -1,0 +1,56 @@
+//! Breadth-first traversal shared by Vue and script virtual-document hosts.
+
+use std::collections::VecDeque;
+use std::path::PathBuf;
+
+use vize_carton::{FxHashMap, FxHashSet, String};
+
+use super::{DependencyScan, ImportQueue, parent_dir, queue_imports};
+use crate::batch::ImportRewriter;
+use crate::corsa_bridge::vue_document::{
+    CorsaVueVirtualDependency, CorsaVueVirtualDocumentOptions,
+};
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn collect_queued_documents(
+    documents: &mut Vec<(String, String)>,
+    mut dependencies: Option<&mut Vec<CorsaVueVirtualDependency>>,
+    options: CorsaVueVirtualDocumentOptions,
+    rewriter: &ImportRewriter,
+    alias_context: &crate::corsa_bridge::vue_dependencies_alias::AliasContext,
+    overlays: &FxHashMap<PathBuf, &str>,
+    visited_vue: &mut FxHashSet<PathBuf>,
+    visited_ts: &mut FxHashSet<PathBuf>,
+    mut queue: VecDeque<DependencyScan>,
+) {
+    while let Some(scan) = queue.pop_front() {
+        let (dir, source_type, code) = match scan {
+            DependencyScan::Vue {
+                dir,
+                source_type,
+                pre_rewrite_code,
+            } => (dir, source_type, pre_rewrite_code),
+            DependencyScan::Script {
+                path,
+                source_type,
+                content,
+            } => (parent_dir(&path), source_type, content),
+        };
+        queue_imports(
+            ImportQueue {
+                documents,
+                dependencies: dependencies.as_deref_mut(),
+                queue: &mut queue,
+                visited_vue,
+                visited_ts,
+                overlays,
+            },
+            options,
+            rewriter,
+            alias_context,
+            &dir,
+            &code,
+            source_type,
+        );
+    }
+}

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -140,7 +140,7 @@ impl CorsaBridge {
         Ok(project.host)
     }
 
-    async fn open_virtual_documents_batch(
+    pub(super) async fn open_virtual_documents_batch(
         &self,
         documents: &[(String, String)],
     ) -> Result<(), CorsaBridgeError> {

--- a/crates/vize_maestro/src/ide/jsx.rs
+++ b/crates/vize_maestro/src/ide/jsx.rs
@@ -38,6 +38,8 @@ mod references;
 mod rename;
 #[cfg(feature = "native")]
 mod service;
+#[cfg(feature = "native")]
+mod service_project;
 
 #[cfg(feature = "native")]
 pub use references::JsxReferencesService;

--- a/crates/vize_maestro/src/ide/jsx/service.rs
+++ b/crates/vize_maestro/src/ide/jsx/service.rs
@@ -77,11 +77,7 @@ impl JsxService {
         let virtual_ts = Self::virtual_ts(ctx)?;
         let (line, character) =
             source_offset_to_virtual_position(&virtual_ts.code, &virtual_ts.mappings, ctx.offset)?;
-        let request_path = Self::request_path(ctx.uri);
-        let uri = bridge
-            .open_or_update_virtual_document(&request_path, &virtual_ts.code)
-            .await
-            .ok()?;
+        let uri = super::service_project::open_virtual_project(ctx, bridge, &virtual_ts).await?;
         Some((virtual_ts, uri, line, character))
     }
 
@@ -192,10 +188,8 @@ impl JsxService {
             return vec![];
         };
 
-        let request_path = Self::request_path(ctx.uri);
-        let Ok(uri) = bridge
-            .open_or_update_virtual_document(&request_path, &virtual_ts.code)
-            .await
+        let Some(uri) =
+            super::service_project::open_virtual_project(ctx, &bridge, &virtual_ts).await
         else {
             return vec![];
         };

--- a/crates/vize_maestro/src/ide/jsx/service_project.rs
+++ b/crates/vize_maestro/src/ide/jsx/service_project.rs
@@ -1,0 +1,35 @@
+//! Canonical Corsa project synchronization for JSX/TSX editor requests.
+
+use oxc_span::SourceType;
+use vize_canon::{CorsaBridge, CorsaVueVirtualDocumentOptions};
+
+use super::service::JsxService;
+use super::virtual_ts::JsxVirtualTs;
+use crate::ide::IdeContext;
+
+pub(super) async fn open_virtual_project(
+    ctx: &IdeContext<'_>,
+    bridge: &CorsaBridge,
+    virtual_ts: &JsxVirtualTs,
+) -> Option<vize_carton::String> {
+    let source_path = ctx.uri.to_file_path().ok()?;
+    let cached_overlays = ctx.state.corsa_overlays();
+    let overlays = cached_overlays
+        .iter()
+        .map(|(path, content)| (path.clone(), &**content))
+        .collect::<Vec<_>>();
+    bridge
+        .open_script_virtual_document_with_vue_dependencies(
+            &source_path,
+            &JsxService::request_path(ctx.uri),
+            &virtual_ts.code,
+            SourceType::ts(),
+            CorsaVueVirtualDocumentOptions {
+                options_api: ctx.state.options_api_enabled(),
+                legacy_vue2: ctx.state.legacy_vue2_enabled(),
+            },
+            &overlays,
+        )
+        .await
+        .ok()
+}

--- a/tests/tooling/lsp-typecheck-jsx-component.test.ts
+++ b/tests/tooling/lsp-typecheck-jsx-component.test.ts
@@ -74,7 +74,6 @@ export const view = <Counter {...props} />;
     const spreadRepaired = spreadBroken.replace('count: "wrong"', "count: 1");
     const counterPath = path.join(sourceDir, "Counter.vue");
     const consumerPath = path.join(sourceDir, "Consumer.tsx");
-    const counterUri = pathToFileURL(counterPath).href;
     const consumerUri = pathToFileURL(consumerPath).href;
     fs.writeFileSync(counterPath, counter, "utf8");
     fs.writeFileSync(consumerPath, broken, "utf8");
@@ -84,12 +83,6 @@ export const view = <Counter {...props} />;
       lint: false,
       typecheck: true,
     });
-    session.notify("textDocument/didOpen", {
-      textDocument: { uri: counterUri, languageId: "vue", version: 1, text: counter },
-    });
-    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
-      isDiagnosticsForUri(params, counterUri),
-    );
     session.notify("textDocument/didOpen", {
       textDocument: {
         uri: consumerUri,


### PR DESCRIPTION
## Summary

- synchronize every reachable Vue virtual document when a JSX/TSX script host is opened in Corsa
- reuse the canonical Vue dependency walk for SFC and script hosts while avoiding unused mapping metadata on the script path
- make TSX and checkJs JSX prop diagnostics work without opening the imported SFC first

## Root cause

JSX editor requests opened only the generated script host. Imported Vue components entered the Corsa session only after the editor separately opened the SFC, so diagnostic correctness depended on tab-opening order and closed real project dependencies could remain unresolved.

## Impact

Type diagnostics, hover, completion, definition, references, and rename now query a script host and its reachable Vue graph from one canonical session snapshot. This also aligns the editor path with the dependency materialization used by batch checking.

Refs #4042
Refs #3953

## Validation

- cargo test -p vize_canon -p vize_maestro --lib
- cargo clippy -p vize_canon -p vize_maestro --lib -- -D warnings
- VIZE_TEST_REQUIRE_TSGO=1 node --test tests/tooling/lsp-typecheck-jsx-component.test.ts
- SOURCE_LENGTH_BASE_REF=ab729b35b5e4a800140ccf0c9e8fe18961b6257e node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->