### PR TITLE
feat(fresco): add diagnostic workspace state

### DIFF
--- a/crates/vize_fresco/README.md
+++ b/crates/vize_fresco/README.md
@@ -13,11 +13,13 @@ Support and deprecation guarantees are defined in the
 - Cross-platform terminal primitives
 - Flexbox-style layout via `taffy`
 - Render tree, buffer, and text measurement utilities
+- Stable-keyed, virtualized diagnostic master-detail workspace state
 - Optional NAPI bindings through the `napi` feature
 
 ## Key Entry Points
 
 - `BoxNode`, `TextNode`, `InputNode`
+- `DiagnosticWorkspaceState`, `DiagnosticWorkspaceLayout`, `VirtualListState`
 - `LayoutEngine`, `FlexStyle`, `Rect`
 - `RenderTree`, `RenderNode`
 - `Backend`, `Buffer`, `Cursor`

--- a/crates/vize_fresco/benches/render.rs
+++ b/crates/vize_fresco/benches/render.rs
@@ -5,7 +5,7 @@ use std::io;
 
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 
-use vize_fresco::component::{VirtualListNavigation, VirtualListState};
+use vize_fresco::component::{DiagnosticWorkspaceState, VirtualListNavigation, VirtualListState};
 use vize_fresco::layout::{FlexStyle, LayoutEngine};
 use vize_fresco::terminal::{Backend, Buffer, Style};
 use vize_fresco::text::{TextWidth, TextWrap, WrapMode};
@@ -167,6 +167,35 @@ fn benchmark_injected_backend_output(c: &mut Criterion) {
     });
 }
 
