### PR TITLE
fix(fresco): make terminal initialization transactional

### DIFF
--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -3,19 +3,17 @@
 use std::io::{self, Write};
 
 use crossterm::{
-    cursor::{Hide, Show},
-    event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture},
     execute,
-    terminal::{
-        Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode,
-        enable_raw_mode,
-    },
+    terminal::{Clear, ClearType},
 };
 
 use super::{buffer::Buffer, cursor::Cursor};
 
+mod lifecycle;
 mod output;
 
+#[cfg(test)]
+mod lifecycle_tests;
 #[cfg(test)]
 mod tests;
 
@@ -106,86 +104,6 @@ impl<W: Write> Backend<W> {
             height,
             writer,
         }
-    }
-
-    /// Initialize the terminal using [`TerminalOptions::default`].
-    pub fn init(&mut self) -> io::Result<()> {
-        self.init_with_options(TerminalOptions::default())
-    }
-
-    /// Initialize the terminal using explicit mode options.
-    pub fn init_with_options(&mut self, options: TerminalOptions) -> io::Result<()> {
-        if options.raw_mode {
-            enable_raw_mode()?;
-            self.raw_mode = true;
-        }
-        if options.alternate_screen {
-            execute!(&mut self.writer, EnterAlternateScreen)?;
-            self.alternate_screen = true;
-        }
-        if options.bracketed_paste {
-            execute!(&mut self.writer, EnableBracketedPaste)?;
-            self.bracketed_paste = true;
-        }
-        if options.mouse_capture {
-            execute!(&mut self.writer, EnableMouseCapture)?;
-            self.mouse_capture = true;
-        }
-        if options.hide_cursor {
-            execute!(&mut self.writer, Hide)?;
-            self.cursor_hidden = true;
-        }
-        Ok(())
-    }
-
-    /// Initialize with mouse capture enabled.
-    pub fn init_with_mouse(&mut self) -> io::Result<()> {
-        self.init_with_options(TerminalOptions {
-            mouse_capture: true,
-            ..TerminalOptions::default()
-        })
-    }
-
-    /// Restore every terminal mode successfully enabled by this backend.
-    ///
-    /// Every independent cleanup action is attempted even when an earlier one
-    /// fails, so a rejected escape sequence cannot leave the process in raw
-    /// mode. The operation is idempotent: a failed action keeps its mode marked
-    /// active so a later explicit call or [`Drop`] can retry it, and the first
-    /// observed error is returned after all attempts.
-    pub fn restore(&mut self) -> io::Result<()> {
-        let mut first_error = None;
-        if self.mouse_capture {
-            match execute!(&mut self.writer, DisableMouseCapture) {
-                Ok(()) => self.mouse_capture = false,
-                Err(error) => first_error = Some(error),
-            }
-        }
-        if self.bracketed_paste {
-            match execute!(&mut self.writer, DisableBracketedPaste) {
-                Ok(()) => self.bracketed_paste = false,
-                Err(error) => first_error = first_error.or(Some(error)),
-            }
-        }
-        if self.alternate_screen {
-            match execute!(&mut self.writer, LeaveAlternateScreen) {
-                Ok(()) => self.alternate_screen = false,
-                Err(error) => first_error = first_error.or(Some(error)),
-            }
-        }
-        if self.cursor_hidden {
-            match execute!(&mut self.writer, Show) {
-                Ok(()) => self.cursor_hidden = false,
-                Err(error) => first_error = first_error.or(Some(error)),
-            }
-        }
-        if self.raw_mode {
-            match disable_raw_mode() {
-                Ok(()) => self.raw_mode = false,
-                Err(error) => first_error = first_error.or(Some(error)),
-            }
-        }
-        first_error.map_or(Ok(()), Err)
     }
 
     /// Return the terminal width in cells.

