### PR TITLE
test(matrix): classify transitive checked sources

### DIFF
--- a/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
@@ -4,6 +4,15 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  summarizeTypecheckerCoverage,
+  validateTypecheckerOutput,
+} from "../../../tools/fixtures/tool-matrix-typechecker.mjs";
+import {
+  collectTypecheckerAuthoredPaths,
+  collectVueInputPaths,
+} from "../../../tools/fixtures/tool-matrix-inputs.mjs";
+
 /**
  * Scaffolding shared by every `tools/fixtures/typecheck-divergence-report.mjs`
  * test. It lives here rather than in one test file so a second suite can drive
@@ -94,6 +103,13 @@ export function setup(options: FixtureOptions = {}) {
   // `vize check` exits 0 only when it found nothing, and the matrix summary
   // status is derived from that, so a fixture with no diagnostics has to agree.
   const exitCode = vizeDiagnostics.length === 0 ? 0 : 1;
+  const typecheckerCoverage = validateTypecheckerOutput(
+    project,
+    parsed,
+    exitCode,
+    ["src/App.vue"],
+    ["src/App.vue"],
+  );
   writeJson(outputPath, {
     schema: "vize.fixtureToolRun",
     version: 1,
@@ -103,10 +119,11 @@ export function setup(options: FixtureOptions = {}) {
     stdout: JSON.stringify(parsed),
     stderr: "",
     parsed,
+    typecheckerCoverage,
   });
   writeJson(path.join(reportDir, "summary.json"), {
     schema: "vize.fixtureToolMatrixReport",
-    version: 2,
+    version: 3,
     evidence: {
       commitSha,
       runtime: { name: "node", version: process.versions.node },
@@ -129,6 +146,7 @@ export function setup(options: FixtureOptions = {}) {
             exitCode,
             fileCount: 1,
             outputPath: path.relative(root, outputPath),
+            coverage: summarizeTypecheckerCoverage(typecheckerCoverage),
           },
         ],
       },
@@ -189,6 +207,30 @@ export function cleanup(fixture: ReturnType<typeof setup>) {
 
 export function readJson(pathname: string) {
   return JSON.parse(fs.readFileSync(pathname, "utf8"));
+}
+
+export function updateVizeOutput(
+  fixture: ReturnType<typeof setup>,
+  mutate: (parsed: Record<string, any>) => void,
+) {
+  const payload = readJson(fixture.outputPath);
+  mutate(payload.parsed);
+  payload.stdout = JSON.stringify(payload.parsed);
+  const project = readJson(fixture.registryPath).projects[0];
+  payload.typecheckerCoverage = validateTypecheckerOutput(
+    project,
+    payload.parsed,
+    payload.exitCode,
+    collectVueInputPaths(fixture.fixtureRoot, project.vueGlobs),
+    collectTypecheckerAuthoredPaths(fixture.fixtureRoot),
+  );
+  writeJson(fixture.outputPath, payload);
+
+  const summaryPath = path.join(fixture.reportDir, "summary.json");
+  const summary = readJson(summaryPath);
+  summary.projects[0].runs[0].fileCount = payload.parsed.fileCount;
+  summary.projects[0].runs[0].coverage = summarizeTypecheckerCoverage(payload.typecheckerCoverage);
+  writeJson(summaryPath, summary);
 }
 
 export function writeJson(pathname: string, value: unknown) {

--- a/tests/tooling/fixture-tool-matrix-report.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report.test.ts
@@ -33,7 +33,7 @@ test("fixture tool matrix plans every registered project across all four require
     assert.equal(result.status, 0, result.stderr);
     const report = JSON.parse(fs.readFileSync(path.join(outputDir, "summary.json"), "utf8"));
     assert.equal(report.schema, "vize.fixtureToolMatrixReport");
-    assert.equal(report.version, 2);
+    assert.equal(report.version, 3);
     assert.match(report.evidence.commitSha, /^[0-9a-f]{40}$/);
     assert.deepEqual(Object.keys(report.evidence).sort(), ["commitSha", "machine", "runtime"]);
     assert.deepEqual(Object.keys(report.evidence.runtime).sort(), ["name", "version"]);
@@ -55,7 +55,10 @@ test("fixture tool matrix plans every registered project across all four require
     assert.match(markdown, new RegExp(`Commit: ${report.evidence.commitSha}`));
     assert.match(markdown, /Runtime: node \d+\.\d+\.\d+/);
     assert.match(markdown, /Machine: [^/]+\/[^,]+, \d+ logical CPUs, \d+ bytes memory/);
-    assert.match(markdown, /\| Project \| Tool \| Status \| Exit \| Files \| Duration \(ms\) \|/);
+    assert.match(
+      markdown,
+      /\| Project \| Tool \| Status \| Exit \| Files \| Requested \| Transitive \| Duration \(ms\) \|/,
+    );
     assert.equal(report.summary.projectCount, 134);
     assert.equal(report.summary.toolCount, 4);
     assert.equal(report.summary.runCount, 536);
@@ -67,7 +70,10 @@ test("fixture tool matrix plans every registered project across all four require
         ["compiler", "typechecker", "linter", "formatter"],
         `${project.id} should exercise every requested tool`,
       );
-      for (const entry of project.runs) assert.equal(entry.fileCount, null);
+      for (const entry of project.runs) {
+        assert.equal(entry.fileCount, null);
+        assert.equal(entry.coverage, null);
+      }
     }
   } finally {
     fs.rmSync(outputDir, { recursive: true, force: true });

--- a/tests/tooling/fixture-tool-matrix-report.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report.test.ts
@@ -55,10 +55,8 @@ test("fixture tool matrix plans every registered project across all four require
     assert.match(markdown, new RegExp(`Commit: ${report.evidence.commitSha}`));
     assert.match(markdown, /Runtime: node \d+\.\d+\.\d+/);
     assert.match(markdown, /Machine: [^/]+\/[^,]+, \d+ logical CPUs, \d+ bytes memory/);
-    assert.match(
-      markdown,
-      /\| Project \| Tool \| Status \| Exit \| Files \| Requested \| Transitive \| Duration \(ms\) \|/,
-    );
+    assert.match(markdown, /\bRequested\b/);
+    assert.match(markdown, /\bTransitive\b/);
     assert.equal(report.summary.projectCount, 134);
     assert.equal(report.summary.toolCount, 4);
     assert.equal(report.summary.runCount, 536);

--- a/tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts
@@ -159,14 +159,20 @@ test("fixture matrix writes exact raw and compact transitive coverage evidence",
   const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-matrix-coverage-"));
   const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-matrix-coverage-report-"));
   const executable = path.join(fakeDir, "fake-vize.mjs");
+  fs.mkdirSync(path.join(fixtureDir, ".storybook"), { recursive: true });
+  fs.mkdirSync(path.join(fixtureDir, ".yarn", "cache"), { recursive: true });
+  fs.mkdirSync(path.join(fixtureDir, "node_modules", "pkg"), { recursive: true });
   fs.mkdirSync(path.join(fixtureDir, "src"), { recursive: true });
   fs.mkdirSync(path.join(fixtureDir, "packages"), { recursive: true });
+  fs.writeFileSync(path.join(fixtureDir, ".storybook", "Hidden.ts"), "export {};\n");
+  fs.writeFileSync(path.join(fixtureDir, ".yarn", "cache", "Injected.ts"), "export {};\n");
+  fs.writeFileSync(path.join(fixtureDir, "node_modules", "pkg", "Injected.ts"), "export {};\n");
   fs.writeFileSync(path.join(fixtureDir, "src", "App.vue"), "<template />\n");
   fs.writeFileSync(path.join(fixtureDir, "packages", "Dep.ts"), "export {};\n");
   fs.writeFileSync(
     executable,
     `#!/usr/bin/env node\nprocess.stdout.write(JSON.stringify(${JSON.stringify(
-      output(["packages/Dep.ts", "src/App.vue"]),
+      output([".storybook/Hidden.ts", "packages/Dep.ts", "src/App.vue"]),
     )}));\n`,
   );
   fs.chmodSync(executable, 0o755);
@@ -187,13 +193,17 @@ test("fixture matrix writes exact raw and compact transitive coverage evidence",
     assert.deepEqual(run.coverage, {
       requestedFileCount: 1,
       requestedSha256: digest(["src/App.vue"]),
-      transitiveAuthoredFileCount: 1,
-      transitiveAuthoredSha256: digest(["packages/Dep.ts"]),
-      checkedFileCount: 2,
-      checkedSha256: digest(["packages/Dep.ts", "src/App.vue"]),
+      transitiveAuthoredFileCount: 2,
+      transitiveAuthoredSha256: digest([".storybook/Hidden.ts", "packages/Dep.ts"]),
+      checkedFileCount: 3,
+      checkedSha256: digest([".storybook/Hidden.ts", "packages/Dep.ts", "src/App.vue"]),
     });
     const raw = JSON.parse(fs.readFileSync(path.resolve(root, run.outputPath as string), "utf8"));
-    assert.deepEqual(raw.typecheckerCoverage.checked.files, ["packages/Dep.ts", "src/App.vue"]);
+    assert.deepEqual(raw.typecheckerCoverage.checked.files, [
+      ".storybook/Hidden.ts",
+      "packages/Dep.ts",
+      "src/App.vue",
+    ]);
   } finally {
     fs.rmSync(fixtureDir, { recursive: true, force: true });
     fs.rmSync(fakeDir, { recursive: true, force: true });

--- a/tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { runTool } from "../../tools/fixtures/tool-matrix-run.mjs";
+import {
+  summarizeTypecheckerCoverage,
+  validateTypecheckerOutput,
+} from "../../tools/fixtures/tool-matrix-typechecker.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const project = { id: "coverage", expectedVueFileCount: 1 };
+
+function digest(files: string[]) {
+  const hash = createHash("sha256");
+  for (const file of files) hash.update(file).update("\0");
+  return hash.digest("hex");
+}
+
+function output(files: string[]) {
+  return {
+    errorCount: 0,
+    warningCount: 0,
+    fileCount: files.length,
+    files: files.map((file) => ({ file, diagnostics: [] })),
+  };
+}
+
+test("typechecker coverage partitions requested and transitive authored sources", () => {
+  const requested = ["src/App.vue"];
+  const transitive = ["packages/Dep.ts", "packages/render.jsx"];
+  const checked = [...transitive, ...requested];
+  const coverage = validateTypecheckerOutput(project, output(checked), 0, requested, checked);
+
+  assert.deepEqual(coverage, {
+    schema: "vize.fixtureTypecheckerCoverage",
+    version: 1,
+    requested: { fileCount: 1, files: requested, sha256: digest(requested) },
+    transitiveAuthored: { fileCount: 2, files: transitive, sha256: digest(transitive) },
+    checked: { fileCount: 3, files: checked, sha256: digest(checked) },
+  });
+  assert.deepEqual(summarizeTypecheckerCoverage(coverage), {
+    requestedFileCount: 1,
+    requestedSha256: digest(requested),
+    transitiveAuthoredFileCount: 2,
+    transitiveAuthoredSha256: digest(transitive),
+    checkedFileCount: 3,
+    checkedSha256: digest(checked),
+  });
+
+  const added = ["packages/Dep.ts", "packages/Extra.mts", "packages/render.jsx", "src/App.vue"];
+  const expanded = validateTypecheckerOutput(project, output(added), 0, requested, added);
+  assert.deepEqual(expanded.requested, coverage.requested);
+  assert.notDeepEqual(expanded.transitiveAuthored, coverage.transitiveAuthored);
+  assert.notDeepEqual(expanded.checked, coverage.checked);
+});
+
+test("typechecker coverage accepts the closed authored source extension set", () => {
+  const requested = ["src/App.vue"];
+  const checked = [
+    "src/App.vue",
+    "src/ambient.d.ts",
+    "src/common.cjs",
+    "src/common.cts",
+    "src/entry.js",
+    "src/entry.jsx",
+    "src/module.mjs",
+    "src/module.mts",
+    "src/source.ts",
+    "src/view.tsx",
+  ];
+  const coverage = validateTypecheckerOutput(project, output(checked), 0, requested, checked);
+  assert.equal(coverage.transitiveAuthored.fileCount, checked.length - requested.length);
+});
+
+test("typechecker coverage fails closed on missing, substituted, or unclassified sources", () => {
+  assert.throws(
+    () =>
+      validateTypecheckerOutput(
+        project,
+        output(["src/App.vue"]),
+        0,
+        ["src/App.vue", "src/Card.vue"],
+        ["src/App.vue", "src/Card.vue"],
+      ),
+    /missing requested fixture inputs: \[src\/Card\.vue\]/,
+  );
+  assert.throws(
+    () =>
+      validateTypecheckerOutput(
+        project,
+        output(["src/App.vue"]),
+        0,
+        ["src/Other.vue"],
+        ["src/App.vue", "src/Other.vue"],
+      ),
+    /missing requested fixture inputs: \[src\/Other\.vue\]/,
+  );
+  assert.throws(
+    () =>
+      validateTypecheckerOutput(
+        project,
+        output(["node_modules/pkg/Injected.ts", "src/App.vue"]),
+        0,
+        ["src/App.vue"],
+        ["src/App.vue"],
+      ),
+    /transitive files are not authored fixture sources: \[node_modules\/pkg\/Injected\.ts\]/,
+  );
+  assert.throws(
+    () =>
+      validateTypecheckerOutput(
+        project,
+        output(["src/App.vue", "src/data.json"]),
+        0,
+        ["src/App.vue"],
+        ["src/App.vue", "src/data.json"],
+      ),
+    /unsupported typecheck extension: src\/data\.json/,
+  );
+});
+
+test("typechecker coverage rejects malformed manifests and digest mutations", () => {
+  const valid = validateTypecheckerOutput(
+    project,
+    output(["packages/Dep.ts", "src/App.vue"]),
+    0,
+    ["src/App.vue"],
+    ["packages/Dep.ts", "src/App.vue"],
+  );
+  for (const [name, mutate, message] of [
+    ["duplicate", (value: any) => value.requested.files.push("src/App.vue"), /duplicate file/],
+    ["order", (value: any) => value.checked.files.reverse(), /files are not sorted/],
+    ["traversal", (value: any) => (value.checked.files[0] = "../Dep.vue"), /normalized relative/],
+    ["digest", (value: any) => (value.checked.sha256 = "0".repeat(64)), /sha256 is inconsistent/],
+    ["count", (value: any) => (value.checked.fileCount = 1), /fileCount is inconsistent/],
+    [
+      "partition",
+      (value: any) => {
+        value.transitiveAuthored.files = [];
+        value.transitiveAuthored.fileCount = 0;
+        value.transitiveAuthored.sha256 = digest([]);
+      },
+      /classes do not partition checked files/,
+    ],
+  ] as const) {
+    const mutated = structuredClone(valid);
+    mutate(mutated);
+    assert.throws(() => summarizeTypecheckerCoverage(mutated), message, name);
+  }
+});
+
+test("fixture matrix writes exact raw and compact transitive coverage evidence", () => {
+  const fixtureDir = fs.mkdtempSync(path.join(root, "tests", "_fixtures", "matrix-coverage-"));
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-matrix-coverage-"));
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-matrix-coverage-report-"));
+  const executable = path.join(fakeDir, "fake-vize.mjs");
+  fs.mkdirSync(path.join(fixtureDir, "src"), { recursive: true });
+  fs.mkdirSync(path.join(fixtureDir, "packages"), { recursive: true });
+  fs.writeFileSync(path.join(fixtureDir, "src", "App.vue"), "<template />\n");
+  fs.writeFileSync(path.join(fixtureDir, "packages", "Dep.ts"), "export {};\n");
+  fs.writeFileSync(
+    executable,
+    `#!/usr/bin/env node\nprocess.stdout.write(JSON.stringify(${JSON.stringify(
+      output(["packages/Dep.ts", "src/App.vue"]),
+    )}));\n`,
+  );
+  fs.chmodSync(executable, 0o755);
+
+  try {
+    const run = runTool(
+      {
+        id: "coverage-fixture",
+        fixturePath: path.relative(root, fixtureDir),
+        vueGlobs: ["src/**/*.vue"],
+      },
+      "typechecker",
+      { dryRun: false, timeoutMs: 5_000 },
+      { command: executable, prefix: [], label: executable },
+      reportDir,
+    );
+    assert.equal(run.status, "ok");
+    assert.deepEqual(run.coverage, {
+      requestedFileCount: 1,
+      requestedSha256: digest(["src/App.vue"]),
+      transitiveAuthoredFileCount: 1,
+      transitiveAuthoredSha256: digest(["packages/Dep.ts"]),
+      checkedFileCount: 2,
+      checkedSha256: digest(["packages/Dep.ts", "src/App.vue"]),
+    });
+    const raw = JSON.parse(fs.readFileSync(path.resolve(root, run.outputPath as string), "utf8"));
+    assert.deepEqual(raw.typecheckerCoverage.checked.files, ["packages/Dep.ts", "src/App.vue"]);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/fixture-tool-matrix-typechecker.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typechecker.test.ts
@@ -74,13 +74,13 @@ test("typechecker oracle requires every fixture input and rejects substitutions"
         "src/App.vue",
         "src/Card.vue",
       ]),
