### PR TITLE
feat(doctor): add OASIS SARIF reporting

### DIFF
--- a/crates/vize/src/commands/doctor.rs
+++ b/crates/vize/src/commands/doctor.rs
@@ -11,7 +11,9 @@ mod tests;
 use clap::{Args, ValueEnum};
 use std::{fmt, io, path::PathBuf};
 use vize_carton::String;
-use vize_doctor::{DoctorReport, ReporterFailure, application_analysis::ApplicationAnalysisError};
+use vize_doctor::{
+    DoctorReport, ReporterFailure, SarifSourceError, application_analysis::ApplicationAnalysisError,
+};
 
 use self::{
     analysis::analyze_application,
@@ -26,6 +28,8 @@ pub enum DoctorFormat {
     Text,
     /// Stable, versioned JSON report for automation and AI consumers.
     Json,
+    /// OASIS SARIF 2.1.0 report for code-hosting annotations.
+    Sarif,
 }
 
 /// Arguments for whole-application health analysis.
@@ -86,6 +90,7 @@ enum DoctorError {
         message: String,
     },
     Analysis(ApplicationAnalysisError),
+    SarifSource(SarifSourceError),
     Report(ReporterFailure),
     Write(io::Error),
 }
@@ -146,6 +151,7 @@ impl fmt::Display for DoctorError {
                 )
             }
             Self::Analysis(error) => write!(formatter, "cannot build health report: {error}"),
+            Self::SarifSource(error) => write!(formatter, "cannot prepare SARIF source: {error}"),
             Self::Report(error) => write!(formatter, "cannot render health report: {error}"),
             Self::Write(error) => write!(formatter, "cannot write health report: {error}"),
         }