+fn benchmark_diagnostic_workspace(c: &mut Criterion) {
+    let keys = (0_u64..10_000).collect::<Vec<_>>();
+    let mut workspace = DiagnosticWorkspaceState::<u64, u64>::new(120, 40);
+    let _ = workspace.reconcile_findings(&keys);
+    let _ = workspace.select_finding(&keys, 9_000);
+    let mut group = c.benchmark_group("diagnostic_workspace_10k");
+
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("navigation", |b| {
+        b.iter(|| {
+            if workspace.findings().selected_index() == Some(keys.len() - 1) {
+                let _ = workspace.navigate_findings(&keys, VirtualListNavigation::First);
+            }
+            black_box(workspace.navigate_findings(black_box(&keys), VirtualListNavigation::Next))
+        });
+    });
+    let mut narrow = false;
+    group.bench_function("responsive_resize", |b| {
+        b.iter(|| {
+            narrow = !narrow;
+            black_box(workspace.resize(if narrow { 60 } else { 120 }, 40))
+        });
+    });
+    group.bench_function("virtual_window", |b| {
+        b.iter(|| black_box(workspace.finding_window()));
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     benchmark_buffer_set_string,
@@ -176,5 +205,6 @@ criterion_group!(
     benchmark_buffer_diff,
     benchmark_virtual_list,
     benchmark_injected_backend_output,
+    benchmark_diagnostic_workspace,
 );
 criterion_main!(benches);

--- a/crates/vize_fresco/src/component.rs
+++ b/crates/vize_fresco/src/component.rs
@@ -6,6 +6,7 @@
 //! - InputNode: Text input with IME support
 
 mod box_node;
+mod diagnostic_workspace;
 mod input_node;
 mod text_node;
 mod virtual_list;
@@ -14,6 +15,10 @@ mod virtual_list;
 mod virtual_list_tests;
 
 pub use box_node::BoxNode;
+pub use diagnostic_workspace::{
+    DiagnosticWorkspaceFocus, DiagnosticWorkspaceLayout, DiagnosticWorkspaceMode,
+    DiagnosticWorkspaceOptions, DiagnosticWorkspacePane, DiagnosticWorkspaceState,
+};
 pub use input_node::InputNode;
 pub use text_node::TextNode;
 pub use virtual_list::{VirtualListNavigation, VirtualListState, VirtualWindow};

--- a/crates/vize_fresco/src/component/diagnostic_workspace.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace.rs
@@ -1,0 +1,282 @@
+//! Semantic state for large master-detail diagnostic workspaces.
+
+mod layout;
+
+#[cfg(test)]
+mod tests;
+
+use super::{VirtualListNavigation, VirtualListState, VirtualWindow};
+
+pub use layout::{
+    DiagnosticWorkspaceLayout, DiagnosticWorkspaceMode, DiagnosticWorkspaceOptions,
+    DiagnosticWorkspacePane,
+};
+
+/// Semantic keyboard focus within a diagnostic master-detail workspace.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum DiagnosticWorkspaceFocus {
+    /// The virtualized finding list.
+    #[default]
+    Findings,
+    /// The selected finding's explanation, location, and fix presentation.
+    Detail,
+    /// The selected finding's related evidence list.
+    Evidence,
+}
+
+/// Bounded interaction state for a semantic diagnostic workspace.
+///
+/// The state owns only stable selected keys and constant-size viewport data. It
+/// never owns finding or evidence rows. Callers retain immutable report data and
+/// pass stable-key slices when reconciling or navigating. This keeps retained
+/// state O(1) while [`VirtualListState`] bounds visible row materialization.
+#[derive(Debug, Clone)]
+pub struct DiagnosticWorkspaceState<FindingKey, EvidenceKey> {
+    findings: VirtualListState<FindingKey>,
+    evidence: VirtualListState<EvidenceKey>,
+    focus: DiagnosticWorkspaceFocus,
+    layout: DiagnosticWorkspaceLayout,
+    options: DiagnosticWorkspaceOptions,
+    detail_scroll: usize,
+    detail_content_rows: usize,
+}
+
+impl<FindingKey: Clone + Eq, EvidenceKey: Clone + Eq>
+    DiagnosticWorkspaceState<FindingKey, EvidenceKey>
+{
+    /// Create an empty workspace for an explicit terminal viewport.
+    ///
+    /// Defaults come from [`DiagnosticWorkspaceOptions::default`]. Construction
+    /// performs no terminal I/O and is suitable for headless tests.
+    pub fn new(width: u16, height: u16) -> Self {
+        Self::with_options(width, height, DiagnosticWorkspaceOptions::default())
+    }
+
+    /// Create an empty workspace with explicit layout and overscan options.
+    pub fn with_options(width: u16, height: u16, options: DiagnosticWorkspaceOptions) -> Self {
+        let options = options.normalized();
+        let layout = DiagnosticWorkspaceLayout::new(width, height, options);
+        let viewport_rows = usize::from(layout.content().height);
+        Self {
+            findings: VirtualListState::with_overscan(viewport_rows, options.overscan()),
+            evidence: VirtualListState::with_overscan(viewport_rows, options.overscan()),
+            focus: DiagnosticWorkspaceFocus::Findings,
+            layout,
+            options,
+            detail_scroll: 0,
+            detail_content_rows: 0,
+        }
+    }
+
+    /// Return the normalized options used for every resize.
+    pub const fn options(&self) -> DiagnosticWorkspaceOptions {
+        self.options
+    }
+
+    /// Return the current split or stacked pane geometry.
+    pub const fn layout(&self) -> DiagnosticWorkspaceLayout {
+        self.layout
+    }
+
+    /// Return the current semantic focus.
+    pub const fn focus(&self) -> DiagnosticWorkspaceFocus {
+        self.focus
+    }
+
+    /// Return the full-width pane selected in stacked mode.
+    pub const fn active_stacked_pane(&self) -> DiagnosticWorkspacePane {
+        match self.focus {
+            DiagnosticWorkspaceFocus::Findings => DiagnosticWorkspacePane::Findings,
+            DiagnosticWorkspaceFocus::Detail | DiagnosticWorkspaceFocus::Evidence => {
+                DiagnosticWorkspacePane::Detail
+            }
+        }
+    }
+
+    /// Return the virtualized finding-list state.
+    pub const fn findings(&self) -> &VirtualListState<FindingKey> {
+        &self.findings
+    }
+
+    /// Return the virtualized related-evidence state.
+    pub const fn evidence(&self) -> &VirtualListState<EvidenceKey> {
+        &self.evidence
+    }
+
+    /// Return the finding rows that may be materialized for this frame.
+    pub fn finding_window(&self) -> VirtualWindow {
+        self.findings.window()
+    }
+
+    /// Return the evidence rows that may be materialized for this frame.
+    pub fn evidence_window(&self) -> VirtualWindow {
+        self.evidence.window()
+    }
+
+    /// Reconcile a filtered or reordered finding sequence.
+    ///
+    /// A changed stable selection resets detail and evidence navigation. The
+    /// caller should then reconcile evidence for the newly selected finding.
+    #[must_use]
+    pub fn reconcile_findings(&mut self, keys: &[FindingKey]) -> bool {
+        let changed = self.findings.reconcile(keys);
+        if changed {
+            self.reset_selected_finding_state();
+        }
+        changed
+    }
+
+    /// Select a finding ordinal and reveal it in the virtual viewport.
+    #[must_use]
+    pub fn select_finding(&mut self, keys: &[FindingKey], index: usize) -> bool {
+        let changed = self.findings.select_index(keys, index);
+        if changed {
+            self.reset_selected_finding_state();
+        }
+        changed
+    }
+
+    /// Apply bounded finding navigation without wrapping.
+    #[must_use]
+    pub fn navigate_findings(
+        &mut self,
+        keys: &[FindingKey],
+        navigation: VirtualListNavigation,
+    ) -> bool {
+        let changed = self.findings.navigate(keys, navigation);
+        if changed {
+            self.reset_selected_finding_state();
+        }
+        changed
+    }
+
+    /// Scroll finding rows independently of selection, for wheel input.
+    pub fn scroll_findings(&mut self, rows: isize) -> bool {
+        self.findings.scroll_by(rows)
+    }
+
+    /// Reconcile stable evidence keys for the selected finding.
+    #[must_use]
+    pub fn reconcile_evidence(&mut self, keys: &[EvidenceKey]) -> bool {
+        let changed = self.evidence.reconcile(keys);
+        if keys.is_empty() && self.focus == DiagnosticWorkspaceFocus::Evidence {
+            self.focus = DiagnosticWorkspaceFocus::Detail;
+        }
+        changed
+    }
+
+    /// Apply bounded related-evidence navigation without wrapping.
+    #[must_use]
+    pub fn navigate_evidence(
+        &mut self,
+        keys: &[EvidenceKey],
+        navigation: VirtualListNavigation,
+    ) -> bool {
+        self.evidence.navigate(keys, navigation)
+    }
+
+    /// Set focus when the requested pane is currently available.
+    ///
+    /// Evidence focus is rejected when no evidence item is selected. Findings
+    /// and detail remain focusable even in a zero-sized viewport.
+    pub fn set_focus(&mut self, focus: DiagnosticWorkspaceFocus) -> bool {
+        if focus == DiagnosticWorkspaceFocus::Evidence && self.evidence.selected_key().is_none() {
+            return false;
+        }
+        let changed = self.focus != focus;
+        self.focus = focus;
+        changed
+    }
+
+    /// Move focus forward through available semantic panes.
+    pub fn focus_next(&mut self) -> bool {
+        let next = match (self.focus, self.evidence.selected_key().is_some()) {
+            (DiagnosticWorkspaceFocus::Findings, _) => DiagnosticWorkspaceFocus::Detail,
+            (DiagnosticWorkspaceFocus::Detail, true) => DiagnosticWorkspaceFocus::Evidence,
+            (DiagnosticWorkspaceFocus::Detail | DiagnosticWorkspaceFocus::Evidence, _) => {
+                DiagnosticWorkspaceFocus::Findings
+            }
+        };
+        self.set_focus(next)
+    }
+
+    /// Move focus backward through available semantic panes.
+    pub fn focus_previous(&mut self) -> bool {
+        let next = match (self.focus, self.evidence.selected_key().is_some()) {
+            (DiagnosticWorkspaceFocus::Findings, true) => DiagnosticWorkspaceFocus::Evidence,
+            (DiagnosticWorkspaceFocus::Findings, false) => DiagnosticWorkspaceFocus::Detail,
+            (DiagnosticWorkspaceFocus::Detail, _) => DiagnosticWorkspaceFocus::Findings,
+            (DiagnosticWorkspaceFocus::Evidence, _) => DiagnosticWorkspaceFocus::Detail,
+        };
+        self.set_focus(next)
+    }
+
+    /// Resize pane geometry while preserving stable finding and evidence keys.
+    pub fn resize(&mut self, width: u16, height: u16) -> bool {
+        let next = DiagnosticWorkspaceLayout::new(width, height, self.options);
+        if next == self.layout {
+            return false;
+        }
+        self.layout = next;
+        let rows = usize::from(next.content().height);
+        self.findings.set_viewport_len(rows);
+        self.evidence.set_viewport_len(rows);
+        self.clamp_detail_scroll();
+        true
+    }
+
+    /// Set the selected detail's full row count and clamp overflow.
+    pub fn set_detail_content_rows(&mut self, rows: usize) -> bool {
+        if self.detail_content_rows == rows {
+            return false;
+        }
+        self.detail_content_rows = rows;
+        self.clamp_detail_scroll();
+        true
+    }
+
+    /// Return the first visible detail row.
+    pub const fn detail_scroll(&self) -> usize {
+        self.detail_scroll
+    }
+
+    /// Return detail rows that remain below the viewport.
+    pub fn detail_rows_below(&self) -> usize {
+        self.detail_content_rows.saturating_sub(
+            self.detail_scroll
+                .saturating_add(usize::from(self.layout.content().height)),
+        )
+    }
+
+    /// Scroll selected-detail rows with saturating, explicitly bounded motion.
+    pub fn scroll_detail(&mut self, rows: isize) -> bool {
+        let max = self.max_detail_scroll();
+        let next = if rows.is_negative() {
+            self.detail_scroll.saturating_sub(rows.unsigned_abs())
+        } else {
+            self.detail_scroll.saturating_add(rows as usize)
+        }
+        .min(max);
+        let changed = next != self.detail_scroll;
+        self.detail_scroll = next;
+        changed
+    }
+
+    fn reset_selected_finding_state(&mut self) {
+        let _ = self.evidence.reconcile(&[]);
+        self.detail_scroll = 0;
+        self.detail_content_rows = 0;
+        if self.focus == DiagnosticWorkspaceFocus::Evidence {
+            self.focus = DiagnosticWorkspaceFocus::Detail;
+        }
+    }
+
+    fn clamp_detail_scroll(&mut self) {
+        self.detail_scroll = self.detail_scroll.min(self.max_detail_scroll());
+    }
+
+    fn max_detail_scroll(&self) -> usize {
+        self.detail_content_rows
+            .saturating_sub(usize::from(self.layout.content().height))
+    }
+}

--- a/crates/vize_fresco/src/component/diagnostic_workspace/layout.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/layout.rs
@@ -1,0 +1,163 @@
+use crate::layout::Rect;
+
+/// Default terminal width at which list and detail panes become simultaneous.
+const DEFAULT_SPLIT_WIDTH: u16 = 80;
+/// Default percentage of split width assigned to the finding list.
+const DEFAULT_LIST_PERCENT: u8 = 40;
+/// Default rows reserved for title, status, and key-hint chrome.
+const DEFAULT_CHROME_ROWS: u16 = 3;
+/// Default virtualized rows retained above and below each viewport.
+const DEFAULT_OVERSCAN: usize = 2;
+
+/// Responsive geometry options for a diagnostic workspace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DiagnosticWorkspaceOptions {
+    /// Width at which master and detail panes split. Defaults to 80 columns.
+    pub split_width: u16,
+    /// Percentage of width assigned to the list in split mode. Defaults to 40.
+    pub list_percent: u8,
+    /// Rows reserved above or below content. Defaults to 3.
+    pub chrome_rows: u16,
+    /// Off-screen virtual rows retained on each side. Defaults to 2.
+    pub overscan: usize,
+}
+
+impl Default for DiagnosticWorkspaceOptions {
+    fn default() -> Self {
+        Self {
+            split_width: DEFAULT_SPLIT_WIDTH,
+            list_percent: DEFAULT_LIST_PERCENT,
+            chrome_rows: DEFAULT_CHROME_ROWS,
+            overscan: DEFAULT_OVERSCAN,
+        }
+    }
+}
+
+impl DiagnosticWorkspaceOptions {
+    pub(super) fn normalized(mut self) -> Self {
+        self.split_width = self.split_width.max(3);
+        self.list_percent = self.list_percent.clamp(10, 90);
+        self
+    }
+
+    pub(super) const fn overscan(self) -> usize {
+        self.overscan
+    }
+}
+
+/// Responsive pane mode selected from the current viewport width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticWorkspaceMode {
+    /// Finding and detail panes are visible side by side.
+    Split,
+    /// One full-width pane is visible according to semantic focus.
+    Stacked,
+}
+
+/// Semantic pane selected for presentation in stacked mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticWorkspacePane {
+    /// Virtualized finding list.
+    Findings,
+    /// Detail and related-evidence presentation.
+    Detail,
+}
+
+/// Deterministic responsive pane rectangles for one terminal viewport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DiagnosticWorkspaceLayout {
+    width: u16,
+    height: u16,
+    mode: DiagnosticWorkspaceMode,
+    content: Rect,
+    findings: Rect,
+    detail: Rect,
+}
+
+impl DiagnosticWorkspaceLayout {
+    pub(super) fn new(width: u16, height: u16, options: DiagnosticWorkspaceOptions) -> Self {
+        let chrome = options.chrome_rows.min(height);
+        let content = Rect::new(0, chrome, width, height.saturating_sub(chrome));
+        let mode = if width >= options.split_width {
+            DiagnosticWorkspaceMode::Split
+        } else {
+            DiagnosticWorkspaceMode::Stacked
+        };
+        let (findings, detail) = match mode {
+            DiagnosticWorkspaceMode::Split if width > 1 => {
+                let list_width = (u32::from(width) * u32::from(options.list_percent) / 100)
+                    .clamp(1, u32::from(width - 2)) as u16;
+                let detail_x = list_width.saturating_add(1).min(width);
+                (
+                    Rect::new(0, chrome, list_width, content.height),
+                    Rect::new(
+                        detail_x,
+                        chrome,
+                        width.saturating_sub(detail_x),
+                        content.height,
+                    ),
+                )
+            }
+            _ => (content, content),
+        };
+        Self {
+            width,
+            height,
+            mode,
+            content,
+            findings,
+            detail,
+        }
+    }
+
+    /// Return the complete terminal width in cells.
+    pub const fn width(self) -> u16 {
+        self.width
+    }
+
+    /// Return the complete terminal height in cells.
+    pub const fn height(self) -> u16 {
+        self.height
+    }
+
+    /// Return the responsive split or stacked mode.
+    pub const fn mode(self) -> DiagnosticWorkspaceMode {
+        self.mode
+    }
+
+    /// Return the content rectangle after reserved chrome rows.
+    pub const fn content(self) -> Rect {
+        self.content
+    }
+
+    /// Return finding pane geometry.
+    pub const fn findings(self) -> Rect {
+        self.findings
+    }
+
+    /// Return detail pane geometry.
+    pub const fn detail(self) -> Rect {
+        self.detail
+    }
+
+    /// Return whether a pane is presented in the current responsive mode.
+    pub const fn presents(
+        self,
+        pane: DiagnosticWorkspacePane,
+        active_stacked_pane: DiagnosticWorkspacePane,
+    ) -> bool {
+        match self.mode {
+            DiagnosticWorkspaceMode::Split => true,
+            DiagnosticWorkspaceMode::Stacked => matches!(
+                (pane, active_stacked_pane),
+                (
+                    DiagnosticWorkspacePane::Findings,
+                    DiagnosticWorkspacePane::Findings
+                ) | (
+                    DiagnosticWorkspacePane::Detail,
+                    DiagnosticWorkspacePane::Detail
+                )
+            ),
+        }
+    }
+}

