### PR TITLE
feat(fresco): add semantic diagnostic presentations

### DIFF
--- a/crates/vize_fresco/benches/render.rs
+++ b/crates/vize_fresco/benches/render.rs
@@ -6,8 +6,9 @@ use std::io;
 use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 
 use vize_fresco::component::{
-    BoxNode, DiagnosticWorkspaceKeymap, DiagnosticWorkspaceState, TextNode, VirtualListNavigation,
-    VirtualListState,
+    BoxNode, DiagnosticPresentation, DiagnosticPresentationKind, DiagnosticPresentationProfile,
+    DiagnosticTone, DiagnosticWorkspaceKeymap, DiagnosticWorkspaceState, TextNode,
+    VirtualListNavigation, VirtualListState,
 };
 use vize_fresco::headless::{
     HeadlessPresentation, HeadlessRenderer, HeadlessSemanticNode, SemanticRole,
@@ -265,6 +266,30 @@ fn benchmark_diagnostic_keymap(c: &mut Criterion) {
     group.finish();
 }
 
+fn benchmark_diagnostic_presentation(c: &mut Criterion) {
+    let presentation = DiagnosticPresentation::new(
+        DiagnosticPresentationKind::Severity,
+        "Critical",
+        DiagnosticTone::Negative,
+    )
+    .unwrap();
+    let wide = DiagnosticPresentationProfile::unicode();
+    let narrow = DiagnosticPresentationProfile::ascii().with_compact(true);
+    let mut group = c.benchmark_group("diagnostic_presentation");
+
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("semantic_node", |b| {
+        b.iter(|| black_box(presentation.semantic_node(black_box(42))));
+    });
+    group.bench_function("wide_text", |b| {
+        b.iter(|| black_box(presentation.text(black_box(wide))));
+    });
+    group.bench_function("narrow_ascii_text", |b| {
+        b.iter(|| black_box(presentation.text(black_box(narrow))));
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     benchmark_buffer_set_string,
@@ -277,5 +302,6 @@ criterion_group!(
     benchmark_diagnostic_workspace,
     benchmark_headless_snapshot,
     benchmark_diagnostic_keymap,
+    benchmark_diagnostic_presentation,
 );
 criterion_main!(benches);

--- a/crates/vize_fresco/src/component.rs
+++ b/crates/vize_fresco/src/component.rs
@@ -16,10 +16,12 @@ mod virtual_list_tests;
 
 pub use box_node::BoxNode;
 pub use diagnostic_workspace::{
-    DiagnosticKeyBinding, DiagnosticKeyChord, DiagnosticKeymapError, DiagnosticWorkspaceAction,
-    DiagnosticWorkspaceCommand, DiagnosticWorkspaceCommandOutcome, DiagnosticWorkspaceFocus,
-    DiagnosticWorkspaceKeymap, DiagnosticWorkspaceLayout, DiagnosticWorkspaceMode,
-    DiagnosticWorkspaceOptions, DiagnosticWorkspacePane, DiagnosticWorkspaceState,
+    DiagnosticKeyBinding, DiagnosticKeyChord, DiagnosticKeymapError, DiagnosticPresentation,
+    DiagnosticPresentationError, DiagnosticPresentationKind, DiagnosticPresentationProfile,
+    DiagnosticTone, DiagnosticWorkspaceAction, DiagnosticWorkspaceCommand,
+    DiagnosticWorkspaceCommandOutcome, DiagnosticWorkspaceFocus, DiagnosticWorkspaceKeymap,
+    DiagnosticWorkspaceLayout, DiagnosticWorkspaceMode, DiagnosticWorkspaceOptions,
+    DiagnosticWorkspacePane, DiagnosticWorkspaceState,
 };
 pub use input_node::InputNode;
 pub use text_node::TextNode;

--- a/crates/vize_fresco/src/component/diagnostic_workspace.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace.rs
@@ -3,9 +3,14 @@
 mod command;
 mod keymap;
 mod layout;
+mod presentation;
 
 #[cfg(test)]
 mod command_tests;
+#[cfg(test)]
+mod presentation_tests;
+#[cfg(test)]
+mod presentation_wire_tests;
 #[cfg(test)]
 mod tests;
 
@@ -20,6 +25,10 @@ pub use keymap::{
 pub use layout::{
     DiagnosticWorkspaceLayout, DiagnosticWorkspaceMode, DiagnosticWorkspaceOptions,
     DiagnosticWorkspacePane,
+};
+pub use presentation::{
+    DiagnosticPresentation, DiagnosticPresentationError, DiagnosticPresentationKind,
+    DiagnosticPresentationProfile, DiagnosticTone,
 };
 
 /// Semantic keyboard focus within a diagnostic master-detail workspace.

--- a/crates/vize_fresco/src/component/diagnostic_workspace/presentation.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/presentation.rs
@@ -1,0 +1,306 @@
+use compact_str::{CompactString, ToCompactString};
+use serde::Serialize;
+use thiserror::Error;
+
+mod model;
+mod wire;
+
+pub use model::{DiagnosticPresentationKind, DiagnosticPresentationProfile, DiagnosticTone};
+
+use crate::{
+    component::TextNode,
+    headless::{HeadlessSemanticNode, SemanticState},
+    render::{NodeId, RenderNode},
+    terminal::{Style, TerminalCapabilities},
+};
+
+/// Invalid semantic diagnostic presentation input.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum DiagnosticPresentationError {
+    /// A required text field contains no visible text.
+    #[error("diagnostic presentation {field} must contain visible text")]
+    EmptyText {
+        /// Stable field name for callers and tests.
+        field: &'static str,
+    },
+    /// A score has no usable maximum or exceeds it.
+    #[error("diagnostic score {value} is outside 0 through {maximum}")]
+    InvalidScore {
+        /// Supplied score.
+        value: u64,
+        /// Supplied inclusive maximum.
+        maximum: u64,
+    },
+    /// Evidence position is zero or outside the declared logical set.
+    #[error("diagnostic evidence position {position} is outside 1 through {set_size}")]
+    InvalidEvidencePosition {
+        /// Supplied one-based position.
+        position: u64,
+        /// Supplied logical set size.
+        set_size: u64,
+    },
+    /// A source line or column uses the invalid zero value.
+    #[error("diagnostic source locations use one-based line and column values")]
+    InvalidCodeLocation,
+    /// Structured metadata is absent, contradictory, or non-canonical.
+    #[error("invalid {kind:?} presentation structure: {reason}")]
+    InvalidStructure {
+        /// Presentation kind whose invariant was violated.
+        kind: DiagnosticPresentationKind,
+        /// Stable explanation suitable for a wire-boundary error.
+        reason: &'static str,
+    },
+}
+
+/// One typed visual and accessible value in a diagnostic workspace.
+///
+/// Fresco deliberately owns presentation semantics rather than Doctor's domain
+/// enums. An analyzer maps its stable values into this small contract, keeping
+/// the TUI reusable for third-party rules and other diagnostic products.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticPresentation {
+    kind: DiagnosticPresentationKind,
+    tone: DiagnosticTone,
+    value: CompactString,
+    description: Option<CompactString>,
+    score: Option<(u64, u64)>,
+    set_position: Option<(u64, u64)>,
+}
+
+impl DiagnosticPresentation {
+    /// Create a typed textual value.
+    pub fn new(
+        kind: DiagnosticPresentationKind,
+        value: impl Into<CompactString>,
+        tone: DiagnosticTone,
+    ) -> Result<Self, DiagnosticPresentationError> {
+        if matches!(
+            kind,
+            DiagnosticPresentationKind::Score
+                | DiagnosticPresentationKind::CodeLocation
+                | DiagnosticPresentationKind::Evidence
+                | DiagnosticPresentationKind::KeyHint
+        ) {
+            return Err(DiagnosticPresentationError::InvalidStructure {
+                kind,
+                reason: "use the dedicated constructor for this presentation kind",
+            });
+        }
+        Self::from_text(kind, value, tone)
+    }
+
+    fn from_text(
+        kind: DiagnosticPresentationKind,
+        value: impl Into<CompactString>,
+        tone: DiagnosticTone,
+    ) -> Result<Self, DiagnosticPresentationError> {
+        Ok(Self {
+            kind,
+            tone,
+            value: visible_text(value, "value")?,
+            description: None,
+            score: None,
+            set_position: None,
+        })
+    }
+
+    /// Create a bounded score presentation.
+    pub fn score(
+        value: u64,
+        maximum: u64,
+        tone: DiagnosticTone,
+    ) -> Result<Self, DiagnosticPresentationError> {
+        if maximum == 0 || value > maximum {
+            return Err(DiagnosticPresentationError::InvalidScore { value, maximum });
+        }
+        let mut text = value.to_compact_string();
+        text.push_str(" / ");
+        text.push_str(&maximum.to_compact_string());
+        let mut presentation = Self::from_text(DiagnosticPresentationKind::Score, text, tone)?;
+        presentation.score = Some((value, maximum));
+        Ok(presentation)
+    }
+
+    /// Create a one-based source location using a portable ASCII path suffix.
+    pub fn code_location(
+        path: impl Into<CompactString>,
+        line: u64,
+        column: u64,
+    ) -> Result<Self, DiagnosticPresentationError> {
+        if line == 0 || column == 0 {
+            return Err(DiagnosticPresentationError::InvalidCodeLocation);
+        }
+        let mut value = visible_text(path, "path")?;
+        value.push(':');
+        value.push_str(&line.to_compact_string());
+        value.push(':');
+        value.push_str(&column.to_compact_string());
+        Self::from_text(
+            DiagnosticPresentationKind::CodeLocation,
+            value,
+            DiagnosticTone::Neutral,
+        )
+    }
+
+    /// Create supporting evidence with virtualized logical-set metadata.
+    pub fn evidence(
+        summary: impl Into<CompactString>,
+        position: u64,
+        set_size: u64,
+    ) -> Result<Self, DiagnosticPresentationError> {
+        if position == 0 || position > set_size {
+            return Err(DiagnosticPresentationError::InvalidEvidencePosition {
+                position,
+                set_size,
+            });
+        }
+        let mut presentation = Self::from_text(
+            DiagnosticPresentationKind::Evidence,
+            summary,
+            DiagnosticTone::Informational,
+        )?;
+        presentation.set_position = Some((position, set_size));
+        Ok(presentation)
+    }
+
+    /// Create a keyboard hint while keeping the key and action independently validated.
+    pub fn key_hint(
+        key: impl Into<CompactString>,
+        action: impl Into<CompactString>,
+    ) -> Result<Self, DiagnosticPresentationError> {
+        let mut value = visible_text(key, "key")?;
+        value.push_str(": ");
+        value.push_str(&visible_text(action, "action")?);
+        Self::from_text(
+            DiagnosticPresentationKind::KeyHint,
+            value,
+            DiagnosticTone::Neutral,
+        )
+    }
+
+    /// Attach a longer accessible explanation.
+    pub fn with_description(
+        mut self,
+        description: impl Into<CompactString>,
+    ) -> Result<Self, DiagnosticPresentationError> {
+        self.description = Some(visible_text(description, "description")?);
+        Ok(self)
+    }
+
+    /// Return the semantic purpose.
+    pub const fn kind(&self) -> DiagnosticPresentationKind {
+        self.kind
+    }
+
+    /// Return the non-color tone.
+    pub const fn tone(&self) -> DiagnosticTone {
+        self.tone
+    }
+
+    /// Return the normalized displayed value.
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    /// Return the optional accessible explanation.
+    pub fn description(&self) -> Option<&str> {
+        self.description.as_deref()
+    }
+
+    /// Return a non-color, Unicode-aware visual row.
+    pub fn text(&self, profile: DiagnosticPresentationProfile) -> CompactString {
+        let mut text = CompactString::new(self.tone.marker(profile.unicode));
+        text.push(' ');
+        if !profile.compact {
+            text.push_str(self.kind.label());
+            text.push_str(": ");
+        }
+        text.push_str(&self.value);
+        text
+    }
+
+    /// Return the portable base style before terminal-capability adaptation.
+    pub const fn style(&self) -> Style {
+        self.tone.style()
+    }
+
+    /// Build a visual row through Fresco's ordinary render-tree path.
+    pub fn render_node(
+        &self,
+        node_id: NodeId,
+        profile: DiagnosticPresentationProfile,
+    ) -> RenderNode {
+        self.render_node_with_style(node_id, profile, self.style())
+    }
+
+    /// Build a visual row adapted to one resolved terminal profile.
+    ///
+    /// The capability contract selects Unicode and compact text and clamps
+    /// color to the supported depth. Text markers continue to carry tone in
+    /// monochrome and redirected output.
+    pub fn render_node_for_capabilities(
+        &self,
+        node_id: NodeId,
+        capabilities: TerminalCapabilities,
+    ) -> RenderNode {
+        self.render_node_with_style(
+            node_id,
+            capabilities.into(),
+            capabilities.adapt_style(self.style()),
+        )
+    }
+
+    /// Build semantic metadata for headless and accessibility assertions.
+    pub fn semantic_node(&self, node_id: NodeId) -> HeadlessSemanticNode {
+        let mut state = SemanticState::default().with_value(self.value.clone());
+        if let Some((position, set_size)) = self.set_position {
+            state = state.with_set_position(position, set_size);
+        }
+        let mut semantic =
+            HeadlessSemanticNode::new(node_id, self.kind.role(self.tone), self.kind.label())
+                .with_state(state);
+        if let Some(description) = &self.description {
+            semantic = semantic.with_description(description.clone());
+        }
+        semantic
+    }
+
+    /// Return score bounds when this is a validated score presentation.
+    pub const fn score_bounds(&self) -> Option<(u64, u64)> {
+        self.score
+    }
+
+    /// Return logical evidence position when present.
+    pub const fn evidence_position(&self) -> Option<(u64, u64)> {
+        self.set_position
+    }
+
+    fn render_node_with_style(
+        &self,
+        node_id: NodeId,
+        profile: DiagnosticPresentationProfile,
+        style: Style,
+    ) -> RenderNode {
+        let mut node = TextNode::new(self.text(profile)).build(node_id);
+        node.appearance.fg = style.fg;
+        node.appearance.bg = style.bg;
+        node.appearance.bold = style.bold;
+        node.appearance.dim = style.dim;
+        node.appearance.italic = style.italic;
+        node.appearance.underline = style.underline;
+        node
+    }
+}
+
+fn visible_text(
+    value: impl Into<CompactString>,
+    field: &'static str,
+) -> Result<CompactString, DiagnosticPresentationError> {
+    let value = value.into();
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(DiagnosticPresentationError::EmptyText { field });
+    }
+    Ok(CompactString::from(trimmed))
+}

--- a/crates/vize_fresco/src/component/diagnostic_workspace/presentation/model.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/presentation/model.rs
@@ -1,0 +1,172 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    headless::SemanticRole,
+    terminal::{Color, Style, TerminalCapabilities},
+};
+
+/// Semantic purpose of one value in a diagnostic workspace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DiagnosticPresentationKind {
+    /// Overall analyzer or rule status.
+    Status,
+    /// Bounded health or category score.
+    Score,
+    /// Finding severity.
+    Severity,
+    /// Finding confidence.
+    Confidence,
+    /// Estimated or measured impact.
+    Impact,
+    /// Authored source-code location.
+    CodeLocation,
+    /// Supporting or related evidence.
+    Evidence,
+    /// Automatic-fix safety classification.
+    FixSafety,
+    /// Keyboard shortcut and its action.
+    KeyHint,
+}
+
+impl DiagnosticPresentationKind {
+    /// Return the stable accessible label for this presentation.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Status => "Status",
+            Self::Score => "Score",
+            Self::Severity => "Severity",
+            Self::Confidence => "Confidence",
+            Self::Impact => "Impact",
+            Self::CodeLocation => "Location",
+            Self::Evidence => "Evidence",
+            Self::FixSafety => "Fix safety",
+            Self::KeyHint => "Key hint",
+        }
+    }
+
+    pub(super) const fn role(self, tone: DiagnosticTone) -> SemanticRole {
+        match self {
+            Self::Score => SemanticRole::Progress,
+            Self::CodeLocation | Self::KeyHint => SemanticRole::Code,
+            Self::Evidence => SemanticRole::Group,
+            Self::Status | Self::Severity
+                if matches!(tone, DiagnosticTone::Caution | DiagnosticTone::Negative) =>
+            {
+                SemanticRole::Alert
+            }
+            Self::Status | Self::Severity | Self::Confidence | Self::Impact | Self::FixSafety => {
+                SemanticRole::Status
+            }
+        }
+    }
+}
+
+/// Non-color meaning used for icons, terminal style, and alert semantics.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DiagnosticTone {
+    /// No success or urgency meaning.
+    #[default]
+    Neutral,
+    /// A passing, safe, or healthy value.
+    Positive,
+    /// Informational context that does not require immediate action.
+    Informational,
+    /// A warning or review-required value.
+    Caution,
+    /// A failing, unsafe, or blocking value.
+    Negative,
+}
+
+impl DiagnosticTone {
+    /// Return a portable style. Text and markers continue to carry meaning when
+    /// a terminal capability profile removes color.
+    pub const fn style(self) -> Style {
+        match self {
+            Self::Neutral => Style::new(),
+            Self::Positive => Style::new().fg(Color::Green).bold(),
+            Self::Informational => Style::new().fg(Color::Blue),
+            Self::Caution => Style::new().fg(Color::Yellow).bold(),
+            Self::Negative => Style::new().fg(Color::Red).bold(),
+        }
+    }
+
+    pub(super) const fn marker(self, unicode: bool) -> &'static str {
+        match (self, unicode) {
+            (Self::Neutral, true) => "•",
+            (Self::Positive, true) => "✓",
+            (Self::Informational, true) => "ℹ",
+            (Self::Caution, true) => "▲",
+            (Self::Negative, true) => "✕",
+            (Self::Neutral, false) => "-",
+            (Self::Positive, false) => "+",
+            (Self::Informational, false) => "i",
+            (Self::Caution, false) => "!",
+            (Self::Negative, false) => "x",
+        }
+    }
+}
+
+/// Text formatting choices resolved by the embedding application.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiagnosticPresentationProfile {
+    pub(super) unicode: bool,
+    pub(super) compact: bool,
+}
+
+impl DiagnosticPresentationProfile {
+    /// Create an ordinary Unicode profile that includes accessible labels.
+    pub const fn unicode() -> Self {
+        Self {
+            unicode: true,
+            compact: false,
+        }
+    }
+
+    /// Create a conservative ASCII profile that includes accessible labels.
+    pub const fn ascii() -> Self {
+        Self {
+            unicode: false,
+            compact: false,
+        }
+    }
+
+    /// Include or omit the stable label in visual text.
+    ///
+    /// Compact text still exposes the label through `DiagnosticPresentation::semantic_node`.
+    pub const fn with_compact(mut self, compact: bool) -> Self {
+        self.compact = compact;
+        self
+    }
+
+    /// Return whether Unicode markers are enabled.
+    pub const fn uses_unicode(self) -> bool {
+        self.unicode
+    }
+
+    /// Return whether visual labels are omitted for narrow layouts.
+    pub const fn is_compact(self) -> bool {
+        self.compact
+    }
+}
+
+impl Default for DiagnosticPresentationProfile {
+    fn default() -> Self {
+        Self::unicode()
+    }
+}
+
+impl From<TerminalCapabilities> for DiagnosticPresentationProfile {
+    /// Derive text choices from Fresco's resolved terminal contract.
+    ///
+    /// Unicode follows the capability decision and narrow viewports omit the
+    /// repeated visual label. The label remains available in the semantic
+    /// node, so compact rendering does not discard accessible meaning.
+    fn from(capabilities: TerminalCapabilities) -> Self {
+        Self {
+            unicode: capabilities.unicode().value(),
+            compact: capabilities.is_narrow(),
+        }
+    }
+}

