### PR TITLE
feat(wasm): support Cloudflare Workers

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -528,39 +528,6 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-  cloudflare-worker:
-    runs-on: blacksmith-32vcpu-ubuntu-2404
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          targets: wasm32-unknown-unknown
-      - uses: ./.github/actions/setup-rust-sticky-cache
-        with:
-          key: cloudflare-worker
-          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
-      - uses: ./.github/actions/setup-moonbit
-      - name: Install wasm-bindgen-cli
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
-        with:
-          tool: wasm-bindgen-cli@0.2.121
-      - name: Setup Vite+ and Node.js
-        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
-        with:
-          node-version-file: ".node-version"
-          cache: true
-          run-install: false
-      - name: Install JS dependencies
-        run: vp install --filter vize-cloudflare-worker-example... --frozen-lockfile --prefer-offline
-      - name: Build browser and workerd WASM artifacts
-        run: moon run --target native tools/moon/cmd/build_vize_wasm_package --
-      - name: Smoke WASM package
-        run: node tools/npm/smoke-wasm-package.mjs npm/wasm
-      - name: Test and bundle Cloudflare Worker
-        run: vp run --filter vize-cloudflare-worker-example check
-
   playground-test:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
@@ -679,7 +646,6 @@ jobs:
       - coverage
       - source-coverage
       - branch-coverage
-      - cloudflare-worker
       - playground-test
     permissions:
       contents: read

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -528,6 +528,39 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  cloudflare-worker:
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: ./.github/actions/setup-rust-sticky-cache
+        with:
+          key: cloudflare-worker
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+      - uses: ./.github/actions/setup-moonbit
+      - name: Install wasm-bindgen-cli
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        with:
+          tool: wasm-bindgen-cli@0.2.121
+      - name: Setup Vite+ and Node.js
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+      - name: Install JS dependencies
+        run: vp install --filter vize-cloudflare-worker-example... --frozen-lockfile --prefer-offline
+      - name: Build browser and workerd WASM artifacts
+        run: moon run --target native tools/moon/cmd/build_vize_wasm_package --
+      - name: Smoke WASM package
+        run: node tools/npm/smoke-wasm-package.mjs npm/wasm
+      - name: Test and bundle Cloudflare Worker
+        run: vp run --filter vize-cloudflare-worker-example check
+
   playground-test:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
@@ -646,6 +679,7 @@ jobs:
       - coverage
       - source-coverage
       - branch-coverage
+      - cloudflare-worker
       - playground-test
     permissions:
       contents: read

--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -1,0 +1,56 @@
+name: Cloudflare Worker
+
+# Kept out of check.yml: that workflow is an over-limit source file, so the
+# source-length gate rejects growing it. The Cloudflare Worker artifact is its
+# own ownership boundary anyway - it builds the focused workerd WASM package
+# and bundles the example against a real workerd runtime.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: cloudflare-worker-${{ github.event.pull_request.number || format('{0}-{1}', github.event_name, github.sha) }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  cloudflare-worker:
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: ./.github/actions/setup-rust-sticky-cache
+        with:
+          key: cloudflare-worker
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+      - uses: ./.github/actions/setup-moonbit
+      - name: Install wasm-bindgen-cli
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        with:
+          tool: wasm-bindgen-cli@0.2.121
+      - name: Setup Vite+ and Node.js
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+      - name: Install JS dependencies
+        run: vp install --filter vize-cloudflare-worker-example... --frozen-lockfile --prefer-offline
+      - name: Build browser and workerd WASM artifacts
+        run: moon run --target native tools/moon/cmd/build_vize_wasm_package --
+      - name: Smoke WASM package
+        run: node tools/npm/smoke-wasm-package.mjs npm/wasm
+      - name: Test and bundle Cloudflare Worker
+        run: vp run --filter vize-cloudflare-worker-example check

--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install wasm-bindgen-cli
         uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
         with:
-          tool: wasm-bindgen-cli@0.2.121
+          tool: wasm-bindgen-cli@0.2.127
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,7 +333,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: npm/wasm
-          key: ${{ runner.os }}-release-wasm-${{ hashFiles('crates/**/*.rs', 'Cargo.lock', 'npm/wasm/package.json', 'npm/wasm/index.js', 'npm/wasm/index.d.ts', 'npm/wasm/lint-format.d.ts', 'tools/moon/cmd/build_vize_wasm_package') }}
+          key: ${{ runner.os }}-release-wasm-${{ hashFiles('crates/**/*.rs', 'Cargo.lock', 'npm/wasm/package.json', 'npm/wasm/index.js', 'npm/wasm/index.d.ts', 'npm/wasm/lint-format.d.ts', 'npm/wasm/workerd.js', 'npm/wasm/workerd.d.ts', 'tools/moon/cmd/build_vize_wasm_package') }}
       - name: Install wasm-bindgen-cli
         if: steps.cache-wasm.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2

--- a/crates/vize_vitrine/Cargo.toml
+++ b/crates/vize_vitrine/Cargo.toml
@@ -29,7 +29,8 @@ napi = [
   "vize_atelier_sfc/native",
   "glyph",
 ]
-wasm = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen", "dep:js-sys", "dep:web-sys", "glyph"]
+workerd = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen", "dep:js-sys", "dep:web-sys"]
+wasm = ["workerd", "glyph"]
 
 [dependencies]
 vize_carton = { workspace = true }

--- a/crates/vize_vitrine/src/lib.rs
+++ b/crates/vize_vitrine/src/lib.rs
@@ -13,10 +13,10 @@ pub mod napi;
 #[path = "napi/lint_fix.rs"]
 mod lint_fix_tests;
 
-#[cfg(feature = "wasm")]
+#[cfg(any(feature = "wasm", feature = "workerd"))]
 pub mod wasm;
 
-#[cfg(any(feature = "napi", feature = "wasm"))]
+#[cfg(any(feature = "napi", feature = "wasm", feature = "workerd"))]
 mod template_syntax;
 pub mod typecheck;
 pub mod types;

--- a/crates/vize_vitrine/src/wasm.rs
+++ b/crates/vize_vitrine/src/wasm.rs
@@ -14,43 +14,61 @@
     clippy::disallowed_macros
 )]
 
+#[cfg(feature = "wasm")]
 mod analyze;
 mod ast;
 mod compiler;
+#[cfg(feature = "wasm")]
 mod cross_file;
+#[cfg(feature = "wasm")]
 mod cross_file_complexity;
 mod experimentals;
 #[cfg(feature = "glyph")]
 mod format;
+#[cfg(feature = "wasm")]
 mod inspector;
+#[cfg(feature = "wasm")]
 mod jsx;
+#[cfg(feature = "wasm")]
 mod lint;
+#[cfg(feature = "wasm")]
 mod musea;
 mod options;
+#[cfg(feature = "wasm")]
 mod reactivity_overlay;
 mod serde;
 mod sfc_types;
+#[cfg(feature = "wasm")]
 mod source_offsets;
 
 #[cfg(test)]
 mod tests;
 
 // Re-export type checking bindings from separate module
+#[cfg(feature = "wasm")]
 #[path = "wasm_typecheck.rs"]
 mod wasm_typecheck;
 
 // Re-export all WASM bindings
+#[cfg(feature = "wasm")]
 pub use analyze::*;
 pub use compiler::*;
