### PR TITLE
fix(tooling): resolve nested Pkl project during config generation

### DIFF
--- a/tests/tooling/config-generation.test.ts
+++ b/tests/tooling/config-generation.test.ts
@@ -14,13 +14,11 @@ type TaskShape = {
   command: string;
 };
 
-function workspaceBinary(name: string): string {
-  return path.join(
-    root,
-    "node_modules",
-    ".bin",
-    process.platform === "win32" ? `${name}.cmd` : name,
-  );
+function runWorkspaceBinary(name: string, args: string[]): SpawnSyncReturns<string> {
+  return spawnSync(process.platform === "win32" ? "pnpm.cmd" : "pnpm", ["exec", name, ...args], {
+    cwd: root,
+    encoding: "utf8",
+  });
 }
 
 function assertCommandSucceeded(
@@ -36,53 +34,29 @@ function assertCommandSucceeded(
 
 test("root config generation resolves and reproduces checked-in artifacts", () => {
   const schemaTask = generationAndCliTasks["gen:schema"] as TaskShape;
-  assert.match(
-    schemaTask.command,
-    /pkl eval --project-dir npm\/cli\/pkl -f json npm\/cli\/pkl\/jsonschema\/generate\.pkl/,
-  );
-  const typesTask = generationAndCliTasks["gen:types"] as TaskShape;
-  assert.match(
-    typesTask.command,
-    /oxfmt --write npm\/cli\/schemas\/vize\.config\.schema\.json npm\/cli\/src\/types\/generated\.ts/,
-  );
+  assert.match(schemaTask.command, /--project-dir\s+npm\/cli\/pkl\b/);
 
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-config-generation-"));
   const schemaPath = path.join(tempDir, "npm", "cli", "schemas", "vize.config.schema.json");
   const typesPath = path.join(tempDir, "npm", "cli", "src", "types", "generated.ts");
-  const pkl = path.join(
-    root,
-    "npm",
-    "cli",
-    "node_modules",
-    ".bin",
-    process.platform === "win32" ? "pkl.cmd" : "pkl",
-  );
 
   try {
     fs.mkdirSync(path.dirname(schemaPath), { recursive: true });
     fs.mkdirSync(path.dirname(typesPath), { recursive: true });
 
-    const pklResult = spawnSync(
-      pkl,
-      [
-        "eval",
-        "--project-dir",
-        "npm/cli/pkl",
-        "-f",
-        "json",
-        "npm/cli/pkl/jsonschema/generate.pkl",
-        "-o",
-        schemaPath,
-      ],
-      { cwd: root, encoding: "utf8" },
-    );
+    const pklResult = runWorkspaceBinary("pkl", [
+      "eval",
+      "--project-dir",
+      "npm/cli/pkl",
+      "-f",
+      "json",
+      "npm/cli/pkl/jsonschema/generate.pkl",
+      "-o",
+      schemaPath,
+    ]);
     assertCommandSucceeded(pklResult, "Pkl schema generation failed");
 
-    const json2tsResult = spawnSync(
-      workspaceBinary("json2ts"),
-      ["-i", schemaPath, "-o", typesPath],
-      { cwd: root, encoding: "utf8" },
-    );
+    const json2tsResult = runWorkspaceBinary("json2ts", ["-i", schemaPath, "-o", typesPath]);
     assertCommandSucceeded(json2tsResult, "TypeScript declaration generation failed");
 
     const postprocessResult = runMoonScript("postprocess_types", [], {
@@ -90,10 +64,7 @@ test("root config generation resolves and reproduces checked-in artifacts", () =
     });
     assertCommandSucceeded(postprocessResult, "Generated declaration post-processing failed");
 
-    const formatResult = spawnSync(workspaceBinary("oxfmt"), ["--write", schemaPath, typesPath], {
-      cwd: root,
-      encoding: "utf8",
-    });
+    const formatResult = runWorkspaceBinary("oxfmt", ["--write", schemaPath, typesPath]);
     assertCommandSucceeded(formatResult, "Generated artifact formatting failed");
 
     assert.equal(

--- a/tests/tooling/config-generation.test.ts
+++ b/tests/tooling/config-generation.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { generationAndCliTasks } from "../../tools/vite-plus/tasks/generation-cli.ts";
+import { repoRoot, runMoonScript } from "./_helpers/moonbit.ts";
+
+const root = repoRoot;
+
+type TaskShape = {
+  command: string;
+};
+
+function workspaceBinary(name: string): string {
+  return path.join(
+    root,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? `${name}.cmd` : name,
+  );
+}
+
+function assertCommandSucceeded(
+  result: SpawnSyncReturns<string>,
+  description: string,
+): asserts result is SpawnSyncReturns<string> & { status: 0 } {
+  assert.equal(
+    result.status,
+    0,
+    `${description}\n${result.error?.message ?? ""}\n${result.stderr ?? ""}\n${result.stdout ?? ""}`.trim(),
+  );
+}
+
+test("root config generation resolves and reproduces checked-in artifacts", () => {
+  const schemaTask = generationAndCliTasks["gen:schema"] as TaskShape;
+  assert.match(
+    schemaTask.command,
+    /pkl eval --project-dir npm\/cli\/pkl -f json npm\/cli\/pkl\/jsonschema\/generate\.pkl/,
+  );
+  const typesTask = generationAndCliTasks["gen:types"] as TaskShape;
+  assert.match(
+    typesTask.command,
+    /oxfmt --write npm\/cli\/schemas\/vize\.config\.schema\.json npm\/cli\/src\/types\/generated\.ts/,
+  );
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-config-generation-"));
+  const schemaPath = path.join(tempDir, "npm", "cli", "schemas", "vize.config.schema.json");
+  const typesPath = path.join(tempDir, "npm", "cli", "src", "types", "generated.ts");
+  const pkl = path.join(
+    root,
+    "npm",
+    "cli",
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "pkl.cmd" : "pkl",
+  );
+
+  try {
+    fs.mkdirSync(path.dirname(schemaPath), { recursive: true });
+    fs.mkdirSync(path.dirname(typesPath), { recursive: true });
+
+    const pklResult = spawnSync(
+      pkl,
+      [
+        "eval",
+        "--project-dir",
+        "npm/cli/pkl",
+        "-f",
+        "json",
+        "npm/cli/pkl/jsonschema/generate.pkl",
+        "-o",
+        schemaPath,
+      ],
+      { cwd: root, encoding: "utf8" },
+    );
+    assertCommandSucceeded(pklResult, "Pkl schema generation failed");
+
+    const json2tsResult = spawnSync(
+      workspaceBinary("json2ts"),
+      ["-i", schemaPath, "-o", typesPath],
+      { cwd: root, encoding: "utf8" },
+    );
+    assertCommandSucceeded(json2tsResult, "TypeScript declaration generation failed");
+
+    const postprocessResult = runMoonScript("postprocess_types", [], {
+      env: { VIZE_REPO_ROOT: tempDir },
+    });
+    assertCommandSucceeded(postprocessResult, "Generated declaration post-processing failed");
+
+    const formatResult = spawnSync(workspaceBinary("oxfmt"), ["--write", schemaPath, typesPath], {
+      cwd: root,
+      encoding: "utf8",
+    });
+    assertCommandSucceeded(formatResult, "Generated artifact formatting failed");
+
+    assert.equal(
+      fs.readFileSync(schemaPath, "utf8"),
+      fs.readFileSync(path.join(root, "npm/cli/schemas/vize.config.schema.json"), "utf8"),
+      "generated schema is stale",
+    );
+    assert.equal(
+      fs.readFileSync(typesPath, "utf8"),
+      fs.readFileSync(path.join(root, "npm/cli/src/types/generated.ts"), "utf8"),
+      "generated TypeScript declarations are stale",
+    );
+  } finally {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  }
+});

--- a/tests/tooling/config-generation.test.ts
+++ b/tests/tooling/config-generation.test.ts
@@ -21,6 +21,22 @@ function runWorkspaceBinary(name: string, args: string[]): SpawnSyncReturns<stri
   });
 }
 
+/**
+ * `pkl` is declared by `npm/cli`, so pnpm links its bin only into that package.
+ * `pnpm exec pkl` from the repository root cannot resolve it, hence the direct path.
+ */
+function runPkl(args: string[]): SpawnSyncReturns<string> {
+  const pkl = path.join(
+    root,
+    "npm",
+    "cli",
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "pkl.cmd" : "pkl",
+  );
+  return spawnSync(pkl, args, { cwd: root, encoding: "utf8" });
+}
+
 function assertCommandSucceeded(
   result: SpawnSyncReturns<string>,
   description: string,
@@ -44,7 +60,7 @@ test("root config generation resolves and reproduces checked-in artifacts", () =
     fs.mkdirSync(path.dirname(schemaPath), { recursive: true });
     fs.mkdirSync(path.dirname(typesPath), { recursive: true });
 
-    const pklResult = runWorkspaceBinary("pkl", [
+    const pklResult = runPkl([
       "eval",
       "--project-dir",
       "npm/cli/pkl",

--- a/tools/vite-plus/tasks/generation-cli.ts
+++ b/tools/vite-plus/tasks/generation-cli.ts
@@ -11,10 +11,10 @@ import { defineTasks, moonScript, noCacheTask, runTask, shellCommand } from "../
  */
 export const generationAndCliTasks = defineTasks({
   "gen:schema": noCacheTask(
-    "pnpm exec pkl eval -f json npm/cli/pkl/jsonschema/generate.pkl -o npm/cli/schemas/vize.config.schema.json",
+    "pnpm exec pkl eval --project-dir npm/cli/pkl -f json npm/cli/pkl/jsonschema/generate.pkl -o npm/cli/schemas/vize.config.schema.json",
   ),
   "gen:types": noCacheTask(
-    `${runTask("gen:schema")} && pnpm exec json2ts -i npm/cli/schemas/vize.config.schema.json -o npm/cli/src/types/generated.ts && ${moonScript("postprocess_types")}`,
+    `${runTask("gen:schema")} && pnpm exec json2ts -i npm/cli/schemas/vize.config.schema.json -o npm/cli/src/types/generated.ts && ${moonScript("postprocess_types")} && pnpm exec oxfmt --write npm/cli/schemas/vize.config.schema.json npm/cli/src/types/generated.ts`,
   ),
   gen: noCacheTask(runTask("gen:types")),
   cli: noCacheTask(


### PR DESCRIPTION
## Summary

- resolve the nested Pkl project explicitly when generating the config schema from the repository root
- format both generated artifacts inside `gen:types` so a clean regeneration leaves no diff
- exercise the complete Pkl, json2ts, MoonBit post-processing, and formatting pipeline in an isolated freshness test

## Verification

- `MOON_HOME=/Users/nishimura/Code/github.com/ubugeeei/vize/.cache/moonbit MOON_BIN=/Users/nishimura/Code/github.com/ubugeeei/vize/.cache/moonbit/bin/moon pnpm vp run gen:types`
- `MOON_HOME=/Users/nishimura/Code/github.com/ubugeeei/vize/.cache/moonbit MOON_BIN=/Users/nishimura/Code/github.com/ubugeeei/vize/.cache/moonbit/bin/moon node --test tests/tooling/config-generation.test.ts tests/tooling/moonbit-postprocess-types.test.ts tests/tooling/task-shell.test.ts tests/tooling/config-json-shape.test.ts`
- `pnpm exec vp check tools/vite-plus/tasks/generation-cli.ts tests/tooling/config-generation.test.ts`
- `git diff --check`

Closes #4019

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4096"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration generation reliability by using the correct project context.
  * Generated schema and TypeScript outputs are now automatically formatted for consistent results.
  * Added cleanup handling to prevent temporary generation artifacts from being left behind.

* **Tests**
  * Added integration coverage confirming configuration schemas and TypeScript declarations can be regenerated, formatted, and matched against the checked-in versions.
  * Verified the generation command completes successfully and produces consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->