--- a/crates/vize_fresco/src/component/diagnostic_workspace/presentation/wire.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/presentation/wire.rs
@@ -1,0 +1,175 @@
+use compact_str::CompactString;
+use serde::{Deserialize, Deserializer, de};
+
+use super::{
+    DiagnosticPresentation, DiagnosticPresentationError, DiagnosticPresentationKind,
+    DiagnosticTone, visible_text,
+};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DiagnosticPresentationWire {
+    kind: DiagnosticPresentationKind,
+    tone: DiagnosticTone,
+    value: CompactString,
+    #[serde(default)]
+    description: Option<CompactString>,
+    #[serde(default)]
+    score: Option<(u64, u64)>,
+    #[serde(default)]
+    set_position: Option<(u64, u64)>,
+}
+
+impl<'de> Deserialize<'de> for DiagnosticPresentation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        DiagnosticPresentationWire::deserialize(deserializer)
+            .and_then(|wire| wire.try_into().map_err(de::Error::custom))
+    }
+}
+
+impl TryFrom<DiagnosticPresentationWire> for DiagnosticPresentation {
+    type Error = DiagnosticPresentationError;
+
+    fn try_from(wire: DiagnosticPresentationWire) -> Result<Self, Self::Error> {
+        let canonical_value = visible_text(wire.value.clone(), "value")?;
+        let mut presentation = match wire.kind {
+            DiagnosticPresentationKind::Score => score(&wire, &canonical_value)?,
+            DiagnosticPresentationKind::CodeLocation => location(&wire, &canonical_value)?,
+            DiagnosticPresentationKind::Evidence => evidence(&wire, canonical_value)?,
+            DiagnosticPresentationKind::KeyHint => key_hint(&wire, &canonical_value)?,
+            kind => {
+                require_no_metadata(&wire, kind)?;
+                DiagnosticPresentation::new(kind, canonical_value, wire.tone)?
+            }
+        };
+        if let Some(description) = wire.description {
+            presentation = presentation.with_description(description)?;
+        }
+        Ok(presentation)
+    }
+}
+
+fn score(
+    wire: &DiagnosticPresentationWire,
+    canonical_value: &str,
+) -> Result<DiagnosticPresentation, DiagnosticPresentationError> {
+    if wire.set_position.is_some() {
+        return invalid(
+            wire.kind,
+            "score presentations cannot have set position metadata",
+        );
+    }
+    let (value, maximum) = wire
+        .score
+        .ok_or(DiagnosticPresentationError::InvalidStructure {
+            kind: wire.kind,
+            reason: "score presentations require score metadata",
+        })?;
+    let presentation = DiagnosticPresentation::score(value, maximum, wire.tone)?;
+    require_canonical_value(wire.kind, canonical_value, presentation.value())?;
+    Ok(presentation)
+}
+
+fn location(
+    wire: &DiagnosticPresentationWire,
+    canonical_value: &str,
+) -> Result<DiagnosticPresentation, DiagnosticPresentationError> {
+    require_no_metadata(wire, wire.kind)?;
+    let (path_and_line, column) = canonical_value
+        .rsplit_once(':')
+        .ok_or(DiagnosticPresentationError::InvalidCodeLocation)?;
+    let (path, line) = path_and_line
+        .rsplit_once(':')
+        .ok_or(DiagnosticPresentationError::InvalidCodeLocation)?;
+    let line = line
+        .parse()
+        .map_err(|_| DiagnosticPresentationError::InvalidCodeLocation)?;
+    let column = column
+        .parse()
+        .map_err(|_| DiagnosticPresentationError::InvalidCodeLocation)?;
+    let presentation = DiagnosticPresentation::code_location(path, line, column)?;
+    require_canonical_value(wire.kind, canonical_value, presentation.value())?;
+    Ok(presentation)
+}
+
+fn evidence(
+    wire: &DiagnosticPresentationWire,
+    canonical_value: CompactString,
+) -> Result<DiagnosticPresentation, DiagnosticPresentationError> {
+    if wire.score.is_some() {
+        return invalid(
+            wire.kind,
+            "evidence presentations cannot have score metadata",
+        );
+    }
+    if wire.tone != DiagnosticTone::Informational {
+        return invalid(
+            wire.kind,
+            "evidence presentations use the informational tone",
+        );
+    }
+    let (position, set_size) =
+        wire.set_position
+            .ok_or(DiagnosticPresentationError::InvalidStructure {
+                kind: wire.kind,
+                reason: "evidence presentations require set position metadata",
+            })?;
+    DiagnosticPresentation::evidence(canonical_value, position, set_size)
+}
+
+fn key_hint(
+    wire: &DiagnosticPresentationWire,
+    canonical_value: &str,
+) -> Result<DiagnosticPresentation, DiagnosticPresentationError> {
+    require_no_metadata(wire, wire.kind)?;
+    if wire.tone != DiagnosticTone::Neutral {
+        return invalid(wire.kind, "key hints use the neutral tone");
+    }
+    let (key, action) =
+        canonical_value
+            .split_once(": ")
+            .ok_or(DiagnosticPresentationError::InvalidStructure {
+                kind: wire.kind,
+                reason: "key hints require the canonical `key: action` value",
+            })?;
+    let presentation = DiagnosticPresentation::key_hint(key, action)?;
+    require_canonical_value(wire.kind, canonical_value, presentation.value())?;
+    Ok(presentation)
+}
+
+fn require_no_metadata(
+    wire: &DiagnosticPresentationWire,
+    kind: DiagnosticPresentationKind,
+) -> Result<(), DiagnosticPresentationError> {
+    if wire.score.is_some() || wire.set_position.is_some() {
+        return invalid(
+            kind,
+            "this presentation kind does not accept structured metadata",
+        );
+    }
+    Ok(())
+}
+
+fn require_canonical_value(
+    kind: DiagnosticPresentationKind,
+    supplied: &str,
+    canonical: &str,
+) -> Result<(), DiagnosticPresentationError> {
+    if supplied != canonical {
+        return invalid(
+            kind,
+            "displayed value disagrees with its structured metadata",
+        );
+    }
+    Ok(())
+}
+
+fn invalid<T>(
+    kind: DiagnosticPresentationKind,
+    reason: &'static str,
+) -> Result<T, DiagnosticPresentationError> {
+    Err(DiagnosticPresentationError::InvalidStructure { kind, reason })
+}

