### PR TITLE
fix(content-mapper): map authored event forms

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -1,0 +1,184 @@
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use corsa::jsonrpc::InboundEvent;
+use corsa::lsp::{LspClient, LspSpawnConfig, VirtualDocument};
+use lsp_types::Uri;
+use serde_json::{Value, json};
+
+#[allow(dead_code)]
+mod content_mapper_lsp_support;
+use content_mapper_lsp_support::{
+    assert_completion, assert_prop_navigation, copy_fixture, editor_capabilities, file_uri,
+    install_packages, position, pull_diagnostics, workspace_root,
+};
+
+const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
+
+struct StopOnDrop<'a>(&'a AtomicBool);
+
+impl Drop for StopOnDrop<'_> {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+}
+
+struct RawInitialize;
+struct RawDiscoverContentMappers;
+struct RawInitialized;
+
+impl lsp_types::request::Request for RawInitialize {
+    type Params = Value;
+    type Result = Value;
+    const METHOD: &'static str = "initialize";
+}
+
+impl lsp_types::request::Request for RawDiscoverContentMappers {
+    type Params = Value;
+    type Result = Value;
+    const METHOD: &'static str = "custom/discoverContentMappers";
+}
+
+impl lsp_types::notification::Notification for RawInitialized {
+    type Params = Value;
+    const METHOD: &'static str = "initialized";
+}
+
+#[test]
+fn standard_tsgo_lsp_maps_call_signature_and_runtime_events() {
+    let Some(tsgo) = std::env::var_os(TSGO_ENV).map(PathBuf::from) else {
+        eprintln!("skipping exact Content Mapper LSP conformance: {TSGO_ENV} is not set");
+        return;
+    };
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/content_mapper_project");
+    let cases_root = workspace_root().join("target/vize-tests/tests");
+    std::fs::create_dir_all(&cases_root).unwrap();
+    let project = tempfile::Builder::new()
+        .prefix("content-mapper-lsp-event-forms-")
+        .tempdir_in(cases_root)
+        .unwrap();
+    copy_fixture(&fixture, project.path());
+    install_packages(project.path());
+
+    let app_path = project.path().join("src/App.vue");
+    let app_source = std::fs::read_to_string(&app_path).unwrap();
+    let app_uri = file_uri(&app_path);
+    let cases = [
+        (
+            "CallSignatureChild.vue",
+            "@submit",
+            "\"submit\"",
+            "submit",
+            "boolean",
+        ),
+        ("RuntimeChild.vue", "@cancel", "cancel:", "cancel", "string"),
+    ]
+    .map(|(file, usage, declaration, name, ty)| {
+        let path = project.path().join("src").join(file);
+        let source = std::fs::read_to_string(&path).unwrap();
+        let uri = file_uri(&path);
+        let usage_position = position(&app_source, app_source.find(usage).unwrap() + 1);
+        let declaration_position = position(&source, source.find(declaration).unwrap());
+        (uri, source, usage_position, declaration_position, name, ty)
+    });
+    let root_uri = file_uri(project.path());
+
+    let stop = AtomicBool::new(false);
+    std::thread::scope(|scope| {
+        let _stop_on_drop = StopOnDrop(&stop);
+        corsa::runtime::block_on(async {
+            let client = LspClient::spawn(
+                LspSpawnConfig::new(&tsgo)
+                    .with_cwd(project.path())
+                    .with_request_timeout(Some(Duration::from_secs(30))),
+            )
+            .await
+            .unwrap();
+            let responder_client = client.clone();
+            let events = responder_client.subscribe();
+            let stop_ref = &stop;
+            let responder = scope.spawn(move || {
+                while !stop_ref.load(Ordering::Relaxed) {
+                    if let Ok(InboundEvent::Request { id, method, params }) =
+                        events.recv_timeout(Duration::from_millis(50))
+                    {
+                        let result = if method.as_str() == "workspace/configuration" {
+                            let count = params
+                                .get("items")
+                                .and_then(Value::as_array)
+                                .map_or(0, Vec::len);
+                            Value::Array(vec![Value::Null; count])
+                        } else {
+                            Value::Null
+                        };
+                        let _ = responder_client.respond(id, result);
+                    }
+                }
+            });
+            let initialize = client
+                .request::<RawInitialize>(json!({
+                    "processId": std::process::id(),
+                    "rootUri": root_uri,
+                    "workspaceFolders": [{ "uri": root_uri, "name": "event-forms" }],
+                    "capabilities": editor_capabilities(),
+                    "initializationOptions": { "loadExternalPlugins": true }
+                }))
+                .await
+                .unwrap();
+            assert!(initialize["capabilities"].is_object(), "{initialize:#}");
+            client.notify::<RawInitialized>(json!({})).unwrap();
+
+            let discovered = client
+                .request::<RawDiscoverContentMappers>(json!({
+                    "textDocuments": cases.iter().map(|case| json!({ "uri": case.0 })).collect::<Vec<_>>(),
+                    "extensions": [".vue"]
+                }))
+                .await
+                .unwrap();
+            assert_eq!(discovered["extensions"], json!([".vue"]), "{discovered:#}");
+
+            let overlay = client.overlay();
+            let app_document_uri = Uri::from_str(&app_uri).unwrap();
+            overlay
+                .open(VirtualDocument::new(
+                    app_document_uri.clone(),
+                    "vue",
+                    app_source.as_str(),
+                ))
+                .unwrap();
+            for (uri, source, usage, declaration, name, ty) in &cases {
+                overlay
+                    .open(VirtualDocument::new(
+                        Uri::from_str(uri).unwrap(),
+                        "vue",
+                        source.as_str(),
+                    ))
+                    .unwrap();
+                assert_prop_navigation(&client, &app_uri, usage, name, ty, uri, declaration).await;
+                let clean = pull_diagnostics(&client, uri).await;
+                assert_eq!(clean["items"], json!([]), "{clean:#}");
+            }
+
+            let partial = app_source
+                .replace("@submit", "@sub")
+                .replace("@cancel", "@can");
+            overlay
+                .replace(&app_document_uri, partial.as_str())
+                .unwrap();
+            for (usage, label, payload) in
+                [("@sub", "submit", "boolean"), ("@can", "cancel", "string")]
+            {
+                let completion_position =
+                    position(&partial, partial.find(usage).unwrap() + usage.len());
+                assert_completion(&client, &app_uri, &completion_position, label, &[payload]).await;
+            }
+
+            stop.store(true, Ordering::Relaxed);
+            client.close().await.unwrap();
+            responder.join().unwrap();
+        });
+    });
+}

