### PR TITLE
feat(fresco): add diagnostic keyboard contracts

### DIFF
--- a/crates/vize_fresco/benches/render.rs
+++ b/crates/vize_fresco/benches/render.rs
@@ -6,11 +6,13 @@ use std::io;
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 
 use vize_fresco::component::{
-    BoxNode, DiagnosticWorkspaceState, TextNode, VirtualListNavigation, VirtualListState,
+    BoxNode, DiagnosticWorkspaceKeymap, DiagnosticWorkspaceState, TextNode, VirtualListNavigation,
+    VirtualListState,
 };
 use vize_fresco::headless::{
     HeadlessPresentation, HeadlessRenderer, HeadlessSemanticNode, SemanticRole,
 };
+use vize_fresco::input::{Key, KeyEvent};
 use vize_fresco::layout::{Dimension, FlexStyle, LayoutEngine};
 use vize_fresco::render::RenderTree;
 use vize_fresco::terminal::{Backend, Buffer, Style};
@@ -247,6 +249,22 @@ fn benchmark_headless_snapshot(c: &mut Criterion) {
     group.finish();
 }
 
+fn benchmark_diagnostic_keymap(c: &mut Criterion) {
+    let keymap = DiagnosticWorkspaceKeymap::default();
+    let navigation = KeyEvent::key(Key::Down);
+    let action = KeyEvent::char('/');
+    let mut group = c.benchmark_group("diagnostic_keymap");
+
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("resolve_navigation", |b| {
+        b.iter(|| black_box(keymap.resolve(black_box(&navigation))));
+    });
+    group.bench_function("resolve_action", |b| {
+        b.iter(|| black_box(keymap.resolve(black_box(&action))));
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     benchmark_buffer_set_string,
@@ -258,5 +276,6 @@ criterion_group!(
     benchmark_injected_backend_output,
     benchmark_diagnostic_workspace,
     benchmark_headless_snapshot,
+    benchmark_diagnostic_keymap,
 );
 criterion_main!(benches);

--- a/crates/vize_fresco/src/component.rs
+++ b/crates/vize_fresco/src/component.rs
@@ -16,7 +16,9 @@ mod virtual_list_tests;
 
 pub use box_node::BoxNode;
 pub use diagnostic_workspace::{
-    DiagnosticWorkspaceFocus, DiagnosticWorkspaceLayout, DiagnosticWorkspaceMode,
+    DiagnosticKeyBinding, DiagnosticKeyChord, DiagnosticKeymapError, DiagnosticWorkspaceAction,
+    DiagnosticWorkspaceCommand, DiagnosticWorkspaceCommandOutcome, DiagnosticWorkspaceFocus,
+    DiagnosticWorkspaceKeymap, DiagnosticWorkspaceLayout, DiagnosticWorkspaceMode,
     DiagnosticWorkspaceOptions, DiagnosticWorkspacePane, DiagnosticWorkspaceState,
 };
 pub use input_node::InputNode;

--- a/crates/vize_fresco/src/component/diagnostic_workspace.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace.rs
@@ -1,12 +1,22 @@
 //! Semantic state for large master-detail diagnostic workspaces.
 
+mod command;
+mod keymap;
 mod layout;
 
+#[cfg(test)]
+mod command_tests;
 #[cfg(test)]
 mod tests;
 
 use super::{VirtualListNavigation, VirtualListState, VirtualWindow};
 
+pub use command::{
+    DiagnosticWorkspaceAction, DiagnosticWorkspaceCommand, DiagnosticWorkspaceCommandOutcome,
+};
+pub use keymap::{
+    DiagnosticKeyBinding, DiagnosticKeyChord, DiagnosticKeymapError, DiagnosticWorkspaceKeymap,
+};
 pub use layout::{
     DiagnosticWorkspaceLayout, DiagnosticWorkspaceMode, DiagnosticWorkspaceOptions,
     DiagnosticWorkspacePane,

--- a/crates/vize_fresco/src/component/diagnostic_workspace/command.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/command.rs
@@ -1,0 +1,278 @@
+//! Semantic commands shared by diagnostic workspace input adapters.
+
+use serde::{Deserialize, Serialize};
+
+use super::{DiagnosticWorkspaceFocus, DiagnosticWorkspaceState, VirtualListNavigation};
+
+/// A semantic diagnostic-workspace command.
+///
+/// Commands intentionally describe user intent instead of physical keys. A
+/// terminal, GUI, accessibility adapter, or test can therefore drive the same
+/// workspace state without duplicating navigation behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DiagnosticWorkspaceCommand {
+    /// Select the following finding without wrapping.
+    NextFinding,
+    /// Select the preceding finding without wrapping.
+    PreviousFinding,
+    /// Select a finding one viewport toward the end.
+    PageDownFindings,
+    /// Select a finding one viewport toward the start.
+    PageUpFindings,
+    /// Select the first finding.
+    FirstFinding,
+    /// Select the last finding.
+    LastFinding,
+    /// Select the following related-evidence item without wrapping.
+    NextEvidence,
+    /// Select the preceding related-evidence item without wrapping.
+    PreviousEvidence,
+    /// Scroll the detail presentation down by one row.
+    ScrollDetailDown,
+    /// Scroll the detail presentation up by one row.
+    ScrollDetailUp,
+    /// Scroll the detail presentation one viewport toward the end.
+    PageDownDetail,
+    /// Scroll the detail presentation one viewport toward the start.
+    PageUpDetail,
+    /// Move keyboard focus to the following available semantic pane.
+    FocusNext,
+    /// Move keyboard focus to the preceding available semantic pane.
+    FocusPrevious,
+    /// Request the following category-filter value.
+    NextCategory,
+    /// Request the preceding category-filter value.
+    PreviousCategory,
+    /// Request the following severity-filter value.
+    NextSeverity,
+    /// Request the preceding severity-filter value.
+    PreviousSeverity,
+    /// Request interactive search.
+    Search,
+    /// Request opening the selected finding's primary source location.
+    OpenSource,
+    /// Request the keyboard help presentation.
+    Help,
+    /// Request a clean interactive-session exit.
+    Exit,
+}
+
+impl DiagnosticWorkspaceCommand {
+    /// Return a stable machine-readable command name.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NextFinding => "next-finding",
+            Self::PreviousFinding => "previous-finding",
+            Self::PageDownFindings => "page-down-findings",
+            Self::PageUpFindings => "page-up-findings",
+            Self::FirstFinding => "first-finding",
+            Self::LastFinding => "last-finding",
+            Self::NextEvidence => "next-evidence",
+            Self::PreviousEvidence => "previous-evidence",
+            Self::ScrollDetailDown => "scroll-detail-down",
+            Self::ScrollDetailUp => "scroll-detail-up",
+            Self::PageDownDetail => "page-down-detail",
+            Self::PageUpDetail => "page-up-detail",
+            Self::FocusNext => "focus-next",
+            Self::FocusPrevious => "focus-previous",
+            Self::NextCategory => "next-category",
+            Self::PreviousCategory => "previous-category",
+            Self::NextSeverity => "next-severity",
+            Self::PreviousSeverity => "previous-severity",
+            Self::Search => "search",
+            Self::OpenSource => "open-source",
+            Self::Help => "help",
+            Self::Exit => "exit",
+        }
+    }
+
+    /// Return a concise human-readable description for help and key hints.
+    pub const fn description(self) -> &'static str {
+        match self {
+            Self::NextFinding => "Next finding",
+            Self::PreviousFinding => "Previous finding",
+            Self::PageDownFindings => "Next page of findings",
+            Self::PageUpFindings => "Previous page of findings",
+            Self::FirstFinding => "First finding",
+            Self::LastFinding => "Last finding",
+            Self::NextEvidence => "Next evidence",
+            Self::PreviousEvidence => "Previous evidence",
+            Self::ScrollDetailDown => "Scroll detail down",
+            Self::ScrollDetailUp => "Scroll detail up",
+            Self::PageDownDetail => "Scroll detail one page down",
+            Self::PageUpDetail => "Scroll detail one page up",
+            Self::FocusNext => "Focus next pane",
+            Self::FocusPrevious => "Focus previous pane",
+            Self::NextCategory => "Next category filter",
+            Self::PreviousCategory => "Previous category filter",
+            Self::NextSeverity => "Next severity filter",
+            Self::PreviousSeverity => "Previous severity filter",
+            Self::Search => "Search findings",
+            Self::OpenSource => "Open source location",
+            Self::Help => "Show keyboard help",
+            Self::Exit => "Exit",
+        }
+    }
+
+    /// Return whether holding the key may safely repeat this command.
+    ///
+    /// Navigation and scrolling repeat. Focus, filters, modal actions, source
+    /// actions, and exit are press-only so one long key press cannot cycle state
+    /// unpredictably or launch an action more than once.
+    pub const fn accepts_repeat(self) -> bool {
+        matches!(
+            self,
+            Self::NextFinding
+                | Self::PreviousFinding
+                | Self::PageDownFindings
+                | Self::PageUpFindings
+                | Self::FirstFinding
+                | Self::LastFinding
+                | Self::NextEvidence
+                | Self::PreviousEvidence
+                | Self::ScrollDetailDown
+                | Self::ScrollDetailUp
+                | Self::PageDownDetail
+                | Self::PageUpDetail
+        )
+    }
+
+    const fn action(self) -> Option<DiagnosticWorkspaceAction> {
+        match self {
+            Self::NextCategory => Some(DiagnosticWorkspaceAction::NextCategory),
+            Self::PreviousCategory => Some(DiagnosticWorkspaceAction::PreviousCategory),
+            Self::NextSeverity => Some(DiagnosticWorkspaceAction::NextSeverity),
+            Self::PreviousSeverity => Some(DiagnosticWorkspaceAction::PreviousSeverity),
+            Self::Search => Some(DiagnosticWorkspaceAction::Search),
+            Self::OpenSource => Some(DiagnosticWorkspaceAction::OpenSource),
+            Self::Help => Some(DiagnosticWorkspaceAction::Help),
+            Self::Exit => Some(DiagnosticWorkspaceAction::Exit),
+            _ => None,
+        }
+    }
+}
+
+/// An application-owned action emitted by a workspace command.
+///
+/// Fresco owns deterministic navigation state, but it does not own filter
+/// vocabularies, an editor launcher, modal presentation, or process lifetime.
+/// Those operations are returned to the application through this enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DiagnosticWorkspaceAction {
+    /// Advance the application's category filter.
+    NextCategory,
+    /// Move the application's category filter backward.
+    PreviousCategory,
+    /// Advance the application's severity filter.
+    NextSeverity,
+    /// Move the application's severity filter backward.
+    PreviousSeverity,
+    /// Open the application's search interaction.
+    Search,
+    /// Open the selected finding's primary source location.
+    OpenSource,
+    /// Open the keyboard help presentation.
+    Help,
+    /// End the interactive session through its normal restoration path.
+    Exit,
+}
+
+/// Result of applying a semantic command to workspace state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticWorkspaceCommandOutcome {
+    /// Fresco changed selection, focus, or scroll state.
+    Changed,
+    /// The command was valid but the relevant list or scroll range was empty or
+    /// already at its non-wrapping boundary.
+    Boundary,
+    /// The application must perform an operation outside Fresco-owned state.
+    Dispatch(DiagnosticWorkspaceAction),
+}
+
+impl<FindingKey: Clone + Eq, EvidenceKey: Clone + Eq>
+    DiagnosticWorkspaceState<FindingKey, EvidenceKey>
+{
+    /// Apply a semantic command to the workspace's bounded state.
+    ///
+    /// `finding_keys` and `evidence_keys` remain application-owned immutable
+    /// report data. Navigation automatically synchronizes stale stable-key
+    /// selections. Application operations are returned as [`Dispatch`](DiagnosticWorkspaceCommandOutcome::Dispatch).
+    #[must_use]
+    pub fn apply_command(
+        &mut self,
+        command: DiagnosticWorkspaceCommand,
+        finding_keys: &[FindingKey],
+        evidence_keys: &[EvidenceKey],
+    ) -> DiagnosticWorkspaceCommandOutcome {
+        if let Some(action) = command.action() {
+            if action == DiagnosticWorkspaceAction::OpenSource
+                && self.findings.selected_key().is_none()
+            {
+                return DiagnosticWorkspaceCommandOutcome::Boundary;
+            }
+            return DiagnosticWorkspaceCommandOutcome::Dispatch(action);
+        }
+
+        let changed = match command {
+            DiagnosticWorkspaceCommand::NextFinding => {
+                self.navigate_findings(finding_keys, VirtualListNavigation::Next)
+            }
+            DiagnosticWorkspaceCommand::PreviousFinding => {
+                self.navigate_findings(finding_keys, VirtualListNavigation::Previous)
+            }
+            DiagnosticWorkspaceCommand::PageDownFindings => {
+                self.navigate_findings(finding_keys, VirtualListNavigation::PageDown)
+            }
+            DiagnosticWorkspaceCommand::PageUpFindings => {
+                self.navigate_findings(finding_keys, VirtualListNavigation::PageUp)
+            }
+            DiagnosticWorkspaceCommand::FirstFinding => {
+                self.navigate_findings(finding_keys, VirtualListNavigation::First)
+            }
+            DiagnosticWorkspaceCommand::LastFinding => {
+                self.navigate_findings(finding_keys, VirtualListNavigation::Last)
+            }
+            DiagnosticWorkspaceCommand::NextEvidence => {
+                self.navigate_and_focus_evidence(evidence_keys, VirtualListNavigation::Next)
+            }
+            DiagnosticWorkspaceCommand::PreviousEvidence => {
+                self.navigate_and_focus_evidence(evidence_keys, VirtualListNavigation::Previous)
+            }
+            DiagnosticWorkspaceCommand::ScrollDetailDown => self.scroll_detail(1),
+            DiagnosticWorkspaceCommand::ScrollDetailUp => self.scroll_detail(-1),
+            DiagnosticWorkspaceCommand::PageDownDetail => {
+                self.scroll_detail(self.detail_page_rows() as isize)
+            }
+            DiagnosticWorkspaceCommand::PageUpDetail => {
+                self.scroll_detail(-(self.detail_page_rows() as isize))
+            }
+            DiagnosticWorkspaceCommand::FocusNext => self.focus_next(),
+            DiagnosticWorkspaceCommand::FocusPrevious => self.focus_previous(),
+            _ => unreachable!("application commands returned before state dispatch"),
+        };
+
+        if changed {
+            DiagnosticWorkspaceCommandOutcome::Changed
+        } else {
+            DiagnosticWorkspaceCommandOutcome::Boundary
+        }
+    }
+
+    fn navigate_and_focus_evidence(
+        &mut self,
+        evidence_keys: &[EvidenceKey],
+        navigation: VirtualListNavigation,
+    ) -> bool {
+        let navigated = self.navigate_evidence(evidence_keys, navigation);
+        let focused = self.set_focus(DiagnosticWorkspaceFocus::Evidence);
+        navigated || focused
+    }
+
+    fn detail_page_rows(&self) -> usize {
+        usize::from(self.layout.content().height)
+            .saturating_sub(1)
+            .max(1)
+    }
+}

