### PR TITLE
refactor(content-mapper): share LSP test support

### DIFF
--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -1,0 +1,121 @@
+use std::path::Path;
+
+use serde_json::{Value, json};
+use vize_carton::String as CompactString;
+
+pub fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+pub fn copy_fixture(source: &Path, destination: &Path) {
+    std::fs::create_dir_all(destination).unwrap();
+    for entry in std::fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_name() == "node_modules" {
+            continue;
+        }
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_fixture(&source_path, &destination_path);
+        } else {
+            std::fs::copy(source_path, destination_path).unwrap();
+        }
+    }
+}
+
+pub fn install_packages(project_root: &Path) {
+    let mapper_root = project_root.join("node_modules/vize");
+    std::fs::create_dir_all(&mapper_root).unwrap();
+    std::fs::write(
+        mapper_root.join("package.json"),
+        serde_json::to_vec_pretty(&json!({
+            "name": "vize",
+            "private": true,
+            "tsContentMapper": {
+                "exec": [env!("CARGO_BIN_EXE_vize"), "content-mapper"],
+                "compilerOptions": ["noUnusedLocals"],
+            },
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let store = workspace_root().join("node_modules/.pnpm");
+    let mut candidates = std::fs::read_dir(&store)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("vue@3."))
+        .map(|entry| entry.path().join("node_modules/vue"))
+        .filter(|path| path.join("package.json").is_file())
+        .collect::<Vec<_>>();
+    candidates.sort();
+    let source = candidates.pop().expect("workspace Vue package");
+    let target = project_root.join("node_modules/vue");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, target).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, target).unwrap();
+}
+
+pub fn file_uri(path: &Path) -> CompactString {
+    let mut uri = CompactString::from("file://");
+    for byte in path.to_string_lossy().bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' | b':' => {
+                uri.push(byte as char)
+            }
+            _ => {
+                use std::fmt::Write;
+                write!(uri, "%{byte:02X}").unwrap();
+            }
+        }
+    }
+    uri
+}
+
+pub fn position(source: &str, offset: usize) -> Value {
+    let before = &source[..offset];
+    let line = before.matches('\n').count();
+    let character = before.rsplit_once('\n').map_or(before, |(_, tail)| tail);
+    json!({ "line": line, "character": character.encode_utf16().count() })
+}
+
+pub fn contains_location(value: &Value, uri: &str, start: &Value) -> bool {
+    match value {
+        Value::Array(values) => values
+            .iter()
+            .any(|value| contains_location(value, uri, start)),
+        Value::Object(object) => {
+            let location_uri = object.get("uri").or_else(|| object.get("targetUri"));
+            let range = object
+                .get("range")
+                .or_else(|| object.get("targetSelectionRange"));
+            location_uri == Some(&Value::String(uri.to_owned()))
+                && range.and_then(|range| range.get("start")) == Some(start)
+        }
+        _ => false,
+    }
+}
+
+pub fn editor_capabilities() -> Value {
+    json!({
+        "workspace": {
+            "configuration": true,
+            "didChangeWatchedFiles": { "dynamicRegistration": true }
+        },
+        "textDocument": {
+            "synchronization": { "dynamicRegistration": true },
+            "diagnostic": { "dynamicRegistration": true },
+            "completion": { "dynamicRegistration": true },
+            "signatureHelp": { "dynamicRegistration": true },
+            "hover": { "dynamicRegistration": true },
+            "definition": { "dynamicRegistration": true },
+            "references": { "dynamicRegistration": true },
+            "rename": { "dynamicRegistration": true }
+        }
+    })
+}

--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -7,7 +7,12 @@ use corsa::jsonrpc::InboundEvent;
 use corsa::lsp::{LspClient, LspSpawnConfig, VirtualDocument};
 use lsp_types::Uri;
 use serde_json::{Value, json};
-use vize_carton::String as CompactString;
+
+mod content_mapper_lsp_support;
+use content_mapper_lsp_support::{
+    contains_location, copy_fixture, editor_capabilities, file_uri, install_packages, position,
+    workspace_root,
+};
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
 
