### PR TITLE
feat(ui): add interaction modality tracking

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -64,6 +64,11 @@
       "import": "./dist/id.mjs",
       "default": "./dist/id.mjs"
     },
+    "./interaction-modality": {
+      "types": "./dist/interaction-modality.d.mts",
+      "import": "./dist/interaction-modality.mjs",
+      "default": "./dist/interaction-modality.mjs"
+    },
     "./primitive": {
       "types": "./dist/primitive.d.mts",
       "import": "./dist/primitive.mjs",

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,13 +5,14 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 10_450],
+  ["index.mjs", 13_150],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
   ["collection.mjs", 5_700],
   ["context.mjs", 700],
   ["controllable-state.mjs", 600],
   ["id.mjs", 2_300],
+  ["interaction-modality.mjs", 3_300],
   ["primitive.mjs", 800],
   ["visually-hidden.mjs", 800],
   ["media.mjs", 2_400],

--- a/npm/ui/core/scripts/check-tree-shaking.mjs
+++ b/npm/ui/core/scripts/check-tree-shaking.mjs
@@ -72,6 +72,7 @@ const familySignatures = Object.freeze({
   checkbox: /aria-checked/,
   collection: /VIZE_UI_COLLECTION_DISPOSED/,
   id: /DeterministicIdProvider/,
+  "interaction-modality": /VIZE_UI_INTERACTION_MODALITY_DISPOSED/,
   primitive: /data-vize-ui.+primitive/,
   "visually-hidden": /visually-hidden/,
 });