--- a/crates/vize_fresco/src/component/diagnostic_workspace/command_tests.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/command_tests.rs
@@ -1,0 +1,154 @@
+use super::{
+    DiagnosticWorkspaceAction, DiagnosticWorkspaceCommand as Command,
+    DiagnosticWorkspaceCommandOutcome as Outcome, DiagnosticWorkspaceFocus,
+    DiagnosticWorkspaceState,
+};
+
+#[test]
+fn finding_commands_are_stable_bounded_and_page_aware() {
+    let findings = (0_u64..100).collect::<Vec<_>>();
+    let mut state = DiagnosticWorkspaceState::<u64, u64>::new(120, 10);
+
+    assert_eq!(
+        state.apply_command(Command::NextFinding, &findings, &[]),
+        Outcome::Changed
+    );
+    assert_eq!(state.findings().selected_key(), Some(&1));
+    assert_eq!(
+        state.apply_command(Command::PageDownFindings, &findings, &[]),
+        Outcome::Changed
+    );
+    assert_eq!(state.findings().selected_key(), Some(&7));
+    assert_eq!(
+        state.apply_command(Command::LastFinding, &findings, &[]),
+        Outcome::Changed
+    );
+    assert_eq!(state.findings().selected_key(), Some(&99));
+    assert_eq!(
+        state.apply_command(Command::NextFinding, &findings, &[]),
+        Outcome::Boundary
+    );
+    assert_eq!(state.findings().selected_key(), Some(&99));
+}
+
+#[test]
+fn evidence_commands_focus_available_evidence_and_fail_closed_when_empty() {
+    let findings = [1_u64];
+    let evidence = [10_u64, 11, 12];
+    let mut state = DiagnosticWorkspaceState::new(100, 20);
+    let _ = state.reconcile_findings(&findings);
+
+    assert_eq!(
+        state.apply_command(Command::NextEvidence, &findings, &[]),
+        Outcome::Boundary
+    );
+    assert_eq!(state.focus(), DiagnosticWorkspaceFocus::Findings);
+
+    let _ = state.reconcile_evidence(&evidence);
+    assert_eq!(
+        state.apply_command(Command::NextEvidence, &findings, &evidence),
+        Outcome::Changed
+    );
+    assert_eq!(state.evidence().selected_key(), Some(&11));
+    assert_eq!(state.focus(), DiagnosticWorkspaceFocus::Evidence);
+    assert_eq!(
+        state.apply_command(Command::PreviousEvidence, &findings, &evidence),
+        Outcome::Changed
+    );
+    assert_eq!(state.evidence().selected_key(), Some(&10));
+}
+
+#[test]
+fn detail_scroll_and_focus_commands_use_explicit_non_wrapping_boundaries() {
+    let mut state = DiagnosticWorkspaceState::<u64, u64>::new(100, 20);
+    let _ = state.set_detail_content_rows(100);
+
+    assert_eq!(
+        state.apply_command(Command::PageDownDetail, &[], &[]),
+        Outcome::Changed
+    );
+    assert_eq!(state.detail_scroll(), 16);
+    assert_eq!(
+        state.apply_command(Command::ScrollDetailUp, &[], &[]),
+        Outcome::Changed
+    );
+    assert_eq!(state.detail_scroll(), 15);
+    assert_eq!(
+        state.apply_command(Command::FocusNext, &[], &[]),
+        Outcome::Changed
+    );
+    assert_eq!(state.focus(), DiagnosticWorkspaceFocus::Detail);
+
+    let _ = state.scroll_detail(isize::MIN);
+    assert_eq!(
+        state.apply_command(Command::ScrollDetailUp, &[], &[]),
+        Outcome::Boundary
+    );
+}
+
+#[test]
+fn application_actions_dispatch_without_mutating_workspace_state() {
+    let findings = [7_u64];
+    let mut state = DiagnosticWorkspaceState::<u64, u64>::new(100, 20);
+    let cases = [
+        (
+            Command::NextCategory,
+            DiagnosticWorkspaceAction::NextCategory,
+        ),
+        (
+            Command::PreviousCategory,
+            DiagnosticWorkspaceAction::PreviousCategory,
+        ),
+        (
+            Command::NextSeverity,
+            DiagnosticWorkspaceAction::NextSeverity,
+        ),
+        (
+            Command::PreviousSeverity,
+            DiagnosticWorkspaceAction::PreviousSeverity,
+        ),
+        (Command::Search, DiagnosticWorkspaceAction::Search),
+        (Command::Help, DiagnosticWorkspaceAction::Help),
+        (Command::Exit, DiagnosticWorkspaceAction::Exit),
+    ];
+
+    for (command, action) in cases {
+        assert_eq!(
+            state.apply_command(command, &findings, &[]),
+            Outcome::Dispatch(action)
+        );
+    }
+    assert_eq!(state.focus(), DiagnosticWorkspaceFocus::Findings);
+    assert_eq!(state.findings().selected_key(), None);
+}
+
+#[test]
+fn open_source_requires_a_selected_finding() {
+    let findings = [7_u64];
+    let mut state = DiagnosticWorkspaceState::<u64, u64>::new(100, 20);
+
+    assert_eq!(
+        state.apply_command(Command::OpenSource, &findings, &[]),
+        Outcome::Boundary
+    );
+    let _ = state.reconcile_findings(&findings);
+    assert_eq!(
+        state.apply_command(Command::OpenSource, &findings, &[]),
+        Outcome::Dispatch(DiagnosticWorkspaceAction::OpenSource)
+    );
+}
+
+#[test]
+fn command_names_descriptions_and_wire_values_are_stable() {
+    let command = Command::PageDownFindings;
+    assert_eq!(command.as_str(), "page-down-findings");
+    assert_eq!(command.description(), "Next page of findings");
+    assert_eq!(
+        serde_json::to_string(&command).unwrap(),
+        "\"page-down-findings\""
+    );
+    assert_eq!(
+        serde_json::from_str::<Command>("\"page-down-findings\"").unwrap(),
+        command
+    );
+}

