### PR TITLE
fix(content-mapper): infer scoped generic events

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -111,6 +111,17 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             false,
         ),
         (
+            "DynamicGenericChild.vue",
+            "@choose",
+            "choose: [value",
+            "choose",
+            "\\\"top-level\\\"",
+            "renamedChoose",
+            0,
+            "choose".len(),
+            true,
+        ),
+        (
             "GenericChild.vue",
             "@pick",
             "pick: [value",
@@ -131,6 +142,17 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             0,
             "\"title\"".len(),
             false,
+        ),
+        (
+            "NestedGenericChild.vue",
+            "@select",
+            "select: [value",
+            "select",
+            "\\\"nested\\\"",
+            "renamedSelect",
+            0,
+            "select".len(),
+            true,
         ),
         (
             "RuntimeChild.vue",
@@ -308,17 +330,40 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
                 assert_eq!(clean["items"], json!([]), "{clean:#}");
             }
 
+            let broken_handler =
+                app_source.replace("@select=\"handleSelect\"", "@select=\"handleSubmit\"");
+            overlay
+                .replace(&app_document_uri, broken_handler.as_str())
+                .unwrap();
+            let broken = pull_diagnostics(&client, &app_uri).await;
+            let broken_text = serde_json::to_string(&broken).unwrap();
+            assert!(broken_text.contains("2322"), "{broken:#}");
+            let event_start =
+                position(&broken_handler, broken_handler.find("@select").unwrap() + 1);
+            assert!(
+                broken["items"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|diagnostic| { diagnostic["range"]["start"] == event_start }),
+                "{broken:#}"
+            );
+
             let partial = app_source
+                .replace("@choose", "@cho")
                 .replace("@submit", "@sub")
                 .replace("@cancel", "@can")
+                .replace("@select", "@sel")
                 .replace("@update:modelValue", "@update:m")
                 .replace("@update:title", "@update:t");
             overlay
                 .replace(&app_document_uri, partial.as_str())
                 .unwrap();
             for (usage, label, payload) in [
+                ("@cho", "choose", "\\\"top-level\\\""),
                 ("@sub", "submit", "boolean"),
                 ("@can", "cancel", "string"),
+                ("@sel", "select", "\\\"nested\\\""),
                 ("@update:m", "update:modelValue", "number"),
                 ("@update:t", "update:title", "string"),
             ] {

--- a/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
@@ -2,26 +2,39 @@
 import CallSignatureChild from "./CallSignatureChild.vue";
 import Child from "./Child.vue";
 import DefaultModelChild from "./DefaultModelChild.vue";
+import DynamicGenericChild from "./DynamicGenericChild.vue";
 import GenericChild from "./GenericChild.vue";
 import ModelChild from "./ModelChild.vue";
+import NestedGenericChild from "./NestedGenericChild.vue";
 import RuntimeChild from "./RuntimeChild.vue";
 import { increment } from "./model";
 
 defineProps<{ count: number }>();
 const defaultModelValue = 1;
 const handleCancel = (reason: string) => reason;
+const handleChoose = (value: "top-level") => value;
 const handleModelValue = (value: number) => value;
 const handlePick = (value: string) => value;
+const handleSelect = (value: "nested") => value;
 const handleSaveItem = (id: string) => id;
 const handleSubmit = (accepted: boolean) => accepted;
 const handleTitle = (title: string) => title;
+const nestedValues = ["nested"] as const;
+const topLevelValue = "top-level" as const;
 </script>
 
 <template>
   <Child :count="increment(count)" @save="increment" @save-item="handleSaveItem" />
   <DefaultModelChild :model-value="defaultModelValue" @update:modelValue="handleModelValue" />
+  <DynamicGenericChild :value="topLevelValue" @choose="handleChoose" />
   <CallSignatureChild @submit="handleSubmit" />
   <GenericChild value="chosen" @pick="handlePick" />
   <ModelChild title="chosen" @update:title="handleTitle" />
+  <NestedGenericChild
+    v-for="value in nestedValues"
+    :key="value"
+    :value="value"
+    @select="handleSelect"
+  />
   <RuntimeChild @cancel="handleCancel" />
 </template>

--- a/crates/vize/tests/fixtures/content_mapper_project/src/DynamicGenericChild.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/DynamicGenericChild.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts" generic="T extends string = string">
+defineProps<{ value: T }>();
+defineEmits<{ choose: [value: T] }>();
+</script>
+
+<template>
+  <button type="button">Choose {{ value }}</button>
+</template>

--- a/crates/vize/tests/fixtures/content_mapper_project/src/NestedGenericChild.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/NestedGenericChild.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts" generic="T extends string = string">
+defineProps<{ value: T }>();
+defineEmits<{ select: [value: T] }>();
+</script>
+
+<template>
+  <button type="button">Select {{ value }}</button>
+</template>

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
 use super::{
-    CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_ATOM,
-    CONTENT_MAPPER_SPAN_FEATURES_COMPLETION, CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL,
-    ContentMapperSpanKind, generate_vue_content_mapper_transform,
+    CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_COMPLETION,
+    CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL, ContentMapperSpanKind,
+    generate_vue_content_mapper_transform,
 };
 
 #[test]
@@ -37,7 +37,7 @@ const handler = (value: number) => value;
         mapping.0[2] == original
             && mapping.0[3] == "sa".len()
             && mapping.0[4] == ContentMapperSpanKind::Atom as usize
-            && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_ATOM
+            && mapping.0[5] == 0
     }));
 }
 
