### PR TITLE
fix(lsp): revalidate JSX component file lifecycles

### DIFF
--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -608,11 +608,11 @@ impl LanguageServer for MaestroServer {
     }
 
     async fn did_create_files(&self, params: CreateFilesParams) {
-        super::workspace_files::did_create_files(&self.state, &params);
+        super::workspace_files::did_create_files(self, &params).await;
     }
 
     async fn did_delete_files(&self, params: DeleteFilesParams) {
-        super::workspace_files::did_delete_files(&self.state, &params);
+        super::workspace_files::did_delete_files(self, &params).await;
     }
 
     async fn did_rename_files(&self, params: RenameFilesParams) {

--- a/crates/vize_maestro/src/server/workspace_files.rs
+++ b/crates/vize_maestro/src/server/workspace_files.rs
@@ -2,8 +2,9 @@
 
 use tower_lsp::lsp_types::{
     ClientCapabilities, CreateFilesParams, DeleteFilesParams, DidChangeWatchedFilesParams,
-    MessageType, RenameFilesParams, WorkspaceEdit,
+    MessageType, RenameFilesParams, Url, WorkspaceEdit,
 };
+use vize_carton::cstr;
 
 use super::{MaestroServer, ServerState};
 use crate::ide::FileRenameService;
@@ -84,64 +85,41 @@ pub(super) async fn did_change_watched_files(
             params.changes.iter().map(|change| change.uri.as_str()),
         );
 
-        let mut dependents = params
-            .changes
-            .iter()
-            .flat_map(|change| super::importers::open_vue_dependents(&server.state, &change.uri))
-            .collect::<Vec<_>>();
-        dependents.sort();
-        dependents.dedup();
-        let dependents = dependents
-            .into_iter()
-            .filter_map(|uri| {
-                server
-                    .state
-                    .documents
-                    .version(&uri)
-                    .map(|version| (uri, version))
-            })
-            .collect::<Vec<_>>();
-        if dependents.is_empty() && !global_components_invalidated {
-            return;
-        }
-        // Recomputation must read the changed files fresh from disk.
-        server.state.invalidate_batch_cache();
-        for (dependent, version) in dependents {
-            server
-                .publish_diagnostics_if_version(&dependent, version)
-                .await;
-        }
+        refresh_dependents(
+            server,
+            params
+                .changes
+                .iter()
+                .map(|change| change.uri.clone())
+                .collect(),
+            global_components_invalidated,
+        )
+        .await;
     }
     #[cfg(not(feature = "native"))]
     let _ = (server, params);
 }
 