-    /checked file count 1 does not match 2 fixture inputs/,
+    /checked files are missing requested fixture inputs: \[src\/Card\.vue\]/,
   );
 
   const substituted = validOutput();
   assert.throws(
     () => validateTypecheckerOutput({ id: "substituted" }, substituted, 1, ["src/Other.vue"]),
-    /checked files do not match fixture inputs: missing \[src\/Other\.vue\], unexpected \[src\/App\.vue\]/,
+    /checked files are missing requested fixture inputs: \[src\/Other\.vue\]/,
   );
 });
 
@@ -298,9 +298,15 @@ process.stdout.write(JSON.stringify({ files: [{ file: "src/App.vue", diagnostics
       reportDir,
     );
     assert.equal(run.status, "failed");
-    assert.match(run.failure, /checked file count 1 does not match 2 fixture inputs/);
+    assert.match(
+      run.failure,
+      /checked files are missing requested fixture inputs: \[src\/Card\.vue\]/,
+    );
     const raw = JSON.parse(fs.readFileSync(path.resolve(root, run.outputPath as string), "utf8"));
-    assert.match(raw.validationError, /checked file count 1 does not match 2 fixture inputs/);
+    assert.match(
+      raw.validationError,
+      /checked files are missing requested fixture inputs: \[src\/Card\.vue\]/,
+    );
   } finally {
     fs.rmSync(fixtureDir, { recursive: true, force: true });
     fs.rmSync(fakeDir, { recursive: true, force: true });

--- a/tests/tooling/typecheck-divergence-baseline.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline.test.ts
@@ -14,6 +14,7 @@ import {
   setup,
   sharedVizeDiagnostic,
   unusableFailure,
+  updateVizeOutput,
 } from "./_helpers/typecheck-divergence-report-fixture.ts";
 
 /**
@@ -184,17 +185,11 @@ test("a diagnostic-free baseline is a real breach when it covered every Vue file
 test("a partially covered Vue corpus is unusable even when diagnostics overlap", () => {
   const fixture = setup();
   try {
-    const payload = readJson(fixture.outputPath);
-    payload.parsed.fileCount = 2;
-    payload.parsed.files.splice(1, 0, { file: "src/Other.vue", diagnostics: [] });
-    payload.stdout = JSON.stringify(payload.parsed);
-    fs.writeFileSync(fixture.outputPath, `${JSON.stringify(payload, null, 2)}\n`);
-    const summary = readJson(path.join(fixture.reportDir, "summary.json"));
-    summary.projects[0].runs[0].fileCount = 2;
-    fs.writeFileSync(
-      path.join(fixture.reportDir, "summary.json"),
-      `${JSON.stringify(summary, null, 2)}\n`,
-    );
+    fs.writeFileSync(path.join(fixture.fixtureRoot, "src", "Other.vue"), "<template />\n");
+    updateVizeOutput(fixture, (parsed) => {
+      parsed.fileCount = 2;
+      parsed.files.splice(1, 0, { file: "src/Other.vue", diagnostics: [] });
+    });
 
     const result = run(fixture);
     assert.equal(result.status, 1);

--- a/tests/tooling/typecheck-divergence-baseline.test.ts
+++ b/tests/tooling/typecheck-divergence-baseline.test.ts
@@ -219,6 +219,30 @@ test("same-sized but different Vue corpora are unusable", () => {
   }
 });
 
+test("transitive authored TypeScript sources stay out of the Vue corpus comparison", () => {
+  const fixture = setup();
+  try {
+    fs.writeFileSync(
+      path.join(fixture.fixtureRoot, "src", "helper.ts"),
+      "export const helper = 1;\n",
+    );
+    updateVizeOutput(fixture, (parsed) => {
+      parsed.fileCount = 2;
+      parsed.files.push({ file: "src/helper.ts", diagnostics: [] });
+    });
+
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    const coverage = readJson(artifactPath(fixture, "json")).baseline.coverage;
+    assert.equal(coverage.verdict, "usable");
+    assert.equal(coverage.vizeVueFileCount, 1);
+    assert.deepEqual(coverage.missingVueFiles, []);
+    assert.deepEqual(coverage.unexpectedVueFiles, []);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
 test("transitive Vue dependencies do not expand the authored fixture corpus", () => {
   const fixture = setup({
     baselineFiles: ["src/App.vue", "node_modules/pkg/RuntimeComponent.vue"],

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -214,6 +214,35 @@ test("typecheck divergence report rejects a mismatched matrix file count", () =>
   }
 });
 
+test("typecheck divergence report rejects mutated raw typechecker coverage", () => {
+  const fixture = setup();
+  try {
+    updateJson(fixture.outputPath, (payload) => {
+      payload.typecheckerCoverage.checked.sha256 = "0".repeat(64);
+    });
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /typechecker coverage is inconsistent/);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("typecheck divergence report rejects mutated summary coverage", () => {
+  const fixture = setup();
+  try {
+    const summaryPath = path.join(fixture.reportDir, "summary.json");
+    updateJson(summaryPath, (summary) => {
+      summary.projects[0].runs[0].coverage.requestedFileCount = 0;
+    });
+    const result = run(fixture);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /summary coverage is inconsistent/);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
 test("typecheck divergence report rejects a mismatched matrix status", () => {
   const fixture = setup();
   try {

--- a/tools/fixtures/tool-matrix-command.mjs
+++ b/tools/fixtures/tool-matrix-command.mjs
@@ -1,0 +1,41 @@
+export function toolArgs(project, tool, compilerOutputDir) {
+  if (tool === "compiler") {
+    return [
+      "build",
+      ...project.vueGlobs,
+      "--format",
+      "json",
+      "--output",
+      compilerOutputDir,
+      "--template-syntax",
+      "quirks",
+      "--continue-on-error",
+      "--no-config",
+    ];
+  }
+  if (tool === "linter") {
+    return [
+      "lint",
+      ...project.vueGlobs,
+      "--format",
+      "json",
+      "--preset",
+      "ecosystem",
+      "--no-config",
+    ];
+  }
+  if (tool === "typechecker") {
+    const args = ["check", ...project.vueGlobs, "--format", "json", "--no-config"];
+    if (project.tsconfig != null) args.push("--tsconfig", project.tsconfig);
+    return args;
+  }
+  return ["fmt", ...project.vueGlobs, "--check", "--no-config"];
+}
+
+export function displayCommand(command, args) {
+  return [command, ...args].map(shellQuote).join(" ");
+}
+
+function shellQuote(value) {
+  return /^[A-Za-z0-9_./:=@*-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
+}

--- a/tools/fixtures/tool-matrix-inputs.mjs
+++ b/tools/fixtures/tool-matrix-inputs.mjs
@@ -3,16 +3,16 @@ import { globSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 
 const typecheckerAuthoredGlobs = [
-  "**/*.vue",
-  "**/*.ts",
-  "**/*.tsx",
-  "**/*.mts",
-  "**/*.cts",
-  "**/*.js",
-  "**/*.jsx",
-  "**/*.mjs",
-  "**/*.cjs",
-];
+  "vue",
+  "ts",
+  "tsx",
+  "mts",
+  "cts",
+  "js",
+  "jsx",
+  "mjs",
+  "cjs",
+].flatMap((extension) => [`**/*.${extension}`, `**/.*/**/*.${extension}`]);
 
 export function collectVueInputPaths(cwd, patterns) {
   return [

--- a/tools/fixtures/tool-matrix-inputs.mjs
+++ b/tools/fixtures/tool-matrix-inputs.mjs
@@ -2,6 +2,18 @@ import { Buffer } from "node:buffer";
 import { globSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 
+const typecheckerAuthoredGlobs = [
+  "**/*.vue",
+  "**/*.ts",
+  "**/*.tsx",
+  "**/*.mts",
+  "**/*.cts",
+  "**/*.js",
+  "**/*.jsx",
+  "**/*.mjs",
+  "**/*.cjs",
+];
+
 export function collectVueInputPaths(cwd, patterns) {
   return [
     ...new Set(
@@ -15,4 +27,8 @@ export function collectVueInputPaths(cwd, patterns) {
     .map((file) => ({ file, bytes: Buffer.from(file) }))
     .sort((left, right) => Buffer.compare(left.bytes, right.bytes))
     .map(({ file }) => file);
+}
+
+export function collectTypecheckerAuthoredPaths(cwd) {
+  return collectVueInputPaths(cwd, typecheckerAuthoredGlobs);
 }

--- a/tools/fixtures/tool-matrix-report.mjs
+++ b/tools/fixtures/tool-matrix-report.mjs
@@ -43,7 +43,7 @@ function main() {
 
   const report = {
     schema,
-    version: 2,
+    version: 3,
     generatedAt: new Date().toISOString(),
     evidence: collectEvidence(),
     registryPath: relative(repoRoot, registryPath),
@@ -186,13 +186,13 @@ function renderMarkdown(report) {
     `Runtime: ${report.evidence.runtime.name} ${report.evidence.runtime.version}`,
     `Machine: ${report.evidence.machine.platform}/${report.evidence.machine.arch}, ${report.evidence.machine.logicalCpuCount} logical CPUs, ${report.evidence.machine.totalMemoryBytes} bytes memory`,
     "",
-    "| Project | Tool | Status | Exit | Files | Duration (ms) | Output |",
-    "| --- | --- | --- | ---: | ---: | ---: | --- |",
+    "| Project | Tool | Status | Exit | Files | Requested | Transitive | Duration (ms) | Output |",
+    "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |",
   ];
   for (const project of report.projects) {
     for (const run of project.runs) {
       lines.push(
-        `| ${project.id} | ${run.tool} | ${run.status} | ${run.exitCode ?? "-"} | ${run.fileCount ?? "-"} | ${run.durationMs} | ${run.outputPath == null ? "-" : `\`${run.outputPath}\``} |`,
+        `| ${project.id} | ${run.tool} | ${run.status} | ${run.exitCode ?? "-"} | ${run.fileCount ?? "-"} | ${run.coverage?.requestedFileCount ?? "-"} | ${run.coverage?.transitiveAuthoredFileCount ?? "-"} | ${run.durationMs} | ${run.outputPath == null ? "-" : `\`${run.outputPath}\``} |`,
       );
     }
   }

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -15,11 +15,15 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { expectedCompilerOutputs } from "./tool-matrix-compiler-paths.mjs";
+import { displayCommand, toolArgs } from "./tool-matrix-command.mjs";
 import { snapshotFormatterInputs, validateFormatterOutput } from "./tool-matrix-formatter.mjs";
-import { collectVueInputPaths } from "./tool-matrix-inputs.mjs";
+import { collectTypecheckerAuthoredPaths, collectVueInputPaths } from "./tool-matrix-inputs.mjs";
 import { validateLinterOutput } from "./tool-matrix-linter.mjs";
 import { validatedFileCount } from "./tool-matrix-metrics.mjs";
-import { validateTypecheckerOutput } from "./tool-matrix-typechecker.mjs";
+import {
+  summarizeTypecheckerCoverage,
+  validateTypecheckerOutput,
+} from "./tool-matrix-typechecker.mjs";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 export function runTool(project, tool, args, launch, outputDir) {
@@ -41,6 +45,7 @@ export function runTool(project, tool, args, launch, outputDir) {
     fileCount: null,
     exitCode: null,
     outputPath: null,
+    coverage: null,
   };
   if (args.dryRun) return { ...base, status: "planned" };
   if (!fixtureExists) return { ...base, status: "missing-fixture" };
@@ -50,7 +55,6 @@ export function runTool(project, tool, args, launch, outputDir) {
     tool === "typechecker" || tool === "linter" || tool === "formatter"
       ? collectVueInputPaths(cwd, project.vueGlobs)
       : null;
-
   try {
     const startedAt = Date.now();
     const result = spawnSync(launch.command, commandArgs, {
@@ -97,7 +101,13 @@ export function runTool(project, tool, args, launch, outputDir) {
       }
       if (tool === "typechecker" && payload.parseError == null) {
         try {
-          validateTypecheckerOutput(project, payload.parsed, result.status, expectedToolFiles);
+          payload.typecheckerCoverage = validateTypecheckerOutput(
+            project,
+            payload.parsed,
+            result.status,
+            expectedToolFiles,
+            collectTypecheckerAuthoredPaths(cwd),
+          );
         } catch (error) {
           payload.validationError = errorMessage(error);
         }
@@ -146,6 +156,8 @@ export function runTool(project, tool, args, launch, outputDir) {
     return {
       ...completed,
       fileCount: validatedFileCount(tool, payload),
+      coverage:
+        tool === "typechecker" ? summarizeTypecheckerCoverage(payload.typecheckerCoverage) : null,
       status: result.status === 0 ? "ok" : "findings",
     };
   } finally {
@@ -281,40 +293,6 @@ function validateCompilerArtifact(outputPath, artifact, inputPath) {
   }
 }
 
-function toolArgs(project, tool, compilerOutputDir) {
-  if (tool === "compiler") {
-    return [
-      "build",
-      ...project.vueGlobs,
-      "--format",
-      "json",
-      "--output",
-      compilerOutputDir,
-      "--template-syntax",
-      "quirks",
-      "--continue-on-error",
-      "--no-config",
-    ];
-  }
-  if (tool === "linter") {
-    return [
-      "lint",
-      ...project.vueGlobs,
-      "--format",
-      "json",
-      "--preset",
-      "ecosystem",
-      "--no-config",
-    ];
-  }
-  if (tool === "typechecker") {
-    const args = ["check", ...project.vueGlobs, "--format", "json", "--no-config"];
-    if (project.tsconfig != null) args.push("--tsconfig", project.tsconfig);
-    return args;
-  }
-  return ["fmt", ...project.vueGlobs, "--check", "--no-config"];
-}
-
 export function resolveVizeLaunch(vizeBin, dryRun) {
   const candidates = [
     vizeBin,
@@ -353,10 +331,4 @@ function failureOutput(result) {
 }
 function truncate(value) {
   return value.length <= 4000 ? value : `${value.slice(0, 4000)}\n...<truncated>`;
-}
-function displayCommand(command, args) {
-  return [command, ...args].map(shellQuote).join(" ");
-}
-function shellQuote(value) {
-  return /^[A-Za-z0-9_./:=@*-]+$/.test(value) ? value : `'${value.replaceAll("'", "'\\''")}'`;
 }

--- a/tools/fixtures/tool-matrix-typechecker.mjs
+++ b/tools/fixtures/tool-matrix-typechecker.mjs
@@ -1,10 +1,18 @@
 import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
 import { isAbsolute } from "node:path";
 
 const outputKeys = ["errorCount", "fileCount", "files", "warningCount"];
 const fileKeys = ["diagnostics", "file"];
+const typecheckSourcePattern = /\.(?:vue|ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
 
-export function validateTypecheckerOutput(project, output, exitCode, expectedFiles = null) {
+export function validateTypecheckerOutput(
+  project,
+  output,
+  exitCode,
+  expectedFiles = null,
+  authoredFiles = expectedFiles,
+) {
   requireRecord(output, "envelope");
   requireExactKeys(output, outputKeys, "envelope");
   for (const field of ["errorCount", "warningCount", "fileCount"]) {
@@ -22,11 +30,6 @@ export function validateTypecheckerOutput(project, output, exitCode, expectedFil
   if (project.expectedVueFileCount !== 0 && output.fileCount === 0) {
     invalid("non-empty fixture checked zero Vue files");
   }
-  if (expectedFiles != null && output.fileCount !== expectedFiles.length) {
-    invalid(
-      `checked file count ${output.fileCount} does not match ${expectedFiles.length} fixture inputs`,
-    );
-  }
 
   const seenFiles = new Set();
   let errorCount = 0;
@@ -40,8 +43,11 @@ export function validateTypecheckerOutput(project, output, exitCode, expectedFil
     if (!Array.isArray(file.diagnostics)) {
       invalid(`files[${index}].diagnostics must be an array`);
     }
-    if (index < output.fileCount && !file.file.endsWith(".vue")) {
+    if (index < output.fileCount && expectedFiles == null && !file.file.endsWith(".vue")) {
       invalid(`checked file is not a Vue SFC: ${file.file}`);
+    }
+    if (index < output.fileCount && !typecheckSourcePattern.test(file.file)) {
+      invalid(`checked file has an unsupported typecheck extension: ${file.file}`);
     }
     if (index >= output.fileCount && file.diagnostics.length === 0) {
       invalid(`project-level file entry has no diagnostics: ${file.file}`);
@@ -64,14 +70,32 @@ export function validateTypecheckerOutput(project, output, exitCode, expectedFil
   if (JSON.stringify(checkedFiles) !== JSON.stringify(sortedFiles)) {
     invalid("checked file entries are not sorted");
   }
-  if (expectedFiles != null && JSON.stringify(checkedFiles) !== JSON.stringify(expectedFiles)) {
+  let requestedFiles = checkedFiles;
+  let transitiveAuthoredFiles = [];
+  if (expectedFiles != null) {
+    validateManifestInput(expectedFiles, "requested fixture inputs", isVueSfc);
+    validateManifestInput(authoredFiles, "authored fixture sources", isTypecheckSource);
     const checkedSet = new Set(checkedFiles);
     const expectedSet = new Set(expectedFiles);
     const missing = expectedFiles.filter((file) => !checkedSet.has(file));
-    const unexpected = checkedFiles.filter((file) => !expectedSet.has(file));
-    invalid(
-      `checked files do not match fixture inputs: missing [${missing.join(", ")}], unexpected [${unexpected.join(", ")}]`,
-    );
+    if (missing.length > 0) {
+      invalid(`checked files are missing requested fixture inputs: [${missing.join(", ")}]`);
+    }
+    const authoredSet = new Set(authoredFiles);
+    const missingAuthoredInputs = expectedFiles.filter((file) => !authoredSet.has(file));
+    if (missingAuthoredInputs.length > 0) {
+      invalid(
+        `requested fixture inputs are not authored sources: [${missingAuthoredInputs.join(", ")}]`,
+      );
+    }
+    transitiveAuthoredFiles = checkedFiles.filter((file) => !expectedSet.has(file));
+    const unclassified = transitiveAuthoredFiles.filter((file) => !authoredSet.has(file));
+    if (unclassified.length > 0) {
+      invalid(
+        `checked transitive files are not authored fixture sources: [${unclassified.join(", ")}]`,
+      );
+    }
+    requestedFiles = expectedFiles;
   }
   if (output.errorCount !== errorCount) {
     invalid(`errorCount ${output.errorCount} does not match ${errorCount} diagnostics`);
@@ -83,6 +107,89 @@ export function validateTypecheckerOutput(project, output, exitCode, expectedFil
   if (exitCode !== expectedExitCode) {
     invalid(`exit code ${exitCode} does not match expected ${expectedExitCode}`);
   }
+
+  return {
+    schema: "vize.fixtureTypecheckerCoverage",
+    version: 1,
+    requested: createManifest(requestedFiles),
+    transitiveAuthored: createManifest(transitiveAuthoredFiles),
+    checked: createManifest(checkedFiles),
+  };
+}
+
+export function summarizeTypecheckerCoverage(coverage) {
+  requireRecord(coverage, "typechecker coverage");
+  requireExactKeys(
+    coverage,
+    ["checked", "requested", "schema", "transitiveAuthored", "version"],
+    "typechecker coverage",
+  );
+  if (coverage.schema !== "vize.fixtureTypecheckerCoverage" || coverage.version !== 1) {
+    invalid("typechecker coverage schema is unsupported");
+  }
+  for (const key of ["requested", "transitiveAuthored", "checked"]) {
+    validateManifest(
+      coverage[key],
+      `typechecker coverage.${key}`,
+      key === "requested" ? isVueSfc : isTypecheckSource,
+    );
+  }
+  const combined = [...coverage.requested.files, ...coverage.transitiveAuthored.files].sort(
+    byteSort,
+  );
+  if (JSON.stringify(combined) !== JSON.stringify(coverage.checked.files)) {
+    invalid("typechecker coverage classes do not partition checked files");
+  }
+  return {
+    requestedFileCount: coverage.requested.fileCount,
+    requestedSha256: coverage.requested.sha256,
+    transitiveAuthoredFileCount: coverage.transitiveAuthored.fileCount,
+    transitiveAuthoredSha256: coverage.transitiveAuthored.sha256,
+    checkedFileCount: coverage.checked.fileCount,
+    checkedSha256: coverage.checked.sha256,
+  };
+}
+
+function createManifest(files) {
+  const digest = createHash("sha256");
+  for (const file of files) digest.update(file).update("\0");
+  return { fileCount: files.length, files: [...files], sha256: digest.digest("hex") };
+}
+
+function validateManifestInput(files, label, acceptsFile) {
+  if (!Array.isArray(files)) invalid(`${label} must be an array`);
+  const seen = new Set();
+  for (const [index, file] of files.entries()) {
+    requireRelativePath(file, `${label}[${index}]`);
+    if (!acceptsFile(file)) invalid(`${label}[${index}] has an unsupported source extension`);
+    if (seen.has(file)) invalid(`${label} contains duplicate file: ${file}`);
+    seen.add(file);
+  }
+  if (JSON.stringify(files) !== JSON.stringify([...files].sort(byteSort))) {
+    invalid(`${label} are not sorted`);
+  }
+}
+
+function validateManifest(manifest, label, acceptsFile) {
+  requireRecord(manifest, label);
+  requireExactKeys(manifest, ["fileCount", "files", "sha256"], label);
+  validateManifestInput(manifest.files, `${label}.files`, acceptsFile);
+  if (manifest.fileCount !== manifest.files.length) invalid(`${label}.fileCount is inconsistent`);
+  if (manifest.sha256 !== createManifest(manifest.files).sha256) {
+    invalid(`${label}.sha256 is inconsistent`);
+  }
+}
+
+function byteSort(left, right) {
+  return Buffer.compare(Buffer.from(left), Buffer.from(right));
+}
+
+function isVueSfc(file) {
+  return file.endsWith(".vue");
+}
+
+function isTypecheckSource(file) {
+  return typecheckSourcePattern.test(file);
 }
 
 function requireRecord(value, label) {

--- a/tools/fixtures/typecheck-baseline-coverage.mjs
+++ b/tools/fixtures/typecheck-baseline-coverage.mjs
@@ -5,12 +5,15 @@ import { isAbsolute, relative } from "node:path";
 /**
  * Prove that the diagnostic comparator ran over the same Vue corpus on both
  * sides. `vue-tsc --listFiles` prints absolute program paths after diagnostics;
- * Vize's matrix artifact already carries its sorted checked-file list.
+ * Vize's matrix artifact already carries its sorted checked-file list. That
+ * list also carries the transitive authored TS/TSX sources Vize pulled into the
+ * program, so only its `.vue` entries are comparable with the baseline set.
  */
 export function evaluateVueProgramCoverage(vizeReport, vueTscOutput, cwd) {
   const vizeVueFiles = vizeReport.files
     .slice(0, vizeReport.fileCount)
     .map((entry) => entry.file)
+    .filter((file) => file.endsWith(".vue"))
     .sort(byteOrder);
   const { authoredFiles: baselineVueFiles, dependencyFiles: baselineDependencyVueFiles } =
     collectVueTscProgramFiles(vueTscOutput, cwd);

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -5,7 +5,11 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { validateTypecheckerOutput } from "./tool-matrix-typechecker.mjs";
+import { collectTypecheckerAuthoredPaths, collectVueInputPaths } from "./tool-matrix-inputs.mjs";
+import {
+  summarizeTypecheckerCoverage,
+  validateTypecheckerOutput,
+} from "./tool-matrix-typechecker.mjs";
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
 import { evaluateBaselineConfiguration } from "./typecheck-baseline-configuration.mjs";
 import { materializeBaselineProject } from "./typecheck-baseline-project.mjs";
@@ -137,7 +141,7 @@ function readDocumentedDifferences() {
 
 function readAndValidateSummary(reportDir, project) {
   const summary = readJson(join(reportDir, "summary.json"));
-  if (summary.schema !== "vize.fixtureToolMatrixReport" || summary.version !== 2) {
+  if (summary.schema !== "vize.fixtureToolMatrixReport" || summary.version !== 3) {
     throw new Error("Fixture matrix summary schema is unsupported");
   }
   if (!/^[0-9a-f]{40}$/.test(summary.evidence?.commitSha ?? "")) {
@@ -181,6 +185,7 @@ function readAndValidateVizeRun(reportDir, project, summary) {
     "stderr",
     "stdout",
     "tool",
+    "typecheckerCoverage",
     "version",
   ];
   if (JSON.stringify(Object.keys(payload).sort()) !== JSON.stringify(expectedKeys)) {
@@ -206,13 +211,31 @@ function readAndValidateVizeRun(reportDir, project, summary) {
       `Fixture matrix typechecker stdout does not match parsed output for ${project.id}`,
     );
   }
-  validateTypecheckerOutput(project, payload.parsed, payload.exitCode);
+  const fixtureRoot = resolve(repoRoot, project.fixturePath);
+  const expectedCoverage = validateTypecheckerOutput(
+    project,
+    payload.parsed,
+    payload.exitCode,
+    collectVueInputPaths(fixtureRoot, project.vueGlobs),
+    collectTypecheckerAuthoredPaths(fixtureRoot),
+  );
+  if (canonicalJson(expectedCoverage) !== canonicalJson(payload.typecheckerCoverage)) {
+    throw new Error(`Fixture matrix typechecker coverage is inconsistent for ${project.id}`);
+  }
   const expectedStatus = payload.exitCode === 0 ? "ok" : "findings";
   if (runs[0].status !== expectedStatus) {
     throw new Error(`Fixture matrix typechecker status is inconsistent for ${project.id}`);
   }
   if (runs[0].fileCount !== payload.parsed.fileCount) {
     throw new Error(`Fixture matrix typechecker file count is inconsistent for ${project.id}`);
+  }
+  if (
+    canonicalJson(runs[0].coverage) !==
+    canonicalJson(summarizeTypecheckerCoverage(payload.typecheckerCoverage))
+  ) {
+    throw new Error(
+      `Fixture matrix typechecker summary coverage is inconsistent for ${project.id}`,
+    );
   }
   return {
     payload,


### PR DESCRIPTION
Closes #4130

## Summary
- replace the false checked-file == requested-Vue invariant with closed requested, transitive-authored, and checked manifests
- bind raw matrix evidence and compact summaries to sorted path lists, counts, and SHA-256 digests
- fail closed on missing requested SFCs, unsupported or dependency paths, malformed partitions, and stale divergence reports

## Validation
- focused tooling tests: 42 passed
- vp run check:repo: 2166 formatted, 1542 linted, 0 warnings
- source length gate: no new or grown file over 350 lines
- git diff --check
- hydrated Naive UI proof: 1708 requested Vue + 1255 transitive authored TS/TSX = 2963 checked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typechecker coverage reporting for requested, authored, and transitive files.
  * Expanded tool-matrix reports with requested and transitive coverage details.
  * Added command generation for compiler, linter, typechecker, and formatter modes.

* **Bug Fixes**
  * Improved validation of malformed, missing, inconsistent, or tampered coverage data.
  * Improved handling of supported TypeScript and JavaScript file extensions.

* **Tests**
  * Added comprehensive coverage scenarios and report consistency checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->