--- a/crates/vize_fresco/src/component/diagnostic_workspace/keymap.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/keymap.rs
@@ -1,0 +1,285 @@
+//! Deterministic physical-key to semantic-command mapping.
+
+mod defaults;
+
+#[cfg(test)]
+mod tests;
+
+use std::fmt;
+
+use rustc_hash::FxHashMap;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use vize_carton::{String, ToCompactString};
+
+use super::DiagnosticWorkspaceCommand;
+use crate::input::{Key, KeyEvent, KeyEventKind, KeyModifiers};
+
+/// A canonical physical key and modifier combination.
+///
+/// Canonicalization accounts for common terminal differences: uppercase ASCII
+/// letters imply Shift, Shift is ignored when a character is itself a shifted
+/// ASCII symbol such as `?`, and `BackTab` already carries its Shift meaning.
+/// All non-Shift modifiers remain exact. Consequently, `Ctrl+C` never matches
+/// plain `C`, and an unsupported modified chord fails closed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DiagnosticKeyChord {
+    /// Physical or character key.
+    pub key: Key,
+    /// Exact canonical modifier set.
+    pub modifiers: KeyModifiers,
+}
+
+impl DiagnosticKeyChord {
+    /// Create and canonicalize a chord.
+    pub fn new(key: Key, modifiers: KeyModifiers) -> Self {
+        Self { key, modifiers }.canonicalized()
+    }
+
+    /// Create an unmodified chord.
+    pub fn key(key: Key) -> Self {
+        Self::new(key, KeyModifiers::NONE)
+    }
+
+    /// Create an unmodified character chord.
+    pub fn char(character: char) -> Self {
+        Self::key(Key::Char(character))
+    }
+
+    /// Create a Ctrl-modified character chord.
+    pub fn ctrl(character: char) -> Self {
+        Self::new(
+            Key::Char(character),
+            KeyModifiers {
+                ctrl: true,
+                ..KeyModifiers::NONE
+            },
+        )
+    }
+
+    /// Create a Shift-modified character chord.
+    pub fn shift(character: char) -> Self {
+        Self::new(
+            Key::Char(character),
+            KeyModifiers {
+                shift: true,
+                ..KeyModifiers::NONE
+            },
+        )
+    }
+
+    /// Return a deterministic, compact label for help and key hints.
+    pub fn label(self) -> String {
+        self.to_compact_string()
+    }
+
+    fn from_event(event: &KeyEvent) -> Self {
+        Self::new(event.key, event.modifiers)
+    }
+
+    fn canonicalized(mut self) -> Self {
+        match self.key {
+            Key::Char(character) if character.is_ascii_uppercase() => {
+                self.key = Key::Char(character.to_ascii_lowercase());
+                self.modifiers.shift = true;
+            }
+            Key::Char(character) if is_shifted_ascii_symbol(character) => {
+                self.modifiers.shift = false;
+            }
+            Key::BackTab => self.modifiers.shift = false,
+            _ => {}
+        }
+        self
+    }
+}
+
+fn is_shifted_ascii_symbol(character: char) -> bool {
+    matches!(
+        character,
+        '~' | '!'
+            | '@'
+            | '#'
+            | '$'
+            | '%'
+            | '^'
+            | '&'
+            | '*'
+            | '('
+            | ')'
+            | '_'
+            | '+'
+            | '{'
+            | '}'
+            | '|'
+            | ':'
+            | '"'
+            | '<'
+            | '>'
+            | '?'
+    )
+}
+
+impl fmt::Display for DiagnosticKeyChord {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let chord = self.canonicalized();
+        for (active, name) in [
+            (chord.modifiers.ctrl, "Ctrl"),
+            (chord.modifiers.alt, "Alt"),
+            (chord.modifiers.shift, "Shift"),
+            (chord.modifiers.super_key, "Super"),
+            (chord.modifiers.hyper, "Hyper"),
+            (chord.modifiers.meta, "Meta"),
+        ] {
+            if active {
+                write!(formatter, "{name}+")?;
+            }
+        }
+        write_key_label(formatter, chord.key)
+    }
+}
+
+/// One deterministic key-to-command assignment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiagnosticKeyBinding {
+    /// Canonical key chord.
+    pub chord: DiagnosticKeyChord,
+    /// Semantic command emitted by the chord.
+    pub command: DiagnosticWorkspaceCommand,
+}
+
+impl DiagnosticKeyBinding {
+    /// Create a binding and canonicalize its chord.
+    pub fn new(chord: DiagnosticKeyChord, command: DiagnosticWorkspaceCommand) -> Self {
+        Self {
+            chord: chord.canonicalized(),
+            command,
+        }
+    }
+}
+
+/// Invalid custom diagnostic keymap.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum DiagnosticKeymapError {
+    /// Two bindings canonicalize to the same physical chord.
+    #[error("diagnostic key chord {chord} maps to both {existing:?} and {duplicate:?}")]
+    DuplicateChord {
+        /// Conflicting canonical chord.
+        chord: DiagnosticKeyChord,
+        /// Command registered first.
+        existing: DiagnosticWorkspaceCommand,
+        /// Later conflicting command.
+        duplicate: DiagnosticWorkspaceCommand,
+    },
+}
+
+/// Validated diagnostic-workspace keyboard contract.
+///
+/// Construction allocates once. Event resolution performs one canonicalization
+/// and one hash lookup with no allocation. Binding order is retained for stable
+/// help presentation, while lookup behavior is independent of that order.
+///
+/// ```
+/// # #[cfg(not(feature = "napi"))]
+/// # {
+/// use vize_fresco::{DiagnosticWorkspaceCommand, DiagnosticWorkspaceKeymap, KeyEvent};
+///
+/// let keymap = DiagnosticWorkspaceKeymap::default();
+/// assert_eq!(
+///     keymap.resolve(&KeyEvent::char('/')),
+///     Some(DiagnosticWorkspaceCommand::Search),
+/// );
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct DiagnosticWorkspaceKeymap {
+    bindings: Vec<DiagnosticKeyBinding>,
+    commands: FxHashMap<DiagnosticKeyChord, DiagnosticWorkspaceCommand>,
+}
+
+impl DiagnosticWorkspaceKeymap {
+    /// Validate and build a custom keymap.
+    ///
+    /// Duplicate chords fail closed, including collisions introduced by
+    /// terminal canonicalization such as uppercase `C` and `Shift+C`.
+    pub fn new(
+        bindings: impl IntoIterator<Item = DiagnosticKeyBinding>,
+    ) -> Result<Self, DiagnosticKeymapError> {
+        let bindings = bindings
+            .into_iter()
+            .map(|binding| DiagnosticKeyBinding::new(binding.chord, binding.command))
+            .collect::<Vec<_>>();
+        let mut commands = FxHashMap::with_capacity_and_hasher(bindings.len(), Default::default());
+        for binding in &bindings {
+            let chord = binding.chord.canonicalized();
+            if let Some(existing) = commands.insert(chord, binding.command) {
+                return Err(DiagnosticKeymapError::DuplicateChord {
+                    chord,
+                    existing,
+                    duplicate: binding.command,
+                });
+            }
+        }
+        Ok(Self { bindings, commands })
+    }
+
+    /// Return the stable binding order used by help presentations.
+    pub fn bindings(&self) -> &[DiagnosticKeyBinding] {
+        &self.bindings
+    }
+
+    /// Resolve a normalized terminal event into a semantic command.
+    ///
+    /// Release events are ignored. Repeat events resolve only for commands
+    /// whose repeat behavior is explicitly safe. Unknown and over-modified
+    /// events return `None`.
+    pub fn resolve(&self, event: &KeyEvent) -> Option<DiagnosticWorkspaceCommand> {
+        if event.kind == KeyEventKind::Release {
+            return None;
+        }
+        let command = self
+            .commands
+            .get(&DiagnosticKeyChord::from_event(event))
+            .copied()?;
+        if event.kind == KeyEventKind::Repeat && !command.accepts_repeat() {
+            return None;
+        }
+        Some(command)
+    }
+
+    pub(super) fn from_valid_defaults(bindings: Vec<DiagnosticKeyBinding>) -> Self {
+        let commands = bindings
+            .iter()
+            .map(|binding| (binding.chord.canonicalized(), binding.command))
+            .collect();
+        Self { bindings, commands }
+    }
+}
+
+fn write_key_label(formatter: &mut fmt::Formatter<'_>, key: Key) -> fmt::Result {
+    match key {
+        Key::Char(character) => write!(formatter, "{character}"),
+        Key::F(number) => write!(formatter, "F{number}"),
+        Key::Backspace => formatter.write_str("Backspace"),
+        Key::Enter => formatter.write_str("Enter"),
+        Key::Left => formatter.write_str("Left"),
+        Key::Right => formatter.write_str("Right"),
+        Key::Up => formatter.write_str("Up"),
+        Key::Down => formatter.write_str("Down"),
+        Key::Home => formatter.write_str("Home"),
+        Key::End => formatter.write_str("End"),
+        Key::PageUp => formatter.write_str("PgUp"),
+        Key::PageDown => formatter.write_str("PgDn"),
+        Key::Tab => formatter.write_str("Tab"),
+        Key::BackTab => formatter.write_str("Shift+Tab"),
+        Key::Delete => formatter.write_str("Delete"),
+        Key::Insert => formatter.write_str("Insert"),
+        Key::Esc => formatter.write_str("Esc"),
+        Key::CapsLock => formatter.write_str("CapsLock"),
+        Key::ScrollLock => formatter.write_str("ScrollLock"),
+        Key::NumLock => formatter.write_str("NumLock"),
+        Key::PrintScreen => formatter.write_str("PrintScreen"),
+        Key::Pause => formatter.write_str("Pause"),
+        Key::Menu => formatter.write_str("Menu"),
+        Key::Null => formatter.write_str("Null"),
+    }
+}

