### PR TITLE
fix(content-mapper): infer generic event navigation

### DIFF
--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -6,6 +6,11 @@ use lsp_types::{FileChangeType, FileEvent, Uri};
 use serde_json::{Value, json};
 use vize_carton::String as CompactString;
 
+#[allow(dead_code)]
+mod navigation;
+#[allow(unused_imports)]
+pub use navigation::{contains_location_range, contains_text_edit, references, rename};
+
 struct RawDocumentDiagnostic;
 struct RawHover;
 struct RawDefinition;

--- a/crates/vize/tests/content_mapper_lsp_support/navigation.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/navigation.rs
@@ -1,0 +1,78 @@
+use corsa::lsp::LspClient;
+use serde_json::{Value, json};
+
+pub struct RawReferences;
+pub struct RawRename;
+
+impl lsp_types::request::Request for RawReferences {
+    type Params = Value;
+    type Result = Value;
+    const METHOD: &'static str = "textDocument/references";
+}
+
+impl lsp_types::request::Request for RawRename {
+    type Params = Value;
+    type Result = Value;
+    const METHOD: &'static str = "textDocument/rename";
+}
+
+pub async fn references(client: &LspClient, uri: &str, position: &Value) -> Value {
+    client
+        .request::<RawReferences>(json!({
+            "textDocument": { "uri": uri },
+            "position": position,
+            "context": { "includeDeclaration": true }
+        }))
+        .await
+        .unwrap()
+}
+
+pub async fn rename(client: &LspClient, uri: &str, position: &Value, new_name: &str) -> Value {
+    client
+        .request::<RawRename>(json!({
+            "textDocument": { "uri": uri },
+            "position": position,
+            "newName": new_name
+        }))
+        .await
+        .unwrap()
+}
+
+pub fn contains_location_range(value: &Value, uri: &str, start: &Value, end: &Value) -> bool {
+    match value {
+        Value::Array(values) => values
+            .iter()
+            .any(|value| contains_location_range(value, uri, start, end)),
+        Value::Object(object) => {
+            object.get("uri") == Some(&Value::String(uri.to_owned()))
+                && object.get("range").and_then(|range| range.get("start")) == Some(start)
+                && object.get("range").and_then(|range| range.get("end")) == Some(end)
+        }
+        _ => false,
+    }
+}
+
+pub fn contains_text_edit(
+    value: &Value,
+    uri: &str,
+    start: &Value,
+    end: &Value,
+    new_name: &str,
+) -> bool {
+    let matches = |edit: &Value| {
+        edit["range"]["start"] == *start
+            && edit["range"]["end"] == *end
+            && edit["newText"].as_str() == Some(new_name)
+    };
+    value["changes"][uri]
+        .as_array()
+        .is_some_and(|edits| edits.iter().any(matches))
+        || value["documentChanges"].as_array().is_some_and(|changes| {
+            changes.iter().any(|change| {
+                change["textDocument"]["uri"] == uri
+                    && change["edits"]
+                        .as_array()
+                        .is_some_and(|edits| edits.iter().any(matches))
+            })
+        })
+}

--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -12,8 +12,9 @@ use vize_carton::FxHashSet;
 #[allow(dead_code)]
 mod content_mapper_lsp_support;
 use content_mapper_lsp_support::{
-    assert_completion, assert_prop_navigation, contains_location, copy_fixture,
-    editor_capabilities, file_uri, install_packages, position, pull_diagnostics, workspace_root,
+    assert_completion, assert_prop_navigation, contains_location, contains_location_range,
+    contains_text_edit, copy_fixture, editor_capabilities, file_uri, install_packages, position,
+    pull_diagnostics, references, rename, workspace_root,
 };
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
@@ -26,8 +27,6 @@ impl Drop for StopOnDrop<'_> {
 }
 struct RawInitialize;
 struct RawDiscoverContentMappers;
