### PR TITLE
test(content-mapper): require unopened SFC lifecycle

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -273,6 +273,13 @@ const value = 1;
             std::fs::write(&created_path, created_source).unwrap();
             let created_uri = file_uri(&created_path);
             notify_file_changes(&client, &[(created_uri.as_str(), FileChangeType::CREATED)]);
+            let unopened_created = pull_diagnostics(&client, &created_uri).await;
+            assert!(
+                serde_json::to_string(&unopened_created)
+                    .unwrap()
+                    .contains("2339"),
+                "{unopened_created:#}"
+            );
             let created_document_uri = Uri::from_str(&created_uri).unwrap();
             overlay
                 .open(VirtualDocument::new(
@@ -302,6 +309,13 @@ const value = 1;
                     (created_uri.as_str(), FileChangeType::DELETED),
                     (renamed_uri.as_str(), FileChangeType::CREATED),
                 ],
+            );
+            let unopened_renamed = pull_diagnostics(&client, &renamed_uri).await;
+            assert!(
+                serde_json::to_string(&unopened_renamed)
+                    .unwrap()
+                    .contains("2339"),
+                "{unopened_renamed:#}"
             );
             let renamed_document_uri = Uri::from_str(&renamed_uri).unwrap();
             overlay


### PR DESCRIPTION
## Summary

- require a watched-file `CREATED` Vue SFC to return authored diagnostics before `didOpen`
- require a `DELETED` + `CREATED` rename to enroll the unopened destination before `didOpen`
- retain the existing deletion assertion that removes the unopened SFC from the project

## Verification

- `VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/vize-tsgo-content-mapper.OA6YI7/tsgo cargo test -p vize --test content_mapper_tsgo_lsp --quiet`
- `cargo clippy -p vize --test content_mapper_tsgo_lsp -- -D warnings`
- `vp run source:lengths`
- `cargo fmt --all --check`
- `git diff --check`

Closes #4064

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->