### PR TITLE
feat(fresco): add headless semantic snapshots

### DIFF
--- a/crates/vize_fresco/README.md
+++ b/crates/vize_fresco/README.md
@@ -14,6 +14,7 @@ Support and deprecation guarantees are defined in the
 - Flexbox-style layout via `taffy`
 - Render tree, buffer, and text measurement utilities
 - Stable-keyed, virtualized diagnostic master-detail workspace state
+- Deterministic headless screen, semantic-tree, focus, cursor, and announcement snapshots
 - Optional NAPI bindings through the `napi` feature
 
 ## Key Entry Points
@@ -22,6 +23,7 @@ Support and deprecation guarantees are defined in the
 - `DiagnosticWorkspaceState`, `DiagnosticWorkspaceLayout`, `VirtualListState`
 - `LayoutEngine`, `FlexStyle`, `Rect`
 - `RenderTree`, `RenderNode`
+- `HeadlessRenderer`, `HeadlessPresentation`, `HeadlessSnapshot`
 - `Backend`, `Buffer`, `Cursor`
 
 ## Related Crates

--- a/crates/vize_fresco/benches/render.rs
+++ b/crates/vize_fresco/benches/render.rs
@@ -5,8 +5,14 @@ use std::io;
 
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 
-use vize_fresco::component::{DiagnosticWorkspaceState, VirtualListNavigation, VirtualListState};
-use vize_fresco::layout::{FlexStyle, LayoutEngine};
+use vize_fresco::component::{
+    BoxNode, DiagnosticWorkspaceState, TextNode, VirtualListNavigation, VirtualListState,
+};
+use vize_fresco::headless::{
+    HeadlessPresentation, HeadlessRenderer, HeadlessSemanticNode, SemanticRole,
+};
+use vize_fresco::layout::{Dimension, FlexStyle, LayoutEngine};
+use vize_fresco::render::RenderTree;
 use vize_fresco::terminal::{Backend, Buffer, Style};
 use vize_fresco::text::{TextWidth, TextWrap, WrapMode};
 
@@ -196,6 +202,51 @@ fn benchmark_diagnostic_workspace(c: &mut Criterion) {
     group.finish();
 }
 