-struct RawReferences;
-struct RawRename;
 struct RawInitialized;
 impl lsp_types::request::Request for RawInitialize {
     type Params = Value;
@@ -41,60 +40,9 @@ impl lsp_types::request::Request for RawDiscoverContentMappers {
     const METHOD: &'static str = "custom/discoverContentMappers";
 }
 
-impl lsp_types::request::Request for RawReferences {
-    type Params = Value;
-    type Result = Value;
-    const METHOD: &'static str = "textDocument/references";
-}
-
-impl lsp_types::request::Request for RawRename {
-    type Params = Value;
-    type Result = Value;
-    const METHOD: &'static str = "textDocument/rename";
-}
-
 impl lsp_types::notification::Notification for RawInitialized {
     type Params = Value;
     const METHOD: &'static str = "initialized";
-}
-
-fn contains_location_range(value: &Value, uri: &str, start: &Value, end: &Value) -> bool {
-    match value {
-        Value::Array(values) => values
-            .iter()
-            .any(|value| contains_location_range(value, uri, start, end)),
-        Value::Object(object) => {
-            object.get("uri") == Some(&Value::String(uri.to_owned()))
-                && object.get("range").and_then(|range| range.get("start")) == Some(start)
-                && object.get("range").and_then(|range| range.get("end")) == Some(end)
-        }
-        _ => false,
-    }
-}
-
-fn contains_text_edit(
-    value: &Value,
-    uri: &str,
-    start: &Value,
-    end: &Value,
-    new_name: &str,
-) -> bool {
-    let matches = |edit: &Value| {
-        edit["range"]["start"] == *start
-            && edit["range"]["end"] == *end
-            && edit["newText"].as_str() == Some(new_name)
-    };
-    value["changes"][uri]
-        .as_array()
-        .is_some_and(|edits| edits.iter().any(matches))
-        || value["documentChanges"].as_array().is_some_and(|changes| {
-            changes.iter().any(|change| {
-                change["textDocument"]["uri"] == uri
-                    && change["edits"]
-                        .as_array()
-                        .is_some_and(|edits| edits.iter().any(matches))
-            })
-        })
 }
 
 #[test]
@@ -146,6 +94,16 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             "boolean",
             "renamedSubmit",
             1,
+            true,
+        ),
+        (
+            "GenericChild.vue",
+            "@pick",
+            "pick: [value",
+            "pick",
+            "\\\"chosen\\\"",
+            "renamedPick",
+            0,
             true,
         ),
         (
@@ -279,14 +237,7 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
                         .unwrap();
                 }
                 assert_prop_navigation(&client, &app_uri, usage, name, ty, uri, declaration).await;
-                let references = client
-                    .request::<RawReferences>(json!({
-                        "textDocument": { "uri": app_uri },
-                        "position": usage,
-                        "context": { "includeDeclaration": true }
-                    }))
-                    .await
-                    .unwrap();
+                let references = references(&client, &app_uri, usage).await;
                 assert!(
                     contains_location_range(&references, &app_uri, usage, usage_end),
                     "{references:#}"
@@ -299,14 +250,7 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
                     !contains_location(&references, uri, &zero),
                     "references must not retain a generated fallback: {references:#}"
                 );
