### PR TITLE
feat(ui): add deterministic id scope

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -54,6 +54,11 @@
       "import": "./dist/controllable-state.mjs",
       "default": "./dist/controllable-state.mjs"
     },
+    "./id": {
+      "types": "./dist/id.d.mts",
+      "import": "./dist/id.mjs",
+      "default": "./dist/id.mjs"
+    },
     "./primitive": {
       "types": "./dist/primitive.d.mts",
       "import": "./dist/primitive.mjs",
@@ -90,8 +95,8 @@
     "lint:sfc": "vp exec node scripts/lint-sfc.ts src",
     "pretest": "vp pack && pnpm check:size",
     "test": "vp test run",
-    "check": "vp check src scripts vite.config.ts",
-    "check:fix": "vp check --fix src scripts vite.config.ts",
+    "check": "vp check src scripts vite.config.ts tsconfig.typecheck.json && vue-tsc --noEmit -p tsconfig.typecheck.json",
+    "check:fix": "vp check --fix src scripts vite.config.ts tsconfig.typecheck.json",
     "check:size": "node scripts/check-size.mjs",
     "fmt": "vp fmt --write src scripts vite.config.ts"
   },
@@ -106,7 +111,8 @@
     "typescript": "catalog:typescript",
     "vite": "catalog:vite-stack",
     "vite-plus": "catalog:vite-stack",
-    "vue": "catalog:vue-stable"
+    "vue": "catalog:vue-stable",
+    "vue-tsc": "catalog:typescript"
   },
   "peerDependencies": {
     "vue": "^3.5.0"

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,11 +5,12 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 3_600],
+  ["index.mjs", 5_400],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
   ["context.mjs", 700],
   ["controllable-state.mjs", 600],
+  ["id.mjs", 2_300],
   ["primitive.mjs", 800],
   ["visually-hidden.mjs", 800],
   ["media.mjs", 2_400],

--- a/npm/ui/core/src/DeterministicIdProvider.vue
+++ b/npm/ui/core/src/DeterministicIdProvider.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { useId as useVueId } from "vue";
+
+import {
+  createDeterministicIdScope,
+  provideDeterministicIdScope,
+  useOptionalDeterministicIdScope,
+} from "./deterministic-id.ts";
+
+const { prefix = undefined, seed = undefined } = defineProps<{
+  /**
+   * Namespace prefix for this subtree.
+   *
+   * @default The parent prefix when nested; otherwise "vize"
+   */
+  readonly prefix?: string;
+
+  /**
+   * Stable request, island, or subtree seed.
+   *
+   * @default Vue's SSR- and hydration-stable useId() value
+   */
+  readonly seed?: string | number;
+}>();
+
+defineSlots<{
+  default(props: { readonly namespace: string; readonly prefix: string }): unknown;
+}>();
+
+const vueSeed = useVueId();
+const parent = useOptionalDeterministicIdScope();
+const resolvedSeed = seed ?? vueSeed;
+const scope =
+  parent === undefined
+    ? createDeterministicIdScope({
+        prefix: prefix ?? "vize",
+        seed: resolvedSeed,
+      })
+    : prefix === undefined
+      ? parent.createChild({ seed: resolvedSeed })
+      : parent.createChild({ prefix, seed: resolvedSeed });
+
+provideDeterministicIdScope(scope);
+
+defineExpose({ namespace: scope.namespace, prefix: scope.prefix });
+</script>
+
+<template>
+  <slot :namespace="scope.namespace" :prefix="scope.prefix" />
+</template>
+
+<style scoped>
+/* This provider renders no element and therefore owns no visual styles. */
+</style>

--- a/npm/ui/core/src/DeterministicIdProvider.vue
+++ b/npm/ui/core/src/DeterministicIdProvider.vue
@@ -42,11 +42,14 @@ const scope =
 
 provideDeterministicIdScope(scope);
 
-defineExpose({ namespace: scope.namespace, prefix: scope.prefix });
+const namespace: string = scope.namespace;
+const resolvedPrefix: string = scope.prefix;
+
+defineExpose({ namespace, prefix: resolvedPrefix });
 </script>
 
 <template>
-  <slot :namespace="scope.namespace" :prefix="scope.prefix" />
+  <slot :namespace="namespace" :prefix="resolvedPrefix" />
 </template>
 
 <style scoped>