+fn benchmark_headless_snapshot(c: &mut Criterion) {
+    let mut tree = RenderTree::new();
+    let root_id = tree.next_id();
+    tree.insert_root(
+        BoxNode::new()
+            .column()
+            .width_percent(100.0)
+            .height_percent(100.0)
+            .build(root_id),
+    );
+    let mut semantics = vec![HeadlessSemanticNode::new(
+        root_id,
+        SemanticRole::Application,
+        "Doctor",
+    )];
+    for _ in 0..50 {
+        let id = tree.next_id();
+        let mut node = TextNode::new("Finding").build(id);
+        node.style.width = Dimension::Percent(100.0);
+        node.style.height = Dimension::Points(1.0);
+        node.style.flex_shrink = 0.0;
+        tree.insert(node);
+        tree.add_child(root_id, id);
+        semantics.push(HeadlessSemanticNode::new(
+            id,
+            SemanticRole::ListItem,
+            "Finding",
+        ));
+    }
+    let presentation = HeadlessPresentation::new().with_semantics(semantics);
+    let mut renderer = HeadlessRenderer::new(120, 40).unwrap();
+    let mut group = c.benchmark_group("headless_snapshot");
+    group.throughput(Throughput::Elements(120 * 40));
+    group.bench_function("120x40_50_semantic_nodes", |b| {
+        b.iter(|| {
+            black_box(
+                renderer
+                    .render(black_box(&mut tree), black_box(&presentation))
+                    .unwrap(),
+            )
+        });
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     benchmark_buffer_set_string,
@@ -206,5 +257,6 @@ criterion_group!(
     benchmark_virtual_list,
     benchmark_injected_backend_output,
     benchmark_diagnostic_workspace,
+    benchmark_headless_snapshot,
 );
 criterion_main!(benches);

--- a/crates/vize_fresco/src/headless.rs
+++ b/crates/vize_fresco/src/headless.rs
@@ -1,0 +1,22 @@
+//! Deterministic, terminal-free rendering and semantic snapshots.
+//!
+//! Headless snapshots exercise Fresco's production layout, painter, and cell
+//! buffer without enabling terminal modes or writing escape sequences. Callers
+//! supply semantic metadata separately from visual nodes so rendering remains
+//! generic while accessibility and focus contracts stay directly assertable.
+
+mod model;
+mod renderer;
+mod snapshot;
+
+#[cfg(test)]
+mod tests;
+#[cfg(test)]
+mod validation_tests;
+
+pub use model::{
+    AnnouncementPoliteness, HeadlessAnnouncement, HeadlessPresentation, HeadlessSemanticNode,
+    SemanticRole, SemanticState,
+};
+pub use renderer::{DEFAULT_HEADLESS_CELL_BUDGET, HeadlessRenderError, HeadlessRenderer};
+pub use snapshot::{HeadlessCell, HeadlessSnapshot, SemanticSnapshotNode};

--- a/crates/vize_fresco/src/headless/model.rs
+++ b/crates/vize_fresco/src/headless/model.rs
@@ -1,0 +1,231 @@
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+
+use crate::{render::NodeId, terminal::Cursor};
+
+/// Platform-neutral role exposed by a rendered semantic node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SemanticRole {
+    /// Root application surface.
+    Application,
+    /// Primary content region.
+    Main,
+    /// Navigation region.
+    Navigation,
+    /// Named region.
+    Region,
+    /// Related group of controls or content.
+    Group,
+    /// Heading with an optional level in [`SemanticState`].
+    Heading,
+    /// Collection of related items.
+    List,
+    /// One item in a collection.
+    ListItem,
+    /// Non-urgent status update.
+    Status,
+    /// Urgent error or warning.
+    Alert,
+    /// Progress or score indicator.
+    Progress,
+    /// Read-only text.
+    Text,
+    /// Editable text input.
+    Input,
+    /// Search input.
+    SearchBox,
+    /// Action control.
+    Button,
+    /// Navigable link.
+    Link,
+    /// Source code or machine-readable identifier.
+    Code,
+}
+
+/// Optional state attached to a semantic node.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SemanticState {
+    /// Human-readable current value, such as `92 / 100`.
+    pub value: Option<CompactString>,
+    /// Heading level when the role is [`SemanticRole::Heading`].
+    pub level: Option<u8>,
+    /// One-based item position within a logical set.
+    pub position: Option<u64>,
+    /// Total logical set size, including virtualized off-screen items.
+    pub set_size: Option<u64>,
+    /// Whether this item is selected.
+    pub selected: bool,
+    /// Whether this item is disabled.
+    pub disabled: bool,
+    /// Whether expandable content is open.
+    pub expanded: Option<bool>,
+    /// Whether the region is waiting for an update.
+    pub busy: bool,
+    /// Whether an input value is read-only.
+    pub read_only: bool,
+}
+
+impl SemanticState {
+    /// Set a human-readable value.
+    pub fn with_value(mut self, value: impl Into<CompactString>) -> Self {
+        self.value = Some(value.into());
+        self
+    }
+
+    /// Set a heading level.
+    pub const fn with_level(mut self, level: u8) -> Self {
+        self.level = Some(level);
+        self
+    }
+
+    /// Set one-based position and total size for a logical collection.
+    pub const fn with_set_position(mut self, position: u64, set_size: u64) -> Self {
+        self.position = Some(position);
+        self.set_size = Some(set_size);
+        self
+    }
+
+    /// Mark the node selected or unselected.
+    pub const fn with_selected(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
+    }
+}
+
+/// Semantic metadata associated with one render-tree node.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HeadlessSemanticNode {
+    /// Render node carrying this semantic meaning.
+    pub node_id: NodeId,
+    /// Platform-neutral role.
+    pub role: SemanticRole,
+    /// Accessible name used in snapshots and announcements.
+    pub name: CompactString,
+    /// Optional longer explanation.
+    pub description: Option<CompactString>,
+    /// Optional role state.
+    pub state: SemanticState,
+}
+
+impl HeadlessSemanticNode {
+    /// Create semantic metadata with a required accessible name.
+    pub fn new(node_id: NodeId, role: SemanticRole, name: impl Into<CompactString>) -> Self {
+        Self {
+            node_id,
+            role,
+            name: name.into(),
+            description: None,
+            state: SemanticState::default(),
+        }
+    }
+
+    /// Set the longer accessible description.
+    pub fn with_description(mut self, description: impl Into<CompactString>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set role-specific state.
+    pub fn with_state(mut self, state: SemanticState) -> Self {
+        self.state = state;
+        self
+    }
+}
+
+/// Urgency used when asserting a live announcement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AnnouncementPoliteness {
+    /// Announce after the current interaction finishes.
+    Polite,
+    /// Interrupt because the message requires immediate attention.
+    Assertive,
+}
+
+/// One semantic announcement emitted by the rendered frame.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HeadlessAnnouncement {
+    /// Announcement urgency.
+    pub politeness: AnnouncementPoliteness,
+    /// Exact message exposed to assistive output.
+    pub message: CompactString,
+    /// Optional semantic node that caused the announcement.
+    pub source: Option<NodeId>,
+}
+
+impl HeadlessAnnouncement {
+    /// Create an announcement without a source node.
+    pub fn new(politeness: AnnouncementPoliteness, message: impl Into<CompactString>) -> Self {
+        Self {
+            politeness,
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    /// Associate the announcement with a semantic node.
+    pub const fn with_source(mut self, source: NodeId) -> Self {
+        self.source = Some(source);
+        self
+    }
+}
+
+/// Per-frame non-visual state supplied to [`super::HeadlessRenderer`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeadlessPresentation {
+    pub(super) semantics: Vec<HeadlessSemanticNode>,
+    pub(super) focus: Option<NodeId>,
+    pub(super) cursor: Cursor,
+    pub(super) announcements: Vec<HeadlessAnnouncement>,
+}
+
+impl HeadlessPresentation {
+    /// Create a presentation with a hidden cursor and no semantic nodes.
+    pub fn new() -> Self {
+        let mut cursor = Cursor::new();
+        cursor.hide();
+        Self {
+            semantics: Vec::new(),
+            focus: None,
+            cursor,
+            announcements: Vec::new(),
+        }
+    }
+
+    /// Supply semantic metadata. Input order does not affect snapshot order.
+    pub fn with_semantics(
+        mut self,
+        semantics: impl IntoIterator<Item = HeadlessSemanticNode>,
+    ) -> Self {
+        self.semantics = semantics.into_iter().collect();
+        self
+    }
+
+    /// Set the focused semantic render node.
+    pub const fn with_focus(mut self, focus: NodeId) -> Self {
+        self.focus = Some(focus);
+        self
+    }
+
+    /// Set exact terminal cursor state.
+    pub const fn with_cursor(mut self, cursor: Cursor) -> Self {
+        self.cursor = cursor;
+        self
+    }
+
+    /// Supply announcements in emission order.
+    pub fn with_announcements(
+        mut self,
+        announcements: impl IntoIterator<Item = HeadlessAnnouncement>,
+    ) -> Self {
+        self.announcements = announcements.into_iter().collect();
+        self
+    }
+}
+
+impl Default for HeadlessPresentation {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/vize_fresco/src/headless/renderer.rs
+++ b/crates/vize_fresco/src/headless/renderer.rs
@@ -1,0 +1,338 @@
+use rustc_hash::{FxHashMap, FxHashSet};
+use thiserror::Error;
+
+use super::{
+    HeadlessCell, HeadlessPresentation, HeadlessSemanticNode, HeadlessSnapshot,
+    SemanticSnapshotNode,
+};
+use crate::{
+    layout::Rect,
+    render::{NodeId, Painter, RenderTree},
+    terminal::Buffer,
+};
+
+/// Default maximum number of cells allocated by a headless viewport.
+pub const DEFAULT_HEADLESS_CELL_BUDGET: usize = 1_000_000;
+
+/// Invalid headless presentation or viewport.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum HeadlessRenderError {
+    /// Requested viewport exceeds the configured allocation budget.
+    #[error("headless viewport {width}x{height} requires {required} cells; budget is {budget}")]
+    CellBudgetExceeded {
+        /// Requested width.
+        width: u16,
+        /// Requested height.
+        height: u16,
+        /// Required row-major cells.
+        required: usize,
+        /// Configured limit.
+        budget: usize,
+    },
+    /// Multiple semantic records reference the same render node.
+    #[error("semantic render node {0} is declared more than once")]
+    DuplicateSemanticNode(NodeId),
+    /// Semantic metadata references a render node that does not exist.
+    #[error("semantic render node {0} does not exist")]
+    UnknownSemanticNode(NodeId),
+    /// Semantic metadata references a node detached from the render root.
+    #[error("semantic render node {0} is detached from the render root")]
+    DetachedSemanticNode(NodeId),
+    /// A semantic node has no accessible name.
+    #[error("semantic render node {0} has an empty accessible name")]
+    EmptySemanticName(NodeId),
+    /// A supplied description contains no accessible text.
+    #[error("semantic render node {0} has an empty accessible description")]
+    EmptySemanticDescription(NodeId),
+    /// Heading level is outside 1 through 6.
+    #[error(
+        "semantic heading render node {node_id} has invalid level {level}; expected 1 through 6"
+    )]
+    InvalidHeadingLevel {
+        /// Invalid render node.
+        node_id: NodeId,
+        /// Invalid heading level.
+        level: u8,
+    },
+    /// A non-heading role supplied a heading level.
+    #[error("non-heading semantic render node {0} supplies a heading level")]
+    UnexpectedHeadingLevel(NodeId),
+    /// Logical set metadata supplied only a position or only a size.
+    #[error("semantic render node {0} must supply set position and size together")]
+    IncompleteSetPosition(NodeId),
+    /// Logical set metadata is zero or outside the declared set.
+    #[error("semantic render node {node_id} has invalid set position {position} of {set_size}")]
+    InvalidSetPosition {
+        /// Invalid render node.
+        node_id: NodeId,
+        /// One-based position.
+        position: u64,
+        /// Declared set size.
+        set_size: u64,
+    },
+    /// Focus references a node without semantic metadata.
+    #[error("focused render node {0} is not semantic")]
+    UnknownFocus(NodeId),
+    /// Focus references a semantic node outside the presented viewport.
+    #[error("focused semantic render node {0} is not presented in the viewport")]
+    FocusNotPresented(NodeId),
+    /// A visible cursor falls outside the viewport.
+    #[error("visible cursor ({x}, {y}) is outside headless viewport {width}x{height}")]
+    CursorOutsideViewport {
+        /// Cursor column.
+        x: u16,
+        /// Cursor row.
+        y: u16,
+        /// Viewport width.
+        width: u16,
+        /// Viewport height.
+        height: u16,
+    },
+    /// An announcement message is empty.
+    #[error("announcement {0} has an empty message")]
+    EmptyAnnouncement(usize),
+    /// An announcement source has no semantic metadata.
+    #[error("announcement {index} references non-semantic render node {node_id}")]
+    UnknownAnnouncementSource {
+        /// Zero-based announcement index.
+        index: usize,
+        /// Invalid render node.
+        node_id: NodeId,
+    },
+}
+
+/// Reusable terminal-free renderer for deterministic frame snapshots.
+pub struct HeadlessRenderer {
+    buffer: Buffer,
+    cell_budget: usize,
+}
+
+impl HeadlessRenderer {
+    /// Create a renderer using [`DEFAULT_HEADLESS_CELL_BUDGET`].
+    pub fn new(width: u16, height: u16) -> Result<Self, HeadlessRenderError> {
+        Self::with_cell_budget(width, height, DEFAULT_HEADLESS_CELL_BUDGET)
+    }
+
+    /// Create a renderer with an explicit maximum cell allocation.
+    pub fn with_cell_budget(
+        width: u16,
+        height: u16,
+        cell_budget: usize,
+    ) -> Result<Self, HeadlessRenderError> {
+        validate_cell_budget(width, height, cell_budget)?;
+        Ok(Self {
+            buffer: Buffer::new(width, height),
+            cell_budget,
+        })
+    }
+
+    /// Return the current viewport.
+    pub fn viewport(&self) -> Rect {
+        self.buffer.area()
+    }
+
+    /// Resize and clear the reusable buffer after validating its allocation.
+    pub fn resize(&mut self, width: u16, height: u16) -> Result<bool, HeadlessRenderError> {
+        validate_cell_budget(width, height, self.cell_budget)?;
+        if self.buffer.width() == width && self.buffer.height() == height {
+            return Ok(false);
+        }
+        self.buffer.resize(width, height);
+        Ok(true)
+    }
+
+    /// Render one complete snapshot through production layout and paint paths.
+    pub fn render(
+        &mut self,
+        tree: &mut RenderTree,
+        presentation: &HeadlessPresentation,
+    ) -> Result<HeadlessSnapshot, HeadlessRenderError> {
+        let semantic_map = validate_presentation(tree, presentation)?;
+        validate_cursor(self.viewport(), presentation)?;
+
+        tree.compute_layout(self.buffer.width(), self.buffer.height());
+        self.buffer.clear();
+        Painter::new(&mut self.buffer).paint_tree(tree);
+
+        let semantics = snapshot_semantics(tree, self.viewport(), &semantic_map)?;
+        if let Some(focus) = presentation.focus
+            && !semantics
+                .iter()
+                .any(|node| node.node_id == focus && node.presented)
+        {
+            return Err(HeadlessRenderError::FocusNotPresented(focus));
+        }
+
+        let cells = self
+            .buffer
+            .iter()
+            .map(|(_, _, cell)| HeadlessCell {
+                symbol: cell.symbol.clone(),
+                style: cell.style,
+                continuation: cell.is_continuation,
+            })
+            .collect();
+
+        Ok(HeadlessSnapshot {
+            viewport: self.viewport(),
+            semantics,
+            cells,
+            cursor: presentation.cursor,
+            focus: presentation.focus,
+            announcements: presentation.announcements.clone(),
+        })
+    }
+}
+
+fn validate_cell_budget(width: u16, height: u16, budget: usize) -> Result<(), HeadlessRenderError> {
+    let required = usize::from(width).saturating_mul(usize::from(height));
+    if required > budget {
+        return Err(HeadlessRenderError::CellBudgetExceeded {
+            width,
+            height,
+            required,
+            budget,
+        });
+    }
+    Ok(())
+}
+
+fn validate_cursor(
+    viewport: Rect,
+    presentation: &HeadlessPresentation,
+) -> Result<(), HeadlessRenderError> {
+    let cursor = presentation.cursor;
+    if cursor.visible && !viewport.contains(cursor.x, cursor.y) {
+        return Err(HeadlessRenderError::CursorOutsideViewport {
+            x: cursor.x,
+            y: cursor.y,
+            width: viewport.width,
+            height: viewport.height,
+        });
+    }
+    Ok(())
+}
+
+fn validate_presentation<'a>(
+    tree: &RenderTree,
+    presentation: &'a HeadlessPresentation,
+) -> Result<FxHashMap<NodeId, &'a HeadlessSemanticNode>, HeadlessRenderError> {
+    let mut semantics = FxHashMap::default();
+    for semantic in &presentation.semantics {
+        if tree.get(semantic.node_id).is_none() {
+            return Err(HeadlessRenderError::UnknownSemanticNode(semantic.node_id));
+        }
+        if semantic.name.trim().is_empty() {
+            return Err(HeadlessRenderError::EmptySemanticName(semantic.node_id));
+        }
+        if semantic
+            .description
+            .as_deref()
+            .is_some_and(|description| description.trim().is_empty())
+        {
+            return Err(HeadlessRenderError::EmptySemanticDescription(
+                semantic.node_id,
+            ));
+        }
+        match (semantic.role, semantic.state.level) {
+            (super::SemanticRole::Heading, Some(1..=6)) | (_, None) => {}
+            (super::SemanticRole::Heading, Some(level)) => {
+                return Err(HeadlessRenderError::InvalidHeadingLevel {
+                    node_id: semantic.node_id,
+                    level,
+                });
+            }
+            (_, Some(_)) => {
+                return Err(HeadlessRenderError::UnexpectedHeadingLevel(
+                    semantic.node_id,
+                ));
+            }
+        }
+        match (semantic.state.position, semantic.state.set_size) {
+            (None, None) => {}
+            (Some(position), Some(set_size)) if position > 0 && position <= set_size => {}
+            (Some(position), Some(set_size)) => {
+                return Err(HeadlessRenderError::InvalidSetPosition {
+                    node_id: semantic.node_id,
+                    position,
+                    set_size,
+                });
+            }
+            _ => {
+                return Err(HeadlessRenderError::IncompleteSetPosition(semantic.node_id));
+            }
+        }
+        if semantics.insert(semantic.node_id, semantic).is_some() {
+            return Err(HeadlessRenderError::DuplicateSemanticNode(semantic.node_id));
+        }
+    }
+    if let Some(focus) = presentation.focus
+        && !semantics.contains_key(&focus)
+    {
+        return Err(HeadlessRenderError::UnknownFocus(focus));
+    }
+    for (index, announcement) in presentation.announcements.iter().enumerate() {
+        if announcement.message.trim().is_empty() {
+            return Err(HeadlessRenderError::EmptyAnnouncement(index));
+        }
+        if let Some(node_id) = announcement.source
+            && !semantics.contains_key(&node_id)
+        {
+            return Err(HeadlessRenderError::UnknownAnnouncementSource { index, node_id });
+        }
+    }
+    Ok(semantics)
+}
+
+fn snapshot_semantics(
+    tree: &RenderTree,
+    viewport: Rect,
+    semantics: &FxHashMap<NodeId, &HeadlessSemanticNode>,
+) -> Result<Vec<SemanticSnapshotNode>, HeadlessRenderError> {
+    let mut snapshot = Vec::with_capacity(semantics.len());
+    let mut visited = FxHashSet::default();
+    let mut stack = tree
+        .root()
+        .into_iter()
+        .map(|root| (root, None, 0_usize))
+        .collect::<Vec<_>>();
+
+    while let Some((node_id, semantic_parent, semantic_depth)) = stack.pop() {
+        let Some(render_node) = tree.get(node_id) else {
+            continue;
+        };
+        let (next_parent, next_depth) = if let Some(semantic) = semantics.get(&node_id) {
+            visited.insert(node_id);
+            let layout = render_node
+                .layout
+                .unwrap_or_default()
+                .intersection(&viewport);
+            snapshot.push(SemanticSnapshotNode {
+                node_id,
+                parent: semantic_parent,
+                depth: semantic_depth,
+                role: semantic.role,
+                name: semantic.name.clone(),
+                description: semantic.description.clone(),
+                state: semantic.state.clone(),
+                layout,
+                presented: !layout.is_empty(),
+            });
+            (Some(node_id), semantic_depth.saturating_add(1))
+        } else {
+            (semantic_parent, semantic_depth)
+        };
+        for child in render_node.children.iter().rev() {
+            stack.push((*child, next_parent, next_depth));
+        }
+    }
+
+    if let Some(detached) = semantics
+        .keys()
+        .filter(|node_id| !visited.contains(node_id))
+        .min()
+    {
+        return Err(HeadlessRenderError::DetachedSemanticNode(*detached));
+    }
+    Ok(snapshot)
+}

