### PR TITLE
fix(content-mapper): complete template component events

### DIFF
--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use corsa::lsp::LspClient;
+use corsa::lsp::{LspClient, LspOverlay};
 use lsp_types::{FileChangeType, FileEvent, Uri};
 use serde_json::{Value, json};
 use vize_carton::String as CompactString;
@@ -9,6 +9,8 @@ use vize_carton::String as CompactString;
 struct RawDocumentDiagnostic;
 struct RawHover;
 struct RawDefinition;
+struct RawCompletion;
+struct RawCompletionResolve;
 
 impl lsp_types::request::Request for RawDocumentDiagnostic {
     type Params = Value;
@@ -28,6 +30,18 @@ impl lsp_types::request::Request for RawDefinition {
     const METHOD: &'static str = "textDocument/definition";
 }
 
+impl lsp_types::request::Request for RawCompletion {
+    type Params = Value;
+    type Result = Value;
+    const METHOD: &'static str = "textDocument/completion";
+}
+
+impl lsp_types::request::Request for RawCompletionResolve {
+    type Params = Value;
+    type Result = Value;
+    const METHOD: &'static str = "completionItem/resolve";
+}
+
 pub async fn hover(client: &LspClient, uri: &str, position: &Value) -> Value {
     client
         .request::<RawHover>(json!({ "textDocument": { "uri": uri }, "position": position }))
@@ -40,6 +54,78 @@ pub async fn definition(client: &LspClient, uri: &str, position: &Value) -> Valu
         .request::<RawDefinition>(json!({ "textDocument": { "uri": uri }, "position": position }))
         .await
         .unwrap()
+}
+
+pub async fn completion(client: &LspClient, uri: &str, position: &Value) -> Value {
+    client
+        .request::<RawCompletion>(json!({ "textDocument": { "uri": uri }, "position": position }))
+        .await
+        .unwrap()
+}
+
+pub async fn assert_completion(
+    client: &LspClient,
+    uri: &str,
+    position: &Value,
+    label: &str,
+    resolved_fragments: &[&str],
+) {
+    let response = completion(client, uri, position).await;
+    let items = response
+        .get("items")
+        .and_then(Value::as_array)
+        .or_else(|| response.as_array())
+        .unwrap_or_else(|| panic!("{response:#}"));
+    let item = items
+        .iter()
+        .find(|item| item["label"] == label)
+        .cloned()
+        .unwrap_or_else(|| panic!("{response:#}"));
+    let resolved = client.request::<RawCompletionResolve>(item).await.unwrap();
+    assert_eq!(resolved["label"], label, "{resolved:#}");
+    let resolved_text = serde_json::to_string(&resolved).unwrap();
+    assert!(
+        resolved_fragments
+            .iter()
+            .all(|fragment| resolved_text.contains(fragment)),
+        "{resolved:#}"
+    );
+    assert!(!resolved_text.contains(".vue.ts"), "{resolved:#}");
+}
+
+pub async fn assert_component_completions(
+    client: &LspClient,
+    overlay: &LspOverlay,
+    uri: &Uri,
+    source: &str,
+) {
+    let partial = source
+        .replace(":count", ":cou")
+        .replace("@save=", "@sa=")
+        .replace("@save-item", "@save-");
+    let prop_position = position(&partial, partial.find(":cou").unwrap() + ":cou".len());
+    let event_position = position(&partial, partial.find("@sa").unwrap() + "@sa".len());
+    let kebab_event_position = position(&partial, partial.find("@save-").unwrap() + "@save-".len());
+    overlay.replace(uri, partial.as_str()).unwrap();
+    let uri_text = uri.as_str();
+    assert_completion(
+        client,
+        uri_text,
+        &prop_position,
+        "count",
+        &["(property) count: number"],
+    )
+    .await;
+    assert_completion(client, uri_text, &event_position, "save", &["number"]).await;
+    assert_completion(
+        client,
+        uri_text,
+        &kebab_event_position,
+        "save-item",
+        &["string"],
+    )
+    .await;
+    overlay.replace(uri, source).unwrap();
 }
 
 pub async fn assert_component_navigation(

--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -10,9 +10,10 @@ use serde_json::{Value, json};
 
 mod content_mapper_lsp_support;
 use content_mapper_lsp_support::{
-    assert_component_navigation, assert_prop_navigation, contains_location, copy_fixture,
-    definition, editor_capabilities, file_uri, hover, install_packages, notify_file_changes,
-    position, pull_diagnostics, try_pull_diagnostics, workspace_root,
+    assert_component_completions, assert_component_navigation, assert_prop_navigation, completion,
+    contains_location, copy_fixture, definition, editor_capabilities, file_uri, hover,
+    install_packages, notify_file_changes, position, pull_diagnostics, try_pull_diagnostics,
+    workspace_root,
 };
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
@@ -27,7 +28,6 @@ impl Drop for StopOnDrop<'_> {
 
 struct RawInitialize;
 struct RawDiscoverContentMappers;
-struct RawCompletion;
 struct RawSignatureHelp;
 struct RawReferences;
 struct RawRename;
@@ -44,7 +44,6 @@ macro_rules! raw_request {
 
 raw_request!(RawInitialize, "initialize");
 raw_request!(RawDiscoverContentMappers, "custom/discoverContentMappers");
-raw_request!(RawCompletion, "textDocument/completion");
 raw_request!(RawSignatureHelp, "textDocument/signatureHelp");
 raw_request!(RawReferences, "textDocument/references");
 raw_request!(RawRename, "textDocument/rename");
@@ -151,7 +150,7 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
             let app_document_uri = Uri::from_str(&app_uri).unwrap();
             overlay
                 .open(VirtualDocument::new(
-                    app_document_uri,
+                    app_document_uri.clone(),
                     "vue",
                     app_source.as_str(),
                 ))
@@ -176,13 +175,9 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
             )
             .await;
 
-            let completion = client
-                .request::<RawCompletion>(json!({
-                    "textDocument": { "uri": child_uri },
-                    "position": completion_position
-                }))
-                .await
-                .unwrap();
+            assert_component_completions(&client, &overlay, &app_document_uri, &app_source).await;
+
+            let completion = completion(&client, &child_uri, &completion_position).await;
             assert!(
                 serde_json::to_string(&completion)
                     .unwrap()

--- a/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
@@ -3,8 +3,9 @@ import Child from "./Child.vue";
 import { increment } from "./model";
 
 defineProps<{ count: number }>();
+const handleSaveItem = (id: string) => id;
 </script>
 
 <template>
-  <Child :count="increment(count)" />
+  <Child :count="increment(count)" @save="increment" @save-item="handleSaveItem" />
 </template>

--- a/crates/vize/tests/fixtures/content_mapper_project/src/Child.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/Child.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
 defineProps<{ count: number }>();
+defineEmits<{
+  save: [value: number];
+  saveItem: [id: string];
+}>();
 </script>
 
 <template>

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -100,6 +100,34 @@ defineProps<{ count: number }>();
 }
 
 #[test]
+fn maps_component_event_navigation_to_the_authored_name() {
+    let source = r#"<script setup lang="ts">
+import Child from "./Child.vue";
+const handler = (value: number) => value;
+</script>
+<template><Child @sa="handler" /></template>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("App.vue"), source).expect("transform");
+    let original = source.find("@sa").unwrap() + 1;
+    let navigation = result.text.find("__vize_events_nav_0.sa").unwrap();
+    let generated = navigation + "__vize_events_nav_0.".len();
+    let handler = result.text.find("// @sa handler").unwrap();
+
+    assert!(
+        navigation < handler,
+        "completion projection must win reverse mapping"
+    );
+    assert!(result.mappings.iter().any(|mapping| {
+        mapping.0[0] == generated
+            && mapping.0[1] == "sa".len()
+            && mapping.0[2] == original
+            && mapping.0[3] == "sa".len()
+            && mapping.0[4] == 0
+    }));
+}
+
+#[test]
 fn maps_synthetic_props_after_a_plain_script_to_the_setup_block() {
     let source = r#"<script lang="ts">
 export const marker = true;

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -19,7 +19,8 @@ use crate::virtual_ts::types::VizeMapping;
 
 use super::children::generate_child_scopes;
 use super::component_prop_expressions::collect_component_prop_expression_ranges;
-use super::component_props::generate_component_props;
+use super::component_prop_navigation::emit_event_references;
+use super::component_props::{collect_checkable_usages, generate_component_props};
 use super::context::{ComponentPropsContext, ScopeGenContext, ScopeGenerationOptions};
 use super::emit::{
     append_v_for_comment, emit_slot_function_open, emit_v_for_loop_open, slot_props_type,
@@ -122,8 +123,22 @@ pub(crate) fn generate_scope_closures(
             generate_instance_global_refs(ts, mappings, summary, template_offset, &options)
         );
     }
-
-    // Process non-nested scopes at template level
+    let props_ctx = ComponentPropsContext {
+        summary,
+        template_source: options.template_ast.map(|root| root.source.as_str()),
+        children_map: &children_map,
+        vfor_enclosing_guards: &vfor_enclosing_guards,
+        template_prop_names,
+        template_offset,
+        options: virtual_ts_options,
+        check_unresolved_global_components: options.check_unresolved_global_components,
+        legacy_vue2: options.legacy_vue2,
+    };
+    let check_props = check_options.check_props;
+    let usages = check_props.then(|| collect_checkable_usages(&props_ctx));
+    if let Some(usages) = &usages {
+        emit_event_references(ts, mappings, &props_ctx, usages);
+    }
     for scope in summary.scopes.iter() {
         let scope_id = scope.id.as_u32();
 
@@ -177,31 +192,16 @@ pub(crate) fn generate_scope_closures(
         );
     }
 
-    // Handle undefined references
     if check_options.check_template_bindings {
         profile!(
             "canon.virtual_ts.undefined_refs",
             generate_undefined_refs(ts, mappings, summary, template_offset, &options)
         );
     }
-    if check_options.check_props {
+    if let Some(usages) = &usages {
         profile!(
             "canon.virtual_ts.component_props",
-            generate_component_props(
-                ts,
-                mappings,
-                &ComponentPropsContext {
-                    summary,
-                    template_source: options.template_ast.map(|root| root.source.as_str()),
-                    children_map: &children_map,
-                    vfor_enclosing_guards: &vfor_enclosing_guards,
-                    template_prop_names,
-                    template_offset,
-                    options: virtual_ts_options,
-                    check_unresolved_global_components: options.check_unresolved_global_components,
-                    legacy_vue2: options.legacy_vue2,
-                },
-            )
+            generate_component_props(ts, mappings, &props_ctx, usages)
         );
     }
 }

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
@@ -166,6 +166,19 @@ pub(super) fn append_prop_check_helpers(ts: &mut String, usages: &[(usize, &Comp
     ts.push_str(
         "  type __VizeEmitListeners<C> = C extends { __vizeEmitProps?: infer __E } ? NonNullable<__E> : {};\n",
     );
+    if usages.iter().any(|(_, usage)| {
+        usage
+            .events
+            .iter()
+            .any(|event| !event.name_is_dynamic && !event.name.is_empty())
+    }) {
+        ts.push_str(
+            "  type __VizeEventName<K extends string> = K extends `on${infer E}` ? Uncapitalize<E> | __VizeKebabCase<Uncapitalize<E>> : never;\n",
+        );
+        ts.push_str(
+            "  type __VizeComponentEvents<C, __L = C extends { __vizeEmitProps?: infer __E } ? NonNullable<__E> : C extends { new (): { $props: infer __P } } ? __P : C extends (props: infer __P) => any ? __P : {}> = { [K in keyof __L & string as __VizeEventName<K>]: __L[K] };\n",
+        );
+    }
     ts.push_str(
         "  type __VizePropChecker<C, P> = __VizeIsAny<C> extends true ? (props: { readonly [K in keyof P]: P[K] } & Record<string, unknown>) => void : C extends { __vizeCheck: infer __F } ? (__F extends (...args: any[]) => any ? __F : (props: { readonly [K in keyof P]: P[K] } & Record<string, unknown>) => void) : (props: { readonly [K in keyof P]: P[K] } & Record<string, unknown>) => void;\n",
     );

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
@@ -1,12 +1,25 @@
 use std::ops::Range;
 
 use vize_carton::{String, append, cstr};
-use vize_croquis::croquis::{ComponentUsage, PassedProp};
+use vize_croquis::croquis::{ComponentUsage, EventListener, PassedProp};
 
 use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier, to_safe_identifier_fragment};
 use crate::virtual_ts::types::VizeMapping;
 
 use super::context::ComponentPropsContext;
+use super::event_handler::event_name_source_range;
+
+pub(super) fn emit_event_references(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    ctx: &ComponentPropsContext<'_>,
+    checkable_usages: &[(usize, &ComponentUsage)],
+) {
+    for &(idx, usage) in checkable_usages {
+        let component_ref = to_safe_identifier(usage.name.as_str());
+        emit_usage_event_references(ts, mappings, ctx, idx, usage, component_ref.as_str());
+    }
+}
 
 pub(super) fn emit_references(
     ts: &mut String,
@@ -34,6 +47,64 @@ pub(super) fn emit_references(
 
         emit_prop_references(ts, mappings, ctx, idx, usage, component_type_name.as_str());
     }
+}
+
+fn emit_usage_event_references(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    ctx: &ComponentPropsContext<'_>,
+    idx: usize,
+    usage: &ComponentUsage,
+    component_ref: &str,
+) {
+    let events_ref = cstr!("__vize_events_nav_{idx}");
+    let mut emitted_events_ref = false;
+    for event in &usage.events {
+        let Some(source_range) = event_navigation_source_range(ctx, event) else {
+            continue;
+        };
+        if !emitted_events_ref {
+            append!(
+                *ts,
+                "  const {events_ref} = undefined as unknown as __VizeComponentEvents<typeof {component_ref}> & Record<string, unknown>;\n"
+            );
+            emitted_events_ref = true;
+        }
+
+        append!(*ts, "  void {events_ref}");
+        let event_gen_range = if is_ts_identifier(event.name.as_str()) {
+            ts.push('.');
+            let start = ts.len();
+            ts.push_str(event.name.as_str());
+            start..ts.len()
+        } else {
+            ts.push('[');
+            let range = push_ts_single_quoted_literal(ts, event.name.as_str());
+            ts.push(']');
+            range
+        };
+        ts.push_str(";\n");
+        mappings.push(VizeMapping {
+            gen_range: event_gen_range,
+            src_range: source_range,
+            sub_spans: Vec::new(),
+        });
+    }
+}
+
+fn event_navigation_source_range(
+    ctx: &ComponentPropsContext<'_>,
+    event: &EventListener,
+) -> Option<Range<usize>> {
+    if event.name_is_dynamic || event.name.is_empty() {
+        return None;
+    }
+    event_name_source_range(
+        ctx.template_source,
+        ctx.template_offset,
+        event.start..event.end,
+        event.name.as_str(),
+    )
 }
 
 fn emit_prop_references(

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -33,39 +33,16 @@ pub(super) fn generate_component_props(
     ts: &mut String,
     mappings: &mut Vec<VizeMapping>,
     ctx: &ComponentPropsContext<'_>,
+    checkable_usages: &[(usize, &ComponentUsage)],
 ) {
     let summary = ctx.summary;
-    if summary.component_usages.is_empty() {
-        return;
-    }
-
-    let external_template_bindings: FxHashSet<&str> = ctx
-        .options
-        .external_template_bindings
-        .iter()
-        .map(|name| name.as_str())
-        .collect();
-    let checkable_usages: Vec<(usize, &ComponentUsage)> = summary
-        .component_usages
-        .iter()
-        .enumerate()
-        .filter(|(_, usage)| {
-            component_usage_has_checkable_binding(
-                summary,
-                usage,
-                &external_template_bindings,
-                ctx.check_unresolved_global_components,
-                ctx.legacy_vue2,
-            )
-        })
-        .collect();
     if checkable_usages.is_empty() {
         return;
     }
 
     let mut components_by_scope: FxHashMap<u32, Vec<(usize, &ComponentUsage)>> =
         FxHashMap::default();
-    for &(idx, usage) in &checkable_usages {
+    for &(idx, usage) in checkable_usages {
         components_by_scope
             .entry(usage.scope_id.as_u32())
             .or_default()
@@ -76,9 +53,9 @@ pub(super) fn generate_component_props(
 
     // Generic children expose `__vizeCheck<T>(props)`; fallback contextual
     // typing is limited to inline function props to avoid duplicate errors.
-    append_prop_check_helpers(ts, &checkable_usages);
+    append_prop_check_helpers(ts, checkable_usages);
 
-    for &(idx, usage) in &checkable_usages {
+    for &(idx, usage) in checkable_usages {
         let component_ref = to_safe_identifier(usage.name.as_str());
         let component_type_name = to_safe_identifier_fragment(usage.name.as_str());
 
@@ -101,7 +78,7 @@ pub(super) fn generate_component_props(
         );
     }
 
-    component_prop_navigation::emit_references(ts, mappings, ctx, &checkable_usages);
+    component_prop_navigation::emit_references(ts, mappings, ctx, checkable_usages);
 
     // Collect all closure scope IDs (v-for and v-slot)
     let closure_scope_ids: FxHashSet<u32> = summary
@@ -154,7 +131,7 @@ pub(super) fn generate_component_props(
         .collect();
 
     ts.push_str("\n  // Component props value checks (template scope)\n");
-    for &(idx, usage) in &checkable_usages {
+    for &(idx, usage) in checkable_usages {
         if closure_scope_ids.contains(&usage.scope_id.as_u32()) {
             continue; // Will be emitted inside v-for/v-slot scope
         }
@@ -175,7 +152,7 @@ pub(super) fn generate_component_props(
         );
     }
 
-    generate_empty_root_checks(ts, mappings, ctx, &checkable_usages, &closure_scope_ids);
+    generate_empty_root_checks(ts, mappings, ctx, checkable_usages, &closure_scope_ids);
 
     for scope in summary.scopes.iter() {
         if !matches!(scope.kind, ScopeKind::VFor | ScopeKind::VSlot) {
@@ -199,6 +176,31 @@ pub(super) fn generate_component_props(
             generate_closure_component_props_recursive(ts, mappings, &props_ctx, scope, "  ")
         );
     }
+}
+
+pub(super) fn collect_checkable_usages<'a>(
+    ctx: &ComponentPropsContext<'a>,
+) -> Vec<(usize, &'a ComponentUsage)> {
+    let external_template_bindings: FxHashSet<&str> = ctx
+        .options
+        .external_template_bindings
+        .iter()
+        .map(|name| name.as_str())
+        .collect();
+    ctx.summary
+        .component_usages
+        .iter()
+        .enumerate()
+        .filter(|(_, usage)| {
+            component_usage_has_checkable_binding(
+                ctx.summary,
+                usage,
+                &external_template_bindings,
+                ctx.check_unresolved_global_components,
+                ctx.legacy_vue2,
+            )
+        })
+        .collect()
 }
 
 pub(super) fn component_usage_has_checkable_binding(


### PR DESCRIPTION
## Summary

- project typed component events into the template scope before handler-only projections
- complete real partial `@sa` and kebab-case `@save-` input through the pinned tsgo LSP
- resolve event payload details without exposing generated `.vue.ts` paths
- share the checkable component-usage plan across early event navigation and later prop checks

## Root cause

Child event listener types were already exported through `__vizeEmitProps`, but authored event names had no property-access projection for language-service completion. The only matching projection was a synthetic handler identifier emitted later for diagnostics, so exact tsgo returned `null` for event-name completion.

The new projection derives authored camel and kebab event names from listener props and is emitted before handler diagnostics. This gives reverse mapping a completion-capable TypeScript property while preserving the existing diagnostic anchor.

## Validation

- `cargo test -p vize_canon --lib -q` (883 passed)
- exact tsgo `content_mapper_tsgo_cli` integration test
- exact tsgo `content_mapper_tsgo_lsp` integration test with real partial authored input
- typed tuple payload and camel-to-kebab event completion/resolve coverage
- targeted `cargo clippy` with `-D warnings`
- `cargo fmt --all`
- `git diff --check`
- oversized files do not grow against stacked base (`content_mapper_tsgo_lsp.rs` 340/345, `closures.rs` 389/389)

Advances #4070.
Advances #4057.
Advances #3282.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->