### PR TITLE
test(content-mapper): cover scoped slot events

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -165,6 +165,17 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             "cancel".len(),
             true,
         ),
+        (
+            "SlotGenericChild.vue",
+            "@activate",
+            "activate: [value",
+            "activate",
+            "\\\"slot\\\"",
+            "renamedActivate",
+            0,
+            "activate".len(),
+            true,
+        ),
     ]
     .map(
         |(
@@ -350,6 +361,7 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             );
 
             let partial = app_source
+                .replace("@activate", "@act")
                 .replace("@choose", "@cho")
                 .replace("@submit", "@sub")
                 .replace("@cancel", "@can")
@@ -360,6 +372,7 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
                 .replace(&app_document_uri, partial.as_str())
                 .unwrap();
             for (usage, label, payload) in [
+                ("@act", "activate", "\\\"slot\\\""),
                 ("@cho", "choose", "\\\"top-level\\\""),
                 ("@sub", "submit", "boolean"),
                 ("@can", "cancel", "string"),

--- a/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
@@ -7,6 +7,8 @@ import GenericChild from "./GenericChild.vue";
 import ModelChild from "./ModelChild.vue";
 import NestedGenericChild from "./NestedGenericChild.vue";
 import RuntimeChild from "./RuntimeChild.vue";
+import SlotGenericChild from "./SlotGenericChild.vue";
+import SlotProvider from "./SlotProvider.vue";
 import { increment } from "./model";
 
 defineProps<{ count: number }>();
@@ -17,6 +19,7 @@ const handleModelValue = (value: number) => value;
 const handlePick = (value: string) => value;
 const handleSelect = (value: "nested") => value;
 const handleSaveItem = (id: string) => id;
+const handleSlotActivate = (value: "slot") => value;
 const handleSubmit = (accepted: boolean) => accepted;
 const handleTitle = (title: string) => title;
 const nestedValues = ["nested"] as const;
@@ -37,4 +40,7 @@ const topLevelValue = "top-level" as const;
     @select="handleSelect"
   />
   <RuntimeChild @cancel="handleCancel" />
+  <SlotProvider v-slot="{ value }">
+    <SlotGenericChild :value="value" @activate="handleSlotActivate" />
+  </SlotProvider>
 </template>

--- a/crates/vize/tests/fixtures/content_mapper_project/src/SlotGenericChild.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/SlotGenericChild.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts" generic="T extends string = string">
+defineProps<{ value: T }>();
+defineEmits<{ activate: [value: T] }>();
+</script>
+
+<template>
+  <button type="button">Activate {{ value }}</button>
+</template>

--- a/crates/vize/tests/fixtures/content_mapper_project/src/SlotProvider.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/SlotProvider.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+defineSlots<{
+  default(props: { value: "slot" }): unknown;
+}>();
+</script>
+
+<template>
+  <slot value="slot" />
+</template>

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
@@ -284,3 +284,38 @@ const handleSelect = (value: "nested") => value;
             && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_ALL
     }));
 }
+
+#[test]
+fn emits_dynamic_generic_event_navigation_inside_the_v_slot_scope() {
+    let source = r#"<script setup lang="ts">
+import SlotGenericChild from "./SlotGenericChild.vue";
+import SlotProvider from "./SlotProvider.vue";
+const handleActivate = (value: "slot") => value;
+</script>
+<template>
+  <SlotProvider v-slot="{ value }">
+    <SlotGenericChild :value="value" @activate="handleActivate" />
+  </SlotProvider>
+</template>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("App.vue"), source).expect("transform");
+    let resolver = result
+        .text
+        .find("const __vize_events_resolved_")
+        .expect("event resolver");
+    let closure = result.text[..resolver]
+        .rfind("// Component props in v-slot scope")
+        .expect("component prop v-slot closure");
+
+    assert!(closure < resolver, "{}", result.text);
+    assert!(
+        result.text[resolver..].contains("\"value\": value"),
+        "{}",
+        result.text
+    );
+    assert_eq!(
+        result.text.matches("const __vize_events_resolved_").count(),
+        1
+    );
+}


### PR DESCRIPTION
## Summary

- cover generic event navigation when the inference prop comes from a scoped-slot alias
- assert the event resolver is emitted once inside the generated VSlot component-prop closure
- verify exact hover, definition, references, rename, partial completion, project checking, and declaration emission for the scoped-slot case

## Test plan

- `cargo test -p vize_canon --lib emits_dynamic_generic_event_navigation_inside_the_v_slot_scope -- --nocapture`
- `cargo clippy -p vize --test content_mapper_tsgo_lsp_event_forms -- -D warnings`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-tsgo-content-mapper.OA6YI7/tsgo cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-tsgo-content-mapper.OA6YI7/tsgo VIZE_TEST_CONTENT_MAPPER_JAVASCRIPT_TSC=./npm/cli/node_modules/.bin/tsc cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture`

Advances #4077 and #4072.
Relates to #4057 and #3282.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->