--- a/crates/vize_fresco/src/component/diagnostic_workspace/presentation_tests.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/presentation_tests.rs
@@ -1,0 +1,340 @@
+use super::{
+    DiagnosticPresentation, DiagnosticPresentationError, DiagnosticPresentationKind,
+    DiagnosticPresentationProfile, DiagnosticTone,
+};
+use crate::{
+    component::BoxNode,
+    headless::{HeadlessPresentation, HeadlessRenderer, HeadlessSemanticNode, SemanticRole},
+    layout::Dimension,
+    render::{NodeKind, RenderTree},
+    terminal::{Color, TerminalCapabilities, TerminalCapabilityProbe, TerminalProfileOptions},
+};
+
+fn presentation(
+    kind: DiagnosticPresentationKind,
+    value: &str,
+    tone: DiagnosticTone,
+) -> DiagnosticPresentation {
+    DiagnosticPresentation::new(kind, value, tone).unwrap()
+}
+
+fn complete_presentations() -> Vec<DiagnosticPresentation> {
+    vec![
+        presentation(
+            DiagnosticPresentationKind::Status,
+            "Ready",
+            DiagnosticTone::Positive,
+        ),
+        DiagnosticPresentation::score(92, 100, DiagnosticTone::Positive).unwrap(),
+        presentation(
+            DiagnosticPresentationKind::Severity,
+            "Error",
+            DiagnosticTone::Negative,
+        ),
+        presentation(
+            DiagnosticPresentationKind::Confidence,
+            "Certain",
+            DiagnosticTone::Informational,
+        ),
+        presentation(
+            DiagnosticPresentationKind::Impact,
+            "Application",
+            DiagnosticTone::Caution,
+        ),
+        DiagnosticPresentation::code_location("src/App.vue", 12, 7).unwrap(),
+        DiagnosticPresentation::evidence("Missing dependency edge", 2, 4).unwrap(),
+        presentation(
+            DiagnosticPresentationKind::FixSafety,
+            "Review required",
+            DiagnosticTone::Caution,
+        ),
+        DiagnosticPresentation::key_hint("j", "Next finding").unwrap(),
+    ]
+}
+
+#[test]
+fn every_required_presentation_has_a_stable_label_and_semantic_role() {
+    let expected = [
+        (
+            DiagnosticPresentationKind::Status,
+            "Status",
+            SemanticRole::Status,
+        ),
+        (
+            DiagnosticPresentationKind::Score,
+            "Score",
+            SemanticRole::Progress,
+        ),
+        (
+            DiagnosticPresentationKind::Severity,
+            "Severity",
+            SemanticRole::Alert,
+        ),
+        (
+            DiagnosticPresentationKind::Confidence,
+            "Confidence",
+            SemanticRole::Status,
+        ),
+        (
+            DiagnosticPresentationKind::Impact,
+            "Impact",
+            SemanticRole::Status,
+        ),
+        (
+            DiagnosticPresentationKind::CodeLocation,
+            "Location",
+            SemanticRole::Code,
+        ),
+        (
+            DiagnosticPresentationKind::Evidence,
+            "Evidence",
+            SemanticRole::Group,
+        ),
+        (
+            DiagnosticPresentationKind::FixSafety,
+            "Fix safety",
+            SemanticRole::Status,
+        ),
+        (
+            DiagnosticPresentationKind::KeyHint,
+            "Key hint",
+            SemanticRole::Code,
+        ),
+    ];
+
+    for ((presentation, (kind, label, role)), node_id) in
+        complete_presentations().iter().zip(expected).zip(1_u64..)
+    {
+        assert_eq!(presentation.kind(), kind);
+        assert_eq!(kind.label(), label);
+        let semantic = presentation.semantic_node(node_id);
+        assert_eq!(semantic.role, role);
+        assert_eq!(semantic.name, label);
+        assert_eq!(semantic.state.value.as_deref(), Some(presentation.value()));
+    }
+}
+
+#[test]
+fn visual_text_never_relies_on_color_and_has_exact_ascii_fallbacks() {
+    let passing = presentation(
+        DiagnosticPresentationKind::Status,
+        "Healthy",
+        DiagnosticTone::Positive,
+    );
+    assert_eq!(
+        passing.text(DiagnosticPresentationProfile::unicode()),
+        "✓ Status: Healthy"
+    );
+    assert_eq!(
+        passing.text(DiagnosticPresentationProfile::ascii()),
+        "+ Status: Healthy"
+    );
+    assert_eq!(
+        passing.text(DiagnosticPresentationProfile::ascii().with_compact(true)),
+        "+ Healthy"
+    );
+
+    let failing = presentation(
+        DiagnosticPresentationKind::Severity,
+        "Critical",
+        DiagnosticTone::Negative,
+    );
+    assert_eq!(
+        failing.text(DiagnosticPresentationProfile::unicode()),
+        "✕ Severity: Critical"
+    );
+    assert_eq!(
+        failing.text(DiagnosticPresentationProfile::ascii()),
+        "x Severity: Critical"
+    );
+}
+
+#[test]
+fn text_inputs_are_trimmed_and_empty_values_fail_closed() {
+    let normalized = DiagnosticPresentation::new(
+        DiagnosticPresentationKind::Status,
+        "  Ready  ",
+        DiagnosticTone::Positive,
+    )
+    .unwrap()
+    .with_description("  Analysis is complete.  ")
+    .unwrap();
+    assert_eq!(normalized.value(), "Ready");
+    assert_eq!(normalized.description(), Some("Analysis is complete."));
+
+    assert_eq!(
+        DiagnosticPresentation::new(
+            DiagnosticPresentationKind::Status,
+            " \n ",
+            DiagnosticTone::Neutral,
+        ),
+        Err(DiagnosticPresentationError::EmptyText { field: "value" })
+    );
+    assert_eq!(
+        DiagnosticPresentation::key_hint(" ", "Next"),
+        Err(DiagnosticPresentationError::EmptyText { field: "key" })
+    );
+    assert_eq!(
+        normalized.clone().with_description("\t"),
+        Err(DiagnosticPresentationError::EmptyText {
+            field: "description"
+        })
+    );
+}
+
+#[test]
+fn score_location_and_evidence_boundaries_are_explicit() {
+    let score = DiagnosticPresentation::score(92, 100, DiagnosticTone::Positive).unwrap();
+    assert_eq!(score.value(), "92 / 100");
+    assert_eq!(score.score_bounds(), Some((92, 100)));
+    assert_eq!(
+        DiagnosticPresentation::score(1, 0, DiagnosticTone::Negative),
+        Err(DiagnosticPresentationError::InvalidScore {
+            value: 1,
+            maximum: 0
+        })
+    );
+    assert_eq!(
+        DiagnosticPresentation::score(101, 100, DiagnosticTone::Negative),
+        Err(DiagnosticPresentationError::InvalidScore {
+            value: 101,
+            maximum: 100
+        })
+    );
+
+    let location = DiagnosticPresentation::code_location("src/日本語.vue", 12, 7).unwrap();
+    assert_eq!(location.value(), "src/日本語.vue:12:7");
+    assert_eq!(
+        DiagnosticPresentation::code_location("src/App.vue", 0, 1),
+        Err(DiagnosticPresentationError::InvalidCodeLocation)
+    );
+
+    let evidence = DiagnosticPresentation::evidence("Related component", 2, 4).unwrap();
+    assert_eq!(evidence.evidence_position(), Some((2, 4)));
+    let semantic = evidence.semantic_node(5);
+    assert_eq!(semantic.state.position, Some(2));
+    assert_eq!(semantic.state.set_size, Some(4));
+    assert_eq!(
+        DiagnosticPresentation::evidence("Related", 5, 4),
+        Err(DiagnosticPresentationError::InvalidEvidencePosition {
+            position: 5,
+            set_size: 4
+        })
+    );
+}
+
+#[test]
+fn render_nodes_preserve_text_and_tone_attributes() {
+    let warning = presentation(
+        DiagnosticPresentationKind::Impact,
+        "Production",
+        DiagnosticTone::Caution,
+    );
+    let node = warning.render_node(7, DiagnosticPresentationProfile::ascii());
+    assert_eq!(node.appearance.fg, Some(Color::Yellow));
+    assert!(node.appearance.bold);
+    match node.kind {
+        NodeKind::Text(content) => assert_eq!(content.text, "! Impact: Production"),
+        other => panic!("expected presentation text node, got {other:?}"),
+    }
+
+    let neutral = DiagnosticPresentation::key_hint("?", "Help").unwrap();
+    let node = neutral.render_node(8, DiagnosticPresentationProfile::unicode());
+    assert_eq!(node.appearance.fg, None);
+    assert!(!node.appearance.bold);
+}
+
+#[test]
+fn terminal_capabilities_select_text_density_symbols_and_safe_color() {
+    let presentation = presentation(
+        DiagnosticPresentationKind::Severity,
+        "Blocking",
+        DiagnosticTone::Negative,
+    );
+    let redirected_ascii = TerminalCapabilities::resolve(
+        &TerminalCapabilityProbe::new(42, 18, false).with_locale("C"),
+        TerminalProfileOptions::default(),
+    );
+    let profile = DiagnosticPresentationProfile::from(redirected_ascii);
+    assert!(!profile.uses_unicode());
+    assert!(profile.is_compact());
+
+    let node = presentation.render_node_for_capabilities(9, redirected_ascii);
+    assert_eq!(node.appearance.fg, None);
+    assert!(node.appearance.bold);
+    match node.kind {
+        NodeKind::Text(content) => assert_eq!(content.text, "x Blocking"),
+        other => panic!("expected capability-adapted text node, got {other:?}"),
+    }
+
+    let wide_unicode = TerminalCapabilities::resolve(
+        &TerminalCapabilityProbe::new(120, 40, true)
+            .with_term("xterm-256color")
+            .with_locale("ja_JP.UTF-8"),
+        TerminalProfileOptions::default(),
+    );
+    let node = presentation.render_node_for_capabilities(10, wide_unicode);
+    assert_eq!(node.appearance.fg, Some(Color::Red));
+    match node.kind {
+        NodeKind::Text(content) => assert_eq!(content.text, "✕ Severity: Blocking"),
+        other => panic!("expected capability-adapted text node, got {other:?}"),
+    }
+}
+
+#[test]
+fn headless_snapshot_covers_all_visual_and_accessible_presentations() {
+    let presentations = complete_presentations();
+    let mut tree = RenderTree::new();
+    let root = tree.next_id();
+    tree.insert_root(
+        BoxNode::new()
+            .column()
+            .width_percent(100.0)
+            .height_percent(100.0)
+            .build(root),
+    );
+    let mut semantics = vec![HeadlessSemanticNode::new(
+        root,
+        SemanticRole::Application,
+        "Diagnostics",
+    )];
+
+    for presentation in &presentations {
+        let node_id = tree.next_id();
+        let mut node = presentation.render_node(node_id, DiagnosticPresentationProfile::ascii());
+        node.style.width = Dimension::Percent(100.0);
+        node.style.height = Dimension::Points(1.0);
+        node.style.flex_shrink = 0.0;
+        tree.insert(node);
+        tree.add_child(root, node_id);
+        semantics.push(presentation.semantic_node(node_id));
+    }
+
+    let snapshot = HeadlessRenderer::new(80, 10)
+        .unwrap()
+        .render(
+            &mut tree,
+            &HeadlessPresentation::new().with_semantics(semantics),
+        )
+        .unwrap();
+
+    assert_eq!(snapshot.semantics().len(), presentations.len() + 1);
+    assert_eq!(snapshot.semantics()[1].name, "Status");
+    assert_eq!(snapshot.semantics()[2].role, SemanticRole::Progress);
+    assert_eq!(snapshot.semantics()[7].state.position, Some(2));
+    let screen = snapshot.screen_text();
+    assert!(screen.contains("+ Status: Ready"), "{screen:?}");
+    assert!(screen.contains("- Key hint: j: Next finding"), "{screen:?}");
+}
+
+#[test]
+fn presentation_contract_round_trips_without_losing_semantics() {
+    let presentation = DiagnosticPresentation::evidence("型の証拠 🧭", 3, 9)
+        .unwrap()
+        .with_description("Combining mark: e\u{301}")
+        .unwrap();
+    let json = serde_json::to_string(&presentation).unwrap();
+    let decoded: DiagnosticPresentation = serde_json::from_str(&json).unwrap();
+    assert_eq!(decoded, presentation);
+    assert_eq!(decoded.semantic_node(9), presentation.semantic_node(9));
+}

