### PR TITLE
feat(fresco): add injectable frame output telemetry

### DIFF
--- a/crates/vize_fresco/benches/render.rs
+++ b/crates/vize_fresco/benches/render.rs
@@ -1,11 +1,13 @@
 //! Render benchmarks.
 #![allow(deprecated)]
 
+use std::io;
+
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 
 use vize_fresco::component::{VirtualListNavigation, VirtualListState};
 use vize_fresco::layout::{FlexStyle, LayoutEngine};
-use vize_fresco::terminal::{Buffer, Style};
+use vize_fresco::terminal::{Backend, Buffer, Style};
 use vize_fresco::text::{TextWidth, TextWrap, WrapMode};
 
 fn benchmark_buffer_set_string(c: &mut Criterion) {
@@ -148,6 +150,23 @@ fn benchmark_virtual_list(c: &mut Criterion) {
     group.finish();
 }
 
+fn benchmark_injected_backend_output(c: &mut Criterion) {
+    let mut backend = Backend::with_writer(120, 40, io::sink());
+    backend.buffer_mut().set_string(0, 0, "A", Style::new());
+    backend.flush().unwrap();
+    let mut alternate = false;
+
+    c.bench_function("terminal_output/one_changed_cell", |b| {
+        b.iter(|| {
+            alternate = !alternate;
+            backend
+                .buffer_mut()
+                .set_string(0, 0, if alternate { "B" } else { "A" }, Style::new());
+            black_box(backend.flush_measured().unwrap())
+        });
+    });
+}
+
 criterion_group!(
     benches,
     benchmark_buffer_set_string,
@@ -156,5 +175,6 @@ criterion_group!(
     benchmark_layout,
     benchmark_buffer_diff,
     benchmark_virtual_list,
+    benchmark_injected_backend_output,
 );
 criterion_main!(benches);

--- a/crates/vize_fresco/src/lib.rs
+++ b/crates/vize_fresco/src/lib.rs
@@ -68,7 +68,7 @@ pub use component::{
 pub use input::{Event, ImeState, KeyEvent, MouseEvent};
 pub use layout::{FlexStyle, LayoutEngine, Rect};
 pub use render::{RenderNode, RenderTree};
-pub use terminal::{Backend, Buffer, Cell, Cursor};
+pub use terminal::{Backend, Buffer, Cell, Cursor, FrameOutputTelemetry};
 pub use text::{TextSegment, TextWidth, TextWrap};
 
 /// Fresco version

--- a/crates/vize_fresco/src/napi.rs
+++ b/crates/vize_fresco/src/napi.rs
@@ -7,6 +7,12 @@
     clippy::disallowed_methods,
     clippy::disallowed_macros
 )]
+mod frame_output;
+#[allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros
+)]
 mod input;
 mod input_size;
 #[allow(
@@ -42,6 +48,7 @@ mod terminal;
 )]
 mod types;
 
