### PR TITLE
feat(compose): add capability result contract

### DIFF
--- a/npm/compose/core/src/capability.test.ts
+++ b/npm/compose/core/src/capability.test.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  availableCapability,
+  isCapabilityAvailable,
+  isCapabilityUnavailable,
+  unavailableCapability,
+} from "./capability.ts";
+import type { CapabilityResult } from "./capability.ts";
+
+void test("creates an available runtime capability without consulting globals", () => {
+  const value = { vibrate: (milliseconds: number) => milliseconds > 0 };
+
+  assert.deepEqual(availableCapability(value), {
+    status: "available",
+    available: true,
+    value,
+    source: "runtime",
+  });
+});
+
+void test("preserves an adapter-specific source", () => {
+  assert.deepEqual(availableCapability("clipboard", "desktop-host"), {
+    status: "available",
+    available: true,
+    value: "clipboard",
+    source: "desktop-host",
+  });
+});
+
+void test("creates an unavailable capability with an explicit reason", () => {
+  assert.deepEqual(unavailableCapability("insecure-context"), {
+    status: "unavailable",
+    available: false,
+    reason: "insecure-context",
+    details: undefined,
+  });
+});
+
+void test("retains structured adapter diagnostics without interpreting them", () => {
+  const details = { permission: "camera", canRequest: true } as const;
+
+  assert.deepEqual(unavailableCapability("permission-denied", details), {
+    status: "unavailable",
+    available: false,
+    reason: "permission-denied",
+    details,
+  });
+});
+
+void test("guards narrow both result branches", () => {
+  const inspect = (result: CapabilityResult<number, "offline", { retry: boolean }>) => {
+    if (isCapabilityAvailable(result)) return `value:${result.value}`;
+    if (isCapabilityUnavailable(result)) {
+      return `${result.reason}:${String(result.details.retry)}`;
+    }
+    return "unreachable";
+  };
+
+  assert.equal(inspect(availableCapability(42)), "value:42");
+  assert.equal(inspect(unavailableCapability("offline", { retry: true })), "offline:true");
+});