--- a/crates/vize_fresco/src/component/diagnostic_workspace/tests.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/tests.rs
@@ -1,0 +1,167 @@
+use std::mem::size_of;
+
+use super::{
+    DiagnosticWorkspaceFocus, DiagnosticWorkspaceMode, DiagnosticWorkspaceOptions,
+    DiagnosticWorkspacePane, DiagnosticWorkspaceState,
+};
+use crate::component::VirtualListNavigation;
+
+#[test]
+fn default_split_layout_reserves_chrome_and_a_divider() {
+    let state = DiagnosticWorkspaceState::<u64, u64>::new(120, 30);
+    let layout = state.layout();
+
+    assert_eq!(layout.mode(), DiagnosticWorkspaceMode::Split);
+    assert_eq!(layout.content(), crate::layout::Rect::new(0, 3, 120, 27));
+    assert_eq!(layout.findings(), crate::layout::Rect::new(0, 3, 48, 27));
+    assert_eq!(layout.detail(), crate::layout::Rect::new(49, 3, 71, 27));
+    assert!(layout.presents(
+        DiagnosticWorkspacePane::Findings,
+        state.active_stacked_pane()
+    ));
+    assert!(layout.presents(DiagnosticWorkspacePane::Detail, state.active_stacked_pane()));
+}
+
+#[test]
+fn narrow_layout_presents_only_the_semantically_focused_pane() {
+    let mut state = DiagnosticWorkspaceState::<u64, u64>::new(79, 20);
+    let layout = state.layout();
+
+    assert_eq!(layout.mode(), DiagnosticWorkspaceMode::Stacked);
+    assert_eq!(layout.findings(), layout.content());
+    assert_eq!(layout.detail(), layout.content());
+    assert!(layout.presents(
+        DiagnosticWorkspacePane::Findings,
+        state.active_stacked_pane()
+    ));
+    assert!(!layout.presents(DiagnosticWorkspacePane::Detail, state.active_stacked_pane()));
+
+    assert!(state.set_focus(DiagnosticWorkspaceFocus::Detail));
+    assert_eq!(state.active_stacked_pane(), DiagnosticWorkspacePane::Detail);
+}
+
+#[test]
+fn ten_thousand_findings_materialize_only_viewport_plus_overscan() {
+    let keys = (0_u64..10_000).collect::<Vec<_>>();
+    let mut state = DiagnosticWorkspaceState::<u64, u64>::new(120, 27);
+
+    assert!(state.reconcile_findings(&keys));
+    assert!(state.select_finding(&keys, 9_000));
+    let window = state.finding_window();
+
+    assert_eq!(state.findings().selected_key(), Some(&9_000));
+    assert!(window.is_visible(9_000));
+    assert_eq!(window.visible_len(), 24);
+    assert!(window.materialized_len() <= 28);
+    assert!(size_of::<DiagnosticWorkspaceState<u64, u64>>() < 256);
+}
+
+#[test]
+fn filtering_preserves_stable_selection_and_resets_only_changed_details() {
+    let keys = (0_u64..10).collect::<Vec<_>>();
+    let filtered = vec![0, 2, 4, 6, 8];
+    let replaced = vec![0, 2, 4, 8];
+    let evidence = vec![100, 101];
+    let mut state = DiagnosticWorkspaceState::new(100, 20);
+
+    let _ = state.reconcile_findings(&keys);
+    let _ = state.select_finding(&keys, 6);
+    let _ = state.reconcile_evidence(&evidence);
+    let _ = state.navigate_evidence(&evidence, VirtualListNavigation::Next);
+    let _ = state.set_detail_content_rows(100);
+    let _ = state.scroll_detail(15);
+
+    assert!(!state.reconcile_findings(&filtered));
+    assert_eq!(state.findings().selected_key(), Some(&6));
+    assert_eq!(state.evidence().selected_key(), Some(&101));
+    assert_eq!(state.detail_scroll(), 15);
+
+    assert!(state.reconcile_findings(&replaced));
+    assert_eq!(state.findings().selected_key(), Some(&8));
+    assert_eq!(state.evidence().selected_key(), None);
+    assert_eq!(state.detail_scroll(), 0);
+}
+
+#[test]
+fn evidence_navigation_is_stable_bounded_and_focus_aware() {
+    let findings = vec![1_u64];
+    let evidence = vec!["型", "🧭", "é"];
+    let reordered = vec!["é", "🧭", "型"];
+    let mut state = DiagnosticWorkspaceState::new(100, 20);
+    let _ = state.reconcile_findings(&findings);
+
+    assert!(!state.set_focus(DiagnosticWorkspaceFocus::Evidence));
+    assert!(state.focus_next());
+    assert_eq!(state.focus(), DiagnosticWorkspaceFocus::Detail);
+    assert!(state.focus_next());
+    assert_eq!(state.focus(), DiagnosticWorkspaceFocus::Findings);
+
+    assert!(state.reconcile_evidence(&evidence));
+    assert!(state.navigate_evidence(&evidence, VirtualListNavigation::Next));
+    assert_eq!(state.evidence().selected_key(), Some(&"🧭"));
+    assert!(!state.reconcile_evidence(&reordered));
+    assert_eq!(state.evidence().selected_key(), Some(&"🧭"));
+
+    assert!(state.focus_previous());
+    assert_eq!(state.focus(), DiagnosticWorkspaceFocus::Evidence);
+    assert!(state.reconcile_evidence(&[]));
+    assert_eq!(state.focus(), DiagnosticWorkspaceFocus::Detail);
+}
+
+#[test]
+fn resize_preserves_selection_and_normalizes_both_virtual_windows() {
+    let findings = (0_u64..100).collect::<Vec<_>>();
+    let evidence = (1_000_u64..1_100).collect::<Vec<_>>();
+    let mut state = DiagnosticWorkspaceState::new(120, 30);
+    let _ = state.reconcile_findings(&findings);
+    let _ = state.select_finding(&findings, 99);
+    let _ = state.reconcile_evidence(&evidence);
+    let _ = state.select_finding(&findings, 99);
+
+    assert!(state.resize(40, 8));
+    assert_eq!(state.layout().mode(), DiagnosticWorkspaceMode::Stacked);
+    assert_eq!(state.findings().selected_key(), Some(&99));
+    assert_eq!(state.evidence().selected_key(), Some(&1_000));
+    assert!(state.finding_window().is_visible(99));
+    assert_eq!(state.finding_window().visible_len(), 5);
+
+    assert!(state.resize(0, 0));
+    assert_eq!(state.finding_window().visible_len(), 0);
+    assert_eq!(state.findings().selected_key(), Some(&99));
+    assert!(!state.resize(0, 0));
+}
+
+#[test]
+fn detail_overflow_is_explicit_and_saturating_across_resize() {
+    let mut state = DiagnosticWorkspaceState::<u64, u64>::new(100, 20);
+    assert!(state.set_detail_content_rows(100));
+    assert!(state.scroll_detail(isize::MAX));
+    assert_eq!(state.detail_scroll(), 83);
+    assert_eq!(state.detail_rows_below(), 0);
+
+    assert!(state.resize(100, 10));
+    assert_eq!(state.detail_scroll(), 83);
+    assert_eq!(state.detail_rows_below(), 10);
+    assert!(state.scroll_detail(isize::MIN));
+    assert_eq!(state.detail_scroll(), 0);
+}
+
+#[test]
+fn options_are_normalized_without_invalid_geometry() {
+    let state = DiagnosticWorkspaceState::<u64, u64>::with_options(
+        5,
+        2,
+        DiagnosticWorkspaceOptions {
+            split_width: 0,
+            list_percent: 100,
+            chrome_rows: 50,
+            overscan: 9,
+        },
+    );
+
+    assert_eq!(state.options().split_width, 3);
+    assert_eq!(state.options().list_percent, 90);
+    assert_eq!(state.layout().content().height, 0);
+    assert_eq!(state.layout().detail().width, 1);
+    assert_eq!(state.findings().overscan(), 9);
+}

