### PR TITLE
feat(doctor): add provider-neutral AI context packets

### DIFF
--- a/crates/vize_doctor/benches/reporter.rs
+++ b/crates/vize_doctor/benches/reporter.rs
@@ -2,10 +2,11 @@ use std::{hint::black_box, io};
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use vize_doctor::{
-    AnalysisProvenance, DoctorCategory, DoctorFinding, DoctorReport, DoctorReporter,
-    FindingAssessment, FindingConfidence, FindingImpact, FindingSeverity, HealthPenalty,
-    JsonReporter, ReporterAudience, ReporterCapability, ReporterDescriptor, ReporterError,
-    ReporterOutput, ReporterTransport, RuleCost, SourceLocation, render_report,
+    AiContextBudget, AnalysisProvenance, DoctorCategory, DoctorFinding, DoctorReport,
+    DoctorReporter, FindingAssessment, FindingConfidence, FindingImpact, FindingSeverity,
+    HealthPenalty, JsonReporter, ReporterAudience, ReporterCapability, ReporterDescriptor,
+    ReporterError, ReporterOutput, ReporterTransport, RuleCost, SourceLocation, build_ai_context,
+    render_report,
 };
 
 struct EmptyReporter {
@@ -74,6 +75,39 @@ fn benchmark_json_reporter(c: &mut Criterion) {
     group.finish();
 }
 
+fn benchmark_ai_context(c: &mut Criterion) {
+    let source = "x".repeat(20_000);
+    let mut group = c.benchmark_group("doctor_ai_context/build");
+
+    for finding_count in [1, 100, 1_000] {
+        let report = report_with_findings(finding_count);
+        let finding_count_u64 = finding_count as u64;
+        let budget = AiContextBudget {
+            max_findings: finding_count_u64,
+            max_source_snippets: finding_count_u64,
+            max_source_bytes: finding_count_u64.saturating_mul(256),
+            max_source_bytes_per_snippet: 256,
+            ..AiContextBudget::default()
+        };
+        group.throughput(Throughput::Elements(finding_count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(finding_count),
+            &report,
+            |b, report| {
+                b.iter(|| {
+                    build_ai_context(
+                        black_box(report),
+                        [("src/Benchmark.vue", black_box(source.as_str()))],
+                        black_box(budget),
+                    )
+                    .unwrap()
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
 fn report_with_findings(finding_count: usize) -> DoctorReport {
     DoctorReport::new(
         "benchmark",
@@ -99,6 +133,7 @@ fn report_with_findings(finding_count: usize) -> DoctorReport {
 criterion_group!(
     reporter_benches,
     benchmark_reporter_contract,
-    benchmark_json_reporter
+    benchmark_json_reporter,
+    benchmark_ai_context
 );
 criterion_main!(reporter_benches);

--- a/crates/vize_doctor/src/ai_context.rs
+++ b/crates/vize_doctor/src/ai_context.rs
@@ -1,0 +1,24 @@
+//! Provider-neutral, budgeted context packets for AI consumers.
+//!
+//! The packet contract deliberately contains no vendor SDK types, prompt
+//! syntax, timestamps, process identifiers, or terminal text. Connectors can
+//! serialize the same packet into any model API while retaining stable source,
+//! evidence, edit-safety, and verification semantics.
+//! Packets are untrusted data: connectors must not execute edit plans or
+//! verification commands without the caller's explicit authorization.
+
+mod builder;
+mod contract;
+mod snippet;
+mod validation;
+
+#[cfg(test)]
+mod tests;
+
+pub use builder::build_ai_context;
+pub use contract::{
+    AiContextBudget, AiContextOmissions, AiContextPacket, AiEditOperation, AiEditPlan,
+    AiEvidenceEdge, AiEvidenceGraph, AiEvidenceNode, AiEvidenceNodeKind, AiEvidenceRelation,
+    AiFindingContext, AiSourceSnippet, AiVerificationStep, DOCTOR_AI_CONTEXT_FORMAT_VERSION,
+};
+pub use validation::AiContextError;

--- a/crates/vize_doctor/src/ai_context/builder.rs
+++ b/crates/vize_doctor/src/ai_context/builder.rs
@@ -1,0 +1,339 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use vize_carton::{String, cstr};
+
+use crate::{DoctorFinding, DoctorReport, SourceLocation};
+
+use super::{
+    contract::{
+        AiContextBudget, AiContextOmissions, AiContextPacket, AiEditOperation, AiEditPlan,
+        AiEvidenceEdge, AiEvidenceGraph, AiEvidenceNode, AiEvidenceNodeKind, AiEvidenceRelation,
+        AiFindingContext, AiSourceSnippet, AiVerificationStep, DOCTOR_AI_CONTEXT_FORMAT_VERSION,
+    },
+    snippet::extract_source_snippet,
+    validation::AiContextError,
+};
+
+/// Build a deterministic, provider-neutral AI context packet.
+///
+/// `sources` maps workspace-relative paths to complete UTF-8 source text. The
+/// builder never reads the filesystem, environment, or terminal, which lets
+/// editors, CI workers, remote caches, and in-memory analyzers supply source
+/// through the same API. Duplicate paths are rejected rather than resolved by
+/// input order.
+pub fn build_ai_context<'a>(
+    report: &DoctorReport,
+    sources: impl IntoIterator<Item = (&'a str, &'a str)>,
+    budget: AiContextBudget,
+) -> Result<AiContextPacket, AiContextError> {
+    let mut source_by_path = BTreeMap::new();
+    for (path, source) in sources {
+        if source_by_path.insert(path, source).is_some() {
+            return Err(AiContextError::DuplicateSourcePath(path.into()));
+        }
+    }
+
+    let max_findings = runtime_limit(budget.max_findings);
+    let mut builder = PacketBuilder::new(report, source_by_path, budget);
+    for (rank, finding) in report.findings().iter().take(max_findings).enumerate() {
+        builder.add_finding(rank, finding);
+    }
+    builder.omissions.dropped_findings = report
+        .findings()
+        .len()
+        .saturating_sub(max_findings)
+        .try_into()
+        .unwrap_or(u64::MAX);
+    builder.finish()
+}
+
+struct PacketBuilder<'a> {
+    report: &'a DoctorReport,
+    source_by_path: BTreeMap<&'a str, &'a str>,
+    budget: AiContextBudget,
+    findings: Vec<AiFindingContext>,
+    graph: AiEvidenceGraph,
+    snippets: Vec<AiSourceSnippet>,
+    snippet_ids: BTreeMap<SourceLocation, String>,
+    requested_locations: BTreeSet<SourceLocation>,
+    missing_paths: BTreeSet<String>,
+    source_bytes: usize,
+    edit_plans: Vec<AiEditPlan>,
+    edit_bytes: usize,
+    verification_bytes: usize,
+    omissions: AiContextOmissions,
+}
+
+impl<'a> PacketBuilder<'a> {
+    fn new(
+        report: &'a DoctorReport,
+        source_by_path: BTreeMap<&'a str, &'a str>,
+        budget: AiContextBudget,
+    ) -> Self {
+        Self {
+            report,
+            source_by_path,
+            budget,
+            findings: Vec::new(),
+            graph: AiEvidenceGraph::default(),
+            snippets: Vec::new(),
+            snippet_ids: BTreeMap::new(),
+            requested_locations: BTreeSet::new(),
+            missing_paths: BTreeSet::new(),
+            source_bytes: 0,
+            edit_plans: Vec::new(),
+            edit_bytes: 0,
+            verification_bytes: 0,
+            omissions: AiContextOmissions::default(),
+        }
+    }
+
+    fn add_finding(&mut self, rank: usize, finding: &DoctorFinding) {
+        let finding_id = cstr!("finding:{rank}");
+        let root_id = finding_id.clone();
+        self.graph.nodes.push(AiEvidenceNode {
+            id: root_id.clone(),
+            finding_id: finding_id.clone(),
+            kind: AiEvidenceNodeKind::Finding,
+            evidence_kind: None,
+            summary: finding.title.clone(),
+            location: Some(finding.primary.clone()),
+            details: BTreeMap::new(),
+        });
+
+        let mut source_candidates = vec![finding.primary.clone()];
+        self.add_evidence_nodes(&finding_id, finding, &mut source_candidates);
+        self.add_related_nodes(&finding_id, finding, &mut source_candidates);
+        let edit_plan_id = self.add_edit_plan(&finding_id, finding, &mut source_candidates);
+
+        let mut source_snippet_ids = Vec::new();
+        let mut retained_source_ids = BTreeSet::new();
+        for location in source_candidates {
+            if let Some(id) = self.add_source_snippet(&location)
+                && retained_source_ids.insert(id.clone())
+            {
+                source_snippet_ids.push(id);
+            }
+        }
+
+        self.findings.push(AiFindingContext {
+            id: finding_id,
+            baseline_key: finding.baseline_key(),
+            code: finding.code.clone(),
+            category: finding.category,
+            assessment: finding.assessment.clone(),
+            primary: finding.primary.clone(),
+            title: finding.title.clone(),
+            message: finding.message.clone(),
+            failure_scenario: finding.failure_scenario.clone(),
+            documentation: finding.documentation.clone(),
+            context: finding.context.clone(),
+            provenance: finding.provenance.clone(),
+            suppression: finding.suppression,
+            evidence_root_id: root_id,
+            source_snippet_ids,
+            edit_plan_id,
+        });
+    }
+
+    fn add_evidence_nodes(
+        &mut self,
+        finding_id: &String,
+        finding: &DoctorFinding,
+        source_candidates: &mut Vec<SourceLocation>,
+    ) {
+        let retained = finding
+            .evidence
+            .len()
+            .min(runtime_limit(self.budget.max_evidence_per_finding));
+        add_omission(
+            &mut self.omissions.dropped_evidence_nodes,
+            finding.evidence.len() - retained,
+        );
+        for (index, evidence) in finding.evidence.iter().take(retained).enumerate() {
+            let node_id = cstr!("{finding_id}:evidence:{index}");
+            self.graph.nodes.push(AiEvidenceNode {
+                id: node_id.clone(),
+                finding_id: finding_id.clone(),
+                kind: AiEvidenceNodeKind::Evidence,
+                evidence_kind: Some(evidence.kind),
+                summary: evidence.summary.clone(),
+                location: evidence.location.clone(),
+                details: evidence.details.clone(),
+            });
+            self.graph.edges.push(AiEvidenceEdge {
+                from: finding_id.clone(),
+                to: node_id,
+                relation: AiEvidenceRelation::Supports,
+            });
+            if let Some(location) = &evidence.location {
+                source_candidates.push(location.clone());
+            }
+        }
+    }
+
+    fn add_related_nodes(
+        &mut self,
+        finding_id: &String,
+        finding: &DoctorFinding,
+        source_candidates: &mut Vec<SourceLocation>,
+    ) {
+        let retained = finding
+            .related
+            .len()
+            .min(runtime_limit(self.budget.max_related_per_finding));
+        add_omission(
+            &mut self.omissions.dropped_related_nodes,
+            finding.related.len() - retained,
+        );
+        for (index, related) in finding.related.iter().take(retained).enumerate() {
+            let node_id = cstr!("{finding_id}:related:{index}");
+            self.graph.nodes.push(AiEvidenceNode {
+                id: node_id.clone(),
+                finding_id: finding_id.clone(),
+                kind: AiEvidenceNodeKind::RelatedLocation,
+                evidence_kind: None,
+                summary: related.message.clone(),
+                location: Some(related.location.clone()),
+                details: BTreeMap::new(),
+            });
+            self.graph.edges.push(AiEvidenceEdge {
+                from: finding_id.clone(),
+                to: node_id,
+                relation: AiEvidenceRelation::Related,
+            });
+            source_candidates.push(related.location.clone());
+        }
+    }
+
+    fn add_edit_plan(
+        &mut self,
+        finding_id: &String,
+        finding: &DoctorFinding,
+        source_candidates: &mut Vec<SourceLocation>,
+    ) -> Option<String> {
+        let fix = finding.fix.as_ref()?;
+        let plan_id = cstr!("{finding_id}:edit-plan");
+        let mut operations = Vec::new();
+        let retained_edits = fix
+            .edits
+            .len()
+            .min(runtime_limit(self.budget.max_edits_per_finding));
+        add_omission(
+            &mut self.omissions.dropped_edit_operations,
+            fix.edits.len() - retained_edits,
+        );
+        for edit in fix.edits.iter().take(retained_edits) {
+            let replacement_bytes = edit.replacement.len();
+            if replacement_bytes
+                > runtime_limit(self.budget.max_edit_bytes).saturating_sub(self.edit_bytes)
+            {
+                self.omissions.dropped_edit_operations =
+                    self.omissions.dropped_edit_operations.saturating_add(1);
+                continue;
+            }
+            self.edit_bytes += replacement_bytes;
+            source_candidates.push(edit.location.clone());
+            operations.push(AiEditOperation {
+                location: edit.location.clone(),
+                replacement: edit.replacement.clone(),
+            });
+        }
+
+        let mut verification = Vec::new();
+        let retained_steps = fix.verification.len().min(runtime_limit(
+            self.budget.max_verification_steps_per_finding,
+        ));
+        add_omission(
+            &mut self.omissions.dropped_verification_steps,
+            fix.verification.len() - retained_steps,
+        );
+        for command in fix.verification.iter().take(retained_steps) {
+            let command_bytes = command.len();
+            if command_bytes
+                > self
+                    .budget
+                    .max_verification_bytes
+                    .try_into()
+                    .unwrap_or(usize::MAX)
+                    .saturating_sub(self.verification_bytes)
+            {
+                self.omissions.dropped_verification_steps =
+                    self.omissions.dropped_verification_steps.saturating_add(1);
+                continue;
+            }
+            self.verification_bytes += command_bytes;
+            verification.push(AiVerificationStep {
+                command: command.clone(),
+                expected_exit_code: 0,
+            });
+        }
+
+        self.edit_plans.push(AiEditPlan {
+            id: plan_id.clone(),
+            finding_id: finding_id.clone(),
+            safety: fix.safety,
+            title: fix.title.clone(),
+            operations,
+            verification,
+        });
+        Some(plan_id)
+    }
+
+    fn add_source_snippet(&mut self, location: &SourceLocation) -> Option<String> {
+        if let Some(id) = self.snippet_ids.get(location) {
+            return Some(id.clone());
+        }
+        if !self.requested_locations.insert(location.clone()) {
+            return None;
+        }
+        let Some(source) = self.source_by_path.get(location.path.as_str()).copied() else {
+            self.missing_paths.insert(location.path.clone());
+            return None;
+        };
+        if self.snippets.len() >= runtime_limit(self.budget.max_source_snippets) {
+            self.omissions.dropped_source_snippets =
+                self.omissions.dropped_source_snippets.saturating_add(1);
+            return None;
+        }
+        let remaining =
+            runtime_limit(self.budget.max_source_bytes).saturating_sub(self.source_bytes);
+        let max_bytes = remaining.min(runtime_limit(self.budget.max_source_bytes_per_snippet));
+        let id = cstr!("source:{}", self.snippets.len());
+        let Some(snippet) = extract_source_snippet(id.clone(), location, source, max_bytes) else {
+            self.omissions.dropped_source_snippets =
+                self.omissions.dropped_source_snippets.saturating_add(1);
+            return None;
+        };
+        self.source_bytes += snippet.text.len();
+        self.snippet_ids.insert(location.clone(), id.clone());
+        self.snippets.push(snippet);
+        Some(id)
+    }
+
+    fn finish(mut self) -> Result<AiContextPacket, AiContextError> {
+        self.omissions.missing_source_paths = self.missing_paths.into_iter().collect();
+        let packet = AiContextPacket {
+            format_version: DOCTOR_AI_CONTEXT_FORMAT_VERSION,
+            report_format_version: self.report.format_version(),
+            scoring_version: self.report.scoring_version(),
+            workspace: self.report.workspace().into(),
+            budget: self.budget,
+            findings: self.findings,
+            evidence_graph: self.graph,
+            source_snippets: self.snippets,
+            edit_plans: self.edit_plans,
+            omissions: self.omissions,
+        };
+        packet.validate()?;
+        Ok(packet)
+    }
+}
+
+fn runtime_limit(limit: u64) -> usize {
+    limit.try_into().unwrap_or(usize::MAX)
+}
+
+fn add_omission(total: &mut u64, count: usize) {
+    *total = total.saturating_add(count.try_into().unwrap_or(u64::MAX));
+}

--- a/crates/vize_doctor/src/ai_context/contract.rs
+++ b/crates/vize_doctor/src/ai_context/contract.rs
@@ -1,0 +1,338 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use vize_carton::String;
+
+use crate::{
+    AnalysisProvenance, DoctorCategory, EvidenceKind, FindingAssessment, FindingContext, FixSafety,
+    SourceLocation, SuppressionPolicy,
+};
+
+/// Current serialized provider-neutral AI context format.
+pub const DOCTOR_AI_CONTEXT_FORMAT_VERSION: u32 = 1;
+
+/// Hard limits applied while constructing an [`AiContextPacket`].
+///
+/// Limits are evaluated in deterministic report order, so higher-ranked
+/// findings receive context first. A zero value intentionally disables that
+/// resource. Source, replacement, and command byte limits count UTF-8 bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AiContextBudget {
+    /// Maximum findings. Defaults to 32.
+    pub max_findings: u64,
+    /// Maximum evidence facts retained for each finding. Defaults to 8.
+    pub max_evidence_per_finding: u64,
+    /// Maximum related locations retained for each finding. Defaults to 8.
+    pub max_related_per_finding: u64,
+    /// Maximum distinct source snippets in the packet. Defaults to 64.
+    pub max_source_snippets: u64,
+    /// Maximum combined source-snippet bytes. Defaults to 128 KiB.
+    pub max_source_bytes: u64,
+    /// Maximum bytes in one source snippet. Defaults to 4 KiB.
+    pub max_source_bytes_per_snippet: u64,
+    /// Maximum edit operations retained for each finding. Defaults to 16.
+    pub max_edits_per_finding: u64,
+    /// Maximum combined replacement-source bytes. Defaults to 64 KiB.
+    pub max_edit_bytes: u64,
+    /// Maximum verification steps retained for each finding. Defaults to 16.
+    pub max_verification_steps_per_finding: u64,
+    /// Maximum combined verification-command bytes. Defaults to 16 KiB.
+    pub max_verification_bytes: u64,
+}
+
+impl Default for AiContextBudget {
+    fn default() -> Self {
+        Self {
+            max_findings: 32,
+            max_evidence_per_finding: 8,
+            max_related_per_finding: 8,
+            max_source_snippets: 64,
+            max_source_bytes: 128 * 1024,
+            max_source_bytes_per_snippet: 4 * 1024,
+            max_edits_per_finding: 16,
+            max_edit_bytes: 64 * 1024,
+            max_verification_steps_per_finding: 16,
+            max_verification_bytes: 16 * 1024,
+        }
+    }
+}
+
+/// Counts and paths explaining information omitted by packet budgets.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AiContextOmissions {
+    /// Lower-ranked findings excluded by `max_findings`.
+    pub dropped_findings: u64,
+    /// Evidence facts excluded by per-finding limits.
+    pub dropped_evidence_nodes: u64,
+    /// Related locations excluded by per-finding limits.
+    pub dropped_related_nodes: u64,
+    /// Distinct source requests excluded by count or byte limits.
+    pub dropped_source_snippets: u64,
+    /// Sorted source paths requested by findings but absent from input sources.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub missing_source_paths: Vec<String>,
+    /// Whole edit operations omitted by edit count or byte limits.
+    pub dropped_edit_operations: u64,
+    /// Whole verification steps omitted by count or byte limits.
+    pub dropped_verification_steps: u64,
+}
+
+/// AI-facing finding data and references to its graph, source, and edit nodes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AiFindingContext {
+    /// Packet-local stable identifier, derived from deterministic report rank.
+    pub id: String,
+    /// Stable baseline identity from the Doctor finding contract.
+    pub baseline_key: String,
+    /// Stable machine-readable rule code.
+    pub code: String,
+    /// Health category.
+    pub category: DoctorCategory,
+    /// Severity, confidence, impact, and health penalty.
+    pub assessment: FindingAssessment,
+    /// Primary authored location.
+    pub primary: SourceLocation,
+    /// Concise finding title.
+    pub title: String,
+    /// Explanation and recommended next action.
+    pub message: String,
+    /// Concrete failure scenario, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_scenario: Option<String>,
+    /// Stable documentation path or URL, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub documentation: Option<String>,
+    /// Application graph context.
+    pub context: FindingContext,
+    /// Analysis capability, cost, and invalidation inputs.
+    pub provenance: AnalysisProvenance,
+    /// Suppression behavior required by policy.
+    pub suppression: SuppressionPolicy,
+    /// Root node in [`AiEvidenceGraph`].
+    pub evidence_root_id: String,
+    /// Packet source snippets relevant to this finding, in priority order.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_snippet_ids: Vec<String>,
+    /// Packet edit plan for this finding, when a fix disposition exists.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub edit_plan_id: Option<String>,
+}
+
+/// Semantic role of a node in an [`AiEvidenceGraph`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AiEvidenceNodeKind {
+    /// Root node representing the complete finding assertion.
+    Finding,
+    /// Structured evidence emitted by an analysis capability.
+    Evidence,
+    /// Related source relationship that explains the assertion.
+    RelatedLocation,
+}
+
+/// One deterministic fact in an AI evidence graph.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AiEvidenceNode {
+    /// Packet-local stable node identifier.
+    pub id: String,
+    /// Owning finding identifier.
+    pub finding_id: String,
+    /// Semantic node role.
+    pub kind: AiEvidenceNodeKind,
+    /// Analysis evidence domain for evidence nodes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_kind: Option<EvidenceKind>,
+    /// Concise factual statement.
+    pub summary: String,
+    /// Supporting authored location, when present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub location: Option<SourceLocation>,
+    /// Stable structured evidence details.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub details: BTreeMap<String, String>,
+}
+
+/// Meaning of a directed [`AiEvidenceEdge`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum AiEvidenceRelation {
+    /// The target fact supports the source assertion.
+    Supports,
+    /// The target source relationship is relevant to the source assertion.
+    Related,
+}
+
+/// Directed relationship between two evidence graph nodes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AiEvidenceEdge {
+    /// Source node identifier.
+    pub from: String,
+    /// Target node identifier.
+    pub to: String,
+    /// Semantic relationship.
+    pub relation: AiEvidenceRelation,
+}
+
+/// Deterministically ordered evidence nodes and edges.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AiEvidenceGraph {
+    /// Nodes ordered by finding rank, then evidence priority.
+    pub nodes: Vec<AiEvidenceNode>,
+    /// Edges ordered with their target nodes.
+    pub edges: Vec<AiEvidenceEdge>,
+}
+
+/// UTF-8 source excerpt with absolute focus and content byte ranges.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AiSourceSnippet {
+    /// Packet-local stable snippet identifier.
+    pub id: String,
+    /// Workspace-relative source path.
+    pub path: String,
+    /// Inclusive absolute byte offset of `text` in the source file.
+    pub content_start: u32,
+    /// Exclusive absolute byte offset of `text` in the source file.
+    pub content_end: u32,
+    /// Inclusive absolute byte offset of the requested focus.
+    pub focus_start: u32,
+    /// Exclusive absolute byte offset of the requested focus.
+    pub focus_end: u32,
+    /// Exact UTF-8 source excerpt.
+    pub text: String,
+    /// Whether authored content exists before this excerpt.
+    pub truncated_before: bool,
+    /// Whether authored content exists after this excerpt.
+    pub truncated_after: bool,
+    /// Whether the source budget could not contain the complete focus span.
+    pub focus_truncated: bool,
+}
+
+impl AiSourceSnippet {
+    /// Return the focus start relative to `text`.
+    pub const fn relative_focus_start(&self) -> u32 {
+        self.focus_start.saturating_sub(self.content_start)
+    }
+
+    /// Return the focus end relative to `text`.
+    pub const fn relative_focus_end(&self) -> u32 {
+        self.focus_end.saturating_sub(self.content_start)
+    }
+}
+
+/// One complete source replacement in an [`AiEditPlan`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AiEditOperation {
+    /// Authored span to replace.
+    pub location: SourceLocation,
+    /// Complete replacement source; never a byte-truncated fragment.
+    pub replacement: String,
+}
+
+/// One opaque, provider-neutral verification request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AiVerificationStep {
+    /// Exact command or check supplied by the rule.
+    ///
+    /// Consumers must treat this as untrusted data and require explicit
+    /// authorization before execution.
+    pub command: String,
+    /// Expected successful process exit code. Defaults to zero.
+    pub expected_exit_code: i32,
+}
+
+/// Safety-classified edit and verification plan for one finding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AiEditPlan {
+    /// Packet-local stable plan identifier.
+    pub id: String,
+    /// Finding this plan addresses.
+    pub finding_id: String,
+    /// Whether edits are safe, review-required, or unavailable.
+    pub safety: FixSafety,
+    /// User-visible fix title or explicit unavailable reason.
+    pub title: String,
+    /// Complete, deterministically ordered edit operations.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub operations: Vec<AiEditOperation>,
+    /// Post-edit verification requests.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub verification: Vec<AiVerificationStep>,
+}
+
+/// Versioned, deterministic context shared by every AI connector.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AiContextPacket {
+    pub(super) format_version: u32,
+    pub(super) report_format_version: u32,
+    pub(super) scoring_version: u32,
+    pub(super) workspace: String,
+    pub(super) budget: AiContextBudget,
+    pub(super) findings: Vec<AiFindingContext>,
+    pub(super) evidence_graph: AiEvidenceGraph,
+    pub(super) source_snippets: Vec<AiSourceSnippet>,
+    pub(super) edit_plans: Vec<AiEditPlan>,
+    pub(super) omissions: AiContextOmissions,
+}
+
+impl AiContextPacket {
+    /// Return the serialized AI context format.
+    pub const fn format_version(&self) -> u32 {
+        self.format_version
+    }
+
+    /// Return the source Doctor report format.
+    pub const fn report_format_version(&self) -> u32 {
+        self.report_format_version
+    }
+
+    /// Return the source Doctor scoring version.
+    pub const fn scoring_version(&self) -> u32 {
+        self.scoring_version
+    }
+
+    /// Return the stable workspace identifier.
+    pub fn workspace(&self) -> &str {
+        &self.workspace
+    }
+
+    /// Return the construction limits recorded with the packet.
+    pub const fn budget(&self) -> AiContextBudget {
+        self.budget
+    }
+
+    /// Return findings in deterministic Doctor rank order.
+    pub fn findings(&self) -> &[AiFindingContext] {
+        &self.findings
+    }
+
+    /// Return the evidence graph for retained findings.
+    pub const fn evidence_graph(&self) -> &AiEvidenceGraph {
+        &self.evidence_graph
+    }
+
+    /// Return source snippets in first-reference order.
+    pub fn source_snippets(&self) -> &[AiSourceSnippet] {
+        &self.source_snippets
+    }
+
+    /// Return safety-classified edit plans in finding order.
+    pub fn edit_plans(&self) -> &[AiEditPlan] {
+        &self.edit_plans
+    }
+
+    /// Return explicit omission accounting.
+    pub const fn omissions(&self) -> &AiContextOmissions {
+        &self.omissions
+    }
+}