--- a/npm/ui/core/src/deterministic-id.ts
+++ b/npm/ui/core/src/deterministic-id.ts
@@ -1,0 +1,223 @@
+import { computed, getCurrentInstance, inject, provide, toValue, useId as useVueId } from "vue";
+import type { ComputedRef, InjectionKey, MaybeRefOrGetter } from "vue";
+
+declare const deterministicIdBrand: unique symbol;
+
+/** A validated DOM identifier created or accepted by the deterministic ID system. */
+export type DeterministicId = string & {
+  readonly [deterministicIdBrand]: "DeterministicId";
+};
+
+/** Stable request, island, or subtree seed accepted by an ID scope. */
+export type DeterministicIdSeed = string | number;
+
+/** Options for a root deterministic ID scope. */
+export interface DeterministicIdScopeOptions {
+  /**
+   * Namespace prefix used by every ID in the scope.
+   *
+   * @default "vize"
+   */
+  readonly prefix?: string;
+
+  /** Stable request, island, or application seed. */
+  readonly seed: DeterministicIdSeed;
+}
+
+/** Options for a nested deterministic ID scope. */
+export interface DeterministicIdChildScopeOptions {
+  /**
+   * Namespace prefix for the child scope.
+   *
+   * @default The parent scope prefix
+   */
+  readonly prefix?: string;
+
+  /** Stable seed that identifies the child subtree. */
+  readonly seed: DeterministicIdSeed;
+}
+
+/** One request-local namespace that allocates stable, collision-resistant DOM IDs. */
+export interface DeterministicIdScope {
+  /** Validated namespace prefix. */
+  readonly prefix: string;
+
+  /** Complete namespace shared by IDs allocated from this scope. */
+  readonly namespace: string;
+
+  /**
+   * Allocate the next ID during component setup.
+   *
+   * The sequence is intentionally independent from child-scope allocation so
+   * adding a nested provider cannot renumber sibling control IDs.
+   */
+  readonly nextId: (hint?: string) => DeterministicId;
+
+  /** Create a request-local child namespace without sharing its ID counter. */
+  readonly createChild: (options: DeterministicIdChildScopeOptions) => DeterministicIdScope;
+}
+
+/** Options for {@link useDeterministicId}. */
+export interface DeterministicIdOptions {
+  /**
+   * Consumer-owned ID. `null` and `undefined` select the generated fallback.
+   *
+   * @default undefined
+   */
+  readonly id?: MaybeRefOrGetter<string | null | undefined>;
+
+  /**
+   * Human-readable role appended to a generated ID.
+   *
+   * @default "id"
+   */
+  readonly hint?: string;
+
+  /**
+   * Prefix used when no {@link IdProvider} is present.
+   *
+   * @default "vize"
+   */
+  readonly prefix?: string;
+}
+
+const deterministicIdScopeKey: InjectionKey<DeterministicIdScope> = Symbol(
+  "VizeUiDeterministicIdScope",
+);
+const safePrefix = /^[A-Za-z][A-Za-z0-9_-]*$/;
+const safeSegment = /^[A-Za-z0-9][A-Za-z0-9_-]*$/;
+
+/**
+ * Validate and brand a consumer-owned HTML ID.
+ *
+ * HTML permits a broad character set, but forbids an empty value and ASCII
+ * whitespace. This contract additionally rejects ASCII controls. Consumers
+ * remain free to use Unicode and punctuation; CSS selectors may need
+ * `CSS.escape()` for those IDs.
+ */
+export function toDeterministicId(value: string): DeterministicId {
+  if (!isValidHtmlId(value)) {
+    throw new Error(
+      "VIZE_UI_ID_VALUE: an id must be non-empty and contain no ASCII whitespace or controls",
+    );
+  }
+  return value as DeterministicId;
+}
+
+function isValidHtmlId(value: string): boolean {
+  if (value.length === 0) return false;
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code <= 0x20 || code === 0x7f) return false;
+  }
+  return true;
+}
+
+/** Append a validated semantic part to an existing DOM ID. */
+export function deriveDeterministicId(id: string, part: string): DeterministicId {
+  const base = toDeterministicId(id);
+  return toDeterministicId(`${base}-${normalizeSegment(part, "part")}`);
+}
+
+/** Create an isolated deterministic ID scope for an application or SSR request. */
+export function createDeterministicIdScope(
+  options: DeterministicIdScopeOptions,
+): DeterministicIdScope {
+  const prefix = normalizePrefix(options.prefix ?? "vize");
+  const seed = normalizeSeed(options.seed);
+  return createScope(prefix, `${prefix}-${seed}`);
+}
+
+/**
+ * Allocate one stable ID for the current component instance.
+ *
+ * Generated IDs use the nearest provider scope. Without a provider, Vue's
+ * hydration-stable `useId()` sequence supplies the seed, including a safe
+ * application `idPrefix`. The generated fallback is allocated once; changing
+ * an explicit reactive ID back to `undefined` restores that same fallback.
+ */
+export function useDeterministicId(
+  options: DeterministicIdOptions = {},
+): ComputedRef<DeterministicId> {
+  if (getCurrentInstance() === null) {
+    throw new Error("VIZE_UI_ID_SETUP: useDeterministicId() must run during component setup");
+  }
+
+  // Always consume Vue's instance-local sequence. This keeps later Vue IDs in
+  // the same order when a component moves into or out of an IdProvider.
+  const vueId = useVueId();
+  const scope = useOptionalDeterministicIdScope();
+  const hint = normalizeSegment(options.hint ?? "id", "hint");
+  const generated =
+    scope?.nextId(hint) ??
+    toDeterministicId(
+      `${normalizePrefix(options.prefix ?? "vize")}-${normalizeSeed(vueId)}-${hint}`,
+    );
+
+  return computed(() => {
+    const explicit = options.id === undefined ? undefined : toValue(options.id);
+    return explicit === null || explicit === undefined ? generated : toDeterministicId(explicit);
+  });
+}
+
+/** @internal Provide the scope owned by `IdProvider.vue`. */
+export function provideDeterministicIdScope(scope: DeterministicIdScope): DeterministicIdScope {
+  provide(deterministicIdScopeKey, scope);
+  return scope;
+}
+
+/** @internal Read the nearest provider without requiring one. */
+export function useOptionalDeterministicIdScope(): DeterministicIdScope | undefined {
+  return inject(deterministicIdScopeKey, undefined);
+}
+
+function createScope(prefix: string, namespace: string): DeterministicIdScope {
+  let idSequence = 0;
+  let childSequence = 0;
+
+  const scope: DeterministicIdScope = {
+    prefix,
+    namespace,
+    nextId: (hint = "id") =>
+      toDeterministicId(`${namespace}-${normalizeSegment(hint, "hint")}-${idSequence++}`),
+    createChild: (options) => {
+      const childPrefix = options.prefix === undefined ? prefix : normalizePrefix(options.prefix);
+      const childSeed = normalizeSeed(options.seed);
+      const childIndex = childSequence++;
+      const inheritedNamespace = `${namespace}-scope-${childIndex}-${childSeed}`;
+      const childNamespace =
+        childPrefix === prefix ? inheritedNamespace : `${childPrefix}-${inheritedNamespace}`;
+      return createScope(childPrefix, childNamespace);
+    },
+  };
+
+  return Object.freeze(scope);
+}
+
+function normalizePrefix(value: string): string {
+  if (!safePrefix.test(value)) {
+    throw new Error(
+      "VIZE_UI_ID_PREFIX: a prefix must start with an ASCII letter and contain only letters, digits, _ or -",
+    );
+  }
+  return value;
+}
+
+function normalizeSeed(value: DeterministicIdSeed): string {
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error("VIZE_UI_ID_SEED: a numeric seed must be a non-negative safe integer");
+    }
+    return String(value);
+  }
+  return normalizeSegment(value, "seed");
+}
+
+function normalizeSegment(value: string, role: "hint" | "part" | "seed"): string {
+  if (!safeSegment.test(value)) {
+    throw new Error(
+      `VIZE_UI_ID_${role.toUpperCase()}: ${role} must contain only ASCII letters, digits, _ or - and may not start with punctuation`,
+    );
+  }
+  return value;
+}

