### PR TITLE
fix(content-mapper): map record event definitions

### DIFF
--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -174,11 +174,29 @@ pub async fn assert_prop_navigation(
         "{prop_definition:#}"
     );
     assert!(
+        !contains_location(&prop_definition, uri, position),
+        "definition must not point back to its usage: {prop_definition:#}"
+    );
+    assert!(
         !serde_json::to_string(&prop_definition)
             .unwrap()
             .contains(".vue.ts"),
         "{prop_definition:#}"
     );
+}
+pub async fn assert_component_members(
+    client: &LspClient,
+    parent: (&str, &str),
+    child: (&str, &str),
+) {
+    for (usage, declaration, name, ty) in [
+        (":count", "count: number", "count", "number"),
+        ("@save", "save: [value", "save", "number"),
+    ] {
+        let usage = position(parent.1, parent.1.find(usage).unwrap() + 1);
+        let declaration = position(child.1, child.1.find(declaration).unwrap());
+        assert_prop_navigation(client, parent.0, &usage, name, ty, child.0, &declaration).await;
+    }
 }
 
 pub async fn pull_diagnostics(client: &LspClient, uri: &str) -> Value {

--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -10,8 +10,8 @@ use serde_json::{Value, json};
 
 mod content_mapper_lsp_support;
 use content_mapper_lsp_support::{
-    assert_component_completions, assert_component_navigation, assert_prop_navigation, completion,
-    contains_location, copy_fixture, definition, editor_capabilities, file_uri, hover,
+    assert_component_completions, assert_component_members, assert_component_navigation,
+    completion, contains_location, copy_fixture, definition, editor_capabilities, file_uri, hover,
     install_packages, notify_file_changes, position, pull_diagnostics, try_pull_diagnostics,
     workspace_root,
 };
@@ -86,7 +86,6 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
     let app_source = std::fs::read_to_string(&app_path).unwrap();
     let app_uri = file_uri(&app_path);
     let component_position = position(&app_source, app_source.find("<Child").unwrap() + 1);
-    let component_prop_position = position(&app_source, app_source.find(":count").unwrap() + 1);
 
     let stop = AtomicBool::new(false);
     std::thread::scope(|scope| {
@@ -164,16 +163,7 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
             )
             .await;
 
-            assert_prop_navigation(
-                &client,
-                &app_uri,
-                &component_prop_position,
-                "count",
-                "number",
-                &child_uri,
-                &declaration_position,
-            )
-            .await;
+            assert_component_members(&client, (&app_uri, &app_source), (&child_uri, &source)).await;
 
             assert_component_completions(&client, &overlay, &app_document_uri, &app_source).await;
 

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -23,7 +23,7 @@ mod span_features;
 #[path = "content_mapper_span_normalize.rs"]
 mod span_normalize;
 
-use span_features::CONTENT_MAPPER_SPAN_FEATURES_ALL;
+use span_features::{CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_ATOM};
 
 const SCRIPT_KIND_TS: u8 = 3;
 const SCRIPT_KIND_TSX: u8 = 4;
@@ -283,13 +283,17 @@ fn protocol_spans(
     accepted
         .into_iter()
         .map(|candidate| {
+            let features = match candidate.kind {
+                ContentMapperSpanKind::Verbatim => CONTENT_MAPPER_SPAN_FEATURES_ALL,
+                ContentMapperSpanKind::Atom => CONTENT_MAPPER_SPAN_FEATURES_ATOM,
+            };
             ContentMapperSpan([
                 candidate.generated.start,
                 candidate.generated.len(),
                 candidate.original.start,
                 candidate.original.len(),
                 candidate.kind as usize,
-                CONTENT_MAPPER_SPAN_FEATURES_ALL,
+                features,
             ])
         })
         .collect()

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
@@ -1,0 +1,64 @@
+use std::path::Path;
+
+use super::{
+    CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_ATOM, ContentMapperSpanKind,
+    generate_vue_content_mapper_transform,
+};
+
+#[test]
+fn maps_component_event_navigation_to_the_authored_name() {
+    let source = r#"<script setup lang="ts">
+import Child from "./Child.vue";
+const handler = (value: number) => value;
+</script>
+<template><Child @sa="handler" /></template>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("App.vue"), source).expect("transform");
+    let original = source.find("@sa").unwrap() + 1;
+    let navigation = result.text.find("__vize_events_nav_0.sa").unwrap();
+    let generated = navigation + "__vize_events_nav_0.".len();
+    let handler = result.text.find("// @sa handler").unwrap();
+
+    assert!(
+        navigation < handler,
+        "completion projection must win reverse mapping"
+    );
+    assert!(result.mappings.iter().any(|mapping| {
+        mapping.0[0] == generated
+            && mapping.0[1] == "sa".len()
+            && mapping.0[2] == original
+            && mapping.0[3] == "sa".len()
+            && mapping.0[4] == ContentMapperSpanKind::Verbatim as usize
+            && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_ALL
+    }));
+    assert!(result.mappings.iter().any(|mapping| {
+        mapping.0[2] == original
+            && mapping.0[3] == "sa".len()
+            && mapping.0[4] == ContentMapperSpanKind::Atom as usize
+            && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_ATOM
+    }));
+}
+
+#[test]
+fn maps_exported_emits_type_to_the_authored_macro() {
+    let source = r#"<script setup lang="ts">
+defineEmits<{ save: [value: number] }>();
+</script>
+<template><button /></template>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("Child.vue"), source).expect("transform");
+    let original = source.find("save: [value").unwrap();
+    let exported = result.text.find("export type Emits").unwrap();
+    let generated = exported + result.text[exported..].find("save: [value").unwrap();
+
+    assert!(result.mappings.iter().any(|mapping| {
+        generated >= mapping.0[0]
+            && generated < mapping.0[0] + mapping.0[1]
+            && original >= mapping.0[2]
+            && original < mapping.0[2] + mapping.0[3]
+            && generated - mapping.0[0] == original - mapping.0[2]
+            && mapping.0[4] == ContentMapperSpanKind::Verbatim as usize
+    }));
+}

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_span_features.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_span_features.rs
@@ -55,3 +55,10 @@ pub(super) const CONTENT_MAPPER_SPAN_FEATURES_ALL: usize = ContentMapperSpanFeat
     | ContentMapperSpanFeature::AutoInsert as usize
     | ContentMapperSpanFeature::DocumentSymbols as usize
     | ContentMapperSpanFeature::CodeLens as usize;
+
+/// Read-only features that can safely project through a synthesized atom.
+/// Symbol navigation and every edit-producing feature require verbatim text;
+/// advertising them on generated identifiers creates self-definitions and
+/// edits that cannot be applied source-faithfully.
+pub(super) const CONTENT_MAPPER_SPAN_FEATURES_ATOM: usize =
+    ContentMapperSpanFeature::Hover as usize | ContentMapperSpanFeature::SignatureHelp as usize;

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 
-use super::CONTENT_MAPPER_SPAN_FEATURES_ALL;
+use super::{
+    CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_ATOM, ContentMapperSpanKind,
+};
 use crate::batch::{
     ContentMapperTransformOptions, generate_vue_content_mapper_transform,
     generate_vue_content_mapper_transform_with_options,
@@ -8,6 +10,8 @@ use crate::batch::{
 
 #[path = "content_mapper_component_export_tests.rs"]
 mod component_exports;
+#[path = "content_mapper_navigation_tests.rs"]
+mod navigation;
 
 #[test]
 fn emits_protocol_v1_spans_without_forbidden_overlaps() {
@@ -44,13 +48,14 @@ const message = "hello"
             );
         }
     }
-    assert!(
-        result
-            .mappings
-            .iter()
-            .all(|mapping| mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_ALL),
-        "protocol v1 spans must participate in every language-service feature"
-    );
+    assert!(result.mappings.iter().all(|mapping| {
+        mapping.0[5]
+            == if mapping.0[4] == ContentMapperSpanKind::Verbatim as usize {
+                CONTENT_MAPPER_SPAN_FEATURES_ALL
+            } else {
+                CONTENT_MAPPER_SPAN_FEATURES_ATOM
+            }
+    }));
 }
 
 #[test]
