### PR TITLE
fix(content-mapper): map cross-file prop definitions

### DIFF
--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -42,6 +42,59 @@ pub async fn definition(client: &LspClient, uri: &str, position: &Value) -> Valu
         .unwrap()
 }
 
+pub async fn assert_component_navigation(
+    client: &LspClient,
+    uri: &str,
+    position: &Value,
+    component_name: &str,
+    target_uri: &str,
+) {
+    let component_hover = hover(client, uri, position).await;
+    let hover_text = serde_json::to_string(&component_hover).unwrap();
+    assert!(
+        hover_text.contains(component_name) && !hover_text.contains("__vize_component__"),
+        "{component_hover:#}"
+    );
+    let component_definition = definition(client, uri, position).await;
+    let definition_text = serde_json::to_string(&component_definition).unwrap();
+    assert!(
+        definition_text.contains(target_uri),
+        "{component_definition:#}"
+    );
+    assert!(
+        !definition_text.contains(".vue.ts"),
+        "{component_definition:#}"
+    );
+}
+
+pub async fn assert_prop_navigation(
+    client: &LspClient,
+    uri: &str,
+    position: &Value,
+    prop_name: &str,
+    prop_type: &str,
+    target_uri: &str,
+    target_start: &Value,
+) {
+    let prop_hover = hover(client, uri, position).await;
+    let hover_text = serde_json::to_string(&prop_hover).unwrap();
+    assert!(
+        hover_text.contains(prop_name) && hover_text.contains(prop_type),
+        "{prop_hover:#}"
+    );
+    let prop_definition = definition(client, uri, position).await;
+    assert!(
+        contains_location(&prop_definition, target_uri, target_start),
+        "{prop_definition:#}"
+    );
+    assert!(
+        !serde_json::to_string(&prop_definition)
+            .unwrap()
+            .contains(".vue.ts"),
+        "{prop_definition:#}"
+    );
+}
+
 pub async fn pull_diagnostics(client: &LspClient, uri: &str) -> Value {
     try_pull_diagnostics(client, uri).await.unwrap()
 }

--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -10,9 +10,9 @@ use serde_json::{Value, json};
 
 mod content_mapper_lsp_support;
 use content_mapper_lsp_support::{
-    contains_location, copy_fixture, definition, editor_capabilities, file_uri, hover,
-    install_packages, notify_file_changes, position, pull_diagnostics, try_pull_diagnostics,
-    workspace_root,
+    assert_component_navigation, assert_prop_navigation, contains_location, copy_fixture,
+    definition, editor_capabilities, file_uri, hover, install_packages, notify_file_changes,
+    position, pull_diagnostics, try_pull_diagnostics, workspace_root,
 };
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
@@ -87,6 +87,7 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
     let app_source = std::fs::read_to_string(&app_path).unwrap();
     let app_uri = file_uri(&app_path);
     let component_position = position(&app_source, app_source.find("<Child").unwrap() + 1);
+    let component_prop_position = position(&app_source, app_source.find(":count").unwrap() + 1);
 
     let stop = AtomicBool::new(false);
     std::thread::scope(|scope| {
@@ -155,23 +156,25 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
                     app_source.as_str(),
                 ))
                 .unwrap();