--- a/crates/vize_fresco/src/component/diagnostic_workspace/presentation_wire_tests.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/presentation_wire_tests.rs
@@ -1,0 +1,84 @@
+use super::{
+    DiagnosticPresentation, DiagnosticPresentationError, DiagnosticPresentationKind, DiagnosticTone,
+};
+
+#[test]
+fn structured_kinds_require_their_validating_constructors() {
+    for kind in [
+        DiagnosticPresentationKind::Score,
+        DiagnosticPresentationKind::CodeLocation,
+        DiagnosticPresentationKind::Evidence,
+        DiagnosticPresentationKind::KeyHint,
+    ] {
+        assert!(matches!(
+            DiagnosticPresentation::new(kind, "value", DiagnosticTone::Neutral),
+            Err(DiagnosticPresentationError::InvalidStructure { .. })
+        ));
+    }
+}
+
+#[test]
+fn wire_shape_is_canonical_and_rejects_unknown_fields() {
+    let presentation = DiagnosticPresentation::evidence("型の証拠 🧭", 3, 9)
+        .unwrap()
+        .with_description("Combining mark: e\u{301}")
+        .unwrap();
+    let value = serde_json::to_value(&presentation).unwrap();
+    assert_eq!(value["kind"], "evidence");
+    assert_eq!(value["tone"], "informational");
+    assert_eq!(value["setPosition"], serde_json::json!([3, 9]));
+    assert!(value.get("set_position").is_none());
+
+    let mut tampered = value.clone();
+    tampered["vendorExtension"] = serde_json::json!(true);
+    assert!(serde_json::from_value::<DiagnosticPresentation>(tampered).is_err());
+    assert_eq!(
+        serde_json::from_value::<DiagnosticPresentation>(value).unwrap(),
+        presentation
+    );
+}
+
+#[test]
+fn wire_input_cannot_bypass_score_or_evidence_invariants() {
+    let invalid_score = serde_json::json!({
+        "kind": "score",
+        "tone": "negative",
+        "value": "101 / 100",
+        "description": null,
+        "score": [101, 100],
+        "setPosition": null
+    });
+    assert!(serde_json::from_value::<DiagnosticPresentation>(invalid_score).is_err());
+
+    let inconsistent_score = serde_json::json!({
+        "kind": "score",
+        "tone": "positive",
+        "value": "99 / 100",
+        "score": [92, 100]
+    });
+    assert!(serde_json::from_value::<DiagnosticPresentation>(inconsistent_score).is_err());
+
+    let incomplete_evidence = serde_json::json!({
+        "kind": "evidence",
+        "tone": "informational",
+        "value": "Related component"
+    });
+    assert!(serde_json::from_value::<DiagnosticPresentation>(incomplete_evidence).is_err());
+}
+
+#[test]
+fn wire_input_revalidates_location_and_key_hint_text() {
+    let invalid_location = serde_json::json!({
+        "kind": "code-location",
+        "tone": "neutral",
+        "value": "src/App.vue:0:1"
+    });
+    assert!(serde_json::from_value::<DiagnosticPresentation>(invalid_location).is_err());
+
+    let invalid_key_hint = serde_json::json!({
+        "kind": "key-hint",
+        "tone": "neutral",
+        "value": "missing action separator"
+    });
+    assert!(serde_json::from_value::<DiagnosticPresentation>(invalid_key_hint).is_err());
+}