--- a/npm/ui/core/src/distribution.test.ts
+++ b/npm/ui/core/src/distribution.test.ts
@@ -10,6 +10,7 @@ const publicEntries = [
   "./button",
   "./checkbox",
   "./controllable-state",
+  "./id",
   "./primitive",
   "./visually-hidden",
 ] as const;

--- a/npm/ui/core/src/id.behavior.md
+++ b/npm/ui/core/src/id.behavior.md
@@ -1,0 +1,46 @@
+# Deterministic ID behavior contract
+
+Normative state × input → outcome table for `DeterministicIdProvider.vue` and
+`@vizejs/ui/id`. Every row is proven by the named test in `src/id.test.ts`;
+compile-only public type assertions live in `src/id.types.test-d.ts`.
+
+| #    | State                     | Input                                                  | Outcome                                                     | Proven by                                                           |
+| ---- | ------------------------- | ------------------------------------------------------ | ----------------------------------------------------------- | ------------------------------------------------------------------- |
+| ID1  | root scope                | explicit prefix and string seed                        | namespace is `prefix-seed`                                  | `creates immutable request-local scopes with independent sequences` |
+| ID2  | root scope                | repeated hint                                          | monotonically increasing unique IDs                         | `creates immutable request-local scopes with independent sequences` |
+| ID3  | root scope                | child scope allocation                                 | child and parent ID counters remain independent             | `creates immutable request-local scopes with independent sequences` |
+| ID4  | nested scope              | duplicate child seeds                                  | allocation index prevents collisions                        | `keeps duplicate nested provider seeds collision-free`              |
+| ID5  | nested scope              | explicit prefix override                               | child prefix changes without losing parent namespace        | `supports a nested namespace prefix override`                       |
+| ID6  | any scope                 | unsafe prefix, seed, hint, or numeric seed             | stable diagnostic rejects the value                         | `rejects namespace values that are unsafe to compose`               |
+| ID7  | consumer ID               | valid punctuation or Unicode                           | exact consumer ID is accepted and branded                   | `validates explicit IDs and derives semantic parts`                 |
+| ID8  | consumer ID               | empty, whitespace, or ASCII control                    | stable diagnostic rejects the value                         | `validates explicit IDs and derives semantic parts`                 |
+| ID9  | component setup           | no provider                                            | Vue `useId()` supplies a hydration-stable seed              | `uses Vue's application ID sequence without a provider`             |
+| ID10 | component setup           | provider                                               | nearest request-local scope allocates the ID                | `allocates descriptive IDs from the nearest provider`               |
+| ID11 | component setup           | reactive explicit ID appears                           | explicit ID replaces the generated fallback                 | `preserves one fallback across reactive explicit ID changes`        |
+| ID12 | component setup           | reactive explicit ID disappears                        | original generated fallback is restored without renumbering | `preserves one fallback across reactive explicit ID changes`        |
+| ID13 | outside setup             | call composable                                        | stable setup diagnostic is thrown                           | `rejects composable use outside component setup`                    |
+| ID14 | provider slot             | render                                                 | slot receives validated namespace and prefix                | `exposes the resolved namespace to its slot and public instance`    |
+| ID15 | nested providers          | mount                                                  | parent and nested consumer IDs are unique                   | `keeps duplicate nested provider seeds collision-free`              |
+| ID16 | SSR request               | repeat identical tree and seed                         | byte-identical IDs are rendered                             | `renders byte-stable IDs for repeated and concurrent SSR requests`  |
+| ID17 | concurrent SSR            | different request seeds                                | request-local sequences never bleed across renders          | `renders byte-stable IDs for repeated and concurrent SSR requests`  |
+| ID18 | SSR followed by hydration | identical provider tree                                | client retains server IDs without mismatch diagnostics      | `hydrates provider IDs without warnings or replacement`             |
+| ID19 | nested provider insertion | sibling control allocation                             | child-scope counter cannot renumber sibling IDs             | `keeps ID and child-scope allocation sequences independent`         |
+| ID20 | public types              | invalid seed, hint, prefix, or unbranded ID assignment | TypeScript rejects closed-contract misuse                   | `src/id.types.test-d.ts`                                            |
+
+## Assistive-technology notes
+
+The primitive only produces IDs; components remain responsible for assigning
+them to correct relationships such as `for`, `aria-labelledby`,
+`aria-describedby`, `aria-controls`, and `aria-errormessage`. Stable IDs avoid
+relationship loss during hydration, but do not make an invalid relationship
+accessible.
+
+## Escape hatches and constraints
+
+- Pass an explicit `id` when an external document contract owns the value.
+- Give separate SSR islands distinct provider seeds, or configure Vue's
+  application `idPrefix`, when their DOM is combined into one document.
+- Allocate generated IDs during setup. Calling a scope's `nextId()` from a
+  render loop intentionally changes the sequence and is unsupported.
+- User-owned IDs allow Unicode and punctuation. Escape them before using them
+  in a CSS selector.

