### PR TITLE
fix(maestro): synchronize editor queries with document generations

### DIFF
--- a/crates/vize_canon/src/lsp_client/diagnostics_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics_lsp.rs
@@ -2,6 +2,7 @@ use crate::file_uri::path_to_file_uri;
 use corsa::runtime::block_on;
 use corsa_lsp::LspClient;
 use lsp_types::{DocumentDiagnosticReportResult, Uri};
+use serde_json::Value;
 use std::path::Path;
 use vize_carton::{String, cstr};
 
@@ -75,5 +76,33 @@ pub(super) fn request_lsp_document_diagnostics(
             }
         })),
     )
+    .map_err(|error| cstr!("{error}"))
+}
+
+/// Wait for a document diagnostic response without interpreting its payload.
+///
+/// Editor readiness only needs the response-backed transport ordering. The
+/// native server's diagnostic payload can contain protocol extensions that are
+/// irrelevant to that ordering and must not make a semantic query fail.
+pub(super) fn request_lsp_document_diagnostic_ack(
+    client: &LspClient,
+    uri: &Uri,
+) -> Result<(), String> {
+    struct RawDocumentDiagnosticAckRequest;
+
+    impl lsp_types::request::Request for RawDocumentDiagnosticAckRequest {
+        type Params = serde_json::Value;
+        type Result = Value;
+        const METHOD: &'static str = "textDocument/diagnostic";
+    }
+
+    block_on(
+        client.request::<RawDocumentDiagnosticAckRequest>(serde_json::json!({
+            "textDocument": {
+                "uri": uri,
+            }
+        })),
+    )
+    .map(|_| ())
     .map_err(|error| cstr!("{error}"))
 }

--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -27,7 +27,7 @@ use std::{
     },
     time::Duration,
 };
-use vize_carton::{FxHashMap, String, cstr};
+use vize_carton::{FxHashMap, FxHashSet, String, cstr};
 
 mod client;
 mod readiness;
@@ -53,6 +53,11 @@ pub(super) struct EditorLspSession {
     document_generation: u64,
     /// Generation acknowledged by a response-backed semantic request.
     ready_generation: Option<u64>,
+    /// Documents opened or changed since the acknowledged generation.
+    dirty_documents: FxHashSet<String>,
+    /// A close cannot be diagnosed directly, so the next query must act as
+    /// the response-backed barrier for that topology change.
+    query_barrier_required: bool,
 }
 
 impl EditorLspSession {
@@ -80,6 +85,8 @@ impl EditorLspSession {
             documents: Default::default(),
             document_generation: 0,
             ready_generation: None,
+            dirty_documents: Default::default(),
+            query_barrier_required: false,
         })
     }
 
@@ -107,6 +114,7 @@ impl EditorLspSession {
             }
         }
         self.documents.insert(document_uri.into(), text.into());
+        self.dirty_documents.insert(document_uri.into());
         self.advance_document_generation();
         Ok(uri)
     }
@@ -127,6 +135,8 @@ impl EditorLspSession {
                 cstr!("Failed to close editor LSP overlay for {document_uri}: {error}")
             })?;
             self.documents.remove(document_uri.as_str());
+            self.dirty_documents.remove(document_uri.as_str());
+            self.query_barrier_required = true;
             self.advance_document_generation();
         }
         for (document_uri, text) in documents {

--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -30,6 +30,7 @@ use std::{
 use vize_carton::{FxHashMap, String, cstr};
 
 mod client;
+mod readiness;
 mod requests;
 #[cfg(test)]
 mod tests;
@@ -48,6 +49,10 @@ pub(super) struct EditorLspSession {
     closed: bool,
     /// Last text mirrored into the server, keyed by session document URI.
     documents: FxHashMap<String, String>,
+    /// Latest notification generation written to this transport.
+    document_generation: u64,
+    /// Generation acknowledged by a response-backed semantic request.
+    ready_generation: Option<u64>,
 }
 
 impl EditorLspSession {
@@ -73,6 +78,8 @@ impl EditorLspSession {
             responder: Some(responder),
             closed: false,
             documents: Default::default(),
+            document_generation: 0,
+            ready_generation: None,
         })
     }
 
@@ -100,6 +107,7 @@ impl EditorLspSession {
             }
         }
         self.documents.insert(document_uri.into(), text.into());
+        self.advance_document_generation();
         Ok(uri)
     }
 
@@ -119,21 +127,12 @@ impl EditorLspSession {
                 cstr!("Failed to close editor LSP overlay for {document_uri}: {error}")
             })?;
             self.documents.remove(document_uri.as_str());
+            self.advance_document_generation();
         }
         for (document_uri, text) in documents {
             self.mirror(document_uri, text)?;
         }
         Ok(())
