### PR TITLE
fix(content-mapper): map template prop symbols

### DIFF
--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -154,6 +154,8 @@ jobs:
       - name: Run exact editor backend conformance
         env:
           TSGO_PATH: ${{ runner.temp }}/tsgo
+          VIZE_TEST_CONTENT_MAPPER_TSGO: ${{ runner.temp }}/tsgo
         run: |
+          cargo test -p vize --test content_mapper_tsgo_lsp -- --nocapture
           cargo test -p vize_canon --test lsp_import_resolution -- --nocapture
           cargo test -p vize_maestro

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,12 +3504,14 @@ name = "vize"
 version = "0.345.0"
 dependencies = [
  "clap",
+ "corsa",
  "dirs",
  "futures",
  "glob",
  "globset",
  "ignore",
  "insta",
+ "lsp-types 0.97.0",
  "mimalloc",
  "oxc_allocator",
  "oxc_ast",

--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -85,4 +85,6 @@ mimalloc.workspace = true
 tempfile.workspace = true
 
 [dev-dependencies]
+corsa.workspace = true
 insta.workspace = true
+lsp-types.workspace = true

--- a/crates/vize/tests/content_mapper_tsgo_build.rs
+++ b/crates/vize/tests/content_mapper_tsgo_build.rs
@@ -18,6 +18,9 @@ fn copy_fixture(source: &Path, destination: &Path) {
     std::fs::create_dir_all(destination).unwrap();
     for entry in std::fs::read_dir(source).unwrap() {
         let entry = entry.unwrap();
+        if entry.file_name() == "node_modules" {
+            continue;
+        }
         let source_path = entry.path();
         let destination_path = destination.join(entry.file_name());
         if entry.file_type().unwrap().is_dir() {

--- a/crates/vize/tests/content_mapper_tsgo_cli.rs
+++ b/crates/vize/tests/content_mapper_tsgo_cli.rs
@@ -19,6 +19,9 @@ fn copy_fixture(source: &Path, destination: &Path) {
     std::fs::create_dir_all(destination).unwrap();
     for entry in std::fs::read_dir(source).unwrap() {
         let entry = entry.unwrap();
+        if entry.file_name() == "node_modules" {
+            continue;
+        }
         let source_path = entry.path();
         let destination_path = destination.join(entry.file_name());
         if entry.file_type().unwrap().is_dir() {

--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -1,0 +1,314 @@
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use corsa::jsonrpc::InboundEvent;
+use corsa::lsp::{LspClient, LspSpawnConfig, VirtualDocument};
+use lsp_types::Uri;
+use serde_json::{Value, json};
+use vize_carton::String as CompactString;
+
+const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
+
+struct StopOnDrop<'a>(&'a AtomicBool);
+
+impl Drop for StopOnDrop<'_> {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+}
+
+struct RawInitialize;
+struct RawDiscoverContentMappers;
+struct RawHover;
+struct RawDefinition;
+struct RawReferences;
+struct RawRename;
+
+macro_rules! raw_request {
+    ($request:ty, $method:literal) => {
+        impl lsp_types::request::Request for $request {
+            type Params = Value;
+            type Result = Value;
+            const METHOD: &'static str = $method;
+        }
+    };
+}
+
+raw_request!(RawInitialize, "initialize");
+raw_request!(RawDiscoverContentMappers, "custom/discoverContentMappers");
+raw_request!(RawHover, "textDocument/hover");
+raw_request!(RawDefinition, "textDocument/definition");
+raw_request!(RawReferences, "textDocument/references");
+raw_request!(RawRename, "textDocument/rename");
+
+struct RawInitialized;
+
+impl lsp_types::notification::Notification for RawInitialized {
+    type Params = Value;
+    const METHOD: &'static str = "initialized";
+}
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn copy_fixture(source: &Path, destination: &Path) {
+    std::fs::create_dir_all(destination).unwrap();
+    for entry in std::fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_name() == "node_modules" {
+            continue;
+        }
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_fixture(&source_path, &destination_path);
+        } else {
+            std::fs::copy(source_path, destination_path).unwrap();
+        }
+    }
+}
+
+fn install_packages(project_root: &Path) {
+    let mapper_root = project_root.join("node_modules/vize");
+    std::fs::create_dir_all(&mapper_root).unwrap();
+    std::fs::write(
+        mapper_root.join("package.json"),
+        serde_json::to_vec_pretty(&json!({
+            "name": "vize",
+            "private": true,
+            "tsContentMapper": {
+                "exec": [env!("CARGO_BIN_EXE_vize"), "content-mapper"],
+                "compilerOptions": ["noUnusedLocals"],
+            },
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let store = workspace_root().join("node_modules/.pnpm");
+    let mut candidates = std::fs::read_dir(&store)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("vue@3."))
+        .map(|entry| entry.path().join("node_modules/vue"))
+        .filter(|path| path.join("package.json").is_file())
+        .collect::<Vec<_>>();
+    candidates.sort();
+    let source = candidates.pop().expect("workspace Vue package");
+    let target = project_root.join("node_modules/vue");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, target).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, target).unwrap();
+}
+
+fn file_uri(path: &Path) -> CompactString {
+    let mut uri = CompactString::from("file://");
+    for byte in path.to_string_lossy().bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' | b':' => {
+                uri.push(byte as char)
+            }
+            _ => {
+                use std::fmt::Write;
+                write!(uri, "%{byte:02X}").unwrap();
+            }
+        }
+    }
+    uri
+}
+
+fn position(source: &str, offset: usize) -> Value {
+    let before = &source[..offset];
+    let line = before.matches('\n').count();
+    let character = before.rsplit_once('\n').map_or(before, |(_, tail)| tail);
+    json!({ "line": line, "character": character.encode_utf16().count() })
+}
+
+fn contains_location(value: &Value, uri: &str, start: &Value) -> bool {
+    match value {
+        Value::Array(values) => values
+            .iter()
+            .any(|value| contains_location(value, uri, start)),
+        Value::Object(object) => {
+            let location_uri = object.get("uri").or_else(|| object.get("targetUri"));
+            let range = object
+                .get("range")
+                .or_else(|| object.get("targetSelectionRange"));
+            location_uri == Some(&Value::String(uri.to_owned()))
+                && range.and_then(|range| range.get("start")) == Some(start)
+        }
+        _ => false,
+    }
+}
+
+fn editor_capabilities() -> Value {
+    json!({
+        "workspace": {
+            "configuration": true,
+            "didChangeWatchedFiles": { "dynamicRegistration": true }
+        },
+        "textDocument": {
+            "synchronization": { "dynamicRegistration": true },
+            "diagnostic": { "dynamicRegistration": true },
+            "hover": { "dynamicRegistration": true },
+            "definition": { "dynamicRegistration": true },
+            "references": { "dynamicRegistration": true },
+            "rename": { "dynamicRegistration": true }
+        }
+    })
+}
+
+#[test]
+fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
+    let Some(tsgo) = std::env::var_os(TSGO_ENV).map(PathBuf::from) else {
+        eprintln!("skipping exact Content Mapper LSP conformance: {TSGO_ENV} is not set");
+        return;
+    };
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/content_mapper_project");
+    let cases_root = workspace_root().join("target/vize-tests/tests");
+    std::fs::create_dir_all(&cases_root).unwrap();
+    let project = tempfile::Builder::new()
+        .prefix("content-mapper-lsp-")
+        .tempdir_in(cases_root)
+        .unwrap();
+    copy_fixture(&fixture, project.path());
+    install_packages(project.path());
+
+    let child_path = project.path().join("src/Child.vue");
+    let source = std::fs::read_to_string(&child_path).unwrap();
+    let child_uri = file_uri(&child_path);
+    let root_uri = file_uri(project.path());
+    let symbol_offset = source.rfind("count.toFixed").unwrap();
+    let symbol_position = position(&source, symbol_offset + 1);
+    let declaration_offset = source.find("count: number").unwrap();
+    let declaration_position = position(&source, declaration_offset);
+
+    let stop = AtomicBool::new(false);
+    std::thread::scope(|scope| {
+        let _stop_on_drop = StopOnDrop(&stop);
+        corsa::runtime::block_on(async {
+            let client = LspClient::spawn(
+                LspSpawnConfig::new(&tsgo)
+                    .with_cwd(project.path())
+                    .with_request_timeout(Some(Duration::from_secs(30))),
+            )
+            .await
+            .unwrap();
+            let responder_client = client.clone();
+            let events = responder_client.subscribe();
+            let stop_ref = &stop;
+            let responder = scope.spawn(move || {
+                while !stop_ref.load(Ordering::Relaxed) {
+                    if let Ok(InboundEvent::Request { id, method, params }) =
+                        events.recv_timeout(Duration::from_millis(50))
+                    {
+                        let result = if method.as_str() == "workspace/configuration" {
+                            let count = params
+                                .get("items")
+                                .and_then(Value::as_array)
+                                .map_or(0, Vec::len);
+                            Value::Array(vec![Value::Null; count])
+                        } else {
+                            Value::Null
+                        };
+                        let _ = responder_client.respond(id, result);
+                    }
+                }
+            });
+            let initialize = client
+                .request::<RawInitialize>(json!({
+                    "processId": std::process::id(),
+                    "rootUri": root_uri,
+                    "workspaceFolders": [{ "uri": root_uri, "name": "content-mapper-lsp" }],
+                    "capabilities": editor_capabilities(),
+                    "initializationOptions": { "loadExternalPlugins": true }
+                }))
+                .await
+                .unwrap();
+            assert!(initialize["capabilities"].is_object(), "{initialize:#}");
+            client.notify::<RawInitialized>(json!({})).unwrap();
+
+            let discovered = client
+                .request::<RawDiscoverContentMappers>(json!({
+                    "textDocuments": [{ "uri": child_uri }],
+                    "extensions": [".vue"]
+                }))
+                .await
+                .unwrap();
+            assert_eq!(discovered["extensions"], json!([".vue"]), "{discovered:#}");
+
+            let uri = Uri::from_str(&child_uri).unwrap();
+            client
+                .overlay()
+                .open(VirtualDocument::new(uri, "vue", source.as_str()))
+                .unwrap();
+            let params =
+                json!({ "textDocument": { "uri": child_uri }, "position": symbol_position });
+
+            let hover = client.request::<RawHover>(params.clone()).await.unwrap();
+            let hover_text = serde_json::to_string(&hover).unwrap();
+            assert!(
+                hover_text.contains("count") && hover_text.contains("number"),
+                "{hover:#}"
+            );
+
+            let definition = client
+                .request::<RawDefinition>(params.clone())
+                .await
+                .unwrap();
+            let definition_text = serde_json::to_string(&definition).unwrap();
+            assert!(
+                definition_text.contains(child_uri.as_str()),
+                "{definition:#}"
+            );
+            assert!(
+                contains_location(&definition, &child_uri, &declaration_position),
+                "{definition:#}"
+            );
+            assert!(!definition_text.contains(".vue.ts"), "{definition:#}");
+
+            let references = client
+                .request::<RawReferences>(json!({
+                    "textDocument": { "uri": child_uri },
+                    "position": symbol_position,
+                    "context": { "includeDeclaration": true }
+                }))
+                .await
+                .unwrap();
+            let references_text = serde_json::to_string(&references).unwrap();
+            assert!(
+                references_text.matches(child_uri.as_str()).count() >= 2,
+                "{references:#}"
+            );
+            assert!(!references_text.contains(".vue.ts"), "{references:#}");
+
+            let rename = client
+                .request::<RawRename>(json!({
+                    "textDocument": { "uri": child_uri },
+                    "position": symbol_position,
+                    "newName": "renamedCount"
+                }))
+                .await
+                .unwrap();
+            let rename_text = serde_json::to_string(&rename).unwrap();
+            assert!(rename_text.contains(child_uri.as_str()), "{rename:#}");
+            assert!(
+                rename_text.matches("renamedCount").count() >= 2,
+                "{rename:#}"
+            );
+            assert!(!rename_text.contains(".vue.ts"), "{rename:#}");
+
+            stop.store(true, Ordering::Relaxed);
+            client.close().await.unwrap();
+            responder.join().unwrap();
+        });
+    });
+}

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -20,6 +20,8 @@ use super::vue_codegen::{GeneratedVueFile, VueCodegenOptions, generate_vue_virtu
 
 #[path = "content_mapper_span_features.rs"]
 mod span_features;
+#[path = "content_mapper_span_normalize.rs"]
+mod span_normalize;
 
 use span_features::CONTENT_MAPPER_SPAN_FEATURES_ALL;
 
@@ -230,7 +232,7 @@ fn protocol_spans(
     generated: &str,
     mappings: &[VizeMapping],
 ) -> Vec<ContentMapperSpan> {
-    let mut candidates = mappings
+    let candidates = mappings
         .iter()
         .filter_map(|mapping| {
             if mapping.sub_spans.is_empty() {
@@ -260,28 +262,7 @@ fn protocol_spans(
         .flatten()
         .collect::<Vec<_>>();
 
-    // Narrow authored spans win over enclosing synthetic projections.
-    candidates.sort_by_key(|candidate| {
-        (
-            candidate.generated.len(),
-            candidate.original.len(),
-            candidate.generated.start,
-        )
-    });
-
-    let mut accepted = Vec::<SpanCandidate>::new();
-    for candidate in candidates {
-        let generated_overlap = accepted
-            .iter()
-            .any(|span| ranges_overlap(&candidate.generated, &span.generated));
-        let invalid_original_overlap = accepted.iter().any(|span| {
-            candidate.original != span.original
-                && ranges_overlap(&candidate.original, &span.original)
-        });
-        if !generated_overlap && !invalid_original_overlap {
-            accepted.push(candidate);
-        }
-    }
+    let mut accepted = span_normalize::normalize(candidates);
     accepted.sort_by_key(|candidate| candidate.generated.start);
     accepted
         .into_iter()

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_span_normalize.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_span_normalize.rs
@@ -1,0 +1,104 @@
+//! Protocol-valid normalization for overlapping authored projections.
+
+use super::{ContentMapperSpanKind, SpanCandidate, ranges_overlap};
+
+pub(super) fn normalize(mut candidates: Vec<SpanCandidate>) -> Vec<SpanCandidate> {
+    candidates.sort_by_key(|candidate| {
+        (
+            candidate.generated.len(),
+            candidate.original.len(),
+            candidate.generated.start,
+        )
+    });
+
+    let mut accepted: Vec<SpanCandidate> = Vec::new();
+    for candidate in candidates {
+        if accepted
+            .iter()
+            .any(|span| ranges_overlap(&candidate.generated, &span.generated))
+        {
+            continue;
+        }
+        accepted.extend(split_original_overlaps(candidate, &accepted));
+    }
+    accepted
+}
+
+fn split_original_overlaps(
+    candidate: SpanCandidate,
+    accepted: &[SpanCandidate],
+) -> Vec<SpanCandidate> {
+    let overlaps = accepted
+        .iter()
+        .filter(|span| ranges_overlap(&candidate.original, &span.original))
+        .collect::<Vec<_>>();
+    if overlaps.is_empty()
+        || overlaps
+            .iter()
+            .all(|span| span.original == candidate.original)
+    {
+        return vec![candidate];
+    }
+    if candidate.kind != ContentMapperSpanKind::Verbatim {
+        return Vec::new();
+    }
+
+    let mut boundaries = vec![candidate.original.start, candidate.original.end];
+    for span in &overlaps {
+        boundaries.push(span.original.start.max(candidate.original.start));
+        boundaries.push(span.original.end.min(candidate.original.end));
+    }
+    boundaries.sort_unstable();
+    boundaries.dedup();
+
+    boundaries
+        .windows(2)
+        .filter_map(|window| {
+            let original = window[0]..window[1];
+            let valid = overlaps.iter().all(|span| {
+                !ranges_overlap(&original, &span.original) || span.original == original
+            });
+            valid.then(|| {
+                let offset = original.start - candidate.original.start;
+                SpanCandidate {
+                    generated: candidate.generated.start + offset
+                        ..candidate.generated.start + offset + original.len(),
+                    original,
+                    kind: ContentMapperSpanKind::Verbatim,
+                }
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_a_broad_verbatim_span_around_a_duplicate_symbol_projection() {
+        let accepted = SpanCandidate {
+            generated: 100..105,
+            original: 10..15,
+            kind: ContentMapperSpanKind::Verbatim,
+        };
+        let broad = SpanCandidate {
+            generated: 200..225,
+            original: 0..25,
+            kind: ContentMapperSpanKind::Verbatim,
+        };
+
+        let normalized = normalize(vec![broad, accepted]);
+        assert_eq!(normalized.len(), 4);
+        assert_eq!(
+            normalized
+                .iter()
+                .filter(|span| span.original == (10..15))
+                .count(),
+            2
+        );
+        assert!(normalized.iter().all(|left| normalized.iter().all(|right| {
+            left.original == right.original || !ranges_overlap(&left.original, &right.original)
+        })));
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -71,6 +71,55 @@ const emoji = "😀"
 }
 
 #[test]
+fn maps_synthetic_prop_bindings_to_the_authored_declaration() {
+    let source = r#"<script setup lang="ts">
+defineProps<{ count: number }>();
+</script>
+<template>{{ count.toFixed(0) }}</template>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("Props.vue"), source).expect("transform");
+    let original = source.find("count: number").unwrap();
+    let matching = result
+        .mappings
+        .iter()
+        .filter(|mapping| mapping.0[2] == original && mapping.0[3] == "count".len())
+        .collect::<Vec<_>>();
+
+    assert!(
+        matching.len() >= 2,
+        "expected authored and synthetic projections: {matching:?}"
+    );
+    assert!(matching.iter().all(|mapping| mapping.0[4] == 0));
+}
+
+#[test]
+fn maps_synthetic_props_after_a_plain_script_to_the_setup_block() {
+    let source = r#"<script lang="ts">
+export const marker = true;
+</script>
+<script setup lang="ts">
+defineProps<{ count: number }>();
+</script>
+<template>{{ count.toFixed(0) }}</template>
+"#;
+    let result = generate_vue_content_mapper_transform(Path::new("SplitProps.vue"), source)
+        .expect("transform");
+    let original = source.find("count: number").unwrap();
+
+    assert!(
+        result
+            .mappings
+            .iter()
+            .filter(|mapping| {
+                mapping.0[2] == original && mapping.0[3] == "count".len() && mapping.0[4] == 0
+            })
+            .count()
+            >= 2
+    );
+}
+
+#[test]
 fn split_script_setup_spans_start_at_the_authored_block() {
     let source = r#"<script lang="ts">
 export type SearchQuery = { value: string };

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -42,7 +42,7 @@ use self::options_api_bridge::generate_options_api_bridge;
 use self::options_api_props_identifiers::PropsConstAssertions;
 use self::options_api_support::find_options_api_props;
 use self::setup_helpers::emit_setup_helpers;
-use self::setup_props::generate_setup_props;
+use self::setup_props::{generate_setup_props, prop_source};
 use self::setup_type_exports::SetupTypeExportsPlan;
 use self::spans::{
     DEFINE_COMPONENT_REF, merge_overlapping_spans, rewrite_export_default_for_module_scope,
@@ -670,7 +670,6 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             template_ref_unwraps.emit_type_captures(&mut ts);
 
             emit_props_shadow_anchor(&mut ts, summary, &template_usage_names);
-
             // Semicolon prevents ASI issues when user script doesn't end with `;`
             // (e.g., `console.log(x)\n(function...)` would be parsed as a call)
             ts.push_str("  ;(function __template() {\n");
@@ -690,11 +689,12 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             );
             ts.push_str(&template_context);
             ts.push('\n');
-
+            let maps = &mut mappings;
+            let src = prop_source(maps, summary, script_content, &script_source_offset);
             profile!("canon.virtual_ts.generate_props_variables", {
                 setup_props_plan.generate_props_variables(
                     &mut ts,
-                    summary,
+                    src,
                     generic_param,
                     check_props && !legacy_vue2,
                 )

--- a/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
@@ -5,10 +5,12 @@ use super::generics::{
     generic_fallback_args, is_ident_byte, references_any_identifier, skip_ascii_ws,
 };
 use crate::virtual_ts::props::{
-    OptionsApiPropsSource, PropsTypeEmission, add_generic_defaults, append_default_props,
-    extract_generic_names, generate_props_type, generate_props_variables,
-    generate_setup_scoped_props_artifact,
+    OptionsApiPropsSource, PropBindingMappings, PropsSource, PropsTypeEmission,
+    add_generic_defaults, append_default_props, extract_generic_names, generate_props_type,
+    generate_props_variables, generate_setup_scoped_props_artifact,
 };
+
+pub(super) use crate::virtual_ts::props::prop_source;
 
 fn is_identifier_start_byte(b: u8) -> bool {
     b == b'_' || b == b'$' || b.is_ascii_alphabetic()
@@ -172,12 +174,16 @@ impl SetupPropsPlan {
     pub(super) fn generate_props_variables(
         &self,
         ts: &mut String,
-        summary: &Croquis,
+        source: PropsSource<'_>,
         generic_param: Option<&str>,
         check_props: bool,
     ) {
+        let summary = source.summary;
+        let mut binding_mappings =
+            PropBindingMappings::new(source.mappings, summary, source.script, source.offset);
         generate_props_variables(
             ts,
+            &mut binding_mappings,
             summary,
             generic_param,
             self.template_props_type_ref(),

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -1,4 +1,5 @@
 mod keyed_template_names;
+mod mappings;
 mod options_api;
 mod setup_scoped;
 mod template_bindings;
@@ -6,6 +7,7 @@ mod template_names;
 mod with_defaults;
 use super::helpers::to_safe_identifier;
 use keyed_template_names::collect_keyed_template_prop_names;
+pub(crate) use mappings::{PropBindingMappings, PropsSource, prop_source};
 pub(crate) use options_api::OptionsApiPropsSource;
 pub(crate) use options_api::append_default_props;
 use options_api::emit_options_api_props_type;
@@ -18,23 +20,6 @@ use vize_croquis::Croquis;
 use vize_croquis::macros::{MacroKind, ModelDefinition};
 use with_defaults::{collect_with_defaults_default_names_from_source, template_props_type_ref};
 
-fn emit_template_prop_binding(
-    ts: &mut String,
-    props_type_ref: &str,
-    prop_name: &str,
-    has_default: bool,
-) {
-    let binding_name = to_safe_identifier(prop_name);
-    if has_default {
-        append!(
-            *ts,
-            "  const {binding_name} = props[\"{prop_name}\"] as Exclude<{props_type_ref}[\"{prop_name}\"], undefined>;\n"
-        );
-    } else {
-        append!(*ts, "  const {binding_name} = props[\"{prop_name}\"];\n");
-    }
-    append!(*ts, "  void {binding_name};\n");
-}
 fn emit_keyed_template_prop_binding(
     ts: &mut String,
     props_type_ref: &str,
@@ -253,6 +238,7 @@ pub(crate) fn generate_props_type(
 
 pub(crate) fn generate_props_variables(
     ts: &mut String,
+    binding_mappings: &mut PropBindingMappings<'_>,
     summary: &Croquis,
     generic_param: Option<&str>,
     props_type_ref_override: Option<&str>,
@@ -303,7 +289,7 @@ pub(crate) fn generate_props_variables(
                 if should_skip_template_prop_binding(summary, prop.name.as_str()) {
                     continue;
                 }
-                emit_template_prop_binding(
+                binding_mappings.emit(
                     ts,
                     template_props_type_ref.as_str(),
                     prop.name.as_str(),
@@ -314,6 +300,7 @@ pub(crate) fn generate_props_variables(
             if has_props {
                 emit_macro_template_prop_bindings(
                     ts,
+                    binding_mappings,
                     summary,
                     template_props_type_ref.as_str(),
                     props,
@@ -341,6 +328,7 @@ pub(crate) fn generate_props_variables(
             // Runtime-declared props: generate individual variables
             emit_macro_template_prop_bindings(
                 ts,
+                binding_mappings,
                 summary,
                 template_props_type_ref.as_str(),
                 props,
@@ -354,7 +342,7 @@ pub(crate) fn generate_props_variables(
             {
                 continue;
             }
-            emit_template_prop_binding(
+            binding_mappings.emit(
                 ts,
                 template_props_type_ref.as_str(),
                 model.name.as_str(),

--- a/crates/vize_canon/src/virtual_ts/props/mappings.rs
+++ b/crates/vize_canon/src/virtual_ts/props/mappings.rs
@@ -1,0 +1,91 @@
+//! Authored anchors for prop bindings synthesized into template scope.
+
+use std::ops::Range;
+
+use vize_carton::{String, append};
+use vize_croquis::Croquis;
+
+use super::super::helpers::to_safe_identifier;
+use crate::virtual_ts::VizeMapping;
+
+pub(crate) struct PropsSource<'a> {
+    pub(crate) mappings: &'a mut Vec<VizeMapping>,
+    pub(crate) summary: &'a Croquis,
+    pub(crate) script: Option<&'a str>,
+    pub(crate) offset: &'a dyn Fn(usize) -> usize,
+}
+
+pub(crate) fn prop_source<'a>(
+    mappings: &'a mut Vec<VizeMapping>,
+    summary: &'a Croquis,
+    script: Option<&'a str>,
+    offset: &'a dyn Fn(usize) -> usize,
+) -> PropsSource<'a> {
+    PropsSource {
+        mappings,
+        summary,
+        script,
+        offset,
+    }
+}
+
+pub(crate) struct PropBindingMappings<'a> {
+    mappings: &'a mut Vec<VizeMapping>,
+    summary: &'a Croquis,
+    script_content: Option<&'a str>,
+    script_source_offset: &'a dyn Fn(usize) -> usize,
+}
+
+impl<'a> PropBindingMappings<'a> {
+    pub(crate) fn new(
+        mappings: &'a mut Vec<VizeMapping>,
+        summary: &'a Croquis,
+        script_content: Option<&'a str>,
+        script_source_offset: &'a dyn Fn(usize) -> usize,
+    ) -> Self {
+        Self {
+            mappings,
+            summary,
+            script_content,
+            script_source_offset,
+        }
+    }
+
+    pub(super) fn emit(
+        &mut self,
+        ts: &mut String,
+        props_type_ref: &str,
+        name: &str,
+        has_default: bool,
+    ) {
+        let binding = to_safe_identifier(name);
+        let start = ts.len() + "  const ".len();
+        if has_default {
+            append!(
+                *ts,
+                "  const {binding} = props[\"{name}\"] as Exclude<{props_type_ref}[\"{name}\"], undefined>;\n"
+            );
+        } else {
+            append!(*ts, "  const {binding} = props[\"{name}\"];\n");
+        }
+        append!(*ts, "  void {binding};\n");
+
+        let Some(original) = self.authored_name_range(name) else {
+            return;
+        };
+        self.mappings.push(VizeMapping {
+            gen_range: start..start + binding.len(),
+            src_range: original,
+            sub_spans: Vec::new(),
+        });
+    }
+
+    fn authored_name_range(&self, name: &str) -> Option<Range<usize>> {
+        let script = self.script_content?;
+        let (start, end) = self.summary.macros.prop_declaration(name)?;
+        let declaration = script.get(start as usize..end as usize)?;
+        let relative = declaration.find(name)?;
+        let start = (self.script_source_offset)(start as usize + relative);
+        Some(start..start + name.len())
+    }
+}

--- a/crates/vize_canon/src/virtual_ts/props/template_bindings.rs
+++ b/crates/vize_canon/src/virtual_ts/props/template_bindings.rs
@@ -3,7 +3,7 @@ use vize_croquis::macros::PropDefinition;
 use vize_croquis::macros::PropsDestructuredBindings;
 use vize_croquis::{BindingType, Croquis};
 
-use super::emit_template_prop_binding;
+use super::mappings::PropBindingMappings;
 
 #[inline]
 pub(super) fn should_skip_template_prop_binding(summary: &Croquis, prop_name: &str) -> bool {
@@ -30,6 +30,7 @@ fn is_define_props_destructure_local(
 
 pub(super) fn emit_macro_template_prop_bindings(
     ts: &mut String,
+    binding_mappings: &mut PropBindingMappings<'_>,
     summary: &Croquis,
     props_type_ref: &str,
     props: &[PropDefinition],
@@ -42,7 +43,7 @@ pub(super) fn emit_macro_template_prop_bindings(
         {
             continue;
         }
-        emit_template_prop_binding(
+        binding_mappings.emit(
             ts,
             props_type_ref,
             prop.name.as_str(),


### PR DESCRIPTION
## Summary

- exercise the pinned upstream tsgo language server through Content Mapper discovery instead of opening generated TypeScript directly
- map synthesized template prop bindings back to their authored declarations for hover, definition, references, and rename
- preserve broad verbatim script mappings by splitting protocol-invalid partial overlaps
- keep exact CLI, project-reference build, and declaration-emit fixtures isolated from generated dependencies

## Verification

- exact tsgo LSP hover, definition, references, and rename conformance
- exact tsgo CLI check and declaration emit, including TS, TSX, JS, and JSX consumers
- exact tsgo incremental project-reference build
- 880 vize_canon library tests
- targeted clippy with warnings denied
- source-length and workflow formatting gates

Advances #4057
Advances #3282

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->