### PR TITLE
feat(ui): add hover interactions

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -69,6 +69,11 @@
       "import": "./dist/interaction-modality.mjs",
       "default": "./dist/interaction-modality.mjs"
     },
+    "./hover": {
+      "types": "./dist/hover.d.mts",
+      "import": "./dist/hover.mjs",
+      "default": "./dist/hover.mjs"
+    },
     "./long-press": {
       "types": "./dist/long-press.d.mts",
       "import": "./dist/long-press.mjs",

--- a/npm/ui/core/scripts/check-renderers.ts
+++ b/npm/ui/core/scripts/check-renderers.ts
@@ -19,6 +19,25 @@ const rendererLanes: readonly RendererLane[] = [
 
 const inlineFixtures = [
   {
+    filename: "HoverConsumer.vue",
+    source: String.raw`<script setup lang="ts">
+import { useHover } from "./hover.ts";
+
+const hover = useHover({
+  onHoverStart(event) {
+    void event.pointerType;
+  },
+});
+</script>
+
+<template>
+  <div v-bind="hover.hoverProps" :data-hovered="hover.isHovered.value || undefined">
+    Hover target
+  </div>
+</template>
+`,
+  },
+  {
     filename: "LongPressConsumer.vue",
     source: String.raw`<script setup lang="ts">
 import { useLongPress } from "./long-press.ts";

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 20_325],
+  ["index.mjs", 21_625],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
   ["collection.mjs", 5_700],
@@ -13,6 +13,7 @@ const budgets = new Map([
   ["controllable-state.mjs", 600],
   ["id.mjs", 2_300],
   ["interaction-modality.mjs", 3_300],
+  ["hover.mjs", 2_200],
   ["long-press.mjs", 8_000],
   ["press.mjs", 5_775],
   ["primitive.mjs", 800],

--- a/npm/ui/core/scripts/check-tree-shaking.mjs
+++ b/npm/ui/core/scripts/check-tree-shaking.mjs
@@ -73,6 +73,7 @@ const familySignatures = Object.freeze({
   collection: /VIZE_UI_COLLECTION_DISPOSED/,
   id: /DeterministicIdProvider/,
   "interaction-modality": /VIZE_UI_INTERACTION_MODALITY_DISPOSED/,
+  hover: /VIZE_UI_HOVER_DISPOSED/,
   "long-press": /VIZE_UI_LONG_PRESS_DISPOSED/,
   press: /VIZE_UI_PRESS_DISPOSED/,
   primitive: /data-vize-ui.+primitive/,
@@ -112,6 +113,12 @@ const componentCases = [
     family: "interaction-modality",
     exportName: "createInteractionModalityTracker",
     maximumJavaScriptGzipBytes: 1_650,
+    maximumCssGzipBytes: 0,
+  },
+  {
+    family: "hover",
+    exportName: "createHover",
+    maximumJavaScriptGzipBytes: 1_450,
     maximumCssGzipBytes: 0,
   },
   {

--- a/npm/ui/core/src/distribution.test.ts
+++ b/npm/ui/core/src/distribution.test.ts
@@ -13,6 +13,7 @@ const publicEntries = [
   "./controllable-state",
   "./id",
   "./interaction-modality",
+  "./hover",
   "./long-press",
   "./press",
   "./primitive",

--- a/npm/ui/core/src/hover-ssr.test.ts
+++ b/npm/ui/core/src/hover-ssr.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { createSSRApp, defineComponent, h, nextTick, ref } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import { useHover } from "./hover.ts";
+
+const SsrProbe = defineComponent({
+  name: "HoverSsrProbe",
+  setup() {
+    const starts = ref(0);
+    const hover = useHover({ onHoverStart: () => starts.value++ });
+    return () =>
+      h(
+        "div",
+        { ...hover.hoverProps, "data-hovered": String(hover.isHovered.value) },
+        `Hover ${starts.value}`,
+      );
+  },
+});
+
+function pointer(type: string): PointerEvent {
+  return new PointerEvent(type, { pointerId: 2, pointerType: "mouse" });
+}
+
+test("renders byte-identical hover SSR output without DOM access or handlers", async () => {
+  const outputs = await Promise.all([
+    renderToString(createSSRApp(SsrProbe)),
+    renderToString(createSSRApp(SsrProbe)),
+  ]);
+  assert.equal(outputs[0], outputs[1]);
+  assert.equal(outputs[0], '<div data-hovered="false">Hover 0</div>');
+  assert.doesNotMatch(outputs[0], /pointerenter|function/);
+});
+
+test("hydrates hover state without replacement or diagnostics", async () => {
+  const serverHtml = await renderToString(createSSRApp(SsrProbe));
+  const host = document.createElement("div");
+  host.innerHTML = serverHtml;
+  document.body.append(host);
+  const serverTarget = host.firstElementChild;
+  const diagnostics: string[] = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  console.error = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  const app = createSSRApp(SsrProbe);
+
+  try {
+    app.mount(host);
+    assert.equal(host.firstElementChild, serverTarget);
+    const target = host.firstElementChild!;
+    target.dispatchEvent(pointer("pointerenter"));
+    await nextTick();
+    assert.equal(target.getAttribute("data-hovered"), "true");
+    assert.equal(target.textContent, "Hover 1");
+    target.dispatchEvent(pointer("pointerleave"));
+    await nextTick();
+    assert.equal(target.getAttribute("data-hovered"), "false");
+    assert.deepEqual(diagnostics, []);
+  } finally {
+    app.unmount();
+    host.remove();
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+});

--- a/npm/ui/core/src/hover-types.ts
+++ b/npm/ui/core/src/hover-types.ts
@@ -1,0 +1,89 @@
+import type { MaybeRefOrGetter, ShallowRef } from "vue";
+
+/** Pointing-device families that have a meaningful hover state. */
+export type HoverPointerType = "mouse" | "pen";
+
+/** Lifecycle notification emitted by a hover controller. */
+export type HoverEventType = "hoverend" | "hoverstart";
+
+/** Immutable snapshot of one hover lifecycle transition. */
+export interface HoverEvent {
+  /** Hover lifecycle phase represented by this snapshot. */
+  readonly type: HoverEventType;
+
+  /** Hover-capable pointing-device family. */
+  readonly pointerType: HoverPointerType;
+
+  /** Element whose bound hover props own the interaction. */
+  readonly target: Element;
+
+  /** Native event responsible for this transition, or `null` for manual cancellation. */
+  readonly originalEvent: Event | null;
+
+  /** Viewport coordinates when present on the native event. */
+  readonly x: number | null;
+  readonly y: number | null;
+
+  /** Modifier-key snapshots captured from the native event. */
+  readonly altKey: boolean;
+  readonly ctrlKey: boolean;
+  readonly metaKey: boolean;
+  readonly shiftKey: boolean;
+
+  /** Whether hover ended due to cancellation rather than a normal boundary exit. */
+  readonly isCanceled: boolean;
+}
+
+/** Options shared by {@link createHover} and {@link useHover}. */
+export interface HoverOptions {
+  /**
+   * Suppress hover while retaining stable bound props.
+   * Reactive values are resolved for every relevant native event.
+   *
+   * @default false
+   */
+  readonly isDisabled?: MaybeRefOrGetter<boolean | undefined>;
+
+  /**
+   * Restrict recognition to one hover-capable device family.
+   *
+   * @default undefined
+   */
+  readonly pointerType?: MaybeRefOrGetter<HoverPointerType | undefined>;
+
+  /** Called after hover state becomes active. */
+  readonly onHoverStart?: (event: HoverEvent) => void;
+
+  /** Called after hover ends or is canceled. */
+  readonly onHoverEnd?: (event: HoverEvent) => void;
+
+  /** Called for every distinct hover-state transition. */
+  readonly onHoverChange?: (isHovered: boolean) => void;
+}
+
+/** Native handlers to spread onto exactly one hover host. */
+export interface HoverProps {
+  readonly onMouseenter: (event: MouseEvent) => void;
+  readonly onMouseleave: (event: MouseEvent) => void;
+  readonly onMousemove: (event: MouseEvent) => void;
+  readonly onPointercancel: (event: PointerEvent) => void;
+  readonly onPointerenter: (event: PointerEvent) => void;
+  readonly onPointerleave: (event: PointerEvent) => void;
+  readonly onPointermove: (event: PointerEvent) => void;
+  readonly onTouchstart: (event: TouchEvent) => void;
+}
+
+/** Stateful hover normalizer with explicit listener ownership. */
+export interface HoverController {
+  /** Whether a qualifying mouse or pen currently hovers the host. */
+  readonly isHovered: Readonly<ShallowRef<boolean>>;
+
+  /** Stable native handlers to merge or spread onto one host. */
+  readonly hoverProps: Readonly<HoverProps>;
+
+  /** Cancel the current hover interaction. */
+  readonly cancel: () => boolean;
+
+  /** Release document listeners and reactive state. */
+  readonly dispose: () => void;
+}

--- a/npm/ui/core/src/hover.behavior.md
+++ b/npm/ui/core/src/hover.behavior.md
@@ -1,0 +1,32 @@
+# Hover behavior contract
+
+Normative state × input → outcome table for `@vizejs/ui/hover`. Every row is
+exercised by `src/hover*.test.ts`; compile-only assertions live in
+`src/hover.types.test-d.ts`.
+
+| #   | State                     | Input                                                         | Outcome                                                      | Proven by                   |
+| --- | ------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------ | --------------------------- |
+| H1  | idle                      | mouse or pen pointer enters                                   | immutable start snapshot and hovered state are published     | boundary test               |
+| H2  | idle                      | touch or extensible unknown pointer enters                    | input is ignored                                             | filter test                 |
+| H3  | idle                      | disabled or nonmatching configured family enters              | input is ignored                                             | filter test                 |
+| H4  | hovered                   | pointer moves between host descendants                        | hover remains owned by the host                              | boundary test               |
+| H5  | hovered                   | owning pointer leaves host                                    | normal end snapshot is emitted                               | boundary test               |
+| H6  | hovered                   | reactive disabled/filter changes then pointer moves           | canceled end is emitted                                      | reactive test               |
+| H7  | hovered                   | touch device switch, pointer cancel, blur, or hidden document | canceled end is emitted                                      | cancellation tests          |
+| H8  | touch just ended          | compatibility mouse enter within 800 ms                       | emulated hover is ignored                                    | legacy fallback test        |
+| H9  | legacy browser            | genuine mouse enter after suppression window                  | fallback hover starts and ends normally                      | legacy fallback test        |
+| H10 | Pointer Events browser    | compatibility mouse handlers also run                         | duplicate mouse lifecycle is ignored                         | legacy fallback test        |
+| H11 | active callback re-enters | start callback cancels                                        | stale `hovered=true` change is not published                 | reentrancy test             |
+| H12 | callbacks throw           | multiple transition notifications                             | state settles and failures aggregate afterward               | callback-failure test       |
+| H13 | active                    | manual cancel, dispose, or scope stop                         | state/listeners release with explicit cancellation semantics | ownership test              |
+| H14 | concurrent SSR requests   | identical component trees                                     | byte-identical markup contains no handlers or DOM reads      | SSR test                    |
+| H15 | SSR followed by hydration | mouse enter/leave                                             | host identity remains and state renders without diagnostics  | hydration test              |
+| H16 | public TypeScript API     | mutation or invalid closed union                              | compilation rejects misuse                                   | `src/hover.types.test-d.ts` |
+
+## Accessibility obligation
+
+Hover must never be the only way to discover or invoke an action. Consumers
+must provide equivalent focus, press, long-press, or visible-control behavior.
+This primitive deliberately ignores touch and unknown pointers, emits no CSS,
+does not change focus, and leaves semantic roles and styling entirely to the
+owning component.

--- a/npm/ui/core/src/hover.test.ts
+++ b/npm/ui/core/src/hover.test.ts
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+
+import { effectScope, ref } from "vue";
+import { test } from "vite-plus/test";
+
+import { createHover, useHover } from "./hover.ts";
+import type { HoverController, HoverEvent, HoverOptions, HoverProps } from "./hover.ts";
+
+const eventNames: Readonly<Record<keyof HoverProps, string>> = {
+  onMouseenter: "mouseenter",
+  onMouseleave: "mouseleave",
+  onMousemove: "mousemove",
+  onPointercancel: "pointercancel",
+  onPointerenter: "pointerenter",
+  onPointerleave: "pointerleave",
+  onPointermove: "pointermove",
+  onTouchstart: "touchstart",
+};
+
+interface Harness {
+  readonly controller: HoverController;
+  readonly events: HoverEvent[];
+  readonly host: HTMLDivElement;
+  readonly unmount: () => void;
+}
+
+function mountHover(options: HoverOptions = {}): Harness {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const events: HoverEvent[] = [];
+  const controller = createHover({
+    ...options,
+    onHoverStart: (event) => {
+      events.push(event);
+      options.onHoverStart?.(event);
+    },
+    onHoverEnd: (event) => {
+      events.push(event);
+      options.onHoverEnd?.(event);
+    },
+  });
+  for (const [property, type] of Object.entries(eventNames) as Array<[keyof HoverProps, string]>) {
+    host.addEventListener(type, controller.hoverProps[property] as EventListener);
+  }
+  return {
+    controller,
+    events,
+    host,
+    unmount: () => {
+      controller.dispose();
+      host.remove();
+    },
+  };
+}
+
+function pointer(
+  type: string,
+  pointerType = "mouse",
+  values: Partial<PointerEventInit> = {},
+): PointerEvent {
+  return new PointerEvent(type, {
+    bubbles: false,
+    clientX: 7,
+    clientY: 13,
+    isPrimary: true,
+    pointerId: 4,
+    pointerType,
+    ...values,
+  });
+}
+
+test("normalizes mouse and pen boundary transitions into immutable snapshots", () => {
+  for (const pointerType of ["mouse", "pen"] as const) {
+    const harness = mountHover();
+    const child = document.createElement("span");
+    const outside = document.createElement("div");
+    harness.host.append(child);
+    document.body.append(outside);
+
+    harness.host.dispatchEvent(pointer("pointerenter", pointerType));
+    assert.equal(harness.controller.isHovered.value, true);
+    assert.deepEqual(
+      harness.events.map(({ type }) => type),
+      ["hoverstart"],
+    );
+    assert.ok(Object.isFrozen(harness.events[0]));
+    assert.deepEqual([harness.events[0]?.x, harness.events[0]?.y], [7, 13]);
+
+    harness.host.dispatchEvent(pointer("pointerleave", pointerType, { relatedTarget: child }));
+    assert.equal(harness.controller.isHovered.value, true);
+    harness.host.dispatchEvent(
+      pointer("pointerleave", pointerType, { clientX: 20, clientY: 30, relatedTarget: outside }),
+    );
+    assert.equal(harness.controller.isHovered.value, false);
+    assert.deepEqual(
+      harness.events.map(({ type }) => type),
+      ["hoverstart", "hoverend"],
+    );
+    assert.equal(harness.events[1]?.isCanceled, false);
+    assert.deepEqual([harness.events[1]?.x, harness.events[1]?.y], [20, 30]);
+    outside.remove();
+    harness.unmount();
+  }
+});
+
+test("ignores touch and unknown pointers, disabled hosts, and filtered families", () => {
+  for (const [actual, filter, disabled, expected] of [
+    ["touch", undefined, false, false],
+    ["trackpad", undefined, false, false],
+    ["mouse", "pen", false, false],
+    ["pen", "pen", false, true],
+    ["mouse", undefined, true, false],
+  ] as const) {
+    const harness = mountHover({ isDisabled: disabled, pointerType: filter });
+    harness.host.dispatchEvent(pointer("pointerenter", actual));
+    assert.equal(harness.controller.isHovered.value, expected);
+    harness.unmount();
+  }
+});
+
+test("reactive disablement and pointer filters cancel on the next native movement", () => {
+  const disabled = ref(false);
+  const pointerType = ref<"mouse" | "pen">("mouse");
+  const harness = mountHover({ isDisabled: disabled, pointerType });
+  harness.host.dispatchEvent(pointer("pointerenter"));
+  disabled.value = true;
+  document.dispatchEvent(pointer("pointermove"));
+  assert.equal(harness.controller.isHovered.value, false);
+  assert.equal(harness.events.at(-1)?.isCanceled, true);
+
+  disabled.value = false;
+  harness.host.dispatchEvent(pointer("pointerenter"));
+  pointerType.value = "pen";
+  document.dispatchEvent(pointer("pointermove"));
+  assert.equal(harness.controller.isHovered.value, false);
+  assert.equal(harness.events.at(-1)?.isCanceled, true);
+  harness.unmount();
+});
+
+test("touch switching, pointer cancellation, lost visibility, and window blur terminate hover", () => {
+  for (const finish of ["touch", "pointercancel", "hidden", "blur"] as const) {
+    const harness = mountHover();
+    harness.host.dispatchEvent(pointer("pointerenter"));
+    if (finish === "touch") {
+      document.dispatchEvent(pointer("pointerdown", "touch", { bubbles: true }));
+    } else if (finish === "pointercancel") {
+      harness.host.dispatchEvent(pointer("pointercancel"));
+    } else if (finish === "hidden") {
+      const descriptor = Object.getOwnPropertyDescriptor(document, "visibilityState");
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "hidden",
+      });
+      try {
+        document.dispatchEvent(new Event("visibilitychange"));
+      } finally {
+        if (descriptor) Object.defineProperty(document, "visibilityState", descriptor);
+        else delete (document as { visibilityState?: DocumentVisibilityState }).visibilityState;
+      }
+    } else {
+      window.dispatchEvent(new Event("blur"));
+    }
+    assert.equal(harness.controller.isHovered.value, false);
+    assert.equal(harness.events.at(-1)?.isCanceled, true);
+    harness.unmount();
+  }
+});
+
+test("legacy mouse fallback suppresses compatibility events after touch", () => {
+  const harness = mountHover();
+  const touch = new Event("touchstart", { bubbles: true });
+  harness.host.dispatchEvent(touch);
+  const emulated = new MouseEvent("mouseenter");
+  Object.defineProperty(emulated, "timeStamp", { value: touch.timeStamp + 1 });
+  harness.host.dispatchEvent(emulated);
+  assert.equal(harness.controller.isHovered.value, false);
+
+  const genuine = new MouseEvent("mouseenter", { clientX: 3, clientY: 5 });
+  Object.defineProperty(genuine, "timeStamp", { value: touch.timeStamp + 801 });
+  harness.host.dispatchEvent(genuine);
+  assert.equal(harness.controller.isHovered.value, true);
+  harness.host.dispatchEvent(new MouseEvent("mouseleave"));
+  assert.equal(harness.controller.isHovered.value, false);
+
+  const modern = new MouseEvent("mouseenter", { view: window });
+  harness.host.dispatchEvent(modern);
+  assert.equal(harness.controller.isHovered.value, false);
+  harness.unmount();
+});
+
+test("manual cancel, disposal, and Vue scope ownership settle state", () => {
+  const harness = mountHover();
+  harness.host.dispatchEvent(pointer("pointerenter"));
+  assert.equal(harness.controller.cancel(), true);
+  assert.equal(harness.events.at(-1)?.isCanceled, true);
+  assert.equal(harness.controller.cancel(), false);
+  harness.controller.dispose();
+  assert.throws(() => harness.controller.cancel(), /VIZE_UI_HOVER_DISPOSED/);
+  harness.host.remove();
+
+  assert.throws(() => useHover(), /VIZE_UI_HOVER_SETUP/);
+  const scope = effectScope();
+  const scoped = scope.run(() => useHover())!;
+  scope.stop();
+  assert.throws(() => scoped.cancel(), /VIZE_UI_HOVER_DISPOSED/);
+});
+
+test("reentrant cancellation cannot publish a stale hovered change", () => {
+  const changes: boolean[] = [];
+  let controller!: HoverController;
+  const host = document.createElement("div");
+  document.body.append(host);
+  controller = createHover({
+    onHoverStart: () => controller.cancel(),
+    onHoverChange: (hovered) => changes.push(hovered),
+  });
+  host.addEventListener("pointerenter", controller.hoverProps.onPointerenter);
+  host.dispatchEvent(pointer("pointerenter"));
+
+  assert.equal(controller.isHovered.value, false);
+  assert.deepEqual(changes, [false]);
+  controller.dispose();
+  host.remove();
+});
+
+test("callback failures settle transitions and aggregate multiple errors", () => {
+  const harness = mountHover({
+    onHoverStart: () => {
+      throw new Error("start failed");
+    },
+    onHoverChange: () => {
+      throw new Error("change failed");
+    },
+  });
+  assert.throws(() => harness.host.dispatchEvent(pointer("pointerenter")), AggregateError);
+  assert.equal(harness.controller.isHovered.value, true);
+  harness.controller.dispose();
+  harness.host.remove();
+});
+
+test("rejects invalid runtime options with stable diagnostics", () => {
+  assert.throws(
+    () => createHover({ pointerType: "touch" as "mouse" }),
+    /VIZE_UI_HOVER_OPTION.*pointerType/,
+  );
+  assert.throws(
+    () => createHover({ onHoverStart: "callback" as never }),
+    /VIZE_UI_HOVER_OPTION.*onHoverStart/,
+  );
+});

--- a/npm/ui/core/src/hover.ts
+++ b/npm/ui/core/src/hover.ts
@@ -1,0 +1,272 @@
+import { getCurrentScope, onScopeDispose, shallowReadonly, shallowRef, toValue } from "vue";
+
+import type {
+  HoverController,
+  HoverEvent,
+  HoverEventType,
+  HoverOptions,
+  HoverPointerType,
+  HoverProps,
+} from "./hover-types.ts";
+
+const invalidOptionDiagnostic = "VIZE_UI_HOVER_OPTION";
+const disposedDiagnostic = "VIZE_UI_HOVER_DISPOSED";
+const setupDiagnostic = "VIZE_UI_HOVER_SETUP";
+const pointerTypes = new Set<HoverPointerType>(["mouse", "pen"]);
+
+interface ActiveHover {
+  readonly pointerType: HoverPointerType;
+  readonly releaseListeners: () => void;
+  readonly target: Element;
+  lastEvent: Event;
+}
+
+function readBoolean(value: HoverOptions["isDisabled"]): boolean {
+  const resolved = toValue(value);
+  if (resolved === undefined) return false;
+  if (typeof resolved !== "boolean") {
+    throw new TypeError(`${invalidOptionDiagnostic}: isDisabled must resolve to a boolean`);
+  }
+  return resolved;
+}
+
+function readPointerType(value: HoverOptions["pointerType"]): HoverPointerType | null {
+  const resolved = toValue(value) ?? null;
+  if (resolved !== null && !pointerTypes.has(resolved)) {
+    throw new TypeError(`${invalidOptionDiagnostic}: pointerType must resolve to mouse or pen`);
+  }
+  return resolved;
+}
+
+function eventElement(event: Event): Element | null {
+  const value = event.currentTarget;
+  return value && (value as Node).nodeType === 1 ? (value as Element) : null;
+}
+
+function modifier(event: Event | null, key: "altKey" | "ctrlKey" | "metaKey" | "shiftKey") {
+  return event && key in event ? Boolean((event as MouseEvent)[key]) : false;
+}
+
+function createHoverEvent(
+  type: HoverEventType,
+  target: Element,
+  pointerType: HoverPointerType,
+  originalEvent: Event | null,
+  isCanceled = false,
+): HoverEvent {
+  const hasPoint = originalEvent && "clientX" in originalEvent && "clientY" in originalEvent;
+  return Object.freeze({
+    type,
+    pointerType,
+    target,
+    originalEvent,
+    x: hasPoint ? Number((originalEvent as MouseEvent).clientX) : null,
+    y: hasPoint ? Number((originalEvent as MouseEvent).clientY) : null,
+    altKey: modifier(originalEvent, "altKey"),
+    ctrlKey: modifier(originalEvent, "ctrlKey"),
+    metaKey: modifier(originalEvent, "metaKey"),
+    shiftKey: modifier(originalEvent, "shiftKey"),
+    isCanceled,
+  });
+}
+
+function notifyAll(notifications: readonly (() => void)[]): void {
+  const errors: unknown[] = [];
+  for (const notify of notifications) {
+    try {
+      notify();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) throw new AggregateError(errors, "Hover callbacks failed");
+}
+
+function validateOptions(options: HoverOptions): void {
+  for (const name of ["onHoverChange", "onHoverEnd", "onHoverStart"] as const) {
+    const callback = options[name];
+    if (callback !== undefined && typeof callback !== "function") {
+      throw new TypeError(`${invalidOptionDiagnostic}: ${name} must be a function`);
+    }
+  }
+  if (typeof options.pointerType !== "function") readPointerType(options.pointerType);
+}
+
+/** Create an SSR-safe mouse and pen hover normalizer for one host. */
+export function createHover(options: HoverOptions = {}): HoverController {
+  validateOptions(options);
+  const hovered = shallowRef(false);
+  let active: ActiveHover | null = null;
+  let disposed = false;
+  let transitionVersion = 0;
+  let lastTouchTime = Number.NEGATIVE_INFINITY;
+
+  const transition = (next: boolean, event: HoverEvent) => {
+    if (hovered.value === next) return;
+    hovered.value = next;
+    const version = ++transitionVersion;
+    const phase = next ? options.onHoverStart : options.onHoverEnd;
+    notifyAll([
+      () => phase?.(event),
+      () => {
+        if (transitionVersion === version) options.onHoverChange?.(next);
+      },
+    ]);
+  };
+
+  const end = (originalEvent: Event | null, isCanceled: boolean): boolean => {
+    const current = active;
+    if (!current) return false;
+    current.releaseListeners();
+    active = null;
+    transition(
+      false,
+      createHoverEvent(
+        "hoverend",
+        current.target,
+        current.pointerType,
+        originalEvent ?? current.lastEvent,
+        isCanceled,
+      ),
+    );
+    return true;
+  };
+
+  const installListeners = (document: Document): (() => void) => {
+    const removals: Array<() => void> = [];
+    const listen = (
+      owner: Document | Window,
+      type: string,
+      callback: EventListener,
+      capture = true,
+    ) => {
+      owner.addEventListener(type, callback, capture);
+      removals.push(() => owner.removeEventListener(type, callback, capture));
+    };
+    const revalidate = (event: Event) => {
+      const current = active;
+      if (!current) return;
+      current.lastEvent = event;
+      const filter = readPointerType(options.pointerType);
+      if (readBoolean(options.isDisabled) || (filter && filter !== current.pointerType)) {
+        end(event, true);
+      }
+    };
+    try {
+      listen(document, "pointermove", revalidate);
+      listen(document, "mousemove", revalidate);
+      listen(document, "pointerdown", ((event: PointerEvent) => {
+        if (event.pointerType === "touch") end(event, true);
+      }) as EventListener);
+      listen(document, "touchstart", ((event: TouchEvent) => {
+        lastTouchTime = event.timeStamp;
+        end(event, true);
+      }) as EventListener);
+      listen(document, "visibilitychange", (() => {
+        if (document.visibilityState === "hidden") end(null, true);
+      }) as EventListener);
+      if (document.defaultView) {
+        listen(document.defaultView, "blur", (event) => end(event, true), false);
+      }
+    } catch (error) {
+      for (const remove of removals.reverse()) remove();
+      throw error;
+    }
+    return () => {
+      for (const remove of removals.splice(0)) remove();
+    };
+  };
+
+  const start = (event: Event, pointerType: HoverPointerType): void => {
+    if (disposed || active || readBoolean(options.isDisabled)) return;
+    const filter = readPointerType(options.pointerType);
+    if (filter && filter !== pointerType) return;
+    const target = eventElement(event);
+    if (!target) return;
+    const current: ActiveHover = {
+      pointerType,
+      releaseListeners: installListeners(target.ownerDocument),
+      target,
+      lastEvent: event,
+    };
+    active = current;
+    transition(true, createHoverEvent("hoverstart", target, pointerType, event));
+  };
+
+  const leave = (event: MouseEvent | PointerEvent): void => {
+    const current = active;
+    if (!current || current.target !== eventElement(event)) return;
+    const related = event.relatedTarget;
+    if (related && (related as Node).nodeType && current.target.contains(related as Node)) return;
+    current.lastEvent = event;
+    end(event, false);
+  };
+
+  const hoverProps: Readonly<HoverProps> = Object.freeze({
+    onMouseenter(event: MouseEvent) {
+      if (event.view && "PointerEvent" in event.view) return;
+      const elapsed = event.timeStamp - lastTouchTime;
+      if (elapsed >= 0 && elapsed < 800) return;
+      start(event, "mouse");
+    },
+    onMouseleave: leave,
+    onMousemove(event: MouseEvent) {
+      const current = active;
+      if (!(event.view && "PointerEvent" in event.view) && current) current.lastEvent = event;
+    },
+    onPointercancel(event: PointerEvent) {
+      if (active?.pointerType === event.pointerType) end(event, true);
+    },
+    onPointerenter(event: PointerEvent) {
+      if (event.pointerType === "mouse" || event.pointerType === "pen") {
+        start(event, event.pointerType);
+      }
+    },
+    onPointerleave: leave,
+    onPointermove(event: PointerEvent) {
+      const current = active;
+      if (current?.pointerType === event.pointerType) current.lastEvent = event;
+    },
+    onTouchstart(event: TouchEvent) {
+      lastTouchTime = event.timeStamp;
+      end(event, true);
+    },
+  });
+
+  return Object.freeze({
+    isHovered: shallowReadonly(hovered),
+    hoverProps,
+    cancel: () => {
+      if (disposed) throw new Error(`${disposedDiagnostic}: the controller has been disposed`);
+      return end(null, true);
+    },
+    dispose: () => {
+      if (disposed) return;
+      active?.releaseListeners();
+      active = null;
+      hovered.value = false;
+      transitionVersion++;
+      disposed = true;
+    },
+  });
+}
+
+/** Create a hover normalizer disposed with the current Vue effect scope. */
+export function useHover(options: HoverOptions = {}): HoverController {
+  if (!getCurrentScope()) {
+    throw new Error(`${setupDiagnostic}: use inside component setup or an active effect scope`);
+  }
+  const controller = createHover(options);
+  onScopeDispose(controller.dispose);
+  return controller;
+}
+
+export type {
+  HoverController,
+  HoverEvent,
+  HoverEventType,
+  HoverOptions,
+  HoverPointerType,
+  HoverProps,
+} from "./hover-types.ts";

--- a/npm/ui/core/src/hover.types.test-d.ts
+++ b/npm/ui/core/src/hover.types.test-d.ts
@@ -1,0 +1,35 @@
+/** Compile-only assertions for the public hover contract. */
+
+import { ref } from "vue";
+import type { HTMLAttributes, ShallowRef } from "vue";
+
+import { createHover, type HoverEvent, type HoverPointerType, type HoverProps } from "./hover.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+export const pointerTypes: readonly HoverPointerType[] = ["mouse", "pen"];
+// @ts-expect-error touch does not have a persistent hover state.
+export const invalidPointerType: HoverPointerType = "touch";
+
+const disabled = ref(false);
+export const controller = createHover({
+  isDisabled: disabled,
+  pointerType: () => "pen",
+  onHoverStart(event: HoverEvent) {
+    const target: Element = event.target;
+    void target;
+  },
+});
+
+type _HoveredIsReadonly = Expect<Equal<typeof controller.isHovered, Readonly<ShallowRef<boolean>>>>;
+type _PropsAreExact = Expect<Equal<typeof controller.hoverProps, Readonly<HoverProps>>>;
+
+export const vueAttributes: HTMLAttributes = controller.hoverProps;
+// @ts-expect-error consumers cannot mutate readonly reactive state.
+controller.isHovered.value = true;
+// @ts-expect-error disabled must resolve to boolean.
+createHover({ isDisabled: "false" });

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -5,6 +5,7 @@ export * from "./controllable-state.ts";
 export * from "./button.ts";
 export * from "./id.ts";
 export * from "./interaction-modality.ts";
+export * from "./hover.ts";
 export * from "./long-press.ts";
 export * from "./press.ts";
 export * from "./primitive.ts";

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       "controllable-state": "src/controllable-state.ts",
       id: "src/id.ts",
       "interaction-modality": "src/interaction-modality.ts",
+      hover: "src/hover.ts",
       "long-press": "src/long-press.ts",
       press: "src/press.ts",
       primitive: "src/primitive.ts",


### PR DESCRIPTION
## Summary

- add a type-safe, SSR-safe mouse and pen hover normalizer with pointer and legacy mouse paths
- preserve host ownership across descendant boundaries and settle on cancellation, touch switching, visibility loss, window blur, disposal, or reactive option changes
- publish immutable lifecycle snapshots, Vue scope ownership, runtime diagnostics, and a CSS-free `@vizejs/ui/hover` subpath
- document the normative accessibility contract and verify hydration plus DOM, SSR, and Vapor consumer compilation

## Quality gates

- `pnpm --filter @vizejs/ui check`
- `pnpm --filter @vizejs/ui test` — 149 tests across 27 files
- root and subpath consumer bundles are byte-identical and retain 0 CSS bytes
- renderer conformance runs in GitHub Actions using the repository native artifact

## Bundle budgets

- package root: 21,555 / 21,625 gzip bytes
- hover entry: 2,136 / 2,200 gzip bytes
- hover consumer: 1,394 / 1,450 gzip bytes

Part of #3134

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->