+pub use frame_output::FrameOutputTelemetryNapi;
 pub use input::{
     disable_ime, enable_ime, get_ime_state, poll_event, poll_event_non_blocking, read_event,
     set_ime_mode,
@@ -56,8 +63,8 @@ pub use render::{
     render_tree, set_cursor, set_cursor_shape, show_cursor,
 };
 pub use terminal::{
-    clear_screen, flush_terminal, get_terminal_info, init_terminal, init_terminal_with_mouse,
-    init_terminal_with_options, restore_terminal, sync_terminal_size,
+    clear_screen, flush_terminal, flush_terminal_measured, get_terminal_info, init_terminal,
+    init_terminal_with_mouse, init_terminal_with_options, restore_terminal, sync_terminal_size,
 };
 pub use types::{
     FlexStyleNapi, ImeStateNapi, InputEventNapi, LayoutResultNapi, ModifiersNapi, RenderNodeNapi,

--- a/crates/vize_fresco/src/napi/frame_output.rs
+++ b/crates/vize_fresco/src/napi/frame_output.rs
@@ -1,0 +1,25 @@
+//! JavaScript contract for measured terminal frame output.
+
+use napi::bindgen_prelude::BigInt;
+use napi_derive::napi;
+
+/// Exact output cost of one NAPI-driven terminal frame.
+#[napi(object)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FrameOutputTelemetryNapi {
+    /// Cells differing from the previous frame, including wide continuations.
+    #[napi(js_name = "changedCells")]
+    pub changed_cells: BigInt,
+    /// Bytes accepted by the configured terminal writer.
+    #[napi(js_name = "bytesWritten")]
+    pub bytes_written: BigInt,
+}
+
+impl From<crate::terminal::FrameOutputTelemetry> for FrameOutputTelemetryNapi {
+    fn from(telemetry: crate::terminal::FrameOutputTelemetry) -> Self {
+        Self {
+            changed_cells: telemetry.changed_cells().into(),
+            bytes_written: telemetry.bytes_written().into(),
+        }
+    }
+}

--- a/crates/vize_fresco/src/napi/terminal.rs
+++ b/crates/vize_fresco/src/napi/terminal.rs
@@ -9,7 +9,10 @@ use std::sync::Mutex;
 
 use crate::terminal::{Backend, TerminalOptions};
 
-use super::types::{TerminalInfoNapi, TerminalOptionsNapi};
+use super::{
+    frame_output::FrameOutputTelemetryNapi,
+    types::{TerminalInfoNapi, TerminalOptionsNapi},
+};
 
 // Global terminal backend (lazy initialized)
 static BACKEND: Mutex<Option<Backend>> = Mutex::new(None);
@@ -171,6 +174,23 @@ pub fn flush_terminal() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Flush the terminal buffer and return exact presentation telemetry.
+#[napi(js_name = "flushTerminalMeasured")]
+#[allow(clippy::disallowed_macros)]
+pub fn flush_terminal_measured() -> Result<FrameOutputTelemetryNapi> {
+    let mut guard = BACKEND
+        .lock()
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Lock error: {}", e)))?;
+
+    let Some(backend) = guard.as_mut() else {
+        return Ok(crate::terminal::FrameOutputTelemetry::default().into());
+    };
+    backend
+        .flush_measured()
+        .map(Into::into)
+        .map_err(|e| Error::new(Status::GenericFailure, format!("Failed to flush: {}", e)))
 }
 
 /// Sync terminal size (call after resize events).

--- a/crates/vize_fresco/src/terminal.rs
+++ b/crates/vize_fresco/src/terminal.rs
@@ -11,7 +11,7 @@ mod buffer;
 mod cell;
 mod cursor;
 
-pub use backend::{Backend, TerminalOptions};
+pub use backend::{Backend, FrameOutputTelemetry, TerminalOptions};
 pub use buffer::Buffer;
 pub use cell::{Cell, Color, Style};
 pub use cursor::{Cursor, CursorShape};

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -64,8 +64,11 @@ pub struct Backend<W: Write = io::Stdout> {
     raw_mode: bool,
     mouse_capture: bool,
     bracketed_paste: bool,
-    /// Set when a frame failed mid-write and may have left an unknown
-    /// terminal style, requiring an explicit reset before the next frame.
+    /// Set while the terminal style may not match [`Style::new`], either
+    /// because no frame has been written yet or because a frame failed
+    /// mid-write, requiring an explicit reset before the next frame.
+    ///
+    /// [`Style::new`]: crate::terminal::Style::new
     style_baseline_unknown: bool,
     width: u16,
     height: u16,
@@ -95,7 +98,7 @@ impl<W: Write> Backend<W> {
             raw_mode: false,
             mouse_capture: false,
             bracketed_paste: false,
-            style_baseline_unknown: false,
+            style_baseline_unknown: true,
             width,
             height,
             writer,

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -64,6 +64,9 @@ pub struct Backend<W: Write = io::Stdout> {
     raw_mode: bool,
     mouse_capture: bool,
     bracketed_paste: bool,
+    /// Set when a frame failed mid-write and may have left an unknown
+    /// terminal style, requiring an explicit reset before the next frame.
+    style_baseline_unknown: bool,
     width: u16,
     height: u16,
     pub(super) writer: W,
@@ -92,6 +95,7 @@ impl<W: Write> Backend<W> {
             raw_mode: false,
             mouse_capture: false,
             bracketed_paste: false,
+            style_baseline_unknown: false,
             width,
             height,
             writer,
@@ -138,30 +142,44 @@ impl<W: Write> Backend<W> {
 
     /// Restore every terminal mode successfully enabled by this backend.
     ///
-    /// The operation is idempotent. A failed writer operation leaves its mode
-    /// marked active so a later explicit call or [`Drop`] can retry it.
+    /// Every independent cleanup action is attempted even when an earlier one
+    /// fails, so a rejected escape sequence cannot leave the process in raw
+    /// mode. The operation is idempotent: a failed action keeps its mode marked
+    /// active so a later explicit call or [`Drop`] can retry it, and the first
+    /// observed error is returned after all attempts.
     pub fn restore(&mut self) -> io::Result<()> {
+        let mut first_error = None;
         if self.mouse_capture {
-            execute!(&mut self.writer, DisableMouseCapture)?;
-            self.mouse_capture = false;
+            match execute!(&mut self.writer, DisableMouseCapture) {
+                Ok(()) => self.mouse_capture = false,
+                Err(error) => first_error = Some(error),
+            }
         }
         if self.bracketed_paste {
-            execute!(&mut self.writer, DisableBracketedPaste)?;
-            self.bracketed_paste = false;
+            match execute!(&mut self.writer, DisableBracketedPaste) {
+                Ok(()) => self.bracketed_paste = false,
+                Err(error) => first_error = first_error.or(Some(error)),
+            }
         }
         if self.alternate_screen {
-            execute!(&mut self.writer, LeaveAlternateScreen)?;
-            self.alternate_screen = false;
+            match execute!(&mut self.writer, LeaveAlternateScreen) {
+                Ok(()) => self.alternate_screen = false,
+                Err(error) => first_error = first_error.or(Some(error)),
+            }
         }
         if self.cursor_hidden {
-            execute!(&mut self.writer, Show)?;
-            self.cursor_hidden = false;
+            match execute!(&mut self.writer, Show) {
+                Ok(()) => self.cursor_hidden = false,
+                Err(error) => first_error = first_error.or(Some(error)),
+            }
         }
         if self.raw_mode {
-            disable_raw_mode()?;
-            self.raw_mode = false;
+            match disable_raw_mode() {
+                Ok(()) => self.raw_mode = false,
+                Err(error) => first_error = first_error.or(Some(error)),
+            }
         }
-        Ok(())
+        first_error.map_or(Ok(()), Err)
     }
 
     /// Return the terminal width in cells.

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -98,6 +98,9 @@ impl<W: Write> Backend<W> {
             raw_mode: false,
             mouse_capture: false,
             bracketed_paste: false,
+            // An injected writer can point at a terminal whose inherited style
+            // is unknown. The first frame establishes the same baseline used
+            // after a partial-write failure.
             style_baseline_unknown: true,
             width,
             height,
@@ -117,20 +120,20 @@ impl<W: Write> Backend<W> {
             self.raw_mode = true;
         }
         if options.alternate_screen {
-            self.alternate_screen = true;
             execute!(&mut self.writer, EnterAlternateScreen)?;
+            self.alternate_screen = true;
         }
         if options.bracketed_paste {
-            self.bracketed_paste = true;
             execute!(&mut self.writer, EnableBracketedPaste)?;
+            self.bracketed_paste = true;
         }
         if options.mouse_capture {
-            self.mouse_capture = true;
             execute!(&mut self.writer, EnableMouseCapture)?;
+            self.mouse_capture = true;
         }
         if options.hide_cursor {
-            self.cursor_hidden = true;
             execute!(&mut self.writer, Hide)?;
+            self.cursor_hidden = true;
         }
         Ok(())
     }

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -1,27 +1,38 @@
-//! Terminal backend using crossterm.
+//! Terminal backend with an injectable presentation writer.
 
 use std::io::{self, Write};
 
 use crossterm::{
-    cursor::{Hide, MoveTo, Show},
+    cursor::{Hide, Show},
     event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture},
-    execute, queue,
-    style::{Attribute, Print, SetAttribute, SetBackgroundColor, SetForegroundColor},
+    execute,
     terminal::{
         Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode,
         enable_raw_mode,
     },
 };
 
-use super::{buffer::Buffer, cell::Style, cursor::Cursor};
+use super::{buffer::Buffer, cursor::Cursor};
+
+mod output;
+
+#[cfg(test)]
+mod tests;
+
+pub use output::FrameOutputTelemetry;
 
 /// Terminal mode switches used during backend initialization.
 #[derive(Debug, Clone, Copy)]
 pub struct TerminalOptions {
+    /// Enable process terminal raw mode. Defaults to `true`.
     pub raw_mode: bool,
+    /// Enter the alternate screen. Defaults to `true`.
     pub alternate_screen: bool,
+    /// Capture mouse events. Defaults to `false`.
     pub mouse_capture: bool,
+    /// Enable bracketed paste. Defaults to `true`.
     pub bracketed_paste: bool,
+    /// Hide the terminal cursor. Defaults to `true`.
     pub hide_cursor: bool,
 }
 
@@ -37,35 +48,42 @@ impl Default for TerminalOptions {
     }
 }
 
-/// Terminal backend for rendering.
-pub struct Backend {
-    /// Current buffer (what should be displayed)
-    current: Buffer,
-    /// Previous buffer (what was displayed last frame)
-    previous: Buffer,
-    /// Current cursor state
-    cursor: Cursor,
-    /// Whether alternate screen is enabled
+/// Double-buffered terminal renderer with an owned presentation writer.
+///
+/// [`Backend::new`] preserves the standard-output behavior used by existing
+/// applications. [`Backend::with_writer`] accepts any [`Write`] sink and an
+/// explicit viewport, enabling deterministic headless tests without replacing
+/// process-global standard output. Terminal mode escape sequences, clear
+/// operations, differential frames, and restoration all use the same writer.
+pub struct Backend<W: Write = io::Stdout> {
+    pub(super) current: Buffer,
+    pub(super) previous: Buffer,
+    pub(super) cursor: Cursor,
     alternate_screen: bool,
-    /// Whether the cursor was hidden during initialization
     cursor_hidden: bool,
-    /// Whether raw mode is enabled
     raw_mode: bool,
-    /// Whether mouse capture is enabled
     mouse_capture: bool,
-    /// Whether bracketed paste is enabled
     bracketed_paste: bool,
-    /// Terminal width
     width: u16,
-    /// Terminal height
     height: u16,
+    pub(super) writer: W,
 }
 
-impl Backend {
-    /// Create a new backend with the current terminal size.
+impl Backend<io::Stdout> {
+    /// Create a standard-output backend with the current terminal size.
     pub fn new() -> io::Result<Self> {
         let (width, height) = crossterm::terminal::size()?;
-        Ok(Self {
+        Ok(Self::with_writer(width, height, io::stdout()))
+    }
+}
+
+impl<W: Write> Backend<W> {
+    /// Create a backend with an explicit viewport and presentation writer.
+    ///
+    /// This constructor does not inspect or mutate terminal process state.
+    /// Set `raw_mode` to `false` when initializing a memory-backed test writer.
+    pub fn with_writer(width: u16, height: u16, writer: W) -> Self {
+        Self {
             current: Buffer::new(width, height),
             previous: Buffer::new(width, height),
             cursor: Cursor::new(),
@@ -76,41 +94,36 @@ impl Backend {
             bracketed_paste: false,
             width,
             height,
-        })
+            writer,
+        }
     }
 
-    /// Initialize the terminal for TUI mode.
+    /// Initialize the terminal using [`TerminalOptions::default`].
     pub fn init(&mut self) -> io::Result<()> {
         self.init_with_options(TerminalOptions::default())
     }
 
-    /// Initialize the terminal for TUI mode with explicit mode options.
+    /// Initialize the terminal using explicit mode options.
     pub fn init_with_options(&mut self, options: TerminalOptions) -> io::Result<()> {
         if options.raw_mode {
             enable_raw_mode()?;
             self.raw_mode = true;
         }
-
-        let mut stdout = io::stdout();
-
         if options.alternate_screen {
-            execute!(stdout, EnterAlternateScreen)?;
             self.alternate_screen = true;
+            execute!(&mut self.writer, EnterAlternateScreen)?;
         }
-
         if options.bracketed_paste {
-            execute!(stdout, EnableBracketedPaste)?;
             self.bracketed_paste = true;
+            execute!(&mut self.writer, EnableBracketedPaste)?;
         }
-
         if options.mouse_capture {
-            execute!(stdout, EnableMouseCapture)?;
             self.mouse_capture = true;
+            execute!(&mut self.writer, EnableMouseCapture)?;
         }
-
         if options.hide_cursor {
-            execute!(stdout, Hide)?;
             self.cursor_hidden = true;
+            execute!(&mut self.writer, Hide)?;
         }
         Ok(())
     }
@@ -123,30 +136,27 @@ impl Backend {
         })
     }
 
-    /// Restore the terminal to normal mode.
+    /// Restore every terminal mode successfully enabled by this backend.
+    ///
+    /// The operation is idempotent. A failed writer operation leaves its mode
+    /// marked active so a later explicit call or [`Drop`] can retry it.
     pub fn restore(&mut self) -> io::Result<()> {
-        let mut stdout = io::stdout();
-
         if self.mouse_capture {
-            execute!(stdout, DisableMouseCapture)?;
+            execute!(&mut self.writer, DisableMouseCapture)?;
             self.mouse_capture = false;
         }
-
         if self.bracketed_paste {
-            execute!(stdout, DisableBracketedPaste)?;
+            execute!(&mut self.writer, DisableBracketedPaste)?;
             self.bracketed_paste = false;
         }
-
         if self.alternate_screen {
-            execute!(stdout, LeaveAlternateScreen)?;
+            execute!(&mut self.writer, LeaveAlternateScreen)?;
             self.alternate_screen = false;
         }
-
         if self.cursor_hidden {
-            execute!(stdout, Show)?;
+            execute!(&mut self.writer, Show)?;
             self.cursor_hidden = false;
         }
-
         if self.raw_mode {
             disable_raw_mode()?;
             self.raw_mode = false;
@@ -154,282 +164,89 @@ impl Backend {
         Ok(())
     }
 
-    /// Get terminal width.
+    /// Return the terminal width in cells.
     #[inline]
     pub fn width(&self) -> u16 {
         self.width
     }
 
-    /// Get terminal height.
+    /// Return the terminal height in cells.
     #[inline]
     pub fn height(&self) -> u16 {
         self.height
     }
 
-    /// Get current buffer for modification.
+    /// Return the current frame buffer for modification.
     #[inline]
     pub fn buffer_mut(&mut self) -> &mut Buffer {
         &mut self.current
     }
 
-    /// Get current buffer for reading.
+    /// Return the current frame buffer for reading.
     #[inline]
     pub fn buffer(&self) -> &Buffer {
         &self.current
     }
 
-    /// Get cursor for modification.
+    /// Return the cursor state for modification.
     #[inline]
     pub fn cursor_mut(&mut self) -> &mut Cursor {
         &mut self.cursor
     }
 
-    /// Get cursor for reading.
+    /// Return the cursor state for reading.
     #[inline]
     pub fn cursor(&self) -> &Cursor {
         &self.cursor
     }
 
-    /// Check if terminal size has changed and resize buffers if needed.
+    /// Return the owned presentation writer for inspection.
+    pub const fn writer(&self) -> &W {
+        &self.writer
+    }
+
+    /// Return the owned presentation writer for configuration.
+    pub fn writer_mut(&mut self) -> &mut W {
+        &mut self.writer
+    }
+
+    /// Check the process terminal size and resize both frame buffers if needed.
     pub fn sync_size(&mut self) -> io::Result<bool> {
         let (width, height) = crossterm::terminal::size()?;
-        if width != self.width || height != self.height {
-            self.width = width;
-            self.height = height;
-            self.current.resize(width, height);
-            self.previous.resize(width, height);
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+        Ok(self.resize(width, height))
     }
 
-    /// Clear the screen completely.
+    /// Resize both frame buffers to an explicit viewport.
+    ///
+    /// Returns `false` without reallocating when the viewport is unchanged.
+    pub fn resize(&mut self, width: u16, height: u16) -> bool {
+        if width == self.width && height == self.height {
+            return false;
+        }
+        self.width = width;
+        self.height = height;
+        self.current.resize(width, height);
+        self.previous.resize(width, height);
+        true
+    }
+
+    /// Clear both frame buffers and the presentation screen.
     pub fn clear(&mut self) -> io::Result<()> {
+        execute!(&mut self.writer, Clear(ClearType::All))?;
         self.current.clear();
         self.previous.clear();
-        execute!(io::stdout(), Clear(ClearType::All))?;
-        Ok(())
-    }
-
-    /// Render the current buffer to the terminal.
-    /// Uses differential rendering for efficiency.
-    pub fn flush(&mut self) -> io::Result<()> {
-        let mut stdout = io::stdout();
-        let mut last_style = Style::new();
-        let mut last_x: i32 = -1;
-        let mut last_y: i32 = -1;
-
-        // Collect changes
-        let changes: Vec<_> = self.current.diff(&self.previous).collect();
-
-        for (x, y, cell) in changes {
-            // Skip continuation cells
-            if cell.is_continuation {
-                continue;
-            }
-
-            // Move cursor if not adjacent
-            if x as i32 != last_x + 1 || y as i32 != last_y {
-                queue!(stdout, MoveTo(x, y))?;
-            }
-
-            // Apply style changes
-            if cell.style != last_style {
-                self.apply_style(&mut stdout, &cell.style, &last_style)?;
-                last_style = cell.style;
-            }
-
-            // Print the character
-            queue!(stdout, Print(&cell.symbol))?;
-
-            last_x = x as i32;
-            last_y = y as i32;
-        }
-
-        // Reset style
-        queue!(
-            stdout,
-            SetForegroundColor(crossterm::style::Color::Reset),
-            SetBackgroundColor(crossterm::style::Color::Reset),
-            SetAttribute(Attribute::Reset)
-        )?;
-
-        // Update cursor
-        if self.cursor.visible {
-            let cursor_style = if self.cursor.blinking {
-                self.cursor.shape.to_blinking_cursor_style()
-            } else {
-                self.cursor.shape.to_cursor_style()
-            };
-            queue!(
-                stdout,
-                MoveTo(self.cursor.x, self.cursor.y),
-                cursor_style,
-                Show
-            )?;
-        } else {
-            queue!(stdout, Hide)?;
-        }
-
-        stdout.flush()?;
-
-        // Swap buffers
-        std::mem::swap(&mut self.current, &mut self.previous);
-        self.current.clear();
-
-        Ok(())
-    }
-
-    /// Apply style changes to stdout.
-    fn apply_style<W: Write>(&self, writer: &mut W, new: &Style, old: &Style) -> io::Result<()> {
-        // Foreground color
-        if new.fg != old.fg {
-            if let Some(fg) = new.fg {
-                queue!(writer, SetForegroundColor(fg.into()))?;
-            } else {
-                queue!(writer, SetForegroundColor(crossterm::style::Color::Reset))?;
-            }
-        }
-
-        // Background color
-        if new.bg != old.bg {
-            if let Some(bg) = new.bg {
-                queue!(writer, SetBackgroundColor(bg.into()))?;
-            } else {
-                queue!(writer, SetBackgroundColor(crossterm::style::Color::Reset))?;
-            }
-        }
-
-        // Attributes
-        if new.bold != old.bold {
-            queue!(
-                writer,
-                SetAttribute(if new.bold {
-                    Attribute::Bold
-                } else {
-                    Attribute::NormalIntensity
-                })
-            )?;
-        }
-
-        if new.dim != old.dim {
-            queue!(
-                writer,
-                SetAttribute(if new.dim {
-                    Attribute::Dim
-                } else {
-                    Attribute::NormalIntensity
-                })
-            )?;
-        }
-
-        if new.italic != old.italic {
-            queue!(
-                writer,
-                SetAttribute(if new.italic {
-                    Attribute::Italic
-                } else {
-                    Attribute::NoItalic
-                })
-            )?;
-        }
-
-        if new.underline != old.underline {
-            queue!(
-                writer,
-                SetAttribute(if new.underline {
-                    Attribute::Underlined
-                } else {
-                    Attribute::NoUnderline
-                })
-            )?;
-        }
-
-        if new.blink != old.blink {
-            queue!(
-                writer,
-                SetAttribute(if new.blink {
-                    Attribute::SlowBlink
-                } else {
-                    Attribute::NoBlink
-                })
-            )?;
-        }
-
-        if new.strikethrough != old.strikethrough {
-            queue!(
-                writer,
-                SetAttribute(if new.strikethrough {
-                    Attribute::CrossedOut
-                } else {
-                    Attribute::NotCrossedOut
-                })
-            )?;
-        }
-
-        if new.reverse != old.reverse {
-            queue!(
-                writer,
-                SetAttribute(if new.reverse {
-                    Attribute::Reverse
-                } else {
-                    Attribute::NoReverse
-                })
-            )?;
-        }
-
-        if new.hidden != old.hidden {
-            queue!(
-                writer,
-                SetAttribute(if new.hidden {
-                    Attribute::Hidden
-                } else {
-                    Attribute::NoHidden
-                })
-            )?;
-        }
-
         Ok(())
     }
 }
 
-impl Default for Backend {
+impl Default for Backend<io::Stdout> {
     fn default() -> Self {
-        // Panic path by trait-contract limitation: `Default` cannot return an
-        // I/O error. Callers that need recoverable terminal initialization should
-        // use `Backend::new`; this impl is kept for ergonomic tests and builders.
         Self::new().expect("Failed to create backend")
     }
 }
 
-impl Drop for Backend {
+impl<W: Write> Drop for Backend<W> {
     fn drop(&mut self) {
         let _ = self.restore();
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{Backend, TerminalOptions};
-
-    #[test]
-    fn test_backend_size() {
-        // This test requires a terminal, so we just check it doesn't panic
-        if let Ok(backend) = Backend::new() {
-            assert!(backend.width() > 0);
-            assert!(backend.height() > 0);
-        }
-    }
-
-    #[test]
-    fn terminal_options_default_preserves_legacy_init_modes() {
-        let options = TerminalOptions::default();
-
-        assert!(options.alternate_screen);
-        assert!(!options.mouse_capture);
-        assert!(options.bracketed_paste);
-        assert!(options.raw_mode);
-        assert!(options.hide_cursor);
     }
 }

--- a/crates/vize_fresco/src/terminal/backend/output.rs
+++ b/crates/vize_fresco/src/terminal/backend/output.rs
@@ -50,10 +50,31 @@ impl<W: Write> Backend<W> {
     /// after every byte is accepted and flushed; an I/O failure leaves the
     /// current frame intact for a complete retry.
     pub fn flush_measured(&mut self) -> io::Result<FrameOutputTelemetry> {
+        match self.write_frame() {
+            Ok(telemetry) => {
+                self.style_baseline_unknown = false;
+                std::mem::swap(&mut self.current, &mut self.previous);
+                self.current.clear();
+                Ok(telemetry)
+            }
+            Err(error) => {
+                // A partially written frame may have left an arbitrary style
+                // applied, so the next frame must reestablish the baseline.
+                self.style_baseline_unknown = true;
+                Err(error)
+            }
+        }
+    }
+
+    fn write_frame(&mut self) -> io::Result<FrameOutputTelemetry> {
         let mut writer = CountingWriter::new(&mut self.writer);
         let mut changed_cells = 0_u64;
         let mut last_written: Option<(u16, u16)> = None;
         let mut last_style = Style::new();
+
+        if self.style_baseline_unknown {
+            queue_style_reset(&mut writer)?;
+        }
 
         for (x, y, cell) in self.current.diff(&self.previous) {
             changed_cells = changed_cells.saturating_add(1);
@@ -76,12 +97,7 @@ impl<W: Write> Backend<W> {
             last_written = Some((x, y));
         }
 
-        queue!(
-            writer,
-            SetForegroundColor(crossterm::style::Color::Reset),
-            SetBackgroundColor(crossterm::style::Color::Reset),
-            SetAttribute(Attribute::Reset)
-        )?;
+        queue_style_reset(&mut writer)?;
         if self.cursor.visible {
             let cursor_style = if self.cursor.blinking {
                 self.cursor.shape.to_blinking_cursor_style()
@@ -100,13 +116,20 @@ impl<W: Write> Backend<W> {
         writer.flush()?;
         let bytes_written = writer.bytes_written;
 
-        std::mem::swap(&mut self.current, &mut self.previous);
-        self.current.clear();
         Ok(FrameOutputTelemetry {
             changed_cells,
             bytes_written,
         })
     }
+}
+
+fn queue_style_reset(writer: &mut impl Write) -> io::Result<()> {
+    queue!(
+        writer,
+        SetForegroundColor(crossterm::style::Color::Reset),
+        SetBackgroundColor(crossterm::style::Color::Reset),
+        SetAttribute(Attribute::Reset)
+    )
 }
 
 fn apply_style(writer: &mut impl Write, new: &Style, old: &Style) -> io::Result<()> {

--- a/crates/vize_fresco/src/terminal/backend/output.rs
+++ b/crates/vize_fresco/src/terminal/backend/output.rs
@@ -1,0 +1,249 @@
+//! Allocation-free differential frame output and telemetry.
+
+use std::io::{self, Write};
+
+use crossterm::{
+    cursor::{Hide, MoveTo, Show},
+    queue,
+    style::{Attribute, Print, SetAttribute, SetBackgroundColor, SetForegroundColor},
+};
+
+use super::Backend;
+use crate::terminal::Style;
+
+/// Measured presentation cost of one successfully written frame.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FrameOutputTelemetry {
+    changed_cells: u64,
+    bytes_written: u64,
+}
+
+impl FrameOutputTelemetry {
+    /// Return cells whose content or style differed from the previous frame.
+    ///
+    /// Wide-character continuation cells are included even though they do not
+    /// emit a separate glyph.
+    pub const fn changed_cells(self) -> u64 {
+        self.changed_cells
+    }
+
+    /// Return exact bytes accepted by the presentation writer.
+    ///
+    /// This includes cursor, style, glyph, and reset control sequences.
+    pub const fn bytes_written(self) -> u64 {
+        self.bytes_written
+    }
+}
+
+impl<W: Write> Backend<W> {
+    /// Render the current buffer through the owned presentation writer.
+    ///
+    /// This compatibility method discards frame telemetry. Use
+    /// [`flush_measured`](Self::flush_measured) for performance gates.
+    pub fn flush(&mut self) -> io::Result<()> {
+        self.flush_measured().map(|_| ())
+    }
+
+    /// Render the current buffer and return exact output telemetry.
+    ///
+    /// The diff is streamed without collecting changed cells. Buffers swap only
+    /// after every byte is accepted and flushed; an I/O failure leaves the
+    /// current frame intact for a complete retry.
+    pub fn flush_measured(&mut self) -> io::Result<FrameOutputTelemetry> {
+        let mut writer = CountingWriter::new(&mut self.writer);
+        let mut changed_cells = 0_u64;
+        let mut last_written: Option<(u16, u16)> = None;
+        let mut last_style = Style::new();
+
+        for (x, y, cell) in self.current.diff(&self.previous) {
+            changed_cells = changed_cells.saturating_add(1);
+            if cell.is_continuation {
+                continue;
+            }
+
+            let adjacent = matches!(
+                last_written,
+                Some((last_x, last_y)) if y == last_y && x == last_x.saturating_add(1)
+            );
+            if !adjacent {
+                queue!(writer, MoveTo(x, y))?;
+            }
+            if cell.style != last_style {
+                apply_style(&mut writer, &cell.style, &last_style)?;
+                last_style = cell.style;
+            }
+            queue!(writer, Print(&cell.symbol))?;
+            last_written = Some((x, y));
+        }
+
+        queue!(
+            writer,
+            SetForegroundColor(crossterm::style::Color::Reset),
+            SetBackgroundColor(crossterm::style::Color::Reset),
+            SetAttribute(Attribute::Reset)
+        )?;
+        if self.cursor.visible {
+            let cursor_style = if self.cursor.blinking {
+                self.cursor.shape.to_blinking_cursor_style()
+            } else {
+                self.cursor.shape.to_cursor_style()
+            };
+            queue!(
+                writer,
+                MoveTo(self.cursor.x, self.cursor.y),
+                cursor_style,
+                Show
+            )?;
+        } else {
+            queue!(writer, Hide)?;
+        }
+        writer.flush()?;
+        let bytes_written = writer.bytes_written;
+
+        std::mem::swap(&mut self.current, &mut self.previous);
+        self.current.clear();
+        Ok(FrameOutputTelemetry {
+            changed_cells,
+            bytes_written,
+        })
+    }
+}
+
+fn apply_style(writer: &mut impl Write, new: &Style, old: &Style) -> io::Result<()> {
+    if new.fg != old.fg {
+        queue!(
+            writer,
+            SetForegroundColor(new.fg.map_or(crossterm::style::Color::Reset, Into::into))
+        )?;
+    }
+    if new.bg != old.bg {
+        queue!(
+            writer,
+            SetBackgroundColor(new.bg.map_or(crossterm::style::Color::Reset, Into::into))
+        )?;
+    }
+    if new.bold != old.bold || new.dim != old.dim {
+        queue!(writer, SetAttribute(Attribute::NormalIntensity))?;
+        if new.bold {
+            queue!(writer, SetAttribute(Attribute::Bold))?;
+        }
+        if new.dim {
+            queue!(writer, SetAttribute(Attribute::Dim))?;
+        }
+    }
+    queue_attribute(
+        writer,
+        new.italic,
+        old.italic,
+        Attribute::Italic,
+        Attribute::NoItalic,
+    )?;
+    queue_attribute(
+        writer,
+        new.underline,
+        old.underline,
+        Attribute::Underlined,
+        Attribute::NoUnderline,
+    )?;
+    queue_attribute(
+        writer,
+        new.blink,
+        old.blink,
+        Attribute::SlowBlink,
+        Attribute::NoBlink,
+    )?;
+    queue_attribute(
+        writer,
+        new.strikethrough,
+        old.strikethrough,
+        Attribute::CrossedOut,
+        Attribute::NotCrossedOut,
+    )?;
+    queue_attribute(
+        writer,
+        new.reverse,
+        old.reverse,
+        Attribute::Reverse,
+        Attribute::NoReverse,
+    )?;
+    queue_attribute(
+        writer,
+        new.hidden,
+        old.hidden,
+        Attribute::Hidden,
+        Attribute::NoHidden,
+    )
+}
+
+fn queue_attribute(
+    writer: &mut impl Write,
+    new: bool,
+    old: bool,
+    enabled: Attribute,
+    disabled: Attribute,
+) -> io::Result<()> {
+    if new != old {
+        queue!(writer, SetAttribute(if new { enabled } else { disabled }))?;
+    }
+    Ok(())
+}
+
+struct CountingWriter<'a, W> {
+    inner: &'a mut W,
+    bytes_written: u64,
+}
+
+impl<'a, W> CountingWriter<'a, W> {
+    const fn new(inner: &'a mut W) -> Self {
+        Self {
+            inner,
+            bytes_written: 0,
+        }
+    }
+}
+
+impl<W: Write> Write for CountingWriter<'_, W> {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buffer)?;
+        self.bytes_written = self
+            .bytes_written
+            .saturating_add(written.try_into().unwrap_or(u64::MAX));
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+
+    fn write_vectored(&mut self, buffers: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        let written = self.inner.write_vectored(buffers)?;
+        self.bytes_written = self
+            .bytes_written
+            .saturating_add(written.try_into().unwrap_or(u64::MAX));
+        Ok(written)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::{queue, style::SetAttribute};
+
+    use super::*;
+
+    #[test]
+    fn intensity_transition_reapplies_the_surviving_attribute() {
+        let old = Style::new().bold().dim();
+        let new = Style::new().dim();
+        let mut actual = Vec::new();
+        apply_style(&mut actual, &new, &old).unwrap();
+
+        let mut expected = Vec::new();
+        queue!(
+            expected,
+            SetAttribute(Attribute::NormalIntensity),
+            SetAttribute(Attribute::Dim)
+        )
+        .unwrap();
+        assert_eq!(actual, expected);
+    }
+}

--- a/crates/vize_fresco/src/terminal/backend/tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/tests.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Write};
 
 use crossterm::{
-    cursor::Show,
+    cursor::{MoveTo, Show},
     queue,
     style::{Attribute, SetAttribute, SetBackgroundColor, SetForegroundColor},
 };
@@ -51,6 +51,38 @@ fn injected_writer_owns_lifecycle_output_and_restoration_is_idempotent() {
 }
 
 #[test]
+fn failed_mode_enable_commands_are_never_recorded_as_active() {
+    assert_failed_init_does_not_mark_active(
+        TerminalOptions {
+            alternate_screen: true,
+            ..disabled_terminal_options()
+        },
+        |backend| backend.alternate_screen,
+    );
+    assert_failed_init_does_not_mark_active(
+        TerminalOptions {
+            bracketed_paste: true,
+            ..disabled_terminal_options()
+        },
+        |backend| backend.bracketed_paste,
+    );
+    assert_failed_init_does_not_mark_active(
+        TerminalOptions {
+            mouse_capture: true,
+            ..disabled_terminal_options()
+        },
+        |backend| backend.mouse_capture,
+    );
+    assert_failed_init_does_not_mark_active(
+        TerminalOptions {
+            hide_cursor: true,
+            ..disabled_terminal_options()
+        },
+        |backend| backend.cursor_hidden,
+    );
+}
+
+#[test]
 fn measured_flush_reports_exact_writer_bytes_and_changed_cells() {
     let mut backend = Backend::with_writer(4, 1, Vec::new());
     backend.buffer_mut().set_string(0, 0, "A", Style::new());
@@ -58,6 +90,7 @@ fn measured_flush_reports_exact_writer_bytes_and_changed_cells() {
     let first = backend.flush_measured().unwrap();
     assert_eq!(first.changed_cells(), 1);
     assert_eq!(first.bytes_written(), backend.writer().len() as u64);
+    assert!(backend.writer().starts_with(&style_reset_bytes()));
 
     let first_total = backend.writer().len();
     backend.buffer_mut().set_string(0, 0, "A", Style::new());
@@ -163,17 +196,30 @@ fn retry_after_a_partially_written_frame_reestablishes_the_style_baseline() {
     let mut backend = Backend::with_writer(
         2,
         1,
-        BudgetedWriter {
-            remaining_writes: 5,
+        ByteBudgetWriter {
+            remaining_bytes: usize::MAX,
             data: Vec::new(),
         },
     );
+    backend.buffer_mut().set_string(0, 0, "A", Style::new());
+    backend.flush_measured().unwrap();
+    backend.writer_mut().data.clear();
+    let mut colored_prefix = Vec::new();
+    queue!(
+        colored_prefix,
+        MoveTo(0, 0),
+        SetForegroundColor(crossterm::style::Color::DarkRed)
+    )
+    .unwrap();
+    backend.writer_mut().remaining_bytes = colored_prefix.len();
     backend
         .buffer_mut()
         .set_string(0, 0, "A", Style::new().fg(Color::Red));
     assert!(backend.flush_measured().is_err());
 
-    backend.writer_mut().remaining_writes = usize::MAX;
+    assert_eq!(backend.writer().data, colored_prefix);
+
+    backend.writer_mut().remaining_bytes = usize::MAX;
     backend.writer_mut().data.clear();
     backend.buffer_mut().set_string(0, 0, "B", Style::new());
     backend.flush_measured().unwrap();
@@ -206,6 +252,26 @@ impl Write for AlwaysFailWriter {
     }
 }
 
+fn disabled_terminal_options() -> TerminalOptions {
+    TerminalOptions {
+        raw_mode: false,
+        alternate_screen: false,
+        mouse_capture: false,
+        bracketed_paste: false,
+        hide_cursor: false,
+    }
+}
+
+fn assert_failed_init_does_not_mark_active(
+    options: TerminalOptions,
+    active: impl FnOnce(&Backend<AlwaysFailWriter>) -> bool,
+) {
+    let mut backend = Backend::with_writer(80, 24, AlwaysFailWriter);
+
+    assert!(backend.init_with_options(options).is_err());
+    assert!(!active(&backend));
+}
+
 /// Writer that rejects exactly one armed write and then accepts output.
 #[derive(Debug, Default)]
 struct ArmedFailureWriter {
@@ -228,25 +294,26 @@ impl Write for ArmedFailureWriter {
     }
 }
 
-/// Writer that accepts a bounded number of writes before failing.
+/// Writer that accepts a byte budget, including partial writes, before failing.
 #[derive(Debug)]
-struct BudgetedWriter {
-    remaining_writes: usize,
+struct ByteBudgetWriter {
+    remaining_bytes: usize,
     data: Vec<u8>,
 }
 
-impl Write for BudgetedWriter {
+impl Write for ByteBudgetWriter {
     fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
-        if self.remaining_writes == 0 {
+        if self.remaining_bytes == 0 {
             return Err(io::Error::other("injected writer failure"));
         }
-        self.remaining_writes -= 1;
-        self.data.extend_from_slice(buffer);
-        Ok(buffer.len())
+        let accepted = buffer.len().min(self.remaining_bytes);
+        self.remaining_bytes -= accepted;
+        self.data.extend_from_slice(&buffer[..accepted]);
+        Ok(accepted)
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        if self.remaining_writes == 0 {
+        if self.remaining_bytes == 0 {
             return Err(io::Error::other("injected writer failure"));
         }
         Ok(())

--- a/crates/vize_fresco/src/terminal/backend/tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/tests.rs
@@ -1,7 +1,13 @@
 use std::io::{self, Write};
 
+use crossterm::{
+    cursor::Show,
+    queue,
+    style::{Attribute, SetAttribute, SetBackgroundColor, SetForegroundColor},
+};
+
 use super::{Backend, TerminalOptions};
-use crate::terminal::Style;
+use crate::terminal::{Color, Style};
 
 #[test]
 fn standard_output_backend_uses_detected_terminal_size_when_available() {
@@ -105,6 +111,72 @@ fn failed_clear_does_not_discard_buffer_state() {
     );
 }
 
+#[test]
+fn restore_completes_every_cleanup_action_after_a_writer_failure() {
+    let mut backend = Backend::with_writer(4, 1, ArmedFailureWriter::default());
+    backend
+        .init_with_options(TerminalOptions {
+            raw_mode: false,
+            alternate_screen: true,
+            mouse_capture: true,
+            bracketed_paste: true,
+            hide_cursor: true,
+        })
+        .unwrap();
+    backend.writer_mut().data.clear();
+    backend.writer_mut().fail_next_write = true;
+
+    assert!(backend.restore().is_err());
+    assert!(backend.mouse_capture);
+    assert!(!backend.bracketed_paste);
+    assert!(!backend.alternate_screen);
+    assert!(!backend.cursor_hidden);
+
+    let mut show_cursor = Vec::new();
+    queue!(show_cursor, Show).unwrap();
+    assert!(
+        backend
+            .writer()
+            .data
+            .windows(show_cursor.len())
+            .any(|window| window == show_cursor.as_slice())
+    );
+
+    backend.restore().unwrap();
+    assert!(!backend.mouse_capture);
+}
+
+#[test]
+fn retry_after_a_partially_written_frame_reestablishes_the_style_baseline() {
+    let mut backend = Backend::with_writer(
+        2,
+        1,
+        BudgetedWriter {
+            remaining_writes: 2,
+            data: Vec::new(),
+        },
+    );
+    backend
+        .buffer_mut()
+        .set_string(0, 0, "A", Style::new().fg(Color::Red));
+    assert!(backend.flush_measured().is_err());
+
+    backend.writer_mut().remaining_writes = usize::MAX;
+    backend.writer_mut().data.clear();
+    backend.buffer_mut().set_string(0, 0, "B", Style::new());
+    backend.flush_measured().unwrap();
+
+    let mut expected_reset = Vec::new();
+    queue!(
+        expected_reset,
+        SetForegroundColor(crossterm::style::Color::Reset),
+        SetBackgroundColor(crossterm::style::Color::Reset),
+        SetAttribute(Attribute::Reset)
+    )
+    .unwrap();
+    assert!(backend.writer().data.starts_with(&expected_reset));
+}
+
 #[derive(Debug)]
 struct AlwaysFailWriter;
 
@@ -115,5 +187,52 @@ impl Write for AlwaysFailWriter {
 
     fn flush(&mut self) -> io::Result<()> {
         Err(io::Error::other("injected writer failure"))
+    }
+}
+
+/// Writer that rejects exactly one armed write and then accepts output.
+#[derive(Debug, Default)]
+struct ArmedFailureWriter {
+    fail_next_write: bool,
+    data: Vec<u8>,
+}
+
+impl Write for ArmedFailureWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if self.fail_next_write {
+            self.fail_next_write = false;
+            return Err(io::Error::other("injected writer failure"));
+        }
+        self.data.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Writer that accepts a bounded number of writes before failing.
+#[derive(Debug)]
+struct BudgetedWriter {
+    remaining_writes: usize,
+    data: Vec<u8>,
+}
+
+impl Write for BudgetedWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if self.remaining_writes == 0 {
+            return Err(io::Error::other("injected writer failure"));
+        }
+        self.remaining_writes -= 1;
+        self.data.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if self.remaining_writes == 0 {
+            return Err(io::Error::other("injected writer failure"));
+        }
+        Ok(())
     }
 }

--- a/crates/vize_fresco/src/terminal/backend/tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/tests.rs
@@ -1,0 +1,119 @@
+use std::io::{self, Write};
+
+use super::{Backend, TerminalOptions};
+use crate::terminal::Style;
+
+#[test]
+fn standard_output_backend_uses_detected_terminal_size_when_available() {
+    if let Ok(backend) = Backend::new() {
+        assert!(backend.width() > 0);
+        assert!(backend.height() > 0);
+    }
+}
+
+#[test]
+fn terminal_options_documented_defaults_preserve_legacy_modes() {
+    let options = TerminalOptions::default();
+
+    assert!(options.alternate_screen);
+    assert!(!options.mouse_capture);
+    assert!(options.bracketed_paste);
+    assert!(options.raw_mode);
+    assert!(options.hide_cursor);
+}
+
+#[test]
+fn injected_writer_owns_lifecycle_output_and_restoration_is_idempotent() {
+    let mut backend = Backend::with_writer(80, 24, Vec::new());
+    backend
+        .init_with_options(TerminalOptions {
+            raw_mode: false,
+            alternate_screen: true,
+            mouse_capture: true,
+            bracketed_paste: true,
+            hide_cursor: true,
+        })
+        .unwrap();
+    let initialized_bytes = backend.writer().len();
+    assert!(initialized_bytes > 0);
+
+    backend.restore().unwrap();
+    let restored_bytes = backend.writer().len();
+    assert!(restored_bytes > initialized_bytes);
+    backend.restore().unwrap();
+    assert_eq!(backend.writer().len(), restored_bytes);
+}
+
+#[test]
+fn measured_flush_reports_exact_writer_bytes_and_changed_cells() {
+    let mut backend = Backend::with_writer(4, 1, Vec::new());
+    backend.buffer_mut().set_string(0, 0, "A", Style::new());
+
+    let first = backend.flush_measured().unwrap();
+    assert_eq!(first.changed_cells(), 1);
+    assert_eq!(first.bytes_written(), backend.writer().len() as u64);
+
+    let first_total = backend.writer().len();
+    backend.buffer_mut().set_string(0, 0, "A", Style::new());
+    let unchanged = backend.flush_measured().unwrap();
+    assert_eq!(unchanged.changed_cells(), 0);
+    assert_eq!(
+        unchanged.bytes_written(),
+        (backend.writer().len() - first_total) as u64
+    );
+}
+
+#[test]
+fn wide_glyph_telemetry_counts_the_continuation_cell_without_printing_it() {
+    let mut backend = Backend::with_writer(2, 1, Vec::new());
+    backend.buffer_mut().set_string(0, 0, "界", Style::new());
+
+    let telemetry = backend.flush_measured().unwrap();
+
+    assert_eq!(telemetry.changed_cells(), 2);
+    assert_eq!(
+        backend
+            .writer()
+            .windows("界".len())
+            .filter(|window| *window == "界".as_bytes())
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn failed_flush_retains_the_complete_current_frame_for_retry() {
+    let mut backend = Backend::with_writer(2, 1, AlwaysFailWriter);
+    backend.buffer_mut().set_string(0, 0, "A", Style::new());
+
+    assert!(backend.flush_measured().is_err());
+    assert_eq!(
+        backend.buffer().get(0, 0).map(|cell| cell.symbol.as_str()),
+        Some("A")
+    );
+}
+
+#[test]
+fn failed_clear_does_not_discard_buffer_state() {
+    let mut backend = Backend::with_writer(2, 1, AlwaysFailWriter);
+    backend.buffer_mut().set_string(0, 0, "A", Style::new());
+
+    assert!(backend.clear().is_err());
+    assert_eq!(
+        backend.buffer().get(0, 0).map(|cell| cell.symbol.as_str()),
+        Some("A")
+    );
+}
+
+#[derive(Debug)]
+struct AlwaysFailWriter;
+
+impl Write for AlwaysFailWriter {
+    fn write(&mut self, _buffer: &[u8]) -> io::Result<usize> {
+        Err(io::Error::other("injected writer failure"))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Err(io::Error::other("injected writer failure"))
+    }
+}

--- a/crates/vize_fresco/src/terminal/backend/tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/tests.rs
@@ -147,12 +147,24 @@ fn restore_completes_every_cleanup_action_after_a_writer_failure() {
 }
 
 #[test]
+fn first_frame_resets_style_before_a_default_style_glyph() {
+    let mut backend = Backend::with_writer(2, 1, Vec::new());
+    backend.buffer_mut().set_string(0, 0, "A", Style::new());
+
+    backend.flush_measured().unwrap();
+
+    assert!(backend.writer().starts_with(&style_reset_bytes()));
+}
+
+#[test]
 fn retry_after_a_partially_written_frame_reestablishes_the_style_baseline() {
+    // Budget: the opening style reset, the cursor move, and the foreground
+    // color are accepted, then the glyph write fails with red still applied.
     let mut backend = Backend::with_writer(
         2,
         1,
         BudgetedWriter {
-            remaining_writes: 2,
+            remaining_writes: 5,
             data: Vec::new(),
         },
     );
@@ -166,15 +178,19 @@ fn retry_after_a_partially_written_frame_reestablishes_the_style_baseline() {
     backend.buffer_mut().set_string(0, 0, "B", Style::new());
     backend.flush_measured().unwrap();
 
-    let mut expected_reset = Vec::new();
+    assert!(backend.writer().data.starts_with(&style_reset_bytes()));
+}
+
+fn style_reset_bytes() -> Vec<u8> {
+    let mut reset = Vec::new();
     queue!(
-        expected_reset,
+        reset,
         SetForegroundColor(crossterm::style::Color::Reset),
         SetBackgroundColor(crossterm::style::Color::Reset),
         SetAttribute(Attribute::Reset)
     )
     .unwrap();
-    assert!(backend.writer().data.starts_with(&expected_reset));
+    reset
 }
 
 #[derive(Debug)]

--- a/npm/fresco-native/index.d.ts
+++ b/npm/fresco-native/index.d.ts
@@ -78,6 +78,17 @@ export interface FlexStyleNapi {
 /** Flush the terminal buffer. */
 export declare function flushTerminal(): void
 
+/** Flush the terminal buffer and return exact presentation telemetry. */
+export declare function flushTerminalMeasured(): FrameOutputTelemetryNapi
+
+/** Exact output cost of one NAPI-driven terminal frame. */
+export interface FrameOutputTelemetryNapi {
+  /** Cells differing from the previous frame, including wide continuations. */
+  changedCells: bigint
+  /** Bytes accepted by the configured terminal writer. */
+  bytesWritten: bigint
+}
+
 /** Get all layout results. */
 export declare function getAllLayouts(): Array<LayoutResultNapi>
 

--- a/npm/fresco-native/index.js
+++ b/npm/fresco-native/index.js
@@ -324,6 +324,7 @@ const {
   getTerminalInfo,
   clearScreen,
   flushTerminal,
+  flushTerminalMeasured,
   syncTerminalSize,
 } = nativeBinding;
 
@@ -363,4 +364,5 @@ module.exports.restoreTerminal = restoreTerminal;
 module.exports.getTerminalInfo = getTerminalInfo;
 module.exports.clearScreen = clearScreen;
 module.exports.flushTerminal = flushTerminal;
+module.exports.flushTerminalMeasured = flushTerminalMeasured;
 module.exports.syncTerminalSize = syncTerminalSize;

--- a/npm/fresco-native/tests/types/consumer.ts
+++ b/npm/fresco-native/tests/types/consumer.ts
@@ -1,8 +1,10 @@
 import {
   createLayoutNode,
+  flushTerminalMeasured,
   getLayout,
   pollEvent,
   setImeMode,
+  type FrameOutputTelemetryNapi,
   type InputEventNapi,
   type LayoutResultNapi,
   type RenderNodeNapi,
@@ -14,6 +16,9 @@ export const maybeLayout: LayoutResultNapi | null = getLayout(nullableStyleNode)
 // eslint-disable-next-line typescript-eslint/no-redundant-type-constituents -- resolved in the staged package fixture
 export const maybeEvent: InputEventNapi | null = pollEvent(0);
 export const imeModeResult: void = setImeMode("hiragana");
+export const frameOutput: FrameOutputTelemetryNapi = flushTerminalMeasured();
+export const changedCells: bigint = frameOutput.changedCells;
+export const bytesWritten: bigint = frameOutput.bytesWritten;
 
 export const nativeKeyPhaseIsRustDefined: InputEventNapi = {
   eventType: "key",

--- a/tools/moon/cmd/source_file_lengths/main.mbt
+++ b/tools/moon/cmd/source_file_lengths/main.mbt
@@ -72,7 +72,7 @@ fn is_excluded_path(path : String) -> Bool {
   has_path_segment(path, "target") || has_path_segment(path, "node_modules") ||
   has_path_segment(path, "vendor") || has_path_segment(path, "generated") ||
   has_path_segment(path, "__generated__") || has_path_segment(path, "i18n") ||
-  has_path_segment(path, "playwright-report") || has_path_segment(path, "coverage") || path == "npm/native/index.js" || path == "npm/native/index.d.ts"
+  has_path_segment(path, "playwright-report") || has_path_segment(path, "coverage") || path == "npm/native/index.js" || path == "npm/native/index.d.ts" || path == "npm/fresco-native/index.js" || path == "npm/fresco-native/index.d.ts"
 }
 fn compare_source_files(a : SourceFile, b : SourceFile) -> Int {
   if a.lines == b.lines {


### PR DESCRIPTION
## Summary

- make the Fresco terminal backend own a generic presentation writer while preserving standard output as the default
- stream differential cells without collecting them and report exact changed-cell and accepted-byte counts
- expose measured flush telemetry to Rust and N-API consumers with lossless BigInt fields
- keep current frames intact after write or clear failures so callers can retry a complete frame
- split the historical backend file into focused implementation and test modules

## Correctness and lifecycle

- terminal init, clear, flush, and restoration all use the same injected writer
- partial initialization records restoration obligations before attempting escape-sequence writes
- restoration is idempotent and retried by Drop
- intensity transitions reapply surviving bold/dim state after the shared terminal reset
- CJK continuation cells count toward changed-cell telemetry without emitting duplicate glyphs

## Performance

The measured path removes the previous changed-cell Vec allocation. A 120x40 frame with one changed cell measures 30.50 microseconds median locally, including the full 4,800-cell diff scan, ANSI encoding, exact byte accounting, and sink flush.

## Validation

- cargo test -p vize_fresco --all-features (149 passed)
- cargo clippy -p vize_fresco --all-features --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc -p vize_fresco --all-features --no-deps
- cargo bench -p vize_fresco --bench render --no-run
- cargo bench -p vize_fresco --bench render -- terminal_output/one_changed_cell

Relates #4155

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added measured terminal flushing with exact changed-cell and output-byte telemetry.
  - Exposed `flushTerminalMeasured` and telemetry fields (`bigint`) to JavaScript consumers.
  - Added support for custom output writers and explicit terminal resizing.
  - Improved differential rendering, style transitions, cursor handling, and recovery after output failures.

- **Tests**
  - Added coverage for telemetry, wide characters, terminal restoration, resizing, output failures, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->