### PR TITLE
fix(ci): forward Nuxt stress environment to coverage

### DIFF
--- a/tests/tooling/vite-plus-task-env.test.ts
+++ b/tests/tooling/vite-plus-task-env.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { testAndBenchmarkTasks } from "../../tools/vite-plus/tasks/test-benchmark.ts";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+type TaskShape = {
+  env?: string[];
+};
+
+test("source coverage tracks the Nuxt stress iteration environment", () => {
+  const coverage = testAndBenchmarkTasks["coverage:source"] as TaskShape;
+
+  assert.deepEqual(coverage.env, ["VIZE_NUXT_CONFIG_ITERATIONS"]);
+});
+
+test("Vite Plus forwards tracked task environment without leaking an undeclared probe", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-vp-task-env-"));
+  const output = path.join(root, "env.json");
+  const vp = process.env.VIZE_VP_BIN ?? path.join(repoRoot, "node_modules", ".bin", "vp");
+
+  try {
+    fs.writeFileSync(path.join(root, "package.json"), '{"name":"vize-task-env-probe"}\n');
+    fs.writeFileSync(
+      path.join(root, "probe.mjs"),
+      `import fs from "node:fs";\nfs.writeFileSync(${JSON.stringify(output)}, JSON.stringify({ tracked: process.env.VIZE_TRACKED_ENV ?? null, hidden: process.env.VIZE_HIDDEN_ENV ?? null }));\n`,
+    );
+    fs.writeFileSync(
+      path.join(root, "vite.config.mjs"),
+      'export default { run: { tasks: { probe: { command: "node probe.mjs", env: ["VIZE_TRACKED_ENV"] } } } };\n',
+    );
+
+    const result = spawnSync(vp, ["run", "--workspace-root", "probe"], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        VIZE_TRACKED_ENV: "forwarded",
+        VIZE_HIDDEN_ENV: "must-not-leak",
+      },
+    });
+
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.deepEqual(JSON.parse(fs.readFileSync(output, "utf8")), {
+      tracked: "forwarded",
+      hidden: null,
+    });
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});

--- a/tools/vite-plus/task-definition.ts
+++ b/tools/vite-plus/task-definition.ts
@@ -8,6 +8,7 @@ import { withRustTaskEnvironment } from "./task-shell.ts";
 export const task = (
   command: string,
   options: {
+    env?: string[];
     forwardArguments?: boolean;
     input?: TaskInput;
   } = {},
@@ -15,6 +16,7 @@ export const task = (
   command: withRustTaskEnvironment(command, {
     forwardArguments: options.forwardArguments,
   }),
+  ...(options.env == null ? {} : { env: options.env }),
   ...(options.input == null ? {} : { input: options.input }),
 });
 

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -155,7 +155,10 @@ export const testAndBenchmarkTasks = defineTasks({
   "test:vue": task("cargo test -p vize_test_runner", { input: cacheInputs.rust }),
   coverage: task("cargo run -p vize_test_runner --bin coverage", { input: cacheInputs.rust }),
   "coverage:all": noCacheTask(runTasks("coverage", "coverage:source")),
-  "coverage:source": task(rustSourceCoverageCommand, { input: cacheInputs.rust }),
+  "coverage:source": task(rustSourceCoverageCommand, {
+    env: ["VIZE_NUXT_CONFIG_ITERATIONS"],
+    input: cacheInputs.rust,
+  }),
   "coverage:source:branch": task(rustBranchCoverageCommand, { input: cacheInputs.rust }),
   "coverage:verbose": task("cargo run -p vize_test_runner --bin coverage -- -v", {
     input: cacheInputs.rust,


### PR DESCRIPTION
## Summary

- expose Vite Plus's tracked `env` field through the typed cacheable task helper
- declare `VIZE_NUXT_CONFIG_ITERATIONS` on `coverage:source` so the CI-owned value reaches the Rust stress oracle and participates in the cache fingerprint
- add a real Vite Plus subprocess regression that proves the declared value is forwarded while an undeclared probe is filtered

## RED / root cause

Exact merged-main source coverage job https://github.com/ubugeeei-prod/vize/actions/runs/31456104134/job/93670092271 shows `VIZE_NUXT_CONFIG_ITERATIONS: 100` at the GitHub step boundary, then fails inside the Nuxt oracle because the cacheable Vite Plus task did not declare the variable.

Before this change, the focused structural test observed `coverage:source.env === undefined`.

## Verification

- `node --test tests/tooling/vite-plus-task-env.test.ts tests/tooling/github-workflows-check.test.ts` — 14/14
- `vp run --workspace-root check:repo` — 2177 formatted, 1552 linted, 0 warnings/errors
- `vp run --workspace-root source:lengths --check --base-ref origin/main` — no new/grown over-limit files
- changed-file `oxfmt`, `oxlint --deny-warnings`, and `git diff --check` — green

The broad local `test:scripts` attempt was stopped after the clean worktree's native build exhausted local disk and unhydrated fixture tests failed; the focused issue contract was already green. Latest-head CI remains the authority for the fully hydrated source-coverage run.

Closes #4140

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tasks can now declare specific environment variables for use during execution.
  * The source coverage task now receives the required configuration iteration setting.

* **Bug Fixes**
  * Improved environment handling so declared variables are forwarded while undeclared variables remain excluded.

* **Tests**
  * Added coverage for task environment forwarding and filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->