### PR TITLE
fix(glyph): preserve shorthand spread binding order

### DIFF
--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -65,7 +65,11 @@ fn sort_attribute_segment(attrs: &mut [ParsedAttribute], options: &FormatOptions
 }
 
 fn is_order_sensitive_spread(name: &str) -> bool {
-    name == "v-bind" || name.starts_with("v-bind.") || name == "v-on" || name.starts_with("v-on.")
+    // `:` and `@` are the normalized names of no-argument object shorthand
+    // directives (`:="props"` / `@="listeners"`), not named bindings.
+    matches!(name, ":" | "@" | "v-bind" | "v-on")
+        || name.starts_with("v-bind.")
+        || name.starts_with("v-on.")
 }
 
 /// Generate a sort key for alphabetical ordering within a group.

--- a/crates/vize_glyph/tests/template_shorthand_spread_order.rs
+++ b/crates/vize_glyph/tests/template_shorthand_spread_order.rs
@@ -1,0 +1,77 @@
+use vize_glyph::{AttributeSortOrder, FormatOptions, format_sfc, format_template};
+
+fn assert_template_fixed_point(source: &str, expected: &str, options: &FormatOptions) {
+    let first = format_template(source, options).unwrap();
+    let second = format_template(&first, options).unwrap();
+
+    assert_eq!(first.as_str(), expected);
+    assert_eq!(first, second, "fmt; fmt must preserve the spread boundary");
+}
+
+#[test]
+fn shorthand_object_bind_is_an_attribute_sorting_barrier() {
+    let options = FormatOptions {
+        print_width: 240,
+        ..FormatOptions::default()
+    };
+
+    assert_template_fixed_point(
+        r#"<a title="link" class="router-link" :="attrs" target="_blank" rel="noopener" :href="href"></a>"#,
+        r#"<a class="router-link" title="link" :="attrs" rel="noopener" target="_blank" :href="href"></a>"#,
+        &options,
+    );
+}
+
+#[test]
+fn shorthand_object_on_is_an_event_sorting_barrier() {
+    let options = FormatOptions {
+        print_width: 240,
+        ..FormatOptions::default()
+    };
+
+    assert_template_fixed_point(
+        r#"<button @keyup="up" @click="click" @="listeners" @mouseup="up" @mousedown="down"></button>"#,
+        r#"<button @click="click" @keyup="up" @="listeners" @mousedown="down" @mouseup="up"></button>"#,
+        &options,
+    );
+}
+
+#[test]
+fn every_longhand_and_shorthand_object_spread_pins_its_segment() {
+    let options = FormatOptions {
+        print_width: 240,
+        ..FormatOptions::default()
+    };
+    let source = r#"<Comp z="z" :="first" b="b" a="a" v-bind="second" d="d" c="c" @="listeners" @keyup="up" @click="click" />"#;
+    let expected = r#"<Comp z="z" :="first" a="a" b="b" v-bind="second" c="c" d="d" @="listeners" @click="click" @keyup="up" />"#;
+
+    assert_template_fixed_point(source, expected, &options);
+}
+
+#[test]
+fn sfc_shorthand_spreads_preserve_order_with_as_written_sorting() {
+    let options = FormatOptions {
+        attribute_sort_order: AttributeSortOrder::AsWritten,
+        ..FormatOptions::default()
+    };
+    let source = r#"<template>
+  <slot :name="column.key" :="{ column, record }" data-after="after" @="listeners" @click="click" />
+</template>
+"#;
+    let first = format_sfc(source, &options).unwrap();
+    let second = format_sfc(&first.code, &options).unwrap();
+
+    assert!(
+        first.code.find(":name").unwrap() < first.code.find(":=").unwrap(),
+        "the named binding must not cross the object-bind shorthand"
+    );
+    assert!(
+        first.code.find(":=").unwrap() < first.code.find("data-after").unwrap(),
+        "the post-spread attribute must stay after the object bind"
+    );
+    assert!(
+        first.code.find("@=").unwrap() < first.code.find("@click").unwrap(),
+        "the event binding must not cross the object-on shorthand"
+    );
+    assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
+}

--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -10,15 +10,6 @@
   },
   {
     "property": "parse-preservation",
-    "category": "semantic-diff",
-    "project": "gui-for-singbox",
-    "path": "frontend/src/components/Table/index.vue",
-    "reason": "Attribute sorting moves a named binding across an order-sensitive v-bind object boundary.",
-    "trackingIssue": 4113,
-    "expiryCondition": "Remove after Glyph preserves binding precedence while sorting attributes."
-  },
-  {
-    "property": "parse-preservation",
     "category": "baseline-unusable",
     "project": "gogocode",
     "path": "packages/gogocode-plugin-vue/test/listeners-removed/Comp.vue",

--- a/tests/tooling/glyph-corpus-parse-preservation.test.ts
+++ b/tests/tooling/glyph-corpus-parse-preservation.test.ts
@@ -217,6 +217,20 @@ test("glyph corpus parse-preservation comparator flags structural corruption", (
     ).join("\n"),
     /<div>\[0\]/,
   );
+  // The no-argument bind/on shorthands are the same merge boundaries as their
+  // longhand forms. Moving a named binding across either changes mergeProps.
+  for (const [before, after] of [
+    [
+      '<template><div title="before" :="rest" id="after" /></template>\n',
+      '<template><div :="rest" title="before" id="after" /></template>\n',
+    ],
+    [
+      '<template><button @click="before" @="listeners" @focus="after" /></template>\n',
+      '<template><button @="listeners" @click="before" @focus="after" /></template>\n',
+    ],
+  ]) {
+    assert.match(compareFile(before, after, "App.vue").join("\n"), /\[0\]/);
+  }
   // Rewriting interpolation content is corruption.
   assert.match(
     compareFile(


### PR DESCRIPTION
Closes #4113

## Summary

- recognize no-argument `:` and `@` directive shorthands as the same order-sensitive spread boundaries as `v-bind` and `v-on`
- sort only the independent attribute segments on each side, preserving Vue `mergeProps` last-write-wins semantics
- remove the exact gui-for-singbox waiver now that the real corpus path is clean

## Strict regression evidence

- RED before fix: shorthand bind, shorthand on, and mixed shorthand/longhand segment tests all reordered bindings across spreads
- new bind/on/mixed/as-written fixed-point matrix: 4/4 green
- existing directive attribute matrix: 13/13 green
- full `vize_glyph` crate: 194 tests green + 1 ignored doctest
- official Vue parser comparator explicitly rejects shorthand spread crossings
- real gui-for-singbox replay: 95/95 idempotence, 95/95 lint agreement, 95/95 parse preservation, 0 waivers, 0 unexplained violations
- production lib and new test target clippy with warnings denied: green
- `vp run check:repo`: 2137 formatted, 1513 linted, 0 warnings/errors
- source-length and `git diff --check`: green

Auto-merge remains disabled until normal head CI and an out-of-band exact-head Real Project Matrix prove the removed waiver stays clean across all 11 shards.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->