### PR TITLE
fix(content-mapper): honor noUnusedLocals

### DIFF
--- a/crates/vize/src/commands/content_mapper.rs
+++ b/crates/vize/src/commands/content_mapper.rs
@@ -54,8 +54,15 @@ struct TransformParams {
     content: CompactString,
     #[serde(default)]
     options: Option<TransformOptions>,
-    #[allow(dead_code)]
-    compiler_options: Value,
+    #[serde(default)]
+    compiler_options: CompilerOptions,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CompilerOptions {
+    #[serde(default)]
+    no_unused_locals: bool,
 }
 
 #[derive(Deserialize)]
@@ -146,10 +153,13 @@ fn serve<R: BufRead, W: Write>(reader: &mut R, writer: &mut W) -> io::Result<()>
                     }
                 };
                 let options = params.options.unwrap_or_default();
+                let transform_options = ContentMapperTransformOptions::default()
+                    .with_options_api(options.options_api)
+                    .with_preserve_unused_diagnostics(params.compiler_options.no_unused_locals);
                 match generate_vue_content_mapper_transform_with_options(
                     Path::new(params.file_name.as_str()),
                     params.content.as_str(),
-                    ContentMapperTransformOptions::default().with_options_api(options.options_api),
+                    transform_options,
                 ) {
                     Ok(result) => write_result(writer, id, result)?,
                     Err(error) => {

--- a/crates/vize/src/commands/content_mapper/tests.rs
+++ b/crates/vize/src/commands/content_mapper/tests.rs
@@ -122,6 +122,29 @@ export default { data() { return { count: 1 } } }
 }
 
 #[test]
+fn transform_honors_no_unused_locals_compiler_option() {
+    let source = r#"<script setup lang="ts">
+const used = 1
+const unused = 2
+</script>
+<template>{{ used }}</template>
+"#;
+    let input = frames(&[
+        initialize_request(),
+        transform_request_with_compiler_options(2, source, json!({ "noUnusedLocals": true })),
+        transform_request_with_compiler_options(3, source, json!({ "noUnusedLocals": false })),
+    ]);
+    let responses = exchange(&input);
+    let preserving = responses[1]["result"]["text"].as_str().unwrap();
+    let suppressing = responses[2]["result"]["text"].as_str().unwrap();
+
+    assert!(preserving.contains("void used;"), "{preserving}");
+    assert!(!preserving.contains("void unused;"), "{preserving}");
+    assert!(suppressing.contains("void used;"), "{suppressing}");
+    assert!(suppressing.contains("void unused;"), "{suppressing}");
+}
+
+#[test]
 fn transform_defaults_options_api_on_for_absent_null_and_empty_options() {
     let source = r#"<script lang="ts">
 export default { data() { return { count: 1 } } }
@@ -213,6 +236,23 @@ fn transform_request(id: u8, content: &str, options: Value) -> Value {
             "content": content,
             "options": options,
             "compilerOptions": {}
+        }
+    })
+}
+
+fn transform_request_with_compiler_options(
+    id: u8,
+    content: &str,
+    compiler_options: Value,
+) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "transform",
+        "params": {
+            "fileName": "Unused.vue",
+            "content": content,
+            "compilerOptions": compiler_options
         }
     })
 }

--- a/crates/vize/tests/content_mapper_tsgo_build.rs
+++ b/crates/vize/tests/content_mapper_tsgo_build.rs
@@ -38,6 +38,7 @@ fn install_packages(project_root: &Path) {
             "private": true,
             "tsContentMapper": {
                 "exec": [env!("CARGO_BIN_EXE_vize"), "content-mapper"],
+                "compilerOptions": ["noUnusedLocals"],
             },
         }))
         .unwrap(),

--- a/crates/vize/tests/content_mapper_tsgo_cli.rs
+++ b/crates/vize/tests/content_mapper_tsgo_cli.rs
@@ -37,6 +37,7 @@ fn install_mapper_manifest(project_root: &Path) {
         "private": true,
         "tsContentMapper": {
             "exec": [env!("CARGO_BIN_EXE_vize"), "content-mapper"],
+            "compilerOptions": ["noUnusedLocals"],
         },
     });
     std::fs::write(
@@ -225,6 +226,22 @@ fn standard_tsgo_checks_vue_project_and_emits_consumable_declarations() {
             && broken_output.contains("not assignable to type 'number'"),
         "{broken_output}"
     );
+    assert!(
+        broken_output.contains("src/Unused.vue")
+            && broken_output.contains("TS6133")
+            && broken_output.contains("'unused' is declared but its value is never read"),
+        "{broken_output}"
+    );
+    assert!(
+        !broken_output.contains("'used' is declared"),
+        "{broken_output}"
+    );
+    assert_eq!(
+        broken_output.matches("TS6133").count(),
+        1,
+        "{broken_output}"
+    );
+    assert!(!broken_output.contains("TS6196"), "{broken_output}");
 
     let emit = run_tsgo(
         &tsgo,

--- a/crates/vize/tests/fixtures/content_mapper_project/src/Unused.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/Unused.vue
@@ -1,0 +1,6 @@
+<script setup lang="ts">
+const used = 1
+const unused = 2
+</script>
+
+<template>{{ used }}</template>

--- a/crates/vize/tests/fixtures/content_mapper_project/tsconfig.emit.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/tsconfig.emit.json
@@ -7,9 +7,11 @@
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,
+    "noUnusedLocals": true,
     "rootDir": "src",
     "outDir": "dist"
   },
   "contentMappers": [{ "package": "vize", "extensions": [".vue"] }],
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/Unused.vue"]
 }

