### PR TITLE
test(ui): enforce runtime conformance

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -92,12 +92,13 @@
   "scripts": {
     "build": "vp pack",
     "dev": "vp pack --watch",
-    "lint:sfc": "vp exec node scripts/lint-sfc.ts src",
-    "pretest": "vp pack && pnpm check:size",
+    "lint:sfc": "vp exec node scripts/lint-sfc.ts src && vp exec node scripts/check-renderers.ts src",
+    "pretest": "vp pack && pnpm check:size && pnpm check:tree-shaking",
     "test": "vp test run",
     "check": "vp check src scripts vite.config.ts tsconfig.typecheck.json && vue-tsc --noEmit -p tsconfig.typecheck.json",
     "check:fix": "vp check --fix src scripts vite.config.ts tsconfig.typecheck.json",
     "check:size": "node scripts/check-size.mjs",
+    "check:tree-shaking": "node scripts/check-tree-shaking.mjs",
     "fmt": "vp fmt --write src scripts vite.config.ts"
   },
   "devDependencies": {

--- a/npm/ui/core/scripts/check-renderers.ts
+++ b/npm/ui/core/scripts/check-renderers.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { compileSfc, type SfcCompileOptionsNapi } from "@vizejs/native";
+
+interface RendererLane {
+  /** Stable lane name emitted in CI diagnostics. */
+  readonly name: "dom" | "ssr" | "vapor";
+  /** Native SFC compiler options that distinguish this lane. */
+  readonly options: Readonly<Pick<SfcCompileOptionsNapi, "ssr" | "vapor">>;
+}
+
+const rendererLanes: readonly RendererLane[] = [
+  { name: "dom", options: { ssr: false, vapor: false } },
+  { name: "ssr", options: { ssr: true, vapor: false } },
+  { name: "vapor", options: { ssr: false, vapor: true } },
+];
+
+/**
+ * Recursively collect authored Vue SFCs in deterministic path order.
+ *
+ * Generated output is deliberately excluded: this gate verifies the canonical,
+ * inspectable source that consumers install and edit.
+ */
+async function collectSfcFiles(sourceRoot: string): Promise<readonly string[]> {
+  const entries = await readdir(sourceRoot, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry): Promise<readonly string[]> => {
+      const entryPath = path.join(sourceRoot, entry.name);
+      if (entry.isDirectory()) return collectSfcFiles(entryPath);
+      return entry.isFile() && entry.name.endsWith(".vue") ? [entryPath] : [];
+    }),
+  );
+
+  return files.flat().sort((left, right) => left.localeCompare(right));
+}
+
+/** Format native diagnostics without losing the file and renderer lane. */
+function formatDiagnostics(
+  file: string,
+  lane: RendererLane,
+  diagnostics: readonly string[],
+): string {
+  return `${file} failed ${lane.name} compilation:\n${diagnostics
+    .map((diagnostic) => `  - ${diagnostic}`)
+    .join("\n")}`;
+}
+
+/**
+ * Compile one component through a production renderer lane.
+ *
+ * The Vapor+SSR cross-product is intentionally absent. Vize currently falls
+ * back to standard SSR for that combination, and issue #3134 tracks native
+ * Vapor SSR as a release-blocking capability rather than treating fallback as
+ * conformance.
+ */
+function verifyRendererLane(file: string, source: string, lane: RendererLane): void {
+  const result = compileSfc(source, {
+    filename: file,
+    isTs: true,
+    mode: "module",
+    sourceMap: true,
+    ...lane.options,
+  });
+
+  assert.equal(result.errors.length, 0, formatDiagnostics(file, lane, result.errors));
+  assert.equal(result.warnings.length, 0, formatDiagnostics(file, lane, result.warnings));
+  assert.ok(result.code.trim().length > 0, `${file} emitted empty ${lane.name} JavaScript`);
+
+  if (lane.name === "vapor") {
+    assert.match(
+      result.code,
+      /defineVaporComponent|__vaporRender|__vapor\s*:\s*true/,
+      `${file} did not emit a Vapor component`,
+    );
+  } else {
+    assert.doesNotMatch(
+      result.code,
+      /defineVaporComponent|__vaporRender|__vapor\s*:\s*true/,
+      `${file} leaked Vapor output into the ${lane.name} lane`,
+    );
+  }
+
+  if (lane.name === "ssr") {
+    assert.match(
+      result.code,
+      /function ssrRender|@vue\/server-renderer/,
+      `${file} did not emit an SSR render function`,
+    );
+  } else {
+    assert.doesNotMatch(
+      result.code,
+      /function ssrRender|@vue\/server-renderer/,
+      `${file} leaked SSR output into the ${lane.name} lane`,
+    );
+  }
+}
+
+const sourceRoots = process.argv.slice(2);
+const resolvedRoots = sourceRoots.length > 0 ? sourceRoots : ["src"];
+const sourceFiles = (
+  await Promise.all(resolvedRoots.map((sourceRoot) => collectSfcFiles(path.resolve(sourceRoot))))
+).flat();
+
+assert.ok(sourceFiles.length > 0, `No Vue SFCs found below: ${resolvedRoots.join(", ")}`);
+
+for (const file of sourceFiles) {
+  const source = await readFile(file, "utf8");
+  for (const lane of rendererLanes) verifyRendererLane(file, source, lane);
+}
+
+console.log(
+  JSON.stringify({
+    check: "@vizejs/ui renderer conformance",
+    sourceFiles: sourceFiles.length,
+    compilations: sourceFiles.length * rendererLanes.length,
+    lanes: rendererLanes.map((lane) => lane.name),
+  }),
+);