--- a/crates/vize_fresco/src/component/diagnostic_workspace/keymap/defaults.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/keymap/defaults.rs
@@ -1,0 +1,62 @@
+use super::{DiagnosticKeyBinding, DiagnosticKeyChord, DiagnosticWorkspaceKeymap};
+use crate::component::DiagnosticWorkspaceCommand;
+use crate::input::Key;
+
+impl Default for DiagnosticWorkspaceKeymap {
+    /// Build Fresco's portable diagnostic-workspace key contract.
+    ///
+    /// Arrow keys coexist with Vim-style finding navigation. Filters and modal
+    /// actions are press-only; navigation and scrolling may repeat. No default
+    /// chord uses Alt, Super, Hyper, or Meta, preserving terminal and window
+    /// manager conventions.
+    fn default() -> Self {
+        use DiagnosticWorkspaceCommand as Command;
+
+        let bindings = vec![
+            binding(DiagnosticKeyChord::key(Key::Down), Command::NextFinding),
+            binding(DiagnosticKeyChord::char('j'), Command::NextFinding),
+            binding(DiagnosticKeyChord::key(Key::Up), Command::PreviousFinding),
+            binding(DiagnosticKeyChord::char('k'), Command::PreviousFinding),
+            binding(
+                DiagnosticKeyChord::key(Key::PageDown),
+                Command::PageDownFindings,
+            ),
+            binding(
+                DiagnosticKeyChord::key(Key::PageUp),
+                Command::PageUpFindings,
+            ),
+            binding(DiagnosticKeyChord::key(Key::Home), Command::FirstFinding),
+            binding(DiagnosticKeyChord::char('g'), Command::FirstFinding),
+            binding(DiagnosticKeyChord::key(Key::End), Command::LastFinding),
+            binding(DiagnosticKeyChord::shift('g'), Command::LastFinding),
+            binding(DiagnosticKeyChord::char(']'), Command::NextEvidence),
+            binding(DiagnosticKeyChord::char('['), Command::PreviousEvidence),
+            binding(DiagnosticKeyChord::ctrl('e'), Command::ScrollDetailDown),
+            binding(DiagnosticKeyChord::ctrl('y'), Command::ScrollDetailUp),
+            binding(DiagnosticKeyChord::ctrl('d'), Command::PageDownDetail),
+            binding(DiagnosticKeyChord::ctrl('u'), Command::PageUpDetail),
+            binding(DiagnosticKeyChord::key(Key::Tab), Command::FocusNext),
+            binding(
+                DiagnosticKeyChord::key(Key::BackTab),
+                Command::FocusPrevious,
+            ),
+            binding(DiagnosticKeyChord::char('c'), Command::NextCategory),
+            binding(DiagnosticKeyChord::shift('c'), Command::PreviousCategory),
+            binding(DiagnosticKeyChord::char('s'), Command::NextSeverity),
+            binding(DiagnosticKeyChord::shift('s'), Command::PreviousSeverity),
+            binding(DiagnosticKeyChord::char('/'), Command::Search),
+            binding(DiagnosticKeyChord::char('o'), Command::OpenSource),
+            binding(DiagnosticKeyChord::char('?'), Command::Help),
+            binding(DiagnosticKeyChord::key(Key::F(1)), Command::Help),
+            binding(DiagnosticKeyChord::char('q'), Command::Exit),
+            binding(DiagnosticKeyChord::key(Key::Esc), Command::Exit),
+            binding(DiagnosticKeyChord::ctrl('c'), Command::Exit),
+        ];
+
+        DiagnosticWorkspaceKeymap::from_valid_defaults(bindings)
+    }
+}
+
+fn binding(chord: DiagnosticKeyChord, command: DiagnosticWorkspaceCommand) -> DiagnosticKeyBinding {
+    DiagnosticKeyBinding::new(chord, command)
+}