--- a/crates/vize_fresco/src/terminal/backend/lifecycle.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle.rs
@@ -1,0 +1,191 @@
+//! Transactional terminal-mode initialization and restoration.
+
+use std::{
+    error::Error,
+    fmt,
+    io::{self, Write},
+};
+
+use crossterm::{
+    cursor::{Hide, Show},
+    event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+
+use super::{Backend, TerminalOptions};
+
+#[derive(Debug, Clone, Copy, Default)]
+struct TerminalModeState {
+    alternate_screen: bool,
+    cursor_hidden: bool,
+    raw_mode: bool,
+    mouse_capture: bool,
+    bracketed_paste: bool,
+}
+
+impl<W: Write> Backend<W> {
+    /// Initialize the terminal using [`TerminalOptions::default`].
+    pub fn init(&mut self) -> io::Result<()> {
+        self.init_with_options(TerminalOptions::default())
+    }
+
+    /// Initialize the terminal using explicit mode options.
+    ///
+    /// Initialization is transactional relative to modes that were already
+    /// active. If any enable operation fails, every mode attempted by this call
+    /// is restored while pre-existing modes remain active. Escape-sequence
+    /// modes are conservatively marked active before writing because an I/O
+    /// error may occur after a terminal accepted a partial command.
+    pub fn init_with_options(&mut self, options: TerminalOptions) -> io::Result<()> {
+        let previous = self.mode_state();
+        if let Err(initialization) = self.enable_modes(options) {
+            return match self.restore_to(previous) {
+                Ok(()) => Err(initialization),
+                Err(rollback) => Err(combine_errors(initialization, rollback)),
+            };
+        }
+        Ok(())
+    }
+
+    /// Initialize with mouse capture enabled.
+    pub fn init_with_mouse(&mut self) -> io::Result<()> {
+        self.init_with_options(TerminalOptions {
+            mouse_capture: true,
+            ..TerminalOptions::default()
+        })
+    }
+
+    /// Restore every terminal mode enabled or possibly enabled by this backend.
+    ///
+    /// Every independent cleanup action is attempted even when an earlier one
+    /// fails, so a rejected escape sequence cannot prevent raw-mode cleanup.
+    /// The operation is idempotent: a failed action remains marked active for a
+    /// later explicit call or [`Drop`] retry, and the first error is returned
+    /// after all actions have been attempted.
+    pub fn restore(&mut self) -> io::Result<()> {
+        self.restore_to(TerminalModeState::default())
+    }
+
+    fn enable_modes(&mut self, options: TerminalOptions) -> io::Result<()> {
+        if options.raw_mode && !self.raw_mode {
+            enable_raw_mode()?;
+            self.raw_mode = true;
+        }
+        if options.alternate_screen && !self.alternate_screen {
+            self.alternate_screen = true;
+            execute!(&mut self.writer, EnterAlternateScreen)?;
+        }
+        if options.bracketed_paste && !self.bracketed_paste {
+            self.bracketed_paste = true;
+            execute!(&mut self.writer, EnableBracketedPaste)?;
+        }
+        if options.mouse_capture && !self.mouse_capture {
+            self.mouse_capture = true;
+            execute!(&mut self.writer, EnableMouseCapture)?;
+        }
+        if options.hide_cursor && !self.cursor_hidden {
+            self.cursor_hidden = true;
+            execute!(&mut self.writer, Hide)?;
+        }
+        Ok(())
+    }
+
+    fn restore_to(&mut self, target: TerminalModeState) -> io::Result<()> {
+        let mut first_error = None;
+        restore_writer_mode(
+            &mut self.writer,
+            &mut self.mouse_capture,
+            target.mouse_capture,
+            DisableMouseCapture,
+            &mut first_error,
+        );
+        restore_writer_mode(
+            &mut self.writer,
+            &mut self.bracketed_paste,
+            target.bracketed_paste,
+            DisableBracketedPaste,
+            &mut first_error,
+        );
+        restore_writer_mode(
+            &mut self.writer,
+            &mut self.alternate_screen,
+            target.alternate_screen,
+            LeaveAlternateScreen,
+            &mut first_error,
+        );
+        restore_writer_mode(
+            &mut self.writer,
+            &mut self.cursor_hidden,
+            target.cursor_hidden,
+            Show,
+            &mut first_error,
+        );
+        if self.raw_mode && !target.raw_mode {
+            match disable_raw_mode() {
+                Ok(()) => self.raw_mode = false,
+                Err(error) => first_error = first_error.or(Some(error)),
+            }
+        }
+        first_error.map_or(Ok(()), Err)
+    }
+
+    const fn mode_state(&self) -> TerminalModeState {
+        TerminalModeState {
+            alternate_screen: self.alternate_screen,
+            cursor_hidden: self.cursor_hidden,
+            raw_mode: self.raw_mode,
+            mouse_capture: self.mouse_capture,
+            bracketed_paste: self.bracketed_paste,
+        }
+    }
+}
+
+fn restore_writer_mode<W: Write, C: crossterm::Command>(
+    writer: &mut W,
+    active: &mut bool,
+    target: bool,
+    command: C,
+    first_error: &mut Option<io::Error>,
+) {
+    if !*active || target {
+        return;
+    }
+    match execute!(writer, command) {
+        Ok(()) => *active = false,
+        Err(error) => *first_error = first_error.take().or(Some(error)),
+    }
+}
+
+fn combine_errors(initialization: io::Error, rollback: io::Error) -> io::Error {
+    let kind = initialization.kind();
+    io::Error::new(
+        kind,
+        TerminalInitializationFailure {
+            initialization,
+            rollback,
+        },
+    )
+}
+
+#[derive(Debug)]
+struct TerminalInitializationFailure {
+    initialization: io::Error,
+    rollback: io::Error,
+}
+
+impl fmt::Display for TerminalInitializationFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "terminal initialization failed: {}; rollback also failed: {}",
+            self.initialization, self.rollback
+        )
+    }
+}
+
+impl Error for TerminalInitializationFailure {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.initialization)
+    }
+}