--- a/npm/compose/core/src/capability.ts
+++ b/npm/compose/core/src/capability.ts
@@ -1,0 +1,171 @@
+/** Runtime families understood by composable capability metadata and adapters. */
+export type CapabilityTarget = "web" | "server" | "worker" | "native" | "desktop" | "terminal";
+
+/** Built-in origins from which a capability value can be resolved. */
+export type CapabilitySource = "runtime" | "adapter" | "fallback";
+
+/**
+ * Standard reasons why a capability cannot currently provide a value.
+ *
+ * Adapters may extend this vocabulary with a narrower string-literal union;
+ * consumers should preserve unknown extension reasons when crossing process
+ * or version boundaries.
+ */
+export type CapabilityUnavailableReason =
+  | "unsupported"
+  | "unavailable"
+  | "permission-denied"
+  | "insecure-context"
+  | "not-active"
+  | "not-ready"
+  | "cancelled"
+  | "adapter-missing"
+  | "adapter-error";
+
+/** A capability value that is ready for use. */
+export interface AvailableCapability<Value, Source extends string = CapabilitySource> {
+  /** Stable discriminant for serialization and exhaustive matching. */
+  readonly status: "available";
+
+  /** Boolean discriminant for ergonomic guards in templates and JavaScript. */
+  readonly available: true;
+
+  /** Resolved capability implementation or value. */
+  readonly value: Value;
+
+  /** Origin that supplied the value, preserved as a string literal. */
+  readonly source: Source;
+}
+
+/** A capability that cannot currently provide a value. */
+export interface UnavailableCapability<
+  Reason extends string = CapabilityUnavailableReason,
+  Details = undefined,
+> {
+  /** Stable discriminant for serialization and exhaustive matching. */
+  readonly status: "unavailable";
+
+  /** Boolean discriminant for ergonomic guards in templates and JavaScript. */
+  readonly available: false;
+
+  /** Typed, machine-readable explanation of the unavailable state. */
+  readonly reason: Reason;
+
+  /** Structured diagnostic or recovery information supplied by the adapter. */
+  readonly details: Details;
+}
+
+/** Explicit result of capability discovery or adapter negotiation. */
+export type CapabilityResult<
+  Value,
+  Reason extends string = CapabilityUnavailableReason,
+  Details = undefined,
+  Source extends string = CapabilitySource,
+> = AvailableCapability<Value, Source> | UnavailableCapability<Reason, Details>;
+
+/**
+ * Create an available capability supplied directly by the current runtime.
+ *
+ * The value and source retain literal types. The helper performs no global
+ * access and is safe during server rendering and module evaluation.
+ *
+ * @param value Resolved capability implementation or value.
+ * @returns An available result whose source is `"runtime"`.
+ */
+export function availableCapability<const Value>(
+  value: Value,
+): AvailableCapability<Value, "runtime">;
+
+/**
+ * Create an available capability with an explicit, literal-preserving source.
+ *
+ * @param value Resolved capability implementation or value.
+ * @param source Runtime, adapter, fallback, or adapter-specific source name.
+ * @returns An available capability result.
+ */
+export function availableCapability<const Value, const Source extends string>(
+  value: Value,
+  source: Source,
+): AvailableCapability<Value, Source>;
+
+export function availableCapability<const Value, const Source extends string>(
+  value: Value,
+  source?: Source,
+): AvailableCapability<Value, Source | "runtime"> {
+  return {
+    status: "available",
+    available: true,
+    value,
+    source: source ?? "runtime",
+  };
+}
+
+/**
+ * Create an unavailable capability without additional details.
+ *
+ * The reason retains its string-literal type. Capability absence is returned
+ * as data rather than thrown, making unsupported server, worker, native,
+ * desktop, and terminal environments deterministic.
+ *
+ * @param reason Machine-readable unavailability reason.
+ * @returns An unavailable result with `undefined` details.
+ */
+export function unavailableCapability<const Reason extends string>(
+  reason: Reason,
+): UnavailableCapability<Reason, undefined>;
+
+/**
+ * Create an unavailable capability with typed recovery or diagnostic details.
+ *
+ * Passing `undefined` explicitly is distinct at the call boundary and still
+ * preserves the exact `undefined` details type.
+ *
+ * @param reason Machine-readable unavailability reason.
+ * @param details Structured diagnostic or recovery information.
+ * @returns An unavailable capability result.
+ */
+export function unavailableCapability<const Reason extends string, const Details>(
+  reason: Reason,
+  details: Details,
+): UnavailableCapability<Reason, Details>;
+
+export function unavailableCapability<const Reason extends string, const Details>(
+  reason: Reason,
+  details?: Details,
+): UnavailableCapability<Reason, Details | undefined> {
+  return {
+    status: "unavailable",
+    available: false,
+    reason,
+    details,
+  };
+}
+
+/**
+ * Narrow a capability result to its available branch.
+ *
+ * @param result Capability discovery or negotiation result.
+ * @returns Whether `result.value` is ready for use.
+ */
+export function isCapabilityAvailable<Value, Reason extends string, Details, Source extends string>(
+  result: CapabilityResult<Value, Reason, Details, Source>,
+): result is AvailableCapability<Value, Source> {
+  return result.available;
+}
+
+/**
+ * Narrow a capability result to its unavailable branch.
+ *
+ * @param result Capability discovery or negotiation result.
+ * @returns Whether the capability has a typed unavailability reason.
+ */
+export function isCapabilityUnavailable<
+  Value,
+  Reason extends string,
+  Details,
+  Source extends string,
+>(
+  result: CapabilityResult<Value, Reason, Details, Source>,
+): result is UnavailableCapability<Reason, Details> {
+  return !result.available;
+}

--- a/npm/compose/core/src/index.ts
+++ b/npm/compose/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./async-resource.ts";
+export * from "./capability.ts";
 export * from "./event-listener.ts";
 export * from "./locale.ts";
 export * from "./media-query.ts";