--- a/npm/ui/core/scripts/check-tree-shaking.mjs
+++ b/npm/ui/core/scripts/check-tree-shaking.mjs
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+
+import { build } from "vite";
+
+const virtualConsumerId = path.resolve(".vize-ui-tree-shaking-consumer.mjs");
+
+/**
+ * Bundle an in-package consumer through the public package exports.
+ *
+ * Resolving the virtual entry inside this package intentionally exercises Node
+ * package self-references, conditional exports, sideEffects metadata, Rolldown,
+ * CSS extraction, and production minification together.
+ */
+async function bundleConsumer(source) {
+  const result = await build({
+    configFile: false,
+    logLevel: "silent",
+    plugins: [
+      {
+        name: "vize-ui-tree-shaking-consumer",
+        resolveId(id) {
+          if (id === "virtual:vize-ui-consumer" || id === virtualConsumerId) {
+            return virtualConsumerId;
+          }
+        },
+        load(id) {
+          if (id === virtualConsumerId) return source;
+        },
+      },
+    ],
+    build: {
+      cssCodeSplit: true,
+      minify: true,
+      target: "es2022",
+      write: false,
+      rollupOptions: {
+        input: "virtual:vize-ui-consumer",
+        external: (id) => id === "vue" || id.startsWith("vue/"),
+      },
+    },
+  });
+
+  assert.ok(!Array.isArray(result), "tree-shaking build unexpectedly returned multiple outputs");
+  const javascript = result.output
+    .filter((output) => output.type === "chunk")
+    .map((output) => output.code)
+    .join("\n");
+  const css = result.output
+    .filter((output) => output.type === "asset" && output.fileName.endsWith(".css"))
+    .map((output) => String(output.source))
+    .join("\n");
+
+  return Object.freeze({
+    javascript,
+    css,
+    javascriptBytes: Buffer.byteLength(javascript),
+    javascriptGzipBytes: gzipSync(javascript).byteLength,
+    cssBytes: Buffer.byteLength(css),
+    cssGzipBytes: css.length === 0 ? 0 : gzipSync(css).byteLength,
+  });
+}
+
+/** Keep a selected component observable so the entry export cannot be discarded. */
+function consumerSource(exportName, packageEntry) {
+  return `import { ${exportName} } from ${JSON.stringify(packageEntry)};globalThis.__vizeUiConsumer=${exportName};`;
+}
+
+const familySignatures = Object.freeze({
+  button: /aria-busy/,
+  checkbox: /aria-checked/,
+  id: /DeterministicIdProvider/,
+  primitive: /data-vize-ui.+primitive/,
+  "visually-hidden": /visually-hidden/,
+});
+
+const componentCases = [
+  {
+    family: "button",
+    exportName: "Button",
+    maximumJavaScriptGzipBytes: 1_000,
+    maximumCssGzipBytes: 0,
+  },
+  {
+    family: "checkbox",
+    exportName: "Checkbox",
+    maximumJavaScriptGzipBytes: 1_100,
+    maximumCssGzipBytes: 0,
+  },
+  {
+    family: "id",
+    exportName: "IdProvider",
+    maximumJavaScriptGzipBytes: 1_050,
+    maximumCssGzipBytes: 0,
+  },
+  {
+    family: "primitive",
+    exportName: "Primitive",
+    maximumJavaScriptGzipBytes: 500,
+    maximumCssGzipBytes: 0,
+  },
+  {
+    family: "visually-hidden",
+    exportName: "VisuallyHidden",
+    maximumJavaScriptGzipBytes: 400,
+    maximumCssGzipBytes: 180,
+  },
+];
+
+for (const {
+  family,
+  exportName,
+  maximumJavaScriptGzipBytes,
+  maximumCssGzipBytes,
+} of componentCases) {
+  const rootOutput = await bundleConsumer(consumerSource(exportName, "@vizejs/ui"));
+  const subpathOutput = await bundleConsumer(consumerSource(exportName, `@vizejs/ui/${family}`));
+  assert.equal(
+    rootOutput.javascript,
+    subpathOutput.javascript,
+    `${exportName} root and subpath exports emitted different JavaScript`,
+  );
+  assert.equal(
+    rootOutput.css,
+    subpathOutput.css,
+    `${exportName} root and subpath exports emitted different CSS`,
+  );
+
+  for (const [signatureFamily, signature] of Object.entries(familySignatures)) {
+    if (signatureFamily === family) {
+      assert.match(
+        rootOutput.javascript,
+        signature,
+        `${exportName} was eliminated from its own consumer bundle`,
+      );
+    } else {
+      assert.doesNotMatch(
+        rootOutput.javascript,
+        signature,
+        `${exportName} retained the unused ${signatureFamily} family`,
+      );
+    }
+  }
+
+  if (family === "visually-hidden") {
+    assert.match(rootOutput.css, /clip-path:inset\(50%\)/);
+  } else {
+    assert.equal(rootOutput.css, "", `${exportName} retained another component's stylesheet`);
+  }
+
+  for (const { entry, output } of [
+    { entry: "root", output: rootOutput },
+    { entry: "subpath", output: subpathOutput },
+  ]) {
+    console.log(
+      JSON.stringify({
+        check: "@vizejs/ui consumer tree shaking",
+        entry: `${entry}-${family}`,
+        javascriptBytes: output.javascriptBytes,
+        javascriptGzipBytes: output.javascriptGzipBytes,
+        maximumJavaScriptGzipBytes,
+        cssBytes: output.cssBytes,
+        cssGzipBytes: output.cssGzipBytes,
+        maximumCssGzipBytes,
+      }),
+    );
+
+    assert.ok(
+      output.javascriptGzipBytes <= maximumJavaScriptGzipBytes,
+      `${entry}-${family} JavaScript is ${output.javascriptGzipBytes} gzip bytes; budget is ${maximumJavaScriptGzipBytes}`,
+    );
+    assert.ok(
+      output.cssGzipBytes <= maximumCssGzipBytes,
+      `${entry}-${family} CSS is ${output.cssGzipBytes} gzip bytes; budget is ${maximumCssGzipBytes}`,
+    );
+  }
+}