@@ -52,123 +57,6 @@ struct RawInitialized;
 impl lsp_types::notification::Notification for RawInitialized {
     type Params = Value;
     const METHOD: &'static str = "initialized";
-}
-
-fn workspace_root() -> &'static Path {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(Path::parent)
-        .expect("workspace root should exist")
-}
-
-fn copy_fixture(source: &Path, destination: &Path) {
-    std::fs::create_dir_all(destination).unwrap();
-    for entry in std::fs::read_dir(source).unwrap() {
-        let entry = entry.unwrap();
-        if entry.file_name() == "node_modules" {
-            continue;
-        }
-        let source_path = entry.path();
-        let destination_path = destination.join(entry.file_name());
-        if entry.file_type().unwrap().is_dir() {
-            copy_fixture(&source_path, &destination_path);
-        } else {
-            std::fs::copy(source_path, destination_path).unwrap();
-        }
-    }
-}
-
-fn install_packages(project_root: &Path) {
-    let mapper_root = project_root.join("node_modules/vize");
-    std::fs::create_dir_all(&mapper_root).unwrap();
-    std::fs::write(
-        mapper_root.join("package.json"),
-        serde_json::to_vec_pretty(&json!({
-            "name": "vize",
-            "private": true,
-            "tsContentMapper": {
-                "exec": [env!("CARGO_BIN_EXE_vize"), "content-mapper"],
-                "compilerOptions": ["noUnusedLocals"],
-            },
-        }))
-        .unwrap(),
-    )
-    .unwrap();
-
-    let store = workspace_root().join("node_modules/.pnpm");
-    let mut candidates = std::fs::read_dir(&store)
-        .unwrap()
-        .filter_map(Result::ok)
-        .filter(|entry| entry.file_name().to_string_lossy().starts_with("vue@3."))
-        .map(|entry| entry.path().join("node_modules/vue"))
-        .filter(|path| path.join("package.json").is_file())
-        .collect::<Vec<_>>();
-    candidates.sort();
-    let source = candidates.pop().expect("workspace Vue package");
-    let target = project_root.join("node_modules/vue");
-    #[cfg(unix)]
-    std::os::unix::fs::symlink(source, target).unwrap();
-    #[cfg(windows)]
-    std::os::windows::fs::symlink_dir(source, target).unwrap();
-}
-
-fn file_uri(path: &Path) -> CompactString {
-    let mut uri = CompactString::from("file://");
-    for byte in path.to_string_lossy().bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' | b':' => {
-                uri.push(byte as char)
-            }
-            _ => {
-                use std::fmt::Write;
-                write!(uri, "%{byte:02X}").unwrap();
-            }
-        }
-    }
-    uri
-}
-
-fn position(source: &str, offset: usize) -> Value {
-    let before = &source[..offset];
-    let line = before.matches('\n').count();
-    let character = before.rsplit_once('\n').map_or(before, |(_, tail)| tail);
-    json!({ "line": line, "character": character.encode_utf16().count() })
-}
-
-fn contains_location(value: &Value, uri: &str, start: &Value) -> bool {
-    match value {
-        Value::Array(values) => values
-            .iter()
-            .any(|value| contains_location(value, uri, start)),
-        Value::Object(object) => {
-            let location_uri = object.get("uri").or_else(|| object.get("targetUri"));
-            let range = object
-                .get("range")
-                .or_else(|| object.get("targetSelectionRange"));
-            location_uri == Some(&Value::String(uri.to_owned()))
-                && range.and_then(|range| range.get("start")) == Some(start)
-        }
-        _ => false,
-    }
-}
-
-fn editor_capabilities() -> Value {
-    json!({
-        "workspace": {
-            "configuration": true,
-            "didChangeWatchedFiles": { "dynamicRegistration": true }
-        },
-        "textDocument": {
-            "synchronization": { "dynamicRegistration": true },
-            "diagnostic": { "dynamicRegistration": true },
-            "completion": { "dynamicRegistration": true },
-            "signatureHelp": { "dynamicRegistration": true },
-            "hover": { "dynamicRegistration": true },
-            "definition": { "dynamicRegistration": true },
-            "references": { "dynamicRegistration": true },
-            "rename": { "dynamicRegistration": true }
-        }
-    })
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- extract exact Content Mapper LSP fixture copying, package installation, URI mapping, and client capabilities into reusable test support
- keep the existing upstream tsgo hover, completion, signature, navigation, reference, and rename coverage behavior-identical
- leave room for isolated diagnostics and file-lifecycle conformance tests without exceeding source-size limits

## Verification

- exact tsgo Content Mapper LSP conformance
- targeted clippy with warnings denied
- source-length gate

Advances #4057
Advances #3282

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->