### PR TITLE
fix(ui): scope composite navigation ID lookups and handler lifetimes

### DIFF
--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -9,7 +9,7 @@ const budgets = new Map([
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
   ["collection.mjs", 5_700],
-  ["composite-navigation.mjs", 5_225],
+  ["composite-navigation.mjs", 5_355],
   ["context.mjs", 700],
   ["controllable-state.mjs", 600],
   ["id.mjs", 2_300],

--- a/npm/ui/core/scripts/check-tree-shaking.mjs
+++ b/npm/ui/core/scripts/check-tree-shaking.mjs
@@ -117,7 +117,7 @@ const componentCases = [
   {
     family: "composite-navigation",
     exportName: "createCompositeNavigation",
-    maximumJavaScriptGzipBytes: 3_800,
+    maximumJavaScriptGzipBytes: 3_900,
     maximumCssGzipBytes: 0,
   },
   {

--- a/npm/ui/core/src/composite-navigation-active-descendant.test.ts
+++ b/npm/ui/core/src/composite-navigation-active-descendant.test.ts
@@ -178,3 +178,28 @@ test("controlled popup relationships resolve inside the host shadow root", () =>
   harness.unmount();
   shell.remove();
 });
+
+test("controlled popup relationships never resolve across the shadow boundary", () => {
+  const harness = mountComposite({
+    focusStrategy: "active-descendant",
+    getItemId: ({ key }) => `item-${key}`,
+  });
+  const shell = document.createElement("div");
+  const shadow = shell.attachShadow({ mode: "open" });
+  const popup = document.createElement("div");
+  popup.id = "document-popup";
+  for (const element of harness.elements.values()) popup.append(element);
+  shadow.append(harness.container);
+  document.body.append(shell, popup);
+  harness.container.setAttribute("role", "combobox");
+  harness.container.setAttribute("aria-controls", popup.id);
+  setDynamicProps(harness);
+  keyboard("Shift", {}, harness.container);
+  assert.throws(
+    () => harness.controller.navigate("next"),
+    /VIZE_UI_COMPOSITE_NAVIGATION_RELATIONSHIP/,
+  );
+  harness.unmount();
+  shell.remove();
+  popup.remove();
+});

--- a/npm/ui/core/src/composite-navigation-dom.ts
+++ b/npm/ui/core/src/composite-navigation-dom.ts
@@ -52,8 +52,8 @@ function tokenIncludes(value: string | null, token: string): boolean {
 
 function relatedElement(host: Element, id: string): Element | null {
   const root = host.getRootNode() as { getElementById?: (value: string) => Element | null };
-  const fromRoot = typeof root.getElementById === "function" ? root.getElementById(id) : null;
-  return fromRoot ?? host.ownerDocument.getElementById(id);
+  if (typeof root.getElementById === "function") return root.getElementById(id);
+  return host.ownerDocument.getElementById(id);
 }
 
 export function validateActiveDescendant<Key extends CollectionKey, Value>(

--- a/npm/ui/core/src/composite-navigation-internal.ts
+++ b/npm/ui/core/src/composite-navigation-internal.ts
@@ -152,18 +152,19 @@ export function validateOptions<Key extends CollectionKey, Value>(
   return strategy;
 }
 
+const nonTextInputType = /^(?:button|checkbox|color|file|image|radio|range|reset|submit)$/iu;
+
 export function isEditableDescendant(event: KeyboardEvent): boolean {
   const path = typeof event.composedPath === "function" ? event.composedPath() : [event.target];
   for (const candidate of path) {
     if (candidate === event.currentTarget) break;
-    const target = candidate as Partial<HTMLElement> | null;
+    const target = candidate as Partial<HTMLInputElement> | null;
     const name = target?.localName;
-    if (
-      name === "input" ||
-      name === "select" ||
-      name === "textarea" ||
-      target?.isContentEditable === true
-    ) {
+    if (name === "input") {
+      if (!nonTextInputType.test(target?.type ?? "text")) return true;
+      continue;
+    }
+    if (name === "select" || name === "textarea" || target?.isContentEditable === true) {
       return true;
     }
   }

--- a/npm/ui/core/src/composite-navigation-lifecycle.test.ts
+++ b/npm/ui/core/src/composite-navigation-lifecycle.test.ts
@@ -104,12 +104,45 @@ test("item handlers are stable, become inert after disposal, and leave registry 
   const second = harness.controller.getItemProps("alpha");
   assert.equal(first.onFocus, second.onFocus);
   assert.equal(first.onPointerdown, second.onPointerdown);
+  const containerProps = harness.controller.getContainerProps();
   harness.controller.dispose();
   first.onFocus(new FocusEvent("focus"));
+  assert.equal(harness.registry.activeKey.value, null);
+  assert.doesNotThrow(() => containerProps.onFocus(new FocusEvent("focus")));
+  assert.doesNotThrow(() =>
+    containerProps.onKeydown(new KeyboardEvent("keydown", { key: "Home" })),
+  );
   assert.equal(harness.registry.activeKey.value, null);
   assert.doesNotThrow(() => harness.registry.setActiveKey("alpha"));
   harness.registry.dispose();
   harness.container.remove();
+});
+
+test("handler caching drops entries for keys the registry no longer holds", () => {
+  const harness = mountComposite();
+  const element = document.createElement("button");
+  harness.container.append(element);
+  const delta = harness.registry.register({ key: "delta", value: { label: "Delta" }, element });
+  const cached = harness.controller.getItemProps("delta");
+  delta.unregister();
+  const other = document.createElement("button");
+  harness.container.append(other);
+  harness.registry.register({ key: "echo", value: { label: "Echo" }, element: other });
+  harness.controller.getItemProps("echo");
+  harness.registry.register({ key: "delta", value: { label: "Delta" }, element });
+  assert.notEqual(harness.controller.getItemProps("delta").onFocus, cached.onFocus);
+  harness.unmount();
+});
+
+test("non-text input descendants keep composite keyboard navigation", () => {
+  const harness = mountComposite();
+  harness.registry.setActiveKey("alpha");
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+  harness.container.append(checkbox);
+  assert.equal(keyboard("ArrowDown", {}, checkbox).defaultPrevented, true);
+  assert.equal(harness.controller.activeKey.value, "bravo");
+  harness.unmount();
 });
 
 test("error aggregation retains every failure without native AggregateError", () => {

--- a/npm/ui/core/src/composite-navigation.behavior.md
+++ b/npm/ui/core/src/composite-navigation.behavior.md
@@ -16,7 +16,7 @@ activation, and styling remain consumer-owned.
 | Arrow keys           | Orientation gates horizontal and vertical arrows. Horizontal movement reverses under reactive RTL direction.            |
 | Boundaries           | `loop` affects arrows only; Home, End, PageUp, and PageDown remain deterministic.                                       |
 | Paging               | `pageSize` counts navigable items, never disabled records, and clamps at collection boundaries.                         |
-| Editable descendants | Keyboard events originating in inputs, selects, textareas, or contenteditable descendants are not consumed.             |
+| Editable descendants | Keyboard events from text-entry inputs, selects, textareas, or contenteditable descendants are not consumed.            |
 | Modified input       | Composition and Alt, Control, or Meta shortcuts are not interpreted as navigation.                                      |
 | Typeahead            | Optional Unicode-aware typeahead commits into the same registry state and synchronizes the configured focus strategy.   |
 | Pointer and focus    | Item-owned pointerdown and focus handlers update logical state without duplicating an unchanged transition.             |
@@ -26,6 +26,6 @@ activation, and styling remain consumer-owned.
 | Callback timing      | Logical state and DOM representation commit before `onNavigate`; snapshots are immutable and retain the native event.   |
 | Failure atomicity    | Focus, reveal, and callback failures are surfaced together after committed state remains observable.                    |
 | Reactivity           | Orientation, direction, loop, page size, disablement, and typeahead controls are read at event time.                    |
-| Disposal             | Disposal is idempotent, releases typeahead timers and handler caches, and does not dispose the caller-owned registry.   |
+| Disposal             | Disposal is idempotent, releases timers and handler caches, makes container handlers inert, and spares the registry.    |
 | Styling              | The module emits no CSS. Consumers freely apply classes, data attributes, CSS, or design-token presets.                 |
 | Tree shaking         | Root and subpath consumers produce identical JavaScript, retain no unrelated family signatures, and emit zero CSS.      |

--- a/npm/ui/core/src/composite-navigation.ts
+++ b/npm/ui/core/src/composite-navigation.ts
@@ -210,6 +210,9 @@ export function createCompositeNavigation<Key extends CollectionKey, Value>(
   const handlersFor = (key: Key): ItemHandlers => {
     const cached = itemHandlers.get(key);
     if (cached) return cached;
+    for (const cachedKey of itemHandlers.keys()) {
+      if (!registry.getItem(cachedKey)) itemHandlers.delete(cachedKey);
+    }
     const handlers = Object.freeze({
       onFocus: (event: FocusEvent) => activateItem(key, event),
       onPointerdown: (event: PointerEvent) => activateItem(key, event),
@@ -219,6 +222,7 @@ export function createCompositeNavigation<Key extends CollectionKey, Value>(
   };
 
   const onFocus = (event: FocusEvent): void => {
+    if (disposed) return;
     container = eventElement(event.currentTarget);
     if (
       strategy !== "active-descendant" ||
@@ -240,6 +244,7 @@ export function createCompositeNavigation<Key extends CollectionKey, Value>(
     }
   };
   const onKeydown = (event: KeyboardEvent): void => {
+    if (disposed) return;
     container = eventElement(event.currentTarget);
     if (
       event.defaultPrevented ||


### PR DESCRIPTION
Follow-up to the review feedback on #4200, which was already merged, so the fixes land here instead.

ARIA IDREFs resolve inside a single tree, but `relatedElement` fell back to the document whenever the host's root returned no match. A shadow-scoped `aria-controls` pointing at a document node was reported as a valid relationship even though assistive technology cannot follow it, and the same fallback weakened the active-descendant identity check:

```ts
function relatedElement(host: Element, id: string): Element | null {
  const root = host.getRootNode() as { getElementById?: (value: string) => Element | null };
  if (typeof root.getElementById === "function") return root.getElementById(id);
  return host.ownerDocument.getElementById(id);
}
```

The container handlers now match `activateItem` and go inert after `dispose`, so a listener that outlives the controller no longer mutates the caller-owned registry from `onFocus` or throws `VIZE_UI_COMPOSITE_NAVIGATION_DISPOSED` out of a DOM event handler via `navigate`.

`itemHandlers` also only cleared on disposal, so churning keys in a virtualized collection grew the cache for the controller lifetime. Cache misses now prune keys the registry no longer holds, which keeps the cost proportional to live items while cached handlers stay identity-stable for registered keys.

Finally, the editable-descendant guard treated every `input` as a text editor, so a toolbar or listbox containing a checkbox, radio, button, or range item lost all keyboard navigation. Only text-entry types short-circuit `onKeydown` now:

```ts
const nonTextInputType = /^(?:button|checkbox|color|file|image|radio|range|reset|submit)$/iu;
```

Size budgets for the root and `composite-navigation` entries move up to cover the added bytes (5,293 / 5,355 gzip for the entry, 3,862 / 3,900 gzip for consumers).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved composite navigation handling for editable fields so text-entry controls don’t interfere with keyboard navigation.
  * Prevented disposed navigation controls from responding to focus or keyboard events.
  * Corrected stale item-handler behavior after navigation items are removed and re-added.
  * Tightened validation for active-descendant relationships across shadow-root boundaries.

* **Documentation**
  * Clarified disposal behavior and keyboard handling for editable descendants.

* **Tests**
  * Added regression coverage for lifecycle cleanup, handler refreshes, input controls, and invalid popup relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->