+#[cfg(feature = "wasm")]
 pub use cross_file::*;
 #[cfg(feature = "glyph")]
 pub use format::*;
+#[cfg(feature = "wasm")]
 pub use inspector::*;
+#[cfg(feature = "wasm")]
 pub use jsx::*;
+#[cfg(feature = "wasm")]
 pub use lint::*;
+#[cfg(feature = "wasm")]
 pub use musea::*;
 pub use sfc_types::*;
+#[cfg(feature = "wasm")]
 pub use wasm_typecheck::*;
 
 // Re-export shared helpers so sibling submodules can reach them via `super::`.
+#[cfg(feature = "wasm")]
 pub(crate) use serde::{to_js_value, to_json_js_value, utf8_byte_to_utf16_offset};

--- a/crates/vize_vitrine/src/wasm/serde.rs
+++ b/crates/vize_vitrine/src/wasm/serde.rs
@@ -19,6 +19,7 @@ pub(crate) fn to_json_js_value<T: Serialize>(value: &T) -> Result<JsValue, JsVal
 /// Convert a UTF-8 byte offset to a JavaScript string offset (UTF-16 code units).
 /// OXC and the SFC parser report byte offsets, while Monaco/JS consumers expect
 /// UTF-16 offsets.
+#[cfg(feature = "wasm")]
 pub(crate) fn utf8_byte_to_utf16_offset(content: &str, byte_offset: u32) -> u32 {
     let byte_offset = byte_offset as usize;
     if byte_offset >= content.len() {

--- a/examples/README.md
+++ b/examples/README.md
@@ -170,6 +170,23 @@ inputs alongside the other checked examples.
 
 ---
 
+## Cloudflare Workers Example
+
+`examples/cloudflare-worker/` runs the focused `@vizejs/wasm` compiler artifact inside workerd. It
+includes a JSON `compileSfc` endpoint, request-handler tests, a Wrangler dry-run size check, and
+deployment instructions.
+
+```bash
+moon run --target native tools/moon/cmd/build_vize_wasm_package --
+vp install
+vp run --filter vize-cloudflare-worker-example check
+```
+
+See [the example README](./cloudflare-worker/README.md) for local remote-preview, deployment, and
+request examples.
+
+---
+
 ## Vite + Musea Example
 
 The `examples/vite-musea/` directory contains a sample component gallery built with Vite + Musea.

--- a/examples/cloudflare-worker/.gitignore
+++ b/examples/cloudflare-worker/.gitignore
@@ -1,0 +1,2 @@
+dist/
+.wrangler/

--- a/examples/cloudflare-worker/README.md
+++ b/examples/cloudflare-worker/README.md
@@ -1,0 +1,38 @@
+# Vize on Cloudflare Workers
+
+This example compiles Vue single-file components inside Cloudflare Workers with the focused
+`@vizejs/wasm` workerd artifact. The Worker follows the same lazy initialization pattern as
+[`oxc-wasip1-workers`](https://github.com/Boshen/oxc-wasip1-workers): Wrangler imports the `.wasm`
+file as a precompiled module, and the request handler initializes it once and reuses the promise for
+warm requests.
+
+## Run
+
+Build the local `@vizejs/wasm` package first, then check the Worker bundle:
+
+```bash
+moon run --target native tools/moon/cmd/build_vize_wasm_package --
+vp install
+vp run --filter vize-cloudflare-worker-example check
+```
+
+Use Cloudflare's remote development runtime or deploy after authenticating Wrangler:
+
+```bash
+vp run --filter vize-cloudflare-worker-example dev
+vp run --filter vize-cloudflare-worker-example deploy
+```
+
+The `check` command runs handler unit tests, starts the local workerd runtime for a real GET/POST
+smoke test, and verifies the compressed Wrangler bundle. `GET /` compiles the built-in
+`Counter.vue`. To compile another SFC:
+
+```bash
+curl -X POST http://localhost:8787 \
+  -H 'content-type: application/json' \
+  --data '{"source":"<template><main>{{ message }}</main></template><script setup lang=\"ts\">const message: string = \"Hello\"</script>","options":{"filename":"App.vue"}}'
+```
+
+The dedicated artifact omits browser-package linting, formatting, cross-file analysis, Musea, and
+inspector exports. That keeps the compressed Worker below Cloudflare Workers' 3 MB free-plan limit
+while exposing template, SFC, CSS, SSR, and Vapor compilation APIs through `instantiate()`.

--- a/examples/cloudflare-worker/package.json
+++ b/examples/cloudflare-worker/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "vize-cloudflare-worker-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "wrangler deploy --dry-run --outdir dist",
+    "check": "pnpm test && pnpm test:runtime && pnpm build",
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev --remote",
+    "test": "node --test src/handler.test.js",
+    "test:runtime": "node scripts/test-runtime.mjs"
+  },
+  "dependencies": {
+    "@vizejs/wasm": "workspace:*"
+  },
+  "devDependencies": {
+    "wrangler": "catalog:integrations"
+  }
+}

--- a/examples/cloudflare-worker/scripts/test-runtime.mjs
+++ b/examples/cloudflare-worker/scripts/test-runtime.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import net from "node:net";
+
+async function availablePort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  await new Promise((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return address.port;
+}
+
+async function waitForWorker(url, child, output) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Wrangler exited before becoming ready.\n${output()}`);
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return response;
+      }
+    } catch {
+      // The local socket is expected to reject until workerd is ready.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for Wrangler.\n${output()}`);
+}
+
+async function stop(child) {
+  if (child.exitCode !== null) return;
+  child.kill("SIGTERM");
+  await Promise.race([
+    new Promise((resolve) => child.once("exit", resolve)),
+    new Promise((resolve) => setTimeout(resolve, 5_000)),
+  ]);
+  if (child.exitCode === null) child.kill("SIGKILL");
+}
+
+const port = await availablePort();
+const url = `http://127.0.0.1:${port}/`;
+const wrangler = process.platform === "win32" ? "wrangler.cmd" : "wrangler";
+const child = spawn(wrangler, ["dev", "--local", "--port", String(port)], {
+  env: { ...process.env, NO_COLOR: "1" },
+  stdio: ["ignore", "pipe", "pipe"],
+});
+let logs = "";
+child.stdout.on("data", (chunk) => {
+  logs += chunk;
+});
+child.stderr.on("data", (chunk) => {
+  logs += chunk;
+});
+
+try {
+  const demoResponse = await waitForWorker(url, child, () => logs);
+  const demo = await demoResponse.json();
+  assert.equal(demo.ok, true);
+  assert.equal(demo.package, "@vizejs/wasm");
+  assert.deepEqual(demo.result.errors, []);
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      source:
+        '<template><main>{{ message }}</main></template><script setup lang="ts">const message: string = "Hello from workerd"</script>',
+      options: { filename: "App.vue" },
+    }),
+  });
+  const payload = await response.json();
+  assert.equal(response.status, 200);
+  assert.equal(payload.ok, true);
+  assert.deepEqual(payload.result.errors, []);
+  assert.match(payload.result.script.code, /Hello from workerd/);
+  console.log("Cloudflare Worker runtime smoke passed");
+} finally {
+  await stop(child);
+}

