### PR TITLE
docs(blog): try the Polonius borrow checker and measure its build cost

### DIFF
--- a/crates/vize_canon/src/lsp_client/editor_lsp/client.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/client.rs
@@ -109,17 +109,15 @@ impl CorsaProjectClient {
             )?);
             self.editor_lsp_documents_dirty = true;
         }
+        let session = self
+            .editor_lsp
+            .as_mut()
+            .ok_or_else(|| cstr!("Corsa editor LSP session did not initialize"))?;
         if self.editor_lsp_documents_dirty {
-            let session = self
-                .editor_lsp
-                .as_mut()
-                .ok_or_else(|| cstr!("Corsa editor LSP session did not initialize"))?;
             session.synchronize(&self.document_texts)?;
             self.editor_lsp_documents_dirty = false;
         }
-        self.editor_lsp
-            .as_mut()
-            .ok_or_else(|| cstr!("Corsa editor LSP session did not initialize"))
+        Ok(session)
     }
 
     /// Drop the editor session so the next request respawns it after a project

--- a/crates/vize_croquis/src/call_graph/analysis.rs
+++ b/crates/vize_croquis/src/call_graph/analysis.rs
@@ -51,46 +51,21 @@ impl CallGraph {
         }
 
         // Update vue_api_calls in_setup_context
