### PR TITLE
fix(content-mapper): name component hover symbols

### DIFF
--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -7,11 +7,39 @@ use serde_json::{Value, json};
 use vize_carton::String as CompactString;
 
 struct RawDocumentDiagnostic;
+struct RawHover;
+struct RawDefinition;
 
 impl lsp_types::request::Request for RawDocumentDiagnostic {
     type Params = Value;
     type Result = Value;
     const METHOD: &'static str = "textDocument/diagnostic";
+}
+
+impl lsp_types::request::Request for RawHover {
+    type Params = Value;
+    type Result = Value;
+    const METHOD: &'static str = "textDocument/hover";
+}
+
+impl lsp_types::request::Request for RawDefinition {
+    type Params = Value;
+    type Result = Value;
+    const METHOD: &'static str = "textDocument/definition";
+}
+
+pub async fn hover(client: &LspClient, uri: &str, position: &Value) -> Value {
+    client
+        .request::<RawHover>(json!({ "textDocument": { "uri": uri }, "position": position }))
+        .await
+        .unwrap()
+}
+
+pub async fn definition(client: &LspClient, uri: &str, position: &Value) -> Value {
+    client
+        .request::<RawDefinition>(json!({ "textDocument": { "uri": uri }, "position": position }))
+        .await
+        .unwrap()
 }
 
 pub async fn pull_diagnostics(client: &LspClient, uri: &str) -> Value {

--- a/crates/vize/tests/content_mapper_tsgo_cli.rs
+++ b/crates/vize/tests/content_mapper_tsgo_cli.rs
@@ -287,7 +287,8 @@ fn standard_tsgo_checks_vue_project_and_emits_consumable_declarations() {
     let options_text = std::fs::read_to_string(&options_declaration).unwrap();
     assert!(options_text.contains("$props"), "{options_text}");
     assert!(
-        options_text.contains("export default __vize_component__"),
+        options_text.contains("declare const Options: typeof __vize_component__")
+            && options_text.contains("export default Options"),
         "{options_text}"
     );
     let public_text = std::fs::read_to_string(&public_declaration).unwrap();

--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -10,8 +10,9 @@ use serde_json::{Value, json};
 
 mod content_mapper_lsp_support;
 use content_mapper_lsp_support::{
-    contains_location, copy_fixture, editor_capabilities, file_uri, install_packages,
-    notify_file_changes, position, pull_diagnostics, try_pull_diagnostics, workspace_root,
+    contains_location, copy_fixture, definition, editor_capabilities, file_uri, hover,
+    install_packages, notify_file_changes, position, pull_diagnostics, try_pull_diagnostics,
+    workspace_root,
 };
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
@@ -28,8 +29,6 @@ struct RawInitialize;
 struct RawDiscoverContentMappers;
 struct RawCompletion;
 struct RawSignatureHelp;
-struct RawHover;
-struct RawDefinition;
 struct RawReferences;
 struct RawRename;
 
@@ -47,8 +46,6 @@ raw_request!(RawInitialize, "initialize");
 raw_request!(RawDiscoverContentMappers, "custom/discoverContentMappers");
 raw_request!(RawCompletion, "textDocument/completion");
 raw_request!(RawSignatureHelp, "textDocument/signatureHelp");
-raw_request!(RawHover, "textDocument/hover");
-raw_request!(RawDefinition, "textDocument/definition");
 raw_request!(RawReferences, "textDocument/references");
 raw_request!(RawRename, "textDocument/rename");
 
@@ -86,6 +83,10 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
     let signature_position = position(&source, symbol_offset + "count.toFixed(".len());
     let declaration_offset = source.find("count: number").unwrap();
     let declaration_position = position(&source, declaration_offset);
+    let app_path = project.path().join("src/App.vue");
+    let app_source = std::fs::read_to_string(&app_path).unwrap();
+    let app_uri = file_uri(&app_path);
+    let component_position = position(&app_source, app_source.find("<Child").unwrap() + 1);
 
     let stop = AtomicBool::new(false);
     std::thread::scope(|scope| {
@@ -146,8 +147,31 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
             overlay
                 .open(VirtualDocument::new(uri.clone(), "vue", source.as_str()))
                 .unwrap();
-            let params =
-                json!({ "textDocument": { "uri": child_uri }, "position": symbol_position });
+            let app_document_uri = Uri::from_str(&app_uri).unwrap();
+            overlay
+                .open(VirtualDocument::new(
+                    app_document_uri,
+                    "vue",
+                    app_source.as_str(),
+                ))
+                .unwrap();
+            let component_hover = hover(&client, &app_uri, &component_position).await;
+            let component_hover_text = serde_json::to_string(&component_hover).unwrap();
+            assert!(
+                component_hover_text.contains("Child")
+                    && !component_hover_text.contains("__vize_component__"),
+                "{component_hover:#}"
+            );
+            let component_definition = definition(&client, &app_uri, &component_position).await;
+            let component_definition_text = serde_json::to_string(&component_definition).unwrap();
+            assert!(
+                component_definition_text.contains(child_uri.as_str()),
+                "{component_definition:#}"
+            );
+            assert!(
+                !component_definition_text.contains(".vue.ts"),
+                "{component_definition:#}"
+            );
 
             let completion = client
                 .request::<RawCompletion>(json!({
@@ -176,17 +200,14 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
                 "{signature:#}"
             );
 
-            let hover = client.request::<RawHover>(params.clone()).await.unwrap();
+            let hover = hover(&client, &child_uri, &symbol_position).await;
             let hover_text = serde_json::to_string(&hover).unwrap();
             assert!(
                 hover_text.contains("count") && hover_text.contains("number"),
                 "{hover:#}"
             );
 
-            let definition = client
-                .request::<RawDefinition>(params.clone())
-                .await
-                .unwrap();
+            let definition = definition(&client, &child_uri, &symbol_position).await;
             let definition_text = serde_json::to_string(&definition).unwrap();
             assert!(
                 definition_text.contains(child_uri.as_str()),

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -141,6 +141,7 @@ pub(super) fn build_vue_registered_file(
                 preserve_unused_diagnostics: context.preserve_unused_diagnostics,
                 options_api: context.options_api,
                 preserve_authored_component: false,
+                component_name: None,
                 legacy_vue2: context.legacy_vue2,
                 dialect: context.dialect,
                 template_syntax: context.template_syntax,

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -10,7 +10,7 @@ use vize_carton::{String as CompactString, ToCompactString, config::VueVersion};
 
 use crate::batch::Diagnostic;
 use crate::batch::error::CorsaResult;
-use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions, VizeMapping};
+use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions, VizeMapping, to_safe_identifier};
 
 use super::build::{
     descriptor_uses_jsx_script, prepend_vue_jsx_reference, virtual_ts_options_for_descriptor,
@@ -143,6 +143,7 @@ pub fn generate_vue_content_mapper_transform_with_options(
 
     let options = virtual_ts_options_for_descriptor(&VirtualTsOptions::default(), &descriptor);
     let use_tsx = descriptor_uses_jsx_script(&descriptor);
+    let component_name = content_mapper_component_name(path);
     let GeneratedVueFile {
         mut code,
         mut mappings,
@@ -157,6 +158,7 @@ pub fn generate_vue_content_mapper_transform_with_options(
             preserve_unused_diagnostics: transform_options.preserve_unused_diagnostics,
             options_api: transform_options.options_api(),
             preserve_authored_component: true,
+            component_name: Some(component_name.as_str()),
             legacy_vue2: false,
             dialect: VueVersion::default(),
             template_syntax: TemplateSyntaxMode::default(),
@@ -183,6 +185,20 @@ pub fn generate_vue_content_mapper_transform_with_options(
             SCRIPT_KIND_TS
         },
     })
+}
+
+fn content_mapper_component_name(path: &Path) -> CompactString {
+    let stem = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("VueComponent");
+    let pascal = vize_croquis::naming::to_pascal_case(stem);
+    let name = to_safe_identifier(pascal.as_str());
+    if name.as_str().bytes().all(|byte| byte == b'_') {
+        CompactString::from("VueComponent")
+    } else {
+        name
+    }
 }
 
 fn sfc_parse_diagnostic(source: &str, error: &SfcError) -> ContentMapperDiagnostic {

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_component_export_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_component_export_tests.rs
@@ -1,0 +1,53 @@
+use std::path::Path;
+
+use crate::batch::generate_vue_content_mapper_transform;
+
+#[test]
+fn names_the_default_export_from_the_sfc_filename() {
+    let source = "<script setup lang=\"ts\"></script>";
+    for (file_name, component_name) in [
+        ("Child.vue", "Child"),
+        ("user-card.vue", "UserCard"),
+        ("123-widget.vue", "_123Widget"),
+        ("日本語.vue", "VueComponent"),
+    ] {
+        let result =
+            generate_vue_content_mapper_transform(Path::new(file_name), source).expect("transform");
+        assert!(
+            result.text.contains(&format!(
+                "declare const {component_name}: typeof __vize_component__;\nexport default {component_name};"
+            )),
+            "{}",
+            result.text
+        );
+    }
+}
+
+#[test]
+fn avoids_a_filename_collision_with_an_authored_module_binding() {
+    let source = r#"<script setup lang="ts">
+import Child from "./dependency";
+void Child;
+</script>"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("Child.vue"), source).expect("transform");
+
+    assert!(
+        result.text.contains(
+            "declare const ChildVueComponent: typeof __vize_component__;\nexport default ChildVueComponent;"
+        ),
+        "{}",
+        result.text
+    );
+
+    let setup_local = r#"<script setup lang="ts">
+const Child = 1;
+</script>"#;
+    let result = generate_vue_content_mapper_transform(Path::new("Child.vue"), setup_local)
+        .expect("transform");
+    assert!(
+        result.text.contains("export default Child;"),
+        "{}",
+        result.text
+    );
+}

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -6,6 +6,9 @@ use crate::batch::{
     generate_vue_content_mapper_transform_with_options,
 };
 
+#[path = "content_mapper_component_export_tests.rs"]
+mod component_exports;
+
 #[test]
 fn emits_protocol_v1_spans_without_forbidden_overlaps() {
     let source = r#"<script setup lang="ts">

--- a/crates/vize_canon/src/batch/virtual_project/document.rs
+++ b/crates/vize_canon/src/batch/virtual_project/document.rs
@@ -115,6 +115,7 @@ pub(crate) fn generate_vue_document_virtual_ts_with_options_and_alias_resolver(
             preserve_unused_diagnostics: false,
             options_api: document_options.options_api,
             preserve_authored_component: false,
+            component_name: None,
             legacy_vue2: document_options.legacy_vue2,
             dialect: vize_carton::config::VueVersion::default(),
             template_syntax: TemplateSyntaxMode::default(),

--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -43,11 +43,12 @@ pub(super) struct GeneratedVueFile {
 }
 
 #[derive(Clone, Copy)]
-pub(super) struct VueCodegenOptions {
+pub(super) struct VueCodegenOptions<'a> {
     pub(super) check_options: VirtualTsCheckOptions,
     pub(super) preserve_unused_diagnostics: bool,
     pub(super) options_api: bool,
     pub(super) preserve_authored_component: bool,
+    pub(super) component_name: Option<&'a str>,
     pub(super) legacy_vue2: bool,
     pub(super) dialect: VueVersion,
     pub(super) template_syntax: TemplateSyntaxMode,
@@ -64,7 +65,7 @@ pub(super) fn generate_vue_virtual_ts(
     source: &str,
     descriptor: &SfcDescriptor,
     options: &VirtualTsOptions,
-    codegen_options: VueCodegenOptions,
+    codegen_options: VueCodegenOptions<'_>,
 ) -> CorsaResult<GeneratedVueFile> {
     let allocator = Bump::new();
     let mut diagnostics = Vec::new();
@@ -247,6 +248,7 @@ pub(super) fn generate_vue_virtual_ts(
                 extra_template_referenced_names: extra_template_referenced_names.as_ref(),
                 options_api: codegen_options.options_api || vue2_compat,
                 preserve_authored_component: codegen_options.preserve_authored_component,
+                component_name: codegen_options.component_name,
                 legacy_vue2: vue2_compat,
                 template_syntax_quirks: matches!(
                     codegen_options.template_syntax,

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -37,6 +37,7 @@ pub use generator::{
     generate_virtual_ts, generate_virtual_ts_with_offsets,
     generate_virtual_ts_with_offsets_legacy_vue2, generate_virtual_ts_with_offsets_options_api,
 };
+pub(crate) use helpers::to_safe_identifier;
 pub use helpers::{
     DECLARATION_HELPERS_DTS, SHARED_PREAMBLE_DTS, SHARED_PREAMBLE_FILE_NAME, VUE_SETUP_HELPERS,
     VUE_TYPE_HELPERS,

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -905,7 +905,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             .map(|(decl, names)| (decl.as_str(), names.as_str())),
         preserve_authored_component,
     );
-    ts.push_str("export default __vize_component__;\n");
+    component_export::emit_component_default_export(&mut ts, generation_options.component_name);
 
     VirtualTsOutput { code: ts, mappings }
 }

--- a/crates/vize_canon/src/virtual_ts/generator/component_export.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/component_export.rs
@@ -81,3 +81,46 @@ pub(super) fn emit_default_export_declaration(
         );
     }
 }
+
+pub(super) fn emit_component_default_export(ts: &mut String, component_name: Option<&str>) {
+    let Some(component_name) = component_name else {
+        ts.push_str("export default __vize_component__;\n");
+        return;
+    };
+    let mut export_name = String::from(component_name);
+    if module_scope_contains_identifier(ts, export_name.as_str()) {
+        export_name.push_str("VueComponent");
+        while module_scope_contains_identifier(ts, export_name.as_str()) {
+            export_name.push('_');
+        }
+    }
+    append!(
+        *ts,
+        "declare const {export_name}: typeof __vize_component__;\nexport default {export_name};\n",
+    );
+}
+
+fn module_scope_contains_identifier(ts: &str, name: &str) -> bool {
+    const SETUP: &str = "// ========== Setup Scope ==========";
+    const AFTER_SETUP: &str = "// Invoke setup to verify types";
+    let before_setup = ts.split_once(SETUP).map_or(ts, |(before, _)| before);
+    let after_setup = ts.rsplit_once(AFTER_SETUP).map_or("", |(_, after)| after);
+    [before_setup, after_setup]
+        .into_iter()
+        .any(|source| contains_identifier(source, name))
+}
+
+fn contains_identifier(source: &str, name: &str) -> bool {
+    source.match_indices(name).any(|(start, _)| {
+        let end = start + name.len();
+        let boundary = |byte: u8| !byte.is_ascii_alphanumeric() && !matches!(byte, b'_' | b'$');
+        source
+            .as_bytes()
+            .get(start.wrapping_sub(1))
+            .is_none_or(|byte| boundary(*byte))
+            && source
+                .as_bytes()
+                .get(end)
+                .is_none_or(|byte| boundary(*byte))
+    })
+}

--- a/crates/vize_canon/src/virtual_ts/types.rs
+++ b/crates/vize_canon/src/virtual_ts/types.rs
@@ -162,6 +162,9 @@ pub(crate) struct VirtualTsGenerationOptions<'a> {
     /// Declaration-producing callers enable this until the batch path can do
     /// so without changing its committed virtual-code baselines.
     pub(crate) preserve_authored_component: bool,
+    /// Public-facing component symbol used by Content Mapper hover responses.
+    /// `None` preserves the internal default export used by batch projections.
+    pub(crate) component_name: Option<&'a str>,
     /// Legacy Vue 2.7 / Nuxt 2 (implies `options_api` plus Nuxt 2 globals).
     pub(crate) legacy_vue2: bool,
     /// Preserve Vue parser compatibility semantics when generating template


### PR DESCRIPTION
## Summary

- give Content Mapper SFC default exports stable filename-derived public symbols
- avoid module-scope collisions while keeping setup-local names untouched
- cover cross-file template component hover and definition with the exact tsgo LSP
- keep exact declaration emit consumable and move shared hover/definition test requests into support code

## Root cause

The transformed SFC exported `__vize_component__` directly. tsgo follows an imported template component through that default export and used the synthetic target declaration name in hover quick info.

A property-expression export removed the name but caused declaration emit to inline a large Vue type that failed when consumed. A named, explicitly typed alias preserves declaration emit while presenting the SFC filename to hover. The alias falls back to a collision-free suffix when the authored module scope already owns that name.

## Validation

- exact tsgo project typecheck, declaration emit, and emitted declaration consumer
- exact tsgo LSP cross-file component hover and authored `.vue` definition
- Content Mapper unit tests, including kebab-case, numeric, non-ASCII, module collision, and setup-local cases
- targeted clippy with warnings denied
- source file length gate

Advances #4066.
Advances #4057.
Advances #3282.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->