--- a/npm/ui/core/src/id.test.ts
+++ b/npm/ui/core/src/id.test.ts
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+
+import { mount } from "@vue/test-utils";
+import { test } from "vite-plus/test";
+import { createSSRApp, defineComponent, h, nextTick, ref } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import IdProvider from "./DeterministicIdProvider.vue";
+import {
+  createDeterministicIdScope,
+  deriveDeterministicId,
+  toDeterministicId,
+  useDeterministicId,
+} from "./deterministic-id.ts";
+
+const IdProbe = defineComponent({
+  name: "IdProbe",
+  props: {
+    hint: { type: String, default: "id" },
+    prefix: { type: String, default: undefined },
+  },
+  setup(props) {
+    const id = useDeterministicId({
+      hint: props.hint,
+      ...(props.prefix === undefined ? {} : { prefix: props.prefix }),
+    });
+    return () => h("span", { id: id.value, "data-id-probe": props.hint }, id.value);
+  },
+});
+
+test("creates immutable request-local scopes with independent sequences", () => {
+  const scope = createDeterministicIdScope({ prefix: "checkout", seed: "request-42" });
+
+  assert.equal(scope.prefix, "checkout");
+  assert.equal(scope.namespace, "checkout-request-42");
+  assert.equal(Object.isFrozen(scope), true);
+  assert.equal(scope.nextId("label"), "checkout-request-42-label-0");
+  assert.equal(scope.nextId("label"), "checkout-request-42-label-1");
+
+  const child = scope.createChild({ seed: "dialog" });
+  assert.equal(child.namespace, "checkout-request-42-scope-0-dialog");
+  assert.equal(child.nextId("title"), "checkout-request-42-scope-0-dialog-title-0");
+  assert.equal(scope.nextId("control"), "checkout-request-42-control-2");
+});
+
+test("keeps ID and child-scope allocation sequences independent", () => {
+  const withoutChild = createDeterministicIdScope({ seed: "request" });
+  assert.equal(withoutChild.nextId("before"), "vize-request-before-0");
+  assert.equal(withoutChild.nextId("after"), "vize-request-after-1");
+
+  const withChild = createDeterministicIdScope({ seed: "request" });
+  assert.equal(withChild.nextId("before"), "vize-request-before-0");
+  withChild.createChild({ seed: "nested" });
+  assert.equal(withChild.nextId("after"), "vize-request-after-1");
+});
+
+test("supports a nested namespace prefix override", () => {
+  const scope = createDeterministicIdScope({ prefix: "page", seed: 7 });
+  const child = scope.createChild({ prefix: "dialog", seed: "settings" });
+
+  assert.equal(child.prefix, "dialog");
+  assert.equal(child.namespace, "dialog-page-7-scope-0-settings");
+  assert.equal(child.nextId(), "dialog-page-7-scope-0-settings-id-0");
+});
+
+test("rejects namespace values that are unsafe to compose", () => {
+  assert.throws(
+    () => createDeterministicIdScope({ prefix: "9field", seed: "request" }),
+    /VIZE_UI_ID_PREFIX/,
+  );
+  assert.throws(() => createDeterministicIdScope({ seed: "request 1" }), /VIZE_UI_ID_SEED/);
+  assert.throws(
+    () => createDeterministicIdScope({ seed: Number.POSITIVE_INFINITY }),
+    /VIZE_UI_ID_SEED/,
+  );
+  assert.throws(() => createDeterministicIdScope({ seed: -1 }), /VIZE_UI_ID_SEED/);
+  const scope = createDeterministicIdScope({ seed: "request" });
+  assert.throws(() => scope.nextId("bad hint"), /VIZE_UI_ID_HINT/);
+});
+
+test("validates explicit IDs and derives semantic parts", () => {
+  assert.equal(toDeterministicId("account.email"), "account.email");
+  assert.equal(toDeterministicId("設定"), "設定");
+  assert.equal(deriveDeterministicId("account.email", "description"), "account.email-description");
+  assert.throws(() => toDeterministicId(""), /VIZE_UI_ID_VALUE/);
+  assert.throws(() => toDeterministicId("two words"), /VIZE_UI_ID_VALUE/);
+  assert.throws(() => toDeterministicId("line\nbreak"), /VIZE_UI_ID_VALUE/);
+  assert.throws(() => deriveDeterministicId("field", "bad part"), /VIZE_UI_ID_PART/);
+});
+
+test("uses Vue's application ID sequence without a provider", () => {
+  const wrapper = mount(IdProbe, { props: { hint: "control", prefix: "field" } });
+  const id = wrapper.get("span").attributes("id");
+
+  assert.ok(id);
+  assert.ok(id.startsWith("field-v-"), `unexpected generated ID: ${id}`);
+  assert.ok(id.endsWith("-control"), `unexpected generated ID: ${id}`);
+  wrapper.unmount();
+});
+
+test("allocates descriptive IDs from the nearest provider", () => {
+  const wrapper = mount(IdProvider, {
+    props: { prefix: "form", seed: "profile" },
+    slots: {
+      default: () => [
+        h(IdProbe, { hint: "label" }),
+        h(IdProbe, { hint: "control" }),
+        h(IdProbe, { hint: "description" }),
+      ],
+    },
+  });
+
+  assert.deepEqual(
+    wrapper.findAll("[data-id-probe]").map((probe) => probe.attributes("id")),
+    ["form-profile-label-0", "form-profile-control-1", "form-profile-description-2"],
+  );
+  wrapper.unmount();
+});
+
+test("preserves one fallback across reactive explicit ID changes", async () => {
+  const explicit = ref<string | undefined>();
+  const Probe = defineComponent({
+    setup() {
+      const id = useDeterministicId({ id: explicit, hint: "control", prefix: "field" });
+      return () => h("input", { id: id.value });
+    },
+  });
+  const wrapper = mount(Probe);
+  const fallback = wrapper.get("input").attributes("id");
+
+  explicit.value = "consumer-control";
+  await nextTick();
+  assert.equal(wrapper.get("input").attributes("id"), "consumer-control");
+
+  explicit.value = undefined;
+  await nextTick();
+  assert.equal(wrapper.get("input").attributes("id"), fallback);
+  wrapper.unmount();
+});
+
+test("rejects composable use outside component setup", () => {
+  assert.throws(() => useDeterministicId(), /VIZE_UI_ID_SETUP/);
+});
+
+test("exposes the resolved namespace to its slot and public instance", () => {
+  const wrapper = mount(IdProvider, {
+    props: { prefix: "checkout", seed: 17 },
+    slots: {
+      default: (state: { namespace: string; prefix: string }) =>
+        h("output", { "data-prefix": state.prefix }, state.namespace),
+    },
+  });
+
+  assert.equal(wrapper.get("output").text(), "checkout-17");
+  assert.equal(wrapper.get("output").attributes("data-prefix"), "checkout");
+  assert.equal((wrapper.vm as unknown as { namespace: string }).namespace, "checkout-17");
+  wrapper.unmount();
+});
+
+test("keeps duplicate nested provider seeds collision-free", () => {
+  const wrapper = mount(IdProvider, {
+    props: { seed: "page" },
+    slots: {
+      default: () => [
+        h(IdProbe, { hint: "control" }),
+        h(IdProvider, { seed: "dialog" }, { default: () => h(IdProbe, { hint: "control" }) }),
+        h(IdProvider, { seed: "dialog" }, { default: () => h(IdProbe, { hint: "control" }) }),
+      ],
+    },
+  });
+
+  assert.deepEqual(
+    wrapper.findAll("[data-id-probe]").map((probe) => probe.attributes("id")),
+    [
+      "vize-page-control-0",
+      "vize-page-scope-0-dialog-control-0",
+      "vize-page-scope-1-dialog-control-0",
+    ],
+  );
+  wrapper.unmount();
+});
+
+function createSsrTree(seed: string) {
+  return defineComponent({
+    name: "DeterministicIdSsrTree",
+    setup() {
+      return () =>
+        h(
+          IdProvider,
+          { seed },
+          {
+            default: () => [
+              h(IdProbe, { hint: "label" }),
+              h(IdProbe, { hint: "control" }),
+              h(
+                IdProvider,
+                { seed: "nested" },
+                { default: () => h(IdProbe, { hint: "description" }) },
+              ),
+            ],
+          },
+        );
+    },
+  });
+}
+
+async function renderSsrTree(seed: string): Promise<string> {
+  return renderToString(createSSRApp(createSsrTree(seed)));
+}
+
+test("renders byte-stable IDs for repeated and concurrent SSR requests", async () => {
+  const repeated = await Promise.all([renderSsrTree("request-a"), renderSsrTree("request-a")]);
+  assert.equal(repeated[0], repeated[1]);
+  assert.match(repeated[0], /id="vize-request-a-label-0"/);
+  assert.match(repeated[0], /id="vize-request-a-control-1"/);
+  assert.match(repeated[0], /id="vize-request-a-scope-0-nested-description-0"/);
+
+  const [left, right] = await Promise.all([
+    renderSsrTree("request-left"),
+    renderSsrTree("request-right"),
+  ]);
+  assert.match(left, /vize-request-left-label-0/);
+  assert.doesNotMatch(left, /request-right/);
+  assert.match(right, /vize-request-right-label-0/);
+  assert.doesNotMatch(right, /request-left/);
+});
+
+test("hydrates provider IDs without warnings or replacement", async () => {
+  const Root = createSsrTree("hydrate");
+  const serverHtml = await renderToString(createSSRApp(Root));
+  const host = document.createElement("div");
+  host.innerHTML = serverHtml;
+  document.body.append(host);
+  const serverIds = [...host.querySelectorAll<HTMLElement>("[id]")].map((element) => element.id);
+  const diagnostics: string[] = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  console.error = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  const app = createSSRApp(Root);
+
+  try {
+    app.mount(host);
+    const hydratedIds = [...host.querySelectorAll<HTMLElement>("[id]")].map(
+      (element) => element.id,
+    );
+    assert.deepEqual(hydratedIds, serverIds);
+    assert.deepEqual(diagnostics, []);
+  } finally {
+    app.unmount();
+    host.remove();
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+});

--- a/npm/ui/core/src/id.ts
+++ b/npm/ui/core/src/id.ts
@@ -1,0 +1,17 @@
+export {
+  createDeterministicIdScope,
+  deriveDeterministicId,
+  toDeterministicId,
+  useDeterministicId,
+} from "./deterministic-id.ts";
+export type {
+  DeterministicId,
+  DeterministicIdChildScopeOptions,
+  DeterministicIdOptions,
+  DeterministicIdScope,
+  DeterministicIdScopeOptions,
+  DeterministicIdSeed,
+} from "./deterministic-id.ts";
+
+/** SSR-safe deterministic ID namespace for one application or component subtree. */
+export { default as IdProvider } from "./DeterministicIdProvider.vue";

--- a/npm/ui/core/src/id.types.test-d.ts
+++ b/npm/ui/core/src/id.types.test-d.ts
@@ -1,0 +1,57 @@
+/** Compile-only assertions for the public deterministic ID contract. */
+
+import { h } from "vue";
+import type { ComputedRef } from "vue";
+
+import {
+  createDeterministicIdScope,
+  type DeterministicId,
+  type DeterministicIdSeed,
+  IdProvider,
+  useDeterministicId,
+} from "./id.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+export const stringSeed: DeterministicIdSeed = "request-42";
+export const numericSeed: DeterministicIdSeed = 42;
+
+// @ts-expect-error boolean seeds are outside the closed public seed contract.
+export const booleanSeed: DeterministicIdSeed = true;
+
+export const typedScope = createDeterministicIdScope({ prefix: "checkout", seed: stringSeed });
+export const typedId = typedScope.nextId("field");
+export const idIsUsableAsAString: string = typedId;
+
+// @ts-expect-error arbitrary strings must be validated before receiving the branded type.
+export const unvalidatedId: DeterministicId = "field-1";
+
+export const composedId = useDeterministicId({
+  id: () => undefined,
+  hint: "control",
+  prefix: "field",
+});
+
+type _ComposableResultRemainsBranded = Expect<
+  Equal<typeof composedId, ComputedRef<DeterministicId>>
+>;
+
+// @ts-expect-error hints remain strings rather than widening to arbitrary values.
+void useDeterministicId({ hint: 1 });
+
+// @ts-expect-error scope seeds reject objects at compile time.
+void createDeterministicIdScope({ seed: { request: 1 } });
+
+export const providerAcceptsDocumentedProps = h(IdProvider, {
+  prefix: "checkout",
+  seed: "request-42",
+});
+
+export function providerRejectsBooleanSeed() {
+  // @ts-expect-error provider seeds preserve the string | number contract.
+  return h(IdProvider, { seed: true });
+}

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -2,5 +2,6 @@ export * from "./checkbox.ts";
 export * from "./context.ts";
 export * from "./controllable-state.ts";
 export * from "./button.ts";
+export * from "./id.ts";
 export * from "./primitive.ts";
 export * from "./visually-hidden.ts";

--- a/npm/ui/core/src/sfc-lint.test.ts
+++ b/npm/ui/core/src/sfc-lint.test.ts
@@ -20,20 +20,25 @@ test("discovers every SFC with the opinionated Vize contract", async () => {
     [
       "src/ActionButton.vue",
       "src/CheckboxControl.vue",
+      "src/DeterministicIdProvider.vue",
       "src/PrimitiveElement.vue",
       "src/VisuallyHidden.vue",
     ],
   );
   assert.deepEqual(
     requests,
-    ["ActionButton.vue", "CheckboxControl.vue", "PrimitiveElement.vue", "VisuallyHidden.vue"].map(
-      (basename) => ({
-        filename: path.resolve("src", basename),
-        preset: "opinionated" as const,
-        typeAware: true as const,
-        helpLevel: "short" as const,
-      }),
-    ),
+    [
+      "ActionButton.vue",
+      "CheckboxControl.vue",
+      "DeterministicIdProvider.vue",
+      "PrimitiveElement.vue",
+      "VisuallyHidden.vue",
+    ].map((basename) => ({
+      filename: path.resolve("src", basename),
+      preset: "opinionated" as const,
+      typeAware: true as const,
+      helpLevel: "short" as const,
+    })),
   );
   assert.equal(formatSfcLintResults(results), "");
 });

