### PR TITLE
fix(ci): update Content Mapper tsgo watcher lifecycle

### DIFF
--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -74,7 +74,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  CONTENT_MAPPER_TSGO_SHA: "bddd2162710e50281fa838456a875fd59ee7c91f"
+  CONTENT_MAPPER_TSGO_SHA: "c18f834e07d992a24cdfbb7cb8bd58812ff3d95e"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
@@ -98,6 +98,9 @@ jobs:
         with:
           go-version-file: typescript-go-content-mapper/go.mod
           cache-dependency-path: typescript-go-content-mapper/go.sum
+      - name: Verify upstream watcher close regression
+        working-directory: typescript-go-content-mapper
+        run: go test ./internal/lsp/lspwatcher -run '^TestWatcher_CloseWhileWatchFilesReconciles$' -count=1
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
@@ -158,4 +161,12 @@ jobs:
         run: |
           cargo test -p vize --test content_mapper_tsgo_lsp -- --nocapture
           cargo test -p vize_canon --test lsp_import_resolution -- --nocapture
-          cargo test -p vize_maestro
+      - name: Stress exact editor lifecycle
+        env:
+          TSGO_PATH: ${{ runner.temp }}/tsgo
+          VIZE_TEST_CONTENT_MAPPER_TSGO: ${{ runner.temp }}/tsgo
+        run: |
+          for iteration in $(seq 1 20); do
+            cargo test -p vize_maestro -- --quiet
+            echo "Content Mapper Maestro lifecycle cycle $iteration/20 passed"
+          done

--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -12,6 +12,10 @@ on:
       - "crates/vize/src/commands/content_mapper/**"
       - "crates/vize/tests/content_mapper_tsgo_cli.rs"
       - "crates/vize/tests/content_mapper_tsgo_build.rs"
+      - "crates/vize/tests/content_mapper_tsgo_lsp.rs"
+      - "crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs"
+      - "crates/vize/tests/content_mapper_tsgo_lsp_event_forms/**"
+      - "crates/vize/tests/content_mapper_lsp_support/**"
       - "crates/vize/tests/fixtures/content_mapper_project/**"
       - "crates/vize_canon/Cargo.toml"
       - "crates/vize_canon/src/batch.rs"
@@ -43,6 +47,10 @@ on:
       - "crates/vize/src/commands/content_mapper/**"
       - "crates/vize/tests/content_mapper_tsgo_cli.rs"
       - "crates/vize/tests/content_mapper_tsgo_build.rs"
+      - "crates/vize/tests/content_mapper_tsgo_lsp.rs"
+      - "crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs"
+      - "crates/vize/tests/content_mapper_tsgo_lsp_event_forms/**"
+      - "crates/vize/tests/content_mapper_lsp_support/**"
       - "crates/vize/tests/fixtures/content_mapper_project/**"
       - "crates/vize_canon/Cargo.toml"
       - "crates/vize_canon/src/batch.rs"
@@ -160,6 +168,7 @@ jobs:
           VIZE_TEST_CONTENT_MAPPER_TSGO: ${{ runner.temp }}/tsgo
         run: |
           cargo test -p vize --test content_mapper_tsgo_lsp -- --nocapture
+          cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture
           cargo test -p vize_canon --test lsp_import_resolution -- --nocapture
       - name: Stress exact editor lifecycle
         env:

--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -8,8 +8,10 @@ use vize_carton::String as CompactString;
 
 #[allow(dead_code)]
 mod navigation;
+mod responder;
 #[allow(unused_imports)]
 pub use navigation::{contains_location_range, contains_text_edit, references, rename};
+pub use responder::EditorResponder;
 
 struct RawDocumentDiagnostic;
 struct RawHover;