-                let rename = client
-                    .request::<RawRename>(json!({
-                        "textDocument": { "uri": app_uri },
-                        "position": usage,
-                        "newName": renamed
-                    }))
-                    .await
-                    .unwrap();
+                let rename = rename(&client, &app_uri, usage, renamed).await;
                 if *rename_supported {
                     assert!(
                         contains_text_edit(&rename, &app_uri, usage, usage_end, renamed),

--- a/crates/vize/tests/fixtures/content_mapper_project/consumer/verify.ts
+++ b/crates/vize/tests/fixtures/content_mapper_project/consumer/verify.ts
@@ -1,4 +1,5 @@
 import CallSignatureChild from "./CallSignatureChild.vue";
+import GenericChild from "./GenericChild.vue";
 import Options from "./Options.vue";
 import RuntimeChild from "./RuntimeChild.vue";
 import type { AppProps, PublicInstance } from "./main";
@@ -7,6 +8,7 @@ import { renderChild } from "./jsx-consumer";
 
 type IsAny<T> = 0 extends 1 & T ? true : false;
 type CallSignatureChildInstance = InstanceType<typeof CallSignatureChild>;
+type GenericChildInstance = InstanceType<typeof GenericChild>;
 type OptionsInstance = InstanceType<typeof Options>;
 type RuntimeChildInstance = InstanceType<typeof RuntimeChild>;
 
@@ -25,10 +27,14 @@ const optionsComputedMustBeTyped: IsAny<OptionsInstance["doubled"]> = false;
 const optionsMethodMustBeTyped: IsAny<OptionsInstance["increment"]> = false;
 declare const options: OptionsInstance;
 declare const callSignatureChild: CallSignatureChildInstance;
+declare const genericChild: GenericChildInstance;
 declare const runtimeChild: RuntimeChildInstance;
 callSignatureChild.$emit("submit", true);
 // @ts-expect-error submit payload must remain boolean through declaration emit
 callSignatureChild.$emit("submit", "yes");
+genericChild.$emit("pick", "value");
+// @ts-expect-error generic event constraint must remain string through declaration emit
+genericChild.$emit("pick", 1);
 runtimeChild.$emit("cancel", "reason");
 // @ts-expect-error cancel payload must remain string through declaration emit
 runtimeChild.$emit("cancel", false);

--- a/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import CallSignatureChild from "./CallSignatureChild.vue";
 import Child from "./Child.vue";
+import GenericChild from "./GenericChild.vue";
 import RuntimeChild from "./RuntimeChild.vue";
 import { increment } from "./model";
 
 defineProps<{ count: number }>();
 const handleCancel = (reason: string) => reason;
+const handlePick = (value: string) => value;
 const handleSaveItem = (id: string) => id;
 const handleSubmit = (accepted: boolean) => accepted;
 </script>
@@ -13,5 +15,6 @@ const handleSubmit = (accepted: boolean) => accepted;
 <template>
   <Child :count="increment(count)" @save="increment" @save-item="handleSaveItem" />
   <CallSignatureChild @submit="handleSubmit" />
+  <GenericChild value="chosen" @pick="handlePick" />
   <RuntimeChild @cancel="handleCancel" />
 </template>

--- a/crates/vize/tests/fixtures/content_mapper_project/src/GenericChild.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/GenericChild.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts" generic="T extends string = string">
+defineProps<{ value: T }>();
+defineEmits<{ pick: [value: T] }>();
+</script>
+
+<template>
+  <button type="button">Pick {{ value }}</button>
+</template>

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
@@ -154,3 +154,38 @@ fn emits_alias_is_mapped(source: &str) -> bool {
         .iter()
         .any(|mapping| mapping.0[0] >= alias && mapping.0[0] + mapping.0[1] <= end)
 }
+
+#[test]
+fn preserves_generic_event_maps_and_static_parent_prop_inference() {
+    let child = r#"<script setup lang="ts" generic="T extends string = string">
+defineProps<{ value: T }>();
+defineEmits<{ pick: [value: T] }>();
+</script>
+"#;
+    let child =
+        generate_vue_content_mapper_transform(Path::new("GenericChild.vue"), child).expect("child");
+    for expected in [
+        "type __VizeAuthoredEventMap<T extends string = string>",
+        "type __VizeStaticEventMap<T extends string = string> = __EmitOptions<Emits<T>>",
+        "__vizeResolveEvents?: <T extends string = string>",
+        "=> __VizeAuthoredEventMap<T>",
+    ] {
+        assert!(child.text.contains(expected), "{}", child.text);
+    }
+
+    let parent = r#"<script setup lang="ts">
+import GenericChild from "./GenericChild.vue";
+const handlePick = (value: string) => value;
+</script>
+<template><GenericChild value="chosen" @pick="handlePick" /></template>
+"#;
+    let parent =
+        generate_vue_content_mapper_transform(Path::new("App.vue"), parent).expect("parent");
+    for expected in [
+        "__vizeResolveEvents?: infer __F",
+        "\"value\": \"chosen\"",
+        "void __vize_events_nav_0.pick",
+    ] {
+        assert!(parent.text.contains(expected), "{}", parent.text);
+    }
+}

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -79,9 +79,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     let check_props = check_options.check_props;
     let script_source_offset =
         |offset| generation_options.script_source_offset(script_offset, offset);
-    // Configured Vue dialect, used to emit dialect-aware template instance typing
-    // (e.g. a Vue 2 `this`/template shape with `$listeners`,
-    // `$children`, `$on`, ... that Vue 3's `ComponentPublicInstance` lacks).
+    // Configured Vue dialect drives the Vue 2/3 template instance shape.
     let dialect = generation_options.dialect;
     let legacy_vue2 =
         generation_options.legacy_vue2 || matches!(dialect, VueVersion::V2 | VueVersion::V2_7);
@@ -728,6 +726,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                             check_unresolved_global_components: global_components.component_check(),
                             legacy_vue2,
                             options_api,
+                            preserve_event_navigation: generation_options.component_name.is_some(),
                             has_default_alias: declared_default_alias,
                             script_content,
                         },

--- a/crates/vize_canon/src/virtual_ts/generator/authored_events.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/authored_events.rs
@@ -1,0 +1,61 @@
+use vize_carton::{FxHashSet, String, append, cstr};
+use vize_croquis::Croquis;
+
+use crate::virtual_ts::macro_type_mappings::MacroTypeMappings;
+
+pub(super) fn emit_authored_event_map(
+    ts: &mut String,
+    summary: &Croquis,
+    mappings: &mut MacroTypeMappings<'_>,
+    can_replace_emits: bool,
+    generic_decl: Option<&str>,
+    generic_names: &str,
+) {
+    let events = summary.macros.emits();
+    let all_events_authored = can_replace_emits
+        && !events.is_empty()
+        && events.iter().all(|emit| {
+            summary
+                .macros
+                .emit_declaration(emit.name.as_str())
+                .is_some()
+        });
+    let authored_map = generic_decl.map_or_else(
+        || String::from("__VizeAuthoredEventMap"),
+        |decl| cstr!("__VizeAuthoredEventMap<{decl}>"),
+    );
+    let generic_suffix = generic_decl
+        .map(|_| cstr!("<{generic_names}>"))
+        .unwrap_or_default();
+    append!(*ts, "type {authored_map} = ");
+    if all_events_authored {
+        ts.push_str("{\n");
+    } else {
+        append!(*ts, "Emits{generic_suffix} & {{\n");
+    }
+    let mut emitted_names = FxHashSet::default();
+    for emit in events {
+        if !emitted_names.insert(emit.name.as_str()) {
+            continue;
+        }
+        let Some(authored_range) = summary.macros.emit_declaration(emit.name.as_str()) else {
+            continue;
+        };
+        let Some(authored_name) = mappings.authored_text(authored_range).map(String::from) else {
+            continue;
+        };
+        ts.push_str("  ");
+        let generated_start = ts.len();
+        ts.push_str(authored_name.as_str());
+        let generated_end = ts.len();
+        append!(*ts, ": __VizeStaticEventMap{generic_suffix}[");
+        ts.push_str(
+            serde_json::to_string(emit.name.as_str())
+                .expect("event names serialize as JSON strings")
+                .as_str(),
+        );
+        ts.push_str("];\n");
+        mappings.map_exact(generated_start..generated_end, authored_range);
+    }
+    ts.push_str("};\n");
+}

--- a/crates/vize_canon/src/virtual_ts/generator/component_export.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/component_export.rs
@@ -59,21 +59,16 @@ pub(super) fn emit_default_export_declaration(
         ""
     };
     if let Some((generic_decl, generic_names)) = generic_component_params {
-        let emit_props_resolver =
-            emits_info.generic_emit_props_resolver_field(generic_decl, generic_names);
+        let emit_resolvers = emits_info.generic_emit_resolver_fields(generic_decl, generic_names);
         let event_map_separator = if emit_props_static.is_empty() || event_map_static.is_empty() {
             ""
         } else {
             " "
         };
-        let emit_props_separator = if emit_props_resolver.is_empty() {
-            ""
-        } else {
-            " "
-        };
+        let emit_props_separator = if emit_resolvers.is_empty() { "" } else { " " };
         append!(
             *ts,
-            "declare const __vize_component__: {authored_component}__VizeGenericComponentConstructor & __VizeComponentConstructor & __VizeVueComponentOptions & {{ __vizeCheck: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => void; __vizeResolveProps?: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => Props<{generic_names}>; {emit_props_static}{event_map_separator}{event_map_static}{emit_props_separator}{emit_props_resolver} }};\n",
+            "declare const __vize_component__: {authored_component}__VizeGenericComponentConstructor & __VizeComponentConstructor & __VizeVueComponentOptions & {{ __vizeCheck: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => void; __vizeResolveProps?: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => Props<{generic_names}>; {emit_props_static}{event_map_separator}{event_map_static}{emit_props_separator}{emit_resolvers} }};\n",
         );
     } else if emits_info.has_emits_for_props {
         let event_map_separator = if event_map_static.is_empty() { "" } else { " " };

--- a/crates/vize_canon/src/virtual_ts/generator/emits.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/emits.rs
@@ -6,8 +6,12 @@ use super::setup_scope::macro_type_requires_setup_scope;
 use crate::virtual_ts::{
     helpers::{EMIT_OVERLOAD_HELPERS, EMIT_PROPS_HELPER},
     macro_type_mappings::MacroTypeMappings,
-    props::{add_generic_defaults, strip_const_modifiers},
+    props::{add_generic_defaults, extract_generic_names, strip_const_modifiers},
 };
+
+#[path = "authored_events.rs"]
+mod authored_events;
+use authored_events::emit_authored_event_map;
 
 /// Inner type of a macro's `<...>` type-argument text.
 fn inner_type_of(type_args: &str) -> &str {
@@ -80,6 +84,8 @@ pub(super) struct EmitsInfo {
     pub(super) has_emits_for_props: bool,
     has_runtime_emits: bool,
     has_generic_emits: bool,
+    generic_event_map_decl: String,
+    generic_event_map_names: String,
     preserve_event_navigation: bool,
 }
 
@@ -106,7 +112,7 @@ impl EmitsInfo {
         }
     }
 
-    pub(super) fn generic_emit_props_resolver_field(
+    pub(super) fn generic_emit_resolver_fields(
         &self,
         generic_decl: &str,
         generic_names: &str,
@@ -116,6 +122,15 @@ impl EmitsInfo {
             append!(
                 field,
                 "__vizeResolveEmitProps?: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => __EmitProps<Emits<{generic_names}>>;"
+            );
+        }
+        if !self.generic_event_map_decl.is_empty() {
+            if !field.is_empty() {
+                field.push(' ');
+            }
+            append!(
+                field,
+                "__vizeResolveEvents?: <{generic_decl}>(props: Partial<Props<{generic_names}>> & Record<string, unknown>) => __VizeAuthoredEventMap<{generic_names}>;"
             );
         }
         field
@@ -172,6 +187,15 @@ pub(super) fn emit_emits_type(
     let emits_generic_suffix = emits_generic_decl
         .as_ref()
         .map(|generic| cstr!("<{generic}>"))
+        .unwrap_or_default();
+    let generic_event_map_decl = if preserve_event_navigation && !has_runtime_emits {
+        emits_generic_decl.clone().unwrap_or_default()
+    } else {
+        String::default()
+    };
+    let generic_event_map_names = generic_param
+        .filter(|_| !generic_event_map_decl.is_empty())
+        .map(extract_generic_names)
         .unwrap_or_default();
 
     if !emits_already_defined {
@@ -246,61 +270,18 @@ pub(super) fn emit_emits_type(
             summary,
             &mut mappings,
             !emits_already_defined && !has_model_emits,
+            emits_generic_decl.as_deref().filter(|_| !has_runtime_emits),
+            generic_event_map_names.as_str(),
         );
     }
     EmitsInfo {
         has_emits_for_props,
         has_runtime_emits,
         has_generic_emits: emits_generic_decl.is_some(),
+        generic_event_map_decl,
+        generic_event_map_names,
         preserve_event_navigation,
     }
-}
-
-fn emit_authored_event_map(
-    ts: &mut String,
-    summary: &Croquis,
-    mappings: &mut MacroTypeMappings<'_>,
-    can_replace_emits: bool,
-) {
-    let events = summary.macros.emits();
-    let all_events_authored = can_replace_emits
-        && !events.is_empty()
-        && events.iter().all(|emit| {
-            summary
-                .macros
-                .emit_declaration(emit.name.as_str())
-                .is_some()
-        });
-    ts.push_str(if all_events_authored {
-        "type __VizeAuthoredEventMap = {\n"
-    } else {
-        "type __VizeAuthoredEventMap = Emits & {\n"
-    });
-    let mut emitted_names = FxHashSet::default();
-    for emit in events {
-        if !emitted_names.insert(emit.name.as_str()) {
-            continue;
-        }
-        let Some(authored_range) = summary.macros.emit_declaration(emit.name.as_str()) else {
-            continue;
-        };
-        let Some(authored_name) = mappings.authored_text(authored_range).map(String::from) else {
-            continue;
-        };
-        ts.push_str("  ");
-        let generated_start = ts.len();
-        ts.push_str(authored_name.as_str());
-        let generated_end = ts.len();
-        ts.push_str(": __VizeStaticEventMap[");
-        ts.push_str(
-            serde_json::to_string(emit.name.as_str())
-                .expect("event names serialize as JSON strings")
-                .as_str(),
-        );
-        ts.push_str("];\n");
-        mappings.map_exact(generated_start..generated_end, authored_range);
-    }
-    ts.push_str("};\n");
 }
 
 pub(super) fn emit_emit_props_helper(
@@ -323,7 +304,16 @@ pub(super) fn emit_emit_props_helper(
         ts.push_str("type __VizeStaticEmitProps = __EmitProps<Awaited<ReturnType<typeof __setup>>[\"__vize_emit_options\"]>;\n\n");
     } else {
         if info.preserve_event_navigation {
-            ts.push_str("type __VizeStaticEventMap = __EmitOptions<Emits>;\n");
+            if info.generic_event_map_decl.is_empty() {
+                ts.push_str("type __VizeStaticEventMap = __EmitOptions<Emits>;\n");
+            } else {
+                append!(
+                    *ts,
+                    "type __VizeStaticEventMap<{}> = __EmitOptions<Emits<{}>>;\n",
+                    info.generic_event_map_decl,
+                    info.generic_event_map_names
+                );
+            }
         }
         ts.push_str("type __VizeStaticEmitProps = __EmitProps<Emits>;\n\n");
     }

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -29,9 +29,8 @@ use super::event_scope::generate_event_handler_scope;
 use super::globals::{generate_instance_global_refs, generate_undefined_refs};
 use super::vif_guard::{callback_vif_guard, common_vif_guard_prefix_outside_v_for_scope};
 
-/// Generate scope closures from Croquis scope chain.
-/// Uses recursive tree-based generation so nested v-for/v-slot scopes
-/// are properly contained within their parent closures.
+/// Generates the Croquis scope chain as a recursive tree so nested v-for/v-slot
+/// scopes remain contained within their parent closures.
 pub(crate) fn generate_scope_closures(
     ts: &mut String,
     mappings: &mut Vec<VizeMapping>,
@@ -131,6 +130,7 @@ pub(crate) fn generate_scope_closures(
         template_prop_names,
         template_offset,
         options: virtual_ts_options,
+        preserve_event_navigation: options.preserve_event_navigation,
         check_unresolved_global_components: options.check_unresolved_global_components,
         legacy_vue2: options.legacy_vue2,
     };

--- a/crates/vize_canon/src/virtual_ts/scope/component_events.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events.rs
@@ -198,7 +198,7 @@ fn push_ts_string_literal(out: &mut String, value: &str) {
     out.push('"');
 }
 
-fn generated_prop_value(
+pub(super) fn generated_prop_value(
     prop: &PassedProp,
     template_prop_names: &FxHashSet<String>,
 ) -> Option<String> {

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
@@ -6,6 +6,7 @@ use vize_croquis::croquis::{ComponentUsage, EventListener, PassedProp};
 use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier, to_safe_identifier_fragment};
 use crate::virtual_ts::types::VizeMapping;
 
+use super::component_events::generated_prop_value;
 use super::context::ComponentPropsContext;
 use super::event_handler::event_name_source_range;
 
@@ -57,10 +58,12 @@ fn emit_usage_event_references(
     usage: &ComponentUsage,
     component_ref: &str,
 ) {
+    let resolved_events = cstr!("__vize_events_resolved_{idx}");
     let direct_events_ref = cstr!("__vize_events_nav_{idx}");
     let kebab_events_ref = cstr!("__vize_kebab_events_nav_{idx}");
     let mut emitted_direct_ref = false;
     let mut emitted_kebab_ref = false;
+    let mut emitted_resolved_events = false;
     for event in &usage.events {
         let camel_event_name = to_camel_case(event.name.as_str());
         let is_complete_kebab = camel_event_name != event.name && !event.name.ends_with('-');
@@ -72,11 +75,19 @@ fn emit_usage_event_references(
         } else {
             (&direct_events_ref, &mut emitted_direct_ref)
         };
+        if !emitted_resolved_events && ctx.preserve_event_navigation {
+            emit_resolved_events(ts, ctx, usage, component_ref, idx, resolved_events.as_str());
+            emitted_resolved_events = true;
+        }
         if !*emitted_ref {
-            append!(
-                *ts,
-                "  const {events_ref} = undefined as unknown as __VizeComponentEvents<typeof {component_ref}> & Record<string, unknown>;\n"
-            );
+            if ctx.preserve_event_navigation {
+                append!(*ts, "  const {events_ref} = {resolved_events};\n");
+            } else {
+                append!(
+                    *ts,
+                    "  const {events_ref} = undefined as unknown as __VizeComponentEvents<typeof {component_ref}> & Record<string, unknown>;\n"
+                );
+            }
             *emitted_ref = true;
         }
 
@@ -111,6 +122,35 @@ fn emit_usage_event_references(
             sub_spans: Vec::new(),
         });
     }
+}
+
+fn emit_resolved_events(
+    ts: &mut String,
+    ctx: &ComponentPropsContext<'_>,
+    usage: &ComponentUsage,
+    component_ref: &str,
+    idx: usize,
+    resolved_events: &str,
+) {
+    append!(
+        *ts,
+        "  type __vize_events_resolver_{idx} = typeof {component_ref} extends {{ __vizeResolveEvents?: infer __F }} ? (__F extends (...args: any[]) => any ? __F : (props: any) => __VizeComponentEvents<typeof {component_ref}>) : (props: any) => __VizeComponentEvents<typeof {component_ref}>;\n  // @ts-ignore Inference-only call; the authored prop checker owns diagnostics.\n  const {resolved_events} = (undefined as unknown as __vize_events_resolver_{idx})({{\n"
+    );
+    for prop in &usage.props {
+        if prop.name_is_dynamic
+            || prop.is_dynamic
+            || prop.name.as_str() == "key"
+            || prop.name.as_str() == "ref"
+        {
+            continue;
+        }
+        let Some(value) = generated_prop_value(prop, ctx.template_prop_names) else {
+            continue;
+        };
+        let name = to_camel_case(prop.name.as_str());
+        append!(*ts, "    \"{name}\": {value},\n");
+    }
+    ts.push_str("  });\n");
 }
 
 fn event_navigation_source_range(

--- a/crates/vize_canon/src/virtual_ts/scope/context.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/context.rs
@@ -57,6 +57,7 @@ pub(crate) struct ScopeGenerationOptions<'a, 'template> {
     /// Options API generation declares `__default__`; template names outside
     /// the known bindings then resolve on the public instance (#3888).
     pub(crate) options_api: bool,
+    pub(crate) preserve_event_navigation: bool,
     /// Whether the default-export rewrite declared the `__default__` alias. The
     /// public-instance form reads `typeof __default__`, so it stays off for a
     /// shape that never produced one (a re-exported default, no default export
@@ -112,6 +113,7 @@ pub(super) struct ComponentPropsContext<'a> {
     pub(super) template_prop_names: &'a FxHashSet<String>,
     pub(super) template_offset: u32,
     pub(super) options: &'a VirtualTsOptions,
+    pub(super) preserve_event_navigation: bool,
     pub(super) check_unresolved_global_components: GlobalComponentCheck,
     pub(super) legacy_vue2: bool,
 }


### PR DESCRIPTION
## Summary

- infer generic event payloads from static authored parent props in Content Mapper navigation
- preserve generic authored event maps so hover resolves the concrete payload while definition, references, and rename stay on child source ranges
- keep ordinary virtual TypeScript unchanged and suppress inference-only duplicate prop diagnostics
- factor exact references/rename assertions into shared LSP test support

## Verification

- `cargo test -p vize_canon --lib -q` (887 passed)
- exact tsgo event LSP conformance, including `(value: "chosen")`
- exact tsgo core LSP conformance
- exact tsgo CLI and declaration emit consumed by JavaScript `tsc`
- target `cargo clippy` with `-D warnings`

Dynamic and nested-scope generic inference remains tracked in #4077.

Advances #4072, #4057, and #3282.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->