### PR TITLE
feat(doctor): add multidimensional finding filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3870,6 +3870,7 @@ name = "vize_doctor"
 version = "0.347.6"
 dependencies = [
  "criterion",
+ "globset",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/vize/src/commands/doctor.rs
+++ b/crates/vize/src/commands/doctor.rs
@@ -3,6 +3,7 @@
 mod analysis;
 mod canonical_sfc;
 mod discovery;
+mod filters;
 mod output;
 
 #[cfg(test)]
@@ -12,7 +13,8 @@ use clap::{Args, ValueEnum};
 use std::{fmt, io, path::PathBuf};
 use vize_carton::String;
 use vize_doctor::{
-    DoctorReport, ReporterFailure, SarifSourceError, application_analysis::ApplicationAnalysisError,
+    DoctorCategory, DoctorFilterError, DoctorReport, FindingConfidence, FindingSeverity,
+    ReporterFailure, SarifSourceError, application_analysis::ApplicationAnalysisError,
 };
 
 use self::{
@@ -55,6 +57,46 @@ pub struct DoctorArgs {
     /// Enforce the canonical public component SFC contract. Defaults to false.
     #[arg(long)]
     pub public_sfc: bool,
+
+    /// Include category values (repeat or comma-separate). Defaults to every category.
+    #[arg(long = "category", value_delimiter = ',', value_parser = filters::parse_category)]
+    pub categories: Vec<DoctorCategory>,
+
+    /// Include severity values (repeat or comma-separate). Defaults to every severity.
+    #[arg(long = "severity", value_delimiter = ',', value_parser = filters::parse_severity)]
+    pub severities: Vec<FindingSeverity>,
+
+    /// Include confidence values (repeat or comma-separate). Defaults to every confidence.
+    #[arg(long = "confidence", value_delimiter = ',', value_parser = filters::parse_confidence)]
+    pub confidences: Vec<FindingConfidence>,
+
+    /// Include target identifiers matching a glob. Defaults to every target.
+    #[arg(long = "target")]
+    pub targets: Vec<String>,
+
+    /// Include stable rule codes matching a glob. Defaults to every rule.
+    #[arg(long = "rule")]
+    pub rules: Vec<String>,
+
+    /// Include primary workspace-relative paths matching a glob. Defaults to every path.
+    #[arg(long = "path")]
+    pub path_filters: Vec<String>,
+
+    /// Include route identifiers matching a glob. Defaults to every route.
+    #[arg(long = "route")]
+    pub routes: Vec<String>,
+
+    /// Include environment identifiers matching a glob. Defaults to every environment.
+    #[arg(long = "environment")]
+    pub environments: Vec<String>,
+
+    /// Include workspace package identifiers matching a glob. Defaults to every package.
+    #[arg(long = "package")]
+    pub packages: Vec<String>,
+
+    /// Include findings affected by a changed-file glob. Defaults to every file.
+    #[arg(long = "changed-file")]
+    pub changed_files: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -91,6 +133,7 @@ enum DoctorError {
     },
     Analysis(ApplicationAnalysisError),
     SarifSource(SarifSourceError),
+    Filter(DoctorFilterError),
     Report(ReporterFailure),
     Write(io::Error),
 }
@@ -152,6 +195,7 @@ impl fmt::Display for DoctorError {
             }
             Self::Analysis(error) => write!(formatter, "cannot build health report: {error}"),
             Self::SarifSource(error) => write!(formatter, "cannot prepare SARIF source: {error}"),
+            Self::Filter(error) => write!(formatter, "cannot apply finding filters: {error}"),
             Self::Report(error) => write!(formatter, "cannot render health report: {error}"),
             Self::Write(error) => write!(formatter, "cannot write health report: {error}"),
         }
@@ -191,6 +235,7 @@ pub fn run(args: DoctorArgs) {
 }
 
 fn execute(args: DoctorArgs) -> Result<DoctorOutcome, DoctorError> {
+    let filter = filters::compile(&args).map_err(DoctorError::Filter)?;
     let cwd = std::env::current_dir().map_err(DoctorError::CurrentDirectory)?;
     let requested_root = if args.root.is_absolute() {
         args.root
@@ -204,7 +249,7 @@ fn execute(args: DoctorArgs) -> Result<DoctorOutcome, DoctorError> {
             source,
         })?;
     let sources = discover_sources(&root, &args.paths)?;
-    let report = analyze_application(&root, &sources, args.public_sfc)?;
+    let report = filter.apply(&analyze_application(&root, &sources, args.public_sfc)?);
     Ok(DoctorOutcome {
         report,
         sources,

--- a/crates/vize/src/commands/doctor/filters.rs
+++ b/crates/vize/src/commands/doctor/filters.rs
@@ -1,0 +1,75 @@
+//! CLI adapters for the reporter-neutral filter contract.
+
+use vize_doctor::{
+    DoctorCategory, DoctorFilter, DoctorFilterError, DoctorFilterSpec, FindingConfidence,
+    FindingSeverity,
+};
+
+use super::DoctorArgs;
+
+pub(super) fn compile(args: &DoctorArgs) -> Result<DoctorFilter, DoctorFilterError> {
+    DoctorFilterSpec {
+        categories: args.categories.clone(),
+        severities: args.severities.clone(),
+        confidences: args.confidences.clone(),
+        targets: args.targets.clone(),
+        rules: args.rules.clone(),
+        paths: args.path_filters.clone(),
+        routes: args.routes.clone(),
+        environments: args.environments.clone(),
+        packages: args.packages.clone(),
+        changed_files: args.changed_files.clone(),
+    }
+    .compile()
+}
+
+pub(super) fn parse_category(value: &str) -> Result<DoctorCategory, &'static str> {
+    match value {
+        "correctness" => Ok(DoctorCategory::Correctness),
+        "accessibility" => Ok(DoctorCategory::Accessibility),
+        "performance" => Ok(DoctorCategory::Performance),
+        "maintainability" => Ok(DoctorCategory::Maintainability),
+        "security" => Ok(DoctorCategory::Security),
+        "production-readiness" => Ok(DoctorCategory::ProductionReadiness),
+        _ => Err(
+            "expected correctness, accessibility, performance, maintainability, security, or production-readiness",
+        ),
+    }
+}
+
+pub(super) fn parse_severity(value: &str) -> Result<FindingSeverity, &'static str> {
+    match value {
+        "error" => Ok(FindingSeverity::Error),
+        "warning" => Ok(FindingSeverity::Warning),
+        "notice" => Ok(FindingSeverity::Notice),
+        _ => Err("expected error, warning, or notice"),
+    }
+}
+
+pub(super) fn parse_confidence(value: &str) -> Result<FindingConfidence, &'static str> {
+    match value {
+        "certain" => Ok(FindingConfidence::Certain),
+        "high" => Ok(FindingConfidence::High),
+        "medium" => Ok(FindingConfidence::Medium),
+        "low" => Ok(FindingConfidence::Low),
+        _ => Err("expected certain, high, medium, or low"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parsers_accept_only_wire_contract_spellings() {
+        assert_eq!(
+            parse_category("production-readiness").unwrap(),
+            DoctorCategory::ProductionReadiness
+        );
+        assert_eq!(parse_severity("warning").unwrap(), FindingSeverity::Warning);
+        assert_eq!(parse_confidence("high").unwrap(), FindingConfidence::High);
+        assert!(parse_category("ProductionReadiness").is_err());
+        assert!(parse_severity("warn").is_err());
+        assert!(parse_confidence("unknown").is_err());
+    }
+}

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_doctor_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_doctor_help.snap
@@ -34,5 +34,35 @@ Options:
       --public-sfc
           Enforce the canonical public component SFC contract. Defaults to false
 
+      --category <CATEGORIES>
+          Include category values (repeat or comma-separate). Defaults to every category
+
+      --severity <SEVERITIES>
+          Include severity values (repeat or comma-separate). Defaults to every severity
+
+      --confidence <CONFIDENCES>
+          Include confidence values (repeat or comma-separate). Defaults to every confidence
+
+      --target <TARGETS>
+          Include target identifiers matching a glob. Defaults to every target
+
+      --rule <RULES>
+          Include stable rule codes matching a glob. Defaults to every rule
+
+      --path <PATH_FILTERS>
+          Include primary workspace-relative paths matching a glob. Defaults to every path
+
+      --route <ROUTES>
+          Include route identifiers matching a glob. Defaults to every route
+
+      --environment <ENVIRONMENTS>
+          Include environment identifiers matching a glob. Defaults to every environment
+
+      --package <PACKAGES>
+          Include workspace package identifiers matching a glob. Defaults to every package
+
+      --changed-file <CHANGED_FILES>
+          Include findings affected by a changed-file glob. Defaults to every file
+
   -h, --help
           Print help (see a summary with '-h')

--- a/crates/vize/tests/doctor_filter_cli.rs
+++ b/crates/vize/tests/doctor_filter_cli.rs
@@ -1,0 +1,119 @@
+use std::{fs, path::Path, process::Command};
+
+use vize_doctor::DoctorReport;
+
+#[test]
+fn multidimensional_filters_share_glob_and_evidence_graph_semantics() {
+    let directory = tempfile::tempdir().unwrap();
+    write(
+        directory.path(),
+        "src/A.vue",
+        "<template><input id=\"shared\" /></template>",
+    );
+    write(
+        directory.path(),
+        "src/B.vue",
+        "<template><input id=\"shared\" /></template>",
+    );
+
+    let selected = doctor(
+        directory.path(),
+        &[
+            "src",
+            "--format",
+            "json",
+            "--category",
+            "accessibility,correctness",
+            "--severity",
+            "warning",
+            "--confidence",
+            "certain",
+            "--rule",
+            "VIZE_DOCTOR_CF_DUPLICATE_*",
+            "--path",
+            "src/*.vue",
+            "--changed-file",
+            "src/B.vue",
+        ],
+    );
+    let report: DoctorReport = serde_json::from_slice(&selected.stdout).unwrap();
+
+    assert!(selected.status.success());
+    assert_eq!(report.findings().len(), 1);
+    assert_eq!(report.findings()[0].code, "VIZE_DOCTOR_CF_DUPLICATE_ID");
+    assert_eq!(report.findings()[0].primary.path, "src/A.vue");
+    assert_eq!(report.findings()[0].related[0].location.path, "src/B.vue");
+}
+
+#[test]
+fn filters_recompute_health_and_exit_from_visible_findings() {
+    let directory = tempfile::tempdir().unwrap();
+    write(
+        directory.path(),
+        "src/Parent.vue",
+        r#"<script setup lang="ts">
+import { reactive } from 'vue'
+import Child from './Child.vue'
+const state = reactive({ count: 0 })
+</script>
+<template><Child :item="state" /></template>"#,
+    );
+    write(
+        directory.path(),
+        "src/Child.vue",
+        r#"<script setup lang="ts">
+const props = defineProps<{ item: { count: number } }>()
+const { item } = props
+</script>"#,
+    );
+
+    let unfiltered = doctor(directory.path(), &["src", "--format", "json"]);
+    let hidden = doctor(
+        directory.path(),
+        &["src", "--format", "json", "--target", "native"],
+    );
+    let hidden_report: DoctorReport = serde_json::from_slice(&hidden.stdout).unwrap();
+
+    assert_eq!(unfiltered.status.code(), Some(1));
+    assert!(hidden.status.success());
+    assert!(hidden_report.findings().is_empty());
+    assert_eq!(hidden_report.summary().overall_score, 100);
+    assert!(!hidden_report.summary().has_blocking_errors);
+}
+
+#[test]
+fn malformed_filter_globs_fail_before_emitting_a_report() {
+    let directory = tempfile::tempdir().unwrap();
+    write(
+        directory.path(),
+        "src/App.vue",
+        "<template><main /></template>",
+    );
+
+    let output = doctor(
+        directory.path(),
+        &["src", "--format", "json", "--changed-file", "[broken"],
+    );
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("invalid changed-file filter pattern")
+    );
+}
+
+fn doctor(root: &Path, arguments: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_vize"))
+        .arg("doctor")
+        .args(arguments)
+        .arg("--root")
+        .arg(root)
+        .output()
+        .unwrap()
+}
+
+fn write(root: &Path, relative: &str, source: &str) {
+    let path = root.join(relative);
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, source).unwrap();
+}

--- a/crates/vize_doctor/Cargo.toml
+++ b/crates/vize_doctor/Cargo.toml
@@ -13,6 +13,7 @@ default = []
 application-analysis = ["dep:vize_croquis_cf"]
 
 [dependencies]
+globset.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 vize_carton.workspace = true

--- a/crates/vize_doctor/README.md
+++ b/crates/vize_doctor/README.md
@@ -25,6 +25,41 @@ When enabled, the adapter converts an existing Vize whole-project analysis into
 source-aware findings and reports without reparsing files. It fails closed if a
 diagnostic references a stale file or a path outside the declared workspace.
 
+## Finding filters
+
+`DoctorFilterSpec` is a serializable, provider-neutral query shared by CLI,
+TUI, editor, CI, and AI clients. Enum values within a dimension are ORed,
+populated dimensions are ANDed, and string dimensions support validated shell
+globs. Applying a compiled filter produces a newly scored `DoctorReport` while
+leaving the source report unchanged.
+
+```rust
+use vize_doctor::{
+    DoctorCategory, DoctorFilterSpec, DoctorReport, FindingSeverity,
+};
+
+# let report = DoctorReport::new("example", []);
+let filter = DoctorFilterSpec {
+    categories: vec![DoctorCategory::Correctness],
+    severities: vec![FindingSeverity::Error],
+    paths: vec!["packages/**/src/*.vue".into()],
+    changed_files: vec!["packages/account/**".into()],
+    ..DoctorFilterSpec::default()
+}
+.compile()?;
+let focused = filter.apply(&report);
+
+assert!(focused
+    .findings()
+    .iter()
+    .all(|finding| filter.matches(finding)));
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Primary `paths` are intentionally distinct from `changed_files`. Changed-file
+matching traverses primary, related, evidence, fix-edit, and invalidation-input
+paths so dependent findings stay visible when a shared contract changes.
+
 ## Reporter integrations
 
 External CI, editor, code-hosting, and AI integrations implement the object-safe

--- a/crates/vize_doctor/benches/reporter.rs
+++ b/crates/vize_doctor/benches/reporter.rs
@@ -2,11 +2,11 @@ use std::{hint::black_box, io};
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use vize_doctor::{
-    AiContextBudget, AnalysisProvenance, DoctorCategory, DoctorFinding, DoctorReport,
-    DoctorReporter, FindingAssessment, FindingConfidence, FindingImpact, FindingSeverity,
-    HealthPenalty, JsonReporter, ReporterAudience, ReporterCapability, ReporterDescriptor,
-    ReporterError, ReporterOutput, ReporterTransport, RuleCost, SarifReporter, SarifSource,
-    SourceLocation, build_ai_context, render_report,
+    AiContextBudget, AnalysisProvenance, DoctorCategory, DoctorFilterSpec, DoctorFinding,
+    DoctorReport, DoctorReporter, FindingAssessment, FindingConfidence, FindingImpact,
+    FindingSeverity, HealthPenalty, JsonReporter, ReporterAudience, ReporterCapability,
+    ReporterDescriptor, ReporterError, ReporterOutput, ReporterTransport, RuleCost, SarifReporter,
+    SarifSource, SourceLocation, build_ai_context, render_report,
 };
 
 struct EmptyReporter {
@@ -134,6 +134,39 @@ fn benchmark_sarif_reporter(c: &mut Criterion) {
     group.finish();
 }
 
+fn benchmark_finding_filter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("doctor_filter/matches");
+    let filter = DoctorFilterSpec {
+        categories: vec![DoctorCategory::Performance],
+        severities: vec![FindingSeverity::Warning],
+        rules: vec!["VIZE_DOCTOR_BENCH".into()],
+        paths: vec!["src/**".into()],
+        changed_files: vec!["src/Benchmark.vue".into()],
+        ..DoctorFilterSpec::default()
+    }
+    .compile()
+    .unwrap();
+
+    for finding_count in [100, 10_000] {
+        let report = report_with_findings(finding_count);
+        group.throughput(Throughput::Elements(finding_count as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(finding_count),
+            &report,
+            |b, report| {
+                b.iter(|| {
+                    black_box(report)
+                        .findings()
+                        .iter()
+                        .filter(|finding| filter.matches(finding))
+                        .count()
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
 fn report_with_findings(finding_count: usize) -> DoctorReport {
     DoctorReport::new(
         "benchmark",
@@ -161,6 +194,7 @@ criterion_group!(
     benchmark_reporter_contract,
     benchmark_json_reporter,
     benchmark_ai_context,
-    benchmark_sarif_reporter
+    benchmark_sarif_reporter,
+    benchmark_finding_filter
 );
 criterion_main!(reporter_benches);

--- a/crates/vize_doctor/src/filter.rs
+++ b/crates/vize_doctor/src/filter.rs
@@ -1,0 +1,289 @@
+//! Deterministic, reporter-neutral finding filters.
+
+mod matcher;
+
+#[cfg(test)]
+mod tests;
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use vize_carton::String;
+
+use crate::{DoctorCategory, DoctorFinding, DoctorReport, FindingConfidence, FindingSeverity};
+
+use self::matcher::PatternSet;
+
+/// Serializable selection contract shared by CLI, TUI, editor, and AI clients.
+///
+/// Empty dimensions accept every value. Values within one dimension are joined
+/// with OR, while populated dimensions are joined with AND. String dimensions
+/// accept shell-style `*`, `?`, character classes, and recursive `**` globs.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct DoctorFilterSpec {
+    /// Accepted health categories. Defaults to every category.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub categories: Vec<DoctorCategory>,
+    /// Accepted gate severities. Defaults to every severity.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub severities: Vec<FindingSeverity>,
+    /// Accepted evidence confidence levels. Defaults to every confidence.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub confidences: Vec<FindingConfidence>,
+    /// Target identifier globs. Defaults to every target, including absent context.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub targets: Vec<String>,
+    /// Stable rule-code globs. Defaults to every rule.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<String>,
+    /// Primary workspace-relative path globs. Defaults to every path.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub paths: Vec<String>,
+    /// Route identifier globs. Defaults to every route, including absent context.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub routes: Vec<String>,
+    /// Environment identifier globs. Defaults to every environment, including absent context.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub environments: Vec<String>,
+    /// Workspace package identifier globs. Defaults to every package, including absent context.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub packages: Vec<String>,
+    /// Changed-file globs matched against all source evidence and invalidation inputs.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub changed_files: Vec<String>,
+}
+
+impl DoctorFilterSpec {
+    /// Compiles and validates every string pattern.
+    pub fn compile(&self) -> Result<DoctorFilter, DoctorFilterError> {
+        DoctorFilter::compile(self)
+    }
+
+    fn normalized(&self) -> Self {
+        let mut normalized = self.clone();
+        sort_dedup(&mut normalized.categories);
+        sort_dedup(&mut normalized.severities);
+        sort_dedup(&mut normalized.confidences);
+        normalize_patterns(&mut normalized.targets, false);
+        normalize_patterns(&mut normalized.rules, false);
+        normalize_patterns(&mut normalized.paths, true);
+        normalize_patterns(&mut normalized.routes, false);
+        normalize_patterns(&mut normalized.environments, false);
+        normalize_patterns(&mut normalized.packages, false);
+        normalize_patterns(&mut normalized.changed_files, true);
+        normalized
+    }
+}
+
+/// Validated finding predicate with precompiled string matchers.
+#[derive(Debug, Clone)]
+pub struct DoctorFilter {
+    spec: DoctorFilterSpec,
+    targets: PatternSet,
+    rules: PatternSet,
+    paths: PatternSet,
+    routes: PatternSet,
+    environments: PatternSet,
+    packages: PatternSet,
+    changed_files: PatternSet,
+}
+
+impl DoctorFilter {
+    /// Compiles a filter spec, rejecting malformed or empty glob patterns.
+    pub fn compile(spec: &DoctorFilterSpec) -> Result<Self, DoctorFilterError> {
+        let spec = spec.normalized();
+        Ok(Self {
+            targets: PatternSet::compile(DoctorFilterDimension::Target, &spec.targets)?,
+            rules: PatternSet::compile(DoctorFilterDimension::Rule, &spec.rules)?,
+            paths: PatternSet::compile(DoctorFilterDimension::Path, &spec.paths)?,
+            routes: PatternSet::compile(DoctorFilterDimension::Route, &spec.routes)?,
+            environments: PatternSet::compile(
+                DoctorFilterDimension::Environment,
+                &spec.environments,
+            )?,
+            packages: PatternSet::compile(DoctorFilterDimension::Package, &spec.packages)?,
+            changed_files: PatternSet::compile(
+                DoctorFilterDimension::ChangedFile,
+                &spec.changed_files,
+            )?,
+            spec,
+        })
+    }
+
+    /// Returns the normalized, deterministically ordered source spec.
+    pub const fn spec(&self) -> &DoctorFilterSpec {
+        &self.spec
+    }
+
+    /// Returns whether a finding satisfies every populated dimension.
+    pub fn matches(&self, finding: &DoctorFinding) -> bool {
+        matches_enum(&self.spec.categories, finding.category)
+            && matches_enum(&self.spec.severities, finding.assessment.severity)
+            && matches_enum(&self.spec.confidences, finding.assessment.confidence)
+            && self.rules.matches(&finding.code)
+            && self.paths.matches_path(&finding.primary.path)
+            && self
+                .targets
+                .matches_optional(finding.context.target.as_deref())
+            && self
+                .routes
+                .matches_optional(finding.context.route.as_deref())
+            && self
+                .environments
+                .matches_optional(finding.context.environment.as_deref())
+            && self
+                .packages
+                .matches_optional(finding.context.package.as_deref())
+            && self.matches_changed_files(finding)
+    }
+
+    /// Creates a newly scored report containing only matching findings.
+    pub fn apply(&self, report: &DoctorReport) -> DoctorReport {
+        DoctorReport::new(
+            report.workspace(),
+            report
+                .findings()
+                .iter()
+                .filter(|finding| self.matches(finding))
+                .cloned(),
+        )
+    }
+
+    fn matches_changed_files(&self, finding: &DoctorFinding) -> bool {
+        self.changed_files.is_unrestricted()
+            || finding_paths(finding).any(|path| self.changed_files.matches_path(path))
+    }
+}
+
+/// String-valued filter dimension associated with a pattern error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DoctorFilterDimension {
+    /// Application target.
+    Target,
+    /// Stable rule code.
+    Rule,
+    /// Primary source path.
+    Path,
+    /// Application route.
+    Route,
+    /// Execution environment.
+    Environment,
+    /// Workspace package.
+    Package,
+    /// Changed source or invalidation input.
+    ChangedFile,
+}
+
+impl fmt::Display for DoctorFilterDimension {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Target => "target",
+            Self::Rule => "rule",
+            Self::Path => "path",
+            Self::Route => "route",
+            Self::Environment => "environment",
+            Self::Package => "package",
+            Self::ChangedFile => "changed-file",
+        })
+    }
+}
+
+/// Invalid string pattern supplied to a doctor filter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DoctorFilterError {
+    dimension: DoctorFilterDimension,
+    pattern: String,
+    reason: String,
+}
+
+impl DoctorFilterError {
+    pub(crate) fn new(
+        dimension: DoctorFilterDimension,
+        pattern: impl Into<String>,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            dimension,
+            pattern: pattern.into(),
+            reason: reason.into(),
+        }
+    }
+
+    /// Returns the dimension containing the invalid pattern.
+    pub const fn dimension(&self) -> DoctorFilterDimension {
+        self.dimension
+    }
+
+    /// Returns the rejected pattern exactly as normalized for matching.
+    pub fn pattern(&self) -> &str {
+        &self.pattern
+    }
+
+    /// Returns the glob compiler's bounded explanation.
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+}
+
+impl fmt::Display for DoctorFilterError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "invalid {} filter pattern {:?}: {}",
+            self.dimension, self.pattern, self.reason
+        )
+    }
+}
+
+impl std::error::Error for DoctorFilterError {}
+
+fn finding_paths(finding: &DoctorFinding) -> impl Iterator<Item = &str> {
+    std::iter::once(finding.primary.path.as_str())
+        .chain(
+            finding
+                .related
+                .iter()
+                .map(|related| related.location.path.as_str()),
+        )
+        .chain(
+            finding
+                .evidence
+                .iter()
+                .filter_map(|evidence| evidence.location.as_ref())
+                .map(|location| location.path.as_str()),
+        )
+        .chain(
+            finding
+                .fix
+                .iter()
+                .flat_map(|fix| &fix.edits)
+                .map(|edit| edit.location.path.as_str()),
+        )
+        .chain(
+            finding
+                .provenance
+                .invalidation_inputs
+                .iter()
+                .map(String::as_str),
+        )
+}
+
+fn matches_enum<T: PartialEq>(accepted: &[T], value: T) -> bool {
+    accepted.is_empty() || accepted.contains(&value)
+}
+
+fn sort_dedup<T: Ord>(values: &mut Vec<T>) {
+    values.sort();
+    values.dedup();
+}
+
+fn normalize_patterns(patterns: &mut Vec<String>, path: bool) {
+    for pattern in patterns.iter_mut() {
+        *pattern = pattern.trim().into();
+        if path && pattern.contains('\\') {
+            *pattern = pattern.replace('\\', "/").into();
+        }
+    }
+    sort_dedup(patterns);
+}

--- a/crates/vize_doctor/src/filter/matcher.rs
+++ b/crates/vize_doctor/src/filter/matcher.rs
@@ -1,0 +1,60 @@
+use globset::{GlobBuilder, GlobMatcher};
+use vize_carton::{String, ToCompactString};
+
+use super::{DoctorFilterDimension, DoctorFilterError};
+
+#[derive(Debug, Clone)]
+pub(super) struct PatternSet {
+    matchers: Vec<GlobMatcher>,
+}
+
+impl PatternSet {
+    pub(super) fn compile(
+        dimension: DoctorFilterDimension,
+        patterns: &[String],
+    ) -> Result<Self, DoctorFilterError> {
+        let matchers = patterns
+            .iter()
+            .map(|pattern| compile_pattern(dimension, pattern))
+            .collect::<Result<_, _>>()?;
+        Ok(Self { matchers })
+    }
+
+    pub(super) fn is_unrestricted(&self) -> bool {
+        self.matchers.is_empty()
+    }
+
+    pub(super) fn matches(&self, value: &str) -> bool {
+        self.is_unrestricted() || self.matchers.iter().any(|matcher| matcher.is_match(value))
+    }
+
+    pub(super) fn matches_optional(&self, value: Option<&str>) -> bool {
+        self.is_unrestricted() || value.is_some_and(|value| self.matches(value))
+    }
+
+    pub(super) fn matches_path(&self, path: &str) -> bool {
+        if !path.contains('\\') {
+            return self.matches(path);
+        }
+        self.matches(&path.replace('\\', "/"))
+    }
+}
+
+fn compile_pattern(
+    dimension: DoctorFilterDimension,
+    pattern: &str,
+) -> Result<GlobMatcher, DoctorFilterError> {
+    if pattern.is_empty() {
+        return Err(DoctorFilterError::new(
+            dimension,
+            pattern,
+            "patterns must not be empty",
+        ));
+    }
+    GlobBuilder::new(pattern)
+        .literal_separator(true)
+        .backslash_escape(false)
+        .build()
+        .map(|glob| glob.compile_matcher())
+        .map_err(|error| DoctorFilterError::new(dimension, pattern, error.to_compact_string()))
+}

--- a/crates/vize_doctor/src/filter/tests.rs
+++ b/crates/vize_doctor/src/filter/tests.rs
@@ -1,0 +1,242 @@
+use crate::{
+    AnalysisProvenance, DoctorCategory, DoctorFinding, DoctorReport, FindingAssessment,
+    FindingConfidence, FindingContext, FindingEvidence, FindingFix, FindingImpact, FindingSeverity,
+    FixSafety, HealthPenalty, RelatedLocation, RuleCost, SourceLocation, TextEdit,
+};
+use vize_carton::{String, cstr};
+
+use super::{DoctorFilterDimension, DoctorFilterSpec};
+
+#[test]
+fn empty_filter_accepts_every_finding_and_preserves_report() {
+    let report = fixture_report();
+    let filter = DoctorFilterSpec::default().compile().unwrap();
+
+    assert!(
+        report
+            .findings()
+            .iter()
+            .all(|finding| filter.matches(finding))
+    );
+    assert_eq!(filter.apply(&report), report);
+}
+
+#[test]
+fn dimensions_are_anded_and_values_within_dimensions_are_ored() {
+    let report = fixture_report();
+    let filter = DoctorFilterSpec {
+        categories: vec![DoctorCategory::Security, DoctorCategory::Correctness],
+        severities: vec![FindingSeverity::Error],
+        confidences: vec![FindingConfidence::Certain, FindingConfidence::High],
+        targets: vec!["w*".into()],
+        rules: vec!["VIZE_DOCTOR_*_001".into()],
+        paths: vec!["packages/**/src/*.vue".into()],
+        routes: vec!["/account/**".into()],
+        environments: vec!["prod*".into()],
+        packages: vec!["@vize/app-*".into()],
+        changed_files: vec!["packages/account/**".into()],
+    }
+    .compile()
+    .unwrap();
+
+    let selected = filter.apply(&report);
+
+    assert_eq!(selected.findings().len(), 1);
+    assert_eq!(selected.findings()[0].code, "VIZE_DOCTOR_SECURITY_001");
+    assert_eq!(selected.summary().counts.errors, 1);
+    assert!(selected.summary().has_blocking_errors);
+}
+
+#[test]
+fn populated_context_dimension_rejects_absent_context() {
+    let report = fixture_report();
+    let filter = DoctorFilterSpec {
+        targets: vec!["web".into()],
+        ..DoctorFilterSpec::default()
+    }
+    .compile()
+    .unwrap();
+
+    assert!(filter.matches(&report.findings()[0]));
+    assert!(!filter.matches(&report.findings()[1]));
+}
+
+#[test]
+fn path_is_primary_only_while_changed_file_uses_complete_evidence_graph() {
+    let report = fixture_report();
+    let finding = &report.findings()[0];
+    let primary_only = DoctorFilterSpec {
+        paths: vec!["packages/shared/src/policy.ts".into()],
+        ..DoctorFilterSpec::default()
+    }
+    .compile()
+    .unwrap();
+    let related_changed = DoctorFilterSpec {
+        changed_files: vec!["packages/shared/src/policy.ts".into()],
+        ..DoctorFilterSpec::default()
+    }
+    .compile()
+    .unwrap();
+    let edit_changed = DoctorFilterSpec {
+        changed_files: vec!["packages/account/src/fix.ts".into()],
+        ..DoctorFilterSpec::default()
+    }
+    .compile()
+    .unwrap();
+    let invalidation_changed = DoctorFilterSpec {
+        changed_files: vec!["packages/account/src/generated.ts".into()],
+        ..DoctorFilterSpec::default()
+    }
+    .compile()
+    .unwrap();
+
+    assert!(!primary_only.matches(finding));
+    assert!(related_changed.matches(finding));
+    assert!(edit_changed.matches(finding));
+    assert!(invalidation_changed.matches(finding));
+}
+
+#[test]
+fn windows_patterns_and_candidate_paths_are_slash_normalized() {
+    let report = fixture_report();
+    let filter = DoctorFilterSpec {
+        paths: vec![r"packages\account\src\*.vue".into()],
+        changed_files: vec![r"packages\shared\**".into()],
+        ..DoctorFilterSpec::default()
+    }
+    .compile()
+    .unwrap();
+
+    assert!(filter.matches(&report.findings()[0]));
+    assert_eq!(
+        filter.spec().paths,
+        [String::from("packages/account/src/*.vue")]
+    );
+}
+
+#[test]
+fn compiling_normalizes_deduplicates_and_serializes_the_spec() {
+    let filter = DoctorFilterSpec {
+        categories: vec![DoctorCategory::Security, DoctorCategory::Security],
+        rules: vec![" VIZE_* ".into(), "VIZE_*".into()],
+        ..DoctorFilterSpec::default()
+    }
+    .compile()
+    .unwrap();
+
+    assert_eq!(filter.spec().categories, [DoctorCategory::Security]);
+    assert_eq!(filter.spec().rules, [String::from("VIZE_*")]);
+    assert_eq!(
+        serde_json::to_string(filter.spec()).unwrap(),
+        r#"{"categories":["security"],"rules":["VIZE_*"]}"#
+    );
+}
+
+#[test]
+fn invalid_and_empty_patterns_fail_closed_with_dimension_context() {
+    for (pattern, expected_reason) in [("[broken", "unclosed"), ("   ", "must not be empty")] {
+        let error = DoctorFilterSpec {
+            changed_files: vec![pattern.into()],
+            ..DoctorFilterSpec::default()
+        }
+        .compile()
+        .unwrap_err();
+
+        assert_eq!(error.dimension(), DoctorFilterDimension::ChangedFile);
+        assert!(error.reason().contains(expected_reason), "{error}");
+        assert!(cstr!("{error}").contains("changed-file"));
+    }
+}
+
+#[test]
+fn filtered_reports_recompute_health_and_blocking_from_visible_findings() {
+    let report = fixture_report();
+    let filter = DoctorFilterSpec {
+        severities: vec![FindingSeverity::Warning],
+        ..DoctorFilterSpec::default()
+    }
+    .compile()
+    .unwrap();
+
+    let selected = filter.apply(&report);
+
+    assert_eq!(selected.summary().counts.total(), 1);
+    assert_eq!(selected.summary().counts.warnings, 1);
+    assert!(!selected.summary().has_blocking_errors);
+    assert!(selected.summary().overall_score > report.summary().overall_score);
+}
+
+fn fixture_report() -> DoctorReport {
+    let security = DoctorFinding::new(
+        "VIZE_DOCTOR_SECURITY_001",
+        DoctorCategory::Security,
+        assessment(
+            FindingSeverity::Error,
+            FindingConfidence::Certain,
+            FindingImpact::Critical,
+            30,
+        ),
+        SourceLocation::new("packages/account/src/Login.vue", 10, 20),
+        "Authorization guard is missing",
+        "Guard the reachable account route before loading private data.",
+        AnalysisProvenance::new("authorization-graph", RuleCost::Moderate)
+            .with_invalidation_inputs(["packages/account/src/generated.ts"]),
+    )
+    .with_context(FindingContext {
+        target: Some("web".into()),
+        environment: Some("production".into()),
+        route: Some("/account/settings".into()),
+        package: Some("@vize/app-account".into()),
+        component: Some("Login".into()),
+        capability: Some("account.read".into()),
+        build_node: Some("account-client".into()),
+    })
+    .with_related(RelatedLocation::new(
+        SourceLocation::new("packages/shared/src/policy.ts", 3, 8),
+        "Policy declaration",
+    ))
+    .with_evidence(
+        FindingEvidence::new(crate::EvidenceKind::Contract, "Guard edge is absent").with_location(
+            SourceLocation::new("packages/account/src/router.ts", 30, 40),
+        ),
+    )
+    .with_fix(
+        FindingFix::new(FixSafety::ReviewRequired, "Add the account guard").with_edit(
+            TextEdit::new(
+                SourceLocation::new("packages/account/src/fix.ts", 0, 0),
+                "requireAccount()",
+            ),
+        ),
+    );
+
+    let warning = DoctorFinding::new(
+        "VIZE_DOCTOR_PERFORMANCE_002",
+        DoctorCategory::Performance,
+        assessment(
+            FindingSeverity::Warning,
+            FindingConfidence::Medium,
+            FindingImpact::Medium,
+            12,
+        ),
+        SourceLocation::new("src/Home.vue", 4, 12),
+        "Avoidable render work",
+        "Move the stable work out of the render path.",
+        AnalysisProvenance::new("render-graph", RuleCost::Low),
+    );
+
+    DoctorReport::new("fixture", [warning, security])
+}
+
+fn assessment(
+    severity: FindingSeverity,
+    confidence: FindingConfidence,
+    impact: FindingImpact,
+    points: u8,
+) -> FindingAssessment {
+    FindingAssessment::new(
+        severity,
+        confidence,
+        impact,
+        HealthPenalty::new(points, "Filter fixture"),
+    )
+}

--- a/crates/vize_doctor/src/lib.rs
+++ b/crates/vize_doctor/src/lib.rs
@@ -56,6 +56,7 @@
 mod ai_context;
 #[cfg(feature = "application-analysis")]
 pub mod application_analysis;
+mod filter;
 mod model;
 mod report;
 mod reporter;
@@ -66,6 +67,7 @@ pub use ai_context::{
     AiEvidenceRelation, AiFindingContext, AiSourceSnippet, AiVerificationStep,
     DOCTOR_AI_CONTEXT_FORMAT_VERSION, build_ai_context,
 };
+pub use filter::{DoctorFilter, DoctorFilterDimension, DoctorFilterError, DoctorFilterSpec};
 pub use model::{
     AnalysisProvenance, DEFAULT_UNAVAILABLE_FIX_REASON, DoctorCategory, DoctorFinding,
     EvidenceKind, FindingAssessment, FindingConfidence, FindingContext, FindingEvidence,

--- a/crates/vize_doctor/src/model/evidence.rs
+++ b/crates/vize_doctor/src/model/evidence.rs
@@ -71,6 +71,9 @@ pub struct FindingContext {
     /// Route identifier. Defaults to absent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub route: Option<String>,
+    /// Workspace package identifier. Defaults to absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub package: Option<String>,
     /// Component identifier. Defaults to absent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component: Option<String>,

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -253,9 +253,9 @@ Key options:
 
 Exit status `0` means the gate passed, `1` means a certain or high-confidence error, and `2` means
 discovery, parsing, analysis, serialization, or output failed. Warnings and lower-confidence findings
-affect the health score but do not block by default. The deterministic `--format json` report carries
-explicit format and scoring versions and is the preferred interface for CI, editors, dashboards, and
-AI tooling:
+affect the health score but do not block by default. See [Doctor diagnostics](doctor.md) for precise
+filter, changed-file, scoring, and automation contracts. The deterministic `--format json` report
+carries explicit format and scoring versions and is the preferred interface for CI and AI tooling:
 
 ```bash
 vize doctor src --format json > doctor-report.json

--- a/docs/content/guide/doctor.md
+++ b/docs/content/guide/doctor.md
@@ -1,0 +1,88 @@
+---
+title: Doctor Diagnostics
+---
+
+# Doctor Diagnostics
+
+`vize doctor` analyzes the application once, then projects the immutable report into the view a
+person, CI gate, editor, or AI integration needs. Filters never change which analyzers run or mutate
+the evidence graph. They select findings after analysis and produce a newly scored report.
+
+## Filter Algebra
+
+Repeat a filter to accept multiple values. Category, severity, and confidence also accept
+comma-separated values. Values within one dimension are ORed, while populated dimensions are ANDed:
+
+```bash
+vize doctor src \
+  --category correctness,security \
+  --severity error \
+  --confidence certain,high \
+  --rule 'VIZE_DOCTOR_CF_*' \
+  --path 'packages/**/src/*.vue' \
+  --changed-file 'packages/account/**'
+```
+
+This example retains a finding only when every populated dimension matches. An empty dimension
+matches everything. Repeating `--rule` therefore broadens the rule dimension; adding `--severity`
+narrows the result across dimensions.
+
+| Option           | Matches                                                                                                 |
+| ---------------- | ------------------------------------------------------------------------------------------------------- |
+| `--category`     | `correctness`, `accessibility`, `performance`, `maintainability`, `security`, or `production-readiness` |
+| `--severity`     | `error`, `warning`, or `notice`                                                                         |
+| `--confidence`   | `certain`, `high`, `medium`, or `low`                                                                   |
+| `--target`       | Analyzer-supplied target identifier                                                                     |
+| `--rule`         | Stable diagnostic code                                                                                  |
+| `--path`         | Primary workspace-relative source path only                                                             |
+| `--route`        | Analyzer-supplied route identifier                                                                      |
+| `--environment`  | Analyzer-supplied runtime environment                                                                   |
+| `--package`      | Analyzer-supplied workspace package                                                                     |
+| `--changed-file` | Any affected source in the complete evidence graph                                                      |
+
+Identifier and path dimensions use case-sensitive shell globs. `*`, `?`, character classes, and
+recursive `**` are supported. Paths are compared with `/` separators on every platform. Invalid or
+empty patterns fail closed before analysis output is written, with exit status `2` and a diagnostic
+that names the invalid dimension.
+
+## Changed-File Semantics
+
+`--changed-file` is intentionally broader than `--path`. A finding matches when the pattern reaches
+any of these inputs:
+
+- its primary or related source location;
+- a nested evidence location;
+- a source edit in the proposed fix; or
+- a provenance invalidation input that would require the analysis to be recomputed.
+
+This preserves findings whose visible primary location did not change but whose conclusion depends
+on a shared component, generated contract, or related declaration that did. It also makes the filter
+suitable for pull-request annotations without discarding cross-file causality.
+
+## Scoring and Exit Status
+
+The filtered report is reconstructed through the normal deterministic ranking and scoring path.
+Counts, category health, overall score, and blocking-error state describe only visible findings.
+Consequently, hiding the last blocking finding changes the command exit status from `1` to `0`.
+
+| Status | Meaning                                                                  |
+| -----: | ------------------------------------------------------------------------ |
+|    `0` | The visible report has no certain or high-confidence error               |
+|    `1` | At least one visible finding is a blocking error                         |
+|    `2` | Discovery, analysis, filter compilation, serialization, or output failed |
+
+Use `--exit-zero` when the report is informative and another system owns policy. It changes the
+process status only; it does not rewrite the report's blocking-error state.
+
+## Automation Contract
+
+Use `--format json` for CI, editors, dashboards, and provider-neutral AI adapters. The JSON document
+has explicit format and scoring versions, stable rule codes, normalized paths, confidence, impact,
+evidence, fix availability, and analysis provenance. Consumers should filter through the CLI or the
+`vize_doctor::DoctorFilterSpec` library contract instead of deleting JSON findings themselves; doing
+so guarantees that derived health metadata and exit policy stay consistent.
+
+Filters are compiled once. Matching a report performs a single pass over findings and only traverses
+the extra evidence graph when `--changed-file` is populated. The reporter receives the resulting
+immutable report, so text, JSON, SARIF, TUI, and future AI vendors share identical selection
+semantics.


### PR DESCRIPTION
## Summary

- publish a serializable, reporter-neutral filter contract for category, severity, confidence, target, rule, primary path, route, environment, package, and changed-file selection
- compile deterministic shell globs once, normalize Windows paths, fail closed on malformed patterns, and apply OR-within / AND-across dimension semantics
- make changed-file selection traverse primary, related, evidence, fix-edit, and invalidation-input paths
- expose the same semantics through `vize doctor`, including filtered rescoring and exit status
- document the Rust and CLI contracts and add a 10,000-finding Criterion benchmark

## Contract details

- empty dimensions are unrestricted
- a populated context dimension does not match absent analyzer context
- `--path` matches the primary location only
- `--changed-file` matches the complete source/evidence graph
- compiled specs are normalized, sorted, and deduplicated
- filtering never mutates the source report and deterministically rebuilds its health summary
- invalid and empty globs return exit status 2 before report output

## Validation

- `cargo test -p vize_doctor --all-features`
  - 42 unit tests
  - 17 application/report integration tests
  - 1 doctest
- `cargo test -p vize --test doctor_cli`
  - 11 CLI integration tests
- `cargo test -p vize --test doctor_filter_cli`
  - 3 filter CLI integration tests
- `cargo test -p vize --lib cli::tests::doctor_help_snapshot`
- `cargo clippy -p vize_doctor --all-features --all-targets -- -D warnings`
- `cargo clippy -p vize --lib --bins -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p vize_doctor --all-features --no-deps`
- `cargo bench -p vize_doctor --bench reporter --no-run`
- Criterion `doctor_filter/matches/10000`: 0.945 ms median, about 10.6 million findings/s

Relates #3138.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

