### PR TITLE
feat(doctor): add provider-neutral reporter contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3869,6 +3869,7 @@ dependencies = [
 name = "vize_doctor"
 version = "0.346.0"
 dependencies = [
+ "criterion",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/vize/src/commands/doctor.rs
+++ b/crates/vize/src/commands/doctor.rs
@@ -11,7 +11,7 @@ mod tests;
 use clap::{Args, ValueEnum};
 use std::{fmt, io, path::PathBuf};
 use vize_carton::String;
-use vize_doctor::{DoctorReport, application_analysis::ApplicationAnalysisError};
+use vize_doctor::{DoctorReport, ReporterFailure, application_analysis::ApplicationAnalysisError};
 
 use self::{
     analysis::analyze_application,
@@ -86,7 +86,7 @@ enum DoctorError {
         message: String,
     },
     Analysis(ApplicationAnalysisError),
-    Serialize(serde_json::Error),
+    Report(ReporterFailure),
     Write(io::Error),
 }
 
@@ -146,7 +146,7 @@ impl fmt::Display for DoctorError {
                 )
             }
             Self::Analysis(error) => write!(formatter, "cannot build health report: {error}"),
-            Self::Serialize(error) => write!(formatter, "cannot serialize health report: {error}"),
+            Self::Report(error) => write!(formatter, "cannot render health report: {error}"),
             Self::Write(error) => write!(formatter, "cannot write health report: {error}"),
         }
     }

--- a/crates/vize/src/commands/doctor/output.rs
+++ b/crates/vize/src/commands/doctor/output.rs
@@ -1,7 +1,9 @@
 //! Deterministic terminal and automation output.
 
 use std::io::{self, Write};
-use vize_doctor::{DoctorFinding, DoctorReport, FindingSeverity, FixSafety};
+use vize_doctor::{
+    DoctorFinding, DoctorReport, FindingSeverity, FixSafety, JsonReporter, render_report,
+};
 
 use super::{DoctorError, DoctorFormat};
 
@@ -10,11 +12,9 @@ pub(super) fn write_report(report: &DoctorReport, format: DoctorFormat) -> Resul
     let mut output = stdout.lock();
     match format {
         DoctorFormat::Text => write_text(&mut output, report).map_err(DoctorError::Write),
-        DoctorFormat::Json => {
-            let serialized =
-                serde_json::to_string_pretty(report).map_err(DoctorError::Serialize)?;
-            writeln!(output, "{serialized}").map_err(DoctorError::Write)
-        }
+        DoctorFormat::Json => render_report(&JsonReporter::new(), report, &mut output)
+            .map(|_| ())
+            .map_err(DoctorError::Report),
     }
 }
 

--- a/crates/vize_doctor/Cargo.toml
+++ b/crates/vize_doctor/Cargo.toml
@@ -14,9 +14,14 @@ application-analysis = ["dep:vize_croquis_cf"]
 
 [dependencies]
 serde.workspace = true
+serde_json.workspace = true
 vize_carton.workspace = true
 vize_croquis_cf = { workspace = true, optional = true }
 
 [dev-dependencies]
+criterion.workspace = true
 tempfile.workspace = true
-serde_json.workspace = true
+
+[[bench]]
+name = "reporter"
+harness = false

--- a/crates/vize_doctor/README.md
+++ b/crates/vize_doctor/README.md
@@ -25,6 +25,76 @@ When enabled, the adapter converts an existing Vize whole-project analysis into
 source-aware findings and reports without reparsing files. It fails closed if a
 diagnostic references a stale file or a path outside the declared workspace.
 
+## Reporter integrations
+
+External CI, editor, code-hosting, and AI integrations implement the object-safe
+`DoctorReporter` trait and advertise a versioned `ReporterDescriptor`. Reporters
+are installed into an explicitly owned `ReporterSet`; there is no process-global
+registry for one integration to replace or reorder another. `render_report`
+streams to any `std::io::Write` destination and returns the reporter identity,
+format versions, finding count, and exact accepted byte count.
+
+Descriptors declare their media type, delivery transport, intended audiences,
+and the Doctor semantics preserved by the output. Registration rejects invalid
+contracts and duplicate stable identifiers. Identical reports and explicit
+reporter configuration must produce identical bytes.
+
+```rust
+use std::io::Write;
+use vize_doctor::{
+    DoctorReport, DoctorReporter, ReporterAudience, ReporterCapability,
+    ReporterDescriptor, ReporterError, ReporterOutput, ReporterTransport,
+    render_report,
+};
+
+struct AgentContextReporter {
+    descriptor: ReporterDescriptor,
+}
+
+impl AgentContextReporter {
+    fn new() -> Self {
+        Self {
+            descriptor: ReporterDescriptor::new(
+                "example.agent-context",
+                "Example agent context",
+                "application/vnd.example.agent-context+json",
+                ReporterTransport::Document,
+            )
+            .with_file_extension("json")
+            .with_audiences([ReporterAudience::Ai])
+            .with_capabilities([
+                ReporterCapability::Findings,
+                ReporterCapability::Evidence,
+                ReporterCapability::Fixes,
+                ReporterCapability::Provenance,
+            ]),
+        }
+    }
+}
+
+impl DoctorReporter for AgentContextReporter {
+    fn descriptor(&self) -> &ReporterDescriptor {
+        &self.descriptor
+    }
+
+    fn write_report(
+        &self,
+        report: &DoctorReport,
+        output: &mut ReporterOutput<'_>,
+    ) -> Result<(), ReporterError> {
+        writeln!(output, "{}", report.summary().overall_score)?;
+        Ok(())
+    }
+}
+
+# let report = DoctorReport::new("example", []);
+let reporter = AgentContextReporter::new();
+let mut bytes = Vec::new();
+let receipt = render_report(&reporter, &report, &mut bytes)?;
+assert_eq!(receipt.reporter_id(), "example.agent-context");
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
 ## Example
 
 ```rust

