### PR TITLE
fix(ci): run Nuxt stress oracle in source coverage

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -413,13 +413,13 @@ jobs:
   source-coverage:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 40
-    # cargo llvm-cov against the whole workspace runs ~4–6 minutes. Coverage is
-    # a trend metric, not a per-PR signal: one PR rarely moves workspace-wide
-    # percentages. Run on push-to-main and on the daily schedule; the
+    # cargo llvm-cov runs ~4–6 minutes and is a trend metric, not a per-PR signal:
+    # run on push-to-main and daily because one PR rarely moves global percentages; the
     # fixture-coverage job (`coverage`) and compiler/lint suites still run per-PR.
     if: ${{ github.event_name != 'pull_request' }}
     env:
       NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+      VIZE_NUXT_CONFIG_ITERATIONS: "100"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -358,6 +358,8 @@ jobs:
   clippy-and-test:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 45
+    env:
+      VIZE_NUXT_CONFIG_ITERATIONS: "100"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -380,7 +382,7 @@ jobs:
       - name: Install Pkl CLI
         run: npm install --global @pkl-community/pkl@0.27.2
       - name: Test
-        env: { VIZE_NUXT_CONFIG_ITERATIONS: "100", VIZE_TEST_REQUIRE_TSGO: "1" }
+        env: { VIZE_TEST_REQUIRE_TSGO: "1" }
         run: cargo test --workspace && cargo test -p vize --features legacy --test check_nuxt_tsconfig_isolation_cli && cargo test -p vize_vitrine --no-default-features --features wasm
 
   coverage:
@@ -413,9 +415,7 @@ jobs:
   source-coverage:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 40
-    # cargo llvm-cov runs ~4–6 minutes and is a trend metric, not a per-PR signal:
-    # run on push-to-main and daily because one PR rarely moves global percentages; the
-    # fixture-coverage job (`coverage`) and compiler/lint suites still run per-PR.
+    # Source coverage is a push/daily trend metric; fixture and compiler/lint gates stay per PR.
     if: ${{ github.event_name != 'pull_request' }}
     env:
       NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
+import { parse } from "yaml";
 
 import { buildComment } from "../../bench/comment-test-report.mjs";
 import { readRepoFile, root, workflowJobBody } from "./support/github-workflows.ts";
@@ -278,12 +279,16 @@ test("check workflow runs JS package unit tests and production dependency audit"
 
 test("check workflow blocks on Rust source and branch coverage budgets", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
-  const clippyJob = workflowJobBody(workflow, "clippy-and-test");
   const sourceJob = workflowJobBody(workflow, "source-coverage");
   const branchJob = workflowJobBody(workflow, "branch-coverage");
+  const jobs = (
+    parse(workflow) as {
+      jobs: Record<string, { env?: Record<string, unknown> }>;
+    }
+  ).jobs;
 
-  assert.equal(clippyJob.match(/VIZE_NUXT_CONFIG_ITERATIONS:\s*"100"/g)?.length, 1);
-  assert.equal(sourceJob.match(/VIZE_NUXT_CONFIG_ITERATIONS:\s*"100"/g)?.length, 1);
+  assert.equal(jobs["clippy-and-test"].env?.VIZE_NUXT_CONFIG_ITERATIONS, "100");
+  assert.equal(jobs["source-coverage"].env?.VIZE_NUXT_CONFIG_ITERATIONS, "100");
   assert.match(sourceJob, /tool:\s*cargo-llvm-cov/);
   assert.match(sourceJob, /vp install --frozen-lockfile --prefer-offline/);
   assert.match(sourceJob, /vp run --workspace-root coverage:source/);

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -278,9 +278,12 @@ test("check workflow runs JS package unit tests and production dependency audit"
 
 test("check workflow blocks on Rust source and branch coverage budgets", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
+  const clippyJob = workflowJobBody(workflow, "clippy-and-test");
   const sourceJob = workflowJobBody(workflow, "source-coverage");
   const branchJob = workflowJobBody(workflow, "branch-coverage");
 
+  assert.equal(clippyJob.match(/VIZE_NUXT_CONFIG_ITERATIONS:\s*"100"/g)?.length, 1);
+  assert.equal(sourceJob.match(/VIZE_NUXT_CONFIG_ITERATIONS:\s*"100"/g)?.length, 1);
   assert.match(sourceJob, /tool:\s*cargo-llvm-cov/);
   assert.match(sourceJob, /vp install --frozen-lockfile --prefer-offline/);
   assert.match(sourceJob, /vp run --workspace-root coverage:source/);


### PR DESCRIPTION
## Summary

- give the push-only `source-coverage` job the same fail-closed `VIZE_NUXT_CONFIG_ITERATIONS=100` contract as `clippy-and-test`
- pin both job-local environment contracts in the workflow structure test
- keep the over-limit workflow file from growing

## Validation

- `node --test --experimental-strip-types tests/tooling/github-workflows-check.test.ts` (12/12)
- `vp run check:repo` (2175 formatted / 1551 linted)
- source-length guard and `git diff --check`
- exact `VIZE_NUXT_CONFIG_ITERATIONS=100 vp run --workspace-root coverage:source` passed the Nuxt stress lane and the 70% budgets: lines 83.04%, functions 87.28%, regions 83.10%
- after rebasing latest main, the exact command again passed the Nuxt lane but later exposed a separate load-dependent Maestro coverage failure; recorded without retry masking as #4138. Ordinary required-Corsa Maestro full suite remains 792 pass / 0 fail / 2 ignored.

Closes #4136

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated source-coverage checks to use a consistent iteration setting.
  * Preserved the existing behavior of running source-coverage checks only when applicable.

* **Tests**
  * Expanded workflow validation to confirm the iteration setting is configured correctly across relevant checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->