-    }
-
-    fn document_uri(&self, document_uri: &str) -> Result<Uri, String> {
-        if !self.documents.contains_key(document_uri) {
-            return Err(cstr!(
-                "Editor LSP virtual project does not contain {document_uri}"
-            ));
-        }
-        Uri::from_str(document_uri)
-            .map_err(|error| cstr!("Invalid LSP document URI {document_uri}: {error}"))
     }
 
     fn hover(
@@ -142,7 +141,7 @@ impl EditorLspSession {
         line: u32,
         character: u32,
     ) -> Result<Option<Value>, String> {
-        let uri = self.document_uri(document_uri)?;
+        let uri = self.ready_document_uri(document_uri)?;
         block_on(self.client.request::<RawHoverRequest>(serde_json::json!({
             "textDocument": { "uri": uri },
             "position": { "line": line, "character": character },
@@ -156,7 +155,7 @@ impl EditorLspSession {
         line: u32,
         character: u32,
     ) -> Result<Option<Value>, String> {
-        let uri = self.document_uri(document_uri)?;
+        let uri = self.ready_document_uri(document_uri)?;
         block_on(
             self.client
                 .request::<RawCompletionRequest>(serde_json::json!({
@@ -174,7 +173,7 @@ impl EditorLspSession {
         line: u32,
         character: u32,
     ) -> Result<Option<Value>, String> {
-        let uri = self.document_uri(document_uri)?;
+        let uri = self.ready_document_uri(document_uri)?;
         block_on(
             self.client
                 .request::<RawDefinitionRequest>(serde_json::json!({
@@ -192,7 +191,7 @@ impl EditorLspSession {
         character: u32,
         include_declaration: bool,
     ) -> Result<Option<Value>, String> {
-        let uri = self.document_uri(document_uri)?;
+        let uri = self.ready_document_uri(document_uri)?;
         block_on(
             self.client
                 .request::<RawReferencesRequest>(serde_json::json!({
@@ -210,7 +209,7 @@ impl EditorLspSession {
         line: u32,
         character: u32,
     ) -> Result<Option<Value>, String> {
-        let uri = self.document_uri(document_uri)?;
+        let uri = self.ready_document_uri(document_uri)?;
         block_on(
             self.client
                 .request::<RawPrepareRenameRequest>(serde_json::json!({
@@ -228,7 +227,7 @@ impl EditorLspSession {
         character: u32,
         new_name: &str,
     ) -> Result<Option<Value>, String> {
-        let uri = self.document_uri(document_uri)?;
+        let uri = self.ready_document_uri(document_uri)?;
         block_on(self.client.request::<RawRenameRequest>(serde_json::json!({
             "textDocument": { "uri": uri },
             "position": { "line": line, "character": character },
@@ -244,7 +243,7 @@ impl EditorLspSession {
         character: u32,
         context: Option<Value>,
     ) -> Result<Option<Value>, String> {
-        let uri = self.document_uri(document_uri)?;
+        let uri = self.ready_document_uri(document_uri)?;
         block_on(
             self.client
                 .request::<RawSignatureHelpRequest>(signature_help_request_params(

--- a/crates/vize_canon/src/lsp_client/editor_lsp/readiness.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/readiness.rs
@@ -2,7 +2,7 @@
 
 use lsp_types::Uri;
 use std::str::FromStr;
-use vize_carton::{String, cstr};
+use vize_carton::{FxHashSet, String, cstr};
 
 use super::EditorLspSession;
 
@@ -13,16 +13,32 @@ impl EditorLspSession {
             return Ok(uri);
         }
 
-        // didOpen/didChange are notifications: a successful write only proves
-        // transport delivery, not that the server has installed this document
-        // generation in its semantic project. A pull-diagnostic request is the
-        // first request that consumes the transport's current project state
-        // and therefore provides an ordered, response-backed readiness barrier
-        // before editor queries, including after another document changed.
-        super::super::diagnostics_lsp::request_lsp_document_diagnostics(&self.client, &uri)
-            .map_err(|error| {
-                cstr!("Failed to establish editor LSP readiness for {document_uri}: {error}")
+        // didOpen/didChange/didClose are notifications: a successful write
+        // only proves transport delivery. A diagnostic response for one query
+        // document does not prove that the server has installed the other
+        // changed documents in the same semantic project, so acknowledge every
+        // dirty identity before accepting the generation. A close has no live
+        // identity to diagnose and instead requires the current query URI as a
+        // response-backed topology barrier.
+        let readiness_documents = readiness_documents(
+            &self.dirty_documents,
+            self.query_barrier_required,
+            document_uri,
+        );
+        for readiness_document in &readiness_documents {
+            let readiness_uri = Uri::from_str(readiness_document).map_err(|error| {
+                cstr!("Invalid LSP readiness document URI {readiness_document}: {error}")
             })?;
+            super::super::diagnostics_lsp::request_lsp_document_diagnostic_ack(
+                &self.client,
+                &readiness_uri,
+            )
+            .map_err(|error| {
+                cstr!("Failed to establish editor LSP readiness for {readiness_document}: {error}")
+            })?;
+        }
+        self.dirty_documents.clear();
+        self.query_barrier_required = false;
         self.ready_generation = Some(self.document_generation);
         Ok(uri)
     }
@@ -40,5 +56,44 @@ impl EditorLspSession {
         }
         Uri::from_str(document_uri)
             .map_err(|error| cstr!("Invalid LSP document URI {document_uri}: {error}"))
+    }
+}
+
+fn readiness_documents(
+    dirty_documents: &FxHashSet<String>,
+    query_barrier_required: bool,
+    query_document: &str,
+) -> Vec<String> {
+    let mut documents = dirty_documents.iter().cloned().collect::<Vec<_>>();
+    if query_barrier_required && !dirty_documents.contains(query_document) {
+        documents.push(query_document.into());
+    }
+    documents.sort_unstable();
+    documents
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dirty_documents_are_acknowledged_in_stable_order() {
+        let dirty = FxHashSet::from_iter([
+            "file:///workspace/z.ts".into(),
+            "file:///workspace/a.ts".into(),
+        ]);
+
+        assert_eq!(
+            readiness_documents(&dirty, false, "file:///workspace/query.ts"),
+            ["file:///workspace/a.ts", "file:///workspace/z.ts"]
+        );
+    }
+
+    #[test]
+    fn close_requires_the_query_document_as_a_barrier() {
+        assert_eq!(
+            readiness_documents(&FxHashSet::default(), true, "file:///workspace/query.ts"),
+            ["file:///workspace/query.ts"]
+        );
     }
 }

--- a/crates/vize_canon/src/lsp_client/editor_lsp/readiness.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/readiness.rs
@@ -1,0 +1,44 @@
+//! Transport-generation readiness barrier for editor LSP documents.
+
+use lsp_types::Uri;
+use std::str::FromStr;
+use vize_carton::{String, cstr};
+
+use super::EditorLspSession;
+
+impl EditorLspSession {
+    pub(super) fn ready_document_uri(&mut self, document_uri: &str) -> Result<Uri, String> {
+        let uri = self.document_uri(document_uri)?;
+        if self.ready_generation == Some(self.document_generation) {
+            return Ok(uri);
+        }
+
+        // didOpen/didChange are notifications: a successful write only proves
+        // transport delivery, not that the server has installed this document
+        // generation in its semantic project. A pull-diagnostic request is the
+        // first request that consumes the transport's current project state
+        // and therefore provides an ordered, response-backed readiness barrier
+        // before editor queries, including after another document changed.
+        super::super::diagnostics_lsp::request_lsp_document_diagnostics(&self.client, &uri)
+            .map_err(|error| {
+                cstr!("Failed to establish editor LSP readiness for {document_uri}: {error}")
+            })?;
+        self.ready_generation = Some(self.document_generation);
+        Ok(uri)
+    }
+
+    pub(super) fn advance_document_generation(&mut self) {
+        self.document_generation = self.document_generation.wrapping_add(1);
+        self.ready_generation = None;
+    }
+
+    fn document_uri(&self, document_uri: &str) -> Result<Uri, String> {
+        if !self.documents.contains_key(document_uri) {
+            return Err(cstr!(
+                "Editor LSP virtual project does not contain {document_uri}"
+            ));
+        }
+        Uri::from_str(document_uri)
+            .map_err(|error| cstr!("Invalid LSP document URI {document_uri}: {error}"))
+    }
+}

--- a/crates/vize_maestro/src/ide/rename/canonical.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical.rs
@@ -10,8 +10,12 @@ use vize_carton::{FxHashSet, String, cstr};
 use crate::ide::{IdeContext, ReferencesService, corsa_support};
 
 mod event_rename;
+mod execute;
 mod failure;
 
+pub(super) use execute::rename;
+#[cfg(test)]
+pub(super) use execute::{CanonicalRenameStage, rename_strict, rename_strict_traced};
 use failure::CanonicalFailure;
 
 pub(super) enum Answer<T> {
@@ -64,129 +68,6 @@ pub(super) async fn prepare_strict(
             .map(PrepareRenameResponse::Range)
             .or_else(|| corsa_support::map_canonical_prepare_rename(ctx, &document, response))
     })))
-}
-
-pub(super) async fn rename(
-    ctx: &IdeContext<'_>,
-    new_name: &str,
-    bridge: Option<&CorsaBridge>,
-) -> Answer<WorkspaceEdit> {
-    match rename_strict(ctx, new_name, bridge).await {
-        Ok(answer) => answer,
-        Err(error) => error.into_lenient_answer(),
-    }
-}
-
-pub(super) async fn rename_strict(
-    ctx: &IdeContext<'_>,
-    new_name: &str,
-    bridge: Option<&CorsaBridge>,
-) -> Result<Answer<WorkspaceEdit>, CanonicalFailure> {
-    let rename_kind = event_rename::query_kind(ctx);
-    let Some(semantic_name) = event_rename::semantic_name(rename_kind, new_name) else {
-        return Ok(Answer::Available(None));
-    };
-    let Some(bridge) = initialized_bridge(bridge) else {
-        return Ok(Answer::Unavailable);
-    };
-    let Some(document) = corsa_support::open_canonical_virtual_project_document_strict(ctx, bridge)
-        .await
-        .map_err(CanonicalFailure::from_project_open)?
-    else {
-        return Ok(Answer::Unavailable);
-    };
-    let Some((line, character)) = event_rename::semantic_position(ctx, &document)
-        .or_else(|| corsa_support::canonical_source_offset_to_position(&document, ctx.offset))
-    else {
-        return Ok(Answer::Unavailable);
-    };
-    let response = bridge
-        .rename(&document.request_uri, line, character, &semantic_name)
-        .await
-        .map_err(CanonicalFailure::FallbackBridge)?;
-    // A null answer from the query identity is not the end of the rename. When
-    // the project session materializes importer-scoped package shadows, the
-    // authored source is duplicated under distinct native module identities and
-    // the identity this document was opened under can stop being the one the
-    // session still knows. The materialized identities below answer for the same
-    // authored position, so only the absence of every identity means the rename
-    // is unavailable.
-    let response = response
-        .map(|response| {
-            serde_json::from_value::<WorkspaceEdit>(response).map_err(|error| {
-                CanonicalFailure::InvalidResponse {
-                    operation: "rename",
-                    message: cstr!("{error}"),
-                }
-            })
-        })
-        .transpose()?;
-    let mut linked = response
-        .as_ref()
-        .map(|response| linked_positions(&document, response))
-        .unwrap_or_default();
-    linked.extend(corsa_support::materialized_semantic_positions(
-        &document, ctx.uri, ctx.offset,
-    ));
-    linked.retain(|position| {
-        position.request_uri != document.request_uri
-            || position.line != line
-            || position.character != character
-    });
-    if matches!(rename_kind, Some(event_rename::RenameKind::Model))
-        && let Some(response) = response.as_ref()
-    {
-        linked.extend(event_rename::model_linked_positions(
-            ctx, &document, response,
-        ));
-    }
-    let mut mapped = response
-        .and_then(|response| {
-            corsa_support::map_canonical_corsa_workspace_edit(ctx, &document, response)
-        })
-        .into_iter()
-        .collect::<Vec<_>>();
-    if mapped.is_empty() && linked.is_empty() {
-        return Ok(Answer::Available(None));
-    }
-
-    for position in linked {
-        let Some(extra) = bridge
-            .rename(
-                &position.request_uri,
-                position.line,
-                position.character,
-                &semantic_name,
-            )
-            .await
-            .map_err(CanonicalFailure::AuthoritativeBridge)?
-        else {
-            return Ok(Answer::Available(None));
-        };
-        let extra =
-            serde_json::from_value(extra).map_err(|error| CanonicalFailure::InvalidResponse {
-                operation: "linked rename",
-                message: cstr!("{error}"),
-            })?;
-        let Some(extra) = corsa_support::map_canonical_corsa_workspace_edit(ctx, &document, extra)
-        else {
-            return Err(CanonicalFailure::UnmappedResponse("linked rename"));
-        };
-        mapped.push(extra);
-    }
-    if let Some(styles) = style_workspace_edit(ctx, &mapped, new_name) {
-        mapped.push(styles);
-    }
-
-    if let Some(kind) = rename_kind {
-        for edit in &mut mapped {
-            event_rename::rewrite_edits(ctx, edit, &semantic_name, kind);
-        }
-    }
-
-    Ok(Answer::Available(
-        corsa_support::merge_canonical_workspace_edits(mapped),
-    ))
 }
 
 fn style_workspace_edit(

--- a/crates/vize_maestro/src/ide/rename/canonical/execute.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/execute.rs
@@ -1,0 +1,212 @@
+use tower_lsp::lsp_types::WorkspaceEdit;
+use vize_canon::CorsaBridge;
+use vize_carton::{String, cstr};
+
+use super::{
+    Answer, CanonicalFailure, event_rename, initialized_bridge, linked_positions,
+    style_workspace_edit,
+};
+use crate::ide::{IdeContext, corsa_support};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::ide::rename) enum CanonicalRenameStage {
+    PrimaryQuery {
+        request_uri: String,
+        line: u32,
+        character: u32,
+    },
+    PrimaryNull,
+    PrimaryMapped,
+    PrimaryMappingDropped,
+    LinkedQuery {
+        request_uri: String,
+        line: u32,
+        character: u32,
+    },
+    LinkedNull {
+        request_uri: String,
+        line: u32,
+        character: u32,
+    },
+    LinkedMapped {
+        request_uri: String,
+        line: u32,
+        character: u32,
+    },
+    Complete,
+}
+
+pub(in crate::ide::rename) async fn rename(
+    ctx: &IdeContext<'_>,
+    new_name: &str,
+    bridge: Option<&CorsaBridge>,
+) -> Answer<WorkspaceEdit> {
+    match rename_strict(ctx, new_name, bridge).await {
+        Ok(answer) => answer,
+        Err(error) => error.into_lenient_answer(),
+    }
+}
+
+pub(in crate::ide::rename) async fn rename_strict(
+    ctx: &IdeContext<'_>,
+    new_name: &str,
+    bridge: Option<&CorsaBridge>,
+) -> Result<Answer<WorkspaceEdit>, CanonicalFailure> {
+    rename_strict_inner(ctx, new_name, bridge, None).await
+}
+
+#[cfg(test)]
+pub(in crate::ide::rename) async fn rename_strict_traced(
+    ctx: &IdeContext<'_>,
+    new_name: &str,
+    bridge: Option<&CorsaBridge>,
+) -> (
+    Result<Answer<WorkspaceEdit>, CanonicalFailure>,
+    Vec<CanonicalRenameStage>,
+) {
+    let mut trace = Vec::new();
+    let answer = rename_strict_inner(ctx, new_name, bridge, Some(&mut trace)).await;
+    (answer, trace)
+}
+
+async fn rename_strict_inner(
+    ctx: &IdeContext<'_>,
+    new_name: &str,
+    bridge: Option<&CorsaBridge>,
+    mut trace: Option<&mut Vec<CanonicalRenameStage>>,
+) -> Result<Answer<WorkspaceEdit>, CanonicalFailure> {
+    let rename_kind = event_rename::query_kind(ctx);
+    let Some(semantic_name) = event_rename::semantic_name(rename_kind, new_name) else {
+        return Ok(Answer::Available(None));
+    };
+    let Some(bridge) = initialized_bridge(bridge) else {
+        return Ok(Answer::Unavailable);
+    };
+    let Some(document) = corsa_support::open_canonical_virtual_project_document_strict(ctx, bridge)
+        .await
+        .map_err(CanonicalFailure::from_project_open)?
+    else {
+        return Ok(Answer::Unavailable);
+    };
+    let Some((line, character)) = event_rename::semantic_position(ctx, &document)
+        .or_else(|| corsa_support::canonical_source_offset_to_position(&document, ctx.offset))
+    else {
+        return Ok(Answer::Unavailable);
+    };
+    record(&mut trace, || CanonicalRenameStage::PrimaryQuery {
+        request_uri: document.request_uri.clone(),
+        line,
+        character,
+    });
+    let response = bridge
+        .rename(&document.request_uri, line, character, &semantic_name)
+        .await
+        .map_err(CanonicalFailure::FallbackBridge)?;
+    if response.is_none() {
+        record(&mut trace, || CanonicalRenameStage::PrimaryNull);
+    }
+    let response = response
+        .map(|response| {
+            serde_json::from_value::<WorkspaceEdit>(response).map_err(|error| {
+                CanonicalFailure::InvalidResponse {
+                    operation: "rename",
+                    message: cstr!("{error}"),
+                }
+            })
+        })
+        .transpose()?;
+    let had_primary_response = response.is_some();
+    let mut linked = response
+        .as_ref()
+        .map(|response| linked_positions(&document, response))
+        .unwrap_or_default();
+    linked.extend(corsa_support::materialized_semantic_positions(
+        &document, ctx.uri, ctx.offset,
+    ));
+    linked.retain(|position| {
+        position.request_uri != document.request_uri
+            || position.line != line
+            || position.character != character
+    });
+    if matches!(rename_kind, Some(event_rename::RenameKind::Model))
+        && let Some(response) = response.as_ref()
+    {
+        linked.extend(event_rename::model_linked_positions(
+            ctx, &document, response,
+        ));
+    }
+    let mapped_primary = response.and_then(|response| {
+        corsa_support::map_canonical_corsa_workspace_edit(ctx, &document, response)
+    });
+    if mapped_primary.is_some() {
+        record(&mut trace, || CanonicalRenameStage::PrimaryMapped);
+    } else if had_primary_response {
+        record(&mut trace, || CanonicalRenameStage::PrimaryMappingDropped);
+    }
+    let mut mapped = mapped_primary.into_iter().collect::<Vec<_>>();
+    if mapped.is_empty() && linked.is_empty() {
+        return Ok(Answer::Available(None));
+    }
+
+    for position in linked {
+        record(&mut trace, || CanonicalRenameStage::LinkedQuery {
+            request_uri: position.request_uri.clone(),
+            line: position.line,
+            character: position.character,
+        });
+        let Some(extra) = bridge
+            .rename(
+                &position.request_uri,
+                position.line,
+                position.character,
+                &semantic_name,
+            )
+            .await
+            .map_err(CanonicalFailure::AuthoritativeBridge)?
+        else {
+            record(&mut trace, || CanonicalRenameStage::LinkedNull {
+                request_uri: position.request_uri.clone(),
+                line: position.line,
+                character: position.character,
+            });
+            return Ok(Answer::Available(None));
+        };
+        let extra =
+            serde_json::from_value(extra).map_err(|error| CanonicalFailure::InvalidResponse {
+                operation: "linked rename",
+                message: cstr!("{error}"),
+            })?;
+        let Some(extra) = corsa_support::map_canonical_corsa_workspace_edit(ctx, &document, extra)
+        else {
+            return Err(CanonicalFailure::UnmappedResponse("linked rename"));
+        };
+        record(&mut trace, || CanonicalRenameStage::LinkedMapped {
+            request_uri: position.request_uri.clone(),
+            line: position.line,
+            character: position.character,
+        });
+        mapped.push(extra);
+    }
+    if let Some(styles) = style_workspace_edit(ctx, &mapped, new_name) {
+        mapped.push(styles);
+    }
+
+    if let Some(kind) = rename_kind {
+        for edit in &mut mapped {
+            event_rename::rewrite_edits(ctx, edit, &semantic_name, kind);
+        }
+    }
+    record(&mut trace, || CanonicalRenameStage::Complete);
+    Ok(Answer::Available(
+        corsa_support::merge_canonical_workspace_edits(mapped),
+    ))
+}
+
+fn record(
+    trace: &mut Option<&mut Vec<CanonicalRenameStage>>,
+    stage: impl FnOnce() -> CanonicalRenameStage,
+) {
+    if let Some(trace) = trace.as_mut() {
+        trace.push(stage());
+    }
+}

--- a/crates/vize_maestro/src/ide/rename/canonical/execute.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/execute.rs
@@ -1,6 +1,6 @@
 use tower_lsp::lsp_types::WorkspaceEdit;
 use vize_canon::CorsaBridge;
-use vize_carton::{String, cstr};
+use vize_carton::{FxHashSet, String, cstr};
 
 use super::{
     Answer, CanonicalFailure, event_rename, initialized_bridge, linked_positions,
@@ -123,11 +123,6 @@ async fn rename_strict_inner(
     linked.extend(corsa_support::materialized_semantic_positions(
         &document, ctx.uri, ctx.offset,
     ));
-    linked.retain(|position| {
-        position.request_uri != document.request_uri
-            || position.line != line
-            || position.character != character
-    });
     if matches!(rename_kind, Some(event_rename::RenameKind::Model))
         && let Some(response) = response.as_ref()
     {
@@ -135,6 +130,7 @@ async fn rename_strict_inner(
             ctx, &document, response,
         ));
     }
+    retain_unique_linked_positions(&mut linked, &document.request_uri, line, character);
     let mapped_primary = response.and_then(|response| {
         corsa_support::map_canonical_corsa_workspace_edit(ctx, &document, response)
     });
@@ -202,11 +198,50 @@ async fn rename_strict_inner(
     ))
 }
 
+fn retain_unique_linked_positions(
+    linked: &mut Vec<corsa_support::CanonicalSemanticPosition>,
+    primary_uri: &str,
+    primary_line: u32,
+    primary_character: u32,
+) {
+    let mut seen = FxHashSet::default();
+    linked.retain(|position| {
+        (position.request_uri != primary_uri
+            || position.line != primary_line
+            || position.character != primary_character)
+            && seen.insert(position.clone())
+    });
+}
+
 fn record(
     trace: &mut Option<&mut Vec<CanonicalRenameStage>>,
     stage: impl FnOnce() -> CanonicalRenameStage,
 ) {
     if let Some(trace) = trace.as_mut() {
         trace.push(stage());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linked_positions_remove_primary_and_cross_producer_duplicates() {
+        let primary = corsa_support::CanonicalSemanticPosition {
+            request_uri: "file:///project/Primary.vue.ts".into(),
+            line: 4,
+            character: 2,
+        };
+        let linked = corsa_support::CanonicalSemanticPosition {
+            request_uri: "file:///project/Linked.vue.ts".into(),
+            line: 8,
+            character: 3,
+        };
+        let mut positions = vec![linked.clone(), primary, linked.clone()];
+
+        retain_unique_linked_positions(&mut positions, "file:///project/Primary.vue.ts", 4, 2);
+
+        assert_eq!(positions, [linked]);
     }
 }

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests.rs
@@ -2,11 +2,12 @@ use std::sync::{Arc, Barrier};
 
 use harness::RealCorsaRenameSession;
 
+mod direct_first;
 mod harness;
 
 #[test]
 fn concurrent_real_corsa_rename_sessions_are_isolated() {
-    const SESSION_COUNT: usize = 12;
+    const SESSION_COUNT: usize = 20;
     const ASSERTED_ROUNDS: usize = 4;
 
     let corsa_path = resolve_tsgo_binary_required();
@@ -37,6 +38,11 @@ fn concurrent_real_corsa_rename_sessions_are_isolated() {
                 let rendezvous = Arc::clone(&rendezvous);
                 scope.spawn(move || -> Result<_, String> {
                     rendezvous.wait();
+                    session
+                        .assert_direct_first_child_rename()
+                        .map_err(|error| {
+                            format!("session {session_index} direct-first rename: {error}")
+                        })?;
                     for round in 0..ASSERTED_ROUNDS {
                         session.assert_prepare_ranges().map_err(|error| {
                             format!("session {session_index} round {round} prepare: {error}")

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/direct_first.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/direct_first.rs
@@ -49,7 +49,9 @@ fn direct_first_renames_survive_twenty_session_shutdown_overlap() {
         .collect::<Result<Vec<_>, _>>()
         .unwrap_or_else(|error| panic!("{error}"));
 
-    std::thread::scope(|scope| {
+    // Own the gates inside the scoped closure so unwinding drops them and
+    // releases blocked shutdown threads before `scope` joins those threads.
+    std::thread::scope(move |scope| {
         let shutdowns = pairs
             .into_iter()
             .map(|(index, mut closing, survivor)| {

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/direct_first.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/direct_first.rs
@@ -1,0 +1,103 @@
+use std::sync::{Arc, Barrier};
+
+use super::{harness::RealCorsaRenameSession, resolve_tsgo_binary_required};
+
+#[test]
+fn dependency_change_rearms_the_shared_editor_transport_once() {
+    let corsa_path = resolve_tsgo_binary_required();
+    let mut session = RealCorsaRenameSession::new(&corsa_path)
+        .unwrap_or_else(|error| panic!("session setup: {error}"));
+    session
+        .assert_parent_queries_before_child_change()
+        .unwrap_or_else(|error| panic!("generation one: {error}"));
+    session
+        .assert_child_change_rearms_parent_rename()
+        .unwrap_or_else(|error| panic!("generation two: {error}"));
+    session
+        .shutdown()
+        .unwrap_or_else(|error| panic!("shutdown: {error}"));
+}
+
+#[test]
+fn direct_first_renames_survive_twenty_session_shutdown_overlap() {
+    const PAIR_COUNT: usize = 10;
+
+    let corsa_path = resolve_tsgo_binary_required();
+    let mut pairs = (0..PAIR_COUNT)
+        .map(|index| {
+            let closing = RealCorsaRenameSession::new_with_shutdown_gate(&corsa_path)
+                .map_err(|error| format!("closing session {index}: {error}"))?;
+            closing
+                .assert_prepare_ranges()
+                .map_err(|error| format!("closing session {index} prepare: {error}"))?;
+            closing
+                .assert_parent_and_child_renames()
+                .map_err(|error| format!("closing session {index} rename: {error}"))?;
+            let survivor = RealCorsaRenameSession::new(&corsa_path)
+                .map_err(|error| format!("survivor session {index}: {error}"))?;
+            Ok((index, closing, survivor))
+        })
+        .collect::<Result<Vec<_>, String>>()
+        .unwrap_or_else(|error| panic!("{error}"));
+    let mut gates = pairs
+        .iter_mut()
+        .map(|(index, closing, _)| {
+            closing
+                .arm_shutdown_gate()
+                .map_err(|error| format!("closing session {index} gate: {error}"))
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap_or_else(|error| panic!("{error}"));
+
+    std::thread::scope(|scope| {
+        let shutdowns = pairs
+            .into_iter()
+            .map(|(index, mut closing, survivor)| {
+                let shutdown = scope.spawn(move || {
+                    closing
+                        .shutdown()
+                        .map_err(|error| format!("closing session {index}: {error}"))
+                });
+                (index, survivor, shutdown)
+            })
+            .collect::<Vec<_>>();
+        for (index, gate) in gates.iter_mut().enumerate() {
+            gate.wait_until_observed()
+                .unwrap_or_else(|error| panic!("closing session {index}: {error}"));
+        }
+
+        let rendezvous = Arc::new(Barrier::new(PAIR_COUNT));
+        let survivors = shutdowns
+            .into_iter()
+            .map(|(index, survivor, shutdown)| {
+                let rendezvous = Arc::clone(&rendezvous);
+                scope.spawn(move || {
+                    rendezvous.wait();
+                    survivor
+                        .assert_direct_first_child_rename()
+                        .map_err(|error| format!("survivor session {index}: {error}"))?;
+                    Ok::<_, String>((survivor, shutdown))
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut survivors = survivors
+            .into_iter()
+            .map(|survivor| survivor.join().expect("survivor thread panicked"))
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap_or_else(|error| panic!("{error}"));
+
+        for (index, gate) in gates.iter_mut().enumerate() {
+            gate.release()
+                .unwrap_or_else(|error| panic!("closing session {index}: {error}"));
+        }
+        for (mut survivor, shutdown) in survivors.drain(..) {
+            shutdown
+                .join()
+                .expect("closing session thread panicked")
+                .unwrap_or_else(|error| panic!("{error}"));
+            survivor
+                .shutdown()
+                .unwrap_or_else(|error| panic!("survivor shutdown: {error}"));
+        }
+    });
+}

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness.rs
@@ -10,6 +10,7 @@ use vize_canon::{CorsaBridge, CorsaBridgeConfig};
 use super::super::canonical;
 use crate::{ide::IdeContext, server::ServerState};
 
+mod generation;
 mod protocol;
 
 const CHILD_SOURCE: &str = r#"<script setup lang="ts">
@@ -33,6 +34,7 @@ pub(super) struct RealCorsaRenameSession {
     parent_uri: Url,
     protocol_trace_dir: PathBuf,
     shutdown_gate: Option<protocol::ShutdownGate>,
+    expected_readiness_generations: usize,
     shutdown_complete: bool,
 }
 
@@ -112,6 +114,7 @@ impl RealCorsaRenameSession {
             parent_uri,
             protocol_trace_dir,
             shutdown_gate,
+            expected_readiness_generations: 1,
             shutdown_complete: false,
         })
     }
@@ -141,6 +144,37 @@ impl RealCorsaRenameSession {
             }
         }
         Ok(())
+    }
+
+    pub(super) fn assert_direct_first_child_rename(&self) -> Result<(), String> {
+        let child_start = CHILD_SOURCE
+            .find("saveItem")
+            .ok_or_else(|| "child event marker missing".to_owned())?;
+        let child_ctx = IdeContext::new(&self.state, &self.child_uri, child_start + 2)
+            .ok_or_else(|| "missing child context".to_owned())?;
+        let (answer, stages) = crate::runtime::block_on(canonical::rename_strict_traced(
+            &child_ctx,
+            "direct-event",
+            Some(self.bridge.as_ref()),
+        ));
+        let answer =
+            answer.map_err(|error| format!("strict rename failed: {error}; {stages:#?}"))?;
+        let canonical::Answer::Available(Some(edit)) = answer else {
+            return Err(format!(
+                "strict rename returned no canonical edit; stages={stages:#?}"
+            ));
+        };
+        if !matches!(
+            stages.last(),
+            Some(canonical::CanonicalRenameStage::Complete)
+        ) {
+            return Err(format!("rename did not complete; stages={stages:#?}"));
+        }
+        assert_exact_event_edit(
+            &edit,
+            (&self.parent_uri, PARENT_SOURCE, "save-item", "direct-event"),
+            (&self.child_uri, CHILD_SOURCE, "saveItem", "directEvent"),
+        )
     }
 
     pub(super) fn assert_parent_and_child_renames(&self) -> Result<(), String> {
@@ -182,6 +216,7 @@ impl RealCorsaRenameSession {
             &self.protocol_trace_dir,
             canonical_uri.as_str(),
             logical_uri.as_str(),
+            self.expected_readiness_generations,
         )
     }
 

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/generation.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/generation.rs
@@ -1,0 +1,101 @@
+use std::fs;
+
+use tower_lsp::lsp_types::TextDocumentContentChangeEvent;
+
+use super::{
+    CHILD_SOURCE, PARENT_SOURCE, RealCorsaRenameSession, assert_exact_event_edit, strict_rename,
+};
+use crate::ide::IdeContext;
+
+const CHILD_SOURCE_V2: &str = r#"<script setup lang="ts">
+const generationTwo = true;
+defineEmits<{ saveItem: [id: string] }>();
+</script>
+"#;
+
+impl RealCorsaRenameSession {
+    pub(in crate::ide::rename::corsa_session_tests) fn assert_parent_queries_before_child_change(
+        &self,
+    ) -> Result<(), String> {
+        assert_parent_rename(
+            self,
+            CHILD_SOURCE,
+            "generationOne",
+            "generation-one",
+            "generationOne",
+        )?;
+        assert_parent_rename(
+            self,
+            CHILD_SOURCE,
+            "stableGeneration",
+            "stable-generation",
+            "stableGeneration",
+        )
+    }
+
+    pub(in crate::ide::rename::corsa_session_tests) fn assert_child_change_rearms_parent_rename(
+        &mut self,
+    ) -> Result<(), String> {
+        let changed = self.state.documents.apply_changes(
+            &self.child_uri,
+            vec![TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: CHILD_SOURCE_V2.to_owned(),
+            }],
+            2,
+        );
+        if !changed {
+            return Err("child overlay did not advance to generation two".to_owned());
+        }
+        self.state
+            .update_virtual_docs(&self.child_uri, CHILD_SOURCE_V2);
+        let child_path = self
+            .child_uri
+            .to_file_path()
+            .map_err(|()| "child URI is not a file path".to_owned())?;
+        fs::write(&child_path, CHILD_SOURCE_V2).map_err(|error| error.to_string())?;
+
+        assert_parent_rename(
+            self,
+            CHILD_SOURCE_V2,
+            "changedEvent",
+            "changed-event",
+            "changedEvent",
+        )?;
+        assert_parent_rename(
+            self,
+            CHILD_SOURCE_V2,
+            "settledEvent",
+            "settled-event",
+            "settledEvent",
+        )?;
+        self.expected_readiness_generations += 1;
+        Ok(())
+    }
+}
+
+fn assert_parent_rename(
+    session: &RealCorsaRenameSession,
+    child_source: &str,
+    new_name: &str,
+    expected_parent: &str,
+    expected_child: &str,
+) -> Result<(), String> {
+    let parent_start = PARENT_SOURCE
+        .find("save-item")
+        .ok_or_else(|| "parent event marker missing".to_owned())?;
+    let parent_ctx = IdeContext::new(&session.state, &session.parent_uri, parent_start + 2)
+        .ok_or_else(|| "missing parent context".to_owned())?;
+    let parent_edit = strict_rename(&parent_ctx, session.bridge.as_ref(), new_name)?;
+    assert_exact_event_edit(
+        &parent_edit,
+        (
+            &session.parent_uri,
+            PARENT_SOURCE,
+            "save-item",
+            expected_parent,
+        ),
+        (&session.child_uri, child_source, "saveItem", expected_child),
+    )
+}

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 mod executable;
+mod readiness;
 
 const SHUTDOWN_OBSERVATION_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -195,6 +196,7 @@ pub(super) fn assert_graceful_lsp_lifecycle(
     trace_dir: &Path,
     canonical_root_uri: &str,
     logical_root_uri: &str,
+    expected_readiness_generations: usize,
 ) -> Result<(), String> {
     let mut lsp_traces = Vec::new();
     for entry in fs::read_dir(trace_dir).map_err(|error| error.to_string())? {
@@ -226,8 +228,8 @@ pub(super) fn assert_graceful_lsp_lifecycle(
             path.display()
         ));
     }
-    let rename = find_bytes(trace, b"textDocument/rename")
-        .ok_or_else(|| format!("missing rename request in {}", path.display()))?;
+    let did_open = find_bytes(trace, b"textDocument/didOpen")
+        .ok_or_else(|| format!("missing didOpen in {}", path.display()))?;
     let shutdown = find_bytes(trace, b"\"shutdown\"").ok_or_else(|| {
         format!(
             "raw-closed editor LSP without shutdown in {}",
@@ -236,12 +238,14 @@ pub(super) fn assert_graceful_lsp_lifecycle(
     })?;
     let exit = find_bytes(trace, b"\"exit\"")
         .ok_or_else(|| format!("closed editor LSP without exit in {}", path.display()))?;
-    if !(rename < shutdown && shutdown < exit) {
-        return Err(format!(
-            "invalid editor LSP lifecycle order in {}: rename={rename}, shutdown={shutdown}, exit={exit}",
-            path.display()
-        ));
-    }
+    readiness::assert_generation_order(
+        path,
+        trace,
+        did_open,
+        shutdown,
+        exit,
+        expected_readiness_generations,
+    )?;
     let pid = path
         .file_stem()
         .and_then(|name| name.to_str())

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/readiness.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/readiness.rs
@@ -9,9 +9,13 @@ pub(super) fn assert_generation_order(
     expected_generations: usize,
 ) -> Result<(), String> {
     let ready = find_all_bytes(trace, b"textDocument/diagnostic");
-    if ready.len() != expected_generations {
+    // The initial generation opens both Parent and Child. Every later
+    // generation in this fixture changes only Child, so each adds one exact
+    // readiness request.
+    let expected_requests = expected_generations + 1;
+    if ready.len() != expected_requests {
         return Err(format!(
-            "expected {expected_generations} readiness requests, found {} in {}",
+            "expected {expected_requests} readiness requests for {expected_generations} generations, found {} in {}",
             ready.len(),
             path.display()
         ));
@@ -27,8 +31,10 @@ pub(super) fn assert_generation_order(
         .first()
         .copied()
         .ok_or_else(|| format!("missing rename request in {}", path.display()))?;
+    let first_generation_ready = ready[1];
     if !(did_open < first_ready
-        && first_ready < first_rename
+        && first_ready < first_generation_ready
+        && first_generation_ready < first_rename
         && renames.iter().all(|rename| *rename < shutdown)
         && shutdown < exit)
     {
@@ -52,16 +58,24 @@ fn assert_cross_document_generation(
 ) -> Result<(), String> {
     let did_change = super::find_bytes(trace, b"textDocument/didChange")
         .ok_or_else(|| format!("missing cross-document didChange in {}", path.display()))?;
+    let first_generation_ready = ready[1];
+    let second_generation_ready = ready[2];
     let first_generation = renames
         .iter()
-        .filter(|rename| ready[0] < **rename && **rename < did_change)
+        .filter(|rename| first_generation_ready < **rename && **rename < did_change)
         .count();
     let second_generation = renames
         .iter()
-        .filter(|rename| ready[1] < **rename && **rename < shutdown)
+        .filter(|rename| second_generation_ready < **rename && **rename < shutdown)
         .count();
-    if ready[0] < did_change
-        && did_change < ready[1]
+    let first_rename_after_change = renames
+        .iter()
+        .find(|rename| did_change < **rename)
+        .copied()
+        .ok_or_else(|| format!("missing rename after didChange in {}", path.display()))?;
+    if first_generation_ready < did_change
+        && did_change < second_generation_ready
+        && second_generation_ready < first_rename_after_change
         && first_generation >= 2
         && second_generation >= 2
     {

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/readiness.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/readiness.rs
@@ -1,0 +1,82 @@
+use std::path::Path;
+
+pub(super) fn assert_generation_order(
+    path: &Path,
+    trace: &[u8],
+    did_open: usize,
+    shutdown: usize,
+    exit: usize,
+    expected_generations: usize,
+) -> Result<(), String> {
+    let ready = find_all_bytes(trace, b"textDocument/diagnostic");
+    if ready.len() != expected_generations {
+        return Err(format!(
+            "expected {expected_generations} readiness requests, found {} in {}",
+            ready.len(),
+            path.display()
+        ));
+    }
+    let first_ready = ready.first().copied().ok_or_else(|| {
+        format!(
+            "missing exact document-readiness request before rename in {}",
+            path.display()
+        )
+    })?;
+    let renames = find_all_bytes(trace, b"textDocument/rename");
+    let first_rename = renames
+        .first()
+        .copied()
+        .ok_or_else(|| format!("missing rename request in {}", path.display()))?;
+    if !(did_open < first_ready
+        && first_ready < first_rename
+        && renames.iter().all(|rename| *rename < shutdown)
+        && shutdown < exit)
+    {
+        return Err(format!(
+            "invalid editor LSP lifecycle order in {}: didOpen={did_open}, ready={ready:?}, rename={renames:?}, shutdown={shutdown}, exit={exit}",
+            path.display()
+        ));
+    }
+    if expected_generations == 2 {
+        assert_cross_document_generation(path, trace, &ready, &renames, shutdown)?;
+    }
+    Ok(())
+}
+
+fn assert_cross_document_generation(
+    path: &Path,
+    trace: &[u8],
+    ready: &[usize],
+    renames: &[usize],
+    shutdown: usize,
+) -> Result<(), String> {
+    let did_change = super::find_bytes(trace, b"textDocument/didChange")
+        .ok_or_else(|| format!("missing cross-document didChange in {}", path.display()))?;
+    let first_generation = renames
+        .iter()
+        .filter(|rename| ready[0] < **rename && **rename < did_change)
+        .count();
+    let second_generation = renames
+        .iter()
+        .filter(|rename| ready[1] < **rename && **rename < shutdown)
+        .count();
+    if ready[0] < did_change
+        && did_change < ready[1]
+        && first_generation >= 2
+        && second_generation >= 2
+    {
+        return Ok(());
+    }
+    Err(format!(
+        "invalid cross-document readiness order in {}: ready={ready:?}, didChange={did_change}, rename={renames:?}, shutdown={shutdown}",
+        path.display()
+    ))
+}
+
+fn find_all_bytes(haystack: &[u8], needle: &[u8]) -> Vec<usize> {
+    haystack
+        .windows(needle.len())
+        .enumerate()
+        .filter_map(|(index, window)| (window == needle).then_some(index))
+        .collect()
+}

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/readiness.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/readiness.rs
@@ -68,21 +68,20 @@ fn assert_cross_document_generation(
         .iter()
         .filter(|rename| second_generation_ready < **rename && **rename < shutdown)
         .count();
-    let first_rename_after_change = renames
+    let unarmed_renames = renames
         .iter()
-        .find(|rename| did_change < **rename)
-        .copied()
-        .ok_or_else(|| format!("missing rename after didChange in {}", path.display()))?;
+        .filter(|rename| did_change < **rename && **rename < second_generation_ready)
+        .count();
     if first_generation_ready < did_change
         && did_change < second_generation_ready
-        && second_generation_ready < first_rename_after_change
+        && unarmed_renames == 0
         && first_generation >= 2
         && second_generation >= 2
     {
         return Ok(());
     }
     Err(format!(
-        "invalid cross-document readiness order in {}: ready={ready:?}, didChange={did_change}, rename={renames:?}, shutdown={shutdown}",
+        "invalid cross-document readiness order in {}: ready={ready:?}, didChange={did_change}, unarmedRenames={unarmed_renames}, rename={renames:?}, shutdown={shutdown}",
         path.display()
     ))
 }

--- a/crates/vize_maestro/src/ide/signature_help.rs
+++ b/crates/vize_maestro/src/ide/signature_help.rs
@@ -29,6 +29,16 @@ use crate::virtual_code::{ArtCursorPosition, ArtVariantInfo, BlockType, VirtualD
 pub struct SignatureHelpService;
 
 #[cfg(feature = "native")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::ide) enum SignatureHelpStage {
+    VirtualOpened,
+    VirtualOpenFailed { message: String },
+    RequestSome,
+    RequestNull,
+    RequestFailed { message: String },
+}
+
+#[cfg(feature = "native")]
 impl SignatureHelpService {
     /// Resolve signature help through the same canonical virtual TypeScript
     /// project used by hover, completion, definition, and diagnostics.
@@ -45,6 +55,31 @@ impl SignatureHelpService {
         corsa_bridge: Option<Arc<CorsaBridge>>,
         context: Option<serde_json::Value>,
     ) -> Option<SignatureHelp> {
+        Self::signature_help_with_corsa_context_traced(ctx, corsa_bridge, context, None).await
+    }
+
+    #[cfg(test)]
+    pub(in crate::ide) async fn signature_help_with_corsa_traced(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<Arc<CorsaBridge>>,
+    ) -> (Option<SignatureHelp>, Vec<SignatureHelpStage>) {
+        let mut trace = Vec::new();
+        let help = Self::signature_help_with_corsa_context_traced(
+            ctx,
+            corsa_bridge,
+            None,
+            Some(&mut trace),
+        )
+        .await;
+        (help, trace)
+    }
+
+    async fn signature_help_with_corsa_context_traced(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<Arc<CorsaBridge>>,
+        context: Option<serde_json::Value>,
+        trace: Option<&mut Vec<SignatureHelpStage>>,
+    ) -> Option<SignatureHelp> {
         let bridge = corsa_bridge?;
         if !bridge.is_initialized() {
             return None;
@@ -57,13 +92,13 @@ impl SignatureHelpService {
                 Self::signature_help_in_canonical_sfc(ctx, &bridge, context).await
             }
             BlockType::Script => {
-                Self::signature_help_in_split_script(ctx, &bridge, false, context).await
+                Self::signature_help_in_split_script(ctx, &bridge, false, context, trace).await
             }
             BlockType::ScriptSetup => {
-                Self::signature_help_in_split_script(ctx, &bridge, true, context).await
+                Self::signature_help_in_split_script(ctx, &bridge, true, context, trace).await
             }
             BlockType::Art(ArtCursorPosition::VariantTemplate(ref info)) => {
-                Self::signature_help_in_art_variant(ctx, &bridge, info, context).await
+                Self::signature_help_in_art_variant(ctx, &bridge, info, context, trace).await
             }
             BlockType::Template | BlockType::Style(_) | BlockType::Art(_) => None,
         }
@@ -89,6 +124,7 @@ impl SignatureHelpService {
         bridge: &CorsaBridge,
         is_setup: bool,
         context: Option<serde_json::Value>,
+        trace: Option<&mut Vec<SignatureHelpStage>>,
     ) -> Option<SignatureHelp> {
         let virtual_docs = ctx.virtual_docs.as_ref()?;
         let script = if is_setup {
@@ -104,6 +140,7 @@ impl SignatureHelpService {
             generated_offset,
             corsa_support::script_request_path(ctx.uri, is_setup),
             context,
+            trace,
         )
         .await
     }
@@ -113,6 +150,7 @@ impl SignatureHelpService {
         bridge: &CorsaBridge,
         info: &ArtVariantInfo,
         context: Option<serde_json::Value>,
+        trace: Option<&mut Vec<SignatureHelpStage>>,
     ) -> Option<SignatureHelp> {
         let template = ctx
             .virtual_docs
@@ -129,6 +167,7 @@ impl SignatureHelpService {
             generated_offset,
             corsa_support::art_template_request_path(ctx.uri, info.variant_index),
             context,
+            trace,
         )
         .await
     }
@@ -140,16 +179,43 @@ impl SignatureHelpService {
         generated_offset: usize,
         request_path: vize_carton::String,
         context: Option<serde_json::Value>,
+        mut trace: Option<&mut Vec<SignatureHelpStage>>,
     ) -> Option<SignatureHelp> {
         let (line, character) = super::offset_to_position(&document.content, generated_offset);
-        let uri = bridge
+        let uri = match bridge
             .open_or_update_virtual_document(&request_path, &document.content)
             .await
-            .ok()?;
-        let help = bridge
+        {
+            Ok(uri) => {
+                record_signature_help_stage(&mut trace, || SignatureHelpStage::VirtualOpened);
+                uri
+            }
+            Err(error) => {
+                record_signature_help_stage(&mut trace, || SignatureHelpStage::VirtualOpenFailed {
+                    message: error.to_string(),
+                });
+                return None;
+            }
+        };
+        let help = match bridge
             .signature_help_with_context(&uri, line, character, context)
             .await
-            .ok()??;
+        {
+            Ok(Some(help)) => {
+                record_signature_help_stage(&mut trace, || SignatureHelpStage::RequestSome);
+                help
+            }
+            Ok(None) => {
+                record_signature_help_stage(&mut trace, || SignatureHelpStage::RequestNull);
+                return None;
+            }
+            Err(error) => {
+                record_signature_help_stage(&mut trace, || SignatureHelpStage::RequestFailed {
+                    message: error.to_string(),
+                });
+                return None;
+            }
+        };
         Some(Self::convert_lsp_signature_help(help))
     }
 
@@ -201,6 +267,16 @@ impl SignatureHelpService {
                 value: markup.value,
             }),
         }
+    }
+}
+
+#[cfg(feature = "native")]
+fn record_signature_help_stage(
+    trace: &mut Option<&mut Vec<SignatureHelpStage>>,
+    stage: impl FnOnce() -> SignatureHelpStage,
+) {
+    if let Some(trace) = trace.as_mut() {
+        trace.push(stage());
     }
 }
 

--- a/crates/vize_maestro/src/ide/signature_help/tests.rs
+++ b/crates/vize_maestro/src/ide/signature_help/tests.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use tower_lsp::lsp_types::Url;
 use vize_canon::{CorsaBridge, CorsaBridgeConfig};
 
-use super::SignatureHelpService;
+use super::{SignatureHelpService, SignatureHelpStage};
 use crate::ide::{IdeContext, JsxService};
 use crate::server::ServerState;
 
@@ -61,10 +61,19 @@ fn signature_help_maps_art_variant_template() {
         let script_marker = "format('script', ";
         let script_offset = source.find(script_marker).unwrap() + script_marker.len();
         let script_ctx = IdeContext::new(&state, &uri, script_offset).unwrap();
-        let help =
-            SignatureHelpService::signature_help_with_corsa(&script_ctx, Some(bridge.clone()))
-                .await
-                .expect("signature help in art script setup");
+        let (help, stages) = SignatureHelpService::signature_help_with_corsa_traced(
+            &script_ctx,
+            Some(bridge.clone()),
+        )
+        .await;
+        let help = help.unwrap_or_else(|| panic!("signature help in art script setup: {stages:?}"));
+        assert_eq!(
+            stages,
+            [
+                SignatureHelpStage::VirtualOpened,
+                SignatureHelpStage::RequestSome,
+            ]
+        );
         assert_signature(help, "format", 1);
 
         let marker = "format('art', ";

--- a/crates/vize_maestro/src/ide/signature_help/tests.rs
+++ b/crates/vize_maestro/src/ide/signature_help/tests.rs
@@ -110,9 +110,17 @@ fn signature_help_maps_art_variant_template() {
             "art cursor mapped to the wrong virtual offset:\n{}",
             template.content
         );
-        let help = SignatureHelpService::signature_help_with_corsa(&ctx, Some(bridge.clone()))
-            .await
-            .expect("signature help in art variant");
+        let (help, stages) =
+            SignatureHelpService::signature_help_with_corsa_traced(&ctx, Some(bridge.clone()))
+                .await;
+        let help = help.unwrap_or_else(|| panic!("signature help in art variant: {stages:?}"));
+        assert_eq!(
+            stages,
+            [
+                SignatureHelpStage::VirtualOpened,
+                SignatureHelpStage::RequestSome,
+            ]
+        );
         assert_signature(help, "format", 1);
 
         bridge.shutdown().await.unwrap();


### PR DESCRIPTION
## Summary

- synchronize editor semantic requests with a transport-wide document generation
- require one successful diagnostic response after each open, change, or close generation
- add direct-first, cross-document, shutdown-overlap, and typed rename-stage regressions

## Root cause

Editor readiness was cached per URI. A dependency could change while an already-ready importer remained marked ready, allowing rename and other semantic requests to race ahead of the editor's project update under coverage instrumentation.

The new contract advances one transport generation after every successful document notification and acknowledges that generation only after the diagnostic barrier returns successfully. It does not add retries, sleeps, timeout increases, global serialization, or thread reductions.

## Validation

- old URI-local readiness ablation fails deterministically: expected two readiness requests, observed one
- focused ordinary and `cargo llvm-cov` generation tests pass
- 20 concurrent direct-first rename sessions and shutdown overlap pass
- full `vize_maestro` suite passes
- workspace strict clippy, formatting, diff, and source-length gates pass
- CI-faithful workspace coverage reached one unrelated fallback-count assertion reproduced unchanged on clean `main`

Closes #4138

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rename accuracy after documents or dependencies change.
  - Renaming now waits for updated editor diagnostics, reducing stale or incomplete workspace edits.
  - Improved rename behavior while related editor sessions are opening or shutting down.
  - Added support for reliably updating both parent and child documents during rename operations.
  - Improved signature-help reliability when opening virtual documents and requesting results.

- **Tests**
  - Expanded coverage for concurrent renames, document updates, readiness checks, signature help, and session lifecycle scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->