### PR TITLE
test(nuxt): exercise authored head macros at runtime

### DIFF
--- a/tests/app/dev/npmx-head-contract.ts
+++ b/tests/app/dev/npmx-head-contract.ts
@@ -1,0 +1,77 @@
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+type SourceContract = {
+  anchors: readonly string[];
+  sha256: string;
+};
+
+export const NPMX_HEAD_SOURCE_CONTRACTS = {
+  "app/app.vue": {
+    sha256: "eb9448db4b25d7ee5baff8fa6b9d6a91f01863a0d8f3db4f5f97366f614165cf",
+    anchors: ["useHead({", "titleTemplate:", "name: 'color-scheme'"],
+  },
+  "app/pages/about.vue": {
+    sha256: "7637a3b8fede9d671a4bb5d748f32079c8631451e58e3090a72121e86ebf06d4",
+    anchors: ["useSeoMeta({", "ogTitle:", "twitterDescription:"],
+  },
+  "app/pages/accessibility.vue": {
+    sha256: "4cd0c9728434c3e6ed527c626252fd2335b53a77eca5f55a7400b2dbcdfe98b0",
+    anchors: ["definePageMeta({", "name: 'accessibility'", "useSeoMeta({"],
+  },
+  "app/pages/package-docs/[...path].vue": {
+    sha256: "4edb381b31dbd711f5b782bfb33ea1d4cb70fa2827afde64576f1b16904c2446",
+    anchors: [
+      "definePageMeta({",
+      "name: 'docs'",
+      "alias: ['/package/docs/:path+', '/docs/:path+']",
+      "scrollMargin: 180",
+      "useSeoMeta({",
+    ],
+  },
+  "app/pages/package/[[org]]/[name].vue": {
+    sha256: "7b69ca1c32f8766ff0dc994c1049e6b76ce32fa4dbd66d1f75bf07a8869653c6",
+    anchors: ["useHead({", "rel: 'canonical'", "useSeoMeta({"],
+  },
+} as const satisfies Record<string, SourceContract>;
+
+export type NpmxHeadSourceEvidence = Record<string, string>;
+
+function sha256(source: string): string {
+  return createHash("sha256").update(source).digest("hex");
+}
+
+export function assertNpmxHeadMacroAnchors(sources: Record<string, string>): void {
+  for (const [relativePath, contract] of Object.entries(NPMX_HEAD_SOURCE_CONTRACTS)) {
+    const source = sources[relativePath];
+    if (source === undefined) {
+      throw new Error(`missing pinned npmx head source: ${relativePath}`);
+    }
+    for (const anchor of contract.anchors) {
+      if (!source.includes(anchor)) {
+        throw new Error(`missing npmx head macro anchor in ${relativePath}: ${anchor}`);
+      }
+    }
+  }
+}
+
+export function readNpmxHeadSourceEvidence(fixtureRoot: string): NpmxHeadSourceEvidence {
+  const sources: Record<string, string> = {};
+  const evidence: NpmxHeadSourceEvidence = {};
+
+  for (const [relativePath, contract] of Object.entries(NPMX_HEAD_SOURCE_CONTRACTS)) {
+    const source = fs.readFileSync(path.join(fixtureRoot, relativePath), "utf8");
+    const digest = sha256(source);
+    if (digest !== contract.sha256) {
+      throw new Error(
+        `pinned npmx head source changed: ${relativePath} expected ${contract.sha256}, got ${digest}`,
+      );
+    }
+    sources[relativePath] = source;
+    evidence[relativePath] = digest;
+  }
+
+  assertNpmxHeadMacroAnchors(sources);
+  return evidence;
+}