--- a/npm/ui/core/src/runtime-conformance.md
+++ b/npm/ui/core/src/runtime-conformance.md
@@ -1,0 +1,29 @@
+# Runtime conformance contract
+
+Every source-owned `@vizejs/ui` component must pass the same cross-runtime
+gates. Compiler coverage discovers SFCs recursively. Runtime fixtures describe
+the component-specific accessible markup, and a coverage assertion rejects any
+new SFC that does not add its SSR and hydration evidence.
+
+| Lane         | Executable evidence                                                | Required invariant                                                                        |
+| ------------ | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| DOM          | Native Vize SFC compilation                                        | No errors, warnings, empty modules, or Vapor markers                                      |
+| SSR          | Native Vize SFC compilation plus concurrent `renderToString` tests | Stable request-local markup, accessible server semantics, and no Vapor fallback           |
+| Hydration    | SSR markup hydrated by a fresh client application                  | No warning, error, or root-node replacement                                               |
+| Vapor        | Native Vize SFC compilation                                        | A real Vapor component marker with no diagnostic fallback                                 |
+| Tree shaking | Production consumer bundles through public package exports         | Root and subpath parity, unused family elimination, exact CSS retention, and gzip budgets |
+
+The hydration suite covers every currently shipped SFC, including the
+renderless deterministic-ID provider. The dedicated ID suite additionally
+exercises repeated and concurrent requests, nested providers, islands with
+distinct seeds, and byte-stable hydration IDs. Interaction suites remain the
+authority for keyboard, pointer, focus, form, controlled/uncontrolled, and
+accessible-name behavior.
+
+## Deliberate non-claim
+
+Vize currently falls back to standard SSR when Vapor and SSR are requested
+together. This contract does not disguise that fallback as support. Native
+Vapor SSR, streaming, async boundaries, Teleport, independently hydrated roots,
+and islands remain a release-blocking item in issue #3134. Once the compiler
+ships that lane, it must be added here without weakening the DOM SSR gate.

