### PR TITLE
feat(fresco): add full frame telemetry

### DIFF
--- a/crates/vize_fresco/benches/render.rs
+++ b/crates/vize_fresco/benches/render.rs
@@ -15,7 +15,7 @@ use vize_fresco::headless::{
 };
 use vize_fresco::input::{Key, KeyEvent};
 use vize_fresco::layout::{Dimension, FlexStyle, LayoutEngine};
-use vize_fresco::render::RenderTree;
+use vize_fresco::render::{FrameCoalescer, FrameRenderer, RenderTree};
 use vize_fresco::terminal::{Backend, Buffer, Style};
 use vize_fresco::text::{TextWidth, TextWrap, WrapMode};
 
@@ -111,7 +111,6 @@ fn benchmark_buffer_diff(c: &mut Criterion) {
     let mut buf2 = Buffer::new(80, 24);
     let style = Style::default();
 
-    // Fill with some content
     for y in 0..24 {
         buf1.set_string(0, y, "Hello, World! This is line content.", style);
         buf2.set_string(0, y, "Hello, World! This is line content.", style);
@@ -290,6 +289,49 @@ fn benchmark_diagnostic_presentation(c: &mut Criterion) {
     group.finish();
 }
 
+fn benchmark_frame_telemetry(c: &mut Criterion) {
+    let mut tree = RenderTree::new();
+    let root = tree.next_id();
+    tree.insert_root(
+        BoxNode::new()
+            .column()
+            .width_percent(100.0)
+            .height_percent(100.0)
+            .build(root),
+    );
+    let row = tree.next_id();
+    let mut node = TextNode::new("Selected finding").build(row);
+    node.style.width = Dimension::Percent(100.0);
+    node.style.height = Dimension::Points(1.0);
+    tree.insert(node);
+    tree.add_child(root, row);
+
+    let mut backend = Backend::with_writer(120, 40, io::sink());
+    let mut renderer = FrameRenderer::new();
+    let mut coalescer = FrameCoalescer::new();
+    coalescer.request_frame();
+    renderer
+        .render_pending(&mut tree, &mut backend, &mut coalescer)
+        .unwrap();
+    let mut selected = false;
+    let mut group = c.benchmark_group("frame_telemetry");
+    group.throughput(Throughput::Elements(tree.node_count() as u64));
+
+    group.bench_function("selection_update", |b| {
+        b.iter(|| {
+            selected = !selected;
+            tree.get_mut(row).unwrap().appearance.bold = selected;
+            coalescer.request_frame();
+            black_box(
+                renderer
+                    .render_pending(&mut tree, &mut backend, &mut coalescer)
+                    .unwrap(),
+            )
+        });
+    });
+    group.finish();
+}
+
 criterion_group!(
     benches,
     benchmark_buffer_set_string,
@@ -303,5 +345,6 @@ criterion_group!(
     benchmark_headless_snapshot,
     benchmark_diagnostic_keymap,
     benchmark_diagnostic_presentation,
+    benchmark_frame_telemetry,
 );
 criterion_main!(benches);

--- a/crates/vize_fresco/src/lib.rs
+++ b/crates/vize_fresco/src/lib.rs
@@ -80,7 +80,10 @@ pub use headless::{
 };
 pub use input::{Event, ImeState, Key, KeyEvent, KeyEventKind, KeyModifiers, MouseEvent};
 pub use layout::{FlexStyle, LayoutEngine, Rect};
-pub use render::{RenderNode, RenderTree};
+pub use render::{
+    FRAME_TELEMETRY_SCHEMA_VERSION, FrameActivityTelemetry, FrameCoalescer, FrameRenderError,
+    FrameRenderer, FrameRequestOutcome, FrameTelemetry, RenderNode, RenderTree,
+};
 pub use terminal::{
     Backend, Buffer, CapabilityDecision, CapabilityReason, Cell, ColorPreference, ColorSupport,
     Cursor, FeaturePreference, FrameOutputTelemetry, TerminalCapabilities, TerminalCapabilityProbe,

--- a/crates/vize_fresco/src/render.rs
+++ b/crates/vize_fresco/src/render.rs
@@ -7,9 +7,18 @@
 //! - Paint operations
 
 mod diff;
+mod frame;
 mod node;
 mod painter;
 mod tree;
+
+#[cfg(test)]
+mod frame_tests;
+
+pub use frame::{
+    FRAME_TELEMETRY_SCHEMA_VERSION, FrameActivityTelemetry, FrameCoalescer, FrameRenderError,
+    FrameRenderer, FrameRequestOutcome, FrameTelemetry,
+};
 
 pub use node::{
     Appearance, BorderStyle, InputContent, NodeId, NodeKind, RawContent, RenderNode, TextContent,

--- a/crates/vize_fresco/src/render/frame.rs
+++ b/crates/vize_fresco/src/render/frame.rs
@@ -1,0 +1,303 @@
+//! Measured frame rendering and bounded request coalescing.
+
+use std::{
+    io::{self, Write},
+    time::Instant,
+};
+
+use compact_str::CompactString;
+use serde::Serialize;
+use thiserror::Error;
+
+use super::{Painter, RenderTree};
+use crate::terminal::Backend;
+
+/// Wire version emitted by [`FrameTelemetry`].
+pub const FRAME_TELEMETRY_SCHEMA_VERSION: u16 = 1;
+
+/// Requests discarded or merged before one frame began.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameActivityTelemetry {
+    dropped_frames: u64,
+    coalesced_frames: u64,
+}
+
+impl FrameActivityTelemetry {
+    /// Return pending frames explicitly discarded before this frame.
+    pub const fn dropped_frames(self) -> u64 {
+        self.dropped_frames
+    }
+
+    /// Return redundant requests merged into the pending frame.
+    pub const fn coalesced_frames(self) -> u64 {
+        self.coalesced_frames
+    }
+}
+
+/// Result of requesting a frame from a one-slot coalescer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameRequestOutcome {
+    /// No frame was pending, so one was scheduled.
+    Scheduled,
+    /// A frame was already pending, so the new request was merged into it.
+    Coalesced,
+}
+
+/// Bounded one-slot frame request queue with loss accounting.
+#[derive(Debug, Clone, Default)]
+pub struct FrameCoalescer {
+    pending: bool,
+    dropped_frames: u64,
+    coalesced_frames: u64,
+}
+
+impl FrameCoalescer {
+    /// Create an empty frame queue.
+    pub const fn new() -> Self {
+        Self {
+            pending: false,
+            dropped_frames: 0,
+            coalesced_frames: 0,
+        }
+    }
+
+    /// Schedule a frame or merge the request into the existing pending frame.
+    pub fn request_frame(&mut self) -> FrameRequestOutcome {
+        if self.pending {
+            self.coalesced_frames = self.coalesced_frames.saturating_add(1);
+            FrameRequestOutcome::Coalesced
+        } else {
+            self.pending = true;
+            FrameRequestOutcome::Scheduled
+        }
+    }
+
+    /// Discard the pending frame and record the loss.
+    pub fn drop_pending_frame(&mut self) -> bool {
+        if !self.pending {
+            return false;
+        }
+        self.pending = false;
+        self.dropped_frames = self.dropped_frames.saturating_add(1);
+        true
+    }
+
+    /// Return whether a frame is waiting to render.
+    pub const fn has_pending_frame(&self) -> bool {
+        self.pending
+    }
+
+    /// Snapshot activity accumulated since the prior begun frame.
+    ///
+    /// This remains observable when the final pending frame is dropped during
+    /// shutdown and no later frame exists to consume the counters.
+    pub const fn activity(&self) -> FrameActivityTelemetry {
+        FrameActivityTelemetry {
+            dropped_frames: self.dropped_frames,
+            coalesced_frames: self.coalesced_frames,
+        }
+    }
+
+    /// Begin the pending frame and transfer activity since the prior frame.
+    pub fn begin_frame(&mut self) -> Option<FrameActivityTelemetry> {
+        if !self.pending {
+            return None;
+        }
+        self.pending = false;
+        Some(FrameActivityTelemetry {
+            dropped_frames: std::mem::take(&mut self.dropped_frames),
+            coalesced_frames: std::mem::take(&mut self.coalesced_frames),
+        })
+    }
+}
+
+/// Complete cost and retention record for one successful frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FrameTelemetry {
+    schema_version: u16,
+    layout_time_ns: u64,
+    paint_time_ns: u64,
+    output_time_ns: u64,
+    changed_cells: u64,
+    bytes_written: u64,
+    retained_nodes: u64,
+    dropped_frames: u64,
+    coalesced_frames: u64,
+}
+
+impl FrameTelemetry {
+    /// Return the telemetry wire version.
+    pub const fn schema_version(self) -> u16 {
+        self.schema_version
+    }
+
+    /// Return layout time in nanoseconds.
+    pub const fn layout_time_ns(self) -> u64 {
+        self.layout_time_ns
+    }
+
+    /// Return paint time in nanoseconds.
+    pub const fn paint_time_ns(self) -> u64 {
+        self.paint_time_ns
+    }
+
+    /// Return differential output time in nanoseconds.
+    pub const fn output_time_ns(self) -> u64 {
+        self.output_time_ns
+    }
+
+    /// Return cells changed from the prior successful frame.
+    pub const fn changed_cells(self) -> u64 {
+        self.changed_cells
+    }
+
+    /// Return exact bytes accepted by the terminal writer.
+    pub const fn bytes_written(self) -> u64 {
+        self.bytes_written
+    }
+
+    /// Return render nodes retained by the frame model.
+    pub const fn retained_nodes(self) -> u64 {
+        self.retained_nodes
+    }
+
+    /// Return pending frames discarded before this frame.
+    pub const fn dropped_frames(self) -> u64 {
+        self.dropped_frames
+    }
+
+    /// Return requests merged into this frame.
+    pub const fn coalesced_frames(self) -> u64 {
+        self.coalesced_frames
+    }
+
+    /// Return total measured layout, paint, and output time in nanoseconds.
+    pub const fn total_time_ns(self) -> u64 {
+        self.layout_time_ns
+            .saturating_add(self.paint_time_ns)
+            .saturating_add(self.output_time_ns)
+    }
+}
+
+/// Failed output after layout and paint completed.
+#[derive(Debug, Error)]
+#[error("cannot write measured Fresco frame: {source}")]
+pub struct FrameRenderError {
+    #[source]
+    source: io::Error,
+    layout_time_ns: u64,
+    paint_time_ns: u64,
+    retained_nodes: u64,
+    activity: FrameActivityTelemetry,
+}
+
+impl FrameRenderError {
+    /// Return the terminal writer failure.
+    pub const fn source_error(&self) -> &io::Error {
+        &self.source
+    }
+
+    /// Return completed layout time in nanoseconds.
+    pub const fn layout_time_ns(&self) -> u64 {
+        self.layout_time_ns
+    }
+
+    /// Return completed paint time in nanoseconds.
+    pub const fn paint_time_ns(&self) -> u64 {
+        self.paint_time_ns
+    }
+
+    /// Return nodes retained by the failed frame.
+    pub const fn retained_nodes(&self) -> u64 {
+        self.retained_nodes
+    }
+
+    /// Return queue activity assigned to the failed frame.
+    pub const fn activity(&self) -> FrameActivityTelemetry {
+        self.activity
+    }
+}
+
+/// Reusable production renderer with retained text-wrap scratch storage.
+#[derive(Debug, Default)]
+pub struct FrameRenderer {
+    wrap_scratch: Vec<CompactString>,
+}
+
+impl FrameRenderer {
+    /// Create a renderer with no allocated text-wrap scratch storage.
+    pub const fn new() -> Self {
+        Self {
+            wrap_scratch: Vec::new(),
+        }
+    }
+
+    /// Render a pending frame, returning `None` without work when the queue is empty.
+    pub fn render_pending<W: Write>(
+        &mut self,
+        tree: &mut RenderTree,
+        backend: &mut Backend<W>,
+        coalescer: &mut FrameCoalescer,
+    ) -> Result<Option<FrameTelemetry>, FrameRenderError> {
+        let Some(activity) = coalescer.begin_frame() else {
+            return Ok(None);
+        };
+        self.render(tree, backend, activity).map(Some)
+    }
+
+    /// Compute layout, paint, flush, and measure one complete frame.
+    pub fn render<W: Write>(
+        &mut self,
+        tree: &mut RenderTree,
+        backend: &mut Backend<W>,
+        activity: FrameActivityTelemetry,
+    ) -> Result<FrameTelemetry, FrameRenderError> {
+        let retained_nodes = count_nodes(tree);
+        let layout_started = Instant::now();
+        tree.compute_layout(backend.width(), backend.height());
+        let layout_time_ns = elapsed_ns(layout_started);
+
+        let paint_started = Instant::now();
+        let mut painter = Painter::with_wrap_scratch(
+            backend.buffer_mut(),
+            std::mem::take(&mut self.wrap_scratch),
+        );
+        painter.paint_tree(tree);
+        self.wrap_scratch = painter.into_wrap_scratch();
+        let paint_time_ns = elapsed_ns(paint_started);
+
+        let output_started = Instant::now();
+        let output = backend
+            .flush_measured()
+            .map_err(|source| FrameRenderError {
+                source,
+                layout_time_ns,
+                paint_time_ns,
+                retained_nodes,
+                activity,
+            })?;
+        let output_time_ns = elapsed_ns(output_started);
+
+        Ok(FrameTelemetry {
+            schema_version: FRAME_TELEMETRY_SCHEMA_VERSION,
+            layout_time_ns,
+            paint_time_ns,
+            output_time_ns,
+            changed_cells: output.changed_cells(),
+            bytes_written: output.bytes_written(),
+            retained_nodes,
+            dropped_frames: activity.dropped_frames,
+            coalesced_frames: activity.coalesced_frames,
+        })
+    }
+}
+
+fn elapsed_ns(started: Instant) -> u64 {
+    started.elapsed().as_nanos().try_into().unwrap_or(u64::MAX)
+}
+
+fn count_nodes(tree: &RenderTree) -> u64 {
+    tree.node_count().try_into().unwrap_or(u64::MAX)
+}

--- a/crates/vize_fresco/src/render/frame_tests.rs
+++ b/crates/vize_fresco/src/render/frame_tests.rs
@@ -1,0 +1,155 @@
+use std::io::{self, Write};
+
+use super::{
+    FRAME_TELEMETRY_SCHEMA_VERSION, FrameCoalescer, FrameRenderer, FrameRequestOutcome, RenderNode,
+    RenderTree,
+};
+use crate::{layout::Dimension, terminal::Backend};
+
+fn text_tree(value: &str) -> RenderTree {
+    let mut tree = RenderTree::new();
+    let id = tree.next_id();
+    let mut node = RenderNode::text_node(id, value);
+    node.style.width = Dimension::Points(4.0);
+    node.style.height = Dimension::Points(1.0);
+    tree.insert_root(node);
+    tree
+}
+
+#[test]
+fn coalescer_has_bounded_state_and_exact_loss_accounting() {
+    let mut coalescer = FrameCoalescer::new();
+    assert!(!coalescer.has_pending_frame());
+    assert_eq!(coalescer.request_frame(), FrameRequestOutcome::Scheduled);
+    assert_eq!(coalescer.request_frame(), FrameRequestOutcome::Coalesced);
+    assert_eq!(coalescer.request_frame(), FrameRequestOutcome::Coalesced);
+    assert!(coalescer.drop_pending_frame());
+    assert!(!coalescer.drop_pending_frame());
+    assert_eq!(coalescer.activity().dropped_frames(), 1);
+    assert_eq!(coalescer.activity().coalesced_frames(), 2);
+    assert_eq!(coalescer.request_frame(), FrameRequestOutcome::Scheduled);
+
+    let activity = coalescer.begin_frame().unwrap();
+    assert_eq!(activity.dropped_frames(), 1);
+    assert_eq!(activity.coalesced_frames(), 2);
+    assert!(coalescer.begin_frame().is_none());
+
+    coalescer.request_frame();
+    let next = coalescer.begin_frame().unwrap();
+    assert_eq!(next.dropped_frames(), 0);
+    assert_eq!(next.coalesced_frames(), 0);
+}
+
+#[test]
+fn measured_renderer_reports_every_frame_budget_dimension() {
+    let mut tree = text_tree("A");
+    let mut backend = Backend::with_writer(4, 1, Vec::new());
+    let mut coalescer = FrameCoalescer::new();
+    let mut renderer = FrameRenderer::new();
+    coalescer.request_frame();
+    coalescer.request_frame();
+
+    let first = renderer
+        .render_pending(&mut tree, &mut backend, &mut coalescer)
+        .unwrap()
+        .unwrap();
+    assert_eq!(first.schema_version(), FRAME_TELEMETRY_SCHEMA_VERSION);
+    assert_eq!(first.changed_cells(), 1);
+    assert_eq!(first.bytes_written(), backend.writer().len() as u64);
+    assert_eq!(first.retained_nodes(), 1);
+    assert_eq!(first.dropped_frames(), 0);
+    assert_eq!(first.coalesced_frames(), 1);
+    assert_eq!(
+        first.total_time_ns(),
+        first
+            .layout_time_ns()
+            .saturating_add(first.paint_time_ns())
+            .saturating_add(first.output_time_ns())
+    );
+
+    let bytes_before = backend.writer().len();
+    coalescer.request_frame();
+    let unchanged = renderer
+        .render_pending(&mut tree, &mut backend, &mut coalescer)
+        .unwrap()
+        .unwrap();
+    assert_eq!(unchanged.changed_cells(), 0);
+    assert_eq!(
+        unchanged.bytes_written(),
+        (backend.writer().len() - bytes_before) as u64
+    );
+}
+
+#[test]
+fn empty_queue_performs_no_layout_paint_or_output_work() {
+    let mut tree = text_tree("A");
+    let mut backend = Backend::with_writer(4, 1, Vec::new());
+    let mut coalescer = FrameCoalescer::new();
+    let mut renderer = FrameRenderer::new();
+
+    assert!(
+        renderer
+            .render_pending(&mut tree, &mut backend, &mut coalescer)
+            .unwrap()
+            .is_none()
+    );
+    assert!(backend.writer().is_empty());
+    assert!(tree.get(tree.root().unwrap()).unwrap().layout.is_none());
+}
+
+#[test]
+fn output_failure_preserves_partial_timing_activity_and_retry_buffer() {
+    let mut tree = text_tree("A");
+    let mut backend = Backend::with_writer(4, 1, AlwaysFailWriter);
+    let mut coalescer = FrameCoalescer::new();
+    let mut renderer = FrameRenderer::new();
+    coalescer.request_frame();
+    coalescer.request_frame();
+
+    let error = renderer
+        .render_pending(&mut tree, &mut backend, &mut coalescer)
+        .unwrap_err();
+    assert_eq!(error.source_error().kind(), io::ErrorKind::Other);
+    assert_eq!(error.retained_nodes(), 1);
+    assert_eq!(error.activity().dropped_frames(), 0);
+    assert_eq!(error.activity().coalesced_frames(), 1);
+    assert_eq!(
+        backend.buffer().get(0, 0).map(|cell| cell.symbol.as_str()),
+        Some("A")
+    );
+}
+
+#[test]
+fn telemetry_serialization_is_versioned_and_uses_portable_units() {
+    let mut tree = text_tree("A");
+    let mut backend = Backend::with_writer(4, 1, io::sink());
+    let mut coalescer = FrameCoalescer::new();
+    let mut renderer = FrameRenderer::new();
+    coalescer.request_frame();
+    let telemetry = renderer
+        .render_pending(&mut tree, &mut backend, &mut coalescer)
+        .unwrap()
+        .unwrap();
+
+    let value = serde_json::to_value(telemetry).unwrap();
+    assert_eq!(value["schemaVersion"], FRAME_TELEMETRY_SCHEMA_VERSION);
+    assert!(value["layoutTimeNs"].is_u64());
+    assert!(value["paintTimeNs"].is_u64());
+    assert!(value["outputTimeNs"].is_u64());
+    assert_eq!(value["retainedNodes"], 1);
+    assert_eq!(value["droppedFrames"], 0);
+    assert_eq!(value["coalescedFrames"], 0);
+}
+
+#[derive(Debug)]
+struct AlwaysFailWriter;
+
+impl Write for AlwaysFailWriter {
+    fn write(&mut self, _buffer: &[u8]) -> io::Result<usize> {
+        Err(io::Error::other("injected frame failure"))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Err(io::Error::other("injected frame failure"))
+    }
+}

--- a/crates/vize_fresco/src/render/painter.rs
+++ b/crates/vize_fresco/src/render/painter.rs
@@ -18,10 +18,21 @@ pub struct Painter<'a> {
 impl<'a> Painter<'a> {
     /// Create a new painter.
     pub fn new(buffer: &'a mut Buffer) -> Self {
+        Self::with_wrap_scratch(buffer, Vec::new())
+    }
+
+    pub(crate) fn with_wrap_scratch(
+        buffer: &'a mut Buffer,
+        wrap_scratch: Vec<CompactString>,
+    ) -> Self {
         Self {
             buffer,
-            wrap_scratch: Vec::new(),
+            wrap_scratch,
         }
+    }
+
+    pub(crate) fn into_wrap_scratch(self) -> Vec<CompactString> {
+        self.wrap_scratch
     }
 
     /// Paint the entire tree to the buffer.


### PR DESCRIPTION
## Summary

- add a reusable production frame renderer that measures layout, paint, and differential output phases
- expose versioned nanosecond telemetry for phase time, changed cells, exact bytes, and retained render nodes
- add a bounded one-slot frame coalescer with saturating dropped/coalesced request accounting
- preserve queue activity, completed phase timings, retained nodes, and the retryable backend buffer when output fails
- retain text-wrap scratch storage across frames instead of reallocating it per render
- serialize output-only telemetry with stable camel-case fields and portable integer units
- benchmark the complete selection-update path through layout, paint, diff, and sink output

## Validation

- `cargo test -p vize_fresco --all-features` — 218 unit tests and 1 doctest
- `cargo clippy -p vize_fresco --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vize_fresco --all-features --no-deps`
- `cargo bench -p vize_fresco --bench render --no-run`
- Criterion `frame_telemetry/selection_update`: 31.29 µs median for the complete measured frame path

Relates #4155 and #3138.

<!-- codesmith:autofix:disabled -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added frame rendering with request coalescing to manage rapid updates efficiently.
  - Added frame activity and performance telemetry, including scheduling, rendering phases, output statistics, and errors.
  - Exposed rendering status and telemetry data for monitoring and diagnostics.

- **Performance**
  - Improved rendering efficiency by reusing text-wrapping resources.
  - Added coverage for frame timing, queued updates, dropped requests, and output handling.

- **Reliability**
  - Improved reporting and preservation of rendering details when output writes fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->