@@ -234,5 +234,53 @@ import ModelChild from "./ModelChild.vue";
     }));
     assert!(parent.mappings.iter().any(|mapping| {
         mapping.0[0] == navigation && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL
+    }));
+}
+
+#[test]
+fn emits_dynamic_generic_event_navigation_inside_the_v_for_scope() {
+    let source = r#"<script setup lang="ts">
+import NestedGenericChild from "./NestedGenericChild.vue";
+const values = ["nested"] as const;
+const handleSelect = (value: "nested") => value;
+</script>
+<template>
+  <NestedGenericChild
+    v-for="value in values"
+    :key="value"
+    :value="value"
+    @select="handleSelect"
+  />
+</template>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("App.vue"), source).expect("transform");
+    let resolver = result
+        .text
+        .find("const __vize_events_resolved_0")
+        .expect("event resolver");
+    let closure = result.text[..resolver]
+        .rfind("// Component props in v-for scope")
+        .expect("component prop v-for closure");
+
+    assert!(closure < resolver, "{}", result.text);
+    assert!(
+        result.text[resolver..].contains("\"value\": value"),
+        "{}",
+        result.text
+    );
+    assert_eq!(
+        result
+            .text
+            .matches("const __vize_events_resolved_0")
+            .count(),
+        1
+    );
+
+    let original = source.find("@select").unwrap() + 1;
+    assert!(result.mappings.iter().any(|mapping| {
+        mapping.0[2] == original
+            && mapping.0[3] == "select".len()
+            && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_ALL
     }));
 }

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_span_features.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_span_features.rs
@@ -82,9 +82,16 @@ pub(super) fn content_mapper_span_features(
     start: usize,
     kind: ContentMapperSpanKind,
 ) -> usize {
+    if is_diagnostic_handler_anchor(generated, start, kind) {
+        return 0;
+    }
     let prefix = projection_prefix(generated, start);
     match (kind, prefix) {
-        (_, Some(prefix)) if prefix.starts_with("  void __vize_model_events_completion_") => {
+        (_, Some(prefix))
+            if prefix
+                .trim_start()
+                .starts_with("void __vize_model_events_completion_") =>
+        {
             CONTENT_MAPPER_SPAN_FEATURES_COMPLETION
         }
         (_, Some(prefix)) if is_whole_symbol_projection(prefix) => {
@@ -93,6 +100,22 @@ pub(super) fn content_mapper_span_features(
         (ContentMapperSpanKind::Verbatim, _) => CONTENT_MAPPER_SPAN_FEATURES_ALL,
         (ContentMapperSpanKind::Atom, _) => CONTENT_MAPPER_SPAN_FEATURES_ATOM,
     }
+}
+
+fn is_diagnostic_handler_anchor(
+    generated: &str,
+    start: usize,
+    kind: ContentMapperSpanKind,
+) -> bool {
+    if kind != ContentMapperSpanKind::Atom
+        || !generated
+            .get(start..)
+            .is_some_and(|suffix| suffix.starts_with("__vize_handler_"))
+    {
+        return false;
+    }
+    let line_start = generated[..start].rfind('\n').map_or(0, |index| index + 1);
+    generated[line_start..start].trim_start() == "const "
 }
 
 fn projection_prefix(generated: &str, start: usize) -> Option<&str> {
@@ -108,7 +131,8 @@ fn projection_prefix(generated: &str, start: usize) -> Option<&str> {
 }
 
 fn is_whole_symbol_projection(prefix: &str) -> bool {
-    prefix.starts_with("  void __vize_kebab_events_nav_")
-        || prefix.starts_with("  void __vize_model_events_nav_")
-        || prefix.starts_with("  /* __vize_model_event */ ")
+    let prefix = prefix.trim_start();
+    prefix.starts_with("void __vize_kebab_events_nav_")
+        || prefix.starts_with("void __vize_model_events_nav_")
+        || prefix.starts_with("/* __vize_model_event */ ")
 }

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -4,6 +4,7 @@ use super::ContentMapperSpanKind;
 use super::span_features::{
     CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_ATOM,
     CONTENT_MAPPER_SPAN_FEATURES_COMPLETION, CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL,
+    content_mapper_span_features,
 };
 use crate::batch::{
     ContentMapperTransformOptions, generate_vue_content_mapper_transform,
@@ -14,6 +15,21 @@ use crate::batch::{
 mod component_exports;
 #[path = "content_mapper_navigation_tests.rs"]
 mod navigation;
+
+#[test]
+fn keeps_diagnostic_handler_anchors_out_of_editor_features() {
+    let generated = "  const __vize_handler_1_2: unknown = handler;";
+    let start = generated.find("__vize_handler_").unwrap();
+
+    assert_eq!(
+        content_mapper_span_features(generated, start, ContentMapperSpanKind::Atom),
+        0
+    );
+    assert_eq!(
+        content_mapper_span_features(generated, start, ContentMapperSpanKind::Verbatim),
+        CONTENT_MAPPER_SPAN_FEATURES_ALL
+    );
+}
 
 #[test]
 fn emits_protocol_v1_spans_without_forbidden_overlaps() {

--- a/crates/vize_canon/src/virtual_ts/scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope.rs
@@ -6,7 +6,9 @@
 
 mod children;
 mod closures;
+mod component_event_navigation;
 mod component_events;
+mod component_navigation;
 mod component_prop_checker;
 mod component_prop_expressions;
 mod component_prop_navigation;

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -18,8 +18,8 @@ use crate::virtual_ts::helpers::to_safe_identifier_fragment;
 use crate::virtual_ts::types::VizeMapping;
 
 use super::children::generate_child_scopes;
+use super::component_event_navigation::emit_event_references;
 use super::component_prop_expressions::collect_component_prop_expression_ranges;
-use super::component_prop_navigation::emit_event_references;
 use super::component_props::{collect_checkable_usages, generate_component_props};
 use super::context::{ComponentPropsContext, ScopeGenContext, ScopeGenerationOptions};
 use super::emit::{

--- a/crates/vize_canon/src/virtual_ts/scope/component_event_navigation.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_event_navigation.rs
@@ -1,0 +1,231 @@
+use std::ops::Range;
+
+use vize_carton::{FxHashSet, String, append, cstr};
+use vize_croquis::croquis::{ComponentUsage, EventListener};
+use vize_croquis::{Croquis, ScopeKind};
+
+use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier};
+use crate::virtual_ts::types::VizeMapping;
+
+use super::component_events::generated_prop_value;
+use super::component_navigation::{is_ts_identifier, push_ts_single_quoted_literal};
+use super::context::{ComponentPropsContext, VForPropsContext};
+use super::event_handler::event_name_source_range;
+
+pub(super) fn emit_event_references(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    ctx: &ComponentPropsContext<'_>,
+    checkable_usages: &[(usize, &ComponentUsage)],
+) {
+    let navigation_ctx = EventNavigationContext {
+        template_source: ctx.template_source,
+        template_offset: ctx.template_offset,
+        template_prop_names: ctx.template_prop_names,
+        preserve_event_navigation: ctx.preserve_event_navigation,
+    };
+    for &(idx, usage) in checkable_usages {
+        if is_closure_scoped(ctx.summary, usage) {
+            continue;
+        }
+        let component_ref = to_safe_identifier(usage.name.as_str());
+        emit_usage_event_references(
+            ts,
+            mappings,
+            &navigation_ctx,
+            idx,
+            usage,
+            component_ref.as_str(),
+            "  ",
+        );
+    }
+}
+
+pub(super) fn emit_scoped_event_references(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    ctx: &VForPropsContext<'_>,
+    usages: &[(usize, &ComponentUsage)],
+    indent: &str,
+) {
+    let navigation_ctx = EventNavigationContext {
+        template_source: ctx.source_context.template,
+        template_offset: ctx.source_context.offset,
+        template_prop_names: ctx.template_prop_names,
+        preserve_event_navigation: ctx.preserve_event_navigation,
+    };
+    for &(idx, usage) in usages {
+        let component_ref = to_safe_identifier(usage.name.as_str());
+        emit_usage_event_references(
+            ts,
+            mappings,
+            &navigation_ctx,
+            idx,
+            usage,
+            component_ref.as_str(),
+            indent,
+        );
+    }
+}
+
+struct EventNavigationContext<'a> {
+    template_source: Option<&'a str>,
+    template_offset: u32,
+    template_prop_names: &'a FxHashSet<String>,
+    preserve_event_navigation: bool,
+}
+
+fn is_closure_scoped(summary: &Croquis, usage: &ComponentUsage) -> bool {
+    summary
+        .scopes
+        .get_scope(usage.scope_id)
+        .is_some_and(|scope| matches!(scope.kind, ScopeKind::VFor | ScopeKind::VSlot))
+}
+
+fn emit_usage_event_references(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    ctx: &EventNavigationContext<'_>,
+    idx: usize,
+    usage: &ComponentUsage,
+    component_ref: &str,
+    indent: &str,
+) {
+    let resolved_events = cstr!("__vize_events_resolved_{idx}");
+    let direct_events_ref = cstr!("__vize_events_nav_{idx}");
+    let kebab_events_ref = cstr!("__vize_kebab_events_nav_{idx}");
+    let model_events_ref = cstr!("__vize_model_events_nav_{idx}");
+    let model_completion_ref = cstr!("__vize_model_events_completion_{idx}");
+    let mut emitted_direct_ref = false;
+    let mut emitted_kebab_ref = false;
+    let mut emitted_model_ref = false;
+    let mut emitted_model_completion_ref = false;
+    let mut emitted_resolved_events = false;
+    for event in &usage.events {
+        let camel_event_name = to_camel_case(event.name.as_str());
+        let is_complete_kebab = camel_event_name != event.name && !event.name.ends_with('-');
+        let Some(source_range) = event_navigation_source_range(ctx, event) else {
+            continue;
+        };
+        let is_model_event = ctx.preserve_event_navigation && event.name.starts_with("update:");
+        if !emitted_resolved_events && ctx.preserve_event_navigation {
+            emit_resolved_events(
+                ts,
+                ctx,
+                usage,
+                component_ref,
+                idx,
+                resolved_events.as_str(),
+                indent,
+            );
+            emitted_resolved_events = true;
+        }
+        if is_model_event {
+            if !emitted_model_completion_ref {
+                append!(
+                    *ts,
+                    "{indent}const {model_completion_ref} = {resolved_events};\n"
+                );
+                emitted_model_completion_ref = true;
+            }
+            append!(*ts, "{indent}void {model_completion_ref}[");
+            let generated = push_ts_single_quoted_literal(ts, event.name.as_str());
+            ts.push_str("];\n");
+            mappings.push(VizeMapping {
+                gen_range: generated,
+                src_range: source_range.clone(),
+                sub_spans: Vec::new(),
+            });
+        }
+        let (events_ref, emitted_ref) = if is_model_event {
+            (&model_events_ref, &mut emitted_model_ref)
+        } else if is_complete_kebab {
+            (&kebab_events_ref, &mut emitted_kebab_ref)
+        } else {
+            (&direct_events_ref, &mut emitted_direct_ref)
+        };
+        if !*emitted_ref {
+            if ctx.preserve_event_navigation {
+                append!(*ts, "{indent}const {events_ref} = {resolved_events};\n");
+            } else {
+                append!(
+                    *ts,
+                    "{indent}const {events_ref} = undefined as unknown as __VizeComponentEvents<typeof {component_ref}> & Record<string, unknown>;\n"
+                );
+            }
+            *emitted_ref = true;
+        }
+
+        append!(*ts, "{indent}void {events_ref}");
+        let event_gen_range = if is_complete_kebab {
+            if is_ts_identifier(camel_event_name.as_str()) {
+                ts.push('.');
+                let start = ts.len();
+                ts.push_str(camel_event_name.as_str());
+                start..ts.len()
+            } else {
+                ts.push('[');
+                let range = push_ts_single_quoted_literal(ts, camel_event_name.as_str());
+                ts.push(']');
+                range
+            }
+        } else if is_ts_identifier(event.name.as_str()) {
+            ts.push('.');
+            let start = ts.len();
+            ts.push_str(event.name.as_str());
+            start..ts.len()
+        } else {
+            ts.push('[');
+            let range = push_ts_single_quoted_literal(ts, event.name.as_str());
+            ts.push(']');
+            range
+        };
+        ts.push_str(";\n");
+        mappings.push(VizeMapping {
+            gen_range: event_gen_range,
+            src_range: source_range,
+            sub_spans: Vec::new(),
+        });
+    }
+}
+
+fn emit_resolved_events(
+    ts: &mut String,
+    ctx: &EventNavigationContext<'_>,
+    usage: &ComponentUsage,
+    component_ref: &str,
+    idx: usize,
+    resolved_events: &str,
+    indent: &str,
+) {
+    append!(
+        *ts,
+        "{indent}type __vize_events_resolver_{idx} = typeof {component_ref} extends {{ __vizeResolveEvents?: infer __F }} ? (__F extends (...args: any[]) => any ? __F : (props: any) => __VizeComponentEvents<typeof {component_ref}>) : (props: any) => __VizeComponentEvents<typeof {component_ref}>;\n{indent}// @ts-ignore Inference-only call; the authored prop checker owns diagnostics.\n{indent}const {resolved_events} = (undefined as unknown as __vize_events_resolver_{idx})({{\n"
+    );
+    for prop in &usage.props {
+        if prop.name_is_dynamic || prop.name.as_str() == "key" || prop.name.as_str() == "ref" {
+            continue;
+        }
+        let Some(value) = generated_prop_value(prop, ctx.template_prop_names) else {
+            continue;
+        };
+        let name = to_camel_case(prop.name.as_str());
+        append!(*ts, "{indent}  \"{name}\": {value},\n");
+    }
+    append!(*ts, "{indent}}});\n");
+}
+
+fn event_navigation_source_range(
+    ctx: &EventNavigationContext<'_>,
+    event: &EventListener,
+) -> Option<Range<usize>> {
+    if event.name_is_dynamic || event.name.is_empty() {
+        return None;
+    }
+    event_name_source_range(
+        ctx.template_source,
+        ctx.template_offset,
+        event.start..event.end,
+        event.name.as_str(),
+    )
+}

--- a/crates/vize_canon/src/virtual_ts/scope/component_navigation.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_navigation.rs
@@ -1,0 +1,32 @@
+use std::ops::Range;
+
+use vize_carton::String;
+
+pub(super) fn push_ts_single_quoted_literal(ts: &mut String, value: &str) -> Range<usize> {
+    ts.push('\'');
+    let start = ts.len();
+    for ch in value.chars() {
+        match ch {
+            '\\' => ts.push_str("\\\\"),
+            '\'' => ts.push_str("\\'"),
+            '\n' => ts.push_str("\\n"),
+            '\r' => ts.push_str("\\r"),
+            '\t' => ts.push_str("\\t"),
+            _ => ts.push(ch),
+        }
+    }
+    let end = ts.len();
+    ts.push('\'');
+    start..end
+}
+
+pub(super) fn is_ts_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+    chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
+}

--- a/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs
@@ -1,26 +1,13 @@
 use std::ops::Range;
 
 use vize_carton::{String, append, cstr};
-use vize_croquis::croquis::{ComponentUsage, EventListener, PassedProp};
+use vize_croquis::croquis::{ComponentUsage, PassedProp};
 
 use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier, to_safe_identifier_fragment};
 use crate::virtual_ts::types::VizeMapping;
 
-use super::component_events::generated_prop_value;
+use super::component_navigation::{is_ts_identifier, push_ts_single_quoted_literal};
 use super::context::ComponentPropsContext;
-use super::event_handler::event_name_source_range;
-
-pub(super) fn emit_event_references(
-    ts: &mut String,
-    mappings: &mut Vec<VizeMapping>,
-    ctx: &ComponentPropsContext<'_>,
-    checkable_usages: &[(usize, &ComponentUsage)],
-) {
-    for &(idx, usage) in checkable_usages {
-        let component_ref = to_safe_identifier(usage.name.as_str());
-        emit_usage_event_references(ts, mappings, ctx, idx, usage, component_ref.as_str());
-    }
-}
 
 pub(super) fn emit_references(
     ts: &mut String,
@@ -48,145 +35,6 @@ pub(super) fn emit_references(
 
         emit_prop_references(ts, mappings, ctx, idx, usage, component_type_name.as_str());
     }
-}
-
-fn emit_usage_event_references(
-    ts: &mut String,
-    mappings: &mut Vec<VizeMapping>,
-    ctx: &ComponentPropsContext<'_>,
-    idx: usize,
-    usage: &ComponentUsage,
-    component_ref: &str,
-) {
-    let resolved_events = cstr!("__vize_events_resolved_{idx}");
-    let direct_events_ref = cstr!("__vize_events_nav_{idx}");
-    let kebab_events_ref = cstr!("__vize_kebab_events_nav_{idx}");
-    let model_events_ref = cstr!("__vize_model_events_nav_{idx}");
-    let model_completion_ref = cstr!("__vize_model_events_completion_{idx}");
-    let mut emitted_direct_ref = false;
-    let mut emitted_kebab_ref = false;
-    let mut emitted_model_ref = false;
-    let mut emitted_model_completion_ref = false;
-    let mut emitted_resolved_events = false;
-    for event in &usage.events {
-        let camel_event_name = to_camel_case(event.name.as_str());
-        let is_complete_kebab = camel_event_name != event.name && !event.name.ends_with('-');
-        let Some(source_range) = event_navigation_source_range(ctx, event) else {
-            continue;
-        };
-        let is_model_event = ctx.preserve_event_navigation && event.name.starts_with("update:");
-        if !emitted_resolved_events && ctx.preserve_event_navigation {
-            emit_resolved_events(ts, ctx, usage, component_ref, idx, resolved_events.as_str());
-            emitted_resolved_events = true;
-        }
-        if is_model_event {
-            if !emitted_model_completion_ref {
-                append!(*ts, "  const {model_completion_ref} = {resolved_events};\n");
-                emitted_model_completion_ref = true;
-            }
-            append!(*ts, "  void {model_completion_ref}[");
-            let generated = push_ts_single_quoted_literal(ts, event.name.as_str());
-            ts.push_str("];\n");
-            mappings.push(VizeMapping {
-                gen_range: generated,
-                src_range: source_range.clone(),
-                sub_spans: Vec::new(),
-            });
-        }
-        let (events_ref, emitted_ref) = if is_model_event {
-            (&model_events_ref, &mut emitted_model_ref)
-        } else if is_complete_kebab {
-            (&kebab_events_ref, &mut emitted_kebab_ref)
-        } else {
-            (&direct_events_ref, &mut emitted_direct_ref)
-        };
-        if !*emitted_ref {
-            if ctx.preserve_event_navigation {
-                append!(*ts, "  const {events_ref} = {resolved_events};\n");
-            } else {
-                append!(
-                    *ts,
-                    "  const {events_ref} = undefined as unknown as __VizeComponentEvents<typeof {component_ref}> & Record<string, unknown>;\n"
-                );
-            }
-            *emitted_ref = true;
-        }
-
-        append!(*ts, "  void {events_ref}");
-        let event_gen_range = if is_complete_kebab {
-            if is_ts_identifier(camel_event_name.as_str()) {
-                ts.push('.');
-                let start = ts.len();
-                ts.push_str(camel_event_name.as_str());
-                start..ts.len()
-            } else {
-                ts.push('[');
-                let range = push_ts_single_quoted_literal(ts, camel_event_name.as_str());
-                ts.push(']');
-                range
-            }
-        } else if is_ts_identifier(event.name.as_str()) {
-            ts.push('.');
-            let start = ts.len();
-            ts.push_str(event.name.as_str());
-            start..ts.len()
-        } else {
-            ts.push('[');
-            let range = push_ts_single_quoted_literal(ts, event.name.as_str());
-            ts.push(']');
-            range
-        };
-        ts.push_str(";\n");
-        mappings.push(VizeMapping {
-            gen_range: event_gen_range,
-            src_range: source_range,
-            sub_spans: Vec::new(),
-        });
-    }
-}
-
-fn emit_resolved_events(
-    ts: &mut String,
-    ctx: &ComponentPropsContext<'_>,
-    usage: &ComponentUsage,
-    component_ref: &str,
-    idx: usize,
-    resolved_events: &str,
-) {
-    append!(
-        *ts,
-        "  type __vize_events_resolver_{idx} = typeof {component_ref} extends {{ __vizeResolveEvents?: infer __F }} ? (__F extends (...args: any[]) => any ? __F : (props: any) => __VizeComponentEvents<typeof {component_ref}>) : (props: any) => __VizeComponentEvents<typeof {component_ref}>;\n  // @ts-ignore Inference-only call; the authored prop checker owns diagnostics.\n  const {resolved_events} = (undefined as unknown as __vize_events_resolver_{idx})({{\n"
-    );
-    for prop in &usage.props {
-        if prop.name_is_dynamic
-            || prop.is_dynamic
-            || prop.name.as_str() == "key"
-            || prop.name.as_str() == "ref"
-        {
-            continue;
-        }
-        let Some(value) = generated_prop_value(prop, ctx.template_prop_names) else {
-            continue;
-        };
-        let name = to_camel_case(prop.name.as_str());
-        append!(*ts, "    \"{name}\": {value},\n");
-    }
-    ts.push_str("  });\n");
-}
-
-fn event_navigation_source_range(
-    ctx: &ComponentPropsContext<'_>,
-    event: &EventListener,
-) -> Option<Range<usize>> {
-    if event.name_is_dynamic || event.name.is_empty() {
-        return None;
-    }
-    event_name_source_range(
-        ctx.template_source,
-        ctx.template_offset,
-        event.start..event.end,
-        event.name.as_str(),
-    )
 }
 
 fn emit_prop_references(
@@ -265,33 +113,4 @@ fn prop_navigation_source_range(
     }
 
     None
-}
-
-fn push_ts_single_quoted_literal(ts: &mut String, value: &str) -> Range<usize> {
-    ts.push('\'');
-    let start = ts.len();
-    for ch in value.chars() {
-        match ch {
-            '\\' => ts.push_str("\\\\"),
-            '\'' => ts.push_str("\\'"),
-            '\n' => ts.push_str("\\n"),
-            '\r' => ts.push_str("\\r"),
-            '\t' => ts.push_str("\\t"),
-            _ => ts.push(ch),
-        }
-    }
-    let end = ts.len();
-    ts.push('\'');
-    start..end
-}
-
-fn is_ts_identifier(value: &str) -> bool {
-    let mut chars = value.chars();
-    let Some(first) = chars.next() else {
-        return false;
-    };
-    if !(first == '_' || first == '$' || first.is_ascii_alphabetic()) {
-        return false;
-    }
-    chars.all(|ch| ch == '_' || ch == '$' || ch.is_ascii_alphanumeric())
 }

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -170,6 +170,7 @@ pub(super) fn generate_component_props(
             vfor_enclosing_guards: &vfor_enclosing_guards,
             template_prop_names: ctx.template_prop_names,
             source_context: ctx.source_context(),
+            preserve_event_navigation: ctx.preserve_event_navigation,
         };
         profile!(
             "canon.virtual_ts.closure_component_props",

--- a/crates/vize_canon/src/virtual_ts/scope/context.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/context.rs
@@ -79,6 +79,7 @@ pub(crate) struct VForPropsContext<'a> {
     pub(crate) vfor_enclosing_guards: &'a FxHashMap<u32, String>,
     pub(crate) template_prop_names: &'a FxHashSet<String>,
     pub(crate) source_context: ComponentPropSource<'a>,
+    pub(crate) preserve_event_navigation: bool,
 }
 
 pub(super) struct EventHandlerExprContext<'a> {

--- a/crates/vize_canon/src/virtual_ts/scope/empty_component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/empty_component_props.rs
@@ -11,6 +11,7 @@ use crate::virtual_ts::expressions::ComponentPropSource;
 use crate::virtual_ts::expressions::generate_component_prop_checks;
 use crate::virtual_ts::types::VizeMapping;
 
+use super::component_event_navigation;
 use super::component_prop_checker::has_inference_props;
 use super::context::{ComponentPropsContext, VForPropsContext};
 
@@ -92,6 +93,7 @@ pub(super) fn generate_scope_checks(
     let Some(usages) = ctx.components_by_scope.get(&scope_id) else {
         return;
     };
+    component_event_navigation::emit_scoped_event_references(ts, mappings, ctx, usages, indent);
     for &(idx, usage) in usages {
         if is_empty_props_usage(usage) {
             continue;


### PR DESCRIPTION
## Summary

- infer generic event payloads from dynamic setup-scope props and `v-for` aliases instead of falling back to the generic default
- emit closure-owned event navigation alongside scope-aware component prop checks so template aliases remain valid inputs to the event resolver
- keep diagnostic-only handler anchors out of hover and other editor features while preserving exact TS2322 diagnostics at the authored event name
- separate event, prop, and shared component-navigation generation responsibilities

## Test plan

- `cargo test -p vize_canon --lib --quiet` (891 passed)
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-tsgo-content-mapper.OA6YI7/tsgo cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-tsgo-content-mapper.OA6YI7/tsgo cargo test -p vize --test content_mapper_tsgo_lsp -- --nocapture`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-tsgo-content-mapper.OA6YI7/tsgo VIZE_TEST_CONTENT_MAPPER_JAVASCRIPT_TSC=./npm/cli/node_modules/.bin/tsc cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture`

Advances #4077 and #4072.
Relates to #4057 and #3282.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->