--- a/crates/vize_doctor/benches/reporter.rs
+++ b/crates/vize_doctor/benches/reporter.rs
@@ -1,0 +1,104 @@
+use std::{hint::black_box, io};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use vize_doctor::{
+    AnalysisProvenance, DoctorCategory, DoctorFinding, DoctorReport, DoctorReporter,
+    FindingAssessment, FindingConfidence, FindingImpact, FindingSeverity, HealthPenalty,
+    JsonReporter, ReporterAudience, ReporterCapability, ReporterDescriptor, ReporterError,
+    ReporterOutput, ReporterTransport, RuleCost, SourceLocation, render_report,
+};
+
+struct EmptyReporter {
+    descriptor: ReporterDescriptor,
+}
+
+impl EmptyReporter {
+    fn new() -> Self {
+        Self {
+            descriptor: ReporterDescriptor::new(
+                "bench.empty",
+                "Empty benchmark reporter",
+                "application/vnd.vize.bench",
+                ReporterTransport::Document,
+            )
+            .with_audiences([ReporterAudience::Automation])
+            .with_capabilities([ReporterCapability::HealthSummary]),
+        }
+    }
+}
+
+impl DoctorReporter for EmptyReporter {
+    fn descriptor(&self) -> &ReporterDescriptor {
+        &self.descriptor
+    }
+
+    fn write_report(
+        &self,
+        _report: &DoctorReport,
+        _output: &mut ReporterOutput<'_>,
+    ) -> Result<(), ReporterError> {
+        Ok(())
+    }
+}
+
+fn benchmark_reporter_contract(c: &mut Criterion) {
+    let report = DoctorReport::new("benchmark", []);
+    let reporter = EmptyReporter::new();
+
+    c.bench_function("doctor_reporter/contract_overhead", |b| {
+        b.iter(|| {
+            render_report(black_box(&reporter), black_box(&report), &mut io::sink()).unwrap()
+        });
+    });
+}
+
+fn benchmark_json_reporter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("doctor_reporter/json_compact");
+    let reporter = JsonReporter::new().with_pretty(false);
+
+    for finding_count in [0, 100, 10_000] {
+        let report = report_with_findings(finding_count);
+        let mut encoded = Vec::new();
+        render_report(&reporter, &report, &mut encoded).unwrap();
+        group.throughput(Throughput::Bytes(encoded.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(finding_count),
+            &report,
+            |b, report| {
+                b.iter(|| {
+                    render_report(black_box(&reporter), black_box(report), &mut io::sink()).unwrap()
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn report_with_findings(finding_count: usize) -> DoctorReport {
+    DoctorReport::new(
+        "benchmark",
+        (0..finding_count).map(|index| {
+            DoctorFinding::new(
+                "VIZE_DOCTOR_BENCH",
+                DoctorCategory::Performance,
+                FindingAssessment::new(
+                    FindingSeverity::Warning,
+                    FindingConfidence::High,
+                    FindingImpact::Medium,
+                    HealthPenalty::new(1, "Measured reporter cost"),
+                ),
+                SourceLocation::new("src/Benchmark.vue", index as u32, index as u32 + 1),
+                "Benchmark finding",
+                "The reporter preserves a complete evidence-rich finding.",
+                AnalysisProvenance::new("benchmark-analysis", RuleCost::Low),
+            )
+        }),
+    )
+}
+
+criterion_group!(
+    reporter_benches,
+    benchmark_reporter_contract,
+    benchmark_json_reporter
+);
+criterion_main!(reporter_benches);

--- a/crates/vize_doctor/src/lib.rs
+++ b/crates/vize_doctor/src/lib.rs
@@ -20,6 +20,8 @@
 //! - A blocking proven error remains blocking regardless of its health score.
 //! - The optional `application-analysis` adapter is disabled by default.
 //! - Enabled adapters reuse registered whole-project analysis without reparsing.
+//! - Reporters are registered explicitly and never mutate global process state.
+//! - Reporter descriptors are versioned, machine-readable, and deterministically ordered.
 //!
 //! # Example
 //!
@@ -54,6 +56,7 @@
 pub mod application_analysis;
 mod model;
 mod report;
+mod reporter;
 
 pub use model::{
     AnalysisProvenance, DEFAULT_UNAVAILABLE_FIX_REASON, DoctorCategory, DoctorFinding,
@@ -64,4 +67,10 @@ pub use model::{
 pub use report::{
     CategoryHealth, DOCTOR_REPORT_FORMAT_VERSION, DOCTOR_SCORING_VERSION, DoctorReport,
     DoctorSummary, FindingCounts,
+};
+pub use reporter::{
+    DOCTOR_REPORTER_CONTRACT_VERSION, DoctorReporter, JsonReporter, ReporterAudience,
+    ReporterCapability, ReporterContractError, ReporterDescriptor, ReporterError,
+    ReporterErrorKind, ReporterFailure, ReporterOutput, ReporterReceipt, ReporterRegistrationError,
+    ReporterSet, ReporterTransport, render_report,
 };

--- a/crates/vize_doctor/src/reporter.rs
+++ b/crates/vize_doctor/src/reporter.rs
@@ -1,0 +1,25 @@
+//! Provider-neutral report rendering contracts.
+//!
+//! Reporters translate one normalized [`crate::DoctorReport`] into a human,
+//! CI, editor, or AI-facing representation. Integrations register reporters
+//! in an explicitly owned [`ReporterSet`]; the crate deliberately has no
+//! global registry, environment-dependent discovery, or mutable singleton.
+
+mod contract;
+mod execution;
+mod json;
+mod registry;
+
+#[cfg(test)]
+mod tests;
+
+pub use contract::{
+    DOCTOR_REPORTER_CONTRACT_VERSION, ReporterAudience, ReporterCapability, ReporterContractError,
+    ReporterDescriptor, ReporterTransport,
+};
+pub use execution::{
+    DoctorReporter, ReporterError, ReporterErrorKind, ReporterFailure, ReporterOutput,
+    ReporterReceipt, render_report,
+};
+pub use json::JsonReporter;
+pub use registry::{ReporterRegistrationError, ReporterSet};

--- a/crates/vize_doctor/src/reporter/contract.rs
+++ b/crates/vize_doctor/src/reporter/contract.rs
@@ -1,0 +1,206 @@
+//! Versioned reporter descriptors and semantic capabilities.
+
+mod validation;
+mod wire;
+
+use serde::Serialize;
+use vize_carton::String;
+
+pub use validation::ReporterContractError;
+
+/// Current machine-readable reporter descriptor contract.
+pub const DOCTOR_REPORTER_CONTRACT_VERSION: u32 = 1;
+
+/// How a reporter presents a Doctor report to its consumer.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReporterTransport {
+    /// One finite document written from a complete report.
+    Document,
+    /// Independently consumable records suitable for incremental pipelines.
+    RecordStream,
+    /// A stateful terminal or graphical view controlled by user input.
+    Interactive,
+}
+
+/// Consumer classes a reporter is designed to serve.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReporterAudience {
+    /// A person reading a finite report.
+    Human,
+    /// A continuous-integration or other automated policy consumer.
+    Automation,
+    /// A code-hosting annotation consumer.
+    CodeHost,
+    /// An editor, language server, or code action consumer.
+    Editor,
+    /// A provider-neutral AI context consumer.
+    Ai,
+}
+
+/// Doctor semantics a reporter promises to preserve in its output.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum ReporterCapability {
+    /// Versioned overall and per-category health summaries.
+    HealthSummary,
+    /// Stable findings and their assessments.
+    Findings,
+    /// Primary authored source spans.
+    PrimaryLocations,
+    /// Related authored source spans and their relationships.
+    RelatedLocations,
+    /// Structured evidence and evidence locations.
+    Evidence,
+    /// Application target, environment, route, component, and graph context.
+    ApplicationContext,
+    /// Fix safety, edits, and post-fix verification steps.
+    Fixes,
+    /// Suppression policy and stable baseline identities.
+    Policy,
+    /// Analysis capability, cost, and invalidation inputs.
+    Provenance,
+}
+
+impl ReporterCapability {
+    /// Every semantic capability in stable descriptor order.
+    pub const ALL: [Self; 9] = [
+        Self::HealthSummary,
+        Self::Findings,
+        Self::PrimaryLocations,
+        Self::RelatedLocations,
+        Self::Evidence,
+        Self::ApplicationContext,
+        Self::Fixes,
+        Self::Policy,
+        Self::Provenance,
+    ];
+}
+
+/// Versioned machine-readable contract advertised by one reporter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReporterDescriptor {
+    contract_version: u32,
+    id: String,
+    display_name: String,
+    format_version: u32,
+    media_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    file_extension: Option<String>,
+    transport: ReporterTransport,
+    audiences: Vec<ReporterAudience>,
+    capabilities: Vec<ReporterCapability>,
+}
+
+impl ReporterDescriptor {
+    /// Creates a descriptor with format version `1` and no declared consumers.
+    ///
+    /// Call [`Self::with_audiences`] and [`Self::with_capabilities`] before
+    /// registration. [`Self::validate`] documents every accepted identifier,
+    /// media-type, extension, and version constraint.
+    pub fn new(
+        id: impl Into<String>,
+        display_name: impl Into<String>,
+        media_type: impl Into<String>,
+        transport: ReporterTransport,
+    ) -> Self {
+        Self {
+            contract_version: DOCTOR_REPORTER_CONTRACT_VERSION,
+            id: id.into(),
+            display_name: display_name.into(),
+            format_version: 1,
+            media_type: media_type.into(),
+            file_extension: None,
+            transport,
+            audiences: Vec::new(),
+            capabilities: Vec::new(),
+        }
+    }
+
+    /// Sets the reporter-specific output format version. Defaults to `1`.
+    pub const fn with_format_version(mut self, format_version: u32) -> Self {
+        self.format_version = format_version;
+        self
+    }
+
+    /// Sets the conventional filename extension without a leading dot.
+    /// Defaults to absent.
+    pub fn with_file_extension(mut self, extension: impl Into<String>) -> Self {
+        self.file_extension = Some(extension.into());
+        self
+    }
+
+    /// Declares intended consumer classes in deterministic order.
+    /// Defaults to empty, which validation rejects.
+    pub fn with_audiences(mut self, audiences: impl IntoIterator<Item = ReporterAudience>) -> Self {
+        self.audiences = audiences.into_iter().collect();
+        self.audiences.sort_unstable();
+        self.audiences.dedup();
+        self
+    }
+
+    /// Declares preserved Doctor semantics in deterministic order.
+    /// Defaults to empty, which validation rejects.
+    pub fn with_capabilities(
+        mut self,
+        capabilities: impl IntoIterator<Item = ReporterCapability>,
+    ) -> Self {
+        self.capabilities = capabilities.into_iter().collect();
+        self.capabilities.sort_unstable();
+        self.capabilities.dedup();
+        self
+    }
+
+    /// Returns the reporter contract version.
+    pub const fn contract_version(&self) -> u32 {
+        self.contract_version
+    }
+
+    /// Returns the stable reporter identifier.
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Returns the user-visible reporter name.
+    pub fn display_name(&self) -> &str {
+        &self.display_name
+    }
+
+    /// Returns the reporter-specific output format version.
+    pub const fn format_version(&self) -> u32 {
+        self.format_version
+    }
+
+    /// Returns the output media type without environment-dependent parameters.
+    pub fn media_type(&self) -> &str {
+        &self.media_type
+    }
+
+    /// Returns the conventional filename extension without a leading dot.
+    pub fn file_extension(&self) -> Option<&str> {
+        self.file_extension.as_deref()
+    }
+
+    /// Returns the presentation transport.
+    pub const fn transport(&self) -> ReporterTransport {
+        self.transport
+    }
+
+    /// Returns intended consumers in stable order.
+    pub fn audiences(&self) -> &[ReporterAudience] {
+        &self.audiences
+    }
+
+    /// Returns preserved Doctor semantics in stable order.
+    pub fn capabilities(&self) -> &[ReporterCapability] {
+        &self.capabilities
+    }
+}

--- a/crates/vize_doctor/src/reporter/contract/validation.rs
+++ b/crates/vize_doctor/src/reporter/contract/validation.rs
@@ -1,0 +1,151 @@
+//! Fail-closed validation for reporter descriptors.
+
+use std::{error::Error, fmt};
+
+use super::{DOCTOR_REPORTER_CONTRACT_VERSION, ReporterDescriptor};
+
+impl ReporterDescriptor {
+    /// Validates all descriptor invariants without consulting global state.
+    pub fn validate(&self) -> Result<(), ReporterContractError> {
+        if self.contract_version != DOCTOR_REPORTER_CONTRACT_VERSION {
+            return Err(ReporterContractError::new(
+                "contractVersion",
+                "unsupported reporter contract version",
+            ));
+        }
+        if !is_stable_id(&self.id) {
+            return Err(ReporterContractError::new(
+                "id",
+                "must start with an ASCII lowercase letter and contain only lowercase letters, digits, dots, and hyphens",
+            ));
+        }
+        if self.display_name.trim().is_empty() || self.display_name.chars().any(char::is_control) {
+            return Err(ReporterContractError::new(
+                "displayName",
+                "must contain visible text without control characters",
+            ));
+        }
+        if self.format_version == 0 {
+            return Err(ReporterContractError::new(
+                "formatVersion",
+                "must be greater than zero",
+            ));
+        }
+        if !is_media_type(&self.media_type) {
+            return Err(ReporterContractError::new(
+                "mediaType",
+                "must be a lowercase type/subtype without parameters",
+            ));
+        }
+        if self
+            .file_extension
+            .as_deref()
+            .is_some_and(|extension| !is_file_extension(extension))
+        {
+            return Err(ReporterContractError::new(
+                "fileExtension",
+                "must contain only lowercase ASCII letters and digits without a leading dot",
+            ));
+        }
+        validate_set(
+            "audiences",
+            &self.audiences,
+            "must declare at least one intended consumer",
+        )?;
+        validate_set(
+            "capabilities",
+            &self.capabilities,
+            "must declare at least one preserved Doctor semantic",
+        )?;
+        Ok(())
+    }
+}
+
+fn validate_set<T: Ord>(
+    field: &'static str,
+    values: &[T],
+    empty_reason: &'static str,
+) -> Result<(), ReporterContractError> {
+    if values.is_empty() {
+        return Err(ReporterContractError::new(field, empty_reason));
+    }
+    if !values.windows(2).all(|window| window[0] < window[1]) {
+        return Err(ReporterContractError::new(
+            field,
+            "must be sorted and contain no duplicates",
+        ));
+    }
+    Ok(())
+}
+
+/// A descriptor field that violates the public reporter contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReporterContractError {
+    field: &'static str,
+    reason: &'static str,
+}
+
+impl ReporterContractError {
+    const fn new(field: &'static str, reason: &'static str) -> Self {
+        Self { field, reason }
+    }
+
+    /// Returns the language-neutral serialized field name.
+    pub const fn field(&self) -> &'static str {
+        self.field
+    }
+
+    /// Returns the stable validation reason.
+    pub const fn reason(&self) -> &'static str {
+        self.reason
+    }
+}
+
+impl fmt::Display for ReporterContractError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "invalid reporter {}: {}",
+            self.field, self.reason
+        )
+    }
+}
+
+impl Error for ReporterContractError {}
+
+fn is_stable_id(value: &str) -> bool {
+    value.as_bytes().first().is_some_and(u8::is_ascii_lowercase)
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'-')
+        })
+        && !value.ends_with(['.', '-'])
+        && !value.contains("..")
+        && !value.contains("--")
+}
+
+fn is_media_type(value: &str) -> bool {
+    let Some((top, subtype)) = value.split_once('/') else {
+        return false;
+    };
+    !top.is_empty()
+        && !subtype.is_empty()
+        && !subtype.contains('/')
+        && top.bytes().all(is_media_token)
+        && subtype.bytes().all(is_media_token)
+}
+
+fn is_media_token(byte: u8) -> bool {
+    byte.is_ascii_lowercase()
+        || byte.is_ascii_digit()
+        || matches!(
+            byte,
+            b'!' | b'#' | b'$' | b'&' | b'^' | b'_' | b'.' | b'+' | b'-'
+        )
+}
+
+fn is_file_extension(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+}