--- a/crates/vize_fresco/src/component/diagnostic_workspace/keymap/tests.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/keymap/tests.rs
@@ -1,0 +1,243 @@
+use super::{
+    DiagnosticKeyBinding, DiagnosticKeyChord, DiagnosticKeymapError, DiagnosticWorkspaceKeymap,
+};
+use crate::component::DiagnosticWorkspaceCommand as Command;
+use crate::input::{Key, KeyEvent, KeyEventKind, KeyModifiers};
+
+#[test]
+fn defaults_cover_every_required_diagnostic_interaction() {
+    let keymap = DiagnosticWorkspaceKeymap::default();
+    let commands = keymap
+        .bindings()
+        .iter()
+        .map(|binding| binding.command)
+        .collect::<Vec<_>>();
+
+    for required in [
+        Command::NextFinding,
+        Command::PreviousFinding,
+        Command::NextCategory,
+        Command::PreviousCategory,
+        Command::NextSeverity,
+        Command::PreviousSeverity,
+        Command::Search,
+        Command::NextEvidence,
+        Command::PreviousEvidence,
+        Command::OpenSource,
+        Command::Help,
+        Command::Exit,
+    ] {
+        assert!(commands.contains(&required), "missing {required:?}");
+    }
+
+    DiagnosticWorkspaceKeymap::new(keymap.bindings().iter().copied()).unwrap();
+}
+
+#[test]
+fn default_navigation_supports_arrows_vim_keys_and_safe_repeat() {
+    let keymap = DiagnosticWorkspaceKeymap::default();
+
+    assert_eq!(
+        keymap.resolve(&KeyEvent::key(Key::Down)),
+        Some(Command::NextFinding)
+    );
+    assert_eq!(
+        keymap.resolve(&KeyEvent::char('k')),
+        Some(Command::PreviousFinding)
+    );
+    assert_eq!(
+        keymap.resolve(&event(
+            Key::Char('j'),
+            KeyModifiers::NONE,
+            KeyEventKind::Repeat
+        )),
+        Some(Command::NextFinding)
+    );
+    assert_eq!(
+        keymap.resolve(&event(
+            Key::Char('j'),
+            KeyModifiers::NONE,
+            KeyEventKind::Release
+        )),
+        None
+    );
+}
+
+#[test]
+fn actions_are_press_only_and_unknown_modifiers_fail_closed() {
+    let keymap = DiagnosticWorkspaceKeymap::default();
+
+    assert_eq!(
+        keymap.resolve(&event(
+            Key::Char('c'),
+            KeyModifiers::NONE,
+            KeyEventKind::Repeat
+        )),
+        None
+    );
+    assert_eq!(
+        keymap.resolve(&event(
+            Key::Char('q'),
+            KeyModifiers {
+                alt: true,
+                ..KeyModifiers::NONE
+            },
+            KeyEventKind::Press,
+        )),
+        None
+    );
+    assert_eq!(
+        keymap.resolve(&event(
+            Key::Char('/'),
+            KeyModifiers {
+                shift: true,
+                ..KeyModifiers::NONE
+            },
+            KeyEventKind::Press,
+        )),
+        None
+    );
+    assert_eq!(
+        keymap.resolve(&event(
+            Key::Char('c'),
+            KeyModifiers {
+                ctrl: true,
+                shift: true,
+                ..KeyModifiers::NONE
+            },
+            KeyEventKind::Press,
+        )),
+        None
+    );
+    assert_eq!(
+        keymap.resolve(&event(
+            Key::Char('c'),
+            KeyModifiers {
+                ctrl: true,
+                ..KeyModifiers::NONE
+            },
+            KeyEventKind::Press,
+        )),
+        Some(Command::Exit)
+    );
+}
+
+#[test]
+fn terminal_shift_variants_resolve_to_one_canonical_chord() {
+    let keymap = DiagnosticWorkspaceKeymap::default();
+
+    assert_eq!(
+        keymap.resolve(&KeyEvent::char('C')),
+        Some(Command::PreviousCategory)
+    );
+    assert_eq!(
+        keymap.resolve(&event(
+            Key::Char('c'),
+            KeyModifiers {
+                shift: true,
+                ..KeyModifiers::NONE
+            },
+            KeyEventKind::Press,
+        )),
+        Some(Command::PreviousCategory)
+    );
+    assert_eq!(
+        keymap.resolve(&event(
+            Key::Char('?'),
+            KeyModifiers {
+                shift: true,
+                ..KeyModifiers::NONE
+            },
+            KeyEventKind::Press,
+        )),
+        Some(Command::Help)
+    );
+    assert_eq!(
+        keymap.resolve(&event(
+            Key::BackTab,
+            KeyModifiers {
+                shift: true,
+                ..KeyModifiers::NONE
+            },
+            KeyEventKind::Press,
+        )),
+        Some(Command::FocusPrevious)
+    );
+}
+
+#[test]
+fn custom_keymaps_reject_collisions_after_canonicalization() {
+    let result = DiagnosticWorkspaceKeymap::new([
+        DiagnosticKeyBinding::new(DiagnosticKeyChord::char('C'), Command::NextCategory),
+        DiagnosticKeyBinding::new(DiagnosticKeyChord::shift('c'), Command::PreviousCategory),
+    ]);
+
+    assert_eq!(
+        result.unwrap_err(),
+        DiagnosticKeymapError::DuplicateChord {
+            chord: DiagnosticKeyChord::shift('c'),
+            existing: Command::NextCategory,
+            duplicate: Command::PreviousCategory,
+        }
+    );
+}
+
+#[test]
+fn custom_keymaps_preserve_help_order_and_resolve_exactly() {
+    let bindings = [
+        DiagnosticKeyBinding::new(DiagnosticKeyChord::char('x'), Command::Help),
+        DiagnosticKeyBinding::new(DiagnosticKeyChord::key(Key::F(12)), Command::Exit),
+    ];
+    let keymap = DiagnosticWorkspaceKeymap::new(bindings).unwrap();
+
+    assert_eq!(keymap.bindings(), &bindings);
+    assert_eq!(keymap.resolve(&KeyEvent::char('x')), Some(Command::Help));
+    assert_eq!(
+        keymap.resolve(&KeyEvent::key(Key::F(12))),
+        Some(Command::Exit)
+    );
+    assert_eq!(keymap.resolve(&KeyEvent::char('q')), None);
+}
+
+#[test]
+fn custom_keymaps_canonicalize_public_field_construction_for_help_and_wire_output() {
+    let raw = DiagnosticKeyBinding {
+        chord: DiagnosticKeyChord {
+            key: Key::Char('C'),
+            modifiers: KeyModifiers::NONE,
+        },
+        command: Command::PreviousCategory,
+    };
+    let keymap = DiagnosticWorkspaceKeymap::new([raw]).unwrap();
+
+    assert_eq!(keymap.bindings()[0].chord, DiagnosticKeyChord::shift('c'));
+    assert_eq!(keymap.bindings()[0].chord.label(), "Shift+c");
+}
+
+#[test]
+fn labels_are_compact_deterministic_and_semantically_shifted() {
+    assert_eq!(DiagnosticKeyChord::ctrl('c').label(), "Ctrl+c");
+    assert_eq!(DiagnosticKeyChord::char('C').label(), "Shift+c");
+    assert_eq!(DiagnosticKeyChord::char('?').label(), "?");
+    assert_eq!(DiagnosticKeyChord::key(Key::PageDown).label(), "PgDn");
+    assert_eq!(DiagnosticKeyChord::key(Key::BackTab).label(), "Shift+Tab");
+}
+
+#[test]
+fn bindings_round_trip_without_changing_command_wire_names() {
+    let binding = DiagnosticKeyBinding::new(DiagnosticKeyChord::ctrl('d'), Command::PageDownDetail);
+    let json = serde_json::to_string(&binding).unwrap();
+    assert!(json.contains("page-down-detail"));
+    assert_eq!(
+        serde_json::from_str::<DiagnosticKeyBinding>(&json).unwrap(),
+        binding
+    );
+}
+
+fn event(key: Key, modifiers: KeyModifiers, kind: KeyEventKind) -> KeyEvent {
+    KeyEvent {
+        key,
+        modifiers,
+        kind,
+    }
+}

