### PR TITLE
fix(canon): honor allowJs for project sources

### DIFF
--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -24,6 +24,7 @@ mod materialize_fs;
 mod materialize_lock;
 mod runtime_deps;
 mod source_map;
+mod source_policy;
 mod type_checker;
 pub(crate) mod virtual_project;
 mod virtual_specifier_message;

--- a/crates/vize_canon/src/batch/executor/session.rs
+++ b/crates/vize_canon/src/batch/executor/session.rs
@@ -14,6 +14,7 @@ use super::{
 };
 use crate::batch::error::CorsaResult;
 use crate::batch::executor::diagnostics::map_batch_diagnostics;
+use crate::batch::source_policy::SourceFilePolicy;
 use crate::batch::type_checker::IncrementalCheckMetrics;
 use crate::batch::virtual_project::{
     AUTO_IMPORT_STUBS_FILE, SHARED_HELPERS_FILE, VUE_MODULE_STUBS_FILE,
@@ -75,7 +76,7 @@ impl CorsaExecutor {
         };
         let mut uris = profile!(
             "canon.corsa.collect_uris",
-            collect_virtual_file_uris(project.virtual_root())
+            collect_virtual_file_uris(project.virtual_root(), project.source_file_policy())
         )?;
         extend_diagnostic_path_uris(project, &mut uris);
         check_session_client(&mut client, project, &uris)
@@ -94,7 +95,7 @@ impl CorsaExecutor {
             )?;
             let mut snapshot = profile!(
                 "canon.corsa.incremental.snapshot",
-                MaterializedSnapshot::capture(project.virtual_root())
+                MaterializedSnapshot::capture(project.virtual_root(), project.source_file_policy())
             )?;
             snapshot.extend_diagnostic_paths(project)?;
             let mut state = self
@@ -136,7 +137,6 @@ impl IncrementalSessionState {
         self.metrics.last_changed_files = 0;
         self.metrics.last_created_files = 0;
         self.metrics.last_deleted_files = 0;
-
         if let Some(session) = &mut self.session {
             self.metrics.last_session_reused = true;
             let delta = snapshot.diff(&session.snapshot);
@@ -180,7 +180,7 @@ impl IncrementalSessionState {
 }
 
 impl MaterializedSnapshot {
-    fn capture(virtual_root: &Path) -> CorsaResult<Self> {
+    fn capture(virtual_root: &Path, source_policy: SourceFilePolicy) -> CorsaResult<Self> {
         let mut snapshot = Self::default();
         for entry in walkdir::WalkDir::new(virtual_root) {
             let entry = entry?;
@@ -195,7 +195,7 @@ impl MaterializedSnapshot {
                 };
                 snapshot.revisions.insert(path.to_path_buf(), revision);
                 if resolves_to_file
-                    && is_diagnostic_input(path)
+                    && source_policy.accepts_diagnostic_input(path)
                     && !is_under_virtual_node_modules(virtual_root, path)
                     && !is_internal_virtual_project_stub(path)
                 {
@@ -211,7 +211,7 @@ impl MaterializedSnapshot {
             snapshot
                 .revisions
                 .insert(path.to_path_buf(), hash_bytes(&content));
-            if is_diagnostic_input(path)
+            if source_policy.accepts_diagnostic_input(path)
                 && !is_under_virtual_node_modules(virtual_root, path)
                 && !is_internal_virtual_project_stub(path)
             {
@@ -298,7 +298,10 @@ fn check_session_client(
     })
 }
 
-pub(super) fn collect_virtual_file_uris(virtual_root: &Path) -> CorsaResult<Vec<String>> {
+pub(super) fn collect_virtual_file_uris(
+    virtual_root: &Path,
+    source_policy: SourceFilePolicy,
+) -> CorsaResult<Vec<String>> {
     let mut uris = Vec::new();
     for entry in walkdir::WalkDir::new(virtual_root) {
         let entry = entry?;
@@ -306,20 +309,13 @@ pub(super) fn collect_virtual_file_uris(virtual_root: &Path) -> CorsaResult<Vec<
         if path.is_file()
             && !is_under_virtual_node_modules(virtual_root, path)
             && !is_internal_virtual_project_stub(path)
-            && is_diagnostic_input(path)
+            && source_policy.accepts_diagnostic_input(path)
         {
             uris.push(path_to_file_uri(path));
         }
     }
     uris.sort();
     Ok(uris)
-}
-
-fn is_diagnostic_input(path: &Path) -> bool {
-    matches!(
-        path.extension().and_then(|extension| extension.to_str()),
-        Some("ts" | "tsx" | "mts" | "cts")
-    )
 }
 
 fn is_internal_virtual_project_stub(path: &Path) -> bool {

--- a/crates/vize_canon/src/batch/executor/session/tests.rs
+++ b/crates/vize_canon/src/batch/executor/session/tests.rs
@@ -1,4 +1,5 @@
 use super::{MaterializedDelta, MaterializedSnapshot, VirtualProject};
+use crate::batch::source_policy::SourceFilePolicy;
 use std::path::PathBuf;
 use vize_carton::FxHashMap;
 
@@ -31,10 +32,10 @@ fn snapshot_keeps_symlinked_typescript_files_as_diagnostic_inputs() {
     std::fs::write(&target, "export const value = 1\n").expect("target should be written");
     symlink(&target, &linked).expect("source symlink should be created");
 
-    let before = MaterializedSnapshot::capture(&virtual_root)
+    let before = MaterializedSnapshot::capture(&virtual_root, SourceFilePolicy::default())
         .expect("materialized snapshot should be captured");
     std::fs::write(&target, "export const value = 2\n").expect("target should be updated");
-    let after = MaterializedSnapshot::capture(&virtual_root)
+    let after = MaterializedSnapshot::capture(&virtual_root, SourceFilePolicy::default())
         .expect("updated materialized snapshot should be captured");
 
     assert!(after.revisions.contains_key(&linked));
@@ -52,11 +53,13 @@ fn snapshot_tracks_in_place_diagnostic_source_changes() {
     let mut project = VirtualProject::new(temp.path()).unwrap();
     std::fs::create_dir_all(project.virtual_root()).unwrap();
     project.set_diagnostic_paths([source.as_path()]);
-    let mut before = MaterializedSnapshot::capture(project.virtual_root()).unwrap();
+    let mut before =
+        MaterializedSnapshot::capture(project.virtual_root(), SourceFilePolicy::default()).unwrap();
     before.extend_diagnostic_paths(&project).unwrap();
 
     std::fs::write(&source, "export const value = 2\n").unwrap();
-    let mut after = MaterializedSnapshot::capture(project.virtual_root()).unwrap();
+    let mut after =
+        MaterializedSnapshot::capture(project.virtual_root(), SourceFilePolicy::default()).unwrap();
     after.extend_diagnostic_paths(&project).unwrap();
 
     let source = source.canonicalize().unwrap();

--- a/crates/vize_canon/src/batch/executor/tests.rs
+++ b/crates/vize_canon/src/batch/executor/tests.rs
@@ -1,5 +1,6 @@
 use super::fallback::{FallbackCause, classify_fallback_cause};
 use super::{CorsaError, CorsaExecutor, collect_declaration_outputs, collect_virtual_file_uris};
+use crate::batch::source_policy::SourceFilePolicy;
 use crate::file_uri::path_to_file_uri;
 use std::{
     fs,
@@ -48,7 +49,7 @@ fn collects_virtual_type_script_files_only() {
     fs::write(root.join("tsconfig.json"), "{}").unwrap();
     fs::write(root.join("ignored.js"), "").unwrap();
 
-    let uris = collect_virtual_file_uris(root).unwrap();
+    let uris = collect_virtual_file_uris(root, SourceFilePolicy::default()).unwrap();
 
     assert_eq!(
         uris,
@@ -61,6 +62,15 @@ fn collects_virtual_type_script_files_only() {
             path_to_file_uri(root.join("module.mts").as_path()),
         ]
     );
+
+    let allow_js = SourceFilePolicy::from_compiler_options(
+        serde_json::json!({ "allowJs": true }).as_object().unwrap(),
+    );
+    let uris = collect_virtual_file_uris(root, allow_js).unwrap();
+    assert!(
+        uris.contains(&path_to_file_uri(root.join("ignored.js").as_path())),
+        "allowJs should make the JavaScript family diagnostic inputs"
+    );
 }
 
 #[test]
@@ -71,7 +81,7 @@ fn encodes_reserved_characters_in_virtual_file_uris() {
     fs::create_dir_all(&route_dir).unwrap();
     fs::write(route_dir.join("[versionRange].vue.ts"), "").unwrap();
 
-    let uris = collect_virtual_file_uris(root.as_path()).unwrap();
+    let uris = collect_virtual_file_uris(root.as_path(), SourceFilePolicy::default()).unwrap();
     let _ = fs::remove_dir_all(&root);
 
     assert_eq!(

--- a/crates/vize_canon/src/batch/source_policy.rs
+++ b/crates/vize_canon/src/batch/source_policy.rs
@@ -1,0 +1,112 @@
+//! One extension and diagnostic policy for a TypeScript project snapshot.
+//!
+//! Source discovery, virtual-project materialization, and Corsa diagnostic
+//! requests must agree on the same effective `allowJs` / `checkJs` values.
+//! Keeping the classification here prevents each layer from growing a slightly
+//! different extension whitelist.
+#![allow(clippy::disallowed_types)] // serde_json::Map keys are std::string::String.
+
+use std::path::Path;
+
+use serde_json::{Map, Value};
+
+use super::declaration_path::is_declaration_file;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct SourceFilePolicy {
+    allow_javascript: bool,
+    check_javascript: bool,
+}
+
+impl SourceFilePolicy {
+    pub(crate) fn from_compiler_options(
+        compiler_options: &Map<std::string::String, Value>,
+    ) -> Self {
+        Self {
+            allow_javascript: option_enabled(compiler_options, "allowJs"),
+            check_javascript: option_enabled(compiler_options, "checkJs"),
+        }
+    }
+
+    pub(crate) fn allows_javascript(self) -> bool {
+        self.allow_javascript
+    }
+
+    pub(crate) fn checks_javascript(self) -> bool {
+        self.check_javascript
+    }
+
+    pub(crate) fn accepts_project_source(self, path: &Path) -> bool {
+        is_typescript_family(path)
+            || is_vue(path)
+            || is_declaration_file(path)
+            || self.allow_javascript && is_javascript_family(path)
+    }
+
+    pub(crate) fn accepts_diagnostic_input(self, path: &Path) -> bool {
+        is_typescript_family(path) || self.allow_javascript && is_javascript_family(path)
+    }
+}
+
+fn option_enabled(options: &Map<std::string::String, Value>, name: &str) -> bool {
+    options.get(name).and_then(Value::as_bool).unwrap_or(false)
+}
+
+fn is_typescript_family(path: &Path) -> bool {
+    matches!(extension(path), Some("ts" | "tsx" | "mts" | "cts"))
+}
+
+fn is_javascript_family(path: &Path) -> bool {
+    matches!(extension(path), Some("js" | "jsx" | "mjs" | "cjs"))
+}
+
+fn is_vue(path: &Path) -> bool {
+    extension(path) == Some("vue")
+}
+
+fn extension(path: &Path) -> Option<&str> {
+    path.extension().and_then(|extension| extension.to_str())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SourceFilePolicy;
+    use serde_json::json;
+    use std::path::Path;
+
+    fn policy(options: serde_json::Value) -> SourceFilePolicy {
+        SourceFilePolicy::from_compiler_options(options.as_object().unwrap())
+    }
+
+    #[test]
+    fn allowjs_controls_membership_while_checkjs_only_controls_diagnostics() {
+        let typescript_only = policy(json!({ "checkJs": true }));
+        let allow_js = policy(json!({ "allowJs": true, "checkJs": false }));
+
+        for path in [
+            "App.vue",
+            "entry.ts",
+            "view.tsx",
+            "module.mts",
+            "config.cts",
+        ] {
+            assert!(
+                typescript_only.accepts_project_source(Path::new(path)),
+                "{path}"
+            );
+            assert!(typescript_only.accepts_diagnostic_input(Path::new(path)) || path == "App.vue");
+        }
+        for path in ["entry.js", "view.jsx", "module.mjs", "config.cjs"] {
+            assert!(
+                !typescript_only.accepts_project_source(Path::new(path)),
+                "{path}"
+            );
+            assert!(allow_js.accepts_project_source(Path::new(path)), "{path}");
+            assert!(allow_js.accepts_diagnostic_input(Path::new(path)), "{path}");
+        }
+        assert!(!typescript_only.allows_javascript());
+        assert!(typescript_only.checks_javascript());
+        assert!(allow_js.allows_javascript());
+        assert!(!allow_js.checks_javascript());
+    }
+}

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -204,7 +204,10 @@ impl BatchTypeChecker {
 
     /// Scan the project for source files.
     pub fn scan_project(&mut self) -> CorsaResult<()> {
-        let paths = collect_project_paths(self.project.project_root())?;
+        let paths = collect_project_paths(
+            self.project.project_root(),
+            self.project.source_file_policy(),
+        )?;
         self.project.set_declaration_roots(&paths);
         self.project.register_paths(&paths)?;
         self.project.register_virtual_module_alias_targets()?;
@@ -279,9 +282,12 @@ impl TypeChecker for BatchTypeChecker {
         // Rebuilding source-derived virtual files preserves the observable
         // correctness contract; the executor reuses Corsa's dependency graph
         // after diffing the complete materialized snapshot.
-        let paths = self.incremental_paths.refresh(&self.project, changed)?;
-
         let mut refreshed = self.project.empty_with_same_options()?;
+        let paths = self.incremental_paths.refresh(
+            &self.project,
+            refreshed.source_file_policy(),
+            changed,
+        )?;
         refreshed.register_paths(&paths)?;
         refreshed.register_virtual_module_alias_targets()?;
         refreshed.register_reachable_dependencies()?;

--- a/crates/vize_canon/src/batch/type_checker/paths.rs
+++ b/crates/vize_canon/src/batch/type_checker/paths.rs
@@ -3,8 +3,8 @@
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
-use super::super::declaration_path::is_declaration_file;
 use super::super::error::{CorsaError, CorsaResult};
+use super::super::source_policy::SourceFilePolicy;
 use super::super::virtual_project::VirtualProject;
 
 /// Source membership carried across incremental checks.
@@ -53,6 +53,7 @@ impl IncrementalPaths {
     pub(super) fn refresh(
         &self,
         project: &VirtualProject,
+        source_policy: SourceFilePolicy,
         changed: &[PathBuf],
     ) -> CorsaResult<Vec<PathBuf>> {
         let mut paths = self
@@ -65,6 +66,7 @@ impl IncrementalPaths {
             &mut paths,
             changed,
             self.allow_new_paths,
+            source_policy,
             &known_source_paths,
         )?;
         Ok(paths.clone())
@@ -79,7 +81,10 @@ impl IncrementalPaths {
     }
 }
 
-pub(super) fn collect_project_paths(project_root: &Path) -> CorsaResult<Vec<PathBuf>> {
+pub(super) fn collect_project_paths(
+    project_root: &Path,
+    source_policy: SourceFilePolicy,
+) -> CorsaResult<Vec<PathBuf>> {
     let mut paths = Vec::new();
     for entry in walkdir::WalkDir::new(project_root)
         .into_iter()
@@ -93,7 +98,7 @@ pub(super) fn collect_project_paths(project_root: &Path) -> CorsaResult<Vec<Path
     {
         let entry = entry?;
         let path = entry.path();
-        if path.is_file() && is_supported_input(path) {
+        if path.is_file() && source_policy.accepts_project_source(path) {
             paths.push(path.to_path_buf());
         }
     }
@@ -105,6 +110,7 @@ pub(super) fn refresh_paths(
     paths: &mut Vec<PathBuf>,
     changed: &[PathBuf],
     allow_new_paths: bool,
+    source_policy: SourceFilePolicy,
     known_source_paths: &[PathBuf],
 ) -> CorsaResult<()> {
     let mut refreshed_paths = paths.clone();
@@ -127,7 +133,7 @@ pub(super) fn refresh_paths(
         if allow_new_paths
             && !already_registered
             && candidate.is_file()
-            && is_supported_input(&candidate)
+            && source_policy.accepts_project_source(&candidate)
         {
             refreshed_paths.push(candidate);
         }
@@ -140,16 +146,10 @@ pub(super) fn refresh_paths(
     Ok(())
 }
 
-fn is_supported_input(path: &Path) -> bool {
-    path.extension()
-        .and_then(|extension| extension.to_str())
-        .is_some_and(|extension| matches!(extension, "vue" | "ts" | "tsx" | "mts" | "cts"))
-        || is_declaration_file(path)
-}
-
 #[cfg(test)]
 mod tests {
     use super::refresh_paths;
+    use crate::batch::source_policy::SourceFilePolicy;
 
     #[test]
     fn validation_error_does_not_partially_grow_membership() {
@@ -165,8 +165,15 @@ mod tests {
         let project_root = vize_carton::path::canonicalize_non_verbatim(project.path());
         let existing = vize_carton::path::canonicalize_non_verbatim(&existing);
         let mut paths = vec![existing.clone()];
-        let error = refresh_paths(&project_root, &mut paths, &[added, outside_file], true, &[])
-            .expect_err("outside path should reject the whole refresh");
+        let error = refresh_paths(
+            &project_root,
+            &mut paths,
+            &[added, outside_file],
+            true,
+            SourceFilePolicy::default(),
+            &[],
+        )
+        .expect_err("outside path should reject the whole refresh");
 
         assert!(matches!(error, crate::batch::CorsaError::PathError { .. }));
         assert_eq!(paths, vec![existing]);
@@ -191,6 +198,7 @@ mod tests {
             &mut paths,
             std::slice::from_ref(&outside_file),
             true,
+            SourceFilePolicy::default(),
             std::slice::from_ref(&outside_file),
         )
         .expect("an already-registered external dependency should refresh");

--- a/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/incremental.rs
@@ -3,6 +3,8 @@ use crate::batch::TypeChecker;
 
 #[path = "incremental/file_lifecycle.rs"]
 mod file_lifecycle;
+#[path = "incremental/javascript.rs"]
+mod javascript;
 #[path = "incremental/workspace_packages.rs"]
 mod workspace_packages;
 

--- a/crates/vize_canon/src/batch/type_checker/tests/incremental/javascript.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/incremental/javascript.rs
@@ -1,0 +1,143 @@
+use super::{BatchTypeChecker, TypeChecker, create_project_case, resolve_test_tsgo_binary};
+
+fn diagnostic<'a>(
+    diagnostics: &'a [crate::batch::Diagnostic],
+    path: &std::path::Path,
+    code: u32,
+) -> &'a crate::batch::Diagnostic {
+    diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.file == path && diagnostic.code == Some(code))
+        .unwrap_or_else(|| panic!("missing {code} for {}: {diagnostics:#?}", path.display()))
+}
+
+#[test]
+fn allowjs_project_refreshes_javascript_family_lifecycle() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(
+        "incremental-allowjs-lifecycle",
+        &[
+            (
+                "src/entry.js",
+                "/** @type {number} */\nexport const entry = 1;\n",
+            ),
+            (
+                "src/view.jsx",
+                "/** @type {number} */\nexport const view = 1;\n",
+            ),
+            (
+                "src/module.mjs",
+                "/** @type {number} */\nexport const moduleValue = 1;\n",
+            ),
+            (
+                "src/config.cjs",
+                "/** @type {number} */\nconst config = 1;\nvoid config;\n",
+            ),
+        ],
+    );
+    std::fs::write(
+        project_root.join("tsconfig.base.json"),
+        r#"{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  }
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{ "extends": "./tsconfig.base.json", "include": ["src/**/*"] }"#,
+    )
+    .unwrap();
+
+    let entry_path = project_root.join("src/entry.js");
+    let added_path = project_root.join("src/added.mjs");
+    let renamed_path = project_root.join("src/renamed.cjs");
+    let mut checker = BatchTypeChecker::new(&project_root).expect("checker should start");
+    checker.scan_project().expect("initial scan should succeed");
+    assert_eq!(
+        checker.file_count(),
+        4,
+        "allowJs should admit every authored JavaScript extension"
+    );
+
+    let clean = checker.check_project().expect("clean check should succeed");
+    assert!(
+        clean
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != Some(2322)),
+        "clean JavaScript family reported TS2322: {:#?}",
+        clean.diagnostics
+    );
+
+    std::fs::write(
+        &entry_path,
+        "/** @type {number} */\nexport const entry = 'broken edit';\n",
+    )
+    .unwrap();
+    let edited = checker
+        .check_incremental(std::slice::from_ref(&entry_path))
+        .expect("JavaScript edit should refresh");
+    let edit_error = diagnostic(&edited.diagnostics, &entry_path, 2322);
+    assert_eq!((edit_error.line, edit_error.column), (1, 13));
+
+    std::fs::write(
+        &added_path,
+        "/** @type {number} */\nexport const added = 'broken create';\n",
+    )
+    .unwrap();
+    let created = checker
+        .check_incremental(std::slice::from_ref(&added_path))
+        .expect("JavaScript create should refresh");
+    assert!(
+        checker.incremental_metrics().last_created_files > 0,
+        "JavaScript create must enter the materialized delta: {:?}",
+        checker.incremental_metrics()
+    );
+    diagnostic(&created.diagnostics, &entry_path, 2322);
+    diagnostic(&created.diagnostics, &added_path, 2322);
+
+    std::fs::rename(&added_path, &renamed_path).unwrap();
+    let renamed = checker
+        .check_incremental(&[added_path.clone(), renamed_path.clone()])
+        .expect("JavaScript rename should refresh");
+    assert!(
+        renamed
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.file != added_path),
+        "rename retained stale diagnostics: {:#?}",
+        renamed.diagnostics
+    );
+    diagnostic(&renamed.diagnostics, &renamed_path, 2322);
+
+    std::fs::write(
+        &entry_path,
+        "/** @type {number} */\nexport const entry = 1;\n",
+    )
+    .unwrap();
+    std::fs::remove_file(&renamed_path).unwrap();
+    let repaired = checker
+        .check_incremental(&[entry_path, renamed_path.clone()])
+        .expect("JavaScript repair and delete should refresh");
+    assert!(
+        repaired
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != Some(2322) && diagnostic.file != renamed_path),
+        "repair or delete retained stale diagnostics: {:#?}",
+        repaired.diagnostics
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -21,6 +21,7 @@ use vize_carton::{FxHashMap, FxHashSet, String as CompactString};
 
 use super::import_rewriter::ImportRewriter;
 use super::source_map::CompositeSourceMap;
+use super::source_policy::SourceFilePolicy;
 use super::{Diagnostic, SfcBlockType};
 use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 
@@ -112,9 +113,8 @@ pub struct VirtualProject {
     /// Whether the effective tsconfig asks TypeScript to report unused symbols.
     preserve_unused_diagnostics: bool,
 
-    /// Whether the effective tsconfig enables `checkJs`. When it does not,
-    /// TypeScript diagnostics on JavaScript SFCs are not reportable (#3322).
-    check_js: bool,
+    /// Effective TypeScript source membership and JavaScript diagnostic policy.
+    source_policy: SourceFilePolicy,
 
     /// Global virtual TS options applied to every Vue file.
     virtual_ts_options: VirtualTsOptions,

--- a/crates/vize_canon/src/batch/virtual_project/javascript_sfc.rs
+++ b/crates/vize_canon/src/batch/virtual_project/javascript_sfc.rs
@@ -18,8 +18,6 @@
 
 use vize_atelier_sfc::SfcDescriptor;
 
-use super::VirtualProject;
-
 /// TypeScript-flavoured `<script lang>` values. Everything else (`js`, `jsx`,
 /// or an absent `lang`) is JavaScript.
 fn is_typescript_lang(lang: &str) -> bool {
@@ -90,22 +88,6 @@ fn opts_into_type_checking(content: &str) -> bool {
         return false;
     }
     false
-}
-
-impl VirtualProject {
-    /// Whether the effective tsconfig asks TypeScript to check JavaScript.
-    pub(super) fn resolve_tsconfig_checks_javascript(&self) -> bool {
-        let Some(tsconfig_path) = self.resolved_tsconfig_path() else {
-            return false;
-        };
-        let Ok(compiler_options) = self.load_compiler_options(Some(tsconfig_path.as_path())) else {
-            return false;
-        };
-        compiler_options
-            .get("checkJs")
-            .and_then(serde_json::Value::as_bool)
-            .unwrap_or(false)
-    }
 }
 
 #[cfg(test)]

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -44,7 +44,7 @@ impl VirtualProject {
             virtual_root,
             tsconfig_path: None,
             preserve_unused_diagnostics: false,
-            check_js: false,
+            source_policy: Default::default(),
             virtual_ts_options: VirtualTsOptions::default(),
             diagnostic_paths: FxHashSet::default(),
             declaration_roots: None,
@@ -67,7 +67,7 @@ impl VirtualProject {
         };
         project.preserve_unused_diagnostics =
             project.resolve_tsconfig_preserves_unused_diagnostics();
-        project.check_js = project.resolve_tsconfig_checks_javascript();
+        project.source_policy = project.resolve_source_file_policy();
         Ok(project)
     }
 

--- a/crates/vize_canon/src/batch/virtual_project/project/config.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project/config.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use vize_atelier_core::TemplateSyntaxMode;
 
 use crate::batch::error::CorsaResult;
+use crate::batch::source_policy::SourceFilePolicy;
 use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 
 use super::super::VirtualProject;
@@ -15,14 +16,30 @@ impl VirtualProject {
     pub fn set_tsconfig_path(&mut self, tsconfig_path: Option<PathBuf>) {
         self.tsconfig_path = tsconfig_path.map(vize_carton::path::normalize_windows_verbatim_path);
         self.preserve_unused_diagnostics = self.resolve_tsconfig_preserves_unused_diagnostics();
-        self.check_js = self.resolve_tsconfig_checks_javascript();
+        self.source_policy = self.resolve_source_file_policy();
+    }
+
+    pub(crate) fn source_file_policy(&self) -> SourceFilePolicy {
+        self.source_policy
+    }
+
+    pub(super) fn resolve_source_file_policy(&self) -> SourceFilePolicy {
+        let Some(tsconfig_path) = self.resolved_tsconfig_path() else {
+            return SourceFilePolicy::default();
+        };
+        self.load_compiler_options(Some(tsconfig_path.as_path()))
+            .ok()
+            .as_ref()
+            .map(SourceFilePolicy::from_compiler_options)
+            .unwrap_or_default()
     }
 
     /// Whether TypeScript diagnostics landing in `virtual_path` must be dropped
     /// because the file is a JavaScript SFC and the project does not enable
     /// `checkJs` (#3322).
     pub(crate) fn skips_typescript_diagnostics(&self, virtual_path: &Path) -> bool {
-        !self.check_js && self.unchecked_javascript_files.contains(virtual_path)
+        !self.source_policy.checks_javascript()
+            && self.unchecked_javascript_files.contains(virtual_path)
     }
 
     /// Set the shared virtual TS options.

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -14,6 +14,7 @@ use vize_carton::{String as CompactString, ToCompactString, cstr};
 
 use crate::batch::error::CorsaResult;
 use crate::batch::materialize_fs::write_if_changed;
+use crate::batch::source_policy::SourceFilePolicy;
 
 use super::{SHARED_HELPERS_FILE, VirtualProject};
 use native_options::normalize_native_removed_options;
@@ -242,7 +243,8 @@ impl VirtualProject {
             compiler_options.insert("noEmit".into(), Value::Bool(true));
         }
 
-        let include_js = compiler_option_enabled(&compiler_options, "allowJs");
+        let include_js =
+            SourceFilePolicy::from_compiler_options(&compiler_options).allows_javascript();
         config.insert("compilerOptions".into(), Value::Object(compiler_options));
         config.insert(
             "include".into(),

--- a/crates/vize_canon/src/lsp_client.rs
+++ b/crates/vize_canon/src/lsp_client.rs
@@ -17,6 +17,7 @@ mod diagnostics;
 mod diagnostics_api;
 mod diagnostics_lsp;
 mod editor_lsp;
+mod language_id;
 mod lifecycle;
 mod lifecycle_setup;
 mod materialized_refresh;

--- a/crates/vize_canon/src/lsp_client/diagnostics.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics.rs
@@ -2,6 +2,7 @@ use super::{
     CorsaProjectClient, DiagnosticFetch, LspDiagnostic,
     diagnostics_api::{document_identifier_uri, flatten_file_diagnostics, map_project_diagnostics},
     diagnostics_lsp::{initialize_lsp_client, request_lsp_document_diagnostics},
+    language_id::for_uri as language_id_for_uri,
     session::uri_document_identifier,
     session_paths::overlay_root_for_project,
     utils::convert_diagnostics,
@@ -623,14 +624,6 @@ fn json_code_to_lsp_code(code: serde_json::Value) -> lsp_types::NumberOrString {
 fn read_file_uri(uri: &str) -> Option<String> {
     let path = file_uri_to_path(uri)?;
     std::fs::read_to_string(path).ok().map(Into::into)
-}
-
-fn language_id_for_uri(uri: &str) -> &'static str {
-    if uri.ends_with(".tsx") || uri.ends_with(".jsx") {
-        "typescriptreact"
-    } else {
-        "typescript"
-    }
 }
 
 #[cfg(test)]

--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -10,7 +10,10 @@
 //! pay for the extra process, and a session that has answered one hover is
 //! reused for every later request.
 
-use super::{CorsaProjectClient, diagnostics_lsp::initialize_lsp_client};
+use super::{
+    CorsaProjectClient, diagnostics_lsp::initialize_lsp_client,
+    language_id::for_uri as language_id_for_uri,
+};
 use corsa::{
     jsonrpc::InboundEvent,
     lsp::{LspClient, LspOverlay, LspSpawnConfig, VirtualDocument},
@@ -92,14 +95,12 @@ impl EditorLspSession {
                 })?;
             }
             None => {
-                let language_id =
-                    if document_uri.ends_with(".tsx") || document_uri.ends_with(".jsx") {
-                        "typescriptreact"
-                    } else {
-                        "typescript"
-                    };
                 self.overlay
-                    .open(VirtualDocument::new(uri.clone(), language_id, text))
+                    .open(VirtualDocument::new(
+                        uri.clone(),
+                        language_id_for_uri(document_uri),
+                        text,
+                    ))
                     .map_err(|error| {
                         cstr!("Failed to open editor LSP overlay for {document_uri}: {error}")
                     })?;

--- a/crates/vize_canon/src/lsp_client/language_id.rs
+++ b/crates/vize_canon/src/lsp_client/language_id.rs
@@ -1,0 +1,41 @@
+//! Canonical LSP language identifiers for TypeScript project sources.
+
+/// Return the language identifier matching the document's authored extension.
+///
+/// TSGo uses this value to choose the document's `ScriptKind` when an overlay
+/// is first opened. Reporting JavaScript as TypeScript disables JavaScript's
+/// JSDoc checking even when the project enables `allowJs` and `checkJs`.
+pub(super) fn for_uri(uri: &str) -> &'static str {
+    if uri.ends_with(".jsx") {
+        "javascriptreact"
+    } else if uri.ends_with(".js") || uri.ends_with(".mjs") || uri.ends_with(".cjs") {
+        "javascript"
+    } else if uri.ends_with(".tsx") {
+        "typescriptreact"
+    } else {
+        "typescript"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::for_uri;
+
+    #[test]
+    fn preserves_the_authored_script_family_for_every_project_extension() {
+        for (uri, expected) in [
+            ("file:///project/source.js", "javascript"),
+            ("file:///project/source.mjs", "javascript"),
+            ("file:///project/source.cjs", "javascript"),
+            ("file:///project/source.jsx", "javascriptreact"),
+            ("file:///project/source.ts", "typescript"),
+            ("file:///project/source.mts", "typescript"),
+            ("file:///project/source.cts", "typescript"),
+            ("file:///project/source.tsx", "typescriptreact"),
+            ("file:///project/App.vue.ts", "typescript"),
+            ("file:///project/App.vue.tsx", "typescriptreact"),
+        ] {
+            assert_eq!(for_uri(uri), expected, "{uri}");
+        }
+    }
+}

--- a/crates/vize_canon/src/lsp_client/lifecycle.rs
+++ b/crates/vize_canon/src/lsp_client/lifecycle.rs
@@ -1,6 +1,7 @@
 use super::{
     CorsaProjectClient,
     bootstrap::resolve_corsa_executable,
+    language_id::for_uri as language_id_for_uri,
     lifecycle_setup::{
         cleanup_stale_sessions, install_node_modules_link, write_session_meta,
         write_shared_helper_decls, write_temp_tsconfig, write_vue_module_stubs,
@@ -157,7 +158,7 @@ impl CorsaProjectClient {
                     document: uri_document_identifier(document_uri.as_str()),
                     text: (*content).into(),
                     version: Some(version),
-                    language_id: Some("typescript".into()),
+                    language_id: Some(language_id_for_uri(document_uri.as_str()).into()),
                 });
             }
         }

--- a/crates/vize_canon/src/lsp_client/materialized_refresh.rs
+++ b/crates/vize_canon/src/lsp_client/materialized_refresh.rs
@@ -74,6 +74,7 @@ mod tests {
             PathBuf::from("/workspace/a.ts"),
             PathBuf::from("/workspace/a.ts"),
         ];
+
         let created = vec![PathBuf::from("/workspace/created.ts")];
         let deleted = vec![PathBuf::from("/workspace/deleted.ts")];
 

--- a/crates/vize_canon/src/lsp_client/session.rs
+++ b/crates/vize_canon/src/lsp_client/session.rs
@@ -206,7 +206,7 @@ impl CorsaProjectClient {
                     document: uri_document_identifier(document_uri.as_str()),
                     text: content.into(),
                     version: Some(version),
-                    language_id: Some("typescript".into()),
+                    language_id: Some(super::language_id::for_uri(document_uri.as_str()).into()),
                 }],
                 delete: Vec::new(),
             }),


### PR DESCRIPTION
## Summary

- derive one effective source policy from the resolved tsconfig and use it for scanning, materialization, diagnostics, and incremental membership
- preserve JavaScript ScriptKind across project diagnostics, editor fallback, and overlay refreshes
- cover direct and extended allowJs/checkJs projects plus JS, JSX, MJS, and CJS edit/create/rename/delete lifecycles with exact authored diagnostics

## Validation

- cargo fmt --all -- --check
- cargo clippy -p vize_canon --features native --lib -- -D warnings
- VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --features native --lib (875 passed)
- VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize --test check_allowjs_imports_cli (10 passed)
- source_file_lengths --check against origin/main

Closes #4038

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->