--- a/crates/vize_doctor/src/reporter/contract/wire.rs
+++ b/crates/vize_doctor/src/reporter/contract/wire.rs
@@ -1,0 +1,42 @@
+//! Validated deserialization for the reporter descriptor wire shape.
+
+use serde::{Deserialize, Deserializer, de};
+use vize_carton::String;
+
+use super::{ReporterAudience, ReporterCapability, ReporterDescriptor, ReporterTransport};
+
+impl<'de> Deserialize<'de> for ReporterDescriptor {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct Wire {
+            contract_version: u32,
+            id: String,
+            display_name: String,
+            format_version: u32,
+            media_type: String,
+            file_extension: Option<String>,
+            transport: ReporterTransport,
+            audiences: Vec<ReporterAudience>,
+            capabilities: Vec<ReporterCapability>,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        let descriptor = Self {
+            contract_version: wire.contract_version,
+            id: wire.id,
+            display_name: wire.display_name,
+            format_version: wire.format_version,
+            media_type: wire.media_type,
+            file_extension: wire.file_extension,
+            transport: wire.transport,
+            audiences: wire.audiences,
+            capabilities: wire.capabilities,
+        };
+        descriptor.validate().map_err(de::Error::custom)?;
+        Ok(descriptor)
+    }
+}