--- a/crates/vize_fresco/src/terminal/backend/lifecycle_tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle_tests.rs
@@ -1,0 +1,253 @@
+use std::io::{self, Write};
+
+use vize_carton::ToCompactString;
+
+use super::{Backend, TerminalOptions};
+
+#[test]
+fn failed_escape_modes_remain_active_when_rollback_cannot_confirm_restoration() {
+    assert_uncertain_mode_remains_active(
+        TerminalOptions {
+            alternate_screen: true,
+            ..disabled_options()
+        },
+        |backend| backend.alternate_screen,
+    );
+    assert_uncertain_mode_remains_active(
+        TerminalOptions {
+            bracketed_paste: true,
+            ..disabled_options()
+        },
+        |backend| backend.bracketed_paste,
+    );
+    assert_uncertain_mode_remains_active(
+        TerminalOptions {
+            mouse_capture: true,
+            ..disabled_options()
+        },
+        |backend| backend.mouse_capture,
+    );
+    assert_uncertain_mode_remains_active(
+        TerminalOptions {
+            hide_cursor: true,
+            ..disabled_options()
+        },
+        |backend| backend.cursor_hidden,
+    );
+}
+
+#[test]
+fn one_shot_enable_failure_is_rolled_back_before_returning() {
+    let mut backend = Backend::with_writer(80, 24, OneShotFailureWriter::default());
+    let error = backend
+        .init_with_options(TerminalOptions {
+            alternate_screen: true,
+            ..disabled_options()
+        })
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_compact_string()
+            .contains("injected enable failure")
+    );
+    assert!(!backend.alternate_screen);
+    assert!(!backend.writer().data.is_empty());
+    backend.restore().unwrap();
+}
+
+#[test]
+fn repeated_initialization_does_not_reenter_active_terminal_modes() {
+    let options = TerminalOptions {
+        alternate_screen: true,
+        bracketed_paste: true,
+        hide_cursor: true,
+        ..disabled_options()
+    };
+    let mut backend = Backend::with_writer(80, 24, Vec::new());
+    backend.init_with_options(options).unwrap();
+    let initialized_bytes = backend.writer().len();
+
+    backend.init_with_options(options).unwrap();
+    assert_eq!(backend.writer().len(), initialized_bytes);
+    backend.restore().unwrap();
+}
+
+#[test]
+fn partial_command_failure_is_retryable_after_rollback_also_fails() {
+    let mut backend = Backend::with_writer(
+        80,
+        24,
+        ByteBudgetWriter {
+            remaining: 1,
+            data: Vec::new(),
+        },
+    );
+    let error = backend
+        .init_with_options(TerminalOptions {
+            alternate_screen: true,
+            ..disabled_options()
+        })
+        .unwrap_err();
+
+    assert!(error.to_compact_string().contains("rollback also failed"));
+    assert!(backend.alternate_screen);
+    assert_eq!(backend.writer().data.len(), 1);
+
+    backend.writer_mut().remaining = usize::MAX;
+    backend.restore().unwrap();
+    assert!(!backend.alternate_screen);
+}
+
+#[test]
+fn rollback_restores_only_modes_started_by_the_failing_call() {
+    let mut backend = Backend::with_writer(80, 24, FailOnFlushWriter::default());
+    backend
+        .init_with_options(TerminalOptions {
+            alternate_screen: true,
+            ..disabled_options()
+        })
+        .unwrap();
+    assert!(backend.alternate_screen);
+
+    backend.writer_mut().fail_on_flush = Some(2);
+    assert!(
+        backend
+            .init_with_options(TerminalOptions {
+                alternate_screen: true,
+                bracketed_paste: true,
+                ..disabled_options()
+            })
+            .is_err()
+    );
+
+    assert!(backend.alternate_screen);
+    assert!(!backend.bracketed_paste);
+    backend.restore().unwrap();
+}
+
+#[test]
+fn rollback_attempts_every_mode_started_before_a_later_failure() {
+    let mut backend = Backend::with_writer(
+        80,
+        24,
+        FailOnFlushWriter {
+            fail_on_flush: Some(2),
+            ..FailOnFlushWriter::default()
+        },
+    );
+
+    assert!(
+        backend
+            .init_with_options(TerminalOptions {
+                alternate_screen: true,
+                bracketed_paste: true,
+                ..disabled_options()
+            })
+            .is_err()
+    );
+    assert!(!backend.alternate_screen);
+    assert!(!backend.bracketed_paste);
+    assert_eq!(backend.writer().flushes, 4);
+}
+
+fn disabled_options() -> TerminalOptions {
+    TerminalOptions {
+        raw_mode: false,
+        alternate_screen: false,
+        mouse_capture: false,
+        bracketed_paste: false,
+        hide_cursor: false,
+    }
+}
+
+fn assert_uncertain_mode_remains_active(
+    options: TerminalOptions,
+    active: impl FnOnce(&Backend<AlwaysFailWriter>) -> bool,
+) {
+    let mut backend = Backend::with_writer(80, 24, AlwaysFailWriter);
+    let error = backend.init_with_options(options).unwrap_err();
+    assert!(error.to_compact_string().contains("rollback also failed"));
+    assert!(active(&backend));
+}
+
+#[derive(Debug)]
+struct AlwaysFailWriter;
+
+impl Write for AlwaysFailWriter {
+    fn write(&mut self, _buffer: &[u8]) -> io::Result<usize> {
+        Err(io::Error::other("injected writer failure"))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Err(io::Error::other("injected writer failure"))
+    }
+}
+
+#[derive(Debug, Default)]
+struct OneShotFailureWriter {
+    fail_next_write: bool,
+    data: Vec<u8>,
+}
+
+impl Write for OneShotFailureWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if !self.fail_next_write {
+            self.fail_next_write = true;
+            return Err(io::Error::other("injected enable failure"));
+        }
+        self.data.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct ByteBudgetWriter {
+    remaining: usize,
+    data: Vec<u8>,
+}
+
+impl Write for ByteBudgetWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        if self.remaining == 0 {
+            return Err(io::Error::other("injected writer failure"));
+        }
+        let accepted = buffer.len().min(self.remaining);
+        self.remaining -= accepted;
+        self.data.extend_from_slice(&buffer[..accepted]);
+        Ok(accepted)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        (self.remaining > 0)
+            .then_some(())
+            .ok_or_else(|| io::Error::other("injected writer failure"))
+    }
+}
+
+#[derive(Debug, Default)]
+struct FailOnFlushWriter {
+    fail_on_flush: Option<usize>,
+    flushes: usize,
+    data: Vec<u8>,
+}
+
+impl Write for FailOnFlushWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.data.extend_from_slice(buffer);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.flushes += 1;
+        if self.fail_on_flush == Some(self.flushes) {
+            self.fail_on_flush = None;
+            return Err(io::Error::other("injected flush failure"));
+        }
+        Ok(())
+    }
+}