--- a/npm/compose/core/src/treeshake.test.ts
+++ b/npm/compose/core/src/treeshake.test.ts
@@ -22,6 +22,10 @@ const entries = {
  */
 const sentinels = {
   scope: ["tryOnScopeDispose"],
+  "capability-available": ['status: "available"'],
+  "capability-unavailable": ['status: "unavailable"'],
+  "capability-is-available": ["isCapabilityAvailable"],
+  "capability-is-unavailable": ["isCapabilityUnavailable"],
   "event-listener": ["useEventListener", "isListening"],
   "media-query": ["useMediaQuery", "matchMedia"],
   locale: ["useLocale", "getTextInfo"],
@@ -47,6 +51,30 @@ interface UtilityCase {
 
 const utilities: readonly UtilityCase[] = [
   { binding: "tryOnScopeDispose", entry: "index", module: "scope", shared: [] },
+  {
+    binding: "availableCapability",
+    entry: "index",
+    module: "capability-available",
+    shared: [],
+  },
+  {
+    binding: "unavailableCapability",
+    entry: "index",
+    module: "capability-unavailable",
+    shared: [],
+  },
+  {
+    binding: "isCapabilityAvailable",
+    entry: "index",
+    module: "capability-is-available",
+    shared: [],
+  },
+  {
+    binding: "isCapabilityUnavailable",
+    entry: "index",
+    module: "capability-is-unavailable",
+    shared: [],
+  },
   { binding: "useEventListener", entry: "index", module: "event-listener", shared: ["scope"] },
   { binding: "useMediaQuery", entry: "index", module: "media-query", shared: [] },
   { binding: "useReducedMotion", entry: "index", module: "media-query", shared: [] },

--- a/npm/compose/core/src/types.test-d.ts
+++ b/npm/compose/core/src/types.test-d.ts
@@ -3,6 +3,15 @@
 import type { ShallowRef } from "vue";
 
 import { type AsyncResourceExecution, useAsyncResource } from "./async-resource.js";
+import {
+  availableCapability,
+  type AvailableCapability,
+  type CapabilityResult,
+  isCapabilityAvailable,
+  isCapabilityUnavailable,
+  unavailableCapability,
+  type UnavailableCapability,
+} from "./capability.js";
 import { type TextDirection, useLocale } from "./locale.js";
 
 type Equal<Left, Right> =
@@ -50,3 +59,55 @@ type _LocaleDirectionNeverWidensToUndefined = Expect<
 
 // @ts-expect-error the public direction ref never exposes capability absence.
 const _undefinedDirection: undefined = locale.direction.value;
+
+const runtimeCapability = availableCapability({ kind: "camera" } as const);
+const adapterCapability = availableCapability(1 as const, "native-camera");
+const unsupportedCapability = unavailableCapability("unsupported");
+const permissionCapability = unavailableCapability("permission-denied", {
+  permission: "camera",
+  canRequest: true,
+} as const);
+
+type _RuntimeCapabilityPreservesValueAndDefaultSource = Expect<
+  Equal<typeof runtimeCapability, AvailableCapability<{ readonly kind: "camera" }, "runtime">>
+>;
+type _AdapterCapabilityPreservesLiteralSource = Expect<
+  Equal<typeof adapterCapability, AvailableCapability<1, "native-camera">>
+>;
+type _UnavailableCapabilityPreservesReason = Expect<
+  Equal<typeof unsupportedCapability, UnavailableCapability<"unsupported", undefined>>
+>;
+type _UnavailableCapabilityPreservesDetails = Expect<
+  Equal<
+    typeof permissionCapability,
+    UnavailableCapability<
+      "permission-denied",
+      { readonly permission: "camera"; readonly canRequest: true }
+    >
+  >
+>;
+
+declare const capabilityResult: CapabilityResult<
+  { readonly request: () => void },
+  "unsupported" | "permission-denied",
+  { readonly canRequest: boolean },
+  "runtime" | "native-host"
+>;
+
+if (isCapabilityAvailable(capabilityResult)) {
+  capabilityResult.value.request();
+  type _AvailableGuardPreservesSource = Expect<
+    Equal<typeof capabilityResult.source, "runtime" | "native-host">
+  >;
+  // @ts-expect-error the available branch has no unavailability reason.
+  void capabilityResult.reason;
+}
+
+if (isCapabilityUnavailable(capabilityResult)) {
+  type _UnavailableGuardPreservesReason = Expect<
+    Equal<typeof capabilityResult.reason, "unsupported" | "permission-denied">
+  >;
+  capabilityResult.details.canRequest satisfies boolean;
+  // @ts-expect-error the unavailable branch has no capability value.
+  void capabilityResult.value;
+}


### PR DESCRIPTION
## Summary

- add a literal-preserving discriminated result for capability discovery
- distinguish runtime, adapter, fallback, and adapter-specific value sources
- model unsupported, denied, insecure, inactive, cancelled, and adapter failure states as typed data
- add ergonomic type guards without runtime-global access
- document every public type, field, parameter, return value, SSR rule, and extension rule

## User impact

Capability adapters can now report absence explicitly instead of collapsing it into `undefined` or exceptions. Values, reasons, details, and custom adapter sources remain exact literal types across web, server, worker, native, desktop, and terminal targets.

## Validation

- `pnpm --filter @vizejs/composable check`
- `pnpm --filter @vizejs/composable test` (109/109)
- package build and gzip budgets through `pretest` (7,974 / 9,216 bytes for the root entry)
- focused runtime and tree-shake isolation tests
- exact and negative public type tests
- semantic documentation coverage
- import-time runtime-global probe
- `git diff --check`

The local repository-wide source-length command was also attempted; its pinned module resolver rejected the repository's existing `moon.mod` `source` key before analyzing this patch. GitHub Actions remains authoritative for that repository gate.

Part of #3136.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->