### PR TITLE
perf(doctor): enroll reporter benchmarks in CI

### DIFF
--- a/bench/criterion-ab.mjs
+++ b/bench/criterion-ab.mjs
@@ -63,6 +63,7 @@ export const CRITERION_SUITES = [
   // cost dimensions surfaces here.
   { package: "vize_atelier_jsx", benches: ["jsx_compile"], label: "JSX compile" },
   { package: "vize_croquis_cf", benches: ["cross_file"], label: "Cross-file analysis" },
+  { package: "vize_doctor", benches: ["reporter"], label: "Doctor reporters" },
   { package: "vize_glyph", benches: ["formatter"], label: "Formatter" },
   { package: "vize_patina", benches: ["lint_bench", "markup_ir_bench"], label: "Lint" },
 ];

--- a/tests/tooling/criterion-impact.test.ts
+++ b/tests/tooling/criterion-impact.test.ts
@@ -97,6 +97,24 @@ test("direct Criterion package changes select only their suite", () => {
   assert.deepEqual(result.selected, ["vize_glyph"]);
 });
 
+test("Doctor reporter benchmarks are enrolled in scoped Criterion A/B runs", () => {
+  const suite = CRITERION_SUITES.find(({ package: packageName }) => packageName === "vize_doctor");
+  assert.deepEqual(suite, {
+    package: "vize_doctor",
+    benches: ["reporter"],
+    label: "Doctor reporters",
+  });
+
+  const result = selectCriterionSuites({
+    changedPaths: ["crates/vize_doctor/src/reporter/json.rs"],
+    metadata: metadata(),
+    repoDir,
+  });
+
+  assert.equal(result.mode, "scoped");
+  assert.deepEqual(result.selected, ["vize_doctor"]);
+});
+
 test("reverse dependency impact selects every suite that consumes a changed package", () => {
   const dependencies = Object.fromEntries(suiteNames.map((name) => [name, ["vize_atelier_core"]]));
   const result = selectCriterionSuites({


### PR DESCRIPTION
Relates to #3138.

## Summary
- enroll the vize_doctor reporter benchmark in the shared Criterion A/B inventory
- scope doctor source changes to the reporter suite through dependency impact selection
- pin the package, bench target, and label in a tooling contract test

## Verification
- node --test --experimental-strip-types tests/tooling/criterion-impact.test.ts
- cargo bench -p vize_doctor --bench reporter --no-run
- cargo fmt --all -- --check
- git diff --check

## Risk
Low. This only expands benchmark selection; it does not change production code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Doctor reporters benchmark suite to Criterion A/B benchmark selection, execution, baseline export, comparison, and summary reporting.

* **Tests**
  * Added coverage confirming Doctor reporter benchmarks are included in scoped benchmark runs when relevant reporter changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->