--- a/crates/vize_doctor/src/reporter/execution.rs
+++ b/crates/vize_doctor/src/reporter/execution.rs
@@ -1,0 +1,263 @@
+//! Object-safe reporter execution and exact output telemetry.
+
+use std::{
+    error::Error,
+    fmt,
+    io::{self, IoSlice, Write},
+};
+
+use vize_carton::{String, ToCompactString};
+
+use super::ReporterDescriptor;
+use crate::DoctorReport;
+
+/// Error category reported by a reporter implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReporterErrorKind {
+    /// The destination rejected or could not persist output.
+    Write,
+    /// The reporter could not encode a valid Doctor report.
+    Encode,
+    /// Reporter-specific configuration or source data was invalid.
+    InvalidData,
+    /// Rendering was explicitly cancelled by its owner.
+    Cancelled,
+}
+
+/// Provider-neutral reporter failure with no provider-specific error type leak.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReporterError {
+    kind: ReporterErrorKind,
+    message: String,
+}
+
+impl ReporterError {
+    /// Creates an error with a stable category and actionable message.
+    pub fn new(kind: ReporterErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    /// Creates an output write failure.
+    pub fn write(error: impl fmt::Display) -> Self {
+        Self::new(ReporterErrorKind::Write, error.to_compact_string())
+    }
+
+    /// Creates an encoding failure.
+    pub fn encode(error: impl fmt::Display) -> Self {
+        Self::new(ReporterErrorKind::Encode, error.to_compact_string())
+    }
+
+    /// Returns the stable failure category.
+    pub const fn kind(&self) -> ReporterErrorKind {
+        self.kind
+    }
+
+    /// Returns the actionable provider-neutral failure message.
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for ReporterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl Error for ReporterError {}
+
+impl From<io::Error> for ReporterError {
+    fn from(error: io::Error) -> Self {
+        Self::write(error)
+    }
+}
+
+/// Counted output passed to reporters.
+///
+/// The wrapper records every successfully written byte, including partial
+/// writes before a destination failure. It never buffers the complete report.
+pub struct ReporterOutput<'a> {
+    inner: &'a mut dyn Write,
+    bytes_written: u64,
+}
+
+impl<'a> ReporterOutput<'a> {
+    fn new(inner: &'a mut dyn Write) -> Self {
+        Self {
+            inner,
+            bytes_written: 0,
+        }
+    }
+
+    /// Returns bytes accepted by the destination so far.
+    pub const fn bytes_written(&self) -> u64 {
+        self.bytes_written
+    }
+}
+
+impl Write for ReporterOutput<'_> {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buffer)?;
+        self.bytes_written = self.bytes_written.saturating_add(written as u64);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+
+    fn write_vectored(&mut self, buffers: &[IoSlice<'_>]) -> io::Result<usize> {
+        let written = self.inner.write_vectored(buffers)?;
+        self.bytes_written = self.bytes_written.saturating_add(written as u64);
+        Ok(written)
+    }
+}
+
+/// Object-safe integration point implemented by built-in and external reporters.
+///
+/// Implementations must produce identical bytes for identical descriptors,
+/// reports, and explicit reporter configuration. They must not read clocks,
+/// random sources, process-global mutable state, or vendor credentials while
+/// rendering. I/O and encoding failures must be returned, never printed.
+pub trait DoctorReporter: Send + Sync {
+    /// Returns the reporter's stable, machine-readable descriptor.
+    fn descriptor(&self) -> &ReporterDescriptor;
+
+    /// Writes one normalized report to the counted destination.
+    fn write_report(
+        &self,
+        report: &DoctorReport,
+        output: &mut ReporterOutput<'_>,
+    ) -> Result<(), ReporterError>;
+}
+
+/// Successful reporter execution telemetry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReporterReceipt {
+    reporter_id: String,
+    reporter_format_version: u32,
+    report_format_version: u32,
+    findings_emitted: u64,
+    bytes_written: u64,
+}
+
+impl ReporterReceipt {
+    /// Returns the reporter identifier used for this execution.
+    pub fn reporter_id(&self) -> &str {
+        &self.reporter_id
+    }
+
+    /// Returns the reporter-specific output format version.
+    pub const fn reporter_format_version(&self) -> u32 {
+        self.reporter_format_version
+    }
+
+    /// Returns the normalized Doctor report format version.
+    pub const fn report_format_version(&self) -> u32 {
+        self.report_format_version
+    }
+
+    /// Returns the number of normalized findings supplied to the reporter.
+    pub const fn findings_emitted(&self) -> u64 {
+        self.findings_emitted
+    }
+
+    /// Returns bytes accepted by the destination.
+    pub const fn bytes_written(&self) -> u64 {
+        self.bytes_written
+    }
+}
+
+/// A rendering failure with reporter identity and partial-output telemetry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReporterFailure {
+    /// The reporter descriptor did not satisfy the public contract.
+    InvalidContract(super::ReporterContractError),
+    /// The reporter failed after writing zero or more bytes.
+    Rendering {
+        /// Stable reporter identifier.
+        reporter_id: String,
+        /// Bytes accepted before the failure.
+        bytes_written: u64,
+        /// Provider-neutral failure.
+        error: ReporterError,
+    },
+}
+
+impl ReporterFailure {
+    /// Returns the reporter identifier when descriptor validation reached it.
+    pub fn reporter_id(&self) -> Option<&str> {
+        match self {
+            Self::InvalidContract(_) => None,
+            Self::Rendering { reporter_id, .. } => Some(reporter_id),
+        }
+    }
+
+    /// Returns bytes accepted before failure. Invalid contracts always return zero.
+    pub const fn bytes_written(&self) -> u64 {
+        match self {
+            Self::InvalidContract(_) => 0,
+            Self::Rendering { bytes_written, .. } => *bytes_written,
+        }
+    }
+}
+
+impl fmt::Display for ReporterFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidContract(error) => error.fmt(formatter),
+            Self::Rendering {
+                reporter_id,
+                bytes_written,
+                error,
+            } => write!(
+                formatter,
+                "reporter {reporter_id} failed after {bytes_written} byte(s): {error}"
+            ),
+        }
+    }
+}
+
+impl Error for ReporterFailure {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InvalidContract(error) => Some(error),
+            Self::Rendering { error, .. } => Some(error),
+        }
+    }
+}
+
+/// Renders a report and returns deterministic output-size telemetry.
+pub fn render_report(
+    reporter: &dyn DoctorReporter,
+    report: &DoctorReport,
+    destination: &mut dyn Write,
+) -> Result<ReporterReceipt, ReporterFailure> {
+    let descriptor = reporter.descriptor();
+    descriptor
+        .validate()
+        .map_err(ReporterFailure::InvalidContract)?;
+    let mut output = ReporterOutput::new(destination);
+    if let Err(error) = reporter.write_report(report, &mut output) {
+        return Err(ReporterFailure::Rendering {
+            reporter_id: descriptor.id().into(),
+            bytes_written: output.bytes_written(),
+            error,
+        });
+    }
+    output.flush().map_err(|error| ReporterFailure::Rendering {
+        reporter_id: descriptor.id().into(),
+        bytes_written: output.bytes_written(),
+        error: error.into(),
+    })?;
+    Ok(ReporterReceipt {
+        reporter_id: descriptor.id().into(),
+        reporter_format_version: descriptor.format_version(),
+        report_format_version: report.format_version(),
+        findings_emitted: report.findings().len() as u64,
+        bytes_written: output.bytes_written(),
+    })
+}

