### PR TITLE
fix(lsp): index JSX importer dependencies

### DIFF
--- a/crates/vize_canon/src/corsa_bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge.rs
@@ -5,6 +5,9 @@
 //! behind the bridge surface.
 
 mod bridge;
+mod script_document;
+#[cfg(test)]
+mod script_document_tests;
 mod session;
 mod types;
 mod vue_dependencies;

--- a/crates/vize_canon/src/corsa_bridge/script_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/script_document.rs
@@ -1,0 +1,70 @@
+//! Script-host synchronization for editor Corsa sessions.
+
+use std::path::{Path, PathBuf};
+
+use oxc_span::SourceType;
+use vize_carton::{FxHashMap, String};
+
+use super::bridge::{CorsaBridge, normalize_document_uri};
+use super::types::CorsaBridgeError;
+use super::vue_dependencies::collect_script_dependency_documents;
+use super::vue_document::CorsaVueVirtualDocumentOptions;
+use crate::batch::ImportRewriter;
+
+impl CorsaBridge {
+    /// Open a generated TS/JS host together with every reachable Vue virtual
+    /// document, using the same graph materialization as an SFC host.
+    pub async fn open_script_virtual_document_with_vue_dependencies(
+        &self,
+        source_path: &Path,
+        request_path: &str,
+        code: &str,
+        source_type: SourceType,
+        options: CorsaVueVirtualDocumentOptions,
+        overlays: &[(PathBuf, &str)],
+    ) -> Result<String, CorsaBridgeError> {
+        let (request_uri, documents) = build_script_virtual_project(
+            source_path,
+            request_path,
+            code,
+            source_type,
+            options,
+            overlays,
+        );
+        self.open_virtual_documents_batch(&documents).await?;
+        Ok(request_uri)
+    }
+}
+
+pub(super) fn build_script_virtual_project(
+    source_path: &Path,
+    request_path: &str,
+    code: &str,
+    source_type: SourceType,
+    options: CorsaVueVirtualDocumentOptions,
+    overlays: &[(PathBuf, &str)],
+) -> (String, Vec<(String, String)>) {
+    let rewriter = ImportRewriter::new();
+    let overlays = overlays
+        .iter()
+        .map(|(path, content)| {
+            let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+            (key, *content)
+        })
+        .collect::<FxHashMap<_, _>>();
+    let alias_context =
+        super::vue_dependencies_alias::AliasContext::for_host_cached(source_path, code, &overlays);
+    let request_uri = normalize_document_uri(request_path);
+    let mut documents = vec![(request_uri.clone(), code.into())];
+    collect_script_dependency_documents(
+        &mut documents,
+        source_path,
+        code,
+        source_type,
+        options,
+        &rewriter,
+        &alias_context,
+        &overlays,
+    );
+    (request_uri, documents)
+}

--- a/crates/vize_canon/src/corsa_bridge/script_document_tests.rs
+++ b/crates/vize_canon/src/corsa_bridge/script_document_tests.rs
@@ -1,0 +1,42 @@
+use oxc_span::SourceType;
+
+use super::script_document::build_script_virtual_project;
+use super::vue_document::CorsaVueVirtualDocumentOptions;
+use crate::file_uri::path_to_file_uri;
+
+#[test]
+fn script_virtual_project_syncs_vue_dependencies_without_opening_the_sfc() {
+    let project = tempfile::TempDir::new().expect("temp project");
+    let host_path = project.path().join("Consumer.tsx");
+    let child_path = project.path().join("Counter.vue");
+    let source = "import Counter from './Counter.vue';\nexport const view = Counter;\n";
+    std::fs::write(&host_path, source).expect("host");
+    std::fs::write(
+        &child_path,
+        "<script setup lang=\"ts\">defineProps<{ count: number }>()</script>",
+    )
+    .expect("child");
+
+    let (request_uri, documents) = build_script_virtual_project(
+        &host_path,
+        host_path.with_extension("tsx.jsx.ts").to_str().unwrap(),
+        source,
+        SourceType::ts(),
+        CorsaVueVirtualDocumentOptions::default(),
+        &[],
+    );
+    let uris = documents
+        .iter()
+        .map(|(uri, _)| uri.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        request_uri,
+        path_to_file_uri(&host_path.with_extension("tsx.jsx.ts"))
+    );
+    assert!(uris.contains(&request_uri.as_str()), "{uris:?}");
+    assert!(
+        uris.contains(&path_to_file_uri(&child_path.with_extension("vue.ts")).as_str()),
+        "script hosts must materialize unopened Vue dependencies: {uris:?}",
+    );
+}

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies.rs
@@ -15,6 +15,9 @@ use super::vue_document::{
 use crate::batch::ImportRewriter;
 use crate::file_uri::path_to_file_uri;
 
+#[path = "vue_dependencies_walk.rs"]
+mod walk;
+
 const VUE_DEPENDENCY_FALLBACK: &str =
     "const component: any = undefined;\nexport default component;\n";
 
@@ -37,55 +40,55 @@ pub(super) fn collect_dependency_documents(
         pre_rewrite_code: host.generated.pre_rewrite_code.clone(),
     });
 