-        // Collect updates first to avoid borrow conflict
-        let vue_updates: Vec<_> = self
-            .vue_api_calls
-            .iter()
-            .enumerate()
-            .map(|(i, call)| {
-                (
-                    i,
-                    self.setup_context_functions.contains(
-                        &call
-                            .containing_function
-                            .unwrap_or(FunctionId::new(u32::MAX)),
-                    ),
-                )
-            })
-            .collect();
-        for (i, in_setup) in vue_updates {
+        for i in 0..self.vue_api_calls.len() {
             // Top-level is always in setup context for script setup
             let containing = self.vue_api_calls[i].containing_function;
+            let in_setup = self
+                .setup_context_functions
+                .contains(&containing.unwrap_or(FunctionId::new(u32::MAX)));
             self.vue_api_calls[i].in_setup_context = containing.is_none() || in_setup;
         }
 
         // Update composable_calls in_setup_context
-        let composable_updates: Vec<_> = self
-            .composable_calls
-            .iter()
-            .enumerate()
-            .map(|(i, call)| {
-                (
-                    i,
-                    self.setup_context_functions.contains(
-                        &call
-                            .containing_function
-                            .unwrap_or(FunctionId::new(u32::MAX)),
-                    ),
-                )
-            })
-            .collect();
-        for (i, in_setup) in composable_updates {
+        for i in 0..self.composable_calls.len() {
             let containing = self.composable_calls[i].containing_function;
+            let in_setup = self
+                .setup_context_functions
+                .contains(&containing.unwrap_or(FunctionId::new(u32::MAX)));
             self.composable_calls[i].in_setup_context = containing.is_none() || in_setup;
         }
     }

--- a/crates/vize_croquis/src/scope/chain/resolution.rs
+++ b/crates/vize_croquis/src/scope/chain/resolution.rs
@@ -69,11 +69,9 @@ impl ScopeChain {
                 return;
             }
 
-            // Collect parents before continuing (to avoid borrow issues)
-            let parents: SmallVec<[ScopeId; 2]> = scope.parents.clone();
-            for parent_id in parents {
-                if !visited.contains(&parent_id) {
-                    queue.push(parent_id);
+            for parent_id in &scope.parents {
+                if !visited.contains(parent_id) {
+                    queue.push(*parent_id);
                 }
             }
         }
@@ -106,11 +104,9 @@ impl ScopeChain {
                 return;
             }
 
-            // Collect parents before continuing (to avoid borrow issues)
-            let parents: SmallVec<[ScopeId; 2]> = scope.parents.clone();
-            for parent_id in parents {
-                if !visited.contains(&parent_id) {
-                    queue.push(parent_id);
+            for parent_id in &scope.parents {
+                if !visited.contains(parent_id) {
+                    queue.push(*parent_id);
                 }
             }
         }

--- a/crates/vize_croquis_cf/src/graph.rs
+++ b/crates/vize_croquis_cf/src/graph.rs
@@ -245,10 +245,7 @@ impl DependencyGraph {
         let mut path = Vec::new();
         let mut cycles = Vec::new();
 
-        // Collect all node IDs first to avoid borrow issues
-        let node_ids: Vec<_> = self.nodes.keys().copied().collect();
-
-        for start_id in node_ids {
+        for start_id in self.nodes.keys().copied() {
             if !visited.contains(&start_id) {
                 Self::dfs_cycle_static(
                     &self.nodes,

--- a/docs/content/blog/index.md
+++ b/docs/content/blog/index.md
@@ -37,6 +37,10 @@ The Vize docs now have two writing lanes:
 ## Latest Posts
 
 <div class="blog-post-list">
+  <a class="blog-post-list-item" href="./notes/2026-08-11-trying-the-polonius-borrow-checker-on-rust-nightly/">
+    <strong>Polonius on Nightly</strong>
+    <span>Rust's next-generation borrow checker is now on by default on nightly. We ran the whole Vize workspace through it, measured what it costs, and audited every borrow-checker workaround in the codebase.</span>
+  </a>
   <a class="blog-post-list-item" href="./notes/2026-06-07-real-world-testing/">
     <strong>Real World Testing</strong>
     <span>Vize enters the Real World Testing phase — real projects are the test suite now, with a clear roadmap to v1.0.0.</span>

--- a/docs/content/blog/notes/2026-08-11-trying-the-polonius-borrow-checker-on-rust-nightly.md
+++ b/docs/content/blog/notes/2026-08-11-trying-the-polonius-borrow-checker-on-rust-nightly.md
@@ -27,7 +27,7 @@ Vize is a 23-crate Rust workspace pinned to stable 1.95.0, with 411 locked packa
 
 - Does anything in the workspace behave differently under the new checker?
 - What does the new checker cost in build time?
-- How much of the code we wrote *around* the old borrow checker can now be deleted?
+- How much of the code we wrote _around_ the old borrow checker can now be deleted?
 
 This note answers all three. The short version: nothing breaks, it costs about 5% of check CPU time, and the amount of code Polonius lets us delete today is smaller than we expected — but not zero.
 
@@ -64,13 +64,13 @@ error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as imm
 
 Polonius makes the analysis flow-sensitive, so the borrow ends where it actually ends. Here is the same file across the configurations we tested, all on `rustc 1.99.0-nightly (2026-08-09)` except the stable row:
 
-| Configuration | Result |
-| --- | --- |
-| stable 1.95.0 | rejected (E0502) |
-| nightly, default | **accepted** — Polonius Alpha is on by default |
-| nightly, `-Zpolonius=no` | rejected — the old NLL checker |
-| nightly, `-Zpolonius=legacy` | accepted — the original datalog prototype |
-| nightly, `-Zpolonius=next` | accepted — the full location-sensitive analysis |
+| Configuration                | Result                                          |
+| ---------------------------- | ----------------------------------------------- |
+| stable 1.95.0                | rejected (E0502)                                |
+| nightly, default             | **accepted** — Polonius Alpha is on by default  |
+| nightly, `-Zpolonius=no`     | rejected — the old NLL checker                  |
+| nightly, `-Zpolonius=legacy` | accepted — the original datalog prototype       |
+| nightly, `-Zpolonius=next`   | accepted — the full location-sensitive analysis |
 
 The alpha that is heading for stabilization is a restricted formulation of the full analysis: flow-sensitive on lifetime outlives relationships, chosen because it covers the common false rejections at an acceptable compile-time cost. `-Zpolonius=next` is the complete location-sensitive implementation that is still under development, and `-Zpolonius=no` is the opt-out the Rust team suggests if the new default causes trouble.
 
@@ -92,17 +92,17 @@ That is the boring result, and boring is what you want here: when Polonius Alpha
 
 The Rust team's own measurements say most crates see minimal impact, with the worst known cases (outside the top 10,000 crates) regressing 2–3x. We measured what it costs Vize.
 
-Our first attempt measured wall-clock time across eight interleaved rounds and produced garbage: ratios against the NLL baseline ranged from 0.66x to 1.97x, and in three of the eight rounds the *slower* checker finished first. On a laptop with background load, wall clock is measuring the machine, not the compiler. So the numbers below are CPU time (`user + sys`), which is far less sensitive to contention, over three clean `cargo check --workspace` runs per configuration with a fresh `CARGO_TARGET_DIR` each time.
+Our first attempt measured wall-clock time across eight interleaved rounds and produced garbage: ratios against the NLL baseline ranged from 0.66x to 1.97x, and in three of the eight rounds the _slower_ checker finished first. On a laptop with background load, wall clock is measuring the machine, not the compiler. So the numbers below are CPU time (`user + sys`), which is far less sensitive to contention, over three clean `cargo check --workspace` runs per configuration with a fresh `CARGO_TARGET_DIR` each time.
 
 Machine: Apple M2 Max (12 cores, 96 GB), `rustc 1.99.0-nightly (969b803cb 2026-08-09)`.
 
-| Configuration | Median CPU time | vs. old NLL |
-| --- | --- | --- |
-| `-Zpolonius=no` (old NLL) | 194.4s | — |
-| default (Polonius Alpha) | 204.2s | **1.05x** |
-| `-Zpolonius=next` (full analysis) | 198.6s | 1.02x |
+| Configuration                     | Median CPU time | vs. old NLL |
+| --------------------------------- | --------------- | ----------- |
+| `-Zpolonius=no` (old NLL)         | 194.4s          | —           |
+| default (Polonius Alpha)          | 204.2s          | **1.05x**   |
+| `-Zpolonius=next` (full analysis) | 198.6s          | 1.02x       |
 
-About 5% more CPU to check the entire workspace. That is comfortably inside the range the Rust team called reasonable, and nowhere near the 2–3x worst case. Interestingly the full `next` analysis measured *cheaper* than the shipping alpha here; with three samples per configuration that gap is inside the noise, and the honest reading is that alpha and next cost about the same on this codebase.
+About 5% more CPU to check the entire workspace. That is comfortably inside the range the Rust team called reasonable, and nowhere near the 2–3x worst case. Interestingly the full `next` analysis measured _cheaper_ than the shipping alpha here; with three samples per configuration that gap is inside the noise, and the honest reading is that alpha and next cost about the same on this codebase.
 
 Note also that this is worst-case exposure: a clean check of all 411 packages. Incremental flows recompile a handful of crates, and full builds bury the difference under codegen.
 
@@ -110,12 +110,12 @@ Note also that this is worst-case exposure: a clean check of all 411 packages. I
 
 A workspace-level number tells you what to budget for but not what happened. `-Ztime-passes` reports the borrow-check pass on its own, so we measured it directly on the three largest crates, with `CARGO_INCREMENTAL=0` and a forced rebuild before each sample so no run could be served from the incremental cache. Five samples per crate per configuration, medians below.
 
-| Crate | old NLL | Polonius Alpha | `-Zpolonius=next` |
-| --- | --- | --- | --- |
-| `vize_patina` (90k lines) | 0.622s | 0.749s (1.20x) | 0.674s (1.08x) |
-| `vize_canon` (75k lines) | 0.729s | 0.876s (1.20x) | 0.798s (1.09x) |
-| `vize_croquis` (36k lines) | 0.443s | 0.468s (1.06x) | 0.472s (1.07x) |
-| **total** | **1.79s** | **2.09s (1.17x)** | **1.94s (1.08x)** |
+| Crate                      | old NLL   | Polonius Alpha    | `-Zpolonius=next` |
+| -------------------------- | --------- | ----------------- | ----------------- |
+| `vize_patina` (90k lines)  | 0.622s    | 0.749s (1.20x)    | 0.674s (1.08x)    |
+| `vize_canon` (75k lines)   | 0.729s    | 0.876s (1.20x)    | 0.798s (1.09x)    |
+| `vize_croquis` (36k lines) | 0.443s    | 0.468s (1.06x)    | 0.472s (1.07x)    |
+| **total**                  | **1.79s** | **2.09s (1.17x)** | **1.94s (1.08x)** |
 
 So the borrow-check pass itself gets about 20% more expensive on the two largest crates — a much larger relative regression than the 5% the workspace showed. Both numbers are true, and the gap between them is the actual lesson: borrow checking is a small enough slice of compilation that a 20% regression inside it lands as a rounding error outside it. In absolute terms the alpha costs an extra 0.30 seconds across 200k lines of Rust.
 
@@ -152,7 +152,7 @@ None of these are Polonius wins. They are code that was shaped defensively aroun
 
 The largest category by far — ten sites — is not a borrow-checker precision problem at all. Every one is the same shape: a shared borrow derived from a context object held across a call that needs `&mut` on that same object. The lint rules are the clearest example, collecting owned strings out of `ctx.analysis()` before calling `ctx.report()`.
 
-Polonius changes *when* borrows end. It does not make them *finer-grained*. Splitting a borrow of `ctx` into disjoint borrows of `ctx.analysis` and `ctx.diagnostics` is view types, a separate feature still in design. Those ten sites stay exactly as they are, and would stay even under the full `-Zpolonius=next`.
+Polonius changes _when_ borrows end. It does not make them _finer-grained_. Splitting a borrow of `ctx` into disjoint borrows of `ctx.analysis` and `ctx.diagnostics` is view types, a separate feature still in design. Those ten sites stay exactly as they are, and would stay even under the full `-Zpolonius=next`.
 
 Worth noting for anyone doing a similar audit: a sweep of this kind produces a lot of false positives. More than fifteen sites in this codebase have the exact silhouette of Problem Case #3 — `contains_key` guards, three-lookup cache reads, an `expect("just inserted")` on an impossible branch — and are accepted by NLL today, because the reference never escapes the function. Several of those triple lookups exist to avoid `entry()`'s owned-key allocation, which is a performance decision, not a borrow-checker one. Reading for the shape is not enough; the compiler has to be the judge.
 

--- a/docs/content/blog/notes/2026-08-11-trying-the-polonius-borrow-checker-on-rust-nightly.md
+++ b/docs/content/blog/notes/2026-08-11-trying-the-polonius-borrow-checker-on-rust-nightly.md
@@ -137,9 +137,9 @@ These three are real Problem Case #3. The natural formulation is rejected by NLL
 
 **None of these are fixed in this PR, and that is deliberate.** Vize pins stable 1.95.0 in `rust-toolchain.toml`, in CI, and in every crate's `rust-version`. Writing any of them in the natural form would break the stable build immediately. They are recorded here so the eventual toolchain bump has a ready-made worklist.
 
-### What we could delete today: 5 sites
+### What we could delete today: 6 sites
 
-Separately, the audit found five workarounds that were never required by NLL in the first place. These are fixed in this PR, and each was verified to compile on stable 1.95.0:
+Separately, the audit found six workarounds that were never required by NLL in the first place. These are fixed in this PR, and each was verified to compile on stable 1.95.0:
 
 - `vize_croquis`, `scope/chain/resolution.rs` (two sites) — cloned a `SmallVec` of parent scope IDs before iterating. A shared reborrow works; the loop body only touches locals.
 - `vize_croquis`, `call_graph/analysis.rs` (two sites) — built an intermediate `Vec` of `(index, bool)` pairs before writing back. An index loop reads the `Copy` field, does the lookup, and writes in place, with no allocation.
@@ -165,6 +165,6 @@ What we bought with this experiment is certainty about that future bump:
 - The entire workspace already borrow-checks cleanly under the new default and under the stricter `-Zpolonius=next`.
 - The cost for this workspace is measured, not guessed: about 5% more CPU on a full clean check, less in any incremental flow.
 - Three specific sites are queued for simplification the day Polonius stabilizes, with the failing error code recorded for each.
-- Five gratuitous workarounds are already gone, independent of any toolchain change.
+- Six gratuitous workarounds are already gone, independent of any toolchain change.
 
 When stabilization lands, the toolchain bump PR can point at this note instead of re-running the investigation.

--- a/docs/content/blog/notes/2026-08-11-trying-the-polonius-borrow-checker-on-rust-nightly.md
+++ b/docs/content/blog/notes/2026-08-11-trying-the-polonius-borrow-checker-on-rust-nightly.md
@@ -49,7 +49,7 @@ fn get_or_insert(map: &mut HashMap<u32, String>) -> &String {
 
 The borrow of `map` in the `if let` only escapes through the early `return`, so the `map.insert` below is fine — but NLL extends the borrow to the whole function body and rejects it:
 
-```
+```text
 error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable
  --> demo.rs:8:5
   |

--- a/docs/content/blog/notes/2026-08-11-trying-the-polonius-borrow-checker-on-rust-nightly.md
+++ b/docs/content/blog/notes/2026-08-11-trying-the-polonius-borrow-checker-on-rust-nightly.md
@@ -1,0 +1,170 @@
+---
+title: Polonius on Nightly
+description: Rust's next-generation borrow checker is now on by default on nightly. We ran the whole Vize workspace through it, measured what it costs, and audited every borrow-checker workaround in the codebase.
+---
+
+# Polonius on Nightly
+
+<div class="blog-post-meta">
+  <span class="blog-meta-chip">
+    <span>
+      <span class="blog-meta-label">Published</span>
+      <span class="blog-meta-value">2026-08-11</span>
+    </span>
+  </span>
+  <a class="blog-author-card" href="https://github.com/ubugeeei">
+    <img src="https://github.com/ubugeeei.png" alt="ubugeeei" />
+    <span class="blog-author-text">
+      <span class="blog-meta-label">Author</span>
+      <span class="blog-meta-value">ubugeeei</span>
+    </span>
+  </a>
+</div>
+
+On August 4, 2026 the Rust project [enabled the next iteration of the borrow checker on nightly](https://blog.rust-lang.org/2026/08/04/enabling-polonius-alpha-on-nightly/). Starting with `nightly-2026-08-06`, the borrow checker known as Polonius Alpha is the default, with stabilization targeted before the end of the year and feedback collected on the [tracking issue](https://github.com/rust-lang/rust/issues/160456).
+
+Vize is a 23-crate Rust workspace pinned to stable 1.95.0, with 411 locked packages in the dependency graph. That makes it a reasonable real-world subject for three questions:
+
+- Does anything in the workspace behave differently under the new checker?
+- What does the new checker cost in build time?
+- How much of the code we wrote *around* the old borrow checker can now be deleted?
+
+This note answers all three. The short version: nothing breaks, it costs about 5% of check CPU time, and the amount of code Polonius lets us delete today is smaller than we expected — but not zero.
+
+## What Polonius Changes
+
+The current borrow checker (non-lexical lifetimes, NLL) rejects some programs that are actually sound. The best-known shape is a borrow returned from one branch while a later statement needs the same collection again — NLL "Problem Case #3":
+
+```rust
+use std::collections::HashMap;
+
+fn get_or_insert(map: &mut HashMap<u32, String>) -> &String {
+    if let Some(v) = map.get(&22) {
+        return v;
+    }
+    map.insert(22, String::from("hi"));
+    &map[&22]
+}
+```
+
+The borrow of `map` in the `if let` only escapes through the early `return`, so the `map.insert` below is fine — but NLL extends the borrow to the whole function body and rejects it:
+
+```
+error[E0502]: cannot borrow `*map` as mutable because it is also borrowed as immutable
+ --> demo.rs:8:5
+  |
+5 |     if let Some(v) = map.get(&22) {
+  |                      --- immutable borrow occurs here
+6 |         return v;
+  |                - returning this value requires that `*map` is borrowed for `'1`
+7 |     }
+8 |     map.insert(22, String::from("hi"));
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
+```
+
+Polonius makes the analysis flow-sensitive, so the borrow ends where it actually ends. Here is the same file across the configurations we tested, all on `rustc 1.99.0-nightly (2026-08-09)` except the stable row:
+
+| Configuration | Result |
+| --- | --- |
+| stable 1.95.0 | rejected (E0502) |
+| nightly, default | **accepted** — Polonius Alpha is on by default |
+| nightly, `-Zpolonius=no` | rejected — the old NLL checker |
+| nightly, `-Zpolonius=legacy` | accepted — the original datalog prototype |
+| nightly, `-Zpolonius=next` | accepted — the full location-sensitive analysis |
+
+The alpha that is heading for stabilization is a restricted formulation of the full analysis: flow-sensitive on lifetime outlives relationships, chosen because it covers the common false rejections at an acceptable compile-time cost. `-Zpolonius=next` is the complete location-sensitive implementation that is still under development, and `-Zpolonius=no` is the opt-out the Rust team suggests if the new default causes trouble.
+
+## Running the Whole Workspace Through It
+
+The interesting question for a codebase this size is not the demo — it is whether anything anywhere in 23 crates changes meaning.
+
+```bash
+cargo +nightly check --workspace                                  # Polonius Alpha (default)
+RUSTFLAGS="-Zpolonius=no"   cargo +nightly check --workspace      # old NLL
+RUSTFLAGS="-Zpolonius=next" cargo +nightly check --workspace      # full analysis
+```
+
+All three configurations check the entire workspace — every Vize crate plus every dependency — with byte-identical diagnostics: zero warnings, zero errors, in every configuration. Nothing in Vize or its dependency graph is affected by the new checker, under either the alpha or the stricter full implementation.
+
+That is the boring result, and boring is what you want here: when Polonius Alpha stabilizes and Vize's pinned toolchain eventually moves past it, the bump will be a non-event as far as borrow checking is concerned.
+
+## The Build-Time Cost
+
+The Rust team's own measurements say most crates see minimal impact, with the worst known cases (outside the top 10,000 crates) regressing 2–3x. We measured what it costs Vize.
+
+Our first attempt measured wall-clock time across eight interleaved rounds and produced garbage: ratios against the NLL baseline ranged from 0.66x to 1.97x, and in three of the eight rounds the *slower* checker finished first. On a laptop with background load, wall clock is measuring the machine, not the compiler. So the numbers below are CPU time (`user + sys`), which is far less sensitive to contention, over three clean `cargo check --workspace` runs per configuration with a fresh `CARGO_TARGET_DIR` each time.
+
+Machine: Apple M2 Max (12 cores, 96 GB), `rustc 1.99.0-nightly (969b803cb 2026-08-09)`.
+
+| Configuration | Median CPU time | vs. old NLL |
+| --- | --- | --- |
+| `-Zpolonius=no` (old NLL) | 194.4s | — |
+| default (Polonius Alpha) | 204.2s | **1.05x** |
+| `-Zpolonius=next` (full analysis) | 198.6s | 1.02x |
+
+About 5% more CPU to check the entire workspace. That is comfortably inside the range the Rust team called reasonable, and nowhere near the 2–3x worst case. Interestingly the full `next` analysis measured *cheaper* than the shipping alpha here; with three samples per configuration that gap is inside the noise, and the honest reading is that alpha and next cost about the same on this codebase.
+
+Note also that this is worst-case exposure: a clean check of all 411 packages. Incremental flows recompile a handful of crates, and full builds bury the difference under codegen.
+
+## Where the 5% Actually Goes
+
+A workspace-level number tells you what to budget for but not what happened. `-Ztime-passes` reports the borrow-check pass on its own, so we measured it directly on the three largest crates, with `CARGO_INCREMENTAL=0` and a forced rebuild before each sample so no run could be served from the incremental cache. Five samples per crate per configuration, medians below.
+
+| Crate | old NLL | Polonius Alpha | `-Zpolonius=next` |
+| --- | --- | --- | --- |
+| `vize_patina` (90k lines) | 0.622s | 0.749s (1.20x) | 0.674s (1.08x) |
+| `vize_canon` (75k lines) | 0.729s | 0.876s (1.20x) | 0.798s (1.09x) |
+| `vize_croquis` (36k lines) | 0.443s | 0.468s (1.06x) | 0.472s (1.07x) |
+| **total** | **1.79s** | **2.09s (1.17x)** | **1.94s (1.08x)** |
+
+So the borrow-check pass itself gets about 20% more expensive on the two largest crates — a much larger relative regression than the 5% the workspace showed. Both numbers are true, and the gap between them is the actual lesson: borrow checking is a small enough slice of compilation that a 20% regression inside it lands as a rounding error outside it. In absolute terms the alpha costs an extra 0.30 seconds across 200k lines of Rust.
+
+This is also why we do not expect the eventual toolchain bump to be visible in day-to-day work. The pass that got slower is under a second on our biggest crate, and incremental rebuilds re-run it for one crate at a time.
+
+## Auditing Every Borrow-Checker Workaround
+
+The more interesting question is what the old checker cost us in code. We swept the workspace for borrow-checker workarounds — both by comment (`avoid borrow`, `to satisfy the borrow checker`, `collect first`) and, more importantly, by code shape, since the shapes that matter often carry no comment at all: double lookups, `contains_key` followed by `insert` followed by `get`, `match map.get_mut(k) { ... None => map.insert(...) }`, functions returning `&T`/`&mut T` that mutate the same collection, and every `unsafe` block in the workspace.
+
+The key methodological point: we did not classify these by reading them. Every candidate was reduced to a minimal reproduction and compiled under `-Zpolonius=no` and under the new default, so each verdict is a compiler result rather than an opinion. That mattered — several candidates that looked exactly like Problem Case #3 turned out to compile fine under NLL, and one that we had already written off turned out to be trivially simplifiable.
+
+### What Polonius genuinely unlocks: 3 sites
+
+These three are real Problem Case #3. The natural formulation is rejected by NLL (verified: E0502, E0502, E0506) and accepted by Polonius Alpha:
+
+- **`vize_canon`, `batch/executor/diagnostics.rs` — `original_source`.** The purest instance. It reads a file into a cache and returns `Option<&CachedSource>`. Because initialization is fallible (`read_to_string(path).ok()?`), neither `entry()` nor `or_insert_with` can express it — a closure cannot propagate the `?`. So the code does `contains_key`, then `insert`, then `get`: three lookups where one would do.
+- **`vize`, `commands/check/tsconfig_inputs/loader.rs` — `load`.** Worked around with `entry().or_insert_with_key()`, which compiles today but forces an owned `PathBuf` key on every call, including cache hits. Polonius would allow a `get`-based hit path with no allocation.
+- **`vize_patina`, `context/reporting.rs` — `sfc_directives`.** Lazy initialization guarded by a separate `sfc_directives_scanned` flag instead of matching on the field itself. This one comes with a caveat: the flag also serves as a negative cache, distinguishing "scanned, found nothing" from "not yet scanned". Removing it would change behavior, not just syntax, so this site is only partly a borrow-checker artifact.
+
+**None of these are fixed in this PR, and that is deliberate.** Vize pins stable 1.95.0 in `rust-toolchain.toml`, in CI, and in every crate's `rust-version`. Writing any of them in the natural form would break the stable build immediately. They are recorded here so the eventual toolchain bump has a ready-made worklist.
+
+### What we could delete today: 5 sites
+
+Separately, the audit found five workarounds that were never required by NLL in the first place. These are fixed in this PR, and each was verified to compile on stable 1.95.0:
+
+- `vize_croquis`, `scope/chain/resolution.rs` (two sites) — cloned a `SmallVec` of parent scope IDs before iterating. A shared reborrow works; the loop body only touches locals.
+- `vize_croquis`, `call_graph/analysis.rs` (two sites) — built an intermediate `Vec` of `(index, bool)` pairs before writing back. An index loop reads the `Copy` field, does the lookup, and writes in place, with no allocation.
+- `vize_croquis_cf`, `graph.rs` — collected all node IDs into a `Vec` before a DFS that only ever reads the same map. Two shared borrows never conflicted.
+- `vize_canon`, `lsp_client/editor_lsp/client.rs` — hoisted a single `as_mut()` above the branch that uses it, removing a redundant second lookup and a duplicated unreachable error branch.
+
+None of these are Polonius wins. They are code that was shaped defensively around a rule that did not apply, and the honest summary is that the audit found more of that than it found genuine NLL limitations.
+
+### What Polonius will never fix
+
+The largest category by far — ten sites — is not a borrow-checker precision problem at all. Every one is the same shape: a shared borrow derived from a context object held across a call that needs `&mut` on that same object. The lint rules are the clearest example, collecting owned strings out of `ctx.analysis()` before calling `ctx.report()`.
+
+Polonius changes *when* borrows end. It does not make them *finer-grained*. Splitting a borrow of `ctx` into disjoint borrows of `ctx.analysis` and `ctx.diagnostics` is view types, a separate feature still in design. Those ten sites stay exactly as they are, and would stay even under the full `-Zpolonius=next`.
+
+Worth noting for anyone doing a similar audit: a sweep of this kind produces a lot of false positives. More than fifteen sites in this codebase have the exact silhouette of Problem Case #3 — `contains_key` guards, three-lookup cache reads, an `expect("just inserted")` on an impossible branch — and are accepted by NLL today, because the reference never escapes the function. Several of those triple lookups exist to avoid `entry()`'s owned-key allocation, which is a performance decision, not a borrow-checker one. Reading for the shape is not enough; the compiler has to be the judge.
+
+## What This Means for Vize
+
+Nothing changes today. The toolchain stays pinned to stable 1.95.0, and stable users are unaffected until the alpha ships in a stable release.
+
+What we bought with this experiment is certainty about that future bump:
+
+- The entire workspace already borrow-checks cleanly under the new default and under the stricter `-Zpolonius=next`.
+- The cost for this workspace is measured, not guessed: about 5% more CPU on a full clean check, less in any incremental flow.
+- Three specific sites are queued for simplification the day Polonius stabilizes, with the failing error code recorded for each.
+- Five gratuitous workarounds are already gone, independent of any toolchain change.
+
+When stabilization lands, the toolchain bump PR can point at this note instead of re-running the investigation.

--- a/docs/content/blog/notes/index.md
+++ b/docs/content/blog/notes/index.md
@@ -17,6 +17,10 @@ Use this section for writing that does not fit a release announcement: architect
 ## Posts
 
 <div class="blog-post-list">
+  <a class="blog-post-list-item" href="./2026-08-11-trying-the-polonius-borrow-checker-on-rust-nightly/">
+    <strong>Polonius on Nightly</strong>
+    <span>Rust's next-generation borrow checker is now on by default on nightly. We ran the whole Vize workspace through it, measured what it costs, and audited every borrow-checker workaround in the codebase.</span>
+  </a>
   <a class="blog-post-list-item" href="./2026-06-07-real-world-testing/">
     <strong>Real World Testing</strong>
     <span>Vize enters the Real World Testing phase — real projects are the test suite now, with a clear roadmap to v1.0.0.</span>


### PR DESCRIPTION
Rust [enabled the Polonius Alpha borrow checker by default on nightly](https://blog.rust-lang.org/2026/08/04/enabling-polonius-alpha-on-nightly/) as of `nightly-2026-08-06`, with stabilization targeted before the end of the year. This runs the whole workspace through it, measures what it costs, and audits every borrow-checker workaround in the codebase.

## Does anything break?

No. All 23 crates plus every dependency check clean under three configurations on `rustc 1.99.0-nightly (2026-08-09)`, with byte-identical diagnostics — zero warnings, zero errors in each:

```bash
cargo +nightly check --workspace                                  # Polonius Alpha (default)
RUSTFLAGS="-Zpolonius=no"   cargo +nightly check --workspace      # old NLL
RUSTFLAGS="-Zpolonius=next" cargo +nightly check --workspace      # full analysis
```

## What does it cost?

Wall clock was useless here — across eight interleaved rounds it ranged from 0.66x to 1.97x, and in three rounds the slower checker finished first. The numbers below are CPU time (`user + sys`) over three clean workspace checks per configuration, plus the borrow-check pass isolated with `-Ztime-passes` (`CARGO_INCREMENTAL=0`, forced rebuild before each of 5 samples). Apple M2 Max, 12 cores.

| Measurement | old NLL | Polonius Alpha | `-Zpolonius=next` |
| --- | --- | --- | --- |
| Workspace check, CPU time | 194.4s | 204.2s (**1.05x**) | 198.6s (1.02x) |
| `MIR_borrow_checking`, 3 largest crates | 1.79s | 2.09s (**1.17x**) | 1.94s (1.08x) |

Both numbers are true and the gap between them is the point: the borrow-check pass gets ~20% more expensive on the two largest crates, but it is a small enough slice of compilation that this lands as ~5% overall. In absolute terms the alpha costs an extra 0.30s across 200k lines of Rust. Well inside what the Rust team called reasonable, and nowhere near the 2–3x worst case they reported.

## Borrow-checker workaround audit

Swept the workspace by comment *and* by code shape (double lookups, `contains_key`+`insert`+`get`, functions returning `&T` that mutate the same collection, every `unsafe` block). Every candidate was reduced to a minimal reproduction and compiled under `-Zpolonius=no` and under the new default, so each verdict is a compiler result rather than a reading.

**Fixed here — 5 sites that NLL never required.** All verified to compile on the pinned stable 1.95.0:

- `vize_croquis` `scope/chain/resolution.rs` (x2) — cloned a `SmallVec` of parent scope IDs; a shared reborrow suffices.
- `vize_croquis` `call_graph/analysis.rs` (x2) — intermediate `Vec<(usize, bool)>` replaced by an index loop, no allocation.
- `vize_croquis_cf` `graph.rs` — collected node IDs before a DFS that only reads the same map.
- `vize_canon` `lsp_client/editor_lsp/client.rs` — hoisted one `as_mut()`, removing a redundant lookup and a duplicated unreachable error branch.

**Recorded, not changed — 3 genuine NLL Problem Case #3 sites.** The natural form is rejected by NLL (E0502, E0502, E0506) and accepted by Polonius: `vize_canon` `batch/executor/diagnostics.rs` (`original_source`), `vize` `commands/check/tsconfig_inputs/loader.rs` (`load`), `vize_patina` `context/reporting.rs` (`sfc_directives`). **These deliberately stay as they are** — the toolchain is pinned to stable 1.95.0, so writing them naturally would break the build today. The note records them as a worklist for the eventual bump.

**Will never be fixed by Polonius — 10 sites.** All the same shape: a shared borrow off a context object held across a call needing `&mut` on it (the lint rules collecting owned strings before `ctx.report()`). Polonius changes *when* borrows end, not how fine-grained they are; that is view types, a separate unshipped feature.

Worth flagging for anyone repeating this: more than fifteen sites have the exact silhouette of Problem Case #3 and are accepted by NLL today because the reference never escapes. Several triple lookups exist to dodge `entry()`'s owned-key allocation — a performance decision, not a borrow-checker one.

## Verification

- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports` — clean (CI's exact command)
- `rustfmt --edition 2024 --config style_edition=2024 --check` on all modified files — clean
- `cargo test -p vize_croquis -p vize_croquis_cf` — 501 passed, 0 failed
- `cargo test -p vize_canon` — 948 passed; the 2 `project_isolation` failures are pre-existing and environmental (they read the workspace `node_modules`, absent in a worktree without `pnpm install`), confirmed by a control run with the change reverted
- `node --test tests/tooling/docs-navigation.test.ts` — 6 passed

## Follow-up

The note is English-only. Every other note carries ja/zh-CN/pt-BR/fr translations via `docs/scripts/i18n/generate.mjs`, which calls an external machine-translation service — left for you to run rather than done unprompted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Polonius on Nightly” blog post.
  * Documented compatibility findings, build-time measurements, borrow-checker behavior, and potential simplifications.
  * Added the post to the blog and notes indexes.

* **Performance**
  * Improved internal editor synchronization and analysis efficiency without changing observable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->