### PR TITLE
fix(ui): preserve shift-modified arrow keys in spatial navigation

### DIFF
--- a/npm/ui/core/scripts/check-renderers.ts
+++ b/npm/ui/core/scripts/check-renderers.ts
@@ -42,8 +42,13 @@ const navigation = useSpatialNavigation({
 </script>
 
 <template>
-  <div v-bind="navigation.spatialNavigationProps" role="grid">
-    <div v-for="key in ['alpha', 'bravo']" :key="key" role="gridcell">
+  <div
+    v-bind="navigation.spatialNavigationProps"
+    role="grid"
+    tabindex="0"
+    :aria-activedescendant="registry.activeKey.value ? 'cell-' + registry.activeKey.value : undefined"
+  >
+    <div v-for="key in ['alpha', 'bravo']" :key="key" :id="'cell-' + key" role="gridcell">
       {{ key }}
     </div>
   </div>

--- a/npm/ui/core/src/spatial-navigation-internal.ts
+++ b/npm/ui/core/src/spatial-navigation-internal.ts
@@ -237,7 +237,9 @@ export function selectWrappedCandidate<Key extends CollectionKey, Value>(
 }
 
 export function keyDirection(event: KeyboardEvent): SpatialNavigationDirection | null {
-  if (event.isComposing || event.altKey || event.ctrlKey || event.metaKey) return null;
+  if (event.isComposing || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+    return null;
+  }
   if (event.key === "ArrowDown") return "down";
   if (event.key === "ArrowLeft") return "left";
   if (event.key === "ArrowRight") return "right";

--- a/npm/ui/core/src/spatial-navigation-lifecycle.test.ts
+++ b/npm/ui/core/src/spatial-navigation-lifecycle.test.ts
@@ -20,6 +20,10 @@ test("modified, composing, handled, and editable descendant keys remain untouche
     keyboard("ArrowRight", harness.container, { metaKey: true }).defaultPrevented,
     false,
   );
+  assert.equal(
+    keyboard("ArrowRight", harness.container, { shiftKey: true }).defaultPrevented,
+    false,
+  );
   const composing = new KeyboardEvent("keydown", {
     bubbles: true,
     cancelable: true,


### PR DESCRIPTION
Follow-up to #4202 (already merged), addressing two review comments from that PR.

`keyDirection` filtered `altKey`, `ctrlKey`, and `metaKey` but not `shiftKey`, so `Shift+ArrowRight` navigated and called `event.preventDefault()`. That consumes shift-extend range selection in consumer composites and contradicts the Editing row of `spatial-navigation.behavior.md`, which documents modified events as preserved:

```ts
export function keyDirection(event: KeyboardEvent): SpatialNavigationDirection | null {
  if (event.isComposing || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
    return null;
  }
  // ...
}
```

The existing "modified, composing, handled, and editable descendant keys remain untouched" test gains a `shiftKey` case alongside the other modifiers.

The `SpatialNavigationConsumer.vue` renderer fixture also gets `tabindex="0"` plus `aria-activedescendant` and cell ids. It binds `onKeydown` to a container that nothing could focus, so as a usage example it demonstrated an unreachable pattern; the sibling `TypeaheadConsumer.vue` fixture already sets `tabindex="0"` for the same reason.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->