--- a/crates/vize/tests/content_mapper_lsp_support/responder.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/responder.rs
@@ -1,0 +1,55 @@
+use std::sync::Mutex;
+
+use serde_json::{Value, json};
+
+/// Answers the server-to-client requests the exact tsgo conformance tests rely on, and records the
+/// dynamic registrations pushed through `client/registerCapability`. Capturing them is what lets a
+/// test assert that the server actually registers content mapper document synchronization for the
+/// authored extension: a responder that blindly answers `null` would pass even if the request never
+/// arrived.
+#[derive(Default)]
+pub struct EditorResponder(Mutex<Vec<Value>>);
+
+impl EditorResponder {
+    pub fn respond_to(&self, method: &str, params: &Value) -> Value {
+        match method {
+            "workspace/configuration" => {
+                let count = params["items"].as_array().map_or(0, Vec::len);
+                Value::Array(vec![Value::Null; count])
+            }
+            "client/registerCapability" => {
+                let registrations = params["registrations"].as_array();
+                self.0
+                    .lock()
+                    .unwrap()
+                    .extend(registrations.into_iter().flatten().cloned());
+                Value::Null
+            }
+            _ => Value::Null,
+        }
+    }
+
+    /// Asserts the server registered `textDocument/didOpen` for `**/*.vue`, which is how a `.vue`
+    /// file starts flowing to the server once a content mapper claims it.
+    pub fn assert_vue_did_open_registration(&self) {
+        let recorded = self.0.lock().unwrap();
+        let did_open = recorded
+            .iter()
+            .find(|registration| registration["id"] == json!("content-mapper-did-open"))
+            .unwrap_or_else(|| panic!("missing didOpen registration: {recorded:#?}"));
+        assert_eq!(
+            did_open["method"],
+            json!("textDocument/didOpen"),
+            "{did_open:#}"
+        );
+        let selector = did_open["registerOptions"]["documentSelector"]
+            .as_array()
+            .unwrap_or_else(|| panic!("missing didOpen document selector: {did_open:#}"));
+        assert!(
+            selector
+                .iter()
+                .any(|filter| filter["pattern"] == json!("**/*.vue")),
+            "{did_open:#}"
+        );
+    }
+}

--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -27,7 +27,7 @@ impl Drop for StopOnDrop<'_> {
 }
 
 struct RawInitialize;
-struct RawDiscoverContentMappers;
+struct RawSetContentMapperContributions;
 struct RawSignatureHelp;
 struct RawReferences;
 struct RawRename;
@@ -43,7 +43,10 @@ macro_rules! raw_request {
 }
 
 raw_request!(RawInitialize, "initialize");
-raw_request!(RawDiscoverContentMappers, "custom/discoverContentMappers");
+raw_request!(
+    RawSetContentMapperContributions,
+    "custom/setContentMapperContributions"
+);
 raw_request!(RawSignatureHelp, "textDocument/signatureHelp");
 raw_request!(RawReferences, "textDocument/references");
 raw_request!(RawRename, "textDocument/rename");
@@ -132,14 +135,14 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
             assert!(initialize["capabilities"].is_object(), "{initialize:#}");
             client.notify::<RawInitialized>(json!({})).unwrap();
 
