### PR TITLE
feat(compose): add abort signal composition

### DIFF
--- a/npm/compose/core/package.json
+++ b/npm/compose/core/package.json
@@ -32,6 +32,11 @@
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
     },
+    "./abort-signal": {
+      "types": "./dist/abort-signal.d.mts",
+      "import": "./dist/abort-signal.mjs",
+      "default": "./dist/abort-signal.mjs"
+    },
     "./async-resource": {
       "types": "./dist/async-resource.d.mts",
       "import": "./dist/async-resource.mjs",

--- a/npm/compose/core/scripts/check-size.mjs
+++ b/npm/compose/core/scripts/check-size.mjs
@@ -5,6 +5,7 @@ const kibibyte = 1024;
 
 /** Per-subpath compressed budgets; every public runtime entry is mandatory. */
 const subpathBudgets = new Map([
+  ["abort-signal.mjs", 1 * kibibyte],
   ["async-resource.mjs", 2 * kibibyte],
   ["capability.mjs", 1 * kibibyte],
   ["disposal-scope.mjs", 2 * kibibyte],

--- a/npm/compose/core/src/abort-signal.test.ts
+++ b/npm/compose/core/src/abort-signal.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { anyAbortSignal } from "./abort-signal.ts";
+
+class TrackingSignal extends EventTarget {
+  aborted = false;
+  onabort: ((this: AbortSignal, event: Event) => unknown) | null = null;
+  reason: unknown;
+  readonly abortListeners = new Set<EventListenerOrEventListenerObject>();
+
+  override addEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: AddEventListenerOptions | boolean,
+  ): void {
+    super.addEventListener(type, callback, options);
+    if (type === "abort" && callback !== null) this.abortListeners.add(callback);
+  }
+
+  override removeEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: EventListenerOptions | boolean,
+  ): void {
+    super.removeEventListener(type, callback, options);
+    if (type === "abort" && callback !== null) this.abortListeners.delete(callback);
+  }
+
+  throwIfAborted(): void {
+    if (this.aborted) throw this.reason;
+  }
+
+  abort(reason: unknown): void {
+    if (this.aborted) return;
+    this.aborted = true;
+    this.reason = reason;
+    this.dispatchEvent(new Event("abort"));
+  }
+
+  asAbortSignal(): AbortSignal {
+    return this as unknown as AbortSignal;
+  }
+}
+
+class RejectingSignal extends TrackingSignal {
+  override addEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: AddEventListenerOptions | boolean,
+  ): void {
+    super.addEventListener(type, callback, options);
+    throw new Error("registration rejected");
+  }
+}
+
+function withoutNativeAny<Value>(callback: () => Value): Value {
+  const descriptor = Object.getOwnPropertyDescriptor(AbortSignal, "any");
+  Object.defineProperty(AbortSignal, "any", {
+    configurable: true,
+    value: undefined,
+    writable: true,
+  });
+  try {
+    return callback();
+  } finally {
+    if (descriptor === undefined) delete (AbortSignal as { any?: unknown }).any;
+    else Object.defineProperty(AbortSignal, "any", descriptor);
+  }
+}
+
+void test("returns a distinct, pending signal for empty input", () => {
+  const signal = anyAbortSignal([]);
+
+  assert.equal(signal.aborted, false);
+  assert.notEqual(signal, anyAbortSignal([]));
+});
+
+void test("forwards the first abort reason and ignores later inputs", () => {
+  const first = new AbortController();
+  const second = new AbortController();
+  const signal = anyAbortSignal([first.signal, second.signal]);
+  const firstReason = { code: "first" };
+
+  second.abort(firstReason);
+  first.abort(new Error("too late"));
+
+  assert.equal(signal.aborted, true);
+  assert.equal(signal.reason, firstReason);
+});
+
+void test("uses iteration order when multiple inputs are already aborted", () => {
+  const first = new AbortController();
+  const second = new AbortController();
+  first.abort("first");
+  second.abort("second");
+
+  assert.equal(anyAbortSignal([first.signal, second.signal]).reason, "first");
+  assert.equal(anyAbortSignal([second.signal, first.signal]).reason, "second");
+});
+
+void test("fallback removes listeners from every input after abort", () => {
+  withoutNativeAny(() => {
+    const first = new TrackingSignal();
+    const second = new TrackingSignal();
+    const signal = anyAbortSignal([first.asAbortSignal(), second.asAbortSignal()]);
+
+    assert.equal(first.abortListeners.size, 1);
+    assert.equal(second.abortListeners.size, 1);
+    first.abort("cancelled");
+
+    assert.equal(signal.aborted, true);
+    assert.equal(signal.reason, "cancelled");
+    assert.equal(first.abortListeners.size, 0);
+    assert.equal(second.abortListeners.size, 0);
+    second.abort("too late");
+    assert.equal(signal.reason, "cancelled");
+  });
+});
+
+void test("fallback resolves already-aborted inputs without retaining listeners", () => {
+  withoutNativeAny(() => {
+    const pending = new TrackingSignal();
+    const aborted = new TrackingSignal();
+    aborted.abort({ source: "adapter" });
+
+    const signal = anyAbortSignal([pending.asAbortSignal(), aborted.asAbortSignal()]);
+
+    assert.equal(signal.reason, aborted.reason);
+    assert.equal(pending.abortListeners.size, 0);
+    assert.equal(aborted.abortListeners.size, 0);
+  });
+});
+
+void test("materializes a failing iterable before fallback listener registration", () => {
+  withoutNativeAny(() => {
+    const input = new TrackingSignal();
+    function* failingSignals(): Iterable<AbortSignal> {
+      yield input.asAbortSignal();
+      throw new Error("iteration failed");
+    }
+
+    assert.throws(() => anyAbortSignal(failingSignals()), /iteration failed/);
+    assert.equal(input.abortListeners.size, 0);
+  });
+});
+
+void test("fallback releases partial subscriptions when registration throws", () => {
+  withoutNativeAny(() => {
+    const attached = new TrackingSignal();
+    const rejecting = new RejectingSignal();
+
+    assert.throws(
+      () => anyAbortSignal([attached.asAbortSignal(), rejecting.asAbortSignal()]),
+      /registration rejected/,
+    );
+    assert.equal(attached.abortListeners.size, 0);
+    assert.equal(rejecting.abortListeners.size, 0);
+  });
+});

