### PR TITLE
test(content-mapper): cover LSP document close

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -259,6 +259,23 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
                 .unwrap();
             assert_eq!(repaired["items"], json!([]), "{repaired:#}");
 
+            overlay.replace(&uri, broken_source.as_str()).unwrap();
+            let dirty = client
+                .request::<RawDocumentDiagnostic>(json!({
+                    "textDocument": { "uri": child_uri }
+                }))
+                .await
+                .unwrap();
+            assert!(!dirty["items"].as_array().unwrap().is_empty(), "{dirty:#}");
+
+            assert!(overlay.close(&uri).unwrap().is_some());
+            let closed = client
+                .request::<RawDocumentDiagnostic>(json!({
+                    "textDocument": { "uri": child_uri }
+                }))
+                .await
+                .unwrap();
+            assert_eq!(closed["items"], json!([]), "{closed:#}");
             stop.store(true, Ordering::Relaxed);
             client.close().await.unwrap();
             responder.join().unwrap();


### PR DESCRIPTION
## Summary

- make an open Vue document dirty with an unsaved template type error
- verify pull diagnostics observe the dirty editor buffer
- close the document and verify diagnostics fall back to the clean on-disk SFC

## Verification

- exact tsgo Content Mapper LSP conformance
- targeted clippy with warnings denied
- source-length gate

Advances #4057
Advances #3282

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->