--- a/npm/ui/core/tsconfig.typecheck.json
+++ b/npm/ui/core/tsconfig.typecheck.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rewriteRelativeImportExtensions": false
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/testing/**"]
+}

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       checkbox: "src/checkbox.ts",
       context: "src/context.ts",
       "controllable-state": "src/controllable-state.ts",
+      id: "src/id.ts",
       primitive: "src/primitive.ts",
       "visually-hidden": "src/visually-hidden.ts",
       media: "src/media.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1020,6 +1020,9 @@ importers:
       vue:
         specifier: catalog:vue-stable
         version: 3.5.35(typescript@6.0.3)
+      vue-tsc:
+        specifier: catalog:typescript
+        version: 3.3.4(typescript@6.0.3)
 
   npm/ui/tooling:
     dependencies:


### PR DESCRIPTION
## Summary

- add a request-local deterministic ID scope and source-authored `IdProvider` SFC
- add a branded `DeterministicId`, reactive explicit-ID fallback, semantic part derivation, nested namespaces, and stable diagnostics
- publish `@vizejs/ui/id` with generated declarations and a measured gzip budget
- make compile-only positive and negative SFC type tests part of the package check

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [x] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

Implements the first unchecked accessible-foundation item in #3134: deterministic identifiers and an SSR/hydration seed provider.

The normative state × input → outcome table is in `npm/ui/core/src/id.behavior.md`.

## Verification Evidence

- [x] `vp run --filter './npm/ui/core' check`
- [x] `vp run --filter './npm/ui/core' test` — 58 tests, including repeated/concurrent SSR and hydration
- [x] generated ESM and declaration distribution entry
- [x] `@vizejs/ui/id` gzip closure: 2,239 / 2,300 bytes
- [x] compile-only positive and `@ts-expect-error` negative type assertions
- [x] SFC authoring gate and mounted-DOM interaction gate
- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

The local native SFC lint command could not load the repository's source binding because the installed optional binary was one release behind. The required Actions job builds the native package from this commit before running that gate. The repository-wide MoonBit wrapper likewise requires the fresh Actions toolchain.

## Risk

This is additive. No module-global counter is introduced, so concurrent SSR requests cannot share sequence state. Separate islands must use distinct provider seeds or Vue application ID prefixes when their DOM is combined. Explicit consumer IDs remain supported and are validated before receiving the branded type.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->