--- a/npm/compose/core/src/abort-signal.ts
+++ b/npm/compose/core/src/abort-signal.ts
@@ -1,0 +1,61 @@
+/**
+ * Create a signal that aborts when the first input signal aborts.
+ *
+ * The standard `AbortSignal.any()` implementation is used when available.
+ * Older runtimes receive an equivalent listener-based implementation that
+ * removes every retained listener as soon as the result aborts. The first
+ * already-aborted input wins in iteration order, and its exact reason is
+ * forwarded. An empty iterable returns a fresh signal that never aborts.
+ *
+ * This function reads runtime constructors only when called and is safe to
+ * import during server rendering. Materializing the iterable happens before
+ * listeners are attached, so an iterable that throws cannot leak a partial
+ * subscription. If a non-standard signal throws while registering, listeners
+ * already attached to earlier inputs are released before the error propagates.
+ *
+ * @param signals Abort signals to compose; consumed exactly once.
+ * @returns A new first-abort-wins signal.
+ */
+export function anyAbortSignal(signals: Iterable<AbortSignal>): AbortSignal {
+  const inputs = [...signals];
+  if (typeof AbortSignal.any === "function") return AbortSignal.any(inputs);
+
+  const controller = new AbortController();
+  const listeners: Array<readonly [AbortSignal, () => void]> = [];
+  const cleanup = () => {
+    for (const [signal, listener] of listeners) {
+      signal.removeEventListener("abort", listener);
+    }
+    listeners.length = 0;
+  };
+  const abortFrom = (signal: AbortSignal) => {
+    if (controller.signal.aborted) return;
+    cleanup();
+    controller.abort(signal.reason);
+  };
+
+  for (const signal of inputs) {
+    if (signal.aborted) {
+      abortFrom(signal);
+      break;
+    }
+    const listener = () => abortFrom(signal);
+    listeners.push([signal, listener]);
+    try {
+      signal.addEventListener("abort", listener, { once: true });
+    } catch (error) {
+      cleanup();
+      throw error;
+    }
+
+    // A host adapter may change state between the preflight read and listener
+    // registration. The second read closes that race without changing native
+    // EventTarget behavior.
+    if (signal.aborted) {
+      abortFrom(signal);
+      break;
+    }
+  }
+
+  return controller.signal;
+}

