### PR TITLE
test(content-mapper): exercise packed CLI artifacts

### DIFF
--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -23,9 +23,15 @@ on:
       - "crates/vize_canon/tests/lsp_import_resolution.rs"
       - "crates/vize_canon/src/virtual_ts/**"
       - "crates/vize_maestro/src/ide/**"
+      - "npm/cli/bin/vize"
       - "npm/cli/package.json"
+      - "npm/cli/src/**"
+      - "npm/native/**"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
+      - "tools/npm/prepare-publish-manifest.mjs"
+      - "tools/npm/smoke-release-install.mjs"
+      - "tools/npm/smoke-release-runtime.mjs"
   push:
     branches: [main]
     paths:
@@ -48,9 +54,15 @@ on:
       - "crates/vize_canon/tests/lsp_import_resolution.rs"
       - "crates/vize_canon/src/virtual_ts/**"
       - "crates/vize_maestro/src/ide/**"
+      - "npm/cli/bin/vize"
       - "npm/cli/package.json"
+      - "npm/cli/src/**"
+      - "npm/native/**"
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
+      - "tools/npm/prepare-publish-manifest.mjs"
+      - "tools/npm/smoke-release-install.mjs"
+      - "tools/npm/smoke-release-runtime.mjs"
   workflow_dispatch:
 
 concurrency:
