### PR TITLE
test(content-mapper): reject broken package contracts

### DIFF
--- a/tests/tooling/content-mapper-package-contract.test.ts
+++ b/tests/tooling/content-mapper-package-contract.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { assertInstalledMapperContract } from "../../tools/npm/smoke-release-runtime.mjs";
+
+function withInstalledMapper(run: (installDir: string, packageRoot: string) => void): void {
+  const installDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-mapper-contract-"));
+  const packageRoot = path.join(installDir, "node_modules", "vize");
+  const mapperPath = path.join(packageRoot, "bin", "vize");
+  try {
+    fs.mkdirSync(path.dirname(mapperPath), { recursive: true });
+    fs.writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({
+        name: "vize",
+        tsContentMapper: {
+          exec: ["node", "./bin/vize", "content-mapper"],
+          compilerOptions: ["noUnusedLocals"],
+        },
+      }),
+    );
+    fs.writeFileSync(mapperPath, "#!/usr/bin/env node\n");
+    fs.chmodSync(mapperPath, 0o755);
+    run(installDir, packageRoot);
+  } finally {
+    fs.rmSync(installDir, { force: true, recursive: true });
+  }
+}
+
+test("installed Content Mapper contract accepts the production package shape", () => {
+  withInstalledMapper((installDir) => assertInstalledMapperContract(installDir));
+});
+
+test("installed Content Mapper contract rejects a corrupted exec entry", () => {
+  withInstalledMapper((installDir, packageRoot) => {
+    const manifestPath = path.join(packageRoot, "package.json");
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+    manifest.tsContentMapper.exec = ["node", "./bin/missing", "content-mapper"];
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest));
+
+    assert.throws(
+      () => assertInstalledMapperContract(installDir),
+      /must expose the production tsContentMapper contract/,
+    );
+  });
+});
+
+test("installed Content Mapper contract rejects a missing executable", () => {
+  withInstalledMapper((installDir, packageRoot) => {
+    fs.rmSync(path.join(packageRoot, "bin", "vize"));
+    assert.throws(() => assertInstalledMapperContract(installDir), /bin[/\\]vize must exist/);
+  });
+});

--- a/tools/npm/smoke-release-runtime.mjs
+++ b/tools/npm/smoke-release-runtime.mjs
@@ -83,18 +83,24 @@ function writeRuntimeSmokeProject(installDir) {
   );
 }
 
-function assertInstalledMapperContract(installDir) {
+export function assertInstalledMapperContract(installDir) {
   const packageRoot = path.join(installDir, "node_modules", "vize");
   assert.equal(fs.lstatSync(packageRoot).isSymbolicLink(), false);
   const manifest = JSON.parse(fs.readFileSync(path.join(packageRoot, "package.json"), "utf8"));
-  assert.deepEqual(manifest.tsContentMapper, {
-    exec: ["node", "./bin/vize", "content-mapper"],
-    compilerOptions: ["noUnusedLocals"],
-  });
-  const mapperBin = fs.statSync(path.join(packageRoot, "bin", "vize"));
+  assert.deepEqual(
+    manifest.tsContentMapper,
+    {
+      exec: ["node", "./bin/vize", "content-mapper"],
+      compilerOptions: ["noUnusedLocals"],
+    },
+    `${path.join(packageRoot, "package.json")} must expose the production tsContentMapper contract`,
+  );
+  const mapperPath = path.join(packageRoot, "bin", "vize");
+  assert.ok(fs.existsSync(mapperPath), `${mapperPath} must exist`);
+  const mapperBin = fs.statSync(mapperPath);
   assert.ok(mapperBin.isFile());
   if (process.platform !== "win32") {
-    assert.notEqual(mapperBin.mode & 0o111, 0);
+    assert.notEqual(mapperBin.mode & 0o111, 0, `${mapperPath} must be executable`);
   }
 }
 


### PR DESCRIPTION
## Summary

- expose the installed Content Mapper package-contract assertion for direct regression coverage
- reject a corrupted `tsContentMapper.exec` before invoking tsgo
- reject a missing or non-executable installed `bin/vize` with its exact path in the failure

## Validation

- `node --test tests/tooling/content-mapper-package-contract.test.ts tests/tooling/content-mapper-workflow.test.ts tests/tooling/release-smoke-install.test.ts`
- fresh-installed release tarball Content Mapper smoke with the exact pinned tsgo
- `oxfmt --check`
- source-length ratchet against the stacked base

Closes #4053.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->