--- a/crates/vize_fresco/src/terminal/backend/tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/tests.rs
@@ -51,38 +51,6 @@ fn injected_writer_owns_lifecycle_output_and_restoration_is_idempotent() {
 }
 
 #[test]
-fn failed_mode_enable_commands_are_never_recorded_as_active() {
-    assert_failed_init_does_not_mark_active(
-        TerminalOptions {
-            alternate_screen: true,
-            ..disabled_terminal_options()
-        },
-        |backend| backend.alternate_screen,
-    );
-    assert_failed_init_does_not_mark_active(
-        TerminalOptions {
-            bracketed_paste: true,
-            ..disabled_terminal_options()
-        },
-        |backend| backend.bracketed_paste,
-    );
-    assert_failed_init_does_not_mark_active(
-        TerminalOptions {
-            mouse_capture: true,
-            ..disabled_terminal_options()
-        },
-        |backend| backend.mouse_capture,
-    );
-    assert_failed_init_does_not_mark_active(
-        TerminalOptions {
-            hide_cursor: true,
-            ..disabled_terminal_options()
-        },
-        |backend| backend.cursor_hidden,
-    );
-}
-
-#[test]
 fn measured_flush_reports_exact_writer_bytes_and_changed_cells() {
     let mut backend = Backend::with_writer(4, 1, Vec::new());
     backend.buffer_mut().set_string(0, 0, "A", Style::new());
@@ -250,26 +218,6 @@ impl Write for AlwaysFailWriter {
     fn flush(&mut self) -> io::Result<()> {
         Err(io::Error::other("injected writer failure"))
     }
-}
-
-fn disabled_terminal_options() -> TerminalOptions {
-    TerminalOptions {
-        raw_mode: false,
-        alternate_screen: false,
-        mouse_capture: false,
-        bracketed_paste: false,
-        hide_cursor: false,
-    }
-}
-
-fn assert_failed_init_does_not_mark_active(
-    options: TerminalOptions,
-    active: impl FnOnce(&Backend<AlwaysFailWriter>) -> bool,
-) {
-    let mut backend = Backend::with_writer(80, 24, AlwaysFailWriter);
-
-    assert!(backend.init_with_options(options).is_err());
-    assert!(!active(&backend));
 }
 
 /// Writer that rejects exactly one armed write and then accepts output.


### PR DESCRIPTION
## Summary

- make terminal-mode initialization transactional relative to modes active before the call
- conservatively record escape-sequence modes before writing so partial I/O failures cannot suppress cleanup
- roll back every newly attempted mode while preserving pre-existing terminal state
- keep uncertain modes active when rollback fails so explicit restoration and `Drop` can retry
- make repeated initialization idempotent and avoid duplicate enter/hide sequences
- preserve both initialization and rollback errors without allocating on the success path

## Validation

- `cargo test -p vize_fresco --all-features` — 201 unit tests and 1 doctest
- `cargo clippy -p vize_fresco --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vize_fresco --all-features --no-deps`

Relates #4155 and #3138.

<!-- codesmith:autofix:disabled -->