### PR TITLE
fix(content-mapper): link component model prop symbols

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_model_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_model_tests.rs
@@ -1,0 +1,124 @@
+use std::path::Path;
+
+use super::{
+    CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_COMPLETION,
+    CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL, ContentMapperSpanKind,
+    generate_vue_content_mapper_transform,
+};
+use crate::batch::ContentMapperTransform;
+
+#[test]
+fn maps_model_events_to_the_authored_model_name() {
+    let source = r#"<script setup lang="ts">
+defineModel<string>("title", { required: true });
+</script>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("ModelChild.vue"), source).expect("model");
+    let marker = "/* __vize_model_event */ \"update:title\"";
+    let generated = result.text.find(marker).unwrap() + "/* __vize_model_event */ ".len();
+    let original = source.find("\"title\"").unwrap();
+    let prop_marker = "export type Props = {\n  \"title\"";
+    let prop_generated = result.text.find(prop_marker).unwrap() + "export type Props = {\n  ".len();
+
+    assert!(has_exact_mapping(&result, prop_generated, original));
+    assert!(
+        result.mappings.iter().any(|mapping| {
+            mapping.0[0] == generated
+                && mapping.0[1] == "\"update:title\"".len()
+                && mapping.0[2] == original
+                && mapping.0[3] == "\"title\"".len()
+                && mapping.0[4] == ContentMapperSpanKind::Atom as usize
+                && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL
+        }),
+        "text:\n{}\n\nmappings:\n{:#?}",
+        result.text,
+        result.mappings
+    );
+
+    let parent = r#"<script setup lang="ts">
+import ModelChild from "./ModelChild.vue";
+</script>
+<template><ModelChild @update:title="() => undefined" /></template>
+"#;
+    let parent =
+        generate_vue_content_mapper_transform(Path::new("App.vue"), parent).expect("parent");
+    let completion = parent
+        .text
+        .find("__vize_model_events_completion_0['update:title']")
+        .expect("completion projection")
+        + "__vize_model_events_completion_0['".len();
+    let navigation = parent
+        .text
+        .find("__vize_model_events_nav_0['update:title']")
+        .expect("navigation projection")
+        + "__vize_model_events_nav_0['".len();
+    assert!(parent.mappings.iter().any(|mapping| {
+        mapping.0[0] == completion && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_COMPLETION
+    }));
+    assert!(parent.mappings.iter().any(|mapping| {
+        mapping.0[0] == navigation && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL
+    }));
+}
+
+#[test]
+fn maps_setup_scoped_model_props_to_the_authored_model_name() {
+    let source = r#"<script setup lang="ts">
+const schema = { title: "example" } as const;
+defineProps<{ value: typeof schema }>();
+defineModel<string>("title", { required: true });
+</script>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("ScopedModel.vue"), source).expect("model");
+    let marker = "type __VizeSetupProps = { value: typeof schema } & {\n  \"title\"";
+    let generated = result.text.find(marker).expect("setup-scoped model prop") + marker.len()
+        - "\"title\"".len();
+    let original = source.find("\"title\"").unwrap();
+
+    assert!(
+        has_exact_mapping(&result, generated, original),
+        "text:\n{}\n\nmappings:\n{:#?}",
+        result.text,
+        result.mappings
+    );
+}
+
+#[test]
+fn maps_models_merged_with_an_authored_public_props_type() {
+    let source = r#"<script setup lang="ts">
+export interface Props { value: string }
+defineProps<Props>();
+defineModel<string>("title", { required: true });
+</script>
+"#;
+    let result =
+        generate_vue_content_mapper_transform(Path::new("PublicProps.vue"), source).expect("model");
+    let marker = "type __VizeResolvedProps = Props & {\n  \"title\"";
+    let generated =
+        result.text.find(marker).expect("resolved model prop") + marker.len() - "\"title\"".len();
+    let original = source.find("\"title\"").unwrap();
+
+    assert!(
+        has_exact_mapping(&result, generated, original),
+        "text:\n{}\n\nmappings:\n{:#?}",
+        result.text,
+        result.mappings
+    );
+    assert!(
+        result
+            .text
+            .contains("$props: __VizeComponentProps<__VizeResolvedProps> &")
+    );
+}
+
+fn has_exact_mapping(result: &ContentMapperTransform, generated: usize, original: usize) -> bool {
+    result.mappings.iter().any(|mapping| {
+        mapping.0[0] == generated
+            && mapping.0[1] == "\"title\"".len()
+            && mapping.0[2] == original
+            && mapping.0[3] == "\"title\"".len()
+            && mapping.0[4] == ContentMapperSpanKind::Verbatim as usize
+            && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_ALL
+    })
+}

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_navigation_tests.rs
@@ -1,9 +1,8 @@
 use std::path::Path;
 
 use super::{
-    CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_COMPLETION,
-    CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL, ContentMapperSpanKind,
-    generate_vue_content_mapper_transform,
+    CONTENT_MAPPER_SPAN_FEATURES_ALL, CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL,
+    ContentMapperSpanKind, generate_vue_content_mapper_transform,
 };
 
 #[test]
