### PR TITLE
fix(fresco): preserve terminal grapheme clusters

### DIFF
--- a/crates/vize_fresco/benches/render.rs
+++ b/crates/vize_fresco/benches/render.rs
@@ -36,6 +36,18 @@ fn benchmark_buffer_set_string(c: &mut Criterion) {
     });
 }
 
+fn benchmark_buffer_ascii_line(c: &mut Criterion) {
+    const ASCII_LINE: &str =
+        "01234567890123456789012345678901234567890123456789012345678901234567890123456789";
+    let mut buffer = Buffer::new(80, 1);
+    let mut group = c.benchmark_group("buffer_set_string_ascii_line");
+    group.throughput(Throughput::Bytes(ASCII_LINE.len() as u64));
+    group.bench_function("80_columns", |b| {
+        b.iter(|| buffer.set_string(0, 0, black_box(ASCII_LINE), Style::new()));
+    });
+    group.finish();
+}
+
 fn benchmark_text_width(c: &mut Criterion) {
     c.bench_function("text_width_ascii", |b| {
         b.iter(|| TextWidth::width(black_box("Hello, World! This is a test string.")));
@@ -293,6 +305,7 @@ fn benchmark_diagnostic_presentation(c: &mut Criterion) {
 criterion_group!(
     benches,
     benchmark_buffer_set_string,
+    benchmark_buffer_ascii_line,
     benchmark_text_width,
     benchmark_text_wrap,
     benchmark_layout,

--- a/crates/vize_fresco/src/headless/tests.rs
+++ b/crates/vize_fresco/src/headless/tests.rs
@@ -121,7 +121,8 @@ fn cell_snapshot_preserves_wide_cells_style_and_visual_rows() {
         snapshot.cell(0, 0).unwrap().style,
         Style::new().fg(Color::LightCyan).bold()
     );
-    assert!(snapshot.row_text(0).unwrap().starts_with("診断🧭e"));
+    assert!(snapshot.row_text(0).unwrap().starts_with("診断🧭e\u{301}"));
+    assert_eq!(snapshot.cell(6, 0).unwrap().symbol, "e\u{301}");
     assert!(snapshot.row_text(1).unwrap().starts_with("92 / 100"));
     assert_eq!(snapshot.row_text(4), None);
     assert_eq!(snapshot.screen_text().lines().count(), 4);

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -13,6 +13,8 @@ mod lifecycle;
 mod output;
 
 #[cfg(test)]
+mod grapheme_tests;
+#[cfg(test)]
 mod lifecycle_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/vize_fresco/src/terminal/backend/grapheme_tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/grapheme_tests.rs
@@ -1,0 +1,39 @@
+use super::Backend;
+use crate::terminal::Style;
+
+#[test]
+fn measured_output_writes_complete_graphemes_and_exact_byte_counts() {
+    let text = "e\u{301}界👨‍👩‍👧‍👦";
+    let mut backend = Backend::with_writer(5, 1, Vec::new());
+    assert_eq!(backend.buffer_mut().set_string(0, 0, text, Style::new()), 5);
+
+    let telemetry = backend.flush_measured().unwrap();
+    let bytes = backend.writer();
+
+    assert_eq!(telemetry.changed_cells(), 5);
+    assert_eq!(telemetry.bytes_written(), bytes.len() as u64);
+    for grapheme in ["e\u{301}", "界", "👨‍👩‍👧‍👦"] {
+        assert_eq!(
+            bytes
+                .windows(grapheme.len())
+                .filter(|window| *window == grapheme.as_bytes())
+                .count(),
+            1
+        );
+    }
+}
+
+#[test]
+fn clipped_graphemes_emit_no_partial_utf8_bytes() {
+    let mut backend = Backend::with_writer(1, 1, Vec::new());
+    assert_eq!(backend.buffer_mut().set_string(0, 0, "界", Style::new()), 0);
+
+    backend.flush_measured().unwrap();
+
+    assert!(
+        !backend
+            .writer()
+            .windows("界".len())
+            .any(|bytes| bytes == "界".as_bytes())
+    );
+}

--- a/crates/vize_fresco/src/terminal/buffer.rs
+++ b/crates/vize_fresco/src/terminal/buffer.rs
@@ -1,9 +1,9 @@
 //! Double-buffered terminal buffer.
 
-use compact_str::ToCompactString;
+use unicode_segmentation::UnicodeSegmentation;
 
 use super::cell::{Cell, Style};
-use crate::layout::Rect;
+use crate::{layout::Rect, text::TextWidth};
 
 /// A buffer representing terminal content.
 ///
@@ -65,12 +65,14 @@ impl Buffer {
     }
 
     /// Clear a specific area of the buffer.
+    ///
+    /// A grapheme intersecting the area is cleared in full, including a
+    /// leading cell outside the area. This prevents partial wide glyphs from
+    /// surviving a clipped repaint.
     pub fn clear_area(&mut self, area: Rect) {
         for y in area.y..area.y.saturating_add(area.height) {
             for x in area.x..area.x.saturating_add(area.width) {
-                if let Some(cell) = self.get_mut(x, y) {
-                    cell.reset();
-                }
+                self.clear_grapheme_at(x, y);
             }
         }
     }
@@ -97,7 +99,10 @@ impl Buffer {
         self.index(x, y).map(|i| &mut self.cells[i])
     }
 
-    /// Set a cell at the given position.
+    /// Set a raw cell at the given position.
+    ///
+    /// Prefer [`set_string`](Self::set_string) for visible text. This low-level
+    /// operation intentionally does not repair adjacent continuation cells.
     #[inline]
     pub fn set(&mut self, x: u16, y: u16, cell: Cell) {
         if let Some(i) = self.index(x, y) {
@@ -107,58 +112,116 @@ impl Buffer {
 
     /// Set a character at the given position with optional style.
     pub fn set_char(&mut self, x: u16, y: u16, ch: char, style: Option<Style>) {
-        if let Some(cell) = self.get_mut(x, y) {
-            cell.set_symbol(ch.to_compact_string());
-            if let Some(s) = style {
-                cell.set_style(s);
+        let inherited_style = self.get(x, y).map_or_else(Style::new, |cell| cell.style);
+        let mut encoded = [0_u8; 4];
+        let text = ch.encode_utf8(&mut encoded);
+        self.set_string(x, y, text, style.unwrap_or(inherited_style));
+    }
+
+    /// Set a string starting at the given position, preserving grapheme clusters.
+    ///
+    /// Each extended grapheme cluster is stored intact in its leading cell;
+    /// any additional terminal columns are continuation cells. A cluster that
+    /// cannot fit is clipped atomically, so no partial glyph is written.
+    /// Returns the number of columns successfully written.
+    pub fn set_string(&mut self, x: u16, y: u16, text: &str, style: Style) -> u16 {
+        if y >= self.height || x >= self.width {
+            return 0;
+        }
+        let mut col = x;
+        if text.is_ascii() {
+            for byte in text.bytes() {
+                if byte.is_ascii_control() {
+                    continue;
+                }
+                let mut encoded = [0_u8; 4];
+                if !self.write_grapheme(
+                    col,
+                    y,
+                    char::from(byte).encode_utf8(&mut encoded),
+                    1,
+                    style,
+                ) {
+                    break;
+                }
+                col += 1;
             }
+        } else {
+            for grapheme in text.graphemes(true) {
+                let Ok(width) = u16::try_from(TextWidth::width(grapheme)) else {
+                    break;
+                };
+                if width == 0 {
+                    continue;
+                }
+                if !self.write_grapheme(col, y, grapheme, width, style) {
+                    break;
+                }
+                col += width;
+            }
+        }
+        col.saturating_sub(x)
+    }
+
+    fn write_grapheme(&mut self, x: u16, y: u16, grapheme: &str, width: u16, style: Style) -> bool {
+        if width == 0 || y >= self.height || width > self.width.saturating_sub(x) {
+            return false;
+        }
+        self.clear_span(x, y, width);
+        let cell = self.get_mut(x, y).expect("validated grapheme origin");
+        cell.set_symbol(grapheme);
+        cell.set_style(style);
+        for offset in 1..width {
+            let continuation = self
+                .get_mut(x + offset, y)
+                .expect("validated grapheme continuation");
+            continuation.set_continuation();
+            continuation.set_style(style);
+        }
+        true
+    }
+
+    fn clear_span(&mut self, x: u16, y: u16, width: u16) {
+        for column in x..x.saturating_add(width).min(self.width) {
+            self.clear_grapheme_at(column, y);
         }
     }
 
-    /// Set a string starting at the given position.
-    /// Returns the number of columns used.
-    pub fn set_string(&mut self, x: u16, y: u16, text: &str, style: Style) -> u16 {
-        use unicode_width::UnicodeWidthChar;
-
-        let mut col = x;
-        for ch in text.chars() {
-            if col >= self.width {
-                break;
-            }
-
-            let width = ch.width().unwrap_or(0) as u16;
-            if width == 0 {
-                continue;
-            }
-
-            // Set the main character cell
-            if let Some(cell) = self.get_mut(col, y) {
-                cell.set_symbol(ch.to_compact_string());
-                cell.set_style(style);
-                cell.is_continuation = false;
-            }
-
-            // For wide characters, mark the next cell as continuation
-            if width > 1 {
-                for i in 1..width {
-                    if let Some(cell) = self.get_mut(col + i, y) {
-                        cell.set_continuation();
-                        cell.set_style(style);
-                    }
-                }
-            }
-
-            col += width;
+    fn clear_grapheme_at(&mut self, x: u16, y: u16) {
+        let Some(index) = self.index(x, y) else {
+            return;
+        };
+        let row_start = usize::from(y) * usize::from(self.width);
+        let row_end = row_start + usize::from(self.width);
+        let mut leader = index;
+        while leader > row_start && self.cells[leader].is_continuation {
+            leader -= 1;
         }
-
-        col.saturating_sub(x)
+        self.cells[leader].reset();
+        let mut continuation = leader + 1;
+        while continuation < row_end && self.cells[continuation].is_continuation {
+            self.cells[continuation].reset();
+            continuation += 1;
+        }
     }
 
     /// Fill a rectangular area with a character.
     pub fn fill(&mut self, area: Rect, ch: char, style: Style) {
+        self.clear_area(area);
+        let width = TextWidth::char_width(ch) as u16;
+        if width == 0 {
+            return;
+        }
+        let mut encoded = [0_u8; 4];
+        let grapheme = ch.encode_utf8(&mut encoded);
         for y in area.y..area.y.saturating_add(area.height) {
-            for x in area.x..area.x.saturating_add(area.width) {
-                self.set_char(x, y, ch, Some(style));
+            let end = area.x.saturating_add(area.width).min(self.width);
+            let mut x = area.x;
+            while width <= end.saturating_sub(x) {
+                if !self.write_grapheme(x, y, grapheme, width, style) {
+                    break;
+                }
+                x += width;
             }
         }
     }
@@ -200,12 +263,42 @@ impl Buffer {
     }
 
     /// Merge another buffer onto this one at the specified position.
+    ///
+    /// Complete source graphemes are copied atomically. A wide grapheme that
+    /// crosses the destination's right edge is skipped rather than truncated.
     pub fn merge(&mut self, other: &Buffer, x: u16, y: u16) {
         for oy in 0..other.height {
-            for ox in 0..other.width {
-                if let Some(cell) = other.get(ox, oy) {
-                    self.set(x + ox, y + oy, cell.clone());
+            let Some(destination_y) = y.checked_add(oy).filter(|row| *row < self.height) else {
+                continue;
+            };
+            let mut ox = 0;
+            while ox < other.width {
+                let cell = other.get(ox, oy).expect("source coordinate is in bounds");
+                if cell.is_continuation {
+                    ox += 1;
+                    continue;
                 }
+                let mut span = 1;
+                while ox + span < other.width
+                    && other
+                        .get(ox + span, oy)
+                        .is_some_and(|next| next.is_continuation)
+                {
+                    span += 1;
+                }
+                let Some(destination_x) = x.checked_add(ox) else {
+                    break;
+                };
+                if span <= self.width.saturating_sub(destination_x) {
+                    self.clear_span(destination_x, destination_y, span);
+                    for offset in 0..span {
+                        let source = other
+                            .get(ox + offset, oy)
+                            .expect("validated source grapheme span");
+                        self.set(destination_x + offset, destination_y, source.clone());
+                    }
+                }
+                ox += span;
             }
         }
     }
@@ -218,65 +311,5 @@ impl Default for Buffer {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::Buffer;
-    use crate::terminal::cell::{Cell, Style};
-
-    #[test]
-    fn test_buffer_new() {
-        let buf = Buffer::new(80, 24);
-        assert_eq!(buf.width(), 80);
-        assert_eq!(buf.height(), 24);
-    }
-
-    #[test]
-    fn test_buffer_set_get() {
-        let mut buf = Buffer::new(10, 10);
-        let cell = Cell::new("A");
-        buf.set(5, 5, cell.clone());
-        assert_eq!(buf.get(5, 5).map(|c| c.symbol.as_str()), Some("A"));
-    }
-
-    #[test]
-    fn test_buffer_set_string() {
-        let mut buf = Buffer::new(20, 1);
-        let cols = buf.set_string(0, 0, "Hello", Style::new());
-        assert_eq!(cols, 5);
-        assert_eq!(buf.get(0, 0).map(|c| c.symbol.as_str()), Some("H"));
-        assert_eq!(buf.get(4, 0).map(|c| c.symbol.as_str()), Some("o"));
-    }
-
-    #[test]
-    fn test_buffer_wide_char() {
-        let mut buf = Buffer::new(20, 1);
-        let cols = buf.set_string(0, 0, "あ", Style::new()); // Wide char
-        assert_eq!(cols, 2);
-        assert_eq!(buf.get(0, 0).map(|c| c.symbol.as_str()), Some("あ"));
-        assert!(buf.get(1, 0).map(|c| c.is_continuation).unwrap_or(false));
-    }
-
-    #[test]
-    fn test_buffer_diff() {
-        let mut buf1 = Buffer::new(5, 1);
-        let mut buf2 = Buffer::new(5, 1);
-
-        buf1.set_char(0, 0, 'A', None);
-        buf2.set_char(0, 0, 'B', None);
-
-        let diffs: Vec<_> = buf1.diff(&buf2).collect();
-        assert_eq!(diffs.len(), 1);
-        assert_eq!(diffs[0].0, 0);
-        assert_eq!(diffs[0].1, 0);
-    }
-
-    #[test]
-    fn test_buffer_resize() {
-        let mut buf = Buffer::new(10, 10);
-        buf.set_char(5, 5, 'X', None);
-        buf.resize(20, 20);
-        assert_eq!(buf.width(), 20);
-        assert_eq!(buf.height(), 20);
-        // Content should be cleared
-        assert_eq!(buf.get(5, 5).map(|c| c.symbol.as_str()), Some(" "));
-    }
-}
+#[path = "buffer_tests.rs"]
+mod tests;

--- a/crates/vize_fresco/src/terminal/buffer_tests.rs
+++ b/crates/vize_fresco/src/terminal/buffer_tests.rs
@@ -1,0 +1,121 @@
+use super::Buffer;
+use crate::{
+    layout::Rect,
+    terminal::cell::{Cell, Style},
+};
+
+#[test]
+fn creates_sets_and_resizes_buffers() {
+    let mut buffer = Buffer::new(10, 10);
+    assert_eq!(buffer.area(), Rect::new(0, 0, 10, 10));
+
+    buffer.set(5, 5, Cell::new("A"));
+    assert_eq!(buffer.get(5, 5).map(|cell| cell.symbol.as_str()), Some("A"));
+
+    buffer.resize(20, 20);
+    assert_eq!(buffer.area(), Rect::new(0, 0, 20, 20));
+    assert_eq!(buffer.get(5, 5).map(|cell| cell.symbol.as_str()), Some(" "));
+}
+
+#[test]
+fn stores_complete_normalized_and_decomposed_graphemes() {
+    let mut buffer = Buffer::new(12, 1);
+    let text = "é e\u{301} は\u{3099} ✈\u{fe0f} 👨‍👩‍👧‍👦";
+
+    let columns = buffer.set_string(0, 0, text, Style::new());
+
+    assert_eq!(columns, 12);
+    assert_eq!(buffer.get(0, 0).unwrap().symbol, "é");
+    assert_eq!(buffer.get(2, 0).unwrap().symbol, "e\u{301}");
+    assert_eq!(buffer.get(4, 0).unwrap().symbol, "は\u{3099}");
+    assert!(buffer.get(5, 0).unwrap().is_continuation);
+    assert_eq!(buffer.get(7, 0).unwrap().symbol, "✈\u{fe0f}");
+    assert!(buffer.get(8, 0).unwrap().is_continuation);
+    assert_eq!(buffer.get(10, 0).unwrap().symbol, "👨‍👩‍👧‍👦");
+    assert!(buffer.get(11, 0).unwrap().is_continuation);
+}
+
+#[test]
+fn clips_only_at_grapheme_boundaries() {
+    let mut buffer = Buffer::new(4, 1);
+    buffer.set_string(0, 0, "keep", Style::new());
+
+    assert_eq!(buffer.set_string(3, 0, "界", Style::new()), 0);
+    assert_eq!(buffer.get(3, 0).unwrap().symbol, "p");
+    assert!(!buffer.get(3, 0).unwrap().is_continuation);
+
+    assert_eq!(buffer.set_string(3, 0, "e\u{301}", Style::new()), 1);
+    assert_eq!(buffer.get(3, 0).unwrap().symbol, "e\u{301}");
+}
+
+#[test]
+fn narrow_replacements_remove_every_stale_wide_cell() {
+    let mut buffer = Buffer::new(4, 1);
+    buffer.set_string(0, 0, "界", Style::new());
+    buffer.set_string(0, 0, "x", Style::new());
+    assert_eq!(buffer.get(0, 0).unwrap().symbol, "x");
+    assert_eq!(buffer.get(1, 0).unwrap(), &Cell::EMPTY);
+
+    buffer.set_string(0, 0, "界", Style::new());
+    buffer.set_string(1, 0, "y", Style::new());
+    assert_eq!(buffer.get(0, 0).unwrap(), &Cell::EMPTY);
+    assert_eq!(buffer.get(1, 0).unwrap().symbol, "y");
+}
+
+#[test]
+fn partial_clear_removes_the_intersected_grapheme_atomically() {
+    let mut buffer = Buffer::new(4, 1);
+    buffer.set_string(0, 0, "界z", Style::new());
+
+    buffer.clear_area(Rect::new(1, 0, 1, 1));
+
+    assert_eq!(buffer.get(0, 0).unwrap(), &Cell::EMPTY);
+    assert_eq!(buffer.get(1, 0).unwrap(), &Cell::EMPTY);
+    assert_eq!(buffer.get(2, 0).unwrap().symbol, "z");
+}
+
+#[test]
+fn merge_preserves_complete_clusters_and_skips_clipped_wide_clusters() {
+    let mut source = Buffer::new(3, 1);
+    source.set_string(0, 0, "e\u{301}界", Style::new());
+    let mut destination = Buffer::new(4, 1);
+    destination.set_string(0, 0, "stay", Style::new());
+
+    destination.merge(&source, 1, 0);
+
+    assert_eq!(destination.get(1, 0).unwrap().symbol, "e\u{301}");
+    assert_eq!(destination.get(2, 0).unwrap().symbol, "界");
+    assert!(destination.get(3, 0).unwrap().is_continuation);
+
+    destination.clear();
+    destination.set_string(0, 0, "keep", Style::new());
+    destination.merge(&source, 3, 0);
+    assert_eq!(destination.get(3, 0).unwrap().symbol, "e\u{301}");
+    assert!(!destination.iter().any(|(_, _, cell)| cell.is_continuation));
+}
+
+#[test]
+fn diff_distinguishes_exact_nfc_and_nfd_cells_at_equal_width() {
+    let mut nfc = Buffer::new(2, 1);
+    let mut nfd = Buffer::new(2, 1);
+    assert_eq!(nfc.set_string(0, 0, "é", Style::new()), 1);
+    assert_eq!(nfd.set_string(0, 0, "e\u{301}", Style::new()), 1);
+
+    let differences = nfc.diff(&nfd).collect::<Vec<_>>();
+    assert_eq!(differences.len(), 1);
+    assert_eq!((differences[0].0, differences[0].1), (0, 0));
+    assert_eq!(differences[0].2.symbol, "é");
+}
+
+#[test]
+fn character_writes_preserve_style_and_repair_continuations() {
+    let style = Style::new().bold();
+    let mut buffer = Buffer::new(3, 1);
+    buffer.set_string(0, 0, "界", style);
+
+    buffer.set_char(1, 0, 'x', None);
+
+    assert_eq!(buffer.get(0, 0).unwrap(), &Cell::EMPTY);
+    assert_eq!(buffer.get(1, 0).unwrap().symbol, "x");
+    assert_eq!(buffer.get(1, 0).unwrap().style, style);
+}

--- a/crates/vize_fresco/src/terminal/cell.rs
+++ b/crates/vize_fresco/src/terminal/cell.rs
@@ -193,13 +193,12 @@ impl From<Color> for crossterm::style::Color {
 /// A single cell in the terminal buffer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Cell {
-    /// The character(s) displayed in this cell.
-    /// May be empty (space) or contain multi-byte Unicode.
+    /// The complete extended grapheme cluster displayed in this cell.
+    /// May be an empty continuation marker, a space, or multi-scalar Unicode.
     pub symbol: CompactString,
     /// The style of this cell.
     pub style: Style,
-    /// Whether this is a wide character continuation cell.
-    /// Wide characters (e.g., CJK) span 2 cells.
+    /// Whether this cell continues the preceding multi-column grapheme.
     pub is_continuation: bool,
 }
 


### PR DESCRIPTION
<!-- codesmith:disable -->
## Summary

- store complete Unicode extended grapheme clusters in leading terminal cells
- make overwrite, partial clear, fill, merge, clipping, diff, headless snapshots, and terminal output respect atomic grapheme spans
- retain an allocation-conscious ASCII fast path and benchmark an 80-column repaint

## Correctness

Covers NFC and NFD text, decomposed Japanese dakuten, emoji variation selectors, family ZWJ sequences, final-column clipping, wide-to-narrow replacement, writes over continuation cells, partial clears, clipped merges, screen text, exact diff cells, and exact output bytes.

## Validation

- `cargo test -p vize_fresco --all-features` (217 unit tests plus doctest)
- `cargo clippy -p vize_fresco --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p vize_fresco --all-features --no-deps`
- `cargo bench -p vize_fresco --bench render --no-run`
- `buffer_set_string_ascii_line/80_columns`: 572.57 ns median, 133.25 MiB/s, no statistically significant performance change

Fixes #4180
Related to #4155 and #3138.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
