### PR TITLE
test(glyph): reject stale corpus formatter waivers

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -253,7 +253,7 @@ jobs:
           fi
           surface_verdict="$FIXTURE_REPORT_DIR/surface-verdict.json"
           if [[ -s "$surface_verdict" ]]; then
-            jq -r '"Surface verdict: \(.status); failed: \(.failedSurfaceNames | join(\", \"))"' \
+            jq -r '"Surface verdict: \(.status); failed: \(.failedSurfaceNames | join(", "))"' \
               "$surface_verdict" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "No real-project surface verdict was produced." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -13,6 +13,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -64,12 +65,25 @@ jobs:
           git submodule update --init --depth 1 -- "${fixture_paths[@]}"
 
       - name: Install pinned typecheck baseline dependencies
+        id: typecheck_dependencies
+        if: ${{ !cancelled() }}
+        continue-on-error: true
         run: |
           node tools/fixtures/typecheck-dependency-prepare.mjs \
             --output-dir "$FIXTURE_REPORT_DIR" \
             --shard-index "$FIXTURE_SHARD_INDEX" \
             --shard-count "$FIXTURE_SHARD_COUNT" \
             --timeout-ms 600000
+
+      - name: Audit formatter waiver owners
+        id: waiver_audit
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          node tools/fixtures/glyph-corpus-waiver-audit.mjs \
+            --output "$FIXTURE_REPORT_DIR/glyph-waiver-issues.json"
 
       - uses: ./.github/actions/setup-moonbit
 
@@ -93,6 +107,9 @@ jobs:
         run: cargo build --profile ci -p vize
 
       - name: Exercise real projects with every core tool
+        id: core_tools
+        if: ${{ !cancelled() }}
+        continue-on-error: true
         run: |
           node tools/fixtures/tool-matrix-report.mjs \
             --shard-index "$FIXTURE_SHARD_INDEX" \
@@ -102,6 +119,9 @@ jobs:
             --output-dir "$FIXTURE_REPORT_DIR"
 
       - name: Check real-project LSP lifecycle
+        id: lsp
+        if: ${{ !cancelled() }}
+        continue-on-error: true
         env:
           CORSA_PATH: ${{ github.workspace }}/node_modules/.bin/tsgo
           REAL_PROJECT_LSP_TIMEOUT_MS: "600000"
@@ -116,6 +136,9 @@ jobs:
           test -s "$FIXTURE_REPORT_DIR/lsp-lifecycle-summary.json"
 
       - name: Check real-project syntax highlighting
+        id: syntax_highlighter
+        if: ${{ !cancelled() }}
+        continue-on-error: true
         env:
           SYNTAX_HIGHLIGHTER_ORACLE_TIMEOUT_MS: "600000"
         run: |
@@ -125,15 +148,30 @@ jobs:
           test -s "$FIXTURE_REPORT_DIR/syntax-highlighter-divergence.md"
 
       - name: Check glyph formatter corpus properties
+        id: glyph
+        if: ${{ !cancelled() }}
+        continue-on-error: true
         env:
           VIZE_TEST_BIN: target/ci/vize
+        shell: bash
         run: |
+          glyph_exit_code=0
           node --test --test-concurrency=1 \
             tests/tooling/glyph-corpus-idempotence.test.ts \
             tests/tooling/glyph-corpus-parse-preservation.test.ts \
-            tests/tooling/glyph-corpus-lint-agreement.test.ts
+            tests/tooling/glyph-corpus-lint-agreement.test.ts || glyph_exit_code=$?
+          for property in idempotence parse-preservation lint-agreement; do
+            if [[ ! -s "$FIXTURE_REPORT_DIR/glyph-$property.json" ]]; then
+              echo "::error title=Missing formatter evidence::$property produced no artifact"
+              glyph_exit_code=1
+            fi
+          done
+          exit "$glyph_exit_code"
 
       - name: Enforce typechecker baseline divergence
+        id: typecheck_divergence
+        if: ${{ !cancelled() }}
+        continue-on-error: true
         env:
           # This workflow is release evidence as well as a scheduled ecosystem
           # sweep. A breached or unusable baseline must fail every entry path.
@@ -145,6 +183,28 @@ jobs:
             --shard-count "$FIXTURE_SHARD_COUNT" \
             --budget-mode "$BUDGET_MODE" \
             --vue-tsc-bin tests/node_modules/.bin/vue-tsc
+
+      - name: Enforce all real-project surface verdicts
+        id: surface_verdict
+        if: ${{ always() }}
+        env:
+          VIZE_WAIVER_AUDIT_OUTCOME: ${{ steps.waiver_audit.outcome }}
+          VIZE_TYPECHECK_DEPENDENCIES_OUTCOME: ${{ steps.typecheck_dependencies.outcome }}
+          VIZE_CORE_TOOLS_OUTCOME: ${{ steps.core_tools.outcome }}
+          VIZE_LSP_OUTCOME: ${{ steps.lsp.outcome }}
+          VIZE_SYNTAX_HIGHLIGHTER_OUTCOME: ${{ steps.syntax_highlighter.outcome }}
+          VIZE_GLYPH_OUTCOME: ${{ steps.glyph.outcome }}
+          VIZE_TYPECHECK_DIVERGENCE_OUTCOME: ${{ steps.typecheck_divergence.outcome }}
+        run: |
+          node tools/fixtures/real-project-surface-verdict.mjs \
+            --output "$FIXTURE_REPORT_DIR/surface-verdict.json" \
+            --surface "waiver-audit=$VIZE_WAIVER_AUDIT_OUTCOME" \
+            --surface "typecheck-dependencies=$VIZE_TYPECHECK_DEPENDENCIES_OUTCOME" \
+            --surface "core-tools=$VIZE_CORE_TOOLS_OUTCOME" \
+            --surface "lsp=$VIZE_LSP_OUTCOME" \
+            --surface "syntax-highlighter=$VIZE_SYNTAX_HIGHLIGHTER_OUTCOME" \
+            --surface "glyph=$VIZE_GLYPH_OUTCOME" \
+            --surface "typecheck-divergence=$VIZE_TYPECHECK_DIVERGENCE_OUTCOME"
 
       - name: Publish shard summary
         if: ${{ always() }}
@@ -183,6 +243,20 @@ jobs:
             cat "${divergence_reports[0]}" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "No unique typecheck divergence report was produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          waiver_report="$FIXTURE_REPORT_DIR/glyph-waiver-issues.json"
+          if [[ -s "$waiver_report" ]]; then
+            jq -r '"Formatter waivers: \(.waiverCount) precise waiver(s), \(.issues | length) open owner Issue(s)"' \
+              "$waiver_report" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No formatter waiver owner report was produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          surface_verdict="$FIXTURE_REPORT_DIR/surface-verdict.json"
+          if [[ -s "$surface_verdict" ]]; then
+            jq -r '"Surface verdict: \(.status); failed: \(.failedSurfaceNames | join(\", \"))"' \
+              "$surface_verdict" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No real-project surface verdict was produced." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload shard report