-            let component_hover = hover(&client, &app_uri, &component_position).await;
-            let component_hover_text = serde_json::to_string(&component_hover).unwrap();
-            assert!(
-                component_hover_text.contains("Child")
-                    && !component_hover_text.contains("__vize_component__"),
-                "{component_hover:#}"
-            );
-            let component_definition = definition(&client, &app_uri, &component_position).await;
-            let component_definition_text = serde_json::to_string(&component_definition).unwrap();
-            assert!(
-                component_definition_text.contains(child_uri.as_str()),
-                "{component_definition:#}"
-            );
-            assert!(
-                !component_definition_text.contains(".vue.ts"),
-                "{component_definition:#}"
-            );
+            assert_component_navigation(
+                &client,
+                &app_uri,
+                &component_position,
+                "Child",
+                &child_uri,
+            )
+            .await;
+
+            assert_prop_navigation(
+                &client,
+                &app_uri,
+                &component_prop_position,
+                "count",
+                "number",
+                &child_uri,
+                &declaration_position,
+            )
+            .await;
 
             let completion = client
                 .request::<RawCompletion>(json!({

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -88,11 +88,14 @@ defineProps<{ count: number }>();
         .iter()
         .filter(|mapping| mapping.0[2] == original && mapping.0[3] == "count".len())
         .collect::<Vec<_>>();
+    let exported = result.text.find("export type Props").unwrap();
+    let exported = exported + result.text[exported..].find("count").unwrap();
 
     assert!(
-        matching.len() >= 2,
-        "expected authored and synthetic projections: {matching:?}"
+        matching.len() >= 3,
+        "expected exported, authored, and synthetic projections: {matching:?}"
     );
+    assert!(matching.iter().any(|mapping| mapping.0[0] == exported));
     assert!(matching.iter().all(|mapping| mapping.0[4] == 0));
 }
 

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -377,19 +377,18 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     global_components.emit(&mut ts, summary, options, &imported_names);
     ts.push('\n');
 
-    // For an Options API component with no `defineProps` macro, derive a real
-    // `export type Props` from its runtime `props:` option so cross-file prop
-    // checking is no longer a `{}` no-op. Macro-driven props (script setup) take
-    // precedence and are emitted by `generate_props_type` itself.
+    // Derive a real cross-file `Props` type from macro or Options API input.
     let options_api_props: Option<OptionsApiPropsSource> =
         if options_api && summary.macros.props().is_empty() {
             script_content.and_then(find_options_api_props)
         } else {
             None
         };
+    let source_offset = &script_source_offset;
+    let src = prop_source(&mut mappings, summary, script_content, source_offset);
     let setup_props_plan = generate_setup_props(
         &mut ts,
-        summary,
+        src,
         generic_param,
         options_api_props.as_ref(),
         setup_type_exports.exports_public_type("Props"),

--- a/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
@@ -100,15 +100,20 @@ pub(super) fn define_props_type_requires_setup_scope(summary: &Croquis) -> bool 
 /// call site (and from growing past the source-length gate).
 pub(super) fn generate_setup_props(
     ts: &mut String,
-    summary: &Croquis,
+    source: PropsSource<'_>,
     generic_param: Option<&str>,
     options_api_props: Option<&OptionsApiPropsSource>,
     props_is_public_export: bool,
 ) -> SetupPropsPlan {
+    let summary = source.summary;
     let plan = SetupPropsPlan::new(summary, options_api_props, props_is_public_export);
+    let generated_start = ts.len();
     profile!("canon.virtual_ts.generate_props_type", {
         plan.generate_props_type(ts, summary, generic_param, options_api_props);
     });
+    let mut binding_mappings =
+        PropBindingMappings::new(source.mappings, summary, source.script, source.offset);
+    binding_mappings.map_exported_props_type(ts, generated_start);
     plan
 }
 

--- a/crates/vize_canon/src/virtual_ts/props/mappings.rs
+++ b/crates/vize_canon/src/virtual_ts/props/mappings.rs
@@ -80,6 +80,46 @@ impl<'a> PropBindingMappings<'a> {
         });
     }
 
+    pub(crate) fn map_exported_props_type(&mut self, ts: &str, generated_start: usize) {
+        let Some(call) = self.summary.macros.define_props() else {
+            return;
+        };
+        let Some(type_args) = call.type_args.as_deref() else {
+            return;
+        };
+        let emitted = type_args
+            .strip_prefix('<')
+            .and_then(|value| value.strip_suffix('>'))
+            .unwrap_or(type_args);
+        let Some(script) = self.script_content else {
+            return;
+        };
+        let Some(call_source) = script.get(call.start as usize..call.end as usize) else {
+            return;
+        };
+        let Some(authored_type_start) = call_source
+            .find(type_args)
+            .and_then(|start| type_args.find(emitted).map(|inner| start + inner))
+        else {
+            return;
+        };
+        let generated = &ts[generated_start..];
+        let Some(generated_type_start) = generated
+            .find("export type Props")
+            .and_then(|start| generated[start..].find(" = ").map(|rhs| start + rhs + 3))
+            .and_then(|start| generated[start..].find(emitted).map(|inner| start + inner))
+        else {
+            return;
+        };
+        let authored_start = (self.script_source_offset)(call.start as usize + authored_type_start);
+        self.mappings.push(VizeMapping {
+            gen_range: generated_start + generated_type_start
+                ..generated_start + generated_type_start + emitted.len(),
+            src_range: authored_start..authored_start + emitted.len(),
+            sub_spans: Vec::new(),
+        });
+    }
+
     fn authored_name_range(&self, name: &str) -> Option<Range<usize>> {
         let script = self.script_content?;
         let (start, end) = self.summary.macros.prop_declaration(name)?;


### PR DESCRIPTION
## Summary

- map the generated module-level `Props` type back to the authored `defineProps` type argument
- verify exact cross-file prop hover and definition locations through the pinned tsgo LSP
- share strict component and prop navigation assertions without accepting virtual `.vue.ts` targets

## Root cause

Cross-file definitions resolve through the exported `Props` member in the generated module. The authored macro and template projections were mapped, but that exported type projection was not, so tsgo could only return the authored Vue URI with a `(0, 0)` fallback location.

## Validation

- `cargo test -p vize_canon --lib -q` (882 passed)
- exact tsgo `content_mapper_tsgo_cli` integration test
- exact tsgo `content_mapper_tsgo_lsp` integration test
- targeted `cargo clippy` with `-D warnings`
- `cargo fmt --all`
- `git diff --check`
- source-length baseline: `generator.rs` is 910 lines versus 911 at the stacked base

Advances #4068.
Advances #4057.
Advances #3282.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->