--- a/crates/vize_fresco/src/lib.rs
+++ b/crates/vize_fresco/src/lib.rs
@@ -67,11 +67,12 @@ pub mod napi;
 // Re-exports for convenience
 pub use component::{
     BoxNode, DiagnosticKeyBinding, DiagnosticKeyChord, DiagnosticKeymapError,
-    DiagnosticWorkspaceAction, DiagnosticWorkspaceCommand, DiagnosticWorkspaceCommandOutcome,
-    DiagnosticWorkspaceFocus, DiagnosticWorkspaceKeymap, DiagnosticWorkspaceLayout,
-    DiagnosticWorkspaceMode, DiagnosticWorkspaceOptions, DiagnosticWorkspacePane,
-    DiagnosticWorkspaceState, InputNode, TextNode, VirtualListNavigation, VirtualListState,
-    VirtualWindow,
+    DiagnosticPresentation, DiagnosticPresentationError, DiagnosticPresentationKind,
+    DiagnosticPresentationProfile, DiagnosticTone, DiagnosticWorkspaceAction,
+    DiagnosticWorkspaceCommand, DiagnosticWorkspaceCommandOutcome, DiagnosticWorkspaceFocus,
+    DiagnosticWorkspaceKeymap, DiagnosticWorkspaceLayout, DiagnosticWorkspaceMode,
+    DiagnosticWorkspaceOptions, DiagnosticWorkspacePane, DiagnosticWorkspaceState, InputNode,
+    TextNode, VirtualListNavigation, VirtualListState, VirtualWindow,
 };
 pub use headless::{
     AnnouncementPoliteness, HeadlessAnnouncement, HeadlessPresentation, HeadlessRenderError,


### PR DESCRIPTION
## Summary

- add typed status, score, severity, confidence, impact, source-location, evidence, fix-safety, and key-hint presentations
- preserve meaning through explicit Unicode/ASCII tone markers, accessible semantic roles, descriptions, progress bounds, and virtualized set positions
- derive compact and Unicode text from `TerminalCapabilities` and clamp color through the resolved terminal profile
- reject empty values, invalid bounds, contradictory metadata, unknown wire fields, and deserialization attempts that bypass dedicated constructors
- exercise the ordinary render tree and deterministic headless semantic snapshot paths
- add Criterion coverage for semantic-node and wide/narrow text construction

## Validation

- `cargo test -p vize_fresco --all-features` — 208 unit tests and 1 doctest
- `cargo clippy -p vize_fresco --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vize_fresco --all-features --no-deps`
- `cargo bench -p vize_fresco --bench render --no-run`
- Criterion medians: semantic node 5.48 ns, wide text 22.58 ns, narrow ASCII text 14.21 ns

Relates #4155 and #3138.

<!-- codesmith:autofix:disabled -->