--- a/npm/compose/core/src/distribution.test.ts
+++ b/npm/compose/core/src/distribution.test.ts
@@ -21,6 +21,7 @@ void test("publishes every utility through a typed side-effect-free subpath", as
   ) as PackageManifest;
   const expectedSubpaths = [
     ".",
+    "./abort-signal",
     "./async-resource",
     "./capability",
     "./disposal-scope",

--- a/npm/compose/core/src/index.ts
+++ b/npm/compose/core/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./abort-signal.ts";
 export * from "./async-resource.ts";
 export * from "./capability.ts";
 export * from "./disposal-scope.ts";

--- a/npm/compose/core/src/treeshake.test.ts
+++ b/npm/compose/core/src/treeshake.test.ts
@@ -21,6 +21,7 @@ const entries = {
  * another module or in the retained external `vue` import specifiers.
  */
 const sentinels = {
+  "abort-signal": ["anyAbortSignal"],
   scope: ["tryOnScopeDispose"],
   "capability-available": ['status: "available"'],
   "capability-unavailable": ['status: "unavailable"'],
@@ -51,6 +52,7 @@ interface UtilityCase {
 }
 
 const utilities: readonly UtilityCase[] = [
+  { binding: "anyAbortSignal", entry: "index", module: "abort-signal", shared: [] },
   { binding: "tryOnScopeDispose", entry: "index", module: "scope", shared: [] },
   {
     binding: "availableCapability",

--- a/npm/compose/core/src/types.test-d.ts
+++ b/npm/compose/core/src/types.test-d.ts
@@ -2,6 +2,7 @@
 
 import type { ShallowRef } from "vue";
 
+import { anyAbortSignal } from "./abort-signal.js";
 import { type AsyncResourceExecution, useAsyncResource } from "./async-resource.js";
 import {
   availableCapability,
@@ -20,6 +21,14 @@ type Equal<Left, Right> =
     ? true
     : false;
 type Expect<Condition extends true> = Condition;
+
+const combinedAbortSignal = anyAbortSignal(new Set<AbortSignal>());
+type _AbortCompositionReturnsThePlatformSignal = Expect<
+  Equal<typeof combinedAbortSignal, AbortSignal>
+>;
+
+// @ts-expect-error cancellation composition accepts AbortSignal inputs only.
+anyAbortSignal([new AbortController()]);
 
 const resource = useAsyncResource(async (_context, id: 1 | 2) => ({ id }) as const);
 

--- a/npm/compose/core/vite.config.ts
+++ b/npm/compose/core/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   pack: {
     entry: {
       index: "src/index.ts",
+      "abort-signal": "src/abort-signal.ts",
       "async-resource": "src/async-resource.ts",
       capability: "src/capability.ts",
       "disposal-scope": "src/disposal-scope.ts",


### PR DESCRIPTION
## Summary

- compose any iterable of abort signals with first-reason-wins semantics
- delegate to AbortSignal.any when the host implements the standard
- provide a compatibility path that releases every listener after abort or partial registration failure
- preserve iteration order for already-aborted inputs and materialize iterables before subscribing
- publish a typed, side-effect-free abort-signal subpath with exact type and tree-shake checks

## Validation

- pnpm --filter @vizejs/composable check
- pnpm --filter @vizejs/composable test (130 tests)
- abort-signal transitive gzip: 838 / 1024 bytes
- git diff --check origin/main...HEAD

Part of #3136.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `anyAbortSignal` to combine multiple abort signals into one.
  * The combined signal aborts with the first signal’s reason and supports empty or already-aborted inputs.
  * Added a dedicated `abort-signal` package entry for direct imports.

* **Bug Fixes**
  * Added fallback support for environments without native `AbortSignal.any`, including listener cleanup and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->