--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -1,524 +1,389 @@
 [
   {
     "property": "parse-preservation",
-    "project": "crater",
-    "path": "resources/scripts/components/base/BaseModal.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "lib/components/borderBox10/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "lib/components/borderBox11/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "lib/components/borderBox12/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "lib/components/borderBox13/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "lib/components/borderBox2/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "lib/components/borderBox3/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "lib/components/borderBox4/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "lib/components/borderBox5/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "lib/components/borderBox6/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "lib/components/borderBox9/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "lib/components/decoration11/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "lib/components/scrollBoard/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "src/components/borderBox10/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "src/components/borderBox11/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "src/components/borderBox12/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "src/components/borderBox13/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "src/components/borderBox2/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "src/components/borderBox3/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "src/components/borderBox4/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "src/components/borderBox5/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "src/components/borderBox6/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "src/components/borderBox9/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "src/components/decoration11/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "datav",
-    "path": "src/components/scrollBoard/src/main.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "element-plus-x",
-    "path": "packages/core/src/components/Bubble/index.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "elk",
-    "path": "app/components/nav/NavSideItem.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
+    "category": "baseline-unusable",
     "project": "gogocode",
     "path": "packages/gogocode-plugin-vue/test/key-attribute/Comp.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "The pinned @vue/compiler-sfc baseline crashes on this legacy v-bind.sync form before equivalence can be evaluated.",
+    "trackingIssue": 4108,
+    "expiryCondition": "Remove after a dialect-aware legacy SFC baseline can compare this file without crashing."
   },
   {
     "property": "parse-preservation",
+    "category": "baseline-unusable",
     "project": "gogocode",
     "path": "packages/gogocode-plugin-vue/test/listeners-removed/Comp.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "The pinned @vue/compiler-sfc baseline crashes on this legacy v-bind.sync form before equivalence can be evaluated.",
+    "trackingIssue": 4108,
+    "expiryCondition": "Remove after a dialect-aware legacy SFC baseline can compare this file without crashing."
   },
   {
     "property": "parse-preservation",
-    "project": "gui-for-singbox",
-    "path": "frontend/src/components/Table/index.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "inspira-ui",
-    "path": "app/components/inspira/ui/spinning-text/SpinningText.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/components/layout/PlayDetail/components/MusicComment/CommentFloor.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/components/layout/PlayDetail/components/MusicComment/index.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/components/layout/PlayDetail/index.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/components/layout/UpdateModal.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/DislikeListModal.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/PlayTimeoutModal.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingAbout.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingBackup.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingBasic.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingDesktopLyric.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingDownload.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingHotKey.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingList.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingNetwork.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingOdc.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingOpenAPI.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingOther.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingPlay.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingPlayDetail.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingSearch.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingSync/ServerDeviceListModal.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingSync/SyncClient.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingSync/SyncServer.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingSync/index.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/SettingUpdate.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/views/Setting/components/UserApiModal.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
-    "project": "pinry",
-    "path": "pinry-spa/src/components/search/SearchPanel.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
+    "category": "semantic-diff",
     "project": "sigma-file-manager",
     "path": "src/components/ui/dialog/dialog-header.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "Formatting removes an empty script setup block, changing the official SFC descriptor.",
+    "trackingIssue": 4107,
+    "expiryCondition": "Remove after formatting preserves the empty script setup block and the semantic comparator is clean."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "splitpanes",
     "path": "src/app.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "splitpanes",
     "path": "src/components/release-notes.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "splitpanes",
     "path": "src/views/documentation.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
-    "project": "vue-bits",
-    "path": "src/components/landing/Hero/ColorValue.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "vue-cal-v4",
     "path": "src/app.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "vue-cal-v4",
     "path": "src/documentation/api.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "vue-cal-v4",
     "path": "src/documentation/examples.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "vue-cal-v4",
     "path": "src/documentation/release-notes.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "vue-cal-v4",
     "path": "src/vue-cal/index.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
-    "project": "vue-data-ui",
-    "path": "src/atoms/Digit.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "vue-data-ui",
-    "path": "src/components/vue-ui-bump.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "vue-data-ui",
-    "path": "src/components/vue-ui-chord.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "vue-data-ui",
-    "path": "src/components/vue-ui-dumbbell.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "vue-data-ui",
-    "path": "src/components/vue-ui-flow.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "vue-data-ui",
-    "path": "src/components/vue-ui-skeleton.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "vue-data-ui",
-    "path": "src/components/vue-ui-stackbar.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "vue-data-ui",
-    "path": "src/components/vue-ui-stackline.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "vue-data-ui",
-    "path": "src/components/vue-ui-word-cloud.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "vue-termui",
-    "path": "playground/src/pages/demos/notifications.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "vue-termui",
-    "path": "playground/src/pages/demos/text-selection.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "vuelidate",
     "path": "docs-v1/LangSwitcher.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "vuelidate",
     "path": "docs-v1/partials/examples/ExampleAnyDirty.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "vuelidate",
     "path": "docs-v1/partials/examples/ExampleBasic.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "vuelidate",
     "path": "docs-v1/partials/examples/ExampleDelayedTouch.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "vuelidate",
     "path": "docs-v1/partials/examples/ExampleEvent.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   },
   {
     "property": "parse-preservation",
+    "category": "oracle-unavailable",
     "project": "vuelidate",
     "path": "docs-v1/partials/examples/ExampleSubmit.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "vuestic-ui",
-    "path": "packages/docs/page-config/ui-elements/image/examples/SrcSet.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
-  },
-  {
-    "property": "parse-preservation",
-    "project": "vuestic-ui",
-    "path": "packages/ui/src/components/va-image/VaImage.demo.vue",
-    "issue": "https://github.com/ubugeeei-prod/vize/issues/3334"
+    "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
+    "trackingIssue": 4106,
+    "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
   }
 ]

--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -10,6 +10,15 @@
   },
   {
     "property": "parse-preservation",
+    "category": "semantic-diff",
+    "project": "gui-for-singbox",
+    "path": "frontend/src/components/Table/index.vue",
+    "reason": "Attribute sorting moves a named binding across an order-sensitive v-bind object boundary.",
+    "trackingIssue": 4113,
+    "expiryCondition": "Remove after Glyph preserves binding precedence while sorting attributes."
+  },
+  {
+    "property": "parse-preservation",
     "category": "baseline-unusable",
     "project": "gogocode",
     "path": "packages/gogocode-plugin-vue/test/listeners-removed/Comp.vue",
@@ -25,6 +34,15 @@
     "reason": "@vue/compiler-sfc does not parse Pug template syntax, so the current semantic comparator has no independent template oracle.",
     "trackingIssue": 4106,
     "expiryCondition": "Remove after a Pug-aware baseline proves formatter output preserves template semantics."
+  },
+  {
+    "property": "parse-preservation",
+    "category": "semantic-diff",
+    "project": "pinry",
+    "path": "pinry-spa/src/components/search/SearchPanel.vue",
+    "reason": "The comparator does not yet normalize Vue-equivalent presence forms of the scoped SFC block attribute.",
+    "trackingIssue": 4114,
+    "expiryCondition": "Remove after the semantic oracle treats equivalent scoped attribute spellings identically."
   },
   {
     "property": "parse-preservation",

--- a/tests/tooling/glyph-corpus-idempotence.test.ts
+++ b/tests/tooling/glyph-corpus-idempotence.test.ts
@@ -1,7 +1,4 @@
-// Corpus-wide glyph formatter idempotence: for every Vue SFC in the hydrated
-// ecosystem fixtures, `fmt(fmt(x)) == fmt(x)` byte-for-byte. In the Real
-// Project Matrix, the preceding `--check` prediction must also equal the first
-// `--write` mutation set. Fixtures are hydrated per-lane, so absent projects
+// Corpus-wide `fmt(fmt(x)) == fmt(x)` and `--check`/`--write` agreement; absent projects
 // are reported as skipped, never failed; the weekly matrix shards hydrate the
 // full registry. Set VIZE_GLYPH_CORPUS_MAX_FILES_PER_PROJECT to cap files for
 // local iteration.
@@ -16,8 +13,8 @@ import {
   assertFormatterCheckWriteAgreement,
   collectFormatterWriteEvidence,
   collectProjectVueFiles,
+  createKnownViolationConsumption,
   diffExcerpt,
-  isKnownViolation,
   loadGlyphCorpusProjects,
   loadFormatterCheckEvidence,
   loadKnownViolations,
@@ -25,6 +22,7 @@ import {
   resolveGlyphLaunch,
   snapshotWorkspaceFiles,
   withFormattedWorkspace,
+  writeGlyphCorpusPropertyEvidence,
 } from "../../tools/fixtures/glyph-corpus.mjs";
 
 type CorpusProject = {
@@ -39,6 +37,7 @@ type Violation = { project: string; file: string; detail: string };
 const property = "idempotence";
 const projects = loadGlyphCorpusProjects() as CorpusProject[];
 const knownViolations = loadKnownViolations(property);
+const waiverConsumption = createKnownViolationConsumption(knownViolations);
 
 function sweepProject(
   project: CorpusProject,
@@ -46,6 +45,7 @@ function sweepProject(
   violations: Violation[],
   counters: { files: number; skipped: number },
   checkEvidence: FormatterEvidence | null = null,
+  waivedViolations: Array<Violation & { waiver: object }> = [],
 ): void {
   const files = collectProjectVueFiles(project) as string[];
   if (files.length === 0) return;
@@ -77,14 +77,17 @@ function sweepProject(
           counters.files += 1;
           continue;
         }
-        if (isKnownViolation(knownViolations, project.id, file)) {
+        const detail = diffExcerpt(before.toString("utf8"), after.toString("utf8"), "fmt1", "fmt2");
+        const waiver = waiverConsumption.consume(project.id, file, null, "semantic-diff");
+        if (waiver) {
+          waivedViolations.push({ project: project.id, file, detail, waiver });
           counters.skipped += 1;
           continue;
         }
         violations.push({
           project: project.id,
           file,
-          detail: diffExcerpt(before.toString("utf8"), after.toString("utf8"), "fmt1", "fmt2"),
+          detail,
         });
       }
     },
@@ -100,10 +103,32 @@ test("glyph corpus idempotence holds for every hydrated fixture", () => {
   }
   const launch = resolveGlyphLaunch();
   const violations: Violation[] = [];
+  const waivedViolations: Array<Violation & { waiver: object }> = [];
   const counters = { files: 0, skipped: 0 };
   for (const project of hydrated) {
-    sweepProject(project, launch, violations, counters, loadFormatterCheckEvidence(project));
+    sweepProject(
+      project,
+      launch,
+      violations,
+      counters,
+      loadFormatterCheckEvidence(project),
+      waivedViolations,
+    );
   }
+  let waiverValidationError: string | null = null;
+  try {
+    waiverConsumption.assertAllConsumed(new Set(hydrated.map((project) => project.id)));
+  } catch (error) {
+    waiverValidationError = error instanceof Error ? error.message : String(error);
+  }
+  writeGlyphCorpusPropertyEvidence(property, {
+    projectIds: hydrated.map((project) => project.id),
+    counters,
+    violations,
+    waivedViolations,
+    waiverValidationError,
+  });
+  assert.equal(waiverValidationError, null, waiverValidationError ?? undefined);
   process.stderr.write(
     `glyph ${property}: ${counters.files} file(s) across ${hydrated.length} project(s), ` +
       `${projects.length - hydrated.length} project(s) not hydrated, ` +

--- a/tests/tooling/glyph-corpus-lint-agreement.test.ts
+++ b/tests/tooling/glyph-corpus-lint-agreement.test.ts
@@ -14,13 +14,14 @@ import { test } from "node:test";
 
 import {
   collectProjectVueFiles,
-  isKnownViolation,
+  createKnownViolationConsumption,
   loadGlyphCorpusProjects,
   loadKnownViolations,
   renderViolations,
   resolveGlyphLaunch,
   runVize,
   withFormattedWorkspace,
+  writeGlyphCorpusPropertyEvidence,
 } from "../../tools/fixtures/glyph-corpus.mjs";
 
 type CorpusProject = {
@@ -38,6 +39,7 @@ type Violation = { project: string; file: string; detail: string };
 const property = "lint-agreement";
 const projects = loadGlyphCorpusProjects() as CorpusProject[];
 const knownViolations = loadKnownViolations(property);
+const waiverConsumption = createKnownViolationConsumption(knownViolations);
 
 function lintTree(launch: Launch, cwd: string, globs: string[]): FindingsByFile {
   const result = runVize(launch, cwd, [
@@ -101,6 +103,7 @@ function sweepProject(
   launch: Launch,
   violations: Violation[],
   counters: { files: number; skipped: number },
+  waivedViolations: Array<Violation & { rule: string; waiver: object }> = [],
 ): void {
   const files = collectProjectVueFiles(project) as string[];
   if (files.length === 0) return;
@@ -111,12 +114,24 @@ function sweepProject(
       const introduced = introducedFindings(baseline.get(file) ?? [], formatted.get(file) ?? []);
       // Skip-list entries are rule-scoped so a tracked systemic disagreement
       // (e.g. one rule) cannot mask newly introduced findings of other rules.
-      const real = introduced.filter(
-        (entry) => !isKnownViolation(knownViolations, project.id, file, entry.ruleId),
-      );
+      const real: typeof introduced = [];
+      for (const entry of introduced) {
+        const waiver = waiverConsumption.consume(project.id, file, entry.ruleId, "semantic-diff");
+        if (waiver) {
+          waivedViolations.push({
+            project: project.id,
+            file,
+            rule: entry.ruleId,
+            detail: entry.detail,
+            waiver,
+          });
+        } else {
+          real.push(entry);
+        }
+      }
       counters.skipped += introduced.length - real.length;
       if (real.length === 0) {
-        counters.files += 1;
+        if (introduced.length === 0) counters.files += 1;
         continue;
       }
       violations.push({
@@ -137,10 +152,25 @@ test("glyph corpus lint-agreement holds for every hydrated fixture", () => {
   }
   const launch = resolveGlyphLaunch();
   const violations: Violation[] = [];
+  const waivedViolations: Array<Violation & { rule: string; waiver: object }> = [];
   const counters = { files: 0, skipped: 0 };
   for (const project of hydrated) {
-    sweepProject(project, launch, violations, counters);
+    sweepProject(project, launch, violations, counters, waivedViolations);
   }
+  let waiverValidationError: string | null = null;
+  try {
+    waiverConsumption.assertAllConsumed(new Set(hydrated.map((project) => project.id)));
+  } catch (error) {
+    waiverValidationError = error instanceof Error ? error.message : String(error);
+  }
+  writeGlyphCorpusPropertyEvidence(property, {
+    projectIds: hydrated.map((project) => project.id),
+    counters,
+    violations,
+    waivedViolations,
+    waiverValidationError,
+  });
+  assert.equal(waiverValidationError, null, waiverValidationError ?? undefined);
   process.stderr.write(
     `glyph ${property}: ${counters.files} file(s) across ${hydrated.length} project(s), ` +
       `${projects.length - hydrated.length} project(s) not hydrated, ` +
@@ -179,11 +209,6 @@ test("glyph corpus lint-agreement comparator allows removals and flags growth", 
   );
   assert.equal(fresh.length, 1);
   assert.match(fresh[0].detail, /template\/no-parsing-error: 0 -> 1 finding\(s\)/);
-  // Rule-scoped waivers match wildcards without masking other rules.
-  const waivers = [{ property, project: "*", path: "*", rule: "vue/attribute-order", issue: "#0" }];
-  assert.equal(isKnownViolation(waivers, "misskey", "a/b.vue", "vue/attribute-order"), true);
-  assert.equal(isKnownViolation(waivers, "misskey", "a/b.vue", "vue/no-v-html"), false);
-  assert.equal(isKnownViolation(waivers, "misskey", "a/b.vue"), false);
 });
 
 test("glyph corpus lint-agreement machinery accepts the real formatter", () => {

--- a/tests/tooling/glyph-corpus-parse-preservation.test.ts
+++ b/tests/tooling/glyph-corpus-parse-preservation.test.ts
@@ -14,12 +14,13 @@ import { test } from "node:test";
 
 import {
   collectProjectVueFiles,
-  isKnownViolation,
+  createKnownViolationConsumption,
   loadGlyphCorpusProjects,
   loadKnownViolations,
   renderViolations,
   resolveGlyphLaunch,
   withFormattedWorkspace,
+  writeGlyphCorpusPropertyEvidence,
 } from "../../tools/fixtures/glyph-corpus.mjs";
 import { compareSfcEquivalence } from "./support/sfc-equivalence.ts";
 
@@ -35,6 +36,35 @@ type Violation = { project: string; file: string; detail: string };
 const property = "parse-preservation";
 const projects = loadGlyphCorpusProjects() as CorpusProject[];
 const knownViolations = loadKnownViolations(property);
+const waiverConsumption = createKnownViolationConsumption(knownViolations);
+
+function violationCategory(
+  original: string,
+  differences: string[],
+): "semantic-diff" | "baseline-unusable" | "oracle-unavailable" {
+  if (/<template(?=[\s>])[^>]*\blang\s*=\s*(["'])pug\1/i.test(original)) {
+    return "oracle-unavailable";
+  }
+  if (differences.some((difference) => difference.startsWith("comparison failed:"))) {
+    return "baseline-unusable";
+  }
+  return "semantic-diff";
+}
+
+test("glyph corpus classifies unavailable and crashed reference oracles precisely", () => {
+  assert.equal(
+    violationCategory('<template lang="pug">\ndiv hi\n</template>\n', ["different"]),
+    "oracle-unavailable",
+  );
+  assert.equal(
+    violationCategory("<template><p /></template>\n", ["comparison failed: parser crashed"]),
+    "baseline-unusable",
+  );
+  assert.equal(
+    violationCategory("<template><p /></template>\n", ["block disappeared"]),
+    "semantic-diff",
+  );
+});
 
 function compareFile(original: string, formatted: string, filename: string): string[] {
   try {
@@ -49,6 +79,7 @@ function sweepProject(
   launch: { command: string; prefix: string[] },
   violations: Violation[],
   counters: { files: number; skipped: number },
+  waivedViolations: Array<Violation & { waiver: object }> = [],
 ): void {
   const files = collectProjectVueFiles(project) as string[];
   if (files.length === 0) return;
@@ -61,14 +92,22 @@ function sweepProject(
         counters.files += 1;
         continue;
       }
-      if (isKnownViolation(knownViolations, project.id, file)) {
+      const detail = differences.map((difference) => `  ${difference}`).join("\n");
+      const waiver = waiverConsumption.consume(
+        project.id,
+        file,
+        null,
+        violationCategory(original, differences),
+      );
+      if (waiver) {
+        waivedViolations.push({ project: project.id, file, detail, waiver });
         counters.skipped += 1;
         continue;
       }
       violations.push({
         project: project.id,
         file,
-        detail: differences.map((difference) => `  ${difference}`).join("\n"),
+        detail,
       });
     }
   });
@@ -83,10 +122,25 @@ test("glyph corpus parse-preservation holds for every hydrated fixture", () => {
   }
   const launch = resolveGlyphLaunch();
   const violations: Violation[] = [];
+  const waivedViolations: Array<Violation & { waiver: object }> = [];
   const counters = { files: 0, skipped: 0 };
   for (const project of hydrated) {
-    sweepProject(project, launch, violations, counters);
+    sweepProject(project, launch, violations, counters, waivedViolations);
   }
+  let waiverValidationError: string | null = null;
+  try {
+    waiverConsumption.assertAllConsumed(new Set(hydrated.map((project) => project.id)));
+  } catch (error) {
+    waiverValidationError = error instanceof Error ? error.message : String(error);
+  }
+  writeGlyphCorpusPropertyEvidence(property, {
+    projectIds: hydrated.map((project) => project.id),
+    counters,
+    violations,
+    waivedViolations,
+    waiverValidationError,
+  });
+  assert.equal(waiverValidationError, null, waiverValidationError ?? undefined);
   process.stderr.write(
     `glyph ${property}: ${counters.files} file(s) across ${hydrated.length} project(s), ` +
       `${projects.length - hydrated.length} project(s) not hydrated, ` +

--- a/tests/tooling/glyph-corpus-waivers.test.ts
+++ b/tests/tooling/glyph-corpus-waivers.test.ts
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  assertHydratedKnownViolationPaths,
+  auditKnownViolationIssues,
+  createKnownViolationConsumption,
+  validateKnownViolationEntries,
+  writeGlyphCorpusPropertyEvidence,
+} from "../../tools/fixtures/glyph-corpus.mjs";
+import { createWaiverIssueAudit } from "../../tools/fixtures/glyph-corpus-waiver-audit.mjs";
+
+const validEntry = {
+  property: "parse-preservation",
+  category: "semantic-diff",
+  project: "fixture-a",
+  path: "src/App.vue",
+  reason: "The formatter currently removes an authored semantic token.",
+  trackingIssue: 4107,
+  expiryCondition: "Remove when the authored fixture passes without a waiver.",
+};
+
+const projects = [
+  {
+    id: "fixture-a",
+    fixtureDir: "/fixtures/a",
+    hydrated: false,
+    vueGlobs: ["src/**/*.vue"],
+  },
+];
+
+test("known formatter waivers require a precise non-overlapping schema", () => {
+  assert.deepEqual(validateKnownViolationEntries([validEntry], projects), [validEntry]);
+
+  for (const [field, value] of [
+    ["property", "unknown-property"],
+    ["category", "unknown-category"],
+    ["project", "unknown-project"],
+    ["path", "*"],
+    ["trackingIssue", 0],
+    ["reason", ""],
+    ["expiryCondition", ""],
+  ] as const) {
+    assert.throws(
+      () => validateKnownViolationEntries([{ ...validEntry, [field]: value }], projects),
+      new RegExp(String(field)),
+    );
+  }
+
+  for (const invalidPath of ["src\\App.vue", "src/../App.vue", "src//App.vue", "src/App.ts"]) {
+    assert.throws(
+      () => validateKnownViolationEntries([{ ...validEntry, path: invalidPath }], projects),
+      /exact relative path/,
+    );
+  }
+
+  assert.throws(
+    () => validateKnownViolationEntries([validEntry, { ...validEntry }], projects),
+    /duplicate known violation identity/,
+  );
+  assert.throws(
+    () => validateKnownViolationEntries([{ ...validEntry, unexpected: true }], projects),
+    /unknown field unexpected/,
+  );
+  assert.throws(
+    () =>
+      validateKnownViolationEntries(
+        [{ ...validEntry, property: "lint-agreement", rule: undefined }],
+        projects,
+      ),
+    /lint-agreement.*rule/,
+  );
+  assert.throws(
+    () => validateKnownViolationEntries([{ ...validEntry, rule: "vue/no-v-html" }], projects),
+    /rule.*lint-agreement/,
+  );
+});
+
+test("hydrated waiver paths must exist inside the registered Vue corpus", () => {
+  const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-glyph-waiver-path-"));
+  const project = {
+    ...projects[0],
+    fixtureDir,
+    hydrated: true,
+  };
+  try {
+    assert.throws(
+      () => assertHydratedKnownViolationPaths([validEntry], [project]),
+      /missing waived fixture path/,
+    );
+    fs.mkdirSync(path.join(fixtureDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(fixtureDir, "src", "App.vue"), "<template><p /></template>\n");
+    assert.doesNotThrow(() => assertHydratedKnownViolationPaths([validEntry], [project]));
+
+    const outsideGlobs = [{ ...validEntry, path: "other/Outside.vue" }];
+    fs.mkdirSync(path.join(fixtureDir, "other"), { recursive: true });
+    fs.writeFileSync(path.join(fixtureDir, "other", "Outside.vue"), "<template><p /></template>\n");
+    assert.throws(
+      () => assertHydratedKnownViolationPaths(outsideGlobs, [project]),
+      /outside registered Vue inputs/,
+    );
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+  }
+});
+
+test("every hydrated waiver is consumed exactly once with the same category", () => {
+  const tracker = createKnownViolationConsumption([validEntry]);
+  assert.throws(() => tracker.assertAllConsumed(new Set(["fixture-a"])), /stale unconsumed waiver/);
+  assert.throws(
+    () => tracker.consume("fixture-a", "src/App.vue", null, "baseline-unusable"),
+    /category mismatch/,
+  );
+  assert.deepEqual(tracker.consume("fixture-a", "src/App.vue", null, "semantic-diff"), validEntry);
+  assert.doesNotThrow(() => tracker.assertAllConsumed(new Set(["fixture-a"])));
+  assert.throws(
+    () => tracker.consume("fixture-a", "src/App.vue", null, "semantic-diff"),
+    /consumed more than once/,
+  );
+
+  const untouched = createKnownViolationConsumption([validEntry]);
+  assert.doesNotThrow(() => untouched.assertAllConsumed(new Set(["another-project"])));
+  assert.equal(untouched.consume("fixture-a", "src/Other.vue", null, "semantic-diff"), null);
+});
+
+test("release evidence records each live owner and its exact waiver count", async () => {
+  const requests: string[] = [];
+  const artifact = await createWaiverIssueAudit(
+    [validEntry, { ...validEntry, path: "src/Other.vue" }],
+    {
+      GITHUB_API_URL: "https://github.example/api/v3",
+      GITHUB_REPOSITORY: "owner/repo",
+      GITHUB_SHA: "0123456789abcdef",
+      GITHUB_TOKEN: "secret",
+    },
+    async (url: string) => {
+      requests.push(url);
+      return {
+        ok: true,
+        json: async () => ({
+          number: 4107,
+          state: "open",
+          title: "strict owner",
+          html_url: "https://github.example/owner/repo/issues/4107",
+          updated_at: "2026-08-10T00:00:00Z",
+        }),
+      } as Response;
+    },
+  );
+  assert.deepEqual(requests, ["https://github.example/api/v3/repos/owner/repo/issues/4107"]);
+  assert.equal(artifact.schema, "vize.glyphCorpusWaiverIssueAudit");
+  assert.equal(artifact.version, 1);
+  assert.equal(artifact.repository, "owner/repo");
+  assert.equal(artifact.sourceCommit, "0123456789abcdef");
+  assert.equal(artifact.waiverCount, 2);
+  assert.deepEqual(artifact.issues, [
+    {
+      number: 4107,
+      state: "OPEN",
+      title: "strict owner",
+      url: "https://github.example/owner/repo/issues/4107",
+      updatedAt: "2026-08-10T00:00:00Z",
+      waiverCount: 2,
+    },
+  ]);
+  assert.match(artifact.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
+});
+
+test("tracking Issue evidence is deduplicated and fails closed on closed Issues", async () => {
+  const calls: number[] = [];
+  const open = await auditKnownViolationIssues(
+    [validEntry, { ...validEntry, path: "src/Other.vue" }],
+    async (number: number) => {
+      calls.push(number);
+      return { number, state: "OPEN", title: "open owner", url: `https://example.test/${number}` };
+    },
+  );
+  assert.deepEqual(calls, [4107]);
+  assert.deepEqual(open, [
+    {
+      number: 4107,
+      state: "OPEN",
+      title: "open owner",
+      url: "https://example.test/4107",
+    },
+  ]);
+
+  await assert.rejects(
+    () =>
+      auditKnownViolationIssues([validEntry], async (number: number) => ({
+        number,
+        state: "CLOSED",
+        title: "fixed owner",
+        url: `https://example.test/${number}`,
+      })),
+    /tracking Issue #4107 is CLOSED/,
+  );
+});
+
+test("formatter property artifacts retain waived and unwaived difference details", () => {
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-glyph-evidence-"));
+  try {
+    const output = writeGlyphCorpusPropertyEvidence(
+      "parse-preservation",
+      {
+        projectIds: ["fixture-b", "fixture-a"],
+        counters: { files: 7, skipped: 1 },
+        violations: [{ project: "fixture-b", file: "src/B.vue", detail: "block changed" }],
+        waivedViolations: [
+          {
+            project: "fixture-a",
+            file: "src/App.vue",
+            detail: "full comparator evidence",
+            waiver: validEntry,
+          },
+        ],
+        waiverValidationError: null,
+      },
+      reportDir,
+    );
+    assert.equal(output, path.join(reportDir, "glyph-parse-preservation.json"));
+    const artifact = JSON.parse(fs.readFileSync(output!, "utf8"));
+    assert.equal(artifact.schema, "vize.glyphCorpusPropertyEvidence");
+    assert.equal(artifact.version, 1);
+    assert.deepEqual(artifact.projectIds, ["fixture-a", "fixture-b"]);
+    assert.deepEqual(artifact.summary, {
+      cleanFileCount: 7,
+      waivedDifferenceCount: 1,
+      violationCount: 1,
+      waiverValidationError: null,
+    });
+    assert.equal(artifact.waivedDifferences[0].detail, "full comparator evidence");
+    assert.equal(artifact.violations[0].detail, "block changed");
+  } finally {
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -258,6 +258,13 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(summary?.run ?? "", /divergence_reports\[@\]/);
   assert.match(summary?.run ?? "", /glyph-waiver-issues\.json/);
   assert.match(summary?.run ?? "", /surface-verdict\.json/);
+  const jqPrograms = summary?.run?.match(/jq -r '[^']*'/g) ?? [];
+  assert.equal(jqPrograms.length, 4);
+  for (const program of jqPrograms) {
+    // A single-quoted shell argument reaches jq verbatim, so an escaped double
+    // quote is a jq compile error rather than a nested string delimiter.
+    assert.doesNotMatch(program, /\\"/, `jq program escapes a double quote: ${program}`);
+  }
   assert.equal(upload?.if, "${{ always() }}");
   assert.match(upload?.uses ?? "", /^actions\/upload-artifact@[0-9a-f]{40}$/);
   assert.deepEqual(upload?.with, {

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -5,8 +5,10 @@ import { parse } from "yaml";
 import { readRepoFile } from "./support/github-workflows.ts";
 
 type WorkflowStep = {
+  "continue-on-error"?: boolean;
   env?: Record<string, string>;
   if?: string;
+  id?: string;
   name?: string;
   run?: string;
   uses?: string;
@@ -34,7 +36,7 @@ test("real-project workflow schedules every balanced fixture shard", () => {
   const job = workflow.jobs?.["real-project-matrix"];
 
   assert.ok(job);
-  assert.deepEqual(workflow.permissions, { contents: "read" });
+  assert.deepEqual(workflow.permissions, { contents: "read", issues: "read" });
   assert.equal(workflow.on?.schedule?.[0]?.cron, "37 5 * * 0");
   const dispatch = workflow.on?.workflow_dispatch;
   assert.ok(dispatch, "Missing workflow_dispatch trigger");
@@ -72,6 +74,9 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   );
   assert.ok(dependency, "Missing 'Install pinned typecheck baseline dependencies' step");
   const dependencyIndex = steps.indexOf(dependency);
+  const waiverAudit = steps.find((step) => step.name === "Audit formatter waiver owners");
+  assert.ok(waiverAudit, "Missing 'Audit formatter waiver owners' step");
+  const waiverAuditIndex = steps.indexOf(waiverAudit);
   const run = steps.find((step) => step.name === "Exercise real projects with every core tool");
   const runIndex = steps.indexOf(run!);
   const lsp = steps.find((step) => step.name === "Check real-project LSP lifecycle");
@@ -88,6 +93,9 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   const glyphPropertiesIndex = steps.indexOf(glyphProperties!);
   const divergence = steps.find((step) => step.name === "Enforce typechecker baseline divergence");
   const divergenceIndex = steps.indexOf(divergence!);
+  const verdict = steps.find((step) => step.name === "Enforce all real-project surface verdicts");
+  assert.ok(verdict, "Missing final real-project surface verdict");
+  const verdictIndex = steps.indexOf(verdict);
   const summary = steps.find((step) => step.name === "Publish shard summary");
   const summaryIndex = steps.indexOf(summary!);
   const upload = steps.find((step) => step.name === "Upload shard report");
@@ -112,16 +120,49 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(hydration?.run ?? "", /git submodule update --init --depth 1/);
   assert.doesNotMatch(hydration?.run ?? "", /--recursive/);
   assert.match(hydration?.run ?? "", /"\$\{fixture_paths\[@\]\}"/);
-  assert.ok(hydrationIndex < dependencyIndex && dependencyIndex < runIndex);
+  assert.ok(
+    hydrationIndex < dependencyIndex &&
+      dependencyIndex < waiverAuditIndex &&
+      waiverAuditIndex < runIndex,
+  );
   assert.match(dependency.run ?? "", /tools\/fixtures\/typecheck-dependency-prepare\.mjs/);
   assert.match(dependency.run ?? "", /--output-dir "\$FIXTURE_REPORT_DIR"/);
   assert.match(dependency.run ?? "", /--shard-index "\$FIXTURE_SHARD_INDEX"/);
   assert.match(dependency.run ?? "", /--shard-count "\$FIXTURE_SHARD_COUNT"/);
   assert.match(dependency.run ?? "", /--timeout-ms 600000/);
+  assert.deepEqual(
+    {
+      id: dependency.id,
+      if: dependency.if,
+      continueOnError: dependency["continue-on-error"],
+    },
+    {
+      id: "typecheck_dependencies",
+      if: "${{ !cancelled() }}",
+      continueOnError: true,
+    },
+  );
+  assert.equal(waiverAudit.id, "waiver_audit");
+  assert.equal(waiverAudit.if, "${{ !cancelled() }}");
+  assert.equal(waiverAudit["continue-on-error"], true);
+  assert.deepEqual(waiverAudit.env, { GITHUB_TOKEN: "${{ github.token }}" });
+  assert.match(waiverAudit.run ?? "", /glyph-corpus-waiver-audit\.mjs/);
+  assert.match(waiverAudit.run ?? "", /glyph-waiver-issues\.json/);
   assert.match(run?.run ?? "", /tools\/fixtures\/tool-matrix-report\.mjs/);
   assert.match(run?.run ?? "", /--vize-bin target\/ci\/vize/);
   assert.match(run?.run ?? "", /--timeout-ms 600000/);
   assert.match(run?.run ?? "", /--output-dir "\$FIXTURE_REPORT_DIR"/);
+  for (const [step, id] of [
+    [run, "core_tools"],
+    [lsp, "lsp"],
+    [syntaxHighlighter, "syntax_highlighter"],
+    [glyphProperties, "glyph"],
+    [divergence, "typecheck_divergence"],
+  ] as const) {
+    assert.equal(step?.id, id);
+    assert.equal(step?.if, "${{ !cancelled() }}");
+    assert.equal(step?.["continue-on-error"], true);
+  }
   assert.ok(
     runIndex < lspIndex && lspIndex < syntaxHighlighterIndex,
     "the hydrated fixture corpus must run through the production LSP before syntax audit",
@@ -163,7 +204,10 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
       new RegExp(`tests/tooling/glyph-corpus-${property}\\.test\\.ts`),
     );
   }
-  assert.ok(runIndex < divergenceIndex && divergenceIndex < summaryIndex);
+  assert.match(glyphProperties?.run ?? "", /glyph-\$property\.json/);
+  assert.ok(
+    runIndex < divergenceIndex && divergenceIndex < verdictIndex && verdictIndex < summaryIndex,
+  );
   assert.match(divergence?.run ?? "", /tools\/fixtures\/typecheck-divergence-report\.mjs/);
   assert.match(divergence?.run ?? "", /--report-dir "\$FIXTURE_REPORT_DIR"/);
   assert.match(divergence?.run ?? "", /--shard-index "\$FIXTURE_SHARD_INDEX"/);
@@ -171,6 +215,29 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(divergence?.run ?? "", /--budget-mode "\$BUDGET_MODE"/);
   assert.match(divergence?.run ?? "", /--vue-tsc-bin tests\/node_modules\/\.bin\/vue-tsc/);
   assert.equal(divergence?.env?.BUDGET_MODE, "enforce");
+  assert.equal(verdict.if, "${{ always() }}");
+  assert.deepEqual(verdict.env, {
+    VIZE_WAIVER_AUDIT_OUTCOME: "${{ steps.waiver_audit.outcome }}",
+    VIZE_TYPECHECK_DEPENDENCIES_OUTCOME: "${{ steps.typecheck_dependencies.outcome }}",
+    VIZE_CORE_TOOLS_OUTCOME: "${{ steps.core_tools.outcome }}",
+    VIZE_LSP_OUTCOME: "${{ steps.lsp.outcome }}",
+    VIZE_SYNTAX_HIGHLIGHTER_OUTCOME: "${{ steps.syntax_highlighter.outcome }}",
+    VIZE_GLYPH_OUTCOME: "${{ steps.glyph.outcome }}",
+    VIZE_TYPECHECK_DIVERGENCE_OUTCOME: "${{ steps.typecheck_divergence.outcome }}",
+  });
+  assert.match(verdict.run ?? "", /real-project-surface-verdict\.mjs/);
+  assert.match(verdict.run ?? "", /surface-verdict\.json/);
+  for (const [surface, variable] of [
+    ["waiver-audit", "VIZE_WAIVER_AUDIT_OUTCOME"],
+    ["typecheck-dependencies", "VIZE_TYPECHECK_DEPENDENCIES_OUTCOME"],
+    ["core-tools", "VIZE_CORE_TOOLS_OUTCOME"],
+    ["lsp", "VIZE_LSP_OUTCOME"],
+    ["syntax-highlighter", "VIZE_SYNTAX_HIGHLIGHTER_OUTCOME"],
+    ["glyph", "VIZE_GLYPH_OUTCOME"],
+    ["typecheck-divergence", "VIZE_TYPECHECK_DIVERGENCE_OUTCOME"],
+  ]) {
+    assert.match(verdict.run ?? "", new RegExp(`--surface "${surface}=\\$${variable}"`));
+  }
   assert.equal(summary?.if, "${{ always() }}");
   assert.match(summary?.run ?? "", /summary\.md/);
   assert.match(summary?.run ?? "", /lsp-lifecycle-summary\.json/);
@@ -189,6 +256,8 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(summary?.run ?? "", /No syntax-highlighter divergence report was produced/);
   assert.match(summary?.run ?? "", /\*-typecheck-divergence\.md/);
   assert.match(summary?.run ?? "", /divergence_reports\[@\]/);
+  assert.match(summary?.run ?? "", /glyph-waiver-issues\.json/);
+  assert.match(summary?.run ?? "", /surface-verdict\.json/);
   assert.equal(upload?.if, "${{ always() }}");
   assert.match(upload?.uses ?? "", /^actions\/upload-artifact@[0-9a-f]{40}$/);
   assert.deepEqual(upload?.with, {

--- a/tests/tooling/real-project-surface-verdict.test.ts
+++ b/tests/tooling/real-project-surface-verdict.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  createRealProjectSurfaceVerdict,
+  realProjectSurfaceNames,
+} from "../../tools/fixtures/real-project-surface-verdict.mjs";
+
+const successfulResults = realProjectSurfaceNames.map((name) => ({ name, outcome: "success" }));
+
+test("the real-project surface verdict accepts only a complete successful set", () => {
+  const verdict = createRealProjectSurfaceVerdict(successfulResults, {
+    GITHUB_SHA: "0123456789abcdef",
+    FIXTURE_SHARD_INDEX: "7",
+  });
+  assert.equal(verdict.status, "success");
+  assert.equal(verdict.sourceCommit, "0123456789abcdef");
+  assert.equal(verdict.shardIndex, "7");
+  assert.deepEqual(verdict.failedSurfaceNames, []);
+  assert.deepEqual(verdict.surfaces, successfulResults);
+});
+
+for (const outcome of ["failure", "cancelled", "skipped"] as const) {
+  test(`the real-project surface verdict fails closed on ${outcome}`, () => {
+    const verdict = createRealProjectSurfaceVerdict(
+      successfulResults.map((result) =>
+        result.name === "core-tools" ? { ...result, outcome } : result,
+      ),
+    );
+    assert.equal(verdict.status, "failure");
+    assert.deepEqual(verdict.failedSurfaceNames, ["core-tools"]);
+  });
+}
+
+test("the real-project surface verdict rejects missing, duplicate, unknown, and empty outcomes", () => {
+  assert.throws(
+    () => createRealProjectSurfaceVerdict(successfulResults.slice(1)),
+    /missing real-project surface verdict.*waiver-audit/,
+  );
+  assert.throws(
+    () => createRealProjectSurfaceVerdict([...successfulResults, successfulResults[0]]),
+    /duplicate real-project surface/,
+  );
+  assert.throws(
+    () =>
+      createRealProjectSurfaceVerdict([
+        ...successfulResults.slice(1),
+        { name: "unknown", outcome: "success" },
+      ]),
+    /unknown real-project surface/,
+  );
+  assert.throws(
+    () =>
+      createRealProjectSurfaceVerdict(
+        successfulResults.map((result) =>
+          result.name === "glyph" ? { ...result, outcome: "" } : result,
+        ),
+      ),
+    /invalid outcome for glyph/,
+  );
+});

--- a/tools/fixtures/glyph-corpus-waiver-audit.mjs
+++ b/tools/fixtures/glyph-corpus-waiver-audit.mjs
@@ -1,0 +1,75 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { auditKnownViolationIssues, loadKnownViolationLedger } from "./glyph-corpus.mjs";
+
+function parseArguments(argv) {
+  if (argv.length !== 2 || argv[0] !== "--output" || argv[1].startsWith("-")) {
+    throw new Error("usage: node glyph-corpus-waiver-audit.mjs --output <path>");
+  }
+  return resolve(argv[1]);
+}
+
+async function resolveGitHubIssue(number, environment, request = fetch) {
+  const repository = environment.GITHUB_REPOSITORY ?? "ubugeeei-prod/vize";
+  const apiUrl = environment.GITHUB_API_URL ?? "https://api.github.com";
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (environment.GITHUB_TOKEN) headers.Authorization = `Bearer ${environment.GITHUB_TOKEN}`;
+  const response = await request(`${apiUrl}/repos/${repository}/issues/${number}`, { headers });
+  if (!response.ok) {
+    throw new Error(`tracking Issue #${number} lookup failed with HTTP ${response.status}`);
+  }
+  const issue = await response.json();
+  return {
+    number: issue.number,
+    state: issue.state,
+    title: issue.title,
+    url: issue.html_url,
+    updatedAt: issue.updated_at,
+  };
+}
+
+export async function createWaiverIssueAudit(entries, environment = process.env, request = fetch) {
+  const issues = await auditKnownViolationIssues(entries, (number) =>
+    resolveGitHubIssue(number, environment, request),
+  );
+  const waiverCounts = new Map();
+  for (const entry of entries) {
+    waiverCounts.set(entry.trackingIssue, (waiverCounts.get(entry.trackingIssue) ?? 0) + 1);
+  }
+  return {
+    schema: "vize.glyphCorpusWaiverIssueAudit",
+    version: 1,
+    repository: environment.GITHUB_REPOSITORY ?? "ubugeeei-prod/vize",
+    sourceCommit: environment.GITHUB_SHA ?? null,
+    generatedAt: new Date().toISOString(),
+    waiverCount: entries.length,
+    issues: issues.map((issue) => ({
+      ...issue,
+      state: issue.state.toUpperCase(),
+      waiverCount: waiverCounts.get(issue.number),
+    })),
+  };
+}
+
+async function main() {
+  const output = parseArguments(process.argv.slice(2));
+  const artifact = await createWaiverIssueAudit(loadKnownViolationLedger());
+  mkdirSync(dirname(output), { recursive: true });
+  writeFileSync(output, `${JSON.stringify(artifact, null, 2)}\n`);
+  process.stdout.write(
+    `audited ${artifact.waiverCount} formatter waiver(s) across ${artifact.issues.length} open Issue(s)\n`,
+  );
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/tools/fixtures/glyph-corpus-waivers.mjs
+++ b/tools/fixtures/glyph-corpus-waivers.mjs
@@ -1,0 +1,195 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import { collectVueInputPaths } from "./tool-matrix-inputs.mjs";
+
+const fields = new Set([
+  "property",
+  "category",
+  "project",
+  "path",
+  "rule",
+  "reason",
+  "trackingIssue",
+  "expiryCondition",
+]);
+const properties = new Set(["idempotence", "parse-preservation", "lint-agreement"]);
+const categories = new Set(["semantic-diff", "baseline-unusable", "oracle-unavailable"]);
+
+function identity(entry) {
+  return [entry.property, entry.project, entry.path, entry.rule ?? ""].join("\0");
+}
+
+export function validateKnownViolationEntries(entries, projects) {
+  if (!Array.isArray(entries)) {
+    throw new Error("glyph-corpus-known-violations.json must be an array");
+  }
+  const projectIds = new Set(projects.map((project) => project.id));
+  const identities = new Set();
+  for (const entry of entries) {
+    if (entry == null || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error("known violation entries must be objects");
+    }
+    for (const field of Object.keys(entry)) {
+      if (!fields.has(field)) throw new Error(`known violation has unknown field ${field}`);
+    }
+    if (!properties.has(entry.property)) {
+      throw new Error(`known violation property is invalid: ${String(entry.property)}`);
+    }
+    if (!categories.has(entry.category)) {
+      throw new Error(`known violation category is invalid: ${String(entry.category)}`);
+    }
+    if (typeof entry.project !== "string" || !projectIds.has(entry.project)) {
+      throw new Error(`known violation project is unknown: ${String(entry.project)}`);
+    }
+    if (
+      typeof entry.path !== "string" ||
+      entry.path.length === 0 ||
+      entry.path.includes("*") ||
+      entry.path.includes("\\") ||
+      entry.path.startsWith("/") ||
+      !entry.path.endsWith(".vue") ||
+      entry.path.split("/").some((segment) => segment === "" || segment === "." || segment === "..")
+    ) {
+      throw new Error(`known violation path must be an exact relative path: ${String(entry.path)}`);
+    }
+    for (const field of ["reason", "expiryCondition"]) {
+      if (typeof entry[field] !== "string" || entry[field].trim().length === 0) {
+        throw new Error(`known violation ${field} must be a non-empty string`);
+      }
+    }
+    if (!Number.isSafeInteger(entry.trackingIssue) || entry.trackingIssue < 1) {
+      throw new Error("known violation trackingIssue must be a positive integer");
+    }
+    if (entry.property === "lint-agreement") {
+      if (typeof entry.rule !== "string" || entry.rule.length === 0) {
+        throw new Error("known violation lint-agreement entries require a non-empty rule");
+      }
+    } else if (entry.rule != null) {
+      throw new Error("known violation rule is only valid for lint-agreement");
+    }
+    const key = identity(entry);
+    if (identities.has(key)) {
+      throw new Error(`duplicate known violation identity: ${key.replaceAll("\0", ":")}`);
+    }
+    identities.add(key);
+  }
+  return entries;
+}
+
+export function assertHydratedKnownViolationPaths(entries, projects) {
+  validateKnownViolationEntries(entries, projects);
+  const projectsById = new Map(projects.map((project) => [project.id, project]));
+  const registeredFiles = new Map();
+  for (const entry of entries) {
+    const project = projectsById.get(entry.project);
+    if (!project?.hydrated) continue;
+    const absolutePath = resolve(project.fixtureDir, entry.path);
+    if (!existsSync(absolutePath)) {
+      throw new Error(`missing waived fixture path: ${entry.project}:${entry.path}`);
+    }
+    let files = registeredFiles.get(entry.project);
+    if (files == null) {
+      files = new Set(collectVueInputPaths(project.fixtureDir, project.vueGlobs));
+      registeredFiles.set(entry.project, files);
+    }
+    if (!files.has(entry.path)) {
+      throw new Error(
+        `waived fixture path is outside registered Vue inputs: ${entry.project}:${entry.path}`,
+      );
+    }
+  }
+}
+
+export function readKnownViolationLedger(path, projects) {
+  if (!existsSync(path)) return [];
+  const entries = validateKnownViolationEntries(JSON.parse(readFileSync(path, "utf8")), projects);
+  assertHydratedKnownViolationPaths(entries, projects);
+  return entries;
+}
+
+export function createKnownViolationConsumption(entries) {
+  const consumed = new Map();
+  return {
+    consume(project, path, rule, category) {
+      const matches = entries.filter(
+        (entry) =>
+          entry.project === project && entry.path === path && (entry.rule ?? null) === rule,
+      );
+      if (matches.length === 0) return null;
+      if (matches.length > 1) throw new Error(`multiple waivers match ${project}:${path}`);
+      const [entry] = matches;
+      if (entry.category !== category) {
+        throw new Error(
+          `known violation category mismatch for ${project}:${path}: ` +
+            `${entry.category} != ${category}`,
+        );
+      }
+      const key = identity(entry);
+      const count = (consumed.get(key) ?? 0) + 1;
+      consumed.set(key, count);
+      if (count > 1) {
+        throw new Error(`known violation consumed more than once: ${project}:${path}`);
+      }
+      return entry;
+    },
+    assertAllConsumed(hydratedProjectIds) {
+      for (const entry of entries) {
+        if (!hydratedProjectIds.has(entry.project)) continue;
+        if ((consumed.get(identity(entry)) ?? 0) !== 1) {
+          throw new Error(
+            `stale unconsumed waiver for hydrated fixture: ${entry.project}:${entry.path}`,
+          );
+        }
+      }
+    },
+  };
+}
+
+export async function auditKnownViolationIssues(entries, resolveIssue) {
+  const issueNumbers = [...new Set(entries.map((entry) => entry.trackingIssue))].sort(
+    (left, right) => left - right,
+  );
+  const evidence = [];
+  for (const number of issueNumbers) {
+    const issue = await resolveIssue(number);
+    if (issue?.number !== number || typeof issue.state !== "string") {
+      throw new Error(`tracking Issue #${String(number)} returned invalid evidence`);
+    }
+    if (issue.state.toUpperCase() !== "OPEN") {
+      throw new Error(`tracking Issue #${String(number)} is ${issue.state.toUpperCase()}`);
+    }
+    evidence.push(issue);
+  }
+  return evidence;
+}
+
+export function writeGlyphCorpusPropertyEvidence(
+  property,
+  { projectIds, counters, violations, waivedViolations, waiverValidationError },
+  reportDir = process.env.FIXTURE_REPORT_DIR,
+) {
+  if (reportDir == null || reportDir === "") return null;
+  if (!properties.has(property)) {
+    throw new Error(`cannot write evidence for unknown glyph property: ${property}`);
+  }
+  const output = resolve(reportDir, `glyph-${property}.json`);
+  const artifact = {
+    schema: "vize.glyphCorpusPropertyEvidence",
+    version: 1,
+    property,
+    sourceCommit: process.env.GITHUB_SHA ?? null,
+    projectIds: [...projectIds].sort((left, right) => left.localeCompare(right)),
+    summary: {
+      cleanFileCount: counters.files,
+      waivedDifferenceCount: waivedViolations.length,
+      violationCount: violations.length,
+      waiverValidationError,
+    },
+    waivedDifferences: waivedViolations,
+    violations,
+  };
+  mkdirSync(dirname(output), { recursive: true });
+  writeFileSync(output, `${JSON.stringify(artifact, null, 2)}\n`);
+  return output;
+}

--- a/tools/fixtures/glyph-corpus.mjs
+++ b/tools/fixtures/glyph-corpus.mjs
@@ -17,6 +17,15 @@ import {
   validateFormatterChangeEvidence,
 } from "./tool-matrix-formatter.mjs";
 import { collectVueInputPaths } from "./tool-matrix-inputs.mjs";
+import { readKnownViolationLedger } from "./glyph-corpus-waivers.mjs";
+
+export {
+  assertHydratedKnownViolationPaths,
+  auditKnownViolationIssues,
+  createKnownViolationConsumption,
+  validateKnownViolationEntries,
+  writeGlyphCorpusPropertyEvidence,
+} from "./glyph-corpus-waivers.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const registryPath = join(repoRoot, "tests", "_fixtures", "vue-ecosystem-fixtures.json");
@@ -239,42 +248,16 @@ function truncateLine(line) {
   return line.length <= 160 ? line : `${line.slice(0, 160)}...`;
 }
 
-/**
- * Known-violation skip list: tracked defects recorded while the property
- * suite stays green. Entries pin `{ property, project, path, issue }` plus an
- * optional `rule` for lint-agreement waivers; `project` and `path` accept the
- * `"*"` wildcard so a systemic defect (e.g. a formatter/linter rule
- * disagreement) is one tracked entry instead of hundreds. The suites skip
- * matching findings and surface the skip count in their output.
- */
+export function loadKnownViolationLedger() {
+  return readKnownViolationLedger(knownViolationsPath, loadGlyphCorpusProjects());
+}
+
+/** Load the checked-in waiver ledger entries for one corpus property. */
 export function loadKnownViolations(property) {
-  if (!existsSync(knownViolationsPath)) return [];
-  const entries = JSON.parse(readFileSync(knownViolationsPath, "utf8"));
-  if (!Array.isArray(entries)) {
-    throw new Error("glyph-corpus-known-violations.json must be an array");
-  }
-  for (const entry of entries) {
-    for (const field of ["property", "project", "path", "issue"]) {
-      if (typeof entry[field] !== "string" || entry[field].length === 0) {
-        throw new Error(`known violation entries require a non-empty ${field}`);
-      }
-    }
-    if (entry.rule != null && (typeof entry.rule !== "string" || entry.rule.length === 0)) {
-      throw new Error("known violation rule must be a non-empty string when present");
-    }
-  }
-  return entries.filter((entry) => entry.property === property);
+  return loadKnownViolationLedger().filter((entry) => entry.property === property);
 }
 
-export function isKnownViolation(knownViolations, projectId, file, rule = null) {
-  return knownViolations.some(
-    (entry) =>
-      (entry.project === "*" || entry.project === projectId) &&
-      (entry.path === "*" || entry.path === file) &&
-      (entry.rule == null ? rule == null : entry.rule === rule),
-  );
-}
-
+/** Track exact waiver consumption so a fixed path makes its old waiver fail. */
 /** Render corpus violations, capped so failures stay readable. */
 export function renderViolations(property, violations, detailLimit = 8) {
   const details = violations

--- a/tools/fixtures/real-project-surface-verdict.mjs
+++ b/tools/fixtures/real-project-surface-verdict.mjs
@@ -1,0 +1,96 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const realProjectSurfaceNames = [
+  "waiver-audit",
+  "typecheck-dependencies",
+  "core-tools",
+  "lsp",
+  "syntax-highlighter",
+  "glyph",
+  "typecheck-divergence",
+];
+
+const validOutcomes = new Set(["success", "failure", "cancelled", "skipped"]);
+
+export function createRealProjectSurfaceVerdict(results, environment = process.env) {
+  const expected = new Set(realProjectSurfaceNames);
+  const seen = new Set();
+  for (const result of results) {
+    if (result == null || typeof result !== "object" || Array.isArray(result)) {
+      throw new Error("surface results must be objects");
+    }
+    if (!expected.has(result.name)) {
+      throw new Error(`unknown real-project surface: ${String(result.name)}`);
+    }
+    if (seen.has(result.name)) {
+      throw new Error(`duplicate real-project surface: ${result.name}`);
+    }
+    if (!validOutcomes.has(result.outcome)) {
+      throw new Error(`invalid outcome for ${result.name}: ${String(result.outcome)}`);
+    }
+    seen.add(result.name);
+  }
+  const missing = realProjectSurfaceNames.filter((name) => !seen.has(name));
+  if (missing.length > 0) {
+    throw new Error(`missing real-project surface verdict(s): ${missing.join(", ")}`);
+  }
+  const failed = results.filter((result) => result.outcome !== "success");
+  return {
+    schema: "vize.realProjectSurfaceVerdict",
+    version: 1,
+    sourceCommit: environment.GITHUB_SHA ?? null,
+    shardIndex: environment.FIXTURE_SHARD_INDEX ?? null,
+    status: failed.length === 0 ? "success" : "failure",
+    surfaces: realProjectSurfaceNames.map((name) => results.find((result) => result.name === name)),
+    failedSurfaceNames: failed
+      .map((result) => result.name)
+      .sort((left, right) => left.localeCompare(right)),
+  };
+}
+
+function parseArguments(argv) {
+  let output = null;
+  const results = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const value = argv[index + 1];
+    if (argument === "--output" && output == null && value && !value.startsWith("--")) {
+      output = resolve(value);
+      index += 1;
+      continue;
+    }
+    if (argument === "--surface" && value && !value.startsWith("--")) {
+      const separator = value.indexOf("=");
+      if (separator < 1) throw new Error(`invalid --surface value: ${value}`);
+      results.push({ name: value.slice(0, separator), outcome: value.slice(separator + 1) });
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown or incomplete argument: ${argument}`);
+  }
+  if (output == null) throw new Error("--output is required");
+  return { output, results };
+}
+
+function main() {
+  const { output, results } = parseArguments(process.argv.slice(2));
+  const artifact = createRealProjectSurfaceVerdict(results);
+  mkdirSync(dirname(output), { recursive: true });
+  writeFileSync(output, `${JSON.stringify(artifact, null, 2)}\n`);
+  if (artifact.status !== "success") {
+    throw new Error(`real-project surfaces failed: ${artifact.failedSurfaceNames.join(", ")}`);
+  }
+  process.stdout.write(`all ${artifact.surfaces.length} real-project surfaces succeeded\n`);
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
Closes #4105

## Summary

- replace the 87-entry closed-Issue skip list with 45 exact, categorized waivers owned by open Issues #4106, #4107, #4108, #4113, and #4114
- reject unknown, missing, duplicate, wildcard, stale, multiply consumed, and misclassified waivers
- publish full waived/unwaived formatter evidence plus live owner-Issue state in every real-project shard artifact
- run all real-project surfaces fail-late and enforce their raw outcomes once at the end, so compiler/typecheck/LSP failures no longer hide formatter evidence
- compile-check the shard summary jq programs so evidence publication cannot fail after the verdict artifact is written

## Strict regression evidence

- `vp run check:repo` (2137 formatted files; 1513 linted files; 0 warnings/errors after latest-main rebase)
- focused Node suites and workflow contract tests: green
- focused hydrated replay: 783 idempotence files, 783 lint-agreement files, 738 clean parse-preservation files, 45 exact waiver consumptions, 0 unexplained violations
- live waiver audit: 45 waivers across 5 open owner Issues
- exact-head Real Project Matrix run 31397441646 at `436599f2dabb50dc1a1e4fef73f9d44ad36610e0`:
  - 134/134 registry fixtures selected exact-once across 11 shards
  - 34,081 idempotence checks clean
  - 34,081 lint-agreement checks clean
  - 34,036 parse-preservation checks clean + 45 exact waivers, 0 unexplained
  - `glyph` and `waiver-audit` success in all 11 fail-closed surface verdicts
- source-length gate: no new or grown file over 350 lines
- `zizmor .github/workflows/real-project-matrix.yml`: no findings
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
