### PR TITLE
fix(lsp): preserve component event rename casing

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -142,6 +142,7 @@ pub(super) fn build_vue_registered_file(
                 options_api: context.options_api,
                 preserve_authored_component: false,
                 component_name: None,
+                preserve_event_navigation: false,
                 legacy_vue2: context.legacy_vue2,
                 dialect: context.dialect,
                 template_syntax: context.template_syntax,

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -159,6 +159,7 @@ pub fn generate_vue_content_mapper_transform_with_options(
             options_api: transform_options.options_api(),
             preserve_authored_component: true,
             component_name: Some(component_name.as_str()),
+            preserve_event_navigation: true,
             legacy_vue2: false,
             dialect: VueVersion::default(),
             template_syntax: TemplateSyntaxMode::default(),

--- a/crates/vize_canon/src/batch/virtual_project/document.rs
+++ b/crates/vize_canon/src/batch/virtual_project/document.rs
@@ -37,6 +37,7 @@ pub struct VueDocumentVirtualTs {
 pub struct VueDocumentVirtualTsOptions {
     pub options_api: bool,
     pub legacy_vue2: bool,
+    pub preserve_event_navigation: bool,
 }
 
 /// Generate the rewritten virtual TypeScript for one in-memory `.vue` document.
@@ -116,6 +117,7 @@ pub(crate) fn generate_vue_document_virtual_ts_with_options_and_alias_resolver(
             options_api: document_options.options_api,
             preserve_authored_component: false,
             component_name: None,
+            preserve_event_navigation: document_options.preserve_event_navigation,
             legacy_vue2: document_options.legacy_vue2,
             dialect: vize_carton::config::VueVersion::default(),
             template_syntax: TemplateSyntaxMode::default(),

--- a/crates/vize_canon/src/batch/virtual_project/tests/setup_props.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/setup_props.rs
@@ -97,6 +97,7 @@ void props
         super::super::VueDocumentVirtualTsOptions {
             legacy_vue2: true,
             options_api: false,
+            ..Default::default()
         },
     )
     .unwrap()
@@ -108,6 +109,39 @@ void props
         ),
         "legacy Vue2 template scope must expose inline defineProps keys:\n{virtual_ts}"
     );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn document_generator_preserves_component_event_symbol_links_on_request() {
+    let case_dir = unique_case_dir("event-navigation");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(&case_dir).unwrap();
+    let vue_path = case_dir.join("Parent.vue");
+    let vue_content = r#"<script setup lang="ts">
+import Child from "./Child.vue";
+</script>
+<template><Child @save-item="() => undefined" /></template>
+"#;
+    let rewriter = super::super::super::import_rewriter::ImportRewriter::new();
+    let virtual_ts = super::super::generate_vue_document_virtual_ts_with_options(
+        &vue_path,
+        vue_content,
+        &VirtualTsOptions::default(),
+        &rewriter,
+        false,
+        super::super::VueDocumentVirtualTsOptions {
+            preserve_event_navigation: true,
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    .pre_rewrite_code;
+
+    assert!(virtual_ts.contains("type __vize_events_resolver_0 = typeof Child"));
+    assert!(virtual_ts.contains("const __vize_kebab_events_nav_0 = __vize_events_resolved_0;"));
+    assert!(virtual_ts.contains("void __vize_kebab_events_nav_0.saveItem;"));
 
     let _ = fs::remove_dir_all(&case_dir);
 }

--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -49,6 +49,7 @@ pub(super) struct VueCodegenOptions<'a> {
     pub(super) options_api: bool,
     pub(super) preserve_authored_component: bool,
     pub(super) component_name: Option<&'a str>,
+    pub(super) preserve_event_navigation: bool,
     pub(super) legacy_vue2: bool,
     pub(super) dialect: VueVersion,
     pub(super) template_syntax: TemplateSyntaxMode,
@@ -249,6 +250,7 @@ pub(super) fn generate_vue_virtual_ts(
                 options_api: codegen_options.options_api || vue2_compat,
                 preserve_authored_component: codegen_options.preserve_authored_component,
                 component_name: codegen_options.component_name,
+                preserve_event_navigation: codegen_options.preserve_event_navigation,
                 legacy_vue2: vue2_compat,
                 template_syntax_quirks: matches!(
                     codegen_options.template_syntax,

--- a/crates/vize_canon/src/corsa_bridge/vue_document.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document.rs
@@ -19,6 +19,7 @@ use crate::virtual_ts::{VirtualTsOptions, VizeMapping};
 pub struct CorsaVueVirtualDocumentOptions {
     pub options_api: bool,
     pub legacy_vue2: bool,
+    pub preserve_event_navigation: bool,
 }
 
 /// A Vue SFC projected into the TypeScript document queried by Corsa.
@@ -289,6 +290,7 @@ fn generate_vue_document_with_options(
         VueDocumentVirtualTsOptions {
             options_api: options.options_api,
             legacy_vue2: options.legacy_vue2,
+            preserve_event_navigation: options.preserve_event_navigation,
         },
         alias_resolver
             .as_ref()

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -726,7 +726,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                             check_unresolved_global_components: global_components.component_check(),
                             legacy_vue2,
                             options_api,
-                            preserve_event_navigation: generation_options.component_name.is_some(),
+                            preserve_event_navigation: generation_options.preserve_event_navigation,
                             has_default_alias: declared_default_alias,
                             script_content,
                         },
@@ -865,7 +865,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         &mut ts,
         summary,
         MacroTypeMappings::new(&mut mappings, script_content, &script_source_offset),
-        generation_options.component_name.is_some(),
+        generation_options.preserve_event_navigation,
         generic_param,
         define_emits_runtime_args.is_some(),
     );

--- a/crates/vize_canon/src/virtual_ts/types.rs
+++ b/crates/vize_canon/src/virtual_ts/types.rs
@@ -165,6 +165,8 @@ pub(crate) struct VirtualTsGenerationOptions<'a> {
     /// Public-facing component symbol used by Content Mapper hover responses.
     /// `None` preserves the internal default export used by batch projections.
     pub(crate) component_name: Option<&'a str>,
+    /// Preserve symbol links from component listeners to authored emit keys.
+    pub(crate) preserve_event_navigation: bool,
     /// Legacy Vue 2.7 / Nuxt 2 (implies `options_api` plus Nuxt 2 globals).
     pub(crate) legacy_vue2: bool,
     /// Preserve Vue parser compatibility semantics when generating template

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/open.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/open.rs
@@ -36,6 +36,7 @@ pub(super) async fn open_canonical_virtual_document_with_overlays(
             CorsaVueVirtualDocumentOptions {
                 options_api: ctx.state.options_api_enabled(),
                 legacy_vue2: ctx.state.legacy_vue2_enabled(),
+                preserve_event_navigation: true,
             },
             overlays,
             &vize_canon::virtual_ts::VirtualTsOptions::default(),

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
@@ -131,6 +131,7 @@ impl DiagnosticService {
                 CorsaVueVirtualDocumentOptions {
                     options_api,
                     legacy_vue2,
+                    preserve_event_navigation: false,
                 },
             )
             .await;
@@ -165,6 +166,7 @@ impl DiagnosticService {
                     CorsaVueVirtualDocumentOptions {
                         options_api,
                         legacy_vue2,
+                        preserve_event_navigation: false,
                     },
                     &overlays,
                     &virtual_ts_options,

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs
@@ -76,6 +76,7 @@ impl DiagnosticService {
             VueDocumentVirtualTsOptions {
                 options_api,
                 legacy_vue2,
+                preserve_event_navigation: false,
             },
         )
         .ok()?;

--- a/crates/vize_maestro/src/ide/jsx/service_project.rs
+++ b/crates/vize_maestro/src/ide/jsx/service_project.rs
@@ -27,6 +27,7 @@ pub(super) async fn open_virtual_project(
             CorsaVueVirtualDocumentOptions {
                 options_api: ctx.state.options_api_enabled(),
                 legacy_vue2: ctx.state.legacy_vue2_enabled(),
+                preserve_event_navigation: true,
             },
             &overlays,
         )

--- a/crates/vize_maestro/src/ide/rename.rs
+++ b/crates/vize_maestro/src/ide/rename.rs
@@ -127,10 +127,6 @@ impl RenameService {
         new_name: &str,
         corsa_bridge: Option<Arc<CorsaBridge>>,
     ) -> Option<WorkspaceEdit> {
-        if !Self::is_valid_identifier(new_name) {
-            return None;
-        }
-
         if let canonical::Answer::Available(edit) =
             canonical::rename(ctx, new_name, corsa_bridge.as_deref()).await
         {

--- a/crates/vize_maestro/src/ide/rename/canonical.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical.rs
@@ -9,6 +9,8 @@ use vize_carton::{FxHashSet, String};
 
 use crate::ide::{IdeContext, ReferencesService, corsa_support};
 
+mod event_rename;
+
 pub(super) enum Answer<T> {
     Unavailable,
     Available(Option<T>),
@@ -24,8 +26,8 @@ pub(super) async fn prepare(
     let Some(document) = corsa_support::open_canonical_virtual_document(ctx, bridge).await else {
         return Answer::Unavailable;
     };
-    let Some((line, character)) =
-        corsa_support::canonical_source_offset_to_position(&document, ctx.offset)
+    let Some((line, character)) = event_rename::semantic_position(ctx, &document)
+        .or_else(|| corsa_support::canonical_source_offset_to_position(&document, ctx.offset))
     else {
         return Answer::Unavailable;
     };
@@ -37,11 +39,11 @@ pub(super) async fn prepare(
         Err(_) => return Answer::Unavailable,
     };
     let response = response.and_then(|response| serde_json::from_value(response).ok());
-    Answer::Available(
-        response.and_then(|response| {
-            corsa_support::map_canonical_prepare_rename(ctx, &document, response)
-        }),
-    )
+    Answer::Available(response.and_then(|response| {
+        event_rename::prepare_range(ctx)
+            .map(PrepareRenameResponse::Range)
+            .or_else(|| corsa_support::map_canonical_prepare_rename(ctx, &document, response))
+    }))
 }
 
 pub(super) async fn rename(
@@ -49,6 +51,10 @@ pub(super) async fn rename(
     new_name: &str,
     bridge: Option<&CorsaBridge>,
 ) -> Answer<WorkspaceEdit> {
+    let is_component_event = event_rename::query_is_component_event(ctx);
+    let Some(semantic_name) = event_rename::semantic_name(is_component_event, new_name) else {
+        return Answer::Available(None);
+    };
     let Some(bridge) = initialized_bridge(bridge) else {
         return Answer::Unavailable;
     };
@@ -56,13 +62,13 @@ pub(super) async fn rename(
     else {
         return Answer::Unavailable;
     };
-    let Some((line, character)) =
-        corsa_support::canonical_source_offset_to_position(&document, ctx.offset)
+    let Some((line, character)) = event_rename::semantic_position(ctx, &document)
+        .or_else(|| corsa_support::canonical_source_offset_to_position(&document, ctx.offset))
     else {
         return Answer::Unavailable;
     };
     let response = match bridge
-        .rename(&document.request_uri, line, character, new_name)
+        .rename(&document.request_uri, line, character, &semantic_name)
         .await
     {
         Ok(response) => response,
@@ -85,7 +91,7 @@ pub(super) async fn rename(
                 &position.request_uri,
                 position.line,
                 position.character,
-                new_name,
+                &semantic_name,
             )
             .await
         else {
@@ -102,6 +108,12 @@ pub(super) async fn rename(
     }
     if let Some(styles) = style_workspace_edit(ctx, &mapped, new_name) {
         mapped.push(styles);
+    }
+
+    if is_component_event {
+        for edit in &mut mapped {
+            event_rename::rewrite_edits(ctx, edit, &semantic_name);
+        }
     }
 
     Answer::Available(corsa_support::merge_canonical_workspace_edits(mapped))

--- a/crates/vize_maestro/src/ide/rename/canonical/event_rename.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/event_rename.rs
@@ -1,0 +1,326 @@
+use std::ops::Range as OffsetRange;
+
+use tower_lsp::lsp_types::{
+    DocumentChangeOperation, DocumentChanges, OneOf, Range, TextEdit, Url, WorkspaceEdit,
+};
+use vize_croquis::{Drawer, DrawerOptions};
+
+use crate::ide::{IdeContext, corsa_support::CanonicalVirtualDocument, pascal_to_kebab};
+
+use super::super::RenameService;
+
+pub(super) fn query_is_component_event(ctx: &IdeContext<'_>) -> bool {
+    component_event_range_at(ctx).is_some() || query_is_event_declaration(ctx)
+}
+
+pub(super) fn semantic_name(is_component_event: bool, new_name: &str) -> Option<String> {
+    if RenameService::is_valid_identifier(new_name) {
+        return Some(new_name.to_string());
+    }
+    if !is_component_event {
+        return None;
+    }
+    if !vize_croquis::naming::is_kebab_case(new_name) {
+        return None;
+    }
+    let camel = crate::ide::definition::helpers::kebab_to_camel(new_name);
+    RenameService::is_valid_identifier(&camel).then_some(camel)
+}
+
+pub(super) fn prepare_range(ctx: &IdeContext<'_>) -> Option<Range> {
+    component_event_range_at(ctx).map(|range| offset_range(&ctx.content, range))
+}
+
+pub(super) fn semantic_position(
+    ctx: &IdeContext<'_>,
+    document: &CanonicalVirtualDocument,
+) -> Option<(u32, u32)> {
+    let source_range = component_event_range_at(ctx)?;
+    let authored = ctx.content.get(source_range.clone())?;
+    let semantic = crate::ide::definition::helpers::kebab_to_camel(authored);
+    document
+        .virtual_result
+        .source_mappings
+        .iter()
+        .filter(|mapping| mapping.src_range == source_range)
+        .find_map(|mapping| {
+            let start = document
+                .virtual_result
+                .import_source_map
+                .get_virtual_offset(mapping.gen_range.start as u32)
+                as usize;
+            let end = document
+                .virtual_result
+                .import_source_map
+                .get_virtual_offset(mapping.gen_range.end as u32) as usize;
+            let line_start = document.virtual_result.code[..start]
+                .rfind('\n')
+                .map_or(0, |index| index + 1);
+            let is_navigation = document.virtual_result.code[line_start..start]
+                .trim_start()
+                .starts_with("void __vize_kebab_events_nav_");
+            (is_navigation
+                && document.virtual_result.code.get(start..end) == Some(semantic.as_str()))
+            .then(|| {
+                crate::ide::offset_to_position(
+                    &document.virtual_result.code,
+                    start + usize::from(start < end),
+                )
+            })
+        })
+}
+
+pub(super) fn rewrite_edits(ctx: &IdeContext<'_>, edit: &mut WorkspaceEdit, semantic_name: &str) {
+    if let Some(changes) = edit.changes.as_mut() {
+        for (uri, edits) in changes {
+            rewrite_text_edits(ctx, uri, edits, semantic_name);
+        }
+    }
+    if let Some(changes) = edit.document_changes.as_mut() {
+        match changes {
+            DocumentChanges::Edits(edits) => {
+                for edit in edits {
+                    rewrite_annotatable_edits(
+                        ctx,
+                        &edit.text_document.uri,
+                        &mut edit.edits,
+                        semantic_name,
+                    );
+                }
+            }
+            DocumentChanges::Operations(operations) => {
+                for operation in operations {
+                    if let DocumentChangeOperation::Edit(edit) = operation {
+                        rewrite_annotatable_edits(
+                            ctx,
+                            &edit.text_document.uri,
+                            &mut edit.edits,
+                            semantic_name,
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn rewrite_annotatable_edits(
+    ctx: &IdeContext<'_>,
+    uri: &Url,
+    edits: &mut [OneOf<TextEdit, tower_lsp::lsp_types::AnnotatedTextEdit>],
+    semantic_name: &str,
+) {
+    let Some(source) = source_for_uri(ctx, uri) else {
+        return;
+    };
+    let ranges = component_event_ranges(&source, uri.path());
+    for edit in edits {
+        match edit {
+            OneOf::Left(edit) => rewrite_text_edit(&source, &ranges, edit, semantic_name),
+            OneOf::Right(edit) => {
+                rewrite_text_edit(&source, &ranges, &mut edit.text_edit, semantic_name);
+            }
+        }
+    }
+}
+
+fn rewrite_text_edits(
+    ctx: &IdeContext<'_>,
+    uri: &Url,
+    edits: &mut [TextEdit],
+    semantic_name: &str,
+) {
+    let Some(source) = source_for_uri(ctx, uri) else {
+        return;
+    };
+    let ranges = component_event_ranges(&source, uri.path());
+    for edit in edits {
+        rewrite_text_edit(&source, &ranges, edit, semantic_name);
+    }
+}
+
+fn rewrite_text_edit(
+    source: &str,
+    ranges: &[OffsetRange<usize>],
+    edit: &mut TextEdit,
+    semantic_name: &str,
+) {
+    let Some(start) =
+        crate::ide::position_to_offset(source, edit.range.start.line, edit.range.start.character)
+    else {
+        return;
+    };
+    let Some(range) = ranges
+        .iter()
+        .find(|range| start >= range.start && start < range.end)
+    else {
+        return;
+    };
+    edit.range = offset_range(source, range.clone());
+    edit.new_text = pascal_to_kebab(semantic_name);
+}
+
+fn source_for_uri(ctx: &IdeContext<'_>, uri: &Url) -> Option<String> {
+    ctx.state
+        .documents
+        .text(uri)
+        .map(|source| source.to_string())
+        .or_else(|| {
+            uri.to_file_path()
+                .ok()
+                .and_then(|path| std::fs::read_to_string(path).ok())
+        })
+}
+
+fn component_event_range_at(ctx: &IdeContext<'_>) -> Option<OffsetRange<usize>> {
+    component_event_ranges(&ctx.content, ctx.uri.path())
+        .into_iter()
+        .find(|range| ctx.offset >= range.start && ctx.offset < range.end)
+}
+
+fn component_event_ranges(source: &str, filename: &str) -> Vec<OffsetRange<usize>> {
+    let Ok(descriptor) = vize_atelier_sfc::parse_sfc(
+        source,
+        vize_atelier_sfc::SfcParseOptions {
+            filename: filename.to_string().into(),
+            ..Default::default()
+        },
+    ) else {
+        return Vec::new();
+    };
+    let Some(template) = descriptor.template else {
+        return Vec::new();
+    };
+    let Some(template_source) = source.get(template.loc.start..template.loc.end) else {
+        return Vec::new();
+    };
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template_source);
+    let mut drawer = Drawer::with_options(DrawerOptions {
+        analyze_template_scopes: true,
+        track_usage: true,
+        ..Default::default()
+    });
+    drawer.draw_template(&root);
+    let croquis = drawer.finish();
+    let mut ranges = Vec::new();
+    for usage in &croquis.component_usages {
+        for event in &usage.events {
+            if event.name_is_dynamic {
+                continue;
+            }
+            let start = template.loc.start + event.start as usize;
+            let end = template.loc.start + event.end as usize;
+            let Some(directive) = source.get(start..end) else {
+                continue;
+            };
+            let Some(prefix_len) = ["@", "v-on:"].into_iter().find_map(|prefix| {
+                directive
+                    .strip_prefix(prefix)
+                    .filter(|rest| rest.starts_with(event.name.as_str()))
+                    .map(|_| prefix.len())
+            }) else {
+                continue;
+            };
+            let name_start = start + prefix_len;
+            ranges.push(name_start..name_start + event.name.len());
+        }
+    }
+    ranges
+}
+
+fn query_is_event_declaration(ctx: &IdeContext<'_>) -> bool {
+    let Ok(descriptor) = vize_atelier_sfc::parse_sfc(
+        &ctx.content,
+        vize_atelier_sfc::SfcParseOptions {
+            filename: ctx.uri.path().to_string().into(),
+            ..Default::default()
+        },
+    ) else {
+        return false;
+    };
+    let Some(script) = descriptor.script_setup else {
+        return false;
+    };
+    let Some(relative) = ctx.offset.checked_sub(script.loc.start) else {
+        return false;
+    };
+    let mut drawer = Drawer::with_options(DrawerOptions {
+        analyze_script: true,
+        ..Default::default()
+    });
+    drawer.analyze_script_setup(&script.content);
+    let croquis = drawer.finish();
+    croquis.macros.emits().iter().any(|event| {
+        croquis
+            .macros
+            .emit_declaration(event.name.as_str())
+            .is_some_and(|range| relative >= range.0 as usize && relative < range.1 as usize)
+    })
+}
+
+fn offset_range(source: &str, range: OffsetRange<usize>) -> Range {
+    let (start_line, start_character) = crate::ide::offset_to_position(source, range.start);
+    let (end_line, end_character) = crate::ide::offset_to_position(source, range.end);
+    Range {
+        start: tower_lsp::lsp_types::Position {
+            line: start_line,
+            character: start_character,
+        },
+        end: tower_lsp::lsp_types::Position {
+            line: end_line,
+            character: end_character,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tower_lsp::lsp_types::Url;
+
+    use super::{component_event_ranges, semantic_name};
+    use crate::ide::IdeContext;
+    use crate::server::ServerState;
+
+    #[test]
+    fn finds_the_whole_authored_component_event_name() {
+        let source = r#"<script setup>import Child from "./Child.vue"</script>
+<template><Child @save-item="handler" /></template>"#;
+        let ranges = component_event_ranges(source, "Parent.vue");
+        assert_eq!(ranges.len(), 1, "{ranges:#?}");
+        assert_eq!(&source[ranges[0].clone()], "save-item");
+    }
+
+    #[test]
+    fn accepts_kebab_replacements_for_static_emit_declarations() {
+        for (index, (source, needle)) in [
+            ("defineEmits<{ saveItem: [id: string] }>();", "saveItem"),
+            (
+                "defineEmits<{ (event: 'saveItem', id: string): void }>();",
+                "saveItem",
+            ),
+            ("defineEmits(['saveItem']);", "saveItem"),
+            (
+                "defineEmits({ saveItem: (id: string) => true });",
+                "saveItem",
+            ),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let source = format!("<script setup lang=\"ts\">{source}</script>");
+            let uri = Url::parse(&format!("file:///Child{index}.vue")).expect("uri");
+            let state = ServerState::new();
+            state
+                .documents
+                .open(uri.clone(), source.clone(), 1, "vue".to_string());
+            let offset = source.find(needle).expect("event declaration") + 1;
+            let ctx = IdeContext::new(&state, &uri, offset).expect("context");
+            assert!(super::query_is_component_event(&ctx), "{source}");
+            assert_eq!(
+                semantic_name(true, "next-event").as_deref(),
+                Some("nextEvent")
+            );
+        }
+    }
+}

--- a/crates/vize_maestro/src/ide/rename/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_tests.rs
@@ -164,6 +164,146 @@ function unrelated() { const shared = 0; return shared }
     });
 }
 
+#[test]
+fn canonical_component_event_rename_preserves_camel_and_kebab_sites() {
+    crate::runtime::block_on(async {
+        let Some(tsgo_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = project.path().join("src");
+        fs::create_dir_all(&src).expect("src");
+        fs::write(
+            project.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .expect("tsconfig");
+
+        let child_source = r#"<script setup lang="ts">
+defineEmits<{ saveItem: [id: string] }>();
+</script>
+"#;
+        let parent_source = r#"<script setup lang="ts">
+import Child from "./Child.vue";
+const handleSave = (id: string) => id;
+</script>
+<template>💥 <Child @save-item="handleSave" /></template>
+"#;
+        let child_path = src.join("Child.vue");
+        let parent_path = src.join("Parent.vue");
+        fs::write(&child_path, child_source).expect("child");
+        fs::write(&parent_path, parent_source).expect("parent");
+        let child_uri = Url::from_file_path(&child_path).expect("child uri");
+        let parent_uri = Url::from_file_path(&parent_path).expect("parent uri");
+        let state = ServerState::new();
+        state.set_workspace_root(project.path().to_path_buf());
+        for (uri, source) in [(&child_uri, child_source), (&parent_uri, parent_source)] {
+            state
+                .documents
+                .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+            state.update_virtual_docs(uri, source);
+        }
+        let bridge = Arc::new(CorsaBridge::with_config(CorsaBridgeConfig {
+            corsa_path: Some(tsgo_path),
+            working_dir: Some(project.path().to_path_buf()),
+            timeout_ms: 30_000,
+            ..Default::default()
+        }));
+        bridge.spawn().await.expect("tsgo session");
+
+        let event_start = parent_source.find("save-item").expect("parent event");
+        for relative in 0.."save-item".len() {
+            let cursor_ctx =
+                IdeContext::new(&state, &parent_uri, event_start + relative).expect("cursor ctx");
+            let prepared =
+                RenameService::prepare_rename_with_corsa(&cursor_ctx, Some(Arc::clone(&bridge)))
+                    .await
+                    .expect("prepare event rename at every cursor");
+            assert_eq!(
+                authored_text(parent_source, prepare_range(prepared)),
+                "save-item"
+            );
+        }
+        let parent_offset = event_start + 2;
+        let parent_ctx = IdeContext::new(&state, &parent_uri, parent_offset).expect("parent ctx");
+        let prepared =
+            RenameService::prepare_rename_with_corsa(&parent_ctx, Some(Arc::clone(&bridge)))
+                .await
+                .expect("prepare event rename");
+        assert_eq!(
+            authored_text(parent_source, prepare_range(prepared)),
+            "save-item"
+        );
+        let from_parent =
+            RenameService::rename_with_corsa(&parent_ctx, "nextItem", Some(Arc::clone(&bridge)))
+                .await
+                .expect("rename from parent");
+        assert_component_event_edits(
+            &from_parent,
+            (&parent_uri, parent_source, "save-item", "next-item"),
+            (&child_uri, child_source, "saveItem", "nextItem"),
+        );
+        let kebab_from_parent =
+            RenameService::rename_with_corsa(&parent_ctx, "next-event", Some(Arc::clone(&bridge)))
+                .await
+                .expect("kebab rename from parent");
+        assert_component_event_edits(
+            &kebab_from_parent,
+            (&parent_uri, parent_source, "save-item", "next-event"),
+            (&child_uri, child_source, "saveItem", "nextEvent"),
+        );
+
+        let child_offset = child_source.find("saveItem").expect("child event") + 2;
+        let child_ctx = IdeContext::new(&state, &child_uri, child_offset).expect("child ctx");
+        let from_child =
+            RenameService::rename_with_corsa(&child_ctx, "anotherEvent", Some(Arc::clone(&bridge)))
+                .await
+                .expect("rename from child");
+        assert_component_event_edits(
+            &from_child,
+            (&parent_uri, parent_source, "save-item", "another-event"),
+            (&child_uri, child_source, "saveItem", "anotherEvent"),
+        );
+        let kebab_from_child =
+            RenameService::rename_with_corsa(&child_ctx, "final-event", Some(Arc::clone(&bridge)))
+                .await
+                .expect("kebab rename from child");
+        bridge.shutdown().await.expect("shutdown");
+        assert_component_event_edits(
+            &kebab_from_child,
+            (&parent_uri, parent_source, "save-item", "final-event"),
+            (&child_uri, child_source, "saveItem", "finalEvent"),
+        );
+    });
+}
+
+fn assert_component_event_edits(
+    edit: &tower_lsp::lsp_types::WorkspaceEdit,
+    parent: (&Url, &str, &str, &str),
+    child: (&Url, &str, &str, &str),
+) {
+    let changes = edit.changes.as_ref().expect("plain workspace changes");
+    for (uri, source, old_name, new_name) in [parent, child] {
+        let edits = changes.get(uri).expect("component event edits");
+        assert!(
+            edits.iter().any(|edit| {
+                authored_text(source, edit.range) == old_name && edit.new_text == new_name
+            }),
+            "missing {old_name} -> {new_name}: {changes:#?}"
+        );
+    }
+    assert!(changes.keys().all(|uri| !uri.path().ends_with(".vue.ts")));
+}
+
 fn prepare_range(response: PrepareRenameResponse) -> Range {
     match response {
         PrepareRenameResponse::Range(range)


### PR DESCRIPTION
## Summary

- preserve component-event symbol links in canonical editor virtual documents
- route complete kebab listener names through the camel-case tsgo symbol while returning the full authored prepare range
- rewrite rename edits back to authored camel/kebab spelling without leaking `.vue.ts` edits
- accept camel or kebab replacement input from both template listeners and static `defineEmits` declarations

## Validation

- `cargo test -p vize_canon --lib --quiet` (894 passed)
- `cargo test -p vize_maestro --features native --lib --quiet` (753 passed, 2 ignored)
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo clippy -p vize_maestro --features native --lib -- -D warnings`
- `vp run source:lengths`
- exact pinned tsgo E2E covers every cursor position, both rename directions, camel/kebab replacements, UTF-16 offsets, and authored-only edits

## Scope

This is the Vize LSP bridge for static component events. Protocol-v1 Content Mapper rename still requires upstream whole-symbol edit projection; runtime/model/generic expansion remains tracked in microsoft/typescript-go#4075.

Refs microsoft/typescript-go#4075
Upstream: https://github.com/microsoft/TypeScript/issues/63879