--- a/crates/vize/tests/fixtures/content_mapper_project/consumer/verify.ts
+++ b/crates/vize/tests/fixtures/content_mapper_project/consumer/verify.ts
@@ -1,10 +1,14 @@
+import CallSignatureChild from "./CallSignatureChild.vue";
 import Options from "./Options.vue";
+import RuntimeChild from "./RuntimeChild.vue";
 import type { AppProps, PublicInstance } from "./main";
 import { readChildCount } from "./javascript-consumer";
 import { renderChild } from "./jsx-consumer";
 
 type IsAny<T> = 0 extends 1 & T ? true : false;
+type CallSignatureChildInstance = InstanceType<typeof CallSignatureChild>;
 type OptionsInstance = InstanceType<typeof Options>;
+type RuntimeChildInstance = InstanceType<typeof RuntimeChild>;
 
 const propsMustBeTyped: IsAny<AppProps> = false;
 const publicInstanceMustBeTyped: IsAny<PublicInstance> = false;
@@ -20,6 +24,14 @@ const optionsLabelMustBeTyped: IsAny<OptionsInstance["label"]> = false;
 const optionsComputedMustBeTyped: IsAny<OptionsInstance["doubled"]> = false;
 const optionsMethodMustBeTyped: IsAny<OptionsInstance["increment"]> = false;
 declare const options: OptionsInstance;
+declare const callSignatureChild: CallSignatureChildInstance;
+declare const runtimeChild: RuntimeChildInstance;
+callSignatureChild.$emit("submit", true);
+// @ts-expect-error submit payload must remain boolean through declaration emit
+callSignatureChild.$emit("submit", "yes");
+runtimeChild.$emit("cancel", "reason");
+// @ts-expect-error cancel payload must remain string through declaration emit
+runtimeChild.$emit("cancel", false);
 const optionsCount: number = options.count;
 const optionsLabel: string = options.label;
 const optionsComputed: number = options.doubled;