--- a/crates/vize_fresco/src/headless/snapshot.rs
+++ b/crates/vize_fresco/src/headless/snapshot.rs
@@ -1,0 +1,125 @@
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+
+use super::{HeadlessAnnouncement, SemanticRole, SemanticState};
+use crate::{
+    layout::Rect,
+    render::NodeId,
+    terminal::{Cursor, Style},
+};
+
+/// Exact terminal cell captured by a headless snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HeadlessCell {
+    /// Displayed symbol, empty for a wide-character continuation cell.
+    pub symbol: CompactString,
+    /// Complete terminal style.
+    pub style: Style,
+    /// Whether this cell continues the preceding wide character.
+    pub continuation: bool,
+}
+
+/// One semantic node in stable render-tree preorder.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SemanticSnapshotNode {
+    /// Render node identifier.
+    pub node_id: NodeId,
+    /// Nearest semantic ancestor, skipping decorative render nodes.
+    pub parent: Option<NodeId>,
+    /// Depth within the semantic tree.
+    pub depth: usize,
+    /// Platform-neutral role.
+    pub role: SemanticRole,
+    /// Accessible name.
+    pub name: CompactString,
+    /// Optional accessible description.
+    pub description: Option<CompactString>,
+    /// Role-specific state.
+    pub state: SemanticState,
+    /// Render layout clipped to the viewport.
+    pub layout: Rect,
+    /// Whether the clipped layout occupies at least one terminal cell.
+    pub presented: bool,
+}
+
+/// Complete deterministic headless frame assertion surface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HeadlessSnapshot {
+    pub(super) viewport: Rect,
+    pub(super) semantics: Vec<SemanticSnapshotNode>,
+    pub(super) cells: Vec<HeadlessCell>,
+    pub(super) cursor: Cursor,
+    pub(super) focus: Option<NodeId>,
+    pub(super) announcements: Vec<HeadlessAnnouncement>,
+}
+
+impl HeadlessSnapshot {
+    /// Return the captured viewport.
+    pub const fn viewport(&self) -> Rect {
+        self.viewport
+    }
+
+    /// Return semantic nodes in stable render-tree preorder.
+    pub fn semantics(&self) -> &[SemanticSnapshotNode] {
+        &self.semantics
+    }
+
+    /// Return row-major terminal cells.
+    pub fn cells(&self) -> &[HeadlessCell] {
+        &self.cells
+    }
+
+    /// Return a cell by terminal coordinate.
+    pub fn cell(&self, x: u16, y: u16) -> Option<&HeadlessCell> {
+        if x >= self.viewport.width || y >= self.viewport.height {
+            return None;
+        }
+        self.cells
+            .get(usize::from(y) * usize::from(self.viewport.width) + usize::from(x))
+    }
+
+    /// Return exact cursor state.
+    pub const fn cursor(&self) -> Cursor {
+        self.cursor
+    }
+
+    /// Return the focused semantic node, if any.
+    pub const fn focus(&self) -> Option<NodeId> {
+        self.focus
+    }
+
+    /// Return announcements in emission order.
+    pub fn announcements(&self) -> &[HeadlessAnnouncement] {
+        &self.announcements
+    }
+
+    /// Reconstruct one visual row, omitting wide-character continuation cells.
+    pub fn row_text(&self, y: u16) -> Option<CompactString> {
+        if y >= self.viewport.height {
+            return None;
+        }
+        let width = usize::from(self.viewport.width);
+        let start = usize::from(y) * width;
+        let mut row = CompactString::new("");
+        for cell in &self.cells[start..start + width] {
+            if !cell.continuation {
+                row.push_str(&cell.symbol);
+            }
+        }
+        Some(row)
+    }
+
+    /// Reconstruct all visual rows separated by `\n`, preserving trailing cells.
+    pub fn screen_text(&self) -> CompactString {
+        let mut screen = CompactString::new("");
+        for y in 0..self.viewport.height {
+            if y > 0 {
+                screen.push('\n');
+            }
+            if let Some(row) = self.row_text(y) {
+                screen.push_str(&row);
+            }
+        }
+        screen
+    }
+}