@@ -99,6 +100,12 @@ const componentCases = [
     family: "id",
     exportName: "IdProvider",
     maximumJavaScriptGzipBytes: 1_050,
+    maximumCssGzipBytes: 0,
+  },
+  {
+    family: "interaction-modality",
+    exportName: "createInteractionModalityTracker",
+    maximumJavaScriptGzipBytes: 1_650,
     maximumCssGzipBytes: 0,
   },
   {

--- a/npm/ui/core/src/distribution.test.ts
+++ b/npm/ui/core/src/distribution.test.ts
@@ -12,6 +12,7 @@ const publicEntries = [
   "./collection",
   "./controllable-state",
   "./id",
+  "./interaction-modality",
   "./primitive",
   "./visually-hidden",
 ] as const;

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -4,5 +4,6 @@ export * from "./context.ts";
 export * from "./controllable-state.ts";
 export * from "./button.ts";
 export * from "./id.ts";
+export * from "./interaction-modality.ts";
 export * from "./primitive.ts";
 export * from "./visually-hidden.ts";

--- a/npm/ui/core/src/interaction-modality-events.ts
+++ b/npm/ui/core/src/interaction-modality-events.ts
@@ -1,0 +1,47 @@
+import type {
+  InteractionModality,
+  InteractionModalityChangeReason,
+} from "./interaction-modality-types.ts";
+
+/** Internal event classification delivered by a document hub. */
+export interface InteractionModalityEvent {
+  readonly modality: InteractionModality;
+  readonly reason: InteractionModalityChangeReason;
+  readonly originalEvent: Event;
+}
+
+const modifierKeys = new Set(["Alt", "AltGraph", "Control", "Meta"]);
+
+/** Classify keyboard intent while excluding composition and modified shortcuts. */
+export function classifyKeyboardEvent(event: KeyboardEvent): InteractionModalityEvent | null {
+  if (
+    event.isComposing ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey ||
+    modifierKeys.has(event.key)
+  ) {
+    return null;
+  }
+
+  return { modality: "keyboard", reason: "keyboard", originalEvent: event };
+}
+
+/** Map pointer hardware into the stable public modality vocabulary. */
+export function classifyPointerEvent(event: PointerEvent): InteractionModalityEvent {
+  if (event.pointerId === -1 && event.pointerType === "") {
+    return { modality: "virtual", reason: "virtual", originalEvent: event };
+  }
+
+  const modality = event.pointerType === "touch" ? "touch" : "pointer";
+  return { modality, reason: modality, originalEvent: event };
+}
+
+/** Classify coordinate-free clicks used by keyboards and assistive technology. */
+export function classifyVirtualClick(
+  event: MouseEvent,
+  current: InteractionModality | null,
+): InteractionModalityEvent | null {
+  if (event.detail !== 0 || current === "keyboard") return null;
+  return { modality: "virtual", reason: "virtual", originalEvent: event };
+}

--- a/npm/ui/core/src/interaction-modality-hub.ts
+++ b/npm/ui/core/src/interaction-modality-hub.ts
@@ -1,0 +1,150 @@
+import {
+  classifyKeyboardEvent,
+  classifyPointerEvent,
+  classifyVirtualClick,
+} from "./interaction-modality-events.ts";
+import type {
+  InteractionModality,
+  InteractionModalityChangeReason,
+} from "./interaction-modality-types.ts";
+
+export interface DocumentModalityUpdate {
+  readonly modality: InteractionModality | null;
+  readonly reason: InteractionModalityChangeReason;
+  readonly originalEvent: Event | null;
+}
+
+interface DocumentModalityHub {
+  readonly subscribers: Set<(update: DocumentModalityUpdate) => void>;
+  publish: (update: DocumentModalityUpdate) => boolean;
+  modality: InteractionModality | null;
+  disposeListeners: () => void;
+}
+
+const hubs = new WeakMap<Document, DocumentModalityHub>();
+
+/** Install one capture listener set for all consumers in a document. */
+function createHub(
+  document: Document,
+  initialModality: InteractionModality | null,
+): DocumentModalityHub {
+  const subscribers = new Set<(update: DocumentModalityUpdate) => void>();
+  const pendingUpdates: DocumentModalityUpdate[] = [];
+  let publishing = false;
+  const hub: DocumentModalityHub = {
+    subscribers,
+    modality: initialModality,
+    disposeListeners: () => undefined,
+    publish: () => false,
+  };
+
+  hub.publish = (update: DocumentModalityUpdate) => {
+    if (hub.modality === update.modality && pendingUpdates.length === 0) return false;
+    pendingUpdates.push(update);
+    if (publishing) return true;
+
+    publishing = true;
+    const errors: unknown[] = [];
+    try {
+      while (pendingUpdates.length > 0) {
+        const nextUpdate = pendingUpdates.shift()!;
+        if (hub.modality === nextUpdate.modality) continue;
+        hub.modality = nextUpdate.modality;
+        for (const subscriber of Array.from(subscribers)) {
+          if (!subscribers.has(subscriber)) continue;
+          try {
+            subscriber(nextUpdate);
+          } catch (error) {
+            errors.push(error);
+          }
+        }
+      }
+    } finally {
+      publishing = false;
+    }
+
+    if (errors.length === 1) throw errors[0];
+    if (errors.length > 1) {
+      throw new AggregateError(errors, "Interaction modality subscribers failed");
+    }
+    return true;
+  };
+  let lastTouchTime = Number.NEGATIVE_INFINITY;
+  const onKeyDown = (event: Event) => {
+    const update = classifyKeyboardEvent(event as KeyboardEvent);
+    if (update) hub.publish(update);
+  };
+  const onPointerDown = (event: Event) => hub.publish(classifyPointerEvent(event as PointerEvent));
+  const onMouseDown = (event: Event) => {
+    const elapsedSinceTouch = event.timeStamp - lastTouchTime;
+    if (elapsedSinceTouch >= 0 && elapsedSinceTouch < 800) return;
+    hub.publish({ modality: "pointer", reason: "pointer", originalEvent: event });
+  };
+  const onTouchStart = (event: Event) => {
+    lastTouchTime = event.timeStamp;
+    hub.publish({ modality: "touch", reason: "touch", originalEvent: event });
+  };
+  const onClick = (event: Event) => {
+    const update = classifyVirtualClick(event as MouseEvent, hub.modality);
+    if (update) hub.publish(update);
+  };
+
+  document.addEventListener("keydown", onKeyDown, true);
+  document.addEventListener("click", onClick, true);
+  const supportsPointerEvents = Boolean(document.defaultView?.PointerEvent);
+  if (supportsPointerEvents) {
+    document.addEventListener("pointerdown", onPointerDown, true);
+  } else {
+    document.addEventListener("mousedown", onMouseDown, true);
+    document.addEventListener("touchstart", onTouchStart, true);
+  }
+
+  hub.disposeListeners = () => {
+    document.removeEventListener("keydown", onKeyDown, true);
+    document.removeEventListener("click", onClick, true);
+    if (supportsPointerEvents) {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+    } else {
+      document.removeEventListener("mousedown", onMouseDown, true);
+      document.removeEventListener("touchstart", onTouchStart, true);
+    }
+  };
+  return hub;
+}
+
+/** Subscribe to shared document state and return an idempotent release callback. */
+export function subscribeToDocumentModality(
+  document: Document,
+  initialModality: InteractionModality | null,
+  subscriber: (update: DocumentModalityUpdate) => void,
+): { readonly current: InteractionModality | null; readonly release: () => void } {
+  let hub = hubs.get(document);
+  if (!hub) {
+    hub = createHub(document, initialModality);
+    hubs.set(document, hub);
+  }
+  hub.subscribers.add(subscriber);
+  let released = false;
+
+  return {
+    current: hub.modality,
+    release: () => {
+      if (released) return;
+      released = true;
+      hub?.subscribers.delete(subscriber);
+      if (hub?.subscribers.size === 0) {
+        hub.disposeListeners();
+        hubs.delete(document);
+      }
+    },
+  };
+}
+
+/** Synchronize an explicit consumer update with every peer in a document. */
+export function publishDocumentModality(
+  document: Document,
+  update: DocumentModalityUpdate,
+): boolean {
+  const hub = hubs.get(document);
+  return hub?.publish(update) ?? false;
+}

--- a/npm/ui/core/src/interaction-modality-lifecycle.test.ts
+++ b/npm/ui/core/src/interaction-modality-lifecycle.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { effectScope, ref } from "vue";
+
+import {
+  createInteractionModalityTracker,
+  useInteractionModality,
+} from "./interaction-modality.ts";
+import type { InteractionModalityChange } from "./interaction-modality.ts";
+
+test("shares exactly one native listener set and state per document", () => {
+  const isolated = document.implementation.createHTMLDocument("shared");
+  const additions: string[] = [];
+  const removals: string[] = [];
+  const addEventListener = isolated.addEventListener.bind(isolated);
+  const removeEventListener = isolated.removeEventListener.bind(isolated);
+  isolated.addEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options,
+  ) => {
+    additions.push(type);
+    addEventListener(type, listener, options);
+  }) as typeof isolated.addEventListener;
+  isolated.removeEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options,
+  ) => {
+    removals.push(type);
+    removeEventListener(type, listener, options);
+  }) as typeof isolated.removeEventListener;
+
+  const first = createInteractionModalityTracker({ document: isolated });
+  const second = createInteractionModalityTracker({ document: isolated });
+  assert.deepEqual(additions.sort(), ["click", "keydown", "mousedown", "touchstart"]);
+
+  isolated.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Tab" }));
+  assert.equal(first.modality.value, "keyboard");
+  assert.equal(second.modality.value, "keyboard");
+  assert.equal(first.setModality("touch"), true);
+  assert.equal(second.modality.value, "touch");
+
+  isolated.dispatchEvent(new Event("touchstart", { bubbles: true }));
+  isolated.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+  assert.equal(first.modality.value, "touch");
+  assert.equal(second.modality.value, "touch");
+
+  first.dispose();
+  assert.deepEqual(removals, []);
+  second.dispose();
+  assert.deepEqual(
+    removals.sort((left, right) => left.localeCompare(right)),
+    ["click", "keydown", "mousedown", "touchstart"],
+  );
+});
+
+test("serializes reentrant updates so every peer reaches the same final state", () => {
+  const isolated = document.implementation.createHTMLDocument("reentrant");
+  const firstChanges: Array<string | null> = [];
+  const secondChanges: Array<string | null> = [];
+  let first!: ReturnType<typeof createInteractionModalityTracker>;
+  first = createInteractionModalityTracker({
+    document: isolated,
+    onChange(change) {
+      firstChanges.push(change.modality);
+      if (change.modality === "keyboard") first.setModality("touch");
+    },
+  });
+  const second = createInteractionModalityTracker({
+    document: isolated,
+    onChange: (change) => secondChanges.push(change.modality),
+  });
+
+  isolated.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Tab" }));
+  assert.equal(first.modality.value, "touch");
+  assert.equal(second.modality.value, "touch");
+  assert.deepEqual(firstChanges, ["keyboard", "touch"]);
+  assert.deepEqual(secondChanges, ["keyboard", "touch"]);
+
+  first.dispose();
+  second.dispose();
+});
+
+test("updates every peer before surfacing a subscriber exception", () => {
+  const isolated = document.implementation.createHTMLDocument("errors");
+  const failure = new Error("consumer callback failed");
+  const failing = createInteractionModalityTracker({
+    document: isolated,
+    onChange: () => {
+      throw failure;
+    },
+  });
+  const peer = createInteractionModalityTracker({ document: isolated });
+
+  assert.throws(() => failing.setModality("keyboard"), failure);
+  assert.equal(failing.modality.value, "keyboard");
+  assert.equal(peer.modality.value, "keyboard");
+  failing.dispose();
+  peer.dispose();
+});
+
+test("rolls back a failed document adoption without leaking a subscription", () => {
+  const isolated = document.implementation.createHTMLDocument("adoption-error");
+  const removals: string[] = [];
+  const removeEventListener = isolated.removeEventListener.bind(isolated);
+  isolated.removeEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options,
+  ) => {
+    removals.push(type);
+    removeEventListener(type, listener, options);
+  }) as typeof isolated.removeEventListener;
+  const anchor = createInteractionModalityTracker({
+    document: isolated,
+    initialModality: "pointer",
+  });
+  const moving = createInteractionModalityTracker({
+    document: null,
+    onChange: () => {
+      throw new Error("reject adoption");
+    },
+  });
+
+  assert.throws(() => moving.attach(isolated), /reject adoption/);
+  assert.equal(moving.document.value, null);
+  anchor.dispose();
+  assert.deepEqual(
+    removals.sort((left, right) => left.localeCompare(right)),
+    ["click", "keydown", "mousedown", "touchstart"],
+  );
+  moving.dispose();
+});
+
+test("isolates separate documents and adopts existing state when moving", () => {
+  const left = document.implementation.createHTMLDocument("left");
+  const right = document.implementation.createHTMLDocument("right");
+  const anchor = createInteractionModalityTracker({ document: right, initialModality: "touch" });
+  const currentDocument = ref<Document | null>(left);
+  const changes: InteractionModalityChange[] = [];
+  const moving = createInteractionModalityTracker({
+    document: currentDocument,
+    initialModality: "pointer",
+    onChange: (change) => changes.push(change),
+  });
+
+  left.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Tab" }));
+  assert.equal(moving.modality.value, "keyboard");
+  assert.equal(anchor.modality.value, "touch");
+
+  currentDocument.value = right;
+  assert.equal(moving.document.value, right);
+  assert.equal(moving.modality.value, "touch");
+  assert.equal(changes.at(-1)?.reason, "document");
+  currentDocument.value = null;
+  assert.equal(moving.document.value, null);
+  assert.equal(moving.modality.value, "touch");
+
+  moving.dispose();
+  anchor.dispose();
+});
+
+test("supports explicit attach and detach without losing the last value", () => {
+  const isolated = document.implementation.createHTMLDocument("attach");
+  const tracker = createInteractionModalityTracker({ document: null });
+
+  assert.equal(tracker.attach(isolated), true);
+  assert.equal(tracker.attach(isolated), false);
+  isolated.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+  assert.equal(tracker.modality.value, "pointer");
+  assert.equal(tracker.detach(), true);
+  assert.equal(tracker.detach(), false);
+  assert.equal(tracker.modality.value, "pointer");
+  tracker.dispose();
+});
+
+test("disposal is idempotent and rejects later mutation", () => {
+  const tracker = createInteractionModalityTracker({ document: null });
+  tracker.dispose();
+  tracker.dispose();
+
+  assert.throws(() => tracker.attach(document), /VIZE_UI_INTERACTION_MODALITY_DISPOSED/);
+  assert.throws(() => tracker.detach(), /VIZE_UI_INTERACTION_MODALITY_DISPOSED/);
+  assert.throws(() => tracker.setModality("keyboard"), /VIZE_UI_INTERACTION_MODALITY_DISPOSED/);
+});
+
+test("the composable requires and follows a Vue effect scope", () => {
+  assert.throws(
+    () => useInteractionModality({ document: null }),
+    /VIZE_UI_INTERACTION_MODALITY_SETUP/,
+  );
+
+  const scope = effectScope();
+  const tracker = scope.run(() => useInteractionModality({ document }))!;
+  assert.equal(tracker.document.value, document);
+  scope.stop();
+  assert.equal(tracker.document.value, null);
+  assert.throws(() => tracker.setModality("pointer"), /VIZE_UI_INTERACTION_MODALITY_DISPOSED/);
+});