--- a/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
@@ -1,11 +1,17 @@
 <script setup lang="ts">
+import CallSignatureChild from "./CallSignatureChild.vue";
 import Child from "./Child.vue";
+import RuntimeChild from "./RuntimeChild.vue";
 import { increment } from "./model";
 
 defineProps<{ count: number }>();
+const handleCancel = (reason: string) => reason;
 const handleSaveItem = (id: string) => id;
+const handleSubmit = (accepted: boolean) => accepted;
 </script>
 
 <template>
   <Child :count="increment(count)" @save="increment" @save-item="handleSaveItem" />
+  <CallSignatureChild @submit="handleSubmit" />
+  <RuntimeChild @cancel="handleCancel" />
 </template>

--- a/crates/vize/tests/fixtures/content_mapper_project/src/CallSignatureChild.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/CallSignatureChild.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineEmits<{
+  (event: "submit", accepted: boolean): void;
+}>();
+</script>
+
+<template>
+  <button type="button">Submit</button>
+</template>

--- a/crates/vize/tests/fixtures/content_mapper_project/src/RuntimeChild.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/RuntimeChild.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineEmits({
+  cancel: (reason: string) => reason.length > 0,
+});
+</script>
+
+<template>
+  <button type="button">Cancel</button>
+</template>

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
@@ -41,7 +41,7 @@ const handler = (value: number) => value;
 }
 
 #[test]