--- a/crates/vize_doctor/src/reporter/json.rs
+++ b/crates/vize_doctor/src/reporter/json.rs
@@ -1,0 +1,82 @@
+//! Built-in stable JSON report rendering.
+
+use std::io::Write;
+
+use super::{
+    DoctorReporter, ReporterAudience, ReporterCapability, ReporterDescriptor, ReporterError,
+    ReporterOutput, ReporterTransport,
+};
+use crate::DoctorReport;
+
+/// Built-in stable JSON reporter used by CLI, editor, CI, and AI consumers.
+pub struct JsonReporter {
+    descriptor: ReporterDescriptor,
+    pretty: bool,
+}
+
+impl JsonReporter {
+    /// Creates the JSON reporter with human-readable indentation enabled.
+    /// Pretty printing defaults to `true` for compatibility with the CLI.
+    pub fn new() -> Self {
+        Self {
+            descriptor: ReporterDescriptor::new(
+                "vize.json",
+                "Vize Doctor JSON",
+                "application/vnd.vize.doctor+json",
+                ReporterTransport::Document,
+            )
+            .with_file_extension("json")
+            .with_audiences([
+                ReporterAudience::Automation,
+                ReporterAudience::CodeHost,
+                ReporterAudience::Editor,
+                ReporterAudience::Ai,
+            ])
+            .with_capabilities(ReporterCapability::ALL),
+            pretty: true,
+        }
+    }
+
+    /// Selects human-readable indentation. Defaults to `true`.
+    pub const fn with_pretty(mut self, pretty: bool) -> Self {
+        self.pretty = pretty;
+        self
+    }
+
+    /// Returns whether human-readable indentation is enabled.
+    pub const fn pretty(&self) -> bool {
+        self.pretty
+    }
+}
+
+impl Default for JsonReporter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DoctorReporter for JsonReporter {
+    fn descriptor(&self) -> &ReporterDescriptor {
+        &self.descriptor
+    }
+
+    fn write_report(
+        &self,
+        report: &DoctorReport,
+        output: &mut ReporterOutput<'_>,
+    ) -> Result<(), ReporterError> {
+        let result = if self.pretty {
+            serde_json::to_writer_pretty(&mut *output, report)
+        } else {
+            serde_json::to_writer(&mut *output, report)
+        };
+        result.map_err(|error| {
+            if error.is_io() {
+                ReporterError::write(error)
+            } else {
+                ReporterError::encode(error)
+            }
+        })?;
+        output.write_all(b"\n").map_err(ReporterError::write)
+    }
+}

