### PR TITLE
fix(content-mapper): narrow guarded generic events

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -78,6 +78,17 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             true,
         ),
         (
+            "ConditionalGenericChild.vue",
+            "@confirm",
+            "confirm: [value",
+            "confirm",
+            "\\\"conditional\\\"",
+            "renamedConfirm",
+            0,
+            "confirm".len(),
+            true,
+        ),
+        (
             "Child.vue",
             "@save-item",
             "saveItem: [id",
@@ -363,6 +374,7 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             let partial = app_source
                 .replace("@activate", "@act")
                 .replace("@choose", "@cho")
+                .replace("@confirm", "@con")
                 .replace("@submit", "@sub")
                 .replace("@cancel", "@can")
                 .replace("@select", "@sel")
@@ -374,6 +386,7 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             for (usage, label, payload) in [
                 ("@act", "activate", "\\\"slot\\\""),
                 ("@cho", "choose", "\\\"top-level\\\""),
+                ("@con", "confirm", "\\\"conditional\\\""),
                 ("@sub", "submit", "boolean"),
                 ("@can", "cancel", "string"),
                 ("@sel", "select", "\\\"nested\\\""),

--- a/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import CallSignatureChild from "./CallSignatureChild.vue";
 import Child from "./Child.vue";
+import ConditionalGenericChild from "./ConditionalGenericChild.vue";
 import DefaultModelChild from "./DefaultModelChild.vue";
 import DynamicGenericChild from "./DynamicGenericChild.vue";
 import GenericChild from "./GenericChild.vue";
@@ -12,9 +13,12 @@ import SlotProvider from "./SlotProvider.vue";
 import { increment } from "./model";
 
 defineProps<{ count: number }>();
+const conditionalValue: "conditional" | null =
+  Math.random() > 0.5 ? "conditional" : null;
 const defaultModelValue = 1;
 const handleCancel = (reason: string) => reason;
 const handleChoose = (value: "top-level") => value;
+const handleConfirm = (value: "conditional") => value;
 const handleModelValue = (value: number) => value;
 const handlePick = (value: string) => value;
 const handleSelect = (value: "nested") => value;
@@ -28,6 +32,11 @@ const topLevelValue = "top-level" as const;
 
 <template>
   <Child :count="increment(count)" @save="increment" @save-item="handleSaveItem" />
+  <ConditionalGenericChild
+    v-if="conditionalValue"
+    :value="conditionalValue"
+    @confirm="handleConfirm"
+  />
   <DefaultModelChild :model-value="defaultModelValue" @update:modelValue="handleModelValue" />
   <DynamicGenericChild :value="topLevelValue" @choose="handleChoose" />
   <CallSignatureChild @submit="handleSubmit" />

--- a/crates/vize/tests/fixtures/content_mapper_project/src/ConditionalGenericChild.vue
+++ b/crates/vize/tests/fixtures/content_mapper_project/src/ConditionalGenericChild.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts" generic="T extends string = string">
+defineProps<{ value: T }>();
+defineEmits<{ confirm: [value: T] }>();
+</script>
+
+<template>
+  <button type="button">Confirm {{ value }}</button>
+</template>

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_scoped_event_navigation_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_scoped_event_navigation_tests.rs
@@ -1,0 +1,63 @@
+use std::path::Path;
+
+use super::{CONTENT_MAPPER_SPAN_FEATURES_ALL, generate_vue_content_mapper_transform};
+
+#[test]
+fn emits_dynamic_generic_event_navigation_inside_the_v_if_guard() {
+    let source = r#"<script setup lang="ts">
+import ConditionalGenericChild from "./ConditionalGenericChild.vue";
+const conditionalValue: "conditional" | null = null;
+const handleConfirm = (value: "conditional") => value;
+</script>
+<template>
+  <ConditionalGenericChild
+    v-if="conditionalValue"
+    :value="conditionalValue"
+    @confirm="handleConfirm"
+  />
+</template>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("App.vue"), source).expect("transform");
+    let guard_comment = result
+        .text
+        .find("Navigation-only guard")
+        .expect("navigation guard comment");
+    let guard = guard_comment
+        + result.text[guard_comment..]
+            .find("if ((conditionalValue))")
+            .expect("navigation guard");
+    let resolver = result
+        .text
+        .find("const __vize_events_resolved_")
+        .expect("event resolver");
+
+    assert!(guard < resolver, "{}", result.text);
+    assert!(
+        result.text[resolver..].contains("\"value\": conditionalValue"),
+        "{}",
+        result.text
+    );
+    assert_eq!(
+        result.text.matches("const __vize_events_resolved_").count(),
+        1
+    );
+    let handler_inference = result
+        .text
+        .find("const __vize_emit_props_")
+        .expect("handler inference");
+    assert!(
+        result.text[handler_inference..].contains("= (() => {")
+            && result.text[handler_inference..]
+                .contains("if ((conditionalValue)) return (undefined as unknown as"),
+        "{}",
+        result.text
+    );
+
+    let original = source.find("@confirm").unwrap() + 1;
+    assert!(result.mappings.iter().any(|mapping| {
+        mapping.0[2] == original
+            && mapping.0[3] == "confirm".len()
+            && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_ALL
+    }));
+}

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -15,6 +15,8 @@ use crate::batch::{
 mod component_exports;
 #[path = "content_mapper_navigation_tests.rs"]
 mod navigation;
+#[path = "content_mapper_scoped_event_navigation_tests.rs"]
+mod scoped_event_navigation;
 
 #[test]
 fn keeps_diagnostic_handler_anchors_out_of_editor_features() {

--- a/crates/vize_canon/src/virtual_ts/scope/component_event_navigation.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_event_navigation.rs
@@ -4,8 +4,11 @@ use vize_carton::{FxHashSet, String, append, cstr};
 use vize_croquis::croquis::{ComponentUsage, EventListener};
 use vize_croquis::{Croquis, ScopeKind};
 
-use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier};
-use crate::virtual_ts::types::VizeMapping;
+use crate::virtual_ts::{
+    expressions::rewrite_reserved_template_prop,
+    helpers::{to_camel_case, to_safe_identifier},
+    types::VizeMapping,
+};
 
 use super::component_events::generated_prop_value;
 use super::component_navigation::{is_ts_identifier, push_ts_single_quoted_literal};
@@ -101,12 +104,28 @@ fn emit_usage_event_references(
     let mut emitted_model_ref = false;
     let mut emitted_model_completion_ref = false;
     let mut emitted_resolved_events = false;
+    let guard = usage.vif_guard.as_ref().map(|guard| {
+        rewrite_reserved_template_prop(guard.as_str(), ctx.template_prop_names)
+            .unwrap_or_else(|| guard.clone())
+    });
+    let guarded_indent = guard.as_ref().map(|_| cstr!("{indent}  "));
+    let event_indent = guarded_indent.as_deref().unwrap_or(indent);
+    let mut emitted_guard = false;
     for event in &usage.events {
         let camel_event_name = to_camel_case(event.name.as_str());
         let is_complete_kebab = camel_event_name != event.name && !event.name.ends_with('-');
         let Some(source_range) = event_navigation_source_range(ctx, event) else {
             continue;
         };
+        if !emitted_guard {
+            if let Some(guard) = guard.as_deref() {
+                append!(
+                    *ts,
+                    "{indent}// @ts-ignore Navigation-only guard; authored binding checks own diagnostics.\n{indent}if ({guard}) {{\n"
+                );
+            }
+            emitted_guard = true;
+        }
         let is_model_event = ctx.preserve_event_navigation && event.name.starts_with("update:");
         if !emitted_resolved_events && ctx.preserve_event_navigation {
             emit_resolved_events(
@@ -116,7 +135,7 @@ fn emit_usage_event_references(
                 component_ref,
                 idx,
                 resolved_events.as_str(),
-                indent,
+                event_indent,
             );
             emitted_resolved_events = true;
         }
@@ -124,11 +143,11 @@ fn emit_usage_event_references(
             if !emitted_model_completion_ref {
                 append!(
                     *ts,
-                    "{indent}const {model_completion_ref} = {resolved_events};\n"
+                    "{event_indent}const {model_completion_ref} = {resolved_events};\n"
                 );
                 emitted_model_completion_ref = true;
             }
-            append!(*ts, "{indent}void {model_completion_ref}[");
+            append!(*ts, "{event_indent}void {model_completion_ref}[");
             let generated = push_ts_single_quoted_literal(ts, event.name.as_str());
             ts.push_str("];\n");
             mappings.push(VizeMapping {
@@ -146,17 +165,20 @@ fn emit_usage_event_references(
         };
         if !*emitted_ref {
             if ctx.preserve_event_navigation {
-                append!(*ts, "{indent}const {events_ref} = {resolved_events};\n");
+                append!(
+                    *ts,
+                    "{event_indent}const {events_ref} = {resolved_events};\n"
+                );
             } else {
                 append!(
                     *ts,
-                    "{indent}const {events_ref} = undefined as unknown as __VizeComponentEvents<typeof {component_ref}> & Record<string, unknown>;\n"
+                    "{event_indent}const {events_ref} = undefined as unknown as __VizeComponentEvents<typeof {component_ref}> & Record<string, unknown>;\n"
                 );
             }
             *emitted_ref = true;
         }
 
-        append!(*ts, "{indent}void {events_ref}");
+        append!(*ts, "{event_indent}void {events_ref}");
         let event_gen_range = if is_complete_kebab {
             if is_ts_identifier(camel_event_name.as_str()) {
                 ts.push('.');
@@ -186,6 +208,9 @@ fn emit_usage_event_references(
             src_range: source_range,
             sub_spans: Vec::new(),
         });
+    }
+    if emitted_guard && guard.is_some() {
+        append!(*ts, "{indent}}}\n");
     }
 }
 

--- a/crates/vize_canon/src/virtual_ts/scope/component_events.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events.rs
@@ -1,18 +1,21 @@
 //! Component event listener type generation.
 
+mod generic_inference;
 mod handler_context;
 mod reference;
 
 use vize_carton::{FxHashSet, String, append, cstr};
 use vize_croquis::croquis::PassedProp;
 use vize_croquis::{
-    Croquis, EventHandlerScopeData, Scope, ScopeData, analysis::ComponentUsage,
-    analyzer::strip_js_comments, naming::to_pascal_case,
+    Croquis, EventHandlerScopeData, Scope, analyzer::strip_js_comments, naming::to_pascal_case,
 };
 
 use crate::virtual_ts::{
     expressions::rewrite_reserved_template_prop,
-    helpers::{to_camel_case, to_safe_identifier, to_safe_identifier_fragment},
+    helpers::{to_safe_identifier, to_safe_identifier_fragment},
+};
+use generic_inference::{
+    EmitInferenceContext, find_component_usage_for_event, generate_inferred_emit_args,
 };
 use handler_context::requires_unresolved_handler_implicit_any;
 use reference::component_reference_expression;
@@ -170,19 +173,6 @@ pub(super) fn generate_component_event_types(
     })
 }
 
-struct EmitInferenceContext<'a> {
-    summary: &'a Croquis,
-    component_name: &'a str,
-    data: &'a EventHandlerScopeData,
-    scope: &'a Scope,
-    component_ref: &'a str,
-    component_type_name: &'a str,
-    safe_event_name: &'a str,
-    prop_key: &'a str,
-    template_prop_names: &'a FxHashSet<String>,
-    indent: &'a str,
-}
-
 fn push_ts_string_literal(out: &mut String, value: &str) {
     out.push('"');
     for ch in value.chars() {
@@ -219,130 +209,4 @@ pub(super) fn generated_prop_value(
         || String::from(value.as_ref()),
         |s| String::from(s.as_str()),
     ))
-}
-
-fn generate_inferred_emit_args(ts: &mut String, ctx: &EmitInferenceContext<'_>) -> Option<String> {
-    if !is_local_vue_component_binding(ctx.summary, ctx.component_name) {
-        return None;
-    }
-    let (usage_idx, usage) =
-        find_component_usage_for_event(ctx.summary, ctx.component_name, ctx.data, ctx.scope)?;
-    if !usage.props.iter().any(|prop| {
-        !prop.name_is_dynamic
-            && prop.name.as_str() != "key"
-            && prop.name.as_str() != "ref"
-            && prop.value.is_some()
-            && prop.is_dynamic
-    }) {
-        return None;
-    }
-
-    let scope_id = ctx.scope.id.as_u32();
-    let resolver_type = cstr!(
-        "__{}_{}_{}_emit_resolver",
-        ctx.component_type_name,
-        scope_id,
-        ctx.safe_event_name
-    );
-    let emit_props = cstr!(
-        "__vize_emit_props_{}_{}_{}",
-        usage_idx,
-        scope_id,
-        ctx.safe_event_name
-    );
-    let inferred_args = cstr!(
-        "__{}_{}_{}_inferred_emit_args",
-        ctx.component_type_name,
-        scope_id,
-        ctx.safe_event_name
-    );
-    append!(
-        *ts,
-        "{}type {resolver_type} = typeof {} extends {{ __vizeResolveEmitProps?: infer __F }} ? (__F extends (...args: any[]) => any ? __F : (props: any) => {{}}) : typeof {} extends {{ __vizeResolveProps?: infer __F }} ? (__F extends (...args: any[]) => any ? __F : (props: any) => {{}}) : (props: any) => {{}};\n",
-        ctx.indent,
-        ctx.component_ref,
-        ctx.component_ref,
-    );
-    append!(
-        *ts,
-        "{}const {emit_props} = (undefined as unknown as {resolver_type})({{\n",
-        ctx.indent,
-    );
-    for prop in &usage.props {
-        if prop.name_is_dynamic || prop.name.as_str() == "key" || prop.name.as_str() == "ref" {
-            continue;
-        }
-        let Some(generated_value) = generated_prop_value(prop, ctx.template_prop_names) else {
-            continue;
-        };
-        let camel_prop_name = to_camel_case(prop.name.as_str());
-        append!(
-            *ts,
-            "{}  \"{camel_prop_name}\": {},\n",
-            ctx.indent,
-            generated_value.as_str(),
-        );
-    }
-    append!(*ts, "{}}});\n", ctx.indent);
-    append!(
-        *ts,
-        "{}type {inferred_args} = typeof {emit_props} extends {{ {}?: (...args: infer __A) => any }} ? __A : unknown[];\n",
-        ctx.indent,
-        ctx.prop_key,
-    );
-    Some(inferred_args)
-}
-
-fn is_local_vue_component_binding(summary: &Croquis, component_name: &str) -> bool {
-    let Some((binding_start, binding_end)) = summary.binding_spans.get(component_name) else {
-        return false;
-    };
-
-    summary.scopes.iter().any(|scope| {
-        scope.span.start <= *binding_start
-            && *binding_end <= scope.span.end
-            && matches!(
-                scope.data(),
-                ScopeData::ExternalModule(data)
-                    if !data.is_type_only && data.source.as_str().ends_with(".vue")
-            )
-    })
-}
-
-fn find_component_usage_for_event<'a>(
-    summary: &'a Croquis,
-    component_name: &str,
-    data: &EventHandlerScopeData,
-    scope: &Scope,
-) -> Option<(usize, &'a ComponentUsage)> {
-    summary
-        .component_usages
-        .iter()
-        .enumerate()
-        .find(|(_, usage)| {
-            usage.name.as_str() == component_name
-                && usage.events.iter().any(|event| {
-                    !event.name_is_dynamic
-                        && event.name.as_str() == data.event_name.as_str()
-                        && event_matches_scope(usage, event.start, event.end, data, scope)
-                })
-        })
-}
-
-fn event_matches_scope(
-    usage: &ComponentUsage,
-    event_start: u32,
-    event_end: u32,
-    data: &EventHandlerScopeData,
-    scope: &Scope,
-) -> bool {
-    let exact = event_start == scope.span.start && event_end == scope.span.end;
-    let event_contains_scope = event_start <= scope.span.start && scope.span.end <= event_end;
-    let scope_in_usage = usage.start <= scope.span.start && scope.span.end <= usage.end;
-    let same_handler = usage.events.iter().any(|event| {
-        event.start == event_start
-            && event.end == event_end
-            && data.handler_expression.as_deref() == event.handler.as_deref()
-    });
-    exact || event_contains_scope || (scope_in_usage && same_handler)
 }

--- a/crates/vize_canon/src/virtual_ts/scope/component_events/generic_inference.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_events/generic_inference.rs
@@ -1,0 +1,173 @@
+use vize_carton::{FxHashSet, String, append, cstr};
+use vize_croquis::{Croquis, EventHandlerScopeData, Scope, ScopeData, analysis::ComponentUsage};
+
+use crate::virtual_ts::{expressions::rewrite_reserved_template_prop, helpers::to_camel_case};
+
+use super::generated_prop_value;
+
+pub(super) struct EmitInferenceContext<'a> {
+    pub(super) summary: &'a Croquis,
+    pub(super) component_name: &'a str,
+    pub(super) data: &'a EventHandlerScopeData,
+    pub(super) scope: &'a Scope,
+    pub(super) component_ref: &'a str,
+    pub(super) component_type_name: &'a str,
+    pub(super) safe_event_name: &'a str,
+    pub(super) prop_key: &'a str,
+    pub(super) template_prop_names: &'a FxHashSet<String>,
+    pub(super) indent: &'a str,
+}
+
+pub(super) fn generate_inferred_emit_args(
+    ts: &mut String,
+    ctx: &EmitInferenceContext<'_>,
+) -> Option<String> {
+    if !is_local_vue_component_binding(ctx.summary, ctx.component_name) {
+        return None;
+    }
+    let (usage_idx, usage) =
+        find_component_usage_for_event(ctx.summary, ctx.component_name, ctx.data, ctx.scope)?;
+    if !usage.props.iter().any(|prop| {
+        !prop.name_is_dynamic
+            && prop.name.as_str() != "key"
+            && prop.name.as_str() != "ref"
+            && prop.value.is_some()
+            && prop.is_dynamic
+    }) {
+        return None;
+    }
+
+    let scope_id = ctx.scope.id.as_u32();
+    let resolver_type = cstr!(
+        "__{}_{}_{}_emit_resolver",
+        ctx.component_type_name,
+        scope_id,
+        ctx.safe_event_name
+    );
+    let emit_props = cstr!(
+        "__vize_emit_props_{}_{}_{}",
+        usage_idx,
+        scope_id,
+        ctx.safe_event_name
+    );
+    let inferred_args = cstr!(
+        "__{}_{}_{}_inferred_emit_args",
+        ctx.component_type_name,
+        scope_id,
+        ctx.safe_event_name
+    );
+    append!(
+        *ts,
+        "{}type {resolver_type} = typeof {} extends {{ __vizeResolveEmitProps?: infer __F }} ? (__F extends (...args: any[]) => any ? __F : (props: any) => {{}}) : typeof {} extends {{ __vizeResolveProps?: infer __F }} ? (__F extends (...args: any[]) => any ? __F : (props: any) => {{}}) : (props: any) => {{}};\n",
+        ctx.indent,
+        ctx.component_ref,
+        ctx.component_ref,
+    );
+    let guard = usage.vif_guard.as_ref().map(|guard| {
+        rewrite_reserved_template_prop(guard.as_str(), ctx.template_prop_names)
+            .unwrap_or_else(|| guard.clone())
+    });
+    let guarded_call_indent = guard.as_ref().map(|_| cstr!("{}  ", ctx.indent));
+    let call_indent = guarded_call_indent.as_deref().unwrap_or(ctx.indent);
+    if guard.is_some() {
+        append!(*ts, "{}const {emit_props} = (() => {{\n", ctx.indent);
+        append!(
+            *ts,
+            "{call_indent}// @ts-ignore Inference-only guard; authored binding checks own diagnostics.\n"
+        );
+        append!(
+            *ts,
+            "{call_indent}if ({}) return (undefined as unknown as {resolver_type})({{\n",
+            guard.as_deref().unwrap()
+        );
+    } else {
+        append!(
+            *ts,
+            "{}const {emit_props} = (undefined as unknown as {resolver_type})({{\n",
+            ctx.indent,
+        );
+    }
+    for prop in &usage.props {
+        if prop.name_is_dynamic || prop.name.as_str() == "key" || prop.name.as_str() == "ref" {
+            continue;
+        }
+        let Some(generated_value) = generated_prop_value(prop, ctx.template_prop_names) else {
+            continue;
+        };
+        let camel_prop_name = to_camel_case(prop.name.as_str());
+        append!(
+            *ts,
+            "{call_indent}  \"{camel_prop_name}\": {},\n",
+            generated_value.as_str(),
+        );
+    }
+    append!(*ts, "{call_indent}}});\n");
+    if guard.is_some() {
+        append!(
+            *ts,
+            "{call_indent}return undefined as never;\n{}}})();\n",
+            ctx.indent
+        );
+    }
+    append!(
+        *ts,
+        "{}type {inferred_args} = typeof {emit_props} extends {{ {}?: (...args: infer __A) => any }} ? __A : unknown[];\n",
+        ctx.indent,
+        ctx.prop_key,
+    );
+    Some(inferred_args)
+}
+
+fn is_local_vue_component_binding(summary: &Croquis, component_name: &str) -> bool {
+    let Some((binding_start, binding_end)) = summary.binding_spans.get(component_name) else {
+        return false;
+    };
+
+    summary.scopes.iter().any(|scope| {
+        scope.span.start <= *binding_start
+            && *binding_end <= scope.span.end
+            && matches!(
+                scope.data(),
+                ScopeData::ExternalModule(data)
+                    if !data.is_type_only && data.source.as_str().ends_with(".vue")
+            )
+    })
+}
+
+pub(super) fn find_component_usage_for_event<'a>(
+    summary: &'a Croquis,
+    component_name: &str,
+    data: &EventHandlerScopeData,
+    scope: &Scope,
+) -> Option<(usize, &'a ComponentUsage)> {
+    summary
+        .component_usages
+        .iter()
+        .enumerate()
+        .find(|(_, usage)| {
+            usage.name.as_str() == component_name
+                && usage.events.iter().any(|event| {
+                    !event.name_is_dynamic
+                        && event.name.as_str() == data.event_name.as_str()
+                        && event_matches_scope(usage, event.start, event.end, data, scope)
+                })
+        })
+}
+
+fn event_matches_scope(
+    usage: &ComponentUsage,
+    event_start: u32,
+    event_end: u32,
+    data: &EventHandlerScopeData,
+    scope: &Scope,
+) -> bool {
+    let exact = event_start == scope.span.start && event_end == scope.span.end;
+    let event_contains_scope = event_start <= scope.span.start && scope.span.end <= event_end;
+    let scope_in_usage = usage.start <= scope.span.start && scope.span.end <= usage.end;
+    let same_handler = usage.events.iter().any(|event| {
+        event.start == event_start
+            && event.end == event_end
+            && data.handler_expression.as_deref() == event.handler.as_deref()
+    });
+    exact || event_contains_scope || (scope_in_usage && same_handler)
+}


### PR DESCRIPTION
## Summary

- evaluate Content Mapper event resolvers inside authored `v-if` guards so nullable dynamic props infer their narrowed generic payload
- guard handler-payload inference in an IIFE as well, preventing unmapped generated TS2322 errors and false-positive listener diagnostics
- keep navigation-only guard diagnostics suppressed while the authored binding checker remains the single diagnostic owner
- move generic event inference into a focused module and keep the unguarded hot path allocation-free

## Test plan

- `cargo test -p vize_canon --lib --quiet` (893 passed)
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-tsgo-content-mapper.OA6YI7/tsgo cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-tsgo-content-mapper.OA6YI7/tsgo cargo test -p vize --test content_mapper_tsgo_lsp -- --nocapture`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-tsgo-content-mapper.OA6YI7/tsgo VIZE_TEST_CONTENT_MAPPER_JAVASCRIPT_TSC=./npm/cli/node_modules/.bin/tsc cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture`

Completes the remaining acceptance case in #4077.
Advances #4072 and relates to #4057 and #3282.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->