-fn maps_exported_emits_type_to_the_authored_macro() {
+fn maps_authored_event_members_without_overlapping_the_macro_type() {
     let source = r#"<script setup lang="ts">
 defineEmits<{ save: [value: number] }>();
 </script>
@@ -50,15 +50,14 @@ defineEmits<{ save: [value: number] }>();
     let result =
         generate_vue_content_mapper_transform(Path::new("Child.vue"), source).expect("transform");
     let original = source.find("save: [value").unwrap();
-    let exported = result.text.find("export type Emits").unwrap();
-    let generated = exported + result.text[exported..].find("save: [value").unwrap();
+    let event_map = result.text.find("type __VizeAuthoredEventMap").unwrap();
+    let generated = event_map + result.text[event_map..].find("save:").unwrap();
 
     assert!(result.mappings.iter().any(|mapping| {
-        generated >= mapping.0[0]
-            && generated < mapping.0[0] + mapping.0[1]
-            && original >= mapping.0[2]
-            && original < mapping.0[2] + mapping.0[3]
-            && generated - mapping.0[0] == original - mapping.0[2]
+        generated == mapping.0[0]
+            && mapping.0[1] == "save".len()
+            && original == mapping.0[2]
+            && mapping.0[3] == "save".len()
             && mapping.0[4] == ContentMapperSpanKind::Verbatim as usize
     }));
 }

--- a/crates/vize_canon/src/virtual_ts/generator/emits.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/emits.rs
@@ -99,7 +99,7 @@ impl EmitsInfo {
 
     pub(super) fn static_event_map_field(&self) -> &'static str {
         if self.has_emits_for_props && self.preserve_event_navigation {
-            "__vizeRawEmits?: Emits; __vizeEventMap?: __VizeStaticEventMap;"
+            "__vizeRawEmits?: __VizeAuthoredEventMap; __vizeEventMap?: __VizeStaticEventMap;"
         } else {
             ""
         }
@@ -229,13 +229,51 @@ pub(super) fn emit_emits_type(
         }
     }
 
-    mappings.map_exported_type(ts, generated_start, summary.macros.define_emits(), "Emits");
+    if summary.macros.emits().is_empty() {
+        mappings.map_exported_type(ts, generated_start, summary.macros.define_emits(), "Emits");
+    }
+    if preserve_event_navigation && has_emits_for_props {
+        emit_authored_event_map(ts, summary, &mut mappings);
+    }
     EmitsInfo {
         has_emits_for_props,
         has_runtime_emits,
         has_generic_emits: emits_generic_decl.is_some(),
         preserve_event_navigation,
     }
+}
+
+fn emit_authored_event_map(
+    ts: &mut String,
+    summary: &Croquis,
+    mappings: &mut MacroTypeMappings<'_>,
+) {
+    ts.push_str("type __VizeAuthoredEventMap = Emits & {\n");
+    let mut emitted_names = FxHashSet::default();
+    for emit in summary.macros.emits() {
+        if !emitted_names.insert(emit.name.as_str()) {
+            continue;
+        }
+        let Some(authored_range) = summary.macros.emit_declaration(emit.name.as_str()) else {
+            continue;
+        };
+        let Some(authored_name) = mappings.authored_text(authored_range).map(String::from) else {
+            continue;
+        };
+        ts.push_str("  ");
+        let generated_start = ts.len();
+        ts.push_str(authored_name.as_str());
+        let generated_end = ts.len();
+        ts.push_str(": __VizeStaticEventMap[");
+        ts.push_str(
+            serde_json::to_string(emit.name.as_str())
+                .expect("event names serialize as JSON strings")
+                .as_str(),
+        );
+        ts.push_str("];\n");
+        mappings.map_exact(generated_start..generated_end, authored_range);
+    }
+    ts.push_str("};\n");
 }
 
 pub(super) fn emit_emit_props_helper(

--- a/crates/vize_canon/src/virtual_ts/macro_type_mappings.rs
+++ b/crates/vize_canon/src/virtual_ts/macro_type_mappings.rs
@@ -1,5 +1,7 @@
 //! Authored mappings for module-level types synthesized from compiler macros.
 
+use std::ops::Range;
+
 use vize_carton::cstr;
 use vize_croquis::macros::MacroCall;
 
@@ -67,6 +69,25 @@ impl<'a> MacroTypeMappings<'a> {
             gen_range: generated_start + generated_type_start
                 ..generated_start + generated_type_start + emitted.len(),
             src_range: authored_start..authored_start + emitted.len(),
+            sub_spans: Vec::new(),
+        });
+    }
+
+    pub(crate) fn authored_text(&self, range: (u32, u32)) -> Option<&str> {
+        self.script?.get(range.0 as usize..range.1 as usize)
+    }
+
+    pub(crate) fn map_exact(&mut self, generated: Range<usize>, authored: (u32, u32)) {
+        let Some(authored_len) = authored.1.checked_sub(authored.0).map(|len| len as usize) else {
+            return;
+        };
+        if generated.len() != authored_len {
+            return;
+        }
+        let authored_start = (self.source_offset)(authored.0 as usize);
+        self.mappings.push(VizeMapping {
+            gen_range: generated,
+            src_range: authored_start..authored_start + authored_len,
             sub_spans: Vec::new(),
         });
     }