--- a/crates/vize_doctor/src/reporter/registry.rs
+++ b/crates/vize_doctor/src/reporter/registry.rs
@@ -1,0 +1,103 @@
+//! Explicitly owned and deterministically ordered reporter registration.
+
+use std::{collections::BTreeMap, error::Error, fmt};
+
+use vize_carton::String;
+
+use super::{DoctorReporter, ReporterContractError, ReporterDescriptor};
+
+/// Registration failure for an explicitly owned reporter set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReporterRegistrationError {
+    /// The reporter descriptor was invalid.
+    InvalidContract(ReporterContractError),
+    /// Another reporter already owns the stable identifier.
+    DuplicateId(String),
+}
+
+impl fmt::Display for ReporterRegistrationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidContract(error) => error.fmt(formatter),
+            Self::DuplicateId(id) => write!(formatter, "reporter id {id} is already registered"),
+        }
+    }
+}
+
+impl Error for ReporterRegistrationError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::InvalidContract(error) => Some(error),
+            Self::DuplicateId(_) => None,
+        }
+    }
+}
+
+/// Deterministically ordered, explicitly owned reporter registry.
+///
+/// Construct one set per application, editor session, CI run, or integration.
+/// Registration never mutates process-global state, so independent consumers
+/// cannot replace each other's reporters.
+#[derive(Default)]
+pub struct ReporterSet {
+    reporters: BTreeMap<String, Box<dyn DoctorReporter>>,
+}
+
+impl ReporterSet {
+    /// Creates an empty reporter set.
+    pub const fn new() -> Self {
+        Self {
+            reporters: BTreeMap::new(),
+        }
+    }
+
+    /// Registers one reporter after validating its descriptor.
+    pub fn register(
+        &mut self,
+        reporter: impl DoctorReporter + 'static,
+    ) -> Result<(), ReporterRegistrationError> {
+        self.register_boxed(Box::new(reporter))
+    }
+
+    /// Registers a dynamically selected reporter after validating its descriptor.
+    ///
+    /// This is the object-safe entry point for integrations that load reporters
+    /// from configuration or another explicit application-owned catalog.
+    pub fn register_boxed(
+        &mut self,
+        reporter: Box<dyn DoctorReporter>,
+    ) -> Result<(), ReporterRegistrationError> {
+        reporter
+            .descriptor()
+            .validate()
+            .map_err(ReporterRegistrationError::InvalidContract)?;
+        let id: String = reporter.descriptor().id().into();
+        if self.reporters.contains_key(&id) {
+            return Err(ReporterRegistrationError::DuplicateId(id));
+        }
+        self.reporters.insert(id, reporter);
+        Ok(())
+    }
+
+    /// Returns a reporter by stable identifier.
+    pub fn get(&self, id: &str) -> Option<&dyn DoctorReporter> {
+        self.reporters.get(id).map(Box::as_ref)
+    }
+
+    /// Returns descriptors in stable identifier order.
+    pub fn descriptors(&self) -> impl ExactSizeIterator<Item = &ReporterDescriptor> {
+        self.reporters
+            .values()
+            .map(|reporter| reporter.descriptor())
+    }
+
+    /// Returns the number of registered reporters.
+    pub fn len(&self) -> usize {
+        self.reporters.len()
+    }
+
+    /// Returns whether no reporters are registered.
+    pub fn is_empty(&self) -> bool {
+        self.reporters.is_empty()
+    }
+}

--- a/crates/vize_doctor/src/reporter/tests.rs
+++ b/crates/vize_doctor/src/reporter/tests.rs
@@ -1,0 +1,69 @@
+//! Shared reporter fixtures and responsibility-scoped tests.
+
+mod contract;
+mod execution;
+mod registry;
+
+use std::io::Write;
+
+use super::*;
+use crate::{
+    AnalysisProvenance, DoctorCategory, DoctorFinding, DoctorReport, FindingAssessment,
+    FindingConfidence, FindingImpact, FindingSeverity, HealthPenalty, RuleCost, SourceLocation,
+};
+
+pub(super) struct TestReporter {
+    descriptor: ReporterDescriptor,
+    payload: &'static [u8],
+}
+
+impl TestReporter {
+    pub(super) fn new(id: &str, payload: &'static [u8]) -> Self {
+        Self {
+            descriptor: ReporterDescriptor::new(
+                id,
+                "Test Reporter",
+                "application/vnd.test+json",
+                ReporterTransport::Document,
+            )
+            .with_audiences([ReporterAudience::Automation])
+            .with_capabilities([ReporterCapability::Findings]),
+            payload,
+        }
+    }
+}
+
+impl DoctorReporter for TestReporter {
+    fn descriptor(&self) -> &ReporterDescriptor {
+        &self.descriptor
+    }
+
+    fn write_report(
+        &self,
+        _report: &DoctorReport,
+        output: &mut ReporterOutput<'_>,
+    ) -> Result<(), ReporterError> {
+        output.write_all(self.payload)?;
+        Ok(())
+    }
+}
+
+pub(super) fn report() -> DoctorReport {
+    DoctorReport::new(
+        "workspace",
+        [DoctorFinding::new(
+            "VIZE_DOCTOR_TEST",
+            DoctorCategory::Correctness,
+            FindingAssessment::new(
+                FindingSeverity::Warning,
+                FindingConfidence::High,
+                FindingImpact::Medium,
+                HealthPenalty::new(10, "Test penalty"),
+            ),
+            SourceLocation::new("src/App.vue", 4, 9),
+            "Test finding",
+            "Test message",
+            AnalysisProvenance::new("test-analysis", RuleCost::Low),
+        )],
+    )
+}