--- a/crates/vize_fresco/src/input.rs
+++ b/crates/vize_fresco/src/input.rs
@@ -12,5 +12,5 @@ mod mouse;
 
 pub use event::{Event, poll, poll_nonblocking, read_event};
 pub use ime::ImeState;
-pub use keyboard::{Key, KeyEvent, KeyModifiers};
+pub use keyboard::{Key, KeyEvent, KeyEventKind, KeyModifiers};
 pub use mouse::{MouseButton, MouseEvent, MouseEventKind};

--- a/crates/vize_fresco/src/lib.rs
+++ b/crates/vize_fresco/src/lib.rs
@@ -66,15 +66,18 @@ pub mod napi;
 
 // Re-exports for convenience
 pub use component::{
-    BoxNode, DiagnosticWorkspaceFocus, DiagnosticWorkspaceLayout, DiagnosticWorkspaceMode,
-    DiagnosticWorkspaceOptions, DiagnosticWorkspacePane, DiagnosticWorkspaceState, InputNode,
-    TextNode, VirtualListNavigation, VirtualListState, VirtualWindow,
+    BoxNode, DiagnosticKeyBinding, DiagnosticKeyChord, DiagnosticKeymapError,
+    DiagnosticWorkspaceAction, DiagnosticWorkspaceCommand, DiagnosticWorkspaceCommandOutcome,
+    DiagnosticWorkspaceFocus, DiagnosticWorkspaceKeymap, DiagnosticWorkspaceLayout,
+    DiagnosticWorkspaceMode, DiagnosticWorkspaceOptions, DiagnosticWorkspacePane,
+    DiagnosticWorkspaceState, InputNode, TextNode, VirtualListNavigation, VirtualListState,
+    VirtualWindow,
 };
 pub use headless::{
     AnnouncementPoliteness, HeadlessAnnouncement, HeadlessPresentation, HeadlessRenderError,
     HeadlessRenderer, HeadlessSemanticNode, HeadlessSnapshot, SemanticRole, SemanticState,
 };
