### PR TITLE
fix(canon): isolate shared dependency virtual projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3707,6 +3707,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",

--- a/crates/vize/src/commands/clean.rs
+++ b/crates/vize/src/commands/clean.rs
@@ -1,7 +1,10 @@
 //! Clean command - Remove Vize-generated cache artifacts.
 
 use std::path::{Path, PathBuf};
-use std::{fs, io::ErrorKind};
+use std::{
+    fs,
+    io::{self, ErrorKind},
+};
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct CleanArgs {
@@ -104,10 +107,7 @@ fn managed_vize_artifact_paths(root: &Path, scope: CleanScope) -> Vec<PathBuf> {
     paths
 }
 
-fn force_vize_artifact_paths(
-    root: &Path,
-    scope: CleanScope,
-) -> Result<Vec<PathBuf>, std::io::Error> {
+fn force_vize_artifact_paths(root: &Path, scope: CleanScope) -> io::Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
     if matches!(scope, CleanScope::All | CleanScope::Project) {
         paths.push(project_vize_dir(root));

--- a/crates/vize/src/commands/clean.rs
+++ b/crates/vize/src/commands/clean.rs
@@ -39,7 +39,17 @@ pub enum CleanScope {
 pub fn run(args: CleanArgs) {
     let root = args.root.canonicalize().unwrap_or(args.root);
     let artifact_paths = if args.force {
-        force_vize_artifact_paths(&root, args.scope)
+        match force_vize_artifact_paths(&root, args.scope) {
+            Ok(artifact_paths) => artifact_paths,
+            Err(error) => {
+                eprintln!(
+                    "Failed to enumerate {}: {}",
+                    node_modules_vize_dir(&root).display(),
+                    error
+                );
+                std::process::exit(1);
+            }
+        }
     } else {
         managed_vize_artifact_paths(&root, args.scope)
     };
@@ -94,25 +104,37 @@ fn managed_vize_artifact_paths(root: &Path, scope: CleanScope) -> Vec<PathBuf> {
     paths
 }
 
-fn force_vize_artifact_paths(root: &Path, scope: CleanScope) -> Vec<PathBuf> {
+fn force_vize_artifact_paths(
+    root: &Path,
+    scope: CleanScope,
+) -> Result<Vec<PathBuf>, std::io::Error> {
     let mut paths = Vec::new();
     if matches!(scope, CleanScope::All | CleanScope::Project) {
         paths.push(project_vize_dir(root));
     }
     if matches!(scope, CleanScope::All | CleanScope::NodeModules) {
         let node_modules_vize = node_modules_vize_dir(root);
-        if let Ok(entries) = fs::read_dir(&node_modules_vize) {
-            paths.extend(entries.filter_map(Result::ok).filter_map(|entry| {
-                // Canon is shared dependency storage with project-keyed mutable
-                // state. Even `--force` may remove only the current project key;
-                // deleting the parent would erase live state owned by another
-                // project that happens to share this node_modules tree.
-                (entry.file_name() != "canon").then(|| entry.path())
-            }));
+        match fs::read_dir(&node_modules_vize) {
+            Ok(entries) => {
+                for entry in entries {
+                    let entry = entry?;
+                    // Canon is shared dependency storage with project-keyed mutable
+                    // state. Even `--force` may remove only the current project key;
+                    // deleting the parent would erase live state owned by another
+                    // project that happens to share this node_modules tree.
+                    if entry.file_name() != "canon" {
+                        paths.push(entry.path());
+                    }
+                }
+            }
+            // An absent artifact root is an empty one; anything else means the
+            // enumeration is incomplete and must not drive deletions.
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
         }
         paths.extend(current_canon_artifact_paths(root));
     }
-    paths
+    Ok(paths)
 }
 
 fn project_vize_dir(root: &Path) -> PathBuf {

--- a/crates/vize/src/commands/clean.rs
+++ b/crates/vize/src/commands/clean.rs
@@ -13,7 +13,7 @@ pub struct CleanArgs {
     #[arg(long, value_enum, default_value_t = CleanScope::All)]
     pub scope: CleanScope,
 
-    /// Remove the selected artifact roots, including unrecognized entries
+    /// Remove unrecognized entries, while preserving other Canon project keys
     #[arg(long)]
     pub force: bool,
 
@@ -39,7 +39,7 @@ pub enum CleanScope {
 pub fn run(args: CleanArgs) {
     let root = args.root.canonicalize().unwrap_or(args.root);
     let artifact_paths = if args.force {
-        vize_artifact_roots(&root, args.scope)
+        force_vize_artifact_paths(&root, args.scope)
     } else {
         managed_vize_artifact_paths(&root, args.scope)
     };
@@ -70,9 +70,7 @@ pub fn run(args: CleanArgs) {
         }
     }
 
-    if !args.force {
-        remove_empty_artifact_roots(&root, args.scope);
-    }
+    remove_empty_artifact_roots(&root, args.scope);
 
     if !removed_any && !args.quiet {
         match artifact_paths.as_slice() {
@@ -96,12 +94,25 @@ fn managed_vize_artifact_paths(root: &Path, scope: CleanScope) -> Vec<PathBuf> {
     paths
 }
 
-fn vize_artifact_roots(root: &Path, scope: CleanScope) -> Vec<PathBuf> {
-    match scope {
-        CleanScope::All => vec![project_vize_dir(root), node_modules_vize_dir(root)],
-        CleanScope::Project => vec![project_vize_dir(root)],
-        CleanScope::NodeModules => vec![node_modules_vize_dir(root)],
+fn force_vize_artifact_paths(root: &Path, scope: CleanScope) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if matches!(scope, CleanScope::All | CleanScope::Project) {
+        paths.push(project_vize_dir(root));
     }
+    if matches!(scope, CleanScope::All | CleanScope::NodeModules) {
+        let node_modules_vize = node_modules_vize_dir(root);
+        if let Ok(entries) = fs::read_dir(&node_modules_vize) {
+            paths.extend(entries.filter_map(Result::ok).filter_map(|entry| {
+                // Canon is shared dependency storage with project-keyed mutable
+                // state. Even `--force` may remove only the current project key;
+                // deleting the parent would erase live state owned by another
+                // project that happens to share this node_modules tree.
+                (entry.file_name() != "canon").then(|| entry.path())
+            }));
+        }
+        paths.extend(current_canon_artifact_paths(root));
+    }
+    paths
 }
 
 fn project_vize_dir(root: &Path) -> PathBuf {
@@ -122,21 +133,29 @@ fn project_vize_artifact_paths(root: &Path) -> Vec<PathBuf> {
 
 fn node_modules_vize_artifact_paths(root: &Path) -> Vec<PathBuf> {
     let node_modules_vize_dir = node_modules_vize_dir(root);
-    [
-        "canon",
-        "check-profile",
-        "corsa",
-        "corsa-overlay",
-        "lsp.log",
-        "oxc-dumps",
-        "oxlint-plugin-vize",
-        "patina",
-        "vize.config.schema.json",
-        "vize.sock",
-    ]
-    .into_iter()
-    .map(|name| node_modules_vize_dir.join(name))
-    .collect()
+    let mut paths = current_canon_artifact_paths(root);
+    paths.extend(
+        [
+            "check-profile",
+            "corsa",
+            "corsa-overlay",
+            "lsp.log",
+            "oxc-dumps",
+            "oxlint-plugin-vize",
+            "patina",
+            "vize.config.schema.json",
+            "vize.sock",
+        ]
+        .into_iter()
+        .map(|name| node_modules_vize_dir.join(name)),
+    );
+    paths
+}
+
+fn current_canon_artifact_paths(root: &Path) -> Vec<PathBuf> {
+    let mut paths = vec![vize_canon::project_virtual_root(root)];
+    paths.extend(vize_canon::project_virtual_lock_paths(root));
+    paths
 }
 
 fn remove_path(path: &Path) -> Result<bool, std::io::Error> {
@@ -156,158 +175,20 @@ fn remove_path(path: &Path) -> Result<bool, std::io::Error> {
 }
 
 fn remove_empty_artifact_roots(root: &Path, scope: CleanScope) {
-    for artifact_root in vize_artifact_roots(root, scope) {
-        let _ = fs::remove_dir(artifact_root);
+    if matches!(scope, CleanScope::All | CleanScope::Project) {
+        let _ = fs::remove_dir(project_vize_dir(root));
+    }
+    if matches!(scope, CleanScope::All | CleanScope::NodeModules) {
+        let virtual_root = vize_canon::project_virtual_root(root);
+        if let Some(projects_dir) = virtual_root.parent() {
+            let _ = fs::remove_dir(projects_dir);
+            if let Some(canon_dir) = projects_dir.parent() {
+                let _ = fs::remove_dir(canon_dir);
+            }
+        }
+        let _ = fs::remove_dir(node_modules_vize_dir(root));
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{
-        CleanArgs, CleanScope, managed_vize_artifact_paths, node_modules_vize_artifact_paths,
-        node_modules_vize_dir, project_vize_artifact_paths, project_vize_dir, run,
-        vize_artifact_roots,
-    };
-    use std::path::Path;
-
-    #[test]
-    fn vize_artifact_roots_default_to_project_and_node_modules() {
-        assert_eq!(
-            vize_artifact_roots(Path::new("/project"), CleanScope::All),
-            vec![
-                Path::new("/project").join(".vize"),
-                Path::new("/project").join("node_modules").join(".vize"),
-            ]
-        );
-    }
-
-    #[test]
-    fn scoped_vize_artifact_roots_can_target_each_root() {
-        assert_eq!(
-            project_vize_dir(Path::new("/project")),
-            Path::new("/project").join(".vize")
-        );
-        assert_eq!(
-            node_modules_vize_dir(Path::new("/project")),
-            Path::new("/project").join("node_modules").join(".vize")
-        );
-        assert_eq!(
-            vize_artifact_roots(Path::new("/project"), CleanScope::Project),
-            vec![Path::new("/project").join(".vize")]
-        );
-        assert_eq!(
-            vize_artifact_roots(Path::new("/project"), CleanScope::NodeModules),
-            vec![Path::new("/project").join("node_modules").join(".vize")]
-        );
-    }
-
-    #[test]
-    fn managed_artifact_paths_are_lifecycle_owned_entries() {
-        let root = Path::new("/project");
-
-        assert_eq!(
-            project_vize_artifact_paths(root),
-            vec![
-                root.join(".vize").join("patina"),
-                root.join(".vize").join("reports"),
-                root.join(".vize").join("snapshots"),
-                root.join(".vize").join("tokens"),
-            ]
-        );
-        assert_eq!(
-            node_modules_vize_artifact_paths(root),
-            vec![
-                root.join("node_modules/.vize/canon"),
-                root.join("node_modules/.vize/check-profile"),
-                root.join("node_modules/.vize/corsa"),
-                root.join("node_modules/.vize/corsa-overlay"),
-                root.join("node_modules/.vize/lsp.log"),
-                root.join("node_modules/.vize/oxc-dumps"),
-                root.join("node_modules/.vize/oxlint-plugin-vize"),
-                root.join("node_modules/.vize/patina"),
-                root.join("node_modules/.vize/vize.config.schema.json"),
-                root.join("node_modules/.vize/vize.sock"),
-            ]
-        );
-        assert_eq!(
-            managed_vize_artifact_paths(root, CleanScope::All).len(),
-            project_vize_artifact_paths(root).len() + node_modules_vize_artifact_paths(root).len()
-        );
-    }
-
-    #[test]
-    fn clean_removes_managed_project_and_node_modules_vize_artifacts() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path();
-        let project_artifact = root.join(".vize").join("patina").join("session-1-0");
-        let node_modules_artifact = root.join("node_modules").join(".vize").join("canon");
-        std::fs::create_dir_all(&project_artifact).unwrap();
-        std::fs::create_dir_all(&node_modules_artifact).unwrap();
-        std::fs::write(root.join("node_modules").join(".vize").join("lsp.log"), "").unwrap();
-        std::fs::write(root.join("node_modules").join("keep.txt"), "keep").unwrap();
-
-        run(CleanArgs {
-            root: root.to_path_buf(),
-            scope: CleanScope::All,
-            force: false,
-            dry_run: false,
-            quiet: true,
-        });
-
-        assert!(!root.join(".vize").exists());
-        assert!(!root.join("node_modules").join(".vize").exists());
-        assert!(root.join("node_modules").join("keep.txt").exists());
-    }
-
-    #[test]
-    fn clean_preserves_unrecognized_entries_without_force() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path();
-        let managed_project_artifact = root.join(".vize").join("reports");
-        let unknown_project_artifact = root.join(".vize").join("custom").join("keep.txt");
-        let managed_node_modules_artifact = root.join("node_modules/.vize/canon");
-        let unknown_node_modules_artifact = root.join("node_modules/.vize/custom/keep.txt");
-        std::fs::create_dir_all(&managed_project_artifact).unwrap();
-        std::fs::create_dir_all(unknown_project_artifact.parent().unwrap()).unwrap();
-        std::fs::write(&unknown_project_artifact, "keep").unwrap();
-        std::fs::create_dir_all(&managed_node_modules_artifact).unwrap();
-        std::fs::create_dir_all(unknown_node_modules_artifact.parent().unwrap()).unwrap();
-        std::fs::write(&unknown_node_modules_artifact, "keep").unwrap();
-
-        run(CleanArgs {
-            root: root.to_path_buf(),
-            scope: CleanScope::All,
-            force: false,
-            dry_run: false,
-            quiet: true,
-        });
-
-        assert!(!managed_project_artifact.exists());
-        assert!(!managed_node_modules_artifact.exists());
-        assert!(unknown_project_artifact.exists());
-        assert!(unknown_node_modules_artifact.exists());
-    }
-
-    #[test]
-    fn force_clean_removes_selected_artifact_roots() {
-        let dir = tempfile::tempdir().unwrap();
-        let root = dir.path();
-        let unknown_project_artifact = root.join(".vize").join("custom").join("keep.txt");
-        let unknown_node_modules_artifact = root.join("node_modules/.vize/custom/keep.txt");
-        std::fs::create_dir_all(unknown_project_artifact.parent().unwrap()).unwrap();
-        std::fs::write(&unknown_project_artifact, "keep").unwrap();
-        std::fs::create_dir_all(unknown_node_modules_artifact.parent().unwrap()).unwrap();
-        std::fs::write(&unknown_node_modules_artifact, "keep").unwrap();
-
-        run(CleanArgs {
-            root: root.to_path_buf(),
-            scope: CleanScope::Project,
-            force: true,
-            dry_run: false,
-            quiet: true,
-        });
-
-        assert!(!root.join(".vize").exists());
-        assert!(unknown_node_modules_artifact.exists());
-    }
-}
+mod tests;

--- a/crates/vize/src/commands/clean/tests.rs
+++ b/crates/vize/src/commands/clean/tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    CleanArgs, CleanScope, managed_vize_artifact_paths, node_modules_vize_artifact_paths,
-    node_modules_vize_dir, project_vize_artifact_paths, project_vize_dir, run,
+    CleanArgs, CleanScope, current_canon_artifact_paths, force_vize_artifact_paths,
+    managed_vize_artifact_paths, node_modules_vize_artifact_paths, node_modules_vize_dir,
+    project_vize_artifact_paths, project_vize_dir, run,
 };
 use std::path::Path;
 
@@ -139,6 +140,26 @@ fn clean_never_removes_a_foreign_canon_namespace() {
             "force={force} removed foreign Windows lock"
         );
     }
+}
+
+#[test]
+fn force_node_modules_paths_treat_a_missing_vize_directory_as_empty() {
+    let dir = tempfile::tempdir().unwrap();
+    assert_eq!(
+        force_vize_artifact_paths(dir.path(), CleanScope::NodeModules).unwrap(),
+        current_canon_artifact_paths(dir.path())
+    );
+}
+
+#[test]
+fn force_node_modules_paths_reject_a_non_directory_vize_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let node_modules = dir.path().join("node_modules");
+    std::fs::create_dir_all(&node_modules).unwrap();
+    std::fs::write(node_modules.join(".vize"), "not a directory").unwrap();
+
+    let error = force_vize_artifact_paths(dir.path(), CleanScope::NodeModules).unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::NotADirectory);
 }
 
 #[test]

--- a/crates/vize/src/commands/clean/tests.rs
+++ b/crates/vize/src/commands/clean/tests.rs
@@ -1,0 +1,164 @@
+use super::{
+    CleanArgs, CleanScope, managed_vize_artifact_paths, node_modules_vize_artifact_paths,
+    node_modules_vize_dir, project_vize_artifact_paths, project_vize_dir, run,
+};
+use std::path::Path;
+
+#[test]
+fn scoped_vize_artifact_dirs_can_target_each_root() {
+    assert_eq!(
+        project_vize_dir(Path::new("/project")),
+        Path::new("/project").join(".vize")
+    );
+    assert_eq!(
+        node_modules_vize_dir(Path::new("/project")),
+        Path::new("/project").join("node_modules").join(".vize")
+    );
+}
+
+#[test]
+fn managed_artifact_paths_are_lifecycle_owned_entries() {
+    let root = Path::new("/project");
+    assert_eq!(
+        project_vize_artifact_paths(root),
+        vec![
+            root.join(".vize/patina"),
+            root.join(".vize/reports"),
+            root.join(".vize/snapshots"),
+            root.join(".vize/tokens"),
+        ]
+    );
+    assert_eq!(
+        node_modules_vize_artifact_paths(root),
+        vec![
+            vize_canon::project_virtual_root(root),
+            vize_canon::project_virtual_lock_paths(root)[0].clone(),
+            vize_canon::project_virtual_lock_paths(root)[1].clone(),
+            root.join("node_modules/.vize/check-profile"),
+            root.join("node_modules/.vize/corsa"),
+            root.join("node_modules/.vize/corsa-overlay"),
+            root.join("node_modules/.vize/lsp.log"),
+            root.join("node_modules/.vize/oxc-dumps"),
+            root.join("node_modules/.vize/oxlint-plugin-vize"),
+            root.join("node_modules/.vize/patina"),
+            root.join("node_modules/.vize/vize.config.schema.json"),
+            root.join("node_modules/.vize/vize.sock"),
+        ]
+    );
+    assert_eq!(
+        managed_vize_artifact_paths(root, CleanScope::All).len(),
+        project_vize_artifact_paths(root).len() + node_modules_vize_artifact_paths(root).len()
+    );
+}
+
+#[test]
+fn clean_removes_managed_project_and_node_modules_vize_artifacts() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let project_artifact = root.join(".vize/patina/session-1-0");
+    let node_modules_artifact = vize_canon::project_virtual_root(root);
+    std::fs::create_dir_all(&project_artifact).unwrap();
+    std::fs::create_dir_all(&node_modules_artifact).unwrap();
+    for lock_path in vize_canon::project_virtual_lock_paths(root) {
+        std::fs::write(lock_path, "").unwrap();
+    }
+    std::fs::write(root.join("node_modules/.vize/lsp.log"), "").unwrap();
+    std::fs::write(root.join("node_modules/keep.txt"), "keep").unwrap();
+
+    run(CleanArgs {
+        root: root.to_path_buf(),
+        scope: CleanScope::All,
+        force: false,
+        dry_run: false,
+        quiet: true,
+    });
+    assert!(!root.join(".vize").exists());
+    assert!(!root.join("node_modules/.vize").exists());
+    assert!(root.join("node_modules/keep.txt").exists());
+}
+
+#[test]
+fn clean_preserves_unrecognized_entries_without_force() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let managed_project_artifact = root.join(".vize/reports");
+    let unknown_project_artifact = root.join(".vize/custom/keep.txt");
+    let managed_node_modules_artifact = vize_canon::project_virtual_root(root);
+    let unknown_node_modules_artifact = root.join("node_modules/.vize/custom/keep.txt");
+    std::fs::create_dir_all(&managed_project_artifact).unwrap();
+    std::fs::create_dir_all(unknown_project_artifact.parent().unwrap()).unwrap();
+    std::fs::write(&unknown_project_artifact, "keep").unwrap();
+    std::fs::create_dir_all(&managed_node_modules_artifact).unwrap();
+    std::fs::create_dir_all(unknown_node_modules_artifact.parent().unwrap()).unwrap();
+    std::fs::write(&unknown_node_modules_artifact, "keep").unwrap();
+
+    run(CleanArgs {
+        root: root.to_path_buf(),
+        scope: CleanScope::All,
+        force: false,
+        dry_run: false,
+        quiet: true,
+    });
+    assert!(!managed_project_artifact.exists());
+    assert!(!managed_node_modules_artifact.exists());
+    assert!(unknown_project_artifact.exists());
+    assert!(unknown_node_modules_artifact.exists());
+}
+
+#[test]
+fn clean_never_removes_a_foreign_canon_namespace() {
+    for force in [false, true] {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let current = vize_canon::project_virtual_root(root);
+        let foreign = current.parent().unwrap().join("foreign-project-key");
+        let foreign_lock = foreign.with_extension("lock");
+        let foreign_windows_lock = foreign.with_extension("materialize.lock");
+        std::fs::create_dir_all(&current).unwrap();
+        std::fs::create_dir_all(&foreign).unwrap();
+        std::fs::write(current.join("current.ts"), "current").unwrap();
+        std::fs::write(foreign.join("foreign.ts"), "foreign").unwrap();
+        std::fs::write(&foreign_lock, "foreign").unwrap();
+        std::fs::write(&foreign_windows_lock, "foreign").unwrap();
+
+        run(CleanArgs {
+            root: root.to_path_buf(),
+            scope: CleanScope::NodeModules,
+            force,
+            dry_run: false,
+            quiet: true,
+        });
+        assert!(!current.exists(), "current key survived force={force}");
+        assert!(
+            foreign.join("foreign.ts").is_file(),
+            "force={force} removed state owned by another project"
+        );
+        assert!(foreign_lock.is_file(), "force={force} removed foreign lock");
+        assert!(
+            foreign_windows_lock.is_file(),
+            "force={force} removed foreign Windows lock"
+        );
+    }
+}
+
+#[test]
+fn force_clean_removes_selected_artifact_roots() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let unknown_project_artifact = root.join(".vize/custom/keep.txt");
+    let unknown_node_modules_artifact = root.join("node_modules/.vize/custom/keep.txt");
+    std::fs::create_dir_all(unknown_project_artifact.parent().unwrap()).unwrap();
+    std::fs::write(&unknown_project_artifact, "keep").unwrap();
+    std::fs::create_dir_all(unknown_node_modules_artifact.parent().unwrap()).unwrap();
+    std::fs::write(&unknown_node_modules_artifact, "keep").unwrap();
+
+    run(CleanArgs {
+        root: root.to_path_buf(),
+        scope: CleanScope::Project,
+        force: true,
+        dry_run: false,
+        quiet: true,
+    });
+    assert!(!root.join(".vize").exists());
+    assert!(unknown_node_modules_artifact.exists());
+}

--- a/crates/vize/src/commands/clean/tests.rs
+++ b/crates/vize/src/commands/clean/tests.rs
@@ -162,3 +162,34 @@ fn force_clean_removes_selected_artifact_roots() {
     assert!(!root.join(".vize").exists());
     assert!(unknown_node_modules_artifact.exists());
 }
+
+#[test]
+fn force_clean_removes_unrecognized_node_modules_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    let unknown_node_modules_artifact = root.join("node_modules/.vize/custom/keep.txt");
+    let current = vize_canon::project_virtual_root(root);
+    let foreign = current.parent().unwrap().join("foreign-project-key");
+    let foreign_lock = foreign.with_extension("lock");
+    let foreign_windows_lock = foreign.with_extension("materialize.lock");
+    std::fs::create_dir_all(unknown_node_modules_artifact.parent().unwrap()).unwrap();
+    std::fs::write(&unknown_node_modules_artifact, "keep").unwrap();
+    std::fs::create_dir_all(&current).unwrap();
+    std::fs::create_dir_all(&foreign).unwrap();
+    std::fs::write(foreign.join("foreign.ts"), "foreign").unwrap();
+    std::fs::write(&foreign_lock, "foreign").unwrap();
+    std::fs::write(&foreign_windows_lock, "foreign").unwrap();
+
+    run(CleanArgs {
+        root: root.to_path_buf(),
+        scope: CleanScope::NodeModules,
+        force: true,
+        dry_run: false,
+        quiet: true,
+    });
+    assert!(!unknown_node_modules_artifact.exists());
+    assert!(!current.exists());
+    assert!(foreign.join("foreign.ts").is_file());
+    assert!(foreign_lock.is_file());
+    assert!(foreign_windows_lock.is_file());
+}

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_clean_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_clean_help.snap
@@ -25,7 +25,7 @@ Options:
           [default: all]
 
       --force
-          Remove the selected artifact roots, including unrecognized entries
+          Remove unrecognized entries, while preserving other Canon project keys
 
       --dry-run
           Print artifact paths without deleting them

--- a/crates/vize/tests/check_ambient_imports_cli.rs
+++ b/crates/vize/tests/check_ambient_imports_cli.rs
@@ -141,8 +141,10 @@ const result: string = window.welcomeRuntime.ping();
     );
 
     let generated: serde_json::Value = serde_json::from_str(
-        &std::fs::read_to_string(project_root.join("node_modules/.vize/canon/tsconfig.json"))
-            .unwrap(),
+        &std::fs::read_to_string(
+            vize_canon::project_virtual_root(&project_root).join("tsconfig.json"),
+        )
+        .unwrap(),
     )
     .unwrap();
     let includes = generated["include"].as_array().unwrap();

--- a/crates/vize/tests/check_canon_graphql_cli.rs
+++ b/crates/vize/tests/check_canon_graphql_cli.rs
@@ -208,13 +208,13 @@ void childComponents
 
     run_check_json(&project_root, &corsa_path);
     assert!(
-        project_root
-            .join("node_modules/.vize/canon/pages/_studyInfoId.vue.ts")
+        vize_canon::project_virtual_root(&project_root)
+            .join("pages/_studyInfoId.vue.ts")
             .exists()
     );
     assert!(
-        !project_root
-            .join("node_modules/.vize/canon/types/codegen/schema.d.ts")
+        !vize_canon::project_virtual_root(&project_root)
+            .join("types/codegen/schema.d.ts")
             .exists()
     );
 }
@@ -329,8 +329,8 @@ void childComponents
         "generated GraphQL symbols should keep one type identity:\n{stdout}"
     );
     assert!(
-        !project_root
-            .join("node_modules/.vize/canon/types/codegen/schema.d.ts")
+        !vize_canon::project_virtual_root(&project_root)
+            .join("types/codegen/schema.d.ts")
             .exists()
     );
 }

--- a/crates/vize/tests/check_canon_path_alias_json_cli.rs
+++ b/crates/vize/tests/check_canon_path_alias_json_cli.rs
@@ -91,8 +91,9 @@ export const versions: [string, string] = [tildeVersion, atVersion];
         output.status.success(),
         "project JSON aliases resolved to Canon control files:\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
+    let canon_package = vize_canon::project_virtual_root(&project_root).join("package");
     assert!(
-        !stdout.contains("node_modules/.vize/canon/package"),
+        !stdout.contains(canon_package.to_string_lossy().as_ref()),
         "diagnostics must not resolve aliases to Canon's package boundary:\n{stdout}\n{stderr}"
     );
     let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();

--- a/crates/vize/tests/check_reference_types_cli.rs
+++ b/crates/vize/tests/check_reference_types_cli.rs
@@ -335,9 +335,10 @@ defineProps<{ itemTitle?: string }>()
         "project check should keep __VizeComponentProps visible:\n{stdout}"
     );
 
-    let helpers =
-        std::fs::read_to_string(project_root.join("node_modules/.vize/canon/__vize_helpers.d.ts"))
-            .unwrap();
+    let helpers = std::fs::read_to_string(
+        vize_canon::project_virtual_root(&project_root).join("__vize_helpers.d.ts"),
+    )
+    .unwrap();
     assert!(
         helpers.contains("type __VizeComponentProps<T>"),
         "shared helpers should define __VizeComponentProps:\n{helpers}"

--- a/crates/vize/tests/check_sfc_import_suppressions_cli.rs
+++ b/crates/vize/tests/check_sfc_import_suppressions_cli.rs
@@ -207,7 +207,7 @@ void Emoji;
         );
     }
     let virtual_chart = std::fs::read_to_string(
-        project_root.join("node_modules/.vize/canon/src/SchoolExamScoreChart.vue.ts"),
+        vize_canon::project_virtual_root(&project_root).join("src/SchoolExamScoreChart.vue.ts"),
     )
     .unwrap();
     assert!(

--- a/crates/vize/tests/check_tsx_intrinsic_elements_cli.rs
+++ b/crates/vize/tests/check_tsx_intrinsic_elements_cli.rs
@@ -148,17 +148,19 @@ fn check_tsx_intrinsic_elements_with_experimental_jsx_vapor() {
     let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
     assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
     assert!(
-        project_root
-            .join("node_modules/.vize/canon/src/Standalone.tsx.ts")
+        vize_canon::project_virtual_root(&project_root)
+            .join("src/Standalone.tsx.ts")
             .exists()
     );
-    let helpers =
-        std::fs::read_to_string(project_root.join("node_modules/.vize/canon/__vize_helpers.d.ts"))
-            .unwrap();
+    let helpers = std::fs::read_to_string(
+        vize_canon::project_virtual_root(&project_root).join("__vize_helpers.d.ts"),
+    )
+    .unwrap();
     assert!(helpers.contains("/// <reference types=\"vue/jsx\" />"));
-    let generated_tsconfig =
-        std::fs::read_to_string(project_root.join("node_modules/.vize/canon/tsconfig.json"))
-            .unwrap();
+    let generated_tsconfig = std::fs::read_to_string(
+        vize_canon::project_virtual_root(&project_root).join("tsconfig.json"),
+    )
+    .unwrap();
     assert!(generated_tsconfig.contains(r#""jsxImportSource": "vue""#));
 
     let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize/tests/check_tsx_sfc_attrs_cli.rs
+++ b/crates/vize/tests/check_tsx_sfc_attrs_cli.rs
@@ -164,9 +164,8 @@ export const Example = () => (
     );
     let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
     assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
-    let helpers =
-        std::fs::read_to_string(project_root.join("node_modules/.vize/canon/__vize_helpers.d.ts"))
-            .unwrap();
+    let helpers_path = vize_canon::project_virtual_root(&project_root).join("__vize_helpers.d.ts");
+    let helpers = std::fs::read_to_string(helpers_path).unwrap();
     assert!(helpers.contains("/// <reference types=\"vue/jsx\" />"));
     assert!(helpers.contains("interface IntrinsicAttributes"));
     assert!(helpers.contains("class?: unknown; style?: unknown"));
@@ -351,9 +350,8 @@ const button = (
     );
     let json: serde_json::Value = serde_json::from_str(stdout).unwrap();
     assert_eq!(json["errorCount"], serde_json::json!(0), "{stdout}");
-    let helpers =
-        std::fs::read_to_string(project_root.join("node_modules/.vize/canon/__vize_helpers.d.ts"))
-            .unwrap();
+    let helpers_path = vize_canon::project_virtual_root(&project_root).join("__vize_helpers.d.ts");
+    let helpers = std::fs::read_to_string(helpers_path).unwrap();
     assert!(helpers.contains("/// <reference types=\"vue/jsx\" />"));
 
     let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize_canon/Cargo.toml
+++ b/crates/vize_canon/Cargo.toml
@@ -49,6 +49,7 @@ tracing.workspace = true
 dirs = { workspace = true, optional = true }
 thiserror.workspace = true
 corsa = { workspace = true, optional = true }
+sha2.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true

--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -2,7 +2,8 @@
 //!
 //! This module provides batch type checking via `corsa-bind`.
 //! It transforms Vue SFC files into pure TypeScript, materializes a virtual
-//! project in `node_modules/.vize/canon/`, and requests diagnostics from
+//! project in a project-keyed namespace under `node_modules/.vize/canon/`, and
+//! requests diagnostics from
 //! Corsa's LSP instead of parsing CLI text output.
 
 mod declaration_path;
@@ -42,7 +43,8 @@ pub use virtual_project::{
     ContentMapperDiagnostic, ContentMapperSpan, ContentMapperTransform, OriginalPosition,
     VirtualFile, VirtualProject, VueDocumentVirtualTs, VueDocumentVirtualTsOptions,
     generate_vue_content_mapper_transform, generate_vue_document_virtual_ts,
-    generate_vue_document_virtual_ts_with_options,
+    generate_vue_document_virtual_ts_with_options, project_virtual_lock_paths,
+    project_virtual_root,
 };
 pub use virtual_specifier_message::{AUTHORED_VUE_TS_SENTINEL, restore_virtual_vue_specifiers};
 pub use virtual_ts::VirtualTsGenerator;

--- a/crates/vize_canon/src/batch/executor/cli/diagnostic_paths.rs
+++ b/crates/vize_canon/src/batch/executor/cli/diagnostic_paths.rs
@@ -116,9 +116,9 @@ mod tests {
 
     #[test]
     fn keeps_missing_paths_untouched() {
-        let virtual_root = Path::new("/does/not/exist/node_modules/.vize/canon");
+        let virtual_root = crate::batch::project_virtual_root(Path::new("/does/not/exist"));
         assert_eq!(
-            normalize_cli_path("src/App.vue.ts", virtual_root),
+            normalize_cli_path("src/App.vue.ts", &virtual_root),
             virtual_root.join("src/App.vue.ts")
         );
     }
@@ -126,7 +126,7 @@ mod tests {
     #[test]
     fn resolves_relative_paths_against_the_virtual_root() {
         let root = temp_dir("cli-diagnostic-paths-plain");
-        let virtual_root = root.join("node_modules/.vize/canon");
+        let virtual_root = crate::batch::project_virtual_root(&root);
         write_virtual_file(&virtual_root, "src/App.vue.ts");
 
         assert_eq!(
@@ -153,16 +153,23 @@ mod tests {
         std::fs::create_dir_all(&store).unwrap();
         std::os::unix::fs::symlink(&store, project_root.join("node_modules")).unwrap();
 
-        let virtual_root = project_root.join("node_modules/.vize/canon");
-        write_virtual_file(&virtual_root, "src/App.vue.ts");
+        let physical_virtual_root = crate::batch::project_virtual_root(&project_root);
+        let relative_in_store = physical_virtual_root
+            .strip_prefix(std::fs::canonicalize(&store).unwrap())
+            .unwrap();
+        let through_link_virtual_root = project_root.join("node_modules").join(relative_in_store);
+        write_virtual_file(&through_link_virtual_root, "src/App.vue.ts");
 
         // What the CLI prints from the link target: up out of
-        // `<store>/.vize/canon` to the shared parent, then down the
+        // the physical virtual root to the shared parent, then down the
         // through-link project path.
-        let reported = "../../../app/node_modules/.vize/canon/src/App.vue.ts";
+        let through_link_root = through_link_virtual_root.strip_prefix(&root).unwrap();
+        let reported = Path::new("../../../../..")
+            .join(through_link_root)
+            .join("src/App.vue.ts");
         assert_eq!(
-            normalize_cli_path(reported, &virtual_root),
-            virtual_root.join("src/App.vue.ts"),
+            normalize_cli_path(reported.to_str().unwrap(), &through_link_virtual_root),
+            through_link_virtual_root.join("src/App.vue.ts"),
             "a diagnostic reported against the link target must map back to the registered virtual path"
         );
 
@@ -174,12 +181,12 @@ mod tests {
     fn keeps_files_outside_the_virtual_project_at_their_resolved_path() {
         let root = temp_dir("cli-diagnostic-paths-outside");
         let project_root = root.join("app");
-        let virtual_root = project_root.join("node_modules/.vize/canon");
+        let virtual_root = crate::batch::project_virtual_root(&project_root);
         std::fs::create_dir_all(&virtual_root).unwrap();
         std::fs::create_dir_all(project_root.join("types")).unwrap();
         std::fs::write(project_root.join("types/globals.d.ts"), "export {};\n").unwrap();
 
-        let resolved = normalize_cli_path("../../../types/globals.d.ts", &virtual_root);
+        let resolved = normalize_cli_path("../../../../../types/globals.d.ts", &virtual_root);
         assert!(
             resolved.ends_with("types/globals.d.ts"),
             "unexpected resolved path: {resolved:?}"

--- a/crates/vize_canon/src/batch/import_rewriter_authored_vue_ts_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_authored_vue_ts_tests.rs
@@ -10,7 +10,7 @@ fn authored_vue_ts_specifiers_cannot_resolve_generated_mirrors() {
     let case = TempDir::new().expect("temp project");
     let project = std::fs::canonicalize(case.path()).expect("canonical temp project");
     let source_dir = project.join("src");
-    let virtual_root = project.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&project);
     std::fs::create_dir_all(&source_dir).expect("source directory");
     std::fs::write(source_dir.join("Mirror.vue"), "<template />").expect("SFC mirror");
     std::fs::write(source_dir.join("MirrorJsx.vue"), "<template />").expect("TSX SFC mirror");

--- a/crates/vize_canon/src/batch/import_rewriter_dts.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_dts.rs
@@ -1,8 +1,8 @@
 //! Redirecting relative re-exports/imports of generated declaration files to
 //! their real on-disk path when a non-`.vue` script is materialized into canon.
 //!
-//! Generated GraphQL `.d.ts` schemas are intentionally never mirrored into
-//! `node_modules/.vize/canon` (#2047). A barrel like `types/index.ts` reached
+//! Generated GraphQL `.d.ts` schemas are intentionally never mirrored into a
+//! Canon project namespace (#2047). A barrel like `types/index.ts` reached
 //! transitively from a `.vue` *is* mirrored, but its relative
 //! `export * from './codegen/schema'` would then dangle inside the mirror where
 //! the schema is absent — dropping the generated module's type identity and

--- a/crates/vize_canon/src/batch/import_rewriter_dts_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_dts_tests.rs
@@ -43,7 +43,7 @@ fn rewrite_relative_generated_dts_import_type_to_real_path_for_virtual_project()
     let schema = vize_carton::path::canonicalize_non_verbatim(&schema);
     let rewriter = ImportRewriter::new();
     let source = "export type Schema = import('./codegen/schema').Schema";
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let roots = (root.as_path(), virtual_root.as_path());
     let result =
         rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots, barrel.parent());
@@ -76,7 +76,7 @@ fn ignores_relative_dts_text_outside_module_specifiers_for_virtual_project() {
     let root = vize_carton::path::canonicalize_non_verbatim(&raw_root);
     let rewriter = ImportRewriter::new();
     let source = "const note = './codegen/schema'\n// export * from './codegen/schema'\n";
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let roots = (root.as_path(), virtual_root.as_path());
     let result =
         rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots, barrel.parent());

--- a/crates/vize_canon/src/batch/import_rewriter_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_tests.rs
@@ -105,7 +105,7 @@ fn rewrite_absolute_vue_specifier_through_symlinked_project_path() {
     std::fs::write(real.path().join("src/App.vue"), "<template />").unwrap();
 
     let source = cstr!(r#"export * from "{}";"#, link.join("src/App.vue").display());
-    let virtual_root = real.path().join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(real.path());
     let roots = (
         vize_carton::path::canonicalize_non_verbatim(&link),
         virtual_root.clone(),
@@ -141,7 +141,7 @@ fn test_keeps_plain_absolute_generated_graphql_import_for_virtual_project() {
         "import type {{ Kind }} from '{}';",
         schema.with_extension("").display()
     );
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let roots = (root.as_path(), virtual_root.as_path());
     let result =
         rewriter.rewrite_for_virtual_project(source.as_str(), SourceType::ts(), roots, None);
@@ -181,7 +181,7 @@ fn test_rewrite_relative_generated_dts_reexport_to_real_path_for_virtual_project
     let schema = vize_carton::path::canonicalize_non_verbatim(&schema);
     let rewriter = ImportRewriter::new();
     let source = "export * from './codegen/schema'";
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let roots = (root.as_path(), virtual_root.as_path());
     let result =
         rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots, barrel.parent());
@@ -207,7 +207,7 @@ fn test_keeps_relative_source_reexport_for_virtual_project() {
     let barrel = write(&root, "types/index.ts", "export * from './helpers'\n");
     let rewriter = ImportRewriter::new();
     let source = "export * from './helpers'";
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let roots = (root.as_path(), virtual_root.as_path());
     let result =
         rewriter.rewrite_for_virtual_project(source, SourceType::ts(), roots, barrel.parent());
@@ -240,7 +240,7 @@ fn test_rewrite_absolute_ts_import_that_needs_vue_rewrite_for_virtual_project() 
         "import {{ Widget }} from '{}';",
         feature.with_extension("").display()
     );
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let roots = (root.as_path(), virtual_root.as_path());
     let result =
         rewriter.rewrite_for_virtual_project(source.as_str(), SourceType::ts(), roots, None);

--- a/crates/vize_canon/src/batch/import_rewriter_virtual_tests.rs
+++ b/crates/vize_canon/src/batch/import_rewriter_virtual_tests.rs
@@ -45,7 +45,7 @@ fn rewrites_absolute_module_declaration_import_that_needs_vue_virtual_path() {
         "import type {{ Feature }} from '{}';",
         feature.with_file_name("feature").display()
     );
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let roots = (root.as_path(), virtual_root.as_path());
     let result =
         rewriter.rewrite_for_virtual_project(source.as_str(), SourceType::ts(), roots, None);
@@ -82,7 +82,7 @@ fn rewrites_absolute_index_module_declaration_import_that_needs_vue_virtual_path
         "import type {{ Feature }} from '{}';",
         root.join("src/feature").display()
     );
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let roots = (root.as_path(), virtual_root.as_path());
     let result =
         rewriter.rewrite_for_virtual_project(source.as_str(), SourceType::ts(), roots, None);

--- a/crates/vize_canon/src/batch/materialize_lock.rs
+++ b/crates/vize_canon/src/batch/materialize_lock.rs
@@ -123,7 +123,7 @@ mod tests {
     #[test]
     fn lock_waits_until_existing_holder_drops() {
         let temp = tempfile::tempdir().unwrap();
-        let root = temp.path().join("node_modules/.vize/canon");
+        let root = crate::batch::project_virtual_root(temp.path());
         let first = MaterializeLock::acquire(&root).unwrap();
         let (acquired_tx, acquired_rx) = mpsc::channel();
         let root_for_thread = root.clone();
@@ -199,23 +199,61 @@ mod tests {
 
     #[test]
     fn windows_lock_path_avoids_the_legacy_directory_name() {
-        let root = Path::new("node_modules/.vize/canon");
-        let legacy = lock_path_with_suffix(root, LEGACY_LOCK_SUFFIX);
-        let current = lock_path_with_suffix(root, WINDOWS_LOCK_SUFFIX);
+        let root = crate::batch::project_virtual_root(Path::new("/project"));
+        let legacy = lock_path_with_suffix(&root, LEGACY_LOCK_SUFFIX);
+        let current = lock_path_with_suffix(&root, WINDOWS_LOCK_SUFFIX);
 
-        assert_eq!(legacy, Path::new("node_modules/.vize/canon.lock"));
-        assert_eq!(
-            current,
-            Path::new("node_modules/.vize/canon.materialize.lock")
-        );
+        assert_eq!(legacy, root.with_extension("lock"));
+        assert_eq!(current, root.with_extension("materialize.lock"));
         assert_ne!(current, legacy);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn project_key_owns_the_materialization_lock_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        let shared_node_modules = temp.path().join("shared-node-modules");
+        let first_project = temp.path().join("first");
+        let second_project = temp.path().join("second");
+        fs::create_dir_all(&shared_node_modules).unwrap();
+        fs::create_dir_all(&first_project).unwrap();
+        fs::create_dir_all(&second_project).unwrap();
+        let first_project_alias = temp.path().join("first-alias");
+        std::os::unix::fs::symlink(&first_project, &first_project_alias).unwrap();
+        std::os::unix::fs::symlink(&shared_node_modules, first_project.join("node_modules"))
+            .unwrap();
+        std::os::unix::fs::symlink(&shared_node_modules, second_project.join("node_modules"))
+            .unwrap();
+
+        let first_root = crate::batch::project_virtual_root(&first_project);
+        let repeated_first_root = crate::batch::project_virtual_root(&first_project);
+        let aliased_first_root = crate::batch::project_virtual_root(&first_project_alias);
+        let second_root = crate::batch::project_virtual_root(&second_project);
+        assert_eq!(
+            lock_path_for(&first_root),
+            lock_path_for(&repeated_first_root),
+            "the same canonical project must always share one lock"
+        );
+        assert_eq!(
+            lock_path_for(&first_root),
+            lock_path_for(&aliased_first_root),
+            "symlink spellings of the same source root must share one key and lock"
+        );
+
+        drop(MaterializeLock::acquire(&first_root).unwrap());
+        drop(MaterializeLock::acquire(&second_root).unwrap());
+        assert_ne!(
+            fs::canonicalize(lock_path_for(&first_root)).unwrap(),
+            fs::canonicalize(lock_path_for(&second_root)).unwrap(),
+            "different projects must not serialize on one physical lock even when node_modules is shared"
+        );
     }
 
     #[cfg(windows)]
     #[test]
     fn stale_legacy_directory_does_not_block_windows_locking() {
         let temp = tempfile::tempdir().unwrap();
-        let root = temp.path().join("node_modules/.vize/canon");
+        let root = crate::batch::project_virtual_root(temp.path());
         fs::create_dir_all(lock_path_with_suffix(&root, LEGACY_LOCK_SUFFIX)).unwrap();
 
         let lock = MaterializeLock::acquire_with_timeout(&root, Duration::from_secs(1)).unwrap();
@@ -235,7 +273,7 @@ mod tests {
         }
 
         let temp = tempfile::tempdir().unwrap();
-        let root = temp.path().join("node_modules/.vize/canon");
+        let root = crate::batch::project_virtual_root(temp.path());
         let ready = temp.path().join("owner-ready");
         let mut child = std::process::Command::new(std::env::current_exe().unwrap())
             .arg("os_lock_is_released_after_abrupt_owner_termination")

--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -19,6 +19,7 @@ mod no_check_props;
 mod no_unused;
 mod options_api_required_props;
 mod package_exports_types;
+mod project_isolation;
 mod recent_issues;
 mod scan;
 mod template_block;
@@ -80,7 +81,6 @@ fn corsa_bridge_completion_returns_inner_members_for_chained_ref_value() {
     // (`toFixed`, `toString`), proving that completion is not silently
     // collapsing to the heuristic fallback.
     use crate::corsa_bridge::{CorsaBridge, CorsaBridgeConfig};
-
     let Some(corsa_path) = resolve_test_tsgo_binary() else {
         return;
     };

--- a/crates/vize_canon/src/batch/type_checker/tests/project_isolation.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/project_isolation.rs
@@ -1,0 +1,224 @@
+#![cfg(unix)]
+
+use super::{BatchTypeChecker, DeclarationEmitOptions, resolve_test_tsgo_binary, unique_case_dir};
+use crate::batch::TypeChecker;
+use std::{
+    sync::{Arc, Barrier},
+    thread,
+};
+
+mod support;
+
+use support::*;
+
+#[test]
+fn concurrent_projects_share_dependencies_without_sharing_mutable_state() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let case_root = unique_case_dir("shared-node-modules-concurrent-projects");
+    let _ = std::fs::remove_dir_all(&case_root);
+    let first_root = case_root.join("first");
+    let second_root = case_root.join("second");
+    let shared_node_modules = case_root.join("shared-node-modules");
+    populate_shared_dependency_tree(&shared_node_modules);
+    create_project(&first_root, "first");
+    create_project(&second_root, "second");
+    link_shared_node_modules(&first_root, &shared_node_modules);
+    link_shared_node_modules(&second_root, &shared_node_modules);
+
+    let first_app = first_root.join("src/App.vue");
+    let first_clean_source = std::fs::read_to_string(&first_app).unwrap();
+
+    let first = scanned_checker(&first_root);
+    let second = scanned_checker(&second_root);
+    assert_canonical_virtual_paths(&first, &first_root, &shared_node_modules);
+    assert_canonical_virtual_paths(&second, &second_root, &shared_node_modules);
+
+    let (first_clean, second_clean) = concurrent_checks(&first, &second);
+    assert_clean_and_owned(&first_clean, &first_root, &second_root, "first clean check");
+    assert_clean_and_owned(
+        &second_clean,
+        &second_root,
+        &first_root,
+        "second clean check",
+    );
+    assert_materialized_source(&first, "const checked: 'first' = owner");
+    assert_materialized_source(&second, "const checked: 'second' = owner");
+
+    std::fs::write(&first_app, first_clean_source.replace("= owner", "= 0")).unwrap();
+    let first_broken_checker = scanned_checker(&first_root);
+    let second_unchanged_checker = scanned_checker(&second_root);
+    let (first_broken, second_unchanged) =
+        concurrent_checks(&first_broken_checker, &second_unchanged_checker);
+    let type_error = first_broken
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.file == first_app && diagnostic.code == Some(2322))
+        .unwrap_or_else(|| {
+            panic!(
+                "broken first project did not report its authored TS2322: {:#?}",
+                first_broken.diagnostics
+            )
+        });
+    assert_eq!((type_error.line, type_error.column), (2, 6));
+    assert_clean_and_owned(
+        &second_unchanged,
+        &second_root,
+        &first_root,
+        "second check while first is broken",
+    );
+
+    std::fs::write(&first_app, &first_clean_source).unwrap();
+    let first_repaired_checker = scanned_checker(&first_root);
+    let second_reused_checker = scanned_checker(&second_root);
+    let (first_repaired, second_reused) =
+        concurrent_checks(&first_repaired_checker, &second_reused_checker);
+    assert_clean_and_owned(
+        &first_repaired,
+        &first_root,
+        &second_root,
+        "first repaired check",
+    );
+    assert_clean_and_owned(
+        &second_reused,
+        &second_root,
+        &first_root,
+        "second reused check",
+    );
+    assert_materialized_source(&first_repaired_checker, "const checked: 'first' = owner");
+    assert_materialized_source(&second_reused_checker, "const checked: 'second' = owner");
+
+    let (first_declarations, second_declarations) = thread::scope(|scope| {
+        let first_checker = &first_repaired_checker;
+        let second_checker = &second_reused_checker;
+        let barrier = Arc::new(Barrier::new(2));
+        let first_barrier = Arc::clone(&barrier);
+        let first_out = first_root.join("types");
+        let second_out = second_root.join("types");
+        let first_task = scope.spawn(move || {
+            first_barrier.wait();
+            first_checker.emit_declarations(&DeclarationEmitOptions::new(first_out))
+        });
+        let second_task = scope.spawn(move || {
+            barrier.wait();
+            second_checker.emit_declarations(&DeclarationEmitOptions::new(second_out))
+        });
+        (
+            first_task
+                .join()
+                .unwrap()
+                .expect("first emit should succeed"),
+            second_task
+                .join()
+                .unwrap()
+                .expect("second emit should succeed"),
+        )
+    });
+    assert_declaration_owner(first_declarations.files, "first", "second");
+    assert_declaration_owner(second_declarations.files, "second", "first");
+    assert_materialized_source(&first_repaired_checker, "const checked: 'first' = owner");
+    assert_materialized_source(&second_reused_checker, "const checked: 'second' = owner");
+
+    let _ = std::fs::remove_dir_all(&case_root);
+}
+
+#[test]
+fn persistent_sessions_refresh_independently_over_shared_dependencies() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let case_root = unique_case_dir("shared-node-modules-persistent-sessions");
+    let _ = std::fs::remove_dir_all(&case_root);
+    let first_root = case_root.join("first");
+    let second_root = case_root.join("second");
+    let shared_node_modules = case_root.join("shared-node-modules");
+    populate_shared_dependency_tree(&shared_node_modules);
+    create_relative_project(&first_root, "first");
+    create_relative_project(&second_root, "second");
+    link_shared_node_modules(&first_root, &shared_node_modules);
+    link_shared_node_modules(&second_root, &shared_node_modules);
+
+    let first_app = first_root.join("src/App.vue");
+    let second_app = second_root.join("src/App.vue");
+    let first_clean_source = std::fs::read_to_string(&first_app).unwrap();
+    let second_clean_source = std::fs::read_to_string(&second_app).unwrap();
+    let first = scanned_checker(&first_root);
+    let second = scanned_checker(&second_root);
+    assert_canonical_virtual_paths(&first, &first_root, &shared_node_modules);
+    assert_canonical_virtual_paths(&second, &second_root, &shared_node_modules);
+
+    std::fs::write(
+        &first_app,
+        first_clean_source.replace("= 'first'", "= 'broken-first'"),
+    )
+    .unwrap();
+    let first_broken = first
+        .check_incremental(std::slice::from_ref(&first_app))
+        .expect("first persistent session should start");
+    assert_type_error(&first_broken, &first_app);
+
+    let second_clean = second
+        .check_incremental(std::slice::from_ref(&second_app))
+        .expect("second persistent session should start");
+    assert_clean_and_owned(
+        &second_clean,
+        &second_root,
+        &first_root,
+        "second persistent session",
+    );
+    assert_materialized_source(&first, "const checked: Owner = 'broken-first'");
+    assert_materialized_source(&second, "const checked: Owner = 'second'");
+
+    std::fs::write(&first_app, &first_clean_source).unwrap();
+    let first_repaired = first
+        .check_incremental(std::slice::from_ref(&first_app))
+        .expect("first persistent session should refresh");
+    assert_clean_and_owned(
+        &first_repaired,
+        &first_root,
+        &second_root,
+        "first repaired persistent session",
+    );
+
+    std::fs::write(
+        &second_app,
+        second_clean_source.replace("= 'second'", "= 'broken-second'"),
+    )
+    .unwrap();
+    let second_broken = second
+        .check_incremental(std::slice::from_ref(&second_app))
+        .expect("second persistent session should refresh");
+    assert_type_error(&second_broken, &second_app);
+
+    let first_reused = first
+        .check_incremental(std::slice::from_ref(&first_app))
+        .expect("first persistent session should remain isolated");
+    assert_clean_and_owned(
+        &first_reused,
+        &first_root,
+        &second_root,
+        "first reused persistent session",
+    );
+    assert_materialized_source(&first, "const checked: Owner = 'first'");
+    assert_materialized_source(&second, "const checked: Owner = 'broken-second'");
+
+    std::fs::write(&second_app, &second_clean_source).unwrap();
+    let second_repaired = second
+        .check_incremental(std::slice::from_ref(&second_app))
+        .expect("second persistent session should repair");
+    assert_clean_and_owned(
+        &second_repaired,
+        &second_root,
+        &first_root,
+        "second repaired persistent session",
+    );
+    assert_eq!(first.incremental_metrics().session_starts, 1);
+    assert_eq!(first.incremental_metrics().session_reuses, 2);
+    assert_eq!(second.incremental_metrics().session_starts, 1);
+    assert_eq!(second.incremental_metrics().session_reuses, 2);
+
+    let _ = std::fs::remove_dir_all(&case_root);
+}

--- a/crates/vize_canon/src/batch/type_checker/tests/project_isolation/support.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/project_isolation/support.rs
@@ -1,0 +1,215 @@
+use super::BatchTypeChecker;
+use crate::batch::{TypeCheckResult, TypeChecker};
+use std::{
+    path::Path,
+    sync::{Arc, Barrier},
+    thread,
+};
+
+pub(super) fn create_project(project_root: &Path, owner: &str) {
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": { "@owner": ["./src/owner.ts"] }
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/owner.ts"),
+        format!("export const owner = '{owner}' as const\n"),
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/public.ts"),
+        format!("export const marker = '{owner}' as const\n"),
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/App.vue"),
+        format!(
+            "<script setup lang=\"ts\">\nimport {{ owner }} from '@owner'\nconst checked: '{owner}' = owner\n</script>\n\n<template><p>{{{{ checked }}}}</p></template>\n"
+        ),
+    )
+    .unwrap();
+}
+
+pub(super) fn create_relative_project(project_root: &Path, owner: &str) {
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/owner.ts"),
+        format!("export type Owner = '{owner}'\n"),
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/App.vue"),
+        format!(
+            "<script setup lang=\"ts\">\nimport type {{ Owner }} from './owner'\nconst checked: Owner = '{owner}'\n</script>\n\n<template><p>{{{{ checked }}}}</p></template>\n"
+        ),
+    )
+    .unwrap();
+}
+
+pub(super) fn populate_shared_dependency_tree(shared_node_modules: &Path) {
+    let workspace_node_modules = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .join("node_modules");
+    std::fs::create_dir_all(shared_node_modules).unwrap();
+    for entry in std::fs::read_dir(workspace_node_modules).unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_name() == ".vize" {
+            continue;
+        }
+        std::os::unix::fs::symlink(entry.path(), shared_node_modules.join(entry.file_name()))
+            .unwrap();
+    }
+}
+
+pub(super) fn link_shared_node_modules(project_root: &Path, shared_node_modules: &Path) {
+    std::os::unix::fs::symlink(shared_node_modules, project_root.join("node_modules")).unwrap();
+}
+
+pub(super) fn scanned_checker(project_root: &Path) -> BatchTypeChecker {
+    let mut checker = BatchTypeChecker::new(project_root).expect("checker should start");
+    checker.scan_project().expect("project should scan");
+    checker
+}
+
+pub(super) fn assert_canonical_virtual_paths(
+    checker: &BatchTypeChecker,
+    project_root: &Path,
+    shared_node_modules: &Path,
+) {
+    let virtual_root = crate::batch::project_virtual_root(project_root);
+    let canonical_storage = std::fs::canonicalize(shared_node_modules).unwrap();
+    assert!(virtual_root.starts_with(&canonical_storage));
+    assert!(
+        checker
+            .virtual_files()
+            .iter()
+            .all(|file| file.virtual_path.starts_with(&virtual_root)),
+        "Corsa workspace and document paths must use the same canonical storage spelling"
+    );
+}
+
+pub(super) fn concurrent_checks(
+    first: &BatchTypeChecker,
+    second: &BatchTypeChecker,
+) -> (TypeCheckResult, TypeCheckResult) {
+    thread::scope(|scope| {
+        let barrier = Arc::new(Barrier::new(2));
+        let first_barrier = Arc::clone(&barrier);
+        let first_task = scope.spawn(move || {
+            first_barrier.wait();
+            first.check_project()
+        });
+        let second_task = scope.spawn(move || {
+            barrier.wait();
+            second.check_project()
+        });
+        (
+            first_task
+                .join()
+                .unwrap()
+                .expect("first check should complete"),
+            second_task
+                .join()
+                .unwrap()
+                .expect("second check should complete"),
+        )
+    })
+}
+
+pub(super) fn assert_clean_and_owned(
+    result: &TypeCheckResult,
+    owner_root: &Path,
+    other_root: &Path,
+    phase: &str,
+) {
+    assert!(
+        result.success,
+        "{phase} should be clean: {:#?}",
+        result.diagnostics
+    );
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|diagnostic| !diagnostic.file.starts_with(other_root)),
+        "{phase} leaked diagnostics from another project: {:#?}",
+        result.diagnostics
+    );
+    assert!(
+        result.diagnostics.iter().all(|diagnostic| {
+            diagnostic.file.starts_with(owner_root) || diagnostic.file == owner_root
+        }),
+        "{phase} reported an unowned path: {:#?}",
+        result.diagnostics
+    );
+}
+
+pub(super) fn assert_materialized_source(checker: &BatchTypeChecker, expected: &str) {
+    let app = checker
+        .virtual_files()
+        .into_iter()
+        .find(|file| file.original_path.ends_with("src/App.vue"))
+        .expect("App.vue should be registered");
+    let materialized = std::fs::read_to_string(&app.virtual_path).unwrap();
+    assert!(
+        materialized.contains(expected),
+        "materialized project state was overwritten: expected {expected:?} in {}",
+        app.virtual_path.display()
+    );
+}
+
+pub(super) fn assert_type_error(result: &TypeCheckResult, app: &Path) {
+    let diagnostic = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.file == app && diagnostic.code == Some(2322))
+        .unwrap_or_else(|| {
+            panic!(
+                "expected authored TS2322 for {}: {result:#?}",
+                app.display()
+            )
+        });
+    assert_eq!((diagnostic.line, diagnostic.column), (2, 6));
+}
+
+pub(super) fn assert_declaration_owner(
+    declarations: Vec<crate::batch::DeclarationOutput>,
+    expected: &str,
+    forbidden: &str,
+) {
+    let public = declarations
+        .iter()
+        .find(|declaration| declaration.path.ends_with("public.d.ts"))
+        .unwrap_or_else(|| panic!("public.d.ts was not emitted: {declarations:#?}"));
+    assert!(public.content.contains(expected), "{public:#?}");
+    assert!(!public.content.contains(forbidden), "{public:#?}");
+}

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/ts_extension_substitution.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/ts_extension_substitution.rs
@@ -106,7 +106,7 @@ const mainNumber: number = main;
         let mut checker = BatchTypeChecker::new(&project_root).unwrap();
         checker.scan_paths(&scan_paths).unwrap();
         let result = checker.check_project().unwrap();
-        let virtual_root = project_root.join("node_modules/.vize/canon");
+        let virtual_root = crate::batch::project_virtual_root(&project_root);
         let virtual_root = virtual_root.to_string_lossy();
         let mut snapshot: Vec<_> = result
             .diagnostics

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -1,7 +1,8 @@
 //! Virtual project management for Corsa-backed type checking.
 //!
 //! This module materializes a mirrored TypeScript project in
-//! `node_modules/.vize/canon/` so Corsa can type-check Vue SFCs together with
+//! a project-keyed namespace under `node_modules/.vize/canon/` so Corsa can
+//! type-check Vue SFCs together with
 //! regular TypeScript sources, ambient declarations, and emitted `.d.ts` files.
 //!
 //! The implementation is split across submodules:
@@ -45,6 +46,8 @@ pub use document::{
 pub(crate) use document::generate_vue_document_virtual_ts_with_options_and_alias_resolver;
 mod diagnostics;
 mod external_mirror;
+mod identity;
+pub use identity::{project_virtual_lock_paths, project_virtual_root};
 mod javascript_sfc;
 mod jsx_build;
 mod jsx_codegen;
@@ -104,7 +107,7 @@ pub struct VirtualProject {
     /// Project root directory.
     project_root: PathBuf,
 
-    /// Virtual project root (`node_modules/.vize/canon`).
+    /// Project-keyed virtual root under `node_modules/.vize/canon/projects`.
     virtual_root: PathBuf,
 
     /// Explicit tsconfig path, if one was provided by the caller.

--- a/crates/vize_canon/src/batch/virtual_project/external_mirror.rs
+++ b/crates/vize_canon/src/batch/virtual_project/external_mirror.rs
@@ -48,24 +48,23 @@ mod tests {
 
     #[test]
     fn an_absolute_path_replays_as_subdirectories() {
+        let virtual_root = crate::batch::project_virtual_root(Path::new("/proj"));
         let mirrored = super::external_mirror_path(
-            Path::new("/proj/node_modules/.vize/canon"),
+            &virtual_root,
             Path::new("/ws/packages/ui/src/UiButton.vue"),
         )
         .unwrap();
         assert_eq!(
             mirrored,
-            Path::new(
-                "/proj/node_modules/.vize/canon/__vize_external__/ws/packages/ui/src/UiButton.vue"
-            )
+            virtual_root.join("__vize_external__/ws/packages/ui/src/UiButton.vue")
         );
     }
 
     #[test]
     fn sibling_files_stay_siblings() {
-        let root = Path::new("/proj/node_modules/.vize/canon");
-        let barrel = super::external_mirror_path(root, Path::new("/ws/pkg/index.ts")).unwrap();
-        let vue = super::external_mirror_path(root, Path::new("/ws/pkg/UiButton.vue")).unwrap();
+        let root = crate::batch::project_virtual_root(Path::new("/proj"));
+        let barrel = super::external_mirror_path(&root, Path::new("/ws/pkg/index.ts")).unwrap();
+        let vue = super::external_mirror_path(&root, Path::new("/ws/pkg/UiButton.vue")).unwrap();
         assert_eq!(barrel.parent(), vue.parent());
     }
 
@@ -73,7 +72,7 @@ mod tests {
     fn a_parent_component_is_refused() {
         assert!(
             super::external_mirror_path(
-                Path::new("/proj/node_modules/.vize/canon"),
+                &crate::batch::project_virtual_root(Path::new("/proj")),
                 Path::new("/ws/../outside/App.vue"),
             )
             .is_err()

--- a/crates/vize_canon/src/batch/virtual_project/identity.rs
+++ b/crates/vize_canon/src/batch/virtual_project/identity.rs
@@ -1,0 +1,133 @@
+//! Stable ownership for materialized Canon projects.
+//!
+//! Dependency storage is not project identity. Workspace hoisting, package
+//! manager stores, fixture symlinks, and CI caches can make distinct project
+//! roots share one physical `node_modules` tree. Every mutable Canon artifact
+//! therefore lives below a namespace derived only from the canonical project
+//! root.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+
+const PROJECTS_DIR: &str = "projects";
+/// Versioned project-key input schema. Changing this deliberately moves every
+/// namespace, so the known-vector test below must change in the same review.
+const PROJECT_KEY_SCHEMA: &[u8] = b"vize-canon-project-key:v1\0";
+
+/// Return the stable, project-owned namespace for Canon's mutable artifacts.
+///
+/// The full SHA-256 digest keeps the namespace a single portable path
+/// component without lossy path conversion or platform path-length growth.
+/// The input bytes preserve the operating system's exact path identity, so two
+/// non-UTF-8 Unix roots cannot collapse through `to_string_lossy`.
+pub fn project_virtual_root(project_root: &Path) -> PathBuf {
+    let project_root = vize_carton::path::canonicalize_non_verbatim(project_root);
+    let project_key = project_key(&project_root);
+    // Corsa compares workspace and document paths by their filesystem
+    // identity. Resolve an existing dependency-store symlink once here so the
+    // workspace root and every URI share one spelling; the project key still
+    // comes exclusively from the canonical source root above.
+    vize_carton::path::canonicalize_non_verbatim(&project_root.join("node_modules"))
+        .join(".vize")
+        .join("canon")
+        .join(PROJECTS_DIR)
+        .join(project_key.as_str())
+}
+
+/// Lock files owned by the current project namespace.
+///
+/// Both spellings are returned so `vize clean` can remove the active platform
+/// lock and a stale lock left by the other spelling after a cross-platform
+/// cache restore.
+pub fn project_virtual_lock_paths(project_root: &Path) -> [PathBuf; 2] {
+    let virtual_root = project_virtual_root(project_root);
+    [
+        virtual_root.with_extension("lock"),
+        virtual_root.with_extension("materialize.lock"),
+    ]
+}
+
+fn project_key(project_root: &Path) -> vize_carton::String {
+    let mut digest = Sha256::new();
+    digest.update(PROJECT_KEY_SCHEMA);
+    update_path_digest(&mut digest, project_root);
+    encode_digest(digest.finalize())
+}
+
+fn encode_digest(digest: impl AsRef<[u8]>) -> vize_carton::String {
+    let digest = digest.as_ref();
+    let mut encoded = vize_carton::String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        write!(encoded, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    encoded
+}
+
+#[cfg(unix)]
+fn update_path_digest(digest: &mut Sha256, path: &Path) {
+    use std::os::unix::ffi::OsStrExt;
+    digest.update(path.as_os_str().as_bytes());
+}
+
+#[cfg(windows)]
+fn update_path_digest(digest: &mut Sha256, path: &Path) {
+    use std::os::windows::ffi::OsStrExt;
+    for unit in path.as_os_str().encode_wide() {
+        digest.update(unit.to_le_bytes());
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn update_path_digest(digest: &mut Sha256, path: &Path) {
+    digest.update(path.as_os_str().to_string_lossy().as_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{project_key, project_virtual_lock_paths, project_virtual_root};
+    use std::path::Path;
+
+    #[test]
+    fn project_namespace_is_stable_and_root_specific() {
+        let first = project_virtual_root(Path::new("/workspace/first"));
+        let repeated = project_virtual_root(Path::new("/workspace/first"));
+        let second = project_virtual_root(Path::new("/workspace/second"));
+
+        assert_eq!(first, repeated);
+        assert_ne!(first, second);
+        assert_eq!(first.parent().unwrap().file_name().unwrap(), "projects");
+        let key = first.file_name().unwrap().to_str().unwrap();
+        assert_eq!(key.len(), 64);
+        assert!(key.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_project_key_schema_has_a_reviewed_known_vector() {
+        assert_eq!(
+            project_key(Path::new("/workspace/project")),
+            "75f1ce1c5f19d5351a5db6aa00d2c1365f245368acefdcd5d8f119f466cd29e1"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_project_key_schema_has_a_reviewed_known_vector() {
+        assert_eq!(
+            project_key(Path::new(r"C:\workspace\project")),
+            "5513ca835150777804e200d8754b63e464fc44787a318b93e4d4da056ec7dfeb"
+        );
+    }
+
+    #[test]
+    fn lock_names_stay_inside_the_project_namespace_parent() {
+        let virtual_root = project_virtual_root(Path::new("/workspace/project"));
+        let [legacy, windows] = project_virtual_lock_paths(Path::new("/workspace/project"));
+        assert_eq!(legacy.parent(), virtual_root.parent());
+        assert_eq!(windows.parent(), virtual_root.parent());
+        assert_eq!(legacy.file_stem(), virtual_root.file_name());
+        assert!(windows.to_string_lossy().ends_with(".materialize.lock"));
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/package_node_modules.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_node_modules.rs
@@ -2,11 +2,12 @@
 //! project so bare specifiers keep resolving.
 //!
 //! Corsa resolves a bare specifier by walking the `node_modules` directories on
-//! the ancestor chain of the *materialized* file. The virtual root lives at
-//! `<project_root>/node_modules/.vize/canon`, so that walk sees
-//! `<canon>/node_modules` (owned by [`crate::batch::runtime_deps`]) and then —
-//! because Node's algorithm skips `node_modules` path components — jumps
-//! straight to `<project_root>/node_modules`. Every real `node_modules`
+//! the ancestor chain of the *materialized* file. The virtual root lives in a
+//! project-keyed namespace under the physical dependency store's
+//! `.vize/canon/projects`, so that walk sees `<project-key>/node_modules`
+//! (owned by [`crate::batch::runtime_deps`]) and then — because Node's
+//! algorithm skips `node_modules` path components — jumps straight to the
+//! shared dependency store. Every real `node_modules`
 //! *between* the project root and the importing file is missing from the chain.
 //!
 //! That gap is invisible in a single-package project but not in a workspace

--- a/crates/vize_canon/src/batch/virtual_project/package_node_modules/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_node_modules/tests.rs
@@ -18,7 +18,7 @@ fn case_dir(name: &str) -> PathBuf {
 fn links_a_sub_package_node_modules_onto_its_mirrored_path() {
     let root = case_dir("sub-package");
     std::fs::create_dir_all(root.join("apps/app/node_modules/dep")).unwrap();
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let file = virtual_root.join("apps/app/main.ts");
 
     let links = package_node_modules_links(&root, &virtual_root, [file.as_path()].into_iter());
@@ -38,7 +38,7 @@ fn skips_the_project_root_and_directories_without_node_modules() {
     let root = case_dir("root-only");
     std::fs::create_dir_all(root.join("node_modules/dep")).unwrap();
     std::fs::create_dir_all(root.join("src")).unwrap();
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let file = virtual_root.join("src/main.ts");
 
     let links = package_node_modules_links(&root, &virtual_root, [file.as_path()].into_iter());
@@ -57,7 +57,7 @@ fn merges_the_real_entries_beside_the_mirrors_own_copies() {
     for entry in ["dep", "other", "@scope/a", "@scope/b"] {
         std::fs::create_dir_all(root.join("apps/app/node_modules").join(entry)).unwrap();
     }
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let mirrored = [
         virtual_root.join("apps/app/node_modules/dep/index.d.cts"),
         virtual_root.join("apps/app/node_modules/@scope/a/index.d.cts"),
@@ -90,7 +90,7 @@ fn links_an_untouched_scope_whole_instead_of_per_package() {
     for entry in ["dep", "@scope/a", "@scope/b"] {
         std::fs::create_dir_all(root.join("apps/app/node_modules").join(entry)).unwrap();
     }
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let mirrored = virtual_root.join("apps/app/node_modules/dep/index.d.cts");
 
     let links = package_node_modules_links(&root, &virtual_root, [mirrored.as_path()].into_iter());
@@ -111,7 +111,7 @@ fn keeps_the_whole_directory_when_a_mirrored_file_sits_in_its_root() {
     // the directory stays the mirror's exactly as it did before #3396.
     let root = case_dir("mirrored-root-file");
     std::fs::create_dir_all(root.join("apps/app/node_modules/dep")).unwrap();
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let mirrored = virtual_root.join("apps/app/node_modules/Widget.vue.ts");
 
     let links = package_node_modules_links(&root, &virtual_root, [mirrored.as_path()].into_iter());
@@ -125,7 +125,7 @@ fn links_every_ancestor_that_carries_its_own_node_modules() {
     let root = case_dir("nested-chain");
     std::fs::create_dir_all(root.join("apps/node_modules/dep")).unwrap();
     std::fs::create_dir_all(root.join("apps/app/node_modules/dep")).unwrap();
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let file = virtual_root.join("apps/app/src/main.ts");
 
     let links = package_node_modules_links(&root, &virtual_root, [file.as_path()].into_iter());
@@ -166,7 +166,7 @@ fn materializing_a_merge_leaves_the_mirrors_own_copy_in_place() {
     )
     .unwrap();
 
-    let virtual_root = root.join("node_modules/.vize/canon");
+    let virtual_root = crate::batch::project_virtual_root(&root);
     let mirrored_copy = virtual_root.join("apps/app/node_modules/dep/index.d.cts");
     std::fs::create_dir_all(mirrored_copy.parent().unwrap()).unwrap();
     std::fs::write(&mirrored_copy, "export declare const generated: 2;\n").unwrap();

--- a/crates/vize_canon/src/batch/virtual_project/passthrough.rs
+++ b/crates/vize_canon/src/batch/virtual_project/passthrough.rs
@@ -227,7 +227,7 @@ mod tests {
             "export declare const runtime: true\n",
         );
         write(&root, "tokens/colors.json", "{}\n");
-        let virtual_root = root.join("node_modules/.vize/canon");
+        let virtual_root = crate::batch::project_virtual_root(&root);
 
         let mut files = collect_passthrough_modules(
             &entry,
@@ -291,7 +291,7 @@ mod tests {
             "src/styles/tokens.d.ts",
             "export declare const tokens: Record<string, string>\n",
         );
-        let virtual_root = root.join("node_modules/.vize/canon");
+        let virtual_root = crate::batch::project_virtual_root(&root);
 
         let mut files = collect_passthrough_modules(
             &entry,

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -16,11 +16,11 @@ use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 
 mod config;
 
-use super::VirtualProject;
 use super::build::{
     RegisteredFile, VirtualBuildContext, build_registered_file, build_script_registered_file,
     build_vue_registered_file, source_type_for_path,
 };
+use super::{VirtualProject, project_virtual_root};
 
 const MUSEA_DEFINE_ART_STUB: &str =
     "declare function defineArt(source: string, options?: Record<string, any>): void;";
@@ -34,10 +34,7 @@ impl VirtualProject {
     /// Create a new virtual project.
     pub fn new(project_root: &Path) -> CorsaResult<Self> {
         let project_root = vize_carton::path::canonicalize_non_verbatim(project_root);
-        let virtual_root = project_root
-            .join("node_modules")
-            .join(".vize")
-            .join("canon");
+        let virtual_root = project_virtual_root(&project_root);
 
         let mut project = Self {
             project_root,

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -9,6 +9,7 @@ mod declaration_root_dir;
 mod graphql_generated;
 mod macro_scope;
 mod module_augmentations;
+mod project_isolation;
 mod ref_arity;
 mod setup_props;
 mod source_types;
@@ -79,19 +80,6 @@ fn snapshot_text(source: &str) -> std::string::String {
     }
     output
 }
-#[test]
-fn test_virtual_project_new() {
-    let case_dir = unique_case_dir("new");
-    let _ = fs::remove_dir_all(&case_dir);
-    fs::create_dir_all(&case_dir).unwrap();
-
-    let project = VirtualProject::new(&case_dir).unwrap();
-    assert_eq!(project.project_root(), case_dir.as_path());
-    assert!(project.virtual_root().ends_with("node_modules/.vize/canon"));
-
-    let _ = fs::remove_dir_all(&case_dir);
-}
-
 #[test]
 fn test_materialize_writes_inert_vue_module_stub_file() {
     let case_dir = unique_case_dir("vue-module-stubs");
@@ -631,9 +619,9 @@ const message = 'Hello'
     project.register_path(&vue_path).unwrap();
     project.materialize().unwrap();
 
-    let virtual_vue_path = case_dir.join("node_modules/.vize/canon/src/App.vue.ts");
-    let tsconfig_path = case_dir.join("node_modules/.vize/canon/tsconfig.json");
-    let auto_imports_path = case_dir.join("node_modules/.vize/canon/__vize_auto_imports.d.ts");
+    let virtual_vue_path = project.virtual_root().join("src/App.vue.ts");
+    let tsconfig_path = project.virtual_root().join("tsconfig.json");
+    let auto_imports_path = project.virtual_root().join("__vize_auto_imports.d.ts");
 
     assert!(virtual_vue_path.exists());
     assert!(tsconfig_path.exists());
@@ -674,8 +662,9 @@ fn test_materialize_writes_relative_json_modules() {
     project.register_path(&ts_path).unwrap();
     project.materialize().unwrap();
 
-    let virtual_json_path =
-        case_dir.join("node_modules/.vize/canon/src/tokens/source/colors.tokens.json");
+    let virtual_json_path = project
+        .virtual_root()
+        .join("src/tokens/source/colors.tokens.json");
     assert_eq!(
         fs::read_to_string(&virtual_json_path).unwrap(),
         "{\"primary\":\"#0057ff\"}\n"
@@ -870,7 +859,7 @@ fn materialized_tsconfig_preserves_original_path_option_bases() {
     project.register_path(&vue_path).unwrap();
     project.materialize().unwrap();
 
-    let tsconfig_path = case_dir.join("node_modules/.vize/canon/tsconfig.json");
+    let tsconfig_path = project.virtual_root().join("tsconfig.json");
     let value: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
     let compiler_options = value["compilerOptions"].as_object().unwrap();
@@ -890,7 +879,7 @@ fn materialized_tsconfig_preserves_original_path_option_bases() {
     // source tree as fallback, so `types: [...]` entries keep resolving.
     assert_eq!(
         compiler_options["typeRoots"],
-        serde_json::json!(["./types", "../../../types"])
+        serde_json::json!(["./types", "../../../../../types"])
     );
 
     let _ = fs::remove_dir_all(&case_dir);
@@ -926,7 +915,7 @@ fn materialized_tsconfig_reanchors_paths_into_virtual_mirror() {
     project.register_path(&vue_path).unwrap();
     project.materialize().unwrap();
 
-    let tsconfig_path = case_dir.join("node_modules/.vize/canon/tsconfig.json");
+    let tsconfig_path = project.virtual_root().join("tsconfig.json");
     let value: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
     let paths = value["compilerOptions"]["paths"].as_object().unwrap();
@@ -935,11 +924,11 @@ fn materialized_tsconfig_reanchors_paths_into_virtual_mirror() {
     // `.vue.ts` mirror candidate for extensionless SFC aliases (#3300).
     assert_eq!(
         paths["@/*"],
-        serde_json::json!(["./src/*", "../../../src/*", "./src/*.vue.ts"])
+        serde_json::json!(["./src/*", "../../../../../src/*", "./src/*.vue.ts"])
     );
     assert_eq!(
         paths["#shared"],
-        serde_json::json!(["./shared/index.ts", "../../../shared/index.ts"])
+        serde_json::json!(["./shared/index.ts", "../../../../../shared/index.ts"])
     );
 
     let _ = fs::remove_dir_all(&case_dir);
@@ -981,15 +970,15 @@ fn materialized_tsconfig_reanchors_extended_paths_from_declaring_config_dir() {
     project.register_path(&vue_path).unwrap();
     project.materialize().unwrap();
 
-    let tsconfig_path = case_dir.join("node_modules/.vize/canon/tsconfig.json");
+    let tsconfig_path = project.virtual_root().join("tsconfig.json");
     let value: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
     let paths = value["compilerOptions"]["paths"].as_object().unwrap();
 
-    let app = ["./app/*", "../../../app/*", "./app/*.vue.ts"];
+    let app = ["./app/*", "../../../../../app/*", "./app/*.vue.ts"];
     let imports = [
         "./.nuxt/imports",
-        "../../../.nuxt/imports",
+        "../../../../../.nuxt/imports",
         "./.nuxt/imports.vue.ts",
     ];
     assert_eq!(paths["~/*"], serde_json::json!(app));

--- a/crates/vize_canon/src/batch/virtual_project/tests/base_url.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/base_url.rs
@@ -9,9 +9,10 @@ use std::fs;
 use std::path::Path;
 
 use super::{VirtualProject, unique_case_dir};
+use crate::batch::project_virtual_root;
 
 fn generated_paths(case_dir: &Path) -> serde_json::Map<String, serde_json::Value> {
-    let tsconfig_path = case_dir.join("node_modules/.vize/canon/tsconfig.json");
+    let tsconfig_path = project_virtual_root(case_dir).join("tsconfig.json");
     let value: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
     value["compilerOptions"]["paths"]
@@ -54,7 +55,7 @@ fn a_root_base_url_synthesizes_the_wildcard_alias() {
     // SFC modules and out-of-mirror sources alike.
     assert_eq!(
         generated_paths(&case_dir)["*"],
-        serde_json::json!(["./*", "../../../*", "./*.vue.ts"])
+        serde_json::json!(["./*", "../../../../../*", "./*.vue.ts"])
     );
 
     let _ = fs::remove_dir_all(&case_dir);
@@ -78,14 +79,18 @@ fn a_nested_base_url_anchors_both_wildcard_and_paths_targets() {
     let paths = generated_paths(&case_dir);
     assert_eq!(
         paths["*"],
-        serde_json::json!(["./src/*", "../../../src/*", "./src/*.vue.ts"])
+        serde_json::json!(["./src/*", "../../../../../src/*", "./src/*.vue.ts"])
     );
     // TypeScript resolves a relative `paths` target against `baseUrl`, so
     // `lib/*` means `src/lib/*` here — anchoring it to the tsconfig directory
     // would silently point the alias one level too high.
     assert_eq!(
         paths["@lib/*"],
-        serde_json::json!(["./src/lib/*", "../../../src/lib/*", "./src/lib/*.vue.ts"])
+        serde_json::json!([
+            "./src/lib/*",
+            "../../../../../src/lib/*",
+            "./src/lib/*.vue.ts"
+        ])
     );
 
     let _ = fs::remove_dir_all(&case_dir);
@@ -108,7 +113,7 @@ fn a_user_declared_wildcard_is_not_overwritten() {
 
     assert_eq!(
         generated_paths(&case_dir)["*"],
-        serde_json::json!(["./vendor/*", "../../../vendor/*", "./vendor/*.vue.ts"])
+        serde_json::json!(["./vendor/*", "../../../../../vendor/*", "./vendor/*.vue.ts"])
     );
 
     let _ = fs::remove_dir_all(&case_dir);
@@ -180,13 +185,13 @@ fn an_inherited_base_url_anchors_paths_declared_by_the_extending_config() {
         paths["#shared/*"],
         serde_json::json!([
             "./config/shared/*",
-            "../../../config/shared/*",
+            "../../../../../config/shared/*",
             "./config/shared/*.vue.ts"
         ])
     );
     assert_eq!(
         paths["*"],
-        serde_json::json!(["./config/*", "../../../config/*", "./config/*.vue.ts"])
+        serde_json::json!(["./config/*", "../../../../../config/*", "./config/*.vue.ts"])
     );
 
     let _ = fs::remove_dir_all(&case_dir);

--- a/crates/vize_canon/src/batch/virtual_project/tests/declaration_root_dir.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/declaration_root_dir.rs
@@ -15,6 +15,7 @@ use std::fs;
 use std::path::Path;
 
 use super::{VirtualProject, unique_case_dir};
+use crate::batch::project_virtual_root;
 
 /// Writes a project whose sources span `lib/` and the project root, so the
 /// common source directory is the root while `rootDir` names `lib`.
@@ -71,7 +72,7 @@ fn declaration_root_dir_from_tsconfig(
         .write_declaration_tsconfig(&case_dir.join("dist"), false)
         .unwrap();
 
-    let config_path = case_dir.join("node_modules/.vize/canon/tsconfig.declaration.json");
+    let config_path = project_virtual_root(case_dir).join("tsconfig.declaration.json");
     let value: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(config_path).unwrap()).unwrap();
     value["compilerOptions"]["rootDir"]
@@ -85,7 +86,7 @@ fn declaration_tsconfig_honors_a_configured_root_dir() {
     let case_dir = unique_case_dir("declaration-root-dir-configured");
     let root_dir = declaration_root_dir(&case_dir, "    \"rootDir\": \"./lib\"");
 
-    let virtual_root = fs::canonicalize(case_dir.join("node_modules/.vize/canon")).unwrap();
+    let virtual_root = fs::canonicalize(project_virtual_root(&case_dir)).unwrap();
     assert_eq!(
         Path::new(&root_dir),
         virtual_root.join("lib"),
@@ -113,7 +114,7 @@ fn declaration_tsconfig_resolves_an_inherited_root_dir_from_its_declaring_config
         )],
     );
 
-    let virtual_root = fs::canonicalize(case_dir.join("node_modules/.vize/canon")).unwrap();
+    let virtual_root = fs::canonicalize(project_virtual_root(&case_dir)).unwrap();
     assert_eq!(
         Path::new(&root_dir),
         virtual_root.join("lib"),
@@ -128,7 +129,7 @@ fn declaration_tsconfig_infers_the_root_dir_when_none_is_configured() {
     let case_dir = unique_case_dir("declaration-root-dir-inferred");
     let root_dir = declaration_root_dir(&case_dir, "    \"strict\": true");
 
-    let virtual_root = fs::canonicalize(case_dir.join("node_modules/.vize/canon")).unwrap();
+    let virtual_root = fs::canonicalize(project_virtual_root(&case_dir)).unwrap();
     assert_eq!(
         Path::new(&root_dir),
         virtual_root,
@@ -148,7 +149,7 @@ fn declaration_tsconfig_ignores_a_root_dir_outside_the_project() {
     let case_dir = unique_case_dir("declaration-root-dir-outside");
     let root_dir = declaration_root_dir(&case_dir, "    \"rootDir\": \"../outside\"");
 
-    let virtual_root = fs::canonicalize(case_dir.join("node_modules/.vize/canon")).unwrap();
+    let virtual_root = fs::canonicalize(project_virtual_root(&case_dir)).unwrap();
     assert_eq!(Path::new(&root_dir), virtual_root);
 
     let _ = fs::remove_dir_all(&case_dir);

--- a/crates/vize_canon/src/batch/virtual_project/tests/graphql_generated.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/graphql_generated.rs
@@ -108,7 +108,7 @@ expectQuestion(question)
         serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
     assert_eq!(
         value["compilerOptions"]["paths"]["~/*"],
-        serde_json::json!(["./*", "../../../*", "./*.vue.ts"])
+        serde_json::json!(["./*", "../../../../../*", "./*.vue.ts"])
     );
 
     let _ = fs::remove_dir_all(&case_dir);

--- a/crates/vize_canon/src/batch/virtual_project/tests/module_augmentations.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/module_augmentations.rs
@@ -37,7 +37,7 @@ const message = 'Hello'
     project.register_path(&vue_path).unwrap();
     project.materialize().unwrap();
 
-    let virtual_root = case_dir.join("node_modules/.vize/canon");
+    let virtual_root = project.virtual_root();
     let auto_imports = fs::read_to_string(virtual_root.join(AUTO_IMPORT_STUBS_FILE)).unwrap();
     let augmentations =
         fs::read_to_string(virtual_root.join(MODULE_AUGMENTATION_STUBS_FILE)).unwrap();

--- a/crates/vize_canon/src/batch/virtual_project/tests/project_isolation.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/project_isolation.rs
@@ -1,0 +1,106 @@
+#![cfg(unix)]
+
+use super::{VirtualProject, fs, unique_case_dir};
+
+#[test]
+fn virtual_project_uses_a_full_project_key() {
+    let case_dir = unique_case_dir("new");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(&case_dir).unwrap();
+
+    let project = VirtualProject::new(&case_dir).unwrap();
+    assert_eq!(project.project_root(), case_dir.as_path());
+    assert_eq!(
+        project.virtual_root().parent().unwrap().file_name(),
+        Some(std::ffi::OsStr::new("projects"))
+    );
+    assert_eq!(
+        project.virtual_root().file_name().unwrap().len(),
+        64,
+        "the project namespace uses the full SHA-256 identity"
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn distinct_projects_sharing_node_modules_have_distinct_virtual_roots() {
+    let case_dir = unique_case_dir("shared-node-modules-project-identity");
+    let _ = fs::remove_dir_all(&case_dir);
+    let first_root = case_dir.join("first");
+    let second_root = case_dir.join("second");
+    let shared_node_modules = case_dir.join("shared-node-modules");
+    fs::create_dir_all(&first_root).unwrap();
+    fs::create_dir_all(&second_root).unwrap();
+    fs::create_dir_all(&shared_node_modules).unwrap();
+    std::os::unix::fs::symlink(&shared_node_modules, first_root.join("node_modules")).unwrap();
+    std::os::unix::fs::symlink(&shared_node_modules, second_root.join("node_modules")).unwrap();
+
+    let first_source = first_root.join("src/App.vue");
+    let second_source = second_root.join("src/App.vue");
+    fs::create_dir_all(first_source.parent().unwrap()).unwrap();
+    fs::create_dir_all(second_source.parent().unwrap()).unwrap();
+    fs::write(
+        &first_source,
+        "<script setup lang=\"ts\">const owner = 'first'</script>",
+    )
+    .unwrap();
+    fs::write(
+        &second_source,
+        "<script setup lang=\"ts\">const owner = 'second'</script>",
+    )
+    .unwrap();
+
+    let mut first = VirtualProject::new(&first_root).unwrap();
+    first.register_path(&first_source).unwrap();
+    first.materialize().unwrap();
+    let first_virtual_source = first.virtual_root().join("src/App.vue.ts");
+    let first_materialized = fs::read_to_string(&first_virtual_source).unwrap();
+    let first_crash_residue = first.virtual_root().join("crash-residue.ts");
+    fs::write(&first_crash_residue, "stale crashed process state").unwrap();
+
+    let mut second = VirtualProject::new(&second_root).unwrap();
+    second.register_path(&second_source).unwrap();
+    second.materialize().unwrap();
+    let second_virtual_source = second.virtual_root().join("src/App.vue.ts");
+    let second_materialized = fs::read_to_string(&second_virtual_source).unwrap();
+
+    let canonical_storage = fs::canonicalize(&shared_node_modules).unwrap();
+    assert!(first.virtual_root().starts_with(&canonical_storage));
+    assert!(second.virtual_root().starts_with(&canonical_storage));
+    assert_ne!(
+        first.virtual_root(),
+        second.virtual_root(),
+        "physical project identity must not collapse when dependency storage is shared"
+    );
+    assert_eq!(
+        fs::read_to_string(&first_virtual_source).unwrap(),
+        first_materialized,
+        "materializing the second project must not overwrite the first project's state"
+    );
+    assert!(
+        first_crash_residue.exists(),
+        "another project must not prune crash residue from a namespace it does not own"
+    );
+    assert!(
+        !second.virtual_root().join("crash-residue.ts").exists(),
+        "another project's crash residue must never appear in this project"
+    );
+    assert_ne!(
+        second_materialized, first_materialized,
+        "the projects must retain their incompatible virtual sources"
+    );
+
+    first.materialize().unwrap();
+    assert!(
+        !first_crash_residue.exists(),
+        "a project must prune its own stale crash residue on the next materialization"
+    );
+    assert_eq!(
+        fs::read_to_string(&second_virtual_source).unwrap(),
+        second_materialized,
+        "pruning one project must not mutate another project's generated state"
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize_canon/src/batch/virtual_project/tests/tsconfig_extends.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/tsconfig_extends.rs
@@ -58,7 +58,7 @@ fn materialized_tsconfig_inlines_extends_chain_without_extending_original() {
     project.register_path(&vue_path).unwrap();
     project.materialize().unwrap();
 
-    let tsconfig_path = case_dir.join("node_modules/.vize/canon/tsconfig.json");
+    let tsconfig_path = project.virtual_root().join("tsconfig.json");
     let value: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
 
@@ -139,7 +139,7 @@ fn a_shared_ancestor_is_inherited_by_every_sibling_extends_entry() {
     project.register_path(&vue_path).unwrap();
     project.materialize().unwrap();
 
-    let tsconfig_path = case_dir.join("node_modules/.vize/canon/tsconfig.json");
+    let tsconfig_path = project.virtual_root().join("tsconfig.json");
     let value: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
     let compiler_options = value["compilerOptions"].as_object().unwrap();

--- a/crates/vize_canon/src/batch/virtual_project/tests/tsconfig_native_options.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/tsconfig_native_options.rs
@@ -31,7 +31,7 @@ fn materialized_tsconfig_normalizes_native_removed_options() {
     project.register_path(&vue_path).unwrap();
     project.materialize().unwrap();
 
-    let tsconfig_path = case_dir.join("node_modules/.vize/canon/tsconfig.json");
+    let tsconfig_path = project.virtual_root().join("tsconfig.json");
     let value: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
     let compiler_options = value["compilerOptions"].as_object().unwrap();

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen/remap.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen/remap.rs
@@ -1,6 +1,6 @@
 //! Re-anchoring of tsconfig path-like options into the virtual mirror.
 
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 
 use serde_json::{Map, Value};
 use vize_carton::{String as CompactString, cstr};
@@ -92,18 +92,94 @@ impl VirtualProject {
         remapped
     }
 
-    /// Relative prefix (e.g. `../../../`) from the virtual root back to the
-    /// project root, used to aim alias fallbacks at the real source tree.
+    /// Relative prefix from the virtual root back to the project root, used to
+    /// aim alias fallbacks at the real source tree. Project-keyed mirrors may
+    /// live in a shared physical dependency store, so this must compare both
+    /// paths instead of assuming that the mirror is nested under the source.
     fn virtual_root_to_project_prefix(&self) -> CompactString {
-        let depth = self
-            .virtual_root
-            .strip_prefix(&self.project_root)
-            .map(|relative| relative.components().count())
-            .unwrap_or(0);
-        let mut prefix = CompactString::with_capacity(depth * 3);
-        for _ in 0..depth {
-            prefix.push_str("../");
+        let relative = relative_path_from(&self.virtual_root, &self.project_root);
+        let normalized = relative.to_string_lossy().replace('\\', "/");
+        if normalized == "." {
+            return CompactString::new("");
+        }
+        let mut prefix = CompactString::from(normalized);
+        if !prefix.ends_with('/') {
+            prefix.push('/');
         }
         prefix
+    }
+}
+
+fn relative_path_from(from_dir: &Path, target: &Path) -> PathBuf {
+    let from = path_components(from_dir);
+    let to = path_components(target);
+    let mut common = 0usize;
+    while common < from.len() && common < to.len() && from[common] == to[common] {
+        common += 1;
+    }
+    if common == 0 {
+        return target.to_path_buf();
+    }
+
+    let mut relative = PathBuf::new();
+    for _ in common..from.len() {
+        relative.push("..");
+    }
+    for component in to.iter().skip(common) {
+        relative.push(component);
+    }
+    if relative.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        relative
+    }
+}
+
+fn path_components(path: &Path) -> Vec<std::ffi::OsString> {
+    path.components()
+        .filter_map(|component| match component {
+            Component::CurDir => None,
+            Component::Prefix(prefix) => Some(prefix.as_os_str().to_os_string()),
+            Component::RootDir => Some(std::path::MAIN_SEPARATOR_STR.into()),
+            Component::ParentDir => Some("..".into()),
+            Component::Normal(value) => Some(value.to_os_string()),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::relative_path_from;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn sibling_storage_paths_rebase_to_the_source_tree() {
+        assert_eq!(
+            relative_path_from(
+                Path::new("/workspace/shared/.vize/canon/projects/key"),
+                Path::new("/workspace/apps/first"),
+            ),
+            PathBuf::from("../../../../../apps/first")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_rebasing_respects_drive_prefix_boundaries() {
+        assert_eq!(
+            relative_path_from(
+                Path::new(r"C:\store\.vize\canon\projects\key"),
+                Path::new(r"C:\repo\app"),
+            ),
+            PathBuf::from(r"..\..\..\..\..\repo\app")
+        );
+        assert_eq!(
+            relative_path_from(
+                Path::new(r"C:\store\.vize\canon\projects\key"),
+                Path::new(r"D:\repo\app"),
+            ),
+            PathBuf::from(r"D:\repo\app"),
+            "a different drive must remain an absolute paths target"
+        );
     }
 }

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias.rs
@@ -31,9 +31,9 @@ use crate::batch::virtual_project::dependency_scan::resolve_dependency;
 /// The checker resolves modules from the disk only — open in-memory documents
 /// are never resolution targets — so alias imports must land on real files.
 /// The batch pipeline already materializes exactly those (#3898): reachable
-/// `.vue` companions and out-of-root barrels inside `node_modules/.vize/canon`.
-/// Editor sessions reuse that machinery and rewrite their imports to relative
-/// paths into the mirror.
+/// `.vue` companions and out-of-root barrels inside the current
+/// `.vize/canon/projects/<key>` namespace. Editor sessions reuse that machinery
+/// and rewrite their imports to relative paths into the mirror.
 #[allow(clippy::disallowed_types)]
 pub(super) struct AliasContext {
     project_root: PathBuf,

--- a/crates/vize_canon/src/corsa_bridge/vue_document_alias_tests.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_document_alias_tests.rs
@@ -26,11 +26,7 @@ fn alias_project() -> tempfile::TempDir {
 }
 
 fn mirror_companion(project: &tempfile::TempDir) -> std::path::PathBuf {
-    project
-        .path()
-        .join("node_modules")
-        .join(".vize")
-        .join("canon")
+    crate::batch::project_virtual_root(project.path())
         .join("src")
         .join("UiButton.vue.ts")
 }

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -20,7 +20,7 @@
 //! │                                                                 │
 //! │  Project                    Virtual Project                     │
 //! │  ┌──────────────┐          ┌──────────────────────────┐        │
-//! │  │ src/         │          │ node_modules/.vize/canon │        │
+//! │  │ src/         │          │ .vize/canon/projects/key │        │
 //! │  │ ├─ App.vue   │ ──────▶  │ ├─ src/                  │        │
 //! │  │ ├─ utils.ts  │          │ │  ├─ App.vue.ts         │        │
 //! │  │ └─ ...       │          │ │  ├─ utils.ts           │        │
@@ -130,6 +130,7 @@ pub use batch::{
     ImportSourceMap, IncrementalCheckMetrics, PackageManager,
     TypeCheckResult as BatchTypeCheckResult, TypeChecker as BatchTypeCheckerTrait, VirtualFile,
     VirtualProject, VirtualTsGenerator, generate_vue_content_mapper_transform,
+    project_virtual_lock_paths, project_virtual_root,
 };
 
 #[cfg(feature = "native")]

--- a/crates/vize_canon/tests/tsconfig_option_diagnostics.rs
+++ b/crates/vize_canon/tests/tsconfig_option_diagnostics.rs
@@ -10,7 +10,7 @@
 
 use std::path::{Path, PathBuf};
 
-use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait};
+use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait, project_virtual_root};
 use vize_carton::cstr;
 
 fn resolve_test_tsgo_binary() -> Option<PathBuf> {
@@ -163,8 +163,8 @@ fn a_config_the_generated_one_carries_through_reports_nothing_extra() {
 
     assert_eq!(diagnostics, Vec::new());
     assert!(
-        !root
-            .join("node_modules/.vize/canon/tsconfig.options.json")
+        !project_virtual_root(&root)
+            .join("tsconfig.options.json")
             .exists(),
         "an unsanitized config needs no probe"
     );
@@ -269,9 +269,8 @@ fn an_explicit_relative_paths_target_stays_valid_without_base_url() {
         "an authored relative path must not produce TS5090: {diagnostics:?}"
     );
 
-    let probe =
-        std::fs::read_to_string(root.join("node_modules/.vize/canon/tsconfig.options.json"))
-            .expect("rootDir should require an option probe");
+    let probe = std::fs::read_to_string(project_virtual_root(&root).join("tsconfig.options.json"))
+        .expect("rootDir should require an option probe");
     let probe: serde_json::Value = serde_json::from_str(&probe).unwrap();
     assert_eq!(
         probe["compilerOptions"]["paths"]["@/*"],


### PR DESCRIPTION
Closes #4095

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Canon-generated project data is now isolated by project, preventing shared dependency storage from mixing files between projects.
  - Added reliable project-specific handling for generated files, locks, and virtual paths.

- **Bug Fixes**
  - Force-clean now removes only the current project’s Canon artifacts while preserving shared data and other projects’ files.
  - Improved path handling across Unix and Windows environments.

- **Tests**
  - Expanded coverage for project isolation, cleanup scope, shared dependencies, symlinks, and generated configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->