### PR TITLE
feat(ui): add press interactions

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -69,6 +69,11 @@
       "import": "./dist/interaction-modality.mjs",
       "default": "./dist/interaction-modality.mjs"
     },
+    "./press": {
+      "types": "./dist/press.d.mts",
+      "import": "./dist/press.mjs",
+      "default": "./dist/press.mjs"
+    },
     "./primitive": {
       "types": "./dist/primitive.d.mts",
       "import": "./dist/primitive.mjs",

--- a/npm/ui/core/scripts/check-renderers.ts
+++ b/npm/ui/core/scripts/check-renderers.ts
@@ -17,6 +17,32 @@ const rendererLanes: readonly RendererLane[] = [
   { name: "vapor", options: { ssr: false, vapor: true } },
 ];
 
+const inlineFixtures = [
+  {
+    filename: "PressConsumer.vue",
+    source: String.raw`<script setup lang="ts">
+import { usePress } from "./press.ts";
+
+const press = usePress({
+  onPress(event) {
+    void event.pointerType;
+  },
+});
+</script>
+
+<template>
+  <button
+    v-bind="press.pressProps"
+    type="button"
+    :data-pressed="press.isPressed.value || undefined"
+  >
+    Activate
+  </button>
+</template>
+`,
+  },
+] as const;
+
 /**
  * Recursively collect authored Vue SFCs in deterministic path order.
  *
@@ -109,12 +135,18 @@ for (const file of sourceFiles) {
   const source = await readFile(file, "utf8");
   for (const lane of rendererLanes) verifyRendererLane(file, source, lane);
 }
+for (const fixture of inlineFixtures) {
+  for (const lane of rendererLanes) {
+    verifyRendererLane(fixture.filename, fixture.source, lane);
+  }
+}
 
 console.log(
   JSON.stringify({
     check: "@vizejs/ui renderer conformance",
     sourceFiles: sourceFiles.length,
-    compilations: sourceFiles.length * rendererLanes.length,
+    inlineFixtures: inlineFixtures.length,
+    compilations: (sourceFiles.length + inlineFixtures.length) * rendererLanes.length,
     lanes: rendererLanes.map((lane) => lane.name),
   }),
 );

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 13_150],
+  ["index.mjs", 18_100],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
   ["collection.mjs", 5_700],
@@ -13,6 +13,7 @@ const budgets = new Map([
   ["controllable-state.mjs", 600],
   ["id.mjs", 2_300],
   ["interaction-modality.mjs", 3_300],
+  ["press.mjs", 5_775],
   ["primitive.mjs", 800],
   ["visually-hidden.mjs", 800],
   ["media.mjs", 2_400],

--- a/npm/ui/core/scripts/check-tree-shaking.mjs
+++ b/npm/ui/core/scripts/check-tree-shaking.mjs
@@ -73,6 +73,7 @@ const familySignatures = Object.freeze({
   collection: /VIZE_UI_COLLECTION_DISPOSED/,
   id: /DeterministicIdProvider/,
   "interaction-modality": /VIZE_UI_INTERACTION_MODALITY_DISPOSED/,
+  press: /VIZE_UI_PRESS_DISPOSED/,
   primitive: /data-vize-ui.+primitive/,
   "visually-hidden": /visually-hidden/,
 });
@@ -106,6 +107,12 @@ const componentCases = [
     family: "interaction-modality",
     exportName: "createInteractionModalityTracker",
     maximumJavaScriptGzipBytes: 1_650,
+    maximumCssGzipBytes: 0,
+  },
+  {
+    family: "press",
+    exportName: "createPress",
+    maximumJavaScriptGzipBytes: 3_550,
     maximumCssGzipBytes: 0,
   },
   {

--- a/npm/ui/core/src/distribution.test.ts
+++ b/npm/ui/core/src/distribution.test.ts
@@ -13,6 +13,7 @@ const publicEntries = [
   "./controllable-state",
   "./id",
   "./interaction-modality",
+  "./press",
   "./primitive",
   "./visually-hidden",
 ] as const;

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -5,5 +5,6 @@ export * from "./controllable-state.ts";
 export * from "./button.ts";
 export * from "./id.ts";
 export * from "./interaction-modality.ts";
+export * from "./press.ts";
 export * from "./primitive.ts";
 export * from "./visually-hidden.ts";

--- a/npm/ui/core/src/press-activation-memory.ts
+++ b/npm/ui/core/src/press-activation-memory.ts
@@ -1,0 +1,71 @@
+import type { PressPointerType } from "./press-types.ts";
+
+interface PendingActivation {
+  readonly pointerType: PressPointerType;
+  readonly target: Element;
+  readonly timer: ReturnType<typeof setTimeout>;
+}
+
+export interface SyntheticActivation {
+  readonly event: MouseEvent;
+  readonly pointerType: PressPointerType;
+  readonly target: Element;
+  canceled: boolean;
+}
+
+/** Own short-lived tokens that associate release, cancellation, and click. */
+export class PressActivationMemory {
+  #pending: PendingActivation | null = null;
+  #suppressedTarget: Element | null = null;
+  #suppressedTimer: ReturnType<typeof setTimeout> | null = null;
+
+  remember(target: Element, pointerType: PressPointerType): void {
+    this.#clearPending();
+    const timer = setTimeout(() => {
+      if (this.#pending?.timer === timer) this.#pending = null;
+    }, 1_000);
+    this.#pending = { target, pointerType, timer };
+  }
+
+  take(target: Element): PressPointerType | null {
+    if (this.#pending?.target !== target) return null;
+    const pointerType = this.#pending.pointerType;
+    this.#clearPending();
+    return pointerType;
+  }
+
+  suppress(target: Element): void {
+    this.#suppressedTarget = target;
+    if (this.#suppressedTimer) clearTimeout(this.#suppressedTimer);
+    this.#suppressedTimer = setTimeout(() => {
+      this.#suppressedTarget = null;
+      this.#suppressedTimer = null;
+    }, 1_000);
+  }
+
+  consumeSuppressed(target: Element): boolean {
+    if (this.#suppressedTarget !== target) return false;
+    this.#suppressedTarget = null;
+    if (this.#suppressedTimer) clearTimeout(this.#suppressedTimer);
+    this.#suppressedTimer = null;
+    return true;
+  }
+
+  begin(target: Element): void {
+    this.#clearPending();
+    this.consumeSuppressed(target);
+  }
+
+  dispose(): void {
+    this.#clearPending();
+    if (this.#suppressedTimer) clearTimeout(this.#suppressedTimer);
+    this.#suppressedTimer = null;
+    this.#suppressedTarget = null;
+  }
+
+  #clearPending(): void {
+    if (!this.#pending) return;
+    clearTimeout(this.#pending.timer);
+    this.#pending = null;
+  }
+}

--- a/npm/ui/core/src/press-event.ts
+++ b/npm/ui/core/src/press-event.ts
@@ -1,0 +1,197 @@
+import { toValue } from "vue";
+
+import type {
+  PressEvent,
+  PressEventType,
+  PressKeyboardBehavior,
+  PressOptions,
+  PressPointerType,
+} from "./press-types.ts";
+
+const invalidOptionDiagnostic = "VIZE_UI_PRESS_OPTION";
+const pointerTypes = new Set<PressPointerType>([
+  "keyboard",
+  "mouse",
+  "pen",
+  "pointer",
+  "touch",
+  "virtual",
+]);
+const keyboardBehaviors = new Set<PressKeyboardBehavior>(["button", "link", "none"]);
+
+interface Point {
+  readonly x: number;
+  readonly y: number;
+}
+
+/** Resolve and validate a reactive boolean option for JavaScript consumers. */
+export function readBooleanOption(
+  value: PressOptions[keyof Pick<
+    PressOptions,
+    "allowTextSelectionOnPress" | "isDisabled" | "preventFocusOnPress" | "shouldCancelOnPointerExit"
+  >],
+  name: string,
+): boolean {
+  const resolved = toValue(value);
+  if (resolved === undefined) return false;
+  if (typeof resolved !== "boolean") {
+    throw new TypeError(`${invalidOptionDiagnostic}: ${name} must resolve to a boolean`);
+  }
+  return resolved;
+}
+
+/** Resolve the closed keyboard behavior union without accepting mistyped JS. */
+export function readKeyboardBehavior(
+  value: PressOptions["keyboardBehavior"],
+): PressKeyboardBehavior {
+  const resolved = toValue(value) ?? "button";
+  if (!keyboardBehaviors.has(resolved)) {
+    throw new TypeError(
+      `${invalidOptionDiagnostic}: keyboardBehavior must resolve to button, link, or none`,
+    );
+  }
+  return resolved;
+}
+
+/** Resolve a cross-realm event currentTarget without instanceof assumptions. */
+export function eventElement(event: Event): Element | null {
+  const value = event.currentTarget;
+  return value && (value as Node).nodeType === 1 ? (value as Element) : null;
+}
+
+/** Map Pointer Events' extensible device string to the stable public union. */
+export function pointerTypeOf(event: PointerEvent): PressPointerType {
+  if (event.pointerId === -1 && event.pointerType === "") return "virtual";
+  if (event.pointerType === "mouse" || event.pointerType === "pen") return event.pointerType;
+  if (event.pointerType === "touch") return "touch";
+  return "pointer";
+}
+
+/** Only a primary contact and its primary button can activate a control. */
+export function isPrimaryPointer(event: PointerEvent): boolean {
+  return event.isPrimary !== false && event.button === 0;
+}
+
+function eventPoint(event: Event | null, touchIdentifier: number | null = null): Point | null {
+  if (!event) return null;
+  if ("clientX" in event && "clientY" in event) {
+    return { x: Number(event.clientX), y: Number(event.clientY) };
+  }
+  if ("changedTouches" in event) {
+    const touches = Array.from((event as TouchEvent).changedTouches);
+    const touch =
+      (touchIdentifier === null
+        ? touches[0]
+        : touches.find(({ identifier }) => identifier === touchIdentifier)) ?? null;
+    if (touch) return { x: touch.clientX, y: touch.clientY };
+  }
+  return null;
+}
+
+function modifier(event: Event | null, key: "altKey" | "ctrlKey" | "metaKey" | "shiftKey") {
+  return event && key in event ? Boolean((event as KeyboardEvent)[key]) : false;
+}
+
+/** Build a frozen snapshot so later browser mutation cannot change callbacks' data. */
+export function createPressEvent(
+  type: PressEventType,
+  target: Element,
+  pointerType: PressPointerType,
+  originalEvent: Event | null,
+  isCanceled = false,
+  touchIdentifier: number | null = null,
+): PressEvent {
+  if (!pointerTypes.has(pointerType)) {
+    throw new TypeError(`${invalidOptionDiagnostic}: invalid press pointer type`);
+  }
+  const point = eventPoint(originalEvent, touchIdentifier);
+  return Object.freeze({
+    type,
+    pointerType,
+    target,
+    originalEvent,
+    x: point?.x ?? null,
+    y: point?.y ?? null,
+    altKey: modifier(originalEvent, "altKey"),
+    ctrlKey: modifier(originalEvent, "ctrlKey"),
+    metaKey: modifier(originalEvent, "metaKey"),
+    shiftKey: modifier(originalEvent, "shiftKey"),
+    isCanceled,
+  });
+}
+
+/** Native elements retain their own activation timing and default actions. */
+export function keyboardActivation(
+  target: Element,
+  key: string,
+  behavior: PressKeyboardBehavior,
+): "custom" | "native" | null {
+  if (behavior === "none") return null;
+  const tag = target.localName;
+  if (tag === "a" || tag === "area") {
+    return target.hasAttribute("href") && key === "Enter" ? "native" : null;
+  }
+  if (tag === "button") return key === "Enter" || key === " " ? "native" : null;
+  if (tag === "summary") return key === "Enter" || key === " " ? "native" : null;
+  if (tag === "input") {
+    const type = (target.getAttribute("type") ?? "text").toLowerCase();
+    if (type === "checkbox" || type === "radio") return key === " " ? "native" : null;
+    const buttonTypes = new Set(["button", "file", "image", "reset", "submit"]);
+    return buttonTypes.has(type) && (key === "Enter" || key === " ") ? "native" : null;
+  }
+  if (behavior === "link") return key === "Enter" ? "custom" : null;
+  return key === "Enter" || key === " " ? "custom" : null;
+}
+
+/** Determine pointer containment without assuming events originate in one realm. */
+export function isEventInside(
+  event: Event,
+  target: Element,
+  touchIdentifier: number | null = null,
+): boolean {
+  const point = eventPoint(event, touchIdentifier);
+  if (point) {
+    const hit = target.ownerDocument.elementFromPoint?.(point.x, point.y);
+    if (hit) return hit === target || target.contains(hit);
+  }
+  return event.composedPath().includes(target);
+}
+
+/** Apply a transient selection guard and return an exact, idempotent restore. */
+export function disableTextSelection(target: Element): () => void {
+  if (!("style" in target)) return () => undefined;
+  const style = (target as HTMLElement).style;
+  if (!style || typeof style.setProperty !== "function") return () => undefined;
+  const properties = ["user-select", "-webkit-user-select"] as const;
+  const previous = properties.map((property) => ({
+    property,
+    value: style.getPropertyValue(property),
+    priority: style.getPropertyPriority(property),
+  }));
+  for (const property of properties) style.setProperty(property, "none");
+  let restored = false;
+  return () => {
+    if (restored) return;
+    restored = true;
+    for (const { property, value, priority } of previous) {
+      if (value) style.setProperty(property, value, priority);
+      else style.removeProperty(property);
+    }
+  };
+}
+
+/** Validate callback slots eagerly so setup failures never install listeners. */
+export function validatePressOptions(options: PressOptions): void {
+  for (const name of [
+    "onPress",
+    "onPressChange",
+    "onPressEnd",
+    "onPressStart",
+    "onPressUp",
+  ] as const) {
+    const callback = options[name];
+    if (callback !== undefined && typeof callback !== "function") {
+      throw new TypeError(`${invalidOptionDiagnostic}: ${name} must be a function`);
+    }
+  }
+}

--- a/npm/ui/core/src/press-handlers.ts
+++ b/npm/ui/core/src/press-handlers.ts
@@ -1,0 +1,222 @@
+import {
+  eventElement,
+  isPrimaryPointer,
+  keyboardActivation,
+  pointerTypeOf,
+  readBooleanOption,
+  readKeyboardBehavior,
+} from "./press-event.ts";
+import type { ActivePress, PressSource } from "./press-lifecycle.ts";
+import { PressLifecycle } from "./press-lifecycle.ts";
+import type { PressProps } from "./press-types.ts";
+
+export interface PressHandlers extends Readonly<PressProps> {
+  readonly installListeners: (document: Document, source: PressSource) => () => void;
+}
+
+/** Adapt Pointer Events plus legacy mouse/touch and keyboard events to one lifecycle. */
+export function createPressHandlers(lifecycle: PressLifecycle): PressHandlers {
+  let lastTouchTime = Number.NEGATIVE_INFINITY;
+
+  function onPointerDown(event: PointerEvent): void {
+    if (lifecycle.disposed || lifecycle.active || !isPrimaryPointer(event)) return;
+    const target = eventElement(event);
+    if (!target || readBooleanOption(lifecycle.options.isDisabled, "isDisabled")) return;
+    lifecycle.start(event, target, "pointer", pointerTypeOf(event), event.pointerId, null, false);
+  }
+  function onPointerMove(event: PointerEvent): void {
+    const current = lifecycle.active;
+    if (!matches(current, "pointer", event.pointerId)) return;
+    lifecycle.updatePointerBoundary(current, event);
+  }
+  function onPointerUp(event: PointerEvent): void {
+    const current = lifecycle.active;
+    if (!matches(current, "pointer", event.pointerId)) return;
+    lifecycle.finishPointer(current, event);
+  }
+  function onPointerCancel(event: PointerEvent): void {
+    const current = lifecycle.active;
+    if (matches(current, "pointer", event.pointerId)) lifecycle.cancelActive(event);
+  }
+  function onMouseDown(event: MouseEvent): void {
+    if (lifecycle.disposed) return;
+    if (readBooleanOption(lifecycle.options.preventFocusOnPress, "preventFocusOnPress")) {
+      event.preventDefault();
+    }
+    if ((event.view && "PointerEvent" in event.view) || lifecycle.active || event.button !== 0) {
+      return;
+    }
+    const elapsed = event.timeStamp - lastTouchTime;
+    if (elapsed >= 0 && elapsed < 800) return;
+    const target = eventElement(event);
+    if (!target || readBooleanOption(lifecycle.options.isDisabled, "isDisabled")) return;
+    lifecycle.start(event, target, "mouse", "mouse", null, null, false);
+  }
+  function onMouseMove(event: MouseEvent): void {
+    const current = lifecycle.active;
+    if (current?.source === "mouse") lifecycle.updatePointerBoundary(current, event);
+  }
+  function onMouseUp(event: MouseEvent): void {
+    const current = lifecycle.active;
+    if (current?.source === "mouse" && event.button === 0) lifecycle.finishPointer(current, event);
+  }
+  function onTouchStart(event: TouchEvent): void {
+    if (
+      lifecycle.disposed ||
+      (event.view && "PointerEvent" in event.view) ||
+      lifecycle.active ||
+      event.changedTouches.length !== 1
+    ) {
+      return;
+    }
+    const target = eventElement(event);
+    if (!target || readBooleanOption(lifecycle.options.isDisabled, "isDisabled")) return;
+    const touch = event.changedTouches.item(0)!;
+    lastTouchTime = event.timeStamp;
+    lifecycle.start(event, target, "touch", "touch", touch.identifier, null, false);
+  }
+  function onTouchMove(event: TouchEvent): void {
+    const current = lifecycle.active;
+    if (current?.source === "touch" && touchMatches(event, current)) {
+      lifecycle.updatePointerBoundary(current, event);
+    }
+  }
+  function onTouchEnd(event: TouchEvent): void {
+    const current = lifecycle.active;
+    if (current?.source === "touch" && touchMatches(event, current)) {
+      lifecycle.finishPointer(current, event);
+    }
+  }
+  function onTouchCancel(event: TouchEvent): void {
+    const current = lifecycle.active;
+    if (current?.source === "touch" && touchMatches(event, current)) {
+      lifecycle.cancelActive(event);
+    }
+  }
+  function onKeyDown(event: KeyboardEvent): void {
+    if (
+      lifecycle.disposed ||
+      lifecycle.active ||
+      event.isComposing ||
+      event.repeat ||
+      event.target !== event.currentTarget
+    ) {
+      return;
+    }
+    const target = eventElement(event);
+    if (!target || readBooleanOption(lifecycle.options.isDisabled, "isDisabled")) return;
+    const activation = keyboardActivation(
+      target,
+      event.key,
+      readKeyboardBehavior(lifecycle.options.keyboardBehavior),
+    );
+    if (!activation) return;
+    if (event.key === " " && activation === "custom") event.preventDefault();
+    lifecycle.start(
+      event,
+      target,
+      "keyboard",
+      "keyboard",
+      null,
+      event.key,
+      activation === "native",
+    );
+  }
+  function onKeyUp(event: KeyboardEvent): void {
+    const current = lifecycle.active;
+    if (current?.source === "keyboard" && event.key === current.key) {
+      lifecycle.finishKeyboard(current, event);
+    }
+  }
+  function onClick(event: MouseEvent): void {
+    if (lifecycle.disposed) return;
+    const target = eventElement(event);
+    if (target) lifecycle.activateClick(target, event);
+  }
+  function onDragStart(event: DragEvent): void {
+    if (lifecycle.active?.target === eventElement(event)) lifecycle.cancelActive(event);
+  }
+  function onWindowBlur(event: Event): void {
+    lifecycle.cancelActive(event);
+  }
+  function onVisibilityChange(event: Event): void {
+    if (lifecycle.active?.document.visibilityState === "hidden") lifecycle.cancelActive(event);
+  }
+  function onFocusIn(event: Event): void {
+    const current = lifecycle.active;
+    if (current?.source === "keyboard" && event.target !== current.target) {
+      lifecycle.cancelActive(event, false);
+    }
+  }
+
+  const pressProps: PressProps = Object.freeze({
+    onClick,
+    onDragstart: onDragStart,
+    onKeydown: onKeyDown,
+    onKeyup: onKeyUp,
+    onMousedown: onMouseDown,
+    onMousemove: onMouseMove,
+    onMouseup: onMouseUp,
+    onPointercancel: onPointerCancel,
+    onPointerdown: onPointerDown,
+    onPointermove: onPointerMove,
+    onPointerup: onPointerUp,
+    onTouchcancel: onTouchCancel,
+    onTouchend: onTouchEnd,
+    onTouchmove: onTouchMove,
+    onTouchstart: onTouchStart,
+  });
+
+  return Object.freeze({
+    ...pressProps,
+    installListeners(document: Document, source: PressSource) {
+      const removals: Array<() => void> = [];
+      const listen = (owner: Document | Window, type: string, listener: EventListener) => {
+        owner.addEventListener(type, listener, true);
+        removals.push(() => owner.removeEventListener(type, listener, true));
+      };
+      try {
+        if (source === "pointer") {
+          listen(document, "pointermove", onPointerMove as EventListener);
+          listen(document, "pointerup", onPointerUp as EventListener);
+          listen(document, "pointercancel", onPointerCancel as EventListener);
+        } else if (source === "mouse") {
+          listen(document, "mousemove", onMouseMove as EventListener);
+          listen(document, "mouseup", onMouseUp as EventListener);
+        } else if (source === "touch") {
+          listen(document, "touchmove", onTouchMove as EventListener);
+          listen(document, "touchend", onTouchEnd as EventListener);
+          listen(document, "touchcancel", onTouchCancel as EventListener);
+        } else {
+          listen(document, "keyup", onKeyUp as EventListener);
+          listen(document, "focusin", onFocusIn as EventListener);
+        }
+        if (document.defaultView) {
+          listen(document.defaultView, "blur", onWindowBlur as EventListener);
+        }
+        listen(document, "visibilitychange", onVisibilityChange as EventListener);
+      } catch (error) {
+        for (const remove of removals.reverse()) remove();
+        throw error;
+      }
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        for (const remove of removals) remove();
+      };
+    },
+  });
+}
+
+function matches(
+  active: ActivePress | null,
+  source: PressSource,
+  id: number,
+): active is ActivePress {
+  return active?.source === source && active.id === id;
+}
+
+function touchMatches(event: TouchEvent, active: ActivePress): boolean {
+  return Array.from(event.changedTouches).some((touch) => touch.identifier === active.id);
+}

--- a/npm/ui/core/src/press-lifecycle.test.ts
+++ b/npm/ui/core/src/press-lifecycle.test.ts
@@ -1,0 +1,308 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { effectScope, ref } from "vue";
+
+import { createPress, usePress } from "./press.ts";
+import type { PressController } from "./press.ts";
+
+function currentTarget<EventType extends Event>(event: EventType, target: Element): EventType {
+  Object.defineProperty(event, "currentTarget", { configurable: true, value: target });
+  Object.defineProperty(event, "target", { configurable: true, value: target });
+  return event;
+}
+
+function pointer(type: string, target: Element, init: PointerEventInit = {}): PointerEvent {
+  return currentTarget(
+    new PointerEvent(type, {
+      bubbles: true,
+      button: 0,
+      isPrimary: true,
+      pointerId: 13,
+      pointerType: "pen",
+      ...init,
+    }),
+    target,
+  );
+}
+
+test("installs listeners only while active and releases every listener exactly once", () => {
+  const isolated = document.implementation.createHTMLDocument("press listeners");
+  const host = isolated.createElement("button");
+  isolated.body.append(host);
+  const additions: string[] = [];
+  const removals: string[] = [];
+  const addEventListener = isolated.addEventListener.bind(isolated);
+  const removeEventListener = isolated.removeEventListener.bind(isolated);
+  isolated.addEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options,
+  ) => {
+    additions.push(type);
+    addEventListener(type, listener, options);
+  }) as typeof isolated.addEventListener;
+  isolated.removeEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options,
+  ) => {
+    removals.push(type);
+    removeEventListener(type, listener, options);
+  }) as typeof isolated.removeEventListener;
+  const controller = createPress();
+
+  controller.pressProps.onPointerdown(pointer("pointerdown", host));
+  assert.deepEqual(additions.sort(), [
+    "pointercancel",
+    "pointermove",
+    "pointerup",
+    "visibilitychange",
+  ]);
+  controller.pressProps.onPointercancel(pointer("pointercancel", host));
+  assert.deepEqual(removals.sort(), additions);
+
+  controller.dispose();
+  controller.dispose();
+  assert.deepEqual(removals.sort(), additions);
+});
+
+test("manual cancellation is idempotent and disposal rejects later mutation", () => {
+  const host = document.createElement("button");
+  const endings: boolean[] = [];
+  const controller = createPress({ onPressEnd: (event) => endings.push(event.isCanceled) });
+  controller.pressProps.onPointerdown(pointer("pointerdown", host));
+
+  assert.equal(controller.cancel(), true);
+  assert.equal(controller.cancel(), false);
+  assert.deepEqual(endings, [true]);
+  assert.equal(controller.isPressed.value, false);
+  controller.dispose();
+  assert.throws(() => controller.cancel(), /VIZE_UI_PRESS_DISPOSED/);
+});
+
+test("the composable requires and follows a Vue effect scope", () => {
+  assert.throws(() => usePress(), /VIZE_UI_PRESS_SETUP/);
+  const scope = effectScope();
+  const controller = scope.run(() => usePress())!;
+  const host = document.createElement("button");
+  controller.pressProps.onPointerdown(pointer("pointerdown", host));
+  assert.equal(controller.isPressed.value, true);
+
+  scope.stop();
+  assert.equal(controller.isPressed.value, false);
+  assert.throws(() => controller.cancel(), /VIZE_UI_PRESS_DISPOSED/);
+});
+
+test("reactive options are read at event time and invalid values have stable diagnostics", () => {
+  const disabled = ref(false);
+  const controller = createPress({ isDisabled: disabled });
+  const host = document.createElement("button");
+  disabled.value = true;
+  controller.pressProps.onPointerdown(pointer("pointerdown", host));
+  assert.equal(controller.isPressed.value, false);
+  controller.dispose();
+
+  const invalid = createPress({ isDisabled: "false" as unknown as boolean });
+  assert.throws(
+    () => invalid.pressProps.onPointerdown(pointer("pointerdown", host)),
+    /VIZE_UI_PRESS_OPTION: isDisabled/,
+  );
+  invalid.dispose();
+  assert.throws(
+    () => createPress({ onPress: "activate" as unknown as () => void }),
+    /VIZE_UI_PRESS_OPTION: onPress/,
+  );
+});
+
+test("synthetic activation completes every phase before callback errors surface", () => {
+  const calls: string[] = [];
+  const failure = new Error("consumer failed");
+  const controller = createPress({
+    onPressStart: () => {
+      calls.push("start");
+      throw failure;
+    },
+    onPressChange: (value) => calls.push(`change:${value}`),
+    onPressUp: () => {
+      calls.push("up");
+      throw failure;
+    },
+    onPressEnd: () => {
+      calls.push("end");
+      throw failure;
+    },
+    onPress: () => {
+      calls.push("press");
+      throw failure;
+    },
+  });
+  const host = document.createElement("button");
+  const click = currentTarget(new MouseEvent("click", { detail: 0 }), host);
+
+  assert.throws(() => controller.pressProps.onClick(click), /Press callbacks failed/);
+  assert.deepEqual(calls, ["start", "change:true", "up", "end", "change:false", "press"]);
+  assert.equal(controller.isPressed.value, false);
+  controller.dispose();
+});
+
+test("a reentrant cancel cannot publish a stale pressed=true change", () => {
+  const changes: boolean[] = [];
+  let controller!: PressController;
+  controller = createPress({
+    onPressStart: () => controller.cancel(),
+    onPressChange: (value) => changes.push(value),
+  });
+  const host = document.createElement("button");
+
+  controller.pressProps.onPointerdown(pointer("pointerdown", host));
+  assert.equal(controller.isPressed.value, false);
+  assert.deepEqual(changes, [false]);
+  controller.dispose();
+});
+
+test("a virtual start callback can cancel the synchronous activation", () => {
+  const calls: string[] = [];
+  let controller!: PressController;
+  controller = createPress({
+    onPressStart: () => {
+      calls.push("start");
+      controller.cancel();
+    },
+    onPressEnd: (event) => calls.push(`end:${event.isCanceled}`),
+    onPress: () => calls.push("press"),
+  });
+  const host = document.createElement("button");
+
+  controller.pressProps.onClick(currentTarget(new MouseEvent("click"), host));
+  assert.deepEqual(calls, ["start", "end:true"]);
+  assert.equal(controller.isPressed.value, false);
+  controller.dispose();
+});
+
+test("a reentrant press-up cancellation cannot activate on keyboard release", () => {
+  const calls: string[] = [];
+  let controller!: PressController;
+  controller = createPress({
+    onPressUp: () => {
+      calls.push("up");
+      controller.cancel();
+    },
+    onPress: () => calls.push("press"),
+  });
+  const host = document.createElement("div");
+  document.body.append(host);
+  controller.pressProps.onKeydown(
+    currentTarget(new KeyboardEvent("keydown", { key: "Enter" }), host),
+  );
+  controller.pressProps.onKeyup(currentTarget(new KeyboardEvent("keyup", { key: "Enter" }), host));
+
+  assert.deepEqual(calls, ["up"]);
+  assert.equal(controller.isPressed.value, false);
+  controller.dispose();
+  host.remove();
+});
+
+test("keyboard ownership cancels when focus moves before keyup", () => {
+  const host = document.createElement("div");
+  const next = document.createElement("button");
+  host.tabIndex = 0;
+  document.body.append(host, next);
+  let presses = 0;
+  const controller = createPress({ onPress: () => presses++ });
+  host.addEventListener("keydown", controller.pressProps.onKeydown);
+  host.focus();
+  host.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: " " }));
+  next.focus();
+  document.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true, key: " " }));
+
+  assert.equal(controller.isPressed.value, false);
+  assert.equal(presses, 0);
+  controller.dispose();
+  host.remove();
+  next.remove();
+});
+
+test("drag, window blur, and host removal terminate pointer ownership", () => {
+  const host = document.createElement("button");
+  document.body.append(host);
+  const controller = createPress();
+  controller.pressProps.onPointerdown(pointer("pointerdown", host));
+  controller.pressProps.onDragstart(currentTarget(new DragEvent("dragstart"), host));
+  assert.equal(controller.isPressed.value, false);
+
+  controller.pressProps.onPointerdown(pointer("pointerdown", host));
+  window.dispatchEvent(new Event("blur"));
+  assert.equal(controller.isPressed.value, false);
+
+  controller.pressProps.onPointerdown(pointer("pointerdown", host));
+  host.remove();
+  controller.pressProps.onPointerup(pointer("pointerup", host));
+  assert.equal(controller.isPressed.value, false);
+  controller.dispose();
+});
+
+test("listener setup failure rolls back earlier registrations and styling", () => {
+  const isolated = document.implementation.createHTMLDocument("listener failure");
+  const host = isolated.createElement("button");
+  host.style.setProperty("user-select", "text", "important");
+  isolated.body.append(host);
+  const removals: string[] = [];
+  const addEventListener = isolated.addEventListener.bind(isolated);
+  const removeEventListener = isolated.removeEventListener.bind(isolated);
+  isolated.addEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options,
+  ) => {
+    if (type === "pointerup") throw new Error("listener rejected");
+    addEventListener(type, listener, options);
+  }) as typeof isolated.addEventListener;
+  isolated.removeEventListener = ((
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options,
+  ) => {
+    removals.push(type);
+    removeEventListener(type, listener, options);
+  }) as typeof isolated.removeEventListener;
+  const controller = createPress();
+
+  assert.throws(
+    () => controller.pressProps.onPointerdown(pointer("pointerdown", host)),
+    /listener rejected/,
+  );
+  assert.deepEqual(removals, ["pointermove"]);
+  assert.equal(host.style.getPropertyValue("user-select"), "text");
+  assert.equal(host.style.getPropertyPriority("user-select"), "important");
+  assert.equal(controller.cancel(), false);
+  controller.dispose();
+});
+
+test("callback failure leaves an active interaction cancelable and leak-free", () => {
+  const host = document.createElement("button");
+  const failure = new Error("start failed");
+  const controller = createPress({
+    onPressStart: () => {
+      throw failure;
+    },
+  });
+
+  assert.throws(() => controller.pressProps.onPointerdown(pointer("pointerdown", host)), failure);
+  assert.equal(controller.isPressed.value, true);
+  assert.equal(controller.cancel(), true);
+  assert.equal(controller.isPressed.value, false);
+  controller.dispose();
+});
+
+test("disposed bound handlers remain inert for late renderer events", () => {
+  const host = document.createElement("button");
+  const controller = createPress();
+  controller.dispose();
+
+  assert.doesNotThrow(() => {
+    controller.pressProps.onPointerdown(pointer("pointerdown", host));
+    controller.pressProps.onClick(currentTarget(new MouseEvent("click"), host));
+  });
+  assert.equal(controller.isPressed.value, false);
+});

