### PR TITLE
fix(compose): guard abort any reason stability

### DIFF
--- a/npm/compose/core/scripts/check-size.mjs
+++ b/npm/compose/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ const kibibyte = 1024;
 
 /** Per-subpath compressed budgets; every public runtime entry is mandatory. */
 const subpathBudgets = new Map([
-  ["abort-signal.mjs", 2.5 * kibibyte],
+  ["abort-signal.mjs", 3 * kibibyte],
   ["async-resource.mjs", 2 * kibibyte],
   ["capability.mjs", 1 * kibibyte],
   ["disposal-scope.mjs", 2 * kibibyte],

--- a/npm/compose/core/src/abort-signal.test.ts
+++ b/npm/compose/core/src/abort-signal.test.ts
@@ -69,6 +69,24 @@ function withoutNativeAny<Value>(callback: () => Value): Value {
   }
 }
 
+function withNativeAny<Value>(
+  replacement: (signals: AbortSignal[]) => AbortSignal,
+  callback: () => Value,
+): Value {
+  const descriptor = Object.getOwnPropertyDescriptor(AbortSignal, "any");
+  Object.defineProperty(AbortSignal, "any", {
+    configurable: true,
+    value: replacement,
+    writable: true,
+  });
+  try {
+    return callback();
+  } finally {
+    if (descriptor === undefined) delete (AbortSignal as { any?: unknown }).any;
+    else Object.defineProperty(AbortSignal, "any", descriptor);
+  }
+}
+
 void test("returns a distinct, pending signal for empty input", () => {
   const signal = anyAbortSignal([]);
 
@@ -87,6 +105,92 @@ void test("forwards the first abort reason and ignores later inputs", () => {
 
   assert.equal(signal.aborted, true);
   assert.equal(signal.reason, firstReason);
+});
+
+void test("falls back when a lazy native implementation changes the winning reason", () => {
+  let nativeCalls = 0;
+  withNativeAny(
+    (signals) => {
+      nativeCalls += 1;
+      return {
+        get aborted() {
+          return signals.some((signal) => signal.aborted);
+        },
+        get reason() {
+          return signals.find((signal) => signal.aborted)?.reason;
+        },
+      } as AbortSignal;
+    },
+    () => {
+      const late = new AbortController();
+      const winner = new AbortController();
+      const expected = { code: "winner" };
+      const signal = anyAbortSignal([late.signal, winner.signal]);
+
+      winner.abort(expected);
+      late.abort(new Error("too late"));
+
+      assert.equal(signal.reason, expected);
+      assert.equal(nativeCalls, 1, "a rejected native candidate is used only for its probe");
+    },
+  );
+});
+
+void test("caches and delegates a conformant native implementation by identity", () => {
+  let nativeCalls = 0;
+  withNativeAny(
+    (signals) => {
+      nativeCalls += 1;
+      const controller = new AbortController();
+      for (const signal of signals) {
+        const forward = () => controller.abort(signal.reason);
+        if (signal.aborted) {
+          forward();
+          break;
+        }
+        signal.addEventListener("abort", forward, { once: true });
+      }
+      return controller.signal;
+    },
+    () => {
+      const first = new AbortController();
+      const expected = { code: "native" };
+      const firstCombined = anyAbortSignal([first.signal]);
+      first.abort(expected);
+      assert.equal(firstCombined.reason, expected);
+      assert.equal(nativeCalls, 2, "the first call performs one probe and one delegation");
+
+      const second = new AbortController();
+      const secondCombined = anyAbortSignal([second.signal]);
+      second.abort(expected);
+      assert.equal(secondCombined.reason, expected);
+      assert.equal(nativeCalls, 3, "the same function identity is not probed twice");
+    },
+  );
+});
+
+void test("falls back when a native accessor cannot be read", () => {
+  const descriptor = Object.getOwnPropertyDescriptor(AbortSignal, "any");
+  let reads = 0;
+  Object.defineProperty(AbortSignal, "any", {
+    configurable: true,
+    get() {
+      reads += 1;
+      throw new Error("native accessor unavailable");
+    },
+  });
+  try {
+    const controller = new AbortController();
+    const expected = { code: "fallback" };
+    const signal = anyAbortSignal([controller.signal]);
+    controller.abort(expected);
+
+    assert.equal(signal.reason, expected);
+    assert.equal(reads, 1);
+  } finally {
+    if (descriptor === undefined) delete (AbortSignal as { any?: unknown }).any;
+    else Object.defineProperty(AbortSignal, "any", descriptor);
+  }
 });
 
 void test("uses iteration order when multiple inputs are already aborted", () => {

--- a/npm/compose/core/src/abort-signal.ts
+++ b/npm/compose/core/src/abort-signal.ts
@@ -18,7 +18,8 @@
  */
 export function anyAbortSignal(signals: Iterable<AbortSignal>): AbortSignal {
   const inputs = [...signals];
-  if (typeof AbortSignal.any === "function") return AbortSignal.any(inputs);
+  const nativeAny = conformantNativeAbortSignalAny();
+  if (nativeAny !== undefined) return nativeAny.call(AbortSignal, inputs);
 
   const controller = new AbortController();
   const listeners: Array<readonly [AbortSignal, () => void]> = [];
@@ -58,6 +59,44 @@ export function anyAbortSignal(signals: Iterable<AbortSignal>): AbortSignal {
   }
 
   return controller.signal;
+}
+
+let probedNativeAny: unknown;
+let cachedNativeAny: typeof AbortSignal.any | undefined;
+
+/** Resolve the current native implementation only after its first-reason contract passes. */
+function conformantNativeAbortSignalAny(): typeof AbortSignal.any | undefined {
+  let candidate: typeof AbortSignal.any | undefined;
+  try {
+    candidate = Reflect.get(AbortSignal, "any") as typeof AbortSignal.any | undefined;
+  } catch {
+    return undefined;
+  }
+  if (candidate === probedNativeAny) return cachedNativeAny;
+
+  probedNativeAny = candidate;
+  cachedNativeAny =
+    typeof candidate === "function" && nativeAnyReasonIsStable(candidate) ? candidate : undefined;
+  return cachedNativeAny;
+}
+
+/**
+ * Detect runtimes whose combined reason changes when an earlier array member
+ * aborts after the winner. The probe deliberately does not read the reason
+ * until both inputs abort, catching lazy native implementations as well.
+ */
+function nativeAnyReasonIsStable(candidate: typeof AbortSignal.any): boolean {
+  try {
+    const late = new AbortController();
+    const winner = new AbortController();
+    const expected = {};
+    const combined = candidate.call(AbortSignal, [late.signal, winner.signal]);
+    winner.abort(expected);
+    late.abort({});
+    return combined.aborted && combined.reason === expected;
+  } catch {
+    return false;
+  }
 }
 
 /** Options for {@link timeoutAbortSignal}. */


### PR DESCRIPTION
## Summary

- probe the current native AbortSignal.any implementation lazily before delegation
- fall back when a runtime changes the winning reason after a later abort
- cache conformance by function identity and cover broken, conformant, and fallback implementations

## Validation

- pnpm --filter @vizejs/composable check
- pnpm --filter @vizejs/composable test
- reproduced the Node 24.19.0 native regression across 10,000 iterations

Part of #3136.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->