### PR TITLE
fix(canon): bound package reachability before editor diagnostics

### DIFF
--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -6,6 +6,7 @@
 
 use std::path::{Path, PathBuf};
 
+use vize_canon::batch::is_vue_runtime_support_specifier;
 use vize_canon::{PackageRouteBinding, PackageRouteResolver, PackageSourceOptions};
 #[cfg(test)]
 use vize_carton::cstr;
@@ -116,6 +117,7 @@ pub(super) fn collect_transitive_local_imports_with_resolver(
                 });
                 match aliased {
                     Some(resolved) => Some(resolved),
+                    None if is_vue_runtime_support_specifier(&specifier) => None,
                     None => {
                         let context_key = (
                             dir.to_path_buf(),
@@ -227,9 +229,7 @@ pub(super) fn collect_transitive_local_imports_with_resolver(
                     &mut discovery,
                 )
             };
-            if needs_registration {
-                package_routes.extend(discovery.package_routes);
-            }
+            package_routes.extend(discovery.package_routes);
             let in_package_graph = package_graph || package_route.is_some();
             if let Some(route) = package_route
                 && needs_registration

--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -23,8 +23,8 @@ use registration::VirtualRegistrationCache;
 use registration::non_relative_import_needs_virtual_registration;
 #[path = "imports_resolution.rs"]
 mod resolution;
-pub(super) use resolution::resolve_import_base;
 use resolution::{absolutize, is_declaration_file, is_node_modules_path, resolve_relative_import};
+pub(super) use resolution::{resolve_import_base, resolve_import_base_with_inputs};
 #[path = "imports_specifiers.rs"]
 mod specifiers;
 use specifiers::{extract_module_specifier_occurrences, is_relative_specifier};

--- a/crates/vize/src/commands/check/imports_aliases.rs
+++ b/crates/vize/src/commands/check/imports_aliases.rs
@@ -63,6 +63,45 @@ impl PathAliasResolver {
             .and_then(|base_url| resolve_base(&base_url.join(specifier), canonical_paths, options))
     }
 
+    pub(super) fn resolve_with_inputs(
+        &self,
+        specifier: &str,
+        canonical_paths: &mut CanonicalPathCache,
+        options: impl Into<ImportFileOptions>,
+        mut resolve_base: impl FnMut(
+            &Path,
+            &mut CanonicalPathCache,
+            ImportFileOptions,
+        ) -> (Option<PathBuf>, Vec<PathBuf>),
+    ) -> (Option<PathBuf>, Vec<PathBuf>) {
+        let options = options.into();
+        let mut inputs = Vec::new();
+        for alias in &self.aliases {
+            let Some(matched) = alias.match_specifier(specifier) else {
+                continue;
+            };
+            for target in &alias.targets {
+                let target = if target.contains('*') {
+                    alias.base_dir.join(target.replace('*', matched))
+                } else {
+                    alias.base_dir.join(target.as_str())
+                };
+                let (resolved, consulted) = resolve_base(&target, canonical_paths, options);
+                inputs.extend(consulted);
+                if resolved.is_some() {
+                    return (resolved, inputs);
+                }
+            }
+        }
+        if let Some(base_url) = &self.base_url {
+            let (resolved, consulted) =
+                resolve_base(&base_url.join(specifier), canonical_paths, options);
+            inputs.extend(consulted);
+            return (resolved, inputs);
+        }
+        (None, inputs)
+    }
+
     pub(super) fn package_resolution_context(
         &self,
         resolver: &mut vize_canon::PackageRouteResolver,

--- a/crates/vize/src/commands/check/imports_aliases_tests.rs
+++ b/crates/vize/src/commands/check/imports_aliases_tests.rs
@@ -1,5 +1,7 @@
 use super::super::{
-    imports::{collect_transitive_local_imports, resolve_import_base},
+    imports::{
+        collect_transitive_local_imports, resolve_import_base, resolve_import_base_with_inputs,
+    },
     path_cache::CanonicalPathCache,
 };
 use super::PathAliasResolver;
@@ -57,6 +59,29 @@ fn exact_alias_does_not_match_prefix() {
         resolver.resolve("@app/prefix", &mut paths, false, resolve_import_base),
         Some(prefix.canonicalize().unwrap())
     );
+}
+
+#[test]
+fn missing_alias_target_retains_every_probed_candidate() {
+    let root = tempfile::tempdir().unwrap();
+    std::fs::write(
+        root.path().join("tsconfig.json"),
+        r#"{"compilerOptions":{"baseUrl":".","paths":{"@missing":["src/Missing"]}}}"#,
+    )
+    .unwrap();
+    let resolver =
+        PathAliasResolver::from_tsconfig(Some(root.path().join("tsconfig.json").as_path()));
+
+    let (resolved, inputs) = resolver.resolve_with_inputs(
+        "@missing",
+        &mut CanonicalPathCache::default(),
+        false,
+        resolve_import_base_with_inputs,
+    );
+
+    assert!(resolved.is_none());
+    assert!(inputs.iter().any(|path| path.ends_with("src/Missing.ts")));
+    assert!(inputs.iter().any(|path| path.ends_with("src/Missing.vue")));
 }
 
 #[test]

--- a/crates/vize/src/commands/check/imports_package_registration_tests.rs
+++ b/crates/vize/src/commands/check/imports_package_registration_tests.rs
@@ -126,7 +126,10 @@ fn exhausted_package_closure_tracks_inputs_without_materializing_a_shadow() {
         &mut discovery,
     );
 
-    assert!(needs_registration);
+    assert!(
+        !needs_registration,
+        "an exhausted native route must not widen the program roots"
+    );
     assert_eq!(discovery.package_routes.len(), 1);
     let binding = &discovery.package_routes[0];
     assert!(binding.route.is_none(), "an exhausted route stays native");
@@ -147,4 +150,49 @@ fn exhausted_package_closure_tracks_inputs_without_materializing_a_shadow() {
     assert_eq!(metrics.reachability_budget_exceeded, 1);
     assert_eq!(metrics.last_reachability_files, 2);
     assert_eq!(metrics.last_reachability_parses, 1);
+}
+
+#[test]
+fn vue_runtime_support_stays_native_without_reachability_work() {
+    let root = tempfile::tempdir().unwrap();
+    let entry = write(
+        root.path(),
+        "src/entry.ts",
+        "import type { Component } from 'vue';\nexport type Entry = Component;\n",
+    );
+    write(
+        root.path(),
+        "node_modules/vue/package.json",
+        r#"{"name":"vue","exports":{".":{"types":"./index.d.ts"}}}"#,
+    );
+    write(
+        root.path(),
+        "node_modules/vue/index.d.ts",
+        "export type { Component } from './runtime';\n",
+    );
+    write(
+        root.path(),
+        "node_modules/vue/runtime.d.ts",
+        "export interface Component { readonly name?: string }\n",
+    );
+
+    let mut resolver = PackageRouteResolver::default();
+    let discovered = collect_transitive_local_imports_with_resolver(
+        &[entry],
+        root.path(),
+        &mut CanonicalPathCache::default(),
+        false,
+        None,
+        &mut resolver,
+    );
+
+    assert!(discovered.registrations.is_empty());
+    assert!(discovered.authored.is_empty());
+    assert!(discovered.package_routes.is_empty());
+    let metrics = resolver.metrics();
+    assert_eq!(metrics.cache_misses, 0, "runtime support stays native");
+    assert_eq!(
+        metrics.reachability_checks, 0,
+        "runtime support is terminal"
+    );
 }

--- a/crates/vize/src/commands/check/imports_package_registration_tests.rs
+++ b/crates/vize/src/commands/check/imports_package_registration_tests.rs
@@ -76,12 +76,72 @@ fn package_aware_registration_walks_a_package_closure_once_per_source() {
         "memoized answers must replay the walked answer: {answers:?}"
     );
     assert_eq!(
-        cache.len(),
+        cache.registration_entries(),
         1,
         "one package closure keeps one memo entry, however many importers reach it"
     );
 
     let _ = std::fs::remove_dir_all(&root);
+}
+
+/// The bounded reachability scan reads and parses a package's dependency
+/// closure, so repeating it for every authored importer of that package
+/// reintroduces exactly the per-importer cost the registration memo removes
+/// (#4137). Distinct importers keep distinct memo entries, so the scan itself
+/// must be memoized against the route it inspects.
+#[test]
+fn package_route_reachability_is_scanned_once_per_route() {
+    let root = tempfile::tempdir().unwrap();
+    let first = write(
+        root.path(),
+        "src/first.ts",
+        "import { widget } from 'widgets';\nvoid widget;\n",
+    );
+    let second = write(
+        root.path(),
+        "src/second.ts",
+        "import { widget } from 'widgets';\nvoid widget;\n",
+    );
+    write(
+        root.path(),
+        "node_modules/widgets/package.json",
+        r#"{"name":"widgets","types":"index.d.ts"}"#,
+    );
+    write(
+        root.path(),
+        "node_modules/widgets/index.d.ts",
+        "export declare const widget: number;\n",
+    );
+
+    let mut canonical_paths = CanonicalPathCache::default();
+    let first = canonical_paths.canonicalize(&first);
+    let second = canonical_paths.canonicalize(&second);
+    let mut packages = PackageRouteResolver::default();
+    let mut cache = registration::VirtualRegistrationCache::default();
+
+    for entry in [&first, &second] {
+        let mut discovery = registration::VirtualRegistrationDiscovery::default();
+        registration::non_relative_import_needs_virtual_registration(
+            entry,
+            &mut canonical_paths,
+            ImportFileOptions::from(false),
+            None,
+            Some(&mut packages),
+            &mut cache,
+            &mut discovery,
+        );
+    }
+
+    assert_eq!(
+        cache.registration_entries(),
+        2,
+        "each authored source keeps its own memo entry"
+    );
+    assert_eq!(
+        packages.metrics().reachability_checks,
+        1,
+        "one package route is scanned once, however many importers reach it"
+    );
 }
 
 #[test]

--- a/crates/vize/src/commands/check/imports_package_registration_tests.rs
+++ b/crates/vize/src/commands/check/imports_package_registration_tests.rs
@@ -83,3 +83,68 @@ fn package_aware_registration_walks_a_package_closure_once_per_source() {
 
     let _ = std::fs::remove_dir_all(&root);
 }
+
+#[test]
+fn exhausted_package_closure_tracks_inputs_without_materializing_a_shadow() {
+    let root = tempfile::tempdir().unwrap();
+    let entry = write(
+        root.path(),
+        "src/entry.ts",
+        "import { Chart } from 'chart-like';\nvoid Chart;\n",
+    );
+    write(
+        root.path(),
+        "node_modules/chart-like/package.json",
+        r#"{"name":"chart-like","exports":{".":{"types":"./index.d.ts","import":"./index.js"}}}"#,
+    );
+    write(
+        root.path(),
+        "node_modules/chart-like/index.d.ts",
+        "export declare class Chart {}\n",
+    );
+    write(
+        root.path(),
+        "node_modules/chart-like/index.js",
+        &"x".repeat(129 * 1024),
+    );
+    let mut canonical_paths = CanonicalPathCache::default();
+    let entry = canonical_paths.canonicalize(&entry);
+    let mut packages = PackageRouteResolver::default();
+    let mut cache = registration::VirtualRegistrationCache::default();
+    let mut discovery = registration::VirtualRegistrationDiscovery::default();
+
+    let needs_registration = registration::non_relative_import_needs_virtual_registration(
+        &entry,
+        &mut canonical_paths,
+        ImportFileOptions {
+            include_js: true,
+            include_jsx: true,
+        },
+        None,
+        Some(&mut packages),
+        &mut cache,
+        &mut discovery,
+    );
+
+    assert!(needs_registration);
+    assert_eq!(discovery.package_routes.len(), 1);
+    let binding = &discovery.package_routes[0];
+    assert!(binding.route.is_none(), "an exhausted route stays native");
+    assert!(
+        binding
+            .invalidation_paths
+            .iter()
+            .any(|path| { path.ends_with("node_modules/chart-like/package.json") })
+    );
+    assert!(
+        binding
+            .invalidation_paths
+            .iter()
+            .any(|path| path.ends_with("node_modules/chart-like/index.js"))
+    );
+    let metrics = packages.metrics();
+    assert_eq!(metrics.reachability_checks, 1);
+    assert_eq!(metrics.reachability_budget_exceeded, 1);
+    assert_eq!(metrics.last_reachability_files, 2);
+    assert_eq!(metrics.last_reachability_parses, 1);
+}

--- a/crates/vize/src/commands/check/imports_registration.rs
+++ b/crates/vize/src/commands/check/imports_registration.rs
@@ -22,7 +22,36 @@ pub(super) struct CachedVirtualRegistration {
     discovery: VirtualRegistrationDiscovery,
 }
 
-pub(super) type VirtualRegistrationCache = FxHashMap<(PathBuf, bool), CachedVirtualRegistration>;
+/// Reachability of one package route never depends on the importer that
+/// reached it: the bounded scan resolves nested specifiers from the package's
+/// own files. Keying on the manifest, spelling, and resolution context keeps
+/// the scan to once per distinct route instead of once per occurrence.
+type PackageReachabilityKey = (
+    PathBuf,
+    vize_carton::String,
+    vize_canon::PackageResolutionContext,
+    u8,
+);
+
+#[derive(Default)]
+pub(super) struct VirtualRegistrationCache {
+    registrations: FxHashMap<(PathBuf, bool), CachedVirtualRegistration>,
+    reachability: FxHashMap<PackageReachabilityKey, vize_canon::batch::PackageRouteReachability>,
+}
+
+impl VirtualRegistrationCache {
+    #[cfg(test)]
+    pub(super) fn registration_entries(&self) -> usize {
+        self.registrations.len()
+    }
+}
+
+/// One walk of the sources reachable from a single registration candidate.
+#[derive(Default)]
+struct RegistrationFrontier {
+    visited: FxHashSet<PathBuf>,
+    queue: Vec<PathBuf>,
+}
 
 pub(super) fn non_relative_import_needs_virtual_registration(
     path: &Path,
@@ -34,7 +63,7 @@ pub(super) fn non_relative_import_needs_virtual_registration(
     discovery: &mut VirtualRegistrationDiscovery,
 ) -> bool {
     let cache_key = (path.to_path_buf(), packages.is_some());
-    if let Some(cached) = cache.get(&cache_key) {
+    if let Some(cached) = cache.registrations.get(&cache_key) {
         discovery
             .package_routes
             .extend(cached.discovery.package_routes.iter().cloned());
@@ -44,22 +73,24 @@ pub(super) fn non_relative_import_needs_virtual_registration(
         return cached.needs_registration;
     }
 
-    let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
-    let mut queue = vec![path.to_path_buf()];
+    let mut frontier = RegistrationFrontier {
+        visited: FxHashSet::default(),
+        queue: vec![path.to_path_buf()],
+    };
     let mut discovered = Vec::new();
     let needs_registration = source_needs_virtual_registration(
-        &mut visited,
-        &mut queue,
+        &mut frontier,
         canonical_paths,
         options,
         aliases,
         packages,
+        &mut cache.reachability,
         &mut discovered,
     );
     let resolved_discovery = VirtualRegistrationDiscovery {
         package_routes: discovered,
         package_sources: if needs_registration {
-            visited.into_iter().collect()
+            frontier.visited.into_iter().collect()
         } else {
             Vec::new()
         },
@@ -70,7 +101,7 @@ pub(super) fn non_relative_import_needs_virtual_registration(
     discovery
         .package_sources
         .extend(resolved_discovery.package_sources.iter().cloned());
-    cache.insert(
+    cache.registrations.insert(
         cache_key,
         CachedVirtualRegistration {
             needs_registration,
@@ -81,17 +112,20 @@ pub(super) fn non_relative_import_needs_virtual_registration(
 }
 
 fn source_needs_virtual_registration(
-    visited: &mut FxHashSet<PathBuf>,
-    queue: &mut Vec<PathBuf>,
+    frontier: &mut RegistrationFrontier,
     canonical_paths: &mut CanonicalPathCache,
     options: ImportFileOptions,
     aliases: Option<&PathAliasResolver>,
     mut packages: Option<&mut vize_canon::PackageRouteResolver>,
+    reachability_cache: &mut FxHashMap<
+        PackageReachabilityKey,
+        vize_canon::batch::PackageRouteReachability,
+    >,
     discovered_routes: &mut Vec<vize_canon::PackageRouteBinding>,
 ) -> bool {
     let mut needs_registration = false;
-    while let Some(file) = queue.pop() {
-        if !visited.insert(file.clone()) {
+    while let Some(file) = frontier.queue.pop() {
+        if !frontier.visited.insert(file.clone()) {
             continue;
         }
         if file.extension().and_then(|extension| extension.to_str()) == Some("vue") {
@@ -150,71 +184,27 @@ fn source_needs_virtual_registration(
                     let mut binding_route = None;
                     let mut track_reachability = false;
                     if let Some(route) = route {
-                        let reachability = vize_canon::batch::scan_package_route_reachability(
-                            &route,
-                            |importer, nested_specifier| {
-                                let nested_dir = importer.parent().unwrap_or(importer);
-                                if is_relative_specifier(nested_specifier) {
-                                    resolve_import_base_with_inputs(
-                                        &nested_dir.join(nested_specifier),
-                                        canonical_paths,
-                                        options,
-                                    )
-                                } else {
-                                    let candidate = Path::new(nested_specifier);
-                                    if candidate.is_absolute() {
-                                        resolve_import_base_with_inputs(
-                                            candidate,
-                                            canonical_paths,
-                                            options,
-                                        )
-                                    } else {
-                                        aliases.map_or_else(
-                                            || (None, Vec::new()),
-                                            |aliases| {
-                                                aliases.resolve_with_inputs(
-                                                    nested_specifier,
-                                                    canonical_paths,
-                                                    options,
-                                                    resolve_import_base_with_inputs,
-                                                )
-                                            },
-                                        )
-                                    }
-                                }
-                            },
-                            |importer, nested_specifier, nested_mode| {
-                                let nested_dir = importer.parent().unwrap_or(importer);
-                                let (nested_context, mut nested_inputs) = match aliases {
-                                    Some(aliases) => aliases.package_resolution_context(
-                                        packages,
-                                        importer,
-                                        nested_mode,
-                                    ),
-                                    None => packages.resolution_context(
-                                        importer,
-                                        nested_mode,
-                                        None,
-                                        None,
-                                        std::iter::empty::<vize_carton::String>(),
-                                    ),
-                                };
-                                let (nested, consulted) = packages
-                                    .lookup_with_context(
-                                        nested_dir,
-                                        nested_specifier,
-                                        vize_canon::PackageSourceOptions::new(
-                                            options.include_js,
-                                            options.include_jsx,
-                                        ),
-                                        nested_context,
-                                    )
-                                    .into_parts();
-                                nested_inputs.extend(consulted);
-                                (nested, nested_inputs)
-                            },
+                        let reachability_key = (
+                            route.manifest_path.clone(),
+                            specifier.clone(),
+                            context.clone(),
+                            vize_canon::batch::PACKAGE_REACHABILITY_BUDGET_REVISION,
                         );
-                        reachability.record_work(packages);
+                        let reachability = match reachability_cache.get(&reachability_key) {
+                            Some(cached) => cached.clone(),
+                            None => {
+                                let scanned = scan_route_reachability(
+                                    &route,
+                                    canonical_paths,
+                                    options,
+                                    aliases,
+                                    packages,
+                                );
+                                scanned.record_work(packages);
+                                reachability_cache.insert(reachability_key, scanned.clone());
+                                scanned
+                            }
+                        };
                         track_reachability = reachability.requires_tracking();
                         let needs_shadow = reachability.requires_shadow();
                         needs_registration |= needs_shadow;
@@ -254,11 +244,77 @@ fn source_needs_virtual_registration(
                 needs_registration = true;
                 continue;
             }
-            if !visited.contains(&resolved) {
-                queue.push(resolved);
+            if !frontier.visited.contains(&resolved) {
+                frontier.queue.push(resolved);
             }
         }
     }
 
     needs_registration
+}
+
+/// Bounded Vue reachability for one package route, using the same local and
+/// package resolution the check import walk uses for authored sources.
+fn scan_route_reachability(
+    route: &vize_canon::PackageRoute,
+    canonical_paths: &mut CanonicalPathCache,
+    options: ImportFileOptions,
+    aliases: Option<&PathAliasResolver>,
+    packages: &mut vize_canon::PackageRouteResolver,
+) -> vize_canon::batch::PackageRouteReachability {
+    vize_canon::batch::scan_package_route_reachability(
+        route,
+        |importer, nested_specifier| {
+            let nested_dir = importer.parent().unwrap_or(importer);
+            if is_relative_specifier(nested_specifier) {
+                resolve_import_base_with_inputs(
+                    &nested_dir.join(nested_specifier),
+                    canonical_paths,
+                    options,
+                )
+            } else {
+                let candidate = Path::new(nested_specifier);
+                if candidate.is_absolute() {
+                    resolve_import_base_with_inputs(candidate, canonical_paths, options)
+                } else {
+                    aliases.map_or_else(
+                        || (None, Vec::new()),
+                        |aliases| {
+                            aliases.resolve_with_inputs(
+                                nested_specifier,
+                                canonical_paths,
+                                options,
+                                resolve_import_base_with_inputs,
+                            )
+                        },
+                    )
+                }
+            }
+        },
+        |importer, nested_specifier, nested_mode| {
+            let nested_dir = importer.parent().unwrap_or(importer);
+            let (nested_context, mut nested_inputs) = match aliases {
+                Some(aliases) => {
+                    aliases.package_resolution_context(packages, importer, nested_mode)
+                }
+                None => packages.resolution_context(
+                    importer,
+                    nested_mode,
+                    None,
+                    None,
+                    std::iter::empty::<vize_carton::String>(),
+                ),
+            };
+            let (nested, consulted) = packages
+                .lookup_with_context(
+                    nested_dir,
+                    nested_specifier,
+                    vize_canon::PackageSourceOptions::new(options.include_js, options.include_jsx),
+                    nested_context,
+                )
+                .into_parts();
+            nested_inputs.extend(consulted);
+            (nested, nested_inputs)
+        },
+    )
 }

--- a/crates/vize/src/commands/check/imports_registration.rs
+++ b/crates/vize/src/commands/check/imports_registration.rs
@@ -56,13 +56,13 @@ pub(super) fn non_relative_import_needs_virtual_registration(
         packages,
         &mut discovered,
     );
-    let resolved_discovery = if needs_registration {
-        VirtualRegistrationDiscovery {
-            package_routes: discovered,
-            package_sources: visited.into_iter().collect(),
-        }
-    } else {
-        VirtualRegistrationDiscovery::default()
+    let resolved_discovery = VirtualRegistrationDiscovery {
+        package_routes: discovered,
+        package_sources: if needs_registration {
+            visited.into_iter().collect()
+        } else {
+            Vec::new()
+        },
     };
     discovery
         .package_routes
@@ -119,6 +119,8 @@ fn source_needs_virtual_registration(
                 });
                 if aliased.is_some() {
                     aliased
+                } else if vize_canon::batch::is_vue_runtime_support_specifier(&specifier) {
+                    None
                 } else if let Some(packages) = packages.as_deref_mut() {
                     let (context, context_inputs) = match aliases {
                         Some(aliases) => {
@@ -215,7 +217,7 @@ fn source_needs_virtual_registration(
                         reachability.record_work(packages);
                         track_reachability = reachability.requires_tracking();
                         let needs_shadow = reachability.requires_shadow();
-                        needs_registration |= track_reachability;
+                        needs_registration |= needs_shadow;
                         invalidation_paths.extend(reachability.inputs);
                         if needs_shadow {
                             binding_route = Some(route);

--- a/crates/vize/src/commands/check/imports_registration.rs
+++ b/crates/vize/src/commands/check/imports_registration.rs
@@ -6,7 +6,8 @@ use super::super::imports_aliases::PathAliasResolver;
 use super::super::path_cache::CanonicalPathCache;
 use super::{
     ImportFileOptions, extract_module_specifier_occurrences, is_declaration_file,
-    is_relative_specifier, resolve_import_base, resolve_relative_import,
+    is_relative_specifier, resolve_import_base, resolve_import_base_with_inputs,
+    resolve_relative_import,
 };
 
 #[derive(Clone, Default)]
@@ -88,13 +89,13 @@ fn source_needs_virtual_registration(
     mut packages: Option<&mut vize_canon::PackageRouteResolver>,
     discovered_routes: &mut Vec<vize_canon::PackageRouteBinding>,
 ) -> bool {
-    let mut reaches_vue = false;
+    let mut needs_registration = false;
     while let Some(file) = queue.pop() {
         if !visited.insert(file.clone()) {
             continue;
         }
         if file.extension().and_then(|extension| extension.to_str()) == Some("vue") {
-            reaches_vue = true;
+            needs_registration = true;
             continue;
         }
 
@@ -131,7 +132,7 @@ fn source_needs_virtual_registration(
                             std::iter::empty::<vize_carton::String>(),
                         ),
                     };
-                    let route = packages.lookup_with_context(
+                    let lookup = packages.lookup_with_context(
                         dir,
                         &specifier,
                         vize_canon::PackageSourceOptions::new(
@@ -140,35 +141,97 @@ fn source_needs_virtual_registration(
                         ),
                         context.clone(),
                     );
-                    let watchable_negative = route.is_watchable_negative();
-                    let (route, mut invalidation_paths) = route.into_parts();
+                    let watchable_negative = lookup.is_watchable_negative();
+                    let (route, mut invalidation_paths) = lookup.into_parts();
                     invalidation_paths.extend(context_inputs);
                     invalidation_paths.push(file.clone());
+                    let mut binding_route = None;
+                    let mut track_reachability = false;
+                    if let Some(route) = route {
+                        let reachability = vize_canon::batch::scan_package_route_reachability(
+                            &route,
+                            |importer, nested_specifier| {
+                                let nested_dir = importer.parent().unwrap_or(importer);
+                                if is_relative_specifier(nested_specifier) {
+                                    resolve_import_base_with_inputs(
+                                        &nested_dir.join(nested_specifier),
+                                        canonical_paths,
+                                        options,
+                                    )
+                                } else {
+                                    let candidate = Path::new(nested_specifier);
+                                    if candidate.is_absolute() {
+                                        resolve_import_base_with_inputs(
+                                            candidate,
+                                            canonical_paths,
+                                            options,
+                                        )
+                                    } else {
+                                        aliases.map_or_else(
+                                            || (None, Vec::new()),
+                                            |aliases| {
+                                                aliases.resolve_with_inputs(
+                                                    nested_specifier,
+                                                    canonical_paths,
+                                                    options,
+                                                    resolve_import_base_with_inputs,
+                                                )
+                                            },
+                                        )
+                                    }
+                                }
+                            },
+                            |importer, nested_specifier, nested_mode| {
+                                let nested_dir = importer.parent().unwrap_or(importer);
+                                let (nested_context, mut nested_inputs) = match aliases {
+                                    Some(aliases) => aliases.package_resolution_context(
+                                        packages,
+                                        importer,
+                                        nested_mode,
+                                    ),
+                                    None => packages.resolution_context(
+                                        importer,
+                                        nested_mode,
+                                        None,
+                                        None,
+                                        std::iter::empty::<vize_carton::String>(),
+                                    ),
+                                };
+                                let (nested, consulted) = packages
+                                    .lookup_with_context(
+                                        nested_dir,
+                                        nested_specifier,
+                                        vize_canon::PackageSourceOptions::new(
+                                            options.include_js,
+                                            options.include_jsx,
+                                        ),
+                                        nested_context,
+                                    )
+                                    .into_parts();
+                                nested_inputs.extend(consulted);
+                                (nested, nested_inputs)
+                            },
+                        );
+                        reachability.record_work(packages);
+                        track_reachability = reachability.requires_tracking();
+                        let needs_shadow = reachability.requires_shadow();
+                        needs_registration |= track_reachability;
+                        invalidation_paths.extend(reachability.inputs);
+                        if needs_shadow {
+                            binding_route = Some(route);
+                        }
+                    }
                     invalidation_paths.sort();
                     invalidation_paths.dedup();
-                    if route.is_some() || watchable_negative {
+                    if track_reachability || watchable_negative {
                         discovered_routes.push(vize_canon::PackageRouteBinding {
                             importer_path: file.clone(),
                             specifier: specifier.clone(),
                             occurrence_mode: occurrence.mode,
                             context: context.clone(),
-                            route: route.clone(),
+                            route: binding_route,
                             invalidation_paths,
                         });
-                    }
-                    if let Some(route) = route {
-                        for source in route.all_source_paths() {
-                            if source
-                                .extension()
-                                .is_some_and(|extension| extension == "vue")
-                            {
-                                reaches_vue = true;
-                                continue;
-                            }
-                            if !visited.contains(source) {
-                                queue.push(source.clone());
-                            }
-                        }
                     }
                     None
                 } else {
@@ -186,7 +249,7 @@ fn source_needs_virtual_registration(
                 .and_then(|extension| extension.to_str())
                 == Some("vue")
             {
-                reaches_vue = true;
+                needs_registration = true;
                 continue;
             }
             if !visited.contains(&resolved) {
@@ -195,5 +258,5 @@ fn source_needs_virtual_registration(
         }
     }
 
-    reaches_vue
+    needs_registration
 }

--- a/crates/vize/src/commands/check/imports_resolution.rs
+++ b/crates/vize/src/commands/check/imports_resolution.rs
@@ -34,34 +34,48 @@ pub(crate) fn resolve_import_base(
     canonical_paths: &mut CanonicalPathCache,
     options: ImportFileOptions,
 ) -> Option<PathBuf> {
+    resolve_import_base_with_inputs(base, canonical_paths, options).0
+}
+
+pub(crate) fn resolve_import_base_with_inputs(
+    base: &Path,
+    canonical_paths: &mut CanonicalPathCache,
+    options: ImportFileOptions,
+) -> (Option<PathBuf>, Vec<PathBuf>) {
+    let mut inputs = vec![base.to_path_buf()];
     if ImportFileOptions::path_has_typescript_source_extension(base) && base.is_file() {
-        return Some(canonical_paths.canonicalize(base));
+        return (Some(canonical_paths.canonicalize(base)), inputs);
     }
-    if let Some(rewritten) = rewrite_js_to_ts(base, canonical_paths, options.include_jsx) {
-        return Some(rewritten);
+    if let Some(rewritten) =
+        rewrite_js_to_ts(base, canonical_paths, options.include_jsx, &mut inputs)
+    {
+        return (Some(rewritten), inputs);
     }
     if options.javascript_extension_is_enabled(base) && base.is_file() {
-        return Some(canonical_paths.canonicalize(base));
+        return (Some(canonical_paths.canonicalize(base)), inputs);
     }
     for ext in options.resolve_extensions() {
         let candidate = append_extension(base, ext);
+        inputs.push(candidate.clone());
         if candidate.is_file() {
-            return Some(canonical_paths.canonicalize(&candidate));
+            return (Some(canonical_paths.canonicalize(&candidate)), inputs);
         }
     }
     for ext in options.resolve_extensions() {
         let candidate = base.join(cstr_index(ext));
+        inputs.push(candidate.clone());
         if candidate.is_file() {
-            return Some(canonical_paths.canonicalize(&candidate));
+            return (Some(canonical_paths.canonicalize(&candidate)), inputs);
         }
     }
-    None
+    (None, inputs)
 }
 
 fn rewrite_js_to_ts(
     base: &Path,
     canonical_paths: &mut CanonicalPathCache,
     include_jsx: bool,
+    inputs: &mut Vec<PathBuf>,
 ) -> Option<PathBuf> {
     let name = base.file_name()?.to_str()?;
     let (stem, extensions): (&str, &[&str]) = if let Some(stem) = name.strip_suffix(".mjs") {
@@ -84,6 +98,7 @@ fn rewrite_js_to_ts(
     };
     for ext in extensions {
         let candidate = base.with_file_name(cstr!("{stem}{ext}"));
+        inputs.push(candidate.clone());
         if candidate.is_file() {
             return Some(canonical_paths.canonicalize(&candidate));
         }

--- a/crates/vize/src/commands/check/imports_resolution.rs
+++ b/crates/vize/src/commands/check/imports_resolution.rs
@@ -29,12 +29,14 @@ pub(super) fn resolve_relative_import(
     resolve_import_base(&dir.join(specifier), canonical_paths, options)
 }
 
+/// Resolution on the authored import walk is the hot path, so consulted
+/// candidates are only materialized when a caller needs them for invalidation.
 pub(crate) fn resolve_import_base(
     base: &Path,
     canonical_paths: &mut CanonicalPathCache,
     options: ImportFileOptions,
 ) -> Option<PathBuf> {
-    resolve_import_base_with_inputs(base, canonical_paths, options).0
+    probe_import_base(base, canonical_paths, options, None)
 }
 
 pub(crate) fn resolve_import_base_with_inputs(
@@ -43,39 +45,58 @@ pub(crate) fn resolve_import_base_with_inputs(
     options: ImportFileOptions,
 ) -> (Option<PathBuf>, Vec<PathBuf>) {
     let mut inputs = vec![base.to_path_buf()];
+    let resolved = probe_import_base(base, canonical_paths, options, Some(&mut inputs));
+    (resolved, inputs)
+}
+
+fn probe_import_base(
+    base: &Path,
+    canonical_paths: &mut CanonicalPathCache,
+    options: ImportFileOptions,
+    mut inputs: Option<&mut Vec<PathBuf>>,
+) -> Option<PathBuf> {
     if ImportFileOptions::path_has_typescript_source_extension(base) && base.is_file() {
-        return (Some(canonical_paths.canonicalize(base)), inputs);
+        return Some(canonical_paths.canonicalize(base));
     }
-    if let Some(rewritten) =
-        rewrite_js_to_ts(base, canonical_paths, options.include_jsx, &mut inputs)
-    {
-        return (Some(rewritten), inputs);
+    if let Some(rewritten) = rewrite_js_to_ts(
+        base,
+        canonical_paths,
+        options.include_jsx,
+        inputs.as_deref_mut(),
+    ) {
+        return Some(rewritten);
     }
     if options.javascript_extension_is_enabled(base) && base.is_file() {
-        return (Some(canonical_paths.canonicalize(base)), inputs);
+        return Some(canonical_paths.canonicalize(base));
     }
     for ext in options.resolve_extensions() {
         let candidate = append_extension(base, ext);
-        inputs.push(candidate.clone());
+        record_consulted(inputs.as_deref_mut(), &candidate);
         if candidate.is_file() {
-            return (Some(canonical_paths.canonicalize(&candidate)), inputs);
+            return Some(canonical_paths.canonicalize(&candidate));
         }
     }
     for ext in options.resolve_extensions() {
         let candidate = base.join(cstr_index(ext));
-        inputs.push(candidate.clone());
+        record_consulted(inputs.as_deref_mut(), &candidate);
         if candidate.is_file() {
-            return (Some(canonical_paths.canonicalize(&candidate)), inputs);
+            return Some(canonical_paths.canonicalize(&candidate));
         }
     }
-    (None, inputs)
+    None
+}
+
+fn record_consulted(inputs: Option<&mut Vec<PathBuf>>, candidate: &Path) {
+    if let Some(inputs) = inputs {
+        inputs.push(candidate.to_path_buf());
+    }
 }
 
 fn rewrite_js_to_ts(
     base: &Path,
     canonical_paths: &mut CanonicalPathCache,
     include_jsx: bool,
-    inputs: &mut Vec<PathBuf>,
+    mut inputs: Option<&mut Vec<PathBuf>>,
 ) -> Option<PathBuf> {
     let name = base.file_name()?.to_str()?;
     let (stem, extensions): (&str, &[&str]) = if let Some(stem) = name.strip_suffix(".mjs") {
@@ -98,7 +119,7 @@ fn rewrite_js_to_ts(
     };
     for ext in extensions {
         let candidate = base.with_file_name(cstr!("{stem}{ext}"));
-        inputs.push(candidate.clone());
+        record_consulted(inputs.as_deref_mut(), &candidate);
         if candidate.is_file() {
             return Some(canonical_paths.canonicalize(&candidate));
         }

--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -43,12 +43,14 @@ pub use type_checker::{
 };
 pub use virtual_project::{
     ContentMapperDiagnostic, ContentMapperSpan, ContentMapperTransform,
-    ContentMapperTransformOptions, OriginalPosition, TsconfigOwnershipCache,
+    ContentMapperTransformOptions, OriginalPosition, PACKAGE_REACHABILITY_BUDGET_REVISION,
+    PackageRouteReachability, ReachabilityOutcome, ReachabilityWork, TsconfigOwnershipCache,
     TsconfigOwnershipOptions, TsconfigSourceKind, VirtualFile, VirtualProject,
     VueDocumentVirtualTs, VueDocumentVirtualTsOptions, external_mirror_original_path,
     generate_vue_content_mapper_transform, generate_vue_content_mapper_transform_with_options,
     generate_vue_document_virtual_ts, generate_vue_document_virtual_ts_with_options,
-    project_virtual_lock_paths, project_virtual_root, snapshot_tsconfig_compiler_options,
+    project_virtual_lock_paths, project_virtual_root, scan_package_route_reachability,
+    snapshot_tsconfig_compiler_options,
 };
 pub use virtual_specifier_message::{AUTHORED_VUE_TS_SENTINEL, restore_virtual_vue_specifiers};
 pub use virtual_ts::VirtualTsGenerator;

--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -49,8 +49,8 @@ pub use virtual_project::{
     VueDocumentVirtualTs, VueDocumentVirtualTsOptions, external_mirror_original_path,
     generate_vue_content_mapper_transform, generate_vue_content_mapper_transform_with_options,
     generate_vue_document_virtual_ts, generate_vue_document_virtual_ts_with_options,
-    project_virtual_lock_paths, project_virtual_root, scan_package_route_reachability,
-    snapshot_tsconfig_compiler_options,
+    is_vue_runtime_support_specifier, project_virtual_lock_paths, project_virtual_root,
+    scan_package_route_reachability, snapshot_tsconfig_compiler_options,
 };
 pub use virtual_specifier_message::{AUTHORED_VUE_TS_SENTINEL, restore_virtual_vue_specifiers};
 pub use virtual_ts::VirtualTsGenerator;

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -68,7 +68,7 @@ mod package_link_owners;
 mod package_node_modules;
 pub(crate) mod package_resolution;
 mod package_route_discovery;
-pub(crate) use package_route_discovery::is_vue_runtime_support_specifier;
+pub use package_route_discovery::is_vue_runtime_support_specifier;
 mod package_route_reachability;
 pub(crate) use package_route_reachability::package_route_reaches_vue;
 pub use package_route_reachability::{

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -68,8 +68,12 @@ mod package_link_owners;
 mod package_node_modules;
 pub(crate) mod package_resolution;
 mod package_route_discovery;
-pub(crate) use package_route_discovery::{
-    PackageRouteReachability, is_vue_runtime_support_specifier, package_route_reaches_vue,
+pub(crate) use package_route_discovery::is_vue_runtime_support_specifier;
+mod package_route_reachability;
+pub(crate) use package_route_reachability::package_route_reaches_vue;
+pub use package_route_reachability::{
+    PACKAGE_REACHABILITY_BUDGET_REVISION, PackageRouteReachability, ReachabilityOutcome,
+    ReachabilityWork, scan_package_route_reachability,
 };
 mod package_shadow;
 mod package_shadow_owners;

--- a/crates/vize_canon/src/batch/virtual_project/dependency_scan.rs
+++ b/crates/vize_canon/src/batch/virtual_project/dependency_scan.rs
@@ -37,11 +37,11 @@ use super::VirtualProject;
 mod resolution;
 #[cfg(test)]
 use resolution::probe_candidates;
-pub(crate) use resolution::resolve_dependency;
 use resolution::{
     alias_may_reach_first_party, canonical_key, inside_node_modules, is_declaration_file,
     may_resolve_a_dependency,
 };
+pub(crate) use resolution::{resolve_dependency, resolve_dependency_with_inputs};
 
 type PackageResolver<'a> = &'a mut dyn FnMut(&Path, &str, crate::PackageResolutionMode) -> bool;
 

--- a/crates/vize_canon/src/batch/virtual_project/dependency_scan/resolution.rs
+++ b/crates/vize_canon/src/batch/virtual_project/dependency_scan/resolution.rs
@@ -68,14 +68,25 @@ pub(crate) fn resolve_dependency(
     project_root: &Path,
     aliases: &[(std::string::String, std::string::String)],
 ) -> Option<PathBuf> {
+    resolve_dependency_with_inputs(specifier, importer_dir, project_root, aliases).0
+}
+
+#[allow(clippy::disallowed_types)]
+pub(crate) fn resolve_dependency_with_inputs(
+    specifier: &str,
+    importer_dir: &Path,
+    project_root: &Path,
+    aliases: &[(std::string::String, std::string::String)],
+) -> (Option<PathBuf>, Vec<PathBuf>) {
     let specifier = specifier
         .strip_suffix(".vue.ts")
         .map_or_else(|| specifier.to_owned(), |stem| cstr!("{stem}.vue").into());
     if specifier.starts_with("./") || specifier.starts_with("../") {
-        return probe_candidates(&importer_dir.join(&specifier));
+        return probe_candidates_with_inputs(&importer_dir.join(&specifier));
     }
 
     let mut best: Option<(usize, PathBuf)> = None;
+    let mut inputs = Vec::new();
     for (pattern, target) in aliases {
         let substituted = if let Some(prefix) = pattern.strip_suffix('*') {
             match (specifier.strip_prefix(prefix), target.strip_suffix('*')) {
@@ -100,35 +111,43 @@ pub(crate) fn resolve_dependency(
             project_root.join(&substituted)
         };
         // Length first: a pattern that cannot win must not cost a probe.
-        if best.as_ref().is_none_or(|(len, _)| pattern.len() > *len)
-            && let Some(resolved) = probe_candidates(&absolute)
-        {
-            best = Some((pattern.len(), resolved));
+        if best.as_ref().is_none_or(|(len, _)| pattern.len() > *len) {
+            let (resolved, consulted) = probe_candidates_with_inputs(&absolute);
+            inputs.extend(consulted);
+            if let Some(resolved) = resolved {
+                best = Some((pattern.len(), resolved));
+            }
         }
     }
-    best.map(|(_, path)| path)
+    (best.map(|(_, path)| path), inputs)
 }
 
 pub(super) fn probe_candidates(base: &Path) -> Option<PathBuf> {
+    probe_candidates_with_inputs(base).0
+}
+
+fn probe_candidates_with_inputs(base: &Path) -> (Option<PathBuf>, Vec<PathBuf>) {
+    let mut inputs = vec![base.to_path_buf()];
     if base.is_file() {
-        return Some(base.to_path_buf());
+        return (Some(base.to_path_buf()), inputs);
     }
     let extension = base.extension().and_then(|extension| extension.to_str());
     let probe_base = match extension {
         Some("js" | "jsx" | "mjs" | "cjs") => base.with_extension(""),
-        Some(_) => return None,
+        Some(_) => return (None, inputs),
         None => base.to_path_buf(),
     };
     for extension in [
         "ts", "tsx", "d.ts", "mts", "d.mts", "cts", "d.cts", "vue", "js", "jsx", "mjs", "cjs",
     ] {
         let candidate = PathBuf::from(cstr!("{}.{extension}", probe_base.display()).as_str());
+        inputs.push(candidate.clone());
         if candidate.is_file() {
-            return Some(candidate);
+            return (Some(candidate), inputs);
         }
     }
     if extension.is_some() {
-        return None;
+        return (None, inputs);
     }
     for index in [
         "index.ts",
@@ -145,9 +164,10 @@ pub(super) fn probe_candidates(base: &Path) -> Option<PathBuf> {
         "index.cjs",
     ] {
         let candidate = base.join(index);
+        inputs.push(candidate.clone());
         if candidate.is_file() {
-            return Some(candidate);
+            return (Some(candidate), inputs);
         }
     }
-    None
+    (None, inputs)
 }

--- a/crates/vize_canon/src/batch/virtual_project/package_route_discovery.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_discovery.rs
@@ -7,6 +7,7 @@ use vize_carton::FxHashSet;
 
 use super::VirtualProject;
 use super::dependency_scan::resolve_dependency;
+use super::package_route_reachability::{PackageRouteReachability, package_route_reaches_vue};
 
 impl VirtualProject {
     pub(crate) fn reconcile_package_routes_for_importers(&mut self, changed: &[PathBuf]) {
@@ -92,6 +93,7 @@ impl VirtualProject {
                 );
                 let watchable_negative = lookup.is_watchable_negative();
                 let (route, mut invalidation_paths) = lookup.into_parts();
+                let has_route = route.is_some();
                 let reachability =
                     route
                         .as_ref()
@@ -104,8 +106,11 @@ impl VirtualProject {
                                 source_options,
                             )
                         });
-                let needs_shadow = reachability.reaches_vue;
-                if !watchable_negative && !needs_shadow {
+                if has_route {
+                    reachability.record_work(&mut resolver);
+                }
+                let needs_shadow = reachability.requires_shadow();
+                if !watchable_negative && !reachability.requires_tracking() {
                     continue;
                 }
                 invalidation_paths.extend(reachability.inputs);
@@ -119,7 +124,7 @@ impl VirtualProject {
                     specifier,
                     occurrence_mode,
                     context,
-                    route,
+                    route: needs_shadow.then_some(route).flatten(),
                     invalidation_paths,
                 });
             }
@@ -173,96 +178,5 @@ mod runtime_support_tests {
         ] {
             assert!(!is_support(specifier), "{specifier}");
         }
-    }
-}
-
-#[allow(clippy::disallowed_types)] // Compiler-option aliases originate in serde_json maps.
-#[derive(Clone, Debug, Default)]
-pub(crate) struct PackageRouteReachability {
-    pub(crate) reaches_vue: bool,
-    pub(crate) inputs: Vec<PathBuf>,
-}
-
-#[allow(clippy::disallowed_types)] // Compiler-option aliases originate in serde_json maps.
-pub(crate) fn package_route_reaches_vue(
-    route: &crate::PackageRoute,
-    aliases: &[(std::string::String, std::string::String)],
-    resolution: &super::package_resolution::PackageResolutionSettings,
-    resolver: &mut crate::PackageRouteResolver,
-    source_options: crate::PackageSourceOptions,
-) -> PackageRouteReachability {
-    let mut queued = FxHashSet::default();
-    let mut queue = route
-        .all_source_paths()
-        .into_iter()
-        .filter(|path| queued.insert((*path).clone()))
-        .cloned()
-        .collect::<Vec<_>>();
-    let mut inputs = Vec::new();
-    let rewriter = crate::batch::ImportRewriter::new();
-    while let Some(path) = queue.pop() {
-        inputs.push(path.clone());
-        if path.extension().is_some_and(|extension| extension == "vue") {
-            return reachability(true, inputs);
-        }
-        let Ok(content) = std::fs::read_to_string(&path) else {
-            continue;
-        };
-        let source_type = if path.extension().is_some_and(|extension| extension == "tsx") {
-            SourceType::tsx()
-        } else {
-            SourceType::ts()
-        };
-        let Some(importer_dir) = path.parent() else {
-            continue;
-        };
-        for (specifier, mode) in rewriter.collect_all_specifier_occurrences(&content, source_type) {
-            if let Some(dependency) =
-                resolve_dependency(&specifier, importer_dir, &route.package_root, aliases)
-            {
-                if queued.insert(dependency.clone()) {
-                    queue.push(dependency);
-                }
-                continue;
-            }
-            if specifier.starts_with('.') || Path::new(specifier.as_str()).is_absolute() {
-                continue;
-            }
-            // Vue's compiler/runtime type packages are supplied by the virtual
-            // project itself. They are terminal support edges, not
-            // importer-scoped component packages: descending through their
-            // transitive compiler graph can walk the whole installed toolchain
-            // and can misclassify an internal fixture SFC as the caller's
-            // package identity. Resolve user aliases above before applying
-            // this native-package boundary.
-            if is_vue_runtime_support_specifier(&specifier) {
-                continue;
-            }
-            let (context, context_inputs) = resolution.context(resolver, &path, mode);
-            let (nested, consulted) = resolver
-                .lookup_with_context(importer_dir, &specifier, source_options, context)
-                .into_parts();
-            inputs.extend(context_inputs);
-            inputs.extend(consulted);
-            if let Some(nested) = nested {
-                queue.extend(
-                    nested
-                        .all_source_paths()
-                        .into_iter()
-                        .filter(|source| queued.insert((*source).clone()))
-                        .cloned(),
-                );
-            }
-        }
-    }
-    reachability(false, inputs)
-}
-
-fn reachability(reaches_vue: bool, mut inputs: Vec<PathBuf>) -> PackageRouteReachability {
-    inputs.sort();
-    inputs.dedup();
-    PackageRouteReachability {
-        reaches_vue,
-        inputs,
     }
 }

--- a/crates/vize_canon/src/batch/virtual_project/package_route_discovery.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_discovery.rs
@@ -110,7 +110,7 @@ impl VirtualProject {
                     reachability.record_work(&mut resolver);
                 }
                 let needs_shadow = reachability.requires_shadow();
-                if !watchable_negative && !reachability.requires_tracking() {
+                if !route_requires_invalidation_binding(has_route, watchable_negative) {
                     continue;
                 }
                 invalidation_paths.extend(reachability.inputs);
@@ -146,18 +146,24 @@ impl VirtualProject {
     }
 }
 
+fn route_requires_invalidation_binding(has_route: bool, watchable_negative: bool) -> bool {
+    has_route || watchable_negative
+}
+
 /// Whether a module specifier belongs to Vue's shared runtime/type support.
 ///
 /// Canon supplies these types to virtual documents. They are terminal support
 /// edges rather than importer-scoped component packages, whether the edge came
 /// from generated helpers or from a package declaration in their runtime graph.
-pub(crate) fn is_vue_runtime_support_specifier(specifier: &str) -> bool {
+pub fn is_vue_runtime_support_specifier(specifier: &str) -> bool {
     specifier == "vue" || specifier.starts_with("@vue/") || specifier == "vite/client"
 }
 
 #[cfg(test)]
 mod runtime_support_tests {
-    use super::is_vue_runtime_support_specifier as is_support;
+    use super::{
+        is_vue_runtime_support_specifier as is_support, route_requires_invalidation_binding,
+    };
 
     #[test]
     fn generated_runtime_support_filter_is_exact() {
@@ -178,5 +184,12 @@ mod runtime_support_tests {
         ] {
             assert!(!is_support(specifier), "{specifier}");
         }
+    }
+
+    #[test]
+    fn positive_non_vue_routes_keep_an_invalidation_binding() {
+        assert!(route_requires_invalidation_binding(true, false));
+        assert!(route_requires_invalidation_binding(false, true));
+        assert!(!route_requires_invalidation_binding(false, false));
     }
 }

--- a/crates/vize_canon/src/batch/virtual_project/package_route_reachability.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_reachability.rs
@@ -1,0 +1,344 @@
+//! Deterministically bounded Vue reachability for importer-scoped packages.
+
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::path::{Path, PathBuf};
+
+use oxc_span::SourceType;
+use vize_carton::{FxHashSet, String as CompactString};
+
+use super::dependency_scan::resolve_dependency_with_inputs;
+use super::is_vue_runtime_support_specifier;
+
+/// Cache and evidence identity for the fixed reachability work contract.
+pub const PACKAGE_REACHABILITY_BUDGET_REVISION: u8 = 1;
+
+// One route may inspect at most 128 package identities, source candidates, or
+// parses, 512 unique edges, 128 KiB per source, and 512 KiB total. Metadata is
+// checked before a source is read, so generated/minified bundles cannot consume
+// the parse budget.
+const DEFAULT_BUDGET: ReachabilityBudget = ReachabilityBudget {
+    max_packages: 128,
+    max_files: 128,
+    max_file_bytes: 128 * 1024,
+    max_total_bytes: 512 * 1024,
+    max_edges: 512,
+    max_parses: 128,
+};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ReachabilityOutcome {
+    #[default]
+    DoesNotReachVue,
+    ReachesVue,
+    BudgetExceeded,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ReachabilityWork {
+    pub files: usize,
+    pub bytes: usize,
+    pub edges: usize,
+    pub parses: usize,
+    pub packages: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PackageRouteReachability {
+    pub outcome: ReachabilityOutcome,
+    pub inputs: Vec<PathBuf>,
+    pub work: ReachabilityWork,
+}
+
+impl PackageRouteReachability {
+    pub fn requires_shadow(&self) -> bool {
+        self.outcome == ReachabilityOutcome::ReachesVue
+    }
+
+    pub fn requires_tracking(&self) -> bool {
+        self.outcome != ReachabilityOutcome::DoesNotReachVue
+    }
+
+    pub fn record_work(&self, resolver: &mut crate::PackageRouteResolver) {
+        resolver.record_reachability_work(
+            self.work.files,
+            self.work.bytes,
+            self.work.edges,
+            self.work.parses,
+            self.work.packages,
+            self.outcome == ReachabilityOutcome::BudgetExceeded,
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ReachabilityBudget {
+    max_packages: usize,
+    max_files: usize,
+    max_file_bytes: usize,
+    max_total_bytes: usize,
+    max_edges: usize,
+    max_parses: usize,
+}
+
+#[path = "package_route_reachability_route_graph.rs"]
+mod route_graph;
+
+#[allow(clippy::disallowed_types)] // Compiler-option aliases originate in serde_json maps.
+pub(crate) fn package_route_reaches_vue(
+    route: &crate::PackageRoute,
+    aliases: &[(std::string::String, std::string::String)],
+    resolution: &super::package_resolution::PackageResolutionSettings,
+    resolver: &mut crate::PackageRouteResolver,
+    source_options: crate::PackageSourceOptions,
+) -> PackageRouteReachability {
+    scan_package_route_reachability_with_budget(
+        route,
+        |importer, specifier| {
+            let importer_dir = importer.parent().unwrap_or(importer);
+            resolve_dependency_with_inputs(specifier, importer_dir, &route.package_root, aliases)
+        },
+        |importer, specifier, mode| {
+            let importer_dir = importer.parent().unwrap_or(importer);
+            let (context, mut inputs) = resolution.context(resolver, importer, mode);
+            let (nested, consulted) = resolver
+                .lookup_with_context(importer_dir, specifier, source_options, context)
+                .into_parts();
+            inputs.extend(consulted);
+            (nested, inputs)
+        },
+        DEFAULT_BUDGET,
+    )
+}
+
+/// Determine whether one package route reaches a Vue source without allowing
+/// an arbitrary dependency graph to delay native project startup.
+pub fn scan_package_route_reachability<ResolveLocal, ResolvePackage>(
+    route: &crate::PackageRoute,
+    resolve_local: ResolveLocal,
+    resolve_package: ResolvePackage,
+) -> PackageRouteReachability
+where
+    ResolveLocal: FnMut(&Path, &str) -> (Option<PathBuf>, Vec<PathBuf>),
+    ResolvePackage: FnMut(
+        &Path,
+        &str,
+        crate::PackageResolutionMode,
+    ) -> (Option<crate::PackageRoute>, Vec<PathBuf>),
+{
+    scan_package_route_reachability_with_budget(
+        route,
+        resolve_local,
+        resolve_package,
+        DEFAULT_BUDGET,
+    )
+}
+
+#[allow(clippy::disallowed_types)] // Compiler-option aliases originate in serde_json maps.
+#[cfg(test)]
+fn package_route_reaches_vue_with_budget(
+    route: &crate::PackageRoute,
+    aliases: &[(std::string::String, std::string::String)],
+    resolution: &super::package_resolution::PackageResolutionSettings,
+    resolver: &mut crate::PackageRouteResolver,
+    source_options: crate::PackageSourceOptions,
+    budget: ReachabilityBudget,
+) -> PackageRouteReachability {
+    scan_package_route_reachability_with_budget(
+        route,
+        |importer, specifier| {
+            let importer_dir = importer.parent().unwrap_or(importer);
+            resolve_dependency_with_inputs(specifier, importer_dir, &route.package_root, aliases)
+        },
+        |importer, specifier, mode| {
+            let importer_dir = importer.parent().unwrap_or(importer);
+            let (context, mut inputs) = resolution.context(resolver, importer, mode);
+            let (nested, consulted) = resolver
+                .lookup_with_context(importer_dir, specifier, source_options, context)
+                .into_parts();
+            inputs.extend(consulted);
+            (nested, inputs)
+        },
+        budget,
+    )
+}
+
+fn scan_package_route_reachability_with_budget<ResolveLocal, ResolvePackage>(
+    route: &crate::PackageRoute,
+    mut resolve_local: ResolveLocal,
+    mut resolve_package: ResolvePackage,
+    budget: ReachabilityBudget,
+) -> PackageRouteReachability
+where
+    ResolveLocal: FnMut(&Path, &str) -> (Option<PathBuf>, Vec<PathBuf>),
+    ResolvePackage: FnMut(
+        &Path,
+        &str,
+        crate::PackageResolutionMode,
+    ) -> (Option<crate::PackageRoute>, Vec<PathBuf>),
+{
+    let mut queued = FxHashSet::default();
+    let mut queue = BinaryHeap::new();
+    let mut inputs = Vec::new();
+    let mut work = ReachabilityWork::default();
+    let mut packages = FxHashSet::default();
+    if !route_graph::seed_route_graph(
+        route,
+        &mut packages,
+        &mut queue,
+        &mut queued,
+        &mut inputs,
+        &mut work,
+        budget,
+    ) {
+        return finish(ReachabilityOutcome::BudgetExceeded, inputs, work, budget);
+    }
+
+    if queued
+        .iter()
+        .any(|path| path.extension().is_some_and(|extension| extension == "vue"))
+    {
+        return finish(ReachabilityOutcome::ReachesVue, inputs, work, budget);
+    }
+
+    let rewriter = crate::batch::ImportRewriter::new();
+    let mut edges = FxHashSet::<(PathBuf, CompactString, crate::PackageResolutionMode)>::default();
+    while let Some((_, Reverse(path))) = queue.pop() {
+        inputs.push(path.clone());
+        if work.files == budget.max_files {
+            return finish(ReachabilityOutcome::BudgetExceeded, inputs, work, budget);
+        }
+        work.files += 1;
+
+        let Ok(metadata) = std::fs::metadata(&path) else {
+            continue;
+        };
+        let Ok(file_bytes) = usize::try_from(metadata.len()) else {
+            return finish(ReachabilityOutcome::BudgetExceeded, inputs, work, budget);
+        };
+        if file_bytes > budget.max_file_bytes
+            || work.bytes.saturating_add(file_bytes) > budget.max_total_bytes
+        {
+            return finish(ReachabilityOutcome::BudgetExceeded, inputs, work, budget);
+        }
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        if content.len() > budget.max_file_bytes
+            || work.bytes.saturating_add(content.len()) > budget.max_total_bytes
+        {
+            return finish(ReachabilityOutcome::BudgetExceeded, inputs, work, budget);
+        }
+        work.bytes += content.len();
+        if work.parses == budget.max_parses {
+            return finish(ReachabilityOutcome::BudgetExceeded, inputs, work, budget);
+        }
+        work.parses += 1;
+        let source_type = if path.extension().is_some_and(|extension| extension == "tsx") {
+            SourceType::tsx()
+        } else {
+            SourceType::ts()
+        };
+        for (specifier, mode) in rewriter.collect_all_specifier_occurrences(&content, source_type) {
+            if !edges.insert((path.clone(), specifier.clone(), mode)) {
+                continue;
+            }
+            if work.edges == budget.max_edges {
+                return finish(ReachabilityOutcome::BudgetExceeded, inputs, work, budget);
+            }
+            work.edges += 1;
+            let (local_dependency, local_inputs) = resolve_local(&path, &specifier);
+            inputs.extend(local_inputs);
+            if let Some(dependency) = local_dependency {
+                inputs.push(dependency.clone());
+                if dependency
+                    .extension()
+                    .is_some_and(|extension| extension == "vue")
+                {
+                    return finish(ReachabilityOutcome::ReachesVue, inputs, work, budget);
+                }
+                if queued.insert(dependency.clone()) {
+                    queue.push((source_priority(&dependency), Reverse(dependency)));
+                }
+                continue;
+            }
+            if specifier.starts_with('.') || Path::new(specifier.as_str()).is_absolute() {
+                continue;
+            }
+            // Canon supplies Vue's compiler/runtime types. They are terminal
+            // support edges, not importer-scoped component packages.
+            if is_vue_runtime_support_specifier(&specifier) {
+                continue;
+            }
+            let (nested, consulted) = resolve_package(&path, &specifier, mode);
+            inputs.extend(consulted);
+            if let Some(nested) = nested {
+                if !route_graph::seed_route_graph(
+                    &nested,
+                    &mut packages,
+                    &mut queue,
+                    &mut queued,
+                    &mut inputs,
+                    &mut work,
+                    budget,
+                ) {
+                    return finish(ReachabilityOutcome::BudgetExceeded, inputs, work, budget);
+                }
+                if queued.iter().any(|source| {
+                    source
+                        .extension()
+                        .is_some_and(|extension| extension == "vue")
+                }) {
+                    return finish(ReachabilityOutcome::ReachesVue, inputs, work, budget);
+                }
+            }
+        }
+    }
+    finish(ReachabilityOutcome::DoesNotReachVue, inputs, work, budget)
+}
+
+fn enqueue(
+    queue: &mut BinaryHeap<(u8, Reverse<PathBuf>)>,
+    queued: &mut FxHashSet<PathBuf>,
+    path: PathBuf,
+) {
+    if queued.insert(path.clone()) {
+        queue.push((source_priority(&path), Reverse(path)));
+    }
+}
+
+fn source_priority(path: &Path) -> u8 {
+    match path.extension().and_then(|extension| extension.to_str()) {
+        Some("vue") => 3,
+        Some("ts" | "tsx" | "mts" | "cts") => 2,
+        Some("js" | "jsx" | "mjs" | "cjs") => 1,
+        _ => 0,
+    }
+}
+
+fn finish(
+    outcome: ReachabilityOutcome,
+    mut inputs: Vec<PathBuf>,
+    work: ReachabilityWork,
+    budget: ReachabilityBudget,
+) -> PackageRouteReachability {
+    inputs.sort();
+    inputs.dedup();
+    debug_assert!(
+        outcome == ReachabilityOutcome::BudgetExceeded
+            || (work.files <= budget.max_files
+                && work.packages <= budget.max_packages
+                && work.bytes <= budget.max_total_bytes
+                && work.edges <= budget.max_edges
+                && work.parses <= budget.max_parses)
+    );
+    PackageRouteReachability {
+        outcome,
+        inputs,
+        work,
+    }
+}
+
+#[cfg(test)]
+#[path = "package_route_reachability_tests.rs"]
+mod tests;

--- a/crates/vize_canon/src/batch/virtual_project/package_route_reachability.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_reachability.rs
@@ -11,15 +11,18 @@ use super::dependency_scan::resolve_dependency_with_inputs;
 use super::is_vue_runtime_support_specifier;
 
 /// Cache and evidence identity for the fixed reachability work contract.
-pub const PACKAGE_REACHABILITY_BUDGET_REVISION: u8 = 1;
+pub const PACKAGE_REACHABILITY_BUDGET_REVISION: u8 = 2;
 
 // One route may inspect at most 128 package identities, source candidates, or
 // parses, 512 unique edges, 128 KiB per source, and 512 KiB total. Metadata is
 // checked before a source is read, so generated/minified bundles cannot consume
-// the parse budget.
+// the parse budget. Queued candidates are bounded separately because seeding a
+// package enumerates its whole source and dependency list before any file is
+// popped, and every queued path is retained as an invalidation input.
 const DEFAULT_BUDGET: ReachabilityBudget = ReachabilityBudget {
     max_packages: 128,
     max_files: 128,
+    max_queued_files: 4096,
     max_file_bytes: 128 * 1024,
     max_total_bytes: 512 * 1024,
     max_edges: 512,
@@ -75,6 +78,7 @@ impl PackageRouteReachability {
 struct ReachabilityBudget {
     max_packages: usize,
     max_files: usize,
+    max_queued_files: usize,
     max_file_bytes: usize,
     max_total_bytes: usize,
     max_edges: usize,
@@ -92,21 +96,12 @@ pub(crate) fn package_route_reaches_vue(
     resolver: &mut crate::PackageRouteResolver,
     source_options: crate::PackageSourceOptions,
 ) -> PackageRouteReachability {
-    scan_package_route_reachability_with_budget(
+    package_route_reaches_vue_with_budget(
         route,
-        |importer, specifier| {
-            let importer_dir = importer.parent().unwrap_or(importer);
-            resolve_dependency_with_inputs(specifier, importer_dir, &route.package_root, aliases)
-        },
-        |importer, specifier, mode| {
-            let importer_dir = importer.parent().unwrap_or(importer);
-            let (context, mut inputs) = resolution.context(resolver, importer, mode);
-            let (nested, consulted) = resolver
-                .lookup_with_context(importer_dir, specifier, source_options, context)
-                .into_parts();
-            inputs.extend(consulted);
-            (nested, inputs)
-        },
+        aliases,
+        resolution,
+        resolver,
+        source_options,
         DEFAULT_BUDGET,
     )
 }
@@ -135,7 +130,6 @@ where
 }
 
 #[allow(clippy::disallowed_types)] // Compiler-option aliases originate in serde_json maps.
-#[cfg(test)]
 fn package_route_reaches_vue_with_budget(
     route: &crate::PackageRoute,
     aliases: &[(std::string::String, std::string::String)],
@@ -257,7 +251,11 @@ where
                 {
                     return finish(ReachabilityOutcome::ReachesVue, inputs, work, budget);
                 }
-                if queued.insert(dependency.clone()) {
+                if !queued.contains(&dependency) {
+                    if queued.len() == budget.max_queued_files {
+                        return finish(ReachabilityOutcome::BudgetExceeded, inputs, work, budget);
+                    }
+                    queued.insert(dependency.clone());
                     queue.push((source_priority(&dependency), Reverse(dependency)));
                 }
                 continue;

--- a/crates/vize_canon/src/batch/virtual_project/package_route_reachability_graph_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_reachability_graph_tests.rs
@@ -1,0 +1,65 @@
+use super::{
+    Fixture, ReachabilityBudget, ReachabilityOutcome, generous_budget, route, route_with_entries,
+    scan_package_route_reachability_with_budget,
+};
+
+#[test]
+fn nested_package_route_with_a_vue_source_reaches_vue() {
+    let fixture = Fixture::new();
+    fixture.write("entry.ts", "export { default } from 'nested-package'\n");
+    let nested_root = fixture.package_root.join("node_modules/nested-package");
+    std::fs::create_dir_all(&nested_root).unwrap();
+    std::fs::write(nested_root.join("Widget.vue"), "<template />\n").unwrap();
+    let nested = route_with_entries(&nested_root, &[nested_root.join("Widget.vue")]);
+    let entry = route(
+        &fixture.package_root,
+        &fixture.package_root.join("entry.ts"),
+    );
+
+    let result = scan_package_route_reachability_with_budget(
+        &entry,
+        |_, _| (None, Vec::new()),
+        |_, _, _| (Some(nested.clone()), Vec::new()),
+        generous_budget(),
+    );
+
+    assert_eq!(result.outcome, ReachabilityOutcome::ReachesVue);
+    assert_eq!(result.work.packages, 2);
+    assert!(
+        result
+            .inputs
+            .iter()
+            .any(|path| path.ends_with("nested-package/Widget.vue"))
+    );
+}
+
+#[test]
+fn seeded_candidates_stop_at_the_queue_bound_before_any_file_is_read() {
+    let fixture = Fixture::new();
+    let entries = (0..8)
+        .map(|index| {
+            let name = format!("entry{index}.ts");
+            fixture.write(&name, "export {}\n");
+            fixture.package_root.join(name)
+        })
+        .collect::<Vec<_>>();
+    let route = route_with_entries(&fixture.package_root, &entries);
+    let budget = ReachabilityBudget {
+        max_queued_files: 4,
+        ..generous_budget()
+    };
+
+    let result = fixture.reachability_for_route(&route, budget);
+
+    assert_eq!(result.outcome, ReachabilityOutcome::BudgetExceeded);
+    assert_eq!(result.work.files, 0);
+    assert_eq!(result.work.parses, 0);
+    assert_eq!(
+        result
+            .inputs
+            .iter()
+            .filter(|path| path.extension().is_some_and(|extension| extension == "ts"))
+            .count(),
+        5
+    );
+}

--- a/crates/vize_canon/src/batch/virtual_project/package_route_reachability_route_graph.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_reachability_route_graph.rs
@@ -37,10 +37,13 @@ pub(super) fn seed_route_graph(
         }
         work.packages += 1;
         for path in route.source_paths.iter().chain(&route.dependency_paths) {
-            if !queued.contains(path) && queued.len() == budget.max_queued_files {
-                return false;
+            if queued.contains(path) {
+                continue;
             }
             inputs.push(path.clone());
+            if queued.len() == budget.max_queued_files {
+                return false;
+            }
             enqueue(queue, queued, path.clone());
         }
         let mut nested = route.nested_routes.iter().collect::<Vec<_>>();

--- a/crates/vize_canon/src/batch/virtual_project/package_route_reachability_route_graph.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_reachability_route_graph.rs
@@ -1,0 +1,52 @@
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::path::PathBuf;
+
+use vize_carton::FxHashSet;
+
+use super::{ReachabilityBudget, ReachabilityWork, enqueue};
+
+type PackageIdentity = (PathBuf, PathBuf, PathBuf);
+
+pub(super) fn seed_route_graph(
+    root: &crate::PackageRoute,
+    packages: &mut FxHashSet<PackageIdentity>,
+    queue: &mut BinaryHeap<(u8, Reverse<PathBuf>)>,
+    queued: &mut FxHashSet<PathBuf>,
+    inputs: &mut Vec<PathBuf>,
+    work: &mut ReachabilityWork,
+    budget: ReachabilityBudget,
+) -> bool {
+    let mut pending = vec![root];
+    while let Some(route) = pending.pop() {
+        let identity = (
+            route.package_link_root.clone(),
+            route.package_root.clone(),
+            route.manifest_path.clone(),
+        );
+        if !packages.insert(identity) {
+            continue;
+        }
+        inputs.extend([
+            route.manifest_path.clone(),
+            route.package_link_root.clone(),
+            route.package_link_root.join("package.json"),
+        ]);
+        if work.packages == budget.max_packages {
+            return false;
+        }
+        work.packages += 1;
+        for path in route.source_paths.iter().chain(&route.dependency_paths) {
+            inputs.push(path.clone());
+            enqueue(queue, queued, path.clone());
+        }
+        let mut nested = route.nested_routes.iter().collect::<Vec<_>>();
+        nested.sort_by(|left, right| left.manifest_path.cmp(&right.manifest_path));
+        pending.extend(nested.into_iter().rev());
+    }
+    true
+}
+
+#[cfg(test)]
+#[path = "package_route_reachability_route_graph_tests.rs"]
+mod tests;

--- a/crates/vize_canon/src/batch/virtual_project/package_route_reachability_route_graph.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_reachability_route_graph.rs
@@ -37,6 +37,9 @@ pub(super) fn seed_route_graph(
         }
         work.packages += 1;
         for path in route.source_paths.iter().chain(&route.dependency_paths) {
+            if !queued.contains(path) && queued.len() == budget.max_queued_files {
+                return false;
+            }
             inputs.push(path.clone());
             enqueue(queue, queued, path.clone());
         }

--- a/crates/vize_canon/src/batch/virtual_project/package_route_reachability_route_graph_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_reachability_route_graph_tests.rs
@@ -1,0 +1,58 @@
+use std::path::Path;
+
+use super::super::{
+    ReachabilityBudget, ReachabilityOutcome, scan_package_route_reachability_with_budget,
+};
+
+#[test]
+fn nested_package_graph_deduplicates_identity_and_stops_before_expansion() {
+    let root = tempfile::tempdir().unwrap();
+    let package_two = route(root.path(), 2, Vec::new());
+    let package_one = route(root.path(), 1, vec![package_two]);
+    let duplicate_one = route(root.path(), 1, Vec::new());
+    let package_zero = route(root.path(), 0, vec![package_one, duplicate_one]);
+    let budget = ReachabilityBudget {
+        max_packages: 2,
+        max_files: 8,
+        max_file_bytes: 1024,
+        max_total_bytes: 1024,
+        max_edges: 8,
+        max_parses: 8,
+    };
+
+    let result = scan_package_route_reachability_with_budget(
+        &package_zero,
+        |_, _| (None, Vec::new()),
+        |_, _, _| (None, Vec::new()),
+        budget,
+    );
+
+    assert_eq!(result.outcome, ReachabilityOutcome::BudgetExceeded);
+    assert_eq!(result.work.packages, 2);
+    assert_eq!(result.work.files, 0);
+    assert!(
+        result
+            .inputs
+            .iter()
+            .any(|path| path.ends_with("p2/package.json"))
+    );
+}
+
+fn route(
+    root: &Path,
+    index: usize,
+    nested_routes: Vec<crate::PackageRoute>,
+) -> crate::PackageRoute {
+    let package_root = root.join(format!("p{index}"));
+    crate::PackageRoute {
+        source_paths: Vec::new(),
+        dependency_paths: Vec::new(),
+        source_targets: Vec::new(),
+        package_root: package_root.clone(),
+        package_link_root: package_root.clone(),
+        manifest_path: package_root.join("package.json"),
+        package_name: Some(format!("p{index}").into()),
+        workspace_source: false,
+        nested_routes,
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/package_route_reachability_route_graph_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_reachability_route_graph_tests.rs
@@ -14,6 +14,7 @@ fn nested_package_graph_deduplicates_identity_and_stops_before_expansion() {
     let budget = ReachabilityBudget {
         max_packages: 2,
         max_files: 8,
+        max_queued_files: 64,
         max_file_bytes: 1024,
         max_total_bytes: 1024,
         max_edges: 8,

--- a/crates/vize_canon/src/batch/virtual_project/package_route_reachability_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_reachability_tests.rs
@@ -272,7 +272,7 @@ fn seeded_candidates_stop_at_the_queue_bound_before_any_file_is_read() {
             .iter()
             .filter(|path| path.extension().is_some_and(|extension| extension == "ts"))
             .count(),
-        4
+        5
     );
 }
 

--- a/crates/vize_canon/src/batch/virtual_project/package_route_reachability_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_reachability_tests.rs
@@ -1,0 +1,330 @@
+use std::path::{Path, PathBuf};
+
+use super::{ReachabilityBudget, ReachabilityOutcome, package_route_reaches_vue_with_budget};
+
+const SOURCE_OPTIONS: crate::PackageSourceOptions = crate::PackageSourceOptions::new(true, true);
+
+#[test]
+fn cycles_and_duplicate_edges_have_exact_unique_work() {
+    let fixture = Fixture::new();
+    fixture.write("entry.ts", "import './a'\nimport './a'\n");
+    fixture.write("a.ts", "export * from './b'\nexport * from './b'\n");
+    fixture.write("b.ts", "export * from './a'\n");
+
+    let result = fixture.reachability("entry.ts", generous_budget());
+
+    assert_eq!(result.outcome, ReachabilityOutcome::DoesNotReachVue);
+    assert_eq!(result.work.files, 3);
+    assert_eq!(result.work.parses, 3);
+    assert_eq!(result.work.edges, 3);
+    assert_eq!(result.work.packages, 1);
+}
+
+#[test]
+fn long_cyclic_duplicate_graph_stops_at_exact_unique_work_bound() {
+    let fixture = Fixture::new();
+    let mut expected_bytes = 0;
+    for index in 0_usize..140 {
+        let previous = index.saturating_sub(1);
+        let next = index + 1;
+        let content = if index == 0 {
+            format!("export * from './f{next}'\nexport * from './f{next}'\n")
+        } else {
+            format!(
+                "export * from './f{previous}'\nexport * from './f{next}'\nexport * from './f{next}'\n"
+            )
+        };
+        if index < 64 {
+            expected_bytes += content.len();
+        }
+        fixture.write(&format!("f{index}.ts"), &content);
+    }
+    let budget = ReachabilityBudget {
+        max_files: 64,
+        max_edges: 512,
+        max_parses: 64,
+        ..generous_budget()
+    };
+
+    let result = fixture.reachability("f0.ts", budget);
+
+    assert_eq!(result.outcome, ReachabilityOutcome::BudgetExceeded);
+    assert_eq!(result.work.files, 64);
+    assert_eq!(result.work.bytes, expected_bytes);
+    assert_eq!(result.work.edges, 127);
+    assert_eq!(result.work.parses, 64);
+    assert_eq!(result.work.packages, 1);
+    assert!(result.inputs.iter().any(|path| path.ends_with("f64.ts")));
+}
+
+#[test]
+fn vue_target_at_the_file_boundary_is_reachable() {
+    let fixture = Fixture::new();
+    fixture.write("entry.ts", "export * from './a'\n");
+    fixture.write("a.ts", "export { default } from './Widget.vue'\n");
+    fixture.write("Widget.vue", "<template />\n");
+    let budget = ReachabilityBudget {
+        max_files: 2,
+        ..generous_budget()
+    };
+
+    let result = fixture.reachability("entry.ts", budget);
+
+    assert_eq!(result.outcome, ReachabilityOutcome::ReachesVue);
+    assert_eq!(result.work.files, 2);
+    assert_eq!(result.work.parses, 2);
+    assert_eq!(result.work.edges, 2);
+    assert!(
+        result
+            .inputs
+            .iter()
+            .any(|path| path.ends_with("Widget.vue"))
+    );
+}
+
+#[test]
+fn vue_target_after_the_file_boundary_fails_closed() {
+    let fixture = Fixture::new();
+    fixture.write("entry.ts", "export * from './a'\n");
+    fixture.write("a.ts", "export * from './b'\n");
+    fixture.write("b.ts", "export { default } from './Widget.vue'\n");
+    fixture.write("Widget.vue", "<template />\n");
+    let budget = ReachabilityBudget {
+        max_files: 2,
+        ..generous_budget()
+    };
+
+    let result = fixture.reachability("entry.ts", budget);
+
+    assert_eq!(result.outcome, ReachabilityOutcome::BudgetExceeded);
+    assert!(!result.requires_shadow());
+    assert!(result.requires_tracking());
+    assert_eq!(result.work.files, 2);
+    assert_eq!(result.work.parses, 2);
+    assert_eq!(result.work.edges, 2);
+    assert!(result.inputs.iter().any(|path| path.ends_with("b.ts")));
+}
+
+#[test]
+fn budget_retains_every_resolved_but_unvisited_local_input() {
+    let fixture = Fixture::new();
+    fixture.write("entry.ts", "export * from './a'\nexport * from './b'\n");
+    fixture.write("a.ts", "export {}\n");
+    fixture.write("b.ts", "export {}\n");
+    let budget = ReachabilityBudget {
+        max_files: 1,
+        ..generous_budget()
+    };
+
+    let result = fixture.reachability("entry.ts", budget);
+
+    assert_eq!(result.outcome, ReachabilityOutcome::BudgetExceeded);
+    assert!(result.inputs.iter().any(|path| path.ends_with("a.ts")));
+    assert!(result.inputs.iter().any(|path| path.ends_with("b.ts")));
+}
+
+#[test]
+fn missing_local_vue_candidate_is_retained_and_reaches_after_create() {
+    let fixture = Fixture::new();
+    fixture.write("entry.ts", "export { default } from './Missing'\n");
+
+    let missing = fixture.reachability("entry.ts", generous_budget());
+
+    assert_eq!(missing.outcome, ReachabilityOutcome::DoesNotReachVue);
+    assert!(
+        missing
+            .inputs
+            .iter()
+            .any(|path| path.ends_with("Missing.vue"))
+    );
+
+    fixture.write("Missing.vue", "<template />\n");
+    let created = fixture.reachability("entry.ts", generous_budget());
+    assert_eq!(created.outcome, ReachabilityOutcome::ReachesVue);
+}
+
+#[test]
+fn oversized_source_is_not_read_or_parsed() {
+    let fixture = Fixture::new();
+    fixture.write("entry.ts", &"x".repeat(129));
+    let budget = ReachabilityBudget {
+        max_file_bytes: 128,
+        max_total_bytes: 128,
+        ..generous_budget()
+    };
+
+    let result = fixture.reachability("entry.ts", budget);
+
+    assert_eq!(result.outcome, ReachabilityOutcome::BudgetExceeded);
+    assert_eq!(result.work.files, 1);
+    assert_eq!(result.work.bytes, 0);
+    assert_eq!(result.work.parses, 0);
+    assert!(result.inputs.iter().any(|path| path.ends_with("entry.ts")));
+}
+
+#[test]
+fn declaration_candidate_reaches_vue_before_oversized_runtime_bundle() {
+    let fixture = Fixture::new();
+    fixture.write("aaa.d.ts", "export { default } from './Widget.vue'\n");
+    fixture.write("zzz.js", &"x".repeat(129));
+    fixture.write("Widget.vue", "<template />\n");
+    let budget = ReachabilityBudget {
+        max_file_bytes: 128,
+        max_total_bytes: 128,
+        ..generous_budget()
+    };
+    let route = route_with_entries(
+        &fixture.package_root,
+        &[
+            fixture.package_root.join("zzz.js"),
+            fixture.package_root.join("aaa.d.ts"),
+        ],
+    );
+
+    let result = fixture.reachability_for_route(&route, budget);
+
+    assert_eq!(result.outcome, ReachabilityOutcome::ReachesVue);
+    assert_eq!(result.work.files, 1);
+    assert_eq!(result.work.parses, 1);
+    assert_eq!(result.work.edges, 1);
+}
+
+#[test]
+fn unique_edge_budget_deduplicates_before_stopping() {
+    let fixture = Fixture::new();
+    fixture.write(
+        "entry.ts",
+        "import './a'\nimport './a'\nimport './b'\nimport './c'\n",
+    );
+    for name in ["a.ts", "b.ts", "c.ts"] {
+        fixture.write(name, "export {}\n");
+    }
+    let budget = ReachabilityBudget {
+        max_edges: 2,
+        ..generous_budget()
+    };
+
+    let result = fixture.reachability("entry.ts", budget);
+
+    assert_eq!(result.outcome, ReachabilityOutcome::BudgetExceeded);
+    assert_eq!(result.work.files, 1);
+    assert_eq!(result.work.edges, 2);
+    assert_eq!(result.work.parses, 1);
+}
+
+#[test]
+fn resolver_metrics_expose_the_exact_last_budgeted_work() {
+    let fixture = Fixture::new();
+    fixture.write("entry.ts", &"x".repeat(129));
+    let route = route(
+        &fixture.package_root,
+        &fixture.package_root.join("entry.ts"),
+    );
+    let budget = ReachabilityBudget {
+        max_file_bytes: 128,
+        max_total_bytes: 128,
+        ..generous_budget()
+    };
+    let mut resolver = crate::PackageRouteResolver::default();
+    let result = package_route_reaches_vue_with_budget(
+        &route,
+        &[],
+        &super::super::package_resolution::PackageResolutionSettings::default(),
+        &mut resolver,
+        SOURCE_OPTIONS,
+        budget,
+    );
+    result.record_work(&mut resolver);
+
+    let metrics = resolver.metrics();
+    assert_eq!(metrics.reachability_checks, 1);
+    assert_eq!(metrics.reachability_budget_exceeded, 1);
+    assert_eq!(metrics.last_reachability_files, 1);
+    assert_eq!(metrics.last_reachability_bytes, 0);
+    assert_eq!(metrics.last_reachability_edges, 0);
+    assert_eq!(metrics.last_reachability_parses, 0);
+    assert_eq!(metrics.last_reachability_packages, 1);
+}
+
+fn generous_budget() -> ReachabilityBudget {
+    ReachabilityBudget {
+        max_packages: 32,
+        max_files: 32,
+        max_file_bytes: 16 * 1024,
+        max_total_bytes: 64 * 1024,
+        max_edges: 64,
+        max_parses: 32,
+    }
+}
+
+struct Fixture {
+    _root: tempfile::TempDir,
+    package_root: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let root = tempfile::tempdir().unwrap();
+        let package_root = root.path().join("package");
+        std::fs::create_dir_all(&package_root).unwrap();
+        std::fs::write(
+            package_root.join("package.json"),
+            r#"{"name":"reachability-fixture"}"#,
+        )
+        .unwrap();
+        Self {
+            _root: root,
+            package_root,
+        }
+    }
+
+    fn write(&self, relative: &str, content: &str) {
+        let path = self.package_root.join(relative);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn reachability(
+        &self,
+        entry: &str,
+        budget: ReachabilityBudget,
+    ) -> super::PackageRouteReachability {
+        let route = route(&self.package_root, &self.package_root.join(entry));
+        self.reachability_for_route(&route, budget)
+    }
+
+    fn reachability_for_route(
+        &self,
+        route: &crate::PackageRoute,
+        budget: ReachabilityBudget,
+    ) -> super::PackageRouteReachability {
+        package_route_reaches_vue_with_budget(
+            route,
+            &[],
+            &super::super::package_resolution::PackageResolutionSettings::default(),
+            &mut crate::PackageRouteResolver::default(),
+            SOURCE_OPTIONS,
+            budget,
+        )
+    }
+}
+
+fn route(package_root: &Path, entry: &Path) -> crate::PackageRoute {
+    route_with_entries(package_root, &[entry.to_path_buf()])
+}
+
+fn route_with_entries(package_root: &Path, entries: &[PathBuf]) -> crate::PackageRoute {
+    crate::PackageRoute {
+        source_paths: entries.to_vec(),
+        dependency_paths: Vec::new(),
+        source_targets: Vec::new(),
+        package_root: package_root.to_path_buf(),
+        package_link_root: package_root.to_path_buf(),
+        manifest_path: package_root.join("package.json"),
+        package_name: Some("reachability-fixture".into()),
+        workspace_source: false,
+        nested_routes: Vec::new(),
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/package_route_reachability_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_reachability_tests.rs
@@ -7,6 +7,9 @@ use super::{
 
 const SOURCE_OPTIONS: crate::PackageSourceOptions = crate::PackageSourceOptions::new(true, true);
 
+#[path = "package_route_reachability_graph_tests.rs"]
+mod graph_tests;
+
 #[test]
 fn cycles_and_duplicate_edges_have_exact_unique_work() {
     let fixture = Fixture::new();
@@ -213,67 +216,6 @@ fn unique_edge_budget_deduplicates_before_stopping() {
     assert_eq!(result.work.files, 1);
     assert_eq!(result.work.edges, 2);
     assert_eq!(result.work.parses, 1);
-}
-
-#[test]
-fn nested_package_route_with_a_vue_source_reaches_vue() {
-    let fixture = Fixture::new();
-    fixture.write("entry.ts", "export { default } from 'nested-package'\n");
-    let nested_root = fixture.package_root.join("node_modules/nested-package");
-    std::fs::create_dir_all(&nested_root).unwrap();
-    std::fs::write(nested_root.join("Widget.vue"), "<template />\n").unwrap();
-    let nested = route_with_entries(&nested_root, &[nested_root.join("Widget.vue")]);
-    let entry = route(
-        &fixture.package_root,
-        &fixture.package_root.join("entry.ts"),
-    );
-
-    let result = scan_package_route_reachability_with_budget(
-        &entry,
-        |_, _| (None, Vec::new()),
-        |_, _, _| (Some(nested.clone()), Vec::new()),
-        generous_budget(),
-    );
-
-    assert_eq!(result.outcome, ReachabilityOutcome::ReachesVue);
-    assert_eq!(result.work.packages, 2);
-    assert!(
-        result
-            .inputs
-            .iter()
-            .any(|path| path.ends_with("nested-package/Widget.vue"))
-    );
-}
-
-#[test]
-fn seeded_candidates_stop_at_the_queue_bound_before_any_file_is_read() {
-    let fixture = Fixture::new();
-    let entries = (0..8)
-        .map(|index| {
-            let name = format!("entry{index}.ts");
-            fixture.write(&name, "export {}\n");
-            fixture.package_root.join(name)
-        })
-        .collect::<Vec<_>>();
-    let route = route_with_entries(&fixture.package_root, &entries);
-    let budget = ReachabilityBudget {
-        max_queued_files: 4,
-        ..generous_budget()
-    };
-
-    let result = fixture.reachability_for_route(&route, budget);
-
-    assert_eq!(result.outcome, ReachabilityOutcome::BudgetExceeded);
-    assert_eq!(result.work.files, 0);
-    assert_eq!(result.work.parses, 0);
-    assert_eq!(
-        result
-            .inputs
-            .iter()
-            .filter(|path| path.extension().is_some_and(|extension| extension == "ts"))
-            .count(),
-        5
-    );
 }
 
 #[test]

--- a/crates/vize_canon/src/batch/virtual_project/package_route_reachability_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_reachability_tests.rs
@@ -1,6 +1,9 @@
 use std::path::{Path, PathBuf};
 
-use super::{ReachabilityBudget, ReachabilityOutcome, package_route_reaches_vue_with_budget};
+use super::{
+    ReachabilityBudget, ReachabilityOutcome, package_route_reaches_vue_with_budget,
+    scan_package_route_reachability_with_budget,
+};
 
 const SOURCE_OPTIONS: crate::PackageSourceOptions = crate::PackageSourceOptions::new(true, true);
 
@@ -213,6 +216,67 @@ fn unique_edge_budget_deduplicates_before_stopping() {
 }
 
 #[test]
+fn nested_package_route_with_a_vue_source_reaches_vue() {
+    let fixture = Fixture::new();
+    fixture.write("entry.ts", "export { default } from 'nested-package'\n");
+    let nested_root = fixture.package_root.join("node_modules/nested-package");
+    std::fs::create_dir_all(&nested_root).unwrap();
+    std::fs::write(nested_root.join("Widget.vue"), "<template />\n").unwrap();
+    let nested = route_with_entries(&nested_root, &[nested_root.join("Widget.vue")]);
+    let entry = route(
+        &fixture.package_root,
+        &fixture.package_root.join("entry.ts"),
+    );
+
+    let result = scan_package_route_reachability_with_budget(
+        &entry,
+        |_, _| (None, Vec::new()),
+        |_, _, _| (Some(nested.clone()), Vec::new()),
+        generous_budget(),
+    );
+
+    assert_eq!(result.outcome, ReachabilityOutcome::ReachesVue);
+    assert_eq!(result.work.packages, 2);
+    assert!(
+        result
+            .inputs
+            .iter()
+            .any(|path| path.ends_with("nested-package/Widget.vue"))
+    );
+}
+
+#[test]
+fn seeded_candidates_stop_at_the_queue_bound_before_any_file_is_read() {
+    let fixture = Fixture::new();
+    let entries = (0..8)
+        .map(|index| {
+            let name = format!("entry{index}.ts");
+            fixture.write(&name, "export {}\n");
+            fixture.package_root.join(name)
+        })
+        .collect::<Vec<_>>();
+    let route = route_with_entries(&fixture.package_root, &entries);
+    let budget = ReachabilityBudget {
+        max_queued_files: 4,
+        ..generous_budget()
+    };
+
+    let result = fixture.reachability_for_route(&route, budget);
+
+    assert_eq!(result.outcome, ReachabilityOutcome::BudgetExceeded);
+    assert_eq!(result.work.files, 0);
+    assert_eq!(result.work.parses, 0);
+    assert_eq!(
+        result
+            .inputs
+            .iter()
+            .filter(|path| path.extension().is_some_and(|extension| extension == "ts"))
+            .count(),
+        4
+    );
+}
+
+#[test]
 fn resolver_metrics_expose_the_exact_last_budgeted_work() {
     let fixture = Fixture::new();
     fixture.write("entry.ts", &"x".repeat(129));
@@ -250,6 +314,7 @@ fn generous_budget() -> ReachabilityBudget {
     ReachabilityBudget {
         max_packages: 32,
         max_files: 32,
+        max_queued_files: 256,
         max_file_bytes: 16 * 1024,
         max_total_bytes: 64 * 1024,
         max_edges: 64,

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes.rs
@@ -12,12 +12,20 @@ use crate::batch::virtual_project::{
 #[allow(clippy::disallowed_types)] // Compiler-option aliases originate in serde_json maps.
 type CompilerAlias = (std::string::String, std::string::String);
 
+type ReachabilityCacheKey = (
+    PathBuf,
+    PathBuf,
+    CompactString,
+    crate::PackageResolutionContext,
+    u8,
+);
+
 #[allow(clippy::disallowed_types)] // Compiler-option aliases originate in serde_json maps.
 pub(super) struct RouteDiscovery<'a> {
     settings: &'a PackageResolutionSettings,
     resolver: &'a mut crate::PackageRouteResolver,
     routes: &'a mut FxHashMap<(PathBuf, CompactString), crate::PackageRoute>,
-    reachability: &'a mut FxHashMap<(PathBuf, CompactString), PackageRouteReachability>,
+    reachability: &'a mut FxHashMap<ReachabilityCacheKey, PackageRouteReachability>,
     bindings: &'a mut Vec<crate::PackageRouteBinding>,
     inputs: &'a mut Vec<PathBuf>,
     aliases: &'a [CompilerAlias],
@@ -28,7 +36,7 @@ impl<'a> RouteDiscovery<'a> {
         settings: &'a PackageResolutionSettings,
         resolver: &'a mut crate::PackageRouteResolver,
         routes: &'a mut FxHashMap<(PathBuf, CompactString), crate::PackageRoute>,
-        reachability: &'a mut FxHashMap<(PathBuf, CompactString), PackageRouteReachability>,
+        reachability: &'a mut FxHashMap<ReachabilityCacheKey, PackageRouteReachability>,
         bindings: &'a mut Vec<crate::PackageRouteBinding>,
         inputs: &'a mut Vec<PathBuf>,
         aliases: &'a [CompilerAlias],
@@ -69,10 +77,17 @@ impl<'a> RouteDiscovery<'a> {
                 .extend(self.settings.input_paths().iter().cloned());
             self.inputs.extend(context_inputs.iter().cloned());
         }
+        let has_route = route.is_some();
         let reachability = route
             .as_ref()
             .map_or_else(PackageRouteReachability::default, |route| {
-                let key = (route.manifest_path.clone(), CompactString::from(specifier));
+                let key = (
+                    logical_absolute(importer),
+                    route.manifest_path.clone(),
+                    CompactString::from(specifier),
+                    context.clone(),
+                    crate::batch::PACKAGE_REACHABILITY_BUDGET_REVISION,
+                );
                 self.reachability
                     .entry(key)
                     .or_insert_with(|| {
@@ -86,7 +101,11 @@ impl<'a> RouteDiscovery<'a> {
                     })
                     .clone()
             });
-        let needs_shadow = reachability.reaches_vue;
+        if has_route {
+            reachability.record_work(self.resolver);
+        }
+        let needs_shadow = reachability.requires_shadow();
+        let track_reachability = reachability.requires_tracking();
         self.inputs.extend(reachability.inputs);
         if needs_shadow && let Some(route) = route.as_ref() {
             self.routes.insert(
@@ -94,13 +113,13 @@ impl<'a> RouteDiscovery<'a> {
                 route.clone(),
             );
         }
-        if needs_shadow || watchable_negative {
+        if track_reachability || watchable_negative {
             self.bindings.push(crate::PackageRouteBinding {
                 importer_path: importer.to_path_buf(),
                 specifier: specifier.into(),
                 occurrence_mode: mode,
                 context,
-                route,
+                route: needs_shadow.then_some(route).flatten(),
                 invalidation_paths: consulted
                     .into_iter()
                     .chain(self.settings.input_paths().iter().cloned())
@@ -323,3 +342,7 @@ export const DecoratorBase = Vue;
         std::fs::write(path, content).unwrap();
     }
 }
+
+#[cfg(test)]
+#[path = "routes_budget_tests.rs"]
+mod budget_tests;

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes.rs
@@ -77,7 +77,6 @@ impl<'a> RouteDiscovery<'a> {
                 .extend(self.settings.input_paths().iter().cloned());
             self.inputs.extend(context_inputs.iter().cloned());
         }
-        let has_route = route.is_some();
         let reachability = route
             .as_ref()
             .map_or_else(PackageRouteReachability::default, |route| {
@@ -91,19 +90,18 @@ impl<'a> RouteDiscovery<'a> {
                 self.reachability
                     .entry(key)
                     .or_insert_with(|| {
-                        crate::batch::virtual_project::package_route_reaches_vue(
+                        let scanned = crate::batch::virtual_project::package_route_reaches_vue(
                             route,
                             self.aliases,
                             self.settings,
                             self.resolver,
                             crate::PackageSourceOptions::new(true, true),
-                        )
+                        );
+                        scanned.record_work(self.resolver);
+                        scanned
                     })
                     .clone()
             });
-        if has_route {
-            reachability.record_work(self.resolver);
-        }
         let needs_shadow = reachability.requires_shadow();
         let track_reachability = reachability.requires_tracking();
         self.inputs.extend(reachability.inputs);

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes_budget_tests.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes_budget_tests.rs
@@ -1,0 +1,105 @@
+use vize_carton::FxHashMap;
+
+use crate::corsa_bridge::vue_dependencies_alias::AliasContext;
+use crate::corsa_bridge::vue_dependencies_alias::context::routes::RouteDiscovery;
+
+#[test]
+fn exhausted_editor_route_keeps_native_spelling_and_invalidation_inputs() {
+    let root = tempfile::tempdir().unwrap();
+    let host = root.path().join("src/App.vue");
+    let package = root.path().join("node_modules/chart-like");
+    let manifest = package.join("package.json");
+    let oversized = package.join("dist/index.js");
+    write(&root.path().join("tsconfig.json"), "{}\n");
+    write(
+        &host,
+        "<script setup lang=\"ts\">import { Chart } from 'chart-like'; void Chart</script>\n",
+    );
+    write(
+        &manifest,
+        r#"{"name":"chart-like","exports":{".":{"types":"./dist/index.d.ts","import":"./dist/index.js"}}}"#,
+    );
+    write(
+        &package.join("dist/index.d.ts"),
+        "export declare class Chart {}\n",
+    );
+    write(&oversized, &"x".repeat(129 * 1024));
+
+    let source = std::fs::read_to_string(&host).unwrap();
+    let context = AliasContext::for_host(&host, &source, &FxHashMap::default());
+
+    assert!(context.aliases.is_empty());
+    assert!(context.package_routes.is_empty());
+    assert!(context.mirror.is_none());
+    assert!(
+        context
+            .route_inputs
+            .iter()
+            .any(|path| { path.ends_with("node_modules/chart-like/package.json") })
+    );
+    assert!(
+        context
+            .route_inputs
+            .iter()
+            .any(|path| path.ends_with("node_modules/chart-like/dist/index.js"))
+    );
+}
+
+#[test]
+fn reachability_cache_separates_importer_and_resolution_context() {
+    let root = tempfile::tempdir().unwrap();
+    let importer = root.path().join("src/entry.ts");
+    let other_importer = root.path().join("other/entry.ts");
+    let package = root.path().join("node_modules/typed-package");
+    write(&importer, "import type { Value } from 'typed-package';\n");
+    write(
+        &other_importer,
+        "import type { Value } from 'typed-package';\n",
+    );
+    write(
+        &package.join("package.json"),
+        r#"{"name":"typed-package","types":"./index.d.ts"}"#,
+    );
+    write(&package.join("index.d.ts"), "export interface Value {}\n");
+    let settings =
+        crate::batch::virtual_project::package_resolution::PackageResolutionSettings::default();
+    let mut resolver = crate::PackageRouteResolver::default();
+    let mut routes = FxHashMap::default();
+    let mut reachability = FxHashMap::default();
+    let mut bindings = Vec::new();
+    let mut inputs = Vec::new();
+    let mut discovery = RouteDiscovery::new(
+        &settings,
+        &mut resolver,
+        &mut routes,
+        &mut reachability,
+        &mut bindings,
+        &mut inputs,
+        &[],
+    );
+
+    assert!(!discovery.resolve(
+        &importer,
+        "typed-package",
+        crate::PackageResolutionMode::Import,
+    ));
+    assert!(!discovery.resolve(
+        &importer,
+        "typed-package",
+        crate::PackageResolutionMode::Require,
+    ));
+    assert!(!discovery.resolve(
+        &other_importer,
+        "typed-package",
+        crate::PackageResolutionMode::Import,
+    ));
+    drop(discovery);
+
+    assert_eq!(reachability.len(), 3);
+    assert_eq!(resolver.metrics().reachability_checks, 3);
+}
+
+fn write(path: &std::path::Path, content: &str) {
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}

--- a/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes_budget_tests.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes_budget_tests.rs
@@ -43,6 +43,32 @@ fn exhausted_editor_route_keeps_native_spelling_and_invalidation_inputs() {
             .iter()
             .any(|path| path.ends_with("node_modules/chart-like/dist/index.js"))
     );
+
+    // The assertions above also hold for a completed scan, so pin the outcome
+    // itself: removing the byte guard turns this into a finished scan and drops
+    // the exhaustion counter back to zero.
+    let settings =
+        crate::batch::virtual_project::package_resolution::PackageResolutionSettings::default();
+    let mut resolver = crate::PackageRouteResolver::default();
+    let mut routes = FxHashMap::default();
+    let mut reachability = FxHashMap::default();
+    let mut bindings = Vec::new();
+    let mut inputs = Vec::new();
+    let mut discovery = RouteDiscovery::new(
+        &settings,
+        &mut resolver,
+        &mut routes,
+        &mut reachability,
+        &mut bindings,
+        &mut inputs,
+        &[],
+    );
+    assert!(!discovery.resolve(&host, "chart-like", crate::PackageResolutionMode::Import));
+    drop(discovery);
+
+    let metrics = resolver.metrics();
+    assert_eq!(metrics.reachability_checks, 1);
+    assert_eq!(metrics.reachability_budget_exceeded, 1);
 }
 
 #[test]
@@ -90,6 +116,13 @@ fn reachability_cache_separates_importer_and_resolution_context() {
     ));
     assert!(!discovery.resolve(
         &other_importer,
+        "typed-package",
+        crate::PackageResolutionMode::Import,
+    ));
+    // A repeated resolution is a cache hit, so it must not scan again or move
+    // the cumulative work counters.
+    assert!(!discovery.resolve(
+        &importer,
         "typed-package",
         crate::PackageResolutionMode::Import,
     ));

--- a/crates/vize_canon/src/package_route/cache.rs
+++ b/crates/vize_canon/src/package_route/cache.rs
@@ -40,6 +40,13 @@ struct PackageRouteResolverState {
     last_refresh_total_routes: u64,
     clock: u64,
     resolution_evictions: u64,
+    reachability_checks: u64,
+    reachability_budget_exceeded: u64,
+    last_reachability_files: u64,
+    last_reachability_bytes: u64,
+    last_reachability_edges: u64,
+    last_reachability_parses: u64,
+    last_reachability_packages: u64,
 }
 
 struct CachedPackageRouteLookup {
@@ -199,6 +206,35 @@ impl PackageRouteResolver {
         state.last_refresh_total_routes = 0;
         state.clock = 0;
         state.resolution_evictions = 0;
+        state.reachability_checks = 0;
+        state.reachability_budget_exceeded = 0;
+        state.last_reachability_files = 0;
+        state.last_reachability_bytes = 0;
+        state.last_reachability_edges = 0;
+        state.last_reachability_parses = 0;
+        state.last_reachability_packages = 0;
+    }
+
+    pub(crate) fn record_reachability_work(
+        &mut self,
+        files: usize,
+        bytes: usize,
+        edges: usize,
+        parses: usize,
+        packages: usize,
+        budget_exceeded: bool,
+    ) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.reachability_checks += 1;
+        state.reachability_budget_exceeded += u64::from(budget_exceeded);
+        state.last_reachability_files = files as u64;
+        state.last_reachability_bytes = bytes as u64;
+        state.last_reachability_edges = edges as u64;
+        state.last_reachability_parses = parses as u64;
+        state.last_reachability_packages = packages as u64;
     }
 
     #[cfg(feature = "native")]
@@ -237,6 +273,13 @@ impl PackageRouteResolver {
             manifest_cache_entries: state.search.len() as u64,
             resolution_cache_evictions: state.resolution_evictions,
             manifest_cache_evictions: state.search.evictions(),
+            reachability_checks: state.reachability_checks,
+            reachability_budget_exceeded: state.reachability_budget_exceeded,
+            last_reachability_files: state.last_reachability_files,
+            last_reachability_bytes: state.last_reachability_bytes,
+            last_reachability_edges: state.last_reachability_edges,
+            last_reachability_parses: state.last_reachability_parses,
+            last_reachability_packages: state.last_reachability_packages,
         }
     }
 }

--- a/crates/vize_canon/src/package_route/cache.rs
+++ b/crates/vize_canon/src/package_route/cache.rs
@@ -215,6 +215,7 @@ impl PackageRouteResolver {
         state.last_reachability_packages = 0;
     }
 
+    #[cfg(feature = "native")]
     pub(crate) fn record_reachability_work(
         &mut self,
         files: usize,

--- a/crates/vize_canon/src/package_route/model.rs
+++ b/crates/vize_canon/src/package_route/model.rs
@@ -276,4 +276,11 @@ pub struct PackageRouteMetrics {
     pub manifest_cache_entries: u64,
     pub resolution_cache_evictions: u64,
     pub manifest_cache_evictions: u64,
+    pub reachability_checks: u64,
+    pub reachability_budget_exceeded: u64,
+    pub last_reachability_files: u64,
+    pub last_reachability_bytes: u64,
+    pub last_reachability_edges: u64,
+    pub last_reachability_parses: u64,
+    pub last_reachability_packages: u64,
 }


### PR DESCRIPTION
## Summary\n\n- add a shared typed package-reachability result with deterministic package, file, byte, edge, and parse budgets\n- deduplicate cycles and repeated edges before work, while retaining consulted and negative resolution inputs for invalidation\n- leave authored package resolution to native TypeScript on budget exhaustion instead of constructing a partial Vue mirror\n- use the same bounded reachability contract in batch, editor, Maestro, and Content Mapper paths\n\n## Root cause\n\nEditor project preparation recursively scanned complete dependency closures to decide whether bare packages could reach Vue. Large non-Vue graphs could consume the entire first-diagnostics deadline before the native project was opened.\n\n## Validation\n\n- old Matrix first-diagnostic timeout set: 10/10 projects now complete open/change/repair in 0.7–6.4 seconds\n- exact long-chain, cycle, duplicate-edge, before-bound, after-bound, invalidation, and importer-context regressions\n- Canon focused package reachability and importer-scoped package matrix green\n- Maestro full: 805 passed, 0 failed, 2 ignored\n- Vize full: 464 unit tests plus all integrations and docs green\n- strict workspace clippy, Rust format, diff-check, and source-length guard green\n- PrimeVue batch check completes within the Matrix limit; the remaining Vue Vben Admin batch-native timeout is separately tracked by #4153\n\nNo retry, sleep, timeout increase, global serialization, or partial alias fallback is included.\n\nCloses #4144

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved import and alias resolution with more complete candidate-file tracking.
  * Enhanced package route analysis across nested dependencies and complex graphs.
  * Added safeguards to limit analysis work while maintaining accurate route and file tracking.
  * Improved caching and invalidation for package metadata and resolved files.
  * Added reachability metrics for analysis workload visibility.

* **Bug Fixes**
  * Fixed unresolved aliases and package routes so consulted files remain available for future updates.
  * Improved handling of oversized files, duplicate dependencies, cycles, and shadowed package routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->