### PR TITLE
fix(lsp): rename component models across authored forms

### DIFF
--- a/crates/vize_maestro/src/ide/rename.rs
+++ b/crates/vize_maestro/src/ide/rename.rs
@@ -9,6 +9,8 @@
 #[cfg(feature = "native")]
 mod canonical;
 #[cfg(all(test, feature = "native"))]
+mod corsa_model_tests;
+#[cfg(all(test, feature = "native"))]
 mod corsa_tests;
 
 use std::collections::HashMap;

--- a/crates/vize_maestro/src/ide/rename/canonical.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical.rs
@@ -51,8 +51,8 @@ pub(super) async fn rename(
     new_name: &str,
     bridge: Option<&CorsaBridge>,
 ) -> Answer<WorkspaceEdit> {
-    let is_component_event = event_rename::query_is_component_event(ctx);
-    let Some(semantic_name) = event_rename::semantic_name(is_component_event, new_name) else {
+    let rename_kind = event_rename::query_kind(ctx);
+    let Some(semantic_name) = event_rename::semantic_name(rename_kind, new_name) else {
         return Answer::Available(None);
     };
     let Some(bridge) = initialized_bridge(bridge) else {
@@ -80,7 +80,12 @@ pub(super) async fn rename(
     let Ok(response) = serde_json::from_value::<WorkspaceEdit>(response) else {
         return Answer::Available(None);
     };
-    let linked = linked_positions(&document, &response);
+    let mut linked = linked_positions(&document, &response);
+    if matches!(rename_kind, Some(event_rename::RenameKind::Model)) {
+        linked.extend(event_rename::model_linked_positions(
+            ctx, &document, &response,
+        ));
+    }
     let mut mapped = corsa_support::map_canonical_corsa_workspace_edit(ctx, &document, response)
         .into_iter()
         .collect::<Vec<_>>();
@@ -110,9 +115,9 @@ pub(super) async fn rename(
         mapped.push(styles);
     }
 
-    if is_component_event {
+    if let Some(kind) = rename_kind {
         for edit in &mut mapped {
-            event_rename::rewrite_edits(ctx, edit, &semantic_name);
+            event_rename::rewrite_edits(ctx, edit, &semantic_name, kind);
         }
     }
 

--- a/crates/vize_maestro/src/ide/rename/canonical/event_rename.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/event_rename.rs
@@ -1,34 +1,58 @@
 use std::ops::Range as OffsetRange;
 
-use tower_lsp::lsp_types::{
-    DocumentChangeOperation, DocumentChanges, OneOf, Range, TextEdit, Url, WorkspaceEdit,
-};
+use tower_lsp::lsp_types::{Range, WorkspaceEdit};
 use vize_croquis::{Drawer, DrawerOptions};
 
-use crate::ide::{IdeContext, corsa_support::CanonicalVirtualDocument, pascal_to_kebab};
+use crate::ide::{IdeContext, corsa_support::CanonicalVirtualDocument};
 
 use super::super::RenameService;
 
-pub(super) fn query_is_component_event(ctx: &IdeContext<'_>) -> bool {
-    component_event_range_at(ctx).is_some() || query_is_event_declaration(ctx)
+mod model;
+mod rewrite;
+
+#[derive(Clone, Copy)]
+pub(super) enum RenameKind {
+    Event,
+    Model,
 }
 
-pub(super) fn semantic_name(is_component_event: bool, new_name: &str) -> Option<String> {
-    if RenameService::is_valid_identifier(new_name) {
-        return Some(new_name.to_string());
+pub(super) fn query_kind(ctx: &IdeContext<'_>) -> Option<RenameKind> {
+    if let Some(range) = component_event_range_at(ctx) {
+        return Some(if ctx.content.get(range)?.starts_with("update:") {
+            RenameKind::Model
+        } else {
+            RenameKind::Event
+        });
     }
-    if !is_component_event {
+    if model::usage_range_at(ctx).is_some() {
+        return Some(RenameKind::Model);
+    }
+    if query_is_event_declaration(ctx) {
+        return Some(RenameKind::Event);
+    }
+    model::query_is_declaration(ctx).then_some(RenameKind::Model)
+}
+
+pub(super) fn semantic_name(kind: Option<RenameKind>, new_name: &str) -> Option<String> {
+    let candidate = match kind {
+        Some(RenameKind::Model) => new_name.strip_prefix("update:").unwrap_or(new_name),
+        _ => new_name,
+    };
+    if RenameService::is_valid_identifier(candidate) {
+        return Some(candidate.to_string());
+    }
+    kind?;
+    if !vize_croquis::naming::is_kebab_case(candidate) {
         return None;
     }
-    if !vize_croquis::naming::is_kebab_case(new_name) {
-        return None;
-    }
-    let camel = crate::ide::definition::helpers::kebab_to_camel(new_name);
+    let camel = crate::ide::definition::helpers::kebab_to_camel(candidate);
     RenameService::is_valid_identifier(&camel).then_some(camel)
 }
 
 pub(super) fn prepare_range(ctx: &IdeContext<'_>) -> Option<Range> {
-    component_event_range_at(ctx).map(|range| offset_range(&ctx.content, range))
+    component_event_range_at(ctx)
+        .or_else(|| model::usage_range_at(ctx))
+        .map(|range| offset_range(&ctx.content, range))
 }
 
 pub(super) fn semantic_position(
@@ -70,106 +94,21 @@ pub(super) fn semantic_position(
         })
 }
 
-pub(super) fn rewrite_edits(ctx: &IdeContext<'_>, edit: &mut WorkspaceEdit, semantic_name: &str) {
-    if let Some(changes) = edit.changes.as_mut() {
-        for (uri, edits) in changes {
-            rewrite_text_edits(ctx, uri, edits, semantic_name);
-        }
-    }
-    if let Some(changes) = edit.document_changes.as_mut() {
-        match changes {
-            DocumentChanges::Edits(edits) => {
-                for edit in edits {
-                    rewrite_annotatable_edits(
-                        ctx,
-                        &edit.text_document.uri,
-                        &mut edit.edits,
-                        semantic_name,
-                    );
-                }
-            }
-            DocumentChanges::Operations(operations) => {
-                for operation in operations {
-                    if let DocumentChangeOperation::Edit(edit) = operation {
-                        rewrite_annotatable_edits(
-                            ctx,
-                            &edit.text_document.uri,
-                            &mut edit.edits,
-                            semantic_name,
-                        );
-                    }
-                }
-            }
-        }
-    }
-}
-
-fn rewrite_annotatable_edits(
+pub(super) fn rewrite_edits(
     ctx: &IdeContext<'_>,
-    uri: &Url,
-    edits: &mut [OneOf<TextEdit, tower_lsp::lsp_types::AnnotatedTextEdit>],
+    edit: &mut WorkspaceEdit,
     semantic_name: &str,
+    kind: RenameKind,
 ) {
-    let Some(source) = source_for_uri(ctx, uri) else {
-        return;
-    };
-    let ranges = component_event_ranges(&source, uri.path());
-    for edit in edits {
-        match edit {
-            OneOf::Left(edit) => rewrite_text_edit(&source, &ranges, edit, semantic_name),
-            OneOf::Right(edit) => {
-                rewrite_text_edit(&source, &ranges, &mut edit.text_edit, semantic_name);
-            }
-        }
-    }
+    rewrite::edits(ctx, edit, semantic_name, kind);
 }
 
-fn rewrite_text_edits(
+pub(super) fn model_linked_positions(
     ctx: &IdeContext<'_>,
-    uri: &Url,
-    edits: &mut [TextEdit],
-    semantic_name: &str,
-) {
-    let Some(source) = source_for_uri(ctx, uri) else {
-        return;
-    };
-    let ranges = component_event_ranges(&source, uri.path());
-    for edit in edits {
-        rewrite_text_edit(&source, &ranges, edit, semantic_name);
-    }
-}
-
-fn rewrite_text_edit(
-    source: &str,
-    ranges: &[OffsetRange<usize>],
-    edit: &mut TextEdit,
-    semantic_name: &str,
-) {
-    let Some(start) =
-        crate::ide::position_to_offset(source, edit.range.start.line, edit.range.start.character)
-    else {
-        return;
-    };
-    let Some(range) = ranges
-        .iter()
-        .find(|range| start >= range.start && start < range.end)
-    else {
-        return;
-    };
-    edit.range = offset_range(source, range.clone());
-    edit.new_text = pascal_to_kebab(semantic_name);
-}
-
-fn source_for_uri(ctx: &IdeContext<'_>, uri: &Url) -> Option<String> {
-    ctx.state
-        .documents
-        .text(uri)
-        .map(|source| source.to_string())
-        .or_else(|| {
-            uri.to_file_path()
-                .ok()
-                .and_then(|path| std::fs::read_to_string(path).ok())
-        })
+    document: &CanonicalVirtualDocument,
+    edit: &WorkspaceEdit,
+) -> Vec<crate::ide::corsa_support::CanonicalSemanticPosition> {
+    model::linked_positions(ctx, document, edit)
 }
 
 fn component_event_range_at(ctx: &IdeContext<'_>) -> Option<OffsetRange<usize>> {
@@ -178,7 +117,7 @@ fn component_event_range_at(ctx: &IdeContext<'_>) -> Option<OffsetRange<usize>> 
         .find(|range| ctx.offset >= range.start && ctx.offset < range.end)
 }
 
-fn component_event_ranges(source: &str, filename: &str) -> Vec<OffsetRange<usize>> {
+pub(super) fn component_event_ranges(source: &str, filename: &str) -> Vec<OffsetRange<usize>> {
     let Ok(descriptor) = vize_atelier_sfc::parse_sfc(
         source,
         vize_atelier_sfc::SfcParseOptions {
@@ -259,7 +198,7 @@ fn query_is_event_declaration(ctx: &IdeContext<'_>) -> bool {
     })
 }
 
-fn offset_range(source: &str, range: OffsetRange<usize>) -> Range {
+pub(super) fn offset_range(source: &str, range: OffsetRange<usize>) -> Range {
     let (start_line, start_character) = crate::ide::offset_to_position(source, range.start);
     let (end_line, end_character) = crate::ide::offset_to_position(source, range.end);
     Range {
@@ -278,7 +217,7 @@ fn offset_range(source: &str, range: OffsetRange<usize>) -> Range {
 mod tests {
     use tower_lsp::lsp_types::Url;
 
-    use super::{component_event_ranges, semantic_name};
+    use super::{RenameKind, component_event_ranges, semantic_name};
     use crate::ide::IdeContext;
     use crate::server::ServerState;
 
@@ -289,6 +228,19 @@ mod tests {
         let ranges = component_event_ranges(source, "Parent.vue");
         assert_eq!(ranges.len(), 1, "{ranges:#?}");
         assert_eq!(&source[ranges[0].clone()], "save-item");
+    }
+
+    #[test]
+    fn normalizes_model_replacements_without_leaking_the_update_event_prefix() {
+        assert_eq!(
+            semantic_name(Some(RenameKind::Model), "update:next-value").as_deref(),
+            Some("nextValue")
+        );
+        assert_eq!(
+            semantic_name(Some(RenameKind::Model), "nextValue").as_deref(),
+            Some("nextValue")
+        );
+        assert_eq!(semantic_name(Some(RenameKind::Model), "bad:name"), None);
     }
 
     #[test]
@@ -316,9 +268,9 @@ mod tests {
                 .open(uri.clone(), source.clone(), 1, "vue".to_string());
             let offset = source.find(needle).expect("event declaration") + 1;
             let ctx = IdeContext::new(&state, &uri, offset).expect("context");
-            assert!(super::query_is_component_event(&ctx), "{source}");
+            assert!(super::query_kind(&ctx).is_some(), "{source}");
             assert_eq!(
-                semantic_name(true, "next-event").as_deref(),
+                semantic_name(Some(RenameKind::Event), "next-event").as_deref(),
                 Some("nextEvent")
             );
         }

--- a/crates/vize_maestro/src/ide/rename/canonical/event_rename/model.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/event_rename/model.rs
@@ -1,0 +1,292 @@
+use std::ops::Range;
+
+use tower_lsp::lsp_types::{DocumentChangeOperation, DocumentChanges, OneOf, WorkspaceEdit};
+use vize_carton::FxHashSet;
+use vize_croquis::{Drawer, DrawerOptions};
+
+use crate::ide::IdeContext;
+use crate::ide::corsa_support::{CanonicalSemanticPosition, CanonicalVirtualDocument};
+
+pub(super) fn query_is_declaration(ctx: &IdeContext<'_>) -> bool {
+    declaration_ranges(&ctx.content, ctx.uri.path())
+        .into_iter()
+        .any(|range| ctx.offset >= range.start && ctx.offset < range.end)
+}
+
+pub(super) fn usage_range_at(ctx: &IdeContext<'_>) -> Option<Range<usize>> {
+    usage_ranges(&ctx.content, ctx.uri.path())
+        .into_iter()
+        .find(|range| ctx.offset >= range.start && ctx.offset < range.end)
+}
+
+pub(super) fn usage_ranges(source: &str, filename: &str) -> Vec<Range<usize>> {
+    let Ok(descriptor) = vize_atelier_sfc::parse_sfc(
+        source,
+        vize_atelier_sfc::SfcParseOptions {
+            filename: filename.to_string().into(),
+            ..Default::default()
+        },
+    ) else {
+        return Vec::new();
+    };
+    let Some(template) = descriptor.template else {
+        return Vec::new();
+    };
+    let Some(template_source) = source.get(template.loc.start..template.loc.end) else {
+        return Vec::new();
+    };
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template_source);
+    let mut drawer = Drawer::with_options(DrawerOptions {
+        analyze_template_scopes: true,
+        track_usage: true,
+        ..Default::default()
+    });
+    drawer.draw_template(&root);
+    let croquis = drawer.finish();
+    croquis
+        .component_usages
+        .iter()
+        .flat_map(|usage| &usage.props)
+        .filter_map(|prop| {
+            if prop.name_is_dynamic {
+                return None;
+            }
+            let start = template.loc.start + prop.start as usize;
+            let end = template.loc.start + prop.end as usize;
+            let directive = source.get(start..end)?;
+            directive
+                .strip_prefix("v-model:")?
+                .starts_with(prop.name.as_str())
+                .then(|| {
+                    let start = start + "v-model:".len();
+                    start..start + prop.name.len()
+                })
+        })
+        .collect()
+}
+
+pub(super) fn declaration_ranges(source: &str, filename: &str) -> Vec<Range<usize>> {
+    let Ok(descriptor) = vize_atelier_sfc::parse_sfc(
+        source,
+        vize_atelier_sfc::SfcParseOptions {
+            filename: filename.to_string().into(),
+            ..Default::default()
+        },
+    ) else {
+        return Vec::new();
+    };
+    let Some(script) = descriptor.script_setup else {
+        return Vec::new();
+    };
+    let mut drawer = Drawer::with_options(DrawerOptions {
+        analyze_script: true,
+        ..Default::default()
+    });
+    drawer.analyze_script_setup(&script.content);
+    let croquis = drawer.finish();
+    croquis
+        .macros
+        .models()
+        .iter()
+        .filter_map(|model| {
+            let (start, end) = croquis.macros.model_declaration(model.name.as_str())?;
+            let mut range = script.loc.start + start as usize..script.loc.start + end as usize;
+            let authored = source.get(range.clone())?;
+            let unquoted = authored
+                .strip_prefix(['\'', '"'])
+                .and_then(|name| name.strip_suffix(['\'', '"']))
+                .unwrap_or(authored);
+            (unquoted == model.name).then(|| {
+                if unquoted.len() != authored.len() {
+                    range.start += 1;
+                    range.end -= 1;
+                }
+                range
+            })
+        })
+        .collect()
+}
+
+pub(super) fn linked_positions(
+    ctx: &IdeContext<'_>,
+    document: &CanonicalVirtualDocument,
+    edit: &WorkspaceEdit,
+) -> Vec<CanonicalSemanticPosition> {
+    let mut positions = FxHashSet::default();
+    let mut collect = |uri: &tower_lsp::lsp_types::Url, range| {
+        collect_linked_positions(ctx, document, uri.as_str(), range, &mut positions);
+    };
+    if let Some(changes) = &edit.changes {
+        for (uri, edits) in changes {
+            for edit in edits {
+                collect(uri, edit.range);
+            }
+        }
+    }
+    if let Some(changes) = &edit.document_changes {
+        match changes {
+            DocumentChanges::Edits(edits) => {
+                for edit in edits {
+                    for entry in &edit.edits {
+                        collect(&edit.text_document.uri, annotatable_range(entry));
+                    }
+                }
+            }
+            DocumentChanges::Operations(operations) => {
+                for operation in operations {
+                    if let DocumentChangeOperation::Edit(edit) = operation {
+                        for entry in &edit.edits {
+                            collect(&edit.text_document.uri, annotatable_range(entry));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    positions.into_iter().collect()
+}
+
+fn collect_linked_positions(
+    ctx: &IdeContext<'_>,
+    document: &CanonicalVirtualDocument,
+    uri: &str,
+    range: tower_lsp::lsp_types::Range,
+    positions: &mut FxHashSet<CanonicalSemanticPosition>,
+) {
+    let Some((request_uri, source_uri, source, result)) = virtual_result(ctx, document, uri) else {
+        return;
+    };
+    let Some(start_post) =
+        crate::ide::position_to_offset(&result.code, range.start.line, range.start.character)
+    else {
+        return;
+    };
+    let start = result
+        .import_source_map
+        .get_original_offset(start_post as u32) as usize;
+    let Some(seed) = result
+        .source_mappings
+        .iter()
+        .filter(|mapping| start >= mapping.gen_range.start && start <= mapping.gen_range.end)
+        .min_by_key(|mapping| mapping.gen_range.len())
+    else {
+        return;
+    };
+    if !mapping_is_model_declaration(source, source_uri.path(), &seed.src_range) {
+        return;
+    }
+    for mapping in result.source_mappings.iter().filter(|mapping| {
+        mapping.src_range == seed.src_range && mapping.gen_range != seed.gen_range
+    }) {
+        let generated = result
+            .import_source_map
+            .get_virtual_offset(mapping.gen_range.start as u32) as usize;
+        let query = generated
+            + usize::from(
+                result
+                    .code
+                    .as_bytes()
+                    .get(generated)
+                    .is_some_and(|byte| matches!(byte, b'\'' | b'"')),
+            );
+        let (line, character) = crate::ide::offset_to_position(&result.code, query);
+        positions.insert(CanonicalSemanticPosition {
+            request_uri: request_uri.clone(),
+            line,
+            character,
+        });
+    }
+}
+
+fn virtual_result<'a>(
+    ctx: &'a IdeContext<'_>,
+    document: &'a CanonicalVirtualDocument,
+    uri: &str,
+) -> Option<(
+    &'a vize_carton::String,
+    &'a tower_lsp::lsp_types::Url,
+    &'a str,
+    &'a crate::ide::diagnostics::VirtualTsResult,
+)> {
+    if uri == document.request_uri {
+        return Some((
+            &document.request_uri,
+            ctx.uri,
+            &ctx.content,
+            &document.virtual_result,
+        ));
+    }
+    document
+        .dependencies
+        .iter()
+        .find(|dependency| uri == dependency.request_uri)
+        .map(|dependency| {
+            (
+                &dependency.request_uri,
+                &dependency.source_uri,
+                dependency.source.as_str(),
+                &dependency.virtual_result,
+            )
+        })
+}
+
+fn mapping_is_model_declaration(source: &str, filename: &str, mapping: &Range<usize>) -> bool {
+    let Some(authored) = source.get(mapping.clone()) else {
+        return false;
+    };
+    if authored.len() < 2
+        || !matches!(authored.as_bytes()[0], b'\'' | b'"')
+        || authored.as_bytes()[0] != authored.as_bytes()[authored.len() - 1]
+    {
+        return false;
+    }
+    declaration_ranges(source, filename)
+        .into_iter()
+        .any(|range| {
+            let Some(start) = range.start.checked_sub(1) else {
+                return false;
+            };
+            let end = range.end.saturating_add(1);
+            source.get(start..end).is_some_and(|authored| {
+                authored.len() >= 2
+                    && matches!(authored.as_bytes()[0], b'\'' | b'"')
+                    && authored.as_bytes()[0] == authored.as_bytes()[authored.len() - 1]
+                    && &(start..end) == mapping
+            })
+        })
+}
+
+fn annotatable_range(
+    edit: &OneOf<tower_lsp::lsp_types::TextEdit, tower_lsp::lsp_types::AnnotatedTextEdit>,
+) -> tower_lsp::lsp_types::Range {
+    match edit {
+        OneOf::Left(edit) => edit.range,
+        OneOf::Right(edit) => edit.text_edit.range,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{declaration_ranges, usage_ranges};
+
+    #[test]
+    fn collects_explicit_model_names_without_their_syntax() {
+        let source = r#"<script setup lang="ts">
+defineModel<string>('title');
+</script>
+<template>
+  <Child v-model:title.trim="value" />
+  <Child v-model="value" />
+  <Child v-model:[dynamic]="value" />
+</template>
+"#;
+        let declarations = declaration_ranges(source, "Child.vue");
+        let usages = usage_ranges(source, "Child.vue");
+
+        assert_eq!(declarations.len(), 1, "{declarations:#?}");
+        assert_eq!(&source[declarations[0].clone()], "title");
+        assert_eq!(usages.len(), 1, "{usages:#?}");
+        assert_eq!(&source[usages[0].clone()], "title");
+    }
+}

--- a/crates/vize_maestro/src/ide/rename/canonical/event_rename/rewrite.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/event_rename/rewrite.rs
@@ -1,0 +1,156 @@
+use std::ops::Range as OffsetRange;
+
+use tower_lsp::lsp_types::{
+    DocumentChangeOperation, DocumentChanges, OneOf, TextEdit, Url, WorkspaceEdit,
+};
+use vize_carton::cstr;
+
+use super::{RenameKind, component_event_ranges, model, offset_range};
+use crate::ide::{IdeContext, pascal_to_kebab};
+
+pub(super) fn edits(
+    ctx: &IdeContext<'_>,
+    edit: &mut WorkspaceEdit,
+    semantic_name: &str,
+    kind: RenameKind,
+) {
+    if let Some(changes) = edit.changes.as_mut() {
+        for (uri, edits) in changes {
+            rewrite_text_edits(ctx, uri, edits, semantic_name, kind);
+        }
+    }
+    if let Some(changes) = edit.document_changes.as_mut() {
+        match changes {
+            DocumentChanges::Edits(edits) => {
+                for edit in edits {
+                    rewrite_annotatable_edits(
+                        ctx,
+                        &edit.text_document.uri,
+                        &mut edit.edits,
+                        semantic_name,
+                        kind,
+                    );
+                }
+            }
+            DocumentChanges::Operations(operations) => {
+                for operation in operations {
+                    if let DocumentChangeOperation::Edit(edit) = operation {
+                        rewrite_annotatable_edits(
+                            ctx,
+                            &edit.text_document.uri,
+                            &mut edit.edits,
+                            semantic_name,
+                            kind,
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn rewrite_annotatable_edits(
+    ctx: &IdeContext<'_>,
+    uri: &Url,
+    edits: &mut [OneOf<TextEdit, tower_lsp::lsp_types::AnnotatedTextEdit>],
+    semantic_name: &str,
+    kind: RenameKind,
+) {
+    let Some(source) = source_for_uri(ctx, uri) else {
+        return;
+    };
+    let ranges = RewriteRanges::new(&source, uri.path(), kind);
+    for edit in edits {
+        match edit {
+            OneOf::Left(edit) => ranges.rewrite(&source, edit, semantic_name),
+            OneOf::Right(edit) => ranges.rewrite(&source, &mut edit.text_edit, semantic_name),
+        }
+    }
+}
+
+fn rewrite_text_edits(
+    ctx: &IdeContext<'_>,
+    uri: &Url,
+    edits: &mut [TextEdit],
+    semantic_name: &str,
+    kind: RenameKind,
+) {
+    let Some(source) = source_for_uri(ctx, uri) else {
+        return;
+    };
+    let ranges = RewriteRanges::new(&source, uri.path(), kind);
+    for edit in edits {
+        ranges.rewrite(&source, edit, semantic_name);
+    }
+}
+
+struct RewriteRanges {
+    events: Vec<OffsetRange<usize>>,
+    model_usages: Vec<OffsetRange<usize>>,
+    model_declarations: Vec<OffsetRange<usize>>,
+}
+
+impl RewriteRanges {
+    fn new(source: &str, filename: &str, kind: RenameKind) -> Self {
+        let is_model = matches!(kind, RenameKind::Model);
+        let (model_usages, model_declarations) = if is_model {
+            (
+                model::usage_ranges(source, filename),
+                model::declaration_ranges(source, filename),
+            )
+        } else {
+            (Vec::new(), Vec::new())
+        };
+        Self {
+            events: component_event_ranges(source, filename),
+            model_usages,
+            model_declarations,
+        }
+    }
+
+    fn rewrite(&self, source: &str, edit: &mut TextEdit, semantic_name: &str) {
+        let Some(start) = crate::ide::position_to_offset(
+            source,
+            edit.range.start.line,
+            edit.range.start.character,
+        ) else {
+            return;
+        };
+        if let Some(range) = containing(&self.events, start) {
+            edit.range = offset_range(source, range.clone());
+            let prefix = source
+                .get(range.clone())
+                .filter(|name| name.starts_with("update:"))
+                .map_or("", |_| "update:");
+            edit.new_text = cstr!("{prefix}{}", pascal_to_kebab(semantic_name)).into();
+        } else if let Some(range) = containing(&self.model_usages, start) {
+            edit.range = offset_range(source, range.clone());
+            edit.new_text = pascal_to_kebab(semantic_name);
+        } else if let Some(range) = self
+            .model_declarations
+            .iter()
+            .find(|range| start >= range.start && start <= range.end)
+        {
+            edit.range = offset_range(source, range.clone());
+            edit.new_text = semantic_name.to_string();
+        }
+    }
+}
+
+fn containing(ranges: &[OffsetRange<usize>], offset: usize) -> Option<&OffsetRange<usize>> {
+    ranges
+        .iter()
+        .find(|range| offset >= range.start && offset < range.end)
+}
+
+fn source_for_uri(ctx: &IdeContext<'_>, uri: &Url) -> Option<String> {
+    ctx.state
+        .documents
+        .text(uri)
+        .map(|source| source.to_string())
+        .or_else(|| {
+            uri.to_file_path()
+                .ok()
+                .and_then(|path| std::fs::read_to_string(path).ok())
+        })
+}

--- a/crates/vize_maestro/src/ide/rename/corsa_model_tests.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_model_tests.rs
@@ -1,0 +1,288 @@
+use std::fs;
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::{PrepareRenameResponse, Range, Url, WorkspaceEdit};
+use vize_canon::{CorsaBridge, CorsaBridgeConfig};
+
+use super::RenameService;
+use crate::ide::IdeContext;
+use crate::server::ServerState;
+
+#[test]
+fn canonical_model_event_rename_preserves_update_prefix_and_authored_casing() {
+    crate::runtime::block_on(async {
+        let Some(tsgo_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = project.path().join("src");
+        fs::create_dir_all(&src).expect("src");
+        fs::write(
+            project.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .expect("tsconfig");
+
+        let child_source = r#"<script setup lang="ts">
+export interface Props { value?: string }
+defineProps<Props>();
+defineModel<string>('title', { required: true });
+</script>
+"#;
+        let parent_source = r#"<script setup lang="ts">
+import Child from "./Child.vue";
+import Other from "./Other.vue";
+const modelValue = "";
+const otherValue = "";
+const handleUpdate = (value: string) => value;
+</script>
+<template>
+  💥 <Child v-model:title="modelValue" />
+  <Child @update:title="handleUpdate" />
+  <Other v-model:title="otherValue" />
+</template>
+"#;
+        let child_path = src.join("Child.vue");
+        let other_path = src.join("Other.vue");
+        let parent_path = src.join("Parent.vue");
+        fs::write(&child_path, child_source).expect("child");
+        fs::write(&other_path, child_source).expect("other");
+        fs::write(&parent_path, parent_source).expect("parent");
+        let child_uri = Url::from_file_path(&child_path).expect("child uri");
+        let other_uri = Url::from_file_path(&other_path).expect("other uri");
+        let parent_uri = Url::from_file_path(&parent_path).expect("parent uri");
+        let state = ServerState::new();
+        state.set_workspace_root(project.path().to_path_buf());
+        for (uri, source) in [
+            (&child_uri, child_source),
+            (&other_uri, child_source),
+            (&parent_uri, parent_source),
+        ] {
+            state
+                .documents
+                .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+            state.update_virtual_docs(uri, source);
+        }
+        let bridge = Arc::new(CorsaBridge::with_config(CorsaBridgeConfig {
+            corsa_path: Some(tsgo_path),
+            working_dir: Some(project.path().to_path_buf()),
+            timeout_ms: 30_000,
+            ..Default::default()
+        }));
+        bridge.spawn().await.expect("tsgo session");
+
+        let parent_start = parent_source.find("update:title").expect("parent event");
+        for cursor in parent_start..parent_start + "update:title".len() {
+            let ctx = IdeContext::new(&state, &parent_uri, cursor).expect("parent prepare ctx");
+            let prepared =
+                RenameService::prepare_rename_with_corsa(&ctx, Some(Arc::clone(&bridge)))
+                    .await
+                    .expect("prepare model rename");
+            assert_eq!(
+                authored_text(parent_source, prepare_range(prepared)),
+                "update:title"
+            );
+        }
+        let parent_offset = parent_start + 8;
+        let parent_ctx = IdeContext::new(&state, &parent_uri, parent_offset).expect("parent ctx");
+        let from_parent = RenameService::rename_with_corsa(
+            &parent_ctx,
+            "update:headline",
+            Some(Arc::clone(&bridge)),
+        )
+        .await
+        .expect("rename model from parent");
+        assert_model_edits(
+            &from_parent,
+            (
+                &parent_uri,
+                parent_source,
+                "update:title",
+                "update:headline",
+            ),
+            (&child_uri, child_source, "title", "headline"),
+        );
+        assert_authored_edit(
+            &from_parent,
+            &parent_uri,
+            parent_source,
+            "title",
+            "headline",
+        );
+        assert_other_model_untouched(&from_parent, &parent_uri, &other_uri, parent_source);
+
+        let child_start = child_source.find("'title'").expect("child model") + 1;
+        for cursor in child_start..child_start + "title".len() {
+            let ctx = IdeContext::new(&state, &child_uri, cursor).expect("child prepare ctx");
+            let prepared =
+                RenameService::prepare_rename_with_corsa(&ctx, Some(Arc::clone(&bridge)))
+                    .await
+                    .expect("prepare model declaration rename");
+            assert_eq!(
+                authored_text(child_source, prepare_range(prepared)),
+                "title"
+            );
+        }
+        let child_offset = child_start + 2;
+        let child_ctx = IdeContext::new(&state, &child_uri, child_offset).expect("child ctx");
+        let from_child = RenameService::rename_with_corsa(
+            &child_ctx,
+            "headline-value",
+            Some(Arc::clone(&bridge)),
+        )
+        .await
+        .expect("rename model from child");
+        assert_model_edits(
+            &from_child,
+            (
+                &parent_uri,
+                parent_source,
+                "update:title",
+                "update:headline-value",
+            ),
+            (&child_uri, child_source, "title", "headlineValue"),
+        );
+        assert_authored_edit(
+            &from_child,
+            &parent_uri,
+            parent_source,
+            "title",
+            "headline-value",
+        );
+        assert_other_model_untouched(&from_child, &parent_uri, &other_uri, parent_source);
+
+        let usage_start =
+            parent_source.find("model:title").expect("v-model usage") + "model:".len();
+        for cursor in usage_start..usage_start + "title".len() {
+            let ctx = IdeContext::new(&state, &parent_uri, cursor).expect("usage prepare ctx");
+            let prepared =
+                RenameService::prepare_rename_with_corsa(&ctx, Some(Arc::clone(&bridge)))
+                    .await
+                    .expect("prepare v-model rename");
+            assert_eq!(
+                authored_text(parent_source, prepare_range(prepared)),
+                "title"
+            );
+        }
+        let usage_offset = usage_start + 1;
+        let usage_ctx = IdeContext::new(&state, &parent_uri, usage_offset).expect("usage ctx");
+        let from_usage =
+            RenameService::rename_with_corsa(&usage_ctx, "final-model", Some(Arc::clone(&bridge)))
+                .await
+                .expect("rename model from v-model");
+        bridge.shutdown().await.expect("shutdown");
+        assert_model_edits(
+            &from_usage,
+            (
+                &parent_uri,
+                parent_source,
+                "update:title",
+                "update:final-model",
+            ),
+            (&child_uri, child_source, "title", "finalModel"),
+        );
+        assert_authored_edit(
+            &from_usage,
+            &parent_uri,
+            parent_source,
+            "title",
+            "final-model",
+        );
+        assert_other_model_untouched(&from_usage, &parent_uri, &other_uri, parent_source);
+    });
+}
+
+fn assert_other_model_untouched(
+    edit: &WorkspaceEdit,
+    parent_uri: &Url,
+    other_uri: &Url,
+    parent_source: &str,
+) {
+    let changes = edit.changes.as_ref().expect("plain workspace changes");
+    assert!(!changes.contains_key(other_uri), "{changes:#?}");
+    let start = parent_source.rfind("model:title").expect("other model") + "model:".len();
+    let (line, character) = crate::ide::offset_to_position(parent_source, start);
+    let edits = changes.get(parent_uri).expect("parent edits");
+    assert!(
+        edits
+            .iter()
+            .all(|edit| edit.range.start.line != line || edit.range.start.character != character),
+        "unrelated model was renamed: {changes:#?}"
+    );
+}
+
+fn assert_authored_edit(
+    edit: &WorkspaceEdit,
+    uri: &Url,
+    source: &str,
+    old_name: &str,
+    new_name: &str,
+) {
+    let changes = edit.changes.as_ref().expect("plain workspace changes");
+    let edits = changes.get(uri).expect("authored model edits");
+    assert!(
+        edits.iter().any(|edit| {
+            authored_text(source, edit.range) == old_name && edit.new_text == new_name
+        }),
+        "missing {old_name} -> {new_name}: {changes:#?}"
+    );
+}
+
+fn assert_model_edits(
+    edit: &WorkspaceEdit,
+    parent: (&Url, &str, &str, &str),
+    child: (&Url, &str, &str, &str),
+) {
+    let changes = edit.changes.as_ref().expect("plain workspace changes");
+    for (uri, source, old_name, new_name) in [parent, child] {
+        let edits = changes.get(uri).expect("model edits");
+        assert!(
+            edits.iter().any(|edit| {
+                authored_text(source, edit.range) == old_name && edit.new_text == new_name
+            }),
+            "missing {old_name} -> {new_name}: {changes:#?}"
+        );
+    }
+    assert!(changes.keys().all(|uri| !uri.path().ends_with(".vue.ts")));
+}
+
+fn prepare_range(response: PrepareRenameResponse) -> Range {
+    match response {
+        PrepareRenameResponse::Range(range)
+        | PrepareRenameResponse::RangeWithPlaceholder { range, .. } => range,
+        PrepareRenameResponse::DefaultBehavior { .. } => panic!("expected concrete range"),
+    }
+}
+
+fn authored_text(source: &str, range: Range) -> &str {
+    let start = crate::ide::position_to_offset(source, range.start.line, range.start.character)
+        .expect("source start");
+    let end = crate::ide::position_to_offset(source, range.end.line, range.end.character)
+        .expect("source end");
+    &source[start..end]
+}
+
+fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return None;
+    }
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)?;
+    vize_carton::corsa_resolver::resolve_corsa_executable(
+        vize_carton::corsa_resolver::CorsaResolveRequest {
+            project_root: Some(workspace_root),
+            ..Default::default()
+        },
+    )
+    .ok()
+}


### PR DESCRIPTION
## Summary

- rename one component model across `defineModel`, `v-model:`, and `@update:` authored forms
- preserve camel/kebab casing and the `update:` prefix for parent- and child-origin renames
- follow generated prop/event symbol links without sweeping unrelated same-name components
- keep ordinary component-event rename on its existing lower-cost analysis path

## Coverage

- every cursor position in model event, model usage, and declaration names
- camel, kebab, and `update:`-prefixed replacement input
- single-quoted declarations and public authored `Props`
- same-name unrelated component false-positive guard
- dynamic and argumentless model directives excluded from static-name rewriting
- UTF-16 positions and authored-file-only edits

## Tests

- `cargo test -p vize_maestro --features native --lib --quiet`
- `cargo clippy -p vize_maestro --features native --lib -- -D warnings`
- `vp run source:lengths`
- `cargo fmt --all --check`
- `git diff --check`

Refs #4075

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->