--- a/crates/vize_fresco/src/headless/tests.rs
+++ b/crates/vize_fresco/src/headless/tests.rs
@@ -1,0 +1,279 @@
+use super::{
+    AnnouncementPoliteness, HeadlessAnnouncement, HeadlessPresentation, HeadlessRenderError,
+    HeadlessRenderer, HeadlessSemanticNode, SemanticRole, SemanticState,
+};
+use crate::{
+    component::{BoxNode, TextNode},
+    layout::Dimension,
+    render::RenderTree,
+    terminal::{Color, Cursor, Style},
+};
+
+fn sized_text(id: u64, text: &str) -> crate::render::RenderNode {
+    let mut node = TextNode::new(text).build(id);
+    node.style.width = Dimension::Percent(100.0);
+    node.style.height = Dimension::Points(1.0);
+    node.style.flex_shrink = 0.0;
+    node
+}
+
+fn diagnostic_tree() -> RenderTree {
+    let mut tree = RenderTree::new();
+    let root_id = tree.next_id();
+    let root = BoxNode::new()
+        .column()
+        .width_percent(100.0)
+        .height_percent(100.0)
+        .build(root_id);
+    tree.insert_root(root);
+
+    let heading_id = tree.next_id();
+    let mut heading = sized_text(heading_id, "診断🧭e\u{301}");
+    heading.appearance.fg = Some(Color::LightCyan);
+    heading.appearance.bold = true;
+    tree.insert(heading);
+    tree.add_child(root_id, heading_id);
+
+    let decoration_id = tree.next_id();
+    let decoration = BoxNode::new()
+        .column()
+        .height(2.0)
+        .shrink(0.0)
+        .build(decoration_id);
+    tree.insert(decoration);
+
+    let score_id = tree.next_id();
+    tree.insert(sized_text(score_id, "92 / 100"));
+    tree.add_child(root_id, score_id);
+    tree.add_child(root_id, decoration_id);
+    tree
+}
+
+fn presentation(order: [u64; 3]) -> HeadlessPresentation {
+    let semantic = |node_id| match node_id {
+        0 => HeadlessSemanticNode::new(0, SemanticRole::Application, "Doctor"),
+        1 => HeadlessSemanticNode::new(1, SemanticRole::Heading, "Diagnostics")
+            .with_state(SemanticState::default().with_level(1)),
+        3 => HeadlessSemanticNode::new(3, SemanticRole::Progress, "Overall health")
+            .with_description("Application health score")
+            .with_state(
+                SemanticState::default()
+                    .with_value("92 / 100")
+                    .with_selected(true),
+            ),
+        _ => unreachable!(),
+    };
+    HeadlessPresentation::new()
+        .with_semantics(order.map(semantic))
+        .with_focus(3)
+        .with_announcements([HeadlessAnnouncement::new(
+            AnnouncementPoliteness::Polite,
+            "1 finding selected",
+        )
+        .with_source(3)])
+}
+
+#[test]
+fn snapshot_is_stable_across_semantic_input_order() {
+    let mut tree = diagnostic_tree();
+    let mut renderer = HeadlessRenderer::new(16, 4).unwrap();
+
+    let first = renderer
+        .render(&mut tree, &presentation([3, 0, 1]))
+        .unwrap();
+    let second = renderer
+        .render(&mut tree, &presentation([1, 3, 0]))
+        .unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(
+        first
+            .semantics()
+            .iter()
+            .map(|node| node.node_id)
+            .collect::<Vec<_>>(),
+        vec![0, 1, 3]
+    );
+    assert_eq!(first.semantics()[2].parent, Some(0));
+    assert_eq!(first.semantics()[2].depth, 1);
+    assert!(first.semantics()[2].presented);
+    assert_eq!(first.focus(), Some(3));
+    assert_eq!(first.announcements()[0].source, Some(3));
+    assert_eq!(first.viewport(), crate::layout::Rect::sized(16, 4));
+    assert_eq!(first.cells().len(), 64);
+    assert_eq!(serde_json::to_value(&first).unwrap()["focus"], 3);
+}
+
+#[test]
+fn cell_snapshot_preserves_wide_cells_style_and_visual_rows() {
+    let mut tree = diagnostic_tree();
+    let mut renderer = HeadlessRenderer::new(16, 4).unwrap();
+    let snapshot = renderer
+        .render(&mut tree, &presentation([0, 1, 3]))
+        .unwrap();
+
+    assert_eq!(snapshot.cell(0, 0).unwrap().symbol, "診");
+    assert!(snapshot.cell(1, 0).unwrap().continuation);
+    assert_eq!(snapshot.cell(2, 0).unwrap().symbol, "断");
+    assert!(snapshot.cell(3, 0).unwrap().continuation);
+    assert_eq!(snapshot.cell(4, 0).unwrap().symbol, "🧭");
+    assert_eq!(
+        snapshot.cell(0, 0).unwrap().style,
+        Style::new().fg(Color::LightCyan).bold()
+    );
+    assert!(snapshot.row_text(0).unwrap().starts_with("診断🧭e"));
+    assert!(snapshot.row_text(1).unwrap().starts_with("92 / 100"));
+    assert_eq!(snapshot.row_text(4), None);
+    assert_eq!(snapshot.screen_text().lines().count(), 4);
+}
+
+#[test]
+fn resize_clears_cells_and_recomputes_presentation() {
+    let mut tree = diagnostic_tree();
+    let mut renderer = HeadlessRenderer::new(16, 4).unwrap();
+    let _ = renderer
+        .render(&mut tree, &presentation([0, 1, 3]))
+        .unwrap();
+
+    assert!(renderer.resize(8, 2).unwrap());
+    assert!(!renderer.resize(8, 2).unwrap());
+    let snapshot = renderer
+        .render(&mut tree, &presentation([0, 1, 3]))
+        .unwrap();
+
+    assert_eq!(snapshot.viewport(), crate::layout::Rect::sized(8, 2));
+    assert_eq!(snapshot.cells().len(), 16);
+    assert!(snapshot.semantics().iter().all(|node| node.presented));
+    assert_eq!(snapshot.cell(8, 0), None);
+}
+
+#[test]
+fn detached_nodes_and_non_presented_focus_fail_closed() {
+    let mut tree = diagnostic_tree();
+    let detached_id = tree.next_id();
+    tree.insert(sized_text(detached_id, "Detached"));
+    let mut renderer = HeadlessRenderer::new(16, 4).unwrap();
+    let error = renderer
+        .render(
+            &mut tree,
+            &HeadlessPresentation::new().with_semantics([HeadlessSemanticNode::new(
+                detached_id,
+                SemanticRole::Status,
+                "Detached",
+            )]),
+        )
+        .unwrap_err();
+    assert_eq!(
+        error,
+        HeadlessRenderError::DetachedSemanticNode(detached_id)
+    );
+
+    let mut zero = HeadlessRenderer::new(0, 0).unwrap();
+    let error = zero
+        .render(
+            &mut tree,
+            &HeadlessPresentation::new()
+                .with_semantics([HeadlessSemanticNode::new(
+                    0,
+                    SemanticRole::Application,
+                    "Doctor",
+                )])
+                .with_focus(0),
+        )
+        .unwrap_err();
+    assert_eq!(error, HeadlessRenderError::FocusNotPresented(0));
+}
+
+#[test]
+fn cursor_and_cell_budgets_are_explicit_before_allocation() {
+    assert_eq!(
+        HeadlessRenderer::with_cell_budget(11, 10, 100)
+            .err()
+            .unwrap(),
+        HeadlessRenderError::CellBudgetExceeded {
+            width: 11,
+            height: 10,
+            required: 110,
+            budget: 100
+        }
+    );
+
+    let mut tree = diagnostic_tree();
+    let mut renderer = HeadlessRenderer::new(10, 2).unwrap();
+    let error = renderer
+        .render(
+            &mut tree,
+            &HeadlessPresentation::new().with_cursor(Cursor::at(10, 1)),
+        )
+        .unwrap_err();
+    assert_eq!(
+        error,
+        HeadlessRenderError::CursorOutsideViewport {
+            x: 10,
+            y: 1,
+            width: 10,
+            height: 2
+        }
+    );
+}
+
+#[test]
+fn empty_tree_and_zero_viewport_have_a_stable_empty_snapshot() {
+    let mut tree = RenderTree::new();
+    let mut renderer = HeadlessRenderer::new(0, 0).unwrap();
+    let snapshot = renderer
+        .render(&mut tree, &HeadlessPresentation::new())
+        .unwrap();
+
+    assert!(snapshot.semantics().is_empty());
+    assert!(snapshot.cells().is_empty());
+    assert_eq!(snapshot.screen_text(), "");
+    assert!(!snapshot.cursor().visible);
+}
+
+#[test]
+fn semantic_state_supports_virtualized_set_positions() {
+    let state = SemanticState::default().with_set_position(9_001, 10_000);
+    assert_eq!(state.position, Some(9_001));
+    assert_eq!(state.set_size, Some(10_000));
+}
+
+#[test]
+fn invalid_heading_and_logical_set_state_fail_closed() {
+    let mut tree = diagnostic_tree();
+    let mut renderer = HeadlessRenderer::new(16, 4).unwrap();
+    let error = renderer
+        .render(
+            &mut tree,
+            &HeadlessPresentation::new().with_semantics([HeadlessSemanticNode::new(
+                1,
+                SemanticRole::Heading,
+                "Diagnostics",
+            )
+            .with_state(SemanticState::default().with_level(7))]),
+        )
+        .unwrap_err();
+    assert_eq!(
+        error,
+        HeadlessRenderError::InvalidHeadingLevel {
+            node_id: 1,
+            level: 7
+        }
+    );
+
+    let error = renderer
+        .render(
+            &mut tree,
+            &HeadlessPresentation::new().with_semantics([HeadlessSemanticNode::new(
+                3,
+                SemanticRole::ListItem,
+                "Finding",
+            )
+            .with_state(SemanticState {
+                position: Some(1),
+                ..SemanticState::default()
+            })]),
+        )
+        .unwrap_err();
+    assert_eq!(error, HeadlessRenderError::IncompleteSetPosition(3));
+}