--- a/npm/ui/core/src/runtime-conformance.test.ts
+++ b/npm/ui/core/src/runtime-conformance.test.ts
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+import { test } from "vite-plus/test";
+import { createSSRApp, defineComponent, h, type VNode } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import ActionButton from "./ActionButton.vue";
+import CheckboxControl from "./CheckboxControl.vue";
+import IdProvider from "./DeterministicIdProvider.vue";
+import { useDeterministicId } from "./deterministic-id.ts";
+import PrimitiveElement from "./PrimitiveElement.vue";
+import VisuallyHidden from "./VisuallyHidden.vue";
+
+interface RuntimeFixture {
+  /** Stable name included in assertion diagnostics. */
+  readonly name: string;
+  /** Canonical SFC whose SSR and hydration behavior this fixture covers. */
+  readonly sourceFile: string;
+  /** Build a fresh vnode so no request can inherit another request's state. */
+  readonly render: () => VNode;
+  /** Assert server output semantics before the browser repairs or normalizes DOM. */
+  readonly assertServerMarkup: (html: string) => void;
+  /** Assert hydrated accessibility semantics in a browser-like DOM. */
+  readonly assertHydratedDom: (host: HTMLElement) => void;
+}
+
+const DeterministicIdProbe = defineComponent({
+  name: "RuntimeConformanceDeterministicIdProbe",
+  setup() {
+    const id = useDeterministicId({ hint: "control" });
+    return () => h("input", { id: id.value, "aria-label": "Email" });
+  },
+});
+
+const runtimeFixtures: readonly RuntimeFixture[] = [
+  {
+    name: "button",
+    sourceFile: "ActionButton.vue",
+    render: () =>
+      h(
+        ActionButton,
+        { loading: true },
+        {
+          default: () => "Save changes",
+        },
+      ),
+    assertServerMarkup(html) {
+      assert.match(html, /<button/);
+      assert.match(html, /aria-busy="true"/);
+      assert.match(html, /data-state="loading"/);
+      assert.match(html, /Save changes/);
+      assert.match(html, /<\/button>/);
+    },
+    assertHydratedDom(host) {
+      const button = host.querySelector('[data-vize-ui="button"]');
+      assert.ok(button instanceof HTMLButtonElement);
+      assert.equal(button.textContent, "Save changes");
+      assert.equal(button.getAttribute("aria-busy"), "true");
+    },
+  },
+  {
+    name: "checkbox",
+    sourceFile: "CheckboxControl.vue",
+    render: () =>
+      h(CheckboxControl, {
+        ariaLabel: "Accept terms",
+        defaultChecked: true,
+      }),
+    assertServerMarkup(html) {
+      assert.match(html, /type="checkbox"/);
+      assert.match(html, /aria-label="Accept terms"/);
+      assert.match(html, /aria-checked="true"/);
+      assert.match(html, /checked/);
+    },
+    assertHydratedDom(host) {
+      const checkbox = host.querySelector('[data-vize-ui="checkbox"]');
+      assert.ok(checkbox instanceof HTMLInputElement);
+      assert.equal(checkbox.checked, true);
+      assert.equal(checkbox.getAttribute("aria-checked"), "true");
+    },
+  },
+  {
+    name: "deterministic-id-provider",
+    sourceFile: "DeterministicIdProvider.vue",
+    render: () =>
+      h(
+        IdProvider,
+        { prefix: "form", seed: "runtime" },
+        {
+          default: () => h(DeterministicIdProbe),
+        },
+      ),
+    assertServerMarkup(html) {
+      assert.match(html, /id="form-runtime-control-0"/);
+      assert.match(html, /aria-label="Email"/);
+    },
+    assertHydratedDom(host) {
+      const input = host.querySelector("input");
+      assert.ok(input instanceof HTMLInputElement);
+      assert.equal(input.id, "form-runtime-control-0");
+      assert.equal(input.getAttribute("aria-label"), "Email");
+    },
+  },
+  {
+    name: "primitive",
+    sourceFile: "PrimitiveElement.vue",
+    render: () =>
+      h(
+        PrimitiveElement,
+        { as: "section" },
+        {
+          default: () => "Composable content",
+        },
+      ),
+    assertServerMarkup(html) {
+      assert.match(html, /^<section/);
+      assert.match(html, /Composable content/);
+      assert.match(html, /<\/section>$/);
+    },
+    assertHydratedDom(host) {
+      const primitive = host.querySelector('[data-vize-ui="primitive"]');
+      assert.ok(primitive instanceof HTMLElement);
+      assert.equal(primitive.tagName, "SECTION");
+    },
+  },
+  {
+    name: "visually-hidden",
+    sourceFile: "VisuallyHidden.vue",
+    render: () =>
+      h(VisuallyHidden, null, {
+        default: () => h("button", { type: "button" }, "Dismiss notification"),
+      }),
+    assertServerMarkup(html) {
+      assert.match(html, /^<span/);
+      assert.match(html, /data-vize-ui="visually-hidden"/);
+      assert.match(html, /<button type="button">Dismiss notification<\/button>/);
+    },
+    assertHydratedDom(host) {
+      const control = host.querySelector("button");
+      assert.ok(control instanceof HTMLButtonElement);
+      assert.equal(control.textContent, "Dismiss notification");
+    },
+  },
+];
+
+/** Recursively collect canonical SFC paths relative to the package source root. */
+async function collectSourceSfcFiles(
+  directory: string,
+  relativeDirectory = "",
+): Promise<readonly string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry): Promise<readonly string[]> => {
+      const entryPath = path.join(directory, entry.name);
+      const relativePath = path.join(relativeDirectory, entry.name);
+      if (entry.isDirectory()) return collectSourceSfcFiles(entryPath, relativePath);
+      return entry.isFile() && entry.name.endsWith(".vue") ? [relativePath] : [];
+    }),
+  );
+  return files.flat().sort((left, right) => left.localeCompare(right));
+}
+
+/** Create an isolated application root for one renderer request. */
+function createFixtureRoot(fixture: RuntimeFixture) {
+  return defineComponent({
+    name: `RuntimeConformance${fixture.name}`,
+    setup: () => fixture.render,
+  });
+}
+
+/** Render with a fresh SSR application so request-local state cannot be reused. */
+async function renderFixture(fixture: RuntimeFixture): Promise<string> {
+  return renderToString(createSSRApp(createFixtureRoot(fixture)));
+}
+
+test("declares an SSR and hydration fixture for every source SFC", async () => {
+  const sourceFiles = await collectSourceSfcFiles(path.resolve("src"));
+  const fixtureFiles = runtimeFixtures
+    .map((fixture) => fixture.sourceFile)
+    .sort((left, right) => left.localeCompare(right));
+
+  assert.deepEqual(fixtureFiles, sourceFiles);
+});
+
+test("renders stable, accessible markup across isolated SSR requests", async () => {
+  for (const fixture of runtimeFixtures) {
+    const [left, right] = await Promise.all([renderFixture(fixture), renderFixture(fixture)]);
+    assert.equal(left, right, `${fixture.name} emitted request-dependent SSR markup`);
+    fixture.assertServerMarkup(left);
+  }
+});
+
+test("hydrates every shipped component without warnings or node replacement", async () => {
+  for (const fixture of runtimeFixtures) {
+    const serverHtml = await renderFixture(fixture);
+    const host = document.createElement("div");
+    host.innerHTML = serverHtml;
+    document.body.append(host);
+    const serverRoot = host.firstElementChild;
+    assert.ok(serverRoot, `${fixture.name} did not emit a root element`);
+
+    const diagnostics: string[] = [];
+    const originalWarn = console.warn;
+    const originalError = console.error;
+    console.warn = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+    console.error = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+    const app = createSSRApp(createFixtureRoot(fixture));
+    let mounted = false;
+
+    try {
+      app.mount(host);
+      mounted = true;
+      assert.ok(
+        host.firstElementChild === serverRoot,
+        `${fixture.name} replaced its server-rendered root during hydration`,
+      );
+      assert.deepEqual(diagnostics, [], `${fixture.name} emitted hydration diagnostics`);
+      fixture.assertHydratedDom(host);
+    } finally {
+      if (mounted) app.unmount();
+      host.remove();
+      console.warn = originalWarn;
+      console.error = originalError;
+    }
+  }
+});


### PR DESCRIPTION
## Summary

- compile every source-owned UI SFC through native DOM, SSR, and Vapor renderer lanes
- require an explicit SSR and hydration fixture for every shipped SFC
- verify deterministic concurrent SSR, accessible markup, warning-free hydration, and root-node preservation
- bundle every component family from the root and subpath exports, reject unused family retention, and enforce exact CSS and gzip budgets
- document the deliberate native Vapor SSR non-claim tracked by #3134

## Validation

- vp run --filter ./npm/ui/core check
- vp run --filter ./npm/ui/core test
- vp run --filter ./npm/ui/core lint:sfc
- 61 tests across 12 files
- 15 native compiler conformance compilations
- 10 production consumer tree-shaking bundles

Refs #3134