@@ -108,6 +120,30 @@ jobs:
         run: |
           go build -tags=noembed -trimpath -o "$RUNNER_TEMP/tsgo" ./cmd/tsgo
           cp internal/bundled/libs/*.d.ts "$RUNNER_TEMP/"
+      - name: Build packed Content Mapper runtime
+        run: |
+          vp run --filter './npm/native' build:ci
+          (cd npm/cli && vp pack)
+      - name: Prepare native platform packages
+        working-directory: npm/native
+        run: |
+          vp exec napi create-npm-dirs
+          vp exec napi pre-publish -t npm --no-gh-release --skip-optional-publish
+          for binary in vize-vitrine.*.node; do
+            [ -f "$binary" ] || continue
+            target="${binary#vize-vitrine.}"
+            target="${target%.node}"
+            if [ -d "npm/$target" ]; then
+              cp "$binary" "npm/$target/"
+            fi
+          done
+      - name: Run standard tsgo through fresh-installed package tarballs
+        env:
+          VIZE_TEST_CONTENT_MAPPER_TSGO: ${{ runner.temp }}/tsgo
+        run: |
+          node tools/npm/smoke-release-install.mjs --prepare-manifests --content-mapper-checks \
+            npm/native npm/native/npm/* \
+            npm/cli
       - name: Run standard project and declaration conformance
         env:
           VIZE_TEST_CONTENT_MAPPER_TSGO: ${{ runner.temp }}/tsgo

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -25,7 +25,13 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
     '"crates/vize/tests/content_mapper_tsgo_cli.rs"',
     '"crates/vize/tests/content_mapper_tsgo_build.rs"',
     '"crates/vize/tests/fixtures/content_mapper_project/**"',
+    '"npm/cli/bin/vize"',
     '"npm/cli/package.json"',
+    '"npm/cli/src/**"',
+    '"npm/native/**"',
+    '"tools/npm/prepare-publish-manifest.mjs"',
+    '"tools/npm/smoke-release-install.mjs"',
+    '"tools/npm/smoke-release-runtime.mjs"',
   ]) {
     assert.match(workflow, new RegExp(relevantPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   }
@@ -48,6 +54,14 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
   );
   assert.match(job, /cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture/);
   assert.match(job, /cargo test -p vize --test content_mapper_tsgo_build -- --nocapture/);
+  assert.match(job, /vp run --filter '\.\/npm\/native' build:ci/);
+  assert.match(job, /\(cd npm\/cli && vp pack\)/);
+  assert.match(job, /vp exec napi create-npm-dirs/);
+  assert.match(job, /cp "\$binary" "npm\/\$target\/"/);
+  assert.match(
+    job,
+    /VIZE_TEST_CONTENT_MAPPER_TSGO: \$\{\{ runner\.temp \}\}\/tsgo[\s\S]*smoke-release-install\.mjs --prepare-manifests --content-mapper-checks[\s\S]*npm\/native npm\/native\/npm\/\*[\s\S]*npm\/cli/,
+  );
   assert.match(job, /TSGO_PATH: \$\{\{ runner\.temp \}\}\/tsgo/);
   assert.match(job, /cargo test -p vize_canon --test lsp_import_resolution -- --nocapture/);
   assert.match(job, /cargo test -p vize_maestro/);

--- a/tests/tooling/release-smoke-install.test.ts
+++ b/tests/tooling/release-smoke-install.test.ts
@@ -174,26 +174,37 @@ test("release install smoke skips libc-incompatible tarballs", () => {
 
 test("release install smoke can run runtime checks for Vize packages", () => {
   const script = fs.readFileSync(smokeScript, "utf8");
+  const runtimeScript = fs.readFileSync(
+    path.join(root, "tools/npm/smoke-release-runtime.mjs"),
+    "utf8",
+  );
+  const smokeSources = `${script}\n${runtimeScript}`;
   const initTypecheckScript = fs.readFileSync(
     path.join(root, "tools/npm/smoke-release-init-typecheck.mjs"),
     "utf8",
   );
 
   assert.match(script, /--runtime-checks/);
+  assert.match(script, /--content-mapper-checks/);
   // vize declares @typescript/native-preview itself, so the fresh-install smoke
   // must not manually add it as a project runtime peer.
-  assert.doesNotMatch(script, /"@typescript\/native-preview":/);
-  assert.match(script, /require\("@vizejs\/native"\)/);
-  assert.match(script, /import\("@vizejs\/native"\)/);
-  assert.match(script, /native\.compileSfc/);
+  assert.doesNotMatch(smokeSources, /"@typescript\/native-preview":/);
+  assert.match(smokeSources, /require\("@vizejs\/native"\)/);
+  assert.match(smokeSources, /import\("@vizejs\/native"\)/);
+  assert.match(smokeSources, /native\.compileSfc/);
   // Bins are resolved out of the installed tree and invoked through
   // `process.execPath` so that `npm exec` cannot re-resolve native optional
   // deps and drop them mid-run (npm/cli#4828).
-  assert.match(script, /resolveInstalledBin\(installDir, "vize", "vize"\)/);
-  assert.match(script, /vizeBin, "--version"/);
-  assert.match(script, /"check"[\s\S]*"src\/App\.vue"/);
-  assert.match(script, /"lint"[\s\S]*"src\/App\.vue"/);
-  assert.match(script, /runInitTypecheckChecks\([\s\S]*RUNTIME_PEER_DEPENDENCIES\)/);
+  assert.match(smokeSources, /resolveInstalledBin\(installDir, "vize", "vize"\)/);
+  assert.match(smokeSources, /vizeBin, "--version"/);
+  assert.match(smokeSources, /"check"[\s\S]*"src\/App\.vue"/);
+  assert.match(smokeSources, /"lint"[\s\S]*"src\/App\.vue"/);
+  assert.match(smokeSources, /runInitTypecheckChecks\([\s\S]*RUNTIME_PEER_DEPENDENCIES\)/);
+  assert.match(runtimeScript, /VIZE_TEST_CONTENT_MAPPER_TSGO/);
+  assert.match(runtimeScript, /runInstalledContentMapperChecks/);
+  assert.match(runtimeScript, /content mapper project with spaces/);
+  assert.match(runtimeScript, /--loadExternalPlugins/);
+  assert.match(runtimeScript, /tsconfig\.emit\.json/);
   assert.match(initTypecheckScript, /`init-smoke-\$\{language\}`/);
   assert.match(initTypecheckScript, /\["typescript", "javascript"\]/);
   assert.match(initTypecheckScript, /"init"[\s\S]*"--typecheck"[\s\S]*"--no-install"/);
@@ -210,10 +221,10 @@ test("release install smoke can run runtime checks for Vize packages", () => {
   // vite is installed as upstream vite 8, one supported
   // `@vizejs/vite-plugin` peer range. Real vite exposes a `vite` bin entry, so
   // the smoke can use the same resolver as vize.
-  assert.match(script, /resolveInstalledBin\(installDir, "vite", "vite"\)/);
-  assert.match(script, /viteBin, "build"/);
-  assert.match(script, /vite:\s*"\^8\.0\.0"/);
-  assert.match(script, /runtime: @vizejs\/vite-plugin vite build/);
+  assert.match(smokeSources, /resolveInstalledBin\(installDir, "vite", "vite"\)/);
+  assert.match(smokeSources, /viteBin, "build"/);
+  assert.match(smokeSources, /vite:\s*"\^8\.0\.0"/);
+  assert.match(smokeSources, /runtime: @vizejs\/vite-plugin vite build/);
   // The combined install must request optional deps explicitly so that an
   // inherited `omit=optional` config does not silently drop platform-specific
   // native bindings (e.g. rolldown).

--- a/tools/npm/smoke-release-install.mjs
+++ b/tools/npm/smoke-release-install.mjs
@@ -8,7 +8,11 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { preparePublishManifest } from "./prepare-publish-manifest.mjs";
-import { runInitTypecheckChecks } from "./smoke-release-init-typecheck.mjs";
+import {
+  RUNTIME_PEER_DEPENDENCIES,
+  runInstalledContentMapperChecks,
+  runRuntimeChecks,
+} from "./smoke-release-runtime.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const dependencySections = [
@@ -20,6 +24,7 @@ const dependencySections = [
 
 function parseArgs(argv) {
   const options = {
+    contentMapperChecks: false,
     keepTemp: false,
     packageDirs: /** @type {string[]} */ ([]),
     prepareManifests: false,
