### PR TITLE
feat(ui): add focus interactions

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -69,6 +69,11 @@
       "import": "./dist/interaction-modality.mjs",
       "default": "./dist/interaction-modality.mjs"
     },
+    "./focus": {
+      "types": "./dist/focus.d.mts",
+      "import": "./dist/focus.mjs",
+      "default": "./dist/focus.mjs"
+    },
     "./hover": {
       "types": "./dist/hover.d.mts",
       "import": "./dist/hover.mjs",

--- a/npm/ui/core/scripts/check-renderers.ts
+++ b/npm/ui/core/scripts/check-renderers.ts
@@ -19,6 +19,30 @@ const rendererLanes: readonly RendererLane[] = [
 
 const inlineFixtures = [
   {
+    filename: "FocusConsumer.vue",
+    source: String.raw`<script setup lang="ts">
+import { useFocusRing } from "./focus.ts";
+
+const focus = useFocusRing({
+  onFocus(event) {
+    void event.isFocusVisible;
+  },
+});
+</script>
+
+<template>
+  <button
+    v-bind="focus.focusProps"
+    type="button"
+    :data-focus-visible="focus.isFocusVisible.value || undefined"
+    :data-focused="focus.isFocused.value || undefined"
+  >
+    Focus target
+  </button>
+</template>
+`,
+  },
+  {
     filename: "MoveConsumer.vue",
     source: String.raw`<script setup lang="ts">
 import { useMove } from "./move.ts";

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 23_825],
+  ["index.mjs", 26_225],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
   ["collection.mjs", 5_700],
@@ -13,6 +13,7 @@ const budgets = new Map([
   ["controllable-state.mjs", 600],
   ["id.mjs", 2_300],
   ["interaction-modality.mjs", 3_300],
+  ["focus.mjs", 5_850],
   ["hover.mjs", 2_200],
   ["long-press.mjs", 8_175],
   ["move.mjs", 5_050],

--- a/npm/ui/core/scripts/check-tree-shaking.mjs
+++ b/npm/ui/core/scripts/check-tree-shaking.mjs
@@ -73,6 +73,7 @@ const familySignatures = Object.freeze({
   collection: /VIZE_UI_COLLECTION_DISPOSED/,
   id: /DeterministicIdProvider/,
   "interaction-modality": /VIZE_UI_INTERACTION_MODALITY_DISPOSED/,
+  focus: /VIZE_UI_FOCUS_DISPOSED/,
   hover: /VIZE_UI_HOVER_DISPOSED/,
   "long-press": /VIZE_UI_LONG_PRESS_DISPOSED/,
   move: /VIZE_UI_MOVE_DISPOSED/,
@@ -82,6 +83,7 @@ const familySignatures = Object.freeze({
 });
 
 const retainedFamilies = Object.freeze({
+  focus: new Set(["focus", "interaction-modality"]),
   "long-press": new Set(["long-press", "press"]),
 });
 
@@ -114,6 +116,12 @@ const componentCases = [
     family: "interaction-modality",
     exportName: "createInteractionModalityTracker",
     maximumJavaScriptGzipBytes: 1_650,
+    maximumCssGzipBytes: 0,
+  },
+  {
+    family: "focus",
+    exportName: "createFocus",
+    maximumJavaScriptGzipBytes: 3_300,
     maximumCssGzipBytes: 0,
   },
   {

--- a/npm/ui/core/src/distribution.test.ts
+++ b/npm/ui/core/src/distribution.test.ts
@@ -13,6 +13,7 @@ const publicEntries = [
   "./controllable-state",
   "./id",
   "./interaction-modality",
+  "./focus",
   "./hover",
   "./long-press",
   "./move",

--- a/npm/ui/core/src/focus-internal.ts
+++ b/npm/ui/core/src/focus-internal.ts
@@ -1,0 +1,135 @@
+import { toValue } from "vue";
+
+import type { FocusChangeReason, FocusEvent, FocusMode, FocusOptions } from "./focus-types.ts";
+
+const invalidOptionDiagnostic = "VIZE_UI_FOCUS_OPTION";
+const invalidTargetDiagnostic = "VIZE_UI_FOCUS_TARGET";
+
+export function capture(errors: unknown[], callback: () => void): void {
+  try {
+    callback();
+  } catch (error) {
+    errors.push(error);
+  }
+}
+
+export function surfaceErrors(errors: readonly unknown[], message: string): void {
+  if (errors.length === 1) throw errors[0];
+  if (errors.length < 2) return;
+  const Aggregate = globalThis.AggregateError as typeof AggregateError | undefined;
+  if (typeof Aggregate === "function") throw new Aggregate(errors, message);
+  const fallback = Object.assign(new Error(message), { errors: [...errors] });
+  fallback.name = "AggregateError";
+  throw fallback;
+}
+
+export function readBoolean(value: FocusOptions["isDisabled"], name: string): boolean {
+  return validateBoolean(toValue(value), name);
+}
+
+export function validateBoolean(resolved: unknown, name: string): boolean {
+  if (resolved === undefined) return false;
+  if (typeof resolved !== "boolean") {
+    throw new TypeError(`${invalidOptionDiagnostic}: ${name} must resolve to a boolean`);
+  }
+  return resolved;
+}
+
+export function readMode(value: FocusMode | undefined): FocusMode {
+  const resolved = value ?? "target";
+  if (resolved !== "target" && resolved !== "within") {
+    throw new TypeError(`${invalidOptionDiagnostic}: mode must be target or within`);
+  }
+  return resolved;
+}
+
+export function validateOptions(options: FocusOptions): FocusMode {
+  const mode = readMode(options.mode);
+  if (options.autoFocus !== undefined && typeof options.autoFocus !== "boolean") {
+    throw new TypeError(`${invalidOptionDiagnostic}: autoFocus must be a boolean`);
+  }
+  for (const name of ["onBlur", "onFocus", "onFocusChange"] as const) {
+    const callback = options[name];
+    if (callback !== undefined && typeof callback !== "function") {
+      throw new TypeError(`${invalidOptionDiagnostic}: ${name} must be a function`);
+    }
+  }
+  if (typeof options.isDisabled !== "function") readBoolean(options.isDisabled, "isDisabled");
+  return mode;
+}
+
+export function eventElement(value: EventTarget | null): Element | null {
+  const candidate = value as Partial<Element> | null;
+  return candidate?.nodeType === 1 && typeof candidate.getRootNode === "function"
+    ? (candidate as Element)
+    : null;
+}
+
+export function validateElement(value: unknown): Element {
+  const candidate = value as Partial<Element> | null;
+  if (
+    candidate?.nodeType !== 1 ||
+    typeof candidate.getRootNode !== "function" ||
+    candidate.ownerDocument?.nodeType !== 9
+  ) {
+    throw new TypeError(`${invalidTargetDiagnostic}: refresh expects an Element`);
+  }
+  return candidate as Element;
+}
+
+/** Test composed ancestry without assuming that both nodes share one realm. */
+export function composedContains(host: Element, candidate: Element | null): boolean {
+  let current: Node | null = candidate;
+  while (current) {
+    if (current === host) return true;
+    const element = current as Element;
+    if (element.assignedSlot) {
+      current = element.assignedSlot;
+      continue;
+    }
+    if (current.parentNode) {
+      current = current.parentNode;
+      continue;
+    }
+    const root = current.getRootNode();
+    current = root && "host" in root ? (root as ShadowRoot).host : null;
+  }
+  return false;
+}
+
+/** Resolve the deepest active element through open shadow roots. */
+export function activeElementOf(host: Element): Element | null {
+  const root = host.getRootNode();
+  let active =
+    root && "activeElement" in root
+      ? (root as Document | ShadowRoot).activeElement
+      : host.ownerDocument.activeElement;
+  while (active?.shadowRoot?.activeElement) active = active.shadowRoot.activeElement;
+  return active;
+}
+
+export function ownsFocus(mode: FocusMode, host: Element, active: Element | null): boolean {
+  return mode === "target" ? active === host : composedContains(host, active);
+}
+
+export function createFocusEvent(
+  type: FocusEvent["type"],
+  mode: FocusMode,
+  host: Element,
+  focusedTarget: Element | null,
+  relatedTarget: Element | null,
+  originalEvent: globalThis.FocusEvent | null,
+  isFocusVisible: boolean,
+  reason: FocusChangeReason,
+): FocusEvent {
+  return Object.freeze({
+    type,
+    mode,
+    target: host,
+    focusedTarget,
+    relatedTarget,
+    originalEvent,
+    isFocusVisible,
+    reason,
+  });
+}

--- a/npm/ui/core/src/focus-lifecycle.test.ts
+++ b/npm/ui/core/src/focus-lifecycle.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+
+import { nextTick, ref } from "vue";
+import { test } from "vite-plus/test";
+
+import { createFocus } from "./focus.ts";
+import { surfaceErrors } from "./focus-internal.ts";
+import { mountFocus } from "./focus-test-utils.ts";
+
+test("removing a focused host settles ownership through the mutation observer", async () => {
+  const harness = mountFocus();
+  harness.host.focus();
+  harness.host.remove();
+  await nextTick();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  assert.equal(harness.controller.isFocused.value, false);
+  assert.deepEqual(harness.transitions, [true, false]);
+  harness.controller.dispose();
+});
+
+test("a document focusin safety net settles ownership when host blur is unavailable", () => {
+  const harness = mountFocus();
+  harness.host.focus();
+  const outside = document.createElement("button");
+  document.body.append(outside);
+  harness.host.removeEventListener("blur", harness.controller.focusProps.onBlur!);
+  outside.focus();
+  assert.equal(harness.controller.isFocused.value, false);
+  outside.remove();
+  harness.unmount();
+});
+
+test("invalid reactive disablement settles before surfacing its diagnostic", () => {
+  const disabled = ref<boolean | string>(false);
+  const harness = mountFocus({ isDisabled: disabled as never });
+  harness.host.focus();
+  assert.throws(() => {
+    disabled.value = "invalid";
+  }, /VIZE_UI_FOCUS_OPTION.*isDisabled/);
+  assert.equal(harness.controller.isFocused.value, false);
+  assert.equal(harness.events.at(-1)?.reason, "disabled");
+  harness.unmount();
+});
+
+test("a nonreactive disabled getter is revalidated on the next focus event", () => {
+  let disabled = false;
+  const harness = mountFocus({ isDisabled: () => disabled });
+  harness.host.focus();
+  disabled = true;
+  harness.host.dispatchEvent(new globalThis.FocusEvent("focus"));
+  assert.equal(harness.controller.isFocused.value, false);
+  assert.equal(harness.events.at(-1)?.reason, "disabled");
+  harness.unmount();
+});
+
+test("listener setup failure rolls back modality ownership", () => {
+  const host = document.createElement("button");
+  document.body.append(host);
+  const controller = createFocus();
+  const OriginalObserver = window.MutationObserver;
+  class FailingObserver extends OriginalObserver {
+    override observe(): void {
+      throw new Error("observe failed");
+    }
+  }
+  window.MutationObserver = FailingObserver;
+  host.addEventListener("focus", controller.focusProps.onFocus!);
+  try {
+    assert.throws(() => host.focus(), /observe failed/);
+    assert.equal(controller.isFocused.value, false);
+  } finally {
+    window.MutationObserver = OriginalObserver;
+    controller.dispose();
+    host.remove();
+  }
+});
+
+test("observer construction failure also rolls back the document listener", () => {
+  const host = document.createElement("button");
+  document.body.append(host);
+  const controller = createFocus();
+  const OriginalObserver = window.MutationObserver;
+  class FailingObserver {
+    constructor(_callback: MutationCallback) {
+      throw new Error("constructor failed");
+    }
+  }
+  window.MutationObserver = FailingObserver as unknown as typeof MutationObserver;
+  host.addEventListener("focus", controller.focusProps.onFocus!);
+  try {
+    assert.throws(() => host.focus(), /constructor failed/);
+    assert.equal(controller.isFocused.value, false);
+  } finally {
+    window.MutationObserver = OriginalObserver;
+    controller.dispose();
+    host.remove();
+  }
+});
+
+test("cross-realm documents are accepted without instanceof assumptions", () => {
+  const isolated = document.implementation.createHTMLDocument("focus realm");
+  const host = isolated.createElement("button");
+  isolated.body.append(host);
+  const controller = createFocus({ autoFocus: true });
+  host.addEventListener("focus", controller.focusProps.onFocus!);
+  host.focus();
+  controller.refresh(host);
+  assert.equal(controller.isFocused.value, true);
+  assert.equal(controller.isFocusVisible.value, true);
+  controller.dispose();
+});
+
+test("cleanup failures do not prevent the remaining owned resources from releasing", () => {
+  const harness = mountFocus();
+  harness.host.focus();
+  const originalRemove = document.removeEventListener.bind(document);
+  let focusRemovalFailed = false;
+  document.removeEventListener = function removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject | null,
+    options?: boolean | EventListenerOptions,
+  ): void {
+    originalRemove(type, listener, options);
+    if (type === "focusin" && !focusRemovalFailed) {
+      focusRemovalFailed = true;
+      throw new Error("focus removal failed");
+    }
+  };
+  try {
+    assert.throws(() => harness.controller.cancel(), /focus removal failed/);
+    assert.equal(harness.controller.isFocused.value, false);
+  } finally {
+    document.removeEventListener = originalRemove;
+    harness.controller.dispose();
+    harness.host.remove();
+  }
+});
+
+test("multiple cleanup errors remain inspectable without native AggregateError", () => {
+  const OriginalAggregateError = globalThis.AggregateError;
+  Object.defineProperty(globalThis, "AggregateError", { configurable: true, value: undefined });
+  try {
+    assert.throws(
+      () => surfaceErrors([new Error("observer"), new Error("modality")], "focus failed"),
+      (error: unknown) => {
+        const aggregate = error as Error & { errors: unknown[] };
+        assert.equal(aggregate.name, "AggregateError");
+        assert.equal(aggregate.message, "focus failed");
+        assert.equal(aggregate.errors.length, 2);
+        return true;
+      },
+    );
+  } finally {
+    Object.defineProperty(globalThis, "AggregateError", {
+      configurable: true,
+      value: OriginalAggregateError,
+    });
+  }
+});

--- a/npm/ui/core/src/focus-ssr.test.ts
+++ b/npm/ui/core/src/focus-ssr.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { createSSRApp, defineComponent, h, nextTick } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import { useFocusRing } from "./focus.ts";
+
+const SsrProbe = defineComponent({
+  name: "FocusSsrProbe",
+  setup() {
+    const focus = useFocusRing({ autoFocus: true });
+    return () =>
+      h(
+        "button",
+        {
+          ...focus.focusProps,
+          "data-focus-visible": String(focus.isFocusVisible.value),
+          "data-focused": String(focus.isFocused.value),
+          type: "button",
+        },
+        "Focus target",
+      );
+  },
+});
+
+test("renders byte-identical focus output without server DOM access or handlers", async () => {
+  const outputs = await Promise.all([
+    renderToString(createSSRApp(SsrProbe)),
+    renderToString(createSSRApp(SsrProbe)),
+  ]);
+  assert.equal(outputs[0], outputs[1]);
+  assert.equal(
+    outputs[0],
+    '<button data-focus-visible="false" data-focused="false" type="button">Focus target</button>',
+  );
+  assert.doesNotMatch(outputs[0], /onFocus|function/);
+});
+
+test("hydrates focus-ring state without replacement or diagnostics", async () => {
+  const serverHtml = await renderToString(createSSRApp(SsrProbe));
+  const host = document.createElement("div");
+  host.innerHTML = serverHtml;
+  document.body.append(host);
+  const serverTarget = host.firstElementChild;
+  const diagnostics: string[] = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  console.error = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  const app = createSSRApp(SsrProbe);
+
+  try {
+    app.mount(host);
+    assert.equal(host.firstElementChild, serverTarget);
+    const target = host.querySelector("button")!;
+    target.focus();
+    await nextTick();
+    assert.equal(target.dataset.focused, "true");
+    assert.equal(target.dataset.focusVisible, "true");
+    target.blur();
+    await nextTick();
+    assert.equal(target.dataset.focused, "false");
+    assert.deepEqual(diagnostics, []);
+  } finally {
+    app.unmount();
+    host.remove();
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+});

--- a/npm/ui/core/src/focus-test-utils.ts
+++ b/npm/ui/core/src/focus-test-utils.ts
@@ -1,0 +1,75 @@
+import { createFocus } from "./focus.ts";
+import type { FocusController, FocusEvent, FocusOptions, FocusProps } from "./focus.ts";
+
+export const focusEventNames: Readonly<Record<keyof FocusProps, string>> = {
+  onBlur: "blur",
+  onFocus: "focus",
+  onFocusin: "focusin",
+  onFocusout: "focusout",
+};
+
+export interface FocusHarness {
+  readonly controller: FocusController;
+  readonly events: FocusEvent[];
+  readonly host: HTMLElement;
+  readonly transitions: boolean[];
+  readonly unmount: () => void;
+}
+
+export function mountFocus(options: FocusOptions = {}, tag = "button"): FocusHarness {
+  const host = document.createElement(tag);
+  if (host instanceof HTMLButtonElement) host.type = "button";
+  else host.tabIndex = -1;
+  document.body.append(host);
+  const events: FocusEvent[] = [];
+  const transitions: boolean[] = [];
+  const controller = createFocus({
+    ...options,
+    onBlur(event) {
+      events.push(event);
+      options.onBlur?.(event);
+    },
+    onFocus(event) {
+      events.push(event);
+      options.onFocus?.(event);
+    },
+    onFocusChange(value, event) {
+      transitions.push(value);
+      options.onFocusChange?.(value, event);
+    },
+  });
+  for (const [property, type] of Object.entries(focusEventNames) as Array<
+    [keyof FocusProps, string]
+  >) {
+    const listener = controller.focusProps[property];
+    if (listener) host.addEventListener(type, listener as EventListener);
+  }
+  return {
+    controller,
+    events,
+    host,
+    transitions,
+    unmount() {
+      try {
+        controller.dispose();
+      } finally {
+        host.remove();
+      }
+    },
+  };
+}
+
+export function forceModalityFallback(element: Element): () => void {
+  const ownDescriptor = Object.getOwnPropertyDescriptor(element, "matches");
+  Object.defineProperty(element, "matches", {
+    configurable: true,
+    value: (selector: string) => {
+      if (selector === ":focus-visible") throw new DOMException("unsupported", "SyntaxError");
+      return Element.prototype.matches.call(element, selector);
+    },
+  });
+  return () => {
+    if (ownDescriptor) Object.defineProperty(element, "matches", ownDescriptor);
+    else delete (element as { matches?: Element["matches"] }).matches;
+  };
+}

--- a/npm/ui/core/src/focus-types.ts
+++ b/npm/ui/core/src/focus-types.ts
@@ -1,0 +1,123 @@
+import type { MaybeRefOrGetter, ShallowRef } from "vue";
+
+/** Scope used to determine whether a host owns the focused element. */
+export type FocusMode = "target" | "within";
+
+/** Why a focus observer entered or left its active state. */
+export type FocusChangeReason = "disabled" | "focus" | "manual" | "refresh";
+
+/** Immutable, renderer-independent focus lifecycle snapshot. */
+export interface FocusEvent {
+  /** Lifecycle phase represented by this snapshot. */
+  readonly type: "blur" | "focus";
+
+  /** Host element that owns this observer. */
+  readonly target: Element;
+
+  /** Focused host or descendant when available. */
+  readonly focusedTarget: Element | null;
+
+  /** Destination supplied by a native blur event when available. */
+  readonly relatedTarget: Element | null;
+
+  /** Native event responsible for this phase, or `null` for synthetic settlement. */
+  readonly originalEvent: globalThis.FocusEvent | null;
+
+  /** Whether focus is currently expected to receive a visible indicator. */
+  readonly isFocusVisible: boolean;
+
+  /** Ownership mode used by this observer. */
+  readonly mode: FocusMode;
+
+  /** Native or lifecycle operation responsible for this snapshot. */
+  readonly reason: FocusChangeReason;
+}
+
+/** Native handlers to merge onto one focus host. */
+export interface FocusProps {
+  /** Direct-target focus handler; present in `target` mode. */
+  readonly onFocus?: (event: globalThis.FocusEvent) => void;
+
+  /** Direct-target blur handler; present in `target` mode. */
+  readonly onBlur?: (event: globalThis.FocusEvent) => void;
+
+  /** Bubbling focus-entry handler; present in `within` mode. */
+  readonly onFocusin?: (event: globalThis.FocusEvent) => void;
+
+  /** Bubbling focus-exit handler; present in `within` mode. */
+  readonly onFocusout?: (event: globalThis.FocusEvent) => void;
+}
+
+/** Options for {@link createFocus}. */
+export interface FocusOptions {
+  /**
+   * Observe only the host or the host and its composed descendants.
+   *
+   * @default "target"
+   */
+  readonly mode?: FocusMode;
+
+  /**
+   * Suppress focus ownership and settle an active observer when this becomes true.
+   *
+   * @default false
+   */
+  readonly isDisabled?: MaybeRefOrGetter<boolean | undefined>;
+
+  /**
+   * Treat owned focus as visibly focused regardless of the current modality.
+   * This is intended for elements focused programmatically during mount.
+   *
+   * @default false
+   */
+  readonly autoFocus?: boolean;
+
+  /** Called after focus ownership is acquired. */
+  readonly onFocus?: (event: FocusEvent) => void;
+
+  /** Called after focus ownership is released. */
+  readonly onBlur?: (event: FocusEvent) => void;
+
+  /** Called after each distinct focus-state transition. */
+  readonly onFocusChange?: (isFocused: boolean, event: FocusEvent) => void;
+}
+
+/** Options for {@link createFocusWithin}. */
+export type FocusWithinOptions = Omit<FocusOptions, "mode">;
+
+/** Options for a direct-target focus ring. */
+export type FocusRingOptions = Omit<FocusOptions, "mode">;
+
+/** Reactive focus observer with explicit DOM ownership. */
+export interface FocusController {
+  /** Whether the host currently owns focus according to {@link FocusOptions.mode}. */
+  readonly isFocused: Readonly<ShallowRef<boolean>>;
+
+  /** Whether the current focus should expose a visible focus indicator. */
+  readonly isFocusVisible: Readonly<ShallowRef<boolean>>;
+
+  /** Stable native handlers to merge onto the host. */
+  readonly focusProps: Readonly<FocusProps>;
+
+  /**
+   * Reconcile state against the host's current composed-tree active element.
+   *
+   * @returns `true` when state changed.
+   * @throws An error carrying `VIZE_UI_FOCUS_DISPOSED` after disposal.
+   */
+  readonly refresh: (target: Element) => boolean;
+
+  /**
+   * Settle current ownership without moving browser focus.
+   *
+   * @returns `true` when a focused state was settled.
+   * @throws An error carrying `VIZE_UI_FOCUS_DISPOSED` after disposal.
+   */
+  readonly cancel: () => boolean;
+
+  /** Release modality and document listeners. Safe to call repeatedly. */
+  readonly dispose: () => void;
+}
+
+/** Direct-target controller returned by {@link createFocusRing}. */
+export type FocusRingController = FocusController;

--- a/npm/ui/core/src/focus.behavior.md
+++ b/npm/ui/core/src/focus.behavior.md
@@ -1,0 +1,40 @@
+# Focus behavior contract
+
+Normative state × input → outcome table for `@vizejs/ui/focus`. Every row is
+exercised by `src/focus*.test.ts`; compile-only assertions live in
+`src/focus.types.test-d.ts`.
+
+| #   | State                      | Input                                              | Outcome                                                              | Proven by                   |
+| --- | -------------------------- | -------------------------------------------------- | -------------------------------------------------------------------- | --------------------------- |
+| F1  | idle target                | host receives focus                                | immutable focus snapshot and owned state are published               | direct-focus test           |
+| F2  | idle target                | descendant receives focus                          | descendant focus is ignored                                          | ownership-mode test         |
+| F3  | idle within                | composed descendant receives focus                 | host owns focus and records the deepest active element               | within/shadow tests         |
+| F4  | focused within             | focus moves between composed descendants           | ownership remains active without duplicate transitions               | within-boundary test        |
+| F5  | focused                    | focus leaves the owned boundary                    | immutable blur snapshot includes the destination                     | direct/within tests         |
+| F6  | focused                    | modality changes from pointer to keyboard          | focus-visible state updates without a duplicate focus phase          | modality test               |
+| F7  | focused after mount        | `autoFocus` is enabled                             | visible-ring state remains true regardless of input modality         | auto-focus test             |
+| F8  | focused                    | reactive disabled becomes true                     | lifecycle settles without moving DOM focus                           | reactive test               |
+| F9  | focused                    | reactive disabled resolves to an invalid value     | lifecycle settles before the stable runtime diagnostic surfaces      | invalid-reactive test       |
+| F10 | DOM focused, observer idle | explicit refresh                                   | ownership and ring state reconcile from the composed active element  | refresh test                |
+| F11 | focused                    | manual cancel                                      | listeners/state release while DOM focus remains unchanged            | cancellation test           |
+| F12 | focused                    | host is removed without blur                       | mutation observer settles leaked ownership                           | removal test                |
+| F13 | focused                    | host blur delivery is unavailable                  | document focus safety net settles ownership                          | safety-net test             |
+| F14 | transition callback active | callback cancels reentrantly                       | true→false is ordered and no stale focus phase is published          | reentrancy test             |
+| F15 | callbacks throw            | multiple independent callbacks fail                | state remains settled and failures aggregate after notification      | callback-failure test       |
+| F16 | listener setup fails       | mutation observation cannot start                  | installed document/modality resources roll back                      | setup-failure test          |
+| F17 | cleanup throws             | one or more owned resources fail to release        | every cleanup runs and all failures remain inspectable               | cleanup tests               |
+| F18 | effect scope ends          | any focus hook is scope-owned                      | controller is terminally disposed without user callbacks             | scope test                  |
+| F19 | concurrent SSR requests    | identical component trees                          | byte-identical handler-free markup renders without a server document | SSR test                    |
+| F20 | SSR followed by hydration  | host receives and loses focus                      | DOM identity remains and reactive state renders without diagnostics  | hydration test              |
+| F21 | DOM, SSR, and Vapor lanes  | authored consumer compiles                         | all renderer lanes accept the same public props and reactive state   | renderer-conformance gate   |
+| F22 | root and subpath consumers | only focus is retained                             | equivalent CSS-free bundles exclude unrelated component signatures   | tree-shaking gate           |
+| F23 | public TypeScript API      | state mutation, invalid mode, or callback mismatch | compile-only assertions reject misuse                                | `src/focus.types.test-d.ts` |
+
+## Accessibility obligation
+
+The controller normalizes ownership and focus-indicator intent; it never moves
+focus, invents a role, or emits CSS. Consumers must bind the returned props to
+the same semantic host, keep keyboard focus order meaningful, and render a
+visible indicator whenever `isFocusVisible` is true. `autoFocus` is reserved
+for programmatic mount focus where a ring is required even without keyboard
+modality. Focus styling remains entirely user-controlled.

--- a/npm/ui/core/src/focus.test.ts
+++ b/npm/ui/core/src/focus.test.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+
+import { effectScope, ref } from "vue";
+import { test } from "vite-plus/test";
+
+import {
+  createFocus,
+  createFocusRing,
+  createFocusWithin,
+  useFocus,
+  useFocusRing,
+  useFocusWithin,
+} from "./focus.ts";
+import type { FocusController } from "./focus.ts";
+import { forceModalityFallback, mountFocus } from "./focus-test-utils.ts";
+
+function keydown(key = "Tab"): void {
+  document.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key }));
+}
+
+function pointerdown(): void {
+  document.dispatchEvent(
+    new PointerEvent("pointerdown", { bubbles: true, pointerId: 1, pointerType: "mouse" }),
+  );
+}
+
+test("publishes immutable direct-focus snapshots and modality-aware ring state", () => {
+  const harness = mountFocus();
+  const restoreMatches = forceModalityFallback(harness.host);
+  pointerdown();
+  harness.host.focus();
+
+  assert.equal(harness.controller.isFocused.value, true);
+  assert.equal(harness.controller.isFocusVisible.value, false);
+  assert.deepEqual(harness.transitions, [true]);
+  assert.equal(harness.events[0]?.type, "focus");
+  assert.equal(harness.events[0]?.target, harness.host);
+  assert.equal(harness.events[0]?.focusedTarget, harness.host);
+  assert.equal(harness.events[0]?.reason, "focus");
+  assert.ok(harness.events[0]?.originalEvent instanceof globalThis.FocusEvent);
+  assert.ok(Object.isFrozen(harness.events[0]));
+
+  keydown();
+  assert.equal(harness.controller.isFocusVisible.value, true);
+  harness.host.blur();
+  assert.equal(harness.controller.isFocused.value, false);
+  assert.equal(harness.controller.isFocusVisible.value, false);
+  assert.deepEqual(harness.transitions, [true, false]);
+  assert.equal(harness.events.at(-1)?.type, "blur");
+  restoreMatches();
+  harness.unmount();
+});
+
+test("autoFocus forces a ring while focused and factory aliases preserve the contract", () => {
+  for (const factory of [createFocus, createFocusRing] as const) {
+    const host = document.createElement("button");
+    document.body.append(host);
+    const controller = factory({ autoFocus: true });
+    host.addEventListener("focus", controller.focusProps.onFocus!);
+    pointerdown();
+    host.focus();
+    assert.equal(controller.isFocused.value, true);
+    assert.equal(controller.isFocusVisible.value, true);
+    controller.dispose();
+    host.remove();
+  }
+});
+
+test("target mode ignores descendant focus while within mode owns composed descendants", () => {
+  const direct = mountFocus({}, "div");
+  const child = document.createElement("button");
+  direct.host.append(child);
+  child.focus();
+  assert.equal(direct.controller.isFocused.value, false);
+  direct.unmount();
+
+  const within = mountFocus({ mode: "within" }, "div");
+  const first = document.createElement("button");
+  const second = document.createElement("button");
+  const outside = document.createElement("button");
+  within.host.append(first, second);
+  document.body.append(outside);
+  first.focus();
+  assert.equal(within.controller.isFocused.value, true);
+  assert.equal(within.events[0]?.focusedTarget, first);
+  second.focus();
+  assert.equal(within.controller.isFocused.value, true);
+  assert.deepEqual(within.transitions, [true]);
+  outside.focus();
+  assert.equal(within.controller.isFocused.value, false);
+  assert.equal(within.events.at(-1)?.relatedTarget, outside);
+  assert.deepEqual(within.transitions, [true, false]);
+  outside.remove();
+  within.unmount();
+});
+
+test("focus within resolves deep active elements through an open shadow root", () => {
+  const harness = mountFocus({ mode: "within" }, "div");
+  const shadow = harness.host.attachShadow({ mode: "open" });
+  const button = document.createElement("button");
+  shadow.append(button);
+  button.focus();
+  harness.controller.refresh(harness.host);
+  assert.equal(harness.controller.isFocused.value, true);
+  assert.equal(harness.events[0]?.focusedTarget, button);
+  harness.unmount();
+});
+
+test("reactive disablement settles first and refresh explicitly reacquires DOM focus", () => {
+  const disabled = ref(false);
+  const harness = mountFocus({ isDisabled: disabled });
+  harness.host.focus();
+  disabled.value = true;
+  assert.equal(harness.controller.isFocused.value, false);
+  assert.equal(document.activeElement, harness.host);
+  assert.equal(harness.events.at(-1)?.reason, "disabled");
+
+  disabled.value = false;
+  assert.equal(harness.controller.refresh(harness.host), true);
+  assert.equal(harness.controller.isFocused.value, true);
+  assert.equal(harness.events.at(-1)?.reason, "refresh");
+  assert.equal(harness.controller.refresh(harness.host), false);
+  harness.unmount();
+});
+
+test("manual cancellation keeps DOM focus and disposal is terminal without callbacks", () => {
+  const harness = mountFocus();
+  harness.host.focus();
+  assert.equal(harness.controller.cancel(), true);
+  assert.equal(document.activeElement, harness.host);
+  assert.equal(harness.events.at(-1)?.reason, "manual");
+  assert.equal(harness.controller.cancel(), false);
+  const transitionCount = harness.transitions.length;
+  harness.controller.refresh(harness.host);
+  harness.controller.dispose();
+  assert.equal(harness.controller.isFocused.value, false);
+  assert.equal(harness.transitions.length, transitionCount + 1);
+  assert.throws(() => harness.controller.cancel(), /VIZE_UI_FOCUS_DISPOSED/);
+  assert.throws(() => harness.controller.refresh(harness.host), /VIZE_UI_FOCUS_DISPOSED/);
+  harness.host.remove();
+});
+
+test("reentrant changes cannot publish a stale phase callback", () => {
+  const transitions: boolean[] = [];
+  const phases: string[] = [];
+  let controller!: FocusController;
+  const host = document.createElement("button");
+  document.body.append(host);
+  controller = createFocus({
+    onFocusChange(value) {
+      transitions.push(value);
+      if (value) controller.cancel();
+    },
+    onFocus: () => phases.push("focus"),
+    onBlur: () => phases.push("blur"),
+  });
+  host.addEventListener("focus", controller.focusProps.onFocus!);
+  host.focus();
+  assert.deepEqual(transitions, [true, false]);
+  assert.deepEqual(phases, ["blur"]);
+  assert.equal(controller.isFocused.value, false);
+  controller.dispose();
+  host.remove();
+});
+
+test("callback failures preserve settled state and aggregate independent errors", () => {
+  const harness = mountFocus({
+    onFocusChange: () => {
+      throw new Error("change failed");
+    },
+    onFocus: () => {
+      throw new Error("focus failed");
+    },
+  });
+  assert.throws(() => harness.host.focus(), AggregateError);
+  assert.equal(harness.controller.isFocused.value, true);
+  harness.controller.dispose();
+  harness.host.remove();
+});
+
+test("rejects invalid runtime options with stable diagnostics", () => {
+  assert.throws(
+    () => createFocus({ mode: "descendants" as "within" }),
+    /VIZE_UI_FOCUS_OPTION.*mode/,
+  );
+  assert.throws(
+    () => createFocus({ autoFocus: "yes" as never }),
+    /VIZE_UI_FOCUS_OPTION.*autoFocus/,
+  );
+  assert.throws(
+    () => createFocus({ isDisabled: "false" as never }),
+    /VIZE_UI_FOCUS_OPTION.*isDisabled/,
+  );
+  assert.throws(
+    () => createFocus({ onFocus: "callback" as never }),
+    /VIZE_UI_FOCUS_OPTION.*onFocus/,
+  );
+  const controller = createFocus();
+  assert.throws(() => controller.refresh({} as Element), /VIZE_UI_FOCUS_TARGET/);
+  controller.dispose();
+});
+
+test("Vue effect scopes own all focus convenience hooks", () => {
+  for (const hook of [useFocus, useFocusWithin, useFocusRing] as const) {
+    assert.throws(() => hook(), /VIZE_UI_FOCUS_SETUP/);
+    const scope = effectScope();
+    const controller = scope.run(() => hook())!;
+    scope.stop();
+    assert.throws(() => controller.cancel(), /VIZE_UI_FOCUS_DISPOSED/);
+  }
+  assert.equal(createFocusWithin().focusProps.onFocusin instanceof Function, true);
+});

--- a/npm/ui/core/src/focus.ts
+++ b/npm/ui/core/src/focus.ts
@@ -1,0 +1,311 @@
+import { getCurrentScope, isRef, onScopeDispose, shallowReadonly, shallowRef, watch } from "vue";
+
+import {
+  activeElementOf,
+  capture,
+  composedContains,
+  createFocusEvent,
+  eventElement,
+  ownsFocus,
+  readBoolean,
+  surfaceErrors,
+  validateBoolean,
+  validateElement,
+  validateOptions,
+} from "./focus-internal.ts";
+import { createInteractionModalityTracker, isElementFocusVisible } from "./interaction-modality.ts";
+import type {
+  FocusChangeReason,
+  FocusController,
+  FocusEvent,
+  FocusMode,
+  FocusOptions,
+  FocusProps,
+  FocusRingController,
+  FocusRingOptions,
+  FocusWithinOptions,
+} from "./focus-types.ts";
+
+const disposedDiagnostic = "VIZE_UI_FOCUS_DISPOSED";
+const setupDiagnostic = "VIZE_UI_FOCUS_SETUP";
+
+interface ActiveFocus {
+  focusedTarget: Element;
+  readonly host: Element;
+  readonly release: () => void;
+}
+
+function installSettlementObserver(mode: FocusMode, host: Element, settle: () => void): () => void {
+  const document = host.ownerDocument;
+  const onFocusIn = () => {
+    if (!ownsFocus(mode, host, activeElementOf(host))) settle();
+  };
+  document.addEventListener("focusin", onFocusIn, true);
+  const Observer = document.defaultView?.MutationObserver ?? globalThis.MutationObserver;
+  let observer: MutationObserver | null = null;
+  try {
+    observer =
+      typeof Observer === "function"
+        ? new Observer(() => {
+            if (!host.isConnected || !ownsFocus(mode, host, activeElementOf(host))) settle();
+          })
+        : null;
+    observer?.observe(document, { childList: true, subtree: true });
+  } catch (error) {
+    const errors: unknown[] = [error];
+    capture(errors, () => document.removeEventListener("focusin", onFocusIn, true));
+    capture(errors, () => observer?.disconnect());
+    surfaceErrors(errors, "Focus observer setup failed");
+  }
+  return () => {
+    const errors: unknown[] = [];
+    capture(errors, () => document.removeEventListener("focusin", onFocusIn, true));
+    capture(errors, () => observer?.disconnect());
+    surfaceErrors(errors, "Focus observer cleanup failed");
+  };
+}
+
+/** Create an SSR-safe observer for direct or composed-descendant focus. */
+export function createFocus(options: FocusOptions = {}): FocusController {
+  const mode = validateOptions(options);
+  const focused = shallowRef(false);
+  const focusVisible = shallowRef(false);
+  let active: ActiveFocus | null = null;
+  let host: Element | null = null;
+  let disposed = false;
+  let transitionVersion = 0;
+
+  const updateVisibility = (): boolean => {
+    const current = active;
+    const next = Boolean(
+      current &&
+      (options.autoFocus || isElementFocusVisible(current.focusedTarget, modality.modality.value)),
+    );
+    if (focusVisible.value === next) return false;
+    focusVisible.value = next;
+    return true;
+  };
+  const modality = createInteractionModalityTracker({
+    onChange: updateVisibility,
+  });
+
+  const notify = (next: boolean, event: FocusEvent): void => {
+    const errors: unknown[] = [];
+    const version = ++transitionVersion;
+    capture(errors, () => options.onFocusChange?.(next, event));
+    if (transitionVersion === version) {
+      capture(errors, () => (next ? options.onFocus?.(event) : options.onBlur?.(event)));
+    }
+    surfaceErrors(errors, "Focus callbacks failed");
+  };
+
+  const settle = (
+    reason: FocusChangeReason,
+    originalEvent: globalThis.FocusEvent | null,
+    relatedTarget: Element | null,
+    notifyCallbacks = true,
+  ): boolean => {
+    const current = active;
+    if (!current) return false;
+    active = null;
+    focused.value = false;
+    focusVisible.value = false;
+    const event = createFocusEvent(
+      "blur",
+      mode,
+      current.host,
+      current.focusedTarget,
+      relatedTarget,
+      originalEvent,
+      false,
+      reason,
+    );
+    const errors: unknown[] = [];
+    capture(errors, current.release);
+    capture(errors, modality.detach);
+    if (notifyCallbacks) capture(errors, () => notify(false, event));
+    else transitionVersion++;
+    surfaceErrors(errors, "Focus settlement failed");
+    return true;
+  };
+
+  const readDisabled = (event: globalThis.FocusEvent | null): boolean => {
+    try {
+      return readBoolean(options.isDisabled, "isDisabled");
+    } catch (error) {
+      const errors: unknown[] = [error];
+      capture(errors, () => settle("disabled", event, eventElement(event?.relatedTarget ?? null)));
+      surfaceErrors(errors, "Focus option validation failed during teardown");
+      throw error;
+    }
+  };
+
+  const acquire = (
+    nextHost: Element,
+    focusedTarget: Element,
+    reason: FocusChangeReason,
+    originalEvent: globalThis.FocusEvent | null,
+  ): boolean => {
+    if (disposed) return false;
+    if (readDisabled(originalEvent)) {
+      settle("disabled", originalEvent, focusedTarget);
+      return false;
+    }
+    if (active?.host === nextHost) {
+      active.focusedTarget = focusedTarget;
+      return updateVisibility();
+    }
+    if (active) settle(reason, originalEvent, focusedTarget);
+    host = nextHost;
+    modality.attach(nextHost.ownerDocument);
+    let release: () => void;
+    try {
+      release = installSettlementObserver(mode, nextHost, () => {
+        settle("focus", null, activeElementOf(nextHost));
+      });
+    } catch (error) {
+      const errors: unknown[] = [error];
+      capture(errors, modality.detach);
+      surfaceErrors(errors, "Focus setup failed");
+      throw error;
+    }
+    active = { focusedTarget, host: nextHost, release };
+    focused.value = true;
+    updateVisibility();
+    const event = createFocusEvent(
+      "focus",
+      mode,
+      nextHost,
+      focusedTarget,
+      null,
+      originalEvent,
+      focusVisible.value,
+      reason,
+    );
+    notify(true, event);
+    return true;
+  };
+
+  const reconcile = (nextHost: Element, reason: FocusChangeReason): boolean => {
+    host = nextHost;
+    const beforeFocused = focused.value;
+    const beforeVisible = focusVisible.value;
+    if (readDisabled(null)) {
+      settle("disabled", null, activeElementOf(nextHost));
+      return beforeFocused !== focused.value || beforeVisible !== focusVisible.value;
+    }
+    const current = activeElementOf(nextHost);
+    if (ownsFocus(mode, nextHost, current) && current) acquire(nextHost, current, reason, null);
+    else settle(reason, null, current);
+    return beforeFocused !== focused.value || beforeVisible !== focusVisible.value;
+  };
+
+  const enter = (event: globalThis.FocusEvent): void => {
+    const nextHost = eventElement(event.currentTarget);
+    const eventTarget = eventElement(event.target);
+    if (!nextHost || !eventTarget || (mode === "target" && eventTarget !== nextHost)) return;
+    acquire(nextHost, activeElementOf(nextHost) ?? eventTarget, "focus", event);
+  };
+  const leave = (event: globalThis.FocusEvent): void => {
+    const current = active;
+    if (!current || current.host !== eventElement(event.currentTarget)) return;
+    const related = eventElement(event.relatedTarget);
+    if (mode === "within" && composedContains(current.host, related)) {
+      if (related) current.focusedTarget = related;
+      return;
+    }
+    settle("focus", event, related);
+  };
+  const focusProps: Readonly<FocusProps> = Object.freeze(
+    mode === "target" ? { onBlur: leave, onFocus: enter } : { onFocusin: enter, onFocusout: leave },
+  );
+
+  let stopDisabledWatch: () => void = () => undefined;
+  const disabledSource = options.isDisabled;
+  if (isRef(disabledSource) || typeof disabledSource === "function") {
+    stopDisabledWatch = watch(
+      () => (isRef(disabledSource) ? disabledSource.value : disabledSource()),
+      (value) => {
+        try {
+          if (validateBoolean(value, "isDisabled")) {
+            settle("disabled", null, host ? activeElementOf(host) : null);
+          }
+        } catch (error) {
+          const errors: unknown[] = [error];
+          capture(errors, () => settle("disabled", null, host ? activeElementOf(host) : null));
+          surfaceErrors(errors, "Focus option validation failed during teardown");
+        }
+      },
+      { flush: "sync" },
+    );
+  }
+
+  return Object.freeze({
+    isFocused: shallowReadonly(focused),
+    isFocusVisible: shallowReadonly(focusVisible),
+    focusProps,
+    refresh: (target: Element) => {
+      if (disposed) throw new Error(`${disposedDiagnostic}: the controller has been disposed`);
+      return reconcile(validateElement(target), "refresh");
+    },
+    cancel: () => {
+      if (disposed) throw new Error(`${disposedDiagnostic}: the controller has been disposed`);
+      return settle("manual", null, host ? activeElementOf(host) : null);
+    },
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      stopDisabledWatch();
+      const errors: unknown[] = [];
+      capture(errors, () => settle("manual", null, null, false));
+      capture(errors, modality.dispose);
+      surfaceErrors(errors, "Focus disposal failed");
+    },
+  });
+}
+
+/** Observe composed-descendant focus ownership. */
+export function createFocusWithin(options: FocusWithinOptions = {}): FocusController {
+  return createFocus({ ...options, mode: "within" });
+}
+
+/** Create direct focus and focus-visible state for a visible ring. */
+export function createFocusRing(options: FocusRingOptions = {}): FocusRingController {
+  return createFocus(options);
+}
+
+function useScopedFocus(options: FocusOptions): FocusController {
+  if (!getCurrentScope()) {
+    throw new Error(`${setupDiagnostic}: use inside component setup or an active effect scope`);
+  }
+  const controller = createFocus(options);
+  onScopeDispose(controller.dispose);
+  return controller;
+}
+
+/** Create a direct focus observer disposed with the current Vue effect scope. */
+export function useFocus(options: FocusOptions = {}): FocusController {
+  return useScopedFocus(options);
+}
+
+/** Create a focus-within observer disposed with the current Vue effect scope. */
+export function useFocusWithin(options: FocusWithinOptions = {}): FocusController {
+  return useScopedFocus({ ...options, mode: "within" });
+}
+
+/** Create focus-ring state disposed with the current Vue effect scope. */
+export function useFocusRing(options: FocusRingOptions = {}): FocusRingController {
+  return useScopedFocus(options);
+}
+
+export type {
+  FocusChangeReason,
+  FocusController,
+  FocusEvent,
+  FocusMode,
+  FocusOptions,
+  FocusProps,
+  FocusRingController,
+  FocusRingOptions,
+  FocusWithinOptions,
+} from "./focus-types.ts";

--- a/npm/ui/core/src/focus.types.test-d.ts
+++ b/npm/ui/core/src/focus.types.test-d.ts
@@ -1,0 +1,49 @@
+/** Compile-only assertions for the public focus contracts. */
+
+import { ref } from "vue";
+import type { HTMLAttributes, ShallowRef } from "vue";
+
+import {
+  createFocus,
+  createFocusRing,
+  createFocusWithin,
+  type FocusEvent,
+  type FocusMode,
+  type FocusProps,
+} from "./focus.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+export const modes: readonly FocusMode[] = ["target", "within"];
+// @ts-expect-error focus ownership has no sibling-only mode.
+export const invalidMode: FocusMode = "siblings";
+
+const disabled = ref(false);
+export const controller = createFocus({
+  isDisabled: disabled,
+  onFocus(event: FocusEvent) {
+    const target: Element = event.target;
+    const original: globalThis.FocusEvent | null = event.originalEvent;
+    void [target, original];
+  },
+});
+export const within = createFocusWithin({ isDisabled: () => false });
+export const ring = createFocusRing({ autoFocus: true });
+
+type _FocusedIsReadonly = Expect<Equal<typeof controller.isFocused, Readonly<ShallowRef<boolean>>>>;
+type _VisibleIsReadonly = Expect<
+  Equal<typeof controller.isFocusVisible, Readonly<ShallowRef<boolean>>>
+>;
+type _PropsAreExact = Expect<Equal<typeof controller.focusProps, Readonly<FocusProps>>>;
+
+export const vueAttributes: HTMLAttributes = controller.focusProps;
+// @ts-expect-error consumers cannot mutate readonly reactive state.
+controller.isFocused.value = true;
+// @ts-expect-error disabled must resolve to boolean.
+createFocus({ isDisabled: "false" });
+// @ts-expect-error direct callbacks receive immutable library snapshots.
+createFocus({ onFocus: (event: globalThis.FocusEvent) => event.preventDefault() });

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -5,6 +5,7 @@ export * from "./controllable-state.ts";
 export * from "./button.ts";
 export * from "./id.ts";
 export * from "./interaction-modality.ts";
+export * from "./focus.ts";
 export * from "./hover.ts";
 export * from "./long-press.ts";
 export * from "./move.ts";

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       "controllable-state": "src/controllable-state.ts",
       id: "src/id.ts",
       "interaction-modality": "src/interaction-modality.ts",
+      focus: "src/focus.ts",
       hover: "src/hover.ts",
       "long-press": "src/long-press.ts",
       move: "src/move.ts",


### PR DESCRIPTION
## Summary

- add type-safe `createFocus`, `createFocusWithin`, and `createFocusRing` foundations with Vue composable aliases
- track keyboard modality before focus, honor native `:focus-visible`, and remain correct across documents and shadow roots
- harden reactive disablement, DOM removal, cleanup, observer/listener failures, reentrancy, and SSR hydration
- expose unstyled prop getters only; no runtime CSS is introduced

## Verification

- `pnpm --filter @vizejs/ui check`
- `pnpm --filter @vizejs/ui test` — 186 tests in 33 files
- root bundle: 26,156 / 26,225 gzip bytes
- focus entry: 5,802 / 5,850 gzip bytes
- root and subpath focus consumers: 3,250 / 3,300 gzip bytes, 0 CSS bytes
- Actions renderer conformance compiles the focus fixture across DOM, SSR, and Vapor lanes

Part of #3134


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added focus management APIs for tracking direct focus, focus-within, and focus-visible focus-ring states.
  * Supports reactive state, callbacks, disabled handling, refresh, cancellation, and cleanup.
  * Added SSR-safe behavior and support for shadow DOM descendants.
  * Exposed the new focus functionality through the public UI package.

* **Documentation**
  * Added focus behavior guidance, including accessibility responsibilities and supported scenarios.

* **Tests**
  * Added coverage for lifecycle behavior, hydration, accessibility-related focus states, validation, cleanup, and renderer compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->