--- a/crates/vize_fresco/src/headless/validation_tests.rs
+++ b/crates/vize_fresco/src/headless/validation_tests.rs
@@ -1,0 +1,152 @@
+use super::{
+    AnnouncementPoliteness, HeadlessAnnouncement, HeadlessPresentation, HeadlessRenderError,
+    HeadlessRenderer, HeadlessSemanticNode, SemanticRole, SemanticState,
+};
+use crate::{
+    component::{BoxNode, TextNode},
+    render::RenderTree,
+};
+
+fn tree() -> RenderTree {
+    let mut tree = RenderTree::new();
+    let root = tree.next_id();
+    tree.insert_root(BoxNode::new().column().build(root));
+    let child = tree.next_id();
+    tree.insert(TextNode::new("Finding").build(child));
+    tree.add_child(root, child);
+    tree
+}
+
+fn render_error(semantic: HeadlessSemanticNode) -> HeadlessRenderError {
+    HeadlessRenderer::new(20, 4)
+        .unwrap()
+        .render(
+            &mut tree(),
+            &HeadlessPresentation::new().with_semantics([semantic]),
+        )
+        .unwrap_err()
+}
+
+#[test]
+fn semantic_node_references_and_accessible_text_fail_closed() {
+    assert_eq!(
+        render_error(HeadlessSemanticNode::new(
+            99,
+            SemanticRole::Status,
+            "Missing"
+        )),
+        HeadlessRenderError::UnknownSemanticNode(99)
+    );
+    assert_eq!(
+        render_error(HeadlessSemanticNode::new(1, SemanticRole::Status, "  \n")),
+        HeadlessRenderError::EmptySemanticName(1)
+    );
+    assert_eq!(
+        render_error(
+            HeadlessSemanticNode::new(1, SemanticRole::Status, "Finding").with_description(" \t")
+        ),
+        HeadlessRenderError::EmptySemanticDescription(1)
+    );
+}
+
+#[test]
+fn role_specific_state_rejects_every_invalid_boundary() {
+    assert_eq!(
+        render_error(
+            HeadlessSemanticNode::new(1, SemanticRole::Heading, "Finding")
+                .with_state(SemanticState::default().with_level(0))
+        ),
+        HeadlessRenderError::InvalidHeadingLevel {
+            node_id: 1,
+            level: 0
+        }
+    );
+    assert_eq!(
+        render_error(
+            HeadlessSemanticNode::new(1, SemanticRole::Status, "Finding")
+                .with_state(SemanticState::default().with_level(2))
+        ),
+        HeadlessRenderError::UnexpectedHeadingLevel(1)
+    );
+    assert_eq!(
+        render_error(
+            HeadlessSemanticNode::new(1, SemanticRole::ListItem, "Finding").with_state(
+                SemanticState {
+                    position: Some(2),
+                    set_size: Some(1),
+                    ..SemanticState::default()
+                }
+            )
+        ),
+        HeadlessRenderError::InvalidSetPosition {
+            node_id: 1,
+            position: 2,
+            set_size: 1
+        }
+    );
+}
+
+#[test]
+fn duplicate_identity_focus_and_announcement_contracts_fail_closed() {
+    let semantic = HeadlessSemanticNode::new(0, SemanticRole::Application, "Doctor");
+    let error = HeadlessRenderer::new(20, 4)
+        .unwrap()
+        .render(
+            &mut tree(),
+            &HeadlessPresentation::new().with_semantics([semantic.clone(), semantic]),
+        )
+        .unwrap_err();
+    assert_eq!(error, HeadlessRenderError::DuplicateSemanticNode(0));
+
+    let error = HeadlessRenderer::new(20, 4)
+        .unwrap()
+        .render(
+            &mut tree(),
+            &HeadlessPresentation::new()
+                .with_semantics([HeadlessSemanticNode::new(
+                    0,
+                    SemanticRole::Application,
+                    "Doctor",
+                )])
+                .with_focus(1),
+        )
+        .unwrap_err();
+    assert_eq!(error, HeadlessRenderError::UnknownFocus(1));
+
+    let error = HeadlessRenderer::new(20, 4)
+        .unwrap()
+        .render(
+            &mut tree(),
+            &HeadlessPresentation::new().with_announcements([HeadlessAnnouncement::new(
+                AnnouncementPoliteness::Polite,
+                " \n",
+            )]),
+        )
+        .unwrap_err();
+    assert_eq!(error, HeadlessRenderError::EmptyAnnouncement(0));
+
+    let error = HeadlessRenderer::new(20, 4)
+        .unwrap()
+        .render(
+            &mut tree(),
+            &HeadlessPresentation::new()
+                .with_semantics([HeadlessSemanticNode::new(
+                    0,
+                    SemanticRole::Application,
+                    "Doctor",
+                )])
+                .with_announcements([HeadlessAnnouncement::new(
+                    AnnouncementPoliteness::Assertive,
+                    "Failure",
+                )
+                .with_source(1)]),
+        )
+        .unwrap_err();
+    assert_eq!(
+        error,
+        HeadlessRenderError::UnknownAnnouncementSource {
+            index: 0,
+            node_id: 1
+        }
+    );
+}