--- a/crates/vize_doctor/src/ai_context/snippet.rs
+++ b/crates/vize_doctor/src/ai_context/snippet.rs
@@ -1,0 +1,103 @@
+use vize_carton::String;
+
+use crate::SourceLocation;
+
+use super::contract::AiSourceSnippet;
+
+pub(super) fn extract_source_snippet(
+    id: String,
+    location: &SourceLocation,
+    source: &str,
+    max_bytes: usize,
+) -> Option<AiSourceSnippet> {
+    let source_len = floor_char_boundary(source, source.len().min(u32::MAX as usize));
+    let max_bytes = max_bytes.min(source_len);
+    if max_bytes == 0 {
+        return None;
+    }
+
+    let requested_start = location.start as usize;
+    let requested_end = location.end as usize;
+    let requested_outside_source = requested_start > source_len || requested_end > source_len;
+    let focus_start = floor_char_boundary(source, requested_start.min(source_len));
+    let focus_end = ceil_char_boundary(source, requested_end.min(source_len), source_len);
+    let line_start = source[..focus_start]
+        .rfind('\n')
+        .map_or(0, |index| index + 1);
+    let line_end = source[focus_end..source_len]
+        .find('\n')
+        .map_or(source_len, |index| focus_end + index + 1);
+
+    let (start, end) = if line_end.saturating_sub(line_start) <= max_bytes {
+        expand_around(source, line_start, line_end, max_bytes, source_len)
+    } else {
+        expand_around(source, focus_start, focus_end, max_bytes, source_len)
+    };
+    if start >= end {
+        return None;
+    }
+
+    let bounded_focus_start = focus_start.max(start).min(end);
+    let bounded_focus_end = focus_end.max(bounded_focus_start).min(end);
+    Some(AiSourceSnippet {
+        id,
+        path: location.path.clone(),
+        content_start: start as u32,
+        content_end: end as u32,
+        focus_start: bounded_focus_start as u32,
+        focus_end: bounded_focus_end as u32,
+        text: source[start..end].into(),
+        truncated_before: start > 0,
+        truncated_after: end < source.len(),
+        focus_truncated: requested_outside_source || start > focus_start || end < focus_end,
+    })
+}
+
+fn expand_around(
+    source: &str,
+    focus_start: usize,
+    focus_end: usize,
+    max_bytes: usize,
+    source_len: usize,
+) -> (usize, usize) {
+    let focus_len = focus_end.saturating_sub(focus_start);
+    if focus_len >= max_bytes {
+        let end = floor_char_boundary(source, focus_start.saturating_add(max_bytes));
+        return (focus_start, end);
+    }
+
+    let context = max_bytes - focus_len;
+    let desired_before = context / 2;
+    let mut start = floor_char_boundary(source, focus_start.saturating_sub(desired_before));
+    let mut end = ceil_char_boundary(
+        source,
+        focus_end.saturating_add(context - (focus_start - start)),
+        source_len,
+    );
+    if end.saturating_sub(start) > max_bytes {
+        end = floor_char_boundary(source, start + max_bytes);
+    }
+
+    let unused = max_bytes.saturating_sub(end.saturating_sub(start));
+    start = floor_char_boundary(source, start.saturating_sub(unused));
+    if end.saturating_sub(start) > max_bytes {
+        start = ceil_char_boundary(source, end - max_bytes, source_len);
+    }
+    (start, end)
+}
+
+fn floor_char_boundary(source: &str, mut offset: usize) -> usize {
+    offset = offset.min(source.len());
+    while offset > 0 && !source.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
+}
+
+fn ceil_char_boundary(source: &str, mut offset: usize, limit: usize) -> usize {
+    offset = offset.min(limit).min(source.len());
+    while offset < limit && !source.is_char_boundary(offset) {
+        offset += 1;
+    }
+    offset
+}

