### PR TITLE
fix(glyph): preserve empty script block identity

### DIFF
--- a/crates/vize_glyph/src/formatter.rs
+++ b/crates/vize_glyph/src/formatter.rs
@@ -189,7 +189,7 @@ impl<'a> GlyphFormatter<'a> {
         let trimmed = block.content.trim();
         let source_type =
             script::source_type_for_script_lang(block.lang.as_ref().map(|lang| lang.as_ref()));
-        let formatted_content = script::format_script_content_stable(
+        let formatted_content = script::format_sfc_script_content_stable(
             trimmed,
             self.options,
             self.allocator,

--- a/crates/vize_glyph/src/script.rs
+++ b/crates/vize_glyph/src/script.rs
@@ -3,12 +3,16 @@
 //! This module provides Prettier-compatible formatting for JavaScript/TypeScript
 //! code using OXC's formatter (oxfmt).
 
+mod block_identity;
+
 use crate::error::FormatError;
 use crate::options::FormatOptions;
 use oxc_allocator::Allocator as OxcAllocator;
 use oxc_formatter::{format_program, parse_for_format};
 use oxc_span::SourceType;
 use vize_carton::{Allocator, String, ToCompactString};
+
+pub(crate) use block_identity::format_sfc_script_content_stable;
 
 const MAX_SCRIPT_STABILIZATION_PASSES: usize = 6;
 

--- a/crates/vize_glyph/src/script/block_identity.rs
+++ b/crates/vize_glyph/src/script/block_identity.rs
@@ -1,0 +1,70 @@
+use super::format_script_content_stable;
+use crate::error::FormatError;
+use crate::options::FormatOptions;
+use oxc_allocator::Allocator as OxcAllocator;
+use oxc_ast::ast::Statement;
+use oxc_formatter::parse_for_format;
+use oxc_span::SourceType;
+use vize_carton::{Allocator, String, ToCompactString};
+
+/// Formats an SFC script without letting cleanup erase its block identity.
+///
+/// Oxfmt deliberately removes empty statements. That remains desirable for a
+/// standalone script, but Vue's official parser ignores an SFC script block
+/// that becomes empty. Only a comment-free, directive-free sequence of empty
+/// statements is replaced with one canonical statement. If a future formatter
+/// unexpectedly erases any other non-empty program, preserve the authored body
+/// rather than silently changing the SFC descriptor.
+pub(crate) fn format_sfc_script_content_stable(
+    source: &str,
+    options: &FormatOptions,
+    allocator: &Allocator,
+    source_type: SourceType,
+) -> Result<String, FormatError> {
+    let formatted = format_script_content_stable(source, options, allocator, source_type)?;
+    if source.trim().is_empty() || !formatted.trim().is_empty() {
+        return Ok(formatted);
+    }
+    if is_empty_statement_only_program(source, source_type) {
+        return Ok(";".into());
+    }
+    Ok(source.trim().to_compact_string())
+}
+
+fn is_empty_statement_only_program(source: &str, source_type: SourceType) -> bool {
+    let allocator = OxcAllocator::default();
+    let parsed = parse_for_format(&allocator, source, source_type);
+    parsed.diagnostics.is_empty()
+        && parsed.program.comments.is_empty()
+        && parsed.program.directives.is_empty()
+        && !parsed.program.body.is_empty()
+        && parsed
+            .program
+            .body
+            .iter()
+            .all(|statement| matches!(statement, Statement::EmptyStatement(_)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_empty_statement_only_program;
+    use oxc_span::SourceType;
+
+    #[test]
+    fn classifies_only_comment_free_empty_statements() {
+        for source_type in [SourceType::ts().with_module(true), SourceType::mjs()] {
+            for source in [";", ";;;", "\n; ;\n;"] {
+                assert!(is_empty_statement_only_program(source, source_type));
+            }
+            for source in [
+                "",
+                "// keep\n;",
+                "/* keep */ ;",
+                "\"use strict\";",
+                "const value = 1;",
+            ] {
+                assert!(!is_empty_statement_only_program(source, source_type));
+            }
+        }
+    }
+}

--- a/crates/vize_glyph/tests/sfc_empty_script_blocks.rs
+++ b/crates/vize_glyph/tests/sfc_empty_script_blocks.rs
@@ -1,0 +1,99 @@
+use vize_glyph::{FormatOptions, FormatResult, format_script, format_sfc};
+
+fn check_options() -> FormatOptions {
+    FormatOptions {
+        skip_script_stabilization: true,
+        ..FormatOptions::default()
+    }
+}
+
+fn canonical(source: &str) -> FormatResult {
+    let write = FormatOptions::default();
+    let check = check_options();
+    let predicted = format_sfc(source, &check).expect("check-mode format");
+    let first = format_sfc(source, &write).expect("first write");
+    let second = format_sfc(first.code.as_str(), &write).expect("second write");
+
+    assert_eq!(
+        predicted.changed, first.changed,
+        "check/write verdict drift"
+    );
+    assert_eq!(predicted.code, first.code, "check/write output drift");
+    assert_eq!(
+        first.code, second.code,
+        "first write must reach a fixed point"
+    );
+    first
+}
+
+fn script_bodies(source: &str) -> Vec<&str> {
+    let mut rest = source;
+    let mut bodies = Vec::new();
+    while let Some(start) = rest.find("<script") {
+        rest = &rest[start..];
+        let content_start = rest.find('>').expect("script opening tag") + 1;
+        rest = &rest[content_start..];
+        let content_end = rest.find("</script>").expect("script closing tag");
+        bodies.push(&rest[..content_end]);
+        rest = &rest[content_end + "</script>".len()..];
+    }
+    bodies
+}
+
+#[test]
+fn empty_statement_only_blocks_keep_a_canonical_statement() {
+    for source in [
+        "<script setup>\n;\n</script>\n",
+        "<script setup lang=\"ts\">\n; ; ;\n</script>\n",
+        "<script>\n;\n</script>\n",
+        "<script lang=\"ts\">\n;\n;\n</script>\n",
+        "<script>\n;\n</script>\n<script setup lang=\"ts\">\n;;\n</script>\n",
+    ] {
+        let output = canonical(source);
+        let bodies = script_bodies(output.code.as_str());
+        assert!(!bodies.is_empty(), "fixture must retain a script block");
+        assert!(
+            bodies.iter().all(|body| body.trim() == ";"),
+            "empty statements must canonicalize without erasing the block:\n{}",
+            output.code
+        );
+    }
+}
+
+#[test]
+fn comments_and_directives_keep_script_blocks_nonempty() {
+    for (source, marker) in [
+        (
+            "<script setup>\n; // keep line\n;\n</script>\n",
+            "// keep line",
+        ),
+        (
+            "<script lang=\"ts\">\n; /* keep block */ ;\n</script>\n",
+            "/* keep block */",
+        ),
+        ("<script>\n\"use strict\"; ;\n</script>\n", "\"use strict\""),
+    ] {
+        let output = canonical(source);
+        assert!(
+            output.code.contains(marker),
+            "script marker disappeared:\n{}",
+            output.code
+        );
+        assert!(
+            script_bodies(output.code.as_str())
+                .iter()
+                .all(|body| !body.trim().is_empty()),
+            "script block became compiler-empty:\n{}",
+            output.code
+        );
+    }
+}
+
+#[test]
+fn standalone_script_cleanup_still_removes_empty_statements() {
+    let output = format_script("; ; ;", &FormatOptions::default()).expect("standalone format");
+    assert!(
+        output.trim().is_empty(),
+        "standalone cleanup changed: {output}"
+    );
+}

--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -253,15 +253,6 @@
   },
   {
     "property": "parse-preservation",
-    "category": "semantic-diff",
-    "project": "sigma-file-manager",
-    "path": "src/components/ui/dialog/dialog-header.vue",
-    "reason": "Formatting removes an empty script setup block, changing the official SFC descriptor.",
-    "trackingIssue": 4107,
-    "expiryCondition": "Remove after formatting preserves the empty script setup block and the semantic comparator is clean."
-  },
-  {
-    "property": "parse-preservation",
     "category": "oracle-unavailable",
     "project": "splitpanes",
     "path": "src/app.vue",

--- a/tests/tooling/glyph-corpus-parse-preservation.test.ts
+++ b/tests/tooling/glyph-corpus-parse-preservation.test.ts
@@ -267,6 +267,14 @@ test("glyph corpus parse-preservation comparator flags structural corruption", (
     ).join("\n"),
     /styles changed/,
   );
+  assert.match(
+    compareFile(
+      "<script setup>;</script>\n<template><p/></template>\n",
+      "<script setup></script>\n<template><p/></template>\n",
+      "App.vue",
+    ).join("\n"),
+    /scriptSetup block disappeared/,
+  );
 });
 
 test("glyph corpus normalizes only compiler-defined presence attributes", () => {


### PR DESCRIPTION
## Summary
- preserve one canonical empty statement when SFC script cleanup would erase the block
- keep standalone script cleanup unchanged and fail closed for unexpected formatter erasure
- remove the sigma-file-manager waiver after formatter, lint, and compiler-sfc equivalence pass

## Verification
- cargo test -p vize_glyph
- strict production and focused test clippy
- repository format/lint and source-length gates
- sigma-file-manager 298/298 idempotence, lint agreement, and compiler-sfc parse preservation

Closes #4107

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved empty Vue `<script>` and `<script setup>` blocks during formatting.
  - Prevented comments, directives, and non-empty script content from being incorrectly removed.
  - Ensured formatting remains stable across repeated runs.

- **Tests**
  - Added regression coverage for empty statements, comments, directives, and removed script blocks.
  - Removed a related known formatting violation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->