--- a/npm/ui/core/src/interaction-modality-ssr.test.ts
+++ b/npm/ui/core/src/interaction-modality-ssr.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { createSSRApp, defineComponent, h, nextTick, onMounted, ref } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import { useInteractionModality } from "./interaction-modality.ts";
+
+const SsrProbe = defineComponent({
+  name: "InteractionModalitySsrProbe",
+  setup() {
+    const ownerDocument = ref<Document | null>(null);
+    const tracker = useInteractionModality({ document: ownerDocument });
+    onMounted(() => {
+      ownerDocument.value = document;
+    });
+    return () =>
+      h(
+        "output",
+        {
+          "data-attached": String(tracker.document.value !== null),
+          "data-focus-visible": String(tracker.isFocusVisible.value),
+        },
+        tracker.modality.value ?? "none",
+      );
+  },
+});
+
+test("renders byte-identical output without touching a server document", async () => {
+  const outputs = await Promise.all([
+    renderToString(createSSRApp(SsrProbe)),
+    renderToString(createSSRApp(SsrProbe)),
+  ]);
+
+  assert.equal(outputs[0], outputs[1]);
+  assert.match(outputs[0], /data-attached="false"/);
+  assert.match(outputs[0], /data-focus-visible="false"/);
+  assert.match(outputs[0], />none<\/output>/);
+});
+
+test("attaches after hydration without mismatch diagnostics", async () => {
+  const serverHtml = await renderToString(createSSRApp(SsrProbe));
+  const host = document.createElement("div");
+  host.innerHTML = serverHtml;
+  document.body.append(host);
+  const diagnostics: string[] = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  console.error = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  const app = createSSRApp(SsrProbe);
+
+  try {
+    app.mount(host);
+    await nextTick();
+    assert.equal(host.querySelector("output")?.dataset.attached, "true");
+    assert.equal(host.querySelector("output")?.textContent, "none");
+    assert.deepEqual(diagnostics, []);
+  } finally {
+    app.unmount();
+    host.remove();
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+});

--- a/npm/ui/core/src/interaction-modality-types.ts
+++ b/npm/ui/core/src/interaction-modality-types.ts
@@ -1,0 +1,77 @@
+import type { ComputedRef, MaybeRefOrGetter, ShallowRef } from "vue";
+
+/**
+ * Input family that most recently expressed user intent.
+ *
+ * Pens and unknown pointing hardware intentionally map to `pointer`; consumers
+ * that need device-specific geometry should inspect the original pointer event.
+ */
+export type InteractionModality = "keyboard" | "pointer" | "touch" | "virtual";
+
+/** Why an {@link InteractionModalityTracker} changed. */
+export type InteractionModalityChangeReason = InteractionModality | "document" | "manual";
+
+/** Immutable notification emitted after a distinct modality change. */
+export interface InteractionModalityChange {
+  /** New modality, or `null` when a consumer explicitly resets detection. */
+  readonly modality: InteractionModality | null;
+
+  /** Value observed immediately before this change. */
+  readonly previousModality: InteractionModality | null;
+
+  /** Event classification or lifecycle operation responsible for the change. */
+  readonly reason: InteractionModalityChangeReason;
+
+  /** Native event when the change came from document input. */
+  readonly originalEvent: Event | null;
+
+  /** Document whose state produced the change, if the tracker is attached. */
+  readonly document: Document | null;
+}
+
+/** Options for {@link createInteractionModalityTracker}. */
+export interface InteractionModalityOptions {
+  /**
+   * Reactive document to observe. Pass `null` for SSR or deferred attachment.
+   *
+   * When omitted, the current global document is resolved lazily. No DOM global
+   * is read while the module is evaluated.
+   *
+   * @default globalThis.document when available
+   */
+  readonly document?: MaybeRefOrGetter<Document | null | undefined>;
+
+  /**
+   * Value used before the first qualifying input event.
+   *
+   * @default null
+   */
+  readonly initialModality?: InteractionModality | null;
+
+  /** Called synchronously after each distinct change. */
+  readonly onChange?: (change: InteractionModalityChange) => void;
+}
+
+/** Reactive, explicitly disposable input-modality observer. */
+export interface InteractionModalityTracker {
+  /** Document currently observed by this tracker. */
+  readonly document: Readonly<ShallowRef<Document | null>>;
+
+  /** Most recently detected input family. */
+  readonly modality: Readonly<ShallowRef<InteractionModality | null>>;
+
+  /** Whether global focus treatment should currently be keyboard-visible. */
+  readonly isFocusVisible: ComputedRef<boolean>;
+
+  /** Attach to another document, retaining the current value until synchronized. */
+  readonly attach: (document: Document | null) => boolean;
+
+  /** Stop observing the current document without clearing the current value. */
+  readonly detach: () => boolean;
+
+  /** Explicitly set or reset modality and synchronize peers on the same document. */
+  readonly setModality: (modality: InteractionModality | null) => boolean;
+
+  /** Release reactive observation and native listeners. Safe to call repeatedly. */
+  readonly dispose: () => void;
+}

--- a/npm/ui/core/src/interaction-modality.behavior.md
+++ b/npm/ui/core/src/interaction-modality.behavior.md
@@ -1,0 +1,68 @@
+# Interaction modality behavior contract
+
+Normative state × input → outcome table for `@vizejs/ui/interaction-modality`.
+Every row is exercised by `src/interaction-modality*.test.ts`; compile-only API
+assertions live in `src/interaction-modality.types.test-d.ts`.
+
+| #    | State                               | Input                               | Outcome                                                   | Proven by                                                           |
+| ---- | ----------------------------------- | ----------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------- |
+| IM1  | no DOM / SSR                        | create with `document: null`        | no native access; reactive state remains usable           | `is inert without a document and remains manually controllable…`    |
+| IM2  | any                                 | unmodified keyboard intent          | modality becomes `keyboard`; focus is globally visible    | `classifies keyboard, pointer, touch, and virtual intent`           |
+| IM3  | any                                 | mouse, pen, or unknown pointer      | modality becomes `pointer`                                | `classifies keyboard, pointer, touch, and virtual intent`           |
+| IM4  | any                                 | touch pointer                       | modality becomes `touch`                                  | `classifies keyboard, pointer, touch, and virtual intent`           |
+| IM5  | any except keyboard                 | coordinate-free click               | modality becomes `virtual`                                | `keeps keyboard-generated coordinate-free clicks…`                  |
+| IM6  | keyboard                            | synthesized click with `detail: 0`  | keyboard modality is retained                             | `keeps keyboard-generated coordinate-free clicks…`                  |
+| IM7  | any                                 | IME or modified shortcut            | event does not alter modality                             | `ignores composition, modifier-only keys, and modified shortcuts`   |
+| IM8  | two trackers in one document        | input or manual update              | one listener set; both trackers receive identical state   | `shares exactly one native listener set and state per document`     |
+| IM9  | trackers in different documents     | input in one document               | other document remains unchanged                          | `isolates separate documents and adopts existing state when moving` |
+| IM10 | tracker moves to populated document | reactive document change            | existing document state is adopted with `document` reason | `isolates separate documents and adopts existing state when moving` |
+| IM11 | attached                            | detach                              | listeners release; last modality remains                  | `supports explicit attach and detach without losing the last value` |
+| IM12 | disposed                            | attach, detach, or state mutation   | stable disposed diagnostic is thrown                      | `disposal is idempotent and rejects later mutation`                 |
+| IM13 | Vue effect scope                    | scope stops                         | tracker disposes and releases its shared subscription     | `the composable requires and follows a Vue effect scope`            |
+| IM14 | focused element, supported browser  | visibility query                    | native `:focus-visible` result wins                       | `defers to native focus-visible semantics…`                         |
+| IM15 | focused element, old browser        | selector throws                     | keyboard/virtual modality supplies the fallback           | `falls back to modality only when focus-visible is unsupported`     |
+| IM16 | unfocused element                   | visibility query                    | result is always false                                    | `defers to native focus-visible semantics…`                         |
+| IM17 | public TypeScript API               | invalid modality or mutable ref use | compilation rejects the misuse                            | `src/interaction-modality.types.test-d.ts`                          |
+| IM18 | legacy touch browser                | touch then compatibility mousedown  | touch modality is retained                                | `shares exactly one native listener set and state per document`     |
+| IM19 | subscriber callback                 | reentrant modality change           | queued delivery leaves every live peer in the same state  | `serializes reentrant updates so every peer reaches…`               |
+| IM20 | subscriber callback                 | callback throws                     | all peers update before the exception is surfaced         | `updates every peer before surfacing a subscriber exception`        |
+| IM21 | document adoption                   | synchronization callback throws     | new subscription rolls back without a listener leak       | `rolls back a failed document adoption without leaking…`            |
+| IM22 | concurrent SSR requests             | identical component trees           | byte-identical, detached, neutral output is rendered      | `renders byte-identical output without touching a server document`  |
+| IM23 | SSR followed by hydration           | document becomes available on mount | listener attaches after warning-free hydration            | `attaches after hydration without mismatch diagnostics`             |
+
+## Accessibility decisions
+
+- Native `:focus-visible` is authoritative when available. This preserves
+  browser heuristics for editable controls, platform conventions, and assistive
+  technology instead of replacing them with a narrower JavaScript guess.
+- `keyboard` and `virtual` are the only globally focus-visible modalities.
+  Components should use `isElementFocusVisible` for the final per-element
+  decision and must still provide an actual visible style.
+- Pointer Events reserve `pointerId: -1` for input not produced by pointing
+  hardware. An empty-type pointer with that ID is classified as `virtual`.
+- Modified shortcuts and composition do not change visual modality. Shift+Tab
+  remains keyboard intent because it directly changes focus.
+
+## SSR, hydration, and document ownership
+
+- Importing this entry performs no DOM read, listener installation, style
+  injection, timer scheduling, or mutation of request-scoped state.
+- With no global document, the default tracker is inert and deterministic.
+- Trackers share listeners only when keyed by the same live `Document`. Weak
+  ownership and reference counting release the hub when its final subscriber
+  disposes; iframes and independently hydrated documents cannot leak state.
+- Pass a reactive document getter when an island, iframe, or portal owner is not
+  known until mount. Passing `null` explicitly is the SSR/deferred escape hatch.
+
+## Styling contract
+
+This primitive emits no CSS and sets no attributes. Consumers may map
+`isFocusVisible` or `isElementFocusVisible` to classes, data attributes, CSS
+variables, utility frameworks, or fully custom styles. Never remove the browser
+outline unless an equivalent visible indicator is supplied.
+
+## Normative references
+
+- [WCAG 2.2 — Focus Visible (2.4.7)](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible)
+- [Selectors Level 4 — `:focus-visible`](https://www.w3.org/TR/selectors-4/#the-focus-visible-pseudo)
+- [Pointer Events — pointer types and non-pointing input](https://w3c.github.io/pointerevents/)

--- a/npm/ui/core/src/interaction-modality.test.ts
+++ b/npm/ui/core/src/interaction-modality.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+
+import { createInteractionModalityTracker, isElementFocusVisible } from "./interaction-modality.ts";
+import type { InteractionModalityChange } from "./interaction-modality.ts";
+
+function dispatchKeyboard(
+  target: Document,
+  key: string,
+  init: KeyboardEventInit = {},
+): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", { bubbles: true, key, ...init });
+  target.dispatchEvent(event);
+  return event;
+}
+
+function dispatchPointer(
+  target: Document,
+  pointerType: string,
+  init: PointerEventInit = {},
+): PointerEvent {
+  const event = new PointerEvent("pointerdown", {
+    bubbles: true,
+    pointerType,
+    ...init,
+  });
+  target.dispatchEvent(event);
+  return event;
+}
+
+test("is inert without a document and remains manually controllable during SSR", () => {
+  const changes: InteractionModalityChange[] = [];
+  const tracker = createInteractionModalityTracker({
+    document: null,
+    onChange: (change) => changes.push(change),
+  });
+
+  assert.equal(tracker.document.value, null);
+  assert.equal(tracker.modality.value, null);
+  assert.equal(tracker.isFocusVisible.value, false);
+  assert.equal(tracker.setModality("keyboard"), true);
+  assert.equal(tracker.isFocusVisible.value, true);
+  assert.equal(tracker.setModality("keyboard"), false);
+  assert.equal(tracker.setModality(null), true);
+  assert.deepEqual(
+    changes.map(({ modality, previousModality, reason, document }) => ({
+      modality,
+      previousModality,
+      reason,
+      document,
+    })),
+    [
+      { modality: "keyboard", previousModality: null, reason: "manual", document: null },
+      { modality: null, previousModality: "keyboard", reason: "manual", document: null },
+    ],
+  );
+  assert.ok(changes.every(Object.isFrozen));
+  tracker.dispose();
+});
+
+test("classifies keyboard, pointer, touch, and virtual intent", () => {
+  const changes: InteractionModalityChange[] = [];
+  const tracker = createInteractionModalityTracker({
+    document,
+    onChange: (change) => changes.push(change),
+  });
+
+  const keyboardEvent = dispatchKeyboard(document, "Tab");
+  assert.equal(tracker.modality.value, "keyboard");
+  assert.equal(changes.at(-1)?.originalEvent, keyboardEvent);
+
+  dispatchPointer(document, "pen");
+  assert.equal(tracker.modality.value, "pointer");
+  dispatchPointer(document, "touch");
+  assert.equal(tracker.modality.value, "touch");
+  dispatchPointer(document, "vendor-device");
+  assert.equal(tracker.modality.value, "pointer");
+
+  const virtualPointer = dispatchPointer(document, "", { pointerId: -1 });
+  assert.equal(tracker.modality.value, "virtual");
+  assert.equal(changes.at(-1)?.originalEvent, virtualPointer);
+  tracker.dispose();
+});
+
+test("keeps keyboard-generated coordinate-free clicks keyboard-visible", () => {
+  const tracker = createInteractionModalityTracker({ document });
+  dispatchKeyboard(document, "Enter");
+  document.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 0 }));
+  assert.equal(tracker.modality.value, "keyboard");
+
+  dispatchPointer(document, "mouse");
+  document.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
+  assert.equal(tracker.modality.value, "pointer");
+  document.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 0 }));
+  assert.equal(tracker.modality.value, "virtual");
+  tracker.dispose();
+});
+
+test("ignores composition, modifier-only keys, and modified shortcuts", () => {
+  const tracker = createInteractionModalityTracker({ document, initialModality: "pointer" });
+
+  dispatchKeyboard(document, "Control");
+  dispatchKeyboard(document, "k", { metaKey: true });
+  dispatchKeyboard(document, "Dead", { isComposing: true });
+  assert.equal(tracker.modality.value, "pointer");
+
+  dispatchKeyboard(document, "Tab", { shiftKey: true });
+  assert.equal(tracker.modality.value, "keyboard");
+  tracker.dispose();
+});
+
+test("rejects invalid runtime documents and modalities", () => {
+  assert.throws(
+    () => createInteractionModalityTracker({ document: {} as Document }),
+    /VIZE_UI_INTERACTION_MODALITY_DOCUMENT/,
+  );
+  assert.throws(
+    () =>
+      createInteractionModalityTracker({
+        document: null,
+        initialModality: "mouse" as "keyboard",
+      }),
+    /VIZE_UI_INTERACTION_MODALITY_VALUE/,
+  );
+  const tracker = createInteractionModalityTracker({ document: null });
+  assert.throws(
+    () => tracker.setModality("mouse" as "keyboard"),
+    /VIZE_UI_INTERACTION_MODALITY_VALUE/,
+  );
+  tracker.dispose();
+});
+
+test("defers to native focus-visible semantics for document and shadow roots", () => {
+  const button = document.createElement("button");
+  const unfocused = document.createElement("button");
+  const host = document.createElement("div");
+  const shadow = host.attachShadow({ mode: "open" });
+  const shadowButton = document.createElement("button");
+  shadow.append(shadowButton);
+  document.body.append(button, unfocused, host);
+
+  button.focus();
+  assert.equal(isElementFocusVisible(button, "pointer"), button.matches(":focus-visible"));
+  assert.equal(isElementFocusVisible(unfocused, "keyboard"), false);
+  shadowButton.focus();
+  assert.equal(
+    isElementFocusVisible(shadowButton, "pointer"),
+    shadowButton.matches(":focus-visible"),
+  );
+
+  button.remove();
+  unfocused.remove();
+  host.remove();
+});
+
+test("falls back to modality only when focus-visible is unsupported", () => {
+  const root = { activeElement: null as Element | null };
+  const element = {
+    getRootNode: () => root,
+    matches: () => {
+      throw new DOMException("unsupported selector", "SyntaxError");
+    },
+    ownerDocument: { activeElement: null },
+  } as unknown as Element;
+  root.activeElement = element;
+
+  assert.equal(isElementFocusVisible(element, "keyboard"), true);
+  assert.equal(isElementFocusVisible(element, "virtual"), true);
+  assert.equal(isElementFocusVisible(element, "pointer"), false);
+  assert.equal(isElementFocusVisible(element, "touch"), false);
+  assert.equal(isElementFocusVisible(null, "keyboard"), false);
+});