--- a/crates/vize_doctor/src/reporter/tests/contract.rs
+++ b/crates/vize_doctor/src/reporter/tests/contract.rs
@@ -1,0 +1,112 @@
+use super::super::*;
+
+#[test]
+fn descriptor_normalizes_and_round_trips_stably() {
+    let descriptor = ReporterDescriptor::new(
+        "vendor.context",
+        "Vendor-neutral Context",
+        "application/vnd.vendor.context+json",
+        ReporterTransport::Document,
+    )
+    .with_format_version(3)
+    .with_file_extension("json")
+    .with_audiences([
+        ReporterAudience::Ai,
+        ReporterAudience::Automation,
+        ReporterAudience::Ai,
+    ])
+    .with_capabilities([
+        ReporterCapability::Evidence,
+        ReporterCapability::Findings,
+        ReporterCapability::Evidence,
+    ]);
+
+    descriptor.validate().unwrap();
+    assert_eq!(
+        descriptor.audiences(),
+        [ReporterAudience::Automation, ReporterAudience::Ai]
+    );
+    assert_eq!(
+        descriptor.capabilities(),
+        [ReporterCapability::Findings, ReporterCapability::Evidence]
+    );
+    let json = serde_json::to_string(&descriptor).unwrap();
+    assert_eq!(
+        serde_json::from_str::<ReporterDescriptor>(&json).unwrap(),
+        descriptor
+    );
+}
+
+#[test]
+fn descriptor_rejects_every_ambiguous_wire_boundary() {
+    for (descriptor, field) in [
+        (
+            descriptor("Vendor.Context", "Context", "application/json"),
+            "id",
+        ),
+        (
+            descriptor("vendor.context", "\n", "application/json"),
+            "displayName",
+        ),
+        (
+            descriptor(
+                "vendor.context",
+                "Context",
+                "Application/JSON; charset=utf-8",
+            ),
+            "mediaType",
+        ),
+        (
+            descriptor("vendor.context", "Context", "application/json").with_format_version(0),
+            "formatVersion",
+        ),
+        (
+            descriptor("vendor.context", "Context", "application/json")
+                .with_file_extension(".json"),
+            "fileExtension",
+        ),
+        (
+            ReporterDescriptor::new(
+                "vendor.context",
+                "Context",
+                "application/json",
+                ReporterTransport::Document,
+            )
+            .with_capabilities([ReporterCapability::Findings]),
+            "audiences",
+        ),
+        (
+            ReporterDescriptor::new(
+                "vendor.context",
+                "Context",
+                "application/json",
+                ReporterTransport::Document,
+            )
+            .with_audiences([ReporterAudience::Ai]),
+            "capabilities",
+        ),
+    ] {
+        let error = descriptor.validate().unwrap_err();
+        assert_eq!(error.field(), field);
+        let value = serde_json::to_value(&descriptor).unwrap();
+        assert!(serde_json::from_value::<ReporterDescriptor>(value).is_err());
+    }
+}
+
+#[test]
+fn descriptor_rejects_unknown_fields_and_contract_versions() {
+    let descriptor = descriptor("vendor.context", "Context", "application/json");
+    let mut unknown = serde_json::to_value(&descriptor).unwrap();
+    unknown["providerSecret"] = "must-not-pass".into();
+    assert!(serde_json::from_value::<ReporterDescriptor>(unknown).is_err());
+
+    let mut future = serde_json::to_value(descriptor).unwrap();
+    future["contractVersion"] = (DOCTOR_REPORTER_CONTRACT_VERSION + 1).into();
+    assert!(serde_json::from_value::<ReporterDescriptor>(future).is_err());
+}
+
+fn descriptor(id: &str, display_name: &str, media_type: &str) -> ReporterDescriptor {
+    ReporterDescriptor::new(id, display_name, media_type, ReporterTransport::Document)
+        .with_audiences([ReporterAudience::Ai])
+        .with_capabilities([ReporterCapability::Findings])
+}

