### PR TITLE
perf(doctor): gate TUI latency budgets

### DIFF
--- a/.github/workflows/criterion-bench.yml
+++ b/.github/workflows/criterion-bench.yml
@@ -6,10 +6,12 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "crates/**"
+      - "benchmarks/**"
       - ".cargo/**"
       - "Cargo.lock"
       - "Cargo.toml"
       - "bench/criterion-ab.mjs"
+      - "bench/criterion-baselines.mjs"
       - "bench/criterion-impact.mjs"
       - "bench/dialect-guard.mjs"
       - "bench/generate.mjs"
@@ -23,10 +25,11 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # Report-only: criterion micro-benchmarks are noisy on shared CI runners, so
-  # the A/B table is surfaced for review but the empty threshold keeps it from
-  # blocking a PR. The dialect guard below is a hard gate because byte-identical
-  # codegen is deterministic and not subject to timing jitter.
+  # Relative Criterion comparisons remain report-only because shared-runner
+  # jitter makes one global percentage threshold unreliable. Individual suites
+  # may additionally declare conservative absolute median budgets; those are
+  # hard gates on the reference runner. The dialect guard below is also a hard
+  # gate because byte-identical codegen is deterministic.
   #
   # The A/B sweep covers the four JSX cost dimensions #1501 requires — parser/
   # lowering (jsx_lower), Croquis analysis (jsx_croquis_analyze), Patina rule

--- a/.github/workflows/criterion-bench.yml
+++ b/.github/workflows/criterion-bench.yml
@@ -13,6 +13,7 @@ on:
       - "bench/criterion-ab.mjs"
       - "bench/criterion-baselines.mjs"
       - "bench/criterion-impact.mjs"
+      - "bench/criterion-summary.mjs"
       - "bench/dialect-guard.mjs"
       - "bench/generate.mjs"
       - "rust-toolchain.toml"

--- a/bench/criterion-ab.mjs
+++ b/bench/criterion-ab.mjs
@@ -12,12 +12,10 @@
  * The script is dependency-free (besides `cargo`, `critcmp`, and a checkout of
  * each side) so GitHub Actions can run it after checking out both commits.
  *