--- a/npm/ui/core/src/press-lifecycle.ts
+++ b/npm/ui/core/src/press-lifecycle.ts
@@ -1,0 +1,345 @@
+import { shallowReadonly, shallowRef } from "vue";
+
+import { PressActivationMemory } from "./press-activation-memory.ts";
+import type { SyntheticActivation } from "./press-activation-memory.ts";
+import {
+  createPressEvent,
+  disableTextSelection,
+  isEventInside,
+  readBooleanOption,
+  validatePressOptions,
+} from "./press-event.ts";
+import { captureError, notifyAll, surfaceErrors } from "./press-notify.ts";
+import type {
+  PressController,
+  PressEvent,
+  PressOptions,
+  PressPointerType,
+  PressProps,
+} from "./press-types.ts";
+
+const disposedDiagnostic = "VIZE_UI_PRESS_DISPOSED";
+
+export type PressSource = "keyboard" | "mouse" | "pointer" | "touch";
+
+export interface ActivePress {
+  readonly document: Document;
+  readonly id: number | null;
+  readonly key: string | null;
+  readonly nativeKeyboard: boolean;
+  readonly pointerType: PressPointerType;
+  readonly releaseListeners: () => void;
+  readonly restoreSelection: () => void;
+  readonly source: PressSource;
+  readonly target: Element;
+  delivered: boolean;
+  inside: boolean;
+  lastEvent: Event;
+}
+
+/** Internal press state machine shared by all native-event adapters. */
+export class PressLifecycle {
+  readonly options: PressOptions;
+  readonly installListeners: (document: Document, source: PressSource) => () => void;
+  readonly #pressed = shallowRef(false);
+  readonly #activation = new PressActivationMemory();
+  #active: ActivePress | null = null;
+  #disposed = false;
+  #synthetic: SyntheticActivation | null = null;
+  #transitionVersion = 0;
+
+  constructor(
+    options: PressOptions,
+    installListeners: (document: Document, source: PressSource) => () => void,
+  ) {
+    validatePressOptions(options);
+    this.options = options;
+    this.installListeners = installListeners;
+  }
+
+  get active(): ActivePress | null {
+    return this.#active;
+  }
+
+  get disposed(): boolean {
+    return this.#disposed;
+  }
+
+  start(
+    event: Event,
+    target: Element,
+    source: PressSource,
+    pointerType: PressPointerType,
+    id: number | null,
+    key: string | null,
+    nativeKeyboard: boolean,
+  ): void {
+    this.#activation.begin(target);
+    let releaseListeners: () => void = () => undefined;
+    let restoreSelection: () => void = () => undefined;
+    try {
+      releaseListeners = this.installListeners(target.ownerDocument, source);
+      if (
+        source !== "keyboard" &&
+        !readBooleanOption(this.options.allowTextSelectionOnPress, "allowTextSelectionOnPress")
+      ) {
+        restoreSelection = disableTextSelection(target);
+      }
+    } catch (error) {
+      releaseListeners();
+      restoreSelection();
+      throw error;
+    }
+    const current: ActivePress = {
+      document: target.ownerDocument,
+      id,
+      key,
+      nativeKeyboard,
+      pointerType,
+      releaseListeners,
+      restoreSelection,
+      source,
+      target,
+      delivered: false,
+      inside: true,
+      lastEvent: event,
+    };
+    this.#active = current;
+    this.#transition(
+      true,
+      createPressEvent(
+        "pressstart",
+        target,
+        pointerType,
+        event,
+        false,
+        source === "touch" ? id : null,
+      ),
+    );
+  }
+
+  updatePointerBoundary(current: ActivePress, event: Event): void {
+    current.lastEvent = event;
+    if (readBooleanOption(this.options.isDisabled, "isDisabled")) {
+      this.cancelActive(event);
+      return;
+    }
+    const inside = isEventInside(
+      event,
+      current.target,
+      current.source === "touch" ? current.id : null,
+    );
+    if (inside === current.inside) return;
+    current.inside = inside;
+    if (
+      !inside &&
+      readBooleanOption(this.options.shouldCancelOnPointerExit, "shouldCancelOnPointerExit")
+    ) {
+      this.cancelActive(event);
+      return;
+    }
+    this.#transition(
+      inside,
+      createPressEvent(
+        inside ? "pressstart" : "pressend",
+        current.target,
+        current.pointerType,
+        event,
+        !inside,
+        current.source === "touch" ? current.id : null,
+      ),
+    );
+  }
+
+  finishPointer(current: ActivePress, event: Event): void {
+    current.lastEvent = event;
+    const inside =
+      current.target.isConnected &&
+      current.inside &&
+      isEventInside(event, current.target, current.source === "touch" ? current.id : null);
+    if (readBooleanOption(this.options.isDisabled, "isDisabled") || !inside) {
+      this.cancelActive(event);
+      return;
+    }
+    const errors: unknown[] = [];
+    captureError(errors, () => this.#emitUp(current, event));
+    if (this.#active === current) {
+      this.#activation.remember(current.target, current.pointerType);
+      captureError(errors, () => this.#endActive(current, event, false));
+    }
+    surfaceErrors(errors);
+  }
+
+  finishKeyboard(current: ActivePress, event: KeyboardEvent): void {
+    current.lastEvent = event;
+    const disabled =
+      !current.target.isConnected || readBooleanOption(this.options.isDisabled, "isDisabled");
+    const errors: unknown[] = [];
+    let completed = false;
+    if (!disabled) captureError(errors, () => this.#emitUp(current, event));
+    if (this.#active === current) {
+      completed = !disabled;
+      captureError(errors, () => this.#endActive(current, event, disabled));
+    }
+    if (completed && !this.#disposed && !current.delivered) {
+      if (current.nativeKeyboard) this.#activation.remember(current.target, "keyboard");
+      else captureError(errors, () => this.#emitPress(current.target, "keyboard", event));
+    }
+    surfaceErrors(errors);
+  }
+
+  activateClick(target: Element, event: MouseEvent): void {
+    if (readBooleanOption(this.options.isDisabled, "isDisabled")) {
+      event.preventDefault();
+      this.cancelActive(event);
+      this.#activation.dispose();
+      return;
+    }
+    if (this.#activation.consumeSuppressed(target)) {
+      event.preventDefault();
+      return;
+    }
+    const current = this.#active;
+    if (current?.target === target && current.source === "keyboard") {
+      const shouldDeliver = !current.delivered;
+      current.delivered = true;
+      if (shouldDeliver) this.#emitPress(target, "keyboard", event);
+      return;
+    }
+    if (current?.target === target) this.finishPointer(current, event);
+    const pendingPointerType = this.#activation.take(target);
+    if (pendingPointerType) {
+      this.#emitPress(target, pendingPointerType, event);
+      return;
+    }
+    this.#syntheticClickCycle(target, event, event.detail === 0 ? "virtual" : "mouse");
+  }
+
+  cancelActive(originalEvent: Event | null, suppress = true): boolean {
+    const current = this.#active;
+    if (current) {
+      if (suppress && current.source !== "keyboard") this.#activation.suppress(current.target);
+      this.#endActive(current, originalEvent ?? current.lastEvent, true);
+      return true;
+    }
+    const synthetic = this.#synthetic;
+    if (!synthetic || synthetic.canceled) return false;
+    synthetic.canceled = true;
+    this.#transition(
+      false,
+      createPressEvent(
+        "pressend",
+        synthetic.target,
+        synthetic.pointerType,
+        originalEvent ?? synthetic.event,
+        true,
+      ),
+    );
+    return true;
+  }
+
+  toController(pressProps: Readonly<PressProps>): PressController {
+    return Object.freeze({
+      isPressed: shallowReadonly(this.#pressed),
+      pressProps,
+      cancel: () => {
+        if (this.#disposed) {
+          throw new Error(`${disposedDiagnostic}: the controller has been disposed`);
+        }
+        return this.cancelActive(null);
+      },
+      dispose: () => this.dispose(),
+    });
+  }
+
+  dispose(): void {
+    if (this.#disposed) return;
+    const current = this.#active;
+    if (current) {
+      current.releaseListeners();
+      current.restoreSelection();
+      this.#active = null;
+      this.#pressed.value = false;
+      this.#transitionVersion++;
+    }
+    if (this.#synthetic) this.#synthetic.canceled = true;
+    this.#synthetic = null;
+    if (this.#pressed.value) {
+      this.#pressed.value = false;
+      this.#transitionVersion++;
+    }
+    this.#activation.dispose();
+    this.#disposed = true;
+  }
+
+  #transition(next: boolean, event: PressEvent): void {
+    if (this.#pressed.value === next) return;
+    this.#pressed.value = next;
+    const version = ++this.#transitionVersion;
+    const phase = next ? this.options.onPressStart : this.options.onPressEnd;
+    notifyAll([
+      () => phase?.(event),
+      () => {
+        if (this.#transitionVersion === version) this.options.onPressChange?.(next);
+      },
+    ]);
+  }
+
+  #endActive(current: ActivePress, originalEvent: Event | null, canceled: boolean): void {
+    current.releaseListeners();
+    current.restoreSelection();
+    if (this.#active === current) this.#active = null;
+    this.#transition(
+      false,
+      createPressEvent(
+        "pressend",
+        current.target,
+        current.pointerType,
+        originalEvent,
+        canceled,
+        current.source === "touch" ? current.id : null,
+      ),
+    );
+  }
+
+  #emitUp(current: ActivePress, event: Event): void {
+    this.options.onPressUp?.(
+      createPressEvent(
+        "pressup",
+        current.target,
+        current.pointerType,
+        event,
+        false,
+        current.source === "touch" ? current.id : null,
+      ),
+    );
+  }
+
+  #emitPress(target: Element, pointerType: PressPointerType, event: Event): void {
+    this.options.onPress?.(createPressEvent("press", target, pointerType, event));
+  }
+
+  #syntheticClickCycle(target: Element, event: MouseEvent, pointerType: PressPointerType): void {
+    const errors: unknown[] = [];
+    const cycle: SyntheticActivation = { event, pointerType, target, canceled: false };
+    this.#synthetic = cycle;
+    captureError(errors, () =>
+      this.#transition(true, createPressEvent("pressstart", target, pointerType, event)),
+    );
+    if (!cycle.canceled && !this.#disposed) {
+      captureError(errors, () =>
+        this.options.onPressUp?.(createPressEvent("pressup", target, pointerType, event)),
+      );
+    }
+    if (!cycle.canceled && !this.#disposed) {
+      captureError(errors, () =>
+        this.#transition(false, createPressEvent("pressend", target, pointerType, event)),
+      );
+    }
+    if (!cycle.canceled && !this.#disposed) {
+      captureError(errors, () => this.#emitPress(target, pointerType, event));
+    }
+    if (this.#synthetic === cycle) this.#synthetic = null;
+    surfaceErrors(errors);
+  }
+}

--- a/npm/ui/core/src/press-notify.ts
+++ b/npm/ui/core/src/press-notify.ts
@@ -1,0 +1,32 @@
+/** Execute every notification before surfacing one or more consumer errors. */
+export function notifyAll(notifications: readonly (() => void)[]): void {
+  const errors: unknown[] = [];
+  for (const notify of notifications) {
+    try {
+      notify();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) throw new AggregateError(errors, "Press callbacks failed");
+}
+
+/** Capture one consumer failure while allowing the lifecycle to settle. */
+export function captureError(errors: unknown[], callback: () => void): void {
+  try {
+    callback();
+  } catch (error) {
+    errors.push(error);
+  }
+}
+
+/** Surface captured failures after every required transition has run. */
+export function surfaceErrors(errors: readonly unknown[]): void {
+  if (errors.length === 0) return;
+  notifyAll(
+    errors.map((error) => () => {
+      throw error;
+    }),
+  );
+}

--- a/npm/ui/core/src/press-ssr.test.ts
+++ b/npm/ui/core/src/press-ssr.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { createSSRApp, defineComponent, h, nextTick } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import { usePress } from "./press.ts";
+
+const SsrProbe = defineComponent({
+  name: "PressSsrProbe",
+  setup() {
+    const presses: string[] = [];
+    const press = usePress({ onPress: (event) => presses.push(event.pointerType) });
+    return () =>
+      h(
+        "button",
+        {
+          ...press.pressProps,
+          "data-pressed": String(press.isPressed.value),
+          type: "button",
+        },
+        `Activate ${presses.length}`,
+      );
+  },
+});
+
+test("renders byte-identical SSR output without DOM access or serialized handlers", async () => {
+  const outputs = await Promise.all([
+    renderToString(createSSRApp(SsrProbe)),
+    renderToString(createSSRApp(SsrProbe)),
+  ]);
+
+  assert.equal(outputs[0], outputs[1]);
+  assert.match(outputs[0], /^<button data-pressed="false" type="button">Activate 0<\/button>$/);
+  assert.doesNotMatch(outputs[0], /onClick|pointerdown|function/);
+});
+
+test("hydrates without diagnostics and activates through the same bound props", async () => {
+  const serverHtml = await renderToString(createSSRApp(SsrProbe));
+  const host = document.createElement("div");
+  host.innerHTML = serverHtml;
+  document.body.append(host);
+  const serverButton = host.firstElementChild;
+  const diagnostics: string[] = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  console.error = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  const app = createSSRApp(SsrProbe);
+
+  try {
+    app.mount(host);
+    assert.equal(host.firstElementChild, serverButton);
+    host
+      .querySelector("button")
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 0 }));
+    await nextTick();
+    assert.equal(host.querySelector("button")?.textContent, "Activate 1");
+    assert.deepEqual(diagnostics, []);
+  } finally {
+    app.unmount();
+    host.remove();
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+});

--- a/npm/ui/core/src/press-types.ts
+++ b/npm/ui/core/src/press-types.ts
@@ -1,0 +1,134 @@
+import type { MaybeRefOrGetter, ShallowRef } from "vue";
+
+/** Stable input family reported by a press interaction. */
+export type PressPointerType = "keyboard" | "mouse" | "pen" | "pointer" | "touch" | "virtual";
+
+/** Lifecycle notification emitted by a press controller. */
+export type PressEventType = "press" | "pressend" | "pressstart" | "pressup";
+
+/** Keyboard semantics applied when the host is not natively activatable. */
+export type PressKeyboardBehavior = "button" | "link" | "none";
+
+/** Immutable, renderer-independent snapshot of one press lifecycle event. */
+export interface PressEvent {
+  /** Press lifecycle phase represented by this snapshot. */
+  readonly type: PressEventType;
+
+  /** Input family that initiated the interaction. */
+  readonly pointerType: PressPointerType;
+
+  /** Element whose bound press props own the interaction. */
+  readonly target: Element;
+
+  /** Native event responsible for this phase, or `null` for manual cancellation. */
+  readonly originalEvent: Event | null;
+
+  /** Viewport coordinate when supplied by pointing hardware. */
+  readonly x: number | null;
+
+  /** Viewport coordinate when supplied by pointing hardware. */
+  readonly y: number | null;
+
+  /** Modifier-key snapshots captured from the native event. */
+  readonly altKey: boolean;
+  readonly ctrlKey: boolean;
+  readonly metaKey: boolean;
+  readonly shiftKey: boolean;
+
+  /** Whether the lifecycle ended without an activation. */
+  readonly isCanceled: boolean;
+}
+
+/** Options shared by {@link createPress} and {@link usePress}. */
+export interface PressOptions {
+  /**
+   * Suppress every activation while retaining the bound props.
+   *
+   * Reactive values are read for every event, so disabling an interaction
+   * between pointer-down and pointer-up cancels it deterministically.
+   *
+   * @default false
+   */
+  readonly isDisabled?: MaybeRefOrGetter<boolean | undefined>;
+
+  /**
+   * Keyboard contract for hosts without native activation behavior.
+   * Native buttons, links, inputs, and summaries always keep browser timing.
+   *
+   * @default "button"
+   */
+  readonly keyboardBehavior?: MaybeRefOrGetter<PressKeyboardBehavior | undefined>;
+
+  /**
+   * End the interaction permanently on its first pointer exit.
+   * When false, leaving pauses pressed state and re-entering resumes it.
+   *
+   * @default false
+   */
+  readonly shouldCancelOnPointerExit?: MaybeRefOrGetter<boolean | undefined>;
+
+  /**
+   * Prevent the compatibility mousedown default that normally moves focus.
+   * Keyboard and virtual activation never lose focus.
+   *
+   * @default false
+   */
+  readonly preventFocusOnPress?: MaybeRefOrGetter<boolean | undefined>;
+
+  /**
+   * Preserve selectable text during an active pointer press. When false, the
+   * host's exact inline user-select declarations are restored at press end.
+   *
+   * @default false
+   */
+  readonly allowTextSelectionOnPress?: MaybeRefOrGetter<boolean | undefined>;
+
+  /** Called after pressed state becomes active. */
+  readonly onPressStart?: (event: PressEvent) => void;
+
+  /** Called after pressed state ends or pauses at the pointer boundary. */
+  readonly onPressEnd?: (event: PressEvent) => void;
+
+  /** Called for every distinct pressed-state transition. */
+  readonly onPressChange?: (isPressed: boolean) => void;
+
+  /** Called when keyboard or pointing hardware is released over the host. */
+  readonly onPressUp?: (event: PressEvent) => void;
+
+  /** Called exactly once for a completed activation. */
+  readonly onPress?: (event: PressEvent) => void;
+}
+
+/** Framework props to spread onto the element that owns a press interaction. */
+export interface PressProps {
+  readonly onClick: (event: MouseEvent) => void;
+  readonly onDragstart: (event: DragEvent) => void;
+  readonly onKeydown: (event: KeyboardEvent) => void;
+  readonly onKeyup: (event: KeyboardEvent) => void;
+  readonly onMousedown: (event: MouseEvent) => void;
+  readonly onMousemove: (event: MouseEvent) => void;
+  readonly onMouseup: (event: MouseEvent) => void;
+  readonly onPointercancel: (event: PointerEvent) => void;
+  readonly onPointerdown: (event: PointerEvent) => void;
+  readonly onPointermove: (event: PointerEvent) => void;
+  readonly onPointerup: (event: PointerEvent) => void;
+  readonly onTouchcancel: (event: TouchEvent) => void;
+  readonly onTouchend: (event: TouchEvent) => void;
+  readonly onTouchmove: (event: TouchEvent) => void;
+  readonly onTouchstart: (event: TouchEvent) => void;
+}
+
+/** Stateful press normalizer with explicit lifecycle ownership. */
+export interface PressController {
+  /** Whether the active input is currently within the pressed region. */
+  readonly isPressed: Readonly<ShallowRef<boolean>>;
+
+  /** Stable handlers to merge or spread onto exactly one host element. */
+  readonly pressProps: Readonly<PressProps>;
+
+  /** Cancel the current interaction without producing an activation. */
+  readonly cancel: () => boolean;
+
+  /** Release document listeners, timers, and transient selection changes. */
+  readonly dispose: () => void;
+}

--- a/npm/ui/core/src/press.behavior.md
+++ b/npm/ui/core/src/press.behavior.md
@@ -1,0 +1,89 @@
+# Press behavior contract
+
+Normative state × input → outcome table for `@vizejs/ui/press`. Every row is
+exercised by `src/press*.test.ts`; compile-only API assertions live in
+`src/press.types.test-d.ts`.
+
+| #   | State                         | Input                                  | Outcome                                                                  | Proven by                                                     |
+| --- | ----------------------------- | -------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| P1  | idle                          | primary pointer down                   | pressed state starts with the normalized device family                   | `normalizes a primary pointer lifecycle…`                     |
+| P2  | idle                          | secondary or non-primary pointer       | input is ignored                                                         | `ignores non-primary contacts and secondary buttons`          |
+| P3  | active pointer                | another pointer down                   | original pointer retains exclusive ownership                             | `ignores non-primary contacts and secondary buttons`          |
+| P4  | active, inside                | primary pointer release then click     | up, end, and exactly one press are delivered                             | `normalizes a primary pointer lifecycle…`                     |
+| P5  | active, inside                | pointer leaves                         | pressed state pauses with a canceled end snapshot                        | `pauses outside, resumes inside…`                             |
+| P6  | paused outside                | owning pointer re-enters               | pressed state resumes with another start                                 | `pauses outside, resumes inside…`                             |
+| P7  | paused outside                | owning pointer releases                | interaction ends without activation                                      | `cancel-on-exit suppresses…` and lifecycle tests              |
+| P8  | cancel-on-exit                | first pointer exit                     | interaction ends permanently and compatibility click is canceled         | `cancel-on-exit suppresses the following compatibility click` |
+| P9  | active                        | pointer cancel, drag, blur, or hidden  | state and transient resources are canceled                               | lifecycle listener and cancellation tests                     |
+| P10 | active                        | reactive disabled becomes true         | release cancels; subsequent click default is prevented                   | `cancels when disabled changes during a press`                |
+| P11 | disabled                      | pointer, keyboard, or click            | no callback is emitted; click default is prevented                       | disabled and reactive-option tests                            |
+| P12 | idle custom button            | Enter                                  | start/up/end/press lifecycle is synthesized                              | `emulates button and link keyboard semantics…`                |
+| P13 | idle custom button            | Space                                  | scrolling is prevented; activation occurs on keyup                       | `emulates button and link keyboard semantics…`                |
+| P14 | idle custom link              | Space / Enter                          | Space is ignored; Enter activates                                        | `emulates button and link keyboard semantics…`                |
+| P15 | native activatable element    | browser keyboard click                 | native timing/default action wins; one normalized press is reported      | `preserves native keyboard click timing…`                     |
+| P16 | keyboard interaction          | IME, repeat, or nested interactive key | event is ignored and no ancestor activation is invented                  | `ignores IME, repeats, nested targets…`                       |
+| P17 | idle                          | coordinate-free click                  | complete lifecycle is reported as `virtual`                              | `maps coordinate-free and click-only activation…`             |
+| P18 | idle                          | click with coordinates/detail          | complete lifecycle is reported as `mouse`                                | `maps coordinate-free and click-only activation…`             |
+| P19 | active pointer                | selection guard                        | exact inline user-select values and priorities restore at end            | `restores exact selection styles…`                            |
+| P20 | prevent-focus option          | compatibility mousedown                | default focus transfer is prevented without suppressing keyboard focus   | `restores exact selection styles…`                            |
+| P21 | callback re-enters controller | start callback cancels                 | stale `pressed=true` change cannot publish after the cancellation        | `a reentrant cancel cannot publish…`                          |
+| P22 | multiple callbacks throw      | coordinate-free activation             | all lifecycle phases run, state settles, then errors surface             | `synthetic activation completes every phase…`                 |
+| P23 | active callback throws        | explicit cancellation                  | interaction remains owned and can still release every listener           | `callback failure leaves an active interaction…`              |
+| P24 | Vue effect scope              | scope stops                            | controller disposes, state resets, listeners and timers release          | `the composable requires and follows…`                        |
+| P25 | disposed                      | late renderer event / explicit cancel  | bound handlers are inert; imperative mutation throws a stable diagnostic | disposal lifecycle tests                                      |
+| P26 | concurrent SSR requests       | identical component trees              | byte-identical markup contains no serialized handler or global DOM read  | `renders byte-identical SSR output…`                          |
+| P27 | SSR followed by hydration     | coordinate-free client activation      | root identity is retained; no diagnostics; callback updates render       | `hydrates without diagnostics…`                               |
+| P28 | public TypeScript API         | mutation or invalid closed-union use   | compilation rejects the misuse                                           | `src/press.types.test-d.ts`                                   |
+| P29 | template consumer             | native DOM / SSR / Vapor compilation   | handler spread and reactive state compile with no warning or fallback    | `scripts/check-renderers.ts` press fixture                    |
+
+## Accessibility and native behavior
+
+- `click` is the activation authority. Pointer release produces `pressup` and
+  `pressend`, while the browser's following click produces `press`. This keeps
+  link navigation, form submission, label forwarding, and assistive-technology
+  activation intact without double invocation.
+- Native buttons, relevant input types, links with `href`, and summaries retain
+  browser keyboard timing and default actions. Custom button-like hosts receive
+  Enter and Space behavior; custom link-like hosts receive Enter only.
+- Space scrolling is canceled only for custom button semantics. The primitive
+  does not cancel native key events whose default action creates the click.
+- Disabled state is evaluated at every phase. If it changes during an active
+  gesture, the gesture and its compatibility click are both canceled.
+- Events from focused descendants never invent an activation on the bound
+  ancestor. Composite widgets remain responsible for their own key routing.
+
+## Pointer ownership and cancellation
+
+- Only the primary contact and primary button can own a press. An active
+  interaction ignores additional contacts until it ends.
+- Pointer Events are preferred. Legacy mouse and touch handlers are present for
+  older engines, including the compatibility-mouse suppression window after a
+  touch contact.
+- Leaving the target pauses pressed feedback and re-entry resumes it. Set
+  `shouldCancelOnPointerExit` to make the first exit terminal.
+- Window blur, hidden documents, pointer cancellation, drag start, manual
+  cancellation, scope disposal, and disabled transitions all release document
+  listeners and restore transient text-selection state.
+
+## SSR, Vapor, styling, and tree shaking
+
+- Module evaluation and `createPress()` perform no DOM read, native listener
+  installation, timer scheduling, style injection, or request-global mutation.
+  Listeners and timers exist only during a client interaction.
+- `usePress()` only requires an active Vue effect scope; its plain handler props
+  are compatible with DOM rendering, standard SSR/hydration, and Vapor-compiled
+  consumers. No renderer-specific VNode or component instance is captured.
+- This entry emits zero CSS and no attributes. Consumers map readonly
+  `isPressed` to any classes, data attributes, utility system, CSS variables, or
+  preset package they choose.
+- `@vizejs/ui/press` is an exact ESM subpath. The production consumer gate
+  requires root/subpath byte parity, zero CSS, unused-family elimination, and a
+  hard gzip budget.
+
+## Normative references
+
+- [Pointer Events Level 4 — primary pointer, buttons, capture, and click](https://www.w3.org/TR/pointerevents/)
+- [UI Events — accessible activation through click](https://www.w3.org/TR/uievents/)
+- [WAI-ARIA APG — Button Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/)
+- [WAI-ARIA APG — Link Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/link/)
+- [WAI-ARIA APG — Developing a Keyboard Interface](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/)

--- a/npm/ui/core/src/press.test.ts
+++ b/npm/ui/core/src/press.test.ts
@@ -1,0 +1,341 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+
+import { createPress } from "./press.ts";
+import type { PressController, PressEvent, PressOptions, PressProps } from "./press.ts";
+
+const eventNames: Readonly<Record<keyof PressProps, string>> = Object.freeze({
+  onClick: "click",
+  onDragstart: "dragstart",
+  onKeydown: "keydown",
+  onKeyup: "keyup",
+  onMousedown: "mousedown",
+  onMousemove: "mousemove",
+  onMouseup: "mouseup",
+  onPointercancel: "pointercancel",
+  onPointerdown: "pointerdown",
+  onPointermove: "pointermove",
+  onPointerup: "pointerup",
+  onTouchcancel: "touchcancel",
+  onTouchend: "touchend",
+  onTouchmove: "touchmove",
+  onTouchstart: "touchstart",
+});
+
+interface PressHarness {
+  readonly controller: PressController;
+  readonly host: HTMLElement;
+  readonly events: PressEvent[];
+  dispatch: (event: Event, target?: EventTarget) => boolean;
+  unmount: () => void;
+}
+
+function mountPress(options: PressOptions = {}, tag = "div"): PressHarness {
+  const events: PressEvent[] = [];
+  const host = document.createElement(tag);
+  host.tabIndex = 0;
+  document.body.append(host);
+  const controller = createPress({
+    ...options,
+    onPressStart(event) {
+      events.push(event);
+      options.onPressStart?.(event);
+    },
+    onPressEnd(event) {
+      events.push(event);
+      options.onPressEnd?.(event);
+    },
+    onPressUp(event) {
+      events.push(event);
+      options.onPressUp?.(event);
+    },
+    onPress(event) {
+      events.push(event);
+      options.onPress?.(event);
+    },
+  });
+  for (const [property, type] of Object.entries(eventNames) as Array<[keyof PressProps, string]>) {
+    host.addEventListener(type, controller.pressProps[property] as EventListener);
+  }
+  return {
+    controller,
+    host,
+    events,
+    dispatch(event, target = host) {
+      return target.dispatchEvent(event);
+    },
+    unmount() {
+      controller.dispose();
+      host.remove();
+    },
+  };
+}
+
+function pointer(type: string, init: PointerEventInit = {}): PointerEvent {
+  return new PointerEvent(type, {
+    bubbles: true,
+    button: 0,
+    isPrimary: true,
+    pointerId: 7,
+    pointerType: "mouse",
+    ...init,
+  });
+}
+
+test("normalizes a primary pointer lifecycle and emits immutable snapshots", () => {
+  const changes: boolean[] = [];
+  const harness = mountPress({ onPressChange: (value) => changes.push(value) });
+  const down = pointer("pointerdown", { clientX: 12, clientY: 34, shiftKey: true });
+  harness.dispatch(down);
+  assert.equal(harness.controller.isPressed.value, true);
+
+  harness.dispatch(pointer("pointerup"));
+  harness.dispatch(new MouseEvent("click", { bubbles: true, detail: 1 }));
+
+  assert.equal(harness.controller.isPressed.value, false);
+  assert.deepEqual(
+    harness.events.map(({ type }) => type),
+    ["pressstart", "pressup", "pressend", "press"],
+  );
+  assert.deepEqual(changes, [true, false]);
+  assert.ok(harness.events.every(Object.isFrozen));
+  assert.equal(harness.events[0]?.originalEvent, down);
+  assert.equal(harness.events[0]?.x, 12);
+  assert.equal(harness.events[0]?.y, 34);
+  assert.equal(harness.events[0]?.shiftKey, true);
+  assert.equal(harness.events.at(-1)?.pointerType, "mouse");
+  harness.unmount();
+});
+
+test("ignores non-primary contacts and secondary buttons", () => {
+  const harness = mountPress();
+  harness.dispatch(pointer("pointerdown", { button: 2 }));
+  harness.dispatch(pointer("pointerdown", { isPrimary: false }));
+  harness.dispatch(pointer("pointerdown", { pointerId: 8, pointerType: "touch" }));
+  harness.dispatch(pointer("pointerdown", { pointerId: 9, pointerType: "touch" }));
+  harness.dispatch(pointer("pointerup", { pointerId: 8, pointerType: "touch" }));
+  harness.dispatch(new MouseEvent("click", { bubbles: true, detail: 1 }));
+
+  assert.equal(harness.events.filter(({ type }) => type === "press").length, 1);
+  assert.equal(harness.events[0]?.pointerType, "touch");
+  harness.unmount();
+});
+
+test("preserves pen, unknown, and non-pointing Pointer Events classifications", () => {
+  const cases = [
+    { pointerId: 1, pointerType: "pen", expected: "pen" },
+    { pointerId: 2, pointerType: "vendor-device", expected: "pointer" },
+    { pointerId: -1, pointerType: "", expected: "virtual" },
+  ] as const;
+  for (const { pointerId, pointerType, expected } of cases) {
+    const harness = mountPress();
+    harness.dispatch(pointer("pointerdown", { pointerId, pointerType }));
+    harness.dispatch(pointer("pointerup", { pointerId, pointerType }));
+    harness.dispatch(new MouseEvent("click", { bubbles: true, detail: 0 }));
+    assert.equal(harness.events.find(({ type }) => type === "press")?.pointerType, expected);
+    harness.unmount();
+  }
+});
+
+test("pauses outside, resumes inside, and activates only after an inside release", () => {
+  const harness = mountPress();
+  const outside = document.createElement("div");
+  document.body.append(outside);
+  harness.dispatch(pointer("pointerdown"));
+  harness.dispatch(pointer("pointermove"), outside);
+  assert.equal(harness.controller.isPressed.value, false);
+  harness.dispatch(pointer("pointermove"));
+  assert.equal(harness.controller.isPressed.value, true);
+  harness.dispatch(pointer("pointerup"));
+  harness.dispatch(new MouseEvent("click", { bubbles: true, detail: 1 }));
+
+  assert.deepEqual(
+    harness.events.map(({ type }) => type),
+    ["pressstart", "pressend", "pressstart", "pressup", "pressend", "press"],
+  );
+  assert.equal(harness.events[1]?.isCanceled, true);
+  outside.remove();
+  harness.unmount();
+});
+
+test("cancel-on-exit suppresses the following compatibility click", () => {
+  const harness = mountPress({ shouldCancelOnPointerExit: true });
+  const outside = document.createElement("div");
+  document.body.append(outside);
+  harness.dispatch(pointer("pointerdown"));
+  harness.dispatch(pointer("pointermove"), outside);
+  const click = new MouseEvent("click", { bubbles: true, cancelable: true, detail: 1 });
+  harness.dispatch(click);
+
+  assert.equal(click.defaultPrevented, true);
+  assert.deepEqual(
+    harness.events.map(({ type }) => type),
+    ["pressstart", "pressend"],
+  );
+  assert.equal(harness.events[1]?.isCanceled, true);
+  outside.remove();
+  harness.unmount();
+});
+
+test("cancels when disabled changes during a press", () => {
+  let disabled = false;
+  const harness = mountPress({ isDisabled: () => disabled });
+  harness.dispatch(pointer("pointerdown"));
+  disabled = true;
+  harness.dispatch(pointer("pointerup"));
+  const click = new MouseEvent("click", { bubbles: true, cancelable: true });
+  harness.dispatch(click);
+
+  assert.equal(click.defaultPrevented, true);
+  assert.deepEqual(
+    harness.events.map(({ type }) => type),
+    ["pressstart", "pressend"],
+  );
+  assert.equal(harness.events[1]?.isCanceled, true);
+  harness.unmount();
+});
+
+test("a disabled click clears stale release ownership before re-enabling", () => {
+  let disabled = false;
+  const pointerTypes: string[] = [];
+  const harness = mountPress({
+    isDisabled: () => disabled,
+    onPress: ({ pointerType }) => pointerTypes.push(pointerType),
+  });
+  harness.dispatch(pointer("pointerdown"));
+  harness.dispatch(pointer("pointerup"));
+  disabled = true;
+  harness.dispatch(new MouseEvent("click", { bubbles: true, cancelable: true, detail: 1 }));
+  disabled = false;
+  harness.dispatch(new MouseEvent("click", { bubbles: true, detail: 0 }));
+
+  assert.deepEqual(pointerTypes, ["virtual"]);
+  harness.unmount();
+});
+
+test("maps coordinate-free and click-only activation without duplication", () => {
+  const harness = mountPress();
+  harness.dispatch(new MouseEvent("click", { bubbles: true, detail: 0 }));
+  harness.dispatch(new MouseEvent("click", { bubbles: true, detail: 2 }));
+
+  assert.deepEqual(
+    harness.events.map(({ type }) => type),
+    ["pressstart", "pressup", "pressend", "press", "pressstart", "pressup", "pressend", "press"],
+  );
+  assert.deepEqual(
+    harness.events.filter(({ type }) => type === "press").map(({ pointerType }) => pointerType),
+    ["virtual", "mouse"],
+  );
+  harness.unmount();
+});
+
+test("emulates button and link keyboard semantics only for custom hosts", () => {
+  const button = mountPress();
+  button.host.focus();
+  const spaceDown = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: " " });
+  button.dispatch(spaceDown);
+  button.dispatch(new KeyboardEvent("keyup", { bubbles: true, key: " " }));
+  assert.equal(spaceDown.defaultPrevented, true);
+  assert.equal(button.events.filter(({ type }) => type === "press").length, 1);
+  button.unmount();
+
+  const link = mountPress({ keyboardBehavior: "link" });
+  link.dispatch(new KeyboardEvent("keydown", { bubbles: true, key: " " }));
+  link.dispatch(new KeyboardEvent("keyup", { bubbles: true, key: " " }));
+  link.dispatch(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+  link.dispatch(new KeyboardEvent("keyup", { bubbles: true, key: "Enter" }));
+  assert.equal(link.events.filter(({ type }) => type === "press").length, 1);
+  link.unmount();
+});
+
+test("preserves native keyboard click timing and delivers exactly one press", () => {
+  for (const key of ["Enter", " "]) {
+    const harness = mountPress({}, "button");
+    harness.dispatch(new KeyboardEvent("keydown", { bubbles: true, key }));
+    if (key === "Enter") harness.dispatch(new MouseEvent("click", { bubbles: true, detail: 0 }));
+    harness.dispatch(new KeyboardEvent("keyup", { bubbles: true, key }));
+    if (key === " ") harness.dispatch(new MouseEvent("click", { bubbles: true, detail: 0 }));
+
+    assert.equal(harness.events.filter(({ type }) => type === "press").length, 1);
+    assert.equal(harness.events.find(({ type }) => type === "press")?.pointerType, "keyboard");
+    harness.unmount();
+  }
+});
+
+test("ignores IME, repeats, nested targets, and disabled keyboard input", () => {
+  const harness = mountPress({ isDisabled: false });
+  const child = document.createElement("span");
+  harness.host.append(child);
+  child.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }));
+  harness.dispatch(
+    new KeyboardEvent("keydown", { bubbles: true, isComposing: true, key: "Enter" }),
+  );
+  harness.dispatch(new KeyboardEvent("keydown", { bubbles: true, key: "Enter", repeat: true }));
+  harness.dispatch(new KeyboardEvent("keyup", { bubbles: true, key: "Enter" }));
+
+  assert.deepEqual(harness.events, []);
+  harness.unmount();
+});
+
+test("restores exact selection styles and can prevent pointer focus", () => {
+  const harness = mountPress({ preventFocusOnPress: true });
+  harness.host.style.setProperty("user-select", "text", "important");
+  harness.dispatch(pointer("pointerdown"));
+  assert.equal(harness.host.style.userSelect, "none");
+  harness.dispatch(pointer("pointercancel"));
+  assert.equal(harness.host.style.getPropertyValue("user-select"), "text");
+  assert.equal(harness.host.style.getPropertyPriority("user-select"), "important");
+
+  const mousedown = new MouseEvent("mousedown", { bubbles: true, cancelable: true });
+  harness.dispatch(mousedown);
+  assert.equal(mousedown.defaultPrevented, true);
+  harness.unmount();
+});
+
+test("normalizes legacy touch and suppresses its compatibility mouse sequence", () => {
+  const isolated = document.implementation.createHTMLDocument("legacy touch");
+  const host = isolated.createElement("button");
+  isolated.body.append(host);
+  const events: PressEvent[] = [];
+  const controller = createPress({
+    onPressStart: (event) => events.push(event),
+    onPressEnd: (event) => events.push(event),
+    onPress: (event) => events.push(event),
+  });
+  for (const [property, type] of Object.entries(eventNames) as Array<[keyof PressProps, string]>) {
+    host.addEventListener(type, controller.pressProps[property] as EventListener);
+  }
+  const touchEvent = (
+    type: string,
+    values: Array<{ clientX: number; clientY: number; identifier: number }>,
+  ) => {
+    const event = new Event(type, { bubbles: true }) as TouchEvent;
+    const touches = Object.assign(values, {
+      item: (index: number) => touches[index] ?? null,
+    }) as unknown as TouchList;
+    Object.defineProperty(event, "changedTouches", { value: touches });
+    Object.defineProperty(event, "view", { value: null });
+    return event;
+  };
+
+  host.dispatchEvent(touchEvent("touchstart", [{ identifier: 31, clientX: 4, clientY: 8 }]));
+  host.dispatchEvent(
+    touchEvent("touchend", [
+      { identifier: 99, clientX: 100, clientY: 200 },
+      { identifier: 31, clientX: 9, clientY: 12 },
+    ]),
+  );
+  host.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+  host.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+  host.dispatchEvent(new MouseEvent("click", { bubbles: true, detail: 1 }));
+
+  assert.deepEqual(
+    events.map(({ type }) => type),
+    ["pressstart", "pressend", "press"],
+  );
+  assert.ok(events.every(({ pointerType }) => pointerType === "touch"));
+  assert.deepEqual([events[0]?.x, events[0]?.y], [4, 8]);
+  assert.deepEqual([events[1]?.x, events[1]?.y], [9, 12]);
+  controller.dispose();
+});

--- a/npm/ui/core/src/press.ts
+++ b/npm/ui/core/src/press.ts
@@ -1,0 +1,43 @@
+import { getCurrentScope, onScopeDispose } from "vue";
+
+import { createPressHandlers } from "./press-handlers.ts";
+import { PressLifecycle } from "./press-lifecycle.ts";
+import type { PressController, PressOptions } from "./press-types.ts";
+
+const setupDiagnostic = "VIZE_UI_PRESS_SETUP";
+
+/**
+ * Create an SSR-safe press normalizer for one host element.
+ *
+ * Spread the returned `pressProps` onto the host and call `dispose` when using
+ * this factory outside a Vue effect scope. No DOM global is read at setup.
+ */
+export function createPress(options: PressOptions = {}): PressController {
+  let handlers!: ReturnType<typeof createPressHandlers>;
+  const lifecycle = new PressLifecycle(options, (document, source) =>
+    handlers.installListeners(document, source),
+  );
+  handlers = createPressHandlers(lifecycle);
+  const { installListeners: _, ...pressProps } = handlers;
+  return lifecycle.toController(Object.freeze(pressProps));
+}
+
+/** Create a press normalizer disposed with the current Vue effect scope. */
+export function usePress(options: PressOptions = {}): PressController {
+  if (!getCurrentScope()) {
+    throw new Error(`${setupDiagnostic}: use inside component setup or an active effect scope`);
+  }
+  const controller = createPress(options);
+  onScopeDispose(controller.dispose);
+  return controller;
+}
+
+export type {
+  PressController,
+  PressEvent,
+  PressEventType,
+  PressKeyboardBehavior,
+  PressOptions,
+  PressPointerType,
+  PressProps,
+} from "./press-types.ts";

--- a/npm/ui/core/src/press.types.test-d.ts
+++ b/npm/ui/core/src/press.types.test-d.ts
@@ -1,0 +1,57 @@
+/** Compile-only assertions for the public press contract. */
+
+import { ref } from "vue";
+import type { HTMLAttributes, ShallowRef } from "vue";
+
+import {
+  createPress,
+  type PressEvent,
+  type PressKeyboardBehavior,
+  type PressPointerType,
+  type PressProps,
+} from "./press.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+export const pointerTypes: readonly PressPointerType[] = [
+  "keyboard",
+  "mouse",
+  "pen",
+  "pointer",
+  "touch",
+  "virtual",
+];
+export const behavior: PressKeyboardBehavior = "button";
+
+// @ts-expect-error pointerType is a closed, device-independent union.
+export const invalidPointerType: PressPointerType = "trackpad";
+// @ts-expect-error keyboard behavior does not accept arbitrary ARIA roles.
+export const invalidBehavior: PressKeyboardBehavior = "menuitem";
+
+const disabled = ref(false);
+export const controller = createPress({
+  isDisabled: disabled,
+  keyboardBehavior: () => "link",
+  onPress(event: PressEvent) {
+    const target: Element = event.target;
+    const native: Event | null = event.originalEvent;
+    void target;
+    void native;
+  },
+});
+
+type _PressedIsReadonly = Expect<Equal<typeof controller.isPressed, Readonly<ShallowRef<boolean>>>>;
+type _PropsAreExact = Expect<Equal<typeof controller.pressProps, Readonly<PressProps>>>;
+
+export const vueAttributes: HTMLAttributes = controller.pressProps;
+controller.pressProps.onClick(new MouseEvent("click"));
+// @ts-expect-error consumers cannot mutate readonly reactive state directly.
+controller.isPressed.value = true;
+// @ts-expect-error isDisabled must resolve to boolean or undefined.
+createPress({ isDisabled: "false" });
+// @ts-expect-error callbacks receive the immutable PressEvent contract.
+createPress({ onPress: (value: boolean) => value });

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       "controllable-state": "src/controllable-state.ts",
       id: "src/id.ts",
       "interaction-modality": "src/interaction-modality.ts",
+      press: "src/press.ts",
       primitive: "src/primitive.ts",
       "visually-hidden": "src/visually-hidden.ts",
       media: "src/media.ts",


### PR DESCRIPTION
## Summary

- add the exact ESM `@vizejs/ui/press` entry with fully typed `createPress` and scope-owned `usePress`
- normalize primary Pointer Events, legacy mouse/touch, keyboard, virtual clicks, focus loss, drag, disabled transitions, and cancellation without replacing native click semantics
- expose immutable press snapshots, readonly reactive state, stable handler props, exact cleanup, callback-error settlement, and reentrant cancellation safety
- prove SSR/hydration behavior, native DOM/SSR/Vapor consumer compilation, zero CSS, root/subpath tree-shaking parity, and hard gzip budgets
- document a 29-row behavior contract and normative accessibility decisions

## Validation

- `pnpm --filter @vizejs/ui check`
- `pnpm --filter @vizejs/ui test` (120 tests across 20 files)
- package build and declaration generation
- root/subpath tree-shaking parity with 0 CSS
- press consumer: 3,529 gzip bytes (budget 3,550)
- press package entry: 5,692 gzip bytes (budget 5,775)
- root package entry: 17,978 gzip bytes (budget 18,100)

Closes the Press foundation slice of #3134. Long press, hover, move, and remaining focus/navigation primitives stay independently reviewable follow-up slices.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public press interaction API for pointer, touch, mouse, and keyboard input.
  * Supports press lifecycle callbacks, cancellation, disabled states, focus handling, and disposal.
  * Added SSR and hydration support without requiring DOM access during setup.
  * Exposed the new functionality through a dedicated package entry point.

* **Documentation**
  * Added a comprehensive press behavior contract covering accessibility and interaction semantics.

* **Tests**
  * Added extensive behavior, accessibility, SSR, type-checking, renderer, and tree-shaking coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->