### PR TITLE
fix(ui): harden long press ownership

### DIFF
--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 19_750],
+  ["index.mjs", 20_325],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
   ["collection.mjs", 5_700],
@@ -13,7 +13,7 @@ const budgets = new Map([
   ["controllable-state.mjs", 600],
   ["id.mjs", 2_300],
   ["interaction-modality.mjs", 3_300],
-  ["long-press.mjs", 7_350],
+  ["long-press.mjs", 8_000],
   ["press.mjs", 5_775],
   ["primitive.mjs", 800],
   ["visually-hidden.mjs", 800],

--- a/npm/ui/core/scripts/check-tree-shaking.mjs
+++ b/npm/ui/core/scripts/check-tree-shaking.mjs
@@ -117,7 +117,7 @@ const componentCases = [
   {
     family: "long-press",
     exportName: "createLongPress",
-    maximumJavaScriptGzipBytes: 4_800,
+    maximumJavaScriptGzipBytes: 5_150,
     maximumCssGzipBytes: 0,
   },
   {

--- a/npm/ui/core/src/long-press-hardening.test.ts
+++ b/npm/ui/core/src/long-press-hardening.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+
+import { ref } from "vue";
+import type { Ref } from "vue";
+import { test } from "vite-plus/test";
+
+import { elapseThreshold, mountLongPress, pointer } from "./long-press-test-utils.ts";
+import { surfaceErrors } from "./long-press-internal.ts";
+import type { LongPressEvent } from "./long-press.ts";
+
+test("multiple cleanup errors remain inspectable without a native AggregateError", () => {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "AggregateError");
+  Object.defineProperty(globalThis, "AggregateError", { configurable: true, value: undefined });
+  try {
+    assert.throws(
+      () => surfaceErrors([new Error("release"), new Error("selection")], "cleanup failed"),
+      (error: unknown) => {
+        const aggregate = error as Error & { errors?: unknown[] };
+        assert.equal(aggregate.name, "AggregateError");
+        assert.equal(aggregate.message, "cleanup failed");
+        assert.deepEqual(
+          aggregate.errors?.map((reason) => (reason as Error).message),
+          ["release", "selection"],
+        );
+        return true;
+      },
+    );
+  } finally {
+    if (descriptor) Object.defineProperty(globalThis, "AggregateError", descriptor);
+  }
+});
+
+test("invalid reactive disablement cannot wedge triggered teardown", async () => {
+  const disabled = ref<unknown>(false);
+  const harness = mountLongPress({
+    isDisabled: disabled as Ref<boolean>,
+    threshold: 0,
+  });
+  harness.host.style.setProperty("user-select", "text", "important");
+  harness.host.dispatchEvent(pointer("pointerdown", "touch"));
+  await elapseThreshold();
+  disabled.value = "invalid";
+
+  let reportedError: unknown;
+  const captureReportedError = (event: ErrorEvent) => {
+    reportedError = event.error;
+    event.preventDefault();
+  };
+  window.addEventListener("error", captureReportedError);
+  try {
+    harness.host.dispatchEvent(pointer("pointerup", "touch"));
+  } catch (error) {
+    // happy-dom propagates listener errors; browsers report them on Window.
+    reportedError ??= error;
+  } finally {
+    window.removeEventListener("error", captureReportedError);
+  }
+  assert.match(String(reportedError), /VIZE_UI_LONG_PRESS_OPTION.*isDisabled/);
+  assert.equal(harness.controller.isPressed.value, false);
+  assert.equal(harness.controller.isLongPressed.value, false);
+  assert.equal(harness.host.style.getPropertyValue("user-select"), "text");
+  assert.equal(harness.host.style.getPropertyPriority("user-select"), "important");
+  assert.equal((harness.events.at(-1) as LongPressEvent).isCanceled, true);
+  harness.controller.dispose();
+  harness.host.remove();
+});
+
+test("disposal finishes every teardown step and becomes terminal after a cleanup failure", async () => {
+  const harness = mountLongPress({ threshold: 0 });
+  harness.host.style.setProperty("user-select", "text", "important");
+  harness.host.dispatchEvent(pointer("pointerdown", "touch"));
+  await elapseThreshold();
+
+  const style = harness.host.style;
+  const originalRemoveProperty = style.removeProperty.bind(style);
+  style.removeProperty = function removeProperty(property: string): string {
+    if (property === "-webkit-user-select") throw new Error("restore failed");
+    return originalRemoveProperty(property);
+  };
+  try {
+    assert.throws(() => harness.controller.dispose(), /restore failed/);
+  } finally {
+    style.removeProperty = originalRemoveProperty;
+  }
+
+  assert.equal(harness.controller.isPressed.value, false);
+  assert.equal(harness.controller.isLongPressed.value, false);
+  assert.equal(harness.host.style.getPropertyValue("user-select"), "text");
+  assert.equal(harness.host.style.getPropertyPriority("user-select"), "important");
+  assert.throws(() => harness.controller.cancel(), /VIZE_UI_LONG_PRESS_DISPOSED/);
+  harness.host.remove();
+});

--- a/npm/ui/core/src/long-press-internal.ts
+++ b/npm/ui/core/src/long-press-internal.ts
@@ -1,0 +1,214 @@
+import { toValue } from "vue";
+
+import { createPressEvent } from "./press-event.ts";
+import type {
+  LongPressEvent,
+  LongPressEventType,
+  LongPressOptions,
+  LongPressPointerType,
+} from "./long-press-types.ts";
+import type { PressEvent } from "./press-types.ts";
+
+const defaultThreshold = 500;
+const invalidOptionDiagnostic = "VIZE_UI_LONG_PRESS_OPTION";
+const hardwarePointers = new Set<LongPressPointerType>(["mouse", "pen", "pointer", "touch"]);
+
+export interface Attempt {
+  readonly event: LongPressEvent;
+  readonly owner: AttemptOwner;
+  readonly pointerType: LongPressPointerType;
+  readonly target: Element;
+  readonly touchIdentifier: number | null;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+type AttemptOwner =
+  | { readonly source: "mouse" }
+  | { readonly id: number; readonly source: "pointer" | "touch" };
+
+export function isHardwarePointer(value: string): value is LongPressPointerType {
+  return hardwarePointers.has(value as LongPressPointerType);
+}
+
+export function ownerOf(event: Omit<PressEvent, "type">): AttemptOwner {
+  const original = event.originalEvent;
+  if (original && "pointerId" in original) {
+    return { id: Number((original as PointerEvent).pointerId), source: "pointer" };
+  }
+  if (original && "changedTouches" in original) {
+    const id = (original as TouchEvent).changedTouches.item(0)?.identifier;
+    if (id !== undefined) return { id, source: "touch" };
+  }
+  return { source: "mouse" };
+}
+
+export function ownerMatches(owner: AttemptOwner, event: Omit<PressEvent, "type">): boolean {
+  const original = event.originalEvent;
+  if (owner.source === "pointer") {
+    return Boolean(
+      original &&
+      "pointerId" in original &&
+      Number((original as PointerEvent).pointerId) === owner.id,
+    );
+  }
+  if (owner.source === "touch") {
+    return Boolean(
+      original &&
+      "changedTouches" in original &&
+      Array.from((original as TouchEvent).changedTouches).some(
+        ({ identifier }) => identifier === owner.id,
+      ),
+    );
+  }
+  return Boolean(original && !("pointerId" in original) && !("changedTouches" in original));
+}
+
+export function captureError(errors: unknown[], callback: () => void): void {
+  try {
+    callback();
+  } catch (error) {
+    errors.push(error);
+  }
+}
+
+export function surfaceErrors(errors: readonly unknown[], message: string): void {
+  if (errors.length === 1) throw errors[0];
+  if (errors.length < 2) return;
+  const Aggregate = globalThis.AggregateError as typeof AggregateError | undefined;
+  if (typeof Aggregate === "function") throw new Aggregate(errors, message);
+  const fallback = Object.assign(new Error(message), { errors: [...errors] });
+  fallback.name = "AggregateError";
+  throw fallback;
+}
+
+export function readBoolean(value: LongPressOptions["isDisabled"], name: string): boolean {
+  const resolved = toValue(value);
+  if (resolved === undefined) return false;
+  if (typeof resolved !== "boolean") {
+    throw new TypeError(`${invalidOptionDiagnostic}: ${name} must resolve to a boolean`);
+  }
+  return resolved;
+}
+
+export function readPointerType(
+  value: LongPressOptions["pointerType"],
+): LongPressPointerType | null {
+  const resolved = toValue(value) ?? null;
+  if (resolved !== null && !hardwarePointers.has(resolved)) {
+    throw new TypeError(
+      `${invalidOptionDiagnostic}: pointerType must resolve to mouse, pen, pointer, or touch`,
+    );
+  }
+  return resolved;
+}
+
+export function readThreshold(value: LongPressOptions["threshold"]): number {
+  const resolved = toValue(value) ?? defaultThreshold;
+  if (typeof resolved !== "number" || !Number.isFinite(resolved) || resolved < 0) {
+    throw new TypeError(
+      `${invalidOptionDiagnostic}: threshold must resolve to a finite number >= 0`,
+    );
+  }
+  return resolved;
+}
+
+export function readText(
+  value: LongPressOptions["accessibilityDescription"],
+  name: string,
+): string | undefined {
+  const resolved = toValue(value);
+  if (resolved === undefined || resolved === "") return undefined;
+  if (typeof resolved !== "string") {
+    throw new TypeError(`${invalidOptionDiagnostic}: ${name} must resolve to a string`);
+  }
+  return resolved;
+}
+
+export function toLongPressEvent(
+  type: LongPressEventType,
+  event: Omit<PressEvent, "type">,
+  originalEvent = event.originalEvent,
+  isCanceled = event.isCanceled,
+  touchIdentifier: number | null = null,
+): LongPressEvent {
+  const snapshot = createPressEvent(
+    "pressend",
+    event.target,
+    event.pointerType,
+    originalEvent,
+    isCanceled,
+    touchIdentifier,
+  );
+  return Object.freeze({ ...snapshot, type }) as LongPressEvent;
+}
+
+export function validateOptions(options: LongPressOptions): void {
+  for (const name of ["onLongPress", "onLongPressEnd", "onLongPressStart", "onPress"] as const) {
+    const callback = options[name];
+    if (callback !== undefined && typeof callback !== "function") {
+      throw new TypeError(`${invalidOptionDiagnostic}: ${name} must be a function`);
+    }
+  }
+  if (typeof options.threshold !== "function") readThreshold(options.threshold);
+  if (typeof options.pointerType !== "function") readPointerType(options.pointerType);
+}
+
+/** Install physical-release listeners for an already triggered attempt. */
+export function installTriggeredRelease(
+  current: Attempt,
+  finish: (event: Event | null, canceled?: boolean) => boolean,
+): () => void {
+  const removals: Array<() => void> = [];
+  const document = current.target.ownerDocument;
+  const listen = (
+    owner: Document | Window,
+    type: string,
+    callback: EventListener,
+    capture = true,
+  ) => {
+    owner.addEventListener(type, callback, capture);
+    removals.push(() => owner.removeEventListener(type, callback, capture));
+  };
+  try {
+    if (current.owner.source === "pointer") {
+      const id = current.owner.id;
+      listen(document, "pointerup", ((event: PointerEvent) => {
+        if (event.pointerId === id) finish(event);
+      }) as EventListener);
+      listen(document, "pointercancel", ((event: PointerEvent) => {
+        if (event.pointerId === id) finish(event, true);
+      }) as EventListener);
+    } else if (current.owner.source === "touch") {
+      const id = current.owner.id;
+      const ownsTouch = (event: TouchEvent) =>
+        Array.from(event.changedTouches).some((touch) => touch.identifier === id);
+      listen(document, "touchend", ((event: TouchEvent) => {
+        if (ownsTouch(event)) finish(event);
+      }) as EventListener);
+      listen(document, "touchcancel", ((event: TouchEvent) => {
+        if (ownsTouch(event)) finish(event, true);
+      }) as EventListener);
+    } else {
+      listen(document, "mouseup", ((event: MouseEvent) => {
+        if (event.button === 0) finish(event);
+      }) as EventListener);
+    }
+    listen(document, "dragstart", (event) => finish(event, true));
+    listen(document, "visibilitychange", (() => {
+      if (document.visibilityState === "hidden") finish(null, true);
+    }) as EventListener);
+    if (document.defaultView) {
+      listen(document.defaultView, "blur", (event) => finish(event, true), false);
+    }
+  } catch (error) {
+    const errors: unknown[] = [error];
+    for (const remove of removals.reverse()) captureError(errors, remove);
+    surfaceErrors(errors, "Long-press listener setup failed");
+    throw error;
+  }
+  return () => {
+    const errors: unknown[] = [];
+    for (const remove of removals.splice(0)) captureError(errors, remove);
+    surfaceErrors(errors, "Long-press listener cleanup failed");
+  };
+}

--- a/npm/ui/core/src/long-press-legacy.test.ts
+++ b/npm/ui/core/src/long-press-legacy.test.ts
@@ -41,7 +41,10 @@ test("normalizes a legacy touch hold and owns only its initiating contact", asyn
   );
   assert.equal(controller.isLongPressed.value, true);
   isolated.body.dispatchEvent(
-    touchEvent("touchend", [{ identifier: 31, clientX: 9, clientY: 12 }]),
+    touchEvent("touchend", [
+      { identifier: 99, clientX: 100, clientY: 200 },
+      { identifier: 31, clientX: 9, clientY: 12 },
+    ]),
   );
 
   assert.deepEqual(

--- a/npm/ui/core/src/long-press-test-utils.ts
+++ b/npm/ui/core/src/long-press-test-utils.ts
@@ -1,0 +1,97 @@
+import type {
+  LongPressController,
+  LongPressEvent,
+  LongPressOptions,
+  LongPressProps,
+} from "./long-press.ts";
+import { createLongPress } from "./long-press.ts";
+import type { PressEvent } from "./press.ts";
+
+const eventNames: Readonly<Record<keyof Omit<LongPressProps, `aria-${string}`>, string>> = {
+  onClick: "click",
+  onContextmenu: "contextmenu",
+  onDragstart: "dragstart",
+  onKeydown: "keydown",
+  onKeyup: "keyup",
+  onMousedown: "mousedown",
+  onMousemove: "mousemove",
+  onMouseup: "mouseup",
+  onPointercancel: "pointercancel",
+  onPointerdown: "pointerdown",
+  onPointermove: "pointermove",
+  onPointerup: "pointerup",
+  onTouchcancel: "touchcancel",
+  onTouchend: "touchend",
+  onTouchmove: "touchmove",
+  onTouchstart: "touchstart",
+};
+
+export interface LongPressHarness {
+  readonly controller: LongPressController;
+  readonly events: Array<LongPressEvent | PressEvent>;
+  readonly host: HTMLButtonElement;
+  readonly unmount: () => void;
+}
+
+export function mountLongPress(options: LongPressOptions = {}): LongPressHarness {
+  const host = document.createElement("button");
+  document.body.append(host);
+  const events: Array<LongPressEvent | PressEvent> = [];
+  const controller = createLongPress({
+    ...options,
+    onLongPressStart: (event) => {
+      events.push(event);
+      options.onLongPressStart?.(event);
+    },
+    onLongPress: (event) => {
+      events.push(event);
+      options.onLongPress?.(event);
+    },
+    onLongPressEnd: (event) => {
+      events.push(event);
+      options.onLongPressEnd?.(event);
+    },
+    onPress: (event) => {
+      events.push(event);
+      options.onPress?.(event);
+    },
+  });
+  for (const [property, type] of Object.entries(eventNames) as Array<
+    [keyof typeof eventNames, string]
+  >) {
+    host.addEventListener(type, controller.longPressProps[property] as EventListener);
+  }
+  return {
+    controller,
+    events,
+    host,
+    unmount: () => {
+      try {
+        controller.dispose();
+      } finally {
+        host.remove();
+      }
+    },
+  };
+}
+
+export function pointer(
+  type: string,
+  pointerType = "mouse",
+  values: Partial<PointerEventInit> = {},
+): PointerEvent {
+  return new PointerEvent(type, {
+    bubbles: true,
+    button: 0,
+    clientX: 12,
+    clientY: 18,
+    isPrimary: true,
+    pointerId: 19,
+    pointerType,
+    ...values,
+  });
+}
+
+export async function elapseThreshold(): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 5));
+}

--- a/npm/ui/core/src/long-press-types.ts
+++ b/npm/ui/core/src/long-press-types.ts
@@ -9,33 +9,12 @@ export type LongPressPointerType = Extract<PressPointerType, "mouse" | "pen" | "
 export type LongPressEventType = "longpress" | "longpressend" | "longpressstart";
 
 /** Immutable snapshot of one long-press lifecycle event. */
-export interface LongPressEvent {
+export interface LongPressEvent extends Omit<PressEvent, "type" | "pointerType"> {
   /** Long-press lifecycle phase represented by this snapshot. */
   readonly type: LongPressEventType;
 
   /** Pointing-device family that initiated the interaction. */
   readonly pointerType: LongPressPointerType;
-
-  /** Element whose bound props own the interaction. */
-  readonly target: Element;
-
-  /** Native event responsible for this phase, or `null` for manual cancellation. */
-  readonly originalEvent: Event | null;
-
-  /** Viewport coordinate when supplied by pointing hardware. */
-  readonly x: number | null;
-
-  /** Viewport coordinate when supplied by pointing hardware. */
-  readonly y: number | null;
-
-  /** Modifier-key snapshots captured from the native event. */
-  readonly altKey: boolean;
-  readonly ctrlKey: boolean;
-  readonly metaKey: boolean;
-  readonly shiftKey: boolean;
-
-  /** Whether the attempt ended without reaching a normal release. */
-  readonly isCanceled: boolean;
 }
 
 /** Options shared by {@link createLongPress} and {@link useLongPress}. */
@@ -125,7 +104,12 @@ export interface LongPressController {
   /** Stable handlers and accessibility attributes for exactly one host. */
   readonly longPressProps: Readonly<LongPressProps>;
 
-  /** Cancel the current pending or triggered interaction. */
+  /**
+   * Cancel the current pending or triggered interaction.
+   * Returns `true` when an interaction was canceled.
+   *
+   * @throws Error with `VIZE_UI_LONG_PRESS_DISPOSED` after disposal.
+   */
   readonly cancel: () => boolean;
 
   /** Release timers, listeners, selection guards, and reactive state. */

--- a/npm/ui/core/src/long-press.behavior.md
+++ b/npm/ui/core/src/long-press.behavior.md
@@ -4,30 +4,30 @@ Normative state × input → outcome table for `@vizejs/ui/long-press`. Every ro
 exercised by `src/long-press*.test.ts`; compile-only assertions live in
 `src/long-press.types.test-d.ts`.
 
-| #    | State                          | Input                                              | Outcome                                                                 | Proven by                                 |
-| ---- | ------------------------------ | -------------------------------------------------- | ----------------------------------------------------------------------- | ----------------------------------------- |
-| L1   | idle                           | primary mouse, pen, touch, or unknown pointer down | start snapshot and pressed state are published                          | stable lifecycle and pointer-filter tests |
-| L2   | idle                           | secondary or non-primary pointer                   | input is ignored                                                        | secondary-contact test                    |
-| L3   | pending                        | threshold elapses                                  | exactly one long event is emitted; short activation is suppressed       | stable lifecycle test                     |
-| L4   | pending                        | primary release before threshold                   | long end without a long event and ordinary short press are emitted      | short-alternative test                    |
-| L5   | pending                        | pointer leaves host                                | timer and attempt cancel permanently                                    | cancellation test                         |
-| L6   | pending or triggered           | reactive disabled becomes true                     | threshold/release cancels or marks the terminal event canceled          | cancellation test                         |
-| L7   | triggered                      | owning pointer releases                            | normal long end is emitted and state settles                            | stable lifecycle test                     |
-| L8   | triggered                      | another contact releases                           | original contact retains ownership                                      | legacy touch test                         |
-| L9   | pending or triggered           | manual cancel                                      | canceled end is emitted and compatibility click is suppressed           | cancellation tests                        |
-| L10  | active                         | dispose or Vue scope stop                          | timers, listeners, guards, and state release without callbacks          | disposal/scope tests                      |
-| L11  | touch or pen attempt           | native context menu                                | active and immediately trailing menus are prevented                     | context-menu test                         |
-| L12  | mouse or idle                  | native context menu                                | browser default remains untouched                                       | context-menu test                         |
-| L13  | active                         | text-selection guard                               | exact inline values and priorities restore at end                       | selection test                            |
-| L13a | touch or pen reaches threshold | host is not focused                                | host receives focus without requesting scroll movement                  | selection/context-menu test               |
-| L14  | configured pointer filter      | another device family                              | long recognition is skipped                                             | pointer-filter test                       |
-| L15  | reactive options               | next attempt/render                                | current threshold, filter, disabled state, and description are resolved | reactive-options test                     |
-| L16  | accessible description ID      | render                                             | `aria-describedby` wins over inline description                         | reactive-options test                     |
-| L17  | inline accessible description  | render                                             | `aria-description` is exposed only for enabled long actions             | reactive-options test                     |
-| L18  | keyboard or virtual activation | press                                              | explicit short/alternative callback remains available                   | short-alternative test                    |
-| L19  | legacy Touch Events browser    | hold and owning release                            | coordinates, identity, and lifecycle normalize to touch                 | legacy touch test                         |
-| L20  | invalid JavaScript options     | setup/read                                         | stable diagnostics reject open unions and invalid values                | runtime-option test                       |
-| L21  | public TypeScript API          | mutation or invalid unions                         | compilation rejects misuse                                              | `src/long-press.types.test-d.ts`          |
+| #    | State                          | Input                                              | Outcome                                                                   | Proven by                                 |
+| ---- | ------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------- |
+| L1   | idle                           | primary mouse, pen, touch, or unknown pointer down | start snapshot and pressed state are published                            | stable lifecycle and pointer-filter tests |
+| L2   | idle                           | secondary or non-primary pointer                   | input is ignored                                                          | secondary-contact test                    |
+| L3   | pending                        | threshold elapses                                  | exactly one long event is emitted; short activation is suppressed         | stable lifecycle test                     |
+| L4   | pending                        | primary release before threshold                   | long end without a long event and ordinary short press are emitted        | short-alternative test                    |
+| L5   | pending                        | pointer leaves host                                | timer and attempt cancel permanently                                      | cancellation test                         |
+| L6   | pending or triggered           | reactive disabled becomes true                     | threshold/release cancels or marks the terminal event canceled            | cancellation test                         |
+| L7   | triggered                      | owning pointer releases                            | normal long end is emitted and state settles                              | stable lifecycle test                     |
+| L8   | triggered                      | another contact starts or releases                 | original contact retains ownership in either release order                | contact-ownership and legacy touch tests  |
+| L9   | pending or triggered           | manual cancel                                      | canceled end is emitted and compatibility click is suppressed             | cancellation tests                        |
+| L10  | active                         | dispose, scope stop, or cleanup callback failure   | every teardown is attempted and the controller becomes terminal           | disposal/scope and cleanup-failure tests  |
+| L11  | touch or pen attempt           | native context menu                                | active and immediately trailing menus are prevented                       | context-menu test                         |
+| L12  | mouse or idle                  | native context menu                                | browser default remains untouched                                         | context-menu test                         |
+| L13  | active                         | text-selection guard                               | exact inline values and priorities restore at end                         | selection test                            |
+| L13a | touch or pen reaches threshold | host is not focused                                | host receives focus without requesting scroll movement                    | selection/context-menu test               |
+| L14  | configured pointer filter      | another device family                              | long recognition is skipped                                               | pointer-filter test                       |
+| L15  | reactive options               | next attempt/render                                | current threshold, filter, disabled state, and description are resolved   | reactive-options test                     |
+| L16  | accessible description ID      | render                                             | `aria-describedby` wins over inline description                           | reactive-options test                     |
+| L17  | inline accessible description  | render                                             | `aria-description` is exposed only for enabled long actions               | reactive-options test                     |
+| L18  | keyboard or virtual activation | press                                              | explicit short/alternative callback remains available                     | short-alternative test                    |
+| L19  | legacy Touch Events browser    | multi-touch owning release                         | coordinates select the owning identifier even when another touch is first | legacy touch test                         |
+| L20  | invalid JavaScript options     | setup or triggered release                         | stable diagnostics reject misuse after terminal state has settled         | runtime-option and teardown tests         |
+| L21  | public TypeScript API          | mutation or invalid unions                         | compilation rejects misuse                                                | `src/long-press.types.test-d.ts`          |
 
 ## Accessibility obligations
 

--- a/npm/ui/core/src/long-press.test.ts
+++ b/npm/ui/core/src/long-press.test.ts
@@ -4,99 +4,8 @@ import { effectScope, ref } from "vue";
 import { test } from "vite-plus/test";
 
 import { createLongPress, useLongPress } from "./long-press.ts";
-import type {
-  LongPressController,
-  LongPressEvent,
-  LongPressOptions,
-  LongPressProps,
-} from "./long-press.ts";
-import type { PressEvent } from "./press.ts";
-
-const eventNames: Readonly<Record<keyof Omit<LongPressProps, `aria-${string}`>, string>> = {
-  onClick: "click",
-  onContextmenu: "contextmenu",
-  onDragstart: "dragstart",
-  onKeydown: "keydown",
-  onKeyup: "keyup",
-  onMousedown: "mousedown",
-  onMousemove: "mousemove",
-  onMouseup: "mouseup",
-  onPointercancel: "pointercancel",
-  onPointerdown: "pointerdown",
-  onPointermove: "pointermove",
-  onPointerup: "pointerup",
-  onTouchcancel: "touchcancel",
-  onTouchend: "touchend",
-  onTouchmove: "touchmove",
-  onTouchstart: "touchstart",
-};
-
-interface Harness {
-  readonly controller: LongPressController;
-  readonly events: Array<LongPressEvent | PressEvent>;
-  readonly host: HTMLButtonElement;
-  readonly unmount: () => void;
-}
-
-function mountLongPress(options: LongPressOptions = {}): Harness {
-  const host = document.createElement("button");
-  document.body.append(host);
-  const events: Array<LongPressEvent | PressEvent> = [];
-  const controller = createLongPress({
-    ...options,
-    onLongPressStart: (event) => {
-      events.push(event);
-      options.onLongPressStart?.(event);
-    },
-    onLongPress: (event) => {
-      events.push(event);
-      options.onLongPress?.(event);
-    },
-    onLongPressEnd: (event) => {
-      events.push(event);
-      options.onLongPressEnd?.(event);
-    },
-    onPress: (event) => {
-      events.push(event);
-      options.onPress?.(event);
-    },
-  });
-  for (const [property, type] of Object.entries(eventNames) as Array<
-    [keyof typeof eventNames, string]
-  >) {
-    host.addEventListener(type, controller.longPressProps[property] as EventListener);
-  }
-  return {
-    controller,
-    events,
-    host,
-    unmount: () => {
-      controller.dispose();
-      host.remove();
-    },
-  };
-}
-
-function pointer(
-  type: string,
-  pointerType = "mouse",
-  values: Partial<PointerEventInit> = {},
-): PointerEvent {
-  return new PointerEvent(type, {
-    bubbles: true,
-    button: 0,
-    clientX: 12,
-    clientY: 18,
-    isPrimary: true,
-    pointerId: 19,
-    pointerType,
-    ...values,
-  });
-}
-
-async function elapseThreshold(): Promise<void> {
-  await new Promise<void>((resolve) => setTimeout(resolve, 5));
-}
+import type { LongPressEvent } from "./long-press.ts";
+import { elapseThreshold, mountLongPress, pointer } from "./long-press-test-utils.ts";
 
 test("reports a stable long-press lifecycle and suppresses the compatibility click", async () => {
   const harness = mountLongPress({ threshold: 0 });
@@ -164,7 +73,10 @@ test("cancels on pointer exit, manual cancellation, disablement, and disposal", 
     assert.equal(harness.controller.isPressed.value, false);
     assert.equal((harness.events.at(-1) as LongPressEvent).isCanceled, true);
     await elapseThreshold();
-    assert.doesNotMatch(harness.events.map(({ type }) => type).join(), /longpress,/);
+    assert.equal(
+      harness.events.some(({ type }) => type === "longpress"),
+      false,
+    );
     harness.unmount();
   }
 
@@ -212,6 +124,35 @@ test("filters pointer families and ignores secondary or non-primary contacts", a
     harness.host.dispatchEvent(pointer("pointerdown", "mouse", values));
     await elapseThreshold();
     assert.deepEqual(harness.events, []);
+    harness.unmount();
+  }
+});
+
+test("a triggered attempt retains ownership when another primary contact starts", async () => {
+  for (const releaseOrder of ["other-first", "owner-first"] as const) {
+    const harness = mountLongPress({ threshold: 0 });
+    harness.host.dispatchEvent(pointer("pointerdown", "touch", { pointerId: 31 }));
+    await elapseThreshold();
+
+    harness.host.dispatchEvent(pointer("pointerdown", "touch", { pointerId: 47 }));
+    assert.equal(harness.controller.isLongPressed.value, true);
+    if (releaseOrder === "other-first") {
+      harness.host.dispatchEvent(pointer("pointerup", "touch", { pointerId: 47 }));
+      assert.equal(harness.controller.isLongPressed.value, true);
+      harness.host.dispatchEvent(pointer("pointerup", "touch", { pointerId: 31 }));
+    } else {
+      harness.host.dispatchEvent(pointer("pointerup", "touch", { pointerId: 31 }));
+      harness.host.dispatchEvent(pointer("pointerup", "touch", { pointerId: 47 }));
+    }
+
+    assert.equal(harness.controller.isLongPressed.value, false);
+    assert.deepEqual(
+      harness.events.map(({ type }) => type),
+      ["longpressstart", "longpress", "longpressend"],
+    );
+    const end = harness.events.at(-1) as LongPressEvent;
+    assert.equal(end.originalEvent?.type, "pointerup");
+    assert.equal((end.originalEvent as PointerEvent).pointerId, 31);
     harness.unmount();
   }
 });

--- a/npm/ui/core/src/long-press.ts
+++ b/npm/ui/core/src/long-press.ts
@@ -1,97 +1,31 @@
-import { getCurrentScope, onScopeDispose, shallowReadonly, shallowRef, toValue } from "vue";
+import { getCurrentScope, onScopeDispose, shallowReadonly, shallowRef } from "vue";
 
-import { createPressEvent, disableTextSelection } from "./press-event.ts";
+import { disableTextSelection } from "./press-event.ts";
 import { createPress } from "./press.ts";
+import {
+  captureError,
+  installTriggeredRelease,
+  isHardwarePointer,
+  ownerMatches,
+  ownerOf,
+  readBoolean,
+  readPointerType,
+  readText,
+  readThreshold,
+  surfaceErrors,
+  toLongPressEvent,
+  validateOptions,
+} from "./long-press-internal.ts";
+import type { Attempt } from "./long-press-internal.ts";
 import type {
   LongPressController,
-  LongPressEvent,
-  LongPressEventType,
   LongPressOptions,
   LongPressPointerType,
   LongPressProps,
 } from "./long-press-types.ts";
-import type { PressEvent } from "./press-types.ts";
-
-const defaultThreshold = 500;
-const invalidOptionDiagnostic = "VIZE_UI_LONG_PRESS_OPTION";
+const contextMenuLingerMs = 50;
 const disposedDiagnostic = "VIZE_UI_LONG_PRESS_DISPOSED";
 const setupDiagnostic = "VIZE_UI_LONG_PRESS_SETUP";
-const hardwarePointers = new Set<LongPressPointerType>(["mouse", "pen", "pointer", "touch"]);
-
-interface Attempt {
-  readonly event: LongPressEvent;
-  readonly pointerType: LongPressPointerType;
-  readonly target: Element;
-  timer: ReturnType<typeof setTimeout> | null;
-}
-
-function readBoolean(value: LongPressOptions["isDisabled"], name: string): boolean {
-  const resolved = toValue(value);
-  if (resolved === undefined) return false;
-  if (typeof resolved !== "boolean") {
-    throw new TypeError(`${invalidOptionDiagnostic}: ${name} must resolve to a boolean`);
-  }
-  return resolved;
-}
-
-function readPointerType(value: LongPressOptions["pointerType"]): LongPressPointerType | null {
-  const resolved = toValue(value) ?? null;
-  if (resolved !== null && !hardwarePointers.has(resolved)) {
-    throw new TypeError(
-      `${invalidOptionDiagnostic}: pointerType must resolve to mouse, pen, pointer, or touch`,
-    );
-  }
-  return resolved;
-}
-
-function readThreshold(value: LongPressOptions["threshold"]): number {
-  const resolved = toValue(value) ?? defaultThreshold;
-  if (typeof resolved !== "number" || !Number.isFinite(resolved) || resolved < 0) {
-    throw new TypeError(
-      `${invalidOptionDiagnostic}: threshold must resolve to a finite number >= 0`,
-    );
-  }
-  return resolved;
-}
-
-function readText(
-  value: LongPressOptions["accessibilityDescription"],
-  name: string,
-): string | undefined {
-  const resolved = toValue(value);
-  if (resolved === undefined || resolved === "") return undefined;
-  if (typeof resolved !== "string") {
-    throw new TypeError(`${invalidOptionDiagnostic}: ${name} must resolve to a string`);
-  }
-  return resolved;
-}
-
-function toLongPressEvent(
-  type: LongPressEventType,
-  event: Omit<PressEvent, "type">,
-  originalEvent = event.originalEvent,
-  isCanceled = event.isCanceled,
-): LongPressEvent {
-  const snapshot = createPressEvent(
-    "pressend",
-    event.target,
-    event.pointerType,
-    originalEvent,
-    isCanceled,
-  );
-  return Object.freeze({ ...snapshot, type }) as LongPressEvent;
-}
-
-function validateOptions(options: LongPressOptions): void {
-  for (const name of ["onLongPress", "onLongPressEnd", "onLongPressStart", "onPress"] as const) {
-    const callback = options[name];
-    if (callback !== undefined && typeof callback !== "function") {
-      throw new TypeError(`${invalidOptionDiagnostic}: ${name} must be a function`);
-    }
-  }
-  if (typeof options.threshold !== "function") readThreshold(options.threshold);
-  if (typeof options.pointerType !== "function") readPointerType(options.pointerType);
-}
 
 /** Create an SSR-safe long-press recognizer for one host element. */
 export function createLongPress(options: LongPressOptions = {}): LongPressController {
@@ -115,83 +49,61 @@ export function createLongPress(options: LongPressOptions = {}): LongPressContro
     contextMenuTimer = setTimeout(() => {
       contextMenuPointer = null;
       contextMenuTimer = null;
-    }, 50);
+    }, contextMenuLingerMs);
   };
   const clearRelease = () => {
-    releaseTriggered?.();
+    const release = releaseTriggered;
+    const restore = restoreTriggeredSelection;
     releaseTriggered = null;
-    restoreTriggeredSelection?.();
     restoreTriggeredSelection = null;
+    const errors: unknown[] = [];
+    try {
+      captureError(errors, () => release?.());
+    } finally {
+      captureError(errors, () => restore?.());
+    }
+    surfaceErrors(errors, "Long-press release cleanup failed");
   };
-  const clearAttempt = () => {
-    const timer = attempt?.timer;
+  const clearAttempt = (owner: Attempt | null = attempt): boolean => {
+    if (!owner || attempt !== owner) return false;
+    const timer = owner.timer;
     if (timer != null) clearTimeout(timer);
     attempt = null;
-  };
-
-  const finishTriggered = (originalEvent: Event | null, isCanceled: boolean): boolean => {
-    if (!isLongPressed.value || !attempt) return false;
-    const current = attempt;
-    const canceled = isCanceled || readBoolean(options.isDisabled, "isDisabled");
-    clearRelease();
-    clearAttempt();
-    isPressed.value = false;
-    isLongPressed.value = false;
-    lingerContextMenuSuppression();
-    options.onLongPressEnd?.(
-      toLongPressEvent("longpressend", current.event, originalEvent, canceled),
-    );
     return true;
   };
 
-  const installTriggeredRelease = (current: Attempt): (() => void) => {
-    const removals: Array<() => void> = [];
-    const document = current.target.ownerDocument;
-    const start = current.event.originalEvent;
-    const listen = (
-      owner: Document | Window,
-      type: string,
-      callback: EventListener,
-      capture = true,
-    ) => {
-      owner.addEventListener(type, callback, capture);
-      removals.push(() => owner.removeEventListener(type, callback, capture));
-    };
-    const finish = (event: Event | null, canceled = false) => finishTriggered(event, canceled);
-    if (start && "pointerId" in start) {
-      const id = Number((start as PointerEvent).pointerId);
-      listen(document, "pointerup", ((event: PointerEvent) => {
-        if (event.pointerId === id) finish(event);
-      }) as EventListener);
-      listen(document, "pointercancel", ((event: PointerEvent) => {
-        if (event.pointerId === id) finish(event, true);
-      }) as EventListener);
-    } else if (start && "changedTouches" in start) {
-      const id = (start as TouchEvent).changedTouches.item(0)?.identifier;
-      const ownsTouch = (event: TouchEvent) =>
-        id !== undefined &&
-        Array.from(event.changedTouches).some((touch) => touch.identifier === id);
-      listen(document, "touchend", ((event: TouchEvent) => {
-        if (ownsTouch(event)) finish(event);
-      }) as EventListener);
-      listen(document, "touchcancel", ((event: TouchEvent) => {
-        if (ownsTouch(event)) finish(event, true);
-      }) as EventListener);
-    } else {
-      listen(document, "mouseup", ((event: MouseEvent) => {
-        if (event.button === 0) finish(event);
-      }) as EventListener);
+  const finishTriggered = (
+    owner: Attempt,
+    originalEvent: Event | null,
+    isCanceled: boolean,
+  ): boolean => {
+    if (!isLongPressed.value || attempt !== owner) return false;
+    const errors: unknown[] = [];
+    captureError(errors, clearRelease);
+    clearAttempt(owner);
+    isPressed.value = false;
+    isLongPressed.value = false;
+    captureError(errors, lingerContextMenuSuppression);
+    let canceled = isCanceled;
+    try {
+      canceled ||= readBoolean(options.isDisabled, "isDisabled");
+    } catch (error) {
+      canceled = true;
+      errors.push(error);
     }
-    listen(document, "dragstart", (event) => finish(event, true));
-    listen(document, "visibilitychange", (() => {
-      if (document.visibilityState === "hidden") finish(null, true);
-    }) as EventListener);
-    if (document.defaultView) {
-      listen(document.defaultView, "blur", (event) => finish(event, true), false);
-    }
-    return () => {
-      for (const remove of removals.splice(0)) remove();
-    };
+    captureError(errors, () =>
+      options.onLongPressEnd?.(
+        toLongPressEvent(
+          "longpressend",
+          owner.event,
+          originalEvent,
+          canceled,
+          owner.touchIdentifier,
+        ),
+      ),
+    );
+    surfaceErrors(errors, "Long-press completion failed");
+    return true;
   };
 
   let press!: ReturnType<typeof createPress>;
@@ -203,7 +115,25 @@ export function createLongPress(options: LongPressOptions = {}): LongPressContro
       return;
     }
     isLongPressed.value = true;
-    releaseTriggered = installTriggeredRelease(current);
+    try {
+      releaseTriggered = installTriggeredRelease(current, (event, canceled = false) =>
+        finishTriggered(current, event, canceled),
+      );
+    } catch (error) {
+      const errors: unknown[] = [error];
+      clearAttempt(current);
+      isPressed.value = false;
+      isLongPressed.value = false;
+      contextMenuPointer = null;
+      endingAtThreshold = true;
+      try {
+        captureError(errors, press.cancel);
+      } finally {
+        endingAtThreshold = false;
+      }
+      surfaceErrors(errors, "Long-press trigger setup failed");
+      return;
+    }
     endingAtThreshold = true;
     try {
       press.cancel();
@@ -225,7 +155,15 @@ export function createLongPress(options: LongPressOptions = {}): LongPressContro
     if (!readBoolean(options.allowTextSelectionOnPress, "allowTextSelectionOnPress")) {
       restoreTriggeredSelection = disableTextSelection(current.target);
     }
-    options.onLongPress?.(toLongPressEvent("longpress", current.event));
+    options.onLongPress?.(
+      toLongPressEvent(
+        "longpress",
+        current.event,
+        current.event.originalEvent,
+        current.event.isCanceled,
+        current.touchIdentifier,
+      ),
+    );
   };
 
   press = createPress({
@@ -238,15 +176,33 @@ export function createLongPress(options: LongPressOptions = {}): LongPressContro
       : { preventFocusOnPress: options.preventFocusOnPress }),
     shouldCancelOnPointerExit: true,
     onPressStart(event) {
-      if (!hardwarePointers.has(event.pointerType as LongPressPointerType)) return;
-      const pointerType = event.pointerType as LongPressPointerType;
+      if (!isHardwarePointer(event.pointerType)) return;
+      const pointerType = event.pointerType;
       const filter = readPointerType(options.pointerType);
       if (filter && filter !== pointerType) return;
-      clearAttempt();
+      if (attempt) {
+        press.cancel();
+        return;
+      }
       contextMenuPointer = pointerType;
       clearContextMenuTimer();
-      const start = toLongPressEvent("longpressstart", event);
-      const current: Attempt = { event: start, pointerType, target: event.target, timer: null };
+      const owner = ownerOf(event);
+      const touchIdentifier = owner.source === "touch" ? owner.id : null;
+      const start = toLongPressEvent(
+        "longpressstart",
+        event,
+        event.originalEvent,
+        event.isCanceled,
+        touchIdentifier,
+      );
+      const current: Attempt = {
+        event: start,
+        owner,
+        pointerType,
+        target: event.target,
+        touchIdentifier,
+        timer: null,
+      };
       attempt = current;
       isPressed.value = true;
       current.timer = setTimeout(() => trigger(current), readThreshold(options.threshold));
@@ -255,7 +211,8 @@ export function createLongPress(options: LongPressOptions = {}): LongPressContro
     onPressEnd(event) {
       if (!attempt || endingAtThreshold) return;
       const current = attempt;
-      clearAttempt();
+      if (!ownerMatches(current.owner, event)) return;
+      clearAttempt(current);
       isPressed.value = false;
       if (current.pointerType === "touch" || current.pointerType === "pen") {
         lingerContextMenuSuppression();
@@ -263,7 +220,13 @@ export function createLongPress(options: LongPressOptions = {}): LongPressContro
         contextMenuPointer = null;
       }
       options.onLongPressEnd?.(
-        toLongPressEvent("longpressend", current.event, event.originalEvent, event.isCanceled),
+        toLongPressEvent(
+          "longpressend",
+          current.event,
+          event.originalEvent,
+          event.isCanceled,
+          current.touchIdentifier,
+        ),
       );
     },
     ...(options.onPress ? { onPress: options.onPress } : {}),
@@ -292,19 +255,21 @@ export function createLongPress(options: LongPressOptions = {}): LongPressContro
     longPressProps: Object.freeze(attributes),
     cancel: () => {
       if (disposed) throw new Error(`${disposedDiagnostic}: the controller has been disposed`);
-      if (finishTriggered(null, true)) return true;
+      if (attempt && finishTriggered(attempt, null, true)) return true;
       return press.cancel();
     },
     dispose: () => {
       if (disposed) return;
-      clearRelease();
-      clearAttempt();
-      clearContextMenuTimer();
+      disposed = true;
+      const errors: unknown[] = [];
+      captureError(errors, clearRelease);
+      captureError(errors, () => clearAttempt());
+      captureError(errors, clearContextMenuTimer);
       contextMenuPointer = null;
       isPressed.value = false;
       isLongPressed.value = false;
-      press.dispose();
-      disposed = true;
+      captureError(errors, press.dispose);
+      surfaceErrors(errors, "Long-press disposal failed");
     },
   });
   return controller;


### PR DESCRIPTION
## Summary

- preserve the triggered contact across overlapping pointer starts and both release orders
- carry the owning legacy touch identifier through every immutable snapshot
- make release/disposal teardown terminal and exhaustive even when cleanup or reactive option reads throw
- preserve multiple cleanup failures on runtimes without a native `AggregateError`
- derive the long-press event contract from the press event contract and document disposal diagnostics
- split recognition, listener ownership, and test harness responsibilities below the 350-line source gate
- keep strict package and consumer tree-shaking budgets after the safety work

Follow-up to #4189. Addresses every actionable item from the delayed review on that merged PR.

## Verification

- `pnpm --filter @vizejs/ui check`
- `pnpm --filter @vizejs/ui test` — 138 tests across 25 files
- pointer ownership regression for owner-first and other-first release order
- legacy multi-touch coordinate regression with the owning touch listed second
- invalid reactive disablement, throwing selection restore, and missing `AggregateError` regressions
- package size: root 20,251 / 20,325 gzip bytes; long-press 7,910 / 8,000
- consumer tree shaking: root/subpath 5,131 / 5,150 gzip bytes; CSS 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved long-press behavior during multi-touch interactions, ensuring the initiating touch remains in control regardless of release order.
  - Prevented unintended long-press events after cancellation.
  - Improved cleanup when disabling or disposing long-press interactions, including restoration of visual state and clearer error reporting.
  - Repeated starts during an active long-press attempt are now safely ignored.
  - Improved handling of input cancellation, setup failures, and completed interactions.

- **Documentation**
  - Clarified long-press ownership, cancellation, cleanup, disposal, and diagnostic behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->