### PR TITLE
fix(lsp): stabilize import identity across file lifecycle

### DIFF
--- a/crates/vize_maestro/src/server/importers.rs
+++ b/crates/vize_maestro/src/server/importers.rs
@@ -188,19 +188,31 @@ fn resolve_relative_import(importer_dir: &Path, specifier: &str) -> Option<PathB
 }
 
 fn comparable_path(path: &Path) -> PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| {
-        let mut normalized = PathBuf::new();
-        for component in path.components() {
-            match component {
-                Component::CurDir => {}
-                Component::ParentDir => {
-                    normalized.pop();
-                }
-                _ => normalized.push(component.as_os_str()),
-            }
+    let mut ancestor = path;
+    let mut unresolved = Vec::new();
+    while let Some(parent) = ancestor.parent() {
+        if let Some(name) = ancestor.file_name() {
+            unresolved.push(name.to_os_string());
         }
-        normalized
-    })
+        if let Ok(mut canonical) = std::fs::canonicalize(parent) {
+            for component in unresolved.into_iter().rev() {
+                canonical.push(component);
+            }
+            return canonical;
+        }
+        ancestor = parent;
+    }
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
 }
 
 fn source_type(lang: Option<&str>) -> SourceType {

--- a/crates/vize_maestro/src/server/importers_tests.rs
+++ b/crates/vize_maestro/src/server/importers_tests.rs
@@ -24,6 +24,35 @@ fn index_tracks_and_removes_open_sfc_imports() {
 }
 
 #[test]
+fn index_keeps_import_identity_across_dependency_creation_and_deletion() {
+    let dir = tempfile::tempdir().unwrap();
+    let child = dir.path().join("CreatedLater.vue");
+    let parent = dir.path().join("Parent.vue");
+    std::fs::write(&parent, "<template />").unwrap();
+    let child_uri = Url::from_file_path(&child).unwrap();
+    let parent_uri = Url::from_file_path(&parent).unwrap();
+    let state = ServerState::new();
+    let source = "<script setup lang=\"ts\">import Child from './CreatedLater.vue'</script>";
+
+    state.update_virtual_docs(&parent_uri, source);
+    assert_eq!(open_importers(&state, &child_uri), vec![parent_uri.clone()]);
+
+    std::fs::write(&child, "<template />").unwrap();
+    assert_eq!(open_importers(&state, &child_uri), vec![parent_uri.clone()]);
+
+    std::fs::remove_file(&child).unwrap();
+    assert_eq!(open_importers(&state, &child_uri), vec![parent_uri.clone()]);
+
+    #[cfg(unix)]
+    {
+        let target = dir.path().join("Actual.vue");
+        std::fs::write(&target, "<template />").unwrap();
+        std::os::unix::fs::symlink(&target, &child).unwrap();
+        assert_eq!(open_importers(&state, &child_uri), vec![parent_uri]);
+    }
+}
+
+#[test]
 fn index_tracks_script_module_specifier_forms() {
     let dir = tempfile::tempdir().unwrap();
     let child = dir.path().join("Child.vue");


### PR DESCRIPTION
## Summary

- keep reverse-import identities stable when a dependency is created after its importer is indexed
- retain the same identity after deletion and symlink replacement
- canonicalize the deepest existing parent while preserving unresolved path components

## Why

Canonical project operations could miss an open reverse importer when the importer was opened before a newly-created dependency. The dependency path changed identity once the file began to exist, especially on platforms whose temporary paths resolve through a symlinked parent.

## Tests

- `cargo test -p vize_maestro --features native --lib --quiet`
- `cargo clippy -p vize_maestro --features native --lib -- -D warnings`
- `vp run source:lengths`
- `cargo fmt --all --check`
- `git diff --check`

Refs #4064
Refs #4075

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->