### PR TITLE
feat(doctor): add interactive Fresco workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3595,6 +3595,7 @@ dependencies = [
  "vize_croquis_cf",
  "vize_curator",
  "vize_doctor",
+ "vize_fresco",
  "vize_glyph",
  "vize_maestro",
  "vize_musea",
@@ -3743,6 +3744,16 @@ dependencies = [
  "vize_atelier_dom",
  "vize_carton",
  "vize_croquis",
+]
+
+[[package]]
+name = "vize_benchmarks"
+version = "0.347.7"
+dependencies = [
+ "criterion",
+ "vize",
+ "vize_doctor",
+ "vize_fresco",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   "crates/vize_fresco",
   "crates/vize_marquette",
   "crates/vize_doctor",
+  "benchmarks/vize",
   "tests/vize_test_runner",
 ]
 

--- a/benchmarks/vize/Cargo.toml
+++ b/benchmarks/vize/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "vize_benchmarks"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+autobenches = false
+
+[dev-dependencies]
+criterion.workspace = true
+vize = { path = "../../crates/vize", features = ["profiling"] }
+vize_doctor.workspace = true
+vize_fresco.workspace = true
+
+[[bench]]
+name = "doctor_tui"
+path = "doctor_tui.rs"
+harness = false

--- a/benchmarks/vize/doctor_tui.rs
+++ b/benchmarks/vize/doctor_tui.rs
@@ -1,0 +1,88 @@
+//! End-to-end Doctor TUI first-frame and input-to-frame benchmarks.
+
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use vize::DoctorTuiBenchmark;
+use vize_doctor::{
+    AnalysisProvenance, DoctorCategory, DoctorFinding, DoctorReport, FindingAssessment,
+    FindingConfidence, FindingImpact, FindingSeverity, HealthPenalty, RuleCost, SourceLocation,
+};
+use vize_fresco::{
+    ColorPreference, FeaturePreference, TerminalCapabilities, TerminalCapabilityProbe,
+    TerminalProfileOptions,
+};
+
+const FINDING_COUNT: usize = 10_000;
+const WIDTH: u16 = 120;
+const HEIGHT: u16 = 40;
+
+fn benchmark_first_frame(criterion: &mut Criterion) {
+    let report = report();
+    let capabilities = capabilities();
+    let mut group = criterion.benchmark_group("doctor_tui_10k");
+    group.throughput(Throughput::Elements(FINDING_COUNT as u64));
+    group.bench_function("first_frame_120x40", |bencher| {
+        bencher.iter(|| {
+            let mut tui =
+                DoctorTuiBenchmark::new(black_box(&report), WIDTH, HEIGHT, black_box(capabilities));
+            black_box(tui.render())
+        });
+    });
+    group.finish();
+}
+
+fn benchmark_input_to_frame(criterion: &mut Criterion) {
+    let report = report();
+    let capabilities = capabilities();
+    let mut tui = DoctorTuiBenchmark::new(&report, WIDTH, HEIGHT, capabilities);
+    let _ = tui.render();
+    assert!(tui.materialized_findings() <= usize::from(HEIGHT));
+
+    let mut group = criterion.benchmark_group("doctor_tui_input_to_frame_10k");
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("selection", |bencher| {
+        bencher.iter(|| black_box(tui.toggle_selection_and_render()));
+    });
+    group.bench_function("search", |bencher| {
+        bencher.iter(|| black_box(tui.toggle_search_and_render()));
+    });
+    group.finish();
+}
+
+fn report() -> DoctorReport {
+    DoctorReport::new(
+        "benchmark",
+        (0..FINDING_COUNT).map(|index| {
+            DoctorFinding::new(
+                "VIZE_DOCTOR_TUI_BENCH",
+                DoctorCategory::Performance,
+                FindingAssessment::new(
+                    FindingSeverity::Warning,
+                    FindingConfidence::High,
+                    FindingImpact::Medium,
+                    HealthPenalty::new(1, "Measured TUI presentation cost"),
+                ),
+                SourceLocation::new("src/Benchmark.vue", index as u32, index as u32 + 1),
+                "Benchmark finding",
+                "The workspace renders a deterministic evidence-rich finding.",
+                AnalysisProvenance::new("benchmark-analysis", RuleCost::Low),
+            )
+        }),
+    )
+}
+
+fn capabilities() -> TerminalCapabilities {
+    TerminalCapabilities::resolve(
+        &TerminalCapabilityProbe::new(WIDTH, HEIGHT, true).with_locale("C.UTF-8"),
+        TerminalProfileOptions {
+            color: ColorPreference::Never,
+            unicode: FeaturePreference::Always,
+            interactive: FeaturePreference::Always,
+            narrow_width: 60,
+        },
+    )
+}
+
+criterion_group!(benches, benchmark_first_frame, benchmark_input_to_frame);
+criterion_main!(benches);

--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -40,6 +40,7 @@ vize_canon = { workspace = true, features = ["native"] }
 vize_croquis = { workspace = true }
 vize_croquis_cf = { workspace = true }
 vize_doctor = { workspace = true, features = ["application-analysis"] }
+vize_fresco = { workspace = true }
 vize_musea = { workspace = true }
 vize_curator = { workspace = true }
 vize_maestro = { workspace = true, optional = true }

--- a/crates/vize/src/commands/doctor.rs
+++ b/crates/vize/src/commands/doctor.rs
@@ -5,6 +5,11 @@ mod canonical_sfc;
 mod discovery;
 mod filters;
 mod output;
+mod tui;
+
+#[cfg(feature = "profiling")]
+#[doc(hidden)]
+pub use tui::DoctorTuiBenchmark;
 
 #[cfg(test)]
 mod tests;
@@ -53,6 +58,10 @@ pub struct DoctorArgs {
     /// Return success even when the report contains blocking findings. Defaults to false.
     #[arg(long)]
     pub exit_zero: bool,
+
+    /// Explore the report in the interactive Fresco terminal workspace. Disabled by default.
+    #[arg(long)]
+    pub tui: bool,
 
     /// Enforce the canonical public component SFC contract. Defaults to false.
     #[arg(long)]
@@ -135,6 +144,7 @@ enum DoctorError {
     SarifSource(SarifSourceError),
     Filter(DoctorFilterError),
     Report(ReporterFailure),
+    Tui(tui::DoctorTuiError),
     Write(io::Error),
 }
 
@@ -197,6 +207,7 @@ impl fmt::Display for DoctorError {
             Self::SarifSource(error) => write!(formatter, "cannot prepare SARIF source: {error}"),
             Self::Filter(error) => write!(formatter, "cannot apply finding filters: {error}"),
             Self::Report(error) => write!(formatter, "cannot render health report: {error}"),
+            Self::Tui(error) => write!(formatter, "cannot run interactive health report: {error}"),
             Self::Write(error) => write!(formatter, "cannot write health report: {error}"),
         }
     }
@@ -211,15 +222,38 @@ impl From<ApplicationAnalysisError> for DoctorError {
 struct DoctorOutcome {
     report: DoctorReport,
     sources: Vec<DoctorSource>,
+    root: PathBuf,
     format: DoctorFormat,
     exit_zero: bool,
 }
 
 pub fn run(args: DoctorArgs) {
+    let capabilities = if args.tui {
+        match tui::validate_request(args.format) {
+            Ok(capabilities) => Some(capabilities),
+            Err(error) => {
+                eprintln!("vize doctor: {}", DoctorError::Tui(error));
+                std::process::exit(2);
+            }
+        }
+    } else {
+        None
+    };
     match execute(args) {
         Ok(outcome) => {
             let blocking = outcome.report.summary().has_blocking_errors;
-            if let Err(error) = write_report(&outcome.report, outcome.format, &outcome.sources) {
+            let result = if let Some(capabilities) = capabilities {
+                tui::run(
+                    &outcome.report,
+                    &outcome.sources,
+                    &outcome.root,
+                    capabilities,
+                )
+                .map_err(DoctorError::Tui)
+            } else {
+                write_report(&outcome.report, outcome.format, &outcome.sources)
+            };
+            if let Err(error) = result {
                 eprintln!("vize doctor: {error}");
                 std::process::exit(2);
             }
@@ -253,6 +287,7 @@ fn execute(args: DoctorArgs) -> Result<DoctorOutcome, DoctorError> {
     Ok(DoctorOutcome {
         report,
         sources,
+        root,
         format: args.format,
         exit_zero: args.exit_zero,
     })

--- a/crates/vize/src/commands/doctor/tui.rs
+++ b/crates/vize/src/commands/doctor/tui.rs
@@ -1,0 +1,249 @@
+//! Interactive Fresco presentation for normalized Doctor reports.
+
+#[cfg(feature = "profiling")]
+mod benchmark;
+mod model;
+mod render;
+
+#[cfg(test)]
+mod tests;
+
+use std::{
+    env, fmt,
+    io::{self, IsTerminal},
+    path::Path,
+    process::Command,
+};
+
+use vize_carton::{String, ToCompactString, cstr};
+use vize_doctor::DoctorReport;
+use vize_fresco::{
+    Backend, Event, TerminalCapabilities, TerminalCapabilityProbe, TerminalProfileOptions,
+    input::read_event, terminal::TerminalOptions,
+};
+
+use super::{DoctorFormat, DoctorSource};
+use model::{DoctorTuiModel, InteractionOutcome};
+use render::render_frame;
+
+const TERMINAL_OPTIONS: TerminalOptions = TerminalOptions {
+    raw_mode: true,
+    alternate_screen: true,
+    mouse_capture: false,
+    bracketed_paste: true,
+    hide_cursor: true,
+};
+
+#[cfg(feature = "profiling")]
+pub use benchmark::DoctorTuiBenchmark;
+
+/// Failure to enter, drive, or restore the interactive Doctor workspace.
+#[derive(Debug)]
+pub(super) enum DoctorTuiError {
+    InvalidFormat,
+    NonInteractive(&'static str),
+    Io(io::Error),
+    Presentation(vize_fresco::DiagnosticPresentationError),
+}
+
+impl fmt::Display for DoctorTuiError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidFormat => {
+                formatter.write_str("--tui cannot be combined with --format json or sarif")
+            }
+            Self::NonInteractive(reason) => write!(
+                formatter,
+                "--tui requires an interactive stdin and stdout ({reason})"
+            ),
+            Self::Io(error) => write!(formatter, "terminal operation failed: {error}"),
+            Self::Presentation(error) => write!(formatter, "invalid diagnostic view: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for DoctorTuiError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::Presentation(error) => Some(error),
+            Self::InvalidFormat | Self::NonInteractive(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for DoctorTuiError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<vize_fresco::DiagnosticPresentationError> for DoctorTuiError {
+    fn from(error: vize_fresco::DiagnosticPresentationError) -> Self {
+        Self::Presentation(error)
+    }
+}
+
+pub(super) fn validate_request(
+    format: DoctorFormat,
+) -> Result<TerminalCapabilities, DoctorTuiError> {
+    if format != DoctorFormat::Text {
+        return Err(DoctorTuiError::InvalidFormat);
+    }
+    let capabilities = TerminalCapabilities::detect_stdout();
+    if !io::stdin().is_terminal() {
+        return Err(DoctorTuiError::NonInteractive("stdin is redirected"));
+    }
+    if !capabilities.interactive().value() {
+        return Err(DoctorTuiError::NonInteractive(
+            capabilities.interactive().reason().as_str(),
+        ));
+    }
+    Ok(capabilities)
+}
+
+pub(super) fn run(
+    report: &DoctorReport,
+    sources: &[DoctorSource],
+    root: &Path,
+    mut capabilities: TerminalCapabilities,
+) -> Result<(), DoctorTuiError> {
+    let mut backend = Backend::new()?;
+    backend.init_with_options(TERMINAL_OPTIONS)?;
+    backend.clear()?;
+    backend.cursor_mut().hide();
+    let mut model = DoctorTuiModel::new(report, backend.width(), backend.height());
+
+    let session = run_loop(&mut backend, &mut model, sources, root, &mut capabilities);
+    let restoration = backend.restore();
+    match (session, restoration) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error.into()),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+fn run_loop(
+    backend: &mut Backend,
+    model: &mut DoctorTuiModel<'_>,
+    sources: &[DoctorSource],
+    root: &Path,
+    capabilities: &mut TerminalCapabilities,
+) -> Result<(), DoctorTuiError> {
+    loop {
+        render_frame(backend.buffer_mut(), model, sources, *capabilities)?;
+        model.place_cursor(backend.cursor_mut());
+        backend.flush_measured()?;
+
+        let outcome = match read_event()? {
+            Event::Resize(width, height) => {
+                backend.resize(width, height);
+                model.resize(width, height);
+                *capabilities = capabilities_for(width, height);
+                InteractionOutcome::Changed
+            }
+            Event::Paste(text) => model.handle_paste(&text),
+            Event::Key(event) => model.handle_key(&event),
+            _ => InteractionOutcome::Boundary,
+        };
+        match outcome {
+            InteractionOutcome::Exit => return Ok(()),
+            InteractionOutcome::OpenSource => {
+                open_selected_source(backend, model, sources, root)?;
+            }
+            InteractionOutcome::Changed | InteractionOutcome::Boundary => {}
+        }
+    }
+}
+
+fn capabilities_for(width: u16, height: u16) -> TerminalCapabilities {
+    TerminalCapabilities::resolve(
+        &TerminalCapabilityProbe::from_process(width, height, io::stdout().is_terminal()),
+        TerminalProfileOptions::default(),
+    )
+}
+
+fn open_selected_source(
+    backend: &mut Backend,
+    model: &mut DoctorTuiModel<'_>,
+    sources: &[DoctorSource],
+    root: &Path,
+) -> Result<(), DoctorTuiError> {
+    backend.restore()?;
+    let result = launch_editor(model, sources, root);
+    backend.init_with_options(TERMINAL_OPTIONS)?;
+    backend.clear()?;
+    match result {
+        Ok(status) | Err(status) => model.set_status(status),
+    }
+    Ok(())
+}
+
+fn launch_editor(
+    model: &DoctorTuiModel<'_>,
+    sources: &[DoctorSource],
+    root: &Path,
+) -> Result<&'static str, &'static str> {
+    let Some(finding) = model.selected_finding() else {
+        return Err("No finding is selected");
+    };
+    let editor = env::var("VISUAL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            env::var("EDITOR")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .ok_or("Set VISUAL or EDITOR to open source")?;
+    let (line, column) = model.source_position(sources);
+    let path = root.join(finding.primary.path.as_str());
+    let mut command = editor_command(&editor, &path, line, column)?;
+    let status = command
+        .status()
+        .map_err(|_| "Editor could not be started")?;
+    if status.success() {
+        Ok("Returned from editor")
+    } else {
+        Err("Editor exited unsuccessfully")
+    }
+}
+
+fn editor_command(
+    editor: &str,
+    path: &Path,
+    line: u64,
+    column: u64,
+) -> Result<Command, &'static str> {
+    let mut parts = editor.split_whitespace();
+    let executable = parts.next().ok_or("VISUAL or EDITOR is empty")?;
+    let program = Path::new(executable)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(executable);
+    let mut command = Command::new(executable);
+    command.args(parts);
+    match program {
+        "code" | "code-insiders" | "codium" => {
+            let target = path_with_position(path, line, column);
+            command.arg("--goto").arg(target.as_str());
+        }
+        "idea" | "idea64" => {
+            let line = line.to_compact_string();
+            command.arg("--line").arg(line.as_str()).arg(path);
+        }
+        _ => {
+            let line = line_argument(line);
+            command.arg(line.as_str()).arg(path);
+        }
+    }
+    Ok(command)
+}
+
+fn line_argument(line: u64) -> String {
+    cstr!("+{line}")
+}
+
+fn path_with_position(path: &Path, line: u64, column: u64) -> String {
+    cstr!("{}:{line}:{column}", path.display())
+}

--- a/crates/vize/src/commands/doctor/tui/benchmark.rs
+++ b/crates/vize/src/commands/doctor/tui/benchmark.rs
@@ -1,0 +1,89 @@
+//! Feature-gated, process-state-free performance harness for the Doctor TUI.
+
+use std::io;
+
+use vize_doctor::DoctorReport;
+use vize_fresco::{Backend, FrameOutputTelemetry, Key, KeyEvent, TerminalCapabilities};
+
+use super::{DoctorTuiModel, render_frame};
+
+/// Headless Doctor workspace used by Criterion and downstream performance gates.
+///
+/// The harness owns an injected sink backend, so measurements include semantic
+/// projection, bounded cell painting, differential output generation, and
+/// exact changed-cell/byte accounting without reading or mutating process
+/// terminal state. It deliberately borrows the immutable report just like the
+/// interactive command.
+#[doc(hidden)]
+pub struct DoctorTuiBenchmark<'report> {
+    model: DoctorTuiModel<'report>,
+    backend: Backend<io::Sink>,
+    capabilities: TerminalCapabilities,
+    selection_forward: bool,
+    search_has_query: bool,
+}
+
+impl<'report> DoctorTuiBenchmark<'report> {
+    /// Create a headless workspace for an immutable report and explicit profile.
+    pub fn new(
+        report: &'report DoctorReport,
+        width: u16,
+        height: u16,
+        capabilities: TerminalCapabilities,
+    ) -> Self {
+        Self {
+            model: DoctorTuiModel::new(report, width, height),
+            backend: Backend::with_writer(width, height, io::sink()),
+            capabilities,
+            selection_forward: true,
+            search_has_query: false,
+        }
+    }
+
+    /// Paint and differentially flush one complete frame.
+    pub fn render(&mut self) -> FrameOutputTelemetry {
+        render_frame(
+            self.backend.buffer_mut(),
+            &mut self.model,
+            &[],
+            self.capabilities,
+        )
+        .expect("benchmark fixture must produce valid semantic presentations");
+        self.model.place_cursor(self.backend.cursor_mut());
+        self.backend
+            .flush_measured()
+            .expect("injected sink must accept a complete frame")
+    }
+
+    /// Alternate between adjacent findings and render the resulting diff frame.
+    pub fn toggle_selection_and_render(&mut self) -> FrameOutputTelemetry {
+        let key = if self.selection_forward {
+            Key::Down
+        } else {
+            Key::Up
+        };
+        self.selection_forward = !self.selection_forward;
+        let _ = self.model.handle_key(&KeyEvent::key(key));
+        self.render()
+    }
+
+    /// Alternate an unmatched one-character query and render the result.
+    pub fn toggle_search_and_render(&mut self) -> FrameOutputTelemetry {
+        if self.model.mode() != super::model::InteractionMode::Search {
+            let _ = self.model.handle_key(&KeyEvent::char('/'));
+        }
+        let key = if self.search_has_query {
+            Key::Backspace
+        } else {
+            Key::Char('\u{10ffff}')
+        };
+        self.search_has_query = !self.search_has_query;
+        let _ = self.model.handle_key(&KeyEvent::key(key));
+        self.render()
+    }
+
+    /// Return the number of finding rows retained for the current viewport.
+    pub fn materialized_findings(&self) -> usize {
+        self.model.workspace().finding_window().materialized_len()
+    }
+}

--- a/crates/vize/src/commands/doctor/tui/model.rs
+++ b/crates/vize/src/commands/doctor/tui/model.rs
@@ -1,0 +1,322 @@
+//! Application-owned filters and interaction state around Fresco's workspace.
+
+mod filter;
+
+use std::path::Path;
+
+use vize_carton::{String, ToCompactString};
+use vize_doctor::{DoctorCategory, DoctorFinding, DoctorReport, FindingSeverity};
+use vize_fresco::{
+    Cursor, DiagnosticWorkspaceAction, DiagnosticWorkspaceCommandOutcome,
+    DiagnosticWorkspaceKeymap, DiagnosticWorkspaceState, Key, KeyEvent, KeyEventKind,
+    terminal::CursorShape,
+};
+
+use super::super::DoctorSource;
+use filter::{cycle, search_document};
+
+pub(super) use filter::{category_label, severity_label};
+
+const CATEGORY_FILTERS: usize = DoctorCategory::ALL.len() + 1;
+const SEVERITY_FILTERS: usize = 4;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum InteractionMode {
+    Browse,
+    Search,
+    Help,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum InteractionOutcome {
+    Changed,
+    Boundary,
+    OpenSource,
+    Exit,
+}
+
+pub(super) struct DoctorTuiModel<'a> {
+    report: &'a DoctorReport,
+    workspace: DiagnosticWorkspaceState<usize, usize>,
+    keymap: DiagnosticWorkspaceKeymap,
+    finding_keys: Vec<usize>,
+    evidence_keys: Vec<usize>,
+    search_documents: Vec<String>,
+    search: String,
+    status: String,
+    category_filter: usize,
+    severity_filter: usize,
+    mode: InteractionMode,
+}
+
+impl<'a> DoctorTuiModel<'a> {
+    pub(super) fn new(report: &'a DoctorReport, width: u16, height: u16) -> Self {
+        let search_documents = report.findings().iter().map(search_document).collect();
+        let mut model = Self {
+            report,
+            workspace: DiagnosticWorkspaceState::new(width, height),
+            keymap: DiagnosticWorkspaceKeymap::default(),
+            finding_keys: Vec::with_capacity(report.findings().len()),
+            evidence_keys: Vec::new(),
+            search_documents,
+            search: String::new(""),
+            status: String::from("Ready"),
+            category_filter: 0,
+            severity_filter: 0,
+            mode: InteractionMode::Browse,
+        };
+        model.rebuild_findings();
+        model
+    }
+
+    pub(super) fn report(&self) -> &DoctorReport {
+        self.report
+    }
+
+    pub(super) const fn workspace(&self) -> &DiagnosticWorkspaceState<usize, usize> {
+        &self.workspace
+    }
+
+    pub(super) fn keymap(&self) -> &DiagnosticWorkspaceKeymap {
+        &self.keymap
+    }
+
+    pub(super) fn finding_keys(&self) -> &[usize] {
+        &self.finding_keys
+    }
+
+    pub(super) const fn mode(&self) -> InteractionMode {
+        self.mode
+    }
+
+    pub(super) fn search(&self) -> &str {
+        &self.search
+    }
+
+    pub(super) fn status(&self) -> &str {
+        &self.status
+    }
+
+    pub(super) fn category_label(&self) -> &'static str {
+        self.category_value().map_or("all", category_label)
+    }
+
+    pub(super) fn severity_label(&self) -> &'static str {
+        self.severity_value().map_or("all", severity_label)
+    }
+
+    pub(super) fn selected_finding(&self) -> Option<&DoctorFinding> {
+        self.workspace
+            .findings()
+            .selected_key()
+            .and_then(|index| self.report.findings().get(*index))
+    }
+
+    pub(super) fn selected_finding_key(&self) -> Option<usize> {
+        self.workspace.findings().selected_key().copied()
+    }
+
+    pub(super) fn selected_evidence_key(&self) -> Option<usize> {
+        self.workspace.evidence().selected_key().copied()
+    }
+
+    pub(super) fn resize(&mut self, width: u16, height: u16) {
+        let _ = self.workspace.resize(width, height);
+    }
+
+    pub(super) fn set_detail_rows(&mut self, rows: usize) {
+        let _ = self.workspace.set_detail_content_rows(rows);
+    }
+
+    pub(super) fn set_status(&mut self, status: &str) {
+        self.status = String::from(status);
+    }
+
+    pub(super) fn place_cursor(&self, cursor: &mut Cursor) {
+        if self.mode != InteractionMode::Search || self.workspace.layout().height() < 2 {
+            cursor.hide();
+            return;
+        }
+        let width = self.workspace.layout().width();
+        if width == 0 {
+            cursor.hide();
+            return;
+        }
+        let x =
+            (2 + vize_fresco::TextWidth::width(&self.search)).min(usize::from(width - 1)) as u16;
+        cursor.move_to(x, 1);
+        cursor.set_shape(CursorShape::Bar);
+        cursor.show();
+    }
+
+    pub(super) fn handle_paste(&mut self, text: &str) -> InteractionOutcome {
+        if self.mode != InteractionMode::Search {
+            return InteractionOutcome::Boundary;
+        }
+        self.search
+            .extend(text.chars().filter(|character| !character.is_control()));
+        self.rebuild_findings();
+        InteractionOutcome::Changed
+    }
+
+    pub(super) fn handle_key(&mut self, event: &KeyEvent) -> InteractionOutcome {
+        if event.kind == KeyEventKind::Release {
+            return InteractionOutcome::Boundary;
+        }
+        if event.is_ctrl_c() {
+            return InteractionOutcome::Exit;
+        }
+        match self.mode {
+            InteractionMode::Search => return self.handle_search_key(event),
+            InteractionMode::Help => {
+                if event.is_escape()
+                    || self.keymap.resolve(event)
+                        == Some(vize_fresco::DiagnosticWorkspaceCommand::Help)
+                {
+                    self.mode = InteractionMode::Browse;
+                    return InteractionOutcome::Changed;
+                }
+            }
+            InteractionMode::Browse => {}
+        }
+
+        let Some(command) = self.keymap.resolve(event) else {
+            return InteractionOutcome::Boundary;
+        };
+        let selected = self.selected_finding_key();
+        match self
+            .workspace
+            .apply_command(command, &self.finding_keys, &self.evidence_keys)
+        {
+            DiagnosticWorkspaceCommandOutcome::Changed => {
+                if selected != self.selected_finding_key() {
+                    self.sync_evidence();
+                }
+                InteractionOutcome::Changed
+            }
+            DiagnosticWorkspaceCommandOutcome::Boundary => {
+                self.set_status("Navigation boundary");
+                InteractionOutcome::Boundary
+            }
+            DiagnosticWorkspaceCommandOutcome::Dispatch(action) => self.dispatch(action),
+        }
+    }
+
+    pub(super) fn source_position(&self, sources: &[DoctorSource]) -> (u64, u64) {
+        let Some(finding) = self.selected_finding() else {
+            return (1, 1);
+        };
+        let Some(source) = sources
+            .iter()
+            .find(|source| source.path == Path::new(finding.primary.path.as_str()))
+        else {
+            return (1, u64::from(finding.primary.start).saturating_add(1));
+        };
+        let mut offset = (finding.primary.start as usize).min(source.source.len());
+        while offset > 0 && !source.source.is_char_boundary(offset) {
+            offset -= 1;
+        }
+        let prefix = &source.source[..offset];
+        let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u64 + 1;
+        let line_start = prefix.rfind('\n').map_or(0, |index| index + 1);
+        let column = prefix[line_start..].chars().count() as u64 + 1;
+        (line, column)
+    }
+
+    fn handle_search_key(&mut self, event: &KeyEvent) -> InteractionOutcome {
+        if event.is_escape() || event.is_enter() {
+            self.mode = InteractionMode::Browse;
+            return InteractionOutcome::Changed;
+        }
+        if event.is_backspace() {
+            if self.search.pop().is_some() {
+                self.rebuild_findings();
+                return InteractionOutcome::Changed;
+            }
+            return InteractionOutcome::Boundary;
+        }
+        let plain_or_shift = !event.modifiers.ctrl
+            && !event.modifiers.alt
+            && !event.modifiers.super_key
+            && !event.modifiers.hyper
+            && !event.modifiers.meta;
+        if plain_or_shift
+            && let Key::Char(character) = event.key
+            && !character.is_control()
+        {
+            self.search.push(character);
+            self.rebuild_findings();
+            return InteractionOutcome::Changed;
+        }
+        InteractionOutcome::Boundary
+    }
+
+    fn dispatch(&mut self, action: DiagnosticWorkspaceAction) -> InteractionOutcome {
+        match action {
+            DiagnosticWorkspaceAction::NextCategory => self.cycle_category(true),
+            DiagnosticWorkspaceAction::PreviousCategory => self.cycle_category(false),
+            DiagnosticWorkspaceAction::NextSeverity => self.cycle_severity(true),
+            DiagnosticWorkspaceAction::PreviousSeverity => self.cycle_severity(false),
+            DiagnosticWorkspaceAction::Search => self.mode = InteractionMode::Search,
+            DiagnosticWorkspaceAction::Help => self.mode = InteractionMode::Help,
+            DiagnosticWorkspaceAction::OpenSource => return InteractionOutcome::OpenSource,
+            DiagnosticWorkspaceAction::Exit => return InteractionOutcome::Exit,
+        }
+        InteractionOutcome::Changed
+    }
+
+    fn cycle_category(&mut self, forward: bool) {
+        self.category_filter = cycle(self.category_filter, CATEGORY_FILTERS, forward);
+        self.rebuild_findings();
+    }
+
+    fn cycle_severity(&mut self, forward: bool) {
+        self.severity_filter = cycle(self.severity_filter, SEVERITY_FILTERS, forward);
+        self.rebuild_findings();
+    }
+
+    fn rebuild_findings(&mut self) {
+        self.finding_keys.clear();
+        let query = self.search.to_lowercase();
+        for (index, finding) in self.report.findings().iter().enumerate() {
+            let category_matches = self
+                .category_value()
+                .is_none_or(|category| finding.category == category);
+            let severity_matches = self
+                .severity_value()
+                .is_none_or(|severity| finding.assessment.severity == severity);
+            let search_matches =
+                query.is_empty() || self.search_documents[index].contains(query.as_str());
+            if category_matches && severity_matches && search_matches {
+                self.finding_keys.push(index);
+            }
+        }
+        let _ = self.workspace.reconcile_findings(&self.finding_keys);
+        self.sync_evidence();
+        self.status = self.finding_keys.len().to_compact_string();
+        self.status.push_str(" matching finding(s)");
+    }
+
+    fn sync_evidence(&mut self) {
+        self.evidence_keys.clear();
+        if let Some(finding) = self.selected_finding() {
+            self.evidence_keys.extend(0..finding.evidence.len());
+        }
+        let _ = self.workspace.reconcile_evidence(&self.evidence_keys);
+    }
+
+    fn category_value(&self) -> Option<DoctorCategory> {
+        self.category_filter
+            .checked_sub(1)
+            .and_then(|index| DoctorCategory::ALL.get(index).copied())
+    }
+
+    fn severity_value(&self) -> Option<FindingSeverity> {
+        match self.severity_filter {
+            0 => None,
+            1 => Some(FindingSeverity::Error),
+            2 => Some(FindingSeverity::Warning),
+            _ => Some(FindingSeverity::Notice),
+        }
+    }
+}

--- a/crates/vize/src/commands/doctor/tui/model/filter.rs
+++ b/crates/vize/src/commands/doctor/tui/model/filter.rs
@@ -1,0 +1,51 @@
+//! Allocation-conscious filter labels and precomputed search documents.
+
+use vize_carton::String;
+use vize_doctor::{DoctorCategory, DoctorFinding, FindingSeverity};
+
+pub(super) fn cycle(current: usize, length: usize, forward: bool) -> usize {
+    if forward {
+        (current + 1) % length
+    } else {
+        current.checked_sub(1).unwrap_or(length - 1)
+    }
+}
+
+pub(super) fn search_document(finding: &DoctorFinding) -> String {
+    let mut document = String::new("");
+    for value in [
+        finding.code.as_str(),
+        finding.title.as_str(),
+        finding.message.as_str(),
+        finding.primary.path.as_str(),
+        category_label(finding.category),
+        severity_label(finding.assessment.severity),
+    ] {
+        document.push_str(value);
+        document.push(' ');
+    }
+    document.to_lowercase()
+}
+
+pub(in crate::commands::doctor::tui) const fn category_label(
+    category: DoctorCategory,
+) -> &'static str {
+    match category {
+        DoctorCategory::Correctness => "correctness",
+        DoctorCategory::Accessibility => "accessibility",
+        DoctorCategory::Performance => "performance",
+        DoctorCategory::Maintainability => "maintainability",
+        DoctorCategory::Security => "security",
+        DoctorCategory::ProductionReadiness => "production readiness",
+    }
+}
+
+pub(in crate::commands::doctor::tui) const fn severity_label(
+    severity: FindingSeverity,
+) -> &'static str {
+    match severity {
+        FindingSeverity::Error => "error",
+        FindingSeverity::Warning => "warning",
+        FindingSeverity::Notice => "notice",
+    }
+}

--- a/crates/vize/src/commands/doctor/tui/render.rs
+++ b/crates/vize/src/commands/doctor/tui/render.rs
@@ -1,0 +1,301 @@
+//! Bounded cell renderer for the interactive Doctor workspace.
+
+mod detail;
+
+use vize_carton::{String, cstr};
+use vize_doctor::FindingSeverity;
+use vize_fresco::{
+    DiagnosticPresentation, DiagnosticPresentationProfile, DiagnosticTone,
+    DiagnosticWorkspaceFocus, DiagnosticWorkspaceMode, DiagnosticWorkspacePane, Rect,
+    TerminalCapabilities, TextWrap,
+    terminal::{Buffer, Color, Style},
+    text::WrapMode,
+};
+
+use super::{DoctorSource, DoctorTuiError};
+use crate::commands::doctor::tui::model::{DoctorTuiModel, InteractionMode, severity_label};
+
+#[derive(Clone)]
+pub(super) struct StyledLine {
+    pub(super) text: String,
+    pub(super) style: Style,
+}
+
+pub(super) fn render_frame(
+    buffer: &mut Buffer,
+    model: &mut DoctorTuiModel<'_>,
+    sources: &[DoctorSource],
+    capabilities: TerminalCapabilities,
+) -> Result<(), DoctorTuiError> {
+    buffer.clear();
+    if buffer.width() == 0 || buffer.height() == 0 {
+        return Ok(());
+    }
+    render_header(buffer, model, capabilities)?;
+    if model.mode() == InteractionMode::Help {
+        render_help(buffer, model, capabilities)?;
+        model.set_detail_rows(0);
+        return Ok(());
+    }
+
+    let layout = model.workspace().layout();
+    let active = model.workspace().active_stacked_pane();
+    if layout.presents(DiagnosticWorkspacePane::Findings, active) {
+        render_findings(buffer, model, layout.findings(), capabilities)?;
+    }
+    if layout.presents(DiagnosticWorkspacePane::Detail, active) {
+        let lines = detail::build(model, sources, layout.detail().width, capabilities)?;
+        model.set_detail_rows(lines.len());
+        render_detail(buffer, model, layout.detail(), &lines);
+    } else {
+        model.set_detail_rows(0);
+    }
+    if layout.mode() == DiagnosticWorkspaceMode::Split {
+        render_divider(buffer, layout, capabilities);
+    }
+    Ok(())
+}
+
+fn render_header(
+    buffer: &mut Buffer,
+    model: &DoctorTuiModel<'_>,
+    capabilities: TerminalCapabilities,
+) -> Result<(), DoctorTuiError> {
+    let width = buffer.width();
+    let title_style = capabilities.adapt_style(Style::new().fg(Color::Cyan).bold());
+    write_clipped(buffer, 0, 0, "VIZE DOCTOR", title_style, width);
+
+    let score = model.report().summary().overall_score;
+    let score_tone = if score >= 90 {
+        DiagnosticTone::Positive
+    } else if score >= 70 {
+        DiagnosticTone::Caution
+    } else {
+        DiagnosticTone::Negative
+    };
+    let presentation = DiagnosticPresentation::score(u64::from(score), 100, score_tone)?;
+    let score_text = presentation.text(profile(capabilities, false));
+    write_clipped(
+        buffer,
+        13,
+        0,
+        &score_text,
+        capabilities.adapt_style(presentation.style()),
+        width.saturating_sub(13),
+    );
+
+    if buffer.height() > 1 {
+        let status = if model.mode() == InteractionMode::Search {
+            cstr!("/ {}", model.search())
+        } else {
+            cstr!(
+                "category={}  severity={}  visible={}/{}  {}",
+                model.category_label(),
+                model.severity_label(),
+                model.finding_keys().len(),
+                model.report().findings().len(),
+                model.status(),
+            )
+        };
+        write_clipped(
+            buffer,
+            0,
+            1,
+            &status,
+            capabilities.adapt_style(Style::new().fg(Color::Gray)),
+            width,
+        );
+    }
+    if buffer.height() > 2 {
+        let separator = capabilities.select_symbol("─", "-");
+        buffer.fill(
+            Rect::new(0, 2, width, 1),
+            separator.chars().next().unwrap_or('-'),
+            Style::new(),
+        );
+        let hints = "j/k navigate  Tab focus  c/C category  s/S severity  / search  ? help  q quit";
+        write_clipped(
+            buffer,
+            1,
+            2,
+            hints,
+            capabilities.adapt_style(Style::new().dim()),
+            width.saturating_sub(2),
+        );
+    }
+    Ok(())
+}
+
+fn render_findings(
+    buffer: &mut Buffer,
+    model: &DoctorTuiModel<'_>,
+    area: Rect,
+    capabilities: TerminalCapabilities,
+) -> Result<(), DoctorTuiError> {
+    if area.is_empty() {
+        return Ok(());
+    }
+    if model.finding_keys().is_empty() {
+        write_clipped(
+            buffer,
+            area.x,
+            area.y,
+            "No findings match the current filters.",
+            capabilities.adapt_style(Style::new().dim()),
+            area.width,
+        );
+        return Ok(());
+    }
+    let selected = model.selected_finding_key();
+    let focus = model.workspace().focus() == DiagnosticWorkspaceFocus::Findings;
+    for (row, position) in model
+        .workspace()
+        .finding_window()
+        .visible_range()
+        .enumerate()
+    {
+        let Some(key) = model.finding_keys().get(position).copied() else {
+            continue;
+        };
+        let finding = &model.report().findings()[key];
+        let marker = if selected == Some(key) {
+            capabilities.select_symbol("›", ">")
+        } else {
+            " "
+        };
+        let severity = DiagnosticPresentation::new(
+            vize_fresco::DiagnosticPresentationKind::Severity,
+            severity_label(finding.assessment.severity),
+            severity_tone(finding.assessment.severity),
+        )?;
+        let text = cstr!(
+            "{marker} {} {} — {}",
+            severity.text(profile(capabilities, true)),
+            finding.code,
+            finding.title,
+        );
+        let mut style = capabilities.adapt_style(severity.style());
+        if selected == Some(key) {
+            style.reverse = true;
+            style.bold = true;
+            style.underline = focus;
+        }
+        write_clipped(
+            buffer,
+            area.x,
+            area.y.saturating_add(row as u16),
+            &text,
+            style,
+            area.width,
+        );
+    }
+    Ok(())
+}
+
+fn render_detail(
+    buffer: &mut Buffer,
+    model: &DoctorTuiModel<'_>,
+    area: Rect,
+    lines: &[StyledLine],
+) {
+    let start = model.workspace().detail_scroll();
+    for (row, line) in lines
+        .iter()
+        .skip(start)
+        .take(usize::from(area.height))
+        .enumerate()
+    {
+        write_clipped(
+            buffer,
+            area.x,
+            area.y.saturating_add(row as u16),
+            &line.text,
+            line.style,
+            area.width,
+        );
+    }
+}
+
+fn render_divider(
+    buffer: &mut Buffer,
+    layout: vize_fresco::DiagnosticWorkspaceLayout,
+    capabilities: TerminalCapabilities,
+) {
+    let x = layout.findings().x.saturating_add(layout.findings().width);
+    let glyph = capabilities
+        .select_symbol("│", "|")
+        .chars()
+        .next()
+        .unwrap_or('|');
+    buffer.fill(
+        Rect::new(x, layout.content().y, 1, layout.content().height),
+        glyph,
+        capabilities.adapt_style(Style::new().dim()),
+    );
+}
+
+fn render_help(
+    buffer: &mut Buffer,
+    model: &DoctorTuiModel<'_>,
+    capabilities: TerminalCapabilities,
+) -> Result<(), DoctorTuiError> {
+    let area = model.workspace().layout().content();
+    write_clipped(
+        buffer,
+        area.x,
+        area.y,
+        "Keyboard help — Esc, ? or F1 closes this view",
+        capabilities.adapt_style(Style::new().fg(Color::Cyan).bold()),
+        area.width,
+    );
+    for (row, binding) in model
+        .keymap()
+        .bindings()
+        .iter()
+        .take(usize::from(area.height.saturating_sub(1)))
+        .enumerate()
+    {
+        let hint =
+            DiagnosticPresentation::key_hint(binding.chord.label(), binding.command.description())?;
+        write_clipped(
+            buffer,
+            area.x,
+            area.y.saturating_add(row as u16 + 1),
+            &hint.text(profile(capabilities, false)),
+            capabilities.adapt_style(hint.style()),
+            area.width,
+        );
+    }
+    Ok(())
+}
+
+pub(super) fn write_clipped(
+    buffer: &mut Buffer,
+    x: u16,
+    y: u16,
+    text: &str,
+    style: Style,
+    width: u16,
+) {
+    if width == 0 || y >= buffer.height() {
+        return;
+    }
+    if let Some(line) = TextWrap::wrap(text, usize::from(width), WrapMode::TruncateEnd).first() {
+        buffer.set_string(x, y, line, style);
+    }
+}
+
+pub(super) const fn severity_tone(severity: FindingSeverity) -> DiagnosticTone {
+    match severity {
+        FindingSeverity::Error => DiagnosticTone::Negative,
+        FindingSeverity::Warning => DiagnosticTone::Caution,
+        FindingSeverity::Notice => DiagnosticTone::Informational,
+    }
+}
+
+pub(super) fn profile(
+    capabilities: TerminalCapabilities,
+    compact: bool,
+) -> DiagnosticPresentationProfile {
+    DiagnosticPresentationProfile::from(capabilities).with_compact(compact)
+}

--- a/crates/vize/src/commands/doctor/tui/render/detail.rs
+++ b/crates/vize/src/commands/doctor/tui/render/detail.rs
@@ -1,0 +1,302 @@
+//! Structured selected-finding rows with semantic Fresco presentations.
+
+mod labels;
+
+use vize_carton::{String, cstr};
+use vize_doctor::{DoctorFinding, FixSafety};
+use vize_fresco::{
+    DiagnosticPresentation, DiagnosticPresentationKind, DiagnosticTone, TerminalCapabilities,
+    TextWrap,
+    terminal::{Color, Style},
+    text::WrapMode,
+};
+
+use super::{StyledLine, profile, severity_tone};
+use crate::commands::doctor::{
+    DoctorSource,
+    tui::{DoctorTuiError, model::DoctorTuiModel},
+};
+use labels::{
+    confidence_label, confidence_tone, evidence_kind_label, fix_safety_label, impact_label,
+    impact_tone, rule_cost_label,
+};
+
+pub(super) fn build(
+    model: &DoctorTuiModel<'_>,
+    sources: &[DoctorSource],
+    width: u16,
+    capabilities: TerminalCapabilities,
+) -> Result<Vec<StyledLine>, DoctorTuiError> {
+    let Some(finding) = model.selected_finding() else {
+        return Ok(vec![line(
+            "No finding selected",
+            capabilities.adapt_style(Style::new().dim()),
+        )]);
+    };
+    let width = usize::from(width.max(1));
+    let mut lines = Vec::new();
+    lines.push(line(
+        cstr!("{} — {}", finding.code, finding.title),
+        capabilities.adapt_style(Style::new().fg(Color::Cyan).bold()),
+    ));
+    presentation(
+        &mut lines,
+        DiagnosticPresentation::new(
+            DiagnosticPresentationKind::Severity,
+            super::super::model::severity_label(finding.assessment.severity),
+            severity_tone(finding.assessment.severity),
+        )?,
+        capabilities,
+    );
+    presentation(
+        &mut lines,
+        DiagnosticPresentation::new(
+            DiagnosticPresentationKind::Confidence,
+            confidence_label(finding.assessment.confidence),
+            confidence_tone(finding.assessment.confidence),
+        )?,
+        capabilities,
+    );
+    presentation(
+        &mut lines,
+        DiagnosticPresentation::new(
+            DiagnosticPresentationKind::Impact,
+            impact_label(finding.assessment.impact),
+            impact_tone(finding.assessment.impact),
+        )?,
+        capabilities,
+    );
+    let (source_line, source_column) = model.source_position(sources);
+    presentation(
+        &mut lines,
+        DiagnosticPresentation::code_location(
+            finding.primary.path.as_str(),
+            source_line,
+            source_column,
+        )?,
+        capabilities,
+    );
+    lines.push(line(
+        cstr!(
+            "Category: {}  Penalty: -{}",
+            super::super::model::category_label(finding.category),
+            finding.assessment.penalty.points,
+        ),
+        capabilities.adapt_style(Style::new().dim()),
+    ));
+    push_wrapped(
+        &mut lines,
+        "",
+        &finding.message,
+        width,
+        Style::new(),
+        capabilities,
+    );
+    if let Some(scenario) = &finding.failure_scenario {
+        push_wrapped(
+            &mut lines,
+            "Failure: ",
+            scenario,
+            width,
+            Style::new().fg(Color::Yellow),
+            capabilities,
+        );
+    }
+    evidence_rows(&mut lines, model, finding, width, capabilities)?;
+    related_rows(&mut lines, finding, width, capabilities);
+    fix_rows(&mut lines, finding, width, capabilities)?;
+    provenance_rows(&mut lines, finding, width, capabilities);
+    if let Some(documentation) = &finding.documentation {
+        push_wrapped(
+            &mut lines,
+            "Docs: ",
+            documentation,
+            width,
+            Style::new().fg(Color::Blue),
+            capabilities,
+        );
+    }
+    Ok(lines)
+}
+
+fn evidence_rows(
+    lines: &mut Vec<StyledLine>,
+    model: &DoctorTuiModel<'_>,
+    finding: &DoctorFinding,
+    width: usize,
+    capabilities: TerminalCapabilities,
+) -> Result<(), DoctorTuiError> {
+    if finding.evidence.is_empty() {
+        return Ok(());
+    }
+    lines.push(section("Evidence", capabilities));
+    let selected = model.selected_evidence_key();
+    for (index, evidence) in finding.evidence.iter().enumerate() {
+        let summary = cstr!(
+            "{}: {}",
+            evidence_kind_label(evidence.kind),
+            evidence.summary
+        );
+        let presentation = DiagnosticPresentation::evidence(
+            summary.as_str(),
+            index as u64 + 1,
+            finding.evidence.len() as u64,
+        )?;
+        let mut style = capabilities.adapt_style(presentation.style());
+        style.reverse = selected == Some(index);
+        push_wrapped(
+            lines,
+            "",
+            &presentation.text(profile(capabilities, false)),
+            width,
+            style,
+            capabilities,
+        );
+        if selected == Some(index) {
+            for (key, value) in &evidence.details {
+                push_wrapped(
+                    lines,
+                    "  ",
+                    &cstr!("{key}={value}"),
+                    width,
+                    Style::new().dim(),
+                    capabilities,
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn related_rows(
+    lines: &mut Vec<StyledLine>,
+    finding: &DoctorFinding,
+    width: usize,
+    capabilities: TerminalCapabilities,
+) {
+    if finding.related.is_empty() {
+        return;
+    }
+    lines.push(section("Related locations", capabilities));
+    for related in &finding.related {
+        push_wrapped(
+            lines,
+            "",
+            &cstr!(
+                "{}:{}..{} — {}",
+                related.location.path,
+                related.location.start,
+                related.location.end,
+                related.message,
+            ),
+            width,
+            Style::new().dim(),
+            capabilities,
+        );
+    }
+}
+
+fn fix_rows(
+    lines: &mut Vec<StyledLine>,
+    finding: &DoctorFinding,
+    width: usize,
+    capabilities: TerminalCapabilities,
+) -> Result<(), DoctorTuiError> {
+    let Some(fix) = &finding.fix else {
+        return Ok(());
+    };
+    lines.push(section("Fix", capabilities));
+    let tone = match fix.safety {
+        FixSafety::Safe => DiagnosticTone::Positive,
+        FixSafety::ReviewRequired => DiagnosticTone::Caution,
+        FixSafety::Unavailable => DiagnosticTone::Neutral,
+    };
+    presentation(
+        lines,
+        DiagnosticPresentation::new(
+            DiagnosticPresentationKind::FixSafety,
+            fix_safety_label(fix.safety),
+            tone,
+        )?,
+        capabilities,
+    );
+    push_wrapped(lines, "", &fix.title, width, Style::new(), capabilities);
+    for verification in &fix.verification {
+        push_wrapped(
+            lines,
+            "Verify: ",
+            verification,
+            width,
+            Style::new().dim(),
+            capabilities,
+        );
+    }
+    if !fix.edits.is_empty() {
+        lines.push(line(
+            cstr!("{} source edit(s)", fix.edits.len()),
+            capabilities.adapt_style(Style::new().dim()),
+        ));
+    }
+    Ok(())
+}
+
+fn provenance_rows(
+    lines: &mut Vec<StyledLine>,
+    finding: &DoctorFinding,
+    width: usize,
+    capabilities: TerminalCapabilities,
+) {
+    lines.push(section("Analysis", capabilities));
+    push_wrapped(
+        lines,
+        "",
+        &cstr!(
+            "{} ({})",
+            finding.provenance.capability,
+            rule_cost_label(finding.provenance.cost),
+        ),
+        width,
+        Style::new().dim(),
+        capabilities,
+    );
+}
+
+fn presentation(
+    lines: &mut Vec<StyledLine>,
+    presentation: DiagnosticPresentation,
+    capabilities: TerminalCapabilities,
+) {
+    lines.push(line(
+        presentation.text(profile(capabilities, false)).as_str(),
+        capabilities.adapt_style(presentation.style()),
+    ));
+}
+
+fn push_wrapped(
+    lines: &mut Vec<StyledLine>,
+    prefix: &str,
+    text: &str,
+    width: usize,
+    style: Style,
+    capabilities: TerminalCapabilities,
+) {
+    let mut value = String::from(prefix);
+    value.push_str(text);
+    for wrapped in TextWrap::wrap(&value, width, WrapMode::Word) {
+        lines.push(line(wrapped.as_str(), capabilities.adapt_style(style)));
+    }
+}
+
+fn section(label: &str, capabilities: TerminalCapabilities) -> StyledLine {
+    line(
+        cstr!("— {label} —"),
+        capabilities.adapt_style(Style::new().fg(Color::Cyan).bold()),
+    )
+}
+
+fn line(text: impl Into<String>, style: Style) -> StyledLine {
+    StyledLine {
+        text: text.into(),
+        style,
+    }
+}

--- a/crates/vize/src/commands/doctor/tui/render/detail/labels.rs
+++ b/crates/vize/src/commands/doctor/tui/render/detail/labels.rs
@@ -1,0 +1,69 @@
+//! Doctor-domain labels and non-color presentation tones.
+
+use vize_doctor::{EvidenceKind, FindingConfidence, FindingImpact, FixSafety, RuleCost};
+use vize_fresco::DiagnosticTone;
+
+pub(super) const fn confidence_label(value: FindingConfidence) -> &'static str {
+    match value {
+        FindingConfidence::Certain => "certain",
+        FindingConfidence::High => "high",
+        FindingConfidence::Medium => "medium",
+        FindingConfidence::Low => "low",
+    }
+}
+
+pub(super) const fn confidence_tone(value: FindingConfidence) -> DiagnosticTone {
+    match value {
+        FindingConfidence::Certain | FindingConfidence::High => DiagnosticTone::Positive,
+        FindingConfidence::Medium => DiagnosticTone::Caution,
+        FindingConfidence::Low => DiagnosticTone::Informational,
+    }
+}
+
+pub(super) const fn impact_label(value: FindingImpact) -> &'static str {
+    match value {
+        FindingImpact::Critical => "critical",
+        FindingImpact::High => "high",
+        FindingImpact::Medium => "medium",
+        FindingImpact::Low => "low",
+    }
+}
+
+pub(super) const fn impact_tone(value: FindingImpact) -> DiagnosticTone {
+    match value {
+        FindingImpact::Critical | FindingImpact::High => DiagnosticTone::Negative,
+        FindingImpact::Medium => DiagnosticTone::Caution,
+        FindingImpact::Low => DiagnosticTone::Informational,
+    }
+}
+
+pub(super) const fn fix_safety_label(value: FixSafety) -> &'static str {
+    match value {
+        FixSafety::Safe => "safe",
+        FixSafety::ReviewRequired => "review required",
+        FixSafety::Unavailable => "unavailable",
+    }
+}
+
+pub(super) const fn evidence_kind_label(value: EvidenceKind) -> &'static str {
+    match value {
+        EvidenceKind::Source => "source",
+        EvidenceKind::Type => "type",
+        EvidenceKind::ControlFlow => "control flow",
+        EvidenceKind::Reactivity => "reactivity",
+        EvidenceKind::Component => "component",
+        EvidenceKind::Css => "css",
+        EvidenceKind::BuildGraph => "build graph",
+        EvidenceKind::Contract => "contract",
+        EvidenceKind::Measurement => "measurement",
+    }
+}
+
+pub(super) const fn rule_cost_label(value: RuleCost) -> &'static str {
+    match value {
+        RuleCost::Trivial => "trivial",
+        RuleCost::Low => "low cost",
+        RuleCost::Moderate => "moderate cost",
+        RuleCost::High => "high cost",
+    }
+}

--- a/crates/vize/src/commands/doctor/tui/snapshots/vize__commands__doctor__tui__tests__doctor_tui_ascii_monochrome.snap
+++ b/crates/vize/src/commands/doctor/tui/snapshots/vize__commands__doctor__tui__tests__doctor_tui_ascii_monochrome.snap
@@ -1,0 +1,20 @@
+---
+source: crates/vize/src/commands/doctor/tui/tests.rs
+expression: screen
+---
+VIZE DOCTOR  + Score: 95 / 100
+category=all  severity=all  visible=2/2  2 matching finding(s)
+-j/k navigate  Tab focus  c/C category  s/S severity  / search  ? help  q quit----------------------
+> x error VIZE_TEST_ERROR — Mutable s...|VIZE_TEST_ERROR — Mutable state crosses a contract
+  ! warning VIZE_TEST_A11Y — Accessib...|x Severity: error
+                                        |+ Confidence: high
+                                        |x Impact: high
+                                        |- Location: src/Parent.vue:2:10
+                                        |Category: correctness  Penalty: -15
+                                        |A detailed explanation with a concrete next action.
+                                        |— Evidence —
+                                        |i Evidence: reactivity: Child destructures the reactive
+                                        |prop
+                                        |i Evidence: component: Parent passes mutable state
+                                        |— Fix —
+                                        |- Fix safety: unavailable

--- a/crates/vize/src/commands/doctor/tui/snapshots/vize__commands__doctor__tui__tests__doctor_tui_narrow.snap
+++ b/crates/vize/src/commands/doctor/tui/snapshots/vize__commands__doctor__tui__tests__doctor_tui_narrow.snap
@@ -1,0 +1,9 @@
+---
+source: crates/vize/src/commands/doctor/tui/tests.rs
+expression: screen_text(&buffer)
+---
+VIZE DOCTOR  ✓ Score: 95 / 100
+category=all  severity=all  visible=2/2  2 matc...
+─j/k navigate  Tab focus  c/C category  s/S se...─
+› ✕ error VIZE_TEST_ERROR — Mutable state cross...
+  ▲ warning VIZE_TEST_A11Y — Accessibility name...

--- a/crates/vize/src/commands/doctor/tui/snapshots/vize__commands__doctor__tui__tests__doctor_tui_wide.snap
+++ b/crates/vize/src/commands/doctor/tui/snapshots/vize__commands__doctor__tui__tests__doctor_tui_wide.snap
@@ -1,0 +1,22 @@
+---
+source: crates/vize/src/commands/doctor/tui/tests.rs
+expression: screen
+---
+VIZE DOCTOR  ✓ Score: 95 / 100
+category=all  severity=all  visible=2/2  2 matching finding(s)
+─j/k navigate  Tab focus  c/C category  s/S severity  / search  ? help  q quit──────────────────────
+› ✕ error VIZE_TEST_ERROR — Mutable s...│VIZE_TEST_ERROR — Mutable state crosses a contract
+  ▲ warning VIZE_TEST_A11Y — Accessib...│✕ Severity: error
+                                        │✓ Confidence: high
+                                        │✕ Impact: high
+                                        │• Location: src/Parent.vue:2:10
+                                        │Category: correctness  Penalty: -15
+                                        │A detailed explanation with a concrete next action.
+                                        │— Evidence —
+                                        │ℹ Evidence: reactivity: Child destructures the reactive
+                                        │prop
+                                        │ℹ Evidence: component: Parent passes mutable state
+                                        │— Fix —
+                                        │• Fix safety: unavailable
+                                        │No automatic fix is available for this finding.
+                                        │— Analysis —

--- a/crates/vize/src/commands/doctor/tui/tests.rs
+++ b/crates/vize/src/commands/doctor/tui/tests.rs
@@ -1,0 +1,337 @@
+use std::path::PathBuf;
+
+use vize_carton::String;
+use vize_doctor::{
+    AnalysisProvenance, DoctorCategory, DoctorFinding, DoctorReport, EvidenceKind,
+    FindingAssessment, FindingConfidence, FindingEvidence, FindingImpact, FindingSeverity,
+    HealthPenalty, RuleCost, SourceLocation,
+};
+use vize_fresco::{
+    Buffer, ColorPreference, DiagnosticWorkspaceFocus, DiagnosticWorkspaceMode,
+    DiagnosticWorkspacePane, FeaturePreference, Key, KeyEvent, TerminalCapabilities,
+    TerminalCapabilityProbe, TerminalProfileOptions,
+};
+
+use super::{
+    DoctorSource, editor_command,
+    model::{DoctorTuiModel, InteractionMode, InteractionOutcome},
+    render::render_frame,
+};
+
+#[test]
+fn frame_contains_semantic_summary_list_detail_and_evidence() {
+    let report = report();
+    let sources = sources();
+    let mut model = DoctorTuiModel::new(&report, 100, 18);
+    let mut buffer = Buffer::new(100, 18);
+
+    render_frame(
+        &mut buffer,
+        &mut model,
+        &sources,
+        capabilities(100, 18, true),
+    )
+    .unwrap();
+    let screen = screen_text(&buffer);
+
+    assert!(screen.contains("VIZE DOCTOR"));
+    assert!(screen.contains("Score: 95 / 100"));
+    assert!(screen.contains("VIZE_TEST_ERROR"));
+    assert!(screen.contains("Severity: error"));
+    assert!(screen.contains("Evidence"));
+    assert!(screen.contains("component: Parent passes mutable state"));
+    assert!(screen.contains("Fix safety: unavailable"));
+    insta::assert_snapshot!("doctor_tui_wide", screen);
+}
+
+#[test]
+fn navigation_filters_and_incremental_search_preserve_stable_selection() {
+    let report = report();
+    let mut model = DoctorTuiModel::new(&report, 100, 18);
+    let first = model.selected_finding_key();
+
+    assert_eq!(
+        model.handle_key(&KeyEvent::key(Key::Down)),
+        InteractionOutcome::Changed
+    );
+    assert_ne!(model.selected_finding_key(), first);
+
+    assert_eq!(
+        model.handle_key(&KeyEvent::char('c')),
+        InteractionOutcome::Changed
+    );
+    assert_eq!(model.category_label(), "correctness");
+    assert_eq!(model.finding_keys().len(), 1);
+
+    let mut search = DoctorTuiModel::new(&report, 100, 18);
+    assert_eq!(
+        search.handle_key(&KeyEvent::char('/')),
+        InteractionOutcome::Changed
+    );
+    for character in "accessibility".chars() {
+        assert_eq!(
+            search.handle_key(&KeyEvent::char(character)),
+            InteractionOutcome::Changed
+        );
+    }
+    assert_eq!(search.mode(), InteractionMode::Search);
+    assert_eq!(search.finding_keys().len(), 1);
+    assert_eq!(
+        search.handle_key(&KeyEvent::key(Key::Esc)),
+        InteractionOutcome::Changed
+    );
+    assert_eq!(search.mode(), InteractionMode::Browse);
+}
+
+#[test]
+fn evidence_focus_and_narrow_stacked_navigation_use_fresco_state() {
+    let report = report();
+    let mut model = DoctorTuiModel::new(&report, 100, 18);
+
+    assert_eq!(
+        model.handle_key(&KeyEvent::char(']')),
+        InteractionOutcome::Changed
+    );
+    assert_eq!(model.selected_evidence_key(), Some(1));
+    assert_eq!(
+        model.workspace().focus(),
+        DiagnosticWorkspaceFocus::Evidence
+    );
+
+    model.resize(50, 14);
+    assert_eq!(
+        model.workspace().layout().mode(),
+        DiagnosticWorkspaceMode::Stacked
+    );
+    let _ = model.workspace().active_stacked_pane();
+    assert_eq!(
+        model.workspace().active_stacked_pane(),
+        DiagnosticWorkspacePane::Detail
+    );
+    assert_eq!(
+        model.handle_key(&KeyEvent::key(Key::Tab)),
+        InteractionOutcome::Changed
+    );
+    assert_eq!(
+        model.workspace().active_stacked_pane(),
+        DiagnosticWorkspacePane::Findings
+    );
+
+    let mut buffer = Buffer::new(50, 14);
+    render_frame(
+        &mut buffer,
+        &mut model,
+        &sources(),
+        capabilities(50, 14, true),
+    )
+    .unwrap();
+    insta::assert_snapshot!("doctor_tui_narrow", screen_text(&buffer));
+}
+
+#[test]
+fn ascii_monochrome_profile_retains_every_meaning_without_color() {
+    let report = report();
+    let sources = sources();
+    let mut model = DoctorTuiModel::new(&report, 100, 16);
+    let mut buffer = Buffer::new(100, 16);
+
+    render_frame(
+        &mut buffer,
+        &mut model,
+        &sources,
+        capabilities(100, 16, false),
+    )
+    .unwrap();
+    let screen = screen_text(&buffer);
+
+    assert!(screen.contains("x Severity: error"));
+    assert!(screen.contains("x Impact: high"));
+    assert!(!screen.contains('│'));
+    assert!(buffer.iter().all(|(_, _, cell)| cell.style.fg.is_none()));
+    insta::assert_snapshot!("doctor_tui_ascii_monochrome", screen);
+}
+
+#[test]
+fn source_positions_are_unicode_safe_and_one_based() {
+    let source = "<template>\n  <p>保存🙂</p>\n</template>";
+    let start = source.find("保存🙂").unwrap() as u32;
+    let finding = finding(
+        "VIZE_UNICODE",
+        DoctorCategory::Correctness,
+        FindingSeverity::Warning,
+        "Unicode source",
+        SourceLocation::new("src/App.vue", start, start + 10),
+    );
+    let report = DoctorReport::new(".", [finding]);
+    let sources = [DoctorSource {
+        path: PathBuf::from("src/App.vue"),
+        source: source.into(),
+    }];
+    let model = DoctorTuiModel::new(&report, 80, 16);
+
+    assert_eq!(model.source_position(&sources), (2, 6));
+}
+
+#[test]
+fn virtual_window_materialization_stays_bounded_for_large_reports() {
+    let report = large_report();
+    let model = DoctorTuiModel::new(&report, 120, 30);
+
+    assert_eq!(model.finding_keys().len(), 10_000);
+    assert!(model.workspace().finding_window().materialized_len() <= 31);
+}
+
+#[cfg(feature = "profiling")]
+#[test]
+fn differential_frame_costs_stay_inside_explicit_budgets() {
+    let report = large_report();
+    let mut tui = super::DoctorTuiBenchmark::new(&report, 120, 30, capabilities(120, 30, true));
+
+    let first_frame = tui.render();
+    assert!(first_frame.changed_cells() <= 1_600, "{first_frame:?}");
+    assert!(first_frame.bytes_written() <= 8_192, "{first_frame:?}");
+
+    let selection_frame = tui.toggle_selection_and_render();
+    assert!(
+        selection_frame.changed_cells() <= 128,
+        "{selection_frame:?}"
+    );
+    assert!(
+        selection_frame.bytes_written() <= 512,
+        "{selection_frame:?}"
+    );
+}
+
+#[test]
+fn source_actions_preserve_editor_flags_and_use_native_location_syntax() {
+    let path = std::path::Path::new("/workspace/Unicode view.vue");
+    let code = editor_command("code --wait", path, 12, 7).unwrap();
+    let code_args: Vec<_> = code.get_args().collect();
+
+    assert_eq!(code.get_program(), "code");
+    assert_eq!(code_args[0], "--wait");
+    assert_eq!(code_args[1], "--goto");
+    assert_eq!(code_args[2], "/workspace/Unicode view.vue:12:7");
+
+    let terminal = editor_command("nvim -f", path, 12, 7).unwrap();
+    let terminal_args: Vec<_> = terminal.get_args().collect();
+    assert_eq!(terminal.get_program(), "nvim");
+    assert_eq!(terminal_args[0], "-f");
+    assert_eq!(terminal_args[1], "+12");
+    assert_eq!(terminal_args[2], path);
+}
+
+fn report() -> DoctorReport {
+    let error = finding(
+        "VIZE_TEST_ERROR",
+        DoctorCategory::Correctness,
+        FindingSeverity::Error,
+        "Mutable state crosses a contract",
+        SourceLocation::new("src/Parent.vue", 20, 25),
+    )
+    .with_evidence(FindingEvidence::new(
+        EvidenceKind::Component,
+        "Parent passes mutable state",
+    ))
+    .with_evidence(FindingEvidence::new(
+        EvidenceKind::Reactivity,
+        "Child destructures the reactive prop",
+    ));
+    let warning = finding(
+        "VIZE_TEST_A11Y",
+        DoctorCategory::Accessibility,
+        FindingSeverity::Warning,
+        "Accessibility name is missing",
+        SourceLocation::new("src/Button.vue", 10, 16),
+    );
+    DoctorReport::new(".", [warning, error])
+}
+
+fn large_report() -> DoctorReport {
+    DoctorReport::new(
+        ".",
+        (0..10_000).map(|index| {
+            finding(
+                "VIZE_MANY",
+                DoctorCategory::Performance,
+                FindingSeverity::Notice,
+                "Repeated finding",
+                SourceLocation::new("src/App.vue", index, index + 1),
+            )
+        }),
+    )
+}
+
+fn finding(
+    code: &str,
+    category: DoctorCategory,
+    severity: FindingSeverity,
+    title: &str,
+    location: SourceLocation,
+) -> DoctorFinding {
+    DoctorFinding::new(
+        code,
+        category,
+        FindingAssessment::new(
+            severity,
+            FindingConfidence::High,
+            FindingImpact::High,
+            HealthPenalty::new(15, "Test penalty"),
+        ),
+        location,
+        title,
+        "A detailed explanation with a concrete next action.",
+        AnalysisProvenance::new("test-analysis", RuleCost::Low),
+    )
+}
+
+fn sources() -> Vec<DoctorSource> {
+    vec![
+        DoctorSource {
+            path: PathBuf::from("src/Parent.vue"),
+            source: "<template>\n  <Child :item=\"state\" />\n</template>".into(),
+        },
+        DoctorSource {
+            path: PathBuf::from("src/Button.vue"),
+            source: "<template><button /></template>".into(),
+        },
+    ]
+}
+
+fn capabilities(width: u16, height: u16, unicode: bool) -> TerminalCapabilities {
+    TerminalCapabilities::resolve(
+        &TerminalCapabilityProbe::new(width, height, true).with_locale(if unicode {
+            "C.UTF-8"
+        } else {
+            "C"
+        }),
+        TerminalProfileOptions {
+            color: ColorPreference::Never,
+            unicode: if unicode {
+                FeaturePreference::Always
+            } else {
+                FeaturePreference::Never
+            },
+            interactive: FeaturePreference::Always,
+            narrow_width: 60,
+        },
+    )
+}
+
+fn screen_text(buffer: &Buffer) -> String {
+    let mut screen = String::new("");
+    for y in 0..buffer.height() {
+        if y > 0 {
+            screen.push('\n');
+        }
+        let mut line = String::new("");
+        for x in 0..buffer.width() {
+            let cell = buffer.get(x, y).unwrap();
+            if !cell.is_continuation {
+                line.push_str(&cell.symbol);
+            }
+        }
+        screen.push_str(line.trim_end());
+    }
+    screen
+}

--- a/crates/vize/src/lib.rs
+++ b/crates/vize/src/lib.rs
@@ -34,6 +34,11 @@ pub mod source_write {
     pub use crate::commands::atomic_write::atomic_write;
 }
 
+/// Headless performance harness for the interactive Doctor workspace.
+#[cfg(feature = "profiling")]
+#[doc(hidden)]
+pub use crate::commands::doctor::DoctorTuiBenchmark;
+
 /// Shared allocator, string, hash, and utility types.
 pub use vize_carton as carton;
 

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_doctor_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_doctor_help.snap
@@ -31,6 +31,9 @@ Options:
       --exit-zero
           Return success even when the report contains blocking findings. Defaults to false
 
+      --tui
+          Explore the report in the interactive Fresco terminal workspace. Disabled by default
+
       --public-sfc
           Enforce the canonical public component SFC contract. Defaults to false
 

--- a/crates/vize/tests/doctor_tui_cli.rs
+++ b/crates/vize/tests/doctor_tui_cli.rs
@@ -1,0 +1,38 @@
+use std::{path::Path, process::Command};
+
+#[test]
+fn tui_requires_an_interactive_terminal_before_analysis() {
+    let directory = tempfile::tempdir().unwrap();
+    let output = doctor(directory.path(), &["--tui"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(
+        std::str::from_utf8(&output.stderr)
+            .unwrap()
+            .contains("--tui requires an interactive stdin and stdout")
+    );
+}
+
+#[test]
+fn tui_rejects_machine_report_formats_before_terminal_detection() {
+    let directory = tempfile::tempdir().unwrap();
+    let output = doctor(directory.path(), &["--tui", "--format", "json"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(
+        std::str::from_utf8(&output.stderr)
+            .unwrap()
+            .contains("--tui cannot be combined with --format json or sarif")
+    );
+}
+
+fn doctor(root: &Path, arguments: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_vize"))
+        .arg("doctor")
+        .args(arguments)
+        .current_dir(root)
+        .output()
+        .unwrap()
+}


### PR DESCRIPTION
## Summary

- add explicit `vize doctor --tui` mode backed by Fresco workspace, keymap, terminal capability, semantic presentation, cell buffer, and differential backend contracts
- provide responsive split/stacked findings and detail panes with stable selection, keyboard navigation, category/severity cycling, incremental search and paste, evidence traversal, help, resize, and source-editor actions
- preserve every diagnostic meaning in Unicode, ASCII, monochrome, narrow, and zero-finding profiles without changing text, JSON, SARIF, or provider-neutral AI reporters
- fail closed before analysis for redirected/non-interactive terminals and machine report formats, and restore terminal modes before launching an editor and after every session outcome

## Performance and terminal correctness

- render only the Fresco virtual window; the 10,000-finding conformance test materializes at most 31 rows at 120x30
- add an isolated `vize_benchmarks` leaf package so Criterion measures the library path without compiling or perturbing the production CLI binary
- benchmark semantic projection, bounded cell painting, differential output generation, and measured sink flush: first frame median 4.33 ms, selection input-to-frame 154.7 µs, and search input-to-frame 171.0 µs for 10,000 findings
- enforce deterministic frame budgets in normal tests: first frame at most 1,600 changed cells / 8 KiB; selection frame at most 128 changed cells / 512 B (measured 1,397 / 3,774 B and 79 / 156 B)
- retain exact wide, narrow, and ASCII-monochrome headless screen snapshots
- exercise a real 100x30 PTY first frame and verify clean `q` exit restores bracketed paste, alternate screen, and cursor state

## Verification

- `cargo test -p vize --lib --all-features` — 476 passed, 1 ignored
- Doctor CLI, filter, SARIF, and TUI integration suites — 17 passed
- `cargo clippy -p vize --lib --bins --all-features -- -D warnings`
- `cargo clippy -p vize --test doctor_tui_cli --all-features -- -D warnings`
- `cargo clippy -p vize_benchmarks --bench doctor_tui -- -D warnings`
- `RUSTDOCFLAGS=-D warnings cargo doc -p vize --no-deps --all-features`
- `cargo test -p vize --doc --all-features`
- `cargo bench -p vize_benchmarks --bench doctor_tui -- --sample-size 20 --warm-up-time 1 --measurement-time 1`

Related to #3138 and #4155.