### PR TITLE
fix(content-mapper): map event symbol references

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -7,28 +7,28 @@ use corsa::jsonrpc::InboundEvent;
 use corsa::lsp::{LspClient, LspSpawnConfig, VirtualDocument};
 use lsp_types::Uri;
 use serde_json::{Value, json};
+use vize_carton::FxHashSet;
 
 #[allow(dead_code)]
 mod content_mapper_lsp_support;
 use content_mapper_lsp_support::{
-    assert_completion, assert_prop_navigation, copy_fixture, editor_capabilities, file_uri,
-    install_packages, position, pull_diagnostics, workspace_root,
+    assert_completion, assert_prop_navigation, contains_location, copy_fixture,
+    editor_capabilities, file_uri, install_packages, position, pull_diagnostics, workspace_root,
 };
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
 
 struct StopOnDrop<'a>(&'a AtomicBool);
-
 impl Drop for StopOnDrop<'_> {
     fn drop(&mut self) {
         self.0.store(true, Ordering::Relaxed);
     }
 }
-
 struct RawInitialize;
 struct RawDiscoverContentMappers;
+struct RawReferences;
+struct RawRename;
 struct RawInitialized;
-
 impl lsp_types::request::Request for RawInitialize {
     type Params = Value;
     type Result = Value;
@@ -41,13 +41,64 @@ impl lsp_types::request::Request for RawDiscoverContentMappers {
     const METHOD: &'static str = "custom/discoverContentMappers";
 }
 
+impl lsp_types::request::Request for RawReferences {
+    type Params = Value;
+    type Result = Value;
+    const METHOD: &'static str = "textDocument/references";
+}
+
+impl lsp_types::request::Request for RawRename {
+    type Params = Value;
+    type Result = Value;
+    const METHOD: &'static str = "textDocument/rename";
+}
+
 impl lsp_types::notification::Notification for RawInitialized {
     type Params = Value;
     const METHOD: &'static str = "initialized";
 }
 
+fn contains_location_range(value: &Value, uri: &str, start: &Value, end: &Value) -> bool {
+    match value {
+        Value::Array(values) => values
+            .iter()
+            .any(|value| contains_location_range(value, uri, start, end)),
+        Value::Object(object) => {
+            object.get("uri") == Some(&Value::String(uri.to_owned()))
+                && object.get("range").and_then(|range| range.get("start")) == Some(start)
+                && object.get("range").and_then(|range| range.get("end")) == Some(end)
+        }
+        _ => false,
+    }
+}
+
+fn contains_text_edit(
+    value: &Value,
+    uri: &str,
+    start: &Value,
+    end: &Value,
+    new_name: &str,
+) -> bool {
+    let matches = |edit: &Value| {
+        edit["range"]["start"] == *start
+            && edit["range"]["end"] == *end
+            && edit["newText"].as_str() == Some(new_name)
+    };
+    value["changes"][uri]
+        .as_array()
+        .is_some_and(|edits| edits.iter().any(matches))
+        || value["documentChanges"].as_array().is_some_and(|changes| {
+            changes.iter().any(|change| {
+                change["textDocument"]["uri"] == uri
+                    && change["edits"]
+                        .as_array()
+                        .is_some_and(|edits| edits.iter().any(matches))
+            })
+        })
+}
+
 #[test]
-fn standard_tsgo_lsp_maps_call_signature_and_runtime_events() {
+fn standard_tsgo_lsp_maps_event_symbol_navigation() {
     let Some(tsgo) = std::env::var_os(TSGO_ENV).map(PathBuf::from) else {
         eprintln!("skipping exact Content Mapper LSP conformance: {TSGO_ENV} is not set");
         return;
@@ -68,22 +119,75 @@ fn standard_tsgo_lsp_maps_call_signature_and_runtime_events() {
     let app_uri = file_uri(&app_path);
     let cases = [
         (
+            "Child.vue",
+            "@save",
+            "save: [value",
+            "save",
+            "number",
+            "renamedSave",
+            0,
+            true,
+        ),
+        (
+            "Child.vue",
+            "@save-item",
+            "saveItem: [id",
+            "saveItem",
+            "string",
+            "renamedSaveItem",
+            0,
+            false,
+        ),
+        (
             "CallSignatureChild.vue",
             "@submit",
             "\"submit\"",
             "submit",
             "boolean",
+            "renamedSubmit",
+            1,
+            true,
         ),
-        ("RuntimeChild.vue", "@cancel", "cancel:", "cancel", "string"),
+        (
+            "RuntimeChild.vue",
+            "@cancel",
+            "cancel:",
+            "cancel",
+            "string",
+            "renamedCancel",
+            0,
+            true,
+        ),
     ]
-    .map(|(file, usage, declaration, name, ty)| {
-        let path = project.path().join("src").join(file);
-        let source = std::fs::read_to_string(&path).unwrap();
-        let uri = file_uri(&path);
-        let usage_position = position(&app_source, app_source.find(usage).unwrap() + 1);
-        let declaration_position = position(&source, source.find(declaration).unwrap());
-        (uri, source, usage_position, declaration_position, name, ty)
-    });
+    .map(
+        |(file, usage, declaration, name, ty, renamed, reference_shift, rename_supported)| {
+            let path = project.path().join("src").join(file);
+            let source = std::fs::read_to_string(&path).unwrap();
+            let uri = file_uri(&path);
+            let usage_position = position(&app_source, app_source.find(usage).unwrap() + 1);
+            let usage_end = position(&app_source, app_source.find(usage).unwrap() + usage.len());
+            let declaration_position = position(&source, source.find(declaration).unwrap());
+            let reference_position =
+                position(&source, source.find(declaration).unwrap() + reference_shift);
+            let reference_end = position(
+                &source,
+                source.find(declaration).unwrap() + reference_shift + name.len(),
+            );
+            (
+                uri,
+                source,
+                usage_position,
+                usage_end,
+                declaration_position,
+                reference_position,
+                reference_end,
+                name,
+                ty,
+                renamed,
+                rename_supported,
+            )
+        },
+    );
     let root_uri = file_uri(project.path());
 
     let stop = AtomicBool::new(false);
@@ -149,15 +253,76 @@ fn standard_tsgo_lsp_maps_call_signature_and_runtime_events() {
                     app_source.as_str(),
                 ))
                 .unwrap();
-            for (uri, source, usage, declaration, name, ty) in &cases {
-                overlay
-                    .open(VirtualDocument::new(
-                        Uri::from_str(uri).unwrap(),
-                        "vue",
-                        source.as_str(),
-                    ))
-                    .unwrap();
+            let mut opened = FxHashSet::default();
+            let zero = json!({ "line": 0, "character": 0 });
+            for (
+                uri,
+                source,
+                usage,
+                usage_end,
+                declaration,
+                reference,
+                reference_end,
+                name,
+                ty,
+                renamed,
+                rename_supported,
+            ) in &cases
+            {
+                if opened.insert(uri.as_str()) {
+                    overlay
+                        .open(VirtualDocument::new(
+                            Uri::from_str(uri).unwrap(),
+                            "vue",
+                            source.as_str(),
+                        ))
+                        .unwrap();
+                }
                 assert_prop_navigation(&client, &app_uri, usage, name, ty, uri, declaration).await;
+                let references = client
+                    .request::<RawReferences>(json!({
+                        "textDocument": { "uri": app_uri },
+                        "position": usage,
+                        "context": { "includeDeclaration": true }
+                    }))
+                    .await
+                    .unwrap();
+                assert!(
+                    contains_location_range(&references, &app_uri, usage, usage_end),
+                    "{references:#}"
+                );
+                assert!(
+                    contains_location_range(&references, uri, reference, reference_end),
+                    "{references:#}"
+                );
+                assert!(
+                    !contains_location(&references, uri, &zero),
+                    "references must not retain a generated fallback: {references:#}"
+                );
+                let rename = client
+                    .request::<RawRename>(json!({
+                        "textDocument": { "uri": app_uri },
+                        "position": usage,
+                        "newName": renamed
+                    }))
+                    .await
+                    .unwrap();
+                if *rename_supported {
+                    assert!(
+                        contains_text_edit(&rename, &app_uri, usage, usage_end, renamed),
+                        "{rename:#}"
+                    );
+                    assert!(
+                        contains_text_edit(&rename, uri, reference, reference_end, renamed),
+                        "{rename:#}"
+                    );
+                    assert!(
+                        !serde_json::to_string(&rename).unwrap().contains(".vue.ts"),
+                        "{rename:#}"
+                    );
+                } else {
+                    assert!(rename.is_null(), "{rename:#}");
+                }
                 let clean = pull_diagnostics(&client, uri).await;
                 assert_eq!(clean["items"], json!([]), "{clean:#}");
             }

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -23,7 +23,7 @@ mod span_features;
 #[path = "content_mapper_span_normalize.rs"]
 mod span_normalize;
 
-use span_features::{CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_ATOM};
+use span_features::content_mapper_span_features;
 
 const SCRIPT_KIND_TS: u8 = 3;
 const SCRIPT_KIND_TSX: u8 = 4;
@@ -283,10 +283,8 @@ fn protocol_spans(
     accepted
         .into_iter()
         .map(|candidate| {
-            let features = match candidate.kind {
-                ContentMapperSpanKind::Verbatim => CONTENT_MAPPER_SPAN_FEATURES_ALL,
-                ContentMapperSpanKind::Atom => CONTENT_MAPPER_SPAN_FEATURES_ATOM,
-            };
+            let features =
+                content_mapper_span_features(generated, candidate.generated.start, candidate.kind);
             ContentMapperSpan([
                 candidate.generated.start,
                 candidate.generated.len(),

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
@@ -1,7 +1,8 @@
 use std::path::Path;
 
 use super::{
-    CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_ATOM, ContentMapperSpanKind,
+    CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_ATOM,
+    CONTENT_MAPPER_SPAN_FEATURES_CASED_SYMBOL, ContentMapperSpanKind,
     generate_vue_content_mapper_transform,
 };
 
@@ -41,6 +42,33 @@ const handler = (value: number) => value;
 }
 
 #[test]
+fn resolves_complete_kebab_events_through_the_authored_camel_key() {
+    let source = r#"<script setup lang="ts">
+import Child from "./Child.vue";
+</script>
+<template><Child @save-item="() => undefined" /></template>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("App.vue"), source).expect("transform");
+    let projection = "__vize_kebab_events_nav_0.saveItem";
+    let generated = result.text.find(projection).unwrap() + "__vize_kebab_events_nav_0.".len();
+    let original = source.find("@save-item").unwrap() + 1;
+
+    assert!(
+        result.mappings.iter().any(|mapping| {
+            mapping.0[0] == generated
+                && mapping.0[1] == "saveItem".len()
+                && mapping.0[2] == original
+                && mapping.0[3] == "save-item".len()
+                && mapping.0[4] == ContentMapperSpanKind::Atom as usize
+                && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_CASED_SYMBOL
+        }),
+        "{:#?}",
+        result.mappings
+    );
+}
+
+#[test]
 fn maps_authored_event_members_without_overlapping_the_macro_type() {
     let source = r#"<script setup lang="ts">
 defineEmits<{ save: [value: number] }>();
@@ -60,4 +88,29 @@ defineEmits<{ save: [value: number] }>();
             && mapping.0[3] == "save".len()
             && mapping.0[4] == ContentMapperSpanKind::Verbatim as usize
     }));
+}
+
+#[test]
+fn retains_model_events_when_removing_duplicate_authored_event_members() {
+    let source = r#"<script setup lang="ts">
+defineModel<string>("title");
+defineEmits<{ save: [value: number] }>();
+</script>
+<template><button /></template>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("Child.vue"), source).expect("transform");
+
+    assert!(
+        result
+            .text
+            .contains("type __VizeAuthoredEventMap = Emits & {")
+    );
+    assert!(
+        result
+            .text
+            .contains("\"update:title\": [value: (string) | undefined]"),
+        "{}",
+        result.text
+    );
 }

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_span_features.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_span_features.rs
@@ -1,5 +1,7 @@
 //! TypeScript Content Mapper protocol-v1 feature bits.
 
+use super::ContentMapperSpanKind;
+
 /// TypeScript Content Mapper protocol-v1 feature bits.
 ///
 /// This is deliberately separate from `crate::source_map::MappingFlags`:
@@ -56,9 +58,37 @@ pub(super) const CONTENT_MAPPER_SPAN_FEATURES_ALL: usize = ContentMapperSpanFeat
     | ContentMapperSpanFeature::DocumentSymbols as usize
     | ContentMapperSpanFeature::CodeLens as usize;
 
-/// Read-only features that can safely project through a synthesized atom.
-/// Symbol navigation and every edit-producing feature require verbatim text;
-/// advertising them on generated identifiers creates self-definitions and
-/// edits that cannot be applied source-faithfully.
+/// Read-only features that can safely project through an ordinary synthesized
+/// atom. Symbol navigation and every edit-producing feature require either
+/// verbatim text or an explicitly recognized whole-symbol projection below.
 pub(super) const CONTENT_MAPPER_SPAN_FEATURES_ATOM: usize =
     ContentMapperSpanFeature::Hover as usize | ContentMapperSpanFeature::SignatureHelp as usize;
+
+/// Whole-symbol features that remain exact across a camel/kebab casing rewrite.
+pub(super) const CONTENT_MAPPER_SPAN_FEATURES_CASED_SYMBOL: usize = ContentMapperSpanFeature::Hover
+    as usize
+    | ContentMapperSpanFeature::Definition as usize
+    | ContentMapperSpanFeature::TypeDefinition as usize
+    | ContentMapperSpanFeature::Implementation as usize
+    | ContentMapperSpanFeature::SourceDefinition as usize
+    | ContentMapperSpanFeature::References as usize
+    | ContentMapperSpanFeature::DocumentHighlights as usize;
+
+pub(super) fn content_mapper_span_features(
+    generated: &str,
+    start: usize,
+    kind: ContentMapperSpanKind,
+) -> usize {
+    match kind {
+        ContentMapperSpanKind::Verbatim => CONTENT_MAPPER_SPAN_FEATURES_ALL,
+        ContentMapperSpanKind::Atom if is_cased_symbol_projection(generated, start) => {
+            CONTENT_MAPPER_SPAN_FEATURES_CASED_SYMBOL
+        }
+        ContentMapperSpanKind::Atom => CONTENT_MAPPER_SPAN_FEATURES_ATOM,
+    }
+}
+
+fn is_cased_symbol_projection(generated: &str, start: usize) -> bool {
+    let line_start = generated[..start].rfind('\n').map_or(0, |index| index + 1);
+    generated[line_start..start].starts_with("  void __vize_kebab_events_nav_")
+}

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -1,7 +1,9 @@
 use std::path::Path;
 
-use super::{
-    CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_ATOM, ContentMapperSpanKind,
+use super::ContentMapperSpanKind;
+use super::span_features::{
+    CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_ATOM,
+    CONTENT_MAPPER_SPAN_FEATURES_CASED_SYMBOL,
 };
 use crate::batch::{
     ContentMapperTransformOptions, generate_vue_content_mapper_transform,

--- a/crates/vize_canon/src/virtual_ts/generator/emits.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/emits.rs
@@ -233,7 +233,12 @@ pub(super) fn emit_emits_type(
         mappings.map_exported_type(ts, generated_start, summary.macros.define_emits(), "Emits");
     }
     if preserve_event_navigation && has_emits_for_props {
-        emit_authored_event_map(ts, summary, &mut mappings);
+        emit_authored_event_map(
+            ts,
+            summary,
+            &mut mappings,
+            !emits_already_defined && !has_model_emits,
+        );
     }
     EmitsInfo {
         has_emits_for_props,
@@ -247,10 +252,24 @@ fn emit_authored_event_map(
     ts: &mut String,
     summary: &Croquis,
     mappings: &mut MacroTypeMappings<'_>,
+    can_replace_emits: bool,
 ) {
-    ts.push_str("type __VizeAuthoredEventMap = Emits & {\n");
+    let events = summary.macros.emits();
+    let all_events_authored = can_replace_emits
+        && !events.is_empty()
+        && events.iter().all(|emit| {
+            summary
+                .macros
+                .emit_declaration(emit.name.as_str())
+                .is_some()
+        });
+    ts.push_str(if all_events_authored {
+        "type __VizeAuthoredEventMap = {\n"
+    } else {
+        "type __VizeAuthoredEventMap = Emits & {\n"
+    });
     let mut emitted_names = FxHashSet::default();
-    for emit in summary.macros.emits() {
+    for emit in events {
         if !emitted_names.insert(emit.name.as_str()) {
             continue;
         }

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
@@ -57,22 +57,43 @@ fn emit_usage_event_references(
     usage: &ComponentUsage,
     component_ref: &str,
 ) {
-    let events_ref = cstr!("__vize_events_nav_{idx}");
-    let mut emitted_events_ref = false;
+    let direct_events_ref = cstr!("__vize_events_nav_{idx}");
+    let kebab_events_ref = cstr!("__vize_kebab_events_nav_{idx}");
+    let mut emitted_direct_ref = false;
+    let mut emitted_kebab_ref = false;
     for event in &usage.events {
+        let camel_event_name = to_camel_case(event.name.as_str());
+        let is_complete_kebab = camel_event_name != event.name && !event.name.ends_with('-');
         let Some(source_range) = event_navigation_source_range(ctx, event) else {
             continue;
         };
-        if !emitted_events_ref {
+        let (events_ref, emitted_ref) = if is_complete_kebab {
+            (&kebab_events_ref, &mut emitted_kebab_ref)
+        } else {
+            (&direct_events_ref, &mut emitted_direct_ref)
+        };
+        if !*emitted_ref {
             append!(
                 *ts,
                 "  const {events_ref} = undefined as unknown as __VizeComponentEvents<typeof {component_ref}> & Record<string, unknown>;\n"
             );
-            emitted_events_ref = true;
+            *emitted_ref = true;
         }
 
         append!(*ts, "  void {events_ref}");
-        let event_gen_range = if is_ts_identifier(event.name.as_str()) {
+        let event_gen_range = if is_complete_kebab {
+            if is_ts_identifier(camel_event_name.as_str()) {
+                ts.push('.');
+                let start = ts.len();
+                ts.push_str(camel_event_name.as_str());
+                start..ts.len()
+            } else {
+                ts.push('[');
+                let range = push_ts_single_quoted_literal(ts, camel_event_name.as_str());
+                ts.push(']');
+                range
+            }
+        } else if is_ts_identifier(event.name.as_str()) {
             ts.push('.');
             let start = ts.len();
             ts.push_str(event.name.as_str());


### PR DESCRIPTION
## Summary

- map record, call-signature, and runtime event references and rename edits across parent and child SFCs
- preserve exact camel/kebab hover, definition, and reference ranges while failing closed for unsupported cross-casing rename
- remove duplicate generated declaration references without dropping `defineModel` update events
- keep event projection generation single-pass and scope elevated Atom features to the reserved generated line

## Verification

- `cargo test -p vize_canon --lib -q` (886 passed)
- exact tsgo Content Mapper event LSP conformance
- exact tsgo Content Mapper core LSP conformance
- exact tsgo CLI check and declaration emit consumed by JavaScript `tsc`
- target `cargo clippy` with `-D warnings`

Advances #4072, #4075, #4057, and #3282.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->