-pub use input::{Event, ImeState, KeyEvent, MouseEvent};
+pub use input::{Event, ImeState, Key, KeyEvent, KeyEventKind, KeyModifiers, MouseEvent};
 pub use layout::{FlexStyle, LayoutEngine, Rect};
 pub use render::{RenderNode, RenderTree};
 pub use terminal::{Backend, Buffer, Cell, Cursor, FrameOutputTelemetry};


### PR DESCRIPTION
## Summary

- add a validated, customizable physical-key to semantic-command contract for diagnostic workspaces
- apply navigation, evidence, detail-scroll, and focus commands through Fresco-owned bounded state
- dispatch category, severity, search, source, help, and exit actions to the host application
- expose deterministic compact key labels and stable serialized command names for help presentations and adapters

## Interaction guarantees

- defaults cover arrow and Vim-style finding navigation, paging, evidence traversal, detail scrolling, focus traversal, bidirectional category/severity filters, search, source, help, and exit
- release events are ignored; key repeats are accepted only for selection and scrolling
- source, filter, modal, and exit actions are press-only
- modifiers match exactly and unsupported modified chords fail closed
- terminal variants for uppercase ASCII, shifted symbols, and BackTab canonicalize consistently
- custom keymaps reject canonical chord collisions and retain stable help order
- empty lists and non-wrapping boundaries return an explicit boundary outcome

## Performance

Criterion, 50 samples on Apple Silicon:

- navigation resolution median: 6.26 ns (159.69 million events/s)
- action resolution median: 6.91 ns (144.76 million events/s)
- resolution performs no allocation after one-time keymap construction

## Validation

- cargo fmt --all -- --check
- cargo clippy -p vize_fresco --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS='-D warnings' cargo doc -p vize_fresco --all-features --no-deps
- cargo test -p vize_fresco --all-features (187 unit tests and 1 doctest)
- cargo bench -p vize_fresco --bench render --no-run
- Criterion diagnostic_keymap benchmark with 50 samples

Related: #4155
Related: #3138

<!-- codesmith:autofix:disabled -->