@@ -184,57 +183,6 @@ const handlePick = (value: string) => value;
     ] {
         assert!(parent.text.contains(expected), "{}", parent.text);
     }
-}
-
-#[test]
-fn maps_model_events_to_the_authored_model_name() {
-    let source = r#"<script setup lang="ts">
-defineModel<string>("title", { required: true });
-</script>
-"#;
-    let result =
-        generate_vue_content_mapper_transform(Path::new("ModelChild.vue"), source).expect("model");
-    let marker = "/* __vize_model_event */ \"update:title\"";
-    let generated = result.text.find(marker).unwrap() + "/* __vize_model_event */ ".len();
-    let original = source.find("\"title\"").unwrap();
-
-    assert!(
-        result.mappings.iter().any(|mapping| {
-            mapping.0[0] == generated
-                && mapping.0[1] == "\"update:title\"".len()
-                && mapping.0[2] == original
-                && mapping.0[3] == "\"title\"".len()
-                && mapping.0[4] == ContentMapperSpanKind::Atom as usize
-                && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL
-        }),
-        "text:\n{}\n\nmappings:\n{:#?}",
-        result.text,
-        result.mappings
-    );
-
-    let parent = r#"<script setup lang="ts">
-import ModelChild from "./ModelChild.vue";
-</script>
-<template><ModelChild @update:title="() => undefined" /></template>
-"#;
-    let parent =
-        generate_vue_content_mapper_transform(Path::new("App.vue"), parent).expect("parent");
-    let completion = parent
-        .text
-        .find("__vize_model_events_completion_0['update:title']")
-        .expect("completion projection")
-        + "__vize_model_events_completion_0['".len();
-    let navigation = parent
-        .text
-        .find("__vize_model_events_nav_0['update:title']")
-        .expect("navigation projection")
-        + "__vize_model_events_nav_0['".len();
-    assert!(parent.mappings.iter().any(|mapping| {
-        mapping.0[0] == completion && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_COMPLETION
-    }));
-    assert!(parent.mappings.iter().any(|mapping| {
-        mapping.0[0] == navigation && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL
-    }));
 }
 
 #[test]

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -13,6 +13,8 @@ use crate::batch::{
 
 #[path = "content_mapper_component_export_tests.rs"]
 mod component_exports;
+#[path = "content_mapper_model_tests.rs"]
+mod models;
 #[path = "content_mapper_navigation_tests.rs"]
 mod navigation;
 #[path = "content_mapper_scoped_event_navigation_tests.rs"]

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -385,15 +385,13 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             None
         };
     let source_offset = &script_source_offset;
-    let src = prop_source(&mut mappings, summary, script_content, source_offset);
     let setup_props_plan = generate_setup_props(
         &mut ts,
-        src,
+        prop_source(&mut mappings, summary, script_content, source_offset),
         generic_param,
         options_api_props.as_ref(),
         setup_type_exports.exports_public_type("Props"),
     );
-
     // Setup scope: function that contains setup helpers and script content
     ts.push_str("// ========== Setup Scope ==========\n");
     let async_prefix = if is_async { "async " } else { "" };
@@ -653,8 +651,10 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             }
         });
     }
