### PR TITLE
test(content-mapper): cover JavaScript project inputs

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_cli.rs
+++ b/crates/vize/tests/content_mapper_tsgo_cli.rs
@@ -226,6 +226,14 @@ fn standard_tsgo_checks_vue_project_and_emits_consumable_declarations() {
             && broken_output.contains("not assignable to type 'number'"),
         "{broken_output}"
     );
+    for script_error in ["errors/JavaScriptConsumer.js", "errors/JsxConsumer.jsx"] {
+        assert!(
+            broken_output
+                .lines()
+                .any(|line| line.contains(script_error) && line.contains("TS2322")),
+            "{script_error} was not checked:\n{broken_output}"
+        );
+    }
     assert!(
         broken_output.contains("src/Unused.vue")
             && broken_output.contains("TS6133")

--- a/crates/vize/tests/fixtures/content_mapper_project/consumer/verify.ts
+++ b/crates/vize/tests/fixtures/content_mapper_project/consumer/verify.ts
@@ -1,5 +1,7 @@
 import Options from "./Options.vue";
 import type { AppProps, PublicInstance } from "./main";
+import { readChildCount } from "./javascript-consumer";
+import { renderChild } from "./jsx-consumer";
 
 type IsAny<T> = 0 extends 1 & T ? true : false;
 type OptionsInstance = InstanceType<typeof Options>;
@@ -8,6 +10,8 @@ const propsMustBeTyped: IsAny<AppProps> = false;
 const publicInstanceMustBeTyped: IsAny<PublicInstance> = false;
 const publicSlotMustBeTyped: IsAny<PublicInstance["$slots"]["default"]> = false;
 const publicExposeMustBeTyped: IsAny<PublicInstance["focus"]> = false;
+const javascriptReturnMustBeTyped: IsAny<ReturnType<typeof readChildCount>> = false;
+const jsxReturnMustBeTyped: IsAny<ReturnType<typeof renderChild>> = false;
 const valid: AppProps = { count: 1 };
 // @ts-expect-error count must remain a number through declaration emit
 const invalid: AppProps = { count: "wrong" };
@@ -26,6 +30,9 @@ options.increment("1");
 declare const publicComponent: PublicInstance;
 const publicValue: string = publicComponent.$props.value;
 const publicModel: number | undefined = publicComponent.$props.modelValue;
+const javascriptResult: number = readChildCount({ count: 1 });
+// @ts-expect-error JavaScript declarations must preserve the Vue prop type
+readChildCount({ count: "wrong" });
 publicComponent.$emit("select", "value");
 publicComponent.$emit("update:modelValue", 1);
 publicComponent.$slots.default?.({ value: "slot" });
@@ -37,6 +44,8 @@ void propsMustBeTyped;
 void publicInstanceMustBeTyped;
 void publicSlotMustBeTyped;
 void publicExposeMustBeTyped;
+void javascriptReturnMustBeTyped;
+void jsxReturnMustBeTyped;
 void valid;
 void invalid;
 void optionsCountMustBeTyped;
@@ -49,3 +58,4 @@ void optionsComputed;
 void optionsMethodResult;
 void publicValue;
 void publicModel;
+void javascriptResult;

--- a/crates/vize/tests/fixtures/content_mapper_project/errors/JavaScriptConsumer.js
+++ b/crates/vize/tests/fixtures/content_mapper_project/errors/JavaScriptConsumer.js
@@ -1,0 +1,6 @@
+import Child from "../src/Child.vue";
+
+/** @type {InstanceType<typeof Child>["$props"]} */
+const props = { count: "wrong" };
+
+void props;

--- a/crates/vize/tests/fixtures/content_mapper_project/errors/JsxConsumer.jsx
+++ b/crates/vize/tests/fixtures/content_mapper_project/errors/JsxConsumer.jsx
@@ -1,0 +1,3 @@
+import Child from "../src/Child.vue";
+
+void (<Child count="wrong" />);

--- a/crates/vize/tests/fixtures/content_mapper_project/src/javascript-consumer.js
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/javascript-consumer.js
@@ -1,0 +1,8 @@
+import Child from "./Child.vue";
+
+/** @param {InstanceType<typeof Child>["$props"]} props */
+export function readChildCount(props) {
+  return props.count;
+}
+
+readChildCount({ count: 1 });

--- a/crates/vize/tests/fixtures/content_mapper_project/src/jsx-consumer.jsx
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/jsx-consumer.jsx
@@ -1,0 +1,3 @@
+import Child from "./Child.vue";
+
+export const renderChild = () => <Child count={1} />;

--- a/crates/vize/tests/fixtures/content_mapper_project/tsconfig.emit.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/tsconfig.emit.json
@@ -1,9 +1,13 @@
 {
   "compilerOptions": {
     "strict": true,
+    "allowJs": true,
+    "checkJs": true,
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,

--- a/crates/vize/tests/fixtures/content_mapper_project/tsconfig.error.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/tsconfig.error.json
@@ -1,9 +1,13 @@
 {
   "compilerOptions": {
     "strict": true,
+    "allowJs": true,
+    "checkJs": true,
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
     "noUnusedLocals": true,
     "noEmit": true
   },

--- a/crates/vize/tests/fixtures/content_mapper_project/tsconfig.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/tsconfig.json
@@ -1,9 +1,13 @@
 {
   "compilerOptions": {
     "strict": true,
+    "allowJs": true,
+    "checkJs": true,
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
     "noEmit": true
   },
   "contentMappers": [{ "package": "vize", "extensions": [".vue"] }],

--- a/tools/npm/smoke-release-runtime.mjs
+++ b/tools/npm/smoke-release-runtime.mjs
@@ -116,8 +116,17 @@ export function runInstalledContentMapperChecks(installDir, repoRoot, run) {
   if (broken.error != null) throw broken.error;
   assert.notEqual(broken.status, 0, "installed mapper error fixture unexpectedly passed");
   const brokenOutput = `${broken.stdout}\n${broken.stderr}`;
-  for (const expected of ["errors/Broken.vue", "TS2322", "src/Unused.vue", "TS6133"]) {
-    assert.ok(brokenOutput.includes(expected), brokenOutput);
+  const diagnosticLines = brokenOutput.split(/\r?\n/u);
+  for (const [file, code] of [
+    ["errors/Broken.vue", "TS2322"],
+    ["errors/JavaScriptConsumer.js", "TS2322"],
+    ["errors/JsxConsumer.jsx", "TS2322"],
+    ["src/Unused.vue", "TS6133"],
+  ]) {
+    assert.ok(
+      diagnosticLines.some((line) => line.includes(file) && line.includes(code)),
+      `${file} did not report ${code}:\n${brokenOutput}`,
+    );
   }
   run(tsgo, [...common, "-p", "tsconfig.emit.json"], { cwd: projectDir });
 


### PR DESCRIPTION
## Summary

- add JavaScript and JSX importers to the exact Content Mapper project fixture
- require file-specific TS2322 diagnostics from direct and packed tsgo runs
- consume emitted JavaScript and JSX declarations with exact tsgo and JavaScript tsc without allowing `any` degradation

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p vize --test content_mapper_tsgo_cli -- -D warnings`
- exact pinned tsgo project and project-reference tests
- fresh-installed release tarball Content Mapper smoke
- release smoke and workflow contract tests
- source-length ratchet against the stacked base

Advances #4053.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->