--- a/npm/ui/core/src/interaction-modality.ts
+++ b/npm/ui/core/src/interaction-modality.ts
@@ -1,0 +1,212 @@
+import {
+  computed,
+  getCurrentScope,
+  isRef,
+  onScopeDispose,
+  shallowReadonly,
+  shallowRef,
+  toValue,
+  watch,
+} from "vue";
+
+import {
+  publishDocumentModality,
+  subscribeToDocumentModality,
+} from "./interaction-modality-hub.ts";
+import type { DocumentModalityUpdate } from "./interaction-modality-hub.ts";
+import type {
+  InteractionModality,
+  InteractionModalityChange,
+  InteractionModalityOptions,
+  InteractionModalityTracker,
+} from "./interaction-modality-types.ts";
+
+const disposedDiagnostic = "VIZE_UI_INTERACTION_MODALITY_DISPOSED";
+const invalidDocumentDiagnostic = "VIZE_UI_INTERACTION_MODALITY_DOCUMENT";
+const setupDiagnostic = "VIZE_UI_INTERACTION_MODALITY_SETUP";
+const invalidValueDiagnostic = "VIZE_UI_INTERACTION_MODALITY_VALUE";
+const modalities = new Set<InteractionModality>(["keyboard", "pointer", "touch", "virtual"]);
+
+function defaultDocument(): Document | null {
+  return typeof globalThis.document === "undefined" ? null : globalThis.document;
+}
+
+/** Accept cross-realm documents without relying on an unreliable instanceof check. */
+function toDocument(value: Document | null | undefined): Document | null {
+  if (value == null) return null;
+  if (
+    value.nodeType !== 9 ||
+    typeof value.addEventListener !== "function" ||
+    typeof value.removeEventListener !== "function"
+  ) {
+    throw new TypeError(`${invalidDocumentDiagnostic}: expected a Document, null, or undefined`);
+  }
+  return value;
+}
+
+/** Validate JavaScript callers without widening the closed TypeScript union. */
+function toModality(value: InteractionModality | null): InteractionModality | null {
+  if (value === null || modalities.has(value)) return value;
+  throw new TypeError(
+    `${invalidValueDiagnostic}: expected keyboard, pointer, touch, virtual, or null`,
+  );
+}
+
+/**
+ * Create an SSR-safe, document-scoped interaction-modality observer.
+ *
+ * Trackers in one document share native capture listeners and state. Separate
+ * documents, including iframes, remain isolated. Call {@link InteractionModalityTracker.dispose}
+ * when using this factory outside a Vue effect scope.
+ */
+export function createInteractionModalityTracker(
+  options: InteractionModalityOptions = {},
+): InteractionModalityTracker {
+  const ownerDocument = shallowRef<Document | null>(null);
+  const modality = shallowRef<InteractionModality | null>(
+    toModality(options.initialModality ?? null),
+  );
+  let releaseDocument: (() => void) | null = null;
+  let disposed = false;
+
+  const assertActive = () => {
+    if (disposed) throw new Error(`${disposedDiagnostic}: the tracker has been disposed`);
+  };
+  const apply = (update: DocumentModalityUpdate) => {
+    if (modality.value === update.modality) return false;
+    const previousModality = modality.value;
+    modality.value = update.modality;
+    const change: InteractionModalityChange = Object.freeze({
+      modality: update.modality,
+      previousModality,
+      reason: update.reason,
+      originalEvent: update.originalEvent,
+      document: ownerDocument.value,
+    });
+    options.onChange?.(change);
+    return true;
+  };
+  const releaseCurrentDocument = () => {
+    const changed = ownerDocument.value !== null;
+    releaseDocument?.();
+    releaseDocument = null;
+    ownerDocument.value = null;
+    return changed;
+  };
+  const attach = (nextDocument: Document | null) => {
+    assertActive();
+    const resolved = toDocument(nextDocument);
+    if (ownerDocument.value === resolved) return false;
+    releaseCurrentDocument();
+    if (!resolved) return true;
+
+    ownerDocument.value = resolved;
+    try {
+      const subscription = subscribeToDocumentModality(resolved, modality.value, apply);
+      releaseDocument = subscription.release;
+      if (subscription.current !== modality.value) {
+        apply({ modality: subscription.current, reason: "document", originalEvent: null });
+      }
+    } catch (error) {
+      releaseCurrentDocument();
+      throw error;
+    }
+    return true;
+  };
+  const detach = () => {
+    assertActive();
+    return releaseCurrentDocument();
+  };
+  const setModality = (nextModality: InteractionModality | null) => {
+    assertActive();
+    const update: DocumentModalityUpdate = {
+      modality: toModality(nextModality),
+      reason: "manual",
+      originalEvent: null,
+    };
+    if (ownerDocument.value) {
+      return publishDocumentModality(ownerDocument.value, update);
+    }
+    return apply(update);
+  };
+
+  let stopDocumentWatch: () => void = () => undefined;
+  if (options.document === undefined) {
+    attach(defaultDocument());
+  } else if (isRef(options.document) || typeof options.document === "function") {
+    stopDocumentWatch = watch(
+      () => toValue(options.document),
+      (nextDocument) => attach(toDocument(nextDocument)),
+      { flush: "sync", immediate: true },
+    );
+  } else {
+    attach(toDocument(options.document));
+  }
+  const dispose = () => {
+    if (disposed) return;
+    stopDocumentWatch();
+    releaseCurrentDocument();
+    disposed = true;
+  };
+
+  return Object.freeze({
+    document: shallowReadonly(ownerDocument),
+    modality: shallowReadonly(modality),
+    isFocusVisible: computed(() => modality.value === "keyboard" || modality.value === "virtual"),
+    attach,
+    detach,
+    setModality,
+    dispose,
+  });
+}
+
+/**
+ * Create a tracker owned by the current Vue effect scope.
+ *
+ * The tracker is disposed automatically when its component or effect scope is
+ * destroyed, preventing document-listener leaks.
+ */
+export function useInteractionModality(
+  options: InteractionModalityOptions = {},
+): InteractionModalityTracker {
+  if (!getCurrentScope()) {
+    throw new Error(`${setupDiagnostic}: use inside component setup or an active effect scope`);
+  }
+  const tracker = createInteractionModalityTracker(options);
+  onScopeDispose(tracker.dispose);
+  return tracker;
+}
+
+/**
+ * Determine whether a focused element should expose its focus indicator.
+ *
+ * Native `:focus-visible` semantics take precedence. The modality fallback is
+ * used only when the selector is unsupported, preserving text-input and
+ * platform heuristics implemented by the browser.
+ */
+export function isElementFocusVisible(
+  element: Element | null | undefined,
+  modality: InteractionModality | null,
+): boolean {
+  if (!element) return false;
+  const root = element.getRootNode();
+  const activeElement =
+    root && "activeElement" in root
+      ? (root as Document | ShadowRoot).activeElement
+      : element.ownerDocument.activeElement;
+  if (activeElement !== element) return false;
+
+  try {
+    return element.matches(":focus-visible");
+  } catch {
+    return modality === "keyboard" || modality === "virtual";
+  }
+}
+
+export type {
+  InteractionModality,
+  InteractionModalityChange,
+  InteractionModalityChangeReason,
+  InteractionModalityOptions,
+  InteractionModalityTracker,
+} from "./interaction-modality-types.ts";

