### PR TITLE
feat(ui): add typeahead interactions

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -94,6 +94,11 @@
       "import": "./dist/press.mjs",
       "default": "./dist/press.mjs"
     },
+    "./typeahead": {
+      "types": "./dist/typeahead.d.mts",
+      "import": "./dist/typeahead.mjs",
+      "default": "./dist/typeahead.mjs"
+    },
     "./primitive": {
       "types": "./dist/primitive.d.mts",
       "import": "./dist/primitive.mjs",

--- a/npm/ui/core/scripts/check-renderers.ts
+++ b/npm/ui/core/scripts/check-renderers.ts
@@ -19,6 +19,29 @@ const rendererLanes: readonly RendererLane[] = [
 
 const inlineFixtures = [
   {
+    filename: "TypeaheadConsumer.vue",
+    source: String.raw`<script setup lang="ts">
+import { createCollectionRegistry } from "./collection.ts";
+import { useTypeahead } from "./typeahead.ts";
+
+const registry = createCollectionRegistry<string, string>();
+registry.register({ key: "alpha", value: "Alpha", textValue: "Alpha" });
+const typeahead = useTypeahead({ registry });
+</script>
+
+<template>
+  <div
+    v-bind="typeahead.typeaheadProps"
+    :data-active="registry.activeKey.value || undefined"
+    :data-query="typeahead.query.value || undefined"
+    tabindex="0"
+  >
+    Typeahead target
+  </div>
+</template>
+`,
+  },
+  {
     filename: "FocusConsumer.vue",
     source: String.raw`<script setup lang="ts">
 import { useFocusRing } from "./focus.ts";

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 26_225],
+  ["index.mjs", 27_575],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
   ["collection.mjs", 5_700],
@@ -18,6 +18,7 @@ const budgets = new Map([
   ["long-press.mjs", 8_175],
   ["move.mjs", 5_050],
   ["press.mjs", 5_950],
+  ["typeahead.mjs", 2_000],
   ["primitive.mjs", 800],
   ["visually-hidden.mjs", 800],
   ["media.mjs", 2_400],

--- a/npm/ui/core/scripts/check-tree-shaking.mjs
+++ b/npm/ui/core/scripts/check-tree-shaking.mjs
@@ -78,6 +78,7 @@ const familySignatures = Object.freeze({
   "long-press": /VIZE_UI_LONG_PRESS_DISPOSED/,
   move: /VIZE_UI_MOVE_DISPOSED/,
   press: /VIZE_UI_PRESS_DISPOSED/,
+  typeahead: /VIZE_UI_TYPEAHEAD_DISPOSED/,
   primitive: /data-vize-ui.+primitive/,
   "visually-hidden": /visually-hidden/,
 });
@@ -146,6 +147,12 @@ const componentCases = [
     family: "press",
     exportName: "createPress",
     maximumJavaScriptGzipBytes: 3_550,
+    maximumCssGzipBytes: 0,
+  },
+  {
+    family: "typeahead",
+    exportName: "createTypeahead",
+    maximumJavaScriptGzipBytes: 1_375,
     maximumCssGzipBytes: 0,
   },
   {

--- a/npm/ui/core/src/distribution.test.ts
+++ b/npm/ui/core/src/distribution.test.ts
@@ -18,6 +18,7 @@ const publicEntries = [
   "./long-press",
   "./move",
   "./press",
+  "./typeahead",
   "./primitive",
   "./visually-hidden",
 ] as const;

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -10,5 +10,6 @@ export * from "./hover.ts";
 export * from "./long-press.ts";
 export * from "./move.ts";
 export * from "./press.ts";
+export * from "./typeahead.ts";
 export * from "./primitive.ts";
 export * from "./visually-hidden.ts";

--- a/npm/ui/core/src/typeahead-internal.ts
+++ b/npm/ui/core/src/typeahead-internal.ts
@@ -1,0 +1,75 @@
+import { toValue } from "vue";
+
+import type { TypeaheadOptions } from "./typeahead-types.ts";
+import type { CollectionKey } from "./collection.ts";
+
+const optionDiagnostic = "VIZE_UI_TYPEAHEAD_OPTION";
+const inputDiagnostic = "VIZE_UI_TYPEAHEAD_INPUT";
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+export function splitGraphemes(value: string): string[] {
+  return [...graphemeSegmenter.segment(value)].map(({ segment }) => segment);
+}
+
+export function readBoolean(
+  source: TypeaheadOptions<CollectionKey, unknown>["isDisabled"],
+  name: string,
+): boolean {
+  const value = toValue(source);
+  if (value === undefined) return false;
+  if (typeof value !== "boolean") {
+    throw new TypeError(`${optionDiagnostic}: ${name} must resolve to a boolean`);
+  }
+  return value;
+}
+
+export function readTimeout(source: TypeaheadOptions<CollectionKey, unknown>["timeout"]): number {
+  const value = toValue(source) ?? 500;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new TypeError(`${optionDiagnostic}: timeout must resolve to a finite number >= 0`);
+  }
+  return value;
+}
+
+export function readGrapheme(value: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new TypeError(`${inputDiagnostic}: input must be exactly one Unicode grapheme`);
+  }
+  const segments = splitGraphemes(value);
+  if (segments.length !== 1 || segments[0] !== value) {
+    throw new TypeError(`${inputDiagnostic}: input must be exactly one Unicode grapheme`);
+  }
+  return value;
+}
+
+export function isCharacterKey(event: KeyboardEvent): boolean {
+  if (event.isComposing || event.key === "Dead" || event.key === "Process") return false;
+  const altGraph = event.getModifierState?.("AltGraph") === true;
+  if (event.metaKey || (event.ctrlKey && !altGraph) || (event.altKey && !altGraph)) return false;
+  try {
+    readGrapheme(event.key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function validateOptions<Key extends CollectionKey, Value>(
+  options: TypeaheadOptions<Key, Value>,
+): void {
+  const registry = options.registry as Partial<typeof options.registry> | null;
+  if (!registry || typeof registry.moveActiveByTextValue !== "function" || !registry.activeKey) {
+    throw new TypeError(`${optionDiagnostic}: registry must be a CollectionRegistry`);
+  }
+  if (options.allowSpace !== undefined && typeof options.allowSpace !== "boolean") {
+    throw new TypeError(`${optionDiagnostic}: allowSpace must be a boolean`);
+  }
+  if (options.onMatch !== undefined && typeof options.onMatch !== "function") {
+    throw new TypeError(`${optionDiagnostic}: onMatch must be a function`);
+  }
+  if (options.collator !== undefined && typeof options.collator.compare !== "function") {
+    throw new TypeError(`${optionDiagnostic}: collator must be an Intl.Collator`);
+  }
+  readTimeout(options.timeout);
+  readBoolean(options.isDisabled, "isDisabled");
+}

--- a/npm/ui/core/src/typeahead-ssr.test.ts
+++ b/npm/ui/core/src/typeahead-ssr.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { createSSRApp, defineComponent, h, nextTick } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import { createCollectionRegistry } from "./collection.ts";
+import { useTypeahead } from "./typeahead.ts";
+
+const SsrProbe = defineComponent({
+  name: "TypeaheadSsrProbe",
+  setup() {
+    const registry = createCollectionRegistry<string, string>();
+    registry.register({ key: "alpha", value: "Alpha", textValue: "Alpha" });
+    registry.register({ key: "bravo", value: "Bravo", textValue: "Bravo" });
+    const typeahead = useTypeahead({ registry });
+    return () =>
+      h(
+        "div",
+        {
+          ...typeahead.typeaheadProps,
+          "data-active": registry.activeKey.value ?? "none",
+          "data-query": typeahead.query.value,
+          tabindex: 0,
+        },
+        "Typeahead target",
+      );
+  },
+});
+
+test("renders byte-identical typeahead markup without timers or handlers", async () => {
+  const outputs = await Promise.all([
+    renderToString(createSSRApp(SsrProbe)),
+    renderToString(createSSRApp(SsrProbe)),
+  ]);
+  assert.equal(outputs[0], outputs[1]);
+  assert.equal(
+    outputs[0],
+    '<div data-active="none" data-query tabindex="0">Typeahead target</div>',
+  );
+  assert.doesNotMatch(outputs[0], /keydown|function/);
+});
+
+test("hydrates buffered matching without replacing the server host", async () => {
+  const serverHtml = await renderToString(createSSRApp(SsrProbe));
+  const host = document.createElement("div");
+  host.innerHTML = serverHtml;
+  document.body.append(host);
+  const serverTarget = host.firstElementChild;
+  const diagnostics: string[] = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  console.error = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  const app = createSSRApp(SsrProbe);
+
+  try {
+    app.mount(host);
+    assert.equal(host.firstElementChild, serverTarget);
+    const target = host.firstElementChild as HTMLElement;
+    target.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "b" }));
+    await nextTick();
+    assert.equal(target.dataset.query, "b");
+    assert.equal(target.dataset.active, "bravo");
+    assert.deepEqual(diagnostics, []);
+  } finally {
+    app.unmount();
+    host.remove();
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+});

--- a/npm/ui/core/src/typeahead-types.ts
+++ b/npm/ui/core/src/typeahead-types.ts
@@ -1,0 +1,78 @@
+import type { MaybeRefOrGetter, ShallowRef } from "vue";
+
+import type { CollectionKey, CollectionRegistry } from "./collection.ts";
+
+/** Immutable snapshot emitted when buffered text matches a collection item. */
+export interface TypeaheadMatch<Key extends CollectionKey> {
+  /** Item selected by the locale-aware collection search. */
+  readonly key: Key;
+
+  /** Active item before the match. */
+  readonly previousKey: Key | null;
+
+  /** Normalized buffered query used for this search. */
+  readonly query: string;
+
+  /** Native key event responsible for the match, or `null` for manual input. */
+  readonly originalEvent: KeyboardEvent | null;
+}
+
+/** Options for {@link createTypeahead}. */
+export interface TypeaheadOptions<Key extends CollectionKey, Value> {
+  /** Mutation-aware collection that owns active state and locale matching. */
+  readonly registry: CollectionRegistry<Key, Value>;
+
+  /**
+   * Idle time before a new grapheme starts a fresh query.
+   *
+   * @default 500
+   */
+  readonly timeout?: MaybeRefOrGetter<number | undefined>;
+
+  /**
+   * Ignore input and synchronously clear a pending query while true.
+   *
+   * @default false
+   */
+  readonly isDisabled?: MaybeRefOrGetter<boolean | undefined>;
+
+  /**
+   * Treat Space as the first grapheme of a query. A space is always accepted
+   * after another character so multi-word labels remain searchable.
+   *
+   * @default false
+   */
+  readonly allowSpace?: boolean;
+
+  /** Comparator used to detect repeated graphemes before cycling matches. */
+  readonly collator?: Intl.Collator;
+
+  /** Called after active collection state moves to a text match. */
+  readonly onMatch?: (match: TypeaheadMatch<Key>) => void;
+}
+
+/** Stable keyboard handler to merge onto a composite focus owner. */
+export interface TypeaheadProps {
+  readonly onKeydown: (event: KeyboardEvent) => void;
+}
+
+/** Buffered, locale-aware collection typeahead controller. */
+export interface TypeaheadController<Key extends CollectionKey> {
+  /** Current query, cleared after the configured timeout. */
+  readonly query: Readonly<ShallowRef<string>>;
+
+  /** Stable keyboard handler for declarative consumers. */
+  readonly typeaheadProps: Readonly<TypeaheadProps>;
+
+  /**
+   * Consume exactly one Unicode grapheme and return the matching item.
+   * Repeating one grapheme cycles through matching items.
+   */
+  readonly input: (grapheme: string, originalEvent?: KeyboardEvent | null) => Key | null;
+
+  /** Clear buffered input and report whether any text was pending. */
+  readonly reset: () => boolean;
+
+  /** Clear timers and make imperative operations terminal. Safe to repeat. */
+  readonly dispose: () => void;
+}

--- a/npm/ui/core/src/typeahead.behavior.md
+++ b/npm/ui/core/src/typeahead.behavior.md
@@ -1,0 +1,38 @@
+# Typeahead behavior contract
+
+Normative state × input → outcome table for `@vizejs/ui/typeahead`. Every row is
+exercised by `src/typeahead*.test.ts`; compile-only assertions live in
+`src/typeahead.types.test-d.ts`.
+
+| #   | State                     | Input                                             | Outcome                                                               | Proven by                |
+| --- | ------------------------- | ------------------------------------------------- | --------------------------------------------------------------------- | ------------------------ |
+| T1  | empty buffer              | one printable grapheme                            | locale-aware prefix match becomes active and immutable snapshot emits | prefix test              |
+| T2  | one-grapheme buffer       | same grapheme with case/diacritic variation       | query stays atomic and matching items cycle                           | repeated-input test      |
+| T3  | mixed buffer              | another grapheme                                  | query extends and narrows the prefix match                            | mixed-input test         |
+| T4  | pending buffer            | timeout elapses                                   | query and timer ownership clear                                       | timeout test             |
+| T5  | pending buffer            | reactive timeout changes                          | existing timer is rescheduled from the change                         | timeout test             |
+| T6  | keyboard host             | IME, Dead/Process, command shortcut, or named key | event is preserved for its native or owning-component behavior        | keyboard-filter test     |
+| T7  | keyboard host             | AltGraph/international printable input            | grapheme is consumed without treating it as a command shortcut        | international-input test |
+| T8  | empty buffer              | Space with default options                        | activation key is preserved                                           | keyboard-filter test     |
+| T9  | nonempty buffer           | Space                                             | multi-word query extends                                              | multi-word test          |
+| T10 | empty buffer, opted in    | Space                                             | leading-space query is accepted                                       | allow-space test         |
+| T11 | Unicode input             | emoji ZWJ grapheme                                | complete grapheme remains one atomic query                            | Unicode test             |
+| T12 | manual input              | zero or multiple graphemes                        | stable runtime diagnostic rejects ambiguous input                     | Unicode test             |
+| T13 | pending buffer            | reactive disabled becomes true                    | query/timer clear synchronously and later input is ignored            | disabled test            |
+| T14 | pending buffer            | reactive source becomes invalid                   | ownership clears before the option diagnostic surfaces                | invalid-reactive test    |
+| T15 | match callback throws     | active state already moved                        | collection/query remain committed and original failure surfaces       | callback-failure test    |
+| T16 | registry is disposed      | input attempts collection mutation                | buffer clears and collection diagnostic is preserved                  | registry-failure test    |
+| T17 | active                    | reset, dispose, or Vue scope stop                 | timers release and imperative calls become terminal                   | lifecycle test           |
+| T18 | concurrent SSR requests   | identical collections                             | byte-identical markup contains no handlers or scheduled timers        | SSR test                 |
+| T19 | SSR followed by hydration | printable key                                     | host identity remains and active/query state renders without warning  | hydration test           |
+| T20 | DOM, SSR, and Vapor lanes | authored consumer compiles                        | every renderer accepts the same keyboard props and reactive query     | renderer gate            |
+| T21 | root and subpath consumer | only typeahead is retained                        | equal CSS-free bundles exclude unrelated component families           | tree-shaking gate        |
+| T22 | public TypeScript API     | mutation or invalid sources                       | compile-only assertions reject misuse                                 | type declaration test    |
+
+## Accessibility obligation
+
+Typeahead supplements a complete composite keyboard interface; it never
+replaces arrow navigation, semantic roles, selection, or a visible focus
+indicator. The controller updates logical active state only. A roving-focus or
+`aria-activedescendant` adapter must expose that state to the DOM, and consumers
+must keep item `textValue` aligned with the name users perceive.

--- a/npm/ui/core/src/typeahead.test.ts
+++ b/npm/ui/core/src/typeahead.test.ts
@@ -1,0 +1,251 @@
+import assert from "node:assert/strict";
+
+import { effectScope, ref } from "vue";
+import { test } from "vite-plus/test";
+
+import { createCollectionRegistry } from "./collection.ts";
+import { createTypeahead, useTypeahead } from "./typeahead.ts";
+import type { TypeaheadMatch } from "./typeahead.ts";
+
+interface ItemValue {
+  readonly label: string;
+}
+
+function createRegistry() {
+  const registry = createCollectionRegistry<string, ItemValue>();
+  for (const label of ["Alpha", "Beta", "Bravo", "New York", "👩‍💻 Developer"]) {
+    registry.register({ key: label.toLowerCase(), value: { label }, textValue: label });
+  }
+  return registry;
+}
+
+function keyboard(key: string, init: KeyboardEventInit = {}): KeyboardEvent {
+  return new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key, ...init });
+}
+
+async function delay(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+test("buffers locale-aware prefixes and publishes immutable match snapshots", () => {
+  const registry = createRegistry();
+  const matches: TypeaheadMatch<string>[] = [];
+  const controller = createTypeahead({ registry, onMatch: (match) => matches.push(match) });
+  registry.setActiveKey("beta");
+
+  assert.equal(controller.input("b"), "bravo");
+  assert.equal(controller.query.value, "b");
+  assert.equal(matches[0]?.previousKey, "beta");
+  assert.equal(matches[0]?.key, "bravo");
+  assert.equal(matches[0]?.query, "b");
+  assert.equal(matches[0]?.originalEvent, null);
+  assert.ok(Object.isFrozen(matches[0]));
+
+  controller.dispose();
+  registry.dispose();
+});
+
+test("repeating one grapheme cycles matches while mixed input extends the query", () => {
+  const registry = createRegistry();
+  const controller = createTypeahead({ registry });
+  registry.setActiveKey("beta");
+  assert.equal(controller.input("b"), "bravo");
+  assert.equal(controller.input("B"), "beta");
+  assert.equal(controller.query.value, "B");
+
+  controller.reset();
+  assert.equal(controller.input("a"), "alpha");
+  assert.equal(controller.input("l"), "alpha");
+  assert.equal(controller.query.value, "al");
+  controller.dispose();
+  registry.dispose();
+});
+
+test("timeout starts a fresh query and reacts while a buffer is pending", async () => {
+  const registry = createRegistry();
+  const timeout = ref(100);
+  const controller = createTypeahead({ registry, timeout });
+  controller.input("a");
+  timeout.value = 1;
+  await delay(5);
+  assert.equal(controller.query.value, "");
+
+  controller.input("b");
+  await delay(5);
+  assert.equal(controller.query.value, "");
+  controller.dispose();
+  registry.dispose();
+});
+
+test("keyboard props consume graphemes but preserve activation Space and shortcuts", () => {
+  const registry = createRegistry();
+  const controller = createTypeahead({ registry });
+  const composing = keyboard("a");
+  Object.defineProperty(composing, "isComposing", { value: true });
+  for (const event of [
+    keyboard(" "),
+    keyboard("Enter"),
+    keyboard("Dead"),
+    composing,
+    keyboard("a", { metaKey: true }),
+    keyboard("a", { ctrlKey: true }),
+  ]) {
+    controller.typeaheadProps.onKeydown(event);
+    assert.equal(
+      event.defaultPrevented,
+      false,
+      `unexpectedly consumed ${JSON.stringify({
+        key: event.key,
+        isComposing: event.isComposing,
+        altKey: event.altKey,
+        ctrlKey: event.ctrlKey,
+        metaKey: event.metaKey,
+        altGraph: event.getModifierState("AltGraph"),
+      })}`,
+    );
+  }
+
+  const international = keyboard("å", { altKey: true });
+  controller.typeaheadProps.onKeydown(international);
+  assert.equal(international.defaultPrevented, true);
+  controller.reset();
+
+  const first = keyboard("n");
+  controller.typeaheadProps.onKeydown(first);
+  assert.equal(first.defaultPrevented, true);
+  const space = keyboard(" ");
+  controller.typeaheadProps.onKeydown(space);
+  assert.equal(space.defaultPrevented, true);
+  assert.equal(controller.query.value, "n ");
+  assert.equal(registry.activeKey.value, "new york");
+  controller.dispose();
+  registry.dispose();
+});
+
+test("allowSpace explicitly permits leading-space searches", () => {
+  const registry = createRegistry();
+  const controller = createTypeahead({ allowSpace: true, registry });
+  const event = keyboard(" ");
+  controller.typeaheadProps.onKeydown(event);
+  assert.equal(event.defaultPrevented, true);
+  assert.equal(controller.query.value, " ");
+  controller.dispose();
+  registry.dispose();
+});
+
+test("Unicode grapheme clusters remain atomic and multi-grapheme input is rejected", () => {
+  const registry = createRegistry();
+  const controller = createTypeahead({ registry });
+  assert.equal(controller.input("👩‍💻"), "👩‍💻 developer");
+  assert.equal(controller.query.value, "👩‍💻");
+  assert.throws(() => controller.input("ab"), /VIZE_UI_TYPEAHEAD_INPUT/);
+  assert.throws(() => controller.input(""), /VIZE_UI_TYPEAHEAD_INPUT/);
+  controller.dispose();
+  registry.dispose();
+});
+
+test("reactive disablement clears pending input and blocks new matches", () => {
+  const registry = createRegistry();
+  const disabled = ref(false);
+  const controller = createTypeahead({ isDisabled: disabled, registry });
+  controller.input("a");
+  disabled.value = true;
+  assert.equal(controller.query.value, "");
+  assert.equal(controller.input("b"), null);
+  assert.equal(registry.activeKey.value, "alpha");
+  controller.dispose();
+  registry.dispose();
+});
+
+test("invalid reactive sources clear pending ownership before diagnostics surface", () => {
+  const registry = createRegistry();
+  const disabled = ref<boolean | string>(false);
+  const timeout = ref<number | string>(100);
+  const controller = createTypeahead({
+    isDisabled: disabled as never,
+    registry,
+    timeout: timeout as never,
+  });
+  controller.input("a");
+  assert.throws(() => {
+    disabled.value = "invalid";
+  }, /VIZE_UI_TYPEAHEAD_OPTION.*isDisabled/);
+  assert.equal(controller.query.value, "");
+
+  disabled.value = false;
+  controller.input("b");
+  assert.throws(() => {
+    timeout.value = "invalid";
+  }, /VIZE_UI_TYPEAHEAD_OPTION.*timeout/);
+  assert.equal(controller.query.value, "");
+  controller.dispose();
+  registry.dispose();
+});
+
+test("match callback failures leave collection and buffer state committed", () => {
+  const registry = createRegistry();
+  const controller = createTypeahead({
+    registry,
+    onMatch: () => {
+      throw new Error("match failed");
+    },
+  });
+  assert.throws(() => controller.input("a"), /match failed/);
+  assert.equal(registry.activeKey.value, "alpha");
+  assert.equal(controller.query.value, "a");
+  controller.dispose();
+  registry.dispose();
+});
+
+test("registry failures release the buffer and retain the original diagnostic", () => {
+  const registry = createRegistry();
+  const controller = createTypeahead({ registry });
+  registry.dispose();
+  assert.throws(() => controller.input("a"), /VIZE_UI_COLLECTION_DISPOSED/);
+  assert.equal(controller.query.value, "");
+  controller.dispose();
+});
+
+test("manual reset, disposal, and Vue scope ownership are terminal and leak-free", () => {
+  const registry = createRegistry();
+  const controller = createTypeahead({ registry });
+  controller.input("a");
+  assert.equal(controller.reset(), true);
+  assert.equal(controller.reset(), false);
+  controller.dispose();
+  controller.dispose();
+  assert.throws(() => controller.input("a"), /VIZE_UI_TYPEAHEAD_DISPOSED/);
+  assert.throws(() => controller.reset(), /VIZE_UI_TYPEAHEAD_DISPOSED/);
+
+  assert.throws(() => useTypeahead({ registry }), /VIZE_UI_TYPEAHEAD_SETUP/);
+  const scope = effectScope();
+  const scoped = scope.run(() => useTypeahead({ registry }))!;
+  scope.stop();
+  assert.throws(() => scoped.input("a"), /VIZE_UI_TYPEAHEAD_DISPOSED/);
+  registry.dispose();
+});
+
+test("rejects malformed runtime options with stable diagnostics", () => {
+  const registry = createRegistry();
+  assert.throws(
+    () => createTypeahead({ registry: {} as never }),
+    /VIZE_UI_TYPEAHEAD_OPTION.*registry/,
+  );
+  assert.throws(
+    () => createTypeahead({ registry, timeout: -1 }),
+    /VIZE_UI_TYPEAHEAD_OPTION.*timeout/,
+  );
+  assert.throws(
+    () => createTypeahead({ allowSpace: "yes" as never, registry }),
+    /VIZE_UI_TYPEAHEAD_OPTION.*allowSpace/,
+  );
+  assert.throws(
+    () => createTypeahead({ onMatch: "callback" as never, registry }),
+    /VIZE_UI_TYPEAHEAD_OPTION.*onMatch/,
+  );
+  assert.throws(
+    () => createTypeahead({ collator: {} as Intl.Collator, registry }),
+    /VIZE_UI_TYPEAHEAD_OPTION.*collator/,
+  );
+  registry.dispose();
+});

--- a/npm/ui/core/src/typeahead.ts
+++ b/npm/ui/core/src/typeahead.ts
@@ -1,0 +1,183 @@
+import { getCurrentScope, isRef, onScopeDispose, shallowReadonly, shallowRef, watch } from "vue";
+
+import {
+  isCharacterKey,
+  readBoolean,
+  readGrapheme,
+  readTimeout,
+  splitGraphemes,
+  validateOptions,
+} from "./typeahead-internal.ts";
+import type {
+  TypeaheadController,
+  TypeaheadMatch,
+  TypeaheadOptions,
+  TypeaheadProps,
+} from "./typeahead-types.ts";
+import type { CollectionKey } from "./collection.ts";
+
+const disposedDiagnostic = "VIZE_UI_TYPEAHEAD_DISPOSED";
+const setupDiagnostic = "VIZE_UI_TYPEAHEAD_SETUP";
+
+/** Create an SSR-safe, locale-aware typeahead buffer for one collection. */
+export function createTypeahead<Key extends CollectionKey, Value>(
+  options: TypeaheadOptions<Key, Value>,
+): TypeaheadController<Key> {
+  validateOptions(options);
+  const query = shallowRef("");
+  const collator =
+    options.collator ?? new Intl.Collator(undefined, { sensitivity: "base", usage: "search" });
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let disposed = false;
+
+  const clearTimer = () => {
+    if (timer !== null) clearTimeout(timer);
+    timer = null;
+  };
+  const reset = (): boolean => {
+    clearTimer();
+    if (query.value.length === 0) return false;
+    query.value = "";
+    return true;
+  };
+  const assertActive = () => {
+    if (disposed) throw new Error(`${disposedDiagnostic}: the controller has been disposed`);
+  };
+  const scheduleReset = (timeout: number) => {
+    clearTimer();
+    timer = setTimeout(() => {
+      query.value = "";
+      timer = null;
+    }, timeout);
+  };
+  const input = (value: string, originalEvent: KeyboardEvent | null = null): Key | null => {
+    assertActive();
+    const grapheme = readGrapheme(value);
+    let timeout: number;
+    try {
+      if (readBoolean(options.isDisabled, "isDisabled")) {
+        reset();
+        return null;
+      }
+      timeout = readTimeout(options.timeout);
+    } catch (error) {
+      reset();
+      throw error;
+    }
+    const previousGraphemes = splitGraphemes(query.value);
+    const isRepeated =
+      previousGraphemes.length > 0 &&
+      previousGraphemes.every((part) => collator.compare(part, grapheme) === 0);
+    const nextQuery = isRepeated ? grapheme : `${query.value}${grapheme}`;
+    query.value = nextQuery;
+    scheduleReset(timeout);
+
+    const previousKey = options.registry.activeKey.value;
+    let key: Key | null;
+    try {
+      key = options.registry.moveActiveByTextValue(nextQuery, { collator });
+    } catch (error) {
+      reset();
+      throw error;
+    }
+    if (key !== null && key !== previousKey) {
+      const match: TypeaheadMatch<Key> = Object.freeze({
+        key,
+        previousKey,
+        query: nextQuery,
+        originalEvent,
+      });
+      options.onMatch?.(match);
+    }
+    return key;
+  };
+
+  const typeaheadProps: Readonly<TypeaheadProps> = Object.freeze({
+    onKeydown(event: KeyboardEvent) {
+      if (!isCharacterKey(event)) return;
+      if (event.key === " " && query.value.length === 0 && options.allowSpace !== true) return;
+      event.preventDefault();
+      input(event.key, event);
+    },
+  });
+
+  const stopWatches: Array<() => void> = [];
+  const disabledSource = options.isDisabled;
+  if (isRef(disabledSource) || typeof disabledSource === "function") {
+    stopWatches.push(
+      watch(
+        () => {
+          try {
+            return isRef(disabledSource) ? disabledSource.value : disabledSource();
+          } catch (error) {
+            reset();
+            throw error;
+          }
+        },
+        () => {
+          try {
+            if (readBoolean(options.isDisabled, "isDisabled")) reset();
+          } catch (error) {
+            reset();
+            throw error;
+          }
+        },
+        { flush: "sync" },
+      ),
+    );
+  }
+  const timeoutSource = options.timeout;
+  if (isRef(timeoutSource) || typeof timeoutSource === "function") {
+    stopWatches.push(
+      watch(
+        () => {
+          try {
+            return readTimeout(timeoutSource);
+          } catch (error) {
+            reset();
+            throw error;
+          }
+        },
+        (timeout) => {
+          if (query.value.length > 0) scheduleReset(timeout);
+        },
+        { flush: "sync" },
+      ),
+    );
+  }
+
+  return Object.freeze({
+    query: shallowReadonly(query),
+    typeaheadProps,
+    input,
+    reset: () => {
+      assertActive();
+      return reset();
+    },
+    dispose: () => {
+      if (disposed) return;
+      disposed = true;
+      for (const stop of stopWatches) stop();
+      reset();
+    },
+  });
+}
+
+/** Create a typeahead controller disposed with the current Vue effect scope. */
+export function useTypeahead<Key extends CollectionKey, Value>(
+  options: TypeaheadOptions<Key, Value>,
+): TypeaheadController<Key> {
+  if (!getCurrentScope()) {
+    throw new Error(`${setupDiagnostic}: use inside component setup or an active effect scope`);
+  }
+  const controller = createTypeahead(options);
+  onScopeDispose(controller.dispose);
+  return controller;
+}
+
+export type {
+  TypeaheadController,
+  TypeaheadMatch,
+  TypeaheadOptions,
+  TypeaheadProps,
+} from "./typeahead-types.ts";

--- a/npm/ui/core/src/typeahead.types.test-d.ts
+++ b/npm/ui/core/src/typeahead.types.test-d.ts
@@ -1,0 +1,39 @@
+/** Compile-only assertions for the public typeahead contract. */
+
+import { ref } from "vue";
+import type { HTMLAttributes, ShallowRef } from "vue";
+
+import { createCollectionRegistry } from "./collection.ts";
+import { createTypeahead, type TypeaheadMatch, type TypeaheadProps } from "./typeahead.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+const registry = createCollectionRegistry<"alpha" | "bravo", { label: string }>();
+registry.register({ key: "alpha", value: { label: "Alpha" }, textValue: "Alpha" });
+const timeout = ref(500);
+export const controller = createTypeahead({
+  registry,
+  timeout,
+  onMatch(match: TypeaheadMatch<"alpha" | "bravo">) {
+    const key: "alpha" | "bravo" = match.key;
+    void key;
+  },
+});
+
+type _QueryIsReadonly = Expect<Equal<typeof controller.query, Readonly<ShallowRef<string>>>>;
+type _PropsAreExact = Expect<Equal<typeof controller.typeaheadProps, Readonly<TypeaheadProps>>>;
+type _InputKeyIsExact = Expect<
+  Equal<ReturnType<typeof controller.input>, "alpha" | "bravo" | null>
+>;
+
+export const vueAttributes: HTMLAttributes = controller.typeaheadProps;
+// @ts-expect-error consumers cannot mutate readonly reactive state.
+controller.query.value = "a";
+// @ts-expect-error timeout must resolve to a number.
+createTypeahead({ registry, timeout: "500" });
+// @ts-expect-error manual input accepts a string grapheme.
+controller.input(1);

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       "long-press": "src/long-press.ts",
       move: "src/move.ts",
       press: "src/press.ts",
+      typeahead: "src/typeahead.ts",
       primitive: "src/primitive.ts",
       "visually-hidden": "src/visually-hidden.ts",
       media: "src/media.ts",


### PR DESCRIPTION
## Summary

- add a fully typed, collection-integrated Unicode typeahead interaction primitive
- keep extended grapheme clusters atomic, cycle repeated graphemes, and match through locale-aware collation
- distinguish printable AltGraph input from shortcuts while preserving IME, dead-key, activation Space, and composition behavior
- harden timer rescheduling, reactive disablement, registry failures, callback failures, SSR hydration, and disposal

## Verification

- `pnpm --filter @vizejs/ui check`
- `pnpm --filter @vizejs/ui test` — 200 tests in 35 files
- root bundle: 27,483 / 27,575 gzip bytes
- typeahead entry: 1,933 / 2,000 gzip bytes
- root and subpath typeahead consumers: 1,315 / 1,375 gzip bytes, 0 CSS bytes
- Actions renderer conformance compiles the typeahead fixture across DOM, SSR, and Vapor lanes

Part of #3134


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a public typeahead API for locale-aware collection navigation.
  - Supports buffered keyboard input, Unicode characters, repeated-match cycling, timeouts, disabled states, match callbacks, reset, and disposal.
  - Added Vue integration with keyboard-ready props and automatic lifecycle cleanup.
  - Added a dedicated `typeahead` package export with TypeScript support.

- **Accessibility**
  - Typeahead updates logical active state while allowing consumers to provide appropriate focus, roles, and keyboard semantics.

- **Tests**
  - Added coverage for SSR, hydration, renderer compatibility, tree shaking, validation, and TypeScript behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->