-    while let Some(scan) = queue.pop_front() {
-        match scan {
-            DependencyScan::Vue {
-                dir,
-                source_type,
-                pre_rewrite_code,
-            } => queue_imports(
-                ImportQueue {
-                    documents,
-                    dependencies,
-                    queue: &mut queue,
-                    visited_vue: &mut visited_vue,
-                    visited_ts: &mut visited_ts,
-                    overlays,
-                },
-                options,
-                rewriter,
-                alias_context,
-                &dir,
-                &pre_rewrite_code,
-                source_type,
-            ),
-            DependencyScan::Script {
-                path,
-                source_type,
-                content,
-            } => queue_imports(
-                ImportQueue {
-                    documents,
-                    dependencies,
-                    queue: &mut queue,
-                    visited_vue: &mut visited_vue,
-                    visited_ts: &mut visited_ts,
-                    overlays,
-                },
-                options,
-                rewriter,
-                alias_context,
-                &parent_dir(&path),
-                &content,
-                source_type,
-            ),
-        }
-    }
+    walk::collect_queued_documents(
+        documents,
+        Some(dependencies),
+        options,
+        rewriter,
+        alias_context,
+        overlays,
+        &mut visited_vue,
+        &mut visited_ts,
+        queue,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn collect_script_dependency_documents(
+    documents: &mut Vec<(String, String)>,
+    source_path: &Path,
+    code: &str,
+    source_type: SourceType,
+    options: CorsaVueVirtualDocumentOptions,
+    rewriter: &ImportRewriter,
+    alias_context: &super::vue_dependencies_alias::AliasContext,
+    overlays: &FxHashMap<PathBuf, &str>,
+) {
+    let mut visited_vue = FxHashSet::<PathBuf>::default();
+    let mut visited_ts = FxHashSet::<PathBuf>::default();
+    visited_ts.insert(source_path.to_path_buf());
+    let mut queue = VecDeque::new();
+    queue.push_back(DependencyScan::Script {
+        path: source_path.to_path_buf(),
+        source_type,
+        content: code.into(),
+    });
+    walk::collect_queued_documents(
+        documents,
+        None,
+        options,
+        rewriter,
+        alias_context,
+        overlays,
+        &mut visited_vue,
+        &mut visited_ts,
+        queue,
+    );
 }
 
 pub(super) struct ImportQueue<'a> {
     pub(super) documents: &'a mut Vec<(String, String)>,
-    pub(super) dependencies: &'a mut Vec<CorsaVueVirtualDependency>,
+    pub(super) dependencies: Option<&'a mut Vec<CorsaVueVirtualDependency>>,
     pub(super) queue: &'a mut VecDeque<DependencyScan>,
     pub(super) visited_vue: &'a mut FxHashSet<PathBuf>,
     pub(super) visited_ts: &'a mut FxHashSet<PathBuf>,
@@ -204,16 +207,18 @@ pub(super) fn queue_vue_dependency(
         source_type: generated.generated.source_type,
         pre_rewrite_code: generated.generated.pre_rewrite_code,
     });