--- a/crates/vize/tests/fixtures/content_mapper_project/tsconfig.error.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/tsconfig.error.json
@@ -4,6 +4,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "noUnusedLocals": true,
     "noEmit": true
   },
   "contentMappers": [{ "package": "vize", "extensions": [".vue"] }],

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -43,18 +43,23 @@ pub struct ContentMapperTransform {
     pub diagnostics: Vec<ContentMapperDiagnostic>,
 }
 
-/// Vize-specific settings supplied through a TypeScript content-mapper entry's
-/// `options` object.
+/// Settings resolved from a TypeScript content-mapper entry and its declared
+/// compiler-option dependencies.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ContentMapperTransformOptions {
     /// Resolve Vue Options API instance bindings in templates.
     options_api: bool,
+    /// Preserve diagnostics for user-authored unused locals.
+    preserve_unused_diagnostics: bool,
 }
 
 impl Default for ContentMapperTransformOptions {
     fn default() -> Self {
-        Self { options_api: true }
+        Self {
+            options_api: true,
+            preserve_unused_diagnostics: false,
+        }
     }
 }
 
@@ -70,6 +75,13 @@ impl ContentMapperTransformOptions {
     #[must_use]
     pub const fn options_api(self) -> bool {
         self.options_api
+    }
+
+    /// Preserve diagnostics for user-authored unused locals.
+    #[must_use]
+    pub const fn with_preserve_unused_diagnostics(mut self, enabled: bool) -> Self {
+        self.preserve_unused_diagnostics = enabled;
+        self
     }
 }
 
@@ -140,7 +152,7 @@ pub fn generate_vue_content_mapper_transform_with_options(
         &options,
         VueCodegenOptions {
             check_options: VirtualTsCheckOptions::default(),
-            preserve_unused_diagnostics: false,
+            preserve_unused_diagnostics: transform_options.preserve_unused_diagnostics,
             options_api: transform_options.options_api(),
             preserve_authored_component: true,
             legacy_vue2: false,

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -224,6 +224,26 @@ export default {
 }
 
 #[test]
+fn unused_diagnostic_setting_only_anchors_template_references() {
+    let source = r#"<script setup lang="ts">
+const used = 1
+const unused = 2
+</script>
+<template>{{ used }}</template>
+"#;
+
+    let result = generate_vue_content_mapper_transform_with_options(
+        Path::new("Unused.vue"),
+        source,
+        ContentMapperTransformOptions::default().with_preserve_unused_diagnostics(true),
+    )
+    .expect("transform");
+
+    assert!(result.text.contains("void used;"), "{}", result.text);
+    assert!(!result.text.contains("void unused;"), "{}", result.text);
+}
+
+#[test]
 fn default_transform_matches_vize_options_api_default() {
     let source = r#"<script lang="ts">
 export default { data() { return { count: 1 } } }

--- a/npm/cli/package.json
+++ b/npm/cli/package.json
@@ -97,6 +97,9 @@
       "node",
       "./bin/vize",
       "content-mapper"
+    ],
+    "compilerOptions": [
+      "noUnusedLocals"
     ]
   }
 }

--- a/tests/tooling/content-mapper-manifest.test.ts
+++ b/tests/tooling/content-mapper-manifest.test.ts
@@ -21,8 +21,8 @@ test("vize package exposes an executable TypeScript content mapper", () => {
 
   assert.deepEqual(packageJson.tsContentMapper, {
     exec: ["node", "./bin/vize", "content-mapper"],
+    compilerOptions: ["noUnusedLocals"],
   });
-  assert.equal(packageJson.tsContentMapper?.compilerOptions, undefined);
   assert.equal(packageJson.bin?.vize, "bin/vize");
   assert.ok(packageJson.files?.includes("bin"));
   assert.notEqual(


### PR DESCRIPTION
## Summary

- declare `noUnusedLocals` as a Content Mapper compiler-option dependency
- pass the effective option through the protocol into Canon's existing unused-binding preservation
- cover true, false, and absent settings with protocol and exact upstream tsgo tests
- verify declaration emit under `noUnusedLocals` without generated TS6133/TS6196 noise

## Validation

- `cargo test -p vize_canon --lib`
- `cargo test -p vize --lib`
- `cargo test -p vize_maestro --lib`
- `cargo clippy -p vize_canon -p vize -p vize_maestro --lib -- -D warnings`
- exact pinned upstream tsgo CLI and project-reference conformance
- source-file length ratchet
- package manifest tooling test

Closes #4050

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->