@@ -27,6 +32,10 @@ function parseArgs(argv) {
   };
 
   for (const arg of argv) {
+    if (arg === "--content-mapper-checks") {
+      options.contentMapperChecks = true;
+      continue;
+    }
     if (arg === "--keep-temp") {
       options.keepTemp = true;
       continue;
@@ -47,7 +56,7 @@ function parseArgs(argv) {
 
   if (options.packageDirs.length === 0) {
     throw new Error(
-      "Usage: node tools/npm/smoke-release-install.mjs [--prepare-manifests] [--runtime-checks] [--keep-temp] <package-dir>...",
+      "Usage: node tools/npm/smoke-release-install.mjs [--prepare-manifests] [--runtime-checks] [--content-mapper-checks] [--keep-temp] <package-dir>...",
     );
   }
 
@@ -255,19 +264,6 @@ function assertInstalledPackage(nodeModules, packageInfo) {
   }
 }
 
-// The fresh-install smoke must mirror what an actual `@vizejs/vite-plugin`
-// consumer would install. Vite 8 is one supported peer range, so we install
-// upstream vite directly. (An earlier iteration aliased vite to
-// `@voidzero-dev/vite-plus-core` to mimic the workspace's own vp tooling, but
-// vite-plus-core ships only the JS API — it has no `vite` bin and its rolldown
-// bindings expect a separate `vite-plus` metapackage at runtime, which together
-// broke `vite build` in CI.)
-const RUNTIME_PEER_DEPENDENCIES = {
-  typescript: "6.0.3",
-  vite: "^8.0.0",
-  vue: "3.5.34",
-};
-
 function installPackedPackages(tempDir, packages, options = {}) {
   const installDir = path.join(tempDir, "install");
   fs.mkdirSync(installDir, { recursive: true });
@@ -335,142 +331,6 @@ function resolveInstalledBin(installDir, packageName, binName) {
   return path.join(packageDir, relative);
 }
 
-function writeRuntimeSmokeProject(installDir) {
-  const sourceDir = path.join(installDir, "src");
-  fs.mkdirSync(sourceDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(installDir, "index.html"),
-    '<div id="app"></div><script type="module" src="/src/main.ts"></script>\n',
-  );
-  fs.writeFileSync(
-    path.join(installDir, "tsconfig.json"),
-    JSON.stringify(
-      {
-        compilerOptions: {
-          lib: ["ES2022", "DOM", "DOM.Iterable"],
-          module: "ESNext",
-          moduleResolution: "Bundler",
-          strict: true,
-          target: "ES2022",
-          types: [],
-        },
-        include: ["src/**/*.ts", "src/**/*.vue"],
-      },
-      null,
-      2,
-    ),
-  );
-  fs.writeFileSync(
-    path.join(installDir, "vite.config.mjs"),
-    [
-      'import { defineConfig } from "vite";',
-      'import vize from "@vizejs/vite-plugin";',
-      "",
-      "export default defineConfig({",
-      "  plugins: [vize()],",
-      '  build: { outDir: "dist", emptyOutDir: true },',
-      "});",
-      "",
-    ].join("\n"),
-  );
-  fs.writeFileSync(
-    path.join(sourceDir, "App.vue"),
-    [
-      "<template>",
-      '  <button class="smoke" @click="count++">{{ label }} {{ count }}</button>',
-      "</template>",
-      "",
-      '<script setup lang="ts">',
-      'import { ref } from "vue";',
-      "",
-      'const label: string = "vize smoke";',
-      "const count = ref(0);",
-      "</script>",
-      "",
-      "<style scoped>",
-      ".smoke {",
-      "  color: #0f766e;",
-      "}",
-      "</style>",
-      "",
-    ].join("\n"),
-  );
-  fs.writeFileSync(
-    path.join(sourceDir, "main.ts"),
-    [
-      'import { createApp } from "vue";',
-      'import App from "./App.vue";',
-      "",
-      'createApp(App).mount("#app");',
-      "",
-    ].join("\n"),
-  );
-}
-
-function runRuntimeChecks(installDir, packages) {
-  writeRuntimeSmokeProject(installDir);
-
-  if (packages.some((pkg) => pkg.name === "@vizejs/native")) {
-    run(
-      process.execPath,
-      [
-        "-e",
-        [
-          'const required = require("@vizejs/native");',
-          "(async () => {",
-          'const imported = await import("@vizejs/native");',
-          "const importedNative = imported.default ?? imported;",
-          "for (const [label, native] of [['require', required], ['import', importedNative]]) {",
-          "if (typeof native.compileSfc !== 'function') {",
-          "  throw new Error(`compileSfc missing from ${label} smoke`);",
-          "}",
-          "const result = native.compileSfc(",
-          '  \'<template><div>{{ msg }}</div></template><script setup lang="ts">const msg: string = "ok";</script>\',',
-          "  { filename: 'Smoke.vue', isTs: true },",
-          ");",
-          "if (!result || result.errors.length > 0 || typeof result.code !== 'string' || result.code.length === 0) {",
-          "  throw new Error(`compileSfc ${label} runtime smoke failed`);",
-          "}",
-          "}",
-          "})().catch((error) => { console.error(error); process.exit(1); });",
-        ].join("\n"),
-      ],
-      { cwd: installDir },
-    );
-    console.log("runtime: @vizejs/native require/import compileSfc");
-  }
-
-  // Bins are invoked through `node <resolved-bin>` instead of `npm exec` so
-  // that npm/cli#4828 cannot re-resolve transitive optional native deps and
-  // drop them mid-run. The single combined install above already settled the
-  // dependency tree; re-entering npm here is what previously broke vite/rolldown
-  // native bindings on the fresh-install smoke matrix.
-  if (packages.some((pkg) => pkg.name === "vize")) {
-    const vizeBin = resolveInstalledBin(installDir, "vize", "vize");
-    run(process.execPath, [vizeBin, "--version"], { cwd: installDir });
-    console.log("runtime: vize --version");
-    run(
-      process.execPath,
-      [vizeBin, "check", "src/App.vue", "--format", "json", "--quiet", "--no-config"],
-      { cwd: installDir },
-    );
-    console.log("runtime: vize check");
-    run(
-      process.execPath,
-      [vizeBin, "lint", "src/App.vue", "--format", "json", "--quiet", "--no-config"],
-      { cwd: installDir },
-    );
-    console.log("runtime: vize lint");
-    runInitTypecheckChecks(installDir, vizeBin, root, RUNTIME_PEER_DEPENDENCIES);
-  }
-
-  if (packages.some((pkg) => pkg.name === "@vizejs/vite-plugin")) {
-    const viteBin = resolveInstalledBin(installDir, "vite", "vite");
-    run(process.execPath, [viteBin, "build"], { cwd: installDir });
-    console.log("runtime: @vizejs/vite-plugin vite build");
-  }
-}
-
 function main() {
   const options = parseArgs(process.argv.slice(2));
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-release-smoke-"));
@@ -519,11 +379,18 @@ function main() {
     const installable = packages.filter((pkg) => pkg.compatible);
     assert.ok(installable.length > 0, "no package tarballs are compatible with this runner");
     const installDir = installPackedPackages(tempDir, installable, {
-      includeRuntimePeers: options.runtimeChecks,
+      includeRuntimePeers: options.runtimeChecks || options.contentMapperChecks,
     });
 
     if (options.runtimeChecks) {
-      runRuntimeChecks(installDir, installable);
+      runRuntimeChecks(installDir, installable, {
+        repoRoot: root,
+        resolveInstalledBin,
+        run,
+      });
+    }
+    if (options.contentMapperChecks) {
+      runInstalledContentMapperChecks(installDir, root, run);
     }
 
     console.log(`smoked ${installable.length}/${packages.length} package tarballs`);

--- a/tools/npm/smoke-release-runtime.mjs
+++ b/tools/npm/smoke-release-runtime.mjs
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { runInitTypecheckChecks } from "./smoke-release-init-typecheck.mjs";
+
+export const RUNTIME_PEER_DEPENDENCIES = {
+  typescript: "6.0.3",
+  vite: "^8.0.0",
+  vue: "3.5.34",
+};
+
+function writeRuntimeSmokeProject(installDir) {
+  const sourceDir = path.join(installDir, "src");
+  fs.mkdirSync(sourceDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, "index.html"),
+    '<div id="app"></div><script type="module" src="/src/main.ts"></script>\n',
+  );
+  fs.writeFileSync(
+    path.join(installDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          lib: ["ES2022", "DOM", "DOM.Iterable"],
+          module: "ESNext",
+          moduleResolution: "Bundler",
+          strict: true,
+          target: "ES2022",
+          types: [],
+        },
+        include: ["src/**/*.ts", "src/**/*.vue"],
+      },
+      null,
+      2,
+    ),
+  );
+  fs.writeFileSync(
+    path.join(installDir, "vite.config.mjs"),
+    [
+      'import { defineConfig } from "vite";',
+      'import vize from "@vizejs/vite-plugin";',
+      "",
+      "export default defineConfig({",
+      "  plugins: [vize()],",
+      '  build: { outDir: "dist", emptyOutDir: true },',
+      "});",
+      "",
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(sourceDir, "App.vue"),
+    [
+      "<template>",
+      '  <button class="smoke" @click="count++">{{ label }} {{ count }}</button>',
+      "</template>",
+      "",
+      '<script setup lang="ts">',
+      'import { ref } from "vue";',
+      "",
+      'const label: string = "vize smoke";',
+      "const count = ref(0);",
+      "</script>",
+      "",
+      "<style scoped>",
+      ".smoke {",
+      "  color: #0f766e;",
+      "}",
+      "</style>",
+      "",
+    ].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(sourceDir, "main.ts"),
+    [
+      'import { createApp } from "vue";',
+      'import App from "./App.vue";',
+      "",
+      'createApp(App).mount("#app");',
+      "",
+    ].join("\n"),
+  );
+}
+
+function assertInstalledMapperContract(installDir) {
+  const packageRoot = path.join(installDir, "node_modules", "vize");
+  assert.equal(fs.lstatSync(packageRoot).isSymbolicLink(), false);
+  const manifest = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"));
+  assert.deepEqual(manifest.tsContentMapper, {
+    exec: ["node", "./bin/vize", "content-mapper"],
+    compilerOptions: ["noUnusedLocals"],
+  });
+  const mapperBin = fs.statSync(path.join(packageRoot, "bin", "vize"));
+  assert.ok(mapperBin.isFile());
+  if (process.platform !== "win32") {
+    assert.notEqual(mapperBin.mode & 0o111, 0);
+  }
+}
+
+export function runInstalledContentMapperChecks(installDir, repoRoot, run) {
+  const tsgo = process.env.VIZE_TEST_CONTENT_MAPPER_TSGO;
+  if (tsgo == null || tsgo === "") return;
+
+  assertInstalledMapperContract(installDir);
+  const projectDir = path.join(installDir, "content mapper project with spaces");
+  fs.cpSync(path.join(repoRoot, "crates/vize/tests/fixtures/content_mapper_project"), projectDir, {
+    recursive: true,
+  });
+  const common = ["--loadExternalPlugins", "--pretty", "false"];
+  run(tsgo, [...common, "--noEmit", "-p", "tsconfig.json"], { cwd: projectDir });
+  const broken = spawnSync(tsgo, [...common, "--noEmit", "-p", "tsconfig.error.json"], {
+    cwd: projectDir,
+    encoding: "utf8",
+  });
+  if (broken.error != null) throw broken.error;
+  assert.notEqual(broken.status, 0, "installed mapper error fixture unexpectedly passed");
+  const brokenOutput = `${broken.stdout}\n${broken.stderr}`;
+  for (const expected of ["errors/Broken.vue", "TS2322", "src/Unused.vue", "TS6133"]) {
+    assert.ok(brokenOutput.includes(expected), brokenOutput);
+  }
+  run(tsgo, [...common, "-p", "tsconfig.emit.json"], { cwd: projectDir });
+
+  const declarationNames = ["App.d.vue.ts", "App.vue.d.ts"];
+  assert.ok(
+    declarationNames.some((name) => fs.existsSync(path.join(projectDir, "dist", name))),
+    "installed mapper did not emit an App.vue declaration",
+  );
+  assert.ok(fs.existsSync(path.join(projectDir, "dist", "main.d.ts")));
+  fs.copyFileSync(
+    path.join(projectDir, "consumer", "verify.ts"),
+    path.join(projectDir, "dist", "verify.ts"),
+  );
+  const consumerArgs = [
+    "--ignoreConfig",
+    "--noEmit",
+    "--strict",
+    "--module",
+    "preserve",
+    "--moduleResolution",
+    "bundler",
+    "--allowArbitraryExtensions",
+    "--pretty",
+    "false",
+    "dist/verify.ts",
+  ];
+  run(tsgo, consumerArgs, { cwd: projectDir });
+  run(
+    process.execPath,
+    [path.join(installDir, "node_modules", "typescript", "bin", "tsc"), ...consumerArgs],
+    { cwd: projectDir },
+  );
+  console.log("runtime: packed vize Content Mapper check and declaration emit");
+}
+
+export function runRuntimeChecks(installDir, packages, { repoRoot, resolveInstalledBin, run }) {
+  writeRuntimeSmokeProject(installDir);
+
+  if (packages.some((pkg) => pkg.name === "@vizejs/native")) {
+    run(
+      process.execPath,
+      [
+        "-e",
+        [
+          'const required = require("@vizejs/native");',
+          "(async () => {",
+          'const imported = await import("@vizejs/native");',
+          "const importedNative = imported.default ?? imported;",
+          "for (const [label, native] of [['require', required], ['import', importedNative]]) {",
+          "if (typeof native.compileSfc !== 'function') {",
+          "  throw new Error(`compileSfc missing from ${label} smoke`);",
+          "}",
+          "const result = native.compileSfc(",
+          '  \'<template><div>{{ msg }}</div></template><script setup lang="ts">const msg: string = "ok";</script>\',',
+          "  { filename: 'Smoke.vue', isTs: true },",
+          ");",
+          "if (!result || result.errors.length > 0 || typeof result.code !== 'string' || result.code.length === 0) {",
+          "  throw new Error(`compileSfc ${label} runtime smoke failed`);",
+          "}",
+          "}",
+          "})().catch((error) => { console.error(error); process.exit(1); });",
+        ].join("\n"),
+      ],
+      { cwd: installDir },
+    );
+    console.log("runtime: @vizejs/native require/import compileSfc");
+  }
+
+  if (packages.some((pkg) => pkg.name === "vize")) {
+    const vizeBin = resolveInstalledBin(installDir, "vize", "vize");
+    run(process.execPath, [vizeBin, "--version"], { cwd: installDir });
+    console.log("runtime: vize --version");
+    run(
+      process.execPath,
+      [vizeBin, "check", "src/App.vue", "--format", "json", "--quiet", "--no-config"],
+      { cwd: installDir },
+    );
+    console.log("runtime: vize check");
+    run(
+      process.execPath,
+      [vizeBin, "lint", "src/App.vue", "--format", "json", "--quiet", "--no-config"],
+      { cwd: installDir },
+    );
+    console.log("runtime: vize lint");
+    runInitTypecheckChecks(installDir, vizeBin, repoRoot, RUNTIME_PEER_DEPENDENCIES);
+  }
+
+  if (packages.some((pkg) => pkg.name === "@vizejs/vite-plugin")) {
+    const viteBin = resolveInstalledBin(installDir, "vite", "vite");
+    run(process.execPath, [viteBin, "build"], { cwd: installDir });
+    console.log("runtime: @vizejs/vite-plugin vite build");
+  }
+}


### PR DESCRIPTION
## Summary

- build and pack the current CLI and host native artifacts in exact Content Mapper CI
- fresh-install release-equivalent tarballs with no workspace package links
- run pinned upstream standard tsgo through the installed `vize/bin/vize` mapper in a path containing spaces
- verify clean and broken mixed project checks, declaration emit, and declaration consumption with both tsgo and JavaScript tsc
- split runtime smoke checks out of the over-limit install script while sharing the release install path

## Validation

- exact local tarball install with current native binding and pinned upstream tsgo
- packed clean check, TS2322/TS6133 error check, declaration emit, tsgo consumer, and JavaScript tsc consumer
- release smoke tooling tests
- Content Mapper workflow contract test
- package/workflow manifest tests
- oxfmt and oxlint
- source-file length ratchet

Advances #4053

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4054"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->