--- a/crates/vize_doctor/src/ai_context/tests.rs
+++ b/crates/vize_doctor/src/ai_context/tests.rs
@@ -1,0 +1,349 @@
+use serde_json::Value;
+
+use crate::{
+    AiContextBudget, AiContextError, AnalysisProvenance, DoctorCategory, DoctorFinding,
+    DoctorReport, EvidenceKind, FindingAssessment, FindingConfidence, FindingEvidence, FindingFix,
+    FindingImpact, FindingSeverity, FixSafety, HealthPenalty, RelatedLocation, RuleCost,
+    SourceLocation, TextEdit, build_ai_context,
+};
+
+fn assessment(severity: FindingSeverity) -> FindingAssessment {
+    FindingAssessment::new(
+        severity,
+        FindingConfidence::High,
+        FindingImpact::High,
+        HealthPenalty::new(20, "fixture"),
+    )
+}
+
+fn finding(code: &str, path: &str, start: u32, end: u32) -> DoctorFinding {
+    DoctorFinding::new(
+        code,
+        DoctorCategory::Correctness,
+        assessment(FindingSeverity::Warning),
+        SourceLocation::new(path, start, end),
+        "Reactive value can become stale",
+        "Read the value inside its reactive owner.",
+        AnalysisProvenance::new("reactivity-graph", RuleCost::Low),
+    )
+    .with_failure_scenario("The rendered value no longer updates.")
+    .with_evidence(
+        FindingEvidence::new(EvidenceKind::Reactivity, "The dependency edge is missing")
+            .with_location(SourceLocation::new(path, start, end))
+            .with_detail("binding", "count"),
+    )
+    .with_related(RelatedLocation::new(
+        SourceLocation::new(path, 0, 5),
+        "Reactive owner",
+    ))
+    .with_fix(
+        FindingFix::new(FixSafety::Safe, "Move the read")
+            .with_edit(TextEdit::new(
+                SourceLocation::new(path, start, end),
+                "count.value",
+            ))
+            .with_verification("vize doctor --format json"),
+    )
+}
+
+#[test]
+fn packet_preserves_graph_source_edit_and_verification_semantics() {
+    let source = "const count = ref(0);\nconst stale = count;\n";
+    let start = source.find("count;\n").unwrap() as u32;
+    let report = DoctorReport::new(
+        "workspace",
+        [finding("VIZE_AI_001", "src/App.vue", start, start + 5)],
+    );
+
+    let packet = build_ai_context(
+        &report,
+        [("src/App.vue", source)],
+        AiContextBudget::default(),
+    )
+    .unwrap();
+
+    assert_eq!(packet.findings().len(), 1);
+    assert_eq!(packet.evidence_graph().nodes.len(), 3);
+    assert_eq!(packet.evidence_graph().edges.len(), 2);
+    assert_eq!(packet.source_snippets().len(), 2);
+    assert_eq!(packet.edit_plans().len(), 1);
+    assert_eq!(
+        packet.edit_plans()[0].operations[0].replacement,
+        "count.value"
+    );
+    assert_eq!(packet.edit_plans()[0].verification[0].expected_exit_code, 0);
+    assert_eq!(packet.omissions(), &Default::default());
+
+    let json = serde_json::to_string(&packet).unwrap();
+    let decoded = serde_json::from_str(&json).unwrap();
+    assert_eq!(packet, decoded);
+}
+
+#[test]
+fn packet_is_deterministic_across_finding_and_source_input_order() {
+    let a = finding("VIZE_AI_A", "src/a.ts", 0, 1);
+    let b = finding("VIZE_AI_B", "src/b.ts", 0, 1);
+    let left_report = DoctorReport::new("workspace", [a.clone(), b.clone()]);
+    let right_report = DoctorReport::new("workspace", [b, a]);
+    let budget = AiContextBudget::default();
+
+    let left =
+        build_ai_context(&left_report, [("src/a.ts", "a"), ("src/b.ts", "b")], budget).unwrap();
+    let right = build_ai_context(
+        &right_report,
+        [("src/b.ts", "b"), ("src/a.ts", "a")],
+        budget,
+    )
+    .unwrap();
+
+    assert_eq!(
+        serde_json::to_vec(&left).unwrap(),
+        serde_json::to_vec(&right).unwrap()
+    );
+}
+
+#[test]
+fn budgets_account_for_every_whole_item_they_drop() {
+    let primary = finding("VIZE_AI_A", "src/a.ts", 0, 2)
+        .with_evidence(FindingEvidence::new(
+            EvidenceKind::Source,
+            "second evidence",
+        ))
+        .with_related(RelatedLocation::new(
+            SourceLocation::new("src/a.ts", 3, 5),
+            "second relation",
+        ))
+        .with_fix(
+            FindingFix::new(FixSafety::ReviewRequired, "Two edits")
+                .with_edit(TextEdit::new(SourceLocation::new("src/a.ts", 0, 1), "ok"))
+                .with_edit(TextEdit::new(
+                    SourceLocation::new("src/a.ts", 1, 2),
+                    "too-long",
+                ))
+                .with_verification("ok")
+                .with_verification("too-long"),
+        );
+    let report = DoctorReport::new(
+        "workspace",
+        [primary, finding("VIZE_AI_B", "src/b.ts", 0, 1)],
+    );
+    let budget = AiContextBudget {
+        max_findings: 1,
+        max_evidence_per_finding: 1,
+        max_related_per_finding: 1,
+        max_source_snippets: 1,
+        max_source_bytes: 8,
+        max_source_bytes_per_snippet: 8,
+        max_edits_per_finding: 2,
+        max_edit_bytes: 3,
+        max_verification_steps_per_finding: 2,
+        max_verification_bytes: 3,
+    };
+
+    let packet = build_ai_context(
+        &report,
+        [("src/a.ts", "0123456789"), ("src/b.ts", "b")],
+        budget,
+    )
+    .unwrap();
+
+    assert_eq!(packet.findings().len(), 1);
+    assert_eq!(packet.source_snippets()[0].text.len(), 8);
+    assert_eq!(packet.edit_plans()[0].operations.len(), 1);
+    assert_eq!(packet.edit_plans()[0].verification.len(), 1);
+    assert_eq!(packet.omissions().dropped_findings, 1);
+    assert_eq!(packet.omissions().dropped_evidence_nodes, 1);
+    assert_eq!(packet.omissions().dropped_related_nodes, 1);
+    assert_eq!(packet.omissions().dropped_edit_operations, 1);
+    assert_eq!(packet.omissions().dropped_verification_steps, 1);
+}
+
+#[test]
+fn source_windows_preserve_utf8_boundaries_and_focus_metadata() {
+    let source = "先頭\nconst 挨拶 = 'こんにちは世界';\n末尾\n";
+    let start = source.find("こんにちは").unwrap() as u32;
+    let end = start + "こんにちは".len() as u32;
+    let report = DoctorReport::new(
+        "workspace",
+        [finding("VIZE_AI_UTF8", "src/挨拶.ts", start, end)],
+    );
+    let budget = AiContextBudget {
+        max_source_bytes_per_snippet: 21,
+        max_source_bytes: 21,
+        max_source_snippets: 1,
+        ..AiContextBudget::default()
+    };
+
+    let packet = build_ai_context(&report, [("src/挨拶.ts", source)], budget).unwrap();
+    let snippet = &packet.source_snippets()[0];
+
+    assert!(std::str::from_utf8(snippet.text.as_bytes()).is_ok());
+    assert!(snippet.text.contains("こんにちは"));
+    assert_eq!(
+        snippet.relative_focus_end() - snippet.relative_focus_start(),
+        "こんにちは".len() as u32
+    );
+    assert!(!snippet.focus_truncated);
+    assert!(snippet.truncated_before);
+    assert!(snippet.truncated_after);
+}
+
+#[test]
+fn source_budget_smaller_than_one_scalar_omits_the_snippet() {
+    let report = DoctorReport::new("workspace", [finding("VIZE_AI_UTF8", "src/App.vue", 0, 3)]);
+    let budget = AiContextBudget {
+        max_source_bytes: 1,
+        max_source_bytes_per_snippet: 1,
+        ..AiContextBudget::default()
+    };
+
+    let packet = build_ai_context(&report, [("src/App.vue", "あ")], budget).unwrap();
+
+    assert!(packet.source_snippets().is_empty());
+    assert_eq!(packet.omissions().dropped_source_snippets, 2);
+}
+
+#[test]
+fn oversized_and_stale_focus_spans_are_explicitly_marked() {
+    let oversized = DoctorReport::new("workspace", [finding("VIZE_AI_WIDE", "src/a.ts", 0, 10)]);
+    let budget = AiContextBudget {
+        max_source_snippets: 1,
+        max_source_bytes: 4,
+        max_source_bytes_per_snippet: 4,
+        ..AiContextBudget::default()
+    };
+    let packet = build_ai_context(&oversized, [("src/a.ts", "0123456789")], budget).unwrap();
+    let snippet = &packet.source_snippets()[0];
+    assert_eq!(snippet.text, "0123");
+    assert!(snippet.focus_truncated);
+
+    let stale = DoctorReport::new("workspace", [finding("VIZE_AI_STALE", "src/a.ts", 2, 99)]);
+    let packet = build_ai_context(
+        &stale,
+        [("src/a.ts", "short")],
+        AiContextBudget {
+            max_source_snippets: 1,
+            ..AiContextBudget::default()
+        },
+    )
+    .unwrap();
+    assert!(packet.source_snippets()[0].focus_truncated);
+}
+
+#[test]
+fn missing_sources_are_sorted_deduplicated_and_explicit() {
+    let report = DoctorReport::new(
+        "workspace",
+        [
+            finding("VIZE_AI_B", "src/b.ts", 0, 1),
+            finding("VIZE_AI_A", "src/a.ts", 0, 1),
+        ],
+    );
+
+    let packet = build_ai_context(&report, [], AiContextBudget::default()).unwrap();
+
+    assert_eq!(
+        packet.omissions().missing_source_paths,
+        ["src/a.ts", "src/b.ts"]
+    );
+    assert!(packet.source_snippets().is_empty());
+}
+
+#[test]
+fn duplicate_source_paths_fail_closed() {
+    let report = DoctorReport::new("workspace", [finding("VIZE_AI", "src/a.ts", 0, 1)]);
+
+    let error = build_ai_context(
+        &report,
+        [("src/a.ts", "a"), ("src/a.ts", "different")],
+        AiContextBudget::default(),
+    )
+    .unwrap_err();
+
+    assert_eq!(
+        error,
+        AiContextError::DuplicateSourcePath("src/a.ts".into())
+    );
+}
+
+#[test]
+fn wire_validation_rejects_version_reference_range_and_unknown_field_tampering() {
+    let report = DoctorReport::new("workspace", [finding("VIZE_AI", "src/a.ts", 0, 1)]);
+    let packet =
+        build_ai_context(&report, [("src/a.ts", "abc")], AiContextBudget::default()).unwrap();
+    let original = serde_json::to_value(packet).unwrap();
+
+    let mut version = original.clone();
+    version["formatVersion"] = Value::from(999);
+    assert!(serde_json::from_value::<crate::AiContextPacket>(version).is_err());
+
+    let mut edge = original.clone();
+    edge["evidenceGraph"]["edges"][0]["to"] = Value::from("missing");
+    assert!(serde_json::from_value::<crate::AiContextPacket>(edge).is_err());
+
+    let mut relation = original.clone();
+    relation["evidenceGraph"]["edges"][0]["relation"] = Value::from("related");
+    assert!(serde_json::from_value::<crate::AiContextPacket>(relation).is_err());
+
+    let mut range = original.clone();
+    range["sourceSnippets"][0]["contentEnd"] = Value::from(999);
+    assert!(serde_json::from_value::<crate::AiContextPacket>(range).is_err());
+
+    let mut orphaned_source = original.clone();
+    orphaned_source["findings"][0]["sourceSnippetIds"] = Value::Array(Vec::new());
+    assert!(serde_json::from_value::<crate::AiContextPacket>(orphaned_source).is_err());
+
+    let mut wrong_plan = original.clone();
+    wrong_plan["editPlans"][0]["findingId"] = Value::from("missing");
+    assert!(serde_json::from_value::<crate::AiContextPacket>(wrong_plan).is_err());
+
+    let mut reordered = original.clone();
+    reordered["evidenceGraph"]["nodes"]
+        .as_array_mut()
+        .unwrap()
+        .swap(0, 1);
+    assert!(serde_json::from_value::<crate::AiContextPacket>(reordered).is_err());
+
+    let mut unknown = original;
+    unknown["vendor"] = Value::from("specific-provider");
+    assert!(serde_json::from_value::<crate::AiContextPacket>(unknown).is_err());
+}
+
+#[test]
+fn zero_budget_produces_a_valid_metadata_only_packet() {
+    let report = DoctorReport::new("workspace", [finding("VIZE_AI", "src/a.ts", 0, 1)]);
+    let budget = AiContextBudget {
+        max_findings: 0,
+        max_evidence_per_finding: 0,
+        max_related_per_finding: 0,
+        max_source_snippets: 0,
+        max_source_bytes: 0,
+        max_source_bytes_per_snippet: 0,
+        max_edits_per_finding: 0,
+        max_edit_bytes: 0,
+        max_verification_steps_per_finding: 0,
+        max_verification_bytes: 0,
+    };
+    let packet = build_ai_context(&report, [("src/a.ts", "a")], budget).unwrap();
+    assert!(packet.findings().is_empty());
+    assert!(packet.evidence_graph().nodes.is_empty());
+    assert_eq!(packet.omissions().dropped_findings, 1);
+    assert_eq!(
+        serde_json::from_value::<crate::AiContextPacket>(serde_json::to_value(&packet).unwrap())
+            .unwrap(),
+        packet
+    );
+}
+
+#[test]
+fn wire_budgets_are_architecture_independent_u64_values() {
+    let report = DoctorReport::new("workspace", []);
+    let budget = AiContextBudget {
+        max_source_bytes: u64::MAX,
+        ..AiContextBudget::default()
+    };
+    let packet = build_ai_context(&report, [], budget).unwrap();
+    let wire = serde_json::to_value(&packet).unwrap();
+    assert_eq!(wire["budget"]["maxSourceBytes"], Value::from(u64::MAX));
+    assert!(serde_json::from_value::<crate::AiContextPacket>(wire).is_ok());
+}