--- a/tests/app/dev/npmx-head-macros.ts
+++ b/tests/app/dev/npmx-head-macros.ts
@@ -1,0 +1,219 @@
+import { expect, type Page } from "@playwright/test";
+import { readNpmxHeadSourceEvidence } from "./npmx-head-contract.ts";
+
+type HeadState = {
+  canonical: string[];
+  colorScheme: string[];
+  description: string[];
+  htmlDir: string | null;
+  htmlKeyboardHints: string | null;
+  htmlLang: string | null;
+  ogDescription: string[];
+  ogTitle: string[];
+  title: string[];
+  twitterDescription: string[];
+  twitterTitle: string[];
+};
+
+export type RouteSnapshot = {
+  fullPath: string;
+  meta: Record<string, unknown>;
+  name: string | null;
+  params: Record<string, unknown>;
+  path: string;
+};
+
+const ABOUT_DESCRIPTION =
+  "npmx is a fast, modern browser for the npm registry. A better UX/DX for exploring npm packages.";
+const ACCESSIBILITY_DESCRIPTION = "We want npmx to be usable by as many people as possible.";
+
+function expectedHead(
+  title: string,
+  description: string,
+  options: { canonical?: string; includeSocial?: boolean } = {},
+): HeadState {
+  const includeSocial = options.includeSocial ?? true;
+  return {
+    canonical: options.canonical === undefined ? [] : [options.canonical],
+    colorScheme: ["dark light"],
+    description: [description],
+    htmlDir: "ltr",
+    htmlKeyboardHints: "false",
+    htmlLang: "en-US",
+    ogDescription: includeSocial ? [description] : [],
+    ogTitle: includeSocial ? [title] : [],
+    title: [title],
+    twitterDescription: includeSocial ? [description] : [],
+    twitterTitle: includeSocial ? [title] : [],
+  };
+}
+
+async function captureHead(page: Page, html: string | null = null): Promise<HeadState> {
+  return page.evaluate((markup) => {
+    const root = markup === null ? document : new DOMParser().parseFromString(markup, "text/html");
+    const attributes = (selector: string, attribute: string): string[] =>
+      [...root.querySelectorAll(selector)].map((element) => element.getAttribute(attribute) ?? "");
+
+    return {
+      canonical: attributes('link[rel="canonical"]', "href"),
+      colorScheme: attributes('meta[name="color-scheme"]', "content"),
+      description: attributes('meta[name="description"]', "content"),
+      htmlDir: root.documentElement.getAttribute("dir"),
+      htmlKeyboardHints: root.documentElement.getAttribute("data-kbd-hints"),
+      htmlLang: root.documentElement.getAttribute("lang"),
+      ogDescription: attributes('meta[property="og:description"]', "content"),
+      ogTitle: attributes('meta[property="og:title"]', "content"),
+      title: [...root.head.querySelectorAll("title")].map((element) => element.textContent ?? ""),
+      twitterDescription: attributes('meta[name="twitter:description"]', "content"),
+      twitterTitle: attributes('meta[name="twitter:title"]', "content"),
+    };
+  }, html);
+}
+
+async function fetchHead(page: Page, url: string): Promise<HeadState> {
+  const response = await page.request.get(url);
+  expect(response.ok(), `SSR request failed: ${url}`).toBe(true);
+  return captureHead(page, await response.text());
+}
+
+async function expectDocumentHead(page: Page, expected: HeadState): Promise<void> {
+  await expect.poll(() => captureHead(page), { timeout: 20_000 }).toEqual(expected);
+}
+
+export async function readCurrentRoute(page: Page): Promise<RouteSnapshot> {
+  await page.waitForFunction(() => {
+    const root = document.querySelector("#__nuxt") as {
+      __vue_app__?: { config?: { globalProperties?: { $router?: { currentRoute?: unknown } } } };
+    } | null;
+    return root?.__vue_app__?.config?.globalProperties?.$router !== undefined;
+  });
+
+  return page.evaluate(() => {
+    const root = document.querySelector("#__nuxt") as {
+      __vue_app__?: {
+        config?: {
+          globalProperties?: {
+            $router?: {
+              currentRoute?: {
+                value?: {
+                  fullPath?: string;
+                  meta?: Record<string, unknown>;
+                  name?: string | symbol | null;
+                  params?: Record<string, unknown>;
+                  path?: string;
+                };
+              };
+            };
+          };
+        };
+      };
+    } | null;
+    const route = root?.__vue_app__?.config?.globalProperties?.$router?.currentRoute?.value;
+    if (!route?.path || !route.fullPath) throw new Error("Nuxt router currentRoute is unavailable");
+    return {
+      fullPath: route.fullPath,
+      meta: JSON.parse(JSON.stringify(route.meta ?? {})) as Record<string, unknown>,
+      name: route.name == null ? null : String(route.name),
+      params: JSON.parse(JSON.stringify(route.params ?? {})) as Record<string, unknown>,
+      path: route.path,
+    };
+  });
+}
+
+export async function navigateWithNuxtRouter(page: Page, targetPath: string): Promise<void> {
+  await page.evaluate(async (path) => {
+    const root = document.querySelector("#__nuxt") as {
+      __vue_app__?: {
+        config?: {
+          globalProperties?: { $router?: { push?: (target: string) => Promise<unknown> } };
+        };
+      };
+    } | null;
+    const push = root?.__vue_app__?.config?.globalProperties?.$router?.push;
+    if (push === undefined) throw new Error("Nuxt router is unavailable");
+    await push(path);
+  }, targetPath);
+  await expect.poll(() => new URL(page.url()).pathname, { timeout: 20_000 }).toBe(targetPath);
+}
+
+async function expectDocsRoute(page: Page, requestedPath: string): Promise<void> {
+  await navigateWithNuxtRouter(page, requestedPath);
+  const route = await readCurrentRoute(page);
+  expect(route).toEqual({
+    fullPath: requestedPath,
+    meta: {
+      alias: ["/package/docs/:path+", "/docs/:path+"],
+      name: "docs",
+      path: "/package-docs/:path+",
+      scrollMargin: 180,
+    },
+    name: "docs",
+    params: { path: ["nuxt", "v", "4.0.0"] },
+    path: requestedPath,
+  });
+  await expectDocumentHead(page, expectedHead("nuxt@4.0.0 docs - npmx", "MIT"));
+}
+
+export async function verifyNpmxHeadMacros(
+  page: Page,
+  baseUrl: string,
+  fixtureRoot: string,
+): Promise<void> {
+  const sourceEvidence = readNpmxHeadSourceEvidence(fixtureRoot);
+  const aboutHead = expectedHead("About - npmx", ABOUT_DESCRIPTION);
+  const accessibilityHead = expectedHead("accessibility - npmx", ACCESSIBILITY_DESCRIPTION, {
+    includeSocial: false,
+  });
+
+  try {
+    expect(await fetchHead(page, `${baseUrl}/about`)).toEqual(aboutHead);
+    expect(await fetchHead(page, `${baseUrl}/accessibility`)).toEqual(accessibilityHead);
+    expect(await fetchHead(page, `${baseUrl}/docs/nuxt/v/4.0.0`)).toEqual(
+      expectedHead("nuxt@4.0.0 docs - npmx", "MIT"),
+    );
+
+    await page.goto(`${baseUrl}/about`, { waitUntil: "load", timeout: 30_000 });
+    await readCurrentRoute(page);
+    await expectDocumentHead(page, aboutHead);
+
+    await navigateWithNuxtRouter(page, "/package/vue");
+    await expect
+      .poll(() => captureHead(page), { timeout: 20_000 })
+      .toMatchObject({
+        canonical: ["https://npmx.dev/package/vue"],
+        ogTitle: ["vue - npmx"],
+        title: ["vue - npmx"],
+        twitterTitle: ["vue - npmx"],
+      });
+    const packageHead = await captureHead(page);
+    expect(packageHead.description).toHaveLength(1);
+    expect(packageHead.description[0]?.length).toBeGreaterThan(0);
+    expect(packageHead.ogDescription).toEqual(packageHead.description);
+    expect(packageHead.twitterDescription).toEqual(packageHead.description);
+
+    await navigateWithNuxtRouter(page, "/about");
+    await expectDocumentHead(page, aboutHead);
+
+    for (const docsPath of [
+      "/package-docs/nuxt/v/4.0.0",
+      "/package/docs/nuxt/v/4.0.0",
+      "/docs/nuxt/v/4.0.0",
+    ]) {
+      await navigateWithNuxtRouter(page, "/about");
+      await expectDocumentHead(page, aboutHead);
+      await expectDocsRoute(page, docsPath);
+    }
+
+    await navigateWithNuxtRouter(page, "/accessibility");
+    expect(await readCurrentRoute(page)).toEqual({
+      fullPath: "/accessibility",
+      meta: {},
+      name: "accessibility",
+      params: {},
+      path: "/accessibility",
+    });
+    await expectDocumentHead(page, accessibilityHead);
+  } finally {
+    expect(readNpmxHeadSourceEvidence(fixtureRoot)).toEqual(sourceEvidence);
+  }
+}