-
-    setup_props_plan.emit_artifact(&mut ts, summary);
+    setup_props_plan.emit_artifact(
+        &mut ts,
+        prop_source(&mut mappings, summary, script_content, source_offset),
+    );
     // Template scope (nested inside setup)
     if has_template_scope && check_options.check_template_bindings {
         profile!("canon.virtual_ts.emit_template_scope", {

--- a/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/setup_props.rs
@@ -30,6 +30,12 @@ pub(super) fn generate_setup_props(
     });
     let mut type_mappings = MacroTypeMappings::new(source.mappings, source.script, source.offset);
     type_mappings.map_exported_type(ts, generated_start, summary.macros.define_props(), "Props");
+    type_mappings.map_model_props(
+        ts,
+        generated_start,
+        summary.macros.models(),
+        &summary.macros,
+    );
     plan
 }
 
@@ -38,6 +44,7 @@ pub(super) struct SetupPropsPlan {
     defer_options_api_props: bool,
     capture_options_api_default: bool,
     module_scope_declares_props: bool,
+    uses_resolved_props: bool,
 }
 
 impl SetupPropsPlan {
@@ -57,14 +64,17 @@ impl SetupPropsPlan {
                 .type_exports
                 .iter()
                 .any(|te| te.hoisted && te.name.as_str() == "Props");
+        let defer = define_props_type_requires_setup_scope(summary);
         Self {
-            defer: define_props_type_requires_setup_scope(summary),
+            defer,
             defer_options_api_props: !module_scope_declares_props
                 && options_api_props
                     .is_some_and(|source| source.deferred_object_source().is_some()),
             capture_options_api_default: options_api_props
                 .is_some_and(OptionsApiPropsSource::captures_default),
             module_scope_declares_props,
+            uses_resolved_props: module_scope_declares_props
+                && (defer || !summary.macros.models().is_empty()),
         }
     }
 
@@ -117,10 +127,9 @@ impl SetupPropsPlan {
     }
 
     pub(super) fn component_props_type_ref(&self) -> &'static str {
-        // Defer to `__VizeResolvedProps` only when a `Props` already lives at
-        // module scope; otherwise the public `Props` alias emitted from the
-        // setup return is the component prop source.
-        if self.defer && self.module_scope_declares_props {
+        // Resolve through the synthesized intersection when an authored
+        // module-level `Props` must absorb models or deferred setup props.
+        if self.uses_resolved_props {
             "__VizeResolvedProps"
         } else {
             "Props"
@@ -164,9 +173,16 @@ impl SetupPropsPlan {
         append!(ts, "  readonly __vizeRawProps?: {props_type_ref};\n");
     }
 
-    pub(super) fn emit_artifact(&self, ts: &mut String, summary: &Croquis) {
+    pub(super) fn emit_artifact(&self, ts: &mut String, source: PropsSource<'_>) {
         if self.defer {
-            generate_setup_scoped_props_artifact(ts, summary);
+            let generated_start = ts.len();
+            generate_setup_scoped_props_artifact(ts, source.summary);
+            MacroTypeMappings::new(source.mappings, source.script, source.offset).map_model_props(
+                ts,
+                generated_start,
+                source.summary.macros.models(),
+                &source.summary.macros,
+            );
         }
     }
 

--- a/crates/vize_canon/src/virtual_ts/macro_type_mappings.rs
+++ b/crates/vize_canon/src/virtual_ts/macro_type_mappings.rs
@@ -3,7 +3,7 @@
 use std::ops::Range;
 
 use vize_carton::cstr;
-use vize_croquis::macros::MacroCall;
+use vize_croquis::macros::{MacroCall, ModelDefinition};
 
 use super::VizeMapping;
 
@@ -75,6 +75,27 @@ impl<'a> MacroTypeMappings<'a> {
 
     pub(crate) fn authored_text(&self, range: (u32, u32)) -> Option<&str> {
         self.script?.get(range.0 as usize..range.1 as usize)
+    }
+
+    pub(crate) fn map_model_props(
+        &mut self,
+        ts: &str,
+        generated_start: usize,
+        models: &[ModelDefinition],
+        declarations: &vize_croquis::macros::MacroTracker,
+    ) {
+        let generated = &ts[generated_start..];
+        for model in models {
+            let Some(authored) = declarations.model_declaration(model.name.as_str()) else {
+                continue;
+            };
+            let needle = cstr!("  \"{}\"", model.name);
+            let Some(start) = generated.find(needle.as_str()) else {
+                continue;
+            };
+            let start = generated_start + start + 2;
+            self.map_exact(start..start + model.name.len() + 2, authored);
+        }
     }
 
     pub(crate) fn map_exact(&mut self, generated: Range<usize>, authored: (u32, u32)) {

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -196,7 +196,11 @@ pub(crate) fn generate_props_type(
 
     if emission == PropsTypeEmission::DeferredToSetup && define_props_type_args.is_some() {
     } else if props_already_defined {
-        // User defined Props, no need to re-export
+        if has_models {
+            ts.push_str("type __VizeResolvedProps = Props & ");
+            append_model_props_type_literal(ts, models);
+            ts.push_str(";\n");
+        }
     } else if let Some(type_args) = define_props_type_args {
         let inner_type = type_args
             .strip_prefix('<')


### PR DESCRIPTION
## Summary

- map generated model prop keys back to explicit `defineModel` names
- preserve the link for setup-scoped props and authored public `Props` types
- use the resolved prop intersection for component instance checks when models extend public props

## Tests

- `cargo test -p vize_canon --lib --quiet`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `vp run source:lengths`
- `cargo fmt --all --check`
- `git diff --check`

Refs #4075

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->