--- a/crates/vize_doctor/src/ai_context/validation.rs
+++ b/crates/vize_doctor/src/ai_context/validation.rs
@@ -1,0 +1,274 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    error::Error,
+    fmt,
+};
+
+use serde::{Deserialize, Deserializer, de};
+use vize_carton::{String, cstr};
+
+use crate::{DOCTOR_REPORT_FORMAT_VERSION, DOCTOR_SCORING_VERSION};
+
+use super::contract::{
+    AiContextBudget, AiContextOmissions, AiContextPacket, AiEditPlan, AiEvidenceGraph,
+    AiFindingContext, AiSourceSnippet, DOCTOR_AI_CONTEXT_FORMAT_VERSION,
+};
+
+mod graph;
+
+/// Failure to build or decode a provider-neutral AI context packet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AiContextError {
+    /// More than one source input used the same workspace-relative path.
+    DuplicateSourcePath(String),
+    /// The serialized AI context format is not supported by this build.
+    UnsupportedFormatVersion {
+        /// Format supported by this build.
+        expected: u32,
+        /// Format found in the packet.
+        actual: u32,
+    },
+    /// Cross-reference, ordering, or budget metadata is inconsistent.
+    Integrity(String),
+}
+
+impl fmt::Display for AiContextError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateSourcePath(path) => {
+                write!(formatter, "duplicate AI context source path: {path}")
+            }
+            Self::UnsupportedFormatVersion { expected, actual } => write!(
+                formatter,
+                "unsupported AI context format version {actual}; expected {expected}"
+            ),
+            Self::Integrity(message) => formatter.write_str(message),
+        }
+    }
+}
+
+impl Error for AiContextError {}
+
+impl AiContextPacket {
+    /// Validate versions, packet-local references, deterministic identity, and budgets.
+    ///
+    /// Deserialization calls this automatically. Connectors that persist or
+    /// transform packets can call it again before sending data to a provider.
+    pub fn validate(&self) -> Result<(), AiContextError> {
+        if self.format_version != DOCTOR_AI_CONTEXT_FORMAT_VERSION {
+            return Err(AiContextError::UnsupportedFormatVersion {
+                expected: DOCTOR_AI_CONTEXT_FORMAT_VERSION,
+                actual: self.format_version,
+            });
+        }
+        if self.report_format_version != DOCTOR_REPORT_FORMAT_VERSION {
+            return integrity("AI context references an unsupported Doctor report format");
+        }
+        if self.scoring_version != DOCTOR_SCORING_VERSION {
+            return integrity("AI context references an unsupported Doctor scoring version");
+        }
+        if self.findings.len() > runtime_limit(self.budget.max_findings) {
+            return integrity("AI context exceeds its finding budget");
+        }
+
+        let finding_ids = unique_ids(
+            self.findings.iter().map(|finding| finding.id.as_str()),
+            "finding",
+        )?;
+        for (rank, finding) in self.findings.iter().enumerate() {
+            if finding.id != cstr!("finding:{rank}") {
+                return integrity("AI context finding identifiers do not match deterministic rank");
+            }
+        }
+        self.validate_graph(&finding_ids)?;
+        let snippet_ids = self.validate_snippets()?;
+        let plan_by_id = self.validate_edit_plans(&finding_ids)?;
+        let plan_ids = plan_by_id.keys().copied().collect::<BTreeSet<_>>();
+        let mut referenced_snippets = BTreeSet::new();
+        let mut referenced_plans = BTreeSet::new();
+
+        for finding in &self.findings {
+            if !finding_ids.contains(finding.evidence_root_id.as_str()) {
+                return integrity("AI finding references a missing evidence root");
+            }
+            let mut local_snippets = BTreeSet::new();
+            for snippet_id in &finding.source_snippet_ids {
+                if !snippet_ids.contains(snippet_id.as_str()) {
+                    return integrity("AI finding references a missing source snippet");
+                }
+                if !local_snippets.insert(snippet_id.as_str()) {
+                    return integrity("AI finding repeats a source snippet reference");
+                }
+                referenced_snippets.insert(snippet_id.as_str());
+            }
+            if let Some(plan_id) = &finding.edit_plan_id {
+                let Some(plan) = plan_by_id.get(plan_id.as_str()) else {
+                    return integrity("AI finding references a missing edit plan");
+                };
+                if plan.finding_id != finding.id || !referenced_plans.insert(plan_id.as_str()) {
+                    return integrity("AI finding references an invalid edit plan");
+                }
+            }
+        }
+        if referenced_snippets != snippet_ids {
+            return integrity("AI context contains an unreferenced source snippet");
+        }
+        if referenced_plans != plan_ids {
+            return integrity("AI context contains an unreferenced edit plan");
+        }
+        if !is_sorted_unique(&self.omissions.missing_source_paths) {
+            return integrity("AI context missing source paths are not sorted and unique");
+        }
+        Ok(())
+    }
+
+    fn validate_snippets(&self) -> Result<BTreeSet<&str>, AiContextError> {
+        if self.source_snippets.len() > runtime_limit(self.budget.max_source_snippets) {
+            return integrity("AI context exceeds its source snippet count budget");
+        }
+        let snippet_ids = unique_ids(
+            self.source_snippets
+                .iter()
+                .map(|snippet| snippet.id.as_str()),
+            "source snippet",
+        )?;
+        let mut source_bytes = 0_usize;
+        for (index, snippet) in self.source_snippets.iter().enumerate() {
+            if snippet.id != cstr!("source:{index}") {
+                return integrity("AI source snippet identifiers are not deterministic");
+            }
+            if snippet.text.len() > runtime_limit(self.budget.max_source_bytes_per_snippet) {
+                return integrity("AI source snippet exceeds its per-snippet byte budget");
+            }
+            source_bytes = source_bytes.saturating_add(snippet.text.len());
+            if snippet.content_end.saturating_sub(snippet.content_start) as usize
+                != snippet.text.len()
+            {
+                return integrity("AI source snippet byte range does not match its text");
+            }
+            if snippet.focus_start < snippet.content_start
+                || snippet.focus_end < snippet.focus_start
+                || snippet.focus_end > snippet.content_end
+            {
+                return integrity("AI source snippet focus is outside its content range");
+            }
+        }
+        if source_bytes > runtime_limit(self.budget.max_source_bytes) {
+            return integrity("AI context exceeds its total source byte budget");
+        }
+        Ok(snippet_ids)
+    }
+
+    fn validate_edit_plans<'a>(
+        &'a self,
+        finding_ids: &BTreeSet<&str>,
+    ) -> Result<BTreeMap<&'a str, &'a AiEditPlan>, AiContextError> {
+        let mut plan_by_id = BTreeMap::new();
+        let mut plan_findings = BTreeSet::new();
+        let mut edit_bytes = 0_usize;
+        let mut verification_bytes = 0_usize;
+        for plan in &self.edit_plans {
+            if plan.id.is_empty() || plan_by_id.insert(plan.id.as_str(), plan).is_some() {
+                return integrity("AI context contains an empty or duplicate edit plan identifier");
+            }
+            if !finding_ids.contains(plan.finding_id.as_str()) {
+                return integrity("AI edit plan references a missing finding");
+            }
+            if !plan_findings.insert(plan.finding_id.as_str()) {
+                return integrity("AI finding has more than one edit plan");
+            }
+            if plan.id != cstr!("{}:edit-plan", plan.finding_id) {
+                return integrity("AI edit plan identifier does not match its finding");
+            }
+            if plan.operations.len() > runtime_limit(self.budget.max_edits_per_finding) {
+                return integrity("AI edit plan exceeds its operation count budget");
+            }
+            if plan.verification.len()
+                > runtime_limit(self.budget.max_verification_steps_per_finding)
+            {
+                return integrity("AI edit plan exceeds its verification count budget");
+            }
+            edit_bytes = plan.operations.iter().fold(edit_bytes, |total, operation| {
+                total.saturating_add(operation.replacement.len())
+            });
+            verification_bytes = plan
+                .verification
+                .iter()
+                .fold(verification_bytes, |total, step| {
+                    total.saturating_add(step.command.len())
+                });
+        }
+        if edit_bytes > runtime_limit(self.budget.max_edit_bytes) {
+            return integrity("AI context exceeds its replacement-source byte budget");
+        }
+        if verification_bytes > runtime_limit(self.budget.max_verification_bytes) {
+            return integrity("AI context exceeds its verification-command byte budget");
+        }
+        Ok(plan_by_id)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AiContextPacketWire {
+    format_version: u32,
+    report_format_version: u32,
+    scoring_version: u32,
+    workspace: String,
+    budget: AiContextBudget,
+    findings: Vec<AiFindingContext>,
+    evidence_graph: AiEvidenceGraph,
+    source_snippets: Vec<AiSourceSnippet>,
+    edit_plans: Vec<AiEditPlan>,
+    omissions: AiContextOmissions,
+}
+
+impl<'de> Deserialize<'de> for AiContextPacket {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = AiContextPacketWire::deserialize(deserializer)?;
+        let packet = Self {
+            format_version: wire.format_version,
+            report_format_version: wire.report_format_version,
+            scoring_version: wire.scoring_version,
+            workspace: wire.workspace,
+            budget: wire.budget,
+            findings: wire.findings,
+            evidence_graph: wire.evidence_graph,
+            source_snippets: wire.source_snippets,
+            edit_plans: wire.edit_plans,
+            omissions: wire.omissions,
+        };
+        packet.validate().map_err(de::Error::custom)?;
+        Ok(packet)
+    }
+}
+
+fn unique_ids<'a>(
+    ids: impl IntoIterator<Item = &'a str>,
+    kind: &str,
+) -> Result<BTreeSet<&'a str>, AiContextError> {
+    let mut unique = BTreeSet::new();
+    for id in ids {
+        if id.is_empty() || !unique.insert(id) {
+            return integrity(cstr!(
+                "AI context contains an empty or duplicate {kind} identifier"
+            ));
+        }
+    }
+    Ok(unique)
+}
+
+fn is_sorted_unique(values: &[String]) -> bool {
+    values.windows(2).all(|pair| pair[0] < pair[1])
+}
+
+pub(super) fn runtime_limit(limit: u64) -> usize {
+    limit.try_into().unwrap_or(usize::MAX)
+}
+
+pub(super) fn integrity<T>(message: impl Into<String>) -> Result<T, AiContextError> {
+    Err(AiContextError::Integrity(message.into()))
+}