--- a/crates/vize_fresco/src/lib.rs
+++ b/crates/vize_fresco/src/lib.rs
@@ -15,6 +15,7 @@
 //! - **CJK Support**: Full Unicode text handling including Japanese IME
 //! - **Efficient Rendering**: Double-buffered differential rendering
 //! - **Diagnostic Workspaces**: Stable, virtualized master-detail navigation
+//! - **Headless Assertions**: Deterministic visual and semantic frame snapshots
 //!
 //! # Architecture
 //!
@@ -53,6 +54,7 @@
 //! ```
 
 pub mod component;
+pub mod headless;
 pub mod input;
 pub mod layout;
 pub mod render;
@@ -67,6 +69,10 @@ pub use component::{
     BoxNode, DiagnosticWorkspaceFocus, DiagnosticWorkspaceLayout, DiagnosticWorkspaceMode,
     DiagnosticWorkspaceOptions, DiagnosticWorkspacePane, DiagnosticWorkspaceState, InputNode,
     TextNode, VirtualListNavigation, VirtualListState, VirtualWindow,
+};
+pub use headless::{
+    AnnouncementPoliteness, HeadlessAnnouncement, HeadlessPresentation, HeadlessRenderError,
+    HeadlessRenderer, HeadlessSemanticNode, HeadlessSnapshot, SemanticRole, SemanticState,
 };
 pub use input::{Event, ImeState, KeyEvent, MouseEvent};
 pub use layout::{FlexStyle, LayoutEngine, Rect};


### PR DESCRIPTION
## Summary

- add a reusable, terminal-free renderer that exercises Fresco's production layout, paint, buffer, Unicode-cell, style, and continuation paths
- capture deterministic viewport, visual cells, semantic tree, clipped layout, focus, cursor, and ordered live-announcement state
- define platform-neutral semantic roles and state for headings, virtualized set positions, selection, progress, expansion, busy, and read-only presentation
- reject oversized viewports and every invalid semantic, focus, cursor, and announcement contract before exposing a misleading snapshot
- document the public API and cover deterministic ordering, resize, zero-size viewports, detached nodes, wide glyphs, styles, and every public error class

## Performance

Criterion, 120x40 viewport with 50 semantic nodes (30 samples):

- 23.364 us median
- 205.44 million cells/second
- no statistically significant regression between final benchmark runs

## Verification

- `cargo test -p vize_fresco --all-features` (164 passed)
- `cargo clippy -p vize_fresco --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vize_fresco --all-features --no-deps`
- `cargo bench -p vize_fresco --bench render --no-run`
- `cargo bench -p vize_fresco --bench render -- headless_snapshot/120x40_50_semantic_nodes --sample-size 30`
- `cargo fmt --all --check`

Relates to #4155.
Relates to #3138.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->