--- a/crates/vize_croquis/src/macros.rs
+++ b/crates/vize_croquis/src/macros.rs
@@ -369,6 +369,7 @@ pub struct MacroTracker {
     /// Written prop declarations, relative to the parsed script block.
     prop_declarations: FxHashMap<CompactString, (u32, u32)>,
     emits: Vec<EmitDefinition>,
+    emit_declarations: FxHashMap<CompactString, (u32, u32)>,
     /// Actual emit() calls in the code (not declarations)
     emit_calls: Vec<EmitCall>,
     models: Vec<ModelDefinition>,
@@ -381,7 +382,6 @@ pub struct MacroTracker {
     props_destructure: Option<PropsDestructuredBindings>,
     top_level_awaits: Vec<TopLevelAwait>,
     next_id: u32,
-    /// Cached indices for quick lookup
     define_props_idx: Option<usize>,
     define_emits_idx: Option<usize>,
     define_expose_idx: Option<usize>,

--- a/crates/vize_croquis/src/macros/tracker.rs
+++ b/crates/vize_croquis/src/macros/tracker.rs
@@ -54,6 +54,20 @@ impl MacroTracker {
         self.prop_declarations.get(name).copied()
     }
 
+    /// Add an event together with the range of its written name.
+    #[inline]
+    pub fn add_emit_with_declaration(&mut self, emit: super::EmitDefinition, start: u32, end: u32) {
+        self.emit_declarations
+            .insert(emit.name.clone(), (start, end));
+        self.emits.push(emit);
+    }
+
+    /// Get an event's written name range, relative to its script block.
+    #[inline]
+    pub fn emit_declaration(&self, name: &str) -> Option<(u32, u32)> {
+        self.emit_declarations.get(name).copied()
+    }
+
     /// Shift every stored script-relative source offset by `delta`.
     pub fn shift_offsets(&mut self, delta: u32) {
         for call in &mut self.calls {
@@ -61,6 +75,10 @@ impl MacroTracker {
             call.end = call.end.saturating_add(delta);
         }
         for range in self.prop_declarations.values_mut() {
+            range.0 = range.0.saturating_add(delta);
+            range.1 = range.1.saturating_add(delta);
+        }
+        for range in self.emit_declarations.values_mut() {
             range.0 = range.0.saturating_add(delta);
             range.1 = range.1.saturating_add(delta);
         }

--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -41,6 +41,9 @@ mod tests;
 mod binding_classification_tests;
 
 #[cfg(test)]
+mod emits_ranges_tests;
+
+#[cfg(test)]
 mod interface_extends_tests;
 
 #[cfg(test)]

--- a/crates/vize_croquis/src/script_parser/emits_ranges_tests.rs
+++ b/crates/vize_croquis/src/script_parser/emits_ranges_tests.rs
@@ -1,0 +1,42 @@
+use super::parse_script_setup;
+
+#[test]
+fn static_emits_retain_their_written_name_ranges() {
+    for (source, name, declaration) in [
+        (
+            "defineEmits<{ (event: \"submit\", accepted: boolean): void }>()",
+            "submit",
+            "\"submit\"",
+        ),
+        ("defineEmits<{ save: [value: number] }>()", "save", "save"),
+        (
+            "defineEmits({ cancel: (reason: string) => true })",
+            "cancel",
+            "cancel",
+        ),
+    ] {
+        let result = parse_script_setup(source);
+        let (start, end) = result
+            .macros
+            .emit_declaration(name)
+            .expect("static event declaration range");
+        assert_eq!(&source[start as usize..end as usize], declaration);
+    }
+}
+
+#[test]
+fn shifting_macros_keeps_event_declarations_in_the_script_coordinate_space() {
+    let source = "defineEmits(['save'])";
+    let mut result = parse_script_setup(source);
+    let declaration = result
+        .macros
+        .emit_declaration("save")
+        .expect("event declaration");
+
+    result.macros.shift_offsets(17);
+
+    assert_eq!(
+        result.macros.emit_declaration("save"),
+        Some((declaration.0 + 17, declaration.1 + 17))
+    );
+}

--- a/crates/vize_croquis/src/script_parser/extract/emits.rs
+++ b/crates/vize_croquis/src/script_parser/extract/emits.rs
@@ -1,5 +1,5 @@
 use oxc_ast::ast::{
-    Argument, Expression, FormalParameters, ObjectPropertyKind, PropertyKey, TSType,
+    Argument, Expression, FormalParameters, ObjectPropertyKind, PropertyKey, TSSignature, TSType,
 };
 use oxc_span::{GetSpan, Span};
 
@@ -15,20 +15,42 @@ pub fn extract_emits_from_type(
 ) {
     for tp in type_params.iter() {
         if let TSType::TSTypeLiteral(lit) = tp {
-            // Handle call signatures like { (e: 'update', value: string): void }
             for member in lit.members.iter() {
-                if let oxc_ast::ast::TSSignature::TSCallSignatureDeclaration(call_sig) = member {
-                    // First parameter is usually the event name: (e: 'eventName', ...)
-                    if let Some(first_param) = call_sig.params.items.first()
-                        && let Some(type_ann) = &first_param.type_annotation
-                        && let TSType::TSLiteralType(lit_type) = &type_ann.type_annotation
-                        && let oxc_ast::ast::TSLiteral::StringLiteral(s) = &lit_type.literal
+                match member {
+                    // Call signatures: { (event: 'update', value: string): void }
+                    TSSignature::TSCallSignatureDeclaration(call_sig)
+                        if let Some(first_param) = call_sig.params.items.first()
+                            && let Some(type_ann) = &first_param.type_annotation
+                            && let TSType::TSLiteralType(lit_type) = &type_ann.type_annotation
+                            && let oxc_ast::ast::TSLiteral::StringLiteral(s) =
+                                &lit_type.literal =>
                     {
-                        result.macros.add_emit(EmitDefinition {
-                            name: CompactString::new(s.value.as_str()),
-                            payload_type: None,
-                        });
+                        result.macros.add_emit_with_declaration(
+                            EmitDefinition {
+                                name: CompactString::new(s.value.as_str()),
+                                payload_type: None,
+                            },
+                            s.span.start,
+                            s.span.end,
+                        );
                     }
+                    // Named tuples: { save: [value: string] }
+                    TSSignature::TSPropertySignature(property) => {
+                        let (name, span) = match &property.key {
+                            PropertyKey::StaticIdentifier(id) => (id.name.as_str(), id.span),
+                            PropertyKey::StringLiteral(s) => (s.value.as_str(), s.span),
+                            _ => continue,
+                        };
+                        result.macros.add_emit_with_declaration(
+                            EmitDefinition {
+                                name: CompactString::new(name),
+                                payload_type: None,
+                            },
+                            span.start,
+                            span.end,
+                        );
+                    }
+                    _ => {}
                 }
             }
         }
@@ -90,10 +112,14 @@ fn extract_emits_from_array(
 ) {
     for elem in arr.elements.iter() {
         if let oxc_ast::ast::ArrayExpressionElement::StringLiteral(s) = elem {
-            result.macros.add_emit(EmitDefinition {
-                name: CompactString::new(s.value.as_str()),
-                payload_type: None,
-            });
+            result.macros.add_emit_with_declaration(
+                EmitDefinition {
+                    name: CompactString::new(s.value.as_str()),
+                    payload_type: None,
+                },
+                s.span.start,
+                s.span.end,
+            );
         }
     }
 }
@@ -106,16 +132,20 @@ fn extract_emits_from_object(
     for prop in obj.properties.iter() {
         match prop {
             ObjectPropertyKind::ObjectProperty(prop) => {
-                let name = match &prop.key {
-                    PropertyKey::StaticIdentifier(id) => id.name.as_str(),
-                    PropertyKey::StringLiteral(s) => s.value.as_str(),
+                let (name, span) = match &prop.key {
+                    PropertyKey::StaticIdentifier(id) => (id.name.as_str(), id.span),
+                    PropertyKey::StringLiteral(s) => (s.value.as_str(), s.span),
                     _ => continue,
                 };
 
-                result.macros.add_emit(EmitDefinition {
-                    name: CompactString::new(name),
-                    payload_type: extract_runtime_emit_payload_type(&prop.value, source),
-                });
+                result.macros.add_emit_with_declaration(
+                    EmitDefinition {
+                        name: CompactString::new(name),
+                        payload_type: extract_runtime_emit_payload_type(&prop.value, source),
+                    },
+                    span.start,
+                    span.end,
+                );
             }
             ObjectPropertyKind::SpreadProperty(spread) => {
                 let Expression::Identifier(identifier) = &spread.argument else {


### PR DESCRIPTION
## Summary

- retain exact AST ranges for typed and runtime `defineEmits` event declarations
- project named-tuple, call-signature, runtime array, and runtime object events through an authored event map without overlapping mapper spans
- cover call-signature and runtime event completion, hover, and definition through the pinned tsgo LSP
- verify emitted declarations retain `$emit` payload types when consumed by both tsgo and JavaScript `tsc`

## Verification

- `cargo test -p vize_croquis --lib -q` (272 passed)
- `cargo test -p vize_canon --lib -q` (884 passed; existing lifetime warning only)
- exact upstream tsgo CLI declaration round-trip
- exact upstream tsgo core LSP integration
- exact upstream tsgo event-form LSP integration
- `cargo clippy -p vize_croquis -p vize_canon --lib -- -D warnings`
- `cargo clippy -p vize --test content_mapper_tsgo_cli --test content_mapper_tsgo_lsp --test content_mapper_tsgo_lsp_event_forms -- -D warnings`

## Scope

This covers direct static event forms. Model events, generic inference, references/rename, and indirect runtime declarations remain tracked in the parent issue.

Advances #4072
Advances #4070
Advances #4057
Advances #3282

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->