--- a/crates/vize_doctor/src/ai_context/validation/graph.rs
+++ b/crates/vize_doctor/src/ai_context/validation/graph.rs
@@ -1,0 +1,140 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use vize_carton::cstr;
+
+use super::{AiContextError, integrity, runtime_limit};
+use crate::ai_context::{
+    AiContextPacket, AiEvidenceNode, AiEvidenceNodeKind, AiEvidenceRelation, AiFindingContext,
+};
+
+impl AiContextPacket {
+    pub(super) fn validate_graph(
+        &self,
+        finding_ids: &BTreeSet<&str>,
+    ) -> Result<(), AiContextError> {
+        let mut node_by_id = BTreeMap::new();
+        let mut node_counts = BTreeMap::<&str, (usize, usize)>::new();
+        for node in &self.evidence_graph.nodes {
+            if node.id.is_empty() || node_by_id.insert(node.id.as_str(), node).is_some() {
+                return integrity(
+                    "AI context contains an empty or duplicate evidence node identifier",
+                );
+            }
+            if !finding_ids.contains(node.finding_id.as_str()) {
+                return integrity("AI evidence node references a missing finding");
+            }
+            match (node.kind, node.evidence_kind) {
+                (AiEvidenceNodeKind::Evidence, Some(_)) => {
+                    node_counts.entry(node.finding_id.as_str()).or_default().0 += 1;
+                }
+                (AiEvidenceNodeKind::RelatedLocation, None) => {
+                    node_counts.entry(node.finding_id.as_str()).or_default().1 += 1;
+                }
+                (AiEvidenceNodeKind::Finding, None) => {}
+                _ => return integrity("AI evidence node has an invalid evidence domain"),
+            }
+        }
+
+        self.validate_node_order(&node_counts)?;
+        self.validate_graph_edges(&node_by_id)
+    }
+
+    fn validate_node_order(
+        &self,
+        node_counts: &BTreeMap<&str, (usize, usize)>,
+    ) -> Result<(), AiContextError> {
+        let mut nodes = self.evidence_graph.nodes.iter();
+        for finding in &self.findings {
+            validate_next_node(&mut nodes, finding, AiEvidenceNodeKind::Finding, None)?;
+            let (evidence_count, related_count) = node_counts
+                .get(finding.id.as_str())
+                .copied()
+                .unwrap_or_default();
+            if evidence_count > runtime_limit(self.budget.max_evidence_per_finding)
+                || related_count > runtime_limit(self.budget.max_related_per_finding)
+            {
+                return integrity("AI evidence graph exceeds a per-finding node budget");
+            }
+            for index in 0..evidence_count {
+                validate_next_node(
+                    &mut nodes,
+                    finding,
+                    AiEvidenceNodeKind::Evidence,
+                    Some(index),
+                )?;
+            }
+            for index in 0..related_count {
+                validate_next_node(
+                    &mut nodes,
+                    finding,
+                    AiEvidenceNodeKind::RelatedLocation,
+                    Some(index),
+                )?;
+            }
+        }
+        if nodes.next().is_some() {
+            return integrity("AI evidence graph contains an unexpected node");
+        }
+        Ok(())
+    }
+
+    fn validate_graph_edges(
+        &self,
+        node_by_id: &BTreeMap<&str, &AiEvidenceNode>,
+    ) -> Result<(), AiContextError> {
+        let mut edge_targets = BTreeSet::new();
+        for edge in &self.evidence_graph.edges {
+            if !node_by_id.contains_key(edge.from.as_str()) {
+                return integrity("AI evidence edge references a missing node");
+            }
+            let Some(target) = node_by_id.get(edge.to.as_str()) else {
+                return integrity("AI evidence edge references a missing node");
+            };
+            let expected_relation = match target.kind {
+                AiEvidenceNodeKind::Evidence => AiEvidenceRelation::Supports,
+                AiEvidenceNodeKind::RelatedLocation => AiEvidenceRelation::Related,
+                AiEvidenceNodeKind::Finding => {
+                    return integrity("AI evidence edge cannot target a finding root");
+                }
+            };
+            if edge.from != target.finding_id
+                || edge.relation != expected_relation
+                || !edge_targets.insert(edge.to.as_str())
+            {
+                return integrity("AI evidence edge does not match its target node");
+            }
+        }
+        let facts = node_by_id
+            .iter()
+            .filter(|(_, node)| node.kind != AiEvidenceNodeKind::Finding)
+            .map(|(id, _)| *id)
+            .collect::<BTreeSet<_>>();
+        if edge_targets != facts {
+            return integrity("AI evidence graph contains an unlinked fact node");
+        }
+        Ok(())
+    }
+}
+
+fn validate_next_node<'a>(
+    nodes: &mut impl Iterator<Item = &'a AiEvidenceNode>,
+    finding: &AiFindingContext,
+    kind: AiEvidenceNodeKind,
+    index: Option<usize>,
+) -> Result<(), AiContextError> {
+    let Some(node) = nodes.next() else {
+        return integrity("AI evidence graph is missing a deterministic node");
+    };
+    let expected_id = index.map_or_else(
+        || finding.id.clone(),
+        |index| match kind {
+            AiEvidenceNodeKind::Evidence => cstr!("{}:evidence:{index}", finding.id),
+            AiEvidenceNodeKind::RelatedLocation => cstr!("{}:related:{index}", finding.id),
+            AiEvidenceNodeKind::Finding => unreachable!("finding roots do not have an index"),
+        },
+    );
+    if node.id != expected_id || node.finding_id != finding.id || node.kind != kind {
+        return integrity("AI evidence graph nodes are not deterministically ordered");
+    }
+    Ok(())
+}