--- a/examples/cloudflare-worker/src/handler.js
+++ b/examples/cloudflare-worker/src/handler.js
@@ -1,0 +1,62 @@
+const DEFAULT_SOURCE = `<template>
+  <button @click="count++">Count: {{ count }}</button>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+
+const count = ref<number>(0);
+</script>`;
+
+const MAX_SOURCE_BYTES = 1024 * 1024;
+
+function errorResponse(error, status) {
+  return Response.json({ ok: false, error }, { status });
+}
+
+async function inputFromRequest(request) {
+  if (request.method === "GET") {
+    return { source: DEFAULT_SOURCE, options: { filename: "Counter.vue" } };
+  }
+  if (request.method !== "POST") {
+    return errorResponse("Use GET for the demo or POST a JSON compile request.", 405);
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse("Request body must be valid JSON.", 400);
+  }
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return errorResponse("Request body must be a JSON object.", 400);
+  }
+  if (typeof body.source !== "string" || body.source.length === 0) {
+    return errorResponse("`source` must be a non-empty Vue SFC string.", 400);
+  }
+  if (new TextEncoder().encode(body.source).byteLength > MAX_SOURCE_BYTES) {
+    return errorResponse("`source` must not exceed 1 MiB.", 413);
+  }
+  if (
+    body.options !== undefined &&
+    (body.options === null || typeof body.options !== "object" || Array.isArray(body.options))
+  ) {
+    return errorResponse("`options` must be a JSON object when provided.", 400);
+  }
+
+  return {
+    source: body.source,
+    options: { filename: "anonymous.vue", ...body.options },
+  };
+}
+
+export async function handleRequest(request, getBinding) {
+  const input = await inputFromRequest(request);
+  if (input instanceof Response) {
+    return input;
+  }
+
+  const vize = await getBinding();
+  const result = vize.compileSfc(input.source, input.options);
+  return Response.json({ ok: true, package: "@vizejs/wasm", result });
+}

--- a/examples/cloudflare-worker/src/handler.test.js
+++ b/examples/cloudflare-worker/src/handler.test.js
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { handleRequest } from "./handler.js";
+
+function binding(calls) {
+  return {
+    compileSfc(source, options) {
+      calls.push({ source, options });
+      return { script: { code: "export default {}" }, errors: [], warnings: [] };
+    },
+  };
+}
+
+test("GET compiles the built-in Vue SFC", async () => {
+  const calls = [];
+  const response = await handleRequest(new Request("https://example.test/"), async () =>
+    binding(calls),
+  );
+  const payload = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(payload.ok, true);
+  assert.equal(payload.package, "@vizejs/wasm");
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].source, /<script setup lang="ts">/);
+  assert.deepEqual(calls[0].options, { filename: "Counter.vue" });
+});
+
+test("POST forwards the source and compiler options", async () => {
+  const calls = [];
+  const response = await handleRequest(
+    new Request("https://example.test/", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        source: "<template><main /></template>",
+        options: { filename: "App.vue", sourceMap: true },
+      }),
+    }),
+    async () => binding(calls),
+  );
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(calls, [
+    {
+      source: "<template><main /></template>",
+      options: { filename: "App.vue", sourceMap: true },
+    },
+  ]);
+});
+
+test("invalid requests are rejected before WASM initialization", async () => {
+  let initialized = false;
+  const getBinding = async () => {
+    initialized = true;
+    return binding([]);
+  };
+  const response = await handleRequest(
+    new Request("https://example.test/", { method: "POST", body: "not json" }),
+    getBinding,
+  );
+
+  assert.equal(response.status, 400);
+  assert.equal(initialized, false);
+  assert.deepEqual(await response.json(), {
+    ok: false,
+    error: "Request body must be valid JSON.",
+  });
+});
+
+test("unsupported methods return 405 without initializing WASM", async () => {
+  let initialized = false;
+  const response = await handleRequest(
+    new Request("https://example.test/", { method: "DELETE" }),
+    async () => {
+      initialized = true;
+      return binding([]);
+    },
+  );
+
+  assert.equal(response.status, 405);
+  assert.equal(initialized, false);
+});

--- a/examples/cloudflare-worker/src/handler.test.js
+++ b/examples/cloudflare-worker/src/handler.test.js
@@ -12,7 +12,7 @@ function binding(calls) {
   };
 }
 
