### PR TITLE
feat(compose): add abort timeouts and deadlines

### DIFF
--- a/npm/compose/core/scripts/check-size.mjs
+++ b/npm/compose/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ const kibibyte = 1024;
 
 /** Per-subpath compressed budgets; every public runtime entry is mandatory. */
 const subpathBudgets = new Map([
-  ["abort-signal.mjs", 1 * kibibyte],
+  ["abort-signal.mjs", 2.5 * kibibyte],
   ["async-resource.mjs", 2 * kibibyte],
   ["capability.mjs", 1 * kibibyte],
   ["disposal-scope.mjs", 2 * kibibyte],

--- a/npm/compose/core/src/abort-signal.ts
+++ b/npm/compose/core/src/abort-signal.ts
@@ -59,3 +59,195 @@ export function anyAbortSignal(signals: Iterable<AbortSignal>): AbortSignal {
 
   return controller.signal;
 }
+
+/** Options for {@link timeoutAbortSignal}. */
+export interface TimeoutAbortSignalOptions {
+  /**
+   * Abort the returned signal early when this parent aborts.
+   *
+   * @default undefined
+   */
+  readonly signal?: AbortSignal;
+
+  /**
+   * Reason used when the timeout elapses. Parent cancellation always forwards
+   * the parent's reason instead.
+   *
+   * @default DOMException("The operation timed out.", "TimeoutError")
+   */
+  readonly reason?: unknown;
+
+  /**
+   * Deterministic or host-specific single-shot timer implementation. Supplying
+   * a scheduler selects the compatibility implementation.
+   *
+   * @default globalThis timer functions
+   */
+  readonly scheduler?: TimeoutScheduler;
+}
+
+/** Options for {@link deadlineAbortSignal}. */
+export interface DeadlineAbortSignalOptions extends TimeoutAbortSignalOptions {
+  /**
+   * Clock returning Unix epoch milliseconds.
+   *
+   * @default Date.now
+   */
+  readonly now?: () => number;
+}
+
+/**
+ * Create a signal that aborts after a portable, non-negative delay.
+ *
+ * The native `AbortSignal.timeout()` implementation is used when available
+ * and neither a custom scheduler nor a custom reason is supplied. Older
+ * runtimes use the same owned-timer path as injected schedulers. Parent
+ * cancellation is composed with first-reason-wins semantics. Compatibility
+ * scheduling owns exactly one timer and removes its parent listener whenever
+ * either source aborts. A zero delay remains asynchronous.
+ *
+ * The delay must be an integer from `0` through `2_147_483_647`; this common
+ * signed 32-bit timer ceiling avoids host-specific clamping. The function
+ * accesses timers and abort constructors only when called and is safe to
+ * import during server rendering.
+ *
+ * @param delayMs Delay in milliseconds.
+ * @param options Parent signal, timeout reason, and scheduler.
+ * @default options {}
+ * @throws {RangeError} Tagged `VIZE_COMPOSE_ABORT_TIMEOUT_INVALID_DELAY` when
+ * the delay is fractional, negative, non-finite, or exceeds the portable
+ * timer ceiling.
+ * @returns A new timeout or parent-cancelled signal.
+ */
+export function timeoutAbortSignal(
+  delayMs: number,
+  options: TimeoutAbortSignalOptions = {},
+): AbortSignal {
+  assertPortableTimeout(delayMs);
+
+  const parent = options.signal;
+  if (parent?.aborted) {
+    const controller = new AbortController();
+    controller.abort(parent.reason);
+    return controller.signal;
+  }
+
+  if (
+    options.scheduler === undefined &&
+    options.reason === undefined &&
+    typeof AbortSignal.timeout === "function"
+  ) {
+    const timeout = AbortSignal.timeout(delayMs);
+    return options.signal === undefined ? timeout : anyAbortSignal([options.signal, timeout]);
+  }
+
+  const controller = new AbortController();
+  const scheduler = options.scheduler ?? defaultTimeoutScheduler;
+
+  let handle: unknown;
+  let timerPending = true;
+  let parentListening = false;
+  const stopTimer = () => {
+    if (!timerPending) return;
+    timerPending = false;
+    scheduler.clearTimeout(handle);
+    handle = undefined;
+  };
+  const stopParent = () => {
+    if (!parentListening || parent === undefined) return;
+    parentListening = false;
+    parent.removeEventListener("abort", abortFromParent);
+  };
+  const abort = (reason: unknown) => {
+    if (controller.signal.aborted) return;
+    stopTimer();
+    stopParent();
+    controller.abort(reason);
+  };
+  const abortFromParent = () => abort(parent?.reason);
+  const timeoutReason =
+    options.reason === undefined
+      ? new DOMException("The operation timed out.", "TimeoutError")
+      : options.reason;
+
+  handle = scheduler.setTimeout(() => {
+    timerPending = false;
+    handle = undefined;
+    abort(timeoutReason);
+  }, delayMs);
+  if (controller.signal.aborted || parent === undefined) return controller.signal;
+
+  try {
+    // Assume registration may have succeeded before a non-standard adapter
+    // throws. Removing an absent listener is harmless, while delaying this
+    // ownership flag until after registration could leak a partial listener.
+    parentListening = true;
+    parent.addEventListener("abort", abortFromParent, { once: true });
+    if (controller.signal.aborted) {
+      parent.removeEventListener("abort", abortFromParent);
+      parentListening = false;
+      return controller.signal;
+    }
+    if (parent.aborted) abortFromParent();
+  } catch (error) {
+    stopParent();
+    stopTimer();
+    throw error;
+  }
+  return controller.signal;
+}
+
+/**
+ * Create a timeout signal from an absolute Unix-epoch deadline.
+ *
+ * Fractional positive differences are rounded up so cancellation never occurs
+ * before the requested deadline. Past deadlines become an asynchronous
+ * zero-delay timeout. `Date` and numeric deadlines are both accepted.
+ *
+ * @param deadline Absolute deadline as a `Date` or Unix epoch milliseconds.
+ * @param options Clock, parent signal, timeout reason, and scheduler.
+ * @default options {}
+ * @throws {RangeError} Tagged `VIZE_COMPOSE_ABORT_DEADLINE_INVALID` when the
+ * deadline, current clock value, or their positive difference is non-finite
+ * or cannot fit the portable timeout range.
+ * @returns A new deadline or parent-cancelled signal.
+ */
+export function deadlineAbortSignal(
+  deadline: Date | number,
+  options: DeadlineAbortSignalOptions = {},
+): AbortSignal {
+  const deadlineMs = deadline instanceof Date ? deadline.getTime() : deadline;
+  const nowMs = (options.now ?? Date.now)();
+  const difference = deadlineMs - nowMs;
+  if (
+    !Number.isFinite(deadlineMs) ||
+    !Number.isFinite(nowMs) ||
+    !Number.isFinite(difference) ||
+    difference > maximumPortableTimeoutMs
+  ) {
+    throw new RangeError(
+      `[VIZE_COMPOSE_ABORT_DEADLINE_INVALID] deadline and now must produce a finite delay from 0 through ${String(maximumPortableTimeoutMs)} milliseconds; received deadline=${String(deadlineMs)}, now=${String(nowMs)}`,
+    );
+  }
+
+  const { now: _now, ...timeoutOptions } = options;
+  return timeoutAbortSignal(Math.ceil(Math.max(0, difference)), timeoutOptions);
+}
+
+function assertPortableTimeout(delayMs: number): void {
+  if (!Number.isSafeInteger(delayMs) || delayMs < 0 || delayMs > maximumPortableTimeoutMs) {
+    throw new RangeError(
+      `[VIZE_COMPOSE_ABORT_TIMEOUT_INVALID_DELAY] delayMs must be an integer from 0 through ${String(maximumPortableTimeoutMs)}; received ${String(delayMs)}`,
+    );
+  }
+}
+import type { TimeoutScheduler } from "./timeout-scheduler.ts";
+
+const maximumPortableTimeoutMs = 2_147_483_647;
+
+const defaultTimeoutScheduler: TimeoutScheduler = {
+  setTimeout: (callback, delayMs) => globalThis.setTimeout(callback, delayMs),
+  clearTimeout: (handle) => {
+    globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>);
+  },
+};

--- a/npm/compose/core/src/abort-timeout.test.ts
+++ b/npm/compose/core/src/abort-timeout.test.ts
@@ -1,0 +1,263 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { deadlineAbortSignal, timeoutAbortSignal } from "./abort-signal.ts";
+import type { TimeoutScheduler } from "./timeout-scheduler.ts";
+
+interface ScheduledTimeout {
+  readonly callback: () => void;
+  readonly delayMs: number;
+}
+
+class TestScheduler implements TimeoutScheduler {
+  readonly active = new Set<ScheduledTimeout>();
+  readonly cleared: ScheduledTimeout[] = [];
+
+  setTimeout(callback: () => void, delayMs: number): ScheduledTimeout {
+    const timeout = { callback, delayMs };
+    this.active.add(timeout);
+    return timeout;
+  }
+
+  clearTimeout(handle: unknown): void {
+    const timeout = handle as ScheduledTimeout;
+    this.active.delete(timeout);
+    this.cleared.push(timeout);
+  }
+
+  fire(timeout?: ScheduledTimeout): void {
+    const selected = timeout ?? [...this.active][0];
+    assert.ok(selected);
+    this.active.delete(selected);
+    selected.callback();
+  }
+}
+
+function withoutNativeTimeout<Value>(callback: () => Value): Value {
+  const descriptor = Object.getOwnPropertyDescriptor(AbortSignal, "timeout");
+  Object.defineProperty(AbortSignal, "timeout", {
+    configurable: true,
+    value: undefined,
+    writable: true,
+  });
+  try {
+    return callback();
+  } finally {
+    if (descriptor === undefined) delete (AbortSignal as { timeout?: unknown }).timeout;
+    else Object.defineProperty(AbortSignal, "timeout", descriptor);
+  }
+}
+
+void test("delegates the simple case to the runtime timeout standard", () => {
+  const descriptor = Object.getOwnPropertyDescriptor(AbortSignal, "timeout");
+  const expected = new AbortController().signal;
+  let receivedDelay: number | undefined;
+  Object.defineProperty(AbortSignal, "timeout", {
+    configurable: true,
+    value: (delayMs: number) => {
+      receivedDelay = delayMs;
+      return expected;
+    },
+    writable: true,
+  });
+  try {
+    assert.equal(timeoutAbortSignal(125), expected);
+    assert.equal(receivedDelay, 125);
+  } finally {
+    if (descriptor === undefined) delete (AbortSignal as { timeout?: unknown }).timeout;
+    else Object.defineProperty(AbortSignal, "timeout", descriptor);
+  }
+});
+
+void test("falls back when the runtime timeout standard is unavailable", async () => {
+  const signal = withoutNativeTimeout(() => timeoutAbortSignal(0));
+
+  assert.equal(signal.aborted, false);
+  await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.equal(signal.aborted, true);
+  assert.ok(signal.reason instanceof DOMException);
+  assert.equal(signal.reason.name, "TimeoutError");
+});
+
+void test("custom scheduling aborts asynchronously with a standard timeout reason", () => {
+  const scheduler = new TestScheduler();
+  const signal = timeoutAbortSignal(0, { scheduler });
+
+  assert.equal(signal.aborted, false);
+  assert.deepEqual(
+    [...scheduler.active].map((timeout) => timeout.delayMs),
+    [0],
+  );
+  scheduler.fire();
+
+  assert.equal(signal.aborted, true);
+  assert.ok(signal.reason instanceof DOMException);
+  assert.equal(signal.reason.name, "TimeoutError");
+  assert.equal(scheduler.active.size, 0);
+});
+
+void test("preserves a custom timeout reason including null", () => {
+  const scheduler = new TestScheduler();
+  const signal = timeoutAbortSignal(10, { scheduler, reason: null });
+
+  scheduler.fire();
+  assert.equal(signal.reason, null);
+});
+
+void test("parent cancellation wins and releases the owned timer", () => {
+  const scheduler = new TestScheduler();
+  const parent = new AbortController();
+  const reason = { code: "navigation" };
+  const signal = timeoutAbortSignal(500, { scheduler, signal: parent.signal });
+
+  parent.abort(reason);
+
+  assert.equal(signal.aborted, true);
+  assert.equal(signal.reason, reason);
+  assert.equal(scheduler.active.size, 0);
+  assert.equal(scheduler.cleared.length, 1);
+});
+
+void test("an already-aborted parent prevents timer allocation", () => {
+  const scheduler = new TestScheduler();
+  const parent = new AbortController();
+  parent.abort("already cancelled");
+
+  const signal = timeoutAbortSignal(500, { scheduler, signal: parent.signal });
+
+  assert.equal(signal.reason, "already cancelled");
+  assert.equal(scheduler.active.size, 0);
+  assert.equal(scheduler.cleared.length, 0);
+});
+
+void test("an already-aborted parent bypasses the native timeout", () => {
+  const descriptor = Object.getOwnPropertyDescriptor(AbortSignal, "timeout");
+  const parent = new AbortController();
+  const reason = { code: "already-cancelled" };
+  let allocations = 0;
+  parent.abort(reason);
+  Object.defineProperty(AbortSignal, "timeout", {
+    configurable: true,
+    value: () => {
+      allocations += 1;
+      return new AbortController().signal;
+    },
+    writable: true,
+  });
+  try {
+    const signal = timeoutAbortSignal(500, { signal: parent.signal });
+
+    assert.equal(signal.reason, reason);
+    assert.equal(allocations, 0);
+  } finally {
+    if (descriptor === undefined) delete (AbortSignal as { timeout?: unknown }).timeout;
+    else Object.defineProperty(AbortSignal, "timeout", descriptor);
+  }
+});
+
+void test("a scheduler failure cannot attach a parent listener", () => {
+  const parent = new AbortController();
+  let additions = 0;
+  const originalAdd = parent.signal.addEventListener.bind(parent.signal);
+  parent.signal.addEventListener = (
+    type: string,
+    callback: EventListenerOrEventListenerObject,
+    options?: AddEventListenerOptions | boolean,
+  ) => {
+    additions += 1;
+    return originalAdd(type, callback, options);
+  };
+  const scheduler: TimeoutScheduler = {
+    setTimeout: () => {
+      throw new Error("scheduler unavailable");
+    },
+    clearTimeout: () => undefined,
+  };
+
+  assert.throws(
+    () => timeoutAbortSignal(1, { scheduler, signal: parent.signal }),
+    /scheduler unavailable/,
+  );
+  assert.equal(additions, 0);
+});
+
+void test("a partial parent registration is released before rethrowing", () => {
+  const scheduler = new TestScheduler();
+  const parent = new AbortController();
+  let removals = 0;
+  const originalAdd = parent.signal.addEventListener.bind(parent.signal);
+  const originalRemove = parent.signal.removeEventListener.bind(parent.signal);
+  parent.signal.addEventListener = (
+    type: string,
+    callback: EventListenerOrEventListenerObject,
+    options?: AddEventListenerOptions | boolean,
+  ) => {
+    originalAdd(type, callback, options);
+    throw new Error("registration failed after attaching");
+  };
+  parent.signal.removeEventListener = (
+    type: string,
+    callback: EventListenerOrEventListenerObject,
+    options?: EventListenerOptions | boolean,
+  ) => {
+    removals += 1;
+    return originalRemove(type, callback, options);
+  };
+
+  assert.throws(
+    () => timeoutAbortSignal(500, { scheduler, signal: parent.signal }),
+    /registration failed after attaching/,
+  );
+  assert.equal(removals, 1);
+  assert.equal(scheduler.active.size, 0);
+  assert.equal(scheduler.cleared.length, 1);
+});
+
+void test("rejects delays that hosts would clamp or reinterpret", () => {
+  for (const delayMs of [-1, 0.5, Number.NaN, Number.POSITIVE_INFINITY, 2_147_483_648]) {
+    assert.throws(
+      () => timeoutAbortSignal(delayMs),
+      (error: unknown) =>
+        error instanceof RangeError &&
+        error.message.startsWith("[VIZE_COMPOSE_ABORT_TIMEOUT_INVALID_DELAY]"),
+    );
+  }
+});
+
+void test("converts future, fractional, and past deadlines predictably", () => {
+  const futureScheduler = new TestScheduler();
+  deadlineAbortSignal(1_500.25, {
+    now: () => 1_000,
+    scheduler: futureScheduler,
+  });
+  assert.deepEqual(
+    [...futureScheduler.active].map((timeout) => timeout.delayMs),
+    [501],
+  );
+
+  const pastScheduler = new TestScheduler();
+  const past = deadlineAbortSignal(900, { now: () => 1_000, scheduler: pastScheduler });
+  assert.equal(past.aborted, false);
+  assert.deepEqual(
+    [...pastScheduler.active].map((timeout) => timeout.delayMs),
+    [0],
+  );
+});
+
+void test("rejects invalid deadlines and clock values before allocating timers", () => {
+  const scheduler = new TestScheduler();
+  for (const [deadline, now] of [
+    [Number.NaN, 0],
+    [0, Number.NaN],
+    [Number.POSITIVE_INFINITY, 0],
+    [2_147_483_648, 0],
+  ] as const) {
+    assert.throws(
+      () => deadlineAbortSignal(deadline, { now: () => now, scheduler }),
+      (error: unknown) =>
+        error instanceof RangeError &&
+        error.message.startsWith("[VIZE_COMPOSE_ABORT_DEADLINE_INVALID]"),
+    );
+  }
+  assert.equal(scheduler.active.size, 0);
+});

--- a/npm/compose/core/src/treeshake.test.ts
+++ b/npm/compose/core/src/treeshake.test.ts
@@ -21,7 +21,9 @@ const entries = {
  * another module or in the retained external `vue` import specifiers.
  */
 const sentinels = {
-  "abort-signal": ["anyAbortSignal"],
+  "abort-signal-any": ["anyAbortSignal"],
+  "abort-signal-timeout": ["timeoutAbortSignal", "VIZE_COMPOSE_ABORT_TIMEOUT_INVALID_DELAY"],
+  "abort-signal-deadline": ["deadlineAbortSignal", "VIZE_COMPOSE_ABORT_DEADLINE_INVALID"],
   scope: ["tryOnScopeDispose"],
   "capability-available": ['status: "available"'],
   "capability-unavailable": ['status: "unavailable"'],
@@ -52,7 +54,19 @@ interface UtilityCase {
 }
 
 const utilities: readonly UtilityCase[] = [
-  { binding: "anyAbortSignal", entry: "index", module: "abort-signal", shared: [] },
+  { binding: "anyAbortSignal", entry: "index", module: "abort-signal-any", shared: [] },
+  {
+    binding: "timeoutAbortSignal",
+    entry: "index",
+    module: "abort-signal-timeout",
+    shared: ["abort-signal-any"],
+  },
+  {
+    binding: "deadlineAbortSignal",
+    entry: "index",
+    module: "abort-signal-deadline",
+    shared: ["abort-signal-timeout", "abort-signal-any"],
+  },
   { binding: "tryOnScopeDispose", entry: "index", module: "scope", shared: [] },
   {
     binding: "availableCapability",

--- a/npm/compose/core/src/types.test-d.ts
+++ b/npm/compose/core/src/types.test-d.ts
@@ -2,7 +2,7 @@
 
 import type { ShallowRef } from "vue";
 
-import { anyAbortSignal } from "./abort-signal.js";
+import { anyAbortSignal, deadlineAbortSignal, timeoutAbortSignal } from "./abort-signal.js";
 import { type AsyncResourceExecution, useAsyncResource } from "./async-resource.js";
 import {
   availableCapability,
@@ -29,6 +29,17 @@ type _AbortCompositionReturnsThePlatformSignal = Expect<
 
 // @ts-expect-error cancellation composition accepts AbortSignal inputs only.
 anyAbortSignal([new AbortController()]);
+
+timeoutAbortSignal(100, {
+  signal: combinedAbortSignal,
+  reason: { code: "timed-out" } as const,
+});
+deadlineAbortSignal(new Date(), { now: () => 0 });
+
+// @ts-expect-error timeout delays are numeric milliseconds.
+timeoutAbortSignal(100n);
+// @ts-expect-error deadlines are Date objects or numeric Unix milliseconds.
+deadlineAbortSignal("tomorrow");
 
 const resource = useAsyncResource(async (_context, id: 1 | 2) => ({ id }) as const);
 


### PR DESCRIPTION
## Summary

- add timeout and deadline AbortSignal factories with native-first behavior
- provide deterministic fallbacks with parent cancellation, injectable scheduling, and exact reason ownership
- validate host timer limits and cover races, cleanup, declarations, tree-shaking, and bundle budgets

## Validation

- pnpm --filter @vizejs/composable check
- pnpm --filter @vizejs/composable test

Part of #3136.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4166"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->