--- a/crates/vize_doctor/src/reporter/tests/execution.rs
+++ b/crates/vize_doctor/src/reporter/tests/execution.rs
@@ -1,0 +1,83 @@
+use std::io::{self, Write};
+
+use super::super::*;
+use super::{TestReporter, report};
+use crate::DoctorReport;
+
+#[test]
+fn execution_receipt_counts_streamed_output_without_buffering() {
+    let reporter = TestReporter::new("vendor.context", b"context");
+    let mut output = Vec::new();
+
+    let receipt = render_report(&reporter, &report(), &mut output).unwrap();
+
+    assert_eq!(output, b"context");
+    assert_eq!(receipt.reporter_id(), "vendor.context");
+    assert_eq!(receipt.reporter_format_version(), 1);
+    assert_eq!(receipt.report_format_version(), 1);
+    assert_eq!(receipt.findings_emitted(), 1);
+    assert_eq!(receipt.bytes_written(), 7);
+}
+
+#[test]
+fn destination_failures_preserve_partial_output_telemetry() {
+    struct LimitedWriter {
+        remaining: usize,
+    }
+
+    impl Write for LimitedWriter {
+        fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+            if self.remaining == 0 {
+                return Err(io::Error::new(io::ErrorKind::WriteZero, "budget exhausted"));
+            }
+            let written = buffer.len().min(self.remaining);
+            self.remaining -= written;
+            Ok(written)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let reporter = TestReporter::new("vendor.context", b"context");
+    let mut output = LimitedWriter { remaining: 3 };
+    let error = render_report(&reporter, &report(), &mut output).unwrap_err();
+
+    assert_eq!(error.reporter_id(), Some("vendor.context"));
+    assert_eq!(error.bytes_written(), 3);
+    let ReporterFailure::Rendering { error, .. } = error else {
+        panic!("expected rendering failure")
+    };
+    assert_eq!(error.kind(), ReporterErrorKind::Write);
+}
+
+#[test]
+fn built_in_json_preserves_the_stable_report_and_pretty_default() {
+    let report = report();
+    let reporter = JsonReporter::new();
+    let mut pretty = Vec::new();
+    let receipt = render_report(&reporter, &report, &mut pretty).unwrap();
+
+    assert!(reporter.pretty());
+    assert_eq!(receipt.bytes_written(), pretty.len() as u64);
+    assert_eq!(
+        serde_json::from_slice::<DoctorReport>(&pretty).unwrap(),
+        report
+    );
+    assert!(pretty.ends_with(b"\n"));
+    assert!(pretty.windows(2).any(|window| window == b"  "));
+
+    let mut compact = Vec::new();
+    render_report(
+        &JsonReporter::new().with_pretty(false),
+        &report,
+        &mut compact,
+    )
+    .unwrap();
+    assert!(compact.len() < pretty.len());
+    assert_eq!(
+        serde_json::from_slice::<DoctorReport>(&compact).unwrap(),
+        report
+    );
+}

--- a/crates/vize_doctor/src/reporter/tests/registry.rs
+++ b/crates/vize_doctor/src/reporter/tests/registry.rs
@@ -1,0 +1,69 @@
+use super::super::*;
+use super::{TestReporter, report};
+
+#[test]
+fn explicit_sets_are_isolated_and_deterministically_ordered() {
+    let mut first = ReporterSet::new();
+    first
+        .register(TestReporter::new("vendor.zeta", b"z"))
+        .unwrap();
+    first
+        .register(TestReporter::new("vendor.alpha", b"a"))
+        .unwrap();
+    let mut second = ReporterSet::new();
+    second
+        .register_boxed(Box::new(TestReporter::new("vendor.private", b"private")))
+        .unwrap();
+
+    assert_eq!(
+        first
+            .descriptors()
+            .map(ReporterDescriptor::id)
+            .collect::<Vec<_>>(),
+        ["vendor.alpha", "vendor.zeta"]
+    );
+    assert!(first.get("vendor.private").is_none());
+    assert!(second.get("vendor.alpha").is_none());
+    assert_eq!(first.len(), 2);
+    assert!(!first.is_empty());
+}
+
+#[test]
+fn duplicate_ids_fail_without_replacing_the_original() {
+    let mut reporters = ReporterSet::new();
+    reporters
+        .register(TestReporter::new("vendor.context", b"original"))
+        .unwrap();
+    let error = reporters
+        .register(TestReporter::new("vendor.context", b"replacement"))
+        .unwrap_err();
+
+    assert_eq!(
+        error,
+        ReporterRegistrationError::DuplicateId("vendor.context".into())
+    );
+    let mut output = Vec::new();
+    render_report(
+        reporters.get("vendor.context").unwrap(),
+        &report(),
+        &mut output,
+    )
+    .unwrap();
+    assert_eq!(output, b"original");
+}
+
+#[test]
+fn invalid_descriptors_never_enter_the_set() {
+    let mut reporter = TestReporter::new("INVALID", b"invalid");
+    reporter.descriptor = reporter
+        .descriptor
+        .clone()
+        .with_audiences([ReporterAudience::Automation]);
+    let mut reporters = ReporterSet::new();
+
+    assert!(matches!(
+        reporters.register(reporter),
+        Err(ReporterRegistrationError::InvalidContract(_))
+    ));
+    assert!(reporters.is_empty());
+}


### PR DESCRIPTION
## Summary

- publish a versioned, machine-readable reporter descriptor for human, automation, code-hosting, editor, and provider-neutral AI consumers
- add an object-safe `DoctorReporter` API, exact byte/finding receipts, partial-write telemetry, and an explicitly owned deterministic `ReporterSet` with no global mutable registry
- route the existing `vize doctor --format json` output through the built-in streaming JSON reporter without changing its wire format or exit behavior
- document external reporter integration and add a Criterion suite for contract overhead and 0/100/10,000-finding JSON output

Part of #3138. Fresco diagnostic workspace requirements are tracked separately in #4155.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [x] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

Issue #3138 requires stable structured output, provider-neutral AI consumption, reporter extensions without global process mutation, deterministic output, documentation comments, and analysis-cost visibility.

## Verification Evidence

- `cargo test -p vize_doctor` — 13 unit tests, 7 report integration tests, and doc tests passed
- `cargo test -p vize --lib doctor` — 12 Doctor/CLI unit tests passed
- `cargo test -p vize --test doctor_cli` — 11 CLI integration tests passed
- `cargo clippy -p vize_doctor --all-targets -- -D warnings` — passed
- `cargo clippy -p vize --lib --bin vize -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `cargo bench -p vize_doctor --bench reporter --no-run` — optimized benchmark target compiled
- short local Criterion sample: contract dispatch ~64 ns; compact JSON ~63 µs for 100 findings and ~6.3 ms for 10,000 findings (~0.8 GiB/s)
- every new Rust source file is below the repository 350-line source-length budget

`cargo package -p vize_doctor --allow-dirty --no-verify` reached dependency resolution and stopped because workspace version `vize_carton = 0.346.0` is not published on crates.io yet; this is pre-existing release ordering, not a package-content failure.

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained — existing Doctor JSON and text snapshots are unchanged
- [x] Parity or real-world fixture coverage considered — existing CLI fixtures cover valid, invalid, boundary, and deterministic-order behavior
- [x] Security/audit impact considered — descriptors reject unknown fields, invalid versions, ambiguous IDs/media types, and never carry vendor credentials
- [x] Performance status or PR benchmark impact considered
- [x] Fuzzing target or crash-reproducer coverage considered — no parser or untrusted recursive input surface added
- [x] Editor/LSP scenario coverage considered — descriptor capabilities explicitly cover editor consumers; no editor behavior changes in this slice
- [x] Ecosystem or broad app compatibility impact considered — existing JSON output is decoded by the unchanged `DoctorReport` contract in CLI tests
- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

The public reporter contract is experimental with the rest of `vize_doctor`, but its descriptor and reporter format versions are explicit and fail closed. The built-in JSON reporter intentionally preserves pretty-printing and the final newline for CLI compatibility.

The new Criterion target cannot join the shared base/head A/B inventory in this same PR because the base checkout does not contain that target. A narrow follow-up will enroll it after this target exists on `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->