### PR TITLE
fix(content-mapper): map model event navigation

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -74,6 +74,7 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             "number",
             "renamedSave",
             0,
+            "save".len(),
             true,
         ),
         (
@@ -84,6 +85,7 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             "string",
             "renamedSaveItem",
             0,
+            "saveItem".len(),
             false,
         ),
         (
@@ -94,7 +96,19 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             "boolean",
             "renamedSubmit",
             1,
+            "submit".len(),
             true,
+        ),
+        (
+            "DefaultModelChild.vue",
+            "@update:modelValue",
+            "defineModel",
+            "update:modelValue",
+            "number",
+            "renamedModelValue",
+            0,
+            "defineModel".len(),
+            false,
         ),
         (
             "GenericChild.vue",
@@ -104,7 +118,19 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             "\\\"chosen\\\"",
             "renamedPick",
             0,
+            "pick".len(),
             true,
+        ),
+        (
+            "ModelChild.vue",
+            "@update:title",
+            "\"title\"",
+            "update:title",
+            "string",
+            "renamedTitle",
+            0,
+            "\"title\"".len(),
+            false,
         ),
         (
             "RuntimeChild.vue",
@@ -114,11 +140,22 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             "string",
             "renamedCancel",
             0,
+            "cancel".len(),
             true,
         ),
     ]
     .map(
-        |(file, usage, declaration, name, ty, renamed, reference_shift, rename_supported)| {
+        |(
+            file,
+            usage,
+            declaration,
+            name,
+            ty,
+            renamed,
+            reference_shift,
+            reference_len,
+            rename_supported,
+        )| {
             let path = project.path().join("src").join(file);
             let source = std::fs::read_to_string(&path).unwrap();
             let uri = file_uri(&path);
@@ -129,7 +166,7 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
                 position(&source, source.find(declaration).unwrap() + reference_shift);
             let reference_end = position(
                 &source,
-                source.find(declaration).unwrap() + reference_shift + name.len(),
+                source.find(declaration).unwrap() + reference_shift + reference_len,
             );
             (
                 uri,
@@ -273,13 +310,18 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
 
             let partial = app_source
                 .replace("@submit", "@sub")
-                .replace("@cancel", "@can");
+                .replace("@cancel", "@can")
+                .replace("@update:modelValue", "@update:m")
+                .replace("@update:title", "@update:t");
             overlay
                 .replace(&app_document_uri, partial.as_str())
                 .unwrap();
-            for (usage, label, payload) in
-                [("@sub", "submit", "boolean"), ("@can", "cancel", "string")]
-            {
+            for (usage, label, payload) in [
+                ("@sub", "submit", "boolean"),
+                ("@can", "cancel", "string"),
+                ("@update:m", "update:modelValue", "number"),
+                ("@update:t", "update:title", "string"),
+            ] {
                 let completion_position =
                     position(&partial, partial.find(usage).unwrap() + usage.len());
                 assert_completion(&client, &app_uri, &completion_position, label, &[payload]).await;

--- a/crates/vize/tests/fixtures/content_mapper_project/consumer/verify.ts
+++ b/crates/vize/tests/fixtures/content_mapper_project/consumer/verify.ts
@@ -1,5 +1,7 @@
 import CallSignatureChild from "./CallSignatureChild.vue";
+import DefaultModelChild from "./DefaultModelChild.vue";
 import GenericChild from "./GenericChild.vue";
+import ModelChild from "./ModelChild.vue";
 import Options from "./Options.vue";
 import RuntimeChild from "./RuntimeChild.vue";
 import type { AppProps, PublicInstance } from "./main";
@@ -8,7 +10,9 @@ import { renderChild } from "./jsx-consumer";
 
 type IsAny<T> = 0 extends 1 & T ? true : false;
 type CallSignatureChildInstance = InstanceType<typeof CallSignatureChild>;
+type DefaultModelChildInstance = InstanceType<typeof DefaultModelChild>;
 type GenericChildInstance = InstanceType<typeof GenericChild>;
+type ModelChildInstance = InstanceType<typeof ModelChild>;
 type OptionsInstance = InstanceType<typeof Options>;
 type RuntimeChildInstance = InstanceType<typeof RuntimeChild>;
 
@@ -27,14 +31,22 @@ const optionsComputedMustBeTyped: IsAny<OptionsInstance["doubled"]> = false;
 const optionsMethodMustBeTyped: IsAny<OptionsInstance["increment"]> = false;
 declare const options: OptionsInstance;
 declare const callSignatureChild: CallSignatureChildInstance;
+declare const defaultModelChild: DefaultModelChildInstance;
 declare const genericChild: GenericChildInstance;
+declare const modelChild: ModelChildInstance;
 declare const runtimeChild: RuntimeChildInstance;
 callSignatureChild.$emit("submit", true);
 // @ts-expect-error submit payload must remain boolean through declaration emit
 callSignatureChild.$emit("submit", "yes");
+defaultModelChild.$emit("update:modelValue", 1);
+// @ts-expect-error default model update payload must remain number through declaration emit
+defaultModelChild.$emit("update:modelValue", "1");
 genericChild.$emit("pick", "value");
 // @ts-expect-error generic event constraint must remain string through declaration emit
 genericChild.$emit("pick", 1);
+modelChild.$emit("update:title", "value");
+// @ts-expect-error model update payload must remain string through declaration emit
+modelChild.$emit("update:title", 1);
 runtimeChild.$emit("cancel", "reason");
 // @ts-expect-error cancel payload must remain string through declaration emit
 runtimeChild.$emit("cancel", false);

--- a/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
@@ -1,20 +1,27 @@
 <script setup lang="ts">
 import CallSignatureChild from "./CallSignatureChild.vue";
 import Child from "./Child.vue";
+import DefaultModelChild from "./DefaultModelChild.vue";
 import GenericChild from "./GenericChild.vue";
+import ModelChild from "./ModelChild.vue";
 import RuntimeChild from "./RuntimeChild.vue";
 import { increment } from "./model";
 
 defineProps<{ count: number }>();
+const defaultModelValue = 1;
 const handleCancel = (reason: string) => reason;
+const handleModelValue = (value: number) => value;
 const handlePick = (value: string) => value;
 const handleSaveItem = (id: string) => id;
 const handleSubmit = (accepted: boolean) => accepted;
+const handleTitle = (title: string) => title;
 </script>
 
 <template>
   <Child :count="increment(count)" @save="increment" @save-item="handleSaveItem" />
+  <DefaultModelChild :model-value="defaultModelValue" @update:modelValue="handleModelValue" />
   <CallSignatureChild @submit="handleSubmit" />
   <GenericChild value="chosen" @pick="handlePick" />
+  <ModelChild title="chosen" @update:title="handleTitle" />
   <RuntimeChild @cancel="handleCancel" />
 </template>

--- a/crates/vize/tests/fixtures/content_mapper_project/src/DefaultModelChild.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/DefaultModelChild.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+const model = defineModel<number>({ required: true });
+void model;
+</script>
+
+<template>
+  <input v-model="model" />
+</template>

--- a/crates/vize/tests/fixtures/content_mapper_project/src/ModelChild.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/ModelChild.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+const title = defineModel<string>("title", { required: true });
+void title;
+</script>
+
+<template>
+  <input v-model="title" />
+</template>

--- a/crates/vize_atelier_sfc/src/script.rs
+++ b/crates/vize_atelier_sfc/src/script.rs
@@ -28,7 +28,7 @@ pub use define_emits::{
     DefineEmitsResult, extract_runtime_emits, gen_runtime_emits, process_define_emits,
 };
 pub(crate) use define_model_metadata::{
-    define_model_metadata, define_model_name, define_model_prop_option_spans,
+    add_model_to_croquis, define_model_metadata, define_model_name, define_model_prop_option_spans,
 };
 pub use define_props_destructure::{
     PropsDestructureBinding, PropsDestructuredBindings, gen_props_access_exp,

--- a/crates/vize_atelier_sfc/src/script/context.rs
+++ b/crates/vize_atelier_sfc/src/script/context.rs
@@ -13,7 +13,7 @@ pub use batch_epoch::{TypeResolutionBatchGuard, begin_type_resolution_batch};
 use crate::types::{BindingMetadata, BindingType};
 use vize_carton::{CompactString, String, ToCompactString};
 use vize_croquis::croquis::Croquis;
-use vize_croquis::macros::{EmitDefinition, ModelDefinition, PropDefinition};
+use vize_croquis::macros::{EmitDefinition, PropDefinition};
 
 use super::ScriptSetupMacros;
 
@@ -167,17 +167,12 @@ impl ScriptCompileContext {
         // Convert models
         for model_call in &self.macros.define_models {
             if let Some(ref binding_name) = model_call.binding_name {
-                let name = CompactString::new(
-                    super::define_model_name(self.source.as_str(), model_call).as_str(),
+                super::add_model_to_croquis(
+                    &mut summary,
+                    self.source.as_str(),
+                    model_call,
+                    binding_name,
                 );
-
-                summary.macros.add_model(ModelDefinition {
-                    name: name.clone(),
-                    local_name: CompactString::new(binding_name),
-                    model_type: None,
-                    required: false,
-                    default_value: None,
-                });
             }
         }
 

--- a/crates/vize_atelier_sfc/src/script/define_model_metadata.rs
+++ b/crates/vize_atelier_sfc/src/script/define_model_metadata.rs
@@ -4,8 +4,9 @@ use oxc_ast::ast::{
     Statement,
 };
 use oxc_parser::Parser;
-use oxc_span::SourceType;
-use vize_carton::{String, ToCompactString};
+use oxc_span::{GetSpan, SourceType};
+use vize_carton::{CompactString, String, ToCompactString};
+use vize_croquis::{croquis::Croquis, macros::ModelDefinition};
 
 use super::MacroCall;
 
@@ -13,14 +14,36 @@ pub(crate) struct DefineModelMetadata {
     pub(crate) name: String,
     pub(crate) options: Option<String>,
     pub(crate) runtime_options: Option<String>,
+    pub(crate) declaration_span: Option<(u32, u32)>,
 }
 
 pub(crate) fn define_model_name(source: &str, call: &MacroCall) -> String {
     define_model_metadata(source, call).name
 }
 
-pub(crate) fn define_model_metadata(source: &str, call: &MacroCall) -> DefineModelMetadata {
-    let Some(source) = source.get(call.start..call.end) else {
+pub(crate) fn add_model_to_croquis(
+    summary: &mut Croquis,
+    source: &str,
+    model_call: &MacroCall,
+    binding_name: &str,
+) {
+    let metadata = define_model_metadata(source, model_call);
+    let model = ModelDefinition {
+        name: CompactString::new(metadata.name.as_str()),
+        local_name: CompactString::new(binding_name),
+        model_type: None,
+        required: false,
+        default_value: None,
+    };
+    if let Some((start, end)) = metadata.declaration_span {
+        summary.macros.add_model_with_declaration(model, start, end);
+    } else {
+        summary.macros.add_model(model);
+    }
+}
+
+pub(crate) fn define_model_metadata(source: &str, macro_call: &MacroCall) -> DefineModelMetadata {
+    let Some(source) = source.get(macro_call.start..macro_call.end) else {
         return default_metadata();
     };
     let allocator = Allocator::default();
@@ -35,11 +58,23 @@ pub(crate) fn define_model_metadata(source: &str, call: &MacroCall) -> DefineMod
         return default_metadata();
     };
 
-    extract_metadata_from_call(call, source)
+    let mut metadata = extract_metadata_from_call(call, source);
+    let Ok(call_start) = u32::try_from(macro_call.start) else {
+        metadata.declaration_span = None;
+        return metadata;
+    };
+    metadata.declaration_span = metadata.declaration_span.and_then(|(start, end)| {
+        Some((call_start.checked_add(start)?, call_start.checked_add(end)?))
+    });
+    metadata
 }
 
 fn extract_metadata_from_call(call: &CallExpression<'_>, source: &str) -> DefineModelMetadata {
     let name_arg = call.arguments.first().and_then(argument_string_literal);
+    let declaration_span = match call.arguments.first() {
+        Some(Argument::StringLiteral(literal)) => literal.span,
+        _ => call.callee.span(),
+    };
     let name = name_arg
         .map(|name| name.to_compact_string())
         .unwrap_or_else(|| "modelValue".to_compact_string());
@@ -54,6 +89,7 @@ fn extract_metadata_from_call(call: &CallExpression<'_>, source: &str) -> Define
         name,
         options,
         runtime_options,
+        declaration_span: Some((declaration_span.start, declaration_span.end)),
     }
 }
 
@@ -62,6 +98,7 @@ fn default_metadata() -> DefineModelMetadata {
         name: "modelValue".into(),
         options: None,
         runtime_options: None,
+        declaration_span: None,
     }
 }
 
@@ -219,5 +256,43 @@ fn static_property_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
         PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
         PropertyKey::StringLiteral(literal) => Some(literal.value.as_str()),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod declaration_tests {
+    use super::*;
+
+    #[test]
+    fn bridges_explicit_and_default_model_declarations_to_croquis() {
+        for (source, name, declaration) in [
+            (
+                "const title = defineModel<string>(\"title\")",
+                "title",
+                "\"title\"",
+            ),
+            (
+                "const model = defineModel<number>()",
+                "modelValue",
+                "defineModel",
+            ),
+        ] {
+            let start = source.find("defineModel").unwrap();
+            let call = MacroCall::new(
+                start,
+                source.len(),
+                String::default(),
+                None,
+                Some(String::from("model")),
+            );
+            let mut summary = Croquis::new();
+            add_model_to_croquis(&mut summary, source, &call, "model");
+            let (start, end) = summary
+                .macros
+                .model_declaration(name)
+                .expect("model declaration");
+
+            assert_eq!(&source[start as usize..end as usize], declaration);
+        }
     }
 }

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 
 use super::{
     CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_ATOM,
-    CONTENT_MAPPER_SPAN_FEATURES_CASED_SYMBOL, ContentMapperSpanKind,
-    generate_vue_content_mapper_transform,
+    CONTENT_MAPPER_SPAN_FEATURES_COMPLETION, CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL,
+    ContentMapperSpanKind, generate_vue_content_mapper_transform,
 };
 
 #[test]
@@ -61,7 +61,7 @@ import Child from "./Child.vue";
                 && mapping.0[2] == original
                 && mapping.0[3] == "save-item".len()
                 && mapping.0[4] == ContentMapperSpanKind::Atom as usize
-                && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_CASED_SYMBOL
+                && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL
         }),
         "{:#?}",
         result.mappings
@@ -91,7 +91,7 @@ defineEmits<{ save: [value: number] }>();
 }
 
 #[test]
-fn retains_model_events_when_removing_duplicate_authored_event_members() {
+fn retains_model_events_when_removing_duplicate_generated_members() {
     let source = r#"<script setup lang="ts">
 defineModel<string>("title");
 defineEmits<{ save: [value: number] }>();
@@ -101,11 +101,7 @@ defineEmits<{ save: [value: number] }>();
     let result =
         generate_vue_content_mapper_transform(Path::new("Child.vue"), source).expect("transform");
 
-    assert!(
-        result
-            .text
-            .contains("type __VizeAuthoredEventMap = Emits & {")
-    );
+    assert!(result.text.contains("type __VizeAuthoredEventMap = {"));
     assert!(
         result
             .text
@@ -188,4 +184,55 @@ const handlePick = (value: string) => value;
     ] {
         assert!(parent.text.contains(expected), "{}", parent.text);
     }
+}
+
+#[test]
+fn maps_model_events_to_the_authored_model_name() {
+    let source = r#"<script setup lang="ts">
+defineModel<string>("title", { required: true });
+</script>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("ModelChild.vue"), source).expect("model");
+    let marker = "/* __vize_model_event */ \"update:title\"";
+    let generated = result.text.find(marker).unwrap() + "/* __vize_model_event */ ".len();
+    let original = source.find("\"title\"").unwrap();
+
+    assert!(
+        result.mappings.iter().any(|mapping| {
+            mapping.0[0] == generated
+                && mapping.0[1] == "\"update:title\"".len()
+                && mapping.0[2] == original
+                && mapping.0[3] == "\"title\"".len()
+                && mapping.0[4] == ContentMapperSpanKind::Atom as usize
+                && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL
+        }),
+        "text:\n{}\n\nmappings:\n{:#?}",
+        result.text,
+        result.mappings
+    );
+
+    let parent = r#"<script setup lang="ts">
+import ModelChild from "./ModelChild.vue";
+</script>
+<template><ModelChild @update:title="() => undefined" /></template>
+"#;
+    let parent =
+        generate_vue_content_mapper_transform(Path::new("App.vue"), parent).expect("parent");
+    let completion = parent
+        .text
+        .find("__vize_model_events_completion_0['update:title']")
+        .expect("completion projection")
+        + "__vize_model_events_completion_0['".len();
+    let navigation = parent
+        .text
+        .find("__vize_model_events_nav_0['update:title']")
+        .expect("navigation projection")
+        + "__vize_model_events_nav_0['".len();
+    assert!(parent.mappings.iter().any(|mapping| {
+        mapping.0[0] == completion && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_COMPLETION
+    }));
+    assert!(parent.mappings.iter().any(|mapping| {
+        mapping.0[0] == navigation && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL
+    }));
 }

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_span_features.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_span_features.rs
@@ -64,8 +64,11 @@ pub(super) const CONTENT_MAPPER_SPAN_FEATURES_ALL: usize = ContentMapperSpanFeat
 pub(super) const CONTENT_MAPPER_SPAN_FEATURES_ATOM: usize =
     ContentMapperSpanFeature::Hover as usize | ContentMapperSpanFeature::SignatureHelp as usize;
 
-/// Whole-symbol features that remain exact across a camel/kebab casing rewrite.
-pub(super) const CONTENT_MAPPER_SPAN_FEATURES_CASED_SYMBOL: usize = ContentMapperSpanFeature::Hover
+pub(super) const CONTENT_MAPPER_SPAN_FEATURES_COMPLETION: usize =
+    ContentMapperSpanFeature::Completion as usize;
+
+/// Whole-symbol features that remain exact across a spelling rewrite.
+pub(super) const CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL: usize = ContentMapperSpanFeature::Hover
     as usize
     | ContentMapperSpanFeature::Definition as usize
     | ContentMapperSpanFeature::TypeDefinition as usize
@@ -79,16 +82,33 @@ pub(super) fn content_mapper_span_features(
     start: usize,
     kind: ContentMapperSpanKind,
 ) -> usize {
-    match kind {
-        ContentMapperSpanKind::Verbatim => CONTENT_MAPPER_SPAN_FEATURES_ALL,
-        ContentMapperSpanKind::Atom if is_cased_symbol_projection(generated, start) => {
-            CONTENT_MAPPER_SPAN_FEATURES_CASED_SYMBOL
+    let prefix = projection_prefix(generated, start);
+    match (kind, prefix) {
+        (_, Some(prefix)) if prefix.starts_with("  void __vize_model_events_completion_") => {
+            CONTENT_MAPPER_SPAN_FEATURES_COMPLETION
         }
-        ContentMapperSpanKind::Atom => CONTENT_MAPPER_SPAN_FEATURES_ATOM,
+        (_, Some(prefix)) if is_whole_symbol_projection(prefix) => {
+            CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL
+        }
+        (ContentMapperSpanKind::Verbatim, _) => CONTENT_MAPPER_SPAN_FEATURES_ALL,
+        (ContentMapperSpanKind::Atom, _) => CONTENT_MAPPER_SPAN_FEATURES_ATOM,
     }
 }
 
-fn is_cased_symbol_projection(generated: &str, start: usize) -> bool {
-    let line_start = generated[..start].rfind('\n').map_or(0, |index| index + 1);
-    generated[line_start..start].starts_with("  void __vize_kebab_events_nav_")
+fn projection_prefix(generated: &str, start: usize) -> Option<&str> {
+    const MARKER: &[u8] = b"__vize_";
+    let probe_start = start.saturating_sub(64);
+    generated.as_bytes()[probe_start..start]
+        .windows(MARKER.len())
+        .any(|window| window == MARKER)
+        .then(|| {
+            let line_start = generated[..start].rfind('\n').map_or(0, |index| index + 1);
+            &generated[line_start..start]
+        })
+}
+
+fn is_whole_symbol_projection(prefix: &str) -> bool {
+    prefix.starts_with("  void __vize_kebab_events_nav_")
+        || prefix.starts_with("  void __vize_model_events_nav_")
+        || prefix.starts_with("  /* __vize_model_event */ ")
 }

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use super::ContentMapperSpanKind;
 use super::span_features::{
     CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_ATOM,
-    CONTENT_MAPPER_SPAN_FEATURES_CASED_SYMBOL,
+    CONTENT_MAPPER_SPAN_FEATURES_COMPLETION, CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL,
 };
 use crate::batch::{
     ContentMapperTransformOptions, generate_vue_content_mapper_transform,

--- a/crates/vize_canon/src/virtual_ts/generator/authored_events.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/authored_events.rs
@@ -12,12 +12,19 @@ pub(super) fn emit_authored_event_map(
     generic_names: &str,
 ) {
     let events = summary.macros.emits();
+    let models = summary.macros.models();
     let all_events_authored = can_replace_emits
-        && !events.is_empty()
+        && (!events.is_empty() || !models.is_empty())
         && events.iter().all(|emit| {
             summary
                 .macros
                 .emit_declaration(emit.name.as_str())
+                .is_some()
+        })
+        && models.iter().all(|model| {
+            summary
+                .macros
+                .model_declaration(model.name.as_str())
                 .is_some()
         });
     let authored_map = generic_decl.map_or_else(
@@ -56,6 +63,35 @@ pub(super) fn emit_authored_event_map(
         );
         ts.push_str("];\n");
         mappings.map_exact(generated_start..generated_end, authored_range);
+    }
+    let mut emitted_models = FxHashSet::default();
+    for model in models {
+        if !emitted_models.insert(model.name.as_str()) {
+            continue;
+        }
+        let event_name = cstr!("update:{}", model.name);
+        if emitted_names.contains(event_name.as_str()) {
+            continue;
+        }
+        let Some(authored_range) = summary.macros.model_declaration(model.name.as_str()) else {
+            continue;
+        };
+        ts.push_str("  /* __vize_model_event */ ");
+        let generated_start = ts.len();
+        ts.push_str(
+            serde_json::to_string(event_name.as_str())
+                .expect("model event names serialize as JSON strings")
+                .as_str(),
+        );
+        let generated_end = ts.len();
+        append!(*ts, ": __VizeStaticEventMap{generic_suffix}[");
+        ts.push_str(
+            serde_json::to_string(event_name.as_str())
+                .expect("model event names serialize as JSON strings")
+                .as_str(),
+        );
+        ts.push_str("];\n");
+        mappings.map_whole_symbol(generated_start..generated_end, authored_range);
     }
     ts.push_str("};\n");
 }

--- a/crates/vize_canon/src/virtual_ts/generator/emits.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/emits.rs
@@ -269,7 +269,7 @@ pub(super) fn emit_emits_type(
             ts,
             summary,
             &mut mappings,
-            !emits_already_defined && !has_model_emits,
+            !emits_already_defined,
             emits_generic_decl.as_deref().filter(|_| !has_runtime_emits),
             generic_event_map_names.as_str(),
         );

--- a/crates/vize_canon/src/virtual_ts/macro_type_mappings.rs
+++ b/crates/vize_canon/src/virtual_ts/macro_type_mappings.rs
@@ -91,4 +91,16 @@ impl<'a> MacroTypeMappings<'a> {
             sub_spans: Vec::new(),
         });
     }
+
+    pub(crate) fn map_whole_symbol(&mut self, generated: Range<usize>, authored: (u32, u32)) {
+        let Some(authored_len) = authored.1.checked_sub(authored.0).map(|len| len as usize) else {
+            return;
+        };
+        let authored_start = (self.source_offset)(authored.0 as usize);
+        self.mappings.push(VizeMapping {
+            gen_range: generated,
+            src_range: authored_start..authored_start + authored_len,
+            sub_spans: Vec::new(),
+        });
+    }
 }

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
@@ -61,8 +61,12 @@ fn emit_usage_event_references(
     let resolved_events = cstr!("__vize_events_resolved_{idx}");
     let direct_events_ref = cstr!("__vize_events_nav_{idx}");
     let kebab_events_ref = cstr!("__vize_kebab_events_nav_{idx}");
+    let model_events_ref = cstr!("__vize_model_events_nav_{idx}");
+    let model_completion_ref = cstr!("__vize_model_events_completion_{idx}");
     let mut emitted_direct_ref = false;
     let mut emitted_kebab_ref = false;
+    let mut emitted_model_ref = false;
+    let mut emitted_model_completion_ref = false;
     let mut emitted_resolved_events = false;
     for event in &usage.events {
         let camel_event_name = to_camel_case(event.name.as_str());
@@ -70,15 +74,32 @@ fn emit_usage_event_references(
         let Some(source_range) = event_navigation_source_range(ctx, event) else {
             continue;
         };
-        let (events_ref, emitted_ref) = if is_complete_kebab {
-            (&kebab_events_ref, &mut emitted_kebab_ref)
-        } else {
-            (&direct_events_ref, &mut emitted_direct_ref)
-        };
+        let is_model_event = ctx.preserve_event_navigation && event.name.starts_with("update:");
         if !emitted_resolved_events && ctx.preserve_event_navigation {
             emit_resolved_events(ts, ctx, usage, component_ref, idx, resolved_events.as_str());
             emitted_resolved_events = true;
         }
+        if is_model_event {
+            if !emitted_model_completion_ref {
+                append!(*ts, "  const {model_completion_ref} = {resolved_events};\n");
+                emitted_model_completion_ref = true;
+            }
+            append!(*ts, "  void {model_completion_ref}[");
+            let generated = push_ts_single_quoted_literal(ts, event.name.as_str());
+            ts.push_str("];\n");
+            mappings.push(VizeMapping {
+                gen_range: generated,
+                src_range: source_range.clone(),
+                sub_spans: Vec::new(),
+            });
+        }
+        let (events_ref, emitted_ref) = if is_model_event {
+            (&model_events_ref, &mut emitted_model_ref)
+        } else if is_complete_kebab {
+            (&kebab_events_ref, &mut emitted_kebab_ref)
+        } else {
+            (&direct_events_ref, &mut emitted_direct_ref)
+        };
         if !*emitted_ref {
             if ctx.preserve_event_navigation {
                 append!(*ts, "  const {events_ref} = {resolved_events};\n");

--- a/crates/vize_croquis/src/macros.rs
+++ b/crates/vize_croquis/src/macros.rs
@@ -370,9 +370,9 @@ pub struct MacroTracker {
     prop_declarations: FxHashMap<CompactString, (u32, u32)>,
     emits: Vec<EmitDefinition>,
     emit_declarations: FxHashMap<CompactString, (u32, u32)>,
-    /// Actual emit() calls in the code (not declarations)
     emit_calls: Vec<EmitCall>,
     models: Vec<ModelDefinition>,
+    model_declarations: FxHashMap<CompactString, (u32, u32)>,
     /// Exposed properties from defineExpose
     exposes: Vec<ExposeDefinition>,
     /// Slots from defineSlots

--- a/crates/vize_croquis/src/macros/tracker.rs
+++ b/crates/vize_croquis/src/macros/tracker.rs
@@ -68,6 +68,25 @@ impl MacroTracker {
         self.emit_declarations.get(name).copied()
     }
 
+    /// Add a model together with the range of its authored name or macro.
+    #[inline]
+    pub fn add_model_with_declaration(
+        &mut self,
+        model: super::ModelDefinition,
+        start: u32,
+        end: u32,
+    ) {
+        self.model_declarations
+            .insert(model.name.clone(), (start, end));
+        self.models.push(model);
+    }
+
+    /// Get a model's authored declaration range, relative to its script block.
+    #[inline]
+    pub fn model_declaration(&self, name: &str) -> Option<(u32, u32)> {
+        self.model_declarations.get(name).copied()
+    }
+
     /// Shift every stored script-relative source offset by `delta`.
     pub fn shift_offsets(&mut self, delta: u32) {
         for call in &mut self.calls {
@@ -79,6 +98,10 @@ impl MacroTracker {
             range.1 = range.1.saturating_add(delta);
         }
         for range in self.emit_declarations.values_mut() {
+            range.0 = range.0.saturating_add(delta);
+            range.1 = range.1.saturating_add(delta);
+        }
+        for range in self.model_declarations.values_mut() {
             range.0 = range.0.saturating_add(delta);
             range.1 = range.1.saturating_add(delta);
         }

--- a/crates/vize_croquis/src/script_parser/emits_ranges_tests.rs
+++ b/crates/vize_croquis/src/script_parser/emits_ranges_tests.rs
@@ -40,3 +40,34 @@ fn shifting_macros_keeps_event_declarations_in_the_script_coordinate_space() {
         Some((declaration.0 + 17, declaration.1 + 17))
     );
 }
+
+#[test]
+fn models_retain_explicit_names_and_default_macro_ranges() {
+    for (source, name, declaration) in [
+        ("defineModel<string>(\"title\")", "title", "\"title\""),
+        ("defineModel<number>()", "modelValue", "defineModel"),
+    ] {
+        let result = parse_script_setup(source);
+        let (start, end) = result
+            .macros
+            .model_declaration(name)
+            .expect("model declaration range");
+        assert_eq!(&source[start as usize..end as usize], declaration);
+    }
+}
+
+#[test]
+fn shifting_macros_keeps_model_declarations_in_script_coordinates() {
+    let mut result = parse_script_setup("defineModel<string>(\"title\")");
+    let declaration = result
+        .macros
+        .model_declaration("title")
+        .expect("model declaration");
+
+    result.macros.shift_offsets(23);
+
+    assert_eq!(
+        result.macros.model_declaration("title"),
+        Some((declaration.0 + 23, declaration.1 + 23))
+    );
+}

--- a/crates/vize_croquis/src/script_parser/extract/macros.rs
+++ b/crates/vize_croquis/src/script_parser/extract/macros.rs
@@ -93,6 +93,14 @@ pub fn process_call_expression(
                     }
                 })
                 .unwrap_or("modelValue");
+            let declaration = call
+                .arguments
+                .first()
+                .and_then(|arg| match arg {
+                    Argument::StringLiteral(literal) => Some(literal.span),
+                    _ => None,
+                })
+                .unwrap_or_else(|| call.callee.span());
             let model_type = call
                 .type_arguments
                 .as_ref()
@@ -120,13 +128,17 @@ pub fn process_call_expression(
                 })
                 .unwrap_or((false, None));
 
-            result.macros.add_model(ModelDefinition {
-                name: CompactString::new(model_name),
-                local_name: CompactString::new(model_name),
-                model_type,
-                required,
-                default_value,
-            });
+            result.macros.add_model_with_declaration(
+                ModelDefinition {
+                    name: CompactString::new(model_name),
+                    local_name: CompactString::new(model_name),
+                    model_type,
+                    required,
+                    default_value,
+                },
+                declaration.start,
+                declaration.end,
+            );
         }
 
         MacroKind::WithDefaults => {


### PR DESCRIPTION
## Summary

- retain exact authored ranges for explicit and default `defineModel` declarations and expose generated `update:*` events through Content Mapper navigation
- split model event completion from read-only symbol navigation so hover, definition, references, and partial completion work while unsafe partial rename fails closed
- cover explicit/default models in the exact tsgo LSP fixture and verify emitted declarations with both tsgo and JavaScript `tsc`

## Test plan

- `cargo test -p vize_croquis`
- `cargo test -p vize_canon`
- `cargo test -p vize_atelier_sfc --lib bridges_explicit_and_default_model_declarations_to_croquis -- --nocapture`
- `cargo clippy -p vize_croquis --lib -- -D warnings`
- `cargo clippy -p vize_atelier_sfc --lib -- -D warnings`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-tsgo-content-mapper.OA6YI7/tsgo cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-tsgo-content-mapper.OA6YI7/tsgo VIZE_TEST_CONTENT_MAPPER_JAVASCRIPT_TSC=./npm/cli/node_modules/.bin/tsc cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture`

Advances #4072.
Relates to #4075, #4057, and #3282.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->