--- a/npm/ui/core/src/interaction-modality.types.test-d.ts
+++ b/npm/ui/core/src/interaction-modality.types.test-d.ts
@@ -1,0 +1,51 @@
+/** Compile-only assertions for the public interaction-modality contract. */
+
+import { ref } from "vue";
+import type { ComputedRef, ShallowRef } from "vue";
+
+import {
+  createInteractionModalityTracker,
+  isElementFocusVisible,
+  type InteractionModality,
+  type InteractionModalityChange,
+} from "./interaction-modality.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+export const keyboardModality: InteractionModality = "keyboard";
+export const pointerModality: InteractionModality = "pointer";
+export const touchModality: InteractionModality = "touch";
+export const virtualModality: InteractionModality = "virtual";
+
+// @ts-expect-error the public modality contract is a closed union.
+export const speechModality: InteractionModality = "speech";
+
+const reactiveDocument = ref<Document | null>(null);
+export const tracker = createInteractionModalityTracker({
+  document: reactiveDocument,
+  initialModality: "keyboard",
+  onChange(change: InteractionModalityChange) {
+    const current: InteractionModality | null = change.modality;
+    const event: Event | null = change.originalEvent;
+    void current;
+    void event;
+  },
+});
+
+type _DocumentIsReadonlyShallowRef = Expect<
+  Equal<typeof tracker.document, Readonly<ShallowRef<Document | null>>>
+>;
+type _VisibilityIsComputed = Expect<Equal<typeof tracker.isFocusVisible, ComputedRef<boolean>>>;
+
+// @ts-expect-error consumers cannot mutate readonly reactive state directly.
+tracker.modality.value = "touch";
+// @ts-expect-error invalid modalities cannot enter the synchronized state.
+tracker.setModality("mouse");
+// @ts-expect-error Window is not a Document.
+tracker.attach(window);
+
+export const focusVisible: boolean = isElementFocusVisible(document.body, tracker.modality.value);

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       context: "src/context.ts",
       "controllable-state": "src/controllable-state.ts",
       id: "src/id.ts",
+      "interaction-modality": "src/interaction-modality.ts",
       primitive: "src/primitive.ts",
       "visually-hidden": "src/visually-hidden.ts",
       media: "src/media.ts",


### PR DESCRIPTION
## Summary

- add a fully typed, document-scoped interaction modality tracker for keyboard, pointer, touch, and virtual input
- share capture listeners per Document while isolating iframes, SSR requests, and independently hydrated roots
- defer to native `:focus-visible`, with a keyboard/virtual fallback only when the selector is unsupported
- serialize reentrant notifications, suppress legacy touch compatibility mouse events, and release listeners deterministically
- publish an exact ESM subpath with zero CSS and root/subpath tree-shaking parity

Part of #3134.

## Verification

- `vp run check`
- `vp run lint:sfc` (15 DOM/SSR/Vapor compiler lanes)
- `vp run test` (92 tests)
- package and consumer gzip budgets
- root/subpath tree-shaking and zero-CSS assertions
- byte-stable SSR and warning-free hydration tests

## Accessibility contract

The behavior table documents WCAG 2.2 Focus Visible, Selectors Level 4 `:focus-visible`, Pointer Events classification, ShadowRoot focus, assistive-technology virtual input, and the requirement that consumers retain a visible focus indicator.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->