- * Cadence note: criterion is noisy on shared CI runners, so this is a reporting
- * gate by default — it prints the critcmp delta table and only fails when
- * `--threshold <pct>` is passed and a benchmark regresses past it. The workflow
- * runs it in report-only mode so micro-benchmark jitter never blocks a PR; the
- * threshold knob is wired so the gate can be tightened later without a code
- * change.
+ * Cadence note: relative Criterion deltas are noisy on shared CI runners, so
+ * the global percentage comparison is report-only by default. Suites can also
+ * declare conservative absolute median budgets for the reference runner; those
+ * remain hard gates even when no global `--threshold <pct>` is supplied.
  *
  * Documented JSX regression threshold (#1501): the four JSX cost dimensions —
  * parser/lowering (`jsx_lower`), Croquis semantic analysis
@@ -42,14 +40,15 @@ import {
   criterionEnvironment,
   critcmpArgs,
   critcmpExportArgs,
+  evaluateAbsoluteBudgets,
   parseCritcmpExport,
   validateComparisonTable,
 } from "./criterion-baselines.mjs";
 
-// Criterion benches that exist under crates/*/benches and represent the hot
-// compiler/analysis/codegen paths. Each entry maps a cargo package to the
-// `[[bench]]` targets it owns; the `bench filter` narrows criterion to the
-// specific group so a full sweep stays inside the job timeout.
+// Criterion benches that exist in workspace benchmark targets and represent
+// hot compiler, analysis, codegen, and presentation paths. Each entry maps a
+// cargo package to the `[[bench]]` targets it owns; the `bench filter` narrows
+// Criterion to the specific group so a full sweep stays inside the job timeout.
 export const CRITERION_SUITES = [
   {
     package: "vize_atelier_sfc",
@@ -64,6 +63,16 @@ export const CRITERION_SUITES = [
   { package: "vize_atelier_jsx", benches: ["jsx_compile"], label: "JSX compile" },
   { package: "vize_croquis_cf", benches: ["cross_file"], label: "Cross-file analysis" },
   { package: "vize_doctor", benches: ["reporter"], label: "Doctor reporters" },
+  {
+    package: "vize_benchmarks",
+    benches: ["doctor_tui"],
+    label: "Doctor TUI",
+    absoluteBudgets: [
+      { name: "doctor_tui_10k/first_frame_120x40", maxMedianNs: 20_000_000 },
+      { name: "doctor_tui_input_to_frame_10k/selection", maxMedianNs: 1_000_000 },
+      { name: "doctor_tui_input_to_frame_10k/search", maxMedianNs: 1_000_000 },
+    ],
+  },
   { package: "vize_glyph", benches: ["formatter"], label: "Formatter" },
   { package: "vize_patina", benches: ["lint_bench", "markup_ir_bench"], label: "Lint" },
 ];
@@ -199,7 +208,13 @@ export function resolveSuiteSelection(selection) {
   };
 }
 
-export function renderSummary({ table, threshold, regressions, selection }) {
+export function renderSummary({
+  table,
+  threshold,
+  regressions,
+  selection,
+  absoluteBudgetResults = [],
+}) {
   const lines = [];
   lines.push("## Criterion A/B");
   lines.push("");
@@ -215,7 +230,7 @@ export function renderSummary({ table, threshold, regressions, selection }) {
   }
   lines.push(
     threshold == null
-      ? "Report-only: micro-benchmark mean estimates for base vs head (no gate)."
+      ? "Relative comparison: micro-benchmark estimates for base vs head (report-only)."
       : `Regression threshold: ${threshold}% (median).`,
   );
   lines.push("");
@@ -229,8 +244,30 @@ export function renderSummary({ table, threshold, regressions, selection }) {
       lines.push(`- ${regression.name}: +${regression.changePercent.toFixed(2)}%`);
     }
   }
+  if (absoluteBudgetResults.length > 0) {
+    lines.push("");
+    lines.push("### Absolute median budgets");
+    lines.push("");
+    lines.push("| Benchmark | Median | Budget | Result |");
+    lines.push("| --- | ---: | ---: | :---: |");
+    for (const result of absoluteBudgetResults) {
+      lines.push(
+        `| ${result.name} | ${formatDuration(result.medianNs)} | ${formatDuration(result.maxMedianNs)} | ${result.exceeded ? "FAIL" : "PASS"} |`,
+      );
+    }
+  }
   lines.push("");
   return `${lines.join("\n")}\n`;
+}
+
+function formatDuration(nanoseconds) {
+  if (nanoseconds >= 1_000_000) {
+    return `${(nanoseconds / 1_000_000).toFixed(2)} ms`;
+  }
+  if (nanoseconds >= 1_000) {
+    return `${(nanoseconds / 1_000).toFixed(2)} µs`;
+  }
+  return `${nanoseconds.toFixed(2)} ns`;
 }
 
 export function main(argv = process.argv.slice(2)) {
@@ -282,7 +319,18 @@ export function main(argv = process.argv.slice(2)) {
   }
   const regressions =
     baseExport && headExport ? compareBaselineExports(baseExport, headExport, threshold) : [];
-  const summary = renderSummary({ table, threshold, regressions, selection });
+  const absoluteBudgets = suites.flatMap((suite) => suite.absoluteBudgets ?? []);
+  const absoluteBudgetResults =
+    headExport && absoluteBudgets.length > 0
+      ? evaluateAbsoluteBudgets(headExport, absoluteBudgets)
+      : [];
+  const summary = renderSummary({
+    table,
+    threshold,
+    regressions,
+    selection,
+    absoluteBudgetResults,
+  });
 
   if (args.out) {
     writeFileSync(resolve(args.out), summary);
@@ -296,6 +344,13 @@ export function main(argv = process.argv.slice(2)) {
   if (threshold != null && regressions.length > 0) {
     console.error(
       `Criterion budget failed: ${regressions.length} benchmark(s) regressed past ${threshold}%.`,
+    );
+    process.exitCode = 1;
+  }
+  const exceededBudgets = absoluteBudgetResults.filter((result) => result.exceeded);
+  if (exceededBudgets.length > 0) {
+    console.error(
+      `Criterion absolute budget failed: ${exceededBudgets.length} benchmark(s) exceeded their median limit.`,
     );
     process.exitCode = 1;
   }

--- a/bench/criterion-ab.mjs
+++ b/bench/criterion-ab.mjs
@@ -44,6 +44,7 @@ import {
   parseCritcmpExport,
   validateComparisonTable,
 } from "./criterion-baselines.mjs";
+import { renderSummary } from "./criterion-summary.mjs";
 
 // Criterion benches that exist in workspace benchmark targets and represent
 // hot compiler, analysis, codegen, and presentation paths. Each entry maps a
@@ -206,68 +207,6 @@ export function resolveSuiteSelection(selection) {
     skipped: inventory.filter((name) => !selection.selected.includes(name)),
     reason: selection.reason,
   };
-}
-
-export function renderSummary({
-  table,
-  threshold,
-  regressions,
-  selection,
-  absoluteBudgetResults = [],
-}) {
-  const lines = [];
-  lines.push("## Criterion A/B");
-  lines.push("");
-  lines.push(`Selection: ${selection.reason}`);
-  lines.push("");
-  lines.push(`- Ran: ${selection.selected.join(", ") || "none"}`);
-  lines.push(`- Skipped: ${selection.skipped.join(", ") || "none"}`);
-  lines.push("");
-  if (selection.selected.length === 0) {
-    lines.push("No configured Criterion suite is affected; timing execution was skipped.");
-    lines.push("");
-    return `${lines.join("\n")}\n`;
-  }
-  lines.push(
-    threshold == null
-      ? "Relative comparison: micro-benchmark estimates for base vs head (report-only)."
-      : `Regression threshold: ${threshold}% (median).`,
-  );
-  lines.push("");
-  lines.push("```");
-  lines.push(table.trimEnd());
-  lines.push("```");
-  if (regressions.length > 0) {
-    lines.push("");
-    lines.push(`Regressions past ${threshold}%:`);
-    for (const regression of regressions) {
-      lines.push(`- ${regression.name}: +${regression.changePercent.toFixed(2)}%`);
-    }
-  }
-  if (absoluteBudgetResults.length > 0) {
-    lines.push("");
-    lines.push("### Absolute median budgets");
-    lines.push("");
-    lines.push("| Benchmark | Median | Budget | Result |");
-    lines.push("| --- | ---: | ---: | :---: |");
-    for (const result of absoluteBudgetResults) {
-      lines.push(
-        `| ${result.name} | ${formatDuration(result.medianNs)} | ${formatDuration(result.maxMedianNs)} | ${result.exceeded ? "FAIL" : "PASS"} |`,
-      );
-    }
-  }
-  lines.push("");
-  return `${lines.join("\n")}\n`;
-}
-
-function formatDuration(nanoseconds) {
-  if (nanoseconds >= 1_000_000) {
-    return `${(nanoseconds / 1_000_000).toFixed(2)} ms`;
-  }
-  if (nanoseconds >= 1_000) {
-    return `${(nanoseconds / 1_000).toFixed(2)} µs`;
-  }
-  return `${nanoseconds.toFixed(2)} ns`;
 }
 
 export function main(argv = process.argv.slice(2)) {

--- a/bench/criterion-baselines.mjs
+++ b/bench/criterion-baselines.mjs
@@ -42,6 +42,44 @@ export function compareBaselineExports(base, head, thresholdPercent) {
   return regressions;
 }
 
+/**
+ * Evaluate exact Criterion benchmark medians against conservative hard limits.
+ *
+ * Criterion exports point estimates in nanoseconds. Missing, duplicate, or
+ * invalid budget declarations fail closed instead of silently weakening CI.
+ */
+export function evaluateAbsoluteBudgets(head, budgets) {
+  if (!isRecord(head) || !isRecord(head.benchmarks)) {
+    throw new Error("Criterion absolute budgets require a parsed head export");
+  }
+  if (!Array.isArray(budgets)) {
+    throw new Error("Criterion absolute budgets must be an array");
+  }
+  const names = new Set();
+  return budgets.map((budget) => {
+    if (!isRecord(budget) || typeof budget.name !== "string" || budget.name.length === 0) {
+      throw new Error("Criterion absolute budget requires a benchmark name");
+    }
+    if (names.has(budget.name)) {
+      throw new Error(`Duplicate Criterion absolute budget: ${budget.name}`);
+    }
+    names.add(budget.name);
+    if (!Number.isFinite(budget.maxMedianNs) || budget.maxMedianNs <= 0) {
+      throw new Error(`Invalid Criterion absolute budget for ${budget.name}`);
+    }
+    if (!(budget.name in head.benchmarks)) {
+      throw new Error(`Criterion absolute budget benchmark is missing: ${budget.name}`);
+    }
+    const medianNs = medianPointEstimate(head.benchmarks[budget.name], `head/${budget.name}`);
+    return {
+      name: budget.name,
+      medianNs,
+      maxMedianNs: budget.maxMedianNs,
+      exceeded: medianNs > budget.maxMedianNs,
+    };
+  });
+}
+
 export function validateComparisonTable(table) {
   const lines = table.split("\n").filter((line) => line.trim().length > 0);
   const columns = lines[0]?.trim().split(/\s+/);

--- a/bench/criterion-impact.mjs
+++ b/bench/criterion-impact.mjs
@@ -14,6 +14,7 @@ const FULL_SWEEP_PATHS = new Set([
   "bench/criterion-ab.mjs",
   "bench/criterion-baselines.mjs",
   "bench/criterion-impact.mjs",
+  "bench/criterion-summary.mjs",
   "bench/dialect-guard.mjs",
   "bench/generate.mjs",
   "rust-toolchain.toml",

--- a/bench/criterion-impact.mjs
+++ b/bench/criterion-impact.mjs
@@ -12,6 +12,7 @@ const FULL_SWEEP_PATHS = new Set([
   "Cargo.lock",
   "Cargo.toml",
   "bench/criterion-ab.mjs",
+  "bench/criterion-baselines.mjs",
   "bench/criterion-impact.mjs",
   "bench/dialect-guard.mjs",
   "bench/generate.mjs",
@@ -148,7 +149,9 @@ export function selectCriterionSuites({ changedPaths, metadata, repoDir }) {
     );
   }
 
-  const rustPaths = normalizedPaths.filter((path) => path.startsWith("crates/"));
+  const rustPaths = normalizedPaths.filter(
+    (path) => path.startsWith("crates/") || path.startsWith("benchmarks/"),
+  );
   const unknownPaths = rustPaths.filter((path) => ownerForPath(path, packages) == null);
   if (unknownPaths.length > 0) {
     return {

--- a/bench/criterion-summary.mjs
+++ b/bench/criterion-summary.mjs
@@ -1,0 +1,67 @@
+/**
+ * Render the Criterion A/B step summary: suite selection, the report-only
+ * critcmp table, relative regressions when a threshold is enabled, and the
+ * absolute median budgets that stay hard gates on the reference runner.
+ */
+
+export function renderSummary({
+  table,
+  threshold,
+  regressions,
+  selection,
+  absoluteBudgetResults = [],
+}) {
+  const lines = [];
+  lines.push("## Criterion A/B");
+  lines.push("");
+  lines.push(`Selection: ${selection.reason}`);
+  lines.push("");
+  lines.push(`- Ran: ${selection.selected.join(", ") || "none"}`);
+  lines.push(`- Skipped: ${selection.skipped.join(", ") || "none"}`);
+  lines.push("");
+  if (selection.selected.length === 0) {
+    lines.push("No configured Criterion suite is affected; timing execution was skipped.");
+    lines.push("");
+    return `${lines.join("\n")}\n`;
+  }
+  lines.push(
+    threshold == null
+      ? "Relative comparison: micro-benchmark estimates for base vs head (report-only)."
+      : `Regression threshold: ${threshold}% (median).`,
+  );
+  lines.push("");
+  lines.push("```");
+  lines.push(table.trimEnd());
+  lines.push("```");
+  if (regressions.length > 0) {
+    lines.push("");
+    lines.push(`Regressions past ${threshold}%:`);
+    for (const regression of regressions) {
+      lines.push(`- ${regression.name}: +${regression.changePercent.toFixed(2)}%`);
+    }
+  }
+  if (absoluteBudgetResults.length > 0) {
+    lines.push("");
+    lines.push("### Absolute median budgets");
+    lines.push("");
+    lines.push("| Benchmark | Median | Budget | Result |");
+    lines.push("| --- | ---: | ---: | :---: |");
+    for (const result of absoluteBudgetResults) {
+      lines.push(
+        `| ${result.name} | ${formatDuration(result.medianNs)} | ${formatDuration(result.maxMedianNs)} | ${result.exceeded ? "FAIL" : "PASS"} |`,
+      );
+    }
+  }
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+function formatDuration(nanoseconds) {
+  if (nanoseconds >= 1_000_000) {
+    return `${(nanoseconds / 1_000_000).toFixed(2)} ms`;
+  }
+  if (nanoseconds >= 1_000) {
+    return `${(nanoseconds / 1_000).toFixed(2)} µs`;
+  }
+  return `${nanoseconds.toFixed(2)} ns`;
+}

--- a/tests/tooling/criterion-baselines.test.ts
+++ b/tests/tooling/criterion-baselines.test.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { criterionBenchRunOptions, resolveSuiteSelection } from "../../bench/criterion-ab.mjs";
+import {
+  compareBaselineExports,
+  criterionEnvironment,
+  critcmpArgs,
+  critcmpExportArgs,
+  evaluateAbsoluteBudgets,
+  parseCritcmpExport,
+  validateComparisonTable,
+} from "../../bench/criterion-baselines.mjs";
+import { renderSummary } from "../../bench/criterion-summary.mjs";
+
+test("Criterion driver snapshots both baselines before comparing them", () => {
+  assert.deepEqual(
+    criterionBenchRunOptions({
+      checkoutDir: "/work/head",
+      targetDir: "/work/head/target",
+    }),
+    {
+      cwd: "/work/head",
+      env: { CARGO_TARGET_DIR: "/work/head/target" },
+      capture: true,
+    },
+  );
+  assert.deepEqual(criterionEnvironment("/work/head/target"), {
+    CARGO_TARGET_DIR: "/work/head/target",
+  });
+  assert.deepEqual(critcmpExportArgs({ targetDir: "/work/head/target", baseline: "base" }), [
+    "--target-dir",
+    "/work/head/target",
+    "--export",
+    "base",
+  ]);
+  assert.deepEqual(
+    critcmpArgs({
+      targetDir: "/work/head/target",
+      baselinePaths: ["/work/base.json", "/work/head.json"],
+    }),
+    ["--target-dir", "/work/head/target", "/work/base.json", "/work/head.json"],
+  );
+});
+
+test("Criterion baseline comparison fails closed and uses exported medians", () => {
+  const base = parseCritcmpExport(baselineExport("base", { shared: 100 }), "base");
+  const head = parseCritcmpExport(baselineExport("head", { shared: 125 }), "head");
+
+  assert.deepEqual(compareBaselineExports(base, head, 10), [{ name: "shared", changePercent: 25 }]);
+  assert.throws(
+    () => parseCritcmpExport(baselineExport("base", {}), "base"),
+    /contains no benchmarks/,
+  );
+  assert.throws(
+    () =>
+      compareBaselineExports(
+        base,
+        parseCritcmpExport(baselineExport("head", { other: 90 }), "head"),
+        10,
+      ),
+    /no shared benchmarks/,
+  );
+});
+
+test("Criterion absolute budgets pass, fail, and reject missing measurements", () => {
+  const head = parseCritcmpExport(
+    baselineExport("head", { first: 4_500_000, selection: 150_000 }),
+    "head",
+  );
+  assert.deepEqual(
+    evaluateAbsoluteBudgets(head, [
+      { name: "first", maxMedianNs: 20_000_000 },
+      { name: "selection", maxMedianNs: 100_000 },
+    ]),
+    [
+      { name: "first", medianNs: 4_500_000, maxMedianNs: 20_000_000, exceeded: false },
+      { name: "selection", medianNs: 150_000, maxMedianNs: 100_000, exceeded: true },
+    ],
+  );
+  assert.throws(
+    () => evaluateAbsoluteBudgets(head, [{ name: "missing", maxMedianNs: 1_000_000 }]),
+    /benchmark is missing/,
+  );
+  assert.throws(
+    () => evaluateAbsoluteBudgets(head, [{ name: "first", maxMedianNs: 0 }]),
+    /Invalid Criterion absolute budget/,
+  );
+  assert.throws(
+    () =>
+      evaluateAbsoluteBudgets(head, [
+        { name: "first", maxMedianNs: 1 },
+        { name: "first", maxMedianNs: 2 },
+      ]),
+    /Duplicate/,
+  );
+});
+
+test("Criterion comparison table requires both base and head columns", () => {
+  assert.doesNotThrow(() =>
+    validateComparisonTable("group  base  head\n-----  ----  ----\nshared  1.00  1.12\n"),
+  );
+  assert.throws(
+    () => validateComparisonTable("group  head\n-----  ----\nshared  1.00\n"),
+    /did not produce base\/head columns/,
+  );
+});
+
+test("Criterion driver reports a useful summary when no suite is affected", () => {
+  const selection = resolveSuiteSelection({ selected: [], reason: "CLI-only change." });
+  const summary = renderSummary({ table: "", threshold: undefined, regressions: [], selection });
+
+  assert.match(summary, /Selection: CLI-only change\./);
+  assert.match(summary, /Ran: none/);
+  assert.match(summary, /Skipped: vize_atelier_sfc, vize_atelier_jsx/);
+  assert.match(summary, /timing execution was skipped/);
+});
+
+test("Criterion summary makes hard absolute budget results reviewable", () => {
+  const selection = resolveSuiteSelection({
+    selected: ["vize_benchmarks"],
+    reason: "Doctor TUI changed.",
+  });
+  const summary = renderSummary({
+    table: "group  base  head\n-----  ----  ----\nfirst  1.00  1.10\n",
+    threshold: undefined,
+    regressions: [],
+    selection,
+    absoluteBudgetResults: [
+      { name: "first", medianNs: 4_500_000, maxMedianNs: 20_000_000, exceeded: false },
+      { name: "selection", medianNs: 1_250_000, maxMedianNs: 1_000_000, exceeded: true },
+    ],
+  });
+
+  assert.match(summary, /Absolute median budgets/);
+  assert.match(summary, /first \| 4\.50 ms \| 20\.00 ms \| PASS/);
+  assert.match(summary, /selection \| 1\.25 ms \| 1\.00 ms \| FAIL/);
+});
+
+function baselineExport(name: string, medians: Record<string, number>): string {
+  return JSON.stringify({
+    name,
+    benchmarks: Object.fromEntries(
+      Object.entries(medians).map(([benchmark, pointEstimate]) => [
+        benchmark,
+        { criterion_estimates_v1: { median: { point_estimate: pointEstimate } } },
+      ]),
+    ),
+  });
+}

--- a/tests/tooling/criterion-impact.test.ts
+++ b/tests/tooling/criterion-impact.test.ts
@@ -5,21 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import {
-  CRITERION_SUITES,
-  criterionBenchRunOptions,
-  renderSummary,
-  resolveSuiteSelection,
-} from "../../bench/criterion-ab.mjs";
-import {
-  compareBaselineExports,
-  criterionEnvironment,
-  critcmpArgs,
-  critcmpExportArgs,
-  evaluateAbsoluteBudgets,
-  parseCritcmpExport,
-  validateComparisonTable,
-} from "../../bench/criterion-baselines.mjs";
+import { CRITERION_SUITES, resolveSuiteSelection } from "../../bench/criterion-ab.mjs";
 import {
   changedPathsBetween,
   parseNameStatusZ,
@@ -180,6 +166,7 @@ test("lockfiles and shared benchmark infrastructure select the full inventory", 
     "Cargo.lock",
     "bench/criterion-ab.mjs",
     "bench/criterion-baselines.mjs",
+    "bench/criterion-summary.mjs",
   ]) {
     const result = selectCriterionSuites({
       changedPaths: [changedPath],
@@ -230,139 +217,3 @@ test("Criterion driver validates scoped suite manifests", () => {
     /unknown suites/,
   );
 });
-
-test("Criterion driver snapshots both baselines before comparing them", () => {
-  assert.deepEqual(
-    criterionBenchRunOptions({
-      checkoutDir: "/work/head",
-      targetDir: "/work/head/target",
-    }),
-    {
-      cwd: "/work/head",
-      env: { CARGO_TARGET_DIR: "/work/head/target" },
-      capture: true,
-    },
-  );
-  assert.deepEqual(criterionEnvironment("/work/head/target"), {
-    CARGO_TARGET_DIR: "/work/head/target",
-  });
-  assert.deepEqual(critcmpExportArgs({ targetDir: "/work/head/target", baseline: "base" }), [
-    "--target-dir",
-    "/work/head/target",
-    "--export",
-    "base",
-  ]);
-  assert.deepEqual(
-    critcmpArgs({
-      targetDir: "/work/head/target",
-      baselinePaths: ["/work/base.json", "/work/head.json"],
-    }),
-    ["--target-dir", "/work/head/target", "/work/base.json", "/work/head.json"],
-  );
-});
-
-test("Criterion baseline comparison fails closed and uses exported medians", () => {
-  const base = parseCritcmpExport(baselineExport("base", { shared: 100 }), "base");
-  const head = parseCritcmpExport(baselineExport("head", { shared: 125 }), "head");
-
-  assert.deepEqual(compareBaselineExports(base, head, 10), [{ name: "shared", changePercent: 25 }]);
-  assert.throws(
-    () => parseCritcmpExport(baselineExport("base", {}), "base"),
-    /contains no benchmarks/,
-  );
-  assert.throws(
-    () =>
-      compareBaselineExports(
-        base,
-        parseCritcmpExport(baselineExport("head", { other: 90 }), "head"),
-        10,
-      ),
-    /no shared benchmarks/,
-  );
-});
-
-test("Criterion absolute budgets pass, fail, and reject missing measurements", () => {
-  const head = parseCritcmpExport(
-    baselineExport("head", { first: 4_500_000, selection: 150_000 }),
-    "head",
-  );
-  assert.deepEqual(
-    evaluateAbsoluteBudgets(head, [
-      { name: "first", maxMedianNs: 20_000_000 },
-      { name: "selection", maxMedianNs: 100_000 },
-    ]),
-    [
-      { name: "first", medianNs: 4_500_000, maxMedianNs: 20_000_000, exceeded: false },
-      { name: "selection", medianNs: 150_000, maxMedianNs: 100_000, exceeded: true },
-    ],
-  );
-  assert.throws(
-    () => evaluateAbsoluteBudgets(head, [{ name: "missing", maxMedianNs: 1_000_000 }]),
-    /benchmark is missing/,
-  );
-  assert.throws(
-    () => evaluateAbsoluteBudgets(head, [{ name: "first", maxMedianNs: 0 }]),
-    /Invalid Criterion absolute budget/,
-  );
-  assert.throws(
-    () =>
-      evaluateAbsoluteBudgets(head, [
-        { name: "first", maxMedianNs: 1 },
-        { name: "first", maxMedianNs: 2 },
-      ]),
-    /Duplicate/,
-  );
-});
-
-test("Criterion comparison table requires both base and head columns", () => {
-  assert.doesNotThrow(() =>
-    validateComparisonTable("group  base  head\n-----  ----  ----\nshared  1.00  1.12\n"),
-  );
-  assert.throws(
-    () => validateComparisonTable("group  head\n-----  ----\nshared  1.00\n"),
-    /did not produce base\/head columns/,
-  );
-});
-
-test("Criterion driver reports a useful summary when no suite is affected", () => {
-  const selection = resolveSuiteSelection({ selected: [], reason: "CLI-only change." });
-  const summary = renderSummary({ table: "", threshold: undefined, regressions: [], selection });
-
-  assert.match(summary, /Selection: CLI-only change\./);
-  assert.match(summary, /Ran: none/);
-  assert.match(summary, /Skipped: vize_atelier_sfc, vize_atelier_jsx/);
-  assert.match(summary, /timing execution was skipped/);
-});
-
-test("Criterion summary makes hard absolute budget results reviewable", () => {
-  const selection = resolveSuiteSelection({
-    selected: ["vize_benchmarks"],
-    reason: "Doctor TUI changed.",
-  });
-  const summary = renderSummary({
-    table: "group  base  head\n-----  ----  ----\nfirst  1.00  1.10\n",
-    threshold: undefined,
-    regressions: [],
-    selection,
-    absoluteBudgetResults: [
-      { name: "first", medianNs: 4_500_000, maxMedianNs: 20_000_000, exceeded: false },
-      { name: "selection", medianNs: 1_250_000, maxMedianNs: 1_000_000, exceeded: true },
-    ],
-  });
-
-  assert.match(summary, /Absolute median budgets/);
-  assert.match(summary, /first \| 4\.50 ms \| 20\.00 ms \| PASS/);
-  assert.match(summary, /selection \| 1\.25 ms \| 1\.00 ms \| FAIL/);
-});
-
-function baselineExport(name: string, medians: Record<string, number>): string {
-  return JSON.stringify({
-    name,
-    benchmarks: Object.fromEntries(
-      Object.entries(medians).map(([benchmark, pointEstimate]) => [
-        benchmark,
-        { criterion_estimates_v1: { median: { point_estimate: pointEstimate } } },
-      ]),
-    ),
-  });
-}

--- a/tests/tooling/criterion-impact.test.ts
+++ b/tests/tooling/criterion-impact.test.ts
@@ -16,6 +16,7 @@ import {
   criterionEnvironment,
   critcmpArgs,
   critcmpExportArgs,
+  evaluateAbsoluteBudgets,
   parseCritcmpExport,
   validateComparisonTable,
 } from "../../bench/criterion-baselines.mjs";
@@ -45,15 +46,19 @@ function metadata(dependencies: Record<string, string[]> = {}) {
   const packages = names.map((name) => ({
     id: `${name}@0.1.0`,
     name,
-    manifest_path: `${repoDir}/crates/${name}/Cargo.toml`,
+    manifest_path:
+      name === "vize_benchmarks"
+        ? `${repoDir}/benchmarks/vize/Cargo.toml`
+        : `${repoDir}/crates/${name}/Cargo.toml`,
   }));
+  const effectiveDependencies = { vize_benchmarks: ["vize"], ...dependencies };
   return {
     packages,
     workspace_members: packages.map((pkg) => pkg.id),
     resolve: {
       nodes: packages.map((pkg) => ({
         id: pkg.id,
-        dependencies: (dependencies[pkg.name] ?? []).map((name) => `${name}@0.1.0`),
+        dependencies: (effectiveDependencies[pkg.name] ?? []).map((name) => `${name}@0.1.0`),
       })),
     },
   };
@@ -115,6 +120,36 @@ test("Doctor reporter benchmarks are enrolled in scoped Criterion A/B runs", () 
   assert.deepEqual(result.selected, ["vize_doctor"]);
 });
 
+test("Doctor TUI benchmarks carry explicit reference-runner latency budgets", () => {
+  const suite = CRITERION_SUITES.find(
+    ({ package: packageName }) => packageName === "vize_benchmarks",
+  );
+  assert.deepEqual(suite, {
+    package: "vize_benchmarks",
+    benches: ["doctor_tui"],
+    label: "Doctor TUI",
+    absoluteBudgets: [
+      { name: "doctor_tui_10k/first_frame_120x40", maxMedianNs: 20_000_000 },
+      { name: "doctor_tui_input_to_frame_10k/selection", maxMedianNs: 1_000_000 },
+      { name: "doctor_tui_input_to_frame_10k/search", maxMedianNs: 1_000_000 },
+    ],
+  });
+
+  const direct = selectCriterionSuites({
+    changedPaths: ["benchmarks/vize/doctor_tui.rs"],
+    metadata: metadata(),
+    repoDir,
+  });
+  assert.deepEqual(direct.selected, ["vize_benchmarks"]);
+
+  const dependency = selectCriterionSuites({
+    changedPaths: ["crates/vize/src/commands/doctor/tui.rs"],
+    metadata: metadata(),
+    repoDir,
+  });
+  assert.deepEqual(dependency.selected, ["vize_benchmarks"]);
+});
+
 test("reverse dependency impact selects every suite that consumes a changed package", () => {
   const dependencies = Object.fromEntries(suiteNames.map((name) => [name, ["vize_atelier_core"]]));
   const result = selectCriterionSuites({
@@ -127,9 +162,9 @@ test("reverse dependency impact selects every suite that consumes a changed pack
   assert.deepEqual(result.skipped, []);
 });
 
-test("CLI-only changes skip unrelated Criterion suites", () => {
+test("non-Rust CLI fixture changes skip unrelated Criterion suites", () => {
   const result = selectCriterionSuites({
-    changedPaths: ["crates/vize/src/build/input.rs"],
+    changedPaths: ["docs/cli.md"],
     metadata: metadata(),
     repoDir,
   });
@@ -137,11 +172,15 @@ test("CLI-only changes skip unrelated Criterion suites", () => {
   assert.equal(result.mode, "scoped");
   assert.deepEqual(result.selected, []);
   assert.deepEqual(result.skipped, suiteNames);
-  assert.match(result.reason, /vize/);
+  assert.match(result.reason, /none/);
 });
 
 test("lockfiles and shared benchmark infrastructure select the full inventory", () => {
-  for (const changedPath of ["Cargo.lock", "bench/criterion-ab.mjs"]) {
+  for (const changedPath of [
+    "Cargo.lock",
+    "bench/criterion-ab.mjs",
+    "bench/criterion-baselines.mjs",
+  ]) {
     const result = selectCriterionSuites({
       changedPaths: [changedPath],
       metadata: metadata(),
@@ -242,6 +281,39 @@ test("Criterion baseline comparison fails closed and uses exported medians", () 
   );
 });
 
+test("Criterion absolute budgets pass, fail, and reject missing measurements", () => {
+  const head = parseCritcmpExport(
+    baselineExport("head", { first: 4_500_000, selection: 150_000 }),
+    "head",
+  );
+  assert.deepEqual(
+    evaluateAbsoluteBudgets(head, [
+      { name: "first", maxMedianNs: 20_000_000 },
+      { name: "selection", maxMedianNs: 100_000 },
+    ]),
+    [
+      { name: "first", medianNs: 4_500_000, maxMedianNs: 20_000_000, exceeded: false },
+      { name: "selection", medianNs: 150_000, maxMedianNs: 100_000, exceeded: true },
+    ],
+  );
+  assert.throws(
+    () => evaluateAbsoluteBudgets(head, [{ name: "missing", maxMedianNs: 1_000_000 }]),
+    /benchmark is missing/,
+  );
+  assert.throws(
+    () => evaluateAbsoluteBudgets(head, [{ name: "first", maxMedianNs: 0 }]),
+    /Invalid Criterion absolute budget/,
+  );
+  assert.throws(
+    () =>
+      evaluateAbsoluteBudgets(head, [
+        { name: "first", maxMedianNs: 1 },
+        { name: "first", maxMedianNs: 2 },
+      ]),
+    /Duplicate/,
+  );
+});
+
 test("Criterion comparison table requires both base and head columns", () => {
   assert.doesNotThrow(() =>
     validateComparisonTable("group  base  head\n-----  ----  ----\nshared  1.00  1.12\n"),
@@ -260,6 +332,27 @@ test("Criterion driver reports a useful summary when no suite is affected", () =
   assert.match(summary, /Ran: none/);
   assert.match(summary, /Skipped: vize_atelier_sfc, vize_atelier_jsx/);
   assert.match(summary, /timing execution was skipped/);
+});
+
+test("Criterion summary makes hard absolute budget results reviewable", () => {
+  const selection = resolveSuiteSelection({
+    selected: ["vize_benchmarks"],
+    reason: "Doctor TUI changed.",
+  });
+  const summary = renderSummary({
+    table: "group  base  head\n-----  ----  ----\nfirst  1.00  1.10\n",
+    threshold: undefined,
+    regressions: [],
+    selection,
+    absoluteBudgetResults: [
+      { name: "first", medianNs: 4_500_000, maxMedianNs: 20_000_000, exceeded: false },
+      { name: "selection", medianNs: 1_250_000, maxMedianNs: 1_000_000, exceeded: true },
+    ],
+  });
+
+  assert.match(summary, /Absolute median budgets/);
+  assert.match(summary, /first \| 4\.50 ms \| 20\.00 ms \| PASS/);
+  assert.match(summary, /selection \| 1\.25 ms \| 1\.00 ms \| FAIL/);
 });
 
 function baselineExport(name: string, medians: Record<string, number>): string {

--- a/tests/tooling/github-workflows-benchmark.test.ts
+++ b/tests/tooling/github-workflows-benchmark.test.ts
@@ -242,10 +242,12 @@ test("criterion bench workflow runs an A/B micro-benchmark and a dialect guard",
   // Only runs on PRs and only when Rust or the bench harness changes.
   assert.match(workflow, /\n  pull_request:\n/);
   assert.match(workflow, /paths:\n\s+- "crates\/\*\*"/);
+  assert.match(workflow, /- "benchmarks\/\*\*"/);
   assert.match(workflow, /- "Cargo\.lock"/);
   assert.match(workflow, /- "Cargo\.toml"/);
   assert.match(workflow, /- "bench\/criterion-ab\.mjs"/);
   assert.match(workflow, /- "bench\/criterion-impact\.mjs"/);
+  assert.match(workflow, /- "bench\/criterion-summary\.mjs"/);
   assert.match(workflow, /- "bench\/dialect-guard\.mjs"/);
   assert.match(workflow, /FORCE_JAVASCRIPT_ACTIONS_TO_NODE24:\s*true/);
 


### PR DESCRIPTION
## Summary

- enroll the 10,000-finding Doctor TUI Criterion suite in impact-aware base/head runs
- trigger the lane for direct `benchmarks/**` changes and select it through Cargo reverse-dependency metadata for `crates/vize` changes
- hard-gate reference-runner medians at 20 ms for a 120x40 first frame and 1 ms for selection/search input-to-frame updates
- keep noisy relative percentages report-only while rendering exact absolute medians, limits, and pass/fail status in the Actions summary
- fail closed when a budget is invalid, duplicated, or missing its expected Criterion measurement

## Reference runner

- first frame, 120x40, 10,000 findings: **2.67 ms** median / 20.00 ms budget
- selection input-to-frame, 10,000 findings: **119.51 µs** median / 1.00 ms budget
- search input-to-frame, 10,000 findings: **126.51 µs** median / 1.00 ms budget

The relative base/head percentages remain report-only; all three absolute reference-runner budgets passed.

## Verification

- `node --test tests/tooling/criterion-baselines.test.ts tests/tooling/criterion-impact.test.ts` — 17 passed
- `node --test tests/tooling/github-workflows-benchmark.test.ts` — 4 passed
- `oxfmt --check` on the workflow, Criterion drivers, and tooling tests
- `oxlint` on the Criterion drivers and tooling tests — 0 warnings, 0 errors
- real `cargo metadata --locked` impact selection resolves `crates/vize` to `vize_benchmarks`
- GitHub Actions Criterion A/B — all absolute budgets passed
- `git diff --check`

Related to #3138 and #4155.
