### PR TITLE
fix(canon): retry transient editor LSP requests

### DIFF
--- a/crates/vize_canon/src/lsp_client.rs
+++ b/crates/vize_canon/src/lsp_client.rs
@@ -118,3 +118,17 @@ pub(crate) struct DiagnosticFetch {
     pub(crate) diagnostics: Vec<Diagnostic>,
     pub(crate) used_cache: bool,
 }
+
+/// Return whether an LSP request failed because its reusable transport became
+/// unusable rather than because the request itself was invalid.
+///
+/// The transport crates currently expose these failures as formatted strings,
+/// so this classifier is deliberately narrow. Callers may rebuild a session
+/// once for these cases; semantic and configuration errors must propagate.
+fn lsp_transport_error_is_transient(error: &str) -> bool {
+    error.contains("protocol error: EOF")
+        || error.contains("EOF while parsing")
+        || error.contains("process is closed: jsonrpc reader")
+        || error.contains("Broken pipe")
+        || error.contains("broken pipe")
+}

--- a/crates/vize_canon/src/lsp_client/diagnostics.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics.rs
@@ -401,7 +401,7 @@ impl CorsaProjectClient {
             match self.request_diagnostics_batch_via_lsp_chunk_once(uris) {
                 Err(error)
                     if attempts < LSP_DIAGNOSTICS_BATCH_TRANSIENT_RETRIES
-                        && lsp_diagnostics_error_is_transient(&error) =>
+                        && super::lsp_transport_error_is_transient(&error) =>
                 {
                     attempts += 1;
                     std::thread::sleep(Duration::from_millis(25));
@@ -517,14 +517,6 @@ fn diagnostics_api_is_unsupported(error: &str) -> bool {
         || error.contains("Unsupported")
         || error.contains("unsupported")
         || error.contains("not supported")
-}
-
-fn lsp_diagnostics_error_is_transient(error: &str) -> bool {
-    error.contains("protocol error: EOF")
-        || error.contains("EOF while parsing")
-        || error.contains("process is closed: jsonrpc reader")
-        || error.contains("Broken pipe")
-        || error.contains("broken pipe")
 }
 
 fn diagnostics_api_error_is_unsupported(error: &impl std::fmt::Display) -> bool {

--- a/crates/vize_canon/src/lsp_client/diagnostics/tests.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics/tests.rs
@@ -1,7 +1,5 @@
-use super::{
-    CorsaError, corsa_diagnostics_error_is_unsupported, diagnostics_api_is_unsupported,
-    lsp_diagnostics_error_is_transient,
-};
+use super::{CorsaError, corsa_diagnostics_error_is_unsupported, diagnostics_api_is_unsupported};
+use crate::lsp_client::lsp_transport_error_is_transient;
 
 // Regression: a missing diagnostics scope on the corsa `ProjectSession`
 // must be detected through the typed `CorsaError::Unsupported` variant
@@ -35,14 +33,14 @@ fn recognizes_unsupported_diagnostics_api_errors() {
 
 #[test]
 fn recognizes_transient_lsp_transport_errors() {
-    assert!(lsp_diagnostics_error_is_transient(
+    assert!(lsp_transport_error_is_transient(
         "protocol error: EOF while parsing a string at line 1 column 150"
     ));
-    assert!(lsp_diagnostics_error_is_transient(
+    assert!(lsp_transport_error_is_transient(
         "Failed to request LSP diagnostics for file:///src/App.vue.ts: process is closed: jsonrpc reader"
     ));
-    assert!(lsp_diagnostics_error_is_transient("Broken pipe"));
-    assert!(!lsp_diagnostics_error_is_transient(
+    assert!(lsp_transport_error_is_transient("Broken pipe"));
+    assert!(!lsp_transport_error_is_transient(
         "TypeScript semantic diagnostics are unavailable"
     ));
 }

--- a/crates/vize_canon/src/lsp_client/editor_lsp/client.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/client.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use vize_carton::{String, cstr};
 
 use super::{CorsaProjectClient, EditorLspSession};
+use crate::lsp_client::lsp_transport_error_is_transient;
 
 impl CorsaProjectClient {
     /// Answer a hover through the editor LSP transport, spawning the session on
@@ -18,7 +19,7 @@ impl CorsaProjectClient {
         if !self.document_texts.contains_key(uri) {
             return Ok(None);
         }
-        self.editor_lsp_session()?.hover(uri, line, character)
+        self.request_with_editor_lsp_recovery(|session| session.hover(uri, line, character))
     }
 
     pub(in crate::lsp_client) fn completion_via_editor_lsp(
@@ -30,7 +31,7 @@ impl CorsaProjectClient {
         if !self.document_texts.contains_key(uri) {
             return Ok(None);
         }
-        self.editor_lsp_session()?.completion(uri, line, character)
+        self.request_with_editor_lsp_recovery(|session| session.completion(uri, line, character))
     }
 
     pub(in crate::lsp_client) fn definition_via_editor_lsp(
@@ -42,7 +43,7 @@ impl CorsaProjectClient {
         if !self.document_texts.contains_key(uri) {
             return Ok(None);
         }
-        self.editor_lsp_session()?.definition(uri, line, character)
+        self.request_with_editor_lsp_recovery(|session| session.definition(uri, line, character))
     }
 
     pub(in crate::lsp_client) fn references_via_editor_lsp(
@@ -55,8 +56,9 @@ impl CorsaProjectClient {
         if !self.document_texts.contains_key(uri) {
             return Ok(None);
         }
-        self.editor_lsp_session()?
-            .references(uri, line, character, include_declaration)
+        self.request_with_editor_lsp_recovery(|session| {
+            session.references(uri, line, character, include_declaration)
+        })
     }
 
     pub(in crate::lsp_client) fn prepare_rename_via_editor_lsp(
@@ -68,8 +70,9 @@ impl CorsaProjectClient {
         if !self.document_texts.contains_key(uri) {
             return Ok(None);
         }
-        self.editor_lsp_session()?
-            .prepare_rename(uri, line, character)
+        self.request_with_editor_lsp_recovery(|session| {
+            session.prepare_rename(uri, line, character)
+        })
     }
 
     pub(in crate::lsp_client) fn rename_via_editor_lsp(
@@ -82,8 +85,9 @@ impl CorsaProjectClient {
         if !self.document_texts.contains_key(uri) {
             return Ok(None);
         }
-        self.editor_lsp_session()?
-            .rename(uri, line, character, new_name)
+        self.request_with_editor_lsp_recovery(|session| {
+            session.rename(uri, line, character, new_name)
+        })
     }
 
     pub(in crate::lsp_client) fn signature_help_via_editor_lsp(
@@ -96,8 +100,29 @@ impl CorsaProjectClient {
         if !self.document_texts.contains_key(uri) {
             return Ok(None);
         }
-        self.editor_lsp_session()?
-            .signature_help(uri, line, character, context)
+        self.request_with_editor_lsp_recovery(|session| {
+            session.signature_help(uri, line, character, context.clone())
+        })
+    }
+
+    /// Execute an idempotent editor query and rebuild the reusable LSP session
+    /// once when its transport has become unusable.
+    ///
+    /// Recreating the session also marks every current virtual document dirty;
+    /// [`editor_lsp_session`](Self::editor_lsp_session) synchronizes that full
+    /// project before the retry. Semantic and protocol-shape failures are never
+    /// retried.
+    fn request_with_editor_lsp_recovery<T>(
+        &mut self,
+        mut request: impl FnMut(&mut EditorLspSession) -> Result<T, String>,
+    ) -> Result<T, String> {
+        let first = self.editor_lsp_session().and_then(&mut request);
+        retry_transient_editor_request(
+            self,
+            first,
+            CorsaProjectClient::retire_editor_lsp,
+            |client| client.editor_lsp_session().and_then(request),
+        )
     }
 
     fn editor_lsp_session(&mut self) -> Result<&mut EditorLspSession, String> {
@@ -130,5 +155,151 @@ impl CorsaProjectClient {
         self.editor_lsp = None;
         self.editor_lsp_documents_dirty = true;
         result
+    }
+}
+
+/// Apply the editor transport's one-retry policy without coupling its state
+/// machine to a concrete process. Keeping this policy generic makes every
+/// branch deterministic under unit test.
+fn retry_transient_editor_request<State, Output>(
+    state: &mut State,
+    first: Result<Output, String>,
+    recover: impl FnOnce(&mut State) -> Result<(), String>,
+    retry: impl FnOnce(&mut State) -> Result<Output, String>,
+) -> Result<Output, String> {
+    let first_error = match first {
+        Ok(output) => return Ok(output),
+        Err(error) if !lsp_transport_error_is_transient(&error) => return Err(error),
+        Err(error) => error,
+    };
+
+    // `retire_editor_lsp` clears the old session even when graceful shutdown
+    // reports an error, so a fresh spawn is still safe and useful.
+    let recovery_error = recover(state).err();
+    match retry(state) {
+        Ok(output) => Ok(output),
+        Err(retry_error) => Err(match recovery_error {
+            Some(recovery_error) => cstr!(
+                "{first_error}; editor LSP session retirement also failed: {recovery_error}; one recovery retry failed: {retry_error}"
+            ),
+            None => cstr!(
+                "{first_error}; one editor LSP transport recovery retry failed: {retry_error}"
+            ),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::retry_transient_editor_request;
+    use vize_carton::{String, cstr};
+
+    #[derive(Default)]
+    struct FakeSession {
+        recoveries: usize,
+        retries: usize,
+    }
+
+    #[test]
+    fn successful_first_request_does_not_recover_or_retry() {
+        let mut session = FakeSession::default();
+        let result = retry_transient_editor_request(
+            &mut session,
+            Ok::<_, String>(41),
+            |_| panic!("successful request must not recover"),
+            |_| panic!("successful request must not retry"),
+        );
+
+        assert_eq!(result.unwrap(), 41);
+        assert_eq!(session.recoveries, 0);
+        assert_eq!(session.retries, 0);
+    }
+
+    #[test]
+    fn transient_failure_recovers_and_retries_exactly_once() {
+        let mut session = FakeSession::default();
+        let result = retry_transient_editor_request(
+            &mut session,
+            Err(cstr!("protocol error: EOF while parsing a string")),
+            |session| {
+                session.recoveries += 1;
+                Ok(())
+            },
+            |session| {
+                session.retries += 1;
+                Ok(42)
+            },
+        );
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(session.recoveries, 1);
+        assert_eq!(session.retries, 1);
+    }
+
+    #[test]
+    fn non_transient_failure_propagates_without_recovery() {
+        let mut session = FakeSession::default();
+        let error = retry_transient_editor_request::<_, ()>(
+            &mut session,
+            Err(cstr!("method not found: textDocument/signatureHelp")),
+            |_| panic!("semantic failure must not recover"),
+            |_| panic!("semantic failure must not retry"),
+        )
+        .unwrap_err();
+
+        assert_eq!(error, "method not found: textDocument/signatureHelp");
+    }
+
+    #[test]
+    fn failed_retry_preserves_both_transport_errors() {
+        let mut session = FakeSession::default();
+        let error = retry_transient_editor_request::<_, ()>(
+            &mut session,
+            Err(cstr!("protocol error: EOF while parsing first response")),
+            |session| {
+                session.recoveries += 1;
+                Ok(())
+            },
+            |session| {
+                session.retries += 1;
+                Err(cstr!("process is closed: jsonrpc reader"))
+            },
+        )
+        .unwrap_err();
+
+        assert!(error.contains("EOF while parsing first response"));
+        assert!(error.contains("process is closed: jsonrpc reader"));
+        assert_eq!(session.recoveries, 1);
+        assert_eq!(session.retries, 1);
+    }
+
+    #[test]
+    fn recovery_error_does_not_prevent_a_fresh_retry_and_is_retained_on_failure() {
+        let mut successful = FakeSession::default();
+        let result = retry_transient_editor_request(
+            &mut successful,
+            Err(cstr!("Broken pipe")),
+            |session| {
+                session.recoveries += 1;
+                Err(cstr!("shutdown acknowledgement timed out"))
+            },
+            |session| {
+                session.retries += 1;
+                Ok(7)
+            },
+        );
+        assert_eq!(result.unwrap(), 7);
+
+        let mut failed = FakeSession::default();
+        let error = retry_transient_editor_request::<_, ()>(
+            &mut failed,
+            Err(cstr!("Broken pipe")),
+            |_| Err(cstr!("shutdown acknowledgement timed out")),
+            |_| Err(cstr!("replacement process failed to initialize")),
+        )
+        .unwrap_err();
+        assert!(error.contains("Broken pipe"));
+        assert!(error.contains("shutdown acknowledgement timed out"));
+        assert!(error.contains("replacement process failed to initialize"));
     }
 }


### PR DESCRIPTION
## Summary

- share a deliberately narrow classifier for editor and diagnostics LSP transport failures
- rebuild the reusable editor LSP session once after EOF, closed-reader, or broken-pipe failures
- resynchronize every current virtual document before the retry and preserve first, retirement, and retry errors
- keep semantic and protocol-shape failures fail-fast without retries
- cover every recovery branch with deterministic process-free tests

## Validation

- `cargo fmt --check`
- `cargo test -p vize_canon lsp_client --lib` (43 passed)
- `cargo clippy -p vize_canon --lib --all-features -- -D warnings`
- `git diff --check origin/main...HEAD`
- Content Mapper Conformance CI (20-cycle editor LSP stress)

Closes #4187
Unblocks #4176

<!-- codesmith:autofix:disabled -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->