@@ -97,34 +102,6 @@ defineProps<{ count: number }>();
     );
     assert!(matching.iter().any(|mapping| mapping.0[0] == exported));
     assert!(matching.iter().all(|mapping| mapping.0[4] == 0));
-}
-
-#[test]
-fn maps_component_event_navigation_to_the_authored_name() {
-    let source = r#"<script setup lang="ts">
-import Child from "./Child.vue";
-const handler = (value: number) => value;
-</script>
-<template><Child @sa="handler" /></template>
-"#;
-    let result =
-        generate_vue_content_mapper_transform(Path::new("App.vue"), source).expect("transform");
-    let original = source.find("@sa").unwrap() + 1;
-    let navigation = result.text.find("__vize_events_nav_0.sa").unwrap();
-    let generated = navigation + "__vize_events_nav_0.".len();
-    let handler = result.text.find("// @sa handler").unwrap();
-
-    assert!(
-        navigation < handler,
-        "completion projection must win reverse mapping"
-    );
-    assert!(result.mappings.iter().any(|mapping| {
-        mapping.0[0] == generated
-            && mapping.0[1] == "sa".len()
-            && mapping.0[2] == original
-            && mapping.0[3] == "sa".len()
-            && mapping.0[4] == 0
-    }));
 }
 
 #[test]

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -24,6 +24,7 @@ pub mod incremental;
 mod interface_extends_tests;
 #[cfg(test)]
 mod legacy_vue2_vuetify_tests;
