### PR TITLE
fix(ci): widen app readiness budget

### DIFF
--- a/.github/actions/app-readiness/action.yml
+++ b/.github/actions/app-readiness/action.yml
@@ -84,7 +84,7 @@ runs:
       shell: bash
       run: |
         set -o pipefail
-        timeout --signal=TERM --kill-after=15s 3m \
+        timeout --signal=TERM --kill-after=15s 5m \
           vp run --filter './tests' test:readiness:check 2>&1 \
           | tee target/app-readiness-logs/check.log
 

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -216,7 +216,7 @@ test("local app readiness action keeps setup, diagnostics, and aggregation bound
   assert.doesNotMatch(action, /playwright install --with-deps chromium/);
 
   for (const [id, script, log, timeout] of [
-    ["check", "test:readiness:check", "check.log", "3m"],
+    ["check", "test:readiness:check", "check.log", "5m"],
     ["lint", "test:readiness:lint", "lint.log", "2m"],
     ["build", "test:readiness:build", "build.log", "3m"],
     ["dev", "test:readiness:dev", "dev.log", "8m"],


### PR DESCRIPTION
## Summary
- increase the fast app readiness check timeout from 3m to 5m
- update the workflow regression test expectation

## Tests
- NODE_OPTIONS='--disable-warning=DEP0040 --disable-warning=DEP0169' node --test --test-concurrency=1 tests/tooling/e2e-workflow.test.ts