-pub(super) fn did_create_files(state: &ServerState, params: &CreateFilesParams) {
+pub(super) async fn did_create_files(server: &MaestroServer, params: &CreateFilesParams) {
     #[cfg(feature = "native")]
     {
-        state.invalidate_global_component_references(
-            params.files.iter().map(|file| file.uri.as_str()),
-        );
-        for file in &params.files {
-            state.track_workspace_vue_file(file.uri.as_str());
-        }
+        let invalidated = register_created_files(&server.state, params);
+        refresh_dependents(server, file_event_uris(params), invalidated).await;
     }
     #[cfg(not(feature = "native"))]
-    let _ = (state, params);
+    let _ = (server, params);
 }
 
-pub(super) fn did_delete_files(state: &ServerState, params: &DeleteFilesParams) {
+pub(super) async fn did_delete_files(server: &MaestroServer, params: &DeleteFilesParams) {
     #[cfg(feature = "native")]
     {
-        state.invalidate_global_component_references(
-            params.files.iter().map(|file| file.uri.as_str()),
-        );
-        for file in &params.files {
-            state.forget_workspace_vue_file(file.uri.as_str());
-        }
+        let invalidated = register_deleted_files(&server.state, params);
+        let dependencies = file_event_uris(params);
+        close_vue_dependency_documents(server, &dependencies).await;
+        refresh_dependents(server, dependencies, invalidated).await;
     }
     #[cfg(not(feature = "native"))]
-    let _ = (state, params);
+    let _ = (server, params);
 }
 
 pub(super) async fn will_rename_files(
@@ -157,7 +135,7 @@ pub(super) async fn will_rename_files(
 pub(super) async fn did_rename_files(server: &MaestroServer, params: &RenameFilesParams) {
     #[cfg(feature = "native")]
     {
-        server.state.invalidate_global_component_references(
+        let invalidated = server.state.invalidate_global_component_references(
             params
                 .files
                 .iter()
@@ -169,6 +147,22 @@ pub(super) async fn did_rename_files(server: &MaestroServer, params: &RenameFile
                 .forget_workspace_vue_file(file.old_uri.as_str());
             server.state.track_workspace_vue_file(file.new_uri.as_str());
         }
+        let dependencies = params
+            .files
+            .iter()
+            .flat_map(|file| [&file.old_uri, &file.new_uri])
+            .filter_map(|uri| Url::parse(uri).ok())
+            .collect();
+        close_vue_dependency_documents(
+            server,
+            &params
+                .files
+                .iter()
+                .filter_map(|file| Url::parse(&file.old_uri).ok())
+                .collect::<Vec<_>>(),
+        )
+        .await;
+        refresh_dependents(server, dependencies, invalidated).await;
     }
     if !server.state.lsp_features().file_rename {
         return;
@@ -184,73 +178,122 @@ pub(super) async fn did_rename_files(server: &MaestroServer, params: &RenameFile
     }
 }
 
-#[cfg(all(test, feature = "native"))]
-mod tests {
-    use tower_lsp::lsp_types::{ClientCapabilities, CreateFilesParams, DeleteFilesParams, Url};
-
-    use super::{
-        ServerState, did_create_files, did_delete_files, global_component_watcher_registration,
-        record_watcher_support,
-    };
-
-    #[test]
-    fn declaration_watcher_tracks_create_change_and_delete_recursively() {
-        let registration = global_component_watcher_registration();
-        assert_eq!(registration.method, "workspace/didChangeWatchedFiles");
-        let options = registration.register_options.unwrap();
-        assert_eq!(options["watchers"][0]["globPattern"], "**/*.d.{ts,mts,cts}");
-        assert!(
-            options["watchers"][0].get("kind").is_none(),
-            "omitted kind must request create, change, and delete events: {options}"
-        );
+#[cfg(feature = "native")]
+fn register_created_files(state: &ServerState, params: &CreateFilesParams) -> bool {
+    let invalidated = state
+        .invalidate_global_component_references(params.files.iter().map(|file| file.uri.as_str()));
+    for file in &params.files {
+        state.track_workspace_vue_file(file.uri.as_str());
     }
+    invalidated
+}
 
-    #[test]
-    fn client_watcher_support_is_recorded_from_initialize_capabilities() {
-        let capabilities: ClientCapabilities = serde_json::from_value(serde_json::json!({
-            "workspace": {
-                "didChangeWatchedFiles": { "dynamicRegistration": true }
-            }
-        }))
-        .unwrap();
-        let state = ServerState::new();
-
-        record_watcher_support(&state, &capabilities);
-
-        assert!(state.global_component_watcher_supported());
+#[cfg(feature = "native")]
+fn register_deleted_files(state: &ServerState, params: &DeleteFilesParams) -> bool {
+    let invalidated = state
+        .invalidate_global_component_references(params.files.iter().map(|file| file.uri.as_str()));
+    for file in &params.files {
+        state.forget_workspace_vue_file(file.uri.as_str());
     }
+    invalidated
+}
 
-    #[test]
-    fn vue_file_events_track_only_existing_created_files_and_forget_deletes() {
-        let root = tempfile::tempdir().unwrap();
-        let vue_path = root.path().join("DiskChild.vue");
-        let declaration_path = root.path().join("components.d.ts");
-        std::fs::write(&vue_path, "<template />\n").unwrap();
-        std::fs::write(&declaration_path, "export {};\n").unwrap();
-        let vue_uri = Url::from_file_path(&vue_path).unwrap();
-        let declaration_uri = Url::from_file_path(&declaration_path).unwrap();
-        let missing_uri = Url::from_file_path(root.path().join("Missing.vue")).unwrap();
-        let state = ServerState::new();
+#[cfg(feature = "native")]
+fn file_event_uris<T>(params: &T) -> Vec<Url>
+where
+    T: FileEventParams,
+{
+    params
+        .uris()
+        .filter_map(|uri| Url::parse(uri).ok())
+        .collect()
+}
 
-        let created: CreateFilesParams = serde_json::from_value(serde_json::json!({
-            "files": [
-                { "uri": vue_uri.as_str() },
-                { "uri": declaration_uri.as_str() },
-                { "uri": missing_uri.as_str() }
-            ]
-        }))
-        .unwrap();
-        did_create_files(&state, &created);
+#[cfg(feature = "native")]
+trait FileEventParams {
+    fn uris(&self) -> impl Iterator<Item = &str>;
+}
 
-        assert_eq!(state.workspace_vue_file_uris(), vec![vue_uri.clone()]);
-
-        std::fs::remove_file(&vue_path).unwrap();
-        let deleted: DeleteFilesParams = serde_json::from_value(serde_json::json!({
-            "files": [{ "uri": vue_uri.as_str() }]
-        }))
-        .unwrap();
-        did_delete_files(&state, &deleted);
-
-        assert!(state.workspace_vue_file_uris().is_empty());
+#[cfg(feature = "native")]
+impl FileEventParams for CreateFilesParams {
+    fn uris(&self) -> impl Iterator<Item = &str> {
+        self.files.iter().map(|file| file.uri.as_str())
     }
 }
+
+#[cfg(feature = "native")]
+impl FileEventParams for DeleteFilesParams {
+    fn uris(&self) -> impl Iterator<Item = &str> {
+        self.files.iter().map(|file| file.uri.as_str())
+    }
+}
+
+#[cfg(feature = "native")]
+async fn refresh_dependents(
+    server: &MaestroServer,
+    dependencies: Vec<Url>,
+    force_invalidate: bool,
+) {
+    let mut dependents = dependencies
+        .iter()
+        .flat_map(|dependency| {
+            super::importers::open_typecheck_dependents(&server.state, dependency)
+        })
+        .collect::<Vec<_>>();
+    dependents.sort();
+    dependents.dedup();
+    let dependents = dependents
+        .into_iter()
+        .filter_map(|uri| {
+            server
+                .state
+                .documents
+                .version(&uri)
+                .map(|version| (uri, version))
+        })
+        .collect::<Vec<_>>();
+    if dependents.is_empty() && !force_invalidate {
+        return;
+    }
+    server.state.invalidate_batch_cache();
+    for (dependent, version) in dependents {
+        server
+            .publish_diagnostics_if_version(&dependent, version)
+            .await;
+    }
+}
+
+#[cfg(feature = "native")]
+async fn close_vue_dependency_documents(server: &MaestroServer, dependencies: &[Url]) {
+    if !server.state.has_corsa_bridge() {
+        return;
+    }
+    let Some(bridge) = server.state.get_corsa_bridge().await else {
+        return;
+    };
+    for source_path in dependencies
+        .iter()
+        .filter_map(|uri| uri.to_file_path().ok())
+    {
+        if source_path
+            .extension()
+            .and_then(|extension| extension.to_str())
+            != Some("vue")
+        {
+            continue;
+        }
+        let Some(file_name) = source_path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        for suffix in [".ts", ".tsx"] {
+            let virtual_path = source_path.with_file_name(cstr!("{file_name}{suffix}"));
+            if let Ok(uri) = Url::from_file_path(virtual_path) {
+                let _ = bridge.close_virtual_document(uri.as_str()).await;
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "native"))]
+#[path = "workspace_files_tests.rs"]
+mod tests;

--- a/crates/vize_maestro/src/server/workspace_files_tests.rs
+++ b/crates/vize_maestro/src/server/workspace_files_tests.rs
@@ -1,0 +1,67 @@
+use tower_lsp::lsp_types::{ClientCapabilities, CreateFilesParams, DeleteFilesParams, Url};
+
+use super::{
+    ServerState, global_component_watcher_registration, record_watcher_support,
+    register_created_files, register_deleted_files,
+};
+
+#[test]
+fn declaration_watcher_tracks_create_change_and_delete_recursively() {
+    let registration = global_component_watcher_registration();
+    assert_eq!(registration.method, "workspace/didChangeWatchedFiles");
+    let options = registration.register_options.unwrap();
+    assert_eq!(options["watchers"][0]["globPattern"], "**/*.d.{ts,mts,cts}");
+    assert!(
+        options["watchers"][0].get("kind").is_none(),
+        "omitted kind must request create, change, and delete events: {options}"
+    );
+}
+
+#[test]
+fn client_watcher_support_is_recorded_from_initialize_capabilities() {
+    let capabilities: ClientCapabilities = serde_json::from_value(serde_json::json!({
+        "workspace": {
+            "didChangeWatchedFiles": { "dynamicRegistration": true }
+        }
+    }))
+    .unwrap();
+    let state = ServerState::new();
+
+    record_watcher_support(&state, &capabilities);
+
+    assert!(state.global_component_watcher_supported());
+}
+
+#[test]
+fn vue_file_events_track_only_existing_created_files_and_forget_deletes() {
+    let root = tempfile::tempdir().unwrap();
+    let vue_path = root.path().join("DiskChild.vue");
+    let declaration_path = root.path().join("components.d.ts");
+    std::fs::write(&vue_path, "<template />\n").unwrap();
+    std::fs::write(&declaration_path, "export {};\n").unwrap();
+    let vue_uri = Url::from_file_path(&vue_path).unwrap();
+    let declaration_uri = Url::from_file_path(&declaration_path).unwrap();
+    let missing_uri = Url::from_file_path(root.path().join("Missing.vue")).unwrap();
+    let state = ServerState::new();
+
+    let created: CreateFilesParams = serde_json::from_value(serde_json::json!({
+        "files": [
+            { "uri": vue_uri.as_str() },
+            { "uri": declaration_uri.as_str() },
+            { "uri": missing_uri.as_str() }
+        ]
+    }))
+    .unwrap();
+    register_created_files(&state, &created);
+
+    assert_eq!(state.workspace_vue_file_uris(), vec![vue_uri.clone()]);
+
+    std::fs::remove_file(&vue_path).unwrap();
+    let deleted: DeleteFilesParams = serde_json::from_value(serde_json::json!({
+        "files": [{ "uri": vue_uri.as_str() }]
+    }))
+    .unwrap();
+    register_deleted_files(&state, &deleted);
+
+    assert!(state.workspace_vue_file_uris().is_empty());
+}

--- a/tests/tooling/lsp-jsx-component-lifecycle.test.ts
+++ b/tests/tooling/lsp-jsx-component-lifecycle.test.ts
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isDiagnosticsForUri } from "./support/lsp/assertions.ts";
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
+
+type WorkspaceEdit = {
+  changes?: Record<string, Array<{ newText: string }>>;
+  documentChanges?: Array<{
+    textDocument?: { uri?: string };
+    edits?: Array<{ newText: string }>;
+  }>;
+} | null;
+
+test("vize lsp revalidates a TSX SFC import across create, edit, rename, and delete", async (t) => {
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTsgoBinary(),
+    "tsgo binary for the TSX SFC lifecycle gate",
+    "tsgo binary not found; skipping TSX SFC lifecycle test",
+  );
+  if (corsaPath == null) return;
+
+  const outputDir = path.join(testOutputRoot, "lsp-jsx-component-lifecycle");
+  fs.mkdirSync(outputDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(outputDir, "workspace-"));
+  const sourceDir = path.join(workspaceDir, "src");
+  fs.mkdirSync(sourceDir, { recursive: true });
+  const session = new LspSession();
+
+  try {
+    writeProjectConfig(workspaceDir, corsaPath);
+    const consumer = `import Counter from "./Counter.vue";
+export const view = <Counter count={1} />;
+`;
+    const renamedConsumer = consumer.replace("./Counter.vue", "./Renamed.vue");
+    const stringCounter = `<script setup lang="ts">
+defineProps<{ count: string }>()
+</script>
+`;
+    const numberCounter = stringCounter.replace("count: string", "count: number");
+    const consumerPath = path.join(sourceDir, "Consumer.tsx");
+    const counterPath = path.join(sourceDir, "Counter.vue");
+    const renamedPath = path.join(sourceDir, "Renamed.vue");
+    const consumerUri = pathToFileURL(consumerPath).href;
+    const counterUri = pathToFileURL(counterPath).href;
+    const renamedUri = pathToFileURL(renamedPath).href;
+    fs.writeFileSync(consumerPath, consumer, "utf8");
+
+    await session.initialize(workspaceDir, {
+      editor: true,
+      fileRename: true,
+      lint: false,
+      typecheck: true,
+    });
+    session.notify("textDocument/didOpen", {
+      textDocument: {
+        uri: consumerUri,
+        languageId: "typescriptreact",
+        version: 1,
+        text: consumer,
+      },
+    });
+    await waitForCode(session, consumerUri, 1, 2307);
+
+    fs.writeFileSync(counterPath, stringCounter, "utf8");
+    session.notify("workspace/didCreateFiles", { files: [{ uri: counterUri }] });
+    const created = await waitForCode(session, consumerUri, 1, 2322);
+    assert.match(created.diagnostics[0]?.message ?? "", /number.*string|not assignable/);
+
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri: counterUri, languageId: "vue", version: 1, text: stringCounter },
+    });
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, counterUri),
+    );
+    fs.writeFileSync(counterPath, numberCounter, "utf8");
+    session.notify("textDocument/didChange", {
+      textDocument: { uri: counterUri, version: 2 },
+      contentChanges: [{ text: numberCounter }],
+    });
+    await waitForClean(session, consumerUri, 1);
+    session.notify("textDocument/didClose", { textDocument: { uri: counterUri } });
+
+    const renameEdit = (await session.request("workspace/willRenameFiles", {
+      files: [{ oldUri: counterUri, newUri: renamedUri }],
+    })) as WorkspaceEdit;
+    assert.deepEqual(editTextsForUri(renameEdit, consumerUri), ["./Renamed.vue"]);
+
+    fs.renameSync(counterPath, renamedPath);
+    session.notify("workspace/didRenameFiles", {
+      files: [{ oldUri: counterUri, newUri: renamedUri }],
+    });
+    await waitForCode(session, consumerUri, 1, 2307);
+
+    fs.writeFileSync(consumerPath, renamedConsumer, "utf8");
+    session.notify("textDocument/didChange", {
+      textDocument: { uri: consumerUri, version: 2 },
+      contentChanges: [{ text: renamedConsumer }],
+    });
+    await waitForClean(session, consumerUri, 2);
+
+    fs.rmSync(renamedPath);
+    session.notify("workspace/didDeleteFiles", { files: [{ uri: renamedUri }] });
+    await waitForCode(session, consumerUri, 2, 2307);
+
+    fs.writeFileSync(renamedPath, numberCounter, "utf8");
+    session.notify("workspace/didCreateFiles", { files: [{ uri: renamedUri }] });
+    await waitForClean(session, consumerUri, 2);
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
+});
+
+async function waitForCode(
+  session: LspSession,
+  uri: string,
+  version: number,
+  code: number,
+): Promise<PublishDiagnosticsParams> {
+  return (await session.waitForNotification(
+    "textDocument/publishDiagnostics",
+    (params) =>
+      isDiagnosticsForUri(params, uri) &&
+      params.version === version &&
+      params.diagnostics.some((diagnostic) => diagnostic.code === code),
+    10_000,
+  )) as PublishDiagnosticsParams;
+}
+
+async function waitForClean(
+  session: LspSession,
+  uri: string,
+  version: number,
+): Promise<PublishDiagnosticsParams> {
+  return (await session.waitForNotification(
+    "textDocument/publishDiagnostics",
+    (params) =>
+      isDiagnosticsForUri(params, uri) &&
+      params.version === version &&
+      params.diagnostics.length === 0,
+    10_000,
+  )) as PublishDiagnosticsParams;
+}
+
+function editTextsForUri(edit: WorkspaceEdit, uri: string): string[] {
+  const texts = (edit?.changes?.[uri] ?? []).map((textEdit) => textEdit.newText);
+  for (const change of edit?.documentChanges ?? []) {
+    if (change.textDocument?.uri === uri) {
+      texts.push(...(change.edits ?? []).map((textEdit) => textEdit.newText));
+    }
+  }
+  return texts;
+}
+
+function resolveTsgoBinary(): string | undefined {
+  return [
+    path.join(root, "../corsa-bind/.cache/tsgo"),
+    path.join(root, "node_modules/.bin/tsgo"),
+    path.join(root, "tests/node_modules/.bin/tsgo"),
+  ].find((candidate) => fs.existsSync(candidate));
+}
+
+function writeProjectConfig(workspaceDir: string, corsaPath: string): void {
+  fs.writeFileSync(
+    path.join(workspaceDir, "vize.config.json"),
+    JSON.stringify({
+      lsp: { lint: false, typecheck: true },
+      typeChecker: { corsaPath, jsxTypecheck: true },
+    }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(workspaceDir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        jsx: "preserve",
+        jsxImportSource: "vue",
+        module: "ESNext",
+        moduleResolution: "bundler",
+        noEmit: true,
+        strict: true,
+        target: "ES2022",
+      },
+      include: ["src/**/*"],
+    }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(workspaceDir, "src/vue-shim.d.ts"),
+    `declare module "vue" {
+  export interface Ref<T = any> { value: T }
+  export interface ShallowRef<T = any> { value: T }
+  export type DefineComponent<Props = {}> = new () => { $props: Props }
+  export interface ComponentPublicInstance {
+    $attrs: Record<string, unknown>
+    $slots: Record<string, unknown>
+    $refs: Record<string, unknown>
+    $emit: (...args: any[]) => void
+  }
+  export interface GlobalComponents {}
+}
+`,
+    "utf8",
+  );
+}


### PR DESCRIPTION
## Summary

- revalidate open JSX/TSX importers after component create, delete, rename, and watched-file notifications
- close stale Vue TS and TSX virtual identities before checking a deleted or renamed dependency
- cover the complete missing, created, edited, renamed, deleted, and recreated component lifecycle through the real LSP process

## Root cause

Workspace file notifications only maintained the global-component and workspace-file caches. They did not schedule diagnostics for open importers, and renamed or deleted Vue dependencies remained open in Corsa under their previous virtual identity. This left false module-not-found errors after creation and false clean diagnostics after deletion or rename.

## Impact

An open TSX consumer now transitions deterministically between TS2307, prop-contract diagnostics, and a clean state as its imported SFC is created, edited, renamed, deleted, and recreated. Rename preparation also updates the authored TSX import before the disk move.

Refs #4042
Refs #3953

## Validation

- cargo test -p vize_canon -p vize_maestro --lib
- cargo clippy -p vize_canon -p vize_maestro --lib -- -D warnings
- VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/lsp-jsx-component-lifecycle.test.ts tests/tooling/lsp-typecheck-jsx-component.test.ts tests/tooling/lsp-file-rename-workspace.test.ts tests/tooling/lsp-watched-refresh.test.ts tests/tooling/lsp-watcher-revalidation.test.ts tests/tooling/lsp-file-create-delete.test.ts
- SOURCE_LENGTH_BASE_REF=ab729b35b5e4a800140ccf0c9e8fe18961b6257e node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->