### PR TITLE
test(glyph): normalize SFC presence attributes

### DIFF
--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -28,15 +28,6 @@
   },
   {
     "property": "parse-preservation",
-    "category": "semantic-diff",
-    "project": "pinry",
-    "path": "pinry-spa/src/components/search/SearchPanel.vue",
-    "reason": "The comparator does not yet normalize Vue-equivalent presence forms of the scoped SFC block attribute.",
-    "trackingIssue": 4114,
-    "expiryCondition": "Remove after the semantic oracle treats equivalent scoped attribute spellings identically."
-  },
-  {
-    "property": "parse-preservation",
     "category": "oracle-unavailable",
     "project": "lx-music-desktop",
     "path": "src/renderer/components/layout/PlayDetail/components/MusicComment/index.vue",

--- a/tests/tooling/glyph-corpus-parse-preservation.test.ts
+++ b/tests/tooling/glyph-corpus-parse-preservation.test.ts
@@ -269,6 +269,48 @@ test("glyph corpus parse-preservation comparator flags structural corruption", (
   );
 });
 
+test("glyph corpus normalizes only compiler-defined presence attributes", () => {
+  const style = (attr: string): string => `<style ${attr}>.a{}</style>`;
+  const script = (attr: string): string => `<script ${attr}>const x=1</script>`;
+  const template = (attr: string): string => `<template ${attr}><p/></template>`;
+  const presenceCases = [
+    ["scoped", style, "<style>.a{}</style>"],
+    ["setup", script, "<script>const x=1</script>"],
+    ["vapor", template, "<template><p/></template>"],
+    ["vapor", script, "<script>const x=1</script>"],
+    ["functional", template, "<template><p/></template>"],
+  ] as const;
+  for (const [attr, render, absent] of presenceCases) {
+    const forms = [attr, `${attr}=""`, `${attr}="${attr}"`, `${attr}="false"`];
+    for (const left of forms) {
+      for (const right of forms) {
+        assert.deepEqual(compareFile(render(left), render(right), "App.vue"), []);
+      }
+    }
+    assert.notDeepEqual(compareFile(render(forms[0]), absent, "App.vue"), []);
+  }
+  for (const [before, after] of [
+    ["<style module>.a{}</style>", '<style module="theme">.a{}</style>'],
+    ['<style module="first">.a{}</style>', '<style module="second">.a{}</style>'],
+    ['<style lang="scss">.a{}</style>', '<style lang="less">.a{}</style>'],
+    ['<style custom="first">.a{}</style>', '<style custom="second">.a{}</style>'],
+    [
+      '<script setup generic="T">const x=1</script>',
+      '<script setup generic="U">const x=1</script>',
+    ],
+    [
+      '<template><p/></template><style src="first.css"></style>',
+      '<template><p/></template><style src="second.css"></style>',
+    ],
+    [
+      '<template><p/></template><docs scoped="first">x</docs>',
+      '<template><p/></template><docs scoped="second">x</docs>',
+    ],
+  ]) {
+    assert.notDeepEqual(compareFile(before, after, "App.vue"), []);
+  }
+});
+
 function makeSyntheticProject(files: Array<[string, string]>): CorpusProject {
   const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-glyph-corpus-"));
   for (const [file, content] of files) {

--- a/tests/tooling/support/sfc-equivalence.ts
+++ b/tests/tooling/support/sfc-equivalence.ts
@@ -107,7 +107,7 @@ function compareBlocks(before: SfcDescriptor, after: SfcDescriptor, differences:
     if ((beforeBlock == null) !== (afterBlock == null)) {
       differences.push(`${kind} block ${beforeBlock == null ? "appeared" : "disappeared"}`);
     } else if (beforeBlock != null && afterBlock != null) {
-      compareAttrs(kind, beforeBlock.attrs, afterBlock.attrs, differences);
+      compareAttrs(kind, beforeBlock, afterBlock, differences);
     }
   }
   for (const kind of ["styles", "customBlocks"] as const) {
@@ -120,7 +120,7 @@ function compareBlocks(before: SfcDescriptor, after: SfcDescriptor, differences:
     const signature = (block: SfcBlock): string =>
       JSON.stringify([
         block.type,
-        sortedAttrEntries(block.attrs),
+        semanticAttrEntries(kind === "styles" ? "style" : "customBlock", block),
         kind === "customBlocks" ? condense(block.content) : null,
       ]);
     const beforeSignatures = beforeBlocks.map(signature).sort();
@@ -137,16 +137,47 @@ function compareBlocks(before: SfcDescriptor, after: SfcDescriptor, differences:
 }
 
 function compareAttrs(
-  label: string,
-  before: Record<string, string | true>,
-  after: Record<string, string | true>,
+  label: "template" | "script" | "scriptSetup",
+  before: SfcBlock,
+  after: SfcBlock,
   differences: string[],
 ): void {
-  const beforeEntries = JSON.stringify(sortedAttrEntries(before));
-  const afterEntries = JSON.stringify(sortedAttrEntries(after));
+  const beforeEntries = JSON.stringify(semanticAttrEntries(label, before));
+  const afterEntries = JSON.stringify(semanticAttrEntries(label, after));
   if (beforeEntries !== afterEntries) {
     differences.push(`${label} block attrs changed: ${beforeEntries} -> ${afterEntries}`);
   }
+}
+
+// These are the attributes compiler-sfc itself consumes by presence: each
+// parser branch coerces the raw value to truthiness or assigns a descriptor
+// slot/boolean. Keep this block-kind table closed so module, lang, src,
+// generic, and custom attributes remain value-sensitive.
+const compilerPresenceAttrs = {
+  template: ["functional", "vapor"],
+  script: [],
+  scriptSetup: ["setup", "vapor"],
+  style: ["scoped"],
+  customBlock: [],
+} as const;
+
+function semanticAttrEntries(
+  kind: keyof typeof compilerPresenceAttrs,
+  block: SfcBlock,
+): Array<[string, string | true]> {
+  const presenceAttrs = compilerPresenceAttrs[kind];
+  if (
+    !presenceAttrs.some(
+      (attribute) => Object.hasOwn(block.attrs, attribute) && block.attrs[attribute] !== true,
+    )
+  ) {
+    return sortedAttrEntries(block.attrs);
+  }
+  const attrs = { ...block.attrs };
+  for (const attribute of presenceAttrs) {
+    if (Object.hasOwn(attrs, attribute)) attrs[attribute] = true;
+  }
+  return sortedAttrEntries(attrs);
 }
 
 function sortedAttrEntries(attrs: Record<string, string | true>): Array<[string, string | true]> {


### PR DESCRIPTION
## Summary

- compare compiler-defined presence attributes by SFC semantics instead of raw HTML spelling
- keep module, lang, src, generic, and custom attribute values fail-closed
- remove the now-clean Pinry parse-preservation waiver

## Validation

- focused compiler-presence positive/negative matrix
- hydrated Pinry formatter idempotence, lint agreement, and parse preservation: 29/29 clean
- Glyph property/waiver suites: 23/23
- exact tsgo strict check for the comparator and corpus test
- repository format/lint warning budget: 2,138 formatted and 1,514 linted
- source-length and diff checks
- independent read-only semantic/performance review

Auto-merge stays disabled until normal CI and an exact-head 134-fixture Real Project Matrix artifact audit complete.

Closes #4114

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->