--- a/crates/vize_doctor/src/lib.rs
+++ b/crates/vize_doctor/src/lib.rs
@@ -22,6 +22,7 @@
 //! - Enabled adapters reuse registered whole-project analysis without reparsing.
 //! - Reporters are registered explicitly and never mutate global process state.
 //! - Reporter descriptors are versioned, machine-readable, and deterministically ordered.
+//! - AI context is vendor-neutral, explicitly source-fed, budgeted, and wire-validated.
 //!
 //! # Example
 //!
@@ -52,12 +53,19 @@
 //! assert_eq!(report.findings().len(), 1);
 //! ```
 
+mod ai_context;
 #[cfg(feature = "application-analysis")]
 pub mod application_analysis;
 mod model;
 mod report;
 mod reporter;
 
+pub use ai_context::{
+    AiContextBudget, AiContextError, AiContextOmissions, AiContextPacket, AiEditOperation,
+    AiEditPlan, AiEvidenceEdge, AiEvidenceGraph, AiEvidenceNode, AiEvidenceNodeKind,
+    AiEvidenceRelation, AiFindingContext, AiSourceSnippet, AiVerificationStep,
+    DOCTOR_AI_CONTEXT_FORMAT_VERSION, build_ai_context,
+};
 pub use model::{
     AnalysisProvenance, DEFAULT_UNAVAILABLE_FIX_REASON, DoctorCategory, DoctorFinding,
     EvidenceKind, FindingAssessment, FindingConfidence, FindingContext, FindingEvidence,


### PR DESCRIPTION
## Summary

- introduce a versioned, provider-neutral AI context packet for deterministic diagnosis handoff
- require callers to inject source text explicitly; the builder never reads the filesystem, environment, terminal, or network
- preserve evidence graphs, bounded UTF-8 source windows, whole edit plans, and explicitly untrusted verification commands
- validate every deserialized reference, range, ordering invariant, omission count, and derived graph edge before accepting a packet

## Safety and interoperability

- the wire contract contains no provider SDK types, prompts, credentials, timestamps, or host-specific integer widths
- duplicate source paths fail closed and missing or stale sources remain explicit in packet metadata
- edit replacements are retained whole or omitted whole; verification commands are data and are never executed by this API
- packet ordering and omission accounting are deterministic across finding and source input order

## Performance

Reporter benchmark measurements on Apple Silicon after strict graph validation:

- 1 finding: 2.1101 us median
- 100 findings: 233.95 us median
- 1,000 findings: 3.0059 ms median

The reporter benchmark is enrolled in the repository Criterion workflow.

## Validation

- cargo test -p vize_doctor --all-features
- cargo clippy -p vize_doctor --all-features --all-targets -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc -p vize_doctor --all-features --no-deps
- cargo bench -p vize_doctor --bench reporter --no-run

Relates #3138

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->