-test("GET compiles the built-in Vue SFC", async () => {
+void test("GET compiles the built-in Vue SFC", async () => {
   const calls = [];
   const response = await handleRequest(new Request("https://example.test/"), async () =>
     binding(calls),
@@ -27,7 +27,7 @@ test("GET compiles the built-in Vue SFC", async () => {
   assert.deepEqual(calls[0].options, { filename: "Counter.vue" });
 });
 
-test("POST forwards the source and compiler options", async () => {
+void test("POST forwards the source and compiler options", async () => {
   const calls = [];
   const response = await handleRequest(
     new Request("https://example.test/", {
@@ -50,7 +50,7 @@ test("POST forwards the source and compiler options", async () => {
   ]);
 });
 
-test("invalid requests are rejected before WASM initialization", async () => {
+void test("invalid requests are rejected before WASM initialization", async () => {
   let initialized = false;
   const getBinding = async () => {
     initialized = true;
@@ -69,7 +69,7 @@ test("invalid requests are rejected before WASM initialization", async () => {
   });
 });
 
-test("unsupported methods return 405 without initializing WASM", async () => {
+void test("unsupported methods return 405 without initializing WASM", async () => {
   let initialized = false;
   const response = await handleRequest(
     new Request("https://example.test/", { method: "DELETE" }),

--- a/examples/cloudflare-worker/src/index.js
+++ b/examples/cloudflare-worker/src/index.js
@@ -1,0 +1,24 @@
+import vizeWasm from "@vizejs/wasm/wasm.wasm";
+import { instantiate } from "@vizejs/wasm/workerd";
+
+import { handleRequest } from "./handler.js";
+
+let bindingPromise;
+
+function getBinding() {
+  bindingPromise ??= instantiate(vizeWasm);
+  return bindingPromise;
+}
+
+export default {
+  async fetch(request) {
+    try {
+      return await handleRequest(request, getBinding);
+    } catch (error) {
+      return Response.json(
+        { ok: false, error: error instanceof Error ? error.message : String(error) },
+        { status: 500 },
+      );
+    }
+  },
+};

--- a/examples/cloudflare-worker/wrangler.jsonc
+++ b/examples/cloudflare-worker/wrangler.jsonc
@@ -1,0 +1,13 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "vize-compiler-worker",
+  "main": "src/index.js",
+  "compatibility_date": "2026-08-08",
+  "rules": [
+    {
+      "type": "CompiledWasm",
+      "globs": ["**/*.wasm"],
+      "fallthrough": true,
+    },
+  ],
+}

--- a/npm/wasm/.gitignore
+++ b/npm/wasm/.gitignore
@@ -1,1 +1,4 @@
 *
+!README.md
+!workerd.js
+!workerd.d.ts

--- a/npm/wasm/README.md
+++ b/npm/wasm/README.md
@@ -1,0 +1,43 @@
+# `@vizejs/wasm`
+
+Vize's WebAssembly compiler bindings support browsers and Cloudflare Workers.
+
+## Browser
+
+```js
+import init, { compileSfc } from "@vizejs/wasm";
+
+await init();
+const result = compileSfc("<template><main /></template>", { filename: "App.vue" });
+```
+
+## Cloudflare Workers
+
+Import the focused compiler artifact as a compiled Wasm module and initialize it from inside the
+request handler. Cache the promise so warm requests reuse the same binding.
+
+```js
+import vizeWasm from "@vizejs/wasm/wasm.wasm";
+import { instantiate } from "@vizejs/wasm/workerd";
+
+let bindingPromise;
+
+function getBinding() {
+  bindingPromise ??= instantiate(vizeWasm);
+  return bindingPromise;
+}
+
+export default {
+  async fetch() {
+    const vize = await getBinding();
+    const result = vize.compileSfc("<template><main /></template>", {
+      filename: "App.vue",
+    });
+    return Response.json({ ok: true, result });
+  },
+};
+```
+
+Wrangler loads `.wasm` imports as `CompiledWasm` modules. The workerd artifact deliberately exposes
+the compiler-only API rather than the browser package's linting, formatting, cross-file analysis,
+Musea, and inspector bindings, keeping its gzip size below the Workers free-plan limit.

--- a/npm/wasm/package.json
+++ b/npm/wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vizejs/wasm",
   "version": "0.348.0",
-  "description": "Vize WASM bindings for browser environments",
+  "description": "Vize WASM bindings for browser and Cloudflare Workers environments",
   "homepage": "https://github.com/ubugeeei-prod/vize",
   "bugs": {
     "url": "https://github.com/ubugeeei-prod/vize/issues"
@@ -16,9 +16,15 @@
     "index.js",
     "index.d.ts",
     "lint-format.d.ts",
+    "README.md",
+    "workerd.js",
+    "workerd.d.ts",
     "vize_vitrine_bg.wasm",
     "vize_vitrine.js",
     "vize_vitrine.d.ts",
+    "vize_workerd_bg.wasm",
+    "vize_workerd.js",
+    "vize_workerd.d.ts",
     "snippets/**"
   ],
   "type": "module",
@@ -38,7 +44,13 @@
       "import": "./vize_vitrine.js",
       "default": "./vize_vitrine.js"
     },
-    "./vize_vitrine_bg.wasm": "./vize_vitrine_bg.wasm"
+    "./vize_vitrine_bg.wasm": "./vize_vitrine_bg.wasm",
+    "./workerd": {
+      "types": "./workerd.d.ts",
+      "import": "./workerd.js",
+      "default": "./workerd.js"
+    },
+    "./wasm.wasm": "./vize_workerd_bg.wasm"
   },
   "publishConfig": {
     "access": "public"

--- a/npm/wasm/workerd.d.ts
+++ b/npm/wasm/workerd.d.ts
@@ -1,0 +1,28 @@
+import {
+  Compiler,
+  compile,
+  compileCss,
+  compileSfc,
+  compileVapor,
+  parseCssAst,
+  parseSfc,
+  parseTemplate,
+  printCssAst,
+} from "./vize_workerd.js";
+
+export interface VizeWorkerdBinding {
+  readonly Compiler: typeof Compiler;
+  readonly compile: typeof compile;
+  readonly compileCss: typeof compileCss;
+  readonly compileSfc: typeof compileSfc;
+  readonly compileVapor: typeof compileVapor;
+  readonly parseCssAst: typeof parseCssAst;
+  readonly parseSfc: typeof parseSfc;
+  readonly parseTemplate: typeof parseTemplate;
+  readonly printCssAst: typeof printCssAst;
+}
+
+/** Initialize Vize from a workerd `CompiledWasm` module. */
+export declare function instantiate(
+  module: WebAssembly.Module,
+): Promise<Readonly<VizeWorkerdBinding>>;

--- a/npm/wasm/workerd.js
+++ b/npm/wasm/workerd.js
@@ -1,0 +1,49 @@
+/**
+ * Cloudflare Workers adapter for the focused Vize compiler artifact.
+ *
+ * Instantiate inside `fetch()` because workerd provides the imported `.wasm`
+ * file as a precompiled `WebAssembly.Module`. The cached promise keeps warm
+ * requests on the same initialized binding.
+ */
+
+import initWasm, {
+  Compiler,
+  compile,
+  compileCss,
+  compileSfc,
+  compileVapor,
+  parseCssAst,
+  parseSfc,
+  parseTemplate,
+  printCssAst,
+} from "./vize_workerd.js";
+
+const binding = Object.freeze({
+  Compiler,
+  compile,
+  compileCss,
+  compileSfc,
+  compileVapor,
+  parseCssAst,
+  parseSfc,
+  parseTemplate,
+  printCssAst,
+});
+
+let bindingPromise;
+
+/**
+ * Initialize Vize from a workerd `CompiledWasm` module.
+ *
+ * @param {WebAssembly.Module} module
+ * @returns {Promise<typeof binding>}
+ */
+export function instantiate(module) {
+  bindingPromise ??= initWasm({ module_or_path: module })
+    .then(() => binding)
+    .catch((error) => {
+      bindingPromise = undefined;
+      throw error;
+    });
+  return bindingPromise;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ catalogs:
     '@ox-content/vite-plugin':
       specifier: 2.81.0
       version: 2.81.0
+    wrangler:
+      specifier: 4.120.0
+      version: 4.120.0
   legacy-vue-oracle:
     '@babel/parser':
       specifier: 7.29.0
@@ -406,6 +409,16 @@ importers:
       vue:
         specifier: catalog:vue-stable
         version: 3.5.35(typescript@6.0.3)
+
+  examples/cloudflare-worker:
+    dependencies:
+      '@vizejs/wasm':
+        specifier: workspace:*
+        version: link:../../npm/wasm
+    devDependencies:
+      wrangler:
+        specifier: catalog:integrations
+        version: 4.120.0
 
   examples/jsx-tsx:
     dependencies:
@@ -1516,6 +1529,49 @@ packages:
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
     engines: {node: '>=18.0.0'}
 
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260801.1':
+    resolution: {integrity: sha512-wuJWbXpKvncJi1P0GKS+iYpN5tHdb7JPJJ/+6ZQe8zzovHHVMkLJPNBsgWpqeUhpM3g9qTwEKd2rglNKejuh5A==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260801.1':
+    resolution: {integrity: sha512-kwoZiTpnhNrF3+APx84Q/oAqvJ3sU9yefGagwm/ASaH/2W19x0vghkW/r4qCoHCK0WW7EPugZ+aXjgPMRtlq1Q==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260801.1':
+    resolution: {integrity: sha512-r0vAxCZH+Jih9Unm1yoyiByPNWNgawcKciOHDm5Q37ZVGOkKLsT9AtLe3yLSaul76WrKqtf+JP2n0WW32VBLJg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260801.1':
+    resolution: {integrity: sha512-zWgpdZtSozvIgzQNmQiDSF8yEOQJUkRAWNsDXXzAAoy+fCn8YUoSibj3mpFSbZRvbUldeBEaW6SCdC2VEMkhNQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260801.1':
+    resolution: {integrity: sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
   '@colordx/core@5.5.0':
     resolution: {integrity: sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==}
 
@@ -1753,6 +1809,10 @@ packages:
   '@cspell/url@10.0.1':
     resolution: {integrity: sha512-abYYgI29wJhWIfWTYrYuzRYDcHQUQ1N5ylnhxYn1NJnIQMqUWGLbDmt12JABtZ+R6h6UNatQrS7rhP86etvJyQ==}
     engines: {node: '>=22.18.0'}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
 
   '@css-render/plugin-bem@0.15.14':
     resolution: {integrity: sha512-QK513CJ7yEQxm/P3EwsI+d+ha8kSOcjGvD6SevM41neEMxdULE+18iuQK6tEChAWMOQNQPLG/Rw3Khb69r5neg==}
@@ -2193,6 +2253,168 @@ packages:
     peerDependencies:
       vue: '>=3.0.0'
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.35.2':
+    resolution: {integrity: sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.2':
+    resolution: {integrity: sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.2':
+    resolution: {integrity: sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    resolution: {integrity: sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.3.1':
+    resolution: {integrity: sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.3.1':
+    resolution: {integrity: sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
+    resolution: {integrity: sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.3.1':
+    resolution: {integrity: sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+    resolution: {integrity: sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.35.2':
+    resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.2':
+    resolution: {integrity: sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.35.2':
+    resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    resolution: {integrity: sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.35.2':
+    resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.2':
+    resolution: {integrity: sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    resolution: {integrity: sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.35.2':
+    resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.2':
+    resolution: {integrity: sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.35.2':
+    resolution: {integrity: sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.35.2':
+    resolution: {integrity: sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.2':
+    resolution: {integrity: sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@inquirer/ansi@2.0.7':
     resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
@@ -2388,6 +2610,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@jsdevtools/ono@7.1.3':
     resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
@@ -4155,6 +4380,9 @@ packages:
 
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
 
   '@poppinss/dumper@0.7.0':
     resolution: {integrity: sha512-0UTYalzk2t6S4rA2uHOz5bSSW2CHdv4vggJI6Alg90yvl0UgXs6XSXpH96OH+bRkX4J/06djv29pqXJ0lq5Kag==}
@@ -6819,6 +7047,9 @@ packages:
   birpc@4.1.0:
     resolution: {integrity: sha512-O8L9vALWGqdEe0cG4HJckauw3WeJETlJnDRPUYpgwB7wrU43b/5NGMdVjdVcRo+4ROgd3ih2wha1glDe4HRVgw==}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
@@ -7110,6 +7341,10 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   copy-anything@4.0.5:
     resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
@@ -9021,6 +9256,10 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
+  miniflare@5.20260801.1-alpha:
+    resolution: {integrity: sha512-BHPVzIDA6mbx7LefxpvkXW7DHx9FKB9GorZatbnrrFTt3CVMU8zuUpbgyCuebwDKcTTOZos43ta8GQ0eMVEpxA==}
+    engines: {node: '>=22.0.0'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -9477,6 +9716,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -10221,6 +10463,10 @@ packages:
   shallow-equal@1.2.1:
     resolution: {integrity: sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==}
 
+  sharp@0.35.2:
+    resolution: {integrity: sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==}
+    engines: {node: '>=20.9.0'}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -10681,6 +10927,10 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
 
   undici@8.10.0:
     resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
@@ -11365,6 +11615,21 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  workerd@1.20260801.1:
+    resolution: {integrity: sha512-/g9JGTyqnHtoIscpBHqKD8swE2V4StBs2i69PmLiOhH45OP95jCFICl4F1hKlgN57rqfni5LiCitttoX5OOkVA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.120.0:
+    resolution: {integrity: sha512-cBmu/MeaB/fPacC0JpATs4duTOCagBxrZo+vBzuTX06tLzwSyAHE1drlHUZ8rP0VqVz1fy3ReGYTiHdKkoHltg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^5.20260801.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -11379,6 +11644,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
@@ -11456,6 +11733,9 @@ packages:
 
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   youch@4.1.1:
     resolution: {integrity: sha512-mxW3qiSnl+GRxXsaUMzv2Mbada1Y8CDltET9UxejDQe6DBYlSekghl5U5K0ReAikcHDi0G1vKZEmmo/NWAGKLA==}
@@ -11927,6 +12207,29 @@ snapshots:
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260801.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260801.1
+
+  '@cloudflare/workerd-darwin-64@1.20260801.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260801.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260801.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260801.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260801.1':
+    optional: true
+
   '@colordx/core@5.5.0': {}
 
   '@cspell/cspell-bundled-dicts@10.0.1':
@@ -12148,6 +12451,10 @@ snapshots:
   '@cspell/strong-weak-map@10.0.1': {}
 
   '@cspell/url@10.0.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
 
   '@css-render/plugin-bem@0.15.14(css-render@0.15.14)':
     dependencies:
@@ -12612,6 +12919,112 @@ snapshots:
       '@iconify/types': 2.0.0
       vue: 3.6.0-beta.10(typescript@6.0.3)
 
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+    optional: true
+
+  '@img/sharp-wasm32@0.35.2':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.2':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.2':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.2':
+    optional: true
+
   '@inquirer/ansi@2.0.7': {}
 
   '@inquirer/checkbox@5.2.1(@types/node@25.9.2)':
@@ -12812,6 +13225,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -14728,6 +15146,12 @@ snapshots:
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
 
   '@poppinss/dumper@0.7.0':
     dependencies:
@@ -17291,6 +17715,8 @@ snapshots:
 
   birpc@4.1.0: {}
 
+  blake3-wasm@2.1.5: {}
+
   body-parser@2.3.0(supports-color@10.2.2):
     dependencies:
       bytes: 3.1.2
@@ -17567,6 +17993,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   copy-anything@4.0.5:
     dependencies:
@@ -19626,6 +20054,18 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
+  miniflare@5.20260801.1-alpha:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.2
+      undici: 7.29.0
+      workerd: 1.20260801.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.9
@@ -20435,6 +20875,8 @@ snapshots:
     dependencies:
       lru-cache: 11.5.2
       minipass: 7.1.3
+
+  path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.4.2: {}
 
@@ -21323,6 +21765,38 @@ snapshots:
 
   shallow-equal@1.2.1: {}
 
+  sharp@0.35.2:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.2
+      '@img/sharp-darwin-x64': 0.35.2
+      '@img/sharp-freebsd-wasm32': 0.35.2
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+      '@img/sharp-libvips-linux-arm': 1.3.1
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+      '@img/sharp-libvips-linux-x64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+      '@img/sharp-linux-arm': 0.35.2
+      '@img/sharp-linux-arm64': 0.35.2
+      '@img/sharp-linux-ppc64': 0.35.2
+      '@img/sharp-linux-riscv64': 0.35.2
+      '@img/sharp-linux-s390x': 0.35.2
+      '@img/sharp-linux-x64': 0.35.2
+      '@img/sharp-linuxmusl-arm64': 0.35.2
+      '@img/sharp-linuxmusl-x64': 0.35.2
+      '@img/sharp-webcontainers-wasm32': 0.35.2
+      '@img/sharp-win32-arm64': 0.35.2
+      '@img/sharp-win32-ia32': 0.35.2
+      '@img/sharp-win32-x64': 0.35.2
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -21759,6 +22233,8 @@ snapshots:
   undici-types@7.24.6: {}
 
   undici-types@8.3.0: {}
+
+  undici@7.29.0: {}
 
   undici@8.10.0: {}
 
@@ -22615,6 +23091,30 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  workerd@1.20260801.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260801.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260801.1
+      '@cloudflare/workerd-linux-64': 1.20260801.1
+      '@cloudflare/workerd-linux-arm64': 1.20260801.1
+      '@cloudflare/workerd-windows-64': 1.20260801.1
+
+  wrangler@4.120.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260801.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 5.20260801.1-alpha
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260801.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -22634,6 +23134,8 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
+
+  ws@8.21.0: {}
 
   ws@8.21.3: {}
 
@@ -22689,6 +23191,14 @@ snapshots:
     dependencies:
       '@poppinss/exception': 1.2.3
       error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.24
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   youch@4.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ packages:
   - "examples/vite-musea"
   - "examples/oxlint-vize"
   - "examples/jsx-tsx"
+  - "examples/cloudflare-worker"
   - "docs"
   - "tests"
   - "bench"
@@ -166,6 +167,7 @@ catalogs:
     "@napi-rs/cli": "3.6.2"
     "@nuxt/kit": "4.5.2"
     "@ox-content/vite-plugin": "2.81.0"
+    wrangler: "4.120.0"
 
   # Runtime kit loaded by @vizejs/nuxt. Keep this aligned with Nuxt 2 Bridge's
   # kit line so Nuxt 2's module loader does not pull in Nuxt 4-only syntax.
@@ -216,3 +218,4 @@ allowBuilds:
   puppeteer: false
   unrs-resolver: false
   vue-demi: false
+  workerd: false

--- a/tests/tooling/cloudflare-worker.test.ts
+++ b/tests/tooling/cloudflare-worker.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}
+
+test("workerd build keeps the focused artifact separate from the browser artifact", () => {
+  const manifest = read("crates/vize_vitrine/Cargo.toml");
+  const wasmModule = read("crates/vize_vitrine/src/wasm.rs");
+  const build = read("tools/moon/cmd/build_vize_wasm_package/main.mbt");
+
+  assert.match(manifest, /^workerd = \[/m);
+  assert.match(manifest, /^wasm = \["workerd", "glyph"\]$/m);
+  assert.match(wasmModule, /#\[cfg\(feature = "wasm"\)\]\nmod lint;/);
+  assert.match(wasmModule, /#\[cfg\(feature = "wasm"\)\]\nmod musea;/);
+  assert.match(build, /"--features",\n\s+"wasm"/);
+  assert.match(build, /"--features",\n\s+"workerd"/);
+  assert.match(build, /"--out-name",\n\s+"vize_workerd"/);
+});
+
+test("Cloudflare Worker lazily instantiates the compiled module and caches warm requests", () => {
+  const entry = read("examples/cloudflare-worker/src/index.js");
+  const config = read("examples/cloudflare-worker/wrangler.jsonc");
+
+  assert.match(entry, /import vizeWasm from "@vizejs\/wasm\/wasm\.wasm";/);
+  assert.match(entry, /import \{ instantiate \} from "@vizejs\/wasm\/workerd";/);
+  assert.match(entry, /bindingPromise \?\?= instantiate\(vizeWasm\);/);
+  assert.match(config, /"type": "CompiledWasm"/);
+  assert.match(config, /"globs": \["\*\*\/\*\.wasm"\]/);
+});
+
+test("PR CI builds, smoke-tests, and bundles the Cloudflare Worker", () => {
+  const workflow = read(".github/workflows/check.yml");
+  const job = workflow.match(/\n  cloudflare-worker:\n([\s\S]*?)\n  playground-test:/)?.[1];
+
+  assert.ok(job, "cloudflare-worker job should exist");
+  assert.match(job, /targets: wasm32-unknown-unknown/);
+  assert.match(job, /moon run --target native tools\/moon\/cmd\/build_vize_wasm_package --/);
+  assert.match(job, /node tools\/npm\/smoke-wasm-package\.mjs npm\/wasm/);
+  assert.match(job, /vp run --filter vize-cloudflare-worker-example check/);
+  assert.match(workflow, /\n      - cloudflare-worker\n      - playground-test/);
+});

--- a/tests/tooling/cloudflare-worker.test.ts
+++ b/tests/tooling/cloudflare-worker.test.ts
@@ -36,13 +36,37 @@ test("Cloudflare Worker lazily instantiates the compiled module and caches warm 
 });
 
 test("PR CI builds, smoke-tests, and bundles the Cloudflare Worker", () => {
-  const workflow = read(".github/workflows/check.yml");
-  const job = workflow.match(/\n  cloudflare-worker:\n([\s\S]*?)\n  playground-test:/)?.[1];
+  const workflow = read(".github/workflows/cloudflare-worker.yml");
 
-  assert.ok(job, "cloudflare-worker job should exist");
-  assert.match(job, /targets: wasm32-unknown-unknown/);
-  assert.match(job, /moon run --target native tools\/moon\/cmd\/build_vize_wasm_package --/);
-  assert.match(job, /node tools\/npm\/smoke-wasm-package\.mjs npm\/wasm/);
-  assert.match(job, /vp run --filter vize-cloudflare-worker-example check/);
-  assert.match(workflow, /\n      - cloudflare-worker\n      - playground-test/);
+  assert.match(workflow, /^ {2}pull_request:\n {4}branches: \[main\]$/m);
+  assert.match(workflow, /^jobs:\n {2}cloudflare-worker:$/m);
+  assert.match(workflow, /targets: wasm32-unknown-unknown/);
+  assert.match(workflow, /moon run --target native tools\/moon\/cmd\/build_vize_wasm_package --/);
+  assert.match(workflow, /node tools\/npm\/smoke-wasm-package\.mjs npm\/wasm/);
+  assert.match(workflow, /vp run --filter vize-cloudflare-worker-example check/);
+});
+
+test("wasm package publishes the workerd entrypoint and focused artifact", () => {
+  const wasmPackage = JSON.parse(read("npm/wasm/package.json")) as {
+    exports?: Record<string, unknown>;
+    files?: string[];
+  };
+
+  assert.deepEqual(wasmPackage.exports?.["./workerd"], {
+    types: "./workerd.d.ts",
+    import: "./workerd.js",
+    default: "./workerd.js",
+  });
+  assert.equal(wasmPackage.exports?.["./wasm.wasm"], "./vize_workerd_bg.wasm");
+
+  for (const file of [
+    "README.md",
+    "workerd.js",
+    "workerd.d.ts",
+    "vize_workerd.js",
+    "vize_workerd.d.ts",
+    "vize_workerd_bg.wasm",
+  ]) {
+    assert.ok(wasmPackage.files?.includes(file), `@vizejs/wasm files include ${file}`);
+  }
 });

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -267,7 +267,7 @@ test("check workflow runs JS package unit tests and production dependency audit"
   assert.match(pnpmWorkspace, /^overrides:\n/m);
   assert.match(
     pnpmWorkspace,
-    /^allowBuilds:\n  "@parcel\/watcher": false\n  core-js: false\n  esbuild: true\n  puppeteer: false\n  unrs-resolver: false\n  vue-demi: false$/m,
+    /^allowBuilds:\n  "@parcel\/watcher": false\n  core-js: false\n  esbuild: true\n  puppeteer: false\n  unrs-resolver: false\n  vue-demi: false\n  workerd: false$/m,
   );
   assert.match(jsPackageJob, /vp run --workspace-root test:js/);
   assert.match(jsPackageJob, /key:\s*test-js-packages/);

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -19,6 +19,7 @@ test("GitHub workflows opt JavaScript actions into Node 24", () => {
   for (const workflowName of [
     "build-docs.yml",
     "check.yml",
+    "cloudflare-worker.yml",
     "deploy-docs.yml",
     "miri.yml",
     "native-smoke.yml",

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -542,26 +542,14 @@ test("wasm package publishes the wrapper entrypoint and raw wasm assets", () => 
     default: "./vize_vitrine.js",
   });
   assert.equal(wasmPackage.exports?.["./vize_vitrine_bg.wasm"], "./vize_vitrine_bg.wasm");
-  assert.deepEqual(wasmPackage.exports?.["./workerd"], {
-    types: "./workerd.d.ts",
-    import: "./workerd.js",
-    default: "./workerd.js",
-  });
-  assert.equal(wasmPackage.exports?.["./wasm.wasm"], "./vize_workerd_bg.wasm");
 
   for (const file of [
     "index.js",
     "index.d.ts",
     "lint-format.d.ts",
-    "README.md",
-    "workerd.js",
-    "workerd.d.ts",
     "vize_vitrine.js",
     "vize_vitrine.d.ts",
     "vize_vitrine_bg.wasm",
-    "vize_workerd.js",
-    "vize_workerd.d.ts",
-    "vize_workerd_bg.wasm",
   ]) {
     assert.ok(wasmPackage.files?.includes(file), `@vizejs/wasm files include ${file}`);
   }

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -542,14 +542,26 @@ test("wasm package publishes the wrapper entrypoint and raw wasm assets", () => 
     default: "./vize_vitrine.js",
   });
   assert.equal(wasmPackage.exports?.["./vize_vitrine_bg.wasm"], "./vize_vitrine_bg.wasm");
+  assert.deepEqual(wasmPackage.exports?.["./workerd"], {
+    types: "./workerd.d.ts",
+    import: "./workerd.js",
+    default: "./workerd.js",
+  });
+  assert.equal(wasmPackage.exports?.["./wasm.wasm"], "./vize_workerd_bg.wasm");
 
   for (const file of [
     "index.js",
     "index.d.ts",
     "lint-format.d.ts",
+    "README.md",
+    "workerd.js",
+    "workerd.d.ts",
     "vize_vitrine.js",
     "vize_vitrine.d.ts",
     "vize_vitrine_bg.wasm",
+    "vize_workerd.js",
+    "vize_workerd.d.ts",
+    "vize_workerd_bg.wasm",
   ]) {
     assert.ok(wasmPackage.files?.includes(file), `@vizejs/wasm files include ${file}`);
   }

--- a/tests/tooling/wasm-package-smoke.test.ts
+++ b/tests/tooling/wasm-package-smoke.test.ts
@@ -21,6 +21,9 @@ test("wasm package smoke validates exports, init guards, and runtime APIs", asyn
   copyRepoFile(packageDir, "npm/wasm/index.js");
   copyRepoFile(packageDir, "npm/wasm/index.d.ts");
   copyRepoFile(packageDir, "npm/wasm/lint-format.d.ts");
+  copyRepoFile(packageDir, "npm/wasm/README.md");
+  copyRepoFile(packageDir, "npm/wasm/workerd.js");
+  copyRepoFile(packageDir, "npm/wasm/workerd.d.ts");
   fs.writeFileSync(path.join(packageDir, "vize_vitrine.d.ts"), "export {};\n");
   fs.writeFileSync(
     path.join(packageDir, "vize_vitrine_bg.wasm"),
@@ -107,6 +110,8 @@ export function compileSfc(_source, options = {}) {
 }
 export function compileJsx() {}
 export function compileCss() {}
+export function parseCssAst() {}
+export function printCssAst() {}
 export function lintSfc(_source, options = {}) {
   return {
     filename: options.filename ?? "anonymous.vue",
@@ -129,6 +134,15 @@ export function formatSfc(source) {
 }
 `,
   );
+  fs.copyFileSync(
+    path.join(packageDir, "vize_vitrine.js"),
+    path.join(packageDir, "vize_workerd.js"),
+  );
+  fs.writeFileSync(path.join(packageDir, "vize_workerd.d.ts"), "export {};\n");
+  fs.writeFileSync(
+    path.join(packageDir, "vize_workerd_bg.wasm"),
+    Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]),
+  );
 
   await smokeWasmPackage(packageDir);
 });
@@ -137,6 +151,7 @@ test("wasm package smoke fails when wrapper entrypoint is missing", async () => 
   const packageDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-wasm-smoke-missing-"));
 
   copyRepoFile(packageDir, "npm/wasm/package.json");
+  copyRepoFile(packageDir, "npm/wasm/README.md");
   fs.writeFileSync(path.join(packageDir, "index.d.ts"), "export {};\n");
   fs.writeFileSync(
     path.join(packageDir, "vize_vitrine.js"),
@@ -144,6 +159,14 @@ test("wasm package smoke fails when wrapper entrypoint is missing", async () => 
   );
   fs.writeFileSync(path.join(packageDir, "vize_vitrine.d.ts"), "export {};\n");
   fs.writeFileSync(path.join(packageDir, "vize_vitrine_bg.wasm"), "");
+  copyRepoFile(packageDir, "npm/wasm/workerd.js");
+  copyRepoFile(packageDir, "npm/wasm/workerd.d.ts");
+  fs.copyFileSync(
+    path.join(packageDir, "vize_vitrine.js"),
+    path.join(packageDir, "vize_workerd.js"),
+  );
+  fs.writeFileSync(path.join(packageDir, "vize_workerd.d.ts"), "export {};\n");
+  fs.writeFileSync(path.join(packageDir, "vize_workerd_bg.wasm"), "");
 
   await assert.rejects(() => smokeWasmPackage(packageDir), /index\.js is missing/);
 });
@@ -155,6 +178,20 @@ test("wasm package declarations type-check a strict consumer", (t) => {
   copyRepoFile(packageDir, "npm/wasm/package.json");
   copyRepoFile(packageDir, "npm/wasm/index.d.ts");
   copyRepoFile(packageDir, "npm/wasm/lint-format.d.ts");
+  copyRepoFile(packageDir, "npm/wasm/workerd.d.ts");
+  fs.writeFileSync(
+    path.join(packageDir, "vize_workerd.d.ts"),
+    `export declare class Compiler {}
+export declare function compile(source: string, options?: object): object;
+export declare function compileCss(source: string, options?: object): object;
+export declare function compileSfc(source: string, options?: object): object;
+export declare function compileVapor(source: string, options?: object): object;
+export declare function parseCssAst(source: string, options?: object): object;
+export declare function parseSfc(source: string, options?: object): object;
+export declare function parseTemplate(source: string, options?: object): object;
+export declare function printCssAst(ast: object, options?: object): object;
+`,
+  );
   t.after(() => fs.rmSync(consumerDir, { force: true, recursive: true }));
 
   fs.writeFileSync(
@@ -168,8 +205,12 @@ test("wasm package declarations type-check a strict consumer", (t) => {
   type FormatResult,
   type LintResult,
 } from "@vizejs/wasm";
+import { instantiate, type VizeWorkerdBinding } from "@vizejs/wasm/workerd";
 
 void init();
+declare const compiledWasm: WebAssembly.Module;
+const workerdBinding: Promise<Readonly<VizeWorkerdBinding>> = instantiate(compiledWasm);
+void workerdBinding;
 
 const bindingMetadata: BindingMetadata = {
   bindings: { message: "setup-ref" },

--- a/tools/moon/cmd/build_vize_wasm_package/main.mbt
+++ b/tools/moon/cmd/build_vize_wasm_package/main.mbt
@@ -1,9 +1,9 @@
 /// Builds the WebAssembly package used for npm publication.
 /// The release workflow treats `npm/wasm` as a generated artifact. This
 /// script encapsulates the exact build steps needed to produce that artifact:
-/// build the Rust crate for `wasm32-unknown-unknown`, run `wasm-bindgen`, and
-/// then restore the checked-in `package.json` from `HEAD` so build tools do not
-/// accidentally overwrite package metadata that should remain version-controlled.
+/// build the full browser and focused Cloudflare Workers artifacts for
+/// `wasm32-unknown-unknown` and run `wasm-bindgen` for both entry points. The
+/// generated files are written alongside the checked-in package metadata.
 
 fn wasm_rustflags() -> String {
   let flag = "--cfg getrandom_backend=\"wasm_js\""
@@ -50,15 +50,43 @@ async fn run_app() -> Int {
     return 1
   }
 
-  let (restore_exit, restore_output) = @process.collect_stdout(
-    "git",
-    ["show", "HEAD:npm/wasm/package.json"],
+  let workerd_cargo_exit = @process.run(
+    "cargo",
+    [
+      "build",
+      "--release",
+      "-p",
+      "vize_vitrine",
+      "--no-default-features",
+      "--features",
+      "workerd",
+      "--target",
+      "wasm32-unknown-unknown",
+    ],
+    extra_env={"RUSTFLAGS": wasm_rustflags()},
   )
-  if restore_exit != 0 {
-    println("Failed to restore npm/wasm/package.json from HEAD")
+  if workerd_cargo_exit != 0 {
+    println("Failed to build the workerd WASM crate")
     return 1
   }
-  @fs.write_string_to_file("npm/wasm/package.json", restore_output.text())
+
+  let workerd_bindgen_exit = @process.run(
+    "wasm-bindgen",
+    [
+      "target/wasm32-unknown-unknown/release/vize_vitrine.wasm",
+      "--out-dir",
+      "npm/wasm",
+      "--out-name",
+      "vize_workerd",
+      "--target",
+      "web",
+    ],
+  )
+  if workerd_bindgen_exit != 0 {
+    println("Failed to run wasm-bindgen for workerd")
+    return 1
+  }
+
   0
 }
 

--- a/tools/moon/cmd/build_vize_wasm_package/moon.pkg
+++ b/tools/moon/cmd/build_vize_wasm_package/moon.pkg
@@ -2,7 +2,6 @@ import {
   "moonbitlang/core/env",
   "moonbitlang/async",
   "moonbitlang/async/process",
-  "moonbitlang/x/fs",
   "moonbitlang/x/sys",
 }
 

--- a/tools/npm/smoke-wasm-package.mjs
+++ b/tools/npm/smoke-wasm-package.mjs
@@ -7,14 +7,21 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { gzipSync } from "node:zlib";
 
 const REQUIRED_FILES = [
   "index.js",
   "index.d.ts",
   "lint-format.d.ts",
+  "README.md",
+  "workerd.js",
+  "workerd.d.ts",
   "vize_vitrine.js",
   "vize_vitrine.d.ts",
   "vize_vitrine_bg.wasm",
+  "vize_workerd.js",
+  "vize_workerd.d.ts",
+  "vize_workerd_bg.wasm",
 ];
 
 const EXPECTED_EXPORTS = [
@@ -55,6 +62,9 @@ function assertManifest(packageJson) {
   assert.equal(packageJson.exports?.["./vize_vitrine.js"]?.import, "./vize_vitrine.js");
   assert.equal(packageJson.exports?.["./vize_vitrine.js"]?.types, "./vize_vitrine.d.ts");
   assert.equal(packageJson.exports?.["./vize_vitrine_bg.wasm"], "./vize_vitrine_bg.wasm");
+  assert.equal(packageJson.exports?.["./workerd"]?.import, "./workerd.js");
+  assert.equal(packageJson.exports?.["./workerd"]?.types, "./workerd.d.ts");
+  assert.equal(packageJson.exports?.["./wasm.wasm"], "./vize_workerd_bg.wasm");
 
   for (const file of REQUIRED_FILES) {
     assert.ok(packageJson.files?.includes(file), `package files must include ${file}`);
@@ -176,11 +186,32 @@ async function assertEntryPoint(packageDir) {
   assert.equal(formatResult.changed, true);
 }
 
+async function assertWorkerdEntryPoint(packageDir) {
+  const entry = await import(
+    `${pathToFileURL(path.join(packageDir, "workerd.js")).href}?smoke=${Date.now()}`
+  );
+  assert.deepEqual(Object.keys(entry), ["instantiate"]);
+
+  const bytes = fs.readFileSync(path.join(packageDir, "vize_workerd_bg.wasm"));
+  assert.ok(
+    gzipSync(bytes, { level: 9 }).byteLength < 3 * 1024 * 1024,
+    "workerd artifact must fit the Cloudflare Workers free-plan compressed size limit",
+  );
+  const module = await WebAssembly.compile(bytes);
+  const first = entry.instantiate(module);
+  const second = entry.instantiate(module);
+  assert.equal(first, second, "warm requests should reuse the same initialization promise");
+
+  const binding = await first;
+  assertCompilerOptions(binding);
+}
+
 export async function smokeWasmPackage(packageDir) {
   const packageJson = readPackageJson(packageDir);
   assertManifest(packageJson);
   assertFilesExist(packageDir);
   await assertEntryPoint(packageDir);
+  await assertWorkerdEntryPoint(packageDir);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
## Summary

- add a focused `workerd` feature and build artifact for the compiler-only WebAssembly API
- expose `@vizejs/wasm/workerd` and `@vizejs/wasm/wasm.wasm` with cached lazy initialization
- add a Cloudflare Worker example with real local workerd smoke tests and bundle-size validation
- add package regressions and a dedicated pull request CI job

## Why

The existing browser artifact is too large for the Cloudflare Workers free-plan compressed upload limit. A focused artifact keeps the compiler APIs available while omitting browser-only linting, formatting, cross-file analysis, Musea, and inspector bindings.

The `cf` abbreviation used by `vize_croquis_cf` remains Cross File; Cloudflare support is isolated to the new workerd package entry and example.

## Validation

- `moon run --target native tools/moon/cmd/build_vize_wasm_package --`
- `node tools/npm/smoke-wasm-package.mjs npm/wasm`
- `pnpm --filter vize-cloudflare-worker-example check`
  - real local workerd GET/POST smoke passed
  - Wrangler dry-run: 5154.99 KiB raw / 1669.53 KiB gzip
- relevant tooling tests: 35 passed
- changed-file Vite+ lint: no warnings or errors
- `cargo fmt --all -- --check`
- targeted `vp fmt --check`
- filtered frozen install
- `npm pack --dry-run --json`
- GitHub Actions: all checks passed (47 passed, 5 skipped)