-    imports.dependencies.push(CorsaVueVirtualDependency {
-        source_path: generated.source_path,
-        source: content,
-        request_uri: generated.virtual_uri,
-        code: generated_code,
-        mappings: generated.generated.mappings,
-        import_source_map: generated.generated.import_source_map,
-        source_type: generated.generated.source_type,
-        virtual_suffix: generated.generated.virtual_suffix,
-    });
+    if let Some(dependencies) = imports.dependencies.as_mut() {
+        dependencies.push(CorsaVueVirtualDependency {
+            source_path: generated.source_path,
+            source: content,
+            request_uri: generated.virtual_uri,
+            code: generated_code,
+            mappings: generated.generated.mappings,
+            import_source_map: generated.generated.import_source_map,
+            source_type: generated.generated.source_type,
+            virtual_suffix: generated.generated.virtual_suffix,
+        });
+    }
 }
 
 pub(super) fn fallback_vue_virtual_uri(path: &Path) -> String {

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_walk.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_walk.rs
@@ -1,0 +1,56 @@
+//! Breadth-first traversal shared by Vue and script virtual-document hosts.
+
+use std::collections::VecDeque;
+use std::path::PathBuf;
+
+use vize_carton::{FxHashMap, FxHashSet, String};
+
+use super::{DependencyScan, ImportQueue, parent_dir, queue_imports};
+use crate::batch::ImportRewriter;
+use crate::corsa_bridge::vue_document::{
+    CorsaVueVirtualDependency, CorsaVueVirtualDocumentOptions,
+};
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn collect_queued_documents(
+    documents: &mut Vec<(String, String)>,
+    mut dependencies: Option<&mut Vec<CorsaVueVirtualDependency>>,
+    options: CorsaVueVirtualDocumentOptions,
+    rewriter: &ImportRewriter,
+    alias_context: &crate::corsa_bridge::vue_dependencies_alias::AliasContext,
+    overlays: &FxHashMap<PathBuf, &str>,
+    visited_vue: &mut FxHashSet<PathBuf>,
+    visited_ts: &mut FxHashSet<PathBuf>,
+    mut queue: VecDeque<DependencyScan>,
+) {
+    while let Some(scan) = queue.pop_front() {
+        let (dir, source_type, code) = match scan {
+            DependencyScan::Vue {
+                dir,
+                source_type,
+                pre_rewrite_code,
+            } => (dir, source_type, pre_rewrite_code),
+            DependencyScan::Script {
+                path,
+                source_type,
+                content,
+            } => (parent_dir(&path), source_type, content),
+        };
+        queue_imports(
+            ImportQueue {
+                documents,
+                dependencies: dependencies.as_deref_mut(),
+                queue: &mut queue,
+                visited_vue,
+                visited_ts,
+                overlays,
+            },
+            options,
+            rewriter,
+            alias_context,
+            &dir,
+            &code,
+            source_type,
+        );
+    }
+}

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -140,7 +140,7 @@ impl CorsaBridge {
         Ok(project.host)
     }
 
-    async fn open_virtual_documents_batch(
+    pub(super) async fn open_virtual_documents_batch(
         &self,
         documents: &[(String, String)],
     ) -> Result<(), CorsaBridgeError> {

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/project.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/project.rs
@@ -52,13 +52,13 @@ pub(crate) async fn open_canonical_virtual_project_document(
         open_canonical_virtual_document_with_overlays(ctx, bridge, &overlays).await?;
     let mut visited = FxHashSet::default();
     visited.insert(ctx.uri.clone());
-    let mut queue = VecDeque::from(ctx.state.open_vue_importers(ctx.uri));
+    let mut queue = VecDeque::from(ctx.state.open_importers(ctx.uri));
 
     while let Some(uri) = queue.pop_front() {
         if !visited.insert(uri.clone()) {
             continue;
         }
-        queue.extend(ctx.state.open_vue_importers(&uri));
+        queue.extend(ctx.state.open_importers(&uri));
         let Some(importer_ctx) = IdeContext::new(ctx.state, &uri, 0) else {
             continue;
         };

--- a/crates/vize_maestro/src/ide/jsx.rs
+++ b/crates/vize_maestro/src/ide/jsx.rs
@@ -38,6 +38,8 @@ mod references;
 mod rename;
 #[cfg(feature = "native")]
 mod service;
+#[cfg(feature = "native")]
+mod service_project;
 
 #[cfg(feature = "native")]
 pub use references::JsxReferencesService;

--- a/crates/vize_maestro/src/ide/jsx/service.rs
+++ b/crates/vize_maestro/src/ide/jsx/service.rs
@@ -77,11 +77,7 @@ impl JsxService {
         let virtual_ts = Self::virtual_ts(ctx)?;
         let (line, character) =
             source_offset_to_virtual_position(&virtual_ts.code, &virtual_ts.mappings, ctx.offset)?;
-        let request_path = Self::request_path(ctx.uri);
-        let uri = bridge
-            .open_or_update_virtual_document(&request_path, &virtual_ts.code)
-            .await
-            .ok()?;
+        let uri = super::service_project::open_virtual_project(ctx, bridge, &virtual_ts).await?;
         Some((virtual_ts, uri, line, character))
     }
 
@@ -192,10 +188,8 @@ impl JsxService {
             return vec![];
         };
 
-        let request_path = Self::request_path(ctx.uri);
-        let Ok(uri) = bridge
-            .open_or_update_virtual_document(&request_path, &virtual_ts.code)
-            .await
+        let Some(uri) =
+            super::service_project::open_virtual_project(ctx, &bridge, &virtual_ts).await
         else {
             return vec![];
         };

--- a/crates/vize_maestro/src/ide/jsx/service_project.rs
+++ b/crates/vize_maestro/src/ide/jsx/service_project.rs
@@ -1,0 +1,35 @@
+//! Canonical Corsa project synchronization for JSX/TSX editor requests.
+
+use oxc_span::SourceType;
+use vize_canon::{CorsaBridge, CorsaVueVirtualDocumentOptions};
+
+use super::service::JsxService;
+use super::virtual_ts::JsxVirtualTs;
+use crate::ide::IdeContext;
+
+pub(super) async fn open_virtual_project(
+    ctx: &IdeContext<'_>,
+    bridge: &CorsaBridge,
+    virtual_ts: &JsxVirtualTs,
+) -> Option<vize_carton::String> {
+    let source_path = ctx.uri.to_file_path().ok()?;
+    let cached_overlays = ctx.state.corsa_overlays();
+    let overlays = cached_overlays
+        .iter()
+        .map(|(path, content)| (path.clone(), &**content))
+        .collect::<Vec<_>>();
+    bridge
+        .open_script_virtual_document_with_vue_dependencies(
+            &source_path,
+            &JsxService::request_path(ctx.uri),
+            &virtual_ts.code,
+            SourceType::ts(),
+            CorsaVueVirtualDocumentOptions {
+                options_api: ctx.state.options_api_enabled(),
+                legacy_vue2: ctx.state.legacy_vue2_enabled(),
+            },
+            &overlays,
+        )
+        .await
+        .ok()
+}

--- a/crates/vize_maestro/src/ide/references/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/references/corsa_tests.rs
@@ -88,10 +88,7 @@ function unrelated() { const shared = 0; return shared }
             "vue".to_string(),
         );
         state.update_virtual_docs(&child_uri, child_source);
-        assert_eq!(
-            state.open_vue_importers(&child_uri),
-            vec![parent_uri.clone()]
-        );
+        assert_eq!(state.open_importers(&child_uri), vec![parent_uri.clone()]);
         let bridge = Arc::new(CorsaBridge::with_config(CorsaBridgeConfig {
             corsa_path: Some(tsgo_path),
             working_dir: Some(project.path().to_path_buf()),

--- a/crates/vize_maestro/src/server/helpers.rs
+++ b/crates/vize_maestro/src/server/helpers.rs
@@ -18,7 +18,7 @@ use vize_carton::append;
 mod supersession_tests;
 
 impl MaestroServer {
-    /// Publish the changed document first, then refresh open Vue files that
+    /// Publish the changed document first, then refresh open typed files that
     /// directly import it. Corsa has already received the changed virtual
     /// document by this point, so importer diagnostics observe the new shape.
     pub(crate) async fn apply_document_changes(
@@ -55,14 +55,14 @@ impl MaestroServer {
         self.publish_importer_diagnostics(uri, version).await;
     }
 
-    /// Refresh the open Vue documents that import `uri`, abandoning the fan-out
+    /// Refresh open typed documents that import `uri`, abandoning the fan-out
     /// as soon as a newer version of `uri` lands. Returns the importers actually
     /// refreshed, in order, so the supersession rule is directly assertable.
     ///
     /// Supersession matters because this loop is the only unbounded work a
     /// single keystroke schedules: each importer costs a full Corsa diagnostics
-    /// pass, and a `.d.ts` edit fans out to *every* open Vue document
-    /// ([`super::importers::open_vue_dependents`]). Without the check, typing at
+    /// pass, and a `.d.ts` edit fans out to *every* open typed document
+    /// ([`super::importers::open_typecheck_dependents`]). Without the check, typing at
     /// editor speed queues one such fan-out per keystroke, each computed from
     /// text the user has already replaced and each republished over the last —
     /// the queue-depth growth behind #3315's silent stalls.
@@ -73,7 +73,7 @@ impl MaestroServer {
     /// because it stops *before* publishing rather than after computing.
     async fn publish_importer_diagnostics(&self, uri: &Url, version: i32) -> Vec<Url> {
         let mut refreshed = Vec::new();
-        for importer in super::importers::open_vue_dependents(&self.state, uri) {
+        for importer in super::importers::open_typecheck_dependents(&self.state, uri) {
             if self.state.documents.version(uri) != Some(version) {
                 tracing::debug!(
                     "abandoning superseded importer refresh for {}: pass version {}, current {:?}",

--- a/crates/vize_maestro/src/server/importers.rs
+++ b/crates/vize_maestro/src/server/importers.rs
@@ -1,10 +1,7 @@
-//! Reverse dependency index for open Vue documents.
+//! Reverse dependency index for open SFC and script documents.
 mod dependents;
 use std::path::{Component, Path, PathBuf};
 
-use oxc_allocator::Allocator;
-use oxc_ast::ast::Statement;
-use oxc_parser::Parser;
 use oxc_span::SourceType;
 use parking_lot::RwLock;
 use tower_lsp::lsp_types::Url;
@@ -12,13 +9,14 @@ use vize_carton::{FxHashMap, FxHashSet};
 
 use self::package::resolve_package_import;
 use super::ServerState;
-pub(super) use dependents::open_vue_dependents;
+pub(super) use dependents::open_typecheck_dependents;
 mod package;
+mod specifiers;
 
 const SCRIPT_EXTENSIONS: &[&str] = &["vue", "ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"];
 
 #[derive(Default)]
-pub(super) struct OpenVueImportIndex {
+pub(super) struct OpenImportIndex {
     inner: RwLock<ImportIndexData>,
 }
 
@@ -28,12 +26,11 @@ struct ImportIndexData {
     by_importer: FxHashMap<Url, Vec<PathBuf>>,
 }
 
-impl OpenVueImportIndex {
+impl OpenImportIndex {
     pub(super) fn update(&self, importer: &Url, source: &str) {
         let dependencies = importer
             .to_file_path()
             .ok()
-            .filter(|path| path.extension().is_some_and(|extension| extension == "vue"))
             .map(|path| collect_dependencies(&path, source))
             .unwrap_or_default();
         let mut index = self.inner.write();
@@ -85,29 +82,40 @@ fn remove_importer(index: &mut ImportIndexData, importer: &Url) {
     }
 }
 
-pub(super) fn open_vue_importers(state: &ServerState, dependency: &Url) -> Vec<Url> {
+pub(super) fn open_importers(state: &ServerState, dependency: &Url) -> Vec<Url> {
     dependency
         .to_file_path()
         .ok()
-        .map(|path| state.open_vue_imports.importers(&path))
+        .map(|path| state.open_imports.importers(&path))
         .unwrap_or_default()
 }
 
 impl ServerState {
-    pub(crate) fn open_vue_importers(&self, dependency: &Url) -> Vec<Url> {
-        open_vue_importers(self, dependency)
+    pub(crate) fn open_importers(&self, dependency: &Url) -> Vec<Url> {
+        open_importers(self, dependency)
     }
 }
 
 fn collect_dependencies(importer: &Path, source: &str) -> Vec<PathBuf> {
+    let Some(importer_dir) = importer.parent() else {
+        return Vec::new();
+    };
+    if importer
+        .extension()
+        .is_none_or(|extension| extension != "vue")
+    {
+        let Ok(source_type) = SourceType::from_path(importer) else {
+            return Vec::new();
+        };
+        let mut dependencies = FxHashSet::default();
+        collect_script_dependencies(source, source_type, importer_dir, &mut dependencies);
+        return dependencies.into_iter().collect();
+    }
     let options = vize_atelier_sfc::SfcParseOptions {
         filename: importer.to_string_lossy().into_owned().into(),
         ..Default::default()
     };
     let Ok(descriptor) = vize_atelier_sfc::parse_sfc(source, options) else {
-        return Vec::new();
-    };
-    let Some(importer_dir) = importer.parent() else {
         return Vec::new();
     };
     let mut dependencies = FxHashSet::default();
@@ -133,14 +141,8 @@ fn collect_script_dependencies(
     importer_dir: &Path,
     dependencies: &mut FxHashSet<PathBuf>,
 ) {
-    let allocator = Allocator::default();
-    let parsed = Parser::new(&allocator, source, source_type).parse();
-
-    for statement in &parsed.program.body {
-        let Statement::ImportDeclaration(import) = statement else {
-            continue;
-        };
-        if let Some(dependency) = resolve_import(importer_dir, import.source.value.as_str()) {
+    for specifier in specifiers::collect(source, source_type) {
+        if let Some(dependency) = resolve_import(importer_dir, specifier.as_str()) {
             dependencies.insert(dependency);
         }
     }
@@ -211,114 +213,5 @@ fn source_type(lang: Option<&str>) -> SourceType {
 }
 
 #[cfg(test)]
-mod tests {
-    #![allow(clippy::disallowed_methods)]
-
-    use super::{open_vue_importers, resolve_import};
-    use crate::server::ServerState;
-    use tower_lsp::lsp_types::Url;
-
-    #[test]
-    fn index_tracks_and_removes_open_vue_imports() {
-        let dir = tempfile::tempdir().unwrap();
-        let child = dir.path().join("Child.vue");
-        let parent = dir.path().join("Parent.vue");
-        std::fs::write(&child, "<template />").unwrap();
-        std::fs::write(&parent, "<template />").unwrap();
-        let child_uri = Url::from_file_path(&child).unwrap();
-        let parent_uri = Url::from_file_path(&parent).unwrap();
-        let state = ServerState::new();
-        let source = "<script setup lang=\"ts\">import Child from './Child'</script>";
-
-        state.update_virtual_docs(&parent_uri, source);
-        assert_eq!(
-            open_vue_importers(&state, &child_uri),
-            vec![parent_uri.clone()]
-        );
-
-        state.update_virtual_docs(&parent_uri, "<script setup>const local = 1</script>");
-        assert!(open_vue_importers(&state, &child_uri).is_empty());
-    }
-
-    #[test]
-    fn index_resolves_explicit_script_dependencies_and_query_suffixes() {
-        let dir = tempfile::tempdir().unwrap();
-        let child = dir.path().join("types.ts");
-        let parent = dir.path().join("Parent.vue");
-        std::fs::write(&child, "export type Count = number").unwrap();
-        std::fs::write(&parent, "<template />").unwrap();
-        let child_uri = Url::from_file_path(&child).unwrap();
-        let parent_uri = Url::from_file_path(&parent).unwrap();
-        let state = ServerState::new();
-        let source = "<script>import './types.ts?raw'</script>";
-
-        state.update_virtual_docs(&parent_uri, source);
-        assert_eq!(open_vue_importers(&state, &child_uri), vec![parent_uri]);
-    }
-
-    #[test]
-    fn index_resolves_package_export_declaration_variants() {
-        let dir = tempfile::tempdir().unwrap();
-        let package = dir.path().join("node_modules/vue-router");
-        let parent = dir.path().join("Parent.vue");
-        let module_declaration = package.join("routes.d.mts");
-        let common_declaration = package.join("plugin.d.cts");
-        std::fs::create_dir_all(&package).unwrap();
-        std::fs::write(
-            package.join("package.json"),
-            r#"{
-  "exports": {
-    "./auto-routes": { "types": "./routes.d.mts" },
-    "./volar/plugin": { "types": "./plugin.d.cts" }
-  }
-}"#,
-        )
-        .unwrap();
-        std::fs::write(
-            &module_declaration,
-            "export declare const routes: unknown[]",
-        )
-        .unwrap();
-        std::fs::write(&common_declaration, "export declare const plugin: unknown").unwrap();
-        std::fs::write(&parent, "<template />").unwrap();
-        let parent_uri = Url::from_file_path(&parent).unwrap();
-        let module_uri = Url::from_file_path(&module_declaration).unwrap();
-        let common_uri = Url::from_file_path(&common_declaration).unwrap();
-        let state = ServerState::new();
-        let source = r#"<script setup lang="ts">
-import { routes } from 'vue-router/auto-routes'
-import { plugin } from 'vue-router/volar/plugin'
-void routes
-void plugin
-</script>"#;
-
-        state.update_virtual_docs(&parent_uri, source);
-
-        assert_eq!(
-            open_vue_importers(&state, &module_uri),
-            vec![parent_uri.clone()]
-        );
-        assert_eq!(open_vue_importers(&state, &common_uri), vec![parent_uri]);
-    }
-
-    #[test]
-    fn exact_directory_specifiers_resolve_index_files() {
-        let dir = tempfile::tempdir().unwrap();
-        let source_dir = dir.path().join("src");
-        let source_index = source_dir.join("index.ts");
-        let parent_index = dir.path().join("index.ts");
-        std::fs::create_dir_all(&source_dir).unwrap();
-        std::fs::write(&source_index, "export const source = true").unwrap();
-        std::fs::write(&parent_index, "export const parent = true").unwrap();
-        std::fs::write(dir.path().join("src.vue"), "<template />").unwrap();
-
-        assert_eq!(
-            resolve_import(&source_dir, ".?raw"),
-            Some(std::fs::canonicalize(&source_index).unwrap())
-        );
-        assert_eq!(
-            resolve_import(&source_dir, "..#parent"),
-            Some(std::fs::canonicalize(&parent_index).unwrap())
-        );
-    }
-}
+#[path = "importers_tests.rs"]
+mod tests;

--- a/crates/vize_maestro/src/server/importers/dependents.rs
+++ b/crates/vize_maestro/src/server/importers/dependents.rs
@@ -1,20 +1,27 @@
-use super::{ServerState, open_vue_importers};
+use super::{ServerState, open_importers};
 use tower_lsp::lsp_types::Url;
 
-/// Return open Vue documents whose diagnostics may change with `dependency`.
+/// Return open Vize-typechecked documents affected by `dependency`.
 ///
 /// Direct source imports use the reverse index. Declaration files can affect a
-/// Vue document through an arbitrary package/relative import chain, so refresh
-/// every open Vue document for `.d.ts`, `.d.mts`, and `.d.cts` edits. This is
-/// bounded by editor-visible documents and avoids a workspace-wide rescan.
-pub(in crate::server) fn open_vue_dependents(state: &ServerState, dependency: &Url) -> Vec<Url> {
-    let mut dependents = open_vue_importers(state, dependency);
+/// document through an arbitrary package/relative import chain, so refresh all
+/// open SFCs and opted-in JSX documents for declaration edits. The fan-out is
+/// bounded by editor-visible documents rather than the workspace.
+pub(in crate::server) fn open_typecheck_dependents(
+    state: &ServerState,
+    dependency: &Url,
+) -> Vec<Url> {
+    let mut dependents = open_importers(state, dependency);
     if is_declaration_uri(dependency) {
         dependents.extend(
             state
                 .documents
                 .iter()
-                .filter(|document| document.key().path().ends_with(".vue"))
+                .filter(|document| {
+                    document.key().path().ends_with(".vue")
+                        || (state.jsx_typecheck_enabled()
+                            && crate::utils::is_jsx_path(document.key().path()))
+                })
                 .map(|document| document.key().clone()),
         );
     }
@@ -32,26 +39,35 @@ fn is_declaration_uri(uri: &Url) -> bool {
 mod tests {
     #![allow(clippy::disallowed_methods)]
 
-    use super::{ServerState, Url, open_vue_dependents};
+    use super::{ServerState, Url, open_typecheck_dependents};
 
     #[test]
-    fn declaration_edits_refresh_all_open_vue_documents_only() {
+    fn declaration_edits_refresh_open_sfc_and_opted_in_jsx_documents() {
         let dir = tempfile::tempdir().unwrap();
         let src = dir.path().join("src");
         let declaration_dir = dir.path().join("node_modules/pkg");
         let direct_dependency = src.join("direct.ts");
         let parent = src.join("Parent.vue");
         let unrelated = src.join("Unrelated.vue");
+        let jsx = src.join("Consumer.tsx");
         std::fs::create_dir_all(&declaration_dir).unwrap();
         std::fs::create_dir_all(&src).unwrap();
         std::fs::write(&direct_dependency, "export const direct = true\n").unwrap();
         std::fs::write(&parent, "<template />\n").unwrap();
         std::fs::write(&unrelated, "<template />\n").unwrap();
+        std::fs::write(&jsx, "import './direct.ts'\n").unwrap();
+        std::fs::write(
+            dir.path().join("vize.config.json"),
+            r#"{ "typeChecker": { "jsxTypecheck": true } }"#,
+        )
+        .unwrap();
 
         let direct_uri = Url::from_file_path(&direct_dependency).unwrap();
         let parent_uri = Url::from_file_path(&parent).unwrap();
         let unrelated_uri = Url::from_file_path(&unrelated).unwrap();
+        let jsx_uri = Url::from_file_path(&jsx).unwrap();
         let state = ServerState::new();
+        state.load_workspace_config(dir.path());
         let parent_source = "<script setup lang=\"ts\">import { direct } from './direct'</script>";
         state.documents.open(
             parent_uri.clone(),
@@ -65,20 +81,27 @@ mod tests {
             1,
             "vue".to_string(),
         );
+        state.documents.open(
+            jsx_uri.clone(),
+            "import './direct.ts'\n".to_string(),
+            1,
+            "typescriptreact".to_string(),
+        );
         state.update_virtual_docs(&parent_uri, parent_source);
         state.update_virtual_docs(&unrelated_uri, "<template />");
+        state.update_virtual_docs(&jsx_uri, "import './direct.ts'\n");
 
         assert_eq!(
-            open_vue_dependents(&state, &direct_uri),
-            vec![parent_uri.clone()],
+            open_typecheck_dependents(&state, &direct_uri),
+            vec![jsx_uri.clone(), parent_uri.clone()],
         );
         for declaration_name in ["theme.d.ts", "theme.d.mts", "theme.d.cts"] {
             let declaration = declaration_dir.join(declaration_name);
             std::fs::write(&declaration, "export interface Theme {}\n").unwrap();
             let declaration_uri = Url::from_file_path(&declaration).unwrap();
             assert_eq!(
-                open_vue_dependents(&state, &declaration_uri),
-                vec![parent_uri.clone(), unrelated_uri.clone()],
+                open_typecheck_dependents(&state, &declaration_uri),
+                vec![jsx_uri.clone(), parent_uri.clone(), unrelated_uri.clone()],
                 "{declaration_name}",
             );
         }

--- a/crates/vize_maestro/src/server/importers/specifiers.rs
+++ b/crates/vize_maestro/src/server/importers/specifiers.rs
@@ -1,0 +1,76 @@
+//! Static module specifiers that can make an open script depend on a file.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    CallExpression, ExportAllDeclaration, ExportNamedDeclaration, Expression, ImportDeclaration,
+    ImportExpression, StringLiteral, TSExternalModuleReference, TSImportType,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{String, ToCompactString};
+
+pub(super) fn collect(source: &str, source_type: SourceType) -> Vec<String> {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    let mut collector = Collector::default();
+    collector.visit_program(&parsed.program);
+    collector.specifiers
+}
+
+#[derive(Default)]
+struct Collector {
+    specifiers: Vec<String>,
+}
+
+impl Collector {
+    fn push(&mut self, literal: &StringLiteral<'_>) {
+        let value = literal.value.as_str();
+        if !self.specifiers.iter().any(|known| known.as_str() == value) {
+            self.specifiers.push(value.to_compact_string());
+        }
+    }
+}
+
+impl<'a> Visit<'a> for Collector {
+    fn visit_import_declaration(&mut self, declaration: &ImportDeclaration<'a>) {
+        self.push(&declaration.source);
+        walk::walk_import_declaration(self, declaration);
+    }
+
+    fn visit_export_named_declaration(&mut self, declaration: &ExportNamedDeclaration<'a>) {
+        if let Some(source) = &declaration.source {
+            self.push(source);
+        }
+        walk::walk_export_named_declaration(self, declaration);
+    }
+
+    fn visit_export_all_declaration(&mut self, declaration: &ExportAllDeclaration<'a>) {
+        self.push(&declaration.source);
+        walk::walk_export_all_declaration(self, declaration);
+    }
+
+    fn visit_import_expression(&mut self, expression: &ImportExpression<'a>) {
+        if let Expression::StringLiteral(source) = &expression.source {
+            self.push(source);
+        }
+        walk::walk_import_expression(self, expression);
+    }
+
+    fn visit_call_expression(&mut self, expression: &CallExpression<'a>) {
+        if let Some(source) = expression.common_js_require() {
+            self.push(source);
+        }
+        walk::walk_call_expression(self, expression);
+    }
+
+    fn visit_ts_import_type(&mut self, import_type: &TSImportType<'a>) {
+        self.push(&import_type.source);
+        walk::walk_ts_import_type(self, import_type);
+    }
+
+    fn visit_ts_external_module_reference(&mut self, reference: &TSExternalModuleReference<'a>) {
+        self.push(&reference.expression);
+        walk::walk_ts_external_module_reference(self, reference);
+    }
+}

--- a/crates/vize_maestro/src/server/importers_tests.rs
+++ b/crates/vize_maestro/src/server/importers_tests.rs
@@ -1,0 +1,134 @@
+#![allow(clippy::disallowed_methods)]
+
+use super::{open_importers, resolve_import};
+use crate::server::ServerState;
+use tower_lsp::lsp_types::Url;
+
+#[test]
+fn index_tracks_and_removes_open_sfc_imports() {
+    let dir = tempfile::tempdir().unwrap();
+    let child = dir.path().join("Child.vue");
+    let parent = dir.path().join("Parent.vue");
+    std::fs::write(&child, "<template />").unwrap();
+    std::fs::write(&parent, "<template />").unwrap();
+    let child_uri = Url::from_file_path(&child).unwrap();
+    let parent_uri = Url::from_file_path(&parent).unwrap();
+    let state = ServerState::new();
+    let source = "<script setup lang=\"ts\">import Child from './Child'</script>";
+
+    state.update_virtual_docs(&parent_uri, source);
+    assert_eq!(open_importers(&state, &child_uri), vec![parent_uri.clone()]);
+
+    state.update_virtual_docs(&parent_uri, "<script setup>const local = 1</script>");
+    assert!(open_importers(&state, &child_uri).is_empty());
+}
+
+#[test]
+fn index_tracks_script_module_specifier_forms() {
+    let dir = tempfile::tempdir().unwrap();
+    let child = dir.path().join("Child.vue");
+    let consumer = dir.path().join("Consumer.tsx");
+    std::fs::write(&child, "<template />").unwrap();
+    std::fs::write(&consumer, "import Child from './Child.vue';\n").unwrap();
+    let child_uri = Url::from_file_path(&child).unwrap();
+    let consumer_uri = Url::from_file_path(&consumer).unwrap();
+    let state = ServerState::new();
+
+    for source in [
+        "import Child from './Child.vue';\n",
+        "export { default as Child } from './Child.vue';\n",
+        "export * from './Child.vue';\n",
+        "const Child = import('./Child.vue');\n",
+        "const Child = require('./Child.vue');\n",
+        "type Child = typeof import('./Child.vue');\n",
+    ] {
+        state.update_virtual_docs(&consumer_uri, source);
+        assert_eq!(
+            open_importers(&state, &child_uri),
+            vec![consumer_uri.clone()],
+            "{source}",
+        );
+    }
+}
+
+#[test]
+fn index_resolves_explicit_script_dependencies_and_query_suffixes() {
+    let dir = tempfile::tempdir().unwrap();
+    let child = dir.path().join("types.ts");
+    let parent = dir.path().join("Parent.vue");
+    std::fs::write(&child, "export type Count = number").unwrap();
+    std::fs::write(&parent, "<template />").unwrap();
+    let child_uri = Url::from_file_path(&child).unwrap();
+    let parent_uri = Url::from_file_path(&parent).unwrap();
+    let state = ServerState::new();
+    let source = "<script>import './types.ts?raw'</script>";
+
+    state.update_virtual_docs(&parent_uri, source);
+    assert_eq!(open_importers(&state, &child_uri), vec![parent_uri]);
+}
+
+#[test]
+fn index_resolves_package_export_declaration_variants() {
+    let dir = tempfile::tempdir().unwrap();
+    let package = dir.path().join("node_modules/vue-router");
+    let parent = dir.path().join("Parent.vue");
+    let module_declaration = package.join("routes.d.mts");
+    let common_declaration = package.join("plugin.d.cts");
+    std::fs::create_dir_all(&package).unwrap();
+    std::fs::write(
+        package.join("package.json"),
+        r#"{
+  "exports": {
+    "./auto-routes": { "types": "./routes.d.mts" },
+    "./volar/plugin": { "types": "./plugin.d.cts" }
+  }
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        &module_declaration,
+        "export declare const routes: unknown[]",
+    )
+    .unwrap();
+    std::fs::write(&common_declaration, "export declare const plugin: unknown").unwrap();
+    std::fs::write(&parent, "<template />").unwrap();
+    let parent_uri = Url::from_file_path(&parent).unwrap();
+    let module_uri = Url::from_file_path(&module_declaration).unwrap();
+    let common_uri = Url::from_file_path(&common_declaration).unwrap();
+    let state = ServerState::new();
+    let source = r#"<script setup lang="ts">
+import { routes } from 'vue-router/auto-routes'
+import { plugin } from 'vue-router/volar/plugin'
+void routes
+void plugin
+</script>"#;
+
+    state.update_virtual_docs(&parent_uri, source);
+
+    assert_eq!(
+        open_importers(&state, &module_uri),
+        vec![parent_uri.clone()]
+    );
+    assert_eq!(open_importers(&state, &common_uri), vec![parent_uri]);
+}
+
+#[test]
+fn exact_directory_specifiers_resolve_index_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let source_dir = dir.path().join("src");
+    let source_index = source_dir.join("index.ts");
+    let parent_index = dir.path().join("index.ts");
+    std::fs::create_dir_all(&source_dir).unwrap();
+    std::fs::write(&source_index, "export const source = true").unwrap();
+    std::fs::write(&parent_index, "export const parent = true").unwrap();
+    std::fs::write(dir.path().join("src.vue"), "<template />").unwrap();
+
+    assert_eq!(
+        resolve_import(&source_dir, ".?raw"),
+        Some(std::fs::canonicalize(&source_index).unwrap())
+    );
+    assert_eq!(
+        resolve_import(&source_dir, "..#parent"),
+        Some(std::fs::canonicalize(&parent_index).unwrap())
+    );
+}

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -68,7 +68,7 @@ pub struct ServerState {
     /// shard guard there deadlocks the whole server against the next
     /// `didOpen`/`didChange` write (#3377, same class as #3315/#3373).
     virtual_docs_cache: DashMap<Url, Arc<VirtualDocuments>>,
-    pub(super) open_vue_imports: super::importers::OpenVueImportIndex,
+    pub(super) open_imports: super::importers::OpenImportIndex,
     /// Parsed metadata for imported components, keyed by resolved path.
     /// Lets template completion skip re-reading + re-parsing + re-analyzing an
     /// imported component on every keystroke; entries are invalidated by the
@@ -174,7 +174,7 @@ impl ServerState {
             documents: DocumentStore::new(),
             virtual_gen: RwLock::new(VirtualCodeGenerator::new()),
             virtual_docs_cache: DashMap::new(),
-            open_vue_imports: super::importers::OpenVueImportIndex::default(),
+            open_imports: super::importers::OpenImportIndex::default(),
             component_metadata_cache: DashMap::new(),
             #[cfg(feature = "native")]
             workspace_vue_files: DashMap::new(),

--- a/crates/vize_maestro/src/server/state/virtual_docs.rs
+++ b/crates/vize_maestro/src/server/state/virtual_docs.rs
@@ -17,7 +17,7 @@ mod tests;
 impl ServerState {
     /// Generate and cache virtual documents for a document.
     pub fn update_virtual_docs(&self, uri: &Url, content: &str) {
-        self.open_vue_imports.update(uri, content);
+        self.open_imports.update(uri, content);
         if uri.path().ends_with(".art.vue") {
             self.update_art_virtual_docs(uri, content);
             return;
@@ -84,7 +84,7 @@ impl ServerState {
     fn update_jsx_virtual_docs(&self, uri: &Url, content: &str) {
         let styles = crate::ide::JsxScopedStyleService::virtual_css_documents(content, uri);
         if styles.is_empty() {
-            self.remove_virtual_docs(uri);
+            self.virtual_docs_cache.remove(uri);
             return;
         }
         let mut docs = VirtualDocuments::new();
@@ -201,13 +201,13 @@ impl ServerState {
 
     /// Remove cached virtual documents when a document is closed.
     pub fn remove_virtual_docs(&self, uri: &Url) {
-        self.open_vue_imports.remove(uri);
+        self.open_imports.remove(uri);
         self.virtual_docs_cache.remove(uri);
     }
 
     /// Clear all cached virtual documents.
     pub fn clear_virtual_docs(&self) {
-        self.open_vue_imports.clear();
+        self.open_imports.clear();
         self.virtual_docs_cache.clear();
     }
 

--- a/tests/tooling/lsp-typecheck-jsx-component.test.ts
+++ b/tests/tooling/lsp-typecheck-jsx-component.test.ts
@@ -74,7 +74,6 @@ export const view = <Counter {...props} />;
     const spreadRepaired = spreadBroken.replace('count: "wrong"', "count: 1");
     const counterPath = path.join(sourceDir, "Counter.vue");
     const consumerPath = path.join(sourceDir, "Consumer.tsx");
-    const counterUri = pathToFileURL(counterPath).href;
     const consumerUri = pathToFileURL(consumerPath).href;
     fs.writeFileSync(counterPath, counter, "utf8");
     fs.writeFileSync(consumerPath, broken, "utf8");
@@ -84,12 +83,6 @@ export const view = <Counter {...props} />;
       lint: false,
       typecheck: true,
     });
-    session.notify("textDocument/didOpen", {
-      textDocument: { uri: counterUri, languageId: "vue", version: 1, text: counter },
-    });
-    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
-      isDiagnosticsForUri(params, counterUri),
-    );
     session.notify("textDocument/didOpen", {
       textDocument: {
         uri: consumerUri,


### PR DESCRIPTION
## Summary

- generalize the reverse dependency index from open SFCs to open SFC and JSX/TSX script documents
- track imports, re-exports, dynamic imports, CommonJS require calls, and TypeScript import types
- refresh opted-in JSX documents after declaration changes while retaining the existing supersession bound

## Root cause

The reverse dependency index discarded every importer whose extension was not Vue. A changed component could therefore refresh an SFC importer but never an open TSX or checkJs JSX importer, leaving editor diagnostics stale until the consumer itself changed.

## Impact

Open JSX/TSX consumers now participate in the same bounded importer graph and declaration fan-out as SFCs. Styleless script documents retain their import edges even though they do not need embedded CSS virtual documents.

Refs #4042
Refs #3953

## Validation

- cargo test -p vize_canon -p vize_maestro --lib
- cargo clippy -p vize_canon -p vize_maestro --lib -- -D warnings
- VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/lsp-typecheck-jsx-component.test.ts tests/tooling/lsp-watched-refresh.test.ts tests/tooling/lsp-watcher-revalidation.test.ts
- SOURCE_LENGTH_BASE_REF=ab729b35b5e4a800140ccf0c9e8fe18961b6257e node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->