--- a/crates/vize_fresco/src/lib.rs
+++ b/crates/vize_fresco/src/lib.rs
@@ -14,6 +14,7 @@
 //! - **Flexbox Layout**: Layout engine powered by taffy
 //! - **CJK Support**: Full Unicode text handling including Japanese IME
 //! - **Efficient Rendering**: Double-buffered differential rendering
+//! - **Diagnostic Workspaces**: Stable, virtualized master-detail navigation
 //!
 //! # Architecture
 //!
@@ -63,7 +64,9 @@ pub mod napi;
 
 // Re-exports for convenience
 pub use component::{
-    BoxNode, InputNode, TextNode, VirtualListNavigation, VirtualListState, VirtualWindow,
+    BoxNode, DiagnosticWorkspaceFocus, DiagnosticWorkspaceLayout, DiagnosticWorkspaceMode,
+    DiagnosticWorkspaceOptions, DiagnosticWorkspacePane, DiagnosticWorkspaceState, InputNode,
+    TextNode, VirtualListNavigation, VirtualListState, VirtualWindow,
 };
 pub use input::{Event, ImeState, KeyEvent, MouseEvent};
 pub use layout::{FlexStyle, LayoutEngine, Rect};


### PR DESCRIPTION
## Summary

- add a stable-keyed semantic master-detail workspace state for diagnostic TUIs
- provide responsive split/stacked geometry, bounded focus, evidence navigation, and explicit detail overflow
- reuse the virtual-list contract so 10,000 findings retain constant-size state and materialize only the visible window
- document the public API and add Unicode, resize, filtering, zero-viewport, and saturation tests

## Performance

Criterion, 10,000 findings (30 samples):

- navigation: 4.40 ns median
- responsive resize: 2.75 ns median
- virtual window: 1.15 ns median

## Verification

- `cargo test -p vize_fresco --all-features` (151 passed)
- `cargo clippy -p vize_fresco --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vize_fresco --all-features --no-deps`
- `cargo bench -p vize_fresco --bench render --no-run`
- `cargo fmt --all --check`

Relates to #4155.
Relates to #3138.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a diagnostic workspace with findings and detail panes.
  * Supports split and stacked layouts that adapt to viewport size.
  * Added finding and evidence navigation, focus management, selection, scrolling, and virtualized lists.
  * Added configurable workspace sizing, pane allocation, and overscan settings.

* **Documentation**
  * Updated documentation to describe diagnostic workspace state, layout, and virtual list APIs.

* **Tests**
  * Added coverage for responsive layouts, navigation, filtering, resizing, focus behavior, and scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->