### PR TITLE
feat(ui): add move interactions

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -79,6 +79,11 @@
       "import": "./dist/long-press.mjs",
       "default": "./dist/long-press.mjs"
     },
+    "./move": {
+      "types": "./dist/move.d.mts",
+      "import": "./dist/move.mjs",
+      "default": "./dist/move.mjs"
+    },
     "./press": {
       "types": "./dist/press.d.mts",
       "import": "./dist/press.mjs",

--- a/npm/ui/core/scripts/check-renderers.ts
+++ b/npm/ui/core/scripts/check-renderers.ts
@@ -19,6 +19,25 @@ const rendererLanes: readonly RendererLane[] = [
 
 const inlineFixtures = [
   {
+    filename: "MoveConsumer.vue",
+    source: String.raw`<script setup lang="ts">
+import { useMove } from "./move.ts";
+
+const move = useMove({
+  onMove(event) {
+    void event.deltaX;
+  },
+});
+</script>
+
+<template>
+  <div v-bind="move.moveProps" :data-moving="move.isMoving.value || undefined" tabindex="0">
+    Move target
+  </div>
+</template>
+`,
+  },
+  {
     filename: "HoverConsumer.vue",
     source: String.raw`<script setup lang="ts">
 import { useHover } from "./hover.ts";

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 21_625],
+  ["index.mjs", 23_825],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
   ["collection.mjs", 5_700],
@@ -14,8 +14,9 @@ const budgets = new Map([
   ["id.mjs", 2_300],
   ["interaction-modality.mjs", 3_300],
   ["hover.mjs", 2_200],
-  ["long-press.mjs", 8_000],
-  ["press.mjs", 5_775],
+  ["long-press.mjs", 8_175],
+  ["move.mjs", 5_050],
+  ["press.mjs", 5_950],
   ["primitive.mjs", 800],
   ["visually-hidden.mjs", 800],
   ["media.mjs", 2_400],

--- a/npm/ui/core/scripts/check-tree-shaking.mjs
+++ b/npm/ui/core/scripts/check-tree-shaking.mjs
@@ -75,6 +75,7 @@ const familySignatures = Object.freeze({
   "interaction-modality": /VIZE_UI_INTERACTION_MODALITY_DISPOSED/,
   hover: /VIZE_UI_HOVER_DISPOSED/,
   "long-press": /VIZE_UI_LONG_PRESS_DISPOSED/,
+  move: /VIZE_UI_MOVE_DISPOSED/,
   press: /VIZE_UI_PRESS_DISPOSED/,
   primitive: /data-vize-ui.+primitive/,
   "visually-hidden": /visually-hidden/,
@@ -125,6 +126,12 @@ const componentCases = [
     family: "long-press",
     exportName: "createLongPress",
     maximumJavaScriptGzipBytes: 5_150,
+    maximumCssGzipBytes: 0,
+  },
+  {
+    family: "move",
+    exportName: "createMove",
+    maximumJavaScriptGzipBytes: 2_750,
     maximumCssGzipBytes: 0,
   },
   {

--- a/npm/ui/core/src/distribution.test.ts
+++ b/npm/ui/core/src/distribution.test.ts
@@ -15,6 +15,7 @@ const publicEntries = [
   "./interaction-modality",
   "./hover",
   "./long-press",
+  "./move",
   "./press",
   "./primitive",
   "./visually-hidden",

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -7,6 +7,7 @@ export * from "./id.ts";
 export * from "./interaction-modality.ts";
 export * from "./hover.ts";
 export * from "./long-press.ts";
+export * from "./move.ts";
 export * from "./press.ts";
 export * from "./primitive.ts";
 export * from "./visually-hidden.ts";

--- a/npm/ui/core/src/move-internal.test.ts
+++ b/npm/ui/core/src/move-internal.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+
+import { surfaceErrors } from "./move-internal.ts";
+
+test("multiple move cleanup errors remain inspectable without native AggregateError", () => {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "AggregateError");
+  Object.defineProperty(globalThis, "AggregateError", { configurable: true, value: undefined });
+  try {
+    assert.throws(
+      () => surfaceErrors([new Error("listeners"), new Error("selection")], "move failed"),
+      (error: unknown) => {
+        const aggregate = error as Error & { errors?: unknown[] };
+        assert.equal(aggregate.name, "AggregateError");
+        assert.equal(aggregate.message, "move failed");
+        assert.deepEqual(
+          aggregate.errors?.map((reason) => (reason as Error).message),
+          ["listeners", "selection"],
+        );
+        return true;
+      },
+    );
+  } finally {
+    if (descriptor) Object.defineProperty(globalThis, "AggregateError", descriptor);
+  }
+});

--- a/npm/ui/core/src/move-internal.ts
+++ b/npm/ui/core/src/move-internal.ts
@@ -1,0 +1,232 @@
+import { toValue } from "vue";
+
+import type { MoveEvent, MoveEventType, MoveOptions, MovePointerType } from "./move-types.ts";
+
+const invalidOptionDiagnostic = "VIZE_UI_MOVE_OPTION";
+
+export type PointerSource = "mouse" | "pointer" | "touch";
+
+export interface Position {
+  readonly x: number;
+  readonly y: number;
+}
+
+export interface ActiveMove {
+  readonly id: number | null;
+  readonly pointerType: Exclude<MovePointerType, "keyboard">;
+  readonly releaseListeners: () => void;
+  readonly restoreSelection: () => void;
+  readonly source: PointerSource;
+  readonly target: Element;
+  didMove: boolean;
+  lastEvent: Event;
+  position: Position;
+}
+
+export interface MoveListenerContext {
+  readonly emitDelta: (current: ActiveMove, event: Event, position: Position) => void;
+  readonly finish: (event: Event | null, canceled: boolean) => boolean;
+  readonly getActive: () => ActiveMove | null;
+  readonly readDisabled: (event: Event) => boolean;
+  readonly rememberTouch: (timeStamp: number) => void;
+}
+
+export function readBoolean(value: MoveOptions["isDisabled"]): boolean {
+  const resolved = toValue(value);
+  if (resolved === undefined) return false;
+  if (typeof resolved !== "boolean") {
+    throw new TypeError(`${invalidOptionDiagnostic}: isDisabled must resolve to a boolean`);
+  }
+  return resolved;
+}
+
+export function readKeyboardStep(value: MoveOptions["keyboardStep"]): number {
+  const resolved = toValue(value) ?? 1;
+  if (typeof resolved !== "number" || !Number.isFinite(resolved) || resolved <= 0) {
+    throw new TypeError(
+      `${invalidOptionDiagnostic}: keyboardStep must resolve to a finite number > 0`,
+    );
+  }
+  return resolved;
+}
+
+function modifier(event: Event | null, key: "altKey" | "ctrlKey" | "metaKey" | "shiftKey") {
+  return event && key in event ? Boolean((event as KeyboardEvent)[key]) : false;
+}
+
+export function positionOf(event: Event, touchId: number | null = null): Position | null {
+  if ("pageX" in event && "pageY" in event) {
+    const x = Number(event.pageX);
+    const y = Number(event.pageY);
+    if (Number.isFinite(x) && Number.isFinite(y)) return { x, y };
+  }
+  if ("clientX" in event && "clientY" in event) {
+    const x = Number(event.clientX);
+    const y = Number(event.clientY);
+    if (Number.isFinite(x) && Number.isFinite(y)) return { x, y };
+  }
+  if ("changedTouches" in event) {
+    const touch = Array.from((event as TouchEvent).changedTouches).find(
+      ({ identifier }) => touchId === null || identifier === touchId,
+    );
+    if (touch) return { x: touch.pageX, y: touch.pageY };
+  }
+  return null;
+}
+
+export function pointerTypeOf(event: PointerEvent): Exclude<MovePointerType, "keyboard"> {
+  if (event.pointerType === "mouse" || event.pointerType === "pen") return event.pointerType;
+  if (event.pointerType === "touch") return "touch";
+  return "pointer";
+}
+
+export function createMoveEvent(
+  type: MoveEventType,
+  target: Element,
+  pointerType: MovePointerType,
+  originalEvent: Event | null,
+  deltaX = 0,
+  deltaY = 0,
+  isCanceled = false,
+  touchId: number | null = null,
+): MoveEvent {
+  const position = originalEvent ? positionOf(originalEvent, touchId) : null;
+  return Object.freeze({
+    type,
+    pointerType,
+    target,
+    originalEvent,
+    x: position?.x ?? null,
+    y: position?.y ?? null,
+    deltaX,
+    deltaY,
+    altKey: modifier(originalEvent, "altKey"),
+    ctrlKey: modifier(originalEvent, "ctrlKey"),
+    metaKey: modifier(originalEvent, "metaKey"),
+    shiftKey: modifier(originalEvent, "shiftKey"),
+    isCanceled,
+  }) as MoveEvent;
+}
+
+export function surfaceErrors(errors: readonly unknown[], message: string): void {
+  if (errors.length === 1) throw errors[0];
+  if (errors.length < 2) return;
+  const Aggregate = globalThis.AggregateError as typeof AggregateError | undefined;
+  if (typeof Aggregate === "function") throw new Aggregate(errors, message);
+  const fallback = Object.assign(new Error(message), { errors: [...errors] });
+  fallback.name = "AggregateError";
+  throw fallback;
+}
+
+export function capture(errors: unknown[], callback: () => void): void {
+  try {
+    callback();
+  } catch (error) {
+    errors.push(error);
+  }
+}
+
+export function validateOptions(options: MoveOptions): void {
+  for (const name of ["onMove", "onMoveEnd", "onMoveStart"] as const) {
+    const callback = options[name];
+    if (callback !== undefined && typeof callback !== "function") {
+      throw new TypeError(`${invalidOptionDiagnostic}: ${name} must be a function`);
+    }
+  }
+  if (typeof options.keyboardStep !== "function") readKeyboardStep(options.keyboardStep);
+}
+
+/** Install and exhaustively clean up the document listeners for one pointer family. */
+export function installMoveListeners(
+  document: Document,
+  source: PointerSource,
+  context: MoveListenerContext,
+): () => void {
+  const removals: Array<() => void> = [];
+  const listen = (
+    owner: Document | Window,
+    type: string,
+    callback: EventListener,
+    capture = true,
+  ) => {
+    owner.addEventListener(type, callback, capture);
+    removals.push(() => owner.removeEventListener(type, callback, capture));
+  };
+  const matches = (family: PointerSource, id: number | null): ActiveMove | null => {
+    const current = context.getActive();
+    return current?.source === family && current.id === id ? current : null;
+  };
+  const pointerMove = (event: PointerEvent) => {
+    const current = matches("pointer", event.pointerId);
+    const position = positionOf(event);
+    if (current && position) context.emitDelta(current, event, position);
+  };
+  const pointerEnd = (event: PointerEvent, canceled: boolean) => {
+    const current = matches("pointer", event.pointerId);
+    if (!current) return;
+    const disabled = context.readDisabled(event);
+    context.finish(event, canceled || disabled || !current.target.isConnected);
+  };
+  const mouseMove = (event: MouseEvent) => {
+    const current = matches("mouse", null);
+    const position = positionOf(event);
+    if (current && position) context.emitDelta(current, event, position);
+  };
+  const mouseUp = (event: MouseEvent) => {
+    const current = matches("mouse", null);
+    if (event.button === 0 && current) {
+      context.finish(event, context.readDisabled(event) || !current.target.isConnected);
+    }
+  };
+  const touchMove = (event: TouchEvent) => {
+    const candidate = context.getActive();
+    const current = candidate?.source === "touch" ? candidate : null;
+    const position = current ? positionOf(event, current.id) : null;
+    if (current && position) context.emitDelta(current, event, position);
+  };
+  const touchEnd = (event: TouchEvent, canceled: boolean) => {
+    const candidate = context.getActive();
+    const current = candidate?.source === "touch" ? candidate : null;
+    if (!current || !positionOf(event, current.id)) return;
+    context.rememberTouch(event.timeStamp);
+    context.finish(event, canceled || context.readDisabled(event) || !current.target.isConnected);
+  };
+  try {
+    if (source === "pointer") {
+      listen(document, "pointermove", pointerMove as EventListener);
+      listen(document, "pointerup", ((event: PointerEvent) =>
+        pointerEnd(event, false)) as EventListener);
+      listen(document, "pointercancel", ((event: PointerEvent) =>
+        pointerEnd(event, true)) as EventListener);
+    } else if (source === "mouse") {
+      listen(document, "mousemove", mouseMove as EventListener);
+      listen(document, "mouseup", mouseUp as EventListener);
+    } else {
+      listen(document, "touchmove", touchMove as EventListener);
+      listen(document, "touchend", ((event: TouchEvent) =>
+        touchEnd(event, false)) as EventListener);
+      listen(document, "touchcancel", ((event: TouchEvent) =>
+        touchEnd(event, true)) as EventListener);
+    }
+    listen(document, "dragstart", (event) => context.finish(event, true));
+    listen(document, "visibilitychange", (() => {
+      if (document.visibilityState === "hidden") context.finish(null, true);
+    }) as EventListener);
+    if (document.defaultView) {
+      listen(document.defaultView, "blur", (event) => context.finish(event, true), false);
+    }
+  } catch (error) {
+    const errors: unknown[] = [error];
+    for (const remove of removals.reverse()) capture(errors, remove);
+    surfaceErrors(errors, "Move listener setup failed");
+    throw error;
+  }
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    const errors: unknown[] = [];
+    for (const remove of removals) capture(errors, remove);
+    surfaceErrors(errors, "Move listener cleanup failed");
+  };
+}

--- a/npm/ui/core/src/move-ssr.test.ts
+++ b/npm/ui/core/src/move-ssr.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { createSSRApp, defineComponent, h, nextTick, ref } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import { useMove } from "./move.ts";
+
+const SsrProbe = defineComponent({
+  name: "MoveSsrProbe",
+  setup() {
+    const x = ref(0);
+    const move = useMove({ onMove: (event) => (x.value += event.deltaX) });
+    return () =>
+      h(
+        "div",
+        { ...move.moveProps, "data-moving": String(move.isMoving.value), tabindex: 0 },
+        `Move ${x.value}`,
+      );
+  },
+});
+
+function pointer(type: string, x: number): PointerEvent {
+  const event = new PointerEvent(type, {
+    bubbles: true,
+    button: 0,
+    clientX: x,
+    clientY: 0,
+    isPrimary: true,
+    pointerId: 2,
+    pointerType: "mouse",
+  });
+  Object.defineProperties(event, {
+    pageX: { value: x },
+    pageY: { value: 0 },
+  });
+  return event;
+}
+
+test("renders byte-identical move SSR output without DOM access or serialized handlers", async () => {
+  const outputs = await Promise.all([
+    renderToString(createSSRApp(SsrProbe)),
+    renderToString(createSSRApp(SsrProbe)),
+  ]);
+  assert.equal(outputs[0], outputs[1]);
+  assert.equal(outputs[0], '<div data-moving="false" tabindex="0">Move 0</div>');
+  assert.doesNotMatch(outputs[0], /pointerdown|function/);
+});
+
+test("hydrates move state without replacement or diagnostics", async () => {
+  const serverHtml = await renderToString(createSSRApp(SsrProbe));
+  const host = document.createElement("div");
+  host.innerHTML = serverHtml;
+  document.body.append(host);
+  const serverTarget = host.firstElementChild;
+  const diagnostics: string[] = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  console.error = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  const app = createSSRApp(SsrProbe);
+
+  try {
+    app.mount(host);
+    assert.equal(host.firstElementChild, serverTarget);
+    const target = host.firstElementChild!;
+    target.dispatchEvent(pointer("pointerdown", 1));
+    document.dispatchEvent(pointer("pointermove", 4));
+    await nextTick();
+    assert.equal(target.getAttribute("data-moving"), "true");
+    assert.equal(target.textContent, "Move 3");
+    document.dispatchEvent(pointer("pointerup", 4));
+    await nextTick();
+    assert.equal(target.getAttribute("data-moving"), "false");
+    assert.deepEqual(diagnostics, []);
+  } finally {
+    app.unmount();
+    host.remove();
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+});

--- a/npm/ui/core/src/move-test-utils.ts
+++ b/npm/ui/core/src/move-test-utils.ts
@@ -1,0 +1,132 @@
+import { createMove } from "./move.ts";
+import type { MoveController, MoveEvent, MoveOptions, MoveProps } from "./move.ts";
+
+export const moveEventNames: Readonly<Record<keyof MoveProps, string>> = {
+  onDragstart: "dragstart",
+  onKeydown: "keydown",
+  onMousedown: "mousedown",
+  onPointercancel: "pointercancel",
+  onPointerdown: "pointerdown",
+  onTouchcancel: "touchcancel",
+  onTouchend: "touchend",
+  onTouchmove: "touchmove",
+  onTouchstart: "touchstart",
+};
+
+export interface MoveHarness {
+  readonly controller: MoveController;
+  readonly events: MoveEvent[];
+  readonly host: HTMLDivElement;
+  readonly unmount: () => void;
+}
+
+/** Capture listener failures in both browsers and propagating test DOMs. */
+export function dispatchReportingError(dispatch: () => void): unknown {
+  let reportedError: unknown;
+  const captureReportedError = (event: ErrorEvent) => {
+    reportedError = event.error;
+    event.preventDefault();
+  };
+  window.addEventListener("error", captureReportedError);
+  try {
+    dispatch();
+  } catch (error) {
+    reportedError ??= error;
+  } finally {
+    window.removeEventListener("error", captureReportedError);
+  }
+  return reportedError;
+}
+
+export function mountMove(options: MoveOptions = {}): MoveHarness {
+  const host = document.createElement("div");
+  host.tabIndex = 0;
+  document.body.append(host);
+  const events: MoveEvent[] = [];
+  const controller = createMove({
+    ...options,
+    onMoveStart: (event) => {
+      events.push(event);
+      options.onMoveStart?.(event);
+    },
+    onMove: (event) => {
+      events.push(event);
+      options.onMove?.(event);
+    },
+    onMoveEnd: (event) => {
+      events.push(event);
+      options.onMoveEnd?.(event);
+    },
+  });
+  for (const [property, type] of Object.entries(moveEventNames) as Array<
+    [keyof MoveProps, string]
+  >) {
+    host.addEventListener(type, controller.moveProps[property] as EventListener);
+  }
+  return {
+    controller,
+    events,
+    host,
+    unmount: () => {
+      try {
+        controller.dispose();
+      } finally {
+        host.remove();
+      }
+    },
+  };
+}
+
+export function pointer(
+  type: string,
+  x: number,
+  y: number,
+  values: Partial<PointerEventInit> = {},
+): PointerEvent {
+  const event = new PointerEvent(type, {
+    bubbles: true,
+    button: 0,
+    clientX: x,
+    clientY: y,
+    isPrimary: true,
+    pointerId: 7,
+    pointerType: "mouse",
+    ...values,
+  });
+  Object.defineProperties(event, {
+    pageX: { value: x },
+    pageY: { value: y },
+  });
+  return event;
+}
+
+export function mouse(type: string, x: number, y: number, values: MouseEventInit = {}): MouseEvent {
+  const event = new MouseEvent(type, {
+    bubbles: true,
+    button: 0,
+    clientX: x,
+    clientY: y,
+    ...values,
+  });
+  Object.defineProperties(event, {
+    pageX: { value: x },
+    pageY: { value: y },
+  });
+  return event;
+}
+
+export function touchEvent(
+  type: string,
+  values: Array<{ clientX: number; clientY: number; identifier: number }>,
+  timeStamp?: number,
+): TouchEvent {
+  const event = new Event(type, { bubbles: true, cancelable: true }) as TouchEvent;
+  const touches = Object.assign(
+    values.map((value) => ({ ...value, pageX: value.clientX, pageY: value.clientY })),
+    { item: (index: number) => touches[index] ?? null },
+  ) as unknown as TouchList;
+  Object.defineProperty(event, "changedTouches", { value: touches });
+  Object.defineProperty(event, "view", { value: null });
+  if (timeStamp !== undefined) Object.defineProperty(event, "timeStamp", { value: timeStamp });
+  return event;
+}

--- a/npm/ui/core/src/move-types.ts
+++ b/npm/ui/core/src/move-types.ts
@@ -1,0 +1,115 @@
+import type { MaybeRefOrGetter, ShallowRef } from "vue";
+
+/** Input families normalized by the move interaction. */
+export type MovePointerType = "keyboard" | "mouse" | "pen" | "pointer" | "touch";
+
+/** Lifecycle phases emitted by a move controller. */
+export type MoveEventType = "move" | "moveend" | "movestart";
+
+interface MoveEventBase<Type extends MoveEventType> {
+  /** Move lifecycle phase represented by this immutable snapshot. */
+  readonly type: Type;
+
+  /** Input family that owns this movement. */
+  readonly pointerType: MovePointerType;
+
+  /** Element whose bound props own the interaction. */
+  readonly target: Element;
+
+  /** Native event responsible for this phase, or `null` for manual cancellation. */
+  readonly originalEvent: Event | null;
+
+  /** Page coordinates when supplied by pointing hardware. */
+  readonly x: number | null;
+  readonly y: number | null;
+
+  /** Modifier-key snapshots captured from the native event. */
+  readonly altKey: boolean;
+  readonly ctrlKey: boolean;
+  readonly metaKey: boolean;
+  readonly shiftKey: boolean;
+}
+
+/** Snapshot emitted immediately before the first non-zero movement. */
+export interface MoveStartEvent extends MoveEventBase<"movestart"> {
+  readonly deltaX: 0;
+  readonly deltaY: 0;
+  readonly isCanceled: false;
+}
+
+/** Snapshot of one non-zero movement since the preceding native event. */
+export interface MoveUpdateEvent extends MoveEventBase<"move"> {
+  readonly deltaX: number;
+  readonly deltaY: number;
+  readonly isCanceled: false;
+}
+
+/** Snapshot emitted after a movement completes or is canceled. */
+export interface MoveEndEvent extends MoveEventBase<"moveend"> {
+  readonly deltaX: 0;
+  readonly deltaY: 0;
+  readonly isCanceled: boolean;
+}
+
+/** Discriminated lifecycle event union for exhaustive consumer handling. */
+export type MoveEvent = MoveEndEvent | MoveStartEvent | MoveUpdateEvent;
+
+/** Options shared by {@link createMove} and {@link useMove}. */
+export interface MoveOptions {
+  /**
+   * Suppress new movement and cancel an active pointer movement on its next event.
+   *
+   * @default false
+   */
+  readonly isDisabled?: MaybeRefOrGetter<boolean | undefined>;
+
+  /**
+   * Distance contributed by each physical arrow-key press, including repeat events.
+   * The resolved value must be finite and greater than zero.
+   *
+   * @default 1
+   */
+  readonly keyboardStep?: MaybeRefOrGetter<number | undefined>;
+
+  /** Called exactly once before the first non-zero delta in an interaction. */
+  readonly onMoveStart?: (event: MoveStartEvent) => void;
+
+  /** Called for every non-zero pointer or keyboard delta. */
+  readonly onMove?: (event: MoveUpdateEvent) => void;
+
+  /** Called after an interaction that emitted at least one move finishes. */
+  readonly onMoveEnd?: (event: MoveEndEvent) => void;
+}
+
+/** Native handlers to spread onto exactly one move host. */
+export interface MoveProps {
+  readonly onDragstart: (event: DragEvent) => void;
+  readonly onKeydown: (event: KeyboardEvent) => void;
+  readonly onMousedown: (event: MouseEvent) => void;
+  readonly onPointercancel: (event: PointerEvent) => void;
+  readonly onPointerdown: (event: PointerEvent) => void;
+  readonly onTouchcancel: (event: TouchEvent) => void;
+  readonly onTouchend: (event: TouchEvent) => void;
+  readonly onTouchmove: (event: TouchEvent) => void;
+  readonly onTouchstart: (event: TouchEvent) => void;
+}
+
+/** Stateful move normalizer with explicit listener and selection ownership. */
+export interface MoveController {
+  /** Whether a pointer or ephemeral keyboard movement is currently being emitted. */
+  readonly isMoving: Readonly<ShallowRef<boolean>>;
+
+  /** Stable native handlers to spread or merge onto one host. */
+  readonly moveProps: Readonly<MoveProps>;
+
+  /**
+   * Cancel the current pointer attempt, including one that has not moved yet.
+   *
+   * @returns `true` when an owned pointer or keyboard transaction was settled.
+   * @throws An error carrying `VIZE_UI_MOVE_DISPOSED` after disposal.
+   */
+  readonly cancel: () => boolean;
+
+  /** Release listeners, selection guards, and reactive state without callbacks. */
+  readonly dispose: () => void;
+}

--- a/npm/ui/core/src/move.behavior.md
+++ b/npm/ui/core/src/move.behavior.md
@@ -1,0 +1,35 @@
+# Move behavior contract
+
+Normative state × input → outcome table for `@vizejs/ui/move`. Every row is
+exercised by `src/move*.test.ts`; compile-only assertions live in
+`src/move.types.test-d.ts`.
+
+| #   | State                     | Input                                                          | Outcome                                                            | Proven by              |
+| --- | ------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------- |
+| M1  | idle                      | primary mouse, pen, touch, or extensible pointer presses       | one contact is owned; selection is guarded; no callback yet        | pointer tests          |
+| M2  | armed                     | zero-distance native movement                                  | lifecycle remains silent                                           | pointer lifecycle test |
+| M3  | armed                     | first non-zero movement                                        | immutable start precedes the exact delta                           | pointer lifecycle test |
+| M4  | moving                    | later movement                                                 | delta is relative to the immediately preceding owned event         | pointer lifecycle test |
+| M5  | moving                    | owning pointer releases                                        | normal end emits; listeners and exact selection styles restore     | pointer lifecycle test |
+| M6  | armed or moving           | unrelated contact moves or releases                            | event is ignored                                                   | ownership tests        |
+| M7  | moving                    | reactive disablement changes or becomes invalid                | canceled end settles before the value or diagnostic is published   | reactive teardown test |
+| M8  | idle                      | physical or legacy arrow key, including repeat                 | atomic start → configured delta → end; native scrolling is stopped | keyboard test          |
+| M9  | idle                      | modified, composing, descendant, or unrelated key              | native behavior is preserved                                       | keyboard filter test   |
+| M10 | legacy touch environment  | owned contact moves; compatibility mouse follows               | touch deltas emit once and emulated mouse is suppressed            | legacy touch test      |
+| M11 | legacy mouse environment  | primary mouse moves outside the host                           | document listeners retain ownership and emit exact deltas          | legacy mouse test      |
+| M12 | armed                     | release without movement                                       | state settles without a synthetic move lifecycle                   | stationary test        |
+| M13 | armed or moving           | cancel, drag, blur, hidden document, dispose, or cleanup error | every teardown runs once and disposal is terminal                  | cancellation tests     |
+| M14 | start callback re-enters  | controller is canceled                                         | canceled end emits and stale delta is suppressed                   | reentrancy test        |
+| M15 | callbacks throw           | multiple required notifications                                | state remains coherent and failures aggregate afterward            | callback-failure test  |
+| M16 | concurrent SSR requests   | identical component trees                                      | byte-identical markup contains no handlers or DOM reads            | SSR test               |
+| M17 | SSR followed by hydration | pointer movement                                               | host identity remains and reactive output updates without warning  | hydration test         |
+| M18 | public TypeScript API     | mutation or invalid closed union                               | compilation rejects misuse                                         | type assertions        |
+
+## Accessibility and touch obligations
+
+The host must be keyboard focusable so every pointer move has an arrow-key
+equivalent. This primitive deliberately assigns no role, label, bounds, or
+visual style. Consumers should announce value changes when movement represents
+a semantic control such as a slider, and must apply `touch-action: none` when
+continuous touch dragging must take precedence over viewport panning. The
+primitive emits no CSS and never assumes layout, direction, or value bounds.

--- a/npm/ui/core/src/move.test.ts
+++ b/npm/ui/core/src/move.test.ts
@@ -1,0 +1,350 @@
+import assert from "node:assert/strict";
+
+import { effectScope, ref, type Ref } from "vue";
+import { test } from "vite-plus/test";
+
+import { createMove, useMove } from "./move.ts";
+import type { MoveController, MoveEvent, MoveProps } from "./move.ts";
+import {
+  dispatchReportingError,
+  mountMove,
+  mouse,
+  moveEventNames,
+  pointer,
+  touchEvent,
+} from "./move-test-utils.ts";
+
+test("normalizes pointer deltas after movement and restores exact selection styles", () => {
+  const harness = mountMove();
+  harness.host.style.setProperty("user-select", "text", "important");
+  harness.host.style.setProperty("-webkit-user-select", "contain");
+  harness.host.dispatchEvent(pointer("pointerdown", 10, 20));
+  assert.equal(harness.controller.isMoving.value, false);
+  assert.equal(harness.host.style.getPropertyValue("user-select"), "none");
+
+  document.dispatchEvent(pointer("pointermove", 10, 20));
+  document.dispatchEvent(pointer("pointermove", 13, 25));
+  document.dispatchEvent(pointer("pointermove", 15, 24));
+  assert.equal(harness.controller.isMoving.value, true);
+  assert.deepEqual(
+    harness.events.map(({ type }) => type),
+    ["movestart", "move", "move"],
+  );
+  assert.deepEqual(
+    harness.events
+      .filter(({ type }) => type === "move")
+      .map(({ deltaX, deltaY }) => [deltaX, deltaY]),
+    [
+      [3, 5],
+      [2, -1],
+    ],
+  );
+  assert.ok(harness.events.every(Object.isFrozen));
+
+  document.dispatchEvent(pointer("pointerup", 15, 24));
+  assert.equal(harness.controller.isMoving.value, false);
+  assert.equal(harness.events.at(-1)?.type, "moveend");
+  assert.equal(harness.events.at(-1)?.isCanceled, false);
+  assert.equal(harness.host.style.getPropertyValue("user-select"), "text");
+  assert.equal(harness.host.style.getPropertyPriority("user-select"), "important");
+  assert.equal(harness.host.style.getPropertyValue("-webkit-user-select"), "contain");
+  harness.unmount();
+});
+
+test("owns one primary pointer and cancels exotic or disabled movement safely", () => {
+  const disabled = ref(false);
+  const harness = mountMove({ isDisabled: disabled });
+  harness.host.dispatchEvent(pointer("pointerdown", 0, 0, { pointerId: 4, pointerType: "eraser" }));
+  document.dispatchEvent(pointer("pointermove", 40, 40, { pointerId: 99 }));
+  assert.equal(harness.events.length, 0);
+  document.dispatchEvent(pointer("pointermove", 4, 6, { pointerId: 4, pointerType: "eraser" }));
+  assert.equal(harness.events[0]?.pointerType, "pointer");
+
+  disabled.value = true;
+  document.dispatchEvent(pointer("pointermove", 5, 7, { pointerId: 4, pointerType: "eraser" }));
+  assert.equal(harness.events.at(-1)?.type, "moveend");
+  assert.equal(harness.events.at(-1)?.isCanceled, true);
+
+  harness.host.dispatchEvent(pointer("pointerdown", 0, 0, { button: 2 }));
+  harness.host.dispatchEvent(pointer("pointerdown", 0, 0, { isPrimary: false }));
+  assert.equal(harness.controller.isMoving.value, false);
+  harness.unmount();
+});
+
+test("arrow keys emit atomic, repeatable movement with a reactive step", () => {
+  const step = ref(3);
+  const harness = mountMove({ keyboardStep: step });
+  for (const [key, expected] of [
+    ["ArrowLeft", [-3, 0]],
+    ["Right", [3, 0]],
+    ["ArrowUp", [0, -3]],
+    ["Down", [0, 3]],
+  ] as const) {
+    const event = new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key });
+    harness.host.dispatchEvent(event);
+    assert.equal(event.defaultPrevented, true);
+    const move = harness.events.at(-2);
+    assert.deepEqual([move?.deltaX, move?.deltaY], expected);
+    assert.equal(move?.pointerType, "keyboard");
+  }
+  assert.deepEqual(
+    harness.events.map(({ type }) => type),
+    Array.from({ length: 4 }, () => ["movestart", "move", "moveend"]).flat(),
+  );
+
+  step.value = 0;
+  assert.throws(
+    () =>
+      harness.host.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "ArrowLeft" })),
+    /VIZE_UI_MOVE_OPTION.*keyboardStep/,
+  );
+  harness.unmount();
+});
+
+test("modified, composing, descendant, and unrelated keys preserve native behavior", () => {
+  const harness = mountMove();
+  const child = document.createElement("span");
+  harness.host.append(child);
+  for (const event of [
+    new KeyboardEvent("keydown", { bubbles: true, key: "ArrowLeft", altKey: true }),
+    new KeyboardEvent("keydown", { bubbles: true, key: "ArrowLeft", ctrlKey: true }),
+    new KeyboardEvent("keydown", { bubbles: true, key: "Enter" }),
+  ]) {
+    harness.host.dispatchEvent(event);
+    assert.equal(event.defaultPrevented, false);
+  }
+  child.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "ArrowLeft" }));
+  const composing = new KeyboardEvent("keydown", { bubbles: true, key: "ArrowLeft" });
+  Object.defineProperty(composing, "isComposing", { value: true });
+  harness.host.dispatchEvent(composing);
+  assert.equal(harness.events.length, 0);
+  harness.unmount();
+});
+
+test("legacy touch owns one contact and suppresses its compatibility mouse event", () => {
+  const isolated = document.implementation.createHTMLDocument("legacy move");
+  const host = isolated.createElement("div");
+  isolated.body.append(host);
+  const events: MoveEvent[] = [];
+  const controller = createMove({
+    onMoveStart: (event) => events.push(event),
+    onMove: (event) => events.push(event),
+    onMoveEnd: (event) => events.push(event),
+  });
+  for (const [property, type] of Object.entries(moveEventNames) as Array<
+    [keyof MoveProps, string]
+  >) {
+    host.addEventListener(type, controller.moveProps[property] as EventListener);
+  }
+
+  host.dispatchEvent(touchEvent("touchstart", [{ identifier: 31, clientX: 4, clientY: 8 }], 100));
+  isolated.dispatchEvent(touchEvent("touchmove", [{ identifier: 99, clientX: 50, clientY: 60 }]));
+  isolated.dispatchEvent(touchEvent("touchmove", [{ identifier: 31, clientX: 9, clientY: 12 }]));
+  isolated.dispatchEvent(
+    touchEvent("touchend", [{ identifier: 31, clientX: 9, clientY: 12 }], 200),
+  );
+  assert.deepEqual(
+    events.map(({ type }) => type),
+    ["movestart", "move", "moveend"],
+  );
+  assert.deepEqual([events[1]?.deltaX, events[1]?.deltaY], [5, 4]);
+  assert.ok(events.every(({ pointerType }) => pointerType === "touch"));
+
+  const emulated = new MouseEvent("mousedown", { bubbles: true, button: 0 });
+  Object.defineProperty(emulated, "timeStamp", { value: 201 });
+  host.dispatchEvent(emulated);
+  isolated.dispatchEvent(
+    new MouseEvent("mousemove", { bubbles: true, clientX: 100, clientY: 100 }),
+  );
+  assert.equal(events.length, 3);
+  controller.dispose();
+});
+
+test("legacy mouse fallback emits deltas when Pointer Events are unavailable", () => {
+  const isolated = document.implementation.createHTMLDocument("legacy mouse move");
+  const host = isolated.createElement("div");
+  isolated.body.append(host);
+  const deltas: Array<readonly [number, number]> = [];
+  const controller = createMove({
+    onMove: ({ deltaX, deltaY }) => deltas.push([deltaX, deltaY]),
+  });
+  host.addEventListener("mousedown", controller.moveProps.onMousedown);
+  host.dispatchEvent(mouse("mousedown", 1, 2));
+  isolated.dispatchEvent(mouse("mousemove", 5, 9));
+  isolated.dispatchEvent(mouse("mouseup", 5, 9));
+  assert.deepEqual(deltas, [[4, 7]]);
+  controller.dispose();
+});
+
+test("manual, drag, visibility, blur, and scope cancellation settle ownership", () => {
+  for (const finish of ["manual", "drag", "hidden", "blur"] as const) {
+    const harness = mountMove();
+    harness.host.dispatchEvent(pointer("pointerdown", 0, 0));
+    document.dispatchEvent(pointer("pointermove", 2, 3));
+    if (finish === "manual") {
+      assert.equal(harness.controller.cancel(), true);
+    } else if (finish === "drag") {
+      harness.host.dispatchEvent(new DragEvent("dragstart", { bubbles: true }));
+    } else if (finish === "hidden") {
+      const descriptor = Object.getOwnPropertyDescriptor(document, "visibilityState");
+      Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+      try {
+        document.dispatchEvent(new Event("visibilitychange"));
+      } finally {
+        if (descriptor) Object.defineProperty(document, "visibilityState", descriptor);
+        else delete (document as { visibilityState?: DocumentVisibilityState }).visibilityState;
+      }
+    } else {
+      window.dispatchEvent(new Event("blur"));
+    }
+    assert.equal(harness.controller.isMoving.value, false);
+    assert.equal(harness.events.at(-1)?.isCanceled, true);
+    harness.unmount();
+  }
+
+  assert.throws(() => useMove(), /VIZE_UI_MOVE_SETUP/);
+  const scope = effectScope();
+  const scoped = scope.run(() => useMove())!;
+  scope.stop();
+  assert.throws(() => scoped.cancel(), /VIZE_UI_MOVE_DISPOSED/);
+});
+
+test("a stationary pointer attempt ends silently and remains manually cancelable", () => {
+  const harness = mountMove();
+  harness.host.dispatchEvent(pointer("pointerdown", 1, 2));
+  assert.equal(harness.controller.cancel(), true);
+  assert.equal(harness.controller.cancel(), false);
+  assert.deepEqual(harness.events, []);
+  harness.unmount();
+});
+
+test("reentrant cancellation suppresses a stale delta and callback failures aggregate", () => {
+  let controller!: MoveController;
+  const events: string[] = [];
+  const host = document.createElement("div");
+  document.body.append(host);
+  controller = createMove({
+    onMoveStart: () => {
+      events.push("start");
+      controller.cancel();
+    },
+    onMove: () => events.push("move"),
+    onMoveEnd: () => events.push("end"),
+  });
+  host.addEventListener("pointerdown", controller.moveProps.onPointerdown);
+  host.dispatchEvent(pointer("pointerdown", 0, 0));
+  document.dispatchEvent(pointer("pointermove", 1, 1));
+  assert.deepEqual(events, ["start", "end"]);
+  assert.equal(controller.isMoving.value, false);
+  controller.dispose();
+  host.remove();
+
+  const keyboardEvents: MoveEvent[] = [];
+  let keyboardController!: MoveController;
+  const keyboardHost = document.createElement("div");
+  document.body.append(keyboardHost);
+  keyboardController = createMove({
+    onMoveStart: (event) => {
+      keyboardEvents.push(event);
+      keyboardController.cancel();
+    },
+    onMove: (event) => keyboardEvents.push(event),
+    onMoveEnd: (event) => keyboardEvents.push(event),
+  });
+  keyboardHost.addEventListener("keydown", keyboardController.moveProps.onKeydown);
+  keyboardHost.dispatchEvent(
+    new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "ArrowRight" }),
+  );
+  assert.deepEqual(
+    keyboardEvents.map(({ type }) => type),
+    ["movestart", "moveend"],
+  );
+  assert.equal(keyboardEvents[1]?.isCanceled, true);
+  assert.equal(keyboardEvents[1]?.originalEvent, null);
+  keyboardController.dispose();
+  keyboardHost.remove();
+
+  const failing = mountMove({
+    onMoveStart: () => {
+      throw new Error("start failed");
+    },
+    onMove: () => {
+      throw new Error("move failed");
+    },
+  });
+  failing.host.dispatchEvent(pointer("pointerdown", 0, 0));
+  assert.throws(() => document.dispatchEvent(pointer("pointermove", 1, 1)), AggregateError);
+  assert.equal(failing.controller.isMoving.value, true);
+  failing.controller.dispose();
+  failing.host.remove();
+});
+
+test("nested move hosts give ownership to the nearest bound target", () => {
+  const outer = mountMove();
+  const inner = mountMove();
+  outer.host.append(inner.host);
+  inner.host.dispatchEvent(pointer("pointerdown", 0, 0));
+  document.dispatchEvent(pointer("pointermove", 2, 1));
+  document.dispatchEvent(pointer("pointerup", 2, 1));
+  assert.deepEqual(
+    inner.events.map(({ type }) => type),
+    ["movestart", "move", "moveend"],
+  );
+  assert.deepEqual(outer.events, []);
+  inner.unmount();
+  outer.unmount();
+});
+
+test("rejects invalid runtime options with stable diagnostics", () => {
+  assert.throws(() => createMove({ keyboardStep: -1 }), /VIZE_UI_MOVE_OPTION.*keyboardStep/);
+  assert.throws(
+    () => createMove({ onMoveStart: "callback" as never }),
+    /VIZE_UI_MOVE_OPTION.*onMoveStart/,
+  );
+});
+
+test("invalid reactive disablement settles movement before surfacing its diagnostic", () => {
+  const disabled = ref<unknown>(false);
+  const harness = mountMove({ isDisabled: disabled as Ref<boolean> });
+  harness.host.style.setProperty("user-select", "text", "important");
+  harness.host.dispatchEvent(pointer("pointerdown", 0, 0));
+  document.dispatchEvent(pointer("pointermove", 2, 3));
+  disabled.value = "invalid";
+
+  const reportedError = dispatchReportingError(() =>
+    document.dispatchEvent(pointer("pointermove", 4, 5)),
+  );
+  assert.match(String(reportedError), /VIZE_UI_MOVE_OPTION.*isDisabled/);
+  assert.equal(harness.controller.isMoving.value, false);
+  assert.equal(harness.events.at(-1)?.type, "moveend");
+  assert.equal(harness.events.at(-1)?.isCanceled, true);
+  assert.equal(harness.host.style.getPropertyValue("user-select"), "text");
+  assert.equal(harness.host.style.getPropertyPriority("user-select"), "important");
+  harness.controller.dispose();
+  harness.host.remove();
+});
+
+test("disposal is terminal and exhaustive after a selection cleanup failure", () => {
+  const harness = mountMove();
+  harness.host.style.setProperty("user-select", "text", "important");
+  harness.host.dispatchEvent(pointer("pointerdown", 0, 0));
+  document.dispatchEvent(pointer("pointermove", 2, 3));
+
+  const style = harness.host.style;
+  const originalRemoveProperty = style.removeProperty.bind(style);
+  style.removeProperty = function removeProperty(property: string): string {
+    if (property === "-webkit-user-select") throw new Error("restore failed");
+    return originalRemoveProperty(property);
+  };
+  try {
+    assert.throws(() => harness.controller.dispose(), /restore failed/);
+  } finally {
+    style.removeProperty = originalRemoveProperty;
+  }
+
+  assert.equal(harness.controller.isMoving.value, false);
+  assert.equal(harness.host.style.getPropertyValue("user-select"), "text");
+  assert.equal(harness.host.style.getPropertyPriority("user-select"), "important");
+  assert.throws(() => harness.controller.cancel(), /VIZE_UI_MOVE_DISPOSED/);
+  harness.host.remove();
+});

--- a/npm/ui/core/src/move.ts
+++ b/npm/ui/core/src/move.ts
@@ -1,0 +1,345 @@
+import { getCurrentScope, onScopeDispose, shallowReadonly, shallowRef } from "vue";
+
+import { disableTextSelection, eventElement, isPrimaryPointer } from "./press-event.ts";
+import {
+  capture,
+  createMoveEvent,
+  installMoveListeners,
+  pointerTypeOf,
+  positionOf,
+  readBoolean,
+  readKeyboardStep,
+  surfaceErrors,
+  validateOptions,
+} from "./move-internal.ts";
+import type { ActiveMove, PointerSource, Position } from "./move-internal.ts";
+import type {
+  MoveController,
+  MoveEndEvent,
+  MovePointerType,
+  MoveOptions,
+  MoveProps,
+  MoveStartEvent,
+  MoveUpdateEvent,
+} from "./move-types.ts";
+
+const disposedDiagnostic = "VIZE_UI_MOVE_DISPOSED";
+const setupDiagnostic = "VIZE_UI_MOVE_SETUP";
+
+interface KeyboardMove {
+  readonly target: Element;
+}
+
+/** Create an SSR-safe mouse, pen, touch, and keyboard move normalizer. */
+export function createMove(options: MoveOptions = {}): MoveController {
+  validateOptions(options);
+  const moving = shallowRef(false);
+  let active: ActiveMove | null = null;
+  let keyboard: KeyboardMove | null = null;
+  let disposed = false;
+  let lastTouchTime = Number.NEGATIVE_INFINITY;
+
+  const finish = (originalEvent: Event | null, isCanceled: boolean): boolean => {
+    const current = active;
+    if (!current) return false;
+    active = null;
+    moving.value = false;
+    const errors: unknown[] = [];
+    capture(errors, current.releaseListeners);
+    capture(errors, current.restoreSelection);
+    if (current.didMove) {
+      capture(errors, () =>
+        options.onMoveEnd?.(
+          createMoveEvent(
+            "moveend",
+            current.target,
+            current.pointerType,
+            originalEvent,
+            0,
+            0,
+            isCanceled,
+            current.source === "touch" ? current.id : null,
+          ) as MoveEndEvent,
+        ),
+      );
+    }
+    surfaceErrors(errors, "Move completion failed");
+    return true;
+  };
+
+  const readDisabledDuringActive = (event: Event): boolean => {
+    try {
+      return readBoolean(options.isDisabled);
+    } catch (error) {
+      const errors: unknown[] = [error];
+      capture(errors, () => finish(event, true));
+      surfaceErrors(errors, "Move option validation failed during teardown");
+      throw error;
+    }
+  };
+
+  const finishKeyboard = (originalEvent: Event | null, isCanceled: boolean): boolean => {
+    const current = keyboard;
+    if (!current) return false;
+    keyboard = null;
+    moving.value = false;
+    options.onMoveEnd?.(
+      createMoveEvent(
+        "moveend",
+        current.target,
+        "keyboard",
+        originalEvent,
+        0,
+        0,
+        isCanceled,
+      ) as MoveEndEvent,
+    );
+    return true;
+  };
+
+  const emitDelta = (current: ActiveMove, event: Event, position: Position): void => {
+    if (active !== current) return;
+    current.lastEvent = event;
+    if (readDisabledDuringActive(event) || !current.target.isConnected) {
+      finish(event, true);
+      return;
+    }
+    const deltaX = position.x - current.position.x;
+    const deltaY = position.y - current.position.y;
+    current.position = position;
+    if (deltaX === 0 && deltaY === 0) return;
+    event.preventDefault();
+    const errors: unknown[] = [];
+    if (!current.didMove) {
+      current.didMove = true;
+      moving.value = true;
+      capture(errors, () =>
+        options.onMoveStart?.(
+          createMoveEvent(
+            "movestart",
+            current.target,
+            current.pointerType,
+            event,
+            0,
+            0,
+            false,
+            current.source === "touch" ? current.id : null,
+          ) as MoveStartEvent,
+        ),
+      );
+    }
+    if (active === current && !disposed) {
+      capture(errors, () =>
+        options.onMove?.(
+          createMoveEvent(
+            "move",
+            current.target,
+            current.pointerType,
+            event,
+            deltaX,
+            deltaY,
+            false,
+            current.source === "touch" ? current.id : null,
+          ) as MoveUpdateEvent,
+        ),
+      );
+    }
+    surfaceErrors(errors, "Move callbacks failed");
+  };
+
+  const matches = (source: PointerSource, id: number | null): ActiveMove | null => {
+    const current = active;
+    return current?.source === source && current.id === id ? current : null;
+  };
+
+  const start = (
+    event: Event,
+    source: PointerSource,
+    pointerType: Exclude<MovePointerType, "keyboard">,
+    id: number | null,
+    position: Position,
+  ): void => {
+    if (disposed || active || readBoolean(options.isDisabled)) return;
+    const target = eventElement(event);
+    if (!target) return;
+    event.preventDefault();
+    event.stopPropagation();
+    let releaseListeners: () => void = () => undefined;
+    let restoreSelection: () => void = () => undefined;
+    try {
+      releaseListeners = installMoveListeners(target.ownerDocument, source, {
+        emitDelta,
+        finish,
+        getActive: () => active,
+        readDisabled: readDisabledDuringActive,
+        rememberTouch: (timeStamp) => {
+          lastTouchTime = timeStamp;
+        },
+      });
+      restoreSelection = disableTextSelection(target);
+    } catch (error) {
+      const errors: unknown[] = [error];
+      capture(errors, releaseListeners);
+      capture(errors, restoreSelection);
+      surfaceErrors(errors, "Move start cleanup failed");
+      throw error;
+    }
+    active = {
+      id,
+      pointerType,
+      releaseListeners,
+      restoreSelection,
+      source,
+      target,
+      didMove: false,
+      lastEvent: event,
+      position,
+    };
+  };
+
+  const keyboardMove = (event: KeyboardEvent, deltaX: number, deltaY: number): void => {
+    if (disposed || active || keyboard || readBoolean(options.isDisabled)) return;
+    const target = eventElement(event);
+    if (!target || event.target !== target) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const step = readKeyboardStep(options.keyboardStep);
+    const errors: unknown[] = [];
+    const current: KeyboardMove = { target };
+    keyboard = current;
+    moving.value = true;
+    capture(errors, () =>
+      options.onMoveStart?.(
+        createMoveEvent("movestart", target, "keyboard", event) as MoveStartEvent,
+      ),
+    );
+    if (keyboard === current && !disposed) {
+      capture(errors, () =>
+        options.onMove?.(
+          createMoveEvent(
+            "move",
+            target,
+            "keyboard",
+            event,
+            deltaX * step,
+            deltaY * step,
+          ) as MoveUpdateEvent,
+        ),
+      );
+    }
+    if (keyboard === current && !disposed) capture(errors, () => finishKeyboard(event, false));
+    surfaceErrors(errors, "Keyboard move callbacks failed");
+  };
+
+  const moveProps: Readonly<MoveProps> = Object.freeze({
+    onDragstart(event: DragEvent) {
+      if (active?.target === eventElement(event)) finish(event, true);
+    },
+    onKeydown(event: KeyboardEvent) {
+      if (event.isComposing || event.altKey || event.ctrlKey || event.metaKey) return;
+      switch (event.key) {
+        case "Left":
+        case "ArrowLeft":
+          keyboardMove(event, -1, 0);
+          break;
+        case "Right":
+        case "ArrowRight":
+          keyboardMove(event, 1, 0);
+          break;
+        case "Up":
+        case "ArrowUp":
+          keyboardMove(event, 0, -1);
+          break;
+        case "Down":
+        case "ArrowDown":
+          keyboardMove(event, 0, 1);
+          break;
+      }
+    },
+    onMousedown(event: MouseEvent) {
+      if (event.button !== 0 || active || (event.view && "PointerEvent" in event.view)) return;
+      const elapsed = event.timeStamp - lastTouchTime;
+      if (elapsed >= 0 && elapsed < 800) return;
+      const position = positionOf(event);
+      if (position) start(event, "mouse", "mouse", null, position);
+    },
+    onPointercancel(event: PointerEvent) {
+      if (matches("pointer", event.pointerId)) finish(event, true);
+    },
+    onPointerdown(event: PointerEvent) {
+      if (!isPrimaryPointer(event)) return;
+      const position = positionOf(event);
+      if (position) start(event, "pointer", pointerTypeOf(event), event.pointerId, position);
+    },
+    onTouchcancel(event: TouchEvent) {
+      const current = active?.source === "touch" ? active : null;
+      if (current && positionOf(event, current.id)) finish(event, true);
+    },
+    onTouchend(event: TouchEvent) {
+      const current = active?.source === "touch" ? active : null;
+      if (current && positionOf(event, current.id)) finish(event, false);
+    },
+    onTouchmove(event: TouchEvent) {
+      const current = active?.source === "touch" ? active : null;
+      const position = current ? positionOf(event, current.id) : null;
+      if (current && position) emitDelta(current, event, position);
+    },
+    onTouchstart(event: TouchEvent) {
+      lastTouchTime = event.timeStamp;
+      if (
+        (event.view && "PointerEvent" in event.view) ||
+        active ||
+        event.changedTouches.length !== 1
+      )
+        return;
+      const touch = event.changedTouches.item(0);
+      if (touch) {
+        start(event, "touch", "touch", touch.identifier, { x: touch.pageX, y: touch.pageY });
+      }
+    },
+  });
+
+  return Object.freeze({
+    isMoving: shallowReadonly(moving),
+    moveProps,
+    cancel: () => {
+      if (disposed) throw new Error(`${disposedDiagnostic}: the controller has been disposed`);
+      return finish(null, true) || finishKeyboard(null, true);
+    },
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      const current = active;
+      active = null;
+      keyboard = null;
+      moving.value = false;
+      if (!current) return;
+      const errors: unknown[] = [];
+      capture(errors, current.releaseListeners);
+      capture(errors, current.restoreSelection);
+      surfaceErrors(errors, "Move disposal failed");
+    },
+  });
+}
+
+/** Create a move normalizer disposed with the current Vue effect scope. */
+export function useMove(options: MoveOptions = {}): MoveController {
+  if (!getCurrentScope()) {
+    throw new Error(`${setupDiagnostic}: use inside component setup or an active effect scope`);
+  }
+  const controller = createMove(options);
+  onScopeDispose(controller.dispose);
+  return controller;
+}
+
+export type {
+  MoveController,
+  MoveEndEvent,
+  MoveEvent,
+  MoveEventType,
+  MoveOptions,
+  MovePointerType,
+  MoveProps,
+  MoveStartEvent,
+  MoveUpdateEvent,
+} from "./move-types.ts";

--- a/npm/ui/core/src/move.types.test-d.ts
+++ b/npm/ui/core/src/move.types.test-d.ts
@@ -1,0 +1,43 @@
+/** Compile-only assertions for the public move contract. */
+
+import { ref } from "vue";
+import type { HTMLAttributes, ShallowRef } from "vue";
+
+import { createMove, type MoveEvent, type MovePointerType, type MoveProps } from "./move.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+export const pointerTypes: readonly MovePointerType[] = [
+  "keyboard",
+  "mouse",
+  "pen",
+  "pointer",
+  "touch",
+];
+// @ts-expect-error virtual activation has no continuous movement coordinate.
+export const invalidPointerType: MovePointerType = "virtual";
+
+const disabled = ref(false);
+export const controller = createMove({
+  isDisabled: disabled,
+  keyboardStep: () => 10,
+  onMove(event: MoveEvent) {
+    if (event.type === "move") {
+      const delta: number = event.deltaX;
+      void delta;
+    }
+  },
+});
+
+type _MovingIsReadonly = Expect<Equal<typeof controller.isMoving, Readonly<ShallowRef<boolean>>>>;
+type _PropsAreExact = Expect<Equal<typeof controller.moveProps, Readonly<MoveProps>>>;
+
+export const vueAttributes: HTMLAttributes = controller.moveProps;
+// @ts-expect-error consumers cannot mutate readonly reactive state.
+controller.isMoving.value = true;
+// @ts-expect-error keyboard step must resolve to a number.
+createMove({ keyboardStep: "10" });

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       "interaction-modality": "src/interaction-modality.ts",
       hover: "src/hover.ts",
       "long-press": "src/long-press.ts",
+      move: "src/move.ts",
       press: "src/press.ts",
       primitive: "src/primitive.ts",
       "visually-hidden": "src/visually-hidden.ts",


### PR DESCRIPTION
## Summary

- add a type-safe, SSR-safe movement normalizer for pointer, mouse, pen, touch, and keyboard input
- preserve primary contact ownership outside the host, suppress compatibility mouse input, and emit exact page-coordinate deltas
- support atomic arrow-key movement, reactive keyboard steps and disablement, composition/modifier guards, nested ownership, selection restoration, and deterministic cancellation
- publish immutable start/update/end snapshots, Vue scope ownership, cleanup/error aggregation, and a CSS-free `@vizejs/ui/move` subpath
- document the normative accessibility contract and verify SSR hydration plus DOM, SSR, and Vapor consumer compilation

## Quality gates

- `pnpm --filter @vizejs/ui check`
- `pnpm --filter @vizejs/ui test` — 165 tests across 30 files
- root and subpath consumer bundles are byte-identical and retain 0 CSS bytes
- renderer conformance runs in GitHub Actions using the repository native artifact

## Bundle budgets

- package root: 23,735 / 23,825 gzip bytes
- move entry: 4,964 / 5,050 gzip bytes
- move consumer: 2,677 / 2,750 gzip bytes

Part of #3134