@@ -160,6 +166,7 @@ impl From<ApplicationAnalysisError> for DoctorError {
 
 struct DoctorOutcome {
     report: DoctorReport,
+    sources: Vec<DoctorSource>,
     format: DoctorFormat,
     exit_zero: bool,
 }
@@ -168,7 +175,7 @@ pub fn run(args: DoctorArgs) {
     match execute(args) {
         Ok(outcome) => {
             let blocking = outcome.report.summary().has_blocking_errors;
-            if let Err(error) = write_report(&outcome.report, outcome.format) {
+            if let Err(error) = write_report(&outcome.report, outcome.format, &outcome.sources) {
                 eprintln!("vize doctor: {error}");
                 std::process::exit(2);
             }
@@ -200,6 +207,7 @@ fn execute(args: DoctorArgs) -> Result<DoctorOutcome, DoctorError> {
     let report = analyze_application(&root, &sources, args.public_sfc)?;
     Ok(DoctorOutcome {
         report,
+        sources,
         format: args.format,
         exit_zero: args.exit_zero,
     })

--- a/crates/vize/src/commands/doctor/output.rs
+++ b/crates/vize/src/commands/doctor/output.rs
@@ -2,19 +2,50 @@
 
 use std::io::{self, Write};
 use vize_doctor::{
-    DoctorFinding, DoctorReport, FindingSeverity, FixSafety, JsonReporter, render_report,
+    DoctorFinding, DoctorReport, FindingSeverity, FixSafety, JsonReporter, SarifReporter,
+    SarifSource, render_report,
 };
 
-use super::{DoctorError, DoctorFormat};
+use super::{DoctorError, DoctorFormat, DoctorSource};
 
-pub(super) fn write_report(report: &DoctorReport, format: DoctorFormat) -> Result<(), DoctorError> {
+pub(super) fn write_report(
+    report: &DoctorReport,
+    format: DoctorFormat,
+    sources: &[DoctorSource],
+) -> Result<(), DoctorError> {
     let stdout = io::stdout();
     let mut output = stdout.lock();
+    write_report_to(&mut output, report, format, sources)
+}
+
+fn write_report_to(
+    output: &mut impl Write,
+    report: &DoctorReport,
+    format: DoctorFormat,
+    sources: &[DoctorSource],
+) -> Result<(), DoctorError> {
     match format {
-        DoctorFormat::Text => write_text(&mut output, report).map_err(DoctorError::Write),
-        DoctorFormat::Json => render_report(&JsonReporter::new(), report, &mut output)
+        DoctorFormat::Text => write_text(output, report).map_err(DoctorError::Write),
+        DoctorFormat::Json => render_report(&JsonReporter::new(), report, output)
             .map(|_| ())
             .map_err(DoctorError::Report),
+        DoctorFormat::Sarif => {
+            let normalized_paths = sources
+                .iter()
+                .map(|source| source.path.to_string_lossy().replace('\\', "/"))
+                .collect::<Vec<_>>();
+            let reporter = SarifReporter::new()
+                .with_sources(
+                    normalized_paths
+                        .iter()
+                        .zip(sources)
+                        .map(|(path, source)| SarifSource::new(path, source.source.as_str())),
+                )
+                .map_err(DoctorError::SarifSource)?;
+            render_report(&reporter, report, output)
+                .map(|_| ())
+                .map_err(DoctorError::Report)
+        }
     }
 }
 
@@ -114,6 +145,41 @@ mod tests {
                 "  Test message\n",
                 "  Fix (unavailable): No automatic fix is available for this finding.\n",
             )
+        );
+    }
+
+    #[test]
+    fn sarif_output_uses_the_exact_discovered_source() {
+        let source = "<template><button>保存🙂</button></template>";
+        let start = source.find("保存🙂").unwrap() as u32;
+        let finding = DoctorFinding::new(
+            "VIZE_DOCTOR_TEST",
+            DoctorCategory::Accessibility,
+            FindingAssessment::new(
+                FindingSeverity::Warning,
+                FindingConfidence::High,
+                FindingImpact::Medium,
+                HealthPenalty::new(10, "Test penalty"),
+            ),
+            SourceLocation::new("src/App.vue", start, start + "保存🙂".len() as u32),
+            "Test finding",
+            "Test message",
+            AnalysisProvenance::new("test-analysis", RuleCost::Low),
+        );
+        let report = DoctorReport::new(".", [finding]);
+        let sources = [DoctorSource {
+            path: "src/App.vue".into(),
+            source: source.into(),
+        }];
+        let mut output = Vec::new();
+
+        write_report_to(&mut output, &report, DoctorFormat::Sarif, &sources).unwrap();
+
+        let value: serde_json::Value = serde_json::from_slice(&output).unwrap();
+        assert_eq!(value["version"], "2.1.0");
+        assert_eq!(
+            value["runs"][0]["results"][0]["locations"][0]["physicalLocation"]["region"]["startColumn"],
+            source[..start as usize].chars().count() + 1
         );
     }
 }

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_doctor_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_doctor_help.snap
@@ -22,8 +22,9 @@ Options:
           Output format. Defaults to `text`
 
           Possible values:
-          - text: Concise terminal-oriented health report
-          - json: Stable, versioned JSON report for automation and AI consumers
+          - text:  Concise terminal-oriented health report
+          - json:  Stable, versioned JSON report for automation and AI consumers
+          - sarif: OASIS SARIF 2.1.0 report for code-hosting annotations
 
           [default: text]
 

--- a/crates/vize/tests/doctor_sarif_cli.rs
+++ b/crates/vize/tests/doctor_sarif_cli.rs
@@ -1,0 +1,57 @@
+use std::{fs, path::Path, process::Command};
+
+#[test]
+fn sarif_output_has_precise_code_host_locations() {
+    let directory = tempfile::tempdir().unwrap();
+    let first = "<template><div id=\"共有🙂\" /></template>";
+    write(directory.path(), "src/画面 #1.vue", first);
+    write(
+        directory.path(),
+        "src/Other.vue",
+        "<template><div id=\"共有🙂\" /></template>",
+    );
+
+    let output = doctor(directory.path(), &["src", "--format", "sarif"]);
+    let sarif: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let result = &sarif["runs"][0]["results"][0];
+    let location = result["relatedLocations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|location| {
+            location["physicalLocation"]["artifactLocation"]["uri"]
+                == "src/%E7%94%BB%E9%9D%A2%20%231.vue"
+        })
+        .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(sarif["version"], "2.1.0");
+    assert_eq!(sarif["runs"][0]["columnKind"], "unicodeCodePoints");
+    assert_eq!(
+        location["physicalLocation"]["artifactLocation"]["uri"],
+        "src/%E7%94%BB%E9%9D%A2%20%231.vue"
+    );
+    assert_eq!(
+        location["physicalLocation"]["region"]["startColumn"],
+        first[..first.find("id=\"共有🙂\"").unwrap()]
+            .chars()
+            .count()
+            + 1
+    );
+}
+
+fn doctor(root: &Path, arguments: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_vize"))
+        .arg("doctor")
+        .args(arguments)
+        .arg("--root")
+        .arg(root)
+        .output()
+        .unwrap()
+}
+
+fn write(root: &Path, relative: &str, source: &str) {
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, source).unwrap();
+}

--- a/crates/vize_doctor/README.md
+++ b/crates/vize_doctor/README.md
@@ -95,6 +95,36 @@ assert_eq!(receipt.reporter_id(), "example.agent-context");
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
+### SARIF code-host annotations
+
+`SarifReporter` emits OASIS SARIF 2.1.0 plus Errata 01 without depending on a
+specific code host. Doctor spans are UTF-8 byte offsets, so the caller injects
+the exact source text that was analyzed. This makes Unicode line and column
+conversion deterministic and keeps the reporter free of filesystem access.
+Missing or stale sources fail before output by default; callers must opt in to
+artifact-only locations when precise annotations are intentionally unavailable.
+
+```rust
+use vize_doctor::{DoctorReport, DoctorReporter, SarifReporter, SarifSource, render_report};
+
+let report = DoctorReport::new("example", []);
+let reporter = SarifReporter::new().with_sources([
+    SarifSource::new("src/App.vue", "<template><main /></template>"),
+])?;
+let mut sarif = Vec::new();
+let receipt = render_report(&reporter, &report, &mut sarif)?;
+
+assert_eq!(receipt.reporter_id(), "vize.sarif");
+assert_eq!(reporter.descriptor().media_type(), "application/sarif+json");
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+The CLI wires its already-discovered sources into the same reporter:
+
+```sh
+vize doctor src --format sarif > vize-doctor.sarif
+```
+
 ## Example
 
 ```rust

--- a/crates/vize_doctor/benches/reporter.rs
+++ b/crates/vize_doctor/benches/reporter.rs
@@ -5,8 +5,8 @@ use vize_doctor::{
     AiContextBudget, AnalysisProvenance, DoctorCategory, DoctorFinding, DoctorReport,
     DoctorReporter, FindingAssessment, FindingConfidence, FindingImpact, FindingSeverity,
     HealthPenalty, JsonReporter, ReporterAudience, ReporterCapability, ReporterDescriptor,
-    ReporterError, ReporterOutput, ReporterTransport, RuleCost, SourceLocation, build_ai_context,
-    render_report,
+    ReporterError, ReporterOutput, ReporterTransport, RuleCost, SarifReporter, SarifSource,
+    SourceLocation, build_ai_context, render_report,
 };
 
 struct EmptyReporter {
@@ -108,6 +108,32 @@ fn benchmark_ai_context(c: &mut Criterion) {
     group.finish();
 }
 
+fn benchmark_sarif_reporter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("doctor_reporter/sarif_compact");
+    let source = "x".repeat(10_001);
+    let reporter = SarifReporter::new()
+        .with_pretty(false)
+        .with_sources([SarifSource::new("src/Benchmark.vue", &source)])
+        .unwrap();
+
+    for finding_count in [0, 100, 10_000] {
+        let report = report_with_findings(finding_count);
+        let mut encoded = Vec::new();
+        render_report(&reporter, &report, &mut encoded).unwrap();
+        group.throughput(Throughput::Bytes(encoded.len() as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(finding_count),
+            &report,
+            |b, report| {
+                b.iter(|| {
+                    render_report(black_box(&reporter), black_box(report), &mut io::sink()).unwrap()
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
 fn report_with_findings(finding_count: usize) -> DoctorReport {
     DoctorReport::new(
         "benchmark",
@@ -134,6 +160,7 @@ criterion_group!(
     reporter_benches,
     benchmark_reporter_contract,
     benchmark_json_reporter,
-    benchmark_ai_context
+    benchmark_ai_context,
+    benchmark_sarif_reporter
 );
 criterion_main!(reporter_benches);

--- a/crates/vize_doctor/src/lib.rs
+++ b/crates/vize_doctor/src/lib.rs
@@ -80,5 +80,6 @@ pub use reporter::{
     DOCTOR_REPORTER_CONTRACT_VERSION, DoctorReporter, JsonReporter, ReporterAudience,
     ReporterCapability, ReporterContractError, ReporterDescriptor, ReporterError,
     ReporterErrorKind, ReporterFailure, ReporterOutput, ReporterReceipt, ReporterRegistrationError,
-    ReporterSet, ReporterTransport, render_report,
+    ReporterSet, ReporterTransport, SarifMissingSourcePolicy, SarifReporter, SarifSource,
+    SarifSourceError, render_report,
 };

--- a/crates/vize_doctor/src/reporter.rs
+++ b/crates/vize_doctor/src/reporter.rs
@@ -9,6 +9,7 @@ mod contract;
 mod execution;
 mod json;
 mod registry;
+mod sarif;
 
 #[cfg(test)]
 mod tests;
@@ -23,3 +24,4 @@ pub use execution::{
 };
 pub use json::JsonReporter;
 pub use registry::{ReporterRegistrationError, ReporterSet};
+pub use sarif::{SarifMissingSourcePolicy, SarifReporter, SarifSource, SarifSourceError};

--- a/crates/vize_doctor/src/reporter/sarif.rs
+++ b/crates/vize_doctor/src/reporter/sarif.rs
@@ -1,0 +1,133 @@
+//! OASIS SARIF 2.1.0 report rendering.
+
+mod plan;
+mod source;
+mod wire;
+
+#[cfg(test)]
+mod tests;
+
+use std::{collections::BTreeMap, io::Write};
+
+use super::{
+    DoctorReporter, ReporterAudience, ReporterCapability, ReporterDescriptor, ReporterError,
+    ReporterOutput, ReporterTransport,
+};
+use crate::DoctorReport;
+
+use source::IndexedSource;
+pub use source::{SarifMissingSourcePolicy, SarifSource, SarifSourceError};
+
+/// Built-in OASIS SARIF 2.1.0 reporter for code-hosting annotations.
+///
+/// Doctor locations are UTF-8 byte spans while SARIF text regions use lines
+/// and Unicode columns. Callers therefore inject the exact analyzed source via
+/// [`Self::with_sources`]. The reporter never reads the filesystem, process
+/// environment, clock, network, or code-host credentials.
+pub struct SarifReporter<'source> {
+    descriptor: ReporterDescriptor,
+    sources: BTreeMap<&'source str, IndexedSource<'source>>,
+    missing_source_policy: SarifMissingSourcePolicy,
+    pretty: bool,
+}
+
+impl<'source> SarifReporter<'source> {
+    /// Creates a strict reporter with no injected sources.
+    ///
+    /// Human-readable indentation defaults to `true`. Missing sources default
+    /// to [`SarifMissingSourcePolicy::Reject`] so a code host never receives a
+    /// silently imprecise annotation.
+    pub fn new() -> Self {
+        Self {
+            descriptor: ReporterDescriptor::new(
+                "vize.sarif",
+                "Vize Doctor SARIF",
+                "application/sarif+json",
+                ReporterTransport::Document,
+            )
+            .with_file_extension("sarif")
+            .with_audiences([
+                ReporterAudience::Automation,
+                ReporterAudience::CodeHost,
+                ReporterAudience::Editor,
+            ])
+            .with_capabilities(ReporterCapability::ALL),
+            sources: BTreeMap::new(),
+            missing_source_policy: SarifMissingSourcePolicy::Reject,
+            pretty: true,
+        }
+    }
+
+    /// Injects analyzed UTF-8 sources used to translate byte spans.
+    ///
+    /// Sources may arrive in any order. Paths must be unique, slash-normalized,
+    /// workspace-relative paths identical to the paths in the report.
+    pub fn with_sources(
+        mut self,
+        sources: impl IntoIterator<Item = SarifSource<'source>>,
+    ) -> Result<Self, SarifSourceError> {
+        for source in sources {
+            let indexed = IndexedSource::new(source)?;
+            if self.sources.insert(source.path(), indexed).is_some() {
+                return Err(SarifSourceError::duplicate(source.path()));
+            }
+        }
+        Ok(self)
+    }
+
+    /// Selects behavior when a finding references a source that was not
+    /// injected. Defaults to [`SarifMissingSourcePolicy::Reject`].
+    pub const fn with_missing_source_policy(mut self, policy: SarifMissingSourcePolicy) -> Self {
+        self.missing_source_policy = policy;
+        self
+    }
+
+    /// Selects human-readable indentation. Defaults to `true`.
+    pub const fn with_pretty(mut self, pretty: bool) -> Self {
+        self.pretty = pretty;
+        self
+    }
+
+    /// Returns whether human-readable indentation is enabled.
+    pub const fn pretty(&self) -> bool {
+        self.pretty
+    }
+
+    /// Returns the configured missing-source behavior.
+    pub const fn missing_source_policy(&self) -> SarifMissingSourcePolicy {
+        self.missing_source_policy
+    }
+}
+
+impl Default for SarifReporter<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DoctorReporter for SarifReporter<'_> {
+    fn descriptor(&self) -> &ReporterDescriptor {
+        &self.descriptor
+    }
+
+    fn write_report(
+        &self,
+        report: &DoctorReport,
+        output: &mut ReporterOutput<'_>,
+    ) -> Result<(), ReporterError> {
+        let plan = plan::SarifPlan::new(report, &self.sources, self.missing_source_policy)?;
+        let result = if self.pretty {
+            serde_json::to_writer_pretty(&mut *output, &wire::SarifLog::new(&plan))
+        } else {
+            serde_json::to_writer(&mut *output, &wire::SarifLog::new(&plan))
+        };
+        result.map_err(|error| {
+            if error.is_io() {
+                ReporterError::write(error)
+            } else {
+                ReporterError::encode(error)
+            }
+        })?;
+        output.write_all(b"\n").map_err(ReporterError::write)
+    }
+}

--- a/crates/vize_doctor/src/reporter/sarif/plan.rs
+++ b/crates/vize_doctor/src/reporter/sarif/plan.rs
@@ -1,0 +1,251 @@
+//! Fail-closed SARIF preflight and deterministic render indexing.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use vize_carton::{String, ToCompactString, cstr};
+
+use super::source::{IndexedSource, SarifMissingSourcePolicy, validate_path};
+use crate::{
+    DoctorFinding, DoctorReport, FixSafety, ReporterError, ReporterErrorKind, SourceLocation,
+};
+
+pub(super) struct ArtifactPlan<'source> {
+    uri: String,
+    source: Option<&'source IndexedSource<'source>>,
+}
+
+impl ArtifactPlan<'_> {
+    pub(super) fn uri(&self) -> &str {
+        &self.uri
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct SarifRegion {
+    start_line: u32,
+    start_column: u32,
+    end_line: u32,
+    end_column: u32,
+}
+
+pub(super) struct SarifPlan<'report, 'source> {
+    report: &'report DoctorReport,
+    artifacts: BTreeMap<&'report str, ArtifactPlan<'source>>,
+    rules: Vec<&'report DoctorFinding>,
+}
+
+impl<'report, 'source> SarifPlan<'report, 'source> {
+    pub(super) fn new(
+        report: &'report DoctorReport,
+        sources: &'source BTreeMap<&'source str, IndexedSource<'source>>,
+        missing_source_policy: SarifMissingSourcePolicy,
+    ) -> Result<Self, ReporterError> {
+        let mut paths = BTreeSet::new();
+        let mut rule_map = BTreeMap::new();
+
+        for finding in report.findings() {
+            validate_rule_id(&finding.code)?;
+            rule_map.entry(finding.code.as_str()).or_insert(finding);
+            paths.insert(finding.primary.path.as_str());
+            paths.extend(
+                finding
+                    .related
+                    .iter()
+                    .map(|related| related.location.path.as_str()),
+            );
+            paths.extend(
+                finding
+                    .evidence
+                    .iter()
+                    .filter_map(|evidence| evidence.location.as_ref())
+                    .map(|location| location.path.as_str()),
+            );
+            if let Some(fix) = &finding.fix {
+                if fix.safety == FixSafety::Unavailable && !fix.edits.is_empty() {
+                    return Err(invalid_data(cstr!(
+                        "finding {} has source edits but marks its fix unavailable",
+                        finding.code
+                    )));
+                }
+                validate_edits(finding)?;
+                paths.extend(fix.edits.iter().map(|edit| edit.location.path.as_str()));
+            }
+        }
+
+        let mut artifacts = BTreeMap::new();
+        for path in paths {
+            validate_path(path).map_err(|error| invalid_data(error.to_compact_string()))?;
+            let source = sources.get(path);
+            if source.is_none() && missing_source_policy == SarifMissingSourcePolicy::Reject {
+                return Err(invalid_data(cstr!(
+                    "SARIF source {} is required to translate its UTF-8 byte spans",
+                    path
+                )));
+            }
+            artifacts.insert(
+                path,
+                ArtifactPlan {
+                    uri: encode_relative_uri(path),
+                    source,
+                },
+            );
+        }
+
+        let plan = Self {
+            report,
+            artifacts,
+            rules: rule_map.into_values().collect(),
+        };
+        plan.validate_locations()?;
+        Ok(plan)
+    }
+
+    pub(super) const fn report(&self) -> &'report DoctorReport {
+        self.report
+    }
+
+    pub(super) fn rules(&self) -> &[&'report DoctorFinding] {
+        &self.rules
+    }
+
+    pub(super) fn rule_index(&self, code: &str) -> usize {
+        self.rules
+            .binary_search_by_key(&code, |finding| finding.code.as_str())
+            .expect("preflight indexed every finding rule")
+    }
+
+    pub(super) fn artifact(&self, path: &str) -> &ArtifactPlan<'source> {
+        self.artifacts
+            .get(path)
+            .expect("preflight indexed every finding artifact")
+    }
+
+    pub(super) fn region(&self, location: &SourceLocation) -> Option<SarifRegion> {
+        let source = self.artifact(&location.path).source?;
+        let (start_line, start_column) = source.position(location.start)?;
+        let (end_line, end_column) = source.position(location.end)?;
+        Some(SarifRegion {
+            start_line,
+            start_column,
+            end_line,
+            end_column,
+        })
+    }
+
+    pub(super) fn can_render_fix(&self, fix: &crate::FindingFix) -> bool {
+        fix.edits
+            .iter()
+            .all(|edit| self.region(&edit.location).is_some())
+    }
+
+    fn validate_locations(&self) -> Result<(), ReporterError> {
+        for finding in self.report.findings() {
+            self.validate_location(&finding.primary)?;
+            for related in &finding.related {
+                self.validate_location(&related.location)?;
+            }
+            for evidence in &finding.evidence {
+                if let Some(location) = &evidence.location {
+                    self.validate_location(location)?;
+                }
+            }
+            if let Some(fix) = &finding.fix {
+                for edit in &fix.edits {
+                    self.validate_location(&edit.location)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_location(&self, location: &SourceLocation) -> Result<(), ReporterError> {
+        let artifact = self.artifact(&location.path);
+        let Some(source) = artifact.source else {
+            return Ok(());
+        };
+        if source.position(location.start).is_none() {
+            return Err(invalid_span(location, "start"));
+        }
+        if source.position(location.end).is_none() {
+            return Err(invalid_span(location, "end"));
+        }
+        Ok(())
+    }
+}
+
+fn validate_edits(finding: &DoctorFinding) -> Result<(), ReporterError> {
+    let Some(fix) = &finding.fix else {
+        return Ok(());
+    };
+    let mut previous: Option<&SourceLocation> = None;
+    for edit in &fix.edits {
+        if let Some(before) = previous
+            && before.path == edit.location.path
+            && (edit.location.start < before.end || edit.location.start == before.start)
+        {
+            return Err(invalid_data(cstr!(
+                "finding {} has ambiguous overlapping edits in {}",
+                finding.code,
+                edit.location.path
+            )));
+        }
+        previous = Some(&edit.location);
+    }
+    Ok(())
+}
+
+fn validate_rule_id(code: &str) -> Result<(), ReporterError> {
+    if code.is_empty()
+        || code
+            .chars()
+            .any(|character| character.is_control() || character.is_whitespace())
+    {
+        return Err(invalid_data(cstr!(
+            "Doctor rule id {:?} is not a valid SARIF hierarchical string",
+            code
+        )));
+    }
+    Ok(())
+}
+
+fn invalid_span(location: &SourceLocation, boundary: &str) -> ReporterError {
+    invalid_data(cstr!(
+        "SARIF location {}:{}..{} has an out-of-range or non-UTF-8 {boundary} boundary",
+        location.path,
+        location.start,
+        location.end
+    ))
+}
+
+fn invalid_data(message: impl Into<String>) -> ReporterError {
+    ReporterError::new(ReporterErrorKind::InvalidData, message)
+}
+
+fn encode_relative_uri(path: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut encoded = String::with_capacity(path.len());
+    for byte in path.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~' | b'/') {
+            encoded.push(byte as char);
+        } else {
+            encoded.push('%');
+            encoded.push(HEX[(byte >> 4) as usize] as char);
+            encoded.push(HEX[(byte & 0x0f) as usize] as char);
+        }
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::encode_relative_uri;
+
+    #[test]
+    fn artifact_uris_are_relative_and_utf8_percent_encoded() {
+        assert_eq!(
+            encode_relative_uri("src/画面 #1%.vue"),
+            "src/%E7%94%BB%E9%9D%A2%20%231%25.vue"
+        );
+    }
+}

--- a/crates/vize_doctor/src/reporter/sarif/source.rs
+++ b/crates/vize_doctor/src/reporter/sarif/source.rs
@@ -1,0 +1,176 @@
+//! Explicit source injection and byte-to-text coordinate indexing.
+
+use std::{error::Error, fmt};
+
+use vize_carton::String;
+
+/// One analyzed UTF-8 source supplied explicitly to the SARIF reporter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SarifSource<'source> {
+    path: &'source str,
+    text: &'source str,
+}
+
+impl<'source> SarifSource<'source> {
+    /// Creates a borrowed source. Validation occurs in
+    /// [`super::SarifReporter::with_sources`].
+    pub const fn new(path: &'source str, text: &'source str) -> Self {
+        Self { path, text }
+    }
+
+    /// Returns the workspace-relative source path.
+    pub const fn path(self) -> &'source str {
+        self.path
+    }
+
+    /// Returns the exact analyzed UTF-8 text.
+    pub const fn text(self) -> &'source str {
+        self.text
+    }
+}
+
+/// Behavior when a report location has no injected source text.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SarifMissingSourcePolicy {
+    /// Reject the report before writing any bytes. This is the default.
+    #[default]
+    Reject,
+    /// Emit the artifact URI but omit its text region explicitly.
+    ArtifactOnly,
+}
+
+/// Invalid explicit source configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SarifSourceError {
+    path: String,
+    reason: &'static str,
+}
+
+impl SarifSourceError {
+    pub(super) fn invalid(path: &str, reason: &'static str) -> Self {
+        Self {
+            path: path.into(),
+            reason,
+        }
+    }
+
+    pub(super) fn duplicate(path: &str) -> Self {
+        Self::invalid(path, "the source path was supplied more than once")
+    }
+
+    /// Returns the rejected source path.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    /// Returns the stable rejection reason.
+    pub const fn reason(&self) -> &'static str {
+        self.reason
+    }
+}
+
+impl fmt::Display for SarifSourceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "invalid SARIF source {}: {}",
+            self.path, self.reason
+        )
+    }
+}
+
+impl Error for SarifSourceError {}
+
+pub(super) struct IndexedSource<'source> {
+    text: &'source str,
+    line_starts: Vec<u32>,
+}
+
+impl<'source> IndexedSource<'source> {
+    pub(super) fn new(source: SarifSource<'source>) -> Result<Self, SarifSourceError> {
+        validate_path(source.path)?;
+        if source.text.len() > u32::MAX as usize {
+            return Err(SarifSourceError::invalid(
+                source.path,
+                "the UTF-8 source is larger than the Doctor offset space",
+            ));
+        }
+        let mut line_starts = vec![0];
+        line_starts.extend(
+            source
+                .text
+                .bytes()
+                .enumerate()
+                .filter(|(_, byte)| *byte == b'\n')
+                .map(|(index, _)| index as u32 + 1),
+        );
+        Ok(Self {
+            text: source.text,
+            line_starts,
+        })
+    }
+
+    pub(super) fn position(&self, offset: u32) -> Option<(u32, u32)> {
+        let offset = offset as usize;
+        if offset > self.text.len() || !self.text.is_char_boundary(offset) {
+            return None;
+        }
+        let line_index = self
+            .line_starts
+            .partition_point(|start| *start as usize <= offset)
+            - 1;
+        let line_start = self.line_starts[line_index] as usize;
+        let column = self.text[line_start..offset].chars().count() as u32 + 1;
+        Some((line_index as u32 + 1, column))
+    }
+}
+
+pub(super) fn validate_path(path: &str) -> Result<(), SarifSourceError> {
+    if path.is_empty() {
+        return Err(SarifSourceError::invalid(path, "the path is empty"));
+    }
+    if path.starts_with('/') || path.starts_with('\\') {
+        return Err(SarifSourceError::invalid(
+            path,
+            "the path must be workspace-relative",
+        ));
+    }
+    if path.contains('\\') {
+        return Err(SarifSourceError::invalid(
+            path,
+            "the path must use slash separators",
+        ));
+    }
+    if path.chars().any(char::is_control) {
+        return Err(SarifSourceError::invalid(
+            path,
+            "the path contains a control character",
+        ));
+    }
+    if path
+        .split('/')
+        .any(|segment| segment.is_empty() || matches!(segment, "." | ".."))
+    {
+        return Err(SarifSourceError::invalid(
+            path,
+            "the path is not lexically normalized",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn positions_are_one_based_unicode_code_points() {
+        let source = IndexedSource::new(SarifSource::new("src/a.vue", "α\r\n東京🙂")).unwrap();
+
+        assert_eq!(source.position(0), Some((1, 1)));
+        assert_eq!(source.position("α\r\n".len() as u32), Some((2, 1)));
+        assert_eq!(source.position("α\r\n東京".len() as u32), Some((2, 3)));
+        assert_eq!(source.position("α\r\n東京🙂".len() as u32), Some((2, 4)));
+        assert_eq!(source.position(1), None);
+    }
+}

--- a/crates/vize_doctor/src/reporter/sarif/tests.rs
+++ b/crates/vize_doctor/src/reporter/sarif/tests.rs
@@ -1,0 +1,256 @@
+use serde_json::Value;
+use vize_carton::{ToCompactString, cstr};
+
+use super::*;
+use crate::{
+    AnalysisProvenance, DoctorCategory, DoctorFinding, FindingAssessment, FindingConfidence,
+    FindingContext, FindingEvidence, FindingFix, FindingImpact, FindingSeverity, FixSafety,
+    HealthPenalty, RelatedLocation, ReporterErrorKind, ReporterFailure, RuleCost, SourceLocation,
+    SuppressionPolicy, TextEdit, render_report,
+};
+
+const SOURCE: &str = "const greeting = \"東京🙂\";\nconst owner = greeting;\n";
+
+fn finding() -> DoctorFinding {
+    let start = SOURCE.find("東京🙂").unwrap() as u32;
+    let end = start + "東京🙂".len() as u32;
+    DoctorFinding::new(
+        "VIZE_DOCTOR_I18N_001",
+        DoctorCategory::Accessibility,
+        FindingAssessment::new(
+            FindingSeverity::Warning,
+            FindingConfidence::High,
+            FindingImpact::Medium,
+            HealthPenalty::new(12, "Locale fallback can hide content"),
+        ),
+        SourceLocation::new("src/画面 #1.vue", start, end),
+        "Localized name has no fallback",
+        "Provide a stable authored fallback for the accessible name.",
+        AnalysisProvenance::new("semantic-tree", RuleCost::Low)
+            .with_invalidation_inputs(["src/画面 #1.vue"]),
+    )
+    .with_failure_scenario("The control becomes unnamed when the locale key is absent.")
+    .with_documentation("/doctor/accessibility/localized-name")
+    .with_related(RelatedLocation::new(
+        SourceLocation::new(
+            "src/画面 #1.vue",
+            SOURCE.find("greeting").unwrap() as u32,
+            SOURCE.find("greeting").unwrap() as u32 + "greeting".len() as u32,
+        ),
+        "Authored binding",
+    ))
+    .with_evidence(
+        FindingEvidence::new(
+            crate::EvidenceKind::Component,
+            "Resolved accessible-name binding",
+        )
+        .with_location(SourceLocation::new("src/画面 #1.vue", 0, 5))
+        .with_detail("binding", "greeting"),
+    )
+    .with_fix(
+        FindingFix::new(FixSafety::Safe, "Add the fallback")
+            .with_edit(TextEdit::new(
+                SourceLocation::new("src/画面 #1.vue", start, end),
+                "東京 (Tokyo)🙂",
+            ))
+            .with_verification("vize doctor --format sarif"),
+    )
+    .with_context(FindingContext {
+        target: Some("web".into()),
+        environment: Some("client".into()),
+        component: Some("LocalizedControl".into()),
+        ..FindingContext::default()
+    })
+    .with_suppression(SuppressionPolicy::ReasonRequired)
+}
+
+fn render_value(
+    reporter: &SarifReporter<'_>,
+    report: &crate::DoctorReport,
+) -> Result<Value, ReporterFailure> {
+    let mut bytes = Vec::new();
+    render_report(reporter, report, &mut bytes)?;
+    Ok(serde_json::from_slice(&bytes).unwrap())
+}
+
+#[test]
+fn empty_log_declares_the_oasis_contract_and_vize_versions() {
+    let report = crate::DoctorReport::new("workspace", []);
+    let value = render_value(&SarifReporter::new(), &report).unwrap();
+
+    assert_eq!(value["version"], "2.1.0");
+    assert_eq!(
+        value["$schema"],
+        "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json"
+    );
+    assert_eq!(value["runs"][0]["tool"]["driver"]["name"], "Vize Doctor");
+    assert_eq!(value["runs"][0]["columnKind"], "unicodeCodePoints");
+    assert_eq!(value["runs"][0]["results"], serde_json::json!([]));
+    assert_eq!(value["runs"][0]["properties"]["vizeReportFormatVersion"], 1);
+}
+
+#[test]
+fn result_preserves_unicode_regions_evidence_policy_and_text_fixes() {
+    let report = crate::DoctorReport::new("workspace", [finding()]);
+    let reporter = SarifReporter::new()
+        .with_sources([SarifSource::new("src/画面 #1.vue", SOURCE)])
+        .unwrap();
+    let value = render_value(&reporter, &report).unwrap();
+    let result = &value["runs"][0]["results"][0];
+    let region = &result["locations"][0]["physicalLocation"]["region"];
+
+    assert_eq!(result["ruleId"], "VIZE_DOCTOR_I18N_001");
+    assert_eq!(result["ruleIndex"], 0);
+    assert_eq!(result["level"], "warning");
+    assert_eq!(
+        result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"],
+        "src/%E7%94%BB%E9%9D%A2%20%231.vue"
+    );
+    assert_eq!(region["startLine"], 1);
+    assert_eq!(region["startColumn"], 19);
+    assert_eq!(region["endLine"], 1);
+    assert_eq!(region["endColumn"], 22);
+    assert_eq!(result["relatedLocations"].as_array().unwrap().len(), 2);
+    assert_eq!(
+        result["relatedLocations"][1]["properties"]["vizeEvidenceDetails"]["binding"],
+        "greeting"
+    );
+    let expected_baseline_key = cstr!(
+        "VIZE_DOCTOR_I18N_001:src/画面 #1.vue:{}:{}",
+        SOURCE.find("東京🙂").unwrap(),
+        SOURCE.find("東京🙂").unwrap() + "東京🙂".len()
+    );
+    assert_eq!(
+        result["partialFingerprints"]["vizeBaselineKey/v1"],
+        expected_baseline_key.as_str()
+    );
+    assert_eq!(result["fixes"][0]["properties"]["vizeSafety"], "safe");
+    assert_eq!(
+        result["fixes"][0]["artifactChanges"][0]["replacements"][0]["insertedContent"]["text"],
+        "東京 (Tokyo)🙂"
+    );
+    assert_eq!(
+        result["properties"]["vizeProvenance"]["capability"],
+        "semantic-tree"
+    );
+}
+
+#[test]
+fn missing_sources_fail_before_any_output_by_default() {
+    let report = crate::DoctorReport::new("workspace", [finding()]);
+    let mut bytes = Vec::new();
+    let failure = render_report(&SarifReporter::new(), &report, &mut bytes).unwrap_err();
+
+    assert!(bytes.is_empty());
+    assert_eq!(failure.bytes_written(), 0);
+    let ReporterFailure::Rendering { error, .. } = failure else {
+        panic!("expected a rendering failure");
+    };
+    assert_eq!(error.kind(), ReporterErrorKind::InvalidData);
+    assert!(error.message().contains("is required"));
+}
+
+#[test]
+fn artifact_only_policy_marks_intentionally_imprecise_results() {
+    let report = crate::DoctorReport::new("workspace", [finding()]);
+    let reporter =
+        SarifReporter::new().with_missing_source_policy(SarifMissingSourcePolicy::ArtifactOnly);
+    let value = render_value(&reporter, &report).unwrap();
+    let result = &value["runs"][0]["results"][0];
+
+    assert!(
+        result["locations"][0]["physicalLocation"]
+            .get("region")
+            .is_none()
+    );
+    assert_eq!(result["properties"]["vizeSourceRegionsOmitted"], 3);
+    assert_eq!(result["properties"]["vizeFixEditsOmitted"], 1);
+    assert!(result.get("fixes").is_none());
+}
+
+#[test]
+fn stale_and_non_utf8_boundaries_are_rejected() {
+    for location in [
+        SourceLocation::new("src/画面 #1.vue", 0, SOURCE.len() as u32 + 1),
+        SourceLocation::new("src/画面 #1.vue", 19, 20),
+    ] {
+        let mut invalid = finding();
+        invalid.primary = location;
+        let report = crate::DoctorReport::new("workspace", [invalid]);
+        let reporter = SarifReporter::new()
+            .with_sources([SarifSource::new("src/画面 #1.vue", SOURCE)])
+            .unwrap();
+        let error = render_value(&reporter, &report).unwrap_err();
+        assert_eq!(error.bytes_written(), 0);
+    }
+}
+
+#[test]
+fn source_configuration_rejects_duplicates_and_non_normalized_paths() {
+    let duplicate = SarifReporter::new()
+        .with_sources([
+            SarifSource::new("src/App.vue", "a"),
+            SarifSource::new("src/App.vue", "a"),
+        ])
+        .err()
+        .unwrap();
+    let parent = SarifReporter::new()
+        .with_sources([SarifSource::new("src/../App.vue", "a")])
+        .err()
+        .unwrap();
+
+    assert_eq!(duplicate.path(), "src/App.vue");
+    assert!(duplicate.reason().contains("more than once"));
+    assert!(parent.reason().contains("normalized"));
+}
+
+#[test]
+fn output_is_deterministic_across_source_order_and_pretty_mode() {
+    let mut second = finding();
+    second.primary.path = "src/Other.vue".into();
+    second.code = "VIZE_DOCTOR_I18N_002".into();
+    second.fix = Some(FindingFix::unavailable("No deterministic edit"));
+    let report = crate::DoctorReport::new("workspace", [second, finding()]);
+    let sources = [
+        SarifSource::new("src/画面 #1.vue", SOURCE),
+        SarifSource::new("src/Other.vue", SOURCE),
+    ];
+    let first = SarifReporter::new()
+        .with_pretty(false)
+        .with_sources(sources)
+        .unwrap();
+    let second = SarifReporter::new()
+        .with_pretty(false)
+        .with_sources(sources.into_iter().rev())
+        .unwrap();
+    let mut first_bytes = Vec::new();
+    let mut second_bytes = Vec::new();
+
+    render_report(&first, &report, &mut first_bytes).unwrap();
+    render_report(&second, &report, &mut second_bytes).unwrap();
+
+    assert_eq!(first_bytes, second_bytes);
+    assert_eq!(first_bytes.last(), Some(&b'\n'));
+}
+
+#[test]
+fn overlapping_fix_edits_fail_closed() {
+    let mut invalid = finding();
+    let fix = invalid.fix.as_mut().unwrap();
+    fix.edits.push(TextEdit::new(
+        SourceLocation::new(
+            "src/画面 #1.vue",
+            fix.edits[0].location.start,
+            fix.edits[0].location.end,
+        ),
+        "duplicate",
+    ));
+    let report = crate::DoctorReport::new("workspace", [invalid]);
+    let reporter = SarifReporter::new()
+        .with_sources([SarifSource::new("src/画面 #1.vue", SOURCE)])
+        .unwrap();
+    let error = render_value(&reporter, &report).unwrap_err();
+
+    assert_eq!(error.bytes_written(), 0);
+    assert!(error.to_compact_string().contains("overlapping edits"));
+}

--- a/crates/vize_doctor/src/reporter/sarif/wire.rs
+++ b/crates/vize_doctor/src/reporter/sarif/wire.rs
@@ -1,0 +1,299 @@
+//! Allocation-bounded SARIF wire serialization.
+
+mod fix;
+mod properties;
+
+use std::collections::BTreeMap;
+
+use serde::{Serialize, Serializer, ser::SerializeSeq};
+use vize_carton::cstr;
+
+use super::plan::{SarifPlan, SarifRegion};
+use crate::{DoctorFinding, EvidenceKind, FindingEvidence, FindingSeverity, SourceLocation};
+
+use fix::SarifFix;
+use properties::{SarifResultProperties, SarifRunProperties};
+
+const SARIF_SCHEMA: &str =
+    "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json";
+
+#[derive(Serialize)]
+pub(super) struct SarifLog<'plan, 'report, 'source> {
+    #[serde(rename = "$schema")]
+    schema: &'static str,
+    version: &'static str,
+    runs: [SarifRun<'plan, 'report, 'source>; 1],
+}
+
+impl<'plan, 'report, 'source> SarifLog<'plan, 'report, 'source> {
+    pub(super) fn new(plan: &'plan SarifPlan<'report, 'source>) -> Self {
+        Self {
+            schema: SARIF_SCHEMA,
+            version: "2.1.0",
+            runs: [SarifRun {
+                tool: SarifTool {
+                    driver: SarifDriver {
+                        name: "Vize Doctor",
+                        semantic_version: env!("CARGO_PKG_VERSION"),
+                        rules: SarifRules { plan },
+                    },
+                },
+                column_kind: "unicodeCodePoints",
+                results: SarifResults { plan },
+                properties: SarifRunProperties::new(plan.report()),
+            }],
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifRun<'plan, 'report, 'source> {
+    tool: SarifTool<'plan, 'report, 'source>,
+    column_kind: &'static str,
+    results: SarifResults<'plan, 'report, 'source>,
+    properties: SarifRunProperties<'report>,
+}
+
+#[derive(Serialize)]
+struct SarifTool<'plan, 'report, 'source> {
+    driver: SarifDriver<'plan, 'report, 'source>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifDriver<'plan, 'report, 'source> {
+    name: &'static str,
+    semantic_version: &'static str,
+    rules: SarifRules<'plan, 'report, 'source>,
+}
+
+struct SarifRules<'plan, 'report, 'source> {
+    plan: &'plan SarifPlan<'report, 'source>,
+}
+
+impl Serialize for SarifRules<'_, '_, '_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut sequence = serializer.serialize_seq(Some(self.plan.rules().len()))?;
+        for finding in self.plan.rules() {
+            sequence.serialize_element(&SarifRule::new(finding))?;
+        }
+        sequence.end()
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifRule<'finding> {
+    id: &'finding str,
+    short_description: SarifMessage<'finding>,
+    default_configuration: SarifRuleConfiguration,
+    properties: SarifRuleProperties<'finding>,
+}
+
+impl<'finding> SarifRule<'finding> {
+    fn new(finding: &'finding DoctorFinding) -> Self {
+        Self {
+            id: &finding.code,
+            short_description: SarifMessage::borrowed(&finding.title),
+            default_configuration: SarifRuleConfiguration {
+                level: sarif_level(finding.assessment.severity),
+            },
+            properties: SarifRuleProperties {
+                category: finding.category,
+                documentation: finding.documentation.as_deref(),
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct SarifRuleConfiguration {
+    level: &'static str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifRuleProperties<'finding> {
+    #[serde(rename = "vizeCategory")]
+    category: crate::DoctorCategory,
+    #[serde(rename = "vizeDocumentation", skip_serializing_if = "Option::is_none")]
+    documentation: Option<&'finding str>,
+}
+
+struct SarifResults<'plan, 'report, 'source> {
+    plan: &'plan SarifPlan<'report, 'source>,
+}
+
+impl Serialize for SarifResults<'_, '_, '_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let findings = self.plan.report().findings();
+        let mut sequence = serializer.serialize_seq(Some(findings.len()))?;
+        for finding in findings {
+            sequence.serialize_element(&SarifResult::new(self.plan, finding))?;
+        }
+        sequence.end()
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifResult<'finding> {
+    rule_id: &'finding str,
+    rule_index: usize,
+    level: &'static str,
+    message: SarifMessage<'finding>,
+    locations: [SarifLocation<'finding>; 1],
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    related_locations: Vec<SarifLocation<'finding>>,
+    partial_fingerprints: SarifPartialFingerprints,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    fixes: Vec<SarifFix<'finding>>,
+    properties: SarifResultProperties<'finding>,
+}
+
+impl<'finding> SarifResult<'finding> {
+    fn new<'source>(plan: &SarifPlan<'finding, 'source>, finding: &'finding DoctorFinding) -> Self {
+        let mut related_locations = finding
+            .related
+            .iter()
+            .map(|related| {
+                SarifLocation::new(plan, &related.location, Some(&related.message), None)
+            })
+            .collect::<Vec<_>>();
+        related_locations.extend(finding.evidence.iter().filter_map(|evidence| {
+            evidence.location.as_ref().map(|location| {
+                SarifLocation::new(plan, location, Some(&evidence.summary), Some(evidence))
+            })
+        }));
+        let fixes = finding
+            .fix
+            .as_ref()
+            .filter(|fix| !fix.edits.is_empty() && plan.can_render_fix(fix))
+            .map(|fix| vec![SarifFix::new(plan, fix)])
+            .unwrap_or_default();
+        Self {
+            rule_id: &finding.code,
+            rule_index: plan.rule_index(&finding.code),
+            level: sarif_level(finding.assessment.severity),
+            message: SarifMessage::owned(cstr!("{}: {}", finding.title, finding.message)),
+            locations: [SarifLocation::new(plan, &finding.primary, None, None)],
+            related_locations,
+            partial_fingerprints: SarifPartialFingerprints {
+                baseline_key: finding.baseline_key(),
+            },
+            fixes,
+            properties: SarifResultProperties::new(plan, finding),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct SarifPartialFingerprints {
+    #[serde(rename = "vizeBaselineKey/v1")]
+    baseline_key: vize_carton::String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifLocation<'finding> {
+    physical_location: SarifPhysicalLocation,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    message: Option<SarifMessage<'finding>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    properties: Option<SarifLocationProperties<'finding>>,
+}
+
+impl<'finding> SarifLocation<'finding> {
+    fn new<'source>(
+        plan: &SarifPlan<'finding, 'source>,
+        location: &'finding SourceLocation,
+        message: Option<&'finding str>,
+        evidence: Option<&'finding FindingEvidence>,
+    ) -> Self {
+        Self {
+            physical_location: SarifPhysicalLocation {
+                artifact_location: SarifArtifactLocation {
+                    uri: plan.artifact(&location.path).uri().into(),
+                },
+                region: plan.region(location),
+            },
+            message: message.map(SarifMessage::borrowed),
+            properties: evidence.map(|evidence| SarifLocationProperties {
+                evidence_kind: evidence.kind,
+                evidence_details: &evidence.details,
+            }),
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifPhysicalLocation {
+    artifact_location: SarifArtifactLocation,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    region: Option<SarifRegion>,
+}
+
+#[derive(Serialize)]
+struct SarifArtifactLocation {
+    uri: vize_carton::String,
+}
+
+#[derive(Serialize)]
+struct SarifLocationProperties<'finding> {
+    #[serde(rename = "vizeEvidenceKind")]
+    evidence_kind: EvidenceKind,
+    #[serde(rename = "vizeEvidenceDetails")]
+    evidence_details: &'finding BTreeMap<vize_carton::String, vize_carton::String>,
+}
+
+#[derive(Serialize)]
+struct SarifMessage<'text> {
+    text: SarifMessageText<'text>,
+}
+
+enum SarifMessageText<'text> {
+    Borrowed(&'text str),
+    Owned(vize_carton::String),
+}
+
+impl Serialize for SarifMessageText<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Borrowed(text) => serializer.serialize_str(text),
+            Self::Owned(text) => serializer.serialize_str(text),
+        }
+    }
+}
+
+impl<'text> SarifMessage<'text> {
+    fn borrowed(text: &'text str) -> Self {
+        Self {
+            text: SarifMessageText::Borrowed(text),
+        }
+    }
+
+    fn owned(text: vize_carton::String) -> Self {
+        Self {
+            text: SarifMessageText::Owned(text),
+        }
+    }
+}
+
+const fn sarif_level(severity: FindingSeverity) -> &'static str {
+    match severity {
+        FindingSeverity::Error => "error",
+        FindingSeverity::Warning => "warning",
+        FindingSeverity::Notice => "note",
+    }
+}

--- a/crates/vize_doctor/src/reporter/sarif/wire/fix.rs
+++ b/crates/vize_doctor/src/reporter/sarif/wire/fix.rs
@@ -1,0 +1,92 @@
+//! SARIF textual fixes grouped into distinct artifact changes.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use super::super::plan::{SarifPlan, SarifRegion};
+use crate::{FindingFix, TextEdit};
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct SarifFix<'finding> {
+    description: SarifMessage<'finding>,
+    artifact_changes: Vec<SarifArtifactChange<'finding>>,
+    properties: SarifFixProperties<'finding>,
+}
+
+impl<'finding> SarifFix<'finding> {
+    pub(super) fn new<'source>(
+        plan: &SarifPlan<'finding, 'source>,
+        fix: &'finding FindingFix,
+    ) -> Self {
+        let mut by_path = BTreeMap::<&str, Vec<&TextEdit>>::new();
+        for edit in &fix.edits {
+            by_path.entry(&edit.location.path).or_default().push(edit);
+        }
+        let artifact_changes = by_path
+            .into_iter()
+            .map(|(path, edits)| SarifArtifactChange {
+                artifact_location: SarifArtifactLocation {
+                    uri: plan.artifact(path).uri().into(),
+                },
+                replacements: edits
+                    .into_iter()
+                    .map(|edit| SarifReplacement {
+                        deleted_region: plan
+                            .region(&edit.location)
+                            .expect("fix sources are mandatory during SARIF preflight"),
+                        inserted_content: SarifArtifactContent {
+                            text: &edit.replacement,
+                        },
+                    })
+                    .collect(),
+            })
+            .collect();
+        Self {
+            description: SarifMessage { text: &fix.title },
+            artifact_changes,
+            properties: SarifFixProperties {
+                safety: fix.safety,
+                verification: &fix.verification,
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct SarifMessage<'finding> {
+    text: &'finding str,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifArtifactChange<'finding> {
+    artifact_location: SarifArtifactLocation,
+    replacements: Vec<SarifReplacement<'finding>>,
+}
+
+#[derive(Serialize)]
+struct SarifArtifactLocation {
+    uri: vize_carton::String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifReplacement<'finding> {
+    deleted_region: SarifRegion,
+    inserted_content: SarifArtifactContent<'finding>,
+}
+
+#[derive(Serialize)]
+struct SarifArtifactContent<'finding> {
+    text: &'finding str,
+}
+
+#[derive(Serialize)]
+struct SarifFixProperties<'finding> {
+    #[serde(rename = "vizeSafety")]
+    safety: crate::FixSafety,
+    #[serde(rename = "vizeVerification", skip_serializing_if = "Vec::is_empty")]
+    verification: &'finding Vec<vize_carton::String>,
+}

--- a/crates/vize_doctor/src/reporter/sarif/wire/properties.rs
+++ b/crates/vize_doctor/src/reporter/sarif/wire/properties.rs
@@ -1,0 +1,114 @@
+//! Vize semantics preserved in SARIF property bags.
+
+use serde::Serialize;
+
+use super::super::plan::SarifPlan;
+use crate::{
+    DoctorFinding, DoctorReport, FindingContext, FindingEvidence, HealthPenalty, SuppressionPolicy,
+};
+
+#[derive(Serialize)]
+pub(super) struct SarifResultProperties<'finding> {
+    #[serde(rename = "vizeCategory")]
+    category: crate::DoctorCategory,
+    #[serde(rename = "vizeConfidence")]
+    confidence: crate::FindingConfidence,
+    #[serde(rename = "vizeImpact")]
+    impact: crate::FindingImpact,
+    #[serde(rename = "vizePenalty")]
+    penalty: &'finding HealthPenalty,
+    #[serde(
+        rename = "vizeFailureScenario",
+        skip_serializing_if = "Option::is_none"
+    )]
+    failure_scenario: Option<&'finding str>,
+    #[serde(rename = "vizeDocumentation", skip_serializing_if = "Option::is_none")]
+    documentation: Option<&'finding str>,
+    #[serde(rename = "vizeEvidence", skip_serializing_if = "Vec::is_empty")]
+    evidence: &'finding Vec<FindingEvidence>,
+    #[serde(rename = "vizeContext")]
+    context: &'finding FindingContext,
+    #[serde(rename = "vizeFixSafety", skip_serializing_if = "Option::is_none")]
+    fix_safety: Option<crate::FixSafety>,
+    #[serde(rename = "vizeFixTitle", skip_serializing_if = "Option::is_none")]
+    fix_title: Option<&'finding str>,
+    #[serde(rename = "vizeVerification", skip_serializing_if = "Option::is_none")]
+    verification: Option<&'finding [vize_carton::String]>,
+    #[serde(rename = "vizeSuppressionPolicy")]
+    suppression_policy: SuppressionPolicy,
+    #[serde(rename = "vizeProvenance")]
+    provenance: &'finding crate::AnalysisProvenance,
+    #[serde(rename = "vizeSourceRegionsOmitted", skip_serializing_if = "is_zero")]
+    source_regions_omitted: u64,
+    #[serde(rename = "vizeFixEditsOmitted", skip_serializing_if = "is_zero")]
+    fix_edits_omitted: u64,
+}
+
+impl<'finding> SarifResultProperties<'finding> {
+    pub(super) fn new<'source>(
+        plan: &SarifPlan<'finding, 'source>,
+        finding: &'finding DoctorFinding,
+    ) -> Self {
+        let fix = finding.fix.as_ref();
+        let source_regions_omitted = std::iter::once(&finding.primary)
+            .chain(finding.related.iter().map(|related| &related.location))
+            .chain(
+                finding
+                    .evidence
+                    .iter()
+                    .filter_map(|evidence| evidence.location.as_ref()),
+            )
+            .filter(|location| plan.region(location).is_none())
+            .count() as u64;
+        let fix_edits_omitted = fix
+            .filter(|fix| !plan.can_render_fix(fix))
+            .map(|fix| fix.edits.len() as u64)
+            .unwrap_or(0);
+        Self {
+            category: finding.category,
+            confidence: finding.assessment.confidence,
+            impact: finding.assessment.impact,
+            penalty: &finding.assessment.penalty,
+            failure_scenario: finding.failure_scenario.as_deref(),
+            documentation: finding.documentation.as_deref(),
+            evidence: &finding.evidence,
+            context: &finding.context,
+            fix_safety: fix.map(|fix| fix.safety),
+            fix_title: fix.map(|fix| fix.title.as_str()),
+            verification: fix
+                .map(|fix| fix.verification.as_slice())
+                .filter(|items| !items.is_empty()),
+            suppression_policy: finding.suppression,
+            provenance: &finding.provenance,
+            source_regions_omitted,
+            fix_edits_omitted,
+        }
+    }
+}
+
+const fn is_zero(value: &u64) -> bool {
+    *value == 0
+}
+
+#[derive(Serialize)]
+pub(super) struct SarifRunProperties<'report> {
+    #[serde(rename = "vizeReportFormatVersion")]
+    report_format_version: u32,
+    #[serde(rename = "vizeScoringVersion")]
+    scoring_version: u32,
+    #[serde(rename = "vizeWorkspace")]
+    workspace: &'report str,
+    #[serde(rename = "vizeHealth")]
+    health: &'report crate::DoctorSummary,
+}
+
+impl<'report> SarifRunProperties<'report> {
+    pub(super) fn new(report: &'report DoctorReport) -> Self {
+        Self {
+            report_format_version: report.format_version(),
+            scoring_version: report.scoring_version(),
+            workspace: report.workspace(),
+            health: report.summary(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a provider-neutral OASIS SARIF 2.1.0 plus Errata 01 reporter with a stable descriptor
- expose vize doctor --format sarif and reuse the exact UTF-8 sources already discovered by the command
- preserve primary and related locations, evidence, severity, confidence, impact, policy, provenance, fingerprints, health metadata, and textual fixes
- percent-encode workspace-relative artifact URIs and measure columns as Unicode code points

## Safety and determinism

- source text is injected explicitly; the reporter never reads the filesystem, environment, clock, network, or provider credentials
- missing sources, stale byte ranges, non-UTF-8 boundaries, invalid paths, unavailable fixes with edits, and overlapping edits fail before any output
- artifact-only fallback is opt-in and records exact source-region and fix-edit omission counts
- rules, artifacts, results, fixes, and source maps are stable across input order
- results stream directly through serde instead of collecting a second 10,000-item result model

## Performance

Criterion measurements for compact SARIF on Apple Silicon:

- empty report: 1.192 us median
- 100 findings: 127.43 us median
- 10,000 findings: 24.70 ms median

## Validation

- OASIS Errata 01 Draft-04 JSON Schema: 0 validation errors
- cargo test -p vize_doctor --all-features
- cargo test -p vize --lib commands::doctor
- cargo test -p vize --test doctor_sarif_cli
- cargo clippy -p vize_doctor --all-features --all-targets -- -D warnings
- cargo clippy -p vize --lib --bins -- -D warnings
- cargo clippy -p vize --test doctor_sarif_cli -- -D warnings
- RUSTDOCFLAGS=-D warnings cargo doc -p vize_doctor --all-features --no-deps
- cargo bench -p vize_doctor --bench reporter --no-run

Relates #3138