-            let discovered = client
-                .request::<RawDiscoverContentMappers>(json!({
-                    "textDocuments": [{ "uri": child_uri }],
-                    "extensions": [".vue"]
+            let contributed = client
+                .request::<RawSetContentMapperContributions>(json!({
+                    "contributions": [{ "contributorId": "vize", "extensions": [".vue"] }],
+                    "openDocuments": [{ "uri": child_uri }, { "uri": app_uri }]
                 }))
                 .await
                 .unwrap();
-            assert_eq!(discovered["extensions"], json!([".vue"]), "{discovered:#}");
+            assert!(contributed.is_null(), "{contributed:#}");
 
             let uri = Uri::from_str(&child_uri).unwrap();
             let overlay = client.overlay();

--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -10,10 +10,10 @@ use serde_json::{Value, json};
 
 mod content_mapper_lsp_support;
 use content_mapper_lsp_support::{
-    assert_component_completions, assert_component_members, assert_component_navigation,
-    completion, contains_location, copy_fixture, definition, editor_capabilities, file_uri, hover,
-    install_packages, notify_file_changes, position, pull_diagnostics, try_pull_diagnostics,
-    workspace_root,
+    EditorResponder, assert_component_completions, assert_component_members,
+    assert_component_navigation, completion, contains_location, copy_fixture, definition,
+    editor_capabilities, file_uri, hover, install_packages, notify_file_changes, position,
+    pull_diagnostics, try_pull_diagnostics, workspace_root,
 };
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
@@ -91,6 +91,7 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
     let component_position = position(&app_source, app_source.find("<Child").unwrap() + 1);
 
     let stop = AtomicBool::new(false);
+    let editor = EditorResponder::default();
     std::thread::scope(|scope| {
         let _stop_on_drop = StopOnDrop(&stop);
         corsa::runtime::block_on(async {
@@ -104,20 +105,13 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
             let responder_client = client.clone();
             let events = responder_client.subscribe();
             let stop_ref = &stop;
+            let editor_ref = &editor;
             let responder = scope.spawn(move || {
                 while !stop_ref.load(Ordering::Relaxed) {
                     if let Ok(InboundEvent::Request { id, method, params }) =
                         events.recv_timeout(Duration::from_millis(50))
                     {
-                        let result = if method.as_str() == "workspace/configuration" {
-                            let count = params
-                                .get("items")
-                                .and_then(Value::as_array)
-                                .map_or(0, Vec::len);
-                            Value::Array(vec![Value::Null; count])
-                        } else {
-                            Value::Null
-                        };
+                        let result = editor_ref.respond_to(method.as_str(), &params);
                         let _ = responder_client.respond(id, result);
                     }
                 }
@@ -143,6 +137,7 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
                 .await
                 .unwrap();
             assert!(contributed.is_null(), "{contributed:#}");
+            editor.assert_vue_did_open_registration();
 
             let uri = Uri::from_str(&child_uri).unwrap();
             let overlay = client.overlay();

--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -30,7 +30,7 @@ impl Drop for StopOnDrop<'_> {
     }
 }
 struct RawInitialize;
-struct RawDiscoverContentMappers;
+struct RawSetContentMapperContributions;
 struct RawInitialized;
 impl lsp_types::request::Request for RawInitialize {
     type Params = Value;
@@ -38,10 +38,10 @@ impl lsp_types::request::Request for RawInitialize {
     const METHOD: &'static str = "initialize";
 }
 
-impl lsp_types::request::Request for RawDiscoverContentMappers {
+impl lsp_types::request::Request for RawSetContentMapperContributions {
     type Params = Value;
     type Result = Value;
-    const METHOD: &'static str = "custom/discoverContentMappers";
+    const METHOD: &'static str = "custom/setContentMapperContributions";
 }
 
 impl lsp_types::notification::Notification for RawInitialized {
@@ -155,14 +155,14 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             assert!(initialize["capabilities"].is_object(), "{initialize:#}");
             client.notify::<RawInitialized>(json!({})).unwrap();
 
-            let discovered = client
-                .request::<RawDiscoverContentMappers>(json!({
-                    "textDocuments": cases.iter().map(|case| json!({ "uri": case.0 })).collect::<Vec<_>>(),
-                    "extensions": [".vue"]
+            let contributed = client
+                .request::<RawSetContentMapperContributions>(json!({
+                    "contributions": [{ "contributorId": "vize", "extensions": [".vue"] }],
+                    "openDocuments": cases.iter().map(|case| json!({ "uri": case.0 })).collect::<Vec<_>>()
                 }))
                 .await
                 .unwrap();
-            assert_eq!(discovered["extensions"], json!([".vue"]), "{discovered:#}");
+            assert!(contributed.is_null(), "{contributed:#}");
 
             let overlay = client.overlay();
             let app_document_uri = Uri::from_str(&app_uri).unwrap();

--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -16,9 +16,9 @@ use cases::EVENT_CASES;
 
 mod content_mapper_lsp_support;
 use content_mapper_lsp_support::{
-    assert_completion, assert_prop_navigation, contains_location, contains_location_range,
-    contains_text_edit, copy_fixture, editor_capabilities, file_uri, install_packages, position,
-    pull_diagnostics, references, rename, workspace_root,
+    EditorResponder, assert_completion, assert_prop_navigation, contains_location,
+    contains_location_range, contains_text_edit, copy_fixture, editor_capabilities, file_uri,
+    install_packages, position, pull_diagnostics, references, rename, workspace_root,
 };
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
@@ -111,6 +111,7 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
     let root_uri = file_uri(project.path());
 
     let stop = AtomicBool::new(false);
+    let editor = EditorResponder::default();
     std::thread::scope(|scope| {
         let _stop_on_drop = StopOnDrop(&stop);
         corsa::runtime::block_on(async {
@@ -124,20 +125,13 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             let responder_client = client.clone();
             let events = responder_client.subscribe();
             let stop_ref = &stop;
+            let editor_ref = &editor;
             let responder = scope.spawn(move || {
                 while !stop_ref.load(Ordering::Relaxed) {
                     if let Ok(InboundEvent::Request { id, method, params }) =
                         events.recv_timeout(Duration::from_millis(50))
                     {
-                        let result = if method.as_str() == "workspace/configuration" {
-                            let count = params
-                                .get("items")
-                                .and_then(Value::as_array)
-                                .map_or(0, Vec::len);
-                            Value::Array(vec![Value::Null; count])
-                        } else {
-                            Value::Null
-                        };
+                        let result = editor_ref.respond_to(method.as_str(), &params);
                         let _ = responder_client.respond(id, result);
                     }
                 }
@@ -163,6 +157,7 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
                 .await
                 .unwrap();
             assert!(contributed.is_null(), "{contributed:#}");
+            editor.assert_vue_did_open_registration();
 
             let overlay = client.overlay();
             let app_document_uri = Uri::from_str(&app_uri).unwrap();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1204,6 +1204,9 @@ importers:
       vue-virtual-scroller:
         specifier: 3.0.4
         version: 3.0.4(vue@3.6.0-beta.10(typescript@6.0.3))
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
 
 packages:
 

--- a/tests/package.json
+++ b/tests/package.json
@@ -79,6 +79,7 @@
     "vue-sfc-compiler-2-6": "catalog:legacy-vue-oracle",
     "vue-sfc-compiler-2-7": "catalog:legacy-vue-oracle",
     "vue-tsc": "catalog:typescript",
-    "vue-virtual-scroller": "3.0.4"
+    "vue-virtual-scroller": "3.0.4",
+    "yaml": "2.9.0"
   }
 }

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -49,6 +49,10 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
     '"crates/vize_maestro/src/ide/**"',
     '"crates/vize/tests/content_mapper_tsgo_cli.rs"',
     '"crates/vize/tests/content_mapper_tsgo_build.rs"',
+    '"crates/vize/tests/content_mapper_tsgo_lsp.rs"',
+    '"crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs"',
+    '"crates/vize/tests/content_mapper_tsgo_lsp_event_forms/**"',
+    '"crates/vize/tests/content_mapper_lsp_support/**"',
     '"crates/vize/tests/fixtures/content_mapper_project/**"',
     '"npm/cli/bin/vize"',
     '"npm/cli/package.json"',
@@ -96,6 +100,8 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
     /VIZE_TEST_CONTENT_MAPPER_TSGO: \$\{\{ runner\.temp \}\}\/tsgo[\s\S]*smoke-release-install\.mjs --prepare-manifests --content-mapper-checks[\s\S]*npm\/native npm\/native\/npm\/\*[\s\S]*npm\/cli/,
   );
   assert.match(job, /TSGO_PATH: \$\{\{ runner\.temp \}\}\/tsgo/);
+  assert.match(job, /cargo test -p vize --test content_mapper_tsgo_lsp -- --nocapture/);
+  assert.match(job, /cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture/);
   assert.match(job, /cargo test -p vize_canon --test lsp_import_resolution -- --nocapture/);
   const stressSteps = stepsRunning(steps, MAESTRO_COMMAND);
   assert.equal(stressSteps.length, 1, "expected exactly one Maestro lifecycle stress step");

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -3,7 +3,8 @@ import { test } from "node:test";
 
 import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
 
-const UPSTREAM_SHA = "bddd2162710e50281fa838456a875fd59ee7c91f";
+const UPSTREAM_SHA = "c18f834e07d992a24cdfbb7cb8bd58812ff3d95e";
+const WATCHER_CLOSE_TEST = "TestWatcher_CloseWhileWatchFilesReconciles";
 
 test("Content Mapper conformance pins and runs the exact upstream project path", () => {
   const workflow = readRepoFile(".github", "workflows", "content-mapper-conformance.yml");
@@ -45,6 +46,9 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
     /uses: \.\/\.github\/actions\/setup-rust-sticky-cache\n\s+with:\n\s+key: content-mapper-conformance\n\s+cache-key-suffix: \$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}/,
   );
   assert.match(job, /go-version-file: typescript-go-content-mapper\/go\.mod/);
+  assert.ok(
+    job.includes(`go test ./internal/lsp/lspwatcher -run '^${WATCHER_CLOSE_TEST}$' -count=1`),
+  );
   assert.match(job, /go build -tags=noembed -trimpath -o "\$RUNNER_TEMP\/tsgo" \.\/cmd\/tsgo/);
   assert.match(job, /cp internal\/bundled\/libs\/\*\.d\.ts "\$RUNNER_TEMP\/"/);
   assert.match(job, /VIZE_TEST_CONTENT_MAPPER_TSGO: \$\{\{ runner\.temp \}\}\/tsgo/);
@@ -64,5 +68,7 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
   );
   assert.match(job, /TSGO_PATH: \$\{\{ runner\.temp \}\}\/tsgo/);
   assert.match(job, /cargo test -p vize_canon --test lsp_import_resolution -- --nocapture/);
-  assert.match(job, /cargo test -p vize_maestro/);
+  assert.match(job, /for iteration in \$\(seq 1 20\); do/);
+  assert.match(job, /cargo test -p vize_maestro -- --quiet/);
+  assert.match(job, /echo "Content Mapper Maestro lifecycle cycle \$iteration\/20 passed"/);
 });

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -1,14 +1,38 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+import { parse } from "yaml";
+
 import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
 
 const UPSTREAM_SHA = "c18f834e07d992a24cdfbb7cb8bd58812ff3d95e";
 const WATCHER_CLOSE_TEST = "TestWatcher_CloseWhileWatchFilesReconciles";
+const WATCHER_COMMAND = `go test ./internal/lsp/lspwatcher -run '^${WATCHER_CLOSE_TEST}$' -count=1`;
+const TSGO_BUILD_COMMAND = 'go build -tags=noembed -trimpath -o "$RUNNER_TEMP/tsgo" ./cmd/tsgo';
+const MAESTRO_COMMAND = "cargo test -p vize_maestro -- --quiet";
+const MAESTRO_LOOP = "for iteration in $(seq 1 20); do";
+const MAESTRO_SUCCESS_LOG = 'echo "Content Mapper Maestro lifecycle cycle $iteration/20 passed"';
+
+interface WorkflowStep {
+  run?: string;
+  "working-directory"?: string;
+}
+
+function jobSteps(workflow: string, jobName: string): WorkflowStep[] {
+  const jobs = (parse(workflow) as { jobs: Record<string, { steps?: WorkflowStep[] }> }).jobs;
+  const steps = jobs[jobName]?.steps;
+  assert.ok(Array.isArray(steps), `missing steps for job ${jobName}`);
+  return steps;
+}
+
+function stepsRunning(steps: WorkflowStep[], command: string): number[] {
+  return steps.flatMap((step, index) => (step.run?.includes(command) ? [index] : []));
+}
 
 test("Content Mapper conformance pins and runs the exact upstream project path", () => {
   const workflow = readRepoFile(".github", "workflows", "content-mapper-conformance.yml");
   const job = workflowJobBody(workflow, "exact-tsgo-project");
+  const steps = jobSteps(workflow, "exact-tsgo-project");
 
   assert.match(workflow, /pull_request:\n\s+branches: \[main\]\n\s+paths:/);
   for (const relevantPath of [
@@ -46,10 +70,15 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
     /uses: \.\/\.github\/actions\/setup-rust-sticky-cache\n\s+with:\n\s+key: content-mapper-conformance\n\s+cache-key-suffix: \$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}/,
   );
   assert.match(job, /go-version-file: typescript-go-content-mapper\/go\.mod/);
+  const watcherSteps = stepsRunning(steps, WATCHER_COMMAND);
+  const buildSteps = stepsRunning(steps, TSGO_BUILD_COMMAND);
+  assert.equal(watcherSteps.length, 1, "expected exactly one watcher regression step");
+  assert.equal(buildSteps.length, 1, "expected exactly one exact tsgo build step");
+  assert.equal(steps[watcherSteps[0]]["working-directory"], "typescript-go-content-mapper");
   assert.ok(
-    job.includes(`go test ./internal/lsp/lspwatcher -run '^${WATCHER_CLOSE_TEST}$' -count=1`),
+    watcherSteps[0] < buildSteps[0],
+    "watcher regression must run before the exact tsgo build",
   );
-  assert.match(job, /go build -tags=noembed -trimpath -o "\$RUNNER_TEMP\/tsgo" \.\/cmd\/tsgo/);
   assert.match(job, /cp internal\/bundled\/libs\/\*\.d\.ts "\$RUNNER_TEMP\/"/);
   assert.match(job, /VIZE_TEST_CONTENT_MAPPER_TSGO: \$\{\{ runner\.temp \}\}\/tsgo/);
   assert.match(
@@ -68,7 +97,15 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
   );
   assert.match(job, /TSGO_PATH: \$\{\{ runner\.temp \}\}\/tsgo/);
   assert.match(job, /cargo test -p vize_canon --test lsp_import_resolution -- --nocapture/);
-  assert.match(job, /for iteration in \$\(seq 1 20\); do/);
-  assert.match(job, /cargo test -p vize_maestro -- --quiet/);
-  assert.match(job, /echo "Content Mapper Maestro lifecycle cycle \$iteration\/20 passed"/);
+  const stressSteps = stepsRunning(steps, MAESTRO_COMMAND);
+  assert.equal(stressSteps.length, 1, "expected exactly one Maestro lifecycle stress step");
+  const stressRun = steps[stressSteps[0]].run ?? "";
+  const loopStart = stressRun.indexOf(MAESTRO_LOOP);
+  assert.ok(loopStart >= 0, "Maestro stress step must run a 20-iteration loop");
+  const maestroRun = stressRun.indexOf(MAESTRO_COMMAND);
+  const successLog = stressRun.indexOf(MAESTRO_SUCCESS_LOG);
+  const loopEnd = stressRun.slice(loopStart).search(/^\s*done\s*$/m) + loopStart;
+  assert.ok(loopStart < maestroRun, "Maestro command must run inside the loop");
+  assert.ok(maestroRun < successLog, "success log must follow the Maestro command");
+  assert.ok(successLog < loopEnd, "success log must run inside the same loop");
 });

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -14,6 +14,7 @@ const MAESTRO_LOOP = "for iteration in $(seq 1 20); do";
 const MAESTRO_SUCCESS_LOG = 'echo "Content Mapper Maestro lifecycle cycle $iteration/20 passed"';
 
 interface WorkflowStep {
+  env?: Record<string, string>;
   run?: string;
   "working-directory"?: string;
 }
@@ -99,13 +100,35 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
     job,
     /VIZE_TEST_CONTENT_MAPPER_TSGO: \$\{\{ runner\.temp \}\}\/tsgo[\s\S]*smoke-release-install\.mjs --prepare-manifests --content-mapper-checks[\s\S]*npm\/native npm\/native\/npm\/\*[\s\S]*npm\/cli/,
   );
-  assert.match(job, /TSGO_PATH: \$\{\{ runner\.temp \}\}\/tsgo/);
-  assert.match(job, /cargo test -p vize --test content_mapper_tsgo_lsp -- --nocapture/);
-  assert.match(job, /cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture/);
-  assert.match(job, /cargo test -p vize_canon --test lsp_import_resolution -- --nocapture/);
+  const editorCommands = [
+    "cargo test -p vize --test content_mapper_tsgo_lsp -- --nocapture",
+    "cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture",
+    "cargo test -p vize_canon --test lsp_import_resolution -- --nocapture",
+  ];
+  const editorSteps = steps.filter((step) =>
+    editorCommands.every((command) => step.run?.includes(command)),
+  );
+  assert.equal(editorSteps.length, 1, "expected one exact editor backend step");
+  assert.equal(editorSteps[0].env?.TSGO_PATH, "${{ runner.temp }}/tsgo");
+  assert.equal(editorSteps[0].env?.VIZE_TEST_CONTENT_MAPPER_TSGO, "${{ runner.temp }}/tsgo");
   const stressSteps = stepsRunning(steps, MAESTRO_COMMAND);
   assert.equal(stressSteps.length, 1, "expected exactly one Maestro lifecycle stress step");
   const stressRun = steps[stressSteps[0]].run ?? "";
+  assert.equal(
+    [...stressRun.matchAll(/^\s*cargo test -p vize_maestro -- --quiet\s*$/gm)].length,
+    1,
+    "expected one direct Maestro command in the iteration loop",
+  );
+  assert.equal(
+    [...stressRun.matchAll(/^\s*(?:for|while|until)\b/gm)].length,
+    1,
+    "retry loops are forbidden in the lifecycle stress step",
+  );
+  assert.doesNotMatch(
+    stressRun,
+    /\bsleep\b|--test-threads(?:=|\s+)1|RUST_TEST_THREADS\s*=\s*1|\|\|\s*true|\bset\s+\+e\b|\b(?:retry|attempt)\b|(?:grep|rg).*\b(?:panic|fail)/i,
+    "stress step must not serialize, retry, sleep, ignore failures, or filter panics",
+  );
   const loopStart = stressRun.indexOf(MAESTRO_LOOP);
   assert.ok(loopStart >= 0, "Maestro stress step must run a 20-iteration loop");
   const maestroRun = stressRun.indexOf(MAESTRO_COMMAND);

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -113,7 +113,10 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
   assert.equal(editorSteps[0].env?.VIZE_TEST_CONTENT_MAPPER_TSGO, "${{ runner.temp }}/tsgo");
   const stressSteps = stepsRunning(steps, MAESTRO_COMMAND);
   assert.equal(stressSteps.length, 1, "expected exactly one Maestro lifecycle stress step");
-  const stressRun = steps[stressSteps[0]].run ?? "";
+  const stressStep = steps[stressSteps[0]];
+  const stressRun = stressStep.run ?? "";
+  assert.equal(stressStep.env?.TSGO_PATH, "${{ runner.temp }}/tsgo");
+  assert.equal(stressStep.env?.VIZE_TEST_CONTENT_MAPPER_TSGO, "${{ runner.temp }}/tsgo");
   assert.equal(
     [...stressRun.matchAll(/^\s*cargo test -p vize_maestro -- --quiet\s*$/gm)].length,
     1,


### PR DESCRIPTION
## Summary

- pin the Content Mapper TypeScript-Go build to `c18f834e07d992a24cdfbb7cb8bd58812ff3d95e`, which contains the upstream watcher-close fix
- fail closed by running upstream `TestWatcher_CloseWhileWatchFilesReconciles` before building tsgo
- exercise the exact tsgo binary through 20 complete Maestro lifecycle cycles without retry, sleep, or hidden serialization

## Root cause

The previous Content Mapper pin predates microsoft/typescript-go#4845. Under parallel Maestro load, closing a watcher while file reconciliation was active could panic with `lspwatcher.WatchFiles: assignment to entry in nil map`, then surface as a shutdown `CommunicationError`.

## Validation

- upstream watcher close regression: 1/1
- exact local tsgo build: `Version 7.1.0-dev`
- full Maestro lifecycle stress: 20/20 cycles, 792 passed and 2 existing ignored per cycle
- Content Mapper workflow contract: 1/1
- `vp run --workspace-root check:repo`
- `vp run --workspace-root check:ci`
- source length, formatting, lint, YAML parse, zizmor, and diff checks

Closes #4142

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated conformance checks to use a newer TypeScript Content Mapper revision.
  * Added coverage for watcher-close regression behavior and LSP event-form handling.
  * Expanded lifecycle validation to run 20 repeated iterations with per-iteration success reporting.
  * Updated language-service tests to validate Vue content mapper contributions for open documents.
  * Expanded workflow coverage to include additional language-service test and support paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->