--- a/tests/app/dev/npmx.spec.ts
+++ b/tests/app/dev/npmx.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import type { ChildProcess } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -19,92 +19,13 @@ import {
   getComputedStyleValue,
   verifySSRContent,
 } from "../../_helpers/assertions";
+import {
+  navigateWithNuxtRouter,
+  readCurrentRoute,
+  verifyNpmxHeadMacros,
+} from "./npmx-head-macros.ts";
 
 const app = npmxApp;
-
-type RouteSnapshot = {
-  fullPath: string;
-  meta: Record<string, unknown>;
-  name: string | null;
-  params: Record<string, unknown>;
-  path: string;
-};
-
-async function readCurrentRoute(page: Page): Promise<RouteSnapshot> {
-  await page.waitForFunction(() => {
-    const root = document.querySelector("#__nuxt") as {
-      __vue_app__?: {
-        config?: {
-          globalProperties?: {
-            $router?: {
-              currentRoute?: {
-                value?: unknown;
-              };
-            };
-          };
-        };
-      };
-    } | null;
-
-    return root?.__vue_app__?.config?.globalProperties?.$router?.currentRoute?.value !== undefined;
-  });
-
-  return page.evaluate(() => {
-    const root = document.querySelector("#__nuxt") as {
-      __vue_app__?: {
-        config?: {
-          globalProperties?: {
-            $router?: {
-              currentRoute?: {
-                value?: {
-                  fullPath?: string;
-                  meta?: Record<string, unknown>;
-                  name?: string | symbol | null;
-                  params?: Record<string, unknown>;
-                  path?: string;
-                };
-              };
-            };
-          };
-        };
-      };
-    } | null;
-    const route = root?.__vue_app__?.config?.globalProperties?.$router?.currentRoute?.value;
-    if (!route?.path || !route.fullPath) {
-      throw new Error("Nuxt router currentRoute is not available");
-    }
-
-    return {
-      fullPath: route.fullPath,
-      meta: JSON.parse(JSON.stringify(route.meta ?? {})) as Record<string, unknown>,
-      name: route.name == null ? null : String(route.name),
-      params: JSON.parse(JSON.stringify(route.params ?? {})) as Record<string, unknown>,
-      path: route.path,
-    };
-  });
-}
-
-async function navigateWithNuxtRouter(page: Page, path: string): Promise<void> {
-  await page.evaluate(async (targetPath) => {
-    const root = document.querySelector("#__nuxt") as {
-      __vue_app__?: {
-        config?: {
-          globalProperties?: {
-            $router?: {
-              push?: (target: string) => Promise<unknown> | void;
-            };
-          };
-        };
-      };
-    } | null;
-    const router = root?.__vue_app__?.config?.globalProperties?.$router;
-    if (typeof router?.push !== "function") {
-      throw new Error("Nuxt router is not available");
-    }
-
-    await router.push(targetPath);
-  }, path);
-}
 
 test.describe("npmx.dev dev", () => {
   let devServer: ChildProcess;
@@ -211,6 +132,14 @@ test.describe("npmx.dev dev", () => {
     expect(route.params).toMatchObject({
       path: ["nuxt", "v", "4.0.0"],
     });
+  });
+
+  test("authored head macros stay exact across SSR, hydration, and navigation", async ({
+    page,
+  }) => {
+    const hydrationErrors = await collectHydrationErrors(page);
+    await verifyNpmxHeadMacros(page, app.url, app.cwd);
+    expect(hydrationErrors).toEqual([]);
   });
 
   test("server logs stay clean during docs prefetch", async ({ page }) => {

--- a/tests/tooling/npmx-head-macros.test.ts
+++ b/tests/tooling/npmx-head-macros.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  assertNpmxHeadMacroAnchors,
+  NPMX_HEAD_SOURCE_CONTRACTS,
+} from "../app/dev/npmx-head-contract.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function validSyntheticSources(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(NPMX_HEAD_SOURCE_CONTRACTS).map(([relativePath, contract]) => [
+      relativePath,
+      contract.anchors.join("\n"),
+    ]),
+  );
+}
+
+test("npmx authored head macro contracts fail closed for every macro family", () => {
+  assert.doesNotThrow(() => assertNpmxHeadMacroAnchors(validSyntheticSources()));
+
+  for (const [relativePath, anchor] of [
+    ["app/pages/package-docs/[...path].vue", "definePageMeta({"],
+    ["app/app.vue", "useHead({"],
+    ["app/pages/about.vue", "useSeoMeta({"],
+  ] as const) {
+    const sources = validSyntheticSources();
+    sources[relativePath] = sources[relativePath]!.replace(anchor, "disabledMacro({");
+    assert.throws(
+      () => assertNpmxHeadMacroAnchors(sources),
+      new RegExp(`missing npmx head macro anchor.*${anchor.replace(/[(){}]/g, "\\$&")}`),
+    );
+  }
+});
+
+test("npmx head runtime oracle is wired and cannot mutate authored sources", () => {
+  const spec = fs.readFileSync(path.join(root, "tests/app/dev/npmx.spec.ts"), "utf8");
+  const runtimeOracle = fs.readFileSync(
+    path.join(root, "tests/app/dev/npmx-head-macros.ts"),
+    "utf8",
+  );
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(root, "tests/package.json"), "utf8"),
+  ) as {
+    scripts?: Record<string, string>;
+  };
+
+  assert.match(spec, /verifyNpmxHeadMacros\(page, app\.url, app\.cwd\)/);
+  assert.match(packageJson.scripts?.["test:dev:npmx"] ?? "", /app\/dev\/npmx\.spec\.ts/);
+  assert.match(packageJson.scripts?.["test:dev:ci"] ?? "", /app\/dev\/npmx\.spec\.ts/);
+  assert.doesNotMatch(
+    runtimeOracle,
+    /\b(?:appendFile|copyFile|rename|rm|truncate|unlink|writeFile)(?:Sync)?\b/,
+    "the SEO runtime oracle must remain read-only instead of relying on cleanup",
+  );
+  for (const evidence of [
+    "SSR request failed",
+    "package-docs/nuxt/v/4.0.0",
+    "package/docs/nuxt/v/4.0.0",
+    "docs/nuxt/v/4.0.0",
+    "https://npmx.dev/package/vue",
+    "readNpmxHeadSourceEvidence(fixtureRoot)",
+  ]) {
+    assert.ok(runtimeOracle.includes(evidence), `missing runtime evidence: ${evidence}`);
+  }
+});


### PR DESCRIPTION
## What changed

- pin the authored `definePageMeta`, `useHead`, and `useSeoMeta` sources by exact SHA and macro anchors
- verify SSR, hydration, client navigation, route aliases, canonical URLs, social metadata, and stale-tag removal in the real npmx Nuxt app
- fail closed if the oracle is disconnected or attempts to mutate the authored fixture

## Validation

- `node --test tests/tooling/npmx-head-macros.test.ts`
- `vp run --workspace-root check:repo`
- `moon run --target native tools/moon/cmd/source_file_lengths -- --check --base-ref origin/main`
- `VIZE_TEST_WORKTREE_ID=codex-4103 npx playwright test --config app/playwright.config.ts app/dev/npmx.spec.ts --grep 'authored head macros' --retries=0`

Closes #4103