+mod macro_type_mappings;
 pub mod mapping;
 mod props;
 mod scope;

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -51,6 +51,7 @@ use self::spans::{
 use super::{
     helpers::{SETUP_SCOPE_HELPER_NAMES, generate_template_context, to_safe_identifier},
     import_meta::emit_import_meta_augmentation,
+    macro_type_mappings::MacroTypeMappings,
     props::{
         OptionsApiPropsSource, add_generic_defaults, collect_template_prop_names,
         extract_generic_names, strip_const_modifiers,
@@ -850,7 +851,6 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         append!(ts, "\n  return {{ {} }};\n", setup_return_fields.join(", "));
     }
 
-    // Close setup function
     ts.push_str("}\n\n");
 
     // Invoke setup to keep diagnostics inside the generated setup body.
@@ -864,14 +864,14 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     let emits_info = emit_emits_type(
         &mut ts,
         summary,
+        MacroTypeMappings::new(&mut mappings, script_content, &script_source_offset),
+        generation_options.component_name.is_some(),
         generic_param,
         define_emits_runtime_args.is_some(),
     );
 
-    // Slots type
     let slots_is_generic = emit_slots_type(&mut ts, summary, generic_injection.as_ref());
 
-    // Exposed type (for InstanceType and useTemplateRef)
     let (has_exposed_type, exposed_is_generic) =
         emit_exposed_type(&mut ts, summary, generic_injection.as_ref());
     ts.push('\n');

--- a/crates/vize_canon/src/virtual_ts/generator/component_export.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/component_export.rs
@@ -52,6 +52,7 @@ pub(super) fn emit_default_export_declaration(
     has_authored_default: bool,
 ) {
     let emit_props_static = emits_info.static_emit_props_field();
+    let event_map_static = emits_info.static_event_map_field();
     let authored_component = if has_authored_default {
         "__VizeAuthoredComponent & "
     } else {
@@ -60,6 +61,11 @@ pub(super) fn emit_default_export_declaration(
     if let Some((generic_decl, generic_names)) = generic_component_params {
         let emit_props_resolver =
             emits_info.generic_emit_props_resolver_field(generic_decl, generic_names);
+        let event_map_separator = if emit_props_static.is_empty() || event_map_static.is_empty() {
+            ""
+        } else {
+            " "
+        };
         let emit_props_separator = if emit_props_resolver.is_empty() {
             ""
         } else {
@@ -67,12 +73,13 @@ pub(super) fn emit_default_export_declaration(
         };
         append!(
             *ts,
-            "declare const __vize_component__: {authored_component}__VizeGenericComponentConstructor & __VizeComponentConstructor & __VizeVueComponentOptions & {{ __vizeCheck: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => void; __vizeResolveProps?: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => Props<{generic_names}>; {emit_props_static}{emit_props_separator}{emit_props_resolver} }};\n",
+            "declare const __vize_component__: {authored_component}__VizeGenericComponentConstructor & __VizeComponentConstructor & __VizeVueComponentOptions & {{ __vizeCheck: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => void; __vizeResolveProps?: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => Props<{generic_names}>; {emit_props_static}{event_map_separator}{event_map_static}{emit_props_separator}{emit_props_resolver} }};\n",
         );
     } else if emits_info.has_emits_for_props {
+        let event_map_separator = if event_map_static.is_empty() { "" } else { " " };
         append!(
             *ts,
-            "declare const __vize_component__: {authored_component}__VizeComponentConstructor & __VizeVueComponentOptions & {{ {emit_props_static} }};\n",
+            "declare const __vize_component__: {authored_component}__VizeComponentConstructor & __VizeVueComponentOptions & {{ {emit_props_static}{event_map_separator}{event_map_static} }};\n",
         );
     } else {
         append!(

--- a/crates/vize_canon/src/virtual_ts/generator/emits.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/emits.rs
@@ -4,6 +4,7 @@ use vize_croquis::Croquis;
 use super::generics::module_alias_generic_suffix;
 use crate::virtual_ts::{
     helpers::{EMIT_OVERLOAD_HELPERS, EMIT_PROPS_HELPER},
+    macro_type_mappings::MacroTypeMappings,
     props::{add_generic_defaults, strip_const_modifiers},
 };
 
@@ -78,6 +79,7 @@ pub(super) struct EmitsInfo {
     pub(super) has_emits_for_props: bool,
     has_runtime_emits: bool,
     has_generic_emits: bool,
+    preserve_event_navigation: bool,
 }
 
 impl EmitsInfo {
@@ -90,6 +92,14 @@ impl EmitsInfo {
     pub(super) fn static_emit_props_field(&self) -> &'static str {
         if self.has_emits_for_props {
             "__vizeEmitProps?: __VizeStaticEmitProps;"
+        } else {
+            ""
+        }
+    }
+
+    pub(super) fn static_event_map_field(&self) -> &'static str {
+        if self.has_emits_for_props && self.preserve_event_navigation {
+            "__vizeRawEmits?: Emits; __vizeEventMap?: __VizeStaticEventMap;"
         } else {
             ""
         }
@@ -132,9 +142,12 @@ fn model_update_payload(model: &vize_croquis::macros::ModelDefinition) -> String
 pub(super) fn emit_emits_type(
     ts: &mut String,
     summary: &Croquis,
+    mut mappings: MacroTypeMappings<'_>,
+    preserve_event_navigation: bool,
     generic_param: Option<&str>,
     has_runtime_emits: bool,
 ) -> EmitsInfo {
+    let generated_start = ts.len();
     let emits_already_defined = summary
         .type_exports
         .iter()
@@ -216,10 +229,12 @@ pub(super) fn emit_emits_type(
         }
     }
 
+    mappings.map_exported_type(ts, generated_start, summary.macros.define_emits(), "Emits");
     EmitsInfo {
         has_emits_for_props,
         has_runtime_emits,
         has_generic_emits: emits_generic_decl.is_some(),
+        preserve_event_navigation,
     }
 }
 
@@ -237,8 +252,14 @@ pub(super) fn emit_emit_props_helper(
     ts.push_str(EMIT_PROPS_HELPER);
     ts.push('\n');
     if info.has_runtime_emits {
+        if info.preserve_event_navigation {
+            ts.push_str("type __VizeStaticEventMap = __EmitOptions<Awaited<ReturnType<typeof __setup>>[\"__vize_emit_options\"]>;\n");
+        }
         ts.push_str("type __VizeStaticEmitProps = __EmitProps<Awaited<ReturnType<typeof __setup>>[\"__vize_emit_options\"]>;\n\n");
     } else {
+        if info.preserve_event_navigation {
+            ts.push_str("type __VizeStaticEventMap = __EmitOptions<Emits>;\n");
+        }
         ts.push_str("type __VizeStaticEmitProps = __EmitProps<Emits>;\n\n");
     }
 }

--- a/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
@@ -4,6 +4,7 @@ use vize_croquis::Croquis;
 use super::generics::{
     generic_fallback_args, is_ident_byte, references_any_identifier, skip_ascii_ws,
 };
+use crate::virtual_ts::macro_type_mappings::MacroTypeMappings;
 use crate::virtual_ts::props::{
     OptionsApiPropsSource, PropBindingMappings, PropsSource, PropsTypeEmission,
     add_generic_defaults, append_default_props, extract_generic_names, generate_props_type,
@@ -111,9 +112,8 @@ pub(super) fn generate_setup_props(
     profile!("canon.virtual_ts.generate_props_type", {
         plan.generate_props_type(ts, summary, generic_param, options_api_props);
     });
-    let mut binding_mappings =
-        PropBindingMappings::new(source.mappings, summary, source.script, source.offset);
-    binding_mappings.map_exported_props_type(ts, generated_start);
+    let mut type_mappings = MacroTypeMappings::new(source.mappings, source.script, source.offset);
+    type_mappings.map_exported_type(ts, generated_start, summary.macros.define_props(), "Props");
     plan
 }
 

--- a/crates/vize_canon/src/virtual_ts/macro_type_mappings.rs
+++ b/crates/vize_canon/src/virtual_ts/macro_type_mappings.rs
@@ -1,0 +1,73 @@
+//! Authored mappings for module-level types synthesized from compiler macros.
+
+use vize_carton::cstr;
+use vize_croquis::macros::MacroCall;
+
+use super::VizeMapping;
+
+pub(crate) struct MacroTypeMappings<'a> {
+    mappings: &'a mut Vec<VizeMapping>,
+    script: Option<&'a str>,
+    source_offset: &'a dyn Fn(usize) -> usize,
+}
+
+impl<'a> MacroTypeMappings<'a> {
+    pub(crate) fn new(
+        mappings: &'a mut Vec<VizeMapping>,
+        script: Option<&'a str>,
+        source_offset: &'a dyn Fn(usize) -> usize,
+    ) -> Self {
+        Self {
+            mappings,
+            script,
+            source_offset,
+        }
+    }
+
+    pub(crate) fn map_exported_type(
+        &mut self,
+        ts: &str,
+        generated_start: usize,
+        call: Option<&MacroCall>,
+        export_name: &str,
+    ) {
+        let Some(call) = call else {
+            return;
+        };
+        let Some(type_args) = call.type_args.as_deref() else {
+            return;
+        };
+        let emitted = type_args
+            .strip_prefix('<')
+            .and_then(|value| value.strip_suffix('>'))
+            .unwrap_or(type_args);
+        let Some(script) = self.script else {
+            return;
+        };
+        let Some(call_source) = script.get(call.start as usize..call.end as usize) else {
+            return;
+        };
+        let Some(authored_type_start) = call_source
+            .find(type_args)
+            .and_then(|start| type_args.find(emitted).map(|inner| start + inner))
+        else {
+            return;
+        };
+        let generated = &ts[generated_start..];
+        let declaration = cstr!("export type {export_name}");
+        let Some(generated_type_start) = generated
+            .find(declaration.as_str())
+            .and_then(|start| generated[start..].find(" = ").map(|rhs| start + rhs + 3))
+            .and_then(|start| generated[start..].find(emitted).map(|inner| start + inner))
+        else {
+            return;
+        };
+        let authored_start = (self.source_offset)(call.start as usize + authored_type_start);
+        self.mappings.push(VizeMapping {
+            gen_range: generated_start + generated_type_start
+                ..generated_start + generated_type_start + emitted.len(),
+            src_range: authored_start..authored_start + emitted.len(),
+            sub_spans: Vec::new(),
+        });
+    }
+}

--- a/crates/vize_canon/src/virtual_ts/props/mappings.rs
+++ b/crates/vize_canon/src/virtual_ts/props/mappings.rs
@@ -80,46 +80,6 @@ impl<'a> PropBindingMappings<'a> {
         });
     }
 
-    pub(crate) fn map_exported_props_type(&mut self, ts: &str, generated_start: usize) {
-        let Some(call) = self.summary.macros.define_props() else {
-            return;
-        };
-        let Some(type_args) = call.type_args.as_deref() else {
-            return;
-        };
-        let emitted = type_args
-            .strip_prefix('<')
-            .and_then(|value| value.strip_suffix('>'))
-            .unwrap_or(type_args);
-        let Some(script) = self.script_content else {
-            return;
-        };
-        let Some(call_source) = script.get(call.start as usize..call.end as usize) else {
-            return;
-        };
-        let Some(authored_type_start) = call_source
-            .find(type_args)
-            .and_then(|start| type_args.find(emitted).map(|inner| start + inner))
-        else {
-            return;
-        };
-        let generated = &ts[generated_start..];
-        let Some(generated_type_start) = generated
-            .find("export type Props")
-            .and_then(|start| generated[start..].find(" = ").map(|rhs| start + rhs + 3))
-            .and_then(|start| generated[start..].find(emitted).map(|inner| start + inner))
-        else {
-            return;
-        };
-        let authored_start = (self.script_source_offset)(call.start as usize + authored_type_start);
-        self.mappings.push(VizeMapping {
-            gen_range: generated_start + generated_type_start
-                ..generated_start + generated_type_start + emitted.len(),
-            src_range: authored_start..authored_start + emitted.len(),
-            sub_spans: Vec::new(),
-        });
-    }
-
     fn authored_name_range(&self, name: &str) -> Option<Range<usize>> {
         let script = self.script_content?;
         let (start, end) = self.summary.macros.prop_declaration(name)?;

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs
@@ -176,7 +176,10 @@ pub(super) fn append_prop_check_helpers(ts: &mut String, usages: &[(usize, &Comp
             "  type __VizeEventName<K extends string> = K extends `on${infer E}` ? Uncapitalize<E> | __VizeKebabCase<Uncapitalize<E>> : never;\n",
         );
         ts.push_str(
-            "  type __VizeComponentEvents<C, __L = C extends { __vizeEmitProps?: infer __E } ? NonNullable<__E> : C extends { new (): { $props: infer __P } } ? __P : C extends (props: infer __P) => any ? __P : {}> = { [K in keyof __L & string as __VizeEventName<K>]: __L[K] };\n",
+            "  type __VizeKebabEventAliases<E> = { [K in keyof E & string as __VizeKebabCase<K> extends K ? never : __VizeKebabCase<K>]: E[K] };\n",
+        );
+        ts.push_str(
+            "  type __VizeComponentEvents<C> = C extends { __vizeRawEmits?: infer __R; __vizeEventMap?: infer __E } ? [keyof NonNullable<__R>] extends [never] ? NonNullable<__E> : NonNullable<__R> & __VizeKebabEventAliases<NonNullable<__R>> : { [K in keyof (C extends { new (): { $props: infer __P } } ? __P : C extends (props: infer __P) => any ? __P : {}) & string as __VizeEventName<K>]: (C extends { new (): { $props: infer __P } } ? __P : C extends (props: infer __P) => any ? __P : {})[K] };\n",
         );
     }
     ts.push_str(


### PR DESCRIPTION
## Summary

- preserve record-style `defineEmits` symbols across component boundaries for authored event hover and definition
- map generated `Emits` aliases back to the macro type argument and keep mapper-only navigation metadata out of ordinary virtual TS output
- restrict synthesized atom spans to hover and signature help so definitions and edit-producing features fail closed
- reject self-definitions at template event usage sites while retaining prop and kebab-case event completion

## Verification

- `cargo test -p vize_canon --lib -q` (884 passed; existing lifetime warning only)
- exact upstream tsgo CLI integration test
- exact upstream tsgo LSP integration test
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo clippy -p vize --test content_mapper_tsgo_cli --test content_mapper_tsgo_lsp -- -D warnings`

## Scope

This advances record-style typed event navigation. Call-signature and runtime event declarations remain